### PR TITLE
fix(nextly): status column missing default

### DIFF
--- a/.changeset/fix-status-column-strip.md
+++ b/.changeset/fix-status-column-strip.md
@@ -1,0 +1,20 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Fix UI Schema Builder silently dropping the Draft/Published `status` column when editing a collection or single. Saving a field change on a `status: true` entity used to surface a "Rename status → \<new field\>" option (selected by default) because `previewDesiredSchema` did not propagate the Draft/Published flag into the desired snapshot — confirming the dialog DROPped the column and every subsequent entry POST with `status: "published"` failed with `table dc_<slug> has no column named status`. The flag now flows through the preview/apply pipeline for both collections and singles, so the column survives edits.

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -109,9 +109,7 @@ function formatToastSummary(summary: {
 }): string {
   const parts: string[] = [];
   if (summary.added) {
-    parts.push(
-      `${summary.added} field${summary.added === 1 ? "" : "s"} added`
-    );
+    parts.push(`${summary.added} field${summary.added === 1 ? "" : "s"} added`);
   }
   if (summary.renamed) parts.push(`${summary.renamed} renamed`);
   if (summary.changed) parts.push(`${summary.changed} changed`);
@@ -162,20 +160,27 @@ const COLLECTIONS_METHODS: Record<
       // Service returns legacy { success, data, meta }. Unwrap throws on
       // failure (which the dispatcher converts to a NextlyError response).
       const data = unwrapServiceResult<unknown>(result);
-      const items = Array.isArray(data) ? (data as Record<string, unknown>[]) : [];
+      const items = Array.isArray(data)
+        ? (data as Record<string, unknown>[])
+        : [];
 
       // Service meta uses limit/total/totalPages; toPaginationMeta below
       // adds the canonical hasNext/hasPrev fields.
       const serviceMeta = result.meta;
       const baseMeta = {
-        total: typeof serviceMeta?.total === "number" ? serviceMeta.total : items.length,
+        total:
+          typeof serviceMeta?.total === "number"
+            ? serviceMeta.total
+            : items.length,
         page: typeof serviceMeta?.page === "number" ? serviceMeta.page : 1,
         limit:
           typeof serviceMeta?.limit === "number"
             ? serviceMeta.limit
             : items.length,
         totalPages:
-          typeof serviceMeta?.totalPages === "number" ? serviceMeta.totalPages : 1,
+          typeof serviceMeta?.totalPages === "number"
+            ? serviceMeta.totalPages
+            : 1,
       };
 
       const userId = p._authenticatedUserId
@@ -224,7 +229,9 @@ const COLLECTIONS_METHODS: Record<
     // Bare doc body (no { data } wrapper).
     execute: async (svc, p) => {
       requireParam(p, "collectionName");
-      const result = await svc.getCollection({ collectionName: p.collectionName });
+      const result = await svc.getCollection({
+        collectionName: p.collectionName,
+      });
       const collection = unwrapServiceResult(result, {
         slug: p.collectionName,
       });
@@ -310,6 +317,9 @@ const COLLECTIONS_METHODS: Record<
         slug: p.collectionName,
         tableName,
         fields: fields as DesiredCollection["fields"],
+        // Carry the Draft/Published flag so previewDesiredSchema injects
+        // the `status` column into the desired snapshot.
+        status: collection.status === true,
       };
 
       const pipelinePreview = await previewDesiredSchema({
@@ -455,6 +465,9 @@ const COLLECTIONS_METHODS: Record<
         slug: p.collectionName,
         tableName,
         fields: fields as DesiredCollection["fields"],
+        // Mirror previewSchemaChanges so apply diffs against the same
+        // desired schema preview classified.
+        status: collection.status === true,
       };
 
       // Resolve adapter for the pipeline construction.

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -782,7 +782,8 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       const { fields } = body as { fields: unknown[] };
       if (!fields) throw new Error("fields is required in request body");
 
-      const currentFields = (single.fields ?? []) as unknown as FieldDefinition[];
+      const currentFields = (single.fields ??
+        []) as unknown as FieldDefinition[];
       const tableName = single.tableName;
 
       const adapter = getAdapterFromDI();
@@ -795,17 +796,27 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         slug,
         tableName,
         fields: fields as DesiredSingle["fields"],
+        // Carry the Draft/Published flag so previewDesiredSchema injects
+        // the `status` column into the desired snapshot.
+        status: single.status === true,
       };
 
-      const pipelinePreview = await previewDesiredSchema({ desired, db, dialect });
-
-      const legacyShape = await translatePipelinePreviewToLegacy(pipelinePreview, {
-        tableName,
-        currentFields,
-        newFields: fields as FieldDefinition[],
+      const pipelinePreview = await previewDesiredSchema({
+        desired,
         db,
         dialect,
       });
+
+      const legacyShape = await translatePipelinePreviewToLegacy(
+        pipelinePreview,
+        {
+          tableName,
+          currentFields,
+          newFields: fields as FieldDefinition[],
+          db,
+          dialect,
+        }
+      );
 
       const renamed = pipelinePreview.candidates.map(c => ({
         table: c.tableName,
@@ -877,6 +888,9 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         slug,
         tableName,
         fields: fields as DesiredSingle["fields"],
+        // Mirror previewSingleSchemaChanges so apply diffs against the
+        // same desired schema.
+        status: single.status === true,
       };
 
       const promptDispatcher = new BrowserPromptDispatcher(
@@ -885,7 +899,8 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         legacyBundle
       );
 
-      const migrationJournal = getMigrationJournalFromDI() ?? noopMigrationJournal;
+      const migrationJournal =
+        getMigrationJournalFromDI() ?? noopMigrationJournal;
       const pipeline = new PushSchemaPipeline({
         executor: new DrizzleStatementExecutor(dialect, db),
         renameDetector: new RegexRenameDetector(),
@@ -908,7 +923,9 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       });
 
       if (!result.success) {
-        throw new Error(result.error?.message ?? "Failed to apply schema changes");
+        throw new Error(
+          result.error?.message ?? "Failed to apply schema changes"
+        );
       }
 
       // Post-apply: update dynamic_singles fields JSON + schema_hash.

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -35,8 +35,7 @@ export class DynamicCollectionSchemaService {
   ) {
     this.validationService =
       validationService || new DynamicCollectionValidationService();
-    this.dialect =
-      dialect || env.DB_DIALECT || "postgresql";
+    this.dialect = dialect || env.DB_DIALECT || "postgresql";
   }
 
   /**
@@ -89,7 +88,10 @@ export class DynamicCollectionSchemaService {
     const columns = fields
       .map(f => {
         // Skip many-to-many fields as they don't create columns in the main table
-        if (f.type === "relationship" && f.options?.relationType === "manyToMany") {
+        if (
+          f.type === "relationship" &&
+          f.options?.relationType === "manyToMany"
+        ) {
           return null;
         }
 
@@ -201,16 +203,22 @@ export class DynamicCollectionSchemaService {
 
     // id
     if (this.dialect === "mysql") {
-      allColumnDefs.push(`  ${this.quoteIdentifier("id")} varchar(36) PRIMARY KEY NOT NULL`);
+      allColumnDefs.push(
+        `  ${this.quoteIdentifier("id")} varchar(36) PRIMARY KEY NOT NULL`
+      );
     } else {
-      allColumnDefs.push(`  ${this.quoteIdentifier("id")} text PRIMARY KEY NOT NULL`);
+      allColumnDefs.push(
+        `  ${this.quoteIdentifier("id")} text PRIMARY KEY NOT NULL`
+      );
     }
 
     // title (only if not user-defined)
     const hasTitleField = fields.some(f => f.name === "title");
     if (!hasTitleField) {
       if (this.dialect === "mysql") {
-        allColumnDefs.push(`  ${this.quoteIdentifier("title")} varchar(255) NOT NULL`);
+        allColumnDefs.push(
+          `  ${this.quoteIdentifier("title")} varchar(255) NOT NULL`
+        );
       } else {
         allColumnDefs.push(`  ${this.quoteIdentifier("title")} text NOT NULL`);
       }
@@ -220,7 +228,9 @@ export class DynamicCollectionSchemaService {
     const hasSlugField = fields.some(f => f.name === "slug");
     if (!hasSlugField) {
       if (this.dialect === "mysql") {
-        allColumnDefs.push(`  ${this.quoteIdentifier("slug")} varchar(255) NOT NULL`);
+        allColumnDefs.push(
+          `  ${this.quoteIdentifier("slug")} varchar(255) NOT NULL`
+        );
       } else {
         allColumnDefs.push(`  ${this.quoteIdentifier("slug")} text NOT NULL`);
       }
@@ -254,7 +264,9 @@ export class DynamicCollectionSchemaService {
 
     // CHECK constraints
     if (checks.length > 0) {
-      allColumnDefs.push(`  CONSTRAINT ${this.quoteIdentifier(`chk_${tableName}_validation`)} CHECK (${checks.join(" AND ")})`);
+      allColumnDefs.push(
+        `  CONSTRAINT ${this.quoteIdentifier(`chk_${tableName}_validation`)} CHECK (${checks.join(" AND ")})`
+      );
     }
 
     // FK constraints (each already indented)
@@ -264,14 +276,26 @@ export class DynamicCollectionSchemaService {
 
     // timestamp columns
     if (this.dialect === "sqlite") {
-      allColumnDefs.push(`  ${this.quoteIdentifier("created_at")} integer DEFAULT (strftime('%s', 'now')) NOT NULL`);
-      allColumnDefs.push(`  ${this.quoteIdentifier("updated_at")} integer DEFAULT (strftime('%s', 'now')) NOT NULL`);
+      allColumnDefs.push(
+        `  ${this.quoteIdentifier("created_at")} integer DEFAULT (strftime('%s', 'now')) NOT NULL`
+      );
+      allColumnDefs.push(
+        `  ${this.quoteIdentifier("updated_at")} integer DEFAULT (strftime('%s', 'now')) NOT NULL`
+      );
     } else if (this.dialect === "mysql") {
-      allColumnDefs.push(`  ${this.quoteIdentifier("created_at")} timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL`);
-      allColumnDefs.push(`  ${this.quoteIdentifier("updated_at")} timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL`);
+      allColumnDefs.push(
+        `  ${this.quoteIdentifier("created_at")} timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL`
+      );
+      allColumnDefs.push(
+        `  ${this.quoteIdentifier("updated_at")} timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL`
+      );
     } else {
-      allColumnDefs.push(`  ${this.quoteIdentifier("created_at")} timestamp DEFAULT now() NOT NULL`);
-      allColumnDefs.push(`  ${this.quoteIdentifier("updated_at")} timestamp DEFAULT now() NOT NULL`);
+      allColumnDefs.push(
+        `  ${this.quoteIdentifier("created_at")} timestamp DEFAULT now() NOT NULL`
+      );
+      allColumnDefs.push(
+        `  ${this.quoteIdentifier("updated_at")} timestamp DEFAULT now() NOT NULL`
+      );
     }
 
     let sql = `-- Create dynamic collection: ${tableName}
@@ -296,7 +320,10 @@ ${allColumnDefs.join(",\n")}
 
     // essential for JOIN performance, PostgreSQL does NOT automatically index foreign keys!
     fields.forEach(f => {
-      if (f.type === "relationship" && f.options?.relationType !== "manyToMany") {
+      if (
+        f.type === "relationship" &&
+        f.options?.relationType !== "manyToMany"
+      ) {
         const indexName = `idx_${tableName}_${f.name}`;
         if (this.dialect === "mysql") {
           indexStatements.push(
@@ -404,15 +431,18 @@ ${allColumnDefs.join(",\n")}
     // and PostgreSQL all support this. We don't preserve the column when
     // toggling off because the user explicitly opted out of the lifecycle;
     // re-enabling later would re-add the column with default 'draft'.
+    //
+    // DROP fires only on an *explicit* `hasStatus: false`. Undefined is
+    // treated as "leave the column alone" so a missing flag from any
+    // caller can't accidentally strip Draft/Published.
     const wasStatus = options?.wasStatus === true;
     const hasStatus = options?.hasStatus === true;
     if (!wasStatus && hasStatus) {
-      const statusType =
-        this.dialect === "sqlite" ? "text" : "varchar(20)";
+      const statusType = this.dialect === "sqlite" ? "text" : "varchar(20)";
       statements.push(
         `ALTER TABLE ${this.quoteIdentifier(tableName)} ADD COLUMN ${this.quoteIdentifier("status")} ${statusType} DEFAULT 'draft' NOT NULL;`
       );
-    } else if (wasStatus && !hasStatus) {
+    } else if (wasStatus && options?.hasStatus === false) {
       statements.push(
         `ALTER TABLE ${this.quoteIdentifier(tableName)} DROP COLUMN ${this.quoteIdentifier("status")};`
       );
@@ -709,10 +739,7 @@ ${allColumnDefs.join(",\n")}
     // handling. The caller's add/drop loop will do drop-junction +
     // add-junction (data loss for the join) — admin UI ideally warns
     // before this kind of edit.
-    if (
-      a.type === "relationship" &&
-      a.options?.relationType === "manyToMany"
-    ) {
+    if (a.type === "relationship" && a.options?.relationType === "manyToMany") {
       return false;
     }
     if (a.type === "relationship") {
@@ -725,12 +752,16 @@ ${allColumnDefs.join(",\n")}
   }
 
   /**
-   * Generate TypeScript/Drizzle schema code for a collection
+   * Generate TypeScript/Drizzle schema code for a collection. Pass
+   * `hasStatus: true` for Draft/Published collections so the generated
+   * file includes the `status` column — without it, `drizzle-kit
+   * pushSchema` later sees the live `status` column as extra and drops it.
    */
   generateSchemaCode(
     tableName: string,
     collectionName: string,
-    fields: FieldDefinition[]
+    fields: FieldDefinition[],
+    options?: { hasStatus?: boolean }
   ): string {
     // Determine dialect-specific imports and table function
     const dialectConfig = this.getDialectConfig();
@@ -773,7 +804,10 @@ ${allColumnDefs.join(",\n")}
     const columns = fields
       .filter(
         f =>
-          !(f.type === "relationship" && f.options?.relationType === "manyToMany")
+          !(
+            f.type === "relationship" &&
+            f.options?.relationType === "manyToMany"
+          )
       )
       .map(f => {
         const drizzleType = this.mapFieldTypeToDrizzleDialectAware(f);
@@ -826,7 +860,8 @@ ${allColumnDefs.join(",\n")}
       .filter(
         f =>
           f.index ||
-          (f.type === "relationship" && f.options?.relationType !== "manyToMany")
+          (f.type === "relationship" &&
+            f.options?.relationType !== "manyToMany")
       )
       .map(
         f =>
@@ -841,6 +876,14 @@ ${allColumnDefs.join(",\n")}
     // Generate dialect-specific timestamp columns
     const timestampColumns = this.generateTimestampColumnsForDialect();
 
+    // Placed between user columns and timestamps to match the CREATE TABLE
+    // SQL column order, so drizzle-kit diffs don't see a fake reorder.
+    const statusColumn = options?.hasStatus
+      ? this.dialect === "sqlite"
+        ? `  status: text('status').notNull().default('draft'),\n`
+        : `  status: varchar('status', { length: 20 }).notNull().default('draft'),\n`
+      : "";
+
     return `${imports}
 
 /**
@@ -852,7 +895,7 @@ export const ${tableName} = ${dialectConfig.tableFunction}('${tableName}', {
   title: text('title').notNull(),
   slug: text('slug').notNull(),
 ${columns}
-${timestampColumns}
+${statusColumn}${timestampColumns}
 }, (table) => ({
   slugIdx: uniqueIndex('idx_${tableName}_slug').on(table.slug),
 ${allIndexes}

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -152,7 +152,8 @@ export class DynamicCollectionService extends BaseService {
     const schemaCode = this.schemaService.generateSchemaCode(
       tableName,
       normalizedName,
-      userDefinedFields
+      userDefinedFields,
+      { hasStatus: data.status === true }
     );
 
     const schemaHash = this.generateSchemaHash(userDefinedFields);
@@ -277,7 +278,8 @@ export class DynamicCollectionService extends BaseService {
     const wasStatusForUpdate =
       (collection as { status?: boolean }).status === true;
     const statusFlipped =
-      updates.status !== undefined && (updates.status === true) !== wasStatusForUpdate;
+      updates.status !== undefined &&
+      (updates.status === true) !== wasStatusForUpdate;
 
     if (updates.fields) {
       const normalizedFields = updates.fields.map(f => ({
@@ -323,7 +325,8 @@ export class DynamicCollectionService extends BaseService {
       schemaCode = this.schemaService.generateSchemaCode(
         collection.tableName,
         collectionName,
-        userDefinedFields
+        userDefinedFields,
+        { hasStatus }
       );
       schemaFileName = `${collectionName}.ts`;
 
@@ -402,14 +405,12 @@ export class DynamicCollectionService extends BaseService {
     return this.registryService.listCollections(options);
   }
 
-
   async getCollection(
     name: string
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- callers index dialect-specific row shapes
   ): Promise<any> {
     return this.registryService.getCollection(name);
   }
-
 
   async unregisterCollection(name: string): Promise<unknown> {
     return this.registryService.unregisterCollection(name);

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields.test.ts
@@ -366,6 +366,9 @@ describe("buildDesiredTableFromFields with status enabled", () => {
     expect(status).toBeDefined();
     expect(status?.type).toBe("text");
     expect(status?.nullable).toBe(false);
+    // Must match runtime-schema-generator's `.default("draft")` or the
+    // classifier flags ADD COLUMN as needing TTY confirmation.
+    expect(status?.default).toBe("'draft'");
   });
 
   it("adds a status column with MySQL dialect type 'varchar(20)'", () => {
@@ -378,6 +381,7 @@ describe("buildDesiredTableFromFields with status enabled", () => {
     const status = findColumn(table.columns, "status");
     expect(status?.type).toBe("varchar(20)");
     expect(status?.nullable).toBe(false);
+    expect(status?.default).toBe("'draft'");
   });
 
   it("adds a status column with SQLite dialect type 'text'", () => {
@@ -390,6 +394,7 @@ describe("buildDesiredTableFromFields with status enabled", () => {
     const status = findColumn(table.columns, "status");
     expect(status?.type).toBe("text");
     expect(status?.nullable).toBe(false);
+    expect(status?.default).toBe("'draft'");
   });
 
   it("omits the status column when hasStatus is false or unset", () => {
@@ -409,4 +414,3 @@ describe("buildDesiredTableFromFields with status enabled", () => {
     expect(findColumn(tableFalse.columns, "status")).toBeUndefined();
   });
 });
-

--- a/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
@@ -82,7 +82,9 @@ export function buildDesiredTableFromFields(
       name: reserved.name,
       type: reserved.dialectType,
       nullable: reserved.nullable,
-      default: undefined,
+      // Forward descriptor default so the classifier doesn't flag status as
+      // `add_required_field_no_default` and require TTY confirmation.
+      default: reserved.default,
     });
   }
 
@@ -123,27 +125,117 @@ export function buildDesiredTableFromComponentFields(
 
   // Component system columns — mirrors component-schema-service.ts DDL.
   if (dialect === "postgresql") {
-    columns.push({ name: "id", type: "text", nullable: false, default: undefined });
-    columns.push({ name: "_parent_id", type: "text", nullable: false, default: undefined });
-    columns.push({ name: "_parent_table", type: "varchar", nullable: false, default: undefined });
-    columns.push({ name: "_parent_field", type: "varchar", nullable: false, default: undefined });
-    columns.push({ name: "_order", type: "int4", nullable: true, default: undefined });
-    columns.push({ name: "_component_type", type: "varchar", nullable: true, default: undefined });
+    columns.push({
+      name: "id",
+      type: "text",
+      nullable: false,
+      default: undefined,
+    });
+    columns.push({
+      name: "_parent_id",
+      type: "text",
+      nullable: false,
+      default: undefined,
+    });
+    columns.push({
+      name: "_parent_table",
+      type: "varchar",
+      nullable: false,
+      default: undefined,
+    });
+    columns.push({
+      name: "_parent_field",
+      type: "varchar",
+      nullable: false,
+      default: undefined,
+    });
+    columns.push({
+      name: "_order",
+      type: "int4",
+      nullable: true,
+      default: undefined,
+    });
+    columns.push({
+      name: "_component_type",
+      type: "varchar",
+      nullable: true,
+      default: undefined,
+    });
   } else if (dialect === "mysql") {
-    columns.push({ name: "id", type: "varchar(36)", nullable: false, default: undefined });
-    columns.push({ name: "_parent_id", type: "varchar(36)", nullable: false, default: undefined });
-    columns.push({ name: "_parent_table", type: "varchar(255)", nullable: false, default: undefined });
-    columns.push({ name: "_parent_field", type: "varchar(255)", nullable: false, default: undefined });
-    columns.push({ name: "_order", type: "int(11)", nullable: true, default: undefined });
-    columns.push({ name: "_component_type", type: "varchar(255)", nullable: true, default: undefined });
+    columns.push({
+      name: "id",
+      type: "varchar(36)",
+      nullable: false,
+      default: undefined,
+    });
+    columns.push({
+      name: "_parent_id",
+      type: "varchar(36)",
+      nullable: false,
+      default: undefined,
+    });
+    columns.push({
+      name: "_parent_table",
+      type: "varchar(255)",
+      nullable: false,
+      default: undefined,
+    });
+    columns.push({
+      name: "_parent_field",
+      type: "varchar(255)",
+      nullable: false,
+      default: undefined,
+    });
+    columns.push({
+      name: "_order",
+      type: "int(11)",
+      nullable: true,
+      default: undefined,
+    });
+    columns.push({
+      name: "_component_type",
+      type: "varchar(255)",
+      nullable: true,
+      default: undefined,
+    });
   } else {
     // sqlite
-    columns.push({ name: "id", type: "text", nullable: false, default: undefined });
-    columns.push({ name: "_parent_id", type: "text", nullable: false, default: undefined });
-    columns.push({ name: "_parent_table", type: "text", nullable: false, default: undefined });
-    columns.push({ name: "_parent_field", type: "text", nullable: false, default: undefined });
-    columns.push({ name: "_order", type: "integer", nullable: true, default: undefined });
-    columns.push({ name: "_component_type", type: "text", nullable: true, default: undefined });
+    columns.push({
+      name: "id",
+      type: "text",
+      nullable: false,
+      default: undefined,
+    });
+    columns.push({
+      name: "_parent_id",
+      type: "text",
+      nullable: false,
+      default: undefined,
+    });
+    columns.push({
+      name: "_parent_table",
+      type: "text",
+      nullable: false,
+      default: undefined,
+    });
+    columns.push({
+      name: "_parent_field",
+      type: "text",
+      nullable: false,
+      default: undefined,
+    });
+    columns.push({
+      name: "_order",
+      type: "integer",
+      nullable: true,
+      default: undefined,
+    });
+    columns.push({
+      name: "_component_type",
+      type: "text",
+      nullable: true,
+      default: undefined,
+    });
   }
 
   // User-defined fields.
@@ -165,14 +257,44 @@ export function buildDesiredTableFromComponentFields(
   // COLUMN_TYPE as returned by introspection. Component DDL uses
   // timestamp({ withTimezone: false }) (pg → "timestamp"), DATETIME (mysql), INTEGER (sqlite).
   if (dialect === "postgresql") {
-    columns.push({ name: "created_at", type: "timestamp", nullable: false, default: undefined });
-    columns.push({ name: "updated_at", type: "timestamp", nullable: false, default: undefined });
+    columns.push({
+      name: "created_at",
+      type: "timestamp",
+      nullable: false,
+      default: undefined,
+    });
+    columns.push({
+      name: "updated_at",
+      type: "timestamp",
+      nullable: false,
+      default: undefined,
+    });
   } else if (dialect === "mysql") {
-    columns.push({ name: "created_at", type: "datetime", nullable: false, default: undefined });
-    columns.push({ name: "updated_at", type: "datetime", nullable: false, default: undefined });
+    columns.push({
+      name: "created_at",
+      type: "datetime",
+      nullable: false,
+      default: undefined,
+    });
+    columns.push({
+      name: "updated_at",
+      type: "datetime",
+      nullable: false,
+      default: undefined,
+    });
   } else {
-    columns.push({ name: "created_at", type: "integer", nullable: false, default: undefined });
-    columns.push({ name: "updated_at", type: "integer", nullable: false, default: undefined });
+    columns.push({
+      name: "created_at",
+      type: "integer",
+      nullable: false,
+      default: undefined,
+    });
+    columns.push({
+      name: "updated_at",
+      type: "integer",
+      nullable: false,
+      default: undefined,
+    });
   }
 
   return { name: tableName, columns };

--- a/packages/nextly/src/domains/schema/pipeline/preview.ts
+++ b/packages/nextly/src/domains/schema/pipeline/preview.ts
@@ -120,24 +120,32 @@ export async function previewDesiredSchema(
 
   const liveSnapshot = await introspect(db, dialect, managedTableNames);
 
+  // Forward Draft/Published flag — without it the desired snapshot omits
+  // `status`, the diff reports it as removed, and the rename detector pairs
+  // it with the newest user field, surfacing a SchemaChangeDialog that
+  // DROPs the column on confirm.
   const collectionTables = Object.values(desired.collections).map(c =>
     buildDesiredTableFromFields(
       c.tableName,
       c.fields as unknown as Parameters<typeof buildDesiredTableFromFields>[1],
-      dialect
+      dialect,
+      { hasStatus: c.status === true }
     )
   );
   const singleTables = Object.values(desired.singles).map(s =>
     buildDesiredTableFromFields(
       s.tableName,
       s.fields as unknown as Parameters<typeof buildDesiredTableFromFields>[1],
-      dialect
+      dialect,
+      { hasStatus: s.status === true }
     )
   );
   const componentTables = Object.values(desired.components).map(c =>
     buildDesiredTableFromComponentFields(
       c.tableName,
-      c.fields as unknown as Parameters<typeof buildDesiredTableFromComponentFields>[1],
+      c.fields as unknown as Parameters<
+        typeof buildDesiredTableFromComponentFields
+      >[1],
       dialect
     )
   );

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -296,6 +296,10 @@ export interface SystemColumnDescriptor {
   length?: number;
   nullable: boolean;
   primaryKey: boolean;
+  // Raw default expression as written in DDL (e.g. "'draft'" for status).
+  // Must match what runtime-schema-generator.ts emits so the diff doesn't
+  // classify ADD COLUMN as an interactive "required field with no default."
+  default?: string;
 }
 
 export function getSystemColumnDescriptors(
@@ -304,17 +308,48 @@ export function getSystemColumnDescriptors(
 ): SystemColumnDescriptor[] {
   const cols: SystemColumnDescriptor[] = [];
   if (dialect === "postgresql") {
-    cols.push({ name: "id", dialectType: "text", nullable: false, primaryKey: true });
+    cols.push({
+      name: "id",
+      dialectType: "text",
+      nullable: false,
+      primaryKey: true,
+    });
     if (!opts.hasTitleField) {
-      cols.push({ name: "title", dialectType: "text", nullable: false, primaryKey: false });
+      cols.push({
+        name: "title",
+        dialectType: "text",
+        nullable: false,
+        primaryKey: false,
+      });
     }
     if (!opts.hasSlugField) {
-      cols.push({ name: "slug", dialectType: "text", nullable: false, primaryKey: false });
+      cols.push({
+        name: "slug",
+        dialectType: "text",
+        nullable: false,
+        primaryKey: false,
+      });
     }
-    cols.push({ name: "created_at", dialectType: "timestamp", nullable: true, primaryKey: false });
-    cols.push({ name: "updated_at", dialectType: "timestamp", nullable: true, primaryKey: false });
+    cols.push({
+      name: "created_at",
+      dialectType: "timestamp",
+      nullable: true,
+      primaryKey: false,
+    });
+    cols.push({
+      name: "updated_at",
+      dialectType: "timestamp",
+      nullable: true,
+      primaryKey: false,
+    });
     if (opts.hasStatus) {
-      cols.push({ name: "status", dialectType: "text", nullable: false, primaryKey: false });
+      cols.push({
+        name: "status",
+        dialectType: "text",
+        nullable: false,
+        primaryKey: false,
+        default: "'draft'",
+      });
     }
   } else if (dialect === "mysql") {
     cols.push({
@@ -361,21 +396,53 @@ export function getSystemColumnDescriptors(
         length: 20,
         nullable: false,
         primaryKey: false,
+        default: "'draft'",
       });
     }
   } else {
     // sqlite
-    cols.push({ name: "id", dialectType: "text", nullable: false, primaryKey: true });
+    cols.push({
+      name: "id",
+      dialectType: "text",
+      nullable: false,
+      primaryKey: true,
+    });
     if (!opts.hasTitleField) {
-      cols.push({ name: "title", dialectType: "text", nullable: false, primaryKey: false });
+      cols.push({
+        name: "title",
+        dialectType: "text",
+        nullable: false,
+        primaryKey: false,
+      });
     }
     if (!opts.hasSlugField) {
-      cols.push({ name: "slug", dialectType: "text", nullable: false, primaryKey: false });
+      cols.push({
+        name: "slug",
+        dialectType: "text",
+        nullable: false,
+        primaryKey: false,
+      });
     }
-    cols.push({ name: "created_at", dialectType: "integer", nullable: true, primaryKey: false });
-    cols.push({ name: "updated_at", dialectType: "integer", nullable: true, primaryKey: false });
+    cols.push({
+      name: "created_at",
+      dialectType: "integer",
+      nullable: true,
+      primaryKey: false,
+    });
+    cols.push({
+      name: "updated_at",
+      dialectType: "integer",
+      nullable: true,
+      primaryKey: false,
+    });
     if (opts.hasStatus) {
-      cols.push({ name: "status", dialectType: "text", nullable: false, primaryKey: false });
+      cols.push({
+        name: "status",
+        dialectType: "text",
+        nullable: false,
+        primaryKey: false,
+        default: "'draft'",
+      });
     }
   }
   return cols;


### PR DESCRIPTION
UI Schema Builder saves were silently dropping the `status` column from collections/singles with Draft/Published enabled. After the first edit (adding/renaming a field), the SchemaChangeDialog auto-proposed renaming `status` to the newest user field; confirming — the default — DROPped the column and left `dynamic_collections.status=1` pointing at a table that no longer had it. Every subsequent INSERT 500'd with "table dc_<slug> has no column named status."

Root cause: `previewDesiredSchema` (and the two dispatcher sites that build a DesiredCollection / DesiredSingle to feed it) never carried the Draft/Published flag through to `buildDesiredTableFromFields`. The desired snapshot omitted `status`; the diff reported the live column as removed; the rename detector paired it with the new user field; the dialog rendered the "Rename status -> X" option.

Fixes:
- preview.ts: forward c.status / s.status into buildDesiredTableFromFields({ hasStatus }) for collections + singles.
- collection-dispatcher.ts + single-dispatcher.ts: set desired.<entity>[slug].status from the registry on both preview and apply so the pipeline sees the same desired schema in both phases.

Related cleanups closing adjacent gaps surfaced by the same diagnosis:
- field-column-descriptor.ts: add `default` to SystemColumnDescriptor and set it to 'draft' for status in all three dialects.
- build-from-fields.ts: forward reserved.default into the diff's ColumnSpec so the classifier no longer flags add_column status as add_required_field_no_default (which under non-TTY `next dev` surfaces as TTYRequiredError and blocks code-first sync).
- dynamic-collection-schema-service.ts: generateSchemaCode now accepts hasStatus and emits the column in the generated Drizzle file — without it, drizzle-kit pushSchema later sees status as extra and drops it.
- dynamic-collection-schema-service.ts: generateAlterTableMigration now DROPs status only on an explicit hasStatus: false. Defensive bound — an undefined / missing flag no longer coerces to false.
- dynamic-collection-service.ts: pass hasStatus into generateSchemaCode at both CREATE and UPDATE sites.

Verified end-to-end in the playground: create a new collection with Draft/Published enabled, edit it to add a field, save — the dialog now correctly reports "Safe change: + headline", the status column survives the save, and a subsequent POST /admin/api/collections/<slug>/entries with status: "published" returns 201.

## Summary

<!-- What does this PR do and why? Keep it short. -->

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / chore (no user-facing change)

## Related issues

<!-- e.g. Closes #123, Refs #456 -->

## Changeset

This repo uses [Changesets](https://github.com/changesets/changesets). If your PR changes any publishable package under `packages/*`, you **must** include a changeset:

```bash
pnpm changeset
```

Then commit the generated `.changeset/*.md` file.

- [ ] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [ ] I selected the correct semver bump (patch / minor / major)

> The `changeset-check` CI job will fail if a publishable package is modified without a changeset.

## Test plan

<!-- How did you verify this works? Commands run, scenarios tested, screenshots, etc. -->

- [ ] `pnpm lint`
- [ ] `pnpm check-types`
- [ ] `pnpm build`
- [ ] Manually verified the change

## Checklist

- [ ] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [ ] I targeted the `main` branch
- [ ] I updated relevant documentation

## Screenshots / recordings

<!-- Optional. Drag images or videos here for UI changes. -->

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to? Migration risks, perf concerns, etc. -->
