### PR TITLE
fix(nextly): build comp_* runtime schema with component generator on reload

### DIFF
--- a/.changeset/hmr-component-runtime-schema.md
+++ b/.changeset/hmr-component-runtime-schema.md
@@ -1,0 +1,22 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/ui": patch
+---
+
+Fix component CRUD breaking with a 500 after a dev-server config hot-reload.
+
+`reloadNextlyConfig` rebuilt the runtime Drizzle descriptors for `comp_*` data tables with the collection/single `generateRuntimeSchema`, which prepends `id`/`title`/`slug` base columns and omits the `_parent_id`/`_parent_table`/`_parent_field`/`_order` link columns that components use to reference their parent document. This overwrote the correct boot-time registration.
+
+After a hot-reload the bad descriptor no longer matched the physical table, so component reads (which filter by `_parent_id`) failed and were swallowed as "no rows", and component writes (which insert the `_parent_*` columns) were rejected by the database. Saving any Single or Collection document that embeds a component returned a 500.
+
+The reload path now builds `comp_*` descriptors with `ComponentSchemaService.generateRuntimeSchema`, matching the boot path and the physical `comp_*` table. Adds a regression test asserting the refreshed descriptor exposes the `_parent_*` link columns and not `title`/`slug`.

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -9,6 +9,7 @@
 // the gate behavior against actual diff output. Pipeline is still mocked
 // so we don't hit drizzle-kit.
 
+import { getTableColumns } from "drizzle-orm";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type { NextlySchemaSnapshot } from "../../domains/schema/pipeline/diff/types";
@@ -841,6 +842,51 @@ describe("reloadNextlyConfig", () => {
       };
       expect(Object.keys(call.desired.components)).toContain("hero");
       expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("refreshes the comp_* runtime schema with component link columns, not document title/slug", async () => {
+      // Regression: the HMR refresh rebuilt comp_* runtime descriptors with the
+      // collection/single generator (id/title/slug, no _parent_id), clobbering
+      // the correct boot-time registration. Component reads filter by _parent_id
+      // and writes insert the _parent_* columns, so a descriptor missing them
+      // makes every save of a document embedding the component fail with a 500.
+      loadConfigSpy.mockResolvedValue({
+        config: {
+          components: [
+            {
+              slug: "meta-data",
+              fields: [{ name: "metaTitle", type: "text" }],
+            },
+          ],
+        },
+      });
+      // metaTitle is absent from the live table, so the diff is an additive
+      // change: hasChanges flips true and the refresh block re-registers the
+      // runtime descriptor (the code path that used the wrong generator).
+      introspectSpy.mockResolvedValue(
+        buildSnapshot([{ name: "comp_meta_data", columns: SQLITE_RESERVED }])
+      );
+
+      const resolver = buildResolver();
+      const { reloadNextlyConfig } = await import("../reload-config");
+      await reloadNextlyConfig({ resolver });
+
+      const registered = resolver.registerDynamicSchemaSpy.mock.calls.find(
+        call => call[0] === "comp_meta_data"
+      );
+      expect(
+        registered,
+        "comp_meta_data must be re-registered after an HMR refresh"
+      ).toBeTruthy();
+      const columns = Object.keys(getTableColumns(registered![1] as never));
+      // Component link columns the query/mutation services depend on.
+      expect(columns).toContain("_parent_id");
+      expect(columns).toContain("_parent_table");
+      expect(columns).toContain("_parent_field");
+      expect(columns).toContain("_order");
+      // Document base columns must never leak onto a component table.
+      expect(columns).not.toContain("title");
+      expect(columns).not.toContain("slug");
     });
 
     it("passes a standalone drop on a component table through to the pipeline", async () => {

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -56,6 +56,7 @@ import { DrizzleStatementExecutor } from "../domains/schema/services/drizzle-sta
 import { generateRuntimeSchema } from "../domains/schema/services/runtime-schema-generator";
 import { resolveCollectionTableName } from "../domains/schema/utils/resolve-table-name";
 import { getProductionNotifier } from "../runtime/notifications/index";
+import { ComponentSchemaService } from "../services/components/component-schema-service";
 
 import { clearLiveSnapshots, setLiveSnapshot } from "./schema-snapshot-cache";
 
@@ -828,11 +829,18 @@ export async function reloadNextlyConfig(opts?: {
         );
         singleFreshTables.set(s.tableName, table);
       }
+      // Components must use the component schema generator, NOT the collection/
+      // single generateRuntimeSchema. Components link to their parent document
+      // via _parent_id/_parent_table/_parent_field/_order; the collection
+      // generator instead injects id/title/slug base columns and omits
+      // _parent_id. Using it here clobbered the correct boot-time descriptor,
+      // breaking every component read (filter by _parent_id) and write (insert
+      // _parent_*) after an HMR config reload.
+      const componentSchemaService = new ComponentSchemaService(dialect);
       for (const comp of Object.values(desiredComponents)) {
-        const { table } = generateRuntimeSchema(
+        const table = componentSchemaService.generateRuntimeSchema(
           comp.tableName,
-          comp.fields as Parameters<typeof generateRuntimeSchema>[1],
-          dialect
+          comp.fields
         );
         componentFreshTables.set(comp.tableName, table);
       }


### PR DESCRIPTION
build comp_* runtime schema with component generator on reload reloadNextlyConfig rebuilt component runtime descriptors with the collection/single generateRuntimeSchema (id/title/slug, no _parent_id), clobbering the correct boot-time registration. Component reads filter by _parent_id and writes insert _parent_*, so the wrong descriptor made every save of a document embedding a component fail with a 500 after an HMR config reload.

Use ComponentSchemaService.generateRuntimeSchema so the in-memory descriptor matches the physical comp_* table. Add a regression test asserting the refreshed descriptor exposes the _parent_* link columns and not title/slug.

## Summary

<!-- What does this PR do and why? Keep it short. -->

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / chore (no user-facing change)

## Related issues

<!-- e.g. Closes #123, Refs #456 -->

## Changeset

This repo uses [Changesets](https://github.com/changesets/changesets). If your PR changes any publishable package under `packages/*`, you **must** include a changeset:

```bash
pnpm changeset
```

Then commit the generated `.changeset/*.md` file.

- [ ] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [ ] I selected the correct semver bump (patch / minor / major)

> The `changeset-check` CI job will fail if a publishable package is modified without a changeset.

## Test plan

<!-- How did you verify this works? Commands run, scenarios tested, screenshots, etc. -->

- [ ] `pnpm lint`
- [ ] `pnpm check-types`
- [ ] `pnpm build`
- [ ] Manually verified the change

## Checklist

- [ ] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [ ] I targeted the `main` branch
- [ ] I updated relevant documentation

## Screenshots / recordings

<!-- Optional. Drag images or videos here for UI changes. -->

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to? Migration risks, perf concerns, etc. -->
