### PR TITLE
fix(nextly): add missing status column to dynamic_collections and dynamic_singles

### DIFF
--- a/.changeset/dynamic-collections-singles-missing-status-column.md
+++ b/.changeset/dynamic-collections-singles-missing-status-column.md
@@ -1,0 +1,17 @@
+---
+"nextly": patch
+---
+
+Fix `dynamic_collections` and `dynamic_singles` registration silently failing on PostgreSQL + MySQL with a swallowed `[INTERNAL_ERROR] An unexpected error occurred.`, blocking code-first collection/single registration and surfacing as a 500 on `GET /admin/api/auth/setup-status` on a fresh database.
+
+**Root cause.** Both tables' Drizzle schemas declare `status: boolean("status").default(false).notNull()` (see [`src/schemas/dynamic-collections/postgres.ts`](packages/nextly/src/schemas/dynamic-collections/postgres.ts) line 140 and [`src/schemas/dynamic-singles/postgres.ts`](packages/nextly/src/schemas/dynamic-singles/postgres.ts)), but no migration ever created the column. The runtime `DynamicCollectionRegistryService.getCollection()` at [`src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts`](packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts) line 297 calls `.select()` without an explicit column list — Drizzle expands that to all declared columns including `status`. PostgreSQL returns `column "status" does not exist`, the adapter wraps it as a generic internal error, and the registration loop reports `errors: N` for every code-first collection/single the user defined.
+
+This is distinct from the existing `migration_status` varchar column on both tables (which tracks schema-apply state, not draft/published lifecycle).
+
+**Fix.** Adds `20260521_120000_000_dynamic_collections_singles_status.sql` for PostgreSQL and MySQL that does `ALTER TABLE … ADD COLUMN status` matching the Drizzle default (`NOT NULL DEFAULT false`). Existing rows (typically empty on fresh boot) inherit the `false` default.
+
+**SQLite — not fixed here, but noted.** SQLite has no bundled migrations for `dynamic_collections` at all (or `dynamic_singles` — verify). The Drizzle schemas declare both tables but no `dist/migrations/sqlite/*` file creates them. Anyone using SQLite as their primary database cannot use code-first collections today. That gap needs its own PR with a `0008_dynamic_collections.sql` (and singles equivalent) bundled for SQLite — out of scope here because the bug surface is much larger than the missing column.
+
+**Test gap that masked this.** The existing [`dynamic-collections-status-column.test.ts`](packages/nextly/src/database/__tests__/dynamic-collections-status-column.test.ts) verifies the Drizzle descriptor has the `status` column, which always passes. There is no integration test that runs the bundled migration chain against a fresh PG container and asserts `SELECT status FROM dynamic_collections` is queryable. Adding one would have caught this. Suggested follow-up alongside the equivalent test for the migration-journal create gap.
+
+**Discovered by.** [`mobeen-site/findings/05-nextly-internal-table-naming-drift.md`](https://github.com/revnix/mobeen-site/blob/dev/findings/05-nextly-internal-table-naming-drift.md) (same investigation that surfaced the missing-create-migration-journal bug).

--- a/packages/nextly/src/database/migrations/mysql/20260521_120000_000_dynamic_collections_singles_status.sql
+++ b/packages/nextly/src/database/migrations/mysql/20260521_120000_000_dynamic_collections_singles_status.sql
@@ -1,0 +1,19 @@
+-- Migration: dynamic_collections_singles_status
+-- Generated at: 2026-05-21T12:00:00.000Z
+-- Dialect: MySQL
+--
+-- Mirror of the PostgreSQL dynamic_collections_singles_status
+-- migration. See the PG file header for the full why.
+
+-- UP
+
+ALTER TABLE `dynamic_collections`
+  ADD COLUMN `status` TINYINT(1) NOT NULL DEFAULT 0;
+
+ALTER TABLE `dynamic_singles`
+  ADD COLUMN `status` TINYINT(1) NOT NULL DEFAULT 0;
+
+-- DOWN
+
+ALTER TABLE `dynamic_collections` DROP COLUMN `status`;
+ALTER TABLE `dynamic_singles` DROP COLUMN `status`;

--- a/packages/nextly/src/database/migrations/postgresql/20260521_120000_000_dynamic_collections_singles_status.sql
+++ b/packages/nextly/src/database/migrations/postgresql/20260521_120000_000_dynamic_collections_singles_status.sql
@@ -1,0 +1,43 @@
+-- Migration: dynamic_collections_singles_status
+-- Generated at: 2026-05-21T12:00:00.000Z
+-- Dialect: PostgreSQL
+--
+-- Adds the `status` column to `dynamic_collections` and
+-- `dynamic_singles`. Both tables' Drizzle schemas declare
+-- `status: boolean("status").default(false).notNull()`
+-- (see src/schemas/dynamic-collections/postgres.ts:140 and
+-- src/schemas/dynamic-singles/postgres.ts), but no migration
+-- ever created the column.
+--
+-- The runtime DynamicCollectionRegistryService.getCollection
+-- (src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts:297)
+-- and the equivalent singles registry call `.select()` without
+-- an explicit column list — Drizzle expands that to every
+-- declared column including `status`. PostgreSQL then returns
+-- `column "status" does not exist`, the adapter swallows the
+-- error as `[INTERNAL_ERROR] An unexpected error occurred.`,
+-- and code-first collection / single registration fails with
+-- `errors: N` for every code-first entry the user defined.
+-- Downstream symptom: `GET /admin/api/auth/setup-status`
+-- returns 500 on a fresh DB, blocking the admin setup flow.
+--
+-- This is distinct from the existing `migration_status`
+-- varchar column (which tracks schema-apply state, not
+-- draft/published lifecycle).
+--
+-- The column is `NOT NULL DEFAULT false`, matching the Drizzle
+-- default. Existing rows (if any — these tables are typically
+-- empty on first boot) get `false` (draft).
+
+-- UP
+
+ALTER TABLE "dynamic_collections"
+  ADD COLUMN IF NOT EXISTS "status" boolean NOT NULL DEFAULT false;
+
+ALTER TABLE "dynamic_singles"
+  ADD COLUMN IF NOT EXISTS "status" boolean NOT NULL DEFAULT false;
+
+-- DOWN
+
+ALTER TABLE "dynamic_collections" DROP COLUMN IF EXISTS "status";
+ALTER TABLE "dynamic_singles" DROP COLUMN IF EXISTS "status";


### PR DESCRIPTION
## Summary

`GET /admin/api/auth/setup-status` returns 500 on a fresh PostgreSQL or MySQL database because **`dynamic_collections.status` and `dynamic_singles.status` are declared in the Drizzle schemas but never created by any bundled migration**. The runtime registry does a bare `.select()` that expands to all declared columns; PG returns `column "status" does not exist`; the adapter wraps it as a generic `[INTERNAL_ERROR]` so the actual postgres message never surfaces. Effect: every code-first collection / single registration fails, admin won't boot.

## The bug

- Drizzle schemas declare it ([`postgres.ts:140`](packages/nextly/src/schemas/dynamic-collections/postgres.ts), mysql/sqlite equivalents).
- A test ([`dynamic-collections-status-column.test.ts`](packages/nextly/src/database/__tests__/dynamic-collections-status-column.test.ts)) verifies the Drizzle descriptor has it — passes trivially.
- **No migration adds it.** PG `0006_dynamic_collections_update.sql` adds 14 columns to `dynamic_collections`; `status` is not one of them. MySQL `0011_missing_tables_and_columns.sql` creates the table with 20 columns; `status` is not one of them.
- Runtime [`DynamicCollectionRegistryService.getCollection()`](packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts) line 297 calls `.select().from(this.dynamicCollections)` — Drizzle expands to all declared columns. PG: `column "status" does not exist`. Adapter swallows: `[INTERNAL_ERROR] An unexpected error occurred.`

Same bug exists on `dynamic_singles` (Drizzle declares the column; no migration adds it).

This is distinct from the `migration_status` varchar column both tables have, which tracks schema-apply state, not the draft/published lifecycle.

## Fix

Adds `20260521_120000_000_dynamic_collections_singles_status.sql` for PG + MySQL: `ALTER TABLE … ADD COLUMN status boolean NOT NULL DEFAULT false` (matching the Drizzle default). Existing rows (typically empty on first boot) inherit `false`.

## SQLite — not fixed here

SQLite has **no bundled migrations for `dynamic_collections` at all** (or for `dynamic_singles` — verify). Anyone using SQLite as their primary DB cannot use code-first collections today. That gap needs its own PR creating the full tables for SQLite, not just a `status` add — much larger scope. Happy to do that PR as a follow-up if no one on your team has started.

## Test gap

The existing test only checks the Drizzle descriptor. An integration test that runs the bundled migration chain against a fresh PG container and asserts `SELECT status FROM dynamic_collections` is queryable would have caught this. Same suggested follow-up location as #59: `packages/nextly/src/database/migrations/__tests__/full-chain.integration.test.ts`.

## Test plan

- [x] `pnpm --filter nextly lint` clean
- [x] `pnpm --filter nextly check-types` clean
- [ ] **Not added in this PR:** integration test (see Test gap above).

## Related

- **#59** — the missing `nextly_migration_journal` create migration. Both bugs surfaced from the same investigation. Both need to land in alpha.15 to unblock fresh-DB usage.

## Discovered by

[`mobeen-site/findings/05-nextly-internal-table-naming-drift.md`](https://github.com/revnix/mobeen-site/blob/dev/findings/05-nextly-internal-table-naming-drift.md) and [`findings/06-nextly-slug-conventions.md`](https://github.com/revnix/mobeen-site/blob/dev/findings/06-nextly-slug-conventions.md). Full reproduction from a fresh `pnpm create nextly-app@alpha`.

## Changeset

`patch` on `nextly`.