### PR TITLE
chore(release): enter alpha prerelease mode + initial changeset

### DIFF
--- a/.changeset/initial-alpha-release.md
+++ b/.changeset/initial-alpha-release.md
@@ -1,0 +1,38 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/plugin-form-builder": patch
+---
+
+Initial alpha release of Nextly — a TypeScript-first, Next.js-native CMS and app framework.
+
+All 12 packages publish at `0.0.2-alpha.0` in lockstep under the `alpha` dist-tag.
+
+**Highlights:**
+
+- **Core (`nextly`)** — REST + Direct API, RBAC, hooks, and the runtime engine. API key prefix is `nx_live_`.
+- **Admin (`@nextlyhq/admin`)** — Full-featured admin dashboard.
+- **UI (`@nextlyhq/ui`)** — Headless component primitives shared across packages and plugins.
+- **CLI (`create-nextly-app`)** — Project scaffolder with blog and blank templates, multi-DB picker, telemetry opt-out.
+- **Database adapters** — `@nextlyhq/adapter-postgres`, `@nextlyhq/adapter-mysql`, `@nextlyhq/adapter-sqlite`, plus the shared `@nextlyhq/adapter-drizzle` base.
+- **Storage adapters** — `@nextlyhq/storage-s3` (also R2 / MinIO / B2 / Wasabi), `@nextlyhq/storage-vercel-blob`, `@nextlyhq/storage-uploadthing`.
+- **Plugins (preview)** — `@nextlyhq/plugin-form-builder` for early exploration; public plugin APIs stabilize at the beta release.
+
+**Alpha caveats:** APIs may change before `1.0`. Pin exact versions in production.
+
+**Install:**
+
+```bash
+pnpm create nextly-app@alpha my-app
+# or
+npx create-nextly-app@alpha my-app
+```

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,24 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "playground": "0.1.1",
+    "@nextlyhq/adapter-drizzle": "0.0.1",
+    "@nextlyhq/adapter-mysql": "0.0.1",
+    "@nextlyhq/adapter-postgres": "0.0.1",
+    "@nextlyhq/adapter-sqlite": "0.0.1",
+    "@nextlyhq/admin": "0.0.1",
+    "create-nextly-app": "0.0.1",
+    "@nextlyhq/eslint-config": "0.0.1",
+    "nextly": "0.0.1",
+    "@nextlyhq/plugin-form-builder": "0.0.1",
+    "@nextlyhq/prettier-config": "0.0.1",
+    "@nextlyhq/storage-s3": "0.0.1",
+    "@nextlyhq/storage-uploadthing": "0.0.1",
+    "@nextlyhq/storage-vercel-blob": "0.0.1",
+    "@nextlyhq/telemetry": "0.0.1",
+    "@nextlyhq/tsconfig": "0.0.1",
+    "@nextlyhq/ui": "0.0.1"
+  },
+  "changesets": []
+}


### PR DESCRIPTION
## Summary

Wires up the first Nextly alpha release. Two files:

- **`.changeset/pre.json`** — created by `pnpm changeset pre enter alpha`. Puts Changesets into prerelease mode so version bumps become `-alpha.N` instead of stable.
- **`.changeset/initial-alpha-release.md`** — patch-level bump for all 12 publishable packages, with a user-facing summary that becomes each package's first CHANGELOG entry and seeds the consolidated GitHub release notes.

## What happens after this merges

The Release workflow ([release.yml](.github/workflows/release.yml)) sees the pending changeset and opens an auto-generated **"Version Packages"** PR with:

- All 12 packages bumped from `0.0.1` → `0.0.2-alpha.0`
- `CHANGELOG.md` updated for each package with the changeset summary
- The changeset markdown consumed (deleted)
- `playground` (private) gets a ricochet patch bump because it depends on workspace packages — won't publish.

When that Version PR is merged, the workflow runs `changeset publish` which pushes every package to npm under the `alpha` dist-tag and creates the `v0.0.2-alpha.0` GitHub release marked Pre-release.

## Test plan

- [ ] After merge, confirm Release workflow opens a "chore: version packages" PR with all 12 packages at `0.0.2-alpha.0`
- [ ] After merging that Version PR, confirm 12 successful `npm publish` runs
- [ ] Confirm `https://github.com/nextlyhq/nextly/releases/tag/v0.0.2-alpha.0` exists with Pre-release badge
- [ ] Verify `npm view nextly@alpha version` returns `0.0.2-alpha.0`