### PR TITLE
fix(ci): skip husky pre-push hook when running in CI

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,19 @@
 #!/usr/bin/env sh
+
+# Skip in CI. The release workflow does an internal `git push` (via
+# `changesets/action`) when it commits version bumps; CI's `ci.yml`
+# already runs the same lint+build validation as a separate gated step.
+# Running them again here is redundant and broke the release flow:
+# `pnpm turbo lint` runs *before* `pnpm run build` in this hook, so
+# in CI (where the turbo cache is fresh) lint can't resolve workspace
+# package imports until build has produced the dist outputs.
+#
+# Local pushes still get the full pre-push validation.
+if [ -n "$CI" ]; then
+  echo "Pre-push hook skipped in CI (validated by .github/workflows/ci.yml)"
+  exit 0
+fi
+
 set -e
 pnpm turbo lint --continue \
   --filter='./packages/*'


### PR DESCRIPTION
## Summary

Unblocks the alpha release flow. The previous Release workflow run on PR #4's merge ([run](https://github.com/nextlyhq/nextly/actions/runs/25605921057)) failed because:

1. `changesets/action` invoked `pnpm release:version` → `changeset version` rewrote 12 `package.json` and CHANGELOG files.
2. The action then ran `git push` to land those changes.
3. That push triggered the **local** `.husky/pre-push` hook, which runs `pnpm turbo lint --continue --filter='./packages/*'` *before* `pnpm run build`.
4. In CI, the turbo cache is fresh, so lint executes against unbuilt workspace packages and produces 345 `import-x/no-unresolved` errors (e.g. `Unable to resolve path to module '@nextlyhq/ui'`) because the consuming packages have no `dist/` outputs yet.
5. Hook exits 1 → `git push` fails → release workflow fails.

## Why PR #2's release run didn't hit this

PR #2 had no pending changesets, so the action took the **publish path** (`turbo build && changeset publish`). Build ran first, dist outputs existed, and the subsequent push happened in a state where lint could have resolved imports if the hook had even fired (publish's push doesn't push branch refs the same way version does). Either way, no failure surfaced.

PR #4 introduced pending changesets, the action took the **version path** instead, and the broken hook tripped.

## Fix

Short-circuit `.husky/pre-push` when `$CI` is set. GitHub Actions sets `CI=true`. Local developer pushes still run the full validation.

The redundancy concern is also resolved: `ci.yml` already gates the same lint+build on every PR, so we're not losing CI coverage.

## What this does NOT change

- Pre-commit hook (`gitleaks` + `lint-staged`) is untouched. It's fast, has no build dependency, and is useful even for CI auto-commits.
- Husky stays installed in CI (`prepare: husky`); only this specific hook short-circuits.

## After this merges

The pending changesets on `main` (`.changeset/initial-alpha-release.md`, `.changeset/pre.json`) will trigger another Release workflow run. With the hook skipped, the version step should succeed and the workflow opens the auto-generated **"chore: version packages"** PR with all 12 packages bumped from `0.0.1` → `0.0.2-alpha.0`.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, Release workflow succeeds in opening the Version Packages PR (no pre-push lint errors in workflow log)
- [ ] Version Packages PR shows 12 package bumps to `0.0.2-alpha.0` + CHANGELOG entries