### PR TITLE
fix(nextly): default HTTP read endpoints to all statuses

### DIFF
--- a/.changeset/api-default-all-statuses.md
+++ b/.changeset/api-default-all-statuses.md
@@ -1,0 +1,20 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+HTTP read endpoints now return entries/documents regardless of status by default. Previously, `GET /api/collections/<slug>/entries`, `GET /api/collections/<slug>/entries/<id>`, `GET /api/collections/<slug>/entries/count`, and `GET /api/singles/<slug>` defaulted to "published-only" and required `?status=all` to see drafts — confusing for the admin API Playground, which returned 404 for any status-enabled single or collection whose only document was still in draft. The new default is to return all records; pass `?status=published` (or `?status=draft`) to filter explicitly. The routes still require authentication, so this only affects callers that already have read permission.

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -690,17 +690,16 @@ const COLLECTIONS_METHODS: Record<
       const rawLimit = p.limit;
 
       // Why: forward the `?status=` URL param so trusted callers (the admin)
-      // can pass `status=all` to see drafts alongside published entries.
-      // Public REST callers omit the param and continue to get the safe
-      // published-only default. Same allowlist as getEntry (Task 7 PR-3) —
-      // any other value is dropped to prevent injection. The status field
+      // HTTP API default returns every entry regardless of status; pass
+      // `?status=published` or `?status=draft` to filter. Same allowlist as
+      // getEntry — any value outside it falls back to "all". The status
       // dropdown in the entry table layers a `where: {status: {equals: ...}}`
-      // clause on top of this; that still works because where-narrowing
-      // happens after the default filter is bypassed.
+      // on top of this; that still works because where-narrowing happens
+      // after the default filter.
       const status =
         p.status === "all" || p.status === "draft" || p.status === "published"
           ? p.status
-          : undefined;
+          : "all";
 
       const result = await svc.listEntries({
         collectionName: p.collectionName,
@@ -737,13 +736,12 @@ const COLLECTIONS_METHODS: Record<
     // `{ totalDocs }` internally; we translate at the boundary.
     execute: async (svc, p) => {
       requireParam(p, "collectionName");
-      // Why: same `?status=` forwarding as listEntries, so admin counts
-      // include drafts when the caller passes `status=all`. See the
-      // listEntries comment for full rationale.
+      // Match listEntries: count every entry regardless of status by
+      // default; pass `?status=published` (or `draft`) to filter.
       const status =
         p.status === "all" || p.status === "draft" || p.status === "published"
           ? p.status
-          : undefined;
+          : "all";
       const result = await svc.countEntries({
         collectionName: p.collectionName,
         search: p.search,
@@ -790,15 +788,12 @@ const COLLECTIONS_METHODS: Record<
       if (!p.collectionName || !p.entryId) {
         throw new Error("collectionName and entryId parameters are required");
       }
-      // can pass `status=all` to bypass the default published-only filter
-      // when re-fetching after Unpublish (otherwise the admin's just-
-      // unpublished entry comes back 404, since its status is now draft
-      // and the public default would hide it). Public callers omit the
-      // param and continue to get the safe published-only default.
+      // HTTP API returns the entry regardless of status by default; pass
+      // `?status=published` (or `draft`) to filter. Matches listEntries.
       const status =
         p.status === "all" || p.status === "draft" || p.status === "published"
           ? p.status
-          : undefined;
+          : "all";
       const result = await svc.getEntry({
         collectionName: p.collectionName,
         entryId: p.entryId,

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -394,16 +394,15 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
     execute: async (svc, p) => {
       const slug = requireParam(p, "slug", "Single slug");
       const richTextFormat = parseRichTextFormat(p.richTextFormat);
-      // admin can pass `status=all` to bypass the default published-only
-      // filter. A freshly-created status-enabled Single auto-creates
-      // its default doc with status='draft'; without this, the admin's
-      // own brand-new Single comes back 404. Public callers omit the
-      // param and continue to get the safe published-only default.
-      // Mirrors the collection-dispatcher fix in PR-3.
+      // HTTP API default returns every document regardless of status; pass
+      // `?status=published` or `?status=draft` to filter. The route requires
+      // auth (see isPublicEndpoint), so this only affects callers who
+      // already have read permission. Anything outside the allowlist falls
+      // back to "all" instead of being silently dropped.
       const status =
         p.status === "all" || p.status === "draft" || p.status === "published"
           ? p.status
-          : undefined;
+          : "all";
       const result = await svc.entry.get(slug, {
         depth: toNumber(p.depth),
         locale: p.locale,


### PR DESCRIPTION
The admin API Playground returned 404 for any status-enabled Single or Collection whose only document was still in draft, because all four HTTP read endpoints defaulted to "published-only" and required `?status=all` to see drafts:

- GET /api/singles/<slug>
- GET /api/collections/<slug>/entries
- GET /api/collections/<slug>/entries/<id>
- GET /api/collections/<slug>/entries/count

Invert the default: return everything by default, pass `?status=published` or `?status=draft` to filter explicitly. The endpoints still require authentication (see isPublicEndpoint), so this only affects callers that already have read permission. Anything outside the {all, published, draft} allowlist now falls back to "all" instead of being silently dropped, which matches "principle of least surprise".

Verified end-to-end against the playground: GET /admin/api/singles/sitedata (no params) now returns the draft doc with 200; ?status=published still returns 404 when no published doc exists; ?status=draft still returns the draft doc.

## Summary

<!-- What does this PR do and why? Keep it short. -->

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / chore (no user-facing change)

## Related issues

<!-- e.g. Closes #123, Refs #456 -->

## Changeset

This repo uses [Changesets](https://github.com/changesets/changesets). If your PR changes any publishable package under `packages/*`, you **must** include a changeset:

```bash
pnpm changeset
```

Then commit the generated `.changeset/*.md` file.

- [ ] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [ ] I selected the correct semver bump (patch / minor / major)

> The `changeset-check` CI job will fail if a publishable package is modified without a changeset.

## Test plan

<!-- How did you verify this works? Commands run, scenarios tested, screenshots, etc. -->

- [ ] `pnpm lint`
- [ ] `pnpm check-types`
- [ ] `pnpm build`
- [ ] Manually verified the change

## Checklist

- [ ] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [ ] I targeted the `main` branch
- [ ] I updated relevant documentation

## Screenshots / recordings

<!-- Optional. Drag images or videos here for UI changes. -->

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to? Migration risks, perf concerns, etc. -->
