### PR TITLE
feat(nextly): forward cc/bcc through Direct API and code-first templates

### DIFF
--- a/.changeset/email-cc-bcc-forwarding.md
+++ b/.changeset/email-cc-bcc-forwarding.md
@@ -1,0 +1,18 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/ui": patch
+---
+
+Forward `cc`/`bcc` consistently across every email send path.
+
+`nextly.email.send` and `nextly.email.sendWithTemplate` (Direct API) now accept and forward `cc`/`bcc` — they are added to `SendEmailArgs` and `SendTemplateEmailArgs`. Previously the Direct API namespace silently dropped both fields, so only the REST route (`/api/email/send-with-template`) honored them. `EmailService.sendWithTemplate` also dropped `cc`/`bcc` on its code-first template fallback branch while the DB-template branch already forwarded them; both branches now forward them. Empty `cc`/`bcc` arrays are not forwarded, so they don't override the "no options" path.

--- a/packages/nextly/src/direct-api/__tests__/email.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/email.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Direct API - Email Namespace Tests
+ *
+ * Verifies that `nextly.email.send` and `nextly.email.sendWithTemplate`
+ * forward cc/bcc (alongside the existing providerId/attachments) down to the
+ * underlying EmailService. The namespace previously dropped cc/bcc silently.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import type { NextlyContext } from "../namespaces/context";
+import { createEmailNamespace } from "../namespaces/email";
+
+function build() {
+  const send = vi
+    .fn()
+    .mockResolvedValue({ success: true, messageId: "m-send" });
+  const sendWithTemplate = vi
+    .fn()
+    .mockResolvedValue({ success: true, messageId: "m-tpl" });
+
+  // Only emailSendService is exercised by this namespace; cast a minimal ctx.
+  const ctx = {
+    emailSendService: { send, sendWithTemplate },
+  } as unknown as NextlyContext;
+
+  return { email: createEmailNamespace(ctx), send, sendWithTemplate };
+}
+
+describe("Direct API - Email namespace", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("sendWithTemplate()", () => {
+    it("forwards cc/bcc to the email service", async () => {
+      const { email, sendWithTemplate } = build();
+
+      await email.sendWithTemplate({
+        to: "user@example.com",
+        template: "welcome",
+        variables: { name: "Sam" },
+        cc: ["cc@example.com"],
+        bcc: ["bcc@example.com"],
+      });
+
+      expect(sendWithTemplate).toHaveBeenCalledWith(
+        "welcome",
+        "user@example.com",
+        { name: "Sam" },
+        expect.objectContaining({
+          cc: ["cc@example.com"],
+          bcc: ["bcc@example.com"],
+        })
+      );
+    });
+
+    it("omits cc/bcc from options when not provided", async () => {
+      const { email, sendWithTemplate } = build();
+
+      await email.sendWithTemplate({
+        to: "user@example.com",
+        template: "welcome",
+      });
+
+      // No cc/bcc supplied and no other options -> options stays undefined.
+      expect(sendWithTemplate).toHaveBeenCalledWith(
+        "welcome",
+        "user@example.com",
+        {},
+        undefined
+      );
+    });
+
+    it("does not forward empty cc/bcc arrays (keeps options undefined)", async () => {
+      const { email, sendWithTemplate } = build();
+
+      await email.sendWithTemplate({
+        to: "user@example.com",
+        template: "welcome",
+        cc: [],
+        bcc: [],
+      });
+
+      // Empty arrays must not make the options object truthy.
+      expect(sendWithTemplate).toHaveBeenCalledWith(
+        "welcome",
+        "user@example.com",
+        {},
+        undefined
+      );
+    });
+
+    it("forwards cc together with providerId", async () => {
+      const { email, sendWithTemplate } = build();
+
+      await email.sendWithTemplate({
+        to: "user@example.com",
+        template: "welcome",
+        providerId: "prov-1",
+        cc: ["cc@example.com"],
+      });
+
+      expect(sendWithTemplate).toHaveBeenCalledWith(
+        "welcome",
+        "user@example.com",
+        {},
+        expect.objectContaining({
+          providerId: "prov-1",
+          cc: ["cc@example.com"],
+        })
+      );
+    });
+
+    it("uses the first recipient when given an array of addresses", async () => {
+      const { email, sendWithTemplate } = build();
+
+      await email.sendWithTemplate({
+        to: ["first@example.com", "second@example.com"],
+        template: "welcome",
+        cc: ["cc@example.com"],
+      });
+
+      expect(sendWithTemplate).toHaveBeenCalledWith(
+        "welcome",
+        "first@example.com",
+        {},
+        expect.objectContaining({ cc: ["cc@example.com"] })
+      );
+    });
+  });
+
+  describe("send()", () => {
+    it("forwards cc/bcc to the email service", async () => {
+      const { email, send } = build();
+
+      await email.send({
+        to: "user@example.com",
+        subject: "Hi",
+        html: "<p>Hi</p>",
+        cc: ["cc@example.com"],
+        bcc: ["bcc@example.com"],
+      });
+
+      expect(send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cc: ["cc@example.com"],
+          bcc: ["bcc@example.com"],
+        })
+      );
+    });
+  });
+});

--- a/packages/nextly/src/direct-api/namespaces/email.ts
+++ b/packages/nextly/src/direct-api/namespaces/email.ts
@@ -49,11 +49,7 @@ import type {
 } from "../types/index";
 
 import type { NextlyContext } from "./context";
-import {
-  isNotFoundError,
-  mergeConfig,
-  sliceListResult,
-} from "./helpers";
+import { isNotFoundError, mergeConfig, sliceListResult } from "./helpers";
 
 /**
  * `nextly.email.*` namespace — send raw or template-based emails.
@@ -76,6 +72,9 @@ export function createEmailNamespace(ctx: NextlyContext): EmailNamespace {
         subject: args.subject,
         html: args.html,
         plainText: args.text,
+        // Forward cc/bcc so the Direct API matches the REST route and service.
+        cc: args.cc,
+        bcc: args.bcc,
         providerId: args.providerId,
         attachments: args.attachments,
       });
@@ -92,9 +91,15 @@ export function createEmailNamespace(ctx: NextlyContext): EmailNamespace {
 
       const sendOptions: {
         providerId?: string;
+        cc?: string[];
+        bcc?: string[];
         attachments?: typeof args.attachments;
       } = {};
       if (args.providerId) sendOptions.providerId = args.providerId;
+      // Only set cc/bcc when non-empty so an empty array doesn't make
+      // sendOptions truthy and override the "no options" undefined below.
+      if (args.cc?.length) sendOptions.cc = args.cc;
+      if (args.bcc?.length) sendOptions.bcc = args.bcc;
       if (args.attachments) sendOptions.attachments = args.attachments;
 
       const result = await ctx.emailSendService.sendWithTemplate(
@@ -118,9 +123,7 @@ export function createEmailNamespace(ctx: NextlyContext): EmailNamespace {
  * non-CRUD action whose primary value is the resulting record itself.
  */
 export interface EmailProvidersNamespace {
-  find(
-    args?: FindEmailProvidersArgs
-  ): Promise<ListResult<EmailProviderRecord>>;
+  find(args?: FindEmailProvidersArgs): Promise<ListResult<EmailProviderRecord>>;
   findByID(
     args: FindEmailProviderByIDArgs
   ): Promise<EmailProviderRecord | null>;
@@ -222,9 +225,7 @@ export function createEmailProvidersNamespace(
  * because they're non-CRUD actions with domain-specific return types.
  */
 export interface EmailTemplatesNamespace {
-  find(
-    args?: FindEmailTemplatesArgs
-  ): Promise<ListResult<EmailTemplateRecord>>;
+  find(args?: FindEmailTemplatesArgs): Promise<ListResult<EmailTemplateRecord>>;
   findByID(
     args: FindEmailTemplateByIDArgs
   ): Promise<EmailTemplateRecord | null>;

--- a/packages/nextly/src/direct-api/types/email.ts
+++ b/packages/nextly/src/direct-api/types/email.ts
@@ -296,6 +296,10 @@ export interface SendEmailArgs extends DirectAPIConfig {
   text?: string;
   /** Override the "from" address */
   from?: string;
+  /** CC recipients (carbon copy). */
+  cc?: string[];
+  /** BCC recipients (blind carbon copy). */
+  bcc?: string[];
   /** Use a specific provider instead of the default */
   providerId?: string;
   /**
@@ -318,6 +322,10 @@ export interface SendTemplateEmailArgs extends DirectAPIConfig {
   variables?: Record<string, string>;
   /** Override the "from" address */
   from?: string;
+  /** CC recipients (carbon copy). */
+  cc?: string[];
+  /** BCC recipients (blind carbon copy). */
+  bcc?: string[];
   /** Use a specific provider instead of the default */
   providerId?: string;
   /**

--- a/packages/nextly/src/domains/email/__tests__/send-with-template-cc-bcc.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/send-with-template-cc-bcc.test.ts
@@ -1,0 +1,163 @@
+/**
+ * EmailService.sendWithTemplate — cc/bcc forwarding.
+ *
+ * The DB-template path already forwarded cc/bcc to the provider adapter; the
+ * code-first template fallback path dropped them. Both paths are asserted here.
+ */
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { EmailTemplateRecord } from "../../../schemas/email-templates/types";
+import type { Logger } from "../../../shared/types";
+import type { EmailProviderService } from "../services/email-provider-service";
+import { EmailService } from "../services/email-service";
+import type { EmailTemplateService } from "../services/email-template-service";
+import type { EmailProviderAdapter } from "../types";
+
+vi.mock("../../../lib/env", () => ({
+  env: {
+    NEXTLY_SECRET: "test-secret-must-be-32chars-long!!",
+    DB_DIALECT: "sqlite",
+    NODE_ENV: "test",
+    NEXT_PUBLIC_APP_URL: "http://localhost:3000",
+  },
+}));
+
+const logger: Logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
+
+function makeAdapter(): DrizzleAdapter {
+  return {
+    dialect: "sqlite" as const,
+    getDrizzle: () => ({}) as never,
+    getCapabilities: () => ({ dialect: "sqlite" as const }) as never,
+    connect: async () => {},
+    disconnect: async () => {},
+    executeQuery: async () => [],
+    transaction: async <T>(fn: (tx: never) => Promise<T>) => fn({} as never),
+  } as unknown as DrizzleAdapter;
+}
+
+function makeProviderService(): EmailProviderService {
+  return {
+    getProviderDecrypted: vi.fn(),
+    getDefaultProviderDecrypted: vi.fn().mockResolvedValue({
+      id: "p1",
+      type: "resend",
+      fromEmail: "no-reply@test.local",
+      fromName: null,
+      configuration: { apiKey: "k" },
+      isActive: true,
+    }),
+  } as unknown as EmailProviderService;
+}
+
+const cc = ["cc@example.com"];
+const bcc = ["bcc@example.com"];
+
+describe("EmailService.sendWithTemplate — cc/bcc forwarding", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("forwards cc/bcc to the provider for a DB template", async () => {
+    const adapterSend = vi
+      .fn<EmailProviderAdapter["send"]>()
+      .mockResolvedValue({ success: true, messageId: "m-db" });
+    const providerAdapter: EmailProviderAdapter = { send: adapterSend };
+
+    const templateRecord = {
+      id: "t-1",
+      name: "Welcome",
+      slug: "welcome",
+      subject: "Welcome {{name}}",
+      htmlContent: "<p>hi</p>",
+      plainTextContent: null,
+      variables: null,
+      useLayout: false,
+      isActive: true,
+      providerId: null,
+      attachments: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } satisfies EmailTemplateRecord;
+
+    const templateService = {
+      getTemplateBySlug: vi.fn().mockResolvedValue(templateRecord),
+      getLayout: vi.fn(),
+    } as unknown as EmailTemplateService;
+
+    const service = new EmailService(
+      makeAdapter(),
+      logger,
+      makeProviderService(),
+      templateService
+    );
+    (service as unknown as { createAdapterFromRecord: unknown })[
+      "createAdapterFromRecord"
+    ] = () => providerAdapter;
+
+    await service.sendWithTemplate(
+      "welcome",
+      "u@e.com",
+      { name: "Dev" },
+      {
+        cc,
+        bcc,
+      }
+    );
+
+    expect(adapterSend).toHaveBeenCalledWith(
+      expect.objectContaining({ cc, bcc })
+    );
+  });
+
+  it("forwards cc/bcc to the provider for a code-first template", async () => {
+    const adapterSend = vi
+      .fn<EmailProviderAdapter["send"]>()
+      .mockResolvedValue({ success: true, messageId: "m-cf" });
+    const providerAdapter: EmailProviderAdapter = { send: adapterSend };
+
+    // DB lookup returns null so sendWithTemplate falls through to code-first.
+    const templateService = {
+      getTemplateBySlug: vi.fn().mockResolvedValue(null),
+      getLayout: vi.fn(),
+    } as unknown as EmailTemplateService;
+
+    const emailConfig = {
+      from: "no-reply@test.local",
+      providerConfig: { provider: "resend" as const, apiKey: "k" },
+      templates: {
+        welcome: () => ({ subject: "Welcome!", html: "<p>hi</p>" }),
+      },
+    };
+
+    const service = new EmailService(
+      makeAdapter(),
+      logger,
+      makeProviderService(),
+      templateService,
+      emailConfig
+    );
+    (service as unknown as { createAdapterFromRecord: unknown })[
+      "createAdapterFromRecord"
+    ] = () => providerAdapter;
+
+    await service.sendWithTemplate(
+      "welcome",
+      "u@e.com",
+      { userName: "Dev" },
+      {
+        cc,
+        bcc,
+      }
+    );
+
+    expect(adapterSend).toHaveBeenCalledWith(
+      expect.objectContaining({ cc, bcc })
+    );
+  });
+});

--- a/packages/nextly/src/domains/email/services/email-service.ts
+++ b/packages/nextly/src/domains/email/services/email-service.ts
@@ -216,6 +216,11 @@ export class EmailService extends BaseService {
         subject: result.subject,
         html: result.html,
         providerId: options?.providerId,
+        // Forward cc/bcc here too — the DB-template path already does, and
+        // omitting them on this branch silently dropped them for code-first
+        // templates.
+        cc: options?.cc,
+        bcc: options?.bcc,
         attachments:
           mergedAttachments.length > 0 ? mergedAttachments : undefined,
       });


### PR DESCRIPTION
## What

Make `cc`/`bcc` work consistently for email sends across every entry point.

Before this change:
- The **Direct API** email namespace (`nextly.email.send` / `nextly.email.sendWithTemplate`) silently dropped `cc`/`bcc` — the args types didn't declare them and the namespace only forwarded `providerId`/`attachments`.
- `EmailService.sendWithTemplate` dropped `cc`/`bcc` on the **code-first template fallback** branch, while the DB-template branch already forwarded them.

The REST route (`/api/email/send-with-template`) already supported `cc`/`bcc`, so the Direct API was the odd one out.

## Changes

- Add `cc?: string[]` / `bcc?: string[]` to `SendEmailArgs` and `SendTemplateEmailArgs`.
- Forward `cc`/`bcc` in `createEmailNamespace` (`send` + `sendWithTemplate`), guarding empty arrays so they don't make the options object truthy and override the "no options → undefined" path.
- Forward `cc`/`bcc` on the `EmailService` code-first fallback branch (parity with the DB-template branch).

## Tests

TDD — tests written first and watched fail before the fix.

- `direct-api/__tests__/email.test.ts` (new): namespace forwards `cc`/`bcc` for `send` and `sendWithTemplate`; omits empty arrays; forwards `cc` together with `providerId`; picks the first recipient from an array.
- `domains/email/__tests__/send-with-template-cc-bcc.test.ts` (new): both DB-template and code-first paths forward `cc`/`bcc` to the provider adapter.

`vitest` (new tests): 8/8 pass. `tsc --noEmit`: clean. `eslint` on changed source: clean.

## Notes

- 5 unrelated test failures exist on `main` (collections where-clause update/delete, media `bulkDelete`, smtp `secure` default) — confirmed pre-existing by running on a clean tree; not touched here.
