### PR TITLE
feat(nextly): support collection dbName overrides and refresh component schema cache

### DIFF
--- a/.changeset/collection-dbname-and-component-schema-refresh.md
+++ b/.changeset/collection-dbname-and-component-schema-refresh.md
@@ -1,0 +1,20 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Collection mutation paths now resolve the physical table through `collection.tableName`, honoring `dbName` overrides instead of always deriving the name from the slug. The code-first boot sync detects when a collection's resolved `tableName` differs from the row in `dynamic_collections`, renames the physical table (Postgres/SQLite/MySQL quoted `ALTER TABLE ... RENAME TO`), writes the new name back, and invalidates the cached Drizzle schema in `CollectionFileManager` so the next request rebuilds against the renamed table — previously a `dbName` change left CRUD pointing at the stale table until a server restart. When both the old and new physical tables exist, the rename is skipped with a warn so the user can resolve the conflict manually. Component runtime-schema refresh after a UI-driven create/update/apply now flows through the DI `SchemaRegistry` (with a typed fallback to the adapter's `tableResolver` for non-DI paths) and surfaces failures as warnings instead of swallowing them in a silent try/catch — the prior behavior left `comp_*` queries selecting pre-rename column names until restart. Generated timestamp columns (`createdAt`, `updatedAt`) now emit `withTimezone: false` / plain `TIMESTAMP` for Postgres, aligning behavior across SQLite, MySQL, and Postgres.

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -633,7 +633,6 @@ async function initializeSchemaRegistry(
   }
 }
 
-
 /**
  * Register every code-first collection and single from the config as a
  * runtime Drizzle schema in the resolver. Complements `loadDynamicTables`
@@ -718,7 +717,6 @@ async function registerConfigTablesInResolver(
   }
 }
 
-
 function logStorageConfiguration(
   mediaStorage: MediaStorage,
   storagePlugins: StoragePlugin[] | undefined,
@@ -759,6 +757,23 @@ async function syncCodeFirstCollections(
   const collectionRegistry = container.get<CollectionRegistryService>(
     "collectionRegistryService"
   );
+
+  // Wire schema-cache invalidation before sync so a dbName change drops the
+  // stale Drizzle table from CollectionFileManager on the next request.
+  if (container.has("collectionService")) {
+    try {
+      const collectionService = container.get<{
+        invalidateSchemaForSlug: (slug: string) => void;
+      }>("collectionService");
+      collectionRegistry.setOnTableNameChanged((slug: string) => {
+        collectionService.invalidateSchemaForSlug(slug);
+      });
+    } catch (err) {
+      logger.warn?.(
+        `[registerServices] Could not wire tableName-change cache invalidation: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
 
   const codeFirstConfigs: CodeFirstCollectionConfig[] =
     transformedConfig.collections.map(collection => ({
@@ -834,8 +849,17 @@ async function syncCodeFirstCollections(
   ];
 
   // Also check unchanged collections that might be missing their tables.
+  // Resolve via the config's dbName (falling back to slug) so dbName-using
+  // collections check the correct physical table.
+  const collectionsBySlug = new Map(
+    (transformedConfig.collections ?? []).map(c => [c.slug, c])
+  );
   for (const slug of syncResult.unchanged) {
-    const tableName = `dc_${slug.replace(/-/g, "_")}`;
+    const collection = collectionsBySlug.get(slug);
+    const baseTableName = collection?.dbName ?? slug.replace(/-/g, "_");
+    const tableName = baseTableName.startsWith("dc_")
+      ? baseTableName
+      : `dc_${baseTableName}`;
     try {
       const tableExists = await adapter.tableExists(tableName);
       if (!tableExists) {
@@ -930,8 +954,7 @@ async function syncCodeFirstCollections(
         slug: collection.slug,
         tableName,
         fields: collection.fields ?? [],
-        status:
-          (collection as { status?: boolean }).status === true,
+        status: (collection as { status?: boolean }).status === true,
       };
       slugsAfterFilter.push(collection.slug);
     }
@@ -1306,8 +1329,7 @@ async function reconcileSingleTablesForBoot(
         let hasStatus = false;
         if (codeFirstConfig) {
           fields = codeFirstConfig.fields as unknown as FieldDefinition[];
-          hasStatus =
-            (codeFirstConfig as { status?: boolean }).status === true;
+          hasStatus = (codeFirstConfig as { status?: boolean }).status === true;
         } else {
           const record = await singleRegistry.getSingleBySlug(single.slug);
           if (!record) {
@@ -1361,10 +1383,7 @@ async function reconcileSingleTablesForBoot(
             const resolver = (
               adapter as unknown as {
                 tableResolver?: {
-                  registerDynamicSchema?: (
-                    name: string,
-                    t: unknown
-                  ) => void;
+                  registerDynamicSchema?: (name: string, t: unknown) => void;
                 };
               }
             ).tableResolver;

--- a/packages/nextly/src/di/registrations/register-collections.ts
+++ b/packages/nextly/src/di/registrations/register-collections.ts
@@ -64,10 +64,7 @@ export function registerCollectionServices(ctx: RegistrationContext): void {
       try {
         const result = await adapter.selectOne<{
           fields: string;
-          table_name: string;
-          // Why: forward the Draft/Published flag so the FileManager's
-          // that includes the `status` column. SQLite returns 0/1; PG
-          // returns booleans; coerce both shapes below.
+          tableName: string;
           status: boolean | number | null;
         }>("dynamic_collections", {
           where: {
@@ -82,7 +79,8 @@ export function registerCollectionServices(ctx: RegistrationContext): void {
               : result.fields;
           return {
             fields,
-            tableName: result.table_name,
+            tableName: result.tableName,
+            // SQLite returns 0/1 for booleans; PG/MySQL return real booleans.
             status: result.status === true || result.status === 1,
           };
         }

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -52,6 +52,7 @@ import {
   getAdapterFromDI,
   getComponentRegistryFromDI,
   getMigrationJournalFromDI,
+  getSchemaRegistryFromDI,
 } from "../helpers/di";
 import { requireParam, toNumber } from "../helpers/validation";
 import type { MethodHandler, Params } from "../types";
@@ -115,6 +116,8 @@ async function executeMigrationStatements(
   }
 }
 
+// Refresh the cached Drizzle table so the next entry query joining this
+// component uses the new column layout without a server restart.
 function registerComponentRuntimeSchema(
   adapter: DrizzleAdapter,
   dialect: string,
@@ -130,6 +133,13 @@ function registerComponentRuntimeSchema(
       fields
     );
 
+    const registry = getSchemaRegistryFromDI();
+    if (registry) {
+      registry.registerDynamicSchema(tableName, runtimeTable);
+      return;
+    }
+
+    // Fallback for paths where DI isn't wired (tests, CLI).
     const resolver = (
       adapter as unknown as {
         tableResolver?: {
@@ -137,12 +147,23 @@ function registerComponentRuntimeSchema(
         };
       }
     ).tableResolver;
-
     if (resolver && typeof resolver.registerDynamicSchema === "function") {
       resolver.registerDynamicSchema(tableName, runtimeTable);
+      return;
     }
-  } catch {
-    // Non-fatal: schema will be registered on next server restart.
+
+    console.warn(
+      `[registerComponentRuntimeSchema] No SchemaRegistry available for ` +
+        `'${tableName}'. Component queries may reference old column names ` +
+        `until next server restart.`
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[registerComponentRuntimeSchema] In-memory schema refresh failed for ` +
+        `'${tableName}': ${msg}. Component queries may reference old ` +
+        `column names until next server restart.`
+    );
   }
 }
 
@@ -325,10 +346,7 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         }
       }
 
-      const updated = await svc.registry.updateComponent(
-        slug,
-        updateData
-      );
+      const updated = await svc.registry.updateComponent(slug, updateData);
 
       return respondMutation(`Component "${slug}" updated.`, updated);
     },
@@ -350,7 +368,8 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
       const { fields } = body as { fields: unknown[] };
       if (!fields) throw new Error("fields is required in request body");
 
-      const currentFields = (component.fields ?? []) as unknown as FieldDefinition[];
+      const currentFields = (component.fields ??
+        []) as unknown as FieldDefinition[];
       const tableName = component.tableName;
 
       const adapter = getAdapterFromDI();
@@ -365,15 +384,22 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         fields: fields as DesiredComponent["fields"],
       };
 
-      const pipelinePreview = await previewDesiredSchema({ desired, db, dialect });
-
-      const legacyShape = await translatePipelinePreviewToLegacy(pipelinePreview, {
-        tableName,
-        currentFields,
-        newFields: fields as FieldDefinition[],
+      const pipelinePreview = await previewDesiredSchema({
+        desired,
         db,
         dialect,
       });
+
+      const legacyShape = await translatePipelinePreviewToLegacy(
+        pipelinePreview,
+        {
+          tableName,
+          currentFields,
+          newFields: fields as FieldDefinition[],
+          db,
+          dialect,
+        }
+      );
 
       const renamed = pipelinePreview.candidates.map(c => ({
         table: c.tableName,
@@ -455,7 +481,8 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         legacyBundle
       );
 
-      const migrationJournal = getMigrationJournalFromDI() ?? noopMigrationJournal;
+      const migrationJournal =
+        getMigrationJournalFromDI() ?? noopMigrationJournal;
       const pipeline = new PushSchemaPipeline({
         executor: new DrizzleStatementExecutor(dialect, db),
         renameDetector: new RegexRenameDetector(),
@@ -478,7 +505,9 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
       });
 
       if (!result.success) {
-        throw new Error(result.error?.message ?? "Failed to apply schema changes");
+        throw new Error(
+          result.error?.message ?? "Failed to apply schema changes"
+        );
       }
 
       // Post-apply: update dynamic_components fields JSON + schema_hash directly
@@ -507,7 +536,12 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
       // so the registered table includes component system columns
       // (_parent_id, _parent_table, _parent_field, _order, _component_type)
       // instead of collection columns (title, slug).
-      registerComponentRuntimeSchema(adapter, dialect, tableName, fields as FieldConfig[]);
+      registerComponentRuntimeSchema(
+        adapter,
+        dialect,
+        tableName,
+        fields as FieldConfig[]
+      );
 
       // Pipeline (PipelineResult) does not carry per-slug schema versions;
       // those live on createApplyDesiredSchema's ApplyResult wrapper. Bump by

--- a/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
@@ -263,6 +263,11 @@ export class CollectionMetadataService extends BaseService {
     this.fileManager.registerSchemas(schemas);
   }
 
+  /** Drop the cached Drizzle schema for one slug so the next load rebuilds it. */
+  invalidateSchemaForSlug(collectionName: string): void {
+    this.fileManager.invalidateSchemaForSlug(collectionName);
+  }
+
   /**
    * Create a new collection.
    * Generates schema, migration files, and registers the collection.

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -144,6 +144,14 @@ export class CollectionMutationService extends BaseService {
     }
   }
 
+  /** Resolve the physical table for a collection, honoring `dbName` overrides. */
+  private resolveTableName(collection: unknown, slug: string): string {
+    return (
+      ((collection as Record<string, unknown>)?.tableName as string) ||
+      getTableName(slug)
+    );
+  }
+
   /**
    * Wrapper around checkFieldUniqueness that matches the QueryDatabaseParams
    * signature expected by CollectionHookService.buildPrebuiltHookContext.
@@ -309,6 +317,11 @@ export class CollectionMutationService extends BaseService {
         [];
       const storedHooks = this.hookService.getStoredHooks(
         collection as Record<string, unknown>
+      );
+
+      const tableName = this.resolveTableName(
+        collection,
+        params.collectionName
       );
 
       // Shared context between all hooks in this request
@@ -603,11 +616,9 @@ export class CollectionMutationService extends BaseService {
       // a component save failure rolls back the entry — no partial state.
       const entry: Record<string, unknown> = {};
       await this.adapter.transaction(async tx => {
-        const rawEntry = await tx.insert<unknown>(
-          getTableName(params.collectionName),
-          entryData,
-          { returning: "*" }
-        );
+        const rawEntry = await tx.insert<unknown>(tableName, entryData, {
+          returning: "*",
+        });
 
         // Convert snake_case keys from DB response back to camelCase field names
         // so hooks and the API response use the original field names.
@@ -624,7 +635,7 @@ export class CollectionMutationService extends BaseService {
         ) {
           await this.componentDataService.saveComponentDataInTransaction(tx, {
             parentId: entry.id as string,
-            parentTable: getTableName(params.collectionName),
+            parentTable: tableName,
             fields: fields as unknown as FieldConfig[],
             data: componentFieldData,
           });
@@ -798,6 +809,11 @@ export class CollectionMutationService extends BaseService {
         [];
       const storedHooks = this.hookService.getStoredHooks(
         collection as Record<string, unknown>
+      );
+
+      const tableName = this.resolveTableName(
+        collection,
+        params.collectionName
       );
 
       // Shared context between all hooks in this request
@@ -1092,7 +1108,6 @@ export class CollectionMutationService extends BaseService {
       // a component save failure rolls back the entry update — no partial state.
       // tx.execute() is used for the UPDATE so it runs on the same DB client
       // as the transaction (unlike tx.update() which delegates to the pool).
-      const tableName = getTableName(params.collectionName);
       await this.adapter.transaction(async tx => {
         const updatePayload = { ...finalData, updatedAt: new Date() };
 
@@ -1314,6 +1329,11 @@ export class CollectionMutationService extends BaseService {
         collection as Record<string, unknown>
       );
 
+      const tableName = this.resolveTableName(
+        collection,
+        params.collectionName
+      );
+
       // Shared context between all hooks in this request
       const sharedContext: Record<string, unknown> = { ...params.context };
 
@@ -1368,7 +1388,7 @@ export class CollectionMutationService extends BaseService {
           []) as FieldConfig[];
         await this.componentDataService.deleteComponentData({
           parentId: params.entryId,
-          parentTable: getTableName(params.collectionName),
+          parentTable: tableName,
           fields: collectionFields,
         });
       }
@@ -1467,8 +1487,6 @@ export class CollectionMutationService extends BaseService {
         return accessDenied;
       }
 
-      const tableName = getTableName(params.collectionName);
-
       // Get collection metadata to identify relation fields and hooks
       const collection = await this.collectionService.getCollection(
         params.collectionName
@@ -1483,6 +1501,11 @@ export class CollectionMutationService extends BaseService {
         [];
       const storedHooks = this.hookService.getStoredHooks(
         collection as Record<string, unknown>
+      );
+
+      const tableName = this.resolveTableName(
+        collection,
+        params.collectionName
       );
 
       // Shared context between all hooks in this request
@@ -1684,7 +1707,26 @@ export class CollectionMutationService extends BaseService {
     body: Record<string, unknown>
   ): Promise<CollectionServiceResult<unknown>> {
     try {
-      const tableName = getTableName(params.collectionName);
+      // Get collection metadata and hooks first
+      const collection = await this.collectionService.getCollection(
+        params.collectionName
+      );
+      const fields =
+        ((
+          (collection as Record<string, unknown>).schemaDefinition as
+            | Record<string, unknown>
+            | undefined
+        )?.fields as FieldDefinition[]) ||
+        ((collection as Record<string, unknown>).fields as FieldDefinition[]) ||
+        [];
+      const storedHooks = this.hookService.getStoredHooks(
+        collection as Record<string, unknown>
+      );
+
+      const tableName = this.resolveTableName(
+        collection,
+        params.collectionName
+      );
 
       // Fetch existing entry first (needed for access control)
       const existingEntry = await tx.selectOne<Record<string, unknown>>(
@@ -1714,22 +1756,6 @@ export class CollectionMutationService extends BaseService {
       if (accessDenied) {
         return accessDenied;
       }
-
-      // Get collection metadata and hooks
-      const collection = await this.collectionService.getCollection(
-        params.collectionName
-      );
-      const fields =
-        ((
-          (collection as Record<string, unknown>).schemaDefinition as
-            | Record<string, unknown>
-            | undefined
-        )?.fields as FieldDefinition[]) ||
-        ((collection as Record<string, unknown>).fields as FieldDefinition[]) ||
-        [];
-      const storedHooks = this.hookService.getStoredHooks(
-        collection as Record<string, unknown>
-      );
 
       // Shared context between all hooks in this request
       const sharedContext: Record<string, unknown> = {};
@@ -1951,7 +1977,18 @@ export class CollectionMutationService extends BaseService {
     }
   ): Promise<CollectionServiceResult<{ deleted: boolean }>> {
     try {
-      const tableName = getTableName(params.collectionName);
+      // Get collection metadata and stored hooks
+      const collection = await this.collectionService.getCollection(
+        params.collectionName
+      );
+      const storedHooks = this.hookService.getStoredHooks(
+        collection as Record<string, unknown>
+      );
+
+      const tableName = this.resolveTableName(
+        collection,
+        params.collectionName
+      );
 
       // Fetch entry first (needed for access control and hooks)
       const entry = await tx.selectOne<Record<string, unknown>>(tableName, {
@@ -1974,14 +2011,6 @@ export class CollectionMutationService extends BaseService {
       if (accessDenied) {
         return accessDenied;
       }
-
-      // Get collection metadata and stored hooks
-      const collection = await this.collectionService.getCollection(
-        params.collectionName
-      );
-      const storedHooks = this.hookService.getStoredHooks(
-        collection as Record<string, unknown>
-      );
 
       // Shared context between all hooks in this request
       const sharedContext: Record<string, unknown> = {};
@@ -2125,8 +2154,6 @@ export class CollectionMutationService extends BaseService {
     skipHooks: boolean
   ): Promise<CollectionServiceResult<unknown>> {
     try {
-      const tableName = getTableName(params.collectionName);
-
       // Get collection metadata to identify relation fields
       const collection = await this.collectionService.getCollection(
         params.collectionName
@@ -2141,6 +2168,11 @@ export class CollectionMutationService extends BaseService {
         [];
       const storedHooks = this.hookService.getStoredHooks(
         collection as Record<string, unknown>
+      );
+
+      const tableName = this.resolveTableName(
+        collection,
+        params.collectionName
       );
 
       let currentData: Record<string, unknown> = { ...body };
@@ -2366,7 +2398,26 @@ export class CollectionMutationService extends BaseService {
     skipHooks: boolean
   ): Promise<CollectionServiceResult<unknown>> {
     try {
-      const tableName = getTableName(params.collectionName);
+      // Get collection metadata to identify relation fields
+      const collection = await this.collectionService.getCollection(
+        params.collectionName
+      );
+      const fields =
+        ((
+          (collection as Record<string, unknown>).schemaDefinition as
+            | Record<string, unknown>
+            | undefined
+        )?.fields as FieldDefinition[]) ||
+        ((collection as Record<string, unknown>).fields as FieldDefinition[]) ||
+        [];
+      const storedHooks = this.hookService.getStoredHooks(
+        collection as Record<string, unknown>
+      );
+
+      const tableName = this.resolveTableName(
+        collection,
+        params.collectionName
+      );
 
       // When update access is `owner-only`, fold the ownership
       // predicate into the SQL WHERE clause of the initial fetch. A
@@ -2379,7 +2430,10 @@ export class CollectionMutationService extends BaseService {
         params.user
       );
       const fetchWhere = ownerConstraint
-        ? this.whereAnd({ id: entryId, [ownerConstraint.field]: ownerConstraint.value })
+        ? this.whereAnd({
+            id: entryId,
+            [ownerConstraint.field]: ownerConstraint.value,
+          })
         : this.whereEq("id", entryId);
 
       // Fetch existing entry first (needed for owner checks and hooks)
@@ -2402,9 +2456,6 @@ export class CollectionMutationService extends BaseService {
       // that fires only if a future refactor accidentally weakens the
       // fetch query — at which point we'd rather return 403 than
       // silently let a non-owner through.
-      const collection = await this.collectionService.getCollection(
-        params.collectionName
-      );
       const accessRules = this.accessService.getAccessRules(
         collection as Record<string, unknown>
       );
@@ -2421,19 +2472,6 @@ export class CollectionMutationService extends BaseService {
           };
         }
       }
-
-      // Get collection metadata to identify relation fields
-      const fields =
-        ((
-          (collection as Record<string, unknown>).schemaDefinition as
-            | Record<string, unknown>
-            | undefined
-        )?.fields as FieldDefinition[]) ||
-        ((collection as Record<string, unknown>).fields as FieldDefinition[]) ||
-        [];
-      const storedHooks = this.hookService.getStoredHooks(
-        collection as Record<string, unknown>
-      );
 
       let currentData: Record<string, unknown> = { ...body };
 
@@ -2677,7 +2715,15 @@ export class CollectionMutationService extends BaseService {
     skipHooks: boolean
   ): Promise<CollectionServiceResult<{ deleted: boolean }>> {
     try {
-      const tableName = getTableName(params.collectionName);
+      // Get collection metadata early
+      const collection = await this.collectionService.getCollection(
+        params.collectionName
+      );
+
+      const tableName = this.resolveTableName(
+        collection,
+        params.collectionName
+      );
 
       // When delete access is `owner-only`, fold the ownership
       // predicate into the SQL WHERE clause of the initial fetch.
@@ -2689,7 +2735,10 @@ export class CollectionMutationService extends BaseService {
         params.user
       );
       const fetchWhere = ownerConstraint
-        ? this.whereAnd({ id: entryId, [ownerConstraint.field]: ownerConstraint.value })
+        ? this.whereAnd({
+            id: entryId,
+            [ownerConstraint.field]: ownerConstraint.value,
+          })
         : this.whereEq("id", entryId);
 
       // Fetch entry first (needed for owner checks and hooks)
@@ -2709,9 +2758,6 @@ export class CollectionMutationService extends BaseService {
       // See updateSingleEntryInTransaction for the rationale:
       // WHERE-clause filter is load-bearing, this comparison is the
       // safety net.
-      const collection = await this.collectionService.getCollection(
-        params.collectionName
-      );
       const accessRules = this.accessService.getAccessRules(
         collection as Record<string, unknown>
       );

--- a/packages/nextly/src/domains/collections/services/collection-registry-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-registry-service.ts
@@ -126,6 +126,8 @@ export class CollectionRegistryService extends BaseRegistryService<
   protected readonly tableNamePrefix = "dc_";
 
   private permissionSeedService?: PermissionSeedService;
+  /** Invoked when code-first sync resolves a new `tableName` for an existing slug. */
+  private onTableNameChanged?: (slug: string) => void;
 
   constructor(adapter: DrizzleAdapter, logger: Logger) {
     super(adapter, logger);
@@ -138,6 +140,11 @@ export class CollectionRegistryService extends BaseRegistryService<
   /** Set the PermissionSeedService for auto-seeding permissions on collection sync. */
   setPermissionSeedService(service: PermissionSeedService): void {
     this.permissionSeedService = service;
+  }
+
+  /** Register a callback fired when sync resolves a new `tableName` for a slug. */
+  setOnTableNameChanged(callback: (slug: string) => void): void {
+    this.onTableNameChanged = callback;
   }
 
   async getCollectionBySlug(
@@ -347,6 +354,10 @@ export class CollectionRegistryService extends BaseRegistryService<
     if (data.status !== undefined) {
       updateData.status = data.status === true ? 1 : 0;
     }
+    // Writeable so code-first sync can reconcile a changed `dbName`.
+    if (data.tableName !== undefined) {
+      updateData.table_name = this.ensureTableNamePrefix(data.tableName);
+    }
 
     try {
       const results = await this.adapter.update<DynamicCollectionRecord>(
@@ -423,12 +434,15 @@ export class CollectionRegistryService extends BaseRegistryService<
       try {
         const existing = await this.getCollectionBySlug(config.slug);
         const schemaHash = calculateSchemaHash(config.fields);
+        const desiredTableName = config.tableName
+          ? this.ensureTableNamePrefix(config.tableName)
+          : this.generateTableName(config.slug);
 
         if (!existing) {
           await this.registerCollection({
             slug: config.slug,
             labels: config.labels,
-            tableName: config.tableName ?? this.generateTableName(config.slug),
+            tableName: desiredTableName,
             description: config.description,
             fields: config.fields,
             timestamps: config.timestamps ?? true,
@@ -445,11 +459,19 @@ export class CollectionRegistryService extends BaseRegistryService<
           await this.seedPermissionsForCollection(config.slug);
         } else if (
           !schemaHashesMatch(schemaHash, existing.schemaHash) ||
-          (config.status === true) !== (existing.status === true)
+          (config.status === true) !== (existing.status === true) ||
+          desiredTableName !== existing.tableName
         ) {
-          // Either fields changed or the status toggle flipped — both warrant
-          // a write so dynamic_collections.status stays in sync with the
-          // code-first config.
+          // Fields changed, status toggle flipped, or `dbName` resolved to a
+          // new physical table — all three need to be written through.
+          if (desiredTableName !== existing.tableName) {
+            await this.renamePhysicalTableIfPossible(
+              existing.tableName,
+              desiredTableName,
+              config.slug
+            );
+            this.onTableNameChanged?.(config.slug);
+          }
           await this.updateCollection(
             config.slug,
             {
@@ -462,6 +484,7 @@ export class CollectionRegistryService extends BaseRegistryService<
               schemaHash,
               locked: true,
               status: config.status === true,
+              tableName: desiredTableName,
             },
             { source: "code" }
           );
@@ -613,6 +636,47 @@ export class CollectionRegistryService extends BaseRegistryService<
     );
 
     return this.deserializeRecord(result);
+  }
+
+  /**
+   * Rename the physical table when a code-first collection's `dbName` changes.
+   * Renames only when old exists and new doesn't; warns when both exist; no-op
+   * otherwise (boot auto-create handles the missing-table case).
+   */
+  private async renamePhysicalTableIfPossible(
+    oldTableName: string,
+    newTableName: string,
+    slug: string
+  ): Promise<void> {
+    let oldExists: boolean;
+    let newExists: boolean;
+    try {
+      oldExists = await this.adapter.tableExists(oldTableName);
+      newExists = await this.adapter.tableExists(newTableName);
+    } catch (error) {
+      this.logger.warn(
+        `Skipping rename for collection "${slug}": table introspection failed (${error instanceof Error ? error.message : String(error)}). Boot pipeline will reconcile.`
+      );
+      return;
+    }
+
+    if (oldExists && !newExists) {
+      try {
+        const { dialect } = this.adapter.getCapabilities();
+        const q = dialect === "mysql" ? "`" : '"';
+        await this.adapter.executeQuery(
+          `ALTER TABLE ${q}${oldTableName}${q} RENAME TO ${q}${newTableName}${q}`
+        );
+      } catch (error) {
+        this.logger.warn(
+          `Failed to rename physical table for collection "${slug}" (${oldTableName} → ${newTableName}): ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    } else if (oldExists && newExists) {
+      this.logger.warn(
+        `Cannot rename physical table for collection "${slug}": both "${oldTableName}" and "${newTableName}" exist. Resolve manually (drop one or copy rows).`
+      );
+    }
   }
 
   private async seedPermissionsForCollection(slug: string): Promise<void> {

--- a/packages/nextly/src/domains/collections/services/collection-registry-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-registry-service.ts
@@ -465,7 +465,7 @@ export class CollectionRegistryService extends BaseRegistryService<
           // Fields changed, status toggle flipped, or `dbName` resolved to a
           // new physical table — all three need to be written through.
           if (desiredTableName !== existing.tableName) {
-            await this.renamePhysicalTableIfPossible(
+            await this.renamePhysicalTable(
               existing.tableName,
               desiredTableName,
               config.slug
@@ -643,7 +643,7 @@ export class CollectionRegistryService extends BaseRegistryService<
    * Renames only when old exists and new doesn't; warns when both exist; no-op
    * otherwise (boot auto-create handles the missing-table case).
    */
-  private async renamePhysicalTableIfPossible(
+  private async renamePhysicalTable(
     oldTableName: string,
     newTableName: string,
     slug: string

--- a/packages/nextly/src/domains/collections/services/collection-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service.ts
@@ -174,6 +174,11 @@ export class CollectionService extends BaseService {
     this.metadataService.registerDynamicSchemas(schemas);
   }
 
+  /** Drop the cached Drizzle schema for one slug so the next load rebuilds it. */
+  invalidateSchemaForSlug(collectionName: string): void {
+    this.metadataService.invalidateSchemaForSlug(collectionName);
+  }
+
   /**
    * Create a new collection
    *

--- a/packages/nextly/src/domains/components/services/component-schema-service.ts
+++ b/packages/nextly/src/domains/components/services/component-schema-service.ts
@@ -81,7 +81,7 @@ const SQL_COLUMN_TYPES: Record<
     boolean: "BOOLEAN",
     integer: "INTEGER",
     real: "REAL",
-    timestamp: "TIMESTAMP WITH TIME ZONE",
+    timestamp: "TIMESTAMP",
     json: "JSONB",
   },
   mysql: {
@@ -123,8 +123,7 @@ export class ComponentSchemaService {
   private readonly q: string;
 
   constructor(dialect?: SupportedDialect) {
-    this.dialect =
-      dialect || env.DB_DIALECT || "postgresql";
+    this.dialect = dialect || env.DB_DIALECT || "postgresql";
     this.q = QUOTE_CHAR[this.dialect];
   }
 
@@ -988,7 +987,11 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
         if (isNumberField(field)) imports.add("double");
         if (isCheckboxField(field)) imports.add("boolean");
         if (isDateField(field)) imports.add("timestamp");
-        if (isRepeaterField(field) || isGroupField(field) || isJSONField(field)) {
+        if (
+          isRepeaterField(field) ||
+          isGroupField(field) ||
+          isJSONField(field)
+        ) {
           imports.add("json");
         }
       } else {
@@ -1004,7 +1007,11 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
         if (isNumberField(field)) imports.add("doublePrecision");
         if (isCheckboxField(field)) imports.add("boolean");
         if (isDateField(field)) imports.add("timestamp");
-        if (isRepeaterField(field) || isGroupField(field) || isJSONField(field)) {
+        if (
+          isRepeaterField(field) ||
+          isGroupField(field) ||
+          isJSONField(field)
+        ) {
           imports.add("jsonb");
         }
       }

--- a/packages/nextly/src/domains/schema/services/schema-generator.ts
+++ b/packages/nextly/src/domains/schema/services/schema-generator.ts
@@ -666,10 +666,7 @@ export class SchemaGenerator {
       lines.push(`}, (table) => [`);
       for (const field of indexedFields) {
         if (!isDataField(field)) continue;
-        const indexDef = this.generateIndexDefinition(
-          field,
-          tableName
-        );
+        const indexDef = this.generateIndexDefinition(field, tableName);
         if (indexDef) {
           lines.push(indexDef);
         }
@@ -734,8 +731,8 @@ export class SchemaGenerator {
     }
 
     return [
-      `  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),`,
-      `  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow().$onUpdate(() => new Date()),`,
+      `  createdAt: timestamp("created_at", { withTimezone: false }).notNull().defaultNow(),`,
+      `  updatedAt: timestamp("updated_at", { withTimezone: false }).notNull().defaultNow().$onUpdate(() => new Date()),`,
     ].join("\n");
   }
 
@@ -1154,7 +1151,7 @@ export class SchemaGenerator {
       return `  updatedAt: ${tsType.fn}("updated_at"${tsOptions}).notNull().$defaultFn(() => new Date()).$onUpdate(() => new Date()),`;
     }
 
-    return `  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow().$onUpdate(() => new Date()),`;
+    return `  updatedAt: timestamp("updated_at", { withTimezone: false }).notNull().defaultNow().$onUpdate(() => new Date()),`;
   }
 
   // ============================================================

--- a/packages/nextly/src/services/collection-file-manager.ts
+++ b/packages/nextly/src/services/collection-file-manager.ts
@@ -28,9 +28,7 @@ export interface FileManagerConfig {
  * the column from `dynamic_collections` / `dynamic_singles` and forwards
  * a coerced boolean to FileManager's runtime generation.
  */
-export type CollectionMetadataFetcher = (
-  collectionName: string
-) => Promise<{
+export type CollectionMetadataFetcher = (collectionName: string) => Promise<{
   fields: FieldDefinition[];
   tableName: string;
   status?: boolean;
@@ -71,10 +69,7 @@ export class CollectionFileManager {
   }
 
   registerSchema(collectionName: string, schema: unknown): void {
-    this.schemaRegistry.set(
-      `dc_${collectionName.replace(/-/g, "_")}`,
-      schema
-    );
+    this.schemaRegistry.set(`dc_${collectionName.replace(/-/g, "_")}`, schema);
   }
 
   registerSchemas(schemas: Record<string, unknown>): void {
@@ -105,6 +100,16 @@ export class CollectionFileManager {
   // (built from the apply payload's `fields` list).
   refreshSchema(tableName: string, freshTable: unknown): void {
     this.schemaRegistry.set(tableName, freshTable);
+  }
+
+  /**
+   * Drop the slug-keyed cache entry so the lazy fetcher rebuilds the Drizzle
+   * table from current `dynamic_collections` state. See `refreshSchema` for
+   * the tableName-keyed variant used when the new table is already built.
+   */
+  invalidateSchemaForSlug(collectionName: string): void {
+    const schemaKey = `dc_${collectionName.replace(/-/g, "_")}`;
+    this.schemaRegistry.delete(schemaKey);
   }
 
   async saveArtifacts(artifacts: CollectionArtifacts): Promise<void> {
@@ -275,8 +280,7 @@ export class CollectionFileManager {
         if (metadata && metadata.fields) {
           const dialect = this.adapter.dialect;
           const tableName =
-            metadata.tableName ||
-            `dc_${collectionName.replace(/-/g, "_")}`;
+            metadata.tableName || `dc_${collectionName.replace(/-/g, "_")}`;
 
           console.log(
             "[FileManager] Generating runtime schema for:",

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -79,11 +79,7 @@ export class CollectionsHandler {
       try {
         const result = await adapter.selectOne<{
           fields: string;
-          table_name: string;
-          // Why: forward the Draft/Published flag so the FileManager's
-          // runtime schema fallback generates a descriptor
-          // that includes the `status` column. SQLite returns 0/1; PG
-          // returns booleans; coerce both shapes below.
+          tableName: string;
           status: boolean | number | null;
         }>("dynamic_collections", {
           where: {
@@ -98,7 +94,8 @@ export class CollectionsHandler {
               : result.fields;
           return {
             fields,
-            tableName: result.table_name,
+            tableName: result.tableName,
+            // SQLite returns 0/1 for booleans; PG/MySQL return real booleans.
             status: result.status === true || result.status === 1,
           };
         }


### PR DESCRIPTION
## Summary 

- Resolve physical table via collection.tableName (dbName override) in collection mutation paths, falling back to slug-derived name.
- Rename physical table on dbName change during code-first sync and wire schema-cache invalidation so the next request rebuilds the Drizzle table.
- Refresh in-memory component runtime schema through SchemaRegistry (DI), replacing the silent try/catch with typed entry + warn fallback.
- Switch generated timestamp columns to withTimezone: false for consistency across dialects.


- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / chore (no user-facing change)

## Changeset

This repo uses [Changesets](https://github.com/changesets/changesets). If your PR changes any publishable package under `packages/*`, you **must** include a changeset:

```bash
pnpm changeset
```

Then commit the generated `.changeset/*.md` file.

- [ ] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [ ] I selected the correct semver bump (patch / minor / major)

> The `changeset-check` CI job will fail if a publishable package is modified without a changeset.

- [X] `pnpm lint`
- [X] `pnpm check-types`
- [X] `pnpm build`
- [X] Manually verified the change

## Checklist

- [ ] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [X] I targeted the `main` branch
- [ ] I updated relevant documentation
