### PR TITLE
fix(nextly): gate schema-apply scope-reduction on PostgreSQL

### DIFF
--- a/.changeset/preserve-system-tables-in-scope-reduction.md
+++ b/.changeset/preserve-system-tables-in-scope-reduction.md
@@ -1,0 +1,20 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Fix drizzle-kit rename TUI ("Is `dc_posts` table created or renamed from another table?") firing on SQLite and MySQL after the schema-apply scope-reduction landed. The scope-reduction filter iterated by managed-table names and stripped the static system tables that `buildDrizzleSchema` injects so drizzle-kit's diff recognises them. On SQLite/MySQL drizzle-kit ignores `tablesFilter`, so the missing system tables looked like drops, paired with the managed adds, and produced the rename TUI on every fresh-install boot — crashing Next.js's non-TTY server thread. The scope-reduction filter now preserves non-managed entries via `!isManagedTable(name)`, restoring the injection's intended effect on every dialect.

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/pushschema-pipeline.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/pushschema-pipeline.test.ts
@@ -1388,6 +1388,86 @@ describe("scoped pushSchema (Task 6)", () => {
     expect(tableNames).toContain("dc_articles");
     expect(tableNames).not.toContain("dc_posts");
   });
+
+  it("skips scope-reduction on non-PG dialects so drizzle-kit sees the full schema", async () => {
+    // drizzle-kit ignores `tablesFilter` on SQLite/MySQL upstream, so a
+    // scoped schema would make it flag the system tables that
+    // buildDrizzleSchema injects (users, roles, accounts, ...) as drops
+    // and fire its rename-detection TUI. The pipeline therefore passes
+    // the full drizzleSchema on non-PG dialects.
+    const pushSchemaImpl = vi
+      .fn<
+        (
+          schema: Record<string, unknown>,
+          db: unknown,
+          tablesFilter?: string[]
+        ) => Promise<{
+          statementsToExecute: string[];
+          warnings: string[];
+          hasDataLoss: boolean;
+        }>
+      >()
+      .mockResolvedValue({
+        statementsToExecute: [],
+        warnings: [],
+        hasDataLoss: false,
+      });
+
+    const buildDrizzleSchemaImpl = () => ({
+      users: { _sentinel: "users" },
+      roles: { _sentinel: "roles" },
+      accounts: { _sentinel: "accounts" },
+      sessions: { _sentinel: "sessions" },
+      dynamic_collections: { _sentinel: "dynamic_collections" },
+      dc_posts: { _sentinel: "dc_posts" },
+    });
+
+    // change_column_type forces the drizzle-kit fallback so pushSchemaImpl
+    // is actually invoked.
+    const { pipeline } = makePipeline({
+      pushSchemaImpl,
+      buildDrizzleSchemaImpl,
+      resolvedOpsOverride: [
+        {
+          type: "change_column_type",
+          tableName: "dc_posts",
+          columnName: "body",
+          fromType: "text",
+          toType: "integer",
+        },
+      ],
+    });
+
+    const result = await pipeline.apply({
+      desired: {
+        collections: {
+          posts: {
+            slug: "posts",
+            tableName: "dc_posts",
+            fields: [{ name: "body", type: "text" }] as never,
+          },
+        },
+        singles: {},
+        components: {},
+      },
+      db: {},
+      dialect: "mysql",
+      source: "ui",
+      promptChannel: "browser",
+    });
+
+    expect(result.success).toBe(true);
+    expect(pushSchemaImpl).toHaveBeenCalledTimes(1);
+
+    const [effectiveSchema] = pushSchemaImpl.mock.calls[0]!;
+    const keys = Object.keys(effectiveSchema);
+    expect(keys).toContain("dc_posts");
+    expect(keys).toContain("users");
+    expect(keys).toContain("roles");
+    expect(keys).toContain("accounts");
+    expect(keys).toContain("sessions");
+    expect(keys).toContain("dynamic_collections");
+  });
 });
 
 // =============================================================================

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
@@ -667,19 +667,26 @@ export class PushSchemaPipeline {
         }
       }
 
+      // Scope-reduction is PostgreSQL-only. drizzle-kit honours
+      // `tablesFilter` on PG so its catalog introspection is limited to
+      // the affected tables, which is where the perf win comes from. On
+      // SQLite/MySQL drizzle-kit ignores `tablesFilter` and walks the
+      // full live DB; handing it a scoped schema makes it flag every
+      // un-scoped system table (users, roles, accounts, sessions, ...)
+      // as a drop and fire its rename-detection TUI, crashing non-TTY
+      // boots. The long-term direction (see DrizzleKitLike comment) is
+      // `generateMigration(prev, cur)` which would let us drop this
+      // gating entirely.
       const scopedSchema: Record<string, unknown> = {};
       for (const [tableName, tableObj] of Object.entries(drizzleSchema)) {
         if (affectedTableNames.has(tableName)) {
           scopedSchema[tableName] = tableObj;
         }
       }
-      // Empty-schema safety net. Fires when resolvedOps contains only
-      // drop_table entries (already applied by pre-resolution; their
-      // tables aren't in patchedDesired anyway), or when a future op
-      // kind escapes the switch above without contributing to the set.
-      // Passing nothing to drizzle-kit would be a contract violation.
       const effectiveDrizzleSchema =
-        Object.keys(scopedSchema).length > 0 ? scopedSchema : drizzleSchema;
+        dialect === "postgresql" && Object.keys(scopedSchema).length > 0
+          ? scopedSchema
+          : drizzleSchema;
 
       const kit: DrizzleKitLike = this.testHooks._kitOverride
         ? this.testHooks._kitOverride


### PR DESCRIPTION
Scope-reduction relies on drizzle-kit honouring tablesFilter, which only happens on PG. On SQLite/MySQL drizzle-kit ignores tablesFilter and walks the full live DB; passing it a scoped schema makes it flag the static system tables as drops and fire its rename TUI, crashing non-TTY boots. Restrict the optimisation to PG and pass the full drizzleSchema on every other dialect.

## Summary

<!-- What does this PR do and why? Keep it short. -->

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / chore (no user-facing change)

## Related issues

<!-- e.g. Closes #123, Refs #456 -->

## Changeset

This repo uses [Changesets](https://github.com/changesets/changesets). If your PR changes any publishable package under `packages/*`, you **must** include a changeset:

```bash
pnpm changeset
```

Then commit the generated `.changeset/*.md` file.

- [ ] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [ ] I selected the correct semver bump (patch / minor / major)

> The `changeset-check` CI job will fail if a publishable package is modified without a changeset.

## Test plan

<!-- How did you verify this works? Commands run, scenarios tested, screenshots, etc. -->

- [ ] `pnpm lint`
- [ ] `pnpm check-types`
- [ ] `pnpm build`
- [ ] Manually verified the change

## Checklist

- [ ] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [ ] I targeted the `main` branch
- [ ] I updated relevant documentation

## Screenshots / recordings

<!-- Optional. Drag images or videos here for UI changes. -->

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to? Migration risks, perf concerns, etc. -->
