### PR TITLE
chore: fix stale @nextly/ brand in adapter descriptions

### DIFF
--- a/packages/adapter-mysql/package.json
+++ b/packages/adapter-mysql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nextlyhq/adapter-mysql",
   "version": "0.0.2-alpha.0",
-  "description": "MySQL database adapter for Nextly - extends @nextly/adapter-drizzle",
+  "description": "MySQL database adapter for Nextly - extends @nextlyhq/adapter-drizzle",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/adapter-postgres/package.json
+++ b/packages/adapter-postgres/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nextlyhq/adapter-postgres",
   "version": "0.0.2-alpha.0",
-  "description": "PostgreSQL database adapter for Nextly - extends @nextly/adapter-drizzle",
+  "description": "PostgreSQL database adapter for Nextly - extends @nextlyhq/adapter-drizzle",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/adapter-sqlite/package.json
+++ b/packages/adapter-sqlite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nextlyhq/adapter-sqlite",
   "version": "0.0.2-alpha.0",
-  "description": "SQLite database adapter for Nextly - extends @nextly/adapter-drizzle",
+  "description": "SQLite database adapter for Nextly - extends @nextlyhq/adapter-drizzle",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary

Caught during the post-publish npm dashboard audit (item #15 of the alpha checklist). The three database-adapter packages still had pre-rebrand `@nextly/` scope references in their `description` field. That's the string shown under each package's name on npm.com.

| Package | Was | Now |
|---|---|---|
| `@nextlyhq/adapter-postgres` | "...extends `@nextly/adapter-drizzle`" | "...extends `@nextlyhq/adapter-drizzle`" |
| `@nextlyhq/adapter-mysql` | same shape | same fix |
| `@nextlyhq/adapter-sqlite` | same shape | same fix |

## Effect

- Source repo: clean immediately on merge
- npm.com descriptions: still show the stale `@nextly/` for `0.0.2-alpha.0` until the next publish (`0.0.2-alpha.1` or later) ships these new descriptions

## Why no changeset

Docstring-only metadata change. No shipped runtime/source-code change. Will ride along on whatever the next iterative alpha bump turns out to be.

## Test plan

- [ ] `git grep -rE '@nextly/' -- 'packages/*/package.json'` returns no matches (verified locally — empty)
- [ ] After next publish, `npm view @nextlyhq/adapter-postgres description` shows `@nextlyhq/` (not `@nextly/`)