### PR TITLE
fix(admin): handle pending state in useCurrentUserPermissions hook

### DIFF
--- a/packages/admin/src/hooks/useCurrentUserPermissions.ts
+++ b/packages/admin/src/hooks/useCurrentUserPermissions.ts
@@ -176,14 +176,16 @@ export function useCurrentUserPermissions() {
   // The `/me/permissions` endpoint returns the canonical
   // UserPermissionsResponse shape directly, so `data` here IS the
   // permissions payload.
-  const { data, isLoading, error } = useQuery<UserPermissionsResponse>({
-    queryKey: ["currentUserPermissions"],
-    queryFn: () => protectedApi.get<UserPermissionsResponse>("/me/permissions"),
-    enabled: isPrivateRoute,
-    staleTime: 0,
-    refetchOnMount: "always",
-    refetchOnWindowFocus: true,
-  });
+  const { data, isLoading, isPending, error } =
+    useQuery<UserPermissionsResponse>({
+      queryKey: ["currentUserPermissions"],
+      queryFn: () =>
+        protectedApi.get<UserPermissionsResponse>("/me/permissions"),
+      enabled: isPrivateRoute,
+      staleTime: 0,
+      refetchOnMount: "always",
+      refetchOnWindowFocus: true,
+    });
 
   const permissions = data?.permissions ?? [];
   const isSuperAdmin = data?.isSuperAdmin ?? false;
@@ -219,7 +221,7 @@ export function useCurrentUserPermissions() {
     permissions,
     roles,
     isSuperAdmin,
-    isLoading,
+    isLoading: isLoading || isPending,
     error,
     hasPermission,
     canAccessCollection,


### PR DESCRIPTION
## Summary

Fixes an issue where hard-reloading the browser on any deep admin route (e.g., `/admin/collections/posts`, `/admin/singles/hero`, `/admin/users`) would immediately redirect to `/admin` instead of staying on the current page.

**Root cause:**  
On a hard reload, `useRouter` starts with `route: null` before the hydration effect fires. This makes `isPrivateRoute` evaluate to `false`, which disables the permissions React Query in `useCurrentUserPermissions`.

In TanStack Query v5, a disabled query has:
- `isLoading: false`
- `isPending: true`

`PermissionGuard` only checked `isLoading`, so it saw:
- `isLoading = false` (query disabled)
- `hasAccess = false` (empty capabilities from the unresolved query)

This caused an immediate `navigateTo('/admin')` before permissions had a chance to load.

---

## Fix

`useCurrentUserPermissions` now returns:

```ts
isLoading: isLoading || isPending