### PR TITLE
fix(nextly, admin): fail closed on setup-status DB errors

### DIFF
--- a/.changeset/auth-setup-status-fail-closed.md
+++ b/.changeset/auth-setup-status-fail-closed.md
@@ -1,0 +1,26 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Fix two related admin-auth failures that surface on hosted databases (Neon, Supabase, PlanetScale, etc.) during transient DB hiccups.
+
+**Login/setup fluctuation.** The `getUserCount` dependency in the auth handler bridge used to swallow any DB error and return `0`, which made `GET /auth/setup-status` reply `{ isSetup: false }` whenever a pool cold-start, brief disconnect, or failover landed on this endpoint — the admin route guards then redirected the user to `/admin/setup`, the next call returned `{ isSetup: true }` once the DB recovered, and the guards redirected back to `/admin/login`, oscillating until the next hiccup or full page reload. The user count is the bootstrap-gate for two security-relevant decisions (setup-status reporting and the first-admin pre-check), and treating an unknown count as zero also opened a window where a transient DB failure during `POST /auth/setup` could allow a second super-admin to be created while the real first user was briefly invisible to the query. `getUserCount` now propagates errors; `handleSetupStatus` and `handleSetup` catch them, emit a canonical `503 SERVICE_UNAVAILABLE` envelope through the shared `buildAuthErrorResponse` helper (`application/problem+json` + `x-request-id`), and log a structured operator event (`setup-status-failed` / `setup-precheck-failed`). The admin's `PrivateRoute` and `PublicRoute` now consume a shared `lib/auth/setup-status.ts` module that fail-safes to "setup complete" on any failure (network error, 5xx, invalid response shape) — staying on the dashboard or login screen is recoverable on the next request, whereas dragging an authenticated user into the setup wizard is destructive. `useCurrentUserPermissions` is gated by `routeType === "private"` so its `refetchOnWindowFocus` cannot fire `/me/permissions` during a brief Suspense window on a public route.
+
+**Intermittent logout around the access-token TTL boundary.** The same swallow-and-return-null pattern lived in `findUserById`, which the refresh handler called after deleting the old refresh token. A momentary DB hiccup at the 15-minute boundary returned `null` from the lookup, the handler interpreted that as "user is gone" and ran `clearAndDeny` — clearing both auth cookies and revoking the still-valid session. `findUserById` now propagates errors; `handleRefresh` was reordered so all read-only lookups (`findUserById`, `fetchRoleIds`, `fetchCustomFields`) run BEFORE the destructive `deleteRefreshToken`, and is wrapped in a try/catch that returns `503 SERVICE_UNAVAILABLE` on any DB failure with cookies and tokens intact — the client retries on the next request and the session survives. The admin's `refreshAccessToken` was a boolean primitive that treated every non-200 response (5xx, network errors, our new 503) as "session invalid" and redirected to login; it now returns a tri-state (`ok` / `auth_failed` / `transient`) so `authFetch` only redirects on a genuine 401 from `/auth/refresh` and surfaces transient server errors to the caller without logging the user out.
+
+Internal: consolidated four identical `build{Login,Register,Forgot,Setup}ErrorResponse` helpers into a single `buildAuthErrorResponse` in `handler-utils.ts`, fixed a long-standing `change-password` test mock missing `auditLog`/`trustProxy`/`trustedProxyIps`, and added regression tests covering the 503 path on both setup endpoints, the refresh-handler 503 path (asserting no cookie clearing and no token deletion), and the "no super-admin is created when the pre-check throws" security invariant.

--- a/packages/admin/src/components/guards/PrivateRoute.tsx
+++ b/packages/admin/src/components/guards/PrivateRoute.tsx
@@ -5,33 +5,9 @@ import type React from "react";
 import { useEffect } from "react";
 
 import { ROUTES } from "@admin/constants/routes";
-import { publicApi } from "@admin/lib/api/publicApi";
 import { isAuthenticated as checkIsAuthenticated } from "@admin/lib/auth/session";
+import { checkSetupStatus } from "@admin/lib/auth/setup-status";
 import { navigateTo } from "@admin/lib/navigation";
-
-// ─── Setup status cache (survives across renders, cleared on session end) ──
-let setupStatusCache: boolean | null = null;
-
-async function checkSetupStatus(): Promise<boolean> {
-  if (setupStatusCache !== null) return setupStatusCache;
-  try {
-    const result = await publicApi.get<{ isSetup: boolean }>(
-      "/auth/setup-status"
-    );
-    setupStatusCache = result.isSetup;
-    return setupStatusCache;
-  } catch {
-    // If setup-status fails (e.g. 429), assume setup is complete and cache it
-    // so we don't hammer the endpoint on every re-render.
-    setupStatusCache = true;
-    return setupStatusCache;
-  }
-}
-
-/** Reset setup cache (call after setup or logout) */
-export function resetSetupStatusCache(): void {
-  setupStatusCache = null;
-}
 
 async function verifyAuth(): Promise<{
   isSetup: boolean;

--- a/packages/admin/src/components/guards/PublicRoute.tsx
+++ b/packages/admin/src/components/guards/PublicRoute.tsx
@@ -4,8 +4,8 @@ import type React from "react";
 import { useEffect, useRef, useState } from "react";
 
 import { ROUTES } from "@admin/constants/routes";
-import { publicApi } from "@admin/lib/api/publicApi";
 import { isAuthenticated } from "@admin/lib/auth/session";
+import { checkSetupStatus } from "@admin/lib/auth/setup-status";
 import { navigateTo } from "@admin/lib/navigation";
 
 interface PublicRouteProps {
@@ -24,41 +24,29 @@ export function PublicRoute({ children }: PublicRouteProps) {
     mountedRef.current = true;
 
     const checkAuth = async () => {
-      try {
-        // Check if initial setup has been completed
-        const setupStatus = await publicApi.get<{ isSetup: boolean }>(
-          "/auth/setup-status"
-        );
+      // `checkSetupStatus` swallows its own failures and fail-safes to
+      // "setup complete," so no try/catch is needed here -- the only way
+      // this function returns is with a definitive boolean.
+      const isSetup = await checkSetupStatus();
+      if (!mountedRef.current) return;
 
-        if (!mountedRef.current) return;
+      const currentPath = window.location.pathname;
+      const isOnSetupPage = currentPath === ROUTES.SETUP;
 
-        const currentPath = window.location.pathname;
-        const isOnSetupPage = currentPath === ROUTES.SETUP;
-
-        if (!setupStatus.isSetup) {
-          // No users exist yet — redirect to setup page (unless already there)
-          if (!isOnSetupPage) {
-            navigateTo(ROUTES.SETUP);
-            return;
-          }
-        } else {
-          // Setup is complete — block access to the setup page
-          if (isOnSetupPage) {
-            navigateTo(ROUTES.LOGIN);
-            return;
-          }
-
-          // Existing behavior: redirect authenticated users to dashboard
-          const authenticated = await isAuthenticated();
-          if (!mountedRef.current) return;
-          if (authenticated) {
-            navigateTo(ROUTES.DASHBOARD);
-            return;
-          }
+      if (!isSetup) {
+        // No users exist yet — redirect to setup page (unless already there)
+        if (!isOnSetupPage) {
+          navigateTo(ROUTES.SETUP);
+          return;
         }
-      } catch {
-        if (!mountedRef.current) return;
-        // If setup-status fails, fall back to existing auth check behavior
+      } else {
+        // Setup is complete — block access to the setup page
+        if (isOnSetupPage) {
+          navigateTo(ROUTES.LOGIN);
+          return;
+        }
+
+        // Redirect authenticated users to dashboard
         const authenticated = await isAuthenticated();
         if (!mountedRef.current) return;
         if (authenticated) {

--- a/packages/admin/src/hooks/useCurrentUserPermissions.ts
+++ b/packages/admin/src/hooks/useCurrentUserPermissions.ts
@@ -7,6 +7,8 @@ import type {
   UserPermissionsResponse,
 } from "../types/permissions";
 
+import { useRouter } from "./useRouter";
+
 /**
  * System resources that are NOT dynamic collections.
  * Permissions for these resources map to dedicated capability flags
@@ -162,12 +164,22 @@ const EMPTY_CAPABILITIES: AdminCapabilities = {
  * ```
  */
 export function useCurrentUserPermissions() {
+  // Gate the protected fetch on the current route being private. During a
+  // navigation transition from /admin to a public route (or before the
+  // router has hydrated), Suspense can keep this hook mounted briefly --
+  // without the gate, `refetchOnWindowFocus` could fire `/me/permissions`
+  // on a route where 401s are expected by design, surfacing benign errors
+  // to operators.
+  const { route } = useRouter();
+  const isPrivateRoute = route?.routeType === "private";
+
   // The `/me/permissions` endpoint returns the canonical
   // UserPermissionsResponse shape directly, so `data` here IS the
   // permissions payload.
   const { data, isLoading, error } = useQuery<UserPermissionsResponse>({
     queryKey: ["currentUserPermissions"],
     queryFn: () => protectedApi.get<UserPermissionsResponse>("/me/permissions"),
+    enabled: isPrivateRoute,
     staleTime: 0,
     refetchOnMount: "always",
     refetchOnWindowFocus: true,

--- a/packages/admin/src/hooks/useLogout.ts
+++ b/packages/admin/src/hooks/useLogout.ts
@@ -2,10 +2,10 @@
 
 import { useQueryClient } from "@tanstack/react-query";
 
-import { resetSetupStatusCache } from "@admin/components/guards/PrivateRoute";
 import { toast } from "@admin/components/ui";
 import { getCsrfToken } from "@admin/lib/api/csrf";
 import { invalidateSessionCache } from "@admin/lib/auth/session";
+import { resetSetupStatusCache } from "@admin/lib/auth/setup-status";
 import { navigateTo } from "@admin/lib/navigation";
 
 import { ROUTES } from "../constants/routes";

--- a/packages/admin/src/lib/api/refreshInterceptor.ts
+++ b/packages/admin/src/lib/api/refreshInterceptor.ts
@@ -86,13 +86,29 @@ export function redirectToLogin(): void {
   window.location.href = loginRedirectPath;
 }
 
-let inFlight: Promise<boolean> | null = null;
+/**
+ * Outcome of a `/auth/refresh` attempt. The tri-state lets `authFetch`
+ * distinguish "session is dead, redirect" from "server hiccupped, keep
+ * the session and surface the error to the caller."
+ *
+ * - `ok`           refresh succeeded; retry the original request.
+ * - `auth_failed`  refresh returned 401 (invalid token, expired refresh
+ *                  token, binding mismatch, ...). Server has already
+ *                  cleared cookies via `clearAndDeny`; redirect to login.
+ * - `transient`    refresh failed for a non-auth reason (5xx, network
+ *                  error). Cookies are intact server-side; do NOT
+ *                  redirect -- the caller's original 401 propagates so
+ *                  the user keeps their session and can retry.
+ */
+export type RefreshResult = "ok" | "auth_failed" | "transient";
+
+let inFlight: Promise<RefreshResult> | null = null;
 
 /**
- * POST `/auth/refresh` and return whether it succeeded. Concurrent callers
- * share a single in-flight request.
+ * POST `/auth/refresh` and report the outcome. Concurrent callers share
+ * a single in-flight request.
  */
-export function refreshAccessToken(): Promise<boolean> {
+export function refreshAccessToken(): Promise<RefreshResult> {
   if (inFlight) return inFlight;
 
   inFlight = (async () => {
@@ -101,9 +117,15 @@ export function refreshAccessToken(): Promise<boolean> {
         method: "POST",
         credentials: "include",
       });
-      return res.ok;
+      if (res.ok) return "ok";
+      // 401 is the only response that means "your session is invalid":
+      // the server's `clearAndDeny` path emits 401 + Set-Cookie clears.
+      // Everything else (503 SERVICE_UNAVAILABLE on DB hiccup, 5xx, ...)
+      // is transient and must not log the user out.
+      return res.status === 401 ? "auth_failed" : "transient";
     } catch {
-      return false;
+      // Network error -- cannot reach the server. Definitively transient.
+      return "transient";
     }
   })().finally(() => {
     inFlight = null;
@@ -138,10 +160,16 @@ export async function authFetch(
   const code = await readAuthErrorCode(res);
 
   if (code === "TOKEN_EXPIRED") {
-    if (await refreshAccessToken()) {
+    const refresh = await refreshAccessToken();
+    if (refresh === "ok") {
       return fetch(input, init);
     }
-    redirectToLogin();
+    if (refresh === "auth_failed") {
+      redirectToLogin();
+    }
+    // "transient": surface the original 401 without redirecting -- the
+    // session is still valid server-side, so logging the user out on a
+    // momentary server hiccup would be destructive.
     return res;
   }
 

--- a/packages/admin/src/lib/auth/setup-status.ts
+++ b/packages/admin/src/lib/auth/setup-status.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared `/auth/setup-status` cache used by both route guards
+ * (`PrivateRoute`, `PublicRoute`) and the logout flow. Centralising the
+ * fetch + cache + reset trio here gives the admin UI a single source of
+ * truth for "has initial setup been completed?" -- if the two guards
+ * disagreed on this answer they could redirect the user in opposite
+ * directions on transient failures.
+ *
+ * Cache lifetime: module-scoped, so it survives client-side navigations
+ * (where module state persists) but is cleared on a full page reload
+ * (where module state is reconstructed). `resetSetupStatusCache()` is
+ * called explicitly from the logout path so the next user starts with a
+ * clean slate.
+ */
+import { publicApi } from "../api/publicApi";
+
+let setupStatusCache: boolean | null = null;
+
+/**
+ * Fetch the setup status, populating the module cache on first call.
+ * Subsequent calls within the same page lifecycle return the cached
+ * value without re-hitting the network.
+ *
+ * On any failure (5xx, 429, network error, invalid response shape) the
+ * cache is fail-safed to `true` ("setup complete"). The alternative --
+ * synthesising `false` -- would drag authenticated users into the setup
+ * wizard on a transient hiccup, which is destructive. Staying on the
+ * dashboard or login screen is recoverable on the next request.
+ */
+export async function checkSetupStatus(): Promise<boolean> {
+  if (setupStatusCache !== null) return setupStatusCache;
+  try {
+    const result = await publicApi.get<{ isSetup: boolean } | undefined>(
+      "/auth/setup-status"
+    );
+    // Require a strict boolean; any other shape (empty body, non-JSON,
+    // schema drift) takes the same fail-safe default as the catch branch
+    // below. Inlined rather than throwing into the catch -- the admin
+    // package doesn't carry a NextlyError dependency, and a bare throw
+    // would just be local control flow with no payload.
+    setupStatusCache =
+      typeof result?.isSetup === "boolean" ? result.isSetup : true;
+    return setupStatusCache;
+  } catch {
+    setupStatusCache = true;
+    return setupStatusCache;
+  }
+}
+
+/**
+ * Clear the cached setup status. Called from the logout flow so the
+ * next user (potentially a different account, potentially after a DB
+ * reset) sees a fresh answer rather than the previous user's.
+ */
+export function resetSetupStatusCache(): void {
+  setupStatusCache = null;
+}

--- a/packages/nextly/src/auth/handlers/__tests__/handler-shapes.test.ts
+++ b/packages/nextly/src/auth/handlers/__tests__/handler-shapes.test.ts
@@ -51,9 +51,7 @@ function makeRequest(
   const csrfToken = extra?.csrfToken ?? "csrf-test-token";
   // Inject a matching csrf cookie so the double-submit check passes
   // unless the caller explicitly overrides the cookie header.
-  const cookie =
-    extra?.cookie ??
-    `nextly_csrf=${csrfToken}`;
+  const cookie = extra?.cookie ?? `nextly_csrf=${csrfToken}`;
   const merged =
     body == null
       ? null
@@ -199,6 +197,58 @@ describe("refresh handler: respondData shape", () => {
     expect(typeof body.refreshToken).toBe("string");
     expect(typeof body.expiresAt).toBe("string");
   });
+
+  // A transient DB failure during the rotation must surface as 503 and
+  // leave the session intact: the old refresh token must not be deleted,
+  // no `Set-Cookie` clears, and the response must carry the canonical
+  // `{ error }` envelope. Logging out the user on a momentary pool hiccup
+  // is the destructive behavior this guards against.
+  it("returns 503 (and does NOT delete old refresh token or clear cookies) when findUserById throws", async () => {
+    const tokenHash = hashRefreshToken("raw-refresh-token");
+    const deleteRefreshToken = vi.fn().mockResolvedValue(undefined);
+    const storeRefreshToken = vi.fn().mockResolvedValue(undefined);
+    const deps = {
+      secret: SECRET,
+      isProduction: false,
+      accessTokenTTL: 900,
+      refreshTokenTTL: 604800,
+      trustProxy: false,
+      trustedProxyIps: [],
+      findRefreshTokenByHash: vi.fn().mockResolvedValue({
+        id: "rt1",
+        userId: "u1",
+        expiresAt: new Date(Date.now() + 60_000),
+      }),
+      deleteRefreshToken,
+      deleteAllRefreshTokensForUser: vi.fn().mockResolvedValue(undefined),
+      storeRefreshToken,
+      findUserById: vi.fn().mockRejectedValue(new Error("connection lost")),
+      fetchRoleIds: vi.fn().mockResolvedValue(["super-admin"]),
+      fetchCustomFields: vi.fn().mockResolvedValue({}),
+    };
+
+    const req = new Request("http://localhost:3000/admin/api/auth/refresh", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        cookie: `nextly_refresh=${tokenHash}`,
+      },
+      body: JSON.stringify({}),
+    });
+
+    const res = await handleRefresh(req, deps);
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
+    // Cookies must NOT be cleared on a transient failure -- the session
+    // is still valid; the next attempt should be able to rotate.
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).not.toMatch(/nextly_session=;/);
+    expect(setCookie).not.toMatch(/nextly_refresh=;/);
+    // Old token must remain in the DB so the next attempt can find it.
+    expect(deleteRefreshToken).not.toHaveBeenCalled();
+    expect(storeRefreshToken).not.toHaveBeenCalled();
+  });
 });
 
 describe("register handler: respondAction shape", () => {
@@ -277,6 +327,25 @@ describe("setup-status handler: respondData shape", () => {
     const body = (await res.json()) as Record<string, unknown>;
     expect(body).toEqual({ isSetup: true, requiresInitialUser: false });
   });
+
+  // A transient DB failure during getUserCount must surface as 503, not
+  // collapse to `{ isSetup: false }` -- the bootstrap-gate must never
+  // synthesise a default on incomplete data.
+  it("when getUserCount throws, returns 503 SERVICE_UNAVAILABLE envelope (not isSetup:false)", async () => {
+    const deps = {
+      getUserCount: vi.fn().mockRejectedValue(new Error("connection lost")),
+    };
+    const req = new Request(
+      "http://localhost:3000/admin/api/auth/setup-status"
+    );
+    const res = await handleSetupStatus(req, deps);
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
+    // Client distinguishes "unknown" from "false" by absence of the field.
+    expect(body).not.toHaveProperty("isSetup");
+    expect(body).not.toHaveProperty("requiresInitialUser");
+  });
 });
 
 describe("setup handler: respondAction shape", () => {
@@ -313,6 +382,36 @@ describe("setup handler: respondAction shape", () => {
     expect(typeof body.accessToken).toBe("string");
     expect(typeof body.refreshToken).toBe("string");
     expect(typeof body.expiresAt).toBe("string");
+  });
+
+  // Security: an unknown user count must never be treated as 0 -- a second
+  // super-admin must not be creatable on the assumption that setup is open.
+  it("when getUserCount throws, returns 503 envelope and does NOT create a user", async () => {
+    const createSuperAdmin = vi.fn();
+    const deps = {
+      secret: SECRET,
+      isProduction: false,
+      accessTokenTTL: 900,
+      refreshTokenTTL: 604800,
+      allowedOrigins: ALLOWED_ORIGINS,
+      trustProxy: false,
+      trustedProxyIps: [],
+      getUserCount: vi.fn().mockRejectedValue(new Error("connection lost")),
+      createSuperAdmin,
+      fetchRoleIds: vi.fn(),
+      seedPermissions: vi.fn(),
+      storeRefreshToken: vi.fn(),
+    };
+    const req = makeRequest("POST", {
+      email: "a@example.com",
+      password: "Pass1234!",
+      name: "A",
+    });
+    const res = await handleSetup(req, deps);
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
+    expect(createSuperAdmin).not.toHaveBeenCalled();
   });
 });
 
@@ -411,6 +510,9 @@ describe("change-password handler: respondAction shape", () => {
       allowedOrigins: ALLOWED_ORIGINS,
       changePassword: vi.fn().mockResolvedValue({ success: true }),
       deleteAllRefreshTokensForUser: vi.fn().mockResolvedValue(undefined),
+      auditLog: { write: vi.fn().mockResolvedValue(undefined) },
+      trustProxy: false,
+      trustedProxyIps: [],
     };
     const req = new Request("http://localhost:3000/admin/api/auth/cp", {
       method: "PATCH",
@@ -447,13 +549,10 @@ describe("session handler: respondData shape", () => {
       900
     );
     const deps = { secret: SECRET };
-    const req = new Request(
-      "http://localhost:3000/admin/api/auth/session",
-      {
-        method: "GET",
-        headers: { cookie: `nextly_session=${accessToken}` },
-      }
-    );
+    const req = new Request("http://localhost:3000/admin/api/auth/session", {
+      method: "GET",
+      headers: { cookie: `nextly_session=${accessToken}` },
+    });
     const res = await handleSession(req, deps);
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;

--- a/packages/nextly/src/auth/handlers/deps-bridge.ts
+++ b/packages/nextly/src/auth/handlers/deps-bridge.ts
@@ -9,6 +9,7 @@
  * we delegate directly. For new operations (refresh tokens, brute-force tracking),
  * we use the database adapter directly.
  */
+
 import { getDialectTables } from "../../database/index";
 import { buildAuditLogWriter } from "../../domains/audit/audit-log-writer";
 import { NextlyError } from "../../errors";
@@ -66,20 +67,22 @@ export function buildAuthRouterDeps(
     },
 
     findUserById: async (userId: string) => {
-      try {
-        const adapter = getService("adapter");
-        const db = adapter.getDrizzle();
-        const schema = getDialectTables();
-        const { eq } = await import("drizzle-orm");
-        const result = await db
-          .select()
-          .from(schema.users)
-          .where(eq(schema.users.id, userId))
-          .limit(1);
-        return result[0] || null;
-      } catch {
-        return null;
-      }
+      // Errors propagate intentionally. The refresh handler relies on this
+      // lookup to decide whether to rotate or `clearAndDeny`; a swallowed
+      // DB error returning `null` was indistinguishable from "user
+      // genuinely missing" and tore down the session on every transient
+      // hiccup. The refresh handler now wraps the lookup and surfaces
+      // failures as a 503 envelope without clearing cookies.
+      const adapter = getService("adapter");
+      const db = adapter.getDrizzle();
+      const schema = getDialectTables();
+      const { eq } = await import("drizzle-orm");
+      const result = await db
+        .select()
+        .from(schema.users)
+        .where(eq(schema.users.id, userId))
+        .limit(1);
+      return result[0] || null;
     },
 
     incrementFailedAttempts: async (userId: string) => {
@@ -236,23 +239,26 @@ export function buildAuthRouterDeps(
     },
 
     getUserCount: async () => {
-      try {
-        const adapter = getService("adapter");
-        const db = adapter.getDrizzle();
-        const schema = getDialectTables();
-        const { count } = await import("drizzle-orm");
-        const result = await db.select({ count: count() }).from(schema.users);
-        return Number(result[0]?.count || 0);
-      } catch {
-        return 0;
-      }
+      // Errors propagate intentionally. The user count gates two
+      // security-relevant decisions (setup-status reporting and the
+      // first-admin pre-check); collapsing an unknown count to 0 would
+      // both lie about setup state and risk a duplicate super-admin.
+      // Callers convert failures to a 503 envelope.
+      const adapter = getService("adapter");
+      const db = adapter.getDrizzle();
+      const schema = getDialectTables();
+      const { count } = await import("drizzle-orm");
+      const result = await db.select({ count: count() }).from(schema.users);
+      return Number(result[0]?.count || 0);
     },
 
     createSuperAdmin: async data => {
-      const { seedPermissions } =
-        await import("../../database/seeders/permissions");
-      const { seedSuperAdmin } =
-        await import("../../database/seeders/super-admin");
+      const { seedPermissions } = await import(
+        "../../database/seeders/permissions"
+      );
+      const { seedSuperAdmin } = await import(
+        "../../database/seeders/super-admin"
+      );
       const adapter = getService("adapter");
 
       // Seed permissions first (seedSuperAdmin needs them to assign to the admin)
@@ -289,8 +295,9 @@ export function buildAuthRouterDeps(
     },
 
     seedPermissions: async () => {
-      const { seedPermissions } =
-        await import("../../database/seeders/permissions");
+      const { seedPermissions } = await import(
+        "../../database/seeders/permissions"
+      );
       const adapter = getService("adapter");
       await seedPermissions(adapter, { silent: true });
     },

--- a/packages/nextly/src/auth/handlers/forgot-password.ts
+++ b/packages/nextly/src/auth/handlers/forgot-password.ts
@@ -15,7 +15,11 @@ import { NextlyError } from "../../errors/nextly-error";
 import { readCsrfCookie, readCsrfFromRequest } from "../csrf/csrf-cookie";
 import { validateCsrf } from "../csrf/validate";
 
-import { jsonResponse, stallResponse } from "./handler-utils";
+import {
+  jsonResponse,
+  stallResponse,
+  buildAuthErrorResponse,
+} from "./handler-utils";
 
 export interface ForgotPasswordHandlerDeps {
   allowedOrigins: string[];
@@ -71,7 +75,11 @@ function sanitizeRedirectPath(raw: unknown): string | undefined {
   // protocol-relative and resolves to a foreign origin) and live under
   // `/admin`.
   if (raw.startsWith("/") && !raw.startsWith("//")) {
-    if (raw === "/admin" || raw.startsWith("/admin/") || raw.startsWith("/admin?")) {
+    if (
+      raw === "/admin" ||
+      raw.startsWith("/admin/") ||
+      raw.startsWith("/admin?")
+    ) {
       return raw;
     }
     console.warn(
@@ -108,22 +116,6 @@ function sanitizeRedirectPath(raw: unknown): string | undefined {
     `[nextly/auth] Rejected forgot-password redirectPath: host ${host} not in ALLOWED_REDIRECT_HOSTS`
   );
   return undefined;
-}
-
-function buildForgotErrorResponse(
-  err: NextlyError,
-  requestId: string
-): Response {
-  return new Response(
-    JSON.stringify({ error: err.toResponseJSON(requestId) }),
-    {
-      status: err.statusCode,
-      headers: {
-        "content-type": "application/problem+json",
-        "x-request-id": requestId,
-      },
-    }
-  );
 }
 
 export async function handleForgotPassword(
@@ -202,9 +194,9 @@ export async function handleForgotPassword(
   } catch (err) {
     await stallResponse(startTime, deps.loginStallTimeMs);
     if (NextlyError.is(err)) {
-      return buildForgotErrorResponse(err, requestId);
+      return buildAuthErrorResponse(err, requestId);
     }
-    return buildForgotErrorResponse(
+    return buildAuthErrorResponse(
       NextlyError.internal({ cause: err as Error }),
       requestId
     );

--- a/packages/nextly/src/auth/handlers/handler-utils.ts
+++ b/packages/nextly/src/auth/handlers/handler-utils.ts
@@ -1,3 +1,5 @@
+import type { NextlyError } from "../../errors";
+
 /**
  * Create a JSON Response with the given status and body.
  */
@@ -13,6 +15,29 @@ export function jsonResponse(
       ...headers,
     },
   });
+}
+
+/**
+ * Build the canonical singular `{ error }` envelope (spec §6.4) for auth
+ * handler failures: `application/problem+json` body, `x-request-id`
+ * header, and status pulled from the NextlyError. Every auth handler
+ * (login, register, forgot-password, reset-password, setup, ...) routes
+ * its catch branches through this helper to keep the wire shape uniform.
+ */
+export function buildAuthErrorResponse(
+  err: NextlyError,
+  requestId: string
+): Response {
+  return new Response(
+    JSON.stringify({ error: err.toResponseJSON(requestId) }),
+    {
+      status: err.statusCode,
+      headers: {
+        "content-type": "application/problem+json",
+        "x-request-id": requestId,
+      },
+    }
+  );
 }
 
 /**
@@ -59,4 +84,3 @@ export async function parseJsonBody(
     return null;
   }
 }
-

--- a/packages/nextly/src/auth/handlers/login.ts
+++ b/packages/nextly/src/auth/handlers/login.ts
@@ -16,11 +16,11 @@ import {
   generateRefreshTokenId,
 } from "../session/refresh";
 
-
 import {
   jsonResponse,
   stallResponse,
   buildCookieHeaders,
+  buildAuthErrorResponse,
 } from "./handler-utils";
 
 export interface LoginHandlerDeps {
@@ -63,31 +63,6 @@ export interface LoginHandlerDeps {
   trustedProxyIps: string[];
   /** Writer for security-sensitive auth events. */
   auditLog: AuditLogWriter;
-}
-
-/**
- * Serialize a NextlyError to the canonical login error response.
- *
- * Every login failure (CSRF, invalid creds, locked, unverified, inactive,
- * internal) is returned as a NextlyError with the same wire format that
- * withErrorHandler produces: application/problem+json with code, message,
- * and requestId. Account-state codes collapse into
- * AUTH_INVALID_CREDENTIALS per spec §13.1.
- */
-function buildLoginErrorResponse(
-  err: NextlyError,
-  requestId: string
-): Response {
-  return new Response(
-    JSON.stringify({ error: err.toResponseJSON(requestId) }),
-    {
-      status: err.statusCode,
-      headers: {
-        "content-type": "application/problem+json",
-        "x-request-id": requestId,
-      },
-    }
-  );
 }
 
 export async function handleLogin(
@@ -239,9 +214,9 @@ export async function handleLogin(
         : { code: "INTERNAL_ERROR" },
     });
     if (NextlyError.is(err)) {
-      return buildLoginErrorResponse(err, requestId);
+      return buildAuthErrorResponse(err, requestId);
     }
-    return buildLoginErrorResponse(
+    return buildAuthErrorResponse(
       NextlyError.internal({ cause: err as Error }),
       requestId
     );

--- a/packages/nextly/src/auth/handlers/refresh.ts
+++ b/packages/nextly/src/auth/handlers/refresh.ts
@@ -3,7 +3,9 @@
  * Rotates the refresh token and issues a new access token.
  * Re-fetches roles from DB (guarantees fresh roles within 15 min).
  */
+import { readOrGenerateRequestId } from "../../api/request-id";
 import { respondData } from "../../api/response-shapes";
+import { NextlyError } from "../../errors";
 import { getNextlyLogger } from "../../observability/logger";
 import { getTrustedClientIp } from "../../utils/get-trusted-client-ip";
 import {
@@ -25,7 +27,7 @@ import {
 } from "../session/refresh";
 import { evaluateRefreshBinding } from "../session/refresh-binding";
 
-import { buildCookieHeaders } from "./handler-utils";
+import { buildCookieHeaders, buildAuthErrorResponse } from "./handler-utils";
 
 export interface RefreshHandlerDeps {
   secret: string;
@@ -75,124 +77,166 @@ export async function handleRefresh(
   }
 
   const tokenHash = hashRefreshToken(rawToken);
-  const tokenRecord = await deps.findRefreshTokenByHash(tokenHash);
 
-  if (!tokenRecord) {
-    // Token not found -- could be token theft (replayed consumed token).
-    // The legitimate user's rotated token is still valid.
-    return clearAndDeny("Invalid refresh token");
-  }
+  // Outer try/catch: ANY DB error during rotation must surface as a 503
+  // envelope rather than `clearAndDeny`. The latter wipes the user's
+  // cookies and forces a re-login -- destructive behavior for what may
+  // be a momentary pool hiccup on a hosted database. As long as we have
+  // not yet deleted the old refresh token, returning 503 leaves the
+  // session intact: the client backs off, the next request fires a new
+  // refresh, and the user keeps working.
+  try {
+    const tokenRecord = await deps.findRefreshTokenByHash(tokenHash);
 
-  if (tokenRecord.expiresAt < new Date()) {
-    await deps.deleteRefreshToken(tokenRecord.id);
-    return clearAndDeny("Refresh token expired");
-  }
+    if (!tokenRecord) {
+      // Token not found -- could be token theft (replayed consumed token).
+      // The legitimate user's rotated token is still valid.
+      return clearAndDeny("Invalid refresh token");
+    }
 
-  // Enforce refresh-token UA + trusted-IP binding before honoring rotation.
-  // A hard mismatch (IP family flip or /24 / /48 prefix change) revokes
-  // every refresh token for the user, since one confirmed network mismatch
-  // suggests theft rather than benign rotation.
-  const currentUserAgent = request.headers.get("user-agent");
-  const currentIp = getTrustedClientIp(request, {
-    trustProxy: deps.trustProxy,
-    trustedProxyIps: deps.trustedProxyIps,
-  });
-  const binding = evaluateRefreshBinding({
-    storedUserAgent: tokenRecord.userAgent,
-    currentUserAgent,
-    storedIp: tokenRecord.ipAddress,
-    currentIp,
-  });
+    if (tokenRecord.expiresAt < new Date()) {
+      await deps.deleteRefreshToken(tokenRecord.id);
+      return clearAndDeny("Refresh token expired");
+    }
 
-  if (binding.kind === "hard") {
-    await deps.deleteRefreshToken(tokenRecord.id);
-    await deps.deleteAllRefreshTokensForUser(tokenRecord.userId);
-    getNextlyLogger().warn({
-      kind: "refresh-binding-hard-fail",
-      reason: binding.reason,
-      tokenId: tokenRecord.id,
-      userId: tokenRecord.userId,
-    });
-    return clearAndDeny("Session binding mismatch");
-  }
-
-  if (binding.kind === "soft") {
-    getNextlyLogger().warn({
-      kind: "refresh-binding-soft-warn",
-      reason: binding.reason,
-      tokenId: tokenRecord.id,
-      userId: tokenRecord.userId,
-    });
-  }
-
-  // Delete the consumed token (rotation)
-  await deps.deleteRefreshToken(tokenRecord.id);
-
-  const user = await deps.findUserById(tokenRecord.userId);
-  if (!user || !user.isActive) {
-    return clearAndDeny("User not found or inactive");
-  }
-
-  // Re-fetch fresh roles and custom fields
-  const [roleIds, customFields] = await Promise.all([
-    deps.fetchRoleIds(user.id),
-    deps.fetchCustomFields(user.id),
-  ]);
-
-  const claims = buildClaims({
-    userId: user.id,
-    email: user.email,
-    name: user.name,
-    image: user.image,
-    roleIds,
-    customFields,
-  });
-  const accessToken = await signAccessToken(
-    claims,
-    deps.secret,
-    deps.accessTokenTTL
-  );
-
-  const newRawToken = generateRefreshToken();
-  const newTokenHash = hashRefreshToken(newRawToken);
-  await deps.storeRefreshToken({
-    id: generateRefreshTokenId(),
-    userId: user.id,
-    tokenHash: newTokenHash,
-    userAgent: request.headers.get("user-agent"),
-    ipAddress: getTrustedClientIp(request, {
+    // Enforce refresh-token UA + trusted-IP binding before honoring
+    // rotation. A hard mismatch (IP family flip or /24 / /48 prefix
+    // change) revokes every refresh token for the user, since one
+    // confirmed network mismatch suggests theft rather than benign
+    // rotation.
+    const currentUserAgent = request.headers.get("user-agent");
+    const currentIp = getTrustedClientIp(request, {
       trustProxy: deps.trustProxy,
       trustedProxyIps: deps.trustedProxyIps,
-    }),
-    expiresAt: new Date(Date.now() + deps.refreshTokenTTL * 1000),
-  });
+    });
+    const binding = evaluateRefreshBinding({
+      storedUserAgent: tokenRecord.userAgent,
+      currentUserAgent,
+      storedIp: tokenRecord.ipAddress,
+      currentIp,
+    });
 
-  const cookies = [
-    setAccessTokenCookie(accessToken, deps.refreshTokenTTL, deps.isProduction),
-    setRefreshTokenCookie(newRawToken, deps.refreshTokenTTL, deps.isProduction),
-  ];
+    if (binding.kind === "hard") {
+      await deps.deleteRefreshToken(tokenRecord.id);
+      await deps.deleteAllRefreshTokensForUser(tokenRecord.userId);
+      getNextlyLogger().warn({
+        kind: "refresh-binding-hard-fail",
+        reason: binding.reason,
+        tokenId: tokenRecord.id,
+        userId: tokenRecord.userId,
+      });
+      return clearAndDeny("Session binding mismatch");
+    }
 
-  // Silent rotation per spec §7.6, no `message`. Body surfaces the
-  // freshly-rotated tokens so non-cookie clients (mobile / SDK) can replace
-  // their stored values; browser clients keep using the HttpOnly cookies.
-  return respondData(
-    {
-      user: {
-        id: user.id,
-        email: user.email,
-        name: user.name,
-        image: user.image,
-        roleIds,
+    if (binding.kind === "soft") {
+      getNextlyLogger().warn({
+        kind: "refresh-binding-soft-warn",
+        reason: binding.reason,
+        tokenId: tokenRecord.id,
+        userId: tokenRecord.userId,
+      });
+    }
+
+    // Read-only phase: do every lookup BEFORE the destructive delete.
+    // If any of these throws on a transient DB failure, the old token is
+    // still valid and the catch block below returns a 503 -- the user's
+    // session survives. The previous order (delete -> findUserById ->
+    // ...) would leave the user with no refresh token if any lookup
+    // failed, permanently breaking the session.
+    const user = await deps.findUserById(tokenRecord.userId);
+    if (!user || !user.isActive) {
+      await deps.deleteRefreshToken(tokenRecord.id);
+      return clearAndDeny("User not found or inactive");
+    }
+    const [roleIds, customFields] = await Promise.all([
+      deps.fetchRoleIds(user.id),
+      deps.fetchCustomFields(user.id),
+    ]);
+
+    const claims = buildClaims({
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+      image: user.image,
+      roleIds,
+      customFields,
+    });
+    const accessToken = await signAccessToken(
+      claims,
+      deps.secret,
+      deps.accessTokenTTL
+    );
+
+    const newRawToken = generateRefreshToken();
+    const newTokenHash = hashRefreshToken(newRawToken);
+
+    // Write phase: delete the consumed token, then persist the new one.
+    // Sequential rather than transactional -- the auth handler layer has
+    // no transaction primitive today. If the second write fails, the
+    // user lands in the "no valid refresh token" state on the next
+    // attempt and falls back to login.
+    await deps.deleteRefreshToken(tokenRecord.id);
+    await deps.storeRefreshToken({
+      id: generateRefreshTokenId(),
+      userId: user.id,
+      tokenHash: newTokenHash,
+      userAgent: request.headers.get("user-agent"),
+      ipAddress: getTrustedClientIp(request, {
+        trustProxy: deps.trustProxy,
+        trustedProxyIps: deps.trustedProxyIps,
+      }),
+      expiresAt: new Date(Date.now() + deps.refreshTokenTTL * 1000),
+    });
+
+    const cookies = [
+      setAccessTokenCookie(
+        accessToken,
+        deps.refreshTokenTTL,
+        deps.isProduction
+      ),
+      setRefreshTokenCookie(
+        newRawToken,
+        deps.refreshTokenTTL,
+        deps.isProduction
+      ),
+    ];
+
+    // Silent rotation per spec §7.6, no `message`. Body surfaces the
+    // freshly-rotated tokens so non-cookie clients (mobile / SDK) can
+    // replace their stored values; browser clients keep using the
+    // HttpOnly cookies.
+    return respondData(
+      {
+        user: {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          image: user.image,
+          roleIds,
+        },
+        accessToken,
+        refreshToken: newRawToken,
+        // Authoritative server-side exp lives on the JWT itself.
+        expiresAt: new Date(
+          Date.now() + deps.accessTokenTTL * 1000
+        ).toISOString(),
       },
-      accessToken,
-      refreshToken: newRawToken,
-      // Authoritative server-side exp lives on the JWT itself (accessTokenTTL).
-      expiresAt: new Date(
-        Date.now() + deps.accessTokenTTL * 1000
-      ).toISOString(),
-    },
-    { status: 200, headers: buildCookieHeaders(cookies) }
-  );
+      { status: 200, headers: buildCookieHeaders(cookies) }
+    );
+  } catch (err) {
+    const requestId = readOrGenerateRequestId(request);
+    const nextlyErr = NextlyError.is(err)
+      ? err
+      : NextlyError.serviceUnavailable({
+          logMessage: "refresh: rotation failed",
+          cause: err as Error,
+        });
+    getNextlyLogger().error({
+      kind: "refresh-failed",
+      ...nextlyErr.toLogJSON(requestId),
+    });
+    return buildAuthErrorResponse(nextlyErr, requestId);
+  }
 }
 
 function clearAndDeny(message: string): Response {

--- a/packages/nextly/src/auth/handlers/register.ts
+++ b/packages/nextly/src/auth/handlers/register.ts
@@ -23,7 +23,11 @@ import { EmailSchema, PasswordSchema } from "../../schemas/validation";
 import { readCsrfCookie, readCsrfFromRequest } from "../csrf/csrf-cookie";
 import { validateCsrf } from "../csrf/validate";
 
-import { jsonResponse, stallResponse } from "./handler-utils";
+import {
+  jsonResponse,
+  stallResponse,
+  buildAuthErrorResponse,
+} from "./handler-utils";
 
 /**
  * Structured payload validation at the route layer. Reuses the canonical
@@ -90,22 +94,6 @@ function zodIssueToCode(issue: z.core.$ZodIssue): string {
     default:
       return "INVALID";
   }
-}
-
-function buildRegisterErrorResponse(
-  err: NextlyError,
-  requestId: string
-): Response {
-  return new Response(
-    JSON.stringify({ error: err.toResponseJSON(requestId) }),
-    {
-      status: err.statusCode,
-      headers: {
-        "content-type": "application/problem+json",
-        "x-request-id": requestId,
-      },
-    }
-  );
 }
 
 export async function handleRegister(
@@ -218,9 +206,9 @@ export async function handleRegister(
   } catch (err) {
     await stallResponse(startTime, deps.loginStallTimeMs);
     if (NextlyError.is(err)) {
-      return buildRegisterErrorResponse(err, requestId);
+      return buildAuthErrorResponse(err, requestId);
     }
-    return buildRegisterErrorResponse(
+    return buildAuthErrorResponse(
       NextlyError.internal({ cause: err as Error }),
       requestId
     );

--- a/packages/nextly/src/auth/handlers/setup.ts
+++ b/packages/nextly/src/auth/handlers/setup.ts
@@ -1,7 +1,10 @@
 // CSRF double-submit cookie + origin check. Setup is a one-time but
 // state-changing bootstrap; CSRF guards against a malicious page racing
 // the legitimate first-admin form. See docs/auth/csrf.md.
+import { readOrGenerateRequestId } from "../../api/request-id";
 import { respondAction, respondData } from "../../api/response-shapes";
+import { NextlyError } from "../../errors";
+import { getNextlyLogger } from "../../observability/logger";
 import { getTrustedClientIp } from "../../utils/get-trusted-client-ip";
 import { setAccessTokenCookie } from "../cookies/access-token-cookie";
 import { setRefreshTokenCookie } from "../cookies/refresh-token-cookie";
@@ -17,8 +20,11 @@ import {
   generateRefreshTokenId,
 } from "../session/refresh";
 
-
-import { jsonResponse, buildCookieHeaders } from "./handler-utils";
+import {
+  jsonResponse,
+  buildCookieHeaders,
+  buildAuthErrorResponse,
+} from "./handler-utils";
 
 export interface SetupHandlerDeps {
   secret: string;
@@ -49,25 +55,61 @@ export interface SetupHandlerDeps {
 }
 
 export async function handleSetupStatus(
-  _request: Request,
+  request: Request,
   deps: Pick<SetupHandlerDeps, "getUserCount">
 ): Promise<Response> {
-  const count = await deps.getUserCount();
-  // Emit `{ isSetup, requiresInitialUser }` per spec §7.7. Both
-  // fields are derived from the user count: `isSetup` is true once a user
-  // exists, `requiresInitialUser` is the inverse so the admin client can
-  // drive the bootstrap-form redirect guard without reinterpreting the
-  // same boolean. The pair also satisfies the section 5.1 "no Boolean-only
-  // respondData payload" rule.
-  const isSetup = count > 0;
-  return respondData({ isSetup, requiresInitialUser: !isSetup });
+  try {
+    const count = await deps.getUserCount();
+    // Emit `{ isSetup, requiresInitialUser }` per spec §7.7. Both
+    // fields are derived from the user count: `isSetup` is true once a user
+    // exists, `requiresInitialUser` is the inverse so the admin client can
+    // drive the bootstrap-form redirect guard without reinterpreting the
+    // same boolean. The pair also satisfies the section 5.1 "no Boolean-only
+    // respondData payload" rule.
+    const isSetup = count > 0;
+    return respondData({ isSetup, requiresInitialUser: !isSetup });
+  } catch (err) {
+    // Surface a 503 rather than synthesising a default `isSetup` -- the
+    // bootstrap-gate must never claim "no users exist" on incomplete data.
+    const requestId = readOrGenerateRequestId(request);
+    const nextlyErr = NextlyError.is(err)
+      ? err
+      : NextlyError.serviceUnavailable({
+          logMessage: "setup-status: user-count lookup failed",
+          cause: err as Error,
+        });
+    getNextlyLogger().error({
+      kind: "setup-status-failed",
+      ...nextlyErr.toLogJSON(requestId),
+    });
+    return buildAuthErrorResponse(nextlyErr, requestId);
+  }
 }
 
 export async function handleSetup(
   request: Request,
   deps: SetupHandlerDeps
 ): Promise<Response> {
-  const userCount = await deps.getUserCount();
+  // Fail closed: an unknown user count must not be treated as 0, otherwise
+  // a transient DB failure could allow a second super-admin to be created
+  // while the real first user is invisible to the query.
+  let userCount: number;
+  try {
+    userCount = await deps.getUserCount();
+  } catch (err) {
+    const requestId = readOrGenerateRequestId(request);
+    const nextlyErr = NextlyError.is(err)
+      ? err
+      : NextlyError.serviceUnavailable({
+          logMessage: "setup: user-count pre-check failed",
+          cause: err as Error,
+        });
+    getNextlyLogger().error({
+      kind: "setup-precheck-failed",
+      ...nextlyErr.toLogJSON(requestId),
+    });
+    return buildAuthErrorResponse(nextlyErr, requestId);
+  }
   if (userCount > 0) {
     return jsonResponse(403, {
       error: {


### PR DESCRIPTION
Prevents the admin UI's login/setup screen ping-pong when getUserCount hits a transient DB failure on hosted databases. Backend returns 503 instead of synthesising `isSetup=false`; the admin guards share a single setup-status cache that fail-safes to "setup complete" on any failure.

## Summary

<!-- What does this PR do and why? Keep it short. -->

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / chore (no user-facing change)

## Related issues

<!-- e.g. Closes #123, Refs #456 -->

## Changeset

This repo uses [Changesets](https://github.com/changesets/changesets). If your PR changes any publishable package under `packages/*`, you **must** include a changeset:

```bash
pnpm changeset
```

Then commit the generated `.changeset/*.md` file.

- [ ] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [ ] I selected the correct semver bump (patch / minor / major)

> The `changeset-check` CI job will fail if a publishable package is modified without a changeset.

## Test plan

<!-- How did you verify this works? Commands run, scenarios tested, screenshots, etc. -->

- [ ] `pnpm lint`
- [ ] `pnpm check-types`
- [ ] `pnpm build`
- [ ] Manually verified the change

## Checklist

- [ ] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [ ] I targeted the `main` branch
- [ ] I updated relevant documentation

## Screenshots / recordings

<!-- Optional. Drag images or videos here for UI changes. -->

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to? Migration risks, perf concerns, etc. -->
