### PR TITLE
feat(plugins): P3a — plugin custom permissions (D36 server-side)

### DIFF
--- a/packages/nextly/src/cli/utils/config-loader.ts
+++ b/packages/nextly/src/cli/utils/config-loader.ts
@@ -32,6 +32,7 @@ import {
 import type { NextlyServiceConfig } from "../../di/register";
 import { NextlyError } from "../../errors/index";
 import { getCoreVersion } from "../../plugins/core-version";
+import { collectCustomPermissions } from "../../plugins/permissions/collect-permissions";
 import type { PluginDefinition } from "../../plugins/plugin-context";
 import { resolvePlugins } from "../../plugins/resolve";
 import { applyPluginSchemaContributions } from "../../plugins/schema/apply-contributions";
@@ -330,6 +331,13 @@ async function loadConfigInternal(
       // so CLI and runtime agree (D50).
       validateMergedRelations(config as unknown as NextlyServiceConfig);
       validateCrossPluginRelations(plugins);
+
+      // Fail fast on invalid plugin-declared custom permissions (D36) — same
+      // collector the runtime boot runs (register.ts), so both paths agree (D50).
+      collectCustomPermissions(
+        config as unknown as NextlyServiceConfig,
+        plugins
+      );
 
       debugLog(
         options,

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -52,6 +52,7 @@ import type { HookRegistry } from "../hooks/hook-registry";
 import { getHookRegistry } from "../hooks/hook-registry";
 import { createSanitizationHook } from "../hooks/sanitization-hooks";
 import { getCoreVersion } from "../plugins/core-version";
+import { collectCustomPermissions } from "../plugins/permissions/collect-permissions";
 import type {
   PluginContext,
   PluginDefinition,
@@ -312,6 +313,10 @@ export async function registerServices(
   // relationship validation runs at boot.
   validateMergedRelations(transformedConfig);
   validateCrossPluginRelations(resolvedPlugins);
+
+  // Fail fast on invalid plugin-declared custom permissions (D36). Validation
+  // only here; the list is re-derived + seeded in runPostInitTasks.
+  collectCustomPermissions(transformedConfig, resolvedPlugins);
 
   const {
     adapter: providedAdapter,

--- a/packages/nextly/src/domains/auth/services/permission-seed-service.ts
+++ b/packages/nextly/src/domains/auth/services/permission-seed-service.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 
 import type { RBACDatabaseInstance } from "@nextly/types/rbac-operations";
 
+import type { CollectedPermission } from "../../../plugins/permissions/collect-permissions";
 import { SYSTEM_RESOURCES } from "../../../schemas/_zod/rbac";
 import { BaseService } from "../../../services/base-service";
 import type { Logger } from "../../../services/shared";
@@ -445,6 +446,40 @@ export class PermissionSeedService extends BaseService {
       this.logger.warn(
         "Could not read dynamic_singles table — skipping single permission seeding."
       );
+    }
+
+    return result;
+  }
+
+  /**
+   * Seed plugin-declared custom permissions (D36). Idempotent — the existing
+   * `(action, resource)` unique index + `ensurePermission` make re-seeding a
+   * no-op. New IDs are returned for super-admin assignment by the caller.
+   */
+  async seedCustomPermissions(
+    perms: CollectedPermission[]
+  ): Promise<SeedResult> {
+    const result = this.emptySeedResult();
+
+    for (const perm of perms) {
+      result.total++;
+      try {
+        const ensured = await this.permissionService.ensurePermission(
+          perm.action,
+          perm.resource,
+          perm.name,
+          perm.slug,
+          perm.description
+        );
+        if (ensured.created) {
+          result.created++;
+          result.newPermissionIds.push(ensured.id);
+        } else {
+          result.skipped++;
+        }
+      } catch {
+        result.errors++;
+      }
     }
 
     return result;

--- a/packages/nextly/src/domains/auth/services/seed-custom-permissions.integration.test.ts
+++ b/packages/nextly/src/domains/auth/services/seed-custom-permissions.integration.test.ts
@@ -1,0 +1,61 @@
+/**
+ * PermissionSeedService.seedCustomPermissions (D36).
+ *
+ * The harness (`createTestNextly`) boots a real Nextly on in-memory SQLite but
+ * only creates code-first collection tables — the core RBAC tables (permissions,
+ * roles, role_permissions, …) are not auto-synced on SQLite. We bootstrap them
+ * with the shared `generateSqliteCoreTableStatements` DDL (the same helper the
+ * auth-events integration test uses) so the seeder runs against live tables.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { generateSqliteCoreTableStatements } from "../../../database/sqlite-core-tables";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+async function bootWithCoreTables(): Promise<TestNextly> {
+  const handle = await createTestNextly({});
+  for (const statement of generateSqliteCoreTableStatements()) {
+    await handle.adapter.executeQuery(statement);
+  }
+  return handle;
+}
+
+describe("seedCustomPermissions", () => {
+  it("seeds a new custom permission and is idempotent", async () => {
+    current = await bootWithCoreTables();
+    const seed = current.getService("permissionSeedService");
+
+    const first = await seed.seedCustomPermissions([
+      {
+        action: "export",
+        resource: "submissions",
+        slug: "export-submissions",
+        name: "Export Submissions",
+        owner: "@acme/x",
+      },
+    ]);
+    expect(first).toMatchObject({ created: 1, skipped: 0 });
+    expect(first.newPermissionIds).toHaveLength(1);
+
+    const second = await seed.seedCustomPermissions([
+      {
+        action: "export",
+        resource: "submissions",
+        slug: "export-submissions",
+        name: "Export Submissions",
+        owner: "@acme/x",
+      },
+    ]);
+    expect(second).toMatchObject({ created: 0, skipped: 1 });
+  });
+});

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -348,6 +348,8 @@ export {
   type PluginContext,
   type PluginContributions,
   type PluginDefinition,
+  type PluginPermission,
+  type PermissionSlug,
   type PluginHookRegistry,
   type PluginFilterRegistry,
   type PluginActionRegistry,

--- a/packages/nextly/src/init/post-init-tasks.ts
+++ b/packages/nextly/src/init/post-init-tasks.ts
@@ -9,6 +9,7 @@
  */
 
 import { getService } from "../di/register";
+import { collectCustomPermissions } from "../plugins/permissions/collect-permissions";
 
 /**
  * Run idempotent post-initialization tasks after services are registered.
@@ -62,9 +63,10 @@ export async function runPostInitTasks(): Promise<void> {
     // Silently skip — userExtSchemaService may not be registered
   }
 
-  // Seed system + collection + single permissions (idempotent).
+  // Seed system + collection + single + plugin custom permissions (idempotent).
   // Ensures CRUD permissions exist for every collection (4 each) and single (2 each),
-  // plus all system resource permissions. New permissions are auto-assigned to super_admin.
+  // plus all system resource permissions and plugin-declared custom permissions
+  // (D36). New permissions are auto-assigned to super_admin.
   try {
     const permissionSeedService = getService("permissionSeedService");
     const systemResult = await permissionSeedService.seedSystemPermissions();
@@ -72,10 +74,16 @@ export async function runPostInitTasks(): Promise<void> {
       await permissionSeedService.seedAllCollectionPermissions();
     const singleResult = await permissionSeedService.seedAllSinglePermissions();
 
+    const config = getService("config");
+    const customResult = await permissionSeedService.seedCustomPermissions(
+      collectCustomPermissions(config, config.plugins ?? [])
+    );
+
     const allNewIds = [
       ...systemResult.newPermissionIds,
       ...collectionResult.newPermissionIds,
       ...singleResult.newPermissionIds,
+      ...customResult.newPermissionIds,
     ];
 
     if (allNewIds.length > 0) {

--- a/packages/nextly/src/plugins/contributions.ts
+++ b/packages/nextly/src/plugins/contributions.ts
@@ -4,6 +4,26 @@ import type { ComponentConfig } from "../components/config/types";
 import type { SingleConfig } from "../singles/config/types";
 
 /**
+ * @experimental A plugin-declared custom permission (D36). CRUD permissions are
+ * auto-seeded per collection/single slug separately — declare only NON-CRUD
+ * custom permissions here (e.g. `{ action: 'export', resource: 'submissions' }`).
+ */
+export interface PluginPermission {
+  action: string;
+  resource: string;
+  label?: string;
+  description?: string;
+  group?: string;
+}
+
+/**
+ * @experimental A permission identifier — the `${action}-${resource}` slug
+ * (e.g. `'export-submissions'`). A plain `string` until typed-slug codegen
+ * (P6, D47) narrows it.
+ */
+export type PermissionSlug = string;
+
+/**
  * Declarative, introspectable plugin contributions (D1). The host can read these
  * WITHOUT running the plugin.
  *
@@ -21,13 +41,7 @@ export interface PluginContributions {
   /** @experimental Add fields to existing entities by slug (P2, D12). */
   extend?: Array<{ target: string | string[]; fields: FieldConfig[] }>;
   /** @experimental Custom permissions; CRUD is auto-seeded separately (P3, D36). */
-  permissions?: Array<{
-    action: string;
-    resource: string;
-    label?: string;
-    description?: string;
-    group?: string;
-  }>;
+  permissions?: PluginPermission[];
   /** @experimental Custom event names this plugin may emit (P1, D9). */
   events?: Array<{ name: string }>;
 }

--- a/packages/nextly/src/plugins/index.ts
+++ b/packages/nextly/src/plugins/index.ts
@@ -23,4 +23,8 @@ export {
   type PluginHookRegistry,
 } from "./plugin-context";
 
-export type { PluginContributions } from "./contributions";
+export type {
+  PluginContributions,
+  PluginPermission,
+  PermissionSlug,
+} from "./contributions";

--- a/packages/nextly/src/plugins/permission-error.test.ts
+++ b/packages/nextly/src/plugins/permission-error.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { NextlyError } from "../errors/nextly-error";
+
+import { permissionCollisionError } from "./permission-error";
+
+describe("permissionCollisionError", () => {
+  it("is a 409 NextlyError carrying reason + owners in logContext", () => {
+    const err = permissionCollisionError(
+      "export",
+      "submissions",
+      ["@acme/a", "@acme/b"],
+      "duplicate-permission"
+    );
+    expect(err).toBeInstanceOf(NextlyError);
+    expect(err.code).toBe("NEXTLY_PERMISSION_COLLISION");
+    expect(err.statusCode).toBe(409);
+    expect(err.logContext).toMatchObject({
+      reason: "duplicate-permission",
+      action: "export",
+      resource: "submissions",
+      owners: ["@acme/a", "@acme/b"],
+    });
+  });
+
+  it("carries the system-resource-reserved reason", () => {
+    const err = permissionCollisionError(
+      "export",
+      "users",
+      ["@acme/a"],
+      "system-resource-reserved"
+    );
+    expect(err.logContext).toMatchObject({
+      reason: "system-resource-reserved",
+    });
+  });
+});

--- a/packages/nextly/src/plugins/permission-error.ts
+++ b/packages/nextly/src/plugins/permission-error.ts
@@ -1,0 +1,28 @@
+import { NextlyError } from "../errors/nextly-error";
+
+/** Why a custom-permission declaration was rejected at boot (D36). */
+export type PermissionCollisionReason =
+  | "duplicate-permission" // same (action, resource) declared by two sources
+  | "system-resource-reserved" // resource is a built-in system resource
+  | "crud-permission-reserved"; // duplicates an auto-seeded collection CRUD / single read-update
+
+/**
+ * Fail-fast boot error for an invalid plugin-declared custom permission (D36).
+ * Mirrors {@link ./schema-error}: the specific failure mode lives in
+ * `logContext.reason`; the public message stays generic while the detail
+ * (action/resource/owners) lives in `logContext` for operators.
+ */
+export function permissionCollisionError(
+  action: string,
+  resource: string,
+  owners: string[],
+  reason: PermissionCollisionReason
+): NextlyError {
+  return new NextlyError({
+    code: "NEXTLY_PERMISSION_COLLISION",
+    statusCode: 409,
+    publicMessage: "Permission configuration is invalid.",
+    logMessage: `Custom permission "${action}-${resource}" rejected (${reason}); declared by ${owners.join(" and ")}`,
+    logContext: { reason, action, resource, owners },
+  });
+}

--- a/packages/nextly/src/plugins/permissions/collect-permissions.test.ts
+++ b/packages/nextly/src/plugins/permissions/collect-permissions.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import type { NextlyServiceConfig } from "../../di/register";
+import type { PluginDefinition } from "../plugin-context";
+
+import { collectCustomPermissions } from "./collect-permissions";
+
+const cfg = (
+  collections: string[] = [],
+  singles: string[] = []
+): NextlyServiceConfig =>
+  ({
+    collections: collections.map(slug => ({ slug, fields: [] })),
+    singles: singles.map(slug => ({ slug, fields: [] })),
+  }) as unknown as NextlyServiceConfig;
+
+const plugin = (
+  name: string,
+  permissions: Array<Record<string, string>>,
+  enabled = true
+): PluginDefinition =>
+  ({
+    name,
+    version: "1.0.0",
+    nextly: ">=0.0.1",
+    enabled,
+    contributes: { permissions },
+  }) as unknown as PluginDefinition;
+
+describe("collectCustomPermissions", () => {
+  it("collects + derives slug/name for a custom permission", () => {
+    const out = collectCustomPermissions(cfg(), [
+      plugin("@acme/seo", [
+        { action: "manage", resource: "seo", label: "Manage SEO" },
+      ]),
+    ]);
+    expect(out).toEqual([
+      {
+        action: "manage",
+        resource: "seo",
+        slug: "manage-seo",
+        name: "Manage SEO",
+        description: undefined,
+        owner: "@acme/seo",
+      },
+    ]);
+  });
+
+  it("auto-generates a name when no label is given", () => {
+    const out = collectCustomPermissions(cfg(), [
+      plugin("@acme/x", [{ action: "export", resource: "submissions" }]),
+    ]);
+    expect(out[0]).toMatchObject({
+      slug: "export-submissions",
+      name: "Export Submissions",
+    });
+  });
+
+  it("collects from disabled plugins too (D49)", () => {
+    const out = collectCustomPermissions(cfg(), [
+      plugin("@acme/x", [{ action: "manage", resource: "seo" }], false),
+    ]);
+    expect(out).toHaveLength(1);
+  });
+
+  it("throws on the same (action,resource) declared by two plugins", () => {
+    expect(() =>
+      collectCustomPermissions(cfg(), [
+        plugin("@acme/a", [{ action: "export", resource: "submissions" }]),
+        plugin("@acme/b", [{ action: "export", resource: "submissions" }]),
+      ])
+    ).toThrowError(/NEXTLY_PERMISSION_COLLISION|invalid/i);
+  });
+
+  it("throws when a custom resource is a system resource", () => {
+    expect(() =>
+      collectCustomPermissions(cfg(), [
+        plugin("@acme/a", [{ action: "export", resource: "users" }]),
+      ])
+    ).toThrow();
+  });
+
+  it("throws when a custom perm shadows a collection CRUD permission", () => {
+    expect(() =>
+      collectCustomPermissions(cfg(["posts"]), [
+        plugin("@acme/a", [{ action: "read", resource: "posts" }]),
+      ])
+    ).toThrow();
+  });
+
+  it("allows a non-CRUD action on a collection resource (e.g. manage-posts)", () => {
+    const out = collectCustomPermissions(cfg(["posts"]), [
+      plugin("@acme/a", [{ action: "manage", resource: "posts" }]),
+    ]);
+    expect(out[0].slug).toBe("manage-posts");
+  });
+
+  it("returns [] for a plugin-free config", () => {
+    expect(collectCustomPermissions(cfg(["posts"]), [])).toEqual([]);
+  });
+});

--- a/packages/nextly/src/plugins/permissions/collect-permissions.ts
+++ b/packages/nextly/src/plugins/permissions/collect-permissions.ts
@@ -1,0 +1,95 @@
+import type { NextlyServiceConfig } from "../../di/register";
+import { isSystemResource } from "../../schemas/_zod/rbac";
+import { permissionCollisionError } from "../permission-error";
+import type { PluginDefinition } from "../plugin-context";
+
+/** A custom permission resolved to its concrete, seedable shape (D36). */
+export interface CollectedPermission {
+  action: string;
+  resource: string;
+  /** `${action}-${resource}` — matches the existing CRUD slug convention. */
+  slug: string;
+  name: string;
+  description?: string;
+  /** Declaring plugin name — provenance for logs (not persisted in P3a). */
+  owner: string;
+}
+
+const CRUD_ACTIONS = new Set(["create", "read", "update", "delete"]);
+const SINGLE_ACTIONS = new Set(["read", "update"]);
+
+const titleCase = (s: string): string =>
+  s
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+
+/**
+ * Fold every plugin's `contributes.permissions` into a deduped, collision-
+ * validated list of seedable custom permissions (D36). Pure. Runs over ALL
+ * plugins incl. disabled ones so declarative permissions stay deterministic
+ * across environments (D49 — same policy as the schema fold). Throws
+ * `NEXTLY_PERMISSION_COLLISION` on:
+ *  - the same (action,resource) declared by two sources (duplicate-permission);
+ *  - a resource that is a built-in system resource (system-resource-reserved);
+ *  - a CRUD action on a collection slug / read|update on a single slug, which
+ *    the auto-seeder already owns (crud-permission-reserved).
+ */
+export function collectCustomPermissions(
+  config: NextlyServiceConfig,
+  plugins: PluginDefinition[]
+): CollectedPermission[] {
+  const collectionSlugs = new Set((config.collections ?? []).map(c => c.slug));
+  const singleSlugs = new Set((config.singles ?? []).map(s => s.slug));
+  const seen = new Map<string, string>(); // `${action}:${resource}` -> first owner
+  const out: CollectedPermission[] = [];
+
+  for (const plugin of plugins) {
+    for (const perm of plugin.contributes?.permissions ?? []) {
+      const { action, resource } = perm;
+      const key = `${action}:${resource}`;
+
+      const prev = seen.get(key);
+      if (prev !== undefined) {
+        throw permissionCollisionError(
+          action,
+          resource,
+          [prev, plugin.name],
+          "duplicate-permission"
+        );
+      }
+      if (isSystemResource(resource)) {
+        throw permissionCollisionError(
+          action,
+          resource,
+          [plugin.name],
+          "system-resource-reserved"
+        );
+      }
+      if (
+        (CRUD_ACTIONS.has(action) && collectionSlugs.has(resource)) ||
+        (SINGLE_ACTIONS.has(action) && singleSlugs.has(resource))
+      ) {
+        throw permissionCollisionError(
+          action,
+          resource,
+          [plugin.name],
+          "crud-permission-reserved"
+        );
+      }
+
+      seen.set(key, plugin.name);
+      out.push({
+        action,
+        resource,
+        slug: `${action}-${resource}`,
+        name: perm.label ?? `${titleCase(action)} ${titleCase(resource)}`,
+        description: perm.description,
+        owner: plugin.name,
+      });
+    }
+  }
+
+  return out;
+}

--- a/packages/nextly/src/plugins/permissions/seed-on-boot.integration.test.ts
+++ b/packages/nextly/src/plugins/permissions/seed-on-boot.integration.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Custom permissions are seeded at boot via runPostInitTasks (D36).
+ *
+ * The harness boots a real Nextly on in-memory SQLite but does not auto-create
+ * the core RBAC tables; we bootstrap them with `generateSqliteCoreTableStatements`
+ * (same helper the auth integration tests use) so seeding writes to live tables.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { generateSqliteCoreTableStatements } from "../../database/sqlite-core-tables";
+import { runPostInitTasks } from "../../init/post-init-tasks";
+import { definePlugin } from "../../plugins";
+import { createTestNextly, type TestNextly } from "../../plugins/test-nextly";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+describe("custom permission seeding on boot", () => {
+  it("seeds a plugin's custom permission via runPostInitTasks", async () => {
+    const seoPlugin = definePlugin({
+      name: "@acme/seo",
+      version: "1.0.0",
+      nextly: ">=0.0.1",
+      contributes: {
+        permissions: [
+          { action: "manage", resource: "seo", label: "Manage SEO" },
+        ],
+      },
+    });
+
+    current = await createTestNextly({ plugins: [seoPlugin] });
+    for (const statement of generateSqliteCoreTableStatements()) {
+      await current.adapter.executeQuery(statement);
+    }
+
+    await runPostInitTasks(); // idempotent; deterministically drives seeding
+
+    const rows = await current.adapter.executeQuery<{ slug: string }>(
+      "SELECT slug FROM permissions WHERE slug = 'manage-seo'"
+    );
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/packages/nextly/src/plugins/permissions/validation-parity.integration.test.ts
+++ b/packages/nextly/src/plugins/permissions/validation-parity.integration.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { definePlugin } from "../../plugins";
+import { createTestNextly } from "../../plugins/test-nextly";
+
+let teardown: (() => Promise<void>) | undefined;
+afterEach(async () => {
+  await teardown?.();
+  teardown = undefined;
+});
+
+const perm = (name: string) =>
+  definePlugin({
+    name,
+    version: "1.0.0",
+    nextly: ">=0.0.1",
+    contributes: {
+      permissions: [{ action: "export", resource: "submissions" }],
+    },
+  });
+
+describe("custom-permission boot validation", () => {
+  it("fails fast when two plugins declare the same custom permission", async () => {
+    await expect(
+      createTestNextly({ plugins: [perm("@acme/a"), perm("@acme/b")] })
+    ).rejects.toMatchObject({ code: "NEXTLY_PERMISSION_COLLISION" });
+  });
+
+  it("boots cleanly with a single valid custom permission", async () => {
+    const t = await createTestNextly({ plugins: [perm("@acme/a")] });
+    teardown = t.destroy;
+    expect(t.nextly).toBeTruthy();
+  });
+});

--- a/packages/plugin-form-builder/src/__tests__/permissions.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/permissions.integration.test.ts
@@ -1,0 +1,46 @@
+/**
+ * form-builder custom permissions (R4, D36).
+ *
+ * Proves the flagship plugin DECLARES a custom permission and that the
+ * declaration passes the new boot-time permission validation (the canonical
+ * example third-party authors copy). End-to-end seeding of custom permissions
+ * is proven generically in the `nextly` package (seed-on-boot integration test);
+ * the seed-path internals (`runPostInitTasks`, `collectCustomPermissions`) are
+ * not part of the public surface a plugin package imports.
+ */
+import {
+  createTestNextly,
+  type TestNextly,
+} from "@nextlyhq/plugin-sdk/testing";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { formBuilder } from "../plugin";
+
+let current: TestNextly | undefined;
+
+beforeEach(() => {
+  // form-builder's init guards against duplicate hook registration via a
+  // globalThis flag; clear it so each boot re-registers cleanly.
+  delete (globalThis as Record<string, unknown>)[
+    "__formBuilder_afterCreate_form-submissions"
+  ];
+});
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+describe("form-builder custom permissions (R4, D36)", () => {
+  it("declares the export-submissions custom permission", () => {
+    const { plugin } = formBuilder();
+    expect(plugin.contributes?.permissions).toContainEqual(
+      expect.objectContaining({ action: "export", resource: "submissions" })
+    );
+  });
+
+  it("boots cleanly with the custom permission declared (passes boot validation)", async () => {
+    current = await createTestNextly({ plugins: [formBuilder().plugin] });
+    expect(current.nextly).toBeTruthy();
+  });
+});

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -182,6 +182,17 @@ export function formBuilder(
     // app schema — no manual `setup()` append needed. Just register the plugin.
     contributes: {
       collections: [formsCol, submissionsCol],
+      // Custom permission (D36) — gates submission export beyond CRUD. The
+      // canonical example third-party plugin authors copy.
+      permissions: [
+        {
+          action: "export",
+          resource: "submissions",
+          label: "Export Submissions",
+          description: "Export form submissions as CSV/JSON",
+          group: "Form Builder",
+        },
+      ],
     },
 
     admin: {

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -5,8 +5,8 @@
  * `@experimental` until first-party plugins have exercised it (D55). `ctx.services`
  * is the highest-scrutiny surface and stays experimental the longest.
  *
- * Added in later phases: `useCan`/`<Can>` (P3/P5). `createTestNextly` (P1) lives
- * on the `@nextlyhq/plugin-sdk/testing` subpath.
+ * Added in P3b: `useCan`/`<Can>` (D36 client) + the `secret` field (D37).
+ * `createTestNextly` (P1) lives on the `@nextlyhq/plugin-sdk/testing` subpath.
  */
 export { definePlugin } from "nextly";
 
@@ -15,6 +15,8 @@ export type {
   PluginContributions,
   PluginContext,
   PluginHookRegistry,
+  PluginPermission,
+  PermissionSlug,
 } from "nextly";
 
 export type { HookType, HookHandler, HookContext } from "nextly";

--- a/packages/plugin-sdk/src/permission-types.test-d.ts
+++ b/packages/plugin-sdk/src/permission-types.test-d.ts
@@ -1,0 +1,14 @@
+import type { PermissionSlug, PluginPermission } from "@nextlyhq/plugin-sdk";
+
+// PluginPermission requires action + resource, allows optional metadata.
+const p: PluginPermission = {
+  action: "export",
+  resource: "submissions",
+  label: "Export Submissions",
+};
+
+// PermissionSlug is assignable from a slug string (codegen narrows it in P6, D47).
+const s: PermissionSlug = "export-submissions";
+
+// Exported so eslint does not flag the assertions as unused.
+export const __permissionTypeCheck = { p, s };


### PR DESCRIPTION
## Summary
First slice of P3 (Permissions & security), split into P3a/P3b/P3c. Adds plugin-declared custom `{ action, resource }` permissions (D36 server-side), built on the existing RBAC stack — **no DB migration, no enforcement changes**.

- `collectCustomPermissions(config, plugins)` — pure fold of `contributes.permissions` with collision rules (duplicate / system-reserved / CRUD-reserved); runs over disabled plugins too (D49)
- Fail-fast `NEXTLY_PERMISSION_COLLISION` boot validation wired into **both** runtime + CLI boot paths (D50 parity)
- `PermissionSeedService.seedCustomPermissions` (idempotent) + seeding at post-init, assigned to super-admin
- `PluginPermission` + `PermissionSlug` public types from `nextly` + `@nextlyhq/plugin-sdk` (`@experimental`, D55)
- form-builder dogfoods `export-submissions` (R4)

Deferred (documented): app-config `config.permissions` (→ P3b), permission provenance + prune (D14 retain-by-default holds), `PermissionSlug` codegen (P6/D47).

## Test Plan
- [x] Unit baseline unchanged (405 fail / 236 pass = documented baseline → zero new failures); +10 new unit tests
- [x] 4 new integration tests (collision fail-fast both paths, idempotent seeding, seed-on-boot)
- [x] form-builder 16/16 green
- [x] build + check-types clean across nextly / plugin-sdk / plugin-form-builder

Base: `feat/plugin-platform` (NOT main). No changeset (phase→base PR releases nothing).