### PR TITLE
fix(nextly): add missing create-migration-journal bundled migration

### DIFF
--- a/.changeset/add-missing-migration-journal-create.md
+++ b/.changeset/add-missing-migration-journal-create.md
@@ -1,0 +1,20 @@
+---
+"nextly": patch
+---
+
+Fix `nextly migrate` failing on every fresh database with `relation "nextly_migration_journal" does not exist` (PostgreSQL) / equivalent on MySQL + SQLite, and the dev cold-boot prompting interactively to "rename" or "create" the missing table with destructive options.
+
+**Root cause.** The `nextly_migration_journal` table (F8 PR 5 — runtime audit journal for every schema apply) is declared in three Drizzle schema files (`src/schemas/migration-journal/{postgres,mysql,sqlite}.ts`) but no bundled migration ever creates it. The chain instead jumped straight to `20260501_000000_journal_batch.sql`, which does `ALTER TABLE nextly_migration_journal ADD COLUMN batch ...` — failing because the table doesn't exist yet.
+
+Two downstream symptoms:
+
+1. `nextly migrate` on a fresh DB fails at the journal_batch ALTER — every migration before it applies, then the chain aborts. Operators see `1 failed` in the summary and downstream migrations never run.
+2. The runtime first-run probe (`PROBE_TABLE` in `src/init/first-run.ts` = `"nextly_migration_journal"`) checks for this table to decide whether `ensureFirstRunSetup` should run. Since the table never gets created by migrations, the probe always returns `false` on cold boot, kicking off `freshPushSchema` which uses `drizzle-kit pull` and emits an interactive TTY prompt offering to "rename example_users → nextly_migration_journal" / "rename field_permissions → nextly_migration_journal" — both of which would silently destroy user data if accepted.
+
+**Fix.** Adds a new bundled migration `20260430_000000_000_create_migration_journal.sql` for each of the three dialects (PostgreSQL, MySQL, SQLite) that creates the table per its Drizzle schema declaration. The synthetic `_000000_000` time component sorts the new migration strictly between `20260429_000000_000_initial_journal.sql` (creates the unrelated `nextly_migrations` file-ledger table) and the existing `20260501_000000_journal_batch.sql` (which now succeeds against the newly-created table).
+
+The new migration omits the `batch` column on purpose — the existing `20260501_journal_batch` migration adds it next, preserving the migration audit trail for environments that already ran the earlier subset.
+
+**Note for migrators on a partial-failed state.** Any environment that ran `nextly migrate` on `0.0.2-alpha.14` and hit the `journal_batch` failure has the `nextly_migrations` table created + populated, but `nextly_migration_journal` missing. `nextly migrate` on `0.0.2-alpha.15+` will run the new `20260430_create_migration_journal` migration (creating the missing table) and then re-attempt `20260501_journal_batch` (which now succeeds). No manual intervention required.
+
+**Follow-up recommended.** The repo has no integration test that runs the full bundled migration chain end-to-end against a fresh PostgreSQL container — adding one would have caught this regression. Suggested location: `packages/nextly/src/database/migrations/__tests__/full-chain.integration.test.ts`.

--- a/packages/nextly/src/database/migrations/mysql/20260430_000000_000_create_migration_journal.sql
+++ b/packages/nextly/src/database/migrations/mysql/20260430_000000_000_create_migration_journal.sql
@@ -1,0 +1,43 @@
+-- Migration: create_migration_journal
+-- Generated at: 2026-04-30T00:00:00.000Z
+-- Dialect: MySQL
+--
+-- Mirror of the PostgreSQL create_migration_journal migration. See
+-- the PG file header for the full why; column shape mirrors
+-- packages/nextly/src/schemas/migration-journal/mysql.ts minus the
+-- `batch` column added by the next migration (20260501_journal_batch).
+
+-- UP
+
+CREATE TABLE IF NOT EXISTS `nextly_migration_journal` (
+  `id`                  VARCHAR(36)   NOT NULL PRIMARY KEY,
+  `source`              VARCHAR(20)   NOT NULL,
+  `status`              VARCHAR(20)   NOT NULL DEFAULT 'in_progress',
+  `started_at`          DATETIME(3)   NOT NULL,
+  `ended_at`            DATETIME(3),
+  `duration_ms`         INT,
+  `statements_planned`  INT           NOT NULL DEFAULT 0,
+  `statements_executed` INT,
+  `renames_applied`     INT,
+  `error_code`          VARCHAR(64),
+  `error_message`       TEXT,
+  `scope_kind`          VARCHAR(20),
+  `scope_slug`          VARCHAR(255),
+  `summary_added`       INT,
+  `summary_removed`     INT,
+  `summary_renamed`     INT,
+  `summary_changed`     INT
+);
+
+CREATE INDEX `nextly_migration_journal_status_idx`
+  ON `nextly_migration_journal` (`status`);
+
+CREATE INDEX `nextly_migration_journal_started_at_idx`
+  ON `nextly_migration_journal` (`started_at`);
+
+CREATE INDEX `nextly_migration_journal_source_idx`
+  ON `nextly_migration_journal` (`source`);
+
+-- DOWN
+
+DROP TABLE IF EXISTS `nextly_migration_journal`;

--- a/packages/nextly/src/database/migrations/postgresql/20260430_000000_000_create_migration_journal.sql
+++ b/packages/nextly/src/database/migrations/postgresql/20260430_000000_000_create_migration_journal.sql
@@ -1,0 +1,64 @@
+-- Migration: create_migration_journal
+-- Generated at: 2026-04-30T00:00:00.000Z
+-- Dialect: PostgreSQL
+--
+-- Creates the `nextly_migration_journal` table that the F8 PR-5
+-- audit pipeline + the runtime first-run probe both depend on. Prior
+-- to this migration, the table was declared in the Drizzle schema
+-- (packages/nextly/src/schemas/migration-journal/postgres.ts) but
+-- nothing in the bundled migration chain actually created it, so:
+--
+--   • `nextly migrate` on a fresh DB failed at the immediately-next
+--     migration (`20260501_000000_journal_batch.sql`) with
+--     `relation "nextly_migration_journal" does not exist` because
+--     the ALTER had nothing to alter.
+--   • The runtime first-run probe (`PROBE_TABLE` in src/init/first-run.ts)
+--     never found the table, so it incorrectly re-ran setup on every
+--     cold boot — surfacing as an interactive drizzle-kit prompt that
+--     offered destructive "rename example_users → nextly_migration_journal"
+--     options.
+--
+-- Synthetic 000000_000 time component sorts this file strictly
+-- between `20260429_000000_000_initial_journal.sql` (creates the
+-- unrelated `nextly_migrations` file-ledger table) and the existing
+-- `20260501_000000_journal_batch.sql` (now succeeds against the table
+-- this migration creates).
+--
+-- Column shape mirrors `nextly_migration_journal` from
+-- src/schemas/migration-journal/postgres.ts, minus the `batch`
+-- column which the existing 20260501 migration adds next.
+
+-- UP
+
+CREATE TABLE IF NOT EXISTS "nextly_migration_journal" (
+  "id"                  text         PRIMARY KEY,
+  "source"              varchar(20)  NOT NULL,
+  "status"              varchar(20)  NOT NULL DEFAULT 'in_progress',
+  "started_at"          timestamptz  NOT NULL,
+  "ended_at"            timestamptz,
+  "duration_ms"         integer,
+  "statements_planned"  integer      NOT NULL DEFAULT 0,
+  "statements_executed" integer,
+  "renames_applied"     integer,
+  "error_code"          varchar(64),
+  "error_message"       text,
+  "scope_kind"          varchar(20),
+  "scope_slug"          text,
+  "summary_added"       integer,
+  "summary_removed"     integer,
+  "summary_renamed"     integer,
+  "summary_changed"     integer
+);
+
+CREATE INDEX IF NOT EXISTS "nextly_migration_journal_status_idx"
+  ON "nextly_migration_journal" ("status");
+
+CREATE INDEX IF NOT EXISTS "nextly_migration_journal_started_at_idx"
+  ON "nextly_migration_journal" ("started_at");
+
+CREATE INDEX IF NOT EXISTS "nextly_migration_journal_source_idx"
+  ON "nextly_migration_journal" ("source");
+
+-- DOWN
+
+DROP TABLE IF EXISTS "nextly_migration_journal";

--- a/packages/nextly/src/database/migrations/sqlite/20260430_000000_000_create_migration_journal.sql
+++ b/packages/nextly/src/database/migrations/sqlite/20260430_000000_000_create_migration_journal.sql
@@ -1,0 +1,45 @@
+-- Migration: create_migration_journal
+-- Generated at: 2026-04-30T00:00:00.000Z
+-- Dialect: SQLite
+--
+-- Mirror of the PostgreSQL create_migration_journal migration. See
+-- the PG file header for the full why; column shape mirrors
+-- packages/nextly/src/schemas/migration-journal/sqlite.ts minus the
+-- `batch` column added by the next migration (20260501_journal_batch).
+-- SQLite stores timestamps as INTEGER epoch-ms (matches the schema's
+-- `mode: "timestamp_ms"`).
+
+-- UP
+
+CREATE TABLE IF NOT EXISTS "nextly_migration_journal" (
+  "id"                  TEXT     PRIMARY KEY NOT NULL,
+  "source"              TEXT     NOT NULL,
+  "status"              TEXT     NOT NULL DEFAULT 'in_progress',
+  "started_at"          INTEGER  NOT NULL,
+  "ended_at"            INTEGER,
+  "duration_ms"         INTEGER,
+  "statements_planned"  INTEGER  NOT NULL DEFAULT 0,
+  "statements_executed" INTEGER,
+  "renames_applied"     INTEGER,
+  "error_code"          TEXT,
+  "error_message"       TEXT,
+  "scope_kind"          TEXT,
+  "scope_slug"          TEXT,
+  "summary_added"       INTEGER,
+  "summary_removed"     INTEGER,
+  "summary_renamed"     INTEGER,
+  "summary_changed"     INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS "nextly_migration_journal_status_idx"
+  ON "nextly_migration_journal" ("status");
+
+CREATE INDEX IF NOT EXISTS "nextly_migration_journal_started_at_idx"
+  ON "nextly_migration_journal" ("started_at");
+
+CREATE INDEX IF NOT EXISTS "nextly_migration_journal_source_idx"
+  ON "nextly_migration_journal" ("source");
+
+-- DOWN
+
+DROP TABLE IF EXISTS "nextly_migration_journal";


### PR DESCRIPTION
## Summary

`nextly migrate` fails on every fresh database at the bundled `20260501_000000_journal_batch.sql` migration with `relation "nextly_migration_journal" does not exist` (PG) / equivalent on MySQL + SQLite — because **no bundled migration creates that table**, even though three Drizzle schema files declare it.

The same root cause makes the runtime first-run probe (`PROBE_TABLE` in `src/init/first-run.ts`) always return `false` on cold boot. That kicks off `freshPushSchema` → `drizzle-kit pull` → an interactive TTY prompt offering to "rename `example_users` → `nextly_migration_journal`" or "rename `field_permissions` → `nextly_migration_journal`". Either choice silently destroys user data.

## The bug, end to end

1. Migration `20260429_000000_000_initial_journal.sql` creates `nextly_migrations` (the F11 file-based migration ledger — different table). ✓
2. Migration `20260501_000000_journal_batch.sql` does `ALTER TABLE "nextly_migration_journal" ADD COLUMN "batch" ...`. ✗ — table doesn't exist.
3. Runtime first-run probe checks for `nextly_migration_journal`. ✗ — table doesn't exist.

The Drizzle schemas are correct (see [`src/schemas/migration-journal/postgres.ts`](packages/nextly/src/schemas/migration-journal/postgres.ts), [`mysql.ts`](packages/nextly/src/schemas/migration-journal/mysql.ts), [`sqlite.ts`](packages/nextly/src/schemas/migration-journal/sqlite.ts)). The migration that creates the table is just missing.

## Fix

Adds `20260430_000000_000_create_migration_journal.sql` for each of the three dialects, slotted strictly between the existing `20260429` and `20260501` migrations. Column shapes mirror each Drizzle schema exactly, minus the `batch` column — the existing `20260501_journal_batch` migration adds it next, so the audit-trail of "schema evolved here" is preserved for environments that already ran the earlier subset.

## Impact on existing installs

- **Fresh installs:** `nextly migrate` completes cleanly through the full chain.
- **Half-applied (alpha.14 hit the `journal_batch` failure):** the new `20260430_create_migration_journal` migration runs (creates the missing table), then the previously-failed `20260501_journal_batch` migration re-attempts and succeeds. No manual SQL required.
- **Already worked-around (e.g. operators who manually patched node_modules to alter `nextly_migrations` instead):** still need to drop the spurious `batch` column from `nextly_migrations` after upgrading. Worth a note in the changelog.

## Test plan

- [x] `pnpm --filter nextly lint` clean
- [x] `pnpm --filter nextly check-types` clean
- [ ] **Not added in this PR:** an integration test that runs the full bundled migration chain end-to-end against a fresh PG container. Suggested location: `packages/nextly/src/database/migrations/__tests__/full-chain.integration.test.ts`. Would have caught this regression at CI time. Happy to add in a follow-up.

## Related bug not fixed in this PR

`dynamic_collections` declares a `status: boolean` column in all three Drizzle schemas (`src/schemas/dynamic-collections/{postgres,mysql,sqlite}.ts`) but no migration creates it. The runtime `getCollection()` method does a bare `.select()` which expands to all columns including `status`, hitting `column "status" does not exist`. Effect: every code-first collection registration fails with a swallowed `[INTERNAL_ERROR]`, blocking `GET /admin/api/auth/setup-status` with a 500. SQLite has no migrations for `dynamic_collections` at all. Will file as a separate PR; happy to bundle if preferred.

## Discovered by

[`mobeen-site/findings/05-nextly-internal-table-naming-drift.md`](https://github.com/revnix/mobeen-site/blob/dev/findings/05-nextly-internal-table-naming-drift.md) — full reproduction from a fresh `pnpm create nextly-app@alpha`.

## Changeset

`patch` on `nextly`.