### PR TITLE
fix(create-nextly-app): allowlist native deps for pnpm 10+

### DIFF
--- a/.changeset/pnpm10-only-built-deps.md
+++ b/.changeset/pnpm10-only-built-deps.md
@@ -1,0 +1,20 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Fresh projects scaffolded with `pnpm create nextly-app` no longer crash at boot under pnpm 10+. pnpm 10 blocks dependency install scripts by default, and without an allowlist `better-sqlite3` never built its native binding, so SQLite scaffolds threw `Could not locate the bindings file` on the first admin request. `sharp`, `esbuild`, and `unrs-resolver` were silently blocked too, producing a slow JS image fallback, drizzle-kit slowness, and an eslint resolver warning respectively. The scaffolder now emits `pnpm.onlyBuiltDependencies` in the generated `package.json`: `sharp`, `esbuild`, and `unrs-resolver` always, plus `better-sqlite3` when the SQLite adapter is selected. npm, yarn, and bun ignore the `pnpm`-namespaced field, so it is harmless under those package managers.

--- a/packages/create-nextly-app/src/__tests__/template.test.ts
+++ b/packages/create-nextly-app/src/__tests__/template.test.ts
@@ -165,6 +165,33 @@ describe("generatePackageJson", () => {
     expect(result.scripts["db:migrate:reset"]).toBe("nextly migrate:reset");
     expect(result.scripts["types:generate"]).toBe("nextly generate:types");
   });
+
+  // Regression guard: pnpm 10+ blocks dependency install scripts unless the
+  // package is in `pnpm.onlyBuiltDependencies`. Without this list, a fresh
+  // `pnpm dev` crashes for sqlite users (better-sqlite3 has no compiled
+  // binding) and silently degrades for everyone else (sharp falls back to
+  // a slow JS path; esbuild and unrs-resolver warn).
+  it("should allowlist non-sqlite native deps in pnpm.onlyBuiltDependencies", async () => {
+    const result = JSON.parse(await generatePackageJson("test", pgDatabase));
+    expect(result.pnpm.onlyBuiltDependencies).toEqual(
+      expect.arrayContaining(["sharp", "esbuild", "unrs-resolver"])
+    );
+    expect(result.pnpm.onlyBuiltDependencies).not.toContain("better-sqlite3");
+  });
+
+  it("should also allowlist better-sqlite3 when sqlite adapter is selected", async () => {
+    const result = JSON.parse(
+      await generatePackageJson("test", sqliteDatabase)
+    );
+    expect(result.pnpm.onlyBuiltDependencies).toEqual(
+      expect.arrayContaining([
+        "better-sqlite3",
+        "sharp",
+        "esbuild",
+        "unrs-resolver",
+      ])
+    );
+  });
 });
 
 // ============================================================

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -342,6 +342,14 @@ export async function generatePackageJson(
     pagefind: "^1.1.0",
   };
 
+  // pnpm 10+ blocks dependency install scripts by default; without this
+  // allowlist better-sqlite3's native binding never builds (sqlite apps
+  // crash at boot) and sharp/esbuild/unrs-resolver silently degrade.
+  const onlyBuiltDependencies = ["sharp", "esbuild", "unrs-resolver"];
+  if (database.type === "sqlite") {
+    onlyBuiltDependencies.push("better-sqlite3");
+  }
+
   const pkg = {
     name: projectName,
     version: "0.1.0",
@@ -374,6 +382,9 @@ export async function generatePackageJson(
     },
     dependencies,
     devDependencies,
+    pnpm: {
+      onlyBuiltDependencies,
+    },
   };
 
   return JSON.stringify(pkg, null, 2) + "\n";


### PR DESCRIPTION
## Summary

- `pnpm create nextly-app` produced a scaffold that crashed at boot under pnpm 10+ with `Could not locate the bindings file` because pnpm 10 blocks dependency install scripts by default, so `better-sqlite3` never built its native binding. `sharp`, `esbuild`, and `unrs-resolver` were silently blocked too (JS image fallback, drizzle-kit slowness, eslint resolver warning).
- [packages/create-nextly-app/src/utils/template.ts](packages/create-nextly-app/src/utils/template.ts) now emits `pnpm.onlyBuiltDependencies` in the scaffolded `package.json`: `sharp`/`esbuild`/`unrs-resolver` always, plus `better-sqlite3` when the SQLite adapter is selected.
- npm, yarn, and bun ignore the `pnpm`-namespaced field, so this is a no-op for those package managers and a fix for pnpm 10+. (Note: bun has its own analogous gate via top-level `trustedDependencies` — not addressed here.)

## Why this only hit pnpm

| Manager | Default install-script behavior | Affected |
|---|---|---|
| npm (all) | Runs all scripts | No |
| yarn 1 / 2–4 | Runs all scripts | No |
| pnpm ≤ 9 | Runs all scripts | No |
| pnpm 10+ | Deny by default; allowlist via `pnpm.onlyBuiltDependencies` | **Yes** |
| bun 1.1+ | Deny by default; allowlist via `trustedDependencies` | Yes (not in this PR) |

The monorepo itself pins `packageManager: pnpm@9.0.0`, which is why this never reproduced in CI/dev — only published-scaffold adopters on pnpm 10 hit it.

## Test plan

- [x] `pnpm test` in `packages/create-nextly-app` — 100/100 tests pass, including two new regression tests:
  - `should allowlist non-sqlite native deps in pnpm.onlyBuiltDependencies` (pg/mysql)
  - `should also allowlist better-sqlite3 when sqlite adapter is selected`
- [x] `pnpm check-types` — clean
- [x] `pnpm lint --max-warnings 0` — clean
- [x] Manually verified: adding the same `pnpm.onlyBuiltDependencies` block to a real broken scaffold + `pnpm install` ran the previously-ignored builds (`better-sqlite3`, `sharp@0.33.5`, `sharp@0.34.5`, `esbuild` x3, `unrs-resolver`), `better_sqlite3.node` binary appeared, and `node_modules/.modules.yaml` `ignoredBuilds` went from 7 entries to `[]`.
- [ ] Reviewer sanity check: scaffold a fresh app with this CLI under pnpm 10 (`pnpm create` from the local build) and confirm `pnpm dev` boots `/admin` without the DatabaseError.