### PR TITLE
feat(nextly): return absolute media URLs in API responses

### DIFF
--- a/.changeset/absolute-media-urls.md
+++ b/.changeset/absolute-media-urls.md
@@ -1,0 +1,22 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Media URLs returned from the API are now absolute. Previously, the local storage adapter wrote `/uploads/...` paths and surfaced them verbatim in API responses — mobile clients, edge workers, and any consumer without the deployment's origin baked in could not resolve the URL. Now, `MediaService` responses, populated `media` relations on entry responses, and the collection upload handlers (`POST` / `GET /admin/api/collections/<slug>/uploads`) prefix relative URLs with `NEXT_PUBLIC_APP_URL` (priority: `emailConfig.baseUrl` override > `NEXT_PUBLIC_APP_URL` > `http://localhost:3000` in dev). Cloud-adapter URLs (S3, Vercel Blob, R2) are already absolute and pass through unchanged. Consumers that previously concatenated the base URL themselves should drop the prefix — double-prefix detection is in place, but the new behaviour means the prefix is no longer needed. The env schema already requires `NEXT_PUBLIC_APP_URL` in production, so the localhost fallback is only reachable in development.
+
+Internal: extracted a shared `getBaseUrl(override?)` helper at `src/shared/lib/get-base-url.ts` so the email service and the new media-absolutization path resolve through one priority chain. `EmailService.getBaseUrl` and the new `getMediaBaseUrl` both delegate to it.

--- a/packages/nextly/src/api/uploads.ts
+++ b/packages/nextly/src/api/uploads.ts
@@ -40,6 +40,7 @@ import { clampLimit } from "../domains/collections/query/query-parser";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
 import { withTimezoneFormatting } from "../lib/date-formatting";
+import { toAbsoluteMediaUrl } from "../lib/media-variant";
 import {
   UploadService,
   type UploadConfig,
@@ -297,14 +298,16 @@ export const POST = withErrorHandler(
       throwFromUploadResult(result, "upload");
     }
 
-    // Transform to client-expected format.
+    // Transform to client-expected format. Absolutize URLs so the local
+    // storage adapter's relative paths (`/uploads/...`) are reachable by
+    // API consumers; cloud-adapter URLs pass through unchanged.
     const uploadData = {
       id: result.data?.id,
       filename: result.data?.filename,
       mimeType: result.data?.mimeType,
       filesize: result.data?.size,
-      url: result.data?.url,
-      thumbnailUrl: result.data?.thumbnailUrl,
+      url: toAbsoluteMediaUrl(result.data?.url),
+      thumbnailUrl: toAbsoluteMediaUrl(result.data?.thumbnailUrl),
       width: result.data?.width,
       height: result.data?.height,
       createdAt: new Date().toISOString(),
@@ -359,8 +362,8 @@ export const GET = withErrorHandler(
       filename: result.data?.filename || result.data?.originalFilename,
       mimeType: result.data?.mimeType,
       filesize: result.data?.size,
-      url: result.data?.url,
-      thumbnailUrl: result.data?.thumbnailUrl,
+      url: toAbsoluteMediaUrl(result.data?.url),
+      thumbnailUrl: toAbsoluteMediaUrl(result.data?.thumbnailUrl),
       width: result.data?.width,
       height: result.data?.height,
       createdAt: result.data?.createdAt,

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -5,6 +5,7 @@ import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 
 import { getDialectTables } from "../../../database";
 import { keysToCamelCase } from "../../../lib/case-conversion";
+import { absolutizeMediaUrls } from "../../../lib/media-variant";
 import type { CollectionFileManager } from "../../../services/collection-file-manager";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
@@ -1493,7 +1494,15 @@ export class CollectionRelationshipService extends BaseService {
       // Recursively convert snake_case fields to camelCase for API response
       // Database may return snake_case columns (thumbnail_url, mime_type, etc.)
       // This handles nested objects and arrays within media records
-      return rows.map(row => keysToCamelCase(row) as Record<string, unknown>);
+      return rows.map(row => {
+        const camel = keysToCamelCase(row) as Record<string, unknown>;
+        // Local storage adapter stores relative URLs (`/uploads/...`); cloud
+        // adapters store absolute URLs. absolutizeMediaUrls leaves absolute
+        // URLs untouched and prefixes relative ones with NEXT_PUBLIC_APP_URL
+        // so populated media in entry responses is reachable by external
+        // clients.
+        return absolutizeMediaUrls(camel);
+      });
     } catch (error) {
       console.error("Failed to fetch media by IDs:", error);
       return [];

--- a/packages/nextly/src/domains/email/services/email-service.ts
+++ b/packages/nextly/src/domains/email/services/email-service.ts
@@ -14,7 +14,7 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import { NextlyError } from "../../../errors";
-import { env } from "../../../lib/env";
+import { getBaseUrl } from "../../../lib/get-base-url";
 import type { EmailTemplateRecord } from "../../../schemas/email-templates/types";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
@@ -581,17 +581,13 @@ export class EmailService extends BaseService {
   // ============================================================
 
   /**
-   * Get the base URL for email links.
-   * Priority: emailConfig.baseUrl > NEXT_PUBLIC_APP_URL > localhost
+   * Get the base URL for email links. Delegates to the shared `getBaseUrl`
+   * helper so email templates and absolutized media URLs resolve through
+   * the same priority chain (emailConfig.baseUrl > NEXT_PUBLIC_APP_URL >
+   * localhost).
    */
   private getBaseUrl(): string {
-    const url =
-      this.emailConfig?.baseUrl ??
-      env.NEXT_PUBLIC_APP_URL ??
-      "http://localhost:3000";
-
-    // Remove trailing slash
-    return url.replace(/\/$/, "");
+    return getBaseUrl(this.emailConfig?.baseUrl);
   }
 
   /**

--- a/packages/nextly/src/domains/media/services/media-service.ts
+++ b/packages/nextly/src/domains/media/services/media-service.ts
@@ -50,6 +50,7 @@
 // logContext per §13.8; public messages remain generic and end with a period.
 import { NextlyError } from "../../../errors";
 import { normalizeDbTimestamp } from "../../../lib/date-formatting";
+import { toAbsoluteMediaUrl } from "../../../lib/media-variant";
 import type { MediaService as LegacyMediaService } from "../../../services/media";
 import type {
   MediaFolderService as LegacyFolderService,
@@ -1015,8 +1016,8 @@ export class MediaService {
       width: data.width,
       height: data.height,
       duration: data.duration,
-      url: data.url,
-      thumbnailUrl: data.thumbnailUrl,
+      url: toAbsoluteMediaUrl(data.url),
+      thumbnailUrl: toAbsoluteMediaUrl(data.thumbnailUrl),
       altText: data.altText,
       caption: data.caption,
       tags: data.tags,

--- a/packages/nextly/src/lib/get-base-url.ts
+++ b/packages/nextly/src/lib/get-base-url.ts
@@ -1,0 +1,1 @@
+export * from "../shared/lib/get-base-url";

--- a/packages/nextly/src/lib/index.ts
+++ b/packages/nextly/src/lib/index.ts
@@ -19,10 +19,14 @@ export {
 
 // Re-export other lib modules
 export * from "./env";
+export * from "./get-base-url";
 export * from "./logger";
 export {
   getMediaVariant,
   getSmallestMediaVariant,
+  getMediaBaseUrl,
+  toAbsoluteMediaUrl,
+  absolutizeMediaUrls,
   type MediaLike,
   type GetMediaVariantOptions,
 } from "./media-variant";

--- a/packages/nextly/src/lib/media-variant.test.ts
+++ b/packages/nextly/src/lib/media-variant.test.ts
@@ -1,0 +1,141 @@
+// Why: media URL absolutization is a contract with every API consumer
+// (mobile apps, SSR, edge workers). The local storage adapter writes
+// relative URLs; cloud adapters write absolute URLs. These tests lock the
+// rules so a future refactor can't silently double-prefix cloud URLs or
+// leak unreachable relative paths to clients. Base-URL resolution itself
+// is covered separately by shared/lib/__tests__/get-base-url.test.ts.
+import { describe, expect, it } from "vitest";
+
+import { absolutizeMediaUrls, toAbsoluteMediaUrl } from "./media-variant";
+
+describe("toAbsoluteMediaUrl", () => {
+  const baseUrl = "https://cms.example.com";
+
+  it("prefixes a leading-slash relative URL", () => {
+    expect(toAbsoluteMediaUrl("/uploads/a.jpg", baseUrl)).toBe(
+      "https://cms.example.com/uploads/a.jpg"
+    );
+  });
+
+  it("inserts a slash when the relative URL has none", () => {
+    expect(toAbsoluteMediaUrl("uploads/a.jpg", baseUrl)).toBe(
+      "https://cms.example.com/uploads/a.jpg"
+    );
+  });
+
+  it("passes https URLs through unchanged", () => {
+    const url = "https://cdn.example.com/a.jpg";
+    expect(toAbsoluteMediaUrl(url, baseUrl)).toBe(url);
+  });
+
+  it("passes http URLs through unchanged", () => {
+    const url = "http://cdn.example.com/a.jpg";
+    expect(toAbsoluteMediaUrl(url, baseUrl)).toBe(url);
+  });
+
+  it("passes s3:// URLs through unchanged", () => {
+    const url = "s3://my-bucket/a.jpg";
+    expect(toAbsoluteMediaUrl(url, baseUrl)).toBe(url);
+  });
+
+  it("passes protocol-relative URLs through unchanged", () => {
+    const url = "//cdn.example.com/a.jpg";
+    expect(toAbsoluteMediaUrl(url, baseUrl)).toBe(url);
+  });
+
+  it("passes null through", () => {
+    expect(toAbsoluteMediaUrl(null, baseUrl)).toBeNull();
+  });
+
+  it("passes undefined through", () => {
+    expect(toAbsoluteMediaUrl(undefined, baseUrl)).toBeUndefined();
+  });
+
+  it("passes empty string through", () => {
+    expect(toAbsoluteMediaUrl("", baseUrl)).toBe("");
+  });
+});
+
+describe("absolutizeMediaUrls", () => {
+  const baseUrl = "https://cms.example.com";
+
+  it("absolutizes url and thumbnailUrl on the row", () => {
+    const row = { url: "/uploads/a.jpg", thumbnailUrl: "/uploads/a-thumb.jpg" };
+    expect(absolutizeMediaUrls(row, baseUrl)).toEqual({
+      url: "https://cms.example.com/uploads/a.jpg",
+      thumbnailUrl: "https://cms.example.com/uploads/a-thumb.jpg",
+    });
+  });
+
+  it("absolutizes nested sizes[*].url", () => {
+    const row = {
+      url: "/uploads/a.jpg",
+      sizes: {
+        card: { url: "/uploads/a-card.jpg", width: 400, height: 300 },
+        thumb: { url: "/uploads/a-thumb.jpg", width: 100, height: 100 },
+      },
+    };
+    const out = absolutizeMediaUrls(row, baseUrl);
+    expect(out.sizes?.card.url).toBe(
+      "https://cms.example.com/uploads/a-card.jpg"
+    );
+    expect(out.sizes?.thumb.url).toBe(
+      "https://cms.example.com/uploads/a-thumb.jpg"
+    );
+    // Non-URL variant fields are preserved verbatim.
+    expect(out.sizes?.card.width).toBe(400);
+    expect(out.sizes?.thumb.height).toBe(100);
+  });
+
+  it("leaves absolute variant URLs untouched (mixed cloud + local)", () => {
+    const row = {
+      url: "/uploads/a.jpg",
+      sizes: {
+        local: { url: "/uploads/a-card.jpg" },
+        cloud: { url: "https://cdn.example.com/a-card.jpg" },
+      },
+    };
+    const out = absolutizeMediaUrls(row, baseUrl);
+    expect(out.sizes?.local.url).toBe(
+      "https://cms.example.com/uploads/a-card.jpg"
+    );
+    expect(out.sizes?.cloud.url).toBe("https://cdn.example.com/a-card.jpg");
+  });
+
+  it("preserves sizes: null", () => {
+    const row = { url: "/uploads/a.jpg", sizes: null };
+    const out = absolutizeMediaUrls(row, baseUrl);
+    expect(out.sizes).toBeNull();
+  });
+
+  it("omits sizes when input does not have the key", () => {
+    const row = { url: "/uploads/a.jpg" };
+    const out = absolutizeMediaUrls(row, baseUrl);
+    expect("sizes" in out).toBe(false);
+  });
+
+  it("does not mutate the input row", () => {
+    const row = {
+      url: "/uploads/a.jpg",
+      thumbnailUrl: "/uploads/a-thumb.jpg",
+      sizes: { card: { url: "/uploads/a-card.jpg" } },
+    };
+    const snapshot = JSON.parse(JSON.stringify(row));
+    absolutizeMediaUrls(row, baseUrl);
+    expect(row).toEqual(snapshot);
+    expect(row.sizes.card.url).toBe("/uploads/a-card.jpg");
+  });
+
+  it("preserves unrelated fields on the row", () => {
+    const row = {
+      id: "abc",
+      url: "/uploads/a.jpg",
+      filename: "a.jpg",
+      altText: "an image",
+    };
+    const out = absolutizeMediaUrls(row, baseUrl);
+    expect(out.id).toBe("abc");
+    expect(out.filename).toBe("a.jpg");
+    expect(out.altText).toBe("an image");
+  });
+});

--- a/packages/nextly/src/lib/media-variant.ts
+++ b/packages/nextly/src/lib/media-variant.ts
@@ -1,12 +1,19 @@
+import { getBaseUrl } from "./get-base-url";
+
 /**
  * Media variant helpers
  *
- * Public-facing utility for picking a sized image variant URL from a Media
- * record. Consumers (admin UI, public Next.js apps reading the API) call
- * `getMediaVariant(media, "card")` instead of cracking open the
- * `media.sizes` JSON themselves.
+ * Public-facing utilities for working with Media URLs in API responses:
  *
- * Selection rules (in order):
+ *   - `getMediaVariant(media, "card")` — pick a sized image variant URL
+ *     from a Media record without cracking open the `sizes` JSON.
+ *   - `toAbsoluteMediaUrl(url)` / `absolutizeMediaUrls(row)` — prefix
+ *     storage-relative URLs (`/uploads/...` from the local adapter) with
+ *     `NEXT_PUBLIC_APP_URL` so API consumers (mobile clients, external
+ *     services, edge workers) can resolve them. Cloud-adapter URLs
+ *     (S3/Vercel Blob/R2) are already absolute and pass through unchanged.
+ *
+ * Variant selection rules (in order):
  *   1. If `media.sizes[name]` exists, return its URL.
  *   2. If `media.sizes[fallbackName]` exists, return its URL (when caller
  *      passes one).
@@ -103,4 +110,80 @@ export function getSmallestMediaVariant(
   }
 
   return media.thumbnailUrl ?? media.url;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// URL absolutization
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Compute the base URL used to absolutize relative media URLs. Thin
+ * wrapper around the shared `getBaseUrl` helper so this module re-exports
+ * a domain-named alias for callers reasoning about media specifically.
+ */
+export function getMediaBaseUrl(): string {
+  return getBaseUrl();
+}
+
+/**
+ * Return `true` when the URL is already absolute (`http(s)://`) or
+ * protocol-relative (`//`). These come from cloud storage adapters and
+ * must not be re-prefixed.
+ */
+function isAbsoluteUrl(url: string): boolean {
+  return /^(?:[a-z][a-z0-9+.-]*:)?\/\//i.test(url);
+}
+
+/**
+ * Prefix a relative media URL with `baseUrl`. Absolute / protocol-relative
+ * URLs are returned unchanged. `null` / `undefined` / `""` pass through.
+ */
+export function toAbsoluteMediaUrl<T extends string | null | undefined>(
+  url: T,
+  baseUrl: string = getMediaBaseUrl()
+): T {
+  if (!url) return url;
+  if (isAbsoluteUrl(url)) return url;
+  const path = url.startsWith("/") ? url : `/${url}`;
+  return `${baseUrl}${path}` as T;
+}
+
+type MediaSizes = Record<
+  string,
+  { url?: string | null; [key: string]: unknown }
+> | null;
+
+/**
+ * Apply `toAbsoluteMediaUrl` to every URL field on a media row, including
+ * the nested `sizes` variants. Returns a new object — does not mutate.
+ */
+export function absolutizeMediaUrls<
+  T extends {
+    url?: string | null;
+    thumbnailUrl?: string | null;
+    sizes?: MediaSizes;
+  },
+>(row: T, baseUrl: string = getMediaBaseUrl()): T {
+  const sizes = row.sizes;
+  let absolutizedSizes: MediaSizes = sizes ?? null;
+  if (sizes && typeof sizes === "object") {
+    absolutizedSizes = Object.fromEntries(
+      Object.entries(sizes).map(([name, variant]) => [
+        name,
+        variant && typeof variant === "object"
+          ? {
+              ...variant,
+              url: toAbsoluteMediaUrl(variant.url ?? null, baseUrl),
+            }
+          : variant,
+      ])
+    );
+  }
+
+  return {
+    ...row,
+    url: toAbsoluteMediaUrl(row.url ?? null, baseUrl),
+    thumbnailUrl: toAbsoluteMediaUrl(row.thumbnailUrl ?? null, baseUrl),
+    ...(sizes !== undefined ? { sizes: absolutizedSizes } : {}),
+  };
 }

--- a/packages/nextly/src/shared/lib/__tests__/get-base-url.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/get-base-url.test.ts
@@ -1,0 +1,89 @@
+// Why: getBaseUrl resolves the public origin used in email links and in
+// absolutized media URLs returned by the API. A regression in the priority
+// chain (override > NEXT_PUBLIC_APP_URL > localhost) or the trailing-slash
+// strip will silently break outbound links and break double-prefix detection
+// in media-variant. These tests lock the rules.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockEnv: { NEXT_PUBLIC_APP_URL?: string } = {
+  NEXT_PUBLIC_APP_URL: undefined,
+};
+vi.mock("../env", () => ({
+  get env() {
+    return mockEnv;
+  },
+}));
+
+import { getBaseUrl } from "../get-base-url";
+
+beforeEach(() => {
+  mockEnv.NEXT_PUBLIC_APP_URL = undefined;
+});
+
+describe("getBaseUrl", () => {
+  describe("priority chain", () => {
+    it("uses the override when provided", () => {
+      mockEnv.NEXT_PUBLIC_APP_URL = "https://env.example.com";
+      expect(getBaseUrl("https://override.example.com")).toBe(
+        "https://override.example.com"
+      );
+    });
+
+    it("falls back to env.NEXT_PUBLIC_APP_URL when override is missing", () => {
+      mockEnv.NEXT_PUBLIC_APP_URL = "https://env.example.com";
+      expect(getBaseUrl()).toBe("https://env.example.com");
+    });
+
+    it("falls back to env when override is empty string", () => {
+      mockEnv.NEXT_PUBLIC_APP_URL = "https://env.example.com";
+      expect(getBaseUrl("")).toBe("https://env.example.com");
+    });
+
+    it("falls back to env when override is whitespace-only", () => {
+      mockEnv.NEXT_PUBLIC_APP_URL = "https://env.example.com";
+      expect(getBaseUrl("   ")).toBe("https://env.example.com");
+    });
+
+    it("falls back to env when override is null", () => {
+      mockEnv.NEXT_PUBLIC_APP_URL = "https://env.example.com";
+      expect(getBaseUrl(null)).toBe("https://env.example.com");
+    });
+
+    it("falls back to localhost when nothing is set", () => {
+      expect(getBaseUrl()).toBe("http://localhost:3000");
+    });
+
+    it("falls back to localhost when env is whitespace-only", () => {
+      mockEnv.NEXT_PUBLIC_APP_URL = "   ";
+      expect(getBaseUrl()).toBe("http://localhost:3000");
+    });
+  });
+
+  describe("normalisation", () => {
+    it("strips a single trailing slash", () => {
+      mockEnv.NEXT_PUBLIC_APP_URL = "https://example.com/";
+      expect(getBaseUrl()).toBe("https://example.com");
+    });
+
+    it("strips multiple trailing slashes", () => {
+      mockEnv.NEXT_PUBLIC_APP_URL = "https://example.com///";
+      expect(getBaseUrl()).toBe("https://example.com");
+    });
+
+    it("trims surrounding whitespace from env", () => {
+      mockEnv.NEXT_PUBLIC_APP_URL = "  https://example.com/  ";
+      expect(getBaseUrl()).toBe("https://example.com");
+    });
+
+    it("trims surrounding whitespace from override", () => {
+      expect(getBaseUrl("  https://override.example.com/  ")).toBe(
+        "https://override.example.com"
+      );
+    });
+
+    it("preserves paths after the host", () => {
+      mockEnv.NEXT_PUBLIC_APP_URL = "https://example.com/cms/";
+      expect(getBaseUrl()).toBe("https://example.com/cms");
+    });
+  });
+});

--- a/packages/nextly/src/shared/lib/get-base-url.ts
+++ b/packages/nextly/src/shared/lib/get-base-url.ts
@@ -1,0 +1,24 @@
+import { env } from "./env";
+
+/**
+ * Resolve the public base URL for outbound links — email templates,
+ * absolutized media URLs in API responses, anywhere the server needs to
+ * hand a fully-qualified URL to an external client.
+ *
+ * Priority:
+ *   1. `override` if provided (e.g. `emailConfig.baseUrl`)
+ *   2. `env.NEXT_PUBLIC_APP_URL`
+ *   3. `http://localhost:3000` (development fallback)
+ *
+ * The env schema enforces presence of `NEXT_PUBLIC_APP_URL` in production
+ * at boot (see `_envSchema.superRefine` in `./env`), so the localhost
+ * fallback is only reachable in development and test.
+ *
+ * Trailing slashes are stripped so callers can concatenate paths
+ * (`${base}${path}`) without producing `//` in the result.
+ */
+export function getBaseUrl(override?: string | null): string {
+  const raw = override?.trim() || env.NEXT_PUBLIC_APP_URL?.trim();
+  const url = raw || "http://localhost:3000";
+  return url.replace(/\/+$/, "");
+}


### PR DESCRIPTION
## Summary

Media URLs returned by MediaService, populated media relations on entry responses, and the collection upload handlers now prefix relative storage paths (`/uploads/...` from the local adapter) with NEXT_PUBLIC_APP_URL so external clients can resolve them. Cloud-adapter URLs (S3, Vercel Blob, R2) are already absolute and pass through unchanged.

Extract a shared getBaseUrl(override?) helper at src/shared/lib so the email service and the new media-absolutization path resolve through one priority chain (override > NEXT_PUBLIC_APP_URL > localhost). EmailService and getMediaBaseUrl both delegate to it.


<!-- Check all that apply -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / chore (no user-facing change)

## Related issues

<!-- e.g. Closes #123, Refs #456 -->

## Changeset

This repo uses [Changesets](https://github.com/changesets/changesets). If your PR changes any publishable package under `packages/*`, you **must** include a changeset:

```bash
pnpm changeset
```

Then commit the generated `.changeset/*.md` file.

- [X] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [X] I selected the correct semver bump (patch / minor / major)

> The `changeset-check` CI job will fail if a publishable package is modified without a changeset.

## Test plan

<!-- How did you verify this works? Commands run, scenarios tested, screenshots, etc. -->

- [X] `pnpm lint`
- [X] `pnpm check-types`
- [X] `pnpm build`
- [X] Manually verified the change

## Checklist

- [ ] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [X] I targeted the `main` branch
- [ ] I updated relevant documentation
