### PR TITLE
docs: pin create-nextly-app install commands to @alpha

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Before opening a bug, please:
 2. Confirm you're on the latest version of the affected package.
 3. Use the [Bug Report template](https://github.com/nextlyhq/nextly/issues/new?template=bug_report.yml) — it asks the questions we need to triage quickly.
 
-The single biggest factor in how fast a bug gets fixed is **a minimal reproduction**. Issues without one are likely to be closed. The fastest way to start one: `pnpm create-nextly-app@latest`, push the failing scenario to a public repo, and link it in the bug report.
+The single biggest factor in how fast a bug gets fixed is **a minimal reproduction**. Issues without one are likely to be closed. The fastest way to start one: `pnpm create nextly-app@alpha`, push the failing scenario to a public repo, and link it in the bug report.
 
 ## Reporting security issues
 

--- a/docs/database/sqlite.mdx
+++ b/docs/database/sqlite.mdx
@@ -7,7 +7,7 @@ import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 
 > **SQLite is for local demos only.** Concurrent writes serialize on a single file lock, the database is fragile across process crashes and shared filesystems, there is no SSL or network access, and you will likely hit issues even during serious local development. Use **PostgreSQL** for any meaningful work -- `docker compose up -d postgres` is a one-liner. Set `DB_DIALECT=postgresql` and point `DATABASE_URL` at it. See the [PostgreSQL setup page](/docs/database/postgres#local-development-with-docker).
 
-The SQLite adapter wraps [`better-sqlite3`](https://github.com/WiseLibs/better-sqlite3) -- a synchronous C++ binding -- behind the same async `DrizzleAdapter` interface as the other dialects. It is in the codebase so a one-off demo, a quick `npx create-nextly-app` walk-through, or a tiny in-memory test suite Just Works without any infrastructure.
+The SQLite adapter wraps [`better-sqlite3`](https://github.com/WiseLibs/better-sqlite3) -- a synchronous C++ binding -- behind the same async `DrizzleAdapter` interface as the other dialects. It is in the codebase so a one-off demo, a quick `npx create-nextly-app@alpha` walk-through, or a tiny in-memory test suite Just Works without any infrastructure.
 
 > **Minimum version: SQLite 3.38.** The pinned `better-sqlite3` ships a much newer SQLite (3.45+ at time of writing), so users on this package always pass the version check. See [database support](/docs/database/support).
 

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -12,22 +12,22 @@ The `create-nextly-app` CLI scaffolds a complete Nextly project with your choice
 <Tabs items={["pnpm", "npm", "yarn", "bun"]}>
 <Tab value="pnpm">
 ```bash
-pnpm create nextly-app my-app
+pnpm create nextly-app@alpha my-app
 ```
 </Tab>
 <Tab value="npm">
 ```bash
-npx create-nextly-app@latest my-app
+npx create-nextly-app@alpha my-app
 ```
 </Tab>
 <Tab value="yarn">
 ```bash
-yarn create nextly-app my-app
+yarn create nextly-app@alpha my-app
 ```
 </Tab>
 <Tab value="bun">
 ```bash
-bun create nextly-app my-app
+bun create nextly-app@alpha my-app
 ```
 </Tab>
 </Tabs>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -30,22 +30,22 @@ The fastest way to start is with the scaffolding CLI:
 <Tabs items={["pnpm", "npm", "yarn", "bun"]}>
 <Tab value="pnpm">
 ```bash
-pnpm create nextly-app my-app
+pnpm create nextly-app@alpha my-app
 ```
 </Tab>
 <Tab value="npm">
 ```bash
-npx create-nextly-app@latest my-app
+npx create-nextly-app@alpha my-app
 ```
 </Tab>
 <Tab value="yarn">
 ```bash
-yarn create nextly-app my-app
+yarn create nextly-app@alpha my-app
 ```
 </Tab>
 <Tab value="bun">
 ```bash
-bun create nextly-app my-app
+bun create nextly-app@alpha my-app
 ```
 </Tab>
 </Tabs>

--- a/docs/templates/blank.mdx
+++ b/docs/templates/blank.mdx
@@ -10,22 +10,22 @@ The **Blank** template scaffolds a minimal Nextly project with no collections or
 <Tabs items={["pnpm", "npm", "yarn", "bun"]}>
 <Tab value="pnpm">
 ```bash
-pnpm create nextly-app my-app --template blank
+pnpm create nextly-app@alpha my-app --template blank
 ```
 </Tab>
 <Tab value="npm">
 ```bash
-npx create-nextly-app@latest my-app --template blank
+npx create-nextly-app@alpha my-app --template blank
 ```
 </Tab>
 <Tab value="yarn">
 ```bash
-yarn create nextly-app my-app --template blank
+yarn create nextly-app@alpha my-app --template blank
 ```
 </Tab>
 <Tab value="bun">
 ```bash
-bun create nextly-app my-app --template blank
+bun create nextly-app@alpha my-app --template blank
 ```
 </Tab>
 </Tabs>

--- a/docs/templates/blog.mdx
+++ b/docs/templates/blog.mdx
@@ -10,22 +10,22 @@ The **Blog** template is a production-quality blog starter. It ships posts, cate
 <Tabs items={["pnpm", "npm", "yarn", "bun"]}>
 <Tab value="pnpm">
 ```bash
-pnpm create nextly-app my-blog --template blog
+pnpm create nextly-app@alpha my-blog --template blog
 ```
 </Tab>
 <Tab value="npm">
 ```bash
-npx create-nextly-app@latest my-blog --template blog
+npx create-nextly-app@alpha my-blog --template blog
 ```
 </Tab>
 <Tab value="yarn">
 ```bash
-yarn create nextly-app my-blog --template blog
+yarn create nextly-app@alpha my-blog --template blog
 ```
 </Tab>
 <Tab value="bun">
 ```bash
-bun create nextly-app my-blog --template blog
+bun create nextly-app@alpha my-blog --template blog
 ```
 </Tab>
 </Tabs>
@@ -33,8 +33,8 @@ bun create nextly-app my-blog --template blog
 To skip the schema-approach prompt, pass `--approach`:
 
 ```bash
-pnpm create nextly-app my-blog --template blog --approach code-first
-pnpm create nextly-app my-blog --template blog --approach visual
+pnpm create nextly-app@alpha my-blog --template blog --approach code-first
+pnpm create nextly-app@alpha my-blog --template blog --approach visual
 ```
 
 ## Schema approach

--- a/docs/templates/index.mdx
+++ b/docs/templates/index.mdx
@@ -10,22 +10,22 @@ Templates are starter projects you scaffold via `create-nextly-app`. The CLI pro
 <Tabs items={["pnpm", "npm", "yarn", "bun"]}>
 <Tab value="pnpm">
 ```bash
-pnpm create nextly-app my-app
+pnpm create nextly-app@alpha my-app
 ```
 </Tab>
 <Tab value="npm">
 ```bash
-npx create-nextly-app@latest my-app
+npx create-nextly-app@alpha my-app
 ```
 </Tab>
 <Tab value="yarn">
 ```bash
-yarn create nextly-app my-app
+yarn create nextly-app@alpha my-app
 ```
 </Tab>
 <Tab value="bun">
 ```bash
-bun create nextly-app my-app
+bun create nextly-app@alpha my-app
 ```
 </Tab>
 </Tabs>
@@ -33,8 +33,8 @@ bun create nextly-app my-app
 Without `--template`, the CLI prompts you to pick one. To skip the prompt, pass `--template <name>`:
 
 ```bash
-pnpm create nextly-app my-app --template blank
-pnpm create nextly-app my-app --template blog
+pnpm create nextly-app@alpha my-app --template blank
+pnpm create nextly-app@alpha my-app --template blog
 ```
 
 ## Available templates

--- a/packages/create-nextly-app/README.md
+++ b/packages/create-nextly-app/README.md
@@ -15,16 +15,16 @@ The official CLI for scaffolding a new Nextly CMS project.
 
 ```bash
 # pnpm
-pnpm create nextly-app my-app
+pnpm create nextly-app@alpha my-app
 
 # npm
-npx create-nextly-app@latest my-app
+npx create-nextly-app@alpha my-app
 
 # yarn
-yarn create nextly-app my-app
+yarn create nextly-app@alpha my-app
 
 # bun
-bun create nextly-app my-app
+bun create nextly-app@alpha my-app
 ```
 
 The CLI walks you through:
@@ -59,13 +59,13 @@ The two approaches are not mutually exclusive: a code-first project can add UI-d
 
 ```bash
 # Blog with code-first approach
-pnpm create nextly-app my-blog --template blog --approach code-first
+pnpm create nextly-app@alpha my-blog --template blog --approach code-first
 
 # Blank project with PostgreSQL
-pnpm create nextly-app my-app --template blank --database postgresql
+pnpm create nextly-app@alpha my-app --template blank --database postgresql
 
 # Skip prompts entirely (defaults: blank, SQLite, local storage)
-pnpm create nextly-app my-app -y
+pnpm create nextly-app@alpha my-app -y
 ```
 
 ## CLI flags
@@ -80,7 +80,7 @@ pnpm create nextly-app my-app -y
 | `--version`         | `-V`  | Print the CLI version                                        |                    |
 | `--help`            | `-h`  | Show help text                                               |                    |
 
-Run `pnpm create nextly-app --help` for the inline reference.
+Run `pnpm create nextly-app@alpha --help` for the inline reference.
 
 <details>
 <summary><strong>Contributor flags</strong> (development only)</summary>

--- a/packages/create-nextly-app/src/cli.ts
+++ b/packages/create-nextly-app/src/cli.ts
@@ -49,12 +49,12 @@ program
     "after",
     `
 Examples:
-  $ npx create-nextly-app my-project
-  $ npx create-nextly-app my-project -y
-  $ npx create-nextly-app my-blog -t blog -a code-first
-  $ npx create-nextly-app my-project --database postgresql
-  $ npx create-nextly-app .
-  `
+  $ npx create-nextly-app@alpha my-project
+  $ npx create-nextly-app@alpha my-project -y
+  $ npx create-nextly-app@alpha my-blog -t blog -a code-first
+  $ npx create-nextly-app@alpha my-project --database postgresql
+  $ npx create-nextly-app@alpha .
+`
   )
   .action(
     async (

--- a/packages/nextly/README.md
+++ b/packages/nextly/README.md
@@ -25,7 +25,7 @@ The core Nextly package: collection runtime, database services, REST and Direct 
 The fastest path is the CLI:
 
 ```bash
-pnpm create nextly-app my-app
+pnpm create nextly-app@alpha my-app
 ```
 
 Or add Nextly to an existing Next.js app:

--- a/templates/README.md
+++ b/templates/README.md
@@ -19,7 +19,7 @@ The CLI downloads templates from this directory at runtime via GitHub's Codeload
 For local development, use `--local-template` to read from the filesystem:
 
 ```bash
-pnpm create nextly-app my-blog \
+pnpm create nextly-app@alpha my-blog \
   --local-template ./templates \
   --template blog \
   --use-yalc

--- a/templates/blank/README.md
+++ b/templates/blank/README.md
@@ -16,7 +16,7 @@ content already wired up.
 ## Scaffold
 
 ```bash
-pnpm create nextly-app my-app --template blank
+pnpm create nextly-app@alpha my-app --template blank
 ```
 
 ## What you get

--- a/templates/blog/src/lib/queries/types.ts
+++ b/templates/blog/src/lib/queries/types.ts
@@ -10,7 +10,7 @@
  * for the generated ones if you want the extra precision.
  *
  * Why hand-maintained types here? Shipping the template with inline
- * types means `npx create-nextly-app` produces a project that typechecks
+ * types means `npx create-nextly-app@alpha` produces a project that typechecks
  * cleanly on first install, without needing a types-regen step.
  */
 


### PR DESCRIPTION
## Summary

Every user-facing install command (`pnpm create nextly-app`, `npx create-nextly-app`, etc.) was pointing at the bare package name or `@latest`. Both inherit from npm's `latest` dist-tag, which today resolves to the alpha (we re-tagged it post-publish) but is fragile:

- The day a stable 1.0 ships, every tutorial in the wild that uses `@latest` silently switches new readers to a stable release while their tutorial steps assume alpha behavior.
- Users skimming docs/READMEs lose the explicit "this is alpha" signal.
- The day we move alpha → beta → rc, the bare commands keep tracking `latest` instead of staying on the alpha train.

This PR pins every user-facing install command to `@alpha`. When we move to beta/rc/stable, we update once.

## What changed

13 files, 44 substitutions, all 1:1:

```
CONTRIBUTING.md                           |  2 +-  (also fixes typo)
docs/database/sqlite.mdx                  |  2 +-
docs/getting-started/installation.mdx     |  8 ++++----
docs/index.mdx                            |  8 ++++----
docs/templates/blank.mdx                  |  8 ++++----
docs/templates/blog.mdx                   | 12 ++++++------
docs/templates/index.mdx                  | 12 ++++++------
packages/create-nextly-app/README.md      | 16 ++++++++--------
packages/create-nextly-app/src/cli.ts     | 12 ++++++------ (--help Examples)
packages/nextly/README.md                 |  2 +-
templates/README.md                       |  2 +-
templates/blank/README.md                 |  2 +-
templates/blog/src/lib/queries/types.ts   |  2 +-  (template JSDoc)
```

The `CONTRIBUTING.md` change also fixes a stray `pnpm create-nextly-app@latest` (with hyphen) — that exact form is not a valid pnpm command. The correct shape is `pnpm create nextly-app@alpha` (with a space; pnpm's create-shorthand convention).

## What was NOT changed (intentional)

- `CHANGELOG.md` files — historical record
- `.changeset/*` — consumed/historical
- `.github/*` — workflows, labels, issue templates (not user-facing install copy)
- `package.json` / lockfile package-name references — those are real deps, not install commands
- Source files where the string is the package name only, not an install command (e.g. `packages/telemetry/src/events.ts` event names, `packages/nextly/src/init/build-service-config.ts` config keys)
- Prose references like "the `create-nextly-app` scaffolder fills in `DB_DIALECT`..." (line 36 of `docs/configuration/environment.mdx`) where `create-nextly-app` is referred to as the noun, not as an install command

## Why no changeset

This is a docs-only change. CHANGELOG entries and version bumps for documentation churn produce noise without value during alpha. The actual published packages (`0.0.2-alpha.0`) are unchanged.

The CLI's `--help` text technically ships in the published package, but the next iterative alpha bump (whenever we add real changeset content) will pick up the `cli.ts` Examples block change. No need to ship a `0.0.2-alpha.1` for this alone.

## Test plan

- [ ] `git grep -rEn '(pnpm\|yarn\|bun) create nextly-app[^@]\|npx create-nextly-app[^@a-z]' -- '*.md' '*.mdx' '*.ts' '*.tsx'` returns no matches outside CHANGELOG/.changeset/CI files (verified locally — empty)
- [ ] `git grep -rEn 'create-nextly-app@latest' -- '*.md' '*.mdx' '*.ts'` returns no matches outside CHANGELOG (verified locally — empty)
- [ ] Visual scan of docs to confirm code blocks render correctly with `@alpha` suffix
- [ ] CI green