### PR TITLE
fix(create-nextly-app): scope plugin-form-builder to blog template

### DIFF
--- a/.changeset/scope-form-builder-to-blog.md
+++ b/.changeset/scope-form-builder-to-blog.md
@@ -1,0 +1,20 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Fix `Cannot find package '@nextlyhq/plugin-form-builder'` on `pnpm dev` for blank scaffolds. The base admin page (`templates/base/src/app/admin/[[...params]]/page.tsx`) and the existing-project admin generator both hard-coded three side-effect imports for `@nextlyhq/plugin-form-builder`, but the package was only added to `package.json` on the fresh-scaffold npm path. Blank scaffolds and existing-project installs got the imports without the dep, so `next dev` failed at module resolution. The plugin is now opt-in per template: blank ships a plugin-less admin page; the blog template overlays a blog-specific admin page that re-adds the imports (mirroring how `formBuilderPlugin` is registered only in the blog config). `generatePackageJson` and the yalc paths in `installDependencies` accept a `projectType` and only include `@nextlyhq/plugin-form-builder` when the selected template uses it.

--- a/packages/create-nextly-app/src/create-nextly.ts
+++ b/packages/create-nextly-app/src/create-nextly.ts
@@ -19,10 +19,7 @@ import {
   cleanupDownload,
   type TemplateSource,
 } from "./lib/download-template";
-import {
-  templateHasApproaches,
-  getDefaultApproach,
-} from "./lib/templates";
+import { templateHasApproaches, getDefaultApproach } from "./lib/templates";
 import { getApproachPromptOptions } from "./prompts/approach";
 import { DATABASE_CONFIGS, DATABASE_LABELS } from "./prompts/database";
 import { isExistingNextProject } from "./prompts/project-name";
@@ -400,7 +397,8 @@ export async function createNextly(
         projectInfo,
         database,
         useYalc,
-        isFreshProject
+        isFreshProject,
+        projectType
       );
       s.stop("Dependencies installed");
       telemetry.capture("install_completed", {

--- a/packages/create-nextly-app/src/generators/admin.ts
+++ b/packages/create-nextly-app/src/generators/admin.ts
@@ -4,19 +4,13 @@ import fs from "fs-extra";
 
 import type { ProjectInfo } from "../types";
 
-// Plugin-side admin imports. Every scaffold ships @nextlyhq/plugin-form-builder
-// as a dependency (see template.ts and installers/dependencies.ts). These three
-// lines register the plugin's custom admin field components and load its CSS so
-// the Forms collection's drag-and-drop field builder and Submissions filter UI
-// render correctly. Without them, the Forms sidebar item still shows but the
-// builder falls back to plain JSON/text inputs. Mirror any future plugin-X the
-// CLI installs by default (keep in sync with TEMPLATE_PLUGIN_PACKAGES).
+// Existing-project installs scaffold a blank-equivalent setup: generateConfig
+// only emits the blank template, so no plugins are registered and no plugin-
+// side admin imports are needed. Templates that register plugins (e.g. blog)
+// supply their own admin page that overlays this one via copyTemplate.
 const ADMIN_PAGE_TEMPLATE = `"use client";
 
 import "@nextlyhq/admin/style.css";
-import "@nextlyhq/plugin-form-builder/admin";
-import "@nextlyhq/plugin-form-builder/styles/builder.css";
-import "@nextlyhq/plugin-form-builder/styles/submissions-filter.css";
 import { RootLayout, QueryProvider, ErrorBoundary } from "@nextlyhq/admin";
 
 export default function AdminPage() {

--- a/packages/create-nextly-app/src/installers/dependencies.ts
+++ b/packages/create-nextly-app/src/installers/dependencies.ts
@@ -1,6 +1,12 @@
 import { execa } from "execa";
 
-import type { DatabaseConfig, PackageManager, ProjectInfo } from "../types";
+import type {
+  DatabaseConfig,
+  PackageManager,
+  ProjectInfo,
+  ProjectType,
+} from "../types";
+import { projectUsesFormBuilder } from "../utils/template";
 
 const INSTALL_COMMANDS: Record<PackageManager, string[]> = {
   npm: ["npm", "install"],
@@ -36,16 +42,22 @@ const ALL_ADAPTER_PACKAGES = [
 ];
 
 /**
- * Plugin packages that are shipped with every scaffold. Must stay in sync
- * with the plugin deps added in `generatePackageJson` (template.ts) - both
- * paths scaffold the same project, the only difference is whether deps
- * resolve from npm or yalc. Omitting these from the yalc list caused
- * runtime "Cannot find package '@nextlyhq/plugin-form-builder'" errors
- * in scaffolded projects whose templates import the plugin.
+ * Plugin packages added only for templates that register the plugin in their
+ * `nextly.config.ts`. Must stay in sync with the deps added by
+ * `generatePackageJson` (template.ts) — both paths scaffold the same project,
+ * the only difference is whether deps resolve from npm or yalc. The
+ * existing-project install path generates a blank-equivalent config, so it
+ * never needs these.
  */
-const TEMPLATE_PLUGIN_PACKAGES = [
-  "@nextlyhq/plugin-form-builder",
-];
+const TEMPLATE_PLUGIN_PACKAGES = ["@nextlyhq/plugin-form-builder"];
+
+function templatePluginPackages(
+  projectType: ProjectType | undefined
+): string[] {
+  return projectType && projectUsesFormBuilder(projectType)
+    ? TEMPLATE_PLUGIN_PACKAGES
+    : [];
+}
 
 /**
  * Get all packages that need to be installed for a given configuration.
@@ -67,9 +79,11 @@ export async function installDependencies(
   projectInfo: ProjectInfo,
   database: DatabaseConfig,
   useYalc: boolean = false,
-  isFreshProject: boolean = false
+  isFreshProject: boolean = false,
+  projectType?: ProjectType
 ): Promise<void> {
   const pm = projectInfo.packageManager;
+  const pluginPackages = templatePluginPackages(projectType);
 
   if (isFreshProject) {
     if (useYalc) {
@@ -84,7 +98,7 @@ export async function installDependencies(
           "@nextlyhq/ui",
           "@nextlyhq/adapter-drizzle",
           ...ALL_ADAPTER_PACKAGES,
-          ...TEMPLATE_PLUGIN_PACKAGES,
+          ...pluginPackages,
         ]),
       ];
 
@@ -114,7 +128,7 @@ export async function installDependencies(
           "@nextlyhq/ui",
           "@nextlyhq/adapter-drizzle",
           ...ALL_ADAPTER_PACKAGES,
-          ...TEMPLATE_PLUGIN_PACKAGES,
+          ...pluginPackages,
         ]),
       ];
 

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -5,6 +5,21 @@ import fs from "fs-extra";
 
 import type { DatabaseConfig, ProjectApproach, ProjectType } from "../types";
 
+/**
+ * Templates whose `nextly.config.ts` registers `formBuilderPlugin`. The
+ * plugin (and its admin imports) only ship with these scaffolds — every
+ * other template gets a leaner package.json and an admin page without the
+ * plugin imports so dev never fails with "Cannot find package
+ * '@nextlyhq/plugin-form-builder'".
+ */
+const PROJECT_TYPES_WITH_FORM_BUILDER: ReadonlySet<ProjectType> = new Set([
+  "blog",
+]);
+
+export function projectUsesFormBuilder(projectType: ProjectType): boolean {
+  return PROJECT_TYPES_WITH_FORM_BUILDER.has(projectType);
+}
+
 // ============================================================
 // Text File Extensions (for placeholder replacement)
 // ============================================================
@@ -268,11 +283,14 @@ async function resolveRuntimeVersions(): Promise<Record<string, string>> {
  * @param projectName - The project name (used as package name)
  * @param database - Database configuration (adapter + driver)
  * @param useYalc - When true, omits @nextlyhq/* packages (they'll be yalc-added)
+ * @param projectType - Selected template. Determines optional plugin deps
+ *   (e.g. `@nextlyhq/plugin-form-builder` ships only with `blog`).
  */
 export async function generatePackageJson(
   projectName: string,
   database: DatabaseConfig,
-  useYalc: boolean = false
+  useYalc: boolean = false,
+  projectType: ProjectType = "blank"
 ): Promise<string> {
   // Fetch latest Next.js (and eslint-config-next) version from npm
   const runtimeVersions = await resolveRuntimeVersions();
@@ -295,12 +313,15 @@ export async function generatePackageJson(
     dependencies["@nextlyhq/adapter-drizzle"] =
       versions["@nextlyhq/adapter-drizzle"];
     dependencies[database.adapter] = versions[database.adapter] || "latest";
-    // Form builder plugin ships with every scaffold so templates that
-    // want it (e.g. the blog template's Newsletter form) work out of
-    // the box. It's a small dep and unused templates simply don't
-    // import it - no runtime cost.
-    dependencies["@nextlyhq/plugin-form-builder"] =
-      versions["@nextlyhq/plugin-form-builder"] || "latest";
+    // Form builder plugin is only included for templates that register
+    // it in nextly.config.ts (currently just `blog`). Including it in
+    // the blank scaffold would leave imports in the admin page that
+    // resolve to an uninstalled package — `next dev` would then fail
+    // with "Cannot find package '@nextlyhq/plugin-form-builder'".
+    if (projectUsesFormBuilder(projectType)) {
+      dependencies["@nextlyhq/plugin-form-builder"] =
+        versions["@nextlyhq/plugin-form-builder"] || "latest";
+    }
   }
 
   // DB drivers are regular deps of their respective adapter packages and
@@ -524,7 +545,8 @@ export async function copyTemplate(
   const packageJsonContent = await generatePackageJson(
     projectName,
     database,
-    useYalc
+    useYalc,
+    projectType
   );
   await fs.writeFile(
     path.join(targetDir, "package.json"),

--- a/templates/base/src/app/admin/[[...params]]/page.tsx
+++ b/templates/base/src/app/admin/[[...params]]/page.tsx
@@ -1,15 +1,6 @@
 "use client";
 
-// Plugin-side admin imports. Every scaffold ships @nextlyhq/plugin-form-builder
-// as a dependency (see packages/create-nextly-app utils/template.ts). These
-// three lines register the plugin's custom admin field components and load its
-// CSS so the Forms collection's drag-and-drop field builder and Submissions
-// filter UI render correctly. Without them, Forms still appears in the sidebar
-// but the builder falls back to plain JSON/text inputs.
 import "@nextlyhq/admin/style.css";
-import "@nextlyhq/plugin-form-builder/admin";
-import "@nextlyhq/plugin-form-builder/styles/builder.css";
-import "@nextlyhq/plugin-form-builder/styles/submissions-filter.css";
 import { RootLayout, QueryProvider, ErrorBoundary } from "@nextlyhq/admin";
 
 export default function AdminPage() {

--- a/templates/blog/src/app/admin/[[...params]]/page.tsx
+++ b/templates/blog/src/app/admin/[[...params]]/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+// The blog template registers `formBuilderPlugin` in nextly.config.ts. These
+// imports register its admin field components and load its CSS so the Forms
+// collection's drag-and-drop builder and Submissions filter UI render
+// correctly. Without them, Forms still appears in the sidebar but the builder
+// falls back to plain JSON/text inputs.
+import "@nextlyhq/admin/style.css";
+import "@nextlyhq/plugin-form-builder/admin";
+import "@nextlyhq/plugin-form-builder/styles/builder.css";
+import "@nextlyhq/plugin-form-builder/styles/submissions-filter.css";
+import { RootLayout, QueryProvider, ErrorBoundary } from "@nextlyhq/admin";
+
+export default function AdminPage() {
+  return (
+    <ErrorBoundary
+      onError={(error, errorInfo) => {
+        console.error("Admin error:", error, errorInfo);
+      }}
+    >
+      <QueryProvider>
+        <RootLayout />
+      </QueryProvider>
+    </ErrorBoundary>
+  );
+}


### PR DESCRIPTION
## Summary

The base admin page and the existing-project admin generator hard-coded side-effect imports for @nextlyhq/plugin-form-builder, but the package was only added to package.json on the fresh-scaffold npm path. Blank scaffolds and existing-project installs got the imports without the dep, so `next dev` failed with "Cannot find package '@nextlyhq/plugin-form-builder'".

The plugin is now opt-in per template: blank ships a plugin-less admin page; the blog template overlays a blog-specific admin page that re-adds the imports (mirroring how formBuilderPlugin is registered only in the blog config). generatePackageJson and the yalc paths in installDependencies now take a projectType and only include the plugin package when the selected template uses it.


- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / chore (no user-facing change)

## Related issues

<!-- e.g. Closes #123, Refs #456 -->

## Changeset

This repo uses [Changesets](https://github.com/changesets/changesets). If your PR changes any publishable package under `packages/*`, you **must** include a changeset:

```bash
pnpm changeset
```

Then commit the generated `.changeset/*.md` file.

- [X] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [X] I selected the correct semver bump (patch / minor/major)

> The `changeset-check` CI job will fail if a publishable package is modified without a changeset.

## Test plan

<!-- How did you verify this works? Commands run, scenarios tested, screenshots, etc. -->

- [X] `pnpm lint`
- [X] `pnpm check-types`
- [X] `pnpm build`
- [ ] Manually verified the change

## Checklist

- [ ] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [X] I targeted the `main` branch
- [ ] I updated relevant documentation
