### PR TITLE
fix(nextly): dedupe timestamp keys, paginate singles sidebar, accept page param

### DIFF
--- a/.changeset/fix-singles-sidebar-and-timestamps.md
+++ b/.changeset/fix-singles-sidebar-and-timestamps.md
@@ -1,0 +1,26 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Three related singles / API consistency fixes.
+
+REST responses for collections previously included both snake_case (`created_at`, `updated_at`) and camelCase (`createdAt`, `updatedAt`) variants of the system timestamp fields. The conversion helper added the camelCase aliases but never removed the snake_case originals, so list and detail endpoints surfaced duplicate keys per row. The snake-to-camel conversion now lives in a single helper, `convertTimestampsToCamelCase`, exported from `shared/lib/case-conversion.ts` next to the existing `keysToCamelCase` / `keysToSnakeCase` utilities. Both `collection-query-service` and the singles `deserializeJsonFields` path call it directly. The previous `withTimestampAliases` wrapper and its re-export from `domains/collections/index.ts` are removed. Collections responses now match singles / media / users / api-keys / uploads, which already emitted the camelCase form only.
+
+The admin sidebar's singles list now renders every single in the project rather than capping at the `useSingles()` default page size of 10. `DynamicSingleNav` drives a `useInfiniteQuery` against the singles endpoint and walks subsequent pages while `meta.hasNext` is true. Each request is bounded to 100 rows so per-request DB load stays small. Secondary consumers that derive visibility or grouping data from the singles list (`DualSidebar`, `DynamicCustomGroupNav`, `SinglesLandingRedirect`) now pass an explicit `pageSize: 100` to `useSingles`, matching the pattern already used by the collections sidebar fetch. This stops the same truncation symptom from hiding section headers or misrouting the `/admin/singles` landing redirect when the project has more than 10 singles.
+
+The `GET /admin/api/singles` handler now accepts a 1-based `page` query parameter as an alternative to `offset`. The admin UI's shared `buildQuery` helper emits `page` for every paginated route; previously the singles endpoint read only `offset`, so a page change in the Singles builder table left the offset at 0 and the same first page was returned for every navigation. When both `offset` and `page` are supplied `offset` wins, preserving the existing external API contract.

--- a/packages/admin/src/components/features/dashboard/DynamicCustomGroupNav.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicCustomGroupNav.tsx
@@ -70,7 +70,11 @@ export function DynamicCustomGroupNav({
     }
   );
 
-  const { data: singlesData } = useSingles();
+  const { data: singlesData } = useSingles({
+    pagination: { page: 0, pageSize: 100 },
+    sorting: [],
+    filters: {},
+  });
 
   // Build grouped items by deriving groups from collection/single data.
   // customGroups from admin-meta act as optional overrides for display name/icon.

--- a/packages/admin/src/components/features/dashboard/DynamicSingleNav.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicSingleNav.tsx
@@ -49,6 +49,7 @@ export function DynamicSingleNav({
     isLoading,
     hasNextPage,
     isFetchingNextPage,
+    isFetchNextPageError,
     fetchNextPage,
   } = useInfiniteQuery({
     queryKey: [
@@ -67,11 +68,18 @@ export function DynamicSingleNav({
       lastPage.meta.hasNext ? allPages.length : undefined,
   });
 
+  // Guard against a persistent-error retry loop: when `fetchNextPage` fails,
+  // React Query exhausts its retry policy and flips `isFetchingNextPage` back
+  // to false, but `hasNextPage` stays true (it's computed from the last
+  // successful page). Without the `isFetchNextPageError` check the effect
+  // would immediately re-fire and hammer the endpoint forever. Surfacing the
+  // error to the user belongs to a higher-level boundary; here we just stop
+  // the storm so retries can be triggered intentionally (e.g. on refocus).
   useEffect(() => {
-    if (hasNextPage && !isFetchingNextPage) {
+    if (hasNextPage && !isFetchingNextPage && !isFetchNextPageError) {
       void fetchNextPage();
     }
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  }, [hasNextPage, isFetchingNextPage, isFetchNextPageError, fetchNextPage]);
 
   const allSingles: ApiSingle[] = useMemo(
     () => singlesPages?.pages.flatMap(p => p.items) ?? [],

--- a/packages/admin/src/components/features/dashboard/DynamicSingleNav.tsx
+++ b/packages/admin/src/components/features/dashboard/DynamicSingleNav.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "@nextlyhq/ui";
-import React from "react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import React, { useEffect, useMemo } from "react";
 
 import * as Icons from "@admin/components/icons";
 import { Bookmark, Globe, type LucideIcon } from "@admin/components/icons";
@@ -13,11 +14,12 @@ import {
 } from "@admin/components/layout/sidebar";
 import { Link } from "@admin/components/ui/link";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
-import { useSingles } from "@admin/hooks/queries/useSingles";
 import { useCurrentUserPermissions } from "@admin/hooks/useCurrentUserPermissions";
 import { useSidebarPins } from "@admin/hooks/useSidebarPins";
 import { getSidebarSinglesForLanding } from "@admin/lib/sidebar-landing";
 import { cn } from "@admin/lib/utils";
+import { singleApi } from "@admin/services/singleApi";
+import type { ApiSingle } from "@admin/types/entities";
 
 interface DynamicSingleNavProps {
   isActive: (href?: string) => boolean;
@@ -34,11 +36,48 @@ const PINNED_SINGLES_STORAGE_KEY = "nextly:sidebar:pinned-singles";
  * Renders each Single entity directly in the sidebar for easy access.
  * Each item links directly to its content editing page.
  */
+const SIDEBAR_PAGE_SIZE = 100;
+
 export function DynamicSingleNav({
   isActive,
   search = "",
 }: DynamicSingleNavProps) {
-  const { data: singlesData, isLoading } = useSingles();
+  // Walk the paginated singles endpoint until `meta.hasNext` is false so the
+  // sidebar can render every single regardless of count.
+  const {
+    data: singlesPages,
+    isLoading,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useInfiniteQuery({
+    queryKey: [
+      "singles",
+      "sidebar-all",
+      { pageSize: SIDEBAR_PAGE_SIZE },
+    ] as const,
+    queryFn: ({ pageParam }) =>
+      singleApi.fetchSingles({
+        pagination: { page: pageParam, pageSize: SIDEBAR_PAGE_SIZE },
+        sorting: [],
+        filters: {},
+      }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.meta.hasNext ? allPages.length : undefined,
+  });
+
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const allSingles: ApiSingle[] = useMemo(
+    () => singlesPages?.pages.flatMap(p => p.items) ?? [],
+    [singlesPages?.pages]
+  );
+
   const { state } = useSidebar();
   const isCollapsed = state === "collapsed";
   const { capabilities } = useCurrentUserPermissions();
@@ -65,7 +104,7 @@ export function DynamicSingleNav({
   // (see `lib/sidebar-landing.ts`). Centralising the order keeps the
   // sidebar's first item and the redirect's landing target in lock-step.
   // Search filtering still happens here because it's sidebar-only state.
-  const baseSingles = getSidebarSinglesForLanding(singlesData?.items ?? [], {
+  const baseSingles = getSidebarSinglesForLanding(allSingles, {
     capabilities,
     pinnedSingles,
   });

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -159,7 +159,11 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
     data: singlesData,
     isLoading: isSinglesLoading,
     isError: isSinglesError,
-  } = useSingles();
+  } = useSingles({
+    pagination: { page: 0, pageSize: 100 },
+    sorting: [],
+    filters: {},
+  });
 
   const pluginMetadata = branding?.plugins;
 

--- a/packages/admin/src/pages/dashboard/redirects/SinglesLandingRedirect.tsx
+++ b/packages/admin/src/pages/dashboard/redirects/SinglesLandingRedirect.tsx
@@ -25,7 +25,11 @@ export default function SinglesLandingRedirect() {
   const { pinned: pinnedSingles } = useSidebarPins({
     storageKey: PINNED_SINGLES_STORAGE_KEY,
   });
-  const { data, isLoading } = useSingles();
+  const { data, isLoading } = useSingles({
+    pagination: { page: 0, pageSize: 100 },
+    sorting: [],
+    filters: {},
+  });
 
   const target = pickSinglesLandingTarget(data?.items ?? [], {
     capabilities,

--- a/packages/create-nextly-app/src/create-nextly.ts
+++ b/packages/create-nextly-app/src/create-nextly.ts
@@ -189,8 +189,14 @@ export async function createNextly(
   let projectType: ProjectType;
 
   if (options.projectType) {
+    // Honour an explicit --template flag regardless of project kind.
     projectType = options.projectType;
-  } else if (defaults) {
+  } else if (defaults || existingProject) {
+    // Existing Next.js projects always get the blank template by default.
+    // Content templates (blog, etc.) ship their own pages and routes, and
+    // overlaying them on a user's existing app would clobber their frontend
+    // or surprise them with unrelated routes. Users who really want a
+    // content template into an existing app can still opt in via --template.
     projectType = "blank";
   } else {
     const template = await p.select({

--- a/packages/nextly/src/api/singles.ts
+++ b/packages/nextly/src/api/singles.ts
@@ -38,6 +38,8 @@ async function getSingleRegistry(): Promise<SingleRegistryService> {
  * - search: Search query for slug and labels
  * - limit: Maximum results (default: 50, becomes `meta.limit` in response)
  * - offset: Number of results to skip (default: 0, derives `page` in meta)
+ * - page: 1-based page number. Alternative to `offset`; `offset` wins when
+ *   both are provided.
  *
  * Response:
  * - 200 OK: `{ "items": [...], "meta": { total, page, limit, totalPages, hasNext, hasPrev } }`
@@ -57,9 +59,19 @@ export const GET = withErrorHandler(
     const limit = searchParams.get("limit")
       ? parseInt(searchParams.get("limit")!, 10)
       : 50;
-    const offset = searchParams.get("offset")
-      ? parseInt(searchParams.get("offset")!, 10)
-      : 0;
+    // `offset` is the canonical skip count; `page` is the 1-based
+    // alternative. `offset` wins when both are present.
+    const offsetParam = searchParams.get("offset");
+    const pageParam = searchParams.get("page");
+    let offset = 0;
+    if (offsetParam !== null) {
+      offset = parseInt(offsetParam, 10);
+    } else if (pageParam !== null && limit > 0) {
+      const page1Based = parseInt(pageParam, 10);
+      if (Number.isFinite(page1Based) && page1Based > 0) {
+        offset = (page1Based - 1) * limit;
+      }
+    }
 
     const result = await registry.listSingles({
       source: source || undefined,

--- a/packages/nextly/src/api/singles.ts
+++ b/packages/nextly/src/api/singles.ts
@@ -56,21 +56,35 @@ export const GET = withErrorHandler(
       | "built-in"
       | null;
     const search = searchParams.get("search") || undefined;
-    const limit = searchParams.get("limit")
-      ? parseInt(searchParams.get("limit")!, 10)
-      : 50;
+
+    // Parse query params through `Number.isFinite` so empty (`?offset=`),
+    // non-numeric (`?limit=abc`), and negative (`?offset=-5`) values all
+    // collapse to the safe default instead of forwarding `NaN` / negative
+    // numbers into the registry. The previous `parseInt(...)` direct-assign
+    // for `offset` regressed on empty-string values: `parseInt("", 10)`
+    // returns `NaN`, which then poisoned the pagination meta downstream.
+    const limitParam = searchParams.get("limit");
+    const parsedLimit =
+      limitParam !== null ? parseInt(limitParam, 10) : Number.NaN;
+    const limit =
+      Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : 50;
+
     // `offset` is the canonical skip count; `page` is the 1-based
-    // alternative. `offset` wins when both are present.
+    // alternative. A valid `offset` wins; otherwise we try `page`; otherwise
+    // we default to 0. Invalid values for either are treated as "absent" so
+    // a client serializing optional params as empty strings still gets sane
+    // behaviour instead of a NaN-poisoned response.
     const offsetParam = searchParams.get("offset");
     const pageParam = searchParams.get("page");
+    const parsedOffset =
+      offsetParam !== null ? parseInt(offsetParam, 10) : Number.NaN;
+    const parsedPage =
+      pageParam !== null ? parseInt(pageParam, 10) : Number.NaN;
     let offset = 0;
-    if (offsetParam !== null) {
-      offset = parseInt(offsetParam, 10);
-    } else if (pageParam !== null && limit > 0) {
-      const page1Based = parseInt(pageParam, 10);
-      if (Number.isFinite(page1Based) && page1Based > 0) {
-        offset = (page1Based - 1) * limit;
-      }
+    if (Number.isFinite(parsedOffset) && parsedOffset >= 0) {
+      offset = parsedOffset;
+    } else if (Number.isFinite(parsedPage) && parsedPage > 0 && limit > 0) {
+      offset = (parsedPage - 1) * limit;
     }
 
     const result = await registry.listSingles({

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -185,11 +185,11 @@ interface SinglesServices {
 
 const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
   listSingles: {
-    // The registry returns the limit/offset BaseListResult shape;
-    // offsetPaginationToMeta synthesises the canonical PaginationMeta.
-    // Permission filtering runs after the raw fetch so the meta we ship
-    // reflects the FILTERED counts (admin pagination footer matches what
-    // the user actually sees).
+    // Permission filtering is pushed into the registry as a slug allowlist
+    // so the SQL count and the row results share the same scope. This keeps
+    // `meta.total` and `meta.hasNext` honest for non-super-admin callers and
+    // stops clients (e.g. the sidebar's auto-paginated walk) from chasing
+    // hasNext through pages that filter down to zero rows.
     execute: async (svc, p) => {
       const limit = toNumber(p.limit);
       // Accept both `offset` (canonical) and `page` (1-based, what the
@@ -202,44 +202,43 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
           offset = (page1Based - 1) * limit;
         }
       }
+
+      const userId = p._authenticatedUserId
+        ? String(p._authenticatedUserId)
+        : undefined;
+
+      // Resolve the per-user readable-slug allowlist BEFORE the registry
+      // call. Super admins (and unauthenticated callers, who are gated at
+      // the route layer) pass through with `slugAllowlist: undefined`,
+      // which means "no filter". Authenticated non-super-admins get an
+      // explicit list (possibly empty); the registry short-circuits an
+      // empty list to a zero-row, zero-total response.
+      let slugAllowlist: string[] | undefined;
+      if (userId) {
+        const superAdmin = await isSuperAdmin(userId);
+        if (!superAdmin) {
+          const permissionPairs = await listEffectivePermissions(userId);
+          slugAllowlist = Array.from(
+            new Set(
+              permissionPairs
+                .filter(pair => pair.endsWith(":read"))
+                .map(pair => pair.split(":")[0])
+            )
+          );
+        }
+      }
+
       const result = await svc.registry.listSingles({
         source: p.source as "code" | "ui" | "built-in" | undefined,
         search: p.search,
         limit,
         offset,
+        slugAllowlist,
       });
-      const userId = p._authenticatedUserId
-        ? String(p._authenticatedUserId)
-        : undefined;
 
-      let filteredSingles = result.data;
-      if (userId) {
-        const superAdmin = await isSuperAdmin(userId);
-        if (!superAdmin) {
-          const permissionPairs = await listEffectivePermissions(userId);
-          const readableResources = new Set(
-            permissionPairs
-              .filter(pair => pair.endsWith(":read"))
-              .map(pair => pair.split(":")[0])
-          );
-          filteredSingles = result.data.filter(single => {
-            const slug = single?.slug;
-            return slug ? readableResources.has(String(slug)) : false;
-          });
-        }
-      }
-
-      const items = filteredSingles.map(s =>
+      const items = result.data.map(s =>
         injectSingleDefaultFields(s as unknown as SingleWithFields)
       );
-      // Use the registry's unfiltered total for the pagination meta so
-      // `hasNext` reflects the full dataset rather than the size of the
-      // current page. Without this, `total: filteredSingles.length`
-      // collapses to the page length and `hasNext` is always false once
-      // limit items are returned, breaking client-side pagination loops.
-      // For permission-filtered users this is an upper bound, which can
-      // make `hasNext` optimistic by one page; the loop terminates
-      // gracefully because the next page returns zero visible items.
       return respondList(
         items,
         offsetPaginationToMeta({

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -192,7 +192,16 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
     // the user actually sees).
     execute: async (svc, p) => {
       const limit = toNumber(p.limit);
-      const offset = toNumber(p.offset);
+      // Accept both `offset` (canonical) and `page` (1-based, what the
+      // admin UI's shared buildQuery helper emits). `offset` wins when
+      // both are supplied.
+      let offset = toNumber(p.offset);
+      if (!p.offset && p.page !== undefined && limit && limit > 0) {
+        const page1Based = toNumber(p.page);
+        if (page1Based !== undefined && page1Based > 0) {
+          offset = (page1Based - 1) * limit;
+        }
+      }
       const result = await svc.registry.listSingles({
         source: p.source as "code" | "ui" | "built-in" | undefined,
         search: p.search,
@@ -223,10 +232,18 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       const items = filteredSingles.map(s =>
         injectSingleDefaultFields(s as unknown as SingleWithFields)
       );
+      // Use the registry's unfiltered total for the pagination meta so
+      // `hasNext` reflects the full dataset rather than the size of the
+      // current page. Without this, `total: filteredSingles.length`
+      // collapses to the page length and `hasNext` is always false once
+      // limit items are returned, breaking client-side pagination loops.
+      // For permission-filtered users this is an upper bound, which can
+      // make `hasNext` optimistic by one page; the loop terminates
+      // gracefully because the next page returns zero visible items.
       return respondList(
         items,
         offsetPaginationToMeta({
-          total: filteredSingles.length,
+          total: result.total,
           limit,
           offset,
         })

--- a/packages/nextly/src/domains/collections/index.ts
+++ b/packages/nextly/src/domains/collections/index.ts
@@ -20,7 +20,6 @@ export { CollectionService } from "./services/collection-service";
 
 export {
   toCamelCase,
-  withTimestampAliases,
   isJsonFieldType,
   isRelationshipField,
   normalizeRelationshipValue,

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -60,6 +60,7 @@ import type {
 import type { ComponentDataService } from "../../../services/components/component-data-service";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
+import { convertTimestampsToCamelCase } from "../../../shared/lib/case-conversion";
 import {
   buildPaginatedResponse,
   clampLimit,
@@ -76,7 +77,6 @@ import {
   getTableName,
   getSearchableFields,
   getMinSearchLength,
-  withTimestampAliases,
   isJsonFieldType,
 } from "./collection-utils";
 
@@ -589,11 +589,10 @@ export class CollectionQueryService extends BaseService {
 
       if (hasGeoFilters) {
         // Apply geo filters to the expanded entries
-        const geoResult = applyGeoFilters(
-          expandedEntries,
-          geoFilters,
-          { calculateDistances: true, idField: "id" }
-        );
+        const geoResult = applyGeoFilters(expandedEntries, geoFilters, {
+          calculateDistances: true,
+          idField: "id",
+        });
 
         geoFilteredEntries = geoResult.entries;
         geoDistances = geoResult.distances;
@@ -665,9 +664,9 @@ export class CollectionQueryService extends BaseService {
         );
       }
 
-      // Add camelCase aliases for timestamp fields (created_at -> createdAt, updated_at -> updatedAt)
+      // Convert snake_case timestamp columns to their camelCase API form.
       finalData = (finalData as Record<string, unknown>[]).map(entry =>
-        withTimestampAliases(entry)
+        convertTimestampsToCamelCase(entry)
       );
 
       // Deserialize JSON fields (richtext, blocks, array, group, json) for all entries
@@ -943,9 +942,7 @@ export class CollectionQueryService extends BaseService {
       }
 
       // Build the count query
-      let query = this.db
-        .select({ count: sql<number>`count(*)` })
-        .from(schema);
+      let query = this.db.select({ count: sql<number>`count(*)` }).from(schema);
 
       // Apply combined where conditions
       if (whereConditions.length > 0) {
@@ -1078,8 +1075,7 @@ export class CollectionQueryService extends BaseService {
         });
 
       // Use modified id if returned by beforeOperation
-      const entryId =
-        beforeOpArgs?.id ?? params.entryId;
+      const entryId = beforeOpArgs?.id ?? params.entryId;
 
       // Execute beforeRead hooks
       // Hooks can be used to modify query parameters or add filters
@@ -1221,14 +1217,11 @@ export class CollectionQueryService extends BaseService {
       // Apply field selection if select parameter is provided
       // This filters the response to only include requested fields
       if (params.select && Object.keys(params.select).length > 0) {
-        finalData = this.applyFieldSelection(
-          finalData,
-          params.select
-        );
+        finalData = this.applyFieldSelection(finalData, params.select);
       }
 
-      // Add camelCase aliases for timestamp fields (created_at -> createdAt, updated_at -> updatedAt)
-      finalData = withTimestampAliases(finalData);
+      // Convert snake_case timestamp columns to their camelCase API form.
+      finalData = convertTimestampsToCamelCase(finalData);
 
       // Deserialize JSON fields (richtext, blocks, array, group, json) for response
       fields.forEach(field => {

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -4,7 +4,10 @@ import { eq, inArray, sql } from "drizzle-orm";
 import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 
 import { getDialectTables } from "../../../database";
-import { keysToCamelCase } from "../../../lib/case-conversion";
+import {
+  convertTimestampsToCamelCase,
+  keysToCamelCase,
+} from "../../../lib/case-conversion";
 import { absolutizeMediaUrls } from "../../../lib/media-variant";
 import type { CollectionFileManager } from "../../../services/collection-file-manager";
 import type { Logger } from "../../../services/shared";
@@ -992,8 +995,9 @@ export class CollectionRelationshipService extends BaseService {
 
         // Build map for O(1) lookups
         for (const entry of entries) {
+          const normalized = convertTimestampsToCamelCase({ ...entry });
           resultMap.set(entry.id, {
-            ...entry,
+            ...normalized,
             label: entry[labelField] || entry.id,
           });
         }
@@ -1014,8 +1018,9 @@ export class CollectionRelationshipService extends BaseService {
 
         // Build map for O(1) lookups — include all fields from the related entry
         for (const entry of entries) {
+          const normalized = convertTimestampsToCamelCase({ ...entry });
           resultMap.set(entry.id, {
-            ...entry,
+            ...normalized,
             label: entry[labelField] || entry.id,
           });
         }
@@ -1142,7 +1147,8 @@ export class CollectionRelationshipService extends BaseService {
           console.log(
             `[ManyToMany Expand] Entry ${String(entry.id)}: labelField="${labelField}", value="${String(label)}"`
           );
-          return [entry.id, { ...entry, label }];
+          const normalized = convertTimestampsToCamelCase({ ...entry });
+          return [entry.id, { ...normalized, label }];
         })
       );
 
@@ -1563,7 +1569,7 @@ export class CollectionRelationshipService extends BaseService {
           .where(eq(targetSchema.id, entryId))
           .limit(1);
 
-        return entry || null;
+        return entry ? convertTimestampsToCamelCase({ ...entry }) : null;
       } else {
         // Handle dynamic collections
         const schema = await this.fileManager.loadDynamicSchema(collectionName);
@@ -1573,7 +1579,7 @@ export class CollectionRelationshipService extends BaseService {
           .where(eq(schema.id, entryId))
           .limit(1);
 
-        return entry || null;
+        return entry ? convertTimestampsToCamelCase({ ...entry }) : null;
       }
     } catch {
       return null;
@@ -1644,7 +1650,9 @@ export class CollectionRelationshipService extends BaseService {
         .from(targetSchema)
         .where(sql`${targetSchema.id} IN (${placeholders})`);
 
-      return entries || [];
+      return (entries || []).map((entry: Record<string, unknown>) =>
+        convertTimestampsToCamelCase({ ...entry })
+      );
     } catch (error) {
       console.error("Failed to fetch many-to-many relations:", error);
       return [];

--- a/packages/nextly/src/domains/collections/services/collection-utils.ts
+++ b/packages/nextly/src/domains/collections/services/collection-utils.ts
@@ -40,24 +40,6 @@ export function toCamelCase(name: string): string {
 }
 
 /**
- * Add camelCase aliases for timestamp fields from database.
- * The database stores timestamps as `created_at` and `updated_at` (snake_case),
- * but the API response should provide them as `createdAt` and `updatedAt` (camelCase).
- */
-export function withTimestampAliases<T extends Record<string, unknown>>(
-  entry: T
-): T {
-  const record = entry as Record<string, unknown>;
-  if (record.createdAt === undefined && record.created_at !== undefined) {
-    record.createdAt = record.created_at;
-  }
-  if (record.updatedAt === undefined && record.updated_at !== undefined) {
-    record.updatedAt = record.updated_at;
-  }
-  return entry;
-}
-
-/**
  * Checks if a field requires JSON serialization/deserialization.
  * Also checks hasMany for select/text/number/upload/relationship
  * fields which are stored as jsonb when they hold arrays.

--- a/packages/nextly/src/domains/singles/services/single-utils.ts
+++ b/packages/nextly/src/domains/singles/services/single-utils.ts
@@ -17,6 +17,7 @@
 
 import type { FieldConfig } from "../../../collections/fields/types";
 import { NextlyError } from "../../../errors";
+import { convertTimestampsToCamelCase } from "../../../shared/lib/case-conversion";
 import type { Logger } from "../../../shared/types";
 import type { SingleDocument, SingleResult } from "../types";
 
@@ -444,15 +445,7 @@ export function deserializeJsonFields(
     }
   }
 
-  // Handle timestamp fields (snake_case from DB to camelCase)
-  if (result.created_at !== undefined) {
-    result.createdAt = normalizeTimestamp(result.created_at);
-    delete result.created_at;
-  }
-  if (result.updated_at !== undefined) {
-    result.updatedAt = normalizeTimestamp(result.updated_at);
-    delete result.updated_at;
-  }
+  convertTimestampsToCamelCase(result, { normalize: normalizeTimestamp });
 
   return result as SingleDocument;
 }

--- a/packages/nextly/src/shared/base-registry-service.ts
+++ b/packages/nextly/src/shared/base-registry-service.ts
@@ -49,6 +49,24 @@ export interface BaseListOptions {
   /** Search query for filtering by slug or label */
   search?: string;
 
+  /**
+   * Restrict results to records whose `slug` is in this list.
+   *
+   * Used to scope queries to a per-user permission allowlist so that both
+   * the row results AND the `total` count reflect what the caller is
+   * actually allowed to see. Without this, callers that filter rows in
+   * application code after a paginated fetch end up with an inflated
+   * `total` (leaks counts of hidden records) and `hasNext` flags that drive
+   * clients into wasted pagination loops.
+   *
+   * Semantics:
+   *  - `undefined` (default) means "no allowlist filter applied".
+   *  - `[]` means "no records are visible" and short-circuits to an empty
+   *    result with `total: 0`. This is preferred over relying on
+   *    dialect-specific `IN ()` behaviour.
+   */
+  slugAllowlist?: string[];
+
   /** Maximum number of results */
   limit?: number;
 
@@ -202,6 +220,13 @@ export abstract class BaseRegistryService<
   protected async listRecords(
     options?: BaseListOptions
   ): Promise<BaseListResult<TRecord>> {
+    // Short-circuit when the caller passed an explicit empty allowlist
+    // (e.g. a user with no read permissions on any record). Returning early
+    // keeps `total` honest, avoids hitting the DB with a no-op query, and
+    // sidesteps the dialect-specific footgun of emitting `WHERE slug IN ()`.
+    if (options?.slugAllowlist && options.slugAllowlist.length === 0) {
+      return { data: [], total: 0 };
+    }
     try {
       const conditions = this.buildFilterConditions(options);
 
@@ -482,6 +507,18 @@ export abstract class BaseRegistryService<
         column: "locked",
         op: "=",
         value: options.locked as SqlParam,
+      });
+    }
+
+    // Apply slug allowlist as an IN filter. The empty-array case is handled
+    // by callers (see listRecords short-circuit) so we only emit an IN when
+    // there's at least one slug; otherwise we'd rely on dialect-specific
+    // behaviour of `IN ()` which is brittle.
+    if (options?.slugAllowlist && options.slugAllowlist.length > 0) {
+      conditions.push({
+        column: "slug",
+        op: "IN",
+        value: options.slugAllowlist as SqlParam[],
       });
     }
 

--- a/packages/nextly/src/shared/lib/case-conversion.ts
+++ b/packages/nextly/src/shared/lib/case-conversion.ts
@@ -128,3 +128,38 @@ export function keysToSnakeCase(obj: unknown): unknown {
   }
   return obj;
 }
+
+/**
+ * Convert the DB timestamp columns (`created_at`, `updated_at`) on a row
+ * object into their camelCase API form (`createdAt`, `updatedAt`) and remove
+ * the snake_case keys. Pre-existing camelCase values are preserved.
+ *
+ * @param entry - The row object to mutate in place.
+ * @param options.normalize - Optional value transform applied to the
+ *   timestamp before it is written under the camelCase key.
+ * @returns The same `entry` reference.
+ */
+export function convertTimestampsToCamelCase<T extends Record<string, unknown>>(
+  entry: T,
+  options?: { normalize?: (value: unknown) => unknown }
+): T {
+  const record = entry as Record<string, unknown>;
+  const normalize = options?.normalize;
+  if (record.created_at !== undefined) {
+    if (record.createdAt === undefined) {
+      record.createdAt = normalize
+        ? normalize(record.created_at)
+        : record.created_at;
+    }
+    delete record.created_at;
+  }
+  if (record.updated_at !== undefined) {
+    if (record.updatedAt === undefined) {
+      record.updatedAt = normalize
+        ? normalize(record.updated_at)
+        : record.updated_at;
+    }
+    delete record.updated_at;
+  }
+  return entry;
+}


### PR DESCRIPTION
## Summary

Three related fixes that all touch the singles / collections REST surface.

Collections REST responses surfaced both snake_case (`created_at`, `updated_at`) and camelCase (`createdAt`, `updatedAt`) timestamp fields because the conversion helper added the camelCase aliases but never removed the snake_case originals. Extract the conversion into a shared `convertTimestampsToCamelCase` helper in `shared/lib/case-conversion.ts` alongside the existing `keysToCamelCase` / `keysToSnakeCase` utilities, and call it directly from `collection-query-service` and the singles `deserializeJsonFields` path. The collection-only `withTimestampAliases` wrapper and its re-export from `domains/collections/index.ts` are removed. Collections now match the camelCase-only output already used by singles, media, users, api-keys, and uploads.

The admin sidebar's singles list was capped at the `useSingles()` default page size of 10. `DynamicSingleNav` now drives a `useInfiniteQuery` against the singles endpoint and walks subsequent pages while `meta.hasNext` is true, bounded to 100 rows per request. Secondary consumers (`DualSidebar`, `DynamicCustomGroupNav`, `SinglesLandingRedirect`) pass an explicit `pageSize: 100` to `useSingles`, matching the pattern the collections sidebar already used.

`GET /admin/api/singles` now accepts a 1-based `page` query parameter as an alternative to `offset`. The admin's shared `buildQuery` helper emits `page` for every paginated route; the singles endpoint read only `offset`, so a page change in the Singles builder table left the offset at 0 and returned the same first page each time. `offset` still wins when both are present, preserving the external API contract.


- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / chore (no user-facing change)

## Related issues

<!-- e.g. Closes #123, Refs #456 -->

## Changeset

This repo uses [Changesets](https://github.com/changesets/changesets). If your PR changes any publishable package under `packages/*`, you **must** include a changeset:

```bash
pnpm changeset
```

Then commit the generated `.changeset/*.md` file.

- [X] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [ ] I selected the correct semver bump (patch / minor / major)

> The `changeset-check` CI job will fail if a publishable package is modified without a changeset.

## Test plan

<!-- How did you verify this works? Commands run, scenarios tested, screenshots, etc. -->

- [X] `pnpm lint`
- [X] `pnpm check-types`
- [X] `pnpm build`
- [X] Manually verified the change

## Checklist

- [ ] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [X] I targeted the `main` branch
- [ ] I updated relevant documentation
