### PR TITLE
feat(plugins): P3b — client permission gating (useCan / <Can>, D36 client)

### DIFF
--- a/packages/admin/src/components/guards/Can.tsx
+++ b/packages/admin/src/components/guards/Can.tsx
@@ -1,0 +1,22 @@
+import type { PermissionSlug } from "nextly";
+import type { ReactNode } from "react";
+
+import { useCan } from "../../hooks/useCan";
+
+export interface CanProps {
+  /** Permission slug required to render `children` (e.g. "manage-seo"). */
+  permission: PermissionSlug;
+  /** Rendered when the user lacks the permission (default: nothing). */
+  fallback?: ReactNode;
+  children: ReactNode;
+}
+
+/**
+ * @experimental Renders `children` only if the current user holds `permission`
+ * (D36); otherwise renders `fallback` (default: nothing). The fallback also
+ * shows while permissions are loading. Client-side UX gating only — the server
+ * still enforces access via `requirePermission`.
+ */
+export function Can({ permission, fallback = null, children }: CanProps) {
+  return useCan(permission) ? <>{children}</> : <>{fallback}</>;
+}

--- a/packages/admin/src/components/guards/Can.tsx
+++ b/packages/admin/src/components/guards/Can.tsx
@@ -1,11 +1,14 @@
-import type { PermissionSlug } from "nextly";
 import type { ReactNode } from "react";
 
 import { useCan } from "../../hooks/useCan";
 
 export interface CanProps {
-  /** Permission slug required to render `children` (e.g. "manage-seo"). */
-  permission: PermissionSlug;
+  /**
+   * Permission slug required to render `children` (`${action}-${resource}`,
+   * e.g. `"manage-seo"`). Assignable from `PermissionSlug` (`@nextlyhq/plugin-sdk`);
+   * typed `string` because admin's bundled d.ts cannot reference nextly types.
+   */
+  permission: string;
   /** Rendered when the user lacks the permission (default: nothing). */
   fallback?: ReactNode;
   children: ReactNode;

--- a/packages/admin/src/components/guards/__tests__/Can.test.tsx
+++ b/packages/admin/src/components/guards/__tests__/Can.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Can } from "../Can";
+
+const mockUseCan = vi.fn();
+vi.mock("../../../hooks/useCan", () => ({
+  useCan: (p: string) => mockUseCan(p),
+}));
+
+describe("Can", () => {
+  it("renders children when the user can", () => {
+    mockUseCan.mockReturnValue(true);
+    render(
+      <Can permission="manage-seo">
+        <span>secret</span>
+      </Can>
+    );
+    expect(screen.getByText("secret")).toBeInTheDocument();
+  });
+
+  it("renders the fallback when the user cannot", () => {
+    mockUseCan.mockReturnValue(false);
+    render(
+      <Can permission="manage-seo" fallback={<span>nope</span>}>
+        <span>secret</span>
+      </Can>
+    );
+    expect(screen.queryByText("secret")).not.toBeInTheDocument();
+    expect(screen.getByText("nope")).toBeInTheDocument();
+  });
+
+  it("renders nothing when denied and no fallback is given", () => {
+    mockUseCan.mockReturnValue(false);
+    const { container } = render(
+      <Can permission="manage-seo">
+        <span>secret</span>
+      </Can>
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/admin/src/hooks/__tests__/useCan.test.tsx
+++ b/packages/admin/src/hooks/__tests__/useCan.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useCan } from "../useCan";
+
+const mockPerms = vi.fn();
+vi.mock("../useCurrentUserPermissions", () => ({
+  useCurrentUserPermissions: () => mockPerms(),
+}));
+
+describe("useCan", () => {
+  it("returns true when the user holds the permission", () => {
+    mockPerms.mockReturnValue({
+      hasPermission: (s: string) => s === "manage-seo",
+      isSuperAdmin: false,
+    });
+    const { result } = renderHook(() => useCan("manage-seo"));
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false when the user lacks the permission", () => {
+    mockPerms.mockReturnValue({
+      hasPermission: () => false,
+      isSuperAdmin: false,
+    });
+    const { result } = renderHook(() => useCan("manage-seo"));
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true for a super-admin (delegates to hasPermission)", () => {
+    mockPerms.mockReturnValue({
+      hasPermission: () => true,
+      isSuperAdmin: true,
+    });
+    const { result } = renderHook(() => useCan("anything-here"));
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false while permissions are still loading", () => {
+    // During load hasPermission returns false (perms empty, not super-admin).
+    mockPerms.mockReturnValue({
+      hasPermission: () => false,
+      isSuperAdmin: false,
+    });
+    const { result } = renderHook(() => useCan("manage-seo"));
+    expect(result.current).toBe(false);
+  });
+});

--- a/packages/admin/src/hooks/useCan.ts
+++ b/packages/admin/src/hooks/useCan.ts
@@ -1,0 +1,15 @@
+import type { PermissionSlug } from "nextly";
+
+import { useCurrentUserPermissions } from "./useCurrentUserPermissions";
+
+/**
+ * @experimental Returns `true` if the current user holds `permission` (D36).
+ * Super-admin always passes (delegated to `hasPermission`). Returns `false`
+ * while permissions are still loading — the gate stays closed until access is
+ * known, a safe default for UX gating. Client-side UX only; the server still
+ * enforces via `requirePermission`.
+ */
+export function useCan(permission: PermissionSlug): boolean {
+  const { hasPermission } = useCurrentUserPermissions();
+  return hasPermission(permission);
+}

--- a/packages/admin/src/hooks/useCan.ts
+++ b/packages/admin/src/hooks/useCan.ts
@@ -1,5 +1,3 @@
-import type { PermissionSlug } from "nextly";
-
 import { useCurrentUserPermissions } from "./useCurrentUserPermissions";
 
 /**
@@ -8,8 +6,14 @@ import { useCurrentUserPermissions } from "./useCurrentUserPermissions";
  * while permissions are still loading — the gate stays closed until access is
  * known, a safe default for UX gating. Client-side UX only; the server still
  * enforces via `requirePermission`.
+ *
+ * `permission` is a permission slug (`${action}-${resource}`, e.g.
+ * `"manage-seo"`) — assignable from `PermissionSlug` (`@nextlyhq/plugin-sdk`).
+ * Typed as `string` (not nextly's `PermissionSlug`) because admin's bundled
+ * d.ts cannot reference nextly's barrel types; `PermissionSlug` is `string`
+ * until codegen narrows it (D47/P6).
  */
-export function useCan(permission: PermissionSlug): boolean {
+export function useCan(permission: string): boolean {
   const { hasPermission } = useCurrentUserPermissions();
   return hasPermission(permission);
 }

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -80,6 +80,8 @@ export { useRecentActivity } from "./hooks/queries/useRecentActivity";
 export { useDebouncedValue } from "./hooks/useDebouncedValue";
 // Permission gating (D36) — client-side UX checks for admin + plugin UI.
 export { useCan } from "./hooks/useCan";
+export { Can } from "./components/guards/Can";
+export type { CanProps } from "./components/guards/Can";
 export { useRowSelection } from "./hooks/useRowSelection";
 export type {
   UseRowSelectionOptions,

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -78,6 +78,8 @@ export { useRecentActivity } from "./hooks/queries/useRecentActivity";
 
 // Custom hooks
 export { useDebouncedValue } from "./hooks/useDebouncedValue";
+// Permission gating (D36) — client-side UX checks for admin + plugin UI.
+export { useCan } from "./hooks/useCan";
 export { useRowSelection } from "./hooks/useRowSelection";
 export type {
   UseRowSelectionOptions,

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -15,6 +15,10 @@
     "./testing": {
       "types": "./dist/testing.d.ts",
       "import": "./dist/testing.mjs"
+    },
+    "./client": {
+      "types": "./dist/client.d.ts",
+      "import": "./dist/client.mjs"
     }
   },
   "files": [
@@ -32,12 +36,30 @@
     "node": ">=20.0.0"
   },
   "peerDependencies": {
-    "nextly": "workspace:*"
+    "@nextlyhq/admin": "workspace:*",
+    "nextly": "workspace:*",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@nextlyhq/admin": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
   },
   "devDependencies": {
+    "@nextlyhq/admin": "workspace:*",
     "@nextlyhq/eslint-config": "workspace:*",
     "@nextlyhq/tsconfig": "workspace:*",
+    "@types/react": "^19.0.0",
     "nextly": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.8"

--- a/packages/plugin-sdk/src/client-exports.test-d.ts
+++ b/packages/plugin-sdk/src/client-exports.test-d.ts
@@ -1,0 +1,10 @@
+import { Can, useCan, type CanProps } from "@nextlyhq/plugin-sdk/client";
+
+// useCan takes a permission slug and returns a boolean.
+const allowed: boolean = useCan("manage-seo");
+
+// Can is a component accepting { permission, fallback?, children }.
+const props: CanProps = { permission: "manage-seo", children: null };
+
+// Exported so eslint does not flag the assertions as unused.
+export const __clientTypeCheck = { Can, allowed, props };

--- a/packages/plugin-sdk/src/client.ts
+++ b/packages/plugin-sdk/src/client.ts
@@ -1,0 +1,9 @@
+/**
+ * @nextlyhq/plugin-sdk/client — the author-facing React surface for plugin
+ * admin UI (D36/D43). Import these in components rendered inside the Nextly
+ * admin shell (which provides `@nextlyhq/admin` + React).
+ *
+ * @experimental
+ */
+export { useCan, Can } from "@nextlyhq/admin";
+export type { CanProps } from "@nextlyhq/admin";

--- a/packages/plugin-sdk/tsup.config.ts
+++ b/packages/plugin-sdk/tsup.config.ts
@@ -1,13 +1,13 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/testing.ts"],
+  entry: ["src/index.ts", "src/testing.ts", "src/client.ts"],
   format: ["esm"],
   dts: true,
   clean: true,
   sourcemap: true,
   treeshake: true,
-  external: ["nextly"],
+  external: ["nextly", "@nextlyhq/admin", "react", "react-dom"],
   outExtension() {
     return { js: ".mjs" };
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1023,15 +1023,27 @@ importers:
 
   packages/plugin-sdk:
     devDependencies:
+      '@nextlyhq/admin':
+        specifier: workspace:*
+        version: link:../admin
       '@nextlyhq/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
       '@nextlyhq/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.0
       nextly:
         specifier: workspace:*
         version: link:../nextly
+      react:
+        specifier: ^19.0.0
+        version: 19.2.0
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.0(react@19.2.0)
       tsup:
         specifier: ^8.5.0
         version: 8.5.0(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)


### PR DESCRIPTION
## Summary
Client-side half of D36 (P3 slice), stacked on P3a. Adds permission-gated admin UX primitives, exported to plugin authors via a new `@nextlyhq/plugin-sdk/client` entry.

- `useCan(permission): boolean` in `@nextlyhq/admin` — wraps the super-admin-aware `useCurrentUserPermissions().hasPermission`
- `<Can permission fallback>{children}</Can>` — inline gate (fallback default nothing; also shows while loading)
- `@nextlyhq/plugin-sdk/client` re-exports both — `@nextlyhq/admin` + React as **optional** peer deps, so the node entry stays React-free

**Scope note:** the `secret` field / D37 half originally grouped here was split out to **P3d (brainstorm-first)** — D37 is ambiguous (collection field vs config option) and needs generic field-level `access.read` enforcement that doesn't exist yet. **D35 elevation → P3c (brainstorm-first).**

**Deviation:** `useCan`/`CanProps.permission` typed `string` (not `PermissionSlug`) — admin's bundled d.ts can't reference nextly barrel types (tsconfig maps `nextly`→source w/o `@nextly/*`); `PermissionSlug` is `string` until P6 codegen, and is assignable. Server enforcement unchanged (UX-only).

## Test Plan
- [x] admin suite: 51 pre-existing failures **unchanged** + 7 new passing (638 total) — zero new failures
- [x] SDK builds 3 entries (`index`/`testing`/`client`); `dist/client.{mjs,d.ts}` emitted; check-types clean
- [x] compile-time `client-exports.test-d.ts` guards the public `@nextlyhq/plugin-sdk/client` surface

Stacked on `feat/plugin-p3a-permissions`; retarget to `feat/plugin-platform` after P3a merges. No changeset.