### PR TITLE
fix(nextly): coerce date field strings to Date in singles + components

### DIFF
--- a/.changeset/date-field-coercion-singles-components.md
+++ b/.changeset/date-field-coercion-singles-components.md
@@ -1,0 +1,22 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Fix `update operation failed on table '<table>': value.toISOString is not a function` when saving a Single document or a component instance that includes a date field. JSON request bodies deliver date values as ISO strings (e.g. `"2026-05-20T12:22:29.417Z"`), but Drizzle binds `timestamp` columns by calling `.toISOString()` on the bound value -- so an unmodified string travelling through the adapter blows up at the driver layer. `CollectionMutationService` already coerced date strings into `Date` objects inline at every write site, but the equivalent step was missing from `SingleMutationService.update` and from `ComponentMutationService.serializeComponentRow` (which feeds every insert / update path in the component service via `buildInsertRow` and direct calls).
+
+A new `coerceDateFieldsToDate(data, fields)` helper in `shared/lib/field-transform.ts` mutates the row in place, converting string values for `field.type === "date"` columns into `Date` objects. Existing `Date`, `null`, and `undefined` values pass through untouched, so the function is idempotent and safe to call on rows that were coerced upstream. The signature accepts a structural `ReadonlyArray<{ name?: string; type?: string }>` so the same helper covers both `FieldConfig[]` (singles, components) and the runtime `FieldDefinition[]` (collections). The helper is wired into `single-mutation-service.update` before snake-casing the row and into `component-mutation-service.serializeComponentRow` before column mapping. The six inline copies of the same coercion block in `collection-mutation-service.ts` were collapsed onto the shared helper as part of the same change so there is one implementation across all three domains. Result: PATCH `/admin/api/singles/<slug>` with a `date` field, inserts / updates on components with date fields, and the existing collection flows that already worked all succeed against Postgres, MySQL, and SQLite. Unit tests cover the helper's coercion, idempotency, null / undefined pass-through, and no-touch behaviour for non-date fields.

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -37,6 +37,7 @@ import type { CollectionRelationshipService } from "../../../services/collection
 import type { ComponentDataService } from "../../../services/components/component-data-service";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
+import { coerceDateFieldsToDate } from "../../../shared/lib/field-transform";
 import type { SupportedDialect } from "../../../types/database";
 import type { DynamicCollectionService } from "../../dynamic-collections";
 
@@ -515,17 +516,10 @@ export class CollectionMutationService extends BaseService {
         }
       });
 
-      // Convert date field strings to Date objects
-      // This is necessary because Drizzle ORM expects Date objects for timestamp fields
-      // (especially SQLite with mode: 'timestamp'), but the API receives ISO strings
-      fields.forEach(field => {
-        if (field.type === "date" && finalData[field.name] != null) {
-          const value = finalData[field.name];
-          if (typeof value === "string") {
-            finalData[field.name] = new Date(value);
-          }
-        }
-      });
+      // Convert date-field strings into `Date` objects so Drizzle can bind
+      // them to `timestamp` columns. See `coerceDateFieldsToDate` for the
+      // failure mode this guards against.
+      coerceDateFieldsToDate(finalData, fields);
 
       // Generate or validate slug
       // All collections have a slug column in their database table,
@@ -1009,17 +1003,10 @@ export class CollectionMutationService extends BaseService {
 
       this.serializeHasManyRelationships(finalData, fields);
 
-      // Convert date field strings to Date objects
-      // This is necessary because Drizzle ORM expects Date objects for timestamp fields
-      // (especially SQLite with mode: 'timestamp'), but the API receives ISO strings
-      fields.forEach(field => {
-        if (field.type === "date" && finalData[field.name] != null) {
-          const value = finalData[field.name];
-          if (typeof value === "string") {
-            finalData[field.name] = new Date(value);
-          }
-        }
-      });
+      // Convert date-field strings into `Date` objects so Drizzle can bind
+      // them to `timestamp` columns. See `coerceDateFieldsToDate` for the
+      // failure mode this guards against.
+      coerceDateFieldsToDate(finalData, fields);
 
       // Sanitize slug if provided in update
       // - Dynamic collections (UI-created) always have a slug column
@@ -1613,16 +1600,10 @@ export class CollectionMutationService extends BaseService {
 
       this.serializeHasManyRelationships(finalData, fields);
 
-      // Convert date field strings to Date objects
-      // This is necessary because Drizzle ORM expects Date objects for timestamp fields
-      fields.forEach(field => {
-        if (field.type === "date" && finalData[field.name] != null) {
-          const value = finalData[field.name];
-          if (typeof value === "string") {
-            finalData[field.name] = new Date(value);
-          }
-        }
-      });
+      // Convert date-field strings into `Date` objects so Drizzle can bind
+      // them to `timestamp` columns. See `coerceDateFieldsToDate` for the
+      // failure mode this guards against.
+      coerceDateFieldsToDate(finalData, fields);
 
       // Prepare entry data
       const nowForTxCreate = new Date();
@@ -1865,16 +1846,10 @@ export class CollectionMutationService extends BaseService {
 
       this.serializeHasManyRelationships(finalData, fields);
 
-      // Convert date field strings to Date objects
-      // This is necessary because Drizzle ORM expects Date objects for timestamp fields
-      fields.forEach(field => {
-        if (field.type === "date" && finalData[field.name] != null) {
-          const value = finalData[field.name];
-          if (typeof value === "string") {
-            finalData[field.name] = new Date(value);
-          }
-        }
-      });
+      // Convert date-field strings into `Date` objects so Drizzle can bind
+      // them to `timestamp` columns. See `coerceDateFieldsToDate` for the
+      // failure mode this guards against.
+      coerceDateFieldsToDate(finalData, fields);
 
       // Update using transaction context
       // IMPORTANT: Use UTC ISO string for updatedAt to ensure consistent timezone handling
@@ -2290,16 +2265,10 @@ export class CollectionMutationService extends BaseService {
 
       this.serializeHasManyRelationships(finalData, fields);
 
-      // Convert date field strings to Date objects
-      // This is necessary because Drizzle ORM expects Date objects for timestamp fields
-      fields.forEach(field => {
-        if (field.type === "date" && finalData[field.name] != null) {
-          const value = finalData[field.name];
-          if (typeof value === "string") {
-            finalData[field.name] = new Date(value);
-          }
-        }
-      });
+      // Convert date-field strings into `Date` objects so Drizzle can bind
+      // them to `timestamp` columns. See `coerceDateFieldsToDate` for the
+      // failure mode this guards against.
+      coerceDateFieldsToDate(finalData, fields);
 
       // Prepare entry data
       const nowForTxCreate = new Date();
@@ -2591,16 +2560,10 @@ export class CollectionMutationService extends BaseService {
 
       this.serializeHasManyRelationships(finalData, fields);
 
-      // Convert date field strings to Date objects
-      // This is necessary because Drizzle ORM expects Date objects for timestamp fields
-      fields.forEach(field => {
-        if (field.type === "date" && finalData[field.name] != null) {
-          const value = finalData[field.name];
-          if (typeof value === "string") {
-            finalData[field.name] = new Date(value);
-          }
-        }
-      });
+      // Convert date-field strings into `Date` objects so Drizzle can bind
+      // them to `timestamp` columns. See `coerceDateFieldsToDate` for the
+      // failure mode this guards against.
+      coerceDateFieldsToDate(finalData, fields);
 
       // Update using transaction context
       // IMPORTANT: Use UTC ISO string for updatedAt to ensure consistent timezone handling

--- a/packages/nextly/src/domains/components/services/component-mutation-service.ts
+++ b/packages/nextly/src/domains/components/services/component-mutation-service.ts
@@ -14,6 +14,7 @@ import { NextlyError } from "../../../errors";
 import type { DynamicComponentRecord } from "../../../schemas/dynamic-components/types";
 import type { ComponentRegistryService } from "../../../services/components/component-registry-service";
 import { BaseService } from "../../../shared/base-service";
+import { coerceDateFieldsToDate } from "../../../shared/lib/field-transform";
 import type { Logger } from "../../../shared/types";
 
 import {
@@ -928,6 +929,14 @@ export class ComponentMutationService extends BaseService {
     fields: FieldConfig[]
   ): Record<string, unknown> {
     const result: Record<string, unknown> = {};
+
+    // Coerce date-field strings into `Date` objects before column mapping
+    // so Drizzle can bind them to `timestamp` columns. JSON request bodies
+    // always deliver dates as ISO strings; without this step the adapter
+    // throws `value.toISOString is not a function`. Covers every component
+    // write path because both `buildInsertRow` and the in-place update
+    // sites funnel through here.
+    coerceDateFieldsToDate(data, fields);
 
     const fieldMap = new Map<string, FieldConfig>();
     for (const field of fields) {

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -27,6 +27,7 @@ import type { HookRegistry } from "../../../hooks/hook-registry";
 import { keysToSnakeCase } from "../../../lib/case-conversion";
 import type { ComponentDataService } from "../../../services/components/component-data-service";
 import { BaseService } from "../../../shared/base-service";
+import { coerceDateFieldsToDate } from "../../../shared/lib/field-transform";
 import type { Logger } from "../../../shared/types";
 import type {
   SingleDocument,
@@ -192,6 +193,12 @@ export class SingleMutationService extends BaseService {
 
       // 6.5. Normalize upload field values (strip expanded media objects to IDs)
       normalizeUploadFields(currentData, fieldConfigs);
+
+      // 6.6. Coerce date-field strings into `Date` objects so Drizzle can
+      // bind them to `timestamp` columns. Without this step the adapter
+      // throws `value.toISOString is not a function` because JSON request
+      // bodies always deliver dates as ISO strings.
+      coerceDateFieldsToDate(currentData, fieldConfigs);
 
       // 7. Serialize JSON fields for storage
       const serializedData = serializeJsonFields(currentData, fieldConfigs);

--- a/packages/nextly/src/shared/lib/__tests__/field-transform.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/field-transform.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import type { FieldConfig } from "../../../collections/fields/types";
+import { coerceDateFieldsToDate } from "../field-transform";
+
+const dateField = (name: string): FieldConfig =>
+  ({ name, type: "date" }) as unknown as FieldConfig;
+const textField = (name: string): FieldConfig =>
+  ({ name, type: "text" }) as unknown as FieldConfig;
+
+describe("coerceDateFieldsToDate", () => {
+  it("converts string values for date fields into Date instances", () => {
+    const data: Record<string, unknown> = {
+      publishedAt: "2026-05-20T12:22:29.417Z",
+    };
+    const fields = [dateField("publishedAt")];
+
+    coerceDateFieldsToDate(data, fields);
+
+    expect(data.publishedAt).toBeInstanceOf(Date);
+    expect((data.publishedAt as Date).toISOString()).toBe(
+      "2026-05-20T12:22:29.417Z"
+    );
+  });
+
+  // Idempotency matters because singles' `update` flow can run the
+  // helper across nested-component data that has already been coerced
+  // upstream. A non-string `Date` must pass through untouched.
+  it("leaves existing Date values unchanged", () => {
+    const existing = new Date("2026-01-01T00:00:00.000Z");
+    const data: Record<string, unknown> = { startsAt: existing };
+    coerceDateFieldsToDate(data, [dateField("startsAt")]);
+    expect(data.startsAt).toBe(existing);
+  });
+
+  it("ignores null and undefined values", () => {
+    const data: Record<string, unknown> = {
+      a: null,
+      b: undefined,
+    };
+    coerceDateFieldsToDate(data, [dateField("a"), dateField("b")]);
+    expect(data.a).toBeNull();
+    expect(data.b).toBeUndefined();
+  });
+
+  it("does not touch non-date fields that happen to hold ISO strings", () => {
+    const data: Record<string, unknown> = {
+      title: "2026-05-20T12:22:29.417Z",
+    };
+    coerceDateFieldsToDate(data, [textField("title")]);
+    expect(data.title).toBe("2026-05-20T12:22:29.417Z");
+  });
+});

--- a/packages/nextly/src/shared/lib/field-transform.ts
+++ b/packages/nextly/src/shared/lib/field-transform.ts
@@ -65,9 +65,7 @@ export interface TransformOptions {
  * Check if a field type is a layout-only field (no data storage).
  */
 function isLayoutField(field: FieldConfig): boolean {
-  return LAYOUT_FIELD_TYPES.includes(
-    field.type
-  );
+  return LAYOUT_FIELD_TYPES.includes(field.type);
 }
 
 /**
@@ -511,6 +509,39 @@ export function requiresTransformation(fieldType: string): boolean {
     fieldType === "upload" ||
     fieldType === "date"
   );
+}
+
+/**
+ * Coerce string values for `field.type === "date"` columns into `Date`
+ * objects, mutating `data` in place. Drizzle binds `timestamp` columns
+ * by calling `.toISOString()` on the bound value, so an ISO string
+ * travelling through the adapter unmodified surfaces as
+ * `value.toISOString is not a function` at the driver layer. JSON
+ * request bodies always deliver dates as strings, so mutation services
+ * must coerce before handing the row to the adapter.
+ *
+ * Non-string values (existing `Date`, `null`, `undefined`) pass through
+ * untouched, so the function is idempotent and safe to call on rows
+ * that were coerced upstream.
+ *
+ * The `fields` parameter is intentionally structural rather than
+ * `FieldConfig[]`: collections feed their stored `FieldDefinition[]`
+ * (from `schemas/dynamic-collections.ts`) through the same path as
+ * singles' static `FieldConfig[]`. Both shapes carry `name` + `type` as
+ * strings, which is all this routine inspects.
+ */
+export function coerceDateFieldsToDate(
+  data: Record<string, unknown>,
+  fields: ReadonlyArray<{ name?: string; type?: string }>
+): void {
+  for (const field of fields) {
+    if (!field.name) continue;
+    if (field.type !== "date") continue;
+    const value = data[field.name];
+    if (typeof value === "string") {
+      data[field.name] = new Date(value);
+    }
+  }
 }
 
 // ============================================================

--- a/packages/nextly/src/shared/lib/index.ts
+++ b/packages/nextly/src/shared/lib/index.ts
@@ -15,6 +15,7 @@ export {
   transformFromStorage,
   getSerializedFieldNames,
   requiresTransformation,
+  coerceDateFieldsToDate,
   type TransformOptions,
   transformRichTextFields,
 } from "./field-transform";


### PR DESCRIPTION
JSON request bodies deliver date values as ISO strings, but Drizzle binds `timestamp` columns by calling `.toISOString()` on the bound value, so an unmodified string blows up at the driver layer with `value.toISOString is not a function`. Singles and components were missing the coercion that collections already had inlined at every write site.

A new `coerceDateFieldsToDate(data, fields)` helper in `shared/lib/field-transform.ts` mutates the row in place, converting string values for `field.type === "date"` columns into `Date` objects. Wired into `SingleMutationService.update` and into `ComponentMutationService.serializeComponentRow` (which feeds every component insert / update path). The six inline copies in `CollectionMutationService` are collapsed onto the same helper so there is one implementation across all three domains. Unit tests cover coercion, idempotency, null / undefined pass-through, and no-touch behaviour for non-date fields.

## Summary

<!-- What does this PR do and why? Keep it short. -->

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / chore (no user-facing change)

## Related issues

<!-- e.g. Closes #123, Refs #456 -->

## Changeset

This repo uses [Changesets](https://github.com/changesets/changesets). If your PR changes any publishable package under `packages/*`, you **must** include a changeset:

```bash
pnpm changeset
```

Then commit the generated `.changeset/*.md` file.

- [ ] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [ ] I selected the correct semver bump (patch / minor / major)

> The `changeset-check` CI job will fail if a publishable package is modified without a changeset.

## Test plan

<!-- How did you verify this works? Commands run, scenarios tested, screenshots, etc. -->

- [ ] `pnpm lint`
- [ ] `pnpm check-types`
- [ ] `pnpm build`
- [ ] Manually verified the change

## Checklist

- [ ] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [ ] I targeted the `main` branch
- [ ] I updated relevant documentation

## Screenshots / recordings

<!-- Optional. Drag images or videos here for UI changes. -->

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to? Migration risks, perf concerns, etc. -->
