### PR TITLE
fix(admin, nextly):  single document cache invalidation & propagate status flag in buildFullDesiredSchema

### DIFF
--- a/.changeset/single-document-cache-invalidation.md
+++ b/.changeset/single-document-cache-invalidation.md
@@ -1,0 +1,20 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Fix Single document fields appearing empty after a component-field rename. Schema-apply and external-schema-update handlers invalidated `["collections"]`, `["entries"]`, `["singles"]`, and `["components"]` — but Single document data lives under a separate `["single-documents"]` namespace (used by `useSingleDocument`), which was never invalidated. After a rename, `useSingleSchema` refetched with the new field name while `useSingleDocument` kept serving cached data keyed by the old name, so the form rendered `data[newName]` as `undefined` and the field appeared blank until a hard refresh. Collections were unaffected because `useEntry` lives under `["entries"]`, which was already in the invalidation list. The `["single-documents"]` key is now invalidated alongside the others. Also propagate the Draft/Published `status` flag through `buildFullDesiredSchema` for both collections and singles, mirroring the earlier preview-pipeline fix so the full-schema build path doesn't drop the column either.

--- a/packages/admin/src/context/RestartContext.tsx
+++ b/packages/admin/src/context/RestartContext.tsx
@@ -88,6 +88,7 @@ export function RestartProvider({ children }: { children: ReactNode }) {
         void queryClient.invalidateQueries({ queryKey: ["collections"] });
         void queryClient.invalidateQueries({ queryKey: ["entries"] });
         void queryClient.invalidateQueries({ queryKey: ["singles"] });
+        void queryClient.invalidateQueries({ queryKey: ["single-documents"] });
         void queryClient.invalidateQueries({ queryKey: ["components"] });
       } else {
         toast.error(message ?? "Failed to apply schema changes");

--- a/packages/admin/src/layout/RootLayout.tsx
+++ b/packages/admin/src/layout/RootLayout.tsx
@@ -46,6 +46,7 @@ function AdminAppContent() {
       void queryClient.invalidateQueries({ queryKey: ["collections"] });
       void queryClient.invalidateQueries({ queryKey: ["entries"] });
       void queryClient.invalidateQueries({ queryKey: ["singles"] });
+      void queryClient.invalidateQueries({ queryKey: ["single-documents"] });
       void queryClient.invalidateQueries({ queryKey: ["components"] });
     };
     window.addEventListener("nextly:schema-updated", handler);

--- a/packages/nextly/src/dispatcher/helpers/desired-schema.ts
+++ b/packages/nextly/src/dispatcher/helpers/desired-schema.ts
@@ -41,6 +41,7 @@ export async function buildFullDesiredSchema(): Promise<DesiredSchema> {
           slug: c.slug,
           tableName: c.tableName,
           fields: c.fields ?? [],
+          status: (c as { status?: boolean }).status === true,
         };
       }
     } catch {
@@ -58,6 +59,7 @@ export async function buildFullDesiredSchema(): Promise<DesiredSchema> {
           slug: s.slug,
           tableName: s.tableName,
           fields: s.fields ?? [],
+          status: (s as { status?: boolean }).status === true,
         };
       }
     } catch {


### PR DESCRIPTION
## Summary

Fix Single document fields appearing empty after a component-field rename. Schema-apply and external-schema-update handlers invalidated `["collections"]`, `["entries"]`, `["singles"]`, and `["components"]` — but Single document data lives under a separate `["single-documents"]` namespace (used by `useSingleDocument`), which was never invalidated. After a rename, `useSingleSchema` refetched with the new field name while `useSingleDocument` kept serving cached data keyed by the old name, so the form rendered `data[newName]` as `undefined` and the field appeared blank until a hard refresh. Collections were unaffected because `useEntry` lives under `["entries"]`, which was already in the invalidation list. The `["single-documents"]` key is now invalidated alongside the others. Also propagate the Draft/Published `status` flag through `buildFullDesiredSchema` for both collections and singles, mirroring the earlier preview-pipeline fix so the full-schema build path doesn't drop the column either.

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / chore (no user-facing change)



## Changeset

This repo uses [Changesets](https://github.com/changesets/changesets). If your PR changes any publishable package under `packages/*`, you **must** include a changeset:

```bash
pnpm changeset
```

Then commit the generated `.changeset/*.md` file.

- [X] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [ ] I selected the correct semver bump (patch / minor / major)

> The `changeset-check` CI job will fail if a publishable package is modified without a changeset.

## Test plan

<!-- How did you verify this works? Commands run, scenarios tested, screenshots, etc. -->

- [X] `pnpm lint`
- [X] `pnpm check-types`
- [X] `pnpm build`
- [X] Manually verified the change

## Checklist

- [ ] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [X] I targeted the `main` branch
- [ ] I updated relevant documentation