### PR TITLE
chore: align CoC contact email with project domain

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at **security@revnix.com**. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at **contact@nextlyhq.com**. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 


### PR DESCRIPTION
## Summary

CODE_OF_CONDUCT.md's reporting address was `security@revnix.com`. Two small problems:

1. **Domain mismatch.** Project is `nextlyhq.com`; reporting address pointed at `revnix.com`. Reporters who don't recognize Revnix may hesitate to send sensitive personal details to an unfamiliar domain.
2. **Shared inbox with SECURITY.md.** Mixing CoC reports (personal details about other contributors) with security vuln reports (about code) makes triage harder.

This switches CoC reports to `contact@nextlyhq.com` — the project's existing catch-all already referenced in LICENSE.md. SECURITY.md stays at `security@revnix.com` since vulnerability disclosure is a separate flow with different handling.

## Pre-merge action item

Make sure `contact@nextlyhq.com` is actually monitored before merging. If the inbox is unset up, this PR creates a black hole for CoC reports.

## Test plan

- [ ] `git grep security@revnix.com -- CODE_OF_CONDUCT.md` returns empty (verified locally)
- [ ] `contact@nextlyhq.com` inbox is monitored