### PR TITLE
fix(playground): auto-handle fresh-clone bootstrap (build + env)

### DIFF
--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -15,9 +15,12 @@ pnpm install
 pnpm dev:app
 ```
 
-The wrapper at `scripts/dev-playground.mjs` runs pre-flight checks (workspace symlinks, `.env` presence, port availability) and then spawns `next dev`. If anything is wrong, you'll get a specific actionable error before Next.js starts.
+The wrapper at `scripts/dev-playground.mjs` runs pre-flight checks (workspace symlinks, `.env` presence, build artifacts, port availability), auto-fixes what it can, then spawns `next dev`. If something can't be auto-fixed you get a specific actionable error before Next.js starts.
 
-If `.env` doesn't exist, the doctor will tell you to run `cp apps/playground/.env.example apps/playground/.env`.
+On a fresh clone the wrapper will:
+
+- **Auto-create `.env`** by copying `apps/playground/.env.example` (safe defaults: SQLite, dev secrets — edit afterward if you want to customize).
+- **Auto-build workspace packages** with `pnpm turbo build --filter='./packages/*'` if no `dist/` outputs exist yet. This adds ~30s on first boot only; turbo's cache makes subsequent boots a no-op. Without this step the seed sub-process can't import the framework runtime and `/admin` returns HTTP 500.
 
 Visit [http://localhost:3000](http://localhost:3000) - `/` redirects to `/admin`.
 

--- a/scripts/dev-doctor.mjs
+++ b/scripts/dev-doctor.mjs
@@ -50,11 +50,48 @@ export async function checkEnvFile(envPath) {
     await fs.access(envPath);
     return { ok: true };
   } catch {
+    // .env missing. Try auto-creating from .env.example. The example is
+    // a checked-in template with safe defaults (SQLite, dev secrets), so
+    // copying it during a fresh-clone boot is the right default. If even
+    // the example is missing, surface a real failure.
     const exampleSibling = envPath.replace(/\.env$/, ".env.example");
+    try {
+      await fs.access(exampleSibling);
+      await fs.copyFile(exampleSibling, envPath);
+      return { ok: true, autoCreated: true, copiedFrom: exampleSibling };
+    } catch {
+      return {
+        ok: false,
+        reason: `.env missing at ${envPath} and .env.example missing as well`,
+        fix: `create ${envPath} manually with DB_DIALECT, DATABASE_URL, NEXTLY_SECRET, NEXT_PUBLIC_APP_URL`,
+      };
+    }
+  }
+}
+
+// Detects whether workspace packages have been built. The seed sub-process
+// imports compiled dist outputs (e.g. @nextlyhq/adapter-drizzle's
+// version-check.cjs), so a fresh clone with no `pnpm build` will crash the
+// seed step. Using packages/nextly/dist as the sentinel because it is the
+// last package built in the turbo graph -- if it exists, the whole
+// dependency chain compiled.
+export async function checkBuildArtifacts(nextlyRoot) {
+  const sentinel = path.join(nextlyRoot, "packages", "nextly", "dist");
+  try {
+    const entries = await fs.readdir(sentinel);
+    if (entries.length === 0) {
+      return {
+        ok: false,
+        reason: "packages/nextly/dist is empty (workspace not built yet)",
+        fix: "pnpm turbo build --filter='./packages/*'",
+      };
+    }
+    return { ok: true };
+  } catch {
     return {
       ok: false,
-      reason: `.env file missing at ${envPath}`,
-      fix: `cp ${exampleSibling} ${envPath}`,
+      reason: "packages/nextly/dist missing (workspace not built yet)",
+      fix: "pnpm turbo build --filter='./packages/*'",
     };
   }
 }
@@ -87,6 +124,7 @@ export async function runAllChecks({ nextlyRoot, envPath, port }) {
   const results = {
     workspaceLinks: await checkWorkspaceLinks(nextlyRoot),
     envFile: await checkEnvFile(envPath),
+    buildArtifacts: await checkBuildArtifacts(nextlyRoot),
     port: await checkPort(port),
   };
   const ok = Object.values(results).every(r => r.ok);

--- a/scripts/dev-playground.mjs
+++ b/scripts/dev-playground.mjs
@@ -145,11 +145,49 @@ async function main() {
   await applyDialectOverride();
 
   console.log("[nextly] Pre-flight checks...");
-  const { ok, results } = await runAllChecks({
+  let { ok, results } = await runAllChecks({
     nextlyRoot: NEXTLY_ROOT,
     envPath,
     port,
   });
+
+  // Surface auto-fixed steps so the contributor knows what changed.
+  if (results.envFile?.autoCreated) {
+    console.log(
+      `[nextly] ℹ auto-created .env from ${path.basename(results.envFile.copiedFrom)} ` +
+        `(safe defaults: SQLite, dev secrets). Edit ${envPath} to customize.`
+    );
+  }
+
+  // Auto-build workspace packages if the doctor flagged missing dist.
+  // The seed sub-process (and the runtime itself) imports compiled dist
+  // artifacts, so a fresh clone without `pnpm build` crashes seed and
+  // produces HTTP 500s in /admin. Turbo's cache makes this a no-op on
+  // subsequent runs once dist exists, so the cost is paid once.
+  if (!results.buildArtifacts.ok) {
+    console.log(
+      "[nextly] First boot detected (no built dist outputs). " +
+        "Running `pnpm turbo build --filter='./packages/*'`..."
+    );
+    const buildExit = await runChild(
+      "pnpm",
+      ["turbo", "build", "--filter=./packages/*"],
+      NEXTLY_ROOT
+    );
+    if (buildExit !== 0) {
+      console.error(
+        `[nextly] ✗ build exited ${buildExit}. ` +
+          `Aborting — fix the build first, then re-run \`pnpm dev:app\`.`
+      );
+      process.exit(buildExit);
+    }
+    // Re-run doctor to refresh the buildArtifacts result.
+    ({ ok, results } = await runAllChecks({
+      nextlyRoot: NEXTLY_ROOT,
+      envPath,
+      port,
+    }));
+  }
 
   if (!ok) {
     for (const [name, r] of Object.entries(results)) {


### PR DESCRIPTION
## Summary

The pre-alpha contributor smoke test on a fresh `git clone` revealed two gaps that broke the CONTRIBUTING.md "one-command boot" promise:

1. **`pnpm install && pnpm dev:app` returned HTTP 500 on `/admin`.** Root cause: the auto-seed step in `scripts/dev-playground.mjs` imports compiled `dist/` outputs (e.g. `@nextlyhq/adapter-drizzle/dist/version-check.cjs`). On a fresh clone `dist/` is empty (no `pnpm build` has run). Seed crashes with `MODULE_NOT_FOUND` → no super-admin is seeded → `devAutoLogin` can't issue a session → `/admin` 500s.
2. **`.env` had to be copied manually.** The previous doctor printed an actionable hint and exited; contributor had to read, copy, re-run. Friction-by-design but not what `apps/playground/README.md` leads contributors to expect.

This PR makes both auto-handled by the wrapper. Reproduces the "one-command boot" claim accurately.

## Changes

### `scripts/dev-doctor.mjs`

- **`checkEnvFile()`** — auto-copies `.env.example` → `.env` when `.env` is missing and the example exists. The example ships safe defaults (SQLite, dev secrets), so this is a one-time bootstrap, not a configuration override. If even the example is missing, surface a real failure with a clear message.
- **New `checkBuildArtifacts()`** — inspects `packages/nextly/dist` as a sentinel (last package built in the turbo graph). Missing dist → failure result with hint.
- `runAllChecks()` now includes `checkBuildArtifacts` alongside the existing checks.

### `scripts/dev-playground.mjs`

- Logs a one-liner when `.env` was auto-created so the contributor knows what changed and where to edit.
- When `checkBuildArtifacts` fails, runs `pnpm turbo build --filter='./packages/*'` automatically, then re-runs the doctor. Turbo's cache makes subsequent boots a no-op, so the ~30s build cost is paid once per fresh clone.
- Build failure short-circuits with a clear "fix the build first" message — doesn't fall through to a confusing seed crash like before.

### `apps/playground/README.md`

Updated the "Run it" section to describe the new auto-fix behaviors so the docs match reality.

## Validation

Reproduced the original failure and confirmed the fix end-to-end:

```bash
# Setup (simulating fresh clone)
$ cd /tmp && git clone https://github.com/nextlyhq/nextly.git nextly-contrib-smoke
$ cd nextly-contrib-smoke
$ pnpm install   # 11.2s

# Before fix
$ pnpm dev:app
[nextly] ✗ envFile: .env file missing
$ cp apps/playground/.env.example apps/playground/.env
$ pnpm dev:app
[nextly] ✓ all checks passed
[nextly] Auto-seeding empty playground...
Error: Cannot find module '...packages/nextly/node_modules/@nextlyhq/adapter-drizzle/dist/version-check.cjs'
[nextly] ✗ seed exited 1. Continuing to start next dev anyway; data may be incomplete.
✓ Ready in 224ms
$ curl http://localhost:3001/admin    # HTTP 500 ✗

# After fix (this PR)
$ rm apps/playground/.env && rm -rf packages/*/dist  # reset to fresh-clone state
$ pnpm dev:app
[nextly] Pre-flight checks...
[nextly] ℹ auto-created .env from .env.example (safe defaults: SQLite, dev secrets). Edit ... to customize.
[nextly] First boot detected (no built dist outputs). Running `pnpm turbo build --filter='./packages/*'`...
[nextly] ✓ all checks passed
[nextly] Auto-seeding empty playground...
[nextly] seed complete: 1 user, 5 posts, 2 categories, 3 tags, 2 media
✓ Ready in 217ms
$ curl http://localhost:3001/admin    # HTTP 200 ✅
```

## Why no changeset

This is a contributor-tooling fix only. Nothing in `packages/*` ships changed code. The `scripts/` and `apps/playground/` aren't published. `apps/playground/README.md` is also not published (private workspace package).

## Test plan

- [ ] CI green
- [ ] Manually verify fresh-clone flow on a second machine: `git clone && cd && pnpm install && pnpm dev:app` → `/admin` returns 200 (currently auto-logged-in as `dev@nextly.local`)
- [ ] Confirm subsequent `pnpm dev:app` runs (with dist already built) skip the auto-build step quickly — turbo cache should see all packages as cached