### PR TITLE
fix(nextly): absolutize variant URLs and defer base-URL lookup

### DIFF
--- a/.changeset/absolutize-media-variants.md
+++ b/.changeset/absolutize-media-variants.md
@@ -1,0 +1,22 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Fix: variant URLs in populated `media.sizes[*].url` are now absolutized too. The initial absolutization pass only rewrote the top-level `url` and `thumbnailUrl` fields, so on SQLite — which stores `media.sizes` as TEXT and returns the column as an unparsed JSON string — clients consuming `getMediaVariant(media, "card")` on populated entries still received relative `/uploads/...` paths. `absolutizeMediaUrls` now normalises string-encoded sizes into an object before rewriting variant URLs, so populated media on entry responses returns reachable variant URLs across every dialect. Unparseable JSON resolves to `null` rather than leaking the raw string to the API consumer.
+
+Also: `toAbsoluteMediaUrl` and `absolutizeMediaUrls` resolve `baseUrl` lazily — the env-backed default fires only when a relative URL actually needs prefixing. Pass-through cases (absolute URLs, null/undefined/empty) no longer touch the env proxy, so the "absolute URLs unchanged" contract holds in contexts that have not booted env validation (isolated tests, bundler-time analysis).

--- a/packages/nextly/src/lib/media-variant.test.ts
+++ b/packages/nextly/src/lib/media-variant.test.ts
@@ -4,7 +4,19 @@
 // rules so a future refactor can't silently double-prefix cloud URLs or
 // leak unreachable relative paths to clients. Base-URL resolution itself
 // is covered separately by shared/lib/__tests__/get-base-url.test.ts.
-import { describe, expect, it } from "vitest";
+//
+// The `getBaseUrl` mock below is configured to throw — pass-through code
+// paths (absolute URLs, null/undefined inputs) must never reach it, and
+// any test that needs a base URL passes one explicitly.
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./get-base-url", () => ({
+  getBaseUrl: () => {
+    throw new Error(
+      "getBaseUrl() should not be called when an explicit baseUrl is provided or the URL is a pass-through"
+    );
+  },
+}));
 
 import { absolutizeMediaUrls, toAbsoluteMediaUrl } from "./media-variant";
 
@@ -137,5 +149,106 @@ describe("absolutizeMediaUrls", () => {
     expect(out.id).toBe("abc");
     expect(out.filename).toBe("a.jpg");
     expect(out.altText).toBe("an image");
+  });
+});
+
+describe("lazy base-URL resolution", () => {
+  // Why: env validation can throw in test/build contexts. The pass-through
+  // contract for absolute URLs must hold without reaching env.
+  it("toAbsoluteMediaUrl does not resolve baseUrl for absolute URLs", () => {
+    expect(() =>
+      toAbsoluteMediaUrl("https://cdn.example.com/a.jpg")
+    ).not.toThrow();
+  });
+
+  it("toAbsoluteMediaUrl does not resolve baseUrl for null/undefined/empty", () => {
+    expect(() => toAbsoluteMediaUrl(null)).not.toThrow();
+    expect(() => toAbsoluteMediaUrl(undefined)).not.toThrow();
+    expect(() => toAbsoluteMediaUrl("")).not.toThrow();
+  });
+
+  it("absolutizeMediaUrls does not resolve baseUrl when all URLs are absolute", () => {
+    const row = {
+      url: "https://cdn.example.com/a.jpg",
+      thumbnailUrl: "https://cdn.example.com/a-thumb.jpg",
+      sizes: {
+        card: { url: "https://cdn.example.com/a-card.jpg" },
+      },
+    };
+    expect(() => absolutizeMediaUrls(row)).not.toThrow();
+  });
+
+  it("toAbsoluteMediaUrl falls back to the resolver only for relative URLs without explicit base", () => {
+    // With the mock throwing, this proves getBaseUrl() *is* the source of
+    // truth for the implicit case — confirms we didn't accidentally swap in
+    // a silent default.
+    expect(() => toAbsoluteMediaUrl("/uploads/a.jpg")).toThrow(/getBaseUrl/);
+  });
+});
+
+describe("string-encoded sizes (SQLite)", () => {
+  // Why: SQLite stores `media.sizes` as TEXT and the better-sqlite3 driver
+  // returns it unparsed. Without normalisation, populated media in entry
+  // responses leak relative variant URLs even after the top-level url and
+  // thumbnailUrl have been absolutized.
+  const baseUrl = "https://cms.example.com";
+
+  it("parses a JSON-encoded sizes string and absolutizes variant URLs", () => {
+    const row = {
+      url: "/uploads/a.jpg",
+      sizes: JSON.stringify({
+        card: { url: "/uploads/a-card.jpg", width: 400, height: 300 },
+        thumb: { url: "/uploads/a-thumb.jpg" },
+      }),
+    };
+    const out = absolutizeMediaUrls(row, baseUrl);
+    expect(out.sizes).toEqual({
+      card: {
+        url: "https://cms.example.com/uploads/a-card.jpg",
+        width: 400,
+        height: 300,
+      },
+      thumb: { url: "https://cms.example.com/uploads/a-thumb.jpg" },
+    });
+    expect(out.url).toBe("https://cms.example.com/uploads/a.jpg");
+  });
+
+  it("leaves absolute variant URLs in a parsed string-sizes payload untouched", () => {
+    const row = {
+      url: "/uploads/a.jpg",
+      sizes: JSON.stringify({
+        cloud: { url: "https://cdn.example.com/a-card.jpg" },
+        local: { url: "/uploads/a-local.jpg" },
+      }),
+    };
+    const out = absolutizeMediaUrls(row, baseUrl);
+    // sizes is narrowed to `string` by the input type but normalised to
+    // an object at runtime; cast for property access.
+    const sizes = out.sizes as unknown as Record<
+      string,
+      { url: string }
+    > | null;
+    expect(sizes?.cloud.url).toBe("https://cdn.example.com/a-card.jpg");
+    expect(sizes?.local.url).toBe(
+      "https://cms.example.com/uploads/a-local.jpg"
+    );
+  });
+
+  it("normalises unparseable string sizes to null rather than leaking the raw string", () => {
+    const row = {
+      url: "/uploads/a.jpg",
+      sizes: "not-valid-json",
+    };
+    const out = absolutizeMediaUrls(row, baseUrl);
+    expect(out.sizes).toBeNull();
+  });
+
+  it("normalises a JSON-encoded non-object (array) to null", () => {
+    const row = {
+      url: "/uploads/a.jpg",
+      sizes: JSON.stringify(["card", "thumb"]),
+    };
+    const out = absolutizeMediaUrls(row, baseUrl);
+    expect(out.sizes).toBeNull();
   });
 });

--- a/packages/nextly/src/lib/media-variant.ts
+++ b/packages/nextly/src/lib/media-variant.ts
@@ -137,15 +137,22 @@ function isAbsoluteUrl(url: string): boolean {
 /**
  * Prefix a relative media URL with `baseUrl`. Absolute / protocol-relative
  * URLs are returned unchanged. `null` / `undefined` / `""` pass through.
+ *
+ * `baseUrl` is resolved lazily — the env-backed default fires only when a
+ * relative URL actually needs prefixing. Pass-through cases (absolute
+ * URLs and nullish inputs) do not access the env, so callers in
+ * contexts that have not booted env validation can still rely on the
+ * "absolute URLs pass through" contract.
  */
 export function toAbsoluteMediaUrl<T extends string | null | undefined>(
   url: T,
-  baseUrl: string = getMediaBaseUrl()
+  baseUrl?: string
 ): T {
   if (!url) return url;
   if (isAbsoluteUrl(url)) return url;
+  const resolvedBase = baseUrl ?? getMediaBaseUrl();
   const path = url.startsWith("/") ? url : `/${url}`;
-  return `${baseUrl}${path}` as T;
+  return `${resolvedBase}${path}` as T;
 }
 
 type MediaSizes = Record<
@@ -154,21 +161,53 @@ type MediaSizes = Record<
 > | null;
 
 /**
+ * Coerce whatever shape Drizzle returned for `media.sizes` into an object
+ * (or null). PostgreSQL/MySQL store the column as `jsonb`/`json` and
+ * return an object; SQLite stores it as TEXT and returns a JSON string —
+ * neither `keysToCamelCase` nor the drizzle better-sqlite3 driver parse
+ * it. Return null on absent / unparseable input so callers can branch
+ * cleanly without re-implementing the dialect check.
+ */
+function normalizeSizes(value: unknown): MediaSizes {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as MediaSizes;
+  }
+  if (typeof value === "string") {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as MediaSizes;
+      }
+    } catch {
+      // Unparseable JSON in the DB column — fall through to null.
+    }
+  }
+  return null;
+}
+
+/**
  * Apply `toAbsoluteMediaUrl` to every URL field on a media row, including
  * the nested `sizes` variants. Returns a new object — does not mutate.
+ *
+ * Tolerates `sizes` arriving as a JSON-encoded string (SQLite) and
+ * normalises it to an object in the output so downstream API consumers
+ * see a uniform shape regardless of dialect. `baseUrl` is lazily resolved
+ * for the same reason as `toAbsoluteMediaUrl`.
  */
 export function absolutizeMediaUrls<
   T extends {
     url?: string | null;
     thumbnailUrl?: string | null;
-    sizes?: MediaSizes;
+    sizes?: MediaSizes | string;
   },
->(row: T, baseUrl: string = getMediaBaseUrl()): T {
-  const sizes = row.sizes;
-  let absolutizedSizes: MediaSizes = sizes ?? null;
-  if (sizes && typeof sizes === "object") {
+>(row: T, baseUrl?: string): T {
+  const hasSizesKey = "sizes" in row;
+  const normalizedSizes = normalizeSizes(row.sizes);
+
+  let absolutizedSizes: MediaSizes = normalizedSizes;
+  if (normalizedSizes) {
     absolutizedSizes = Object.fromEntries(
-      Object.entries(sizes).map(([name, variant]) => [
+      Object.entries(normalizedSizes).map(([name, variant]) => [
         name,
         variant && typeof variant === "object"
           ? {
@@ -184,6 +223,6 @@ export function absolutizeMediaUrls<
     ...row,
     url: toAbsoluteMediaUrl(row.url ?? null, baseUrl),
     thumbnailUrl: toAbsoluteMediaUrl(row.thumbnailUrl ?? null, baseUrl),
-    ...(sizes !== undefined ? { sizes: absolutizedSizes } : {}),
+    ...(hasSizesKey ? { sizes: absolutizedSizes } : {}),
   };
 }


### PR DESCRIPTION
## Summary

Two follow-ups on the media URL absolutization work:

1. P2 — variant URLs in `media.sizes[*].url` were not absolutized on SQLite. SQLite stores `media.sizes` as TEXT and drizzle returns it as a JSON-encoded string; `keysToCamelCase` does not parse it; the `typeof === "object"` guard in `absolutizeMediaUrls` then skipped the rewrite. Normalise string-encoded sizes to an object before absolutising so populated media in entry responses returns reachable variant URLs across every dialect. Unparseable JSON resolves to null rather than leaking the raw string.

2. P1 — `toAbsoluteMediaUrl` / `absolutizeMediaUrls` evaluated the env-backed `getMediaBaseUrl()` in their default-parameter expression, so absolute URLs and nullish inputs touched env validation unnecessarily. Switch to optional `baseUrl?: string` and resolve lazily inside the function, after the pass-through checks. The "absolute URLs unchanged" contract now holds even in contexts where env validation has not been booted.



<!-- Check all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / chore (no user-facing change)

## Related issues

<!-- e.g. Closes #123, Refs #456 -->

## Changeset

This repo uses [Changesets](https://github.com/changesets/changesets). If your PR changes any publishable package under `packages/*`, you **must** include a changeset:

```bash
pnpm changeset
```

Then commit the generated `.changeset/*.md` file.

- [ ] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [ ] I selected the correct semver bump (patch / minor / major)

> The `changeset-check` CI job will fail if a publishable package is modified without a changeset.

## Test plan

<!-- How did you verify this works? Commands run, scenarios tested, screenshots, etc. -->

- [x] `pnpm lint`
- [x] `pnpm check-types`
- [x] `pnpm build`
- [ ] Manually verified the change

## Checklist

- [ ] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [x] I targeted the `main` branch
- [ ] I updated relevant documentation

## Screenshots / recordings

<!-- Optional. Drag images or videos here for UI changes. -->

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to? Migration risks, perf concerns, etc. -->
