### PR TITLE
feat(plugins): P3c — secret() redaction (D37) + app-config permissions (D36)

### DIFF
--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -51,6 +51,7 @@ import { registerActivityLogHooks } from "../hooks/activity-log-hooks";
 import type { HookRegistry } from "../hooks/hook-registry";
 import { getHookRegistry } from "../hooks/hook-registry";
 import { createSanitizationHook } from "../hooks/sanitization-hooks";
+import type { PluginPermission } from "../plugins/contributions";
 import { getCoreVersion } from "../plugins/core-version";
 import { collectCustomPermissions } from "../plugins/permissions/collect-permissions";
 import type {
@@ -163,6 +164,9 @@ export interface NextlyServiceConfig {
 
   /** Plugins to initialize with Nextly. */
   plugins?: PluginDefinition[];
+
+  /** @experimental App-declared custom permissions, seeded like plugin permissions (D36). */
+  permissions?: PluginPermission[];
 
   /** Collection configurations. */
   collections?: CollectionConfig[];

--- a/packages/nextly/src/init/build-service-config.ts
+++ b/packages/nextly/src/init/build-service-config.ts
@@ -119,6 +119,12 @@ export function buildServiceConfig(
       }
     }
 
+    // If app-level custom permissions not explicitly provided, use from
+    // nextly.config.ts so they seed alongside plugin permissions (D36).
+    if (!serviceConfig.permissions && nextlyConfig?.permissions) {
+      serviceConfig.permissions = nextlyConfig.permissions;
+    }
+
     // If users config not explicitly provided, use from nextly.config.ts
     if (!serviceConfig.users && nextlyConfig?.users) {
       serviceConfig.users = nextlyConfig.users;

--- a/packages/nextly/src/plugins/permissions/collect-permissions.test.ts
+++ b/packages/nextly/src/plugins/permissions/collect-permissions.test.ts
@@ -98,4 +98,48 @@ describe("collectCustomPermissions", () => {
   it("returns [] for a plugin-free config", () => {
     expect(collectCustomPermissions(cfg(["posts"]), [])).toEqual([]);
   });
+
+  it("folds app-level config.permissions with owner 'app' (D36)", () => {
+    const out = collectCustomPermissions(
+      {
+        ...cfg(),
+        permissions: [{ action: "export", resource: "reports" }],
+      } as unknown as NextlyServiceConfig,
+      []
+    );
+    expect(out).toEqual([
+      {
+        action: "export",
+        resource: "reports",
+        slug: "export-reports",
+        name: "Export Reports",
+        description: undefined,
+        owner: "app",
+      },
+    ]);
+  });
+
+  it("throws when an app permission duplicates a plugin permission", () => {
+    expect(() =>
+      collectCustomPermissions(
+        {
+          ...cfg(),
+          permissions: [{ action: "export", resource: "submissions" }],
+        } as unknown as NextlyServiceConfig,
+        [plugin("@acme/a", [{ action: "export", resource: "submissions" }])]
+      )
+    ).toThrow();
+  });
+
+  it("throws when an app permission shadows a collection CRUD permission", () => {
+    expect(() =>
+      collectCustomPermissions(
+        {
+          ...cfg(["posts"]),
+          permissions: [{ action: "read", resource: "posts" }],
+        } as unknown as NextlyServiceConfig,
+        []
+      )
+    ).toThrow();
+  });
 });

--- a/packages/nextly/src/plugins/permissions/collect-permissions.ts
+++ b/packages/nextly/src/plugins/permissions/collect-permissions.ts
@@ -1,5 +1,6 @@
 import type { NextlyServiceConfig } from "../../di/register";
 import { isSystemResource } from "../../schemas/_zod/rbac";
+import type { PluginPermission } from "../contributions";
 import { permissionCollisionError } from "../permission-error";
 import type { PluginDefinition } from "../plugin-context";
 
@@ -45,49 +46,57 @@ export function collectCustomPermissions(
   const seen = new Map<string, string>(); // `${action}:${resource}` -> first owner
   const out: CollectedPermission[] = [];
 
-  for (const plugin of plugins) {
-    for (const perm of plugin.contributes?.permissions ?? []) {
-      const { action, resource } = perm;
-      const key = `${action}:${resource}`;
+  // One declared custom permission from a given owner ("app" or a plugin name).
+  // Shared by the app and plugin passes so both validate + collide identically.
+  const consider = (perm: PluginPermission, owner: string): void => {
+    const { action, resource } = perm;
+    const key = `${action}:${resource}`;
 
-      const prev = seen.get(key);
-      if (prev !== undefined) {
-        throw permissionCollisionError(
-          action,
-          resource,
-          [prev, plugin.name],
-          "duplicate-permission"
-        );
-      }
-      if (isSystemResource(resource)) {
-        throw permissionCollisionError(
-          action,
-          resource,
-          [plugin.name],
-          "system-resource-reserved"
-        );
-      }
-      if (
-        (CRUD_ACTIONS.has(action) && collectionSlugs.has(resource)) ||
-        (SINGLE_ACTIONS.has(action) && singleSlugs.has(resource))
-      ) {
-        throw permissionCollisionError(
-          action,
-          resource,
-          [plugin.name],
-          "crud-permission-reserved"
-        );
-      }
-
-      seen.set(key, plugin.name);
-      out.push({
+    const prev = seen.get(key);
+    if (prev !== undefined) {
+      throw permissionCollisionError(
         action,
         resource,
-        slug: `${action}-${resource}`,
-        name: perm.label ?? `${titleCase(action)} ${titleCase(resource)}`,
-        description: perm.description,
-        owner: plugin.name,
-      });
+        [prev, owner],
+        "duplicate-permission"
+      );
+    }
+    if (isSystemResource(resource)) {
+      throw permissionCollisionError(
+        action,
+        resource,
+        [owner],
+        "system-resource-reserved"
+      );
+    }
+    if (
+      (CRUD_ACTIONS.has(action) && collectionSlugs.has(resource)) ||
+      (SINGLE_ACTIONS.has(action) && singleSlugs.has(resource))
+    ) {
+      throw permissionCollisionError(
+        action,
+        resource,
+        [owner],
+        "crud-permission-reserved"
+      );
+    }
+
+    seen.set(key, owner);
+    out.push({
+      action,
+      resource,
+      slug: `${action}-${resource}`,
+      name: perm.label ?? `${titleCase(action)} ${titleCase(resource)}`,
+      description: perm.description,
+      owner,
+    });
+  };
+
+  // App-declared permissions first (owner "app"), then each plugin's (D36).
+  for (const perm of config.permissions ?? []) consider(perm, "app");
+  for (const plugin of plugins) {
+    for (const perm of plugin.contributes?.permissions ?? []) {
+      consider(perm, plugin.name);
     }
   }
 

--- a/packages/nextly/src/shared/types/config-permissions.test.ts
+++ b/packages/nextly/src/shared/types/config-permissions.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeConfig } from "./config";
+
+describe("sanitizeConfig — custom permissions (D36)", () => {
+  it("passes through app-declared permissions", () => {
+    const out = sanitizeConfig({
+      permissions: [
+        { action: "export", resource: "reports", label: "Export Reports" },
+      ],
+    });
+    expect(out.permissions).toEqual([
+      { action: "export", resource: "reports", label: "Export Reports" },
+    ]);
+  });
+
+  it("leaves permissions undefined when omitted", () => {
+    const out = sanitizeConfig({});
+    expect(out.permissions ?? []).toEqual([]);
+  });
+});

--- a/packages/nextly/src/shared/types/config.ts
+++ b/packages/nextly/src/shared/types/config.ts
@@ -16,6 +16,7 @@ import type { CorsConfig } from "../../middleware/cors";
 import type { RateLimitStore } from "../../middleware/rate-limit";
 import type { SecurityHeadersConfig } from "../../middleware/security-headers";
 import type { AdminPlacement } from "../../plugins/admin-placement";
+import type { PluginPermission } from "../../plugins/contributions";
 import type {
   PluginAdminAppearance,
   PluginDefinition,
@@ -605,6 +606,9 @@ export interface NextlyConfig {
   /** Plugins to extend Nextly functionality. */
   plugins?: PluginDefinition[];
 
+  /** @experimental Custom permissions declared by the app (seeded like plugin permissions, D36). */
+  permissions?: PluginPermission[];
+
   /** Security configuration for headers, CORS, uploads, and sanitization. */
   security?: SecurityConfig;
 
@@ -667,6 +671,9 @@ export interface SanitizedNextlyConfig {
 
   /** Plugins to extend Nextly functionality (empty array if none configured). */
   plugins: PluginDefinition[];
+
+  /** @experimental App-declared custom permissions (undefined if none). Seeded like plugin permissions (D36). */
+  permissions?: PluginPermission[];
 
   /** Security configuration for headers, CORS, uploads, and sanitization. */
   security?: SecurityConfig;
@@ -832,6 +839,7 @@ export function sanitizeConfig(config: NextlyConfig): SanitizedNextlyConfig {
     },
     storage: config.storage ?? [],
     plugins: config.plugins ?? [],
+    permissions: config.permissions,
     security: config.security,
     admin: config.admin,
   };

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -50,3 +50,6 @@ export {
   type ListQueryWhere,
   type ListQueryFilterContext,
 } from "nextly";
+
+// Secrets (D37) — redact secret config/env values at every leak vector.
+export { Secret, secret, isSecret } from "./secret";

--- a/packages/plugin-sdk/src/secret.test.ts
+++ b/packages/plugin-sdk/src/secret.test.ts
@@ -1,0 +1,32 @@
+import { inspect } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+import { isSecret, secret, Secret } from "./secret";
+
+describe("secret()", () => {
+  it("redacts in JSON.stringify", () => {
+    expect(JSON.stringify({ apiKey: secret("sk-123") })).toBe(
+      '{"apiKey":"[redacted]"}'
+    );
+  });
+  it("redacts in String() and template interpolation", () => {
+    const s = secret("sk-123");
+    expect(String(s)).toBe("[redacted]");
+    expect(`${s}`).toBe("[redacted]");
+  });
+  it("redacts under util.inspect (console.log)", () => {
+    expect(inspect(secret("sk-123"))).toBe("[redacted]");
+  });
+  it("reveals the real value explicitly", () => {
+    expect(secret("sk-123").reveal()).toBe("sk-123");
+  });
+  it("preserves non-string value types via reveal", () => {
+    expect(secret({ token: 1 }).reveal()).toEqual({ token: 1 });
+  });
+  it("isSecret distinguishes wrapped from raw", () => {
+    expect(isSecret(secret("x"))).toBe(true);
+    expect(isSecret("x")).toBe(false);
+    expect(isSecret(new Secret("x"))).toBe(true);
+  });
+});

--- a/packages/plugin-sdk/src/secret.ts
+++ b/packages/plugin-sdk/src/secret.ts
@@ -1,0 +1,38 @@
+const REDACTED = "[redacted]";
+
+/**
+ * @experimental A secret value that auto-redacts at every common leak vector —
+ * `JSON.stringify` (`toJSON`), `String()`/template interpolation (`toString`),
+ * and `console.log`/`util.inspect` (the node inspect symbol). The real value is
+ * available only via the explicit, greppable `.reveal()`. Wrap secret config /
+ * env values (D37): `secret(process.env.API_KEY)`.
+ */
+export class Secret<T = string> {
+  readonly #value: T;
+  constructor(value: T) {
+    this.#value = value;
+  }
+  /** Return the underlying secret value. The only way to read it. */
+  reveal(): T {
+    return this.#value;
+  }
+  toJSON(): string {
+    return REDACTED;
+  }
+  toString(): string {
+    return REDACTED;
+  }
+  [Symbol.for("nodejs.util.inspect.custom")](): string {
+    return REDACTED;
+  }
+}
+
+/** @experimental Wrap a value so it redacts unless explicitly `.reveal()`ed (D37). */
+export function secret<T>(value: T): Secret<T> {
+  return new Secret(value);
+}
+
+/** @experimental True if `value` is a {@link Secret}. */
+export function isSecret(value: unknown): value is Secret<unknown> {
+  return value instanceof Secret;
+}


### PR DESCRIPTION
## Summary
Part of the P3 remainder, stacked on P3b. Ships two of the three planned components; **D35 (ctx.services elevation) was deferred** — see below.

- **D37 — `secret()` redaction primitive** (`@nextlyhq/plugin-sdk`): `Secret<T>`/`secret()`/`isSecret` that auto-redact via `toJSON`/`toString`/`util.inspect` (→ `[redacted]`) with explicit `.reveal()`. Protects logs, `NextlyError.logContext`, any `JSON.stringify`. Framework-free; no collection field type (matches D37's "via env/config only").
- **D36 — app-config custom permissions**: `config.permissions?: PluginPermission[]` on `NextlyConfig`/`NextlyServiceConfig` (+ sanitize + `buildServiceConfig` threading); `collectCustomPermissions` folds app perms (owner `app`) under the same collision rules as plugin perms. Seeds via the existing P3a boot/post-init wiring.

## D35 deferred (honest note)
The combined plan assumed `ctx.services.collections` was the entry service `(params{user,overrideAccess}, body)`. The real facade is `domains/.../collection-service.ts` `(name, data, context: RequestContext)` — no override path, throws on denial, used by the direct API, and `RequestContext.user` ({id,email,role,permissions}) is incompatible with `AuthUser`. Real `{as:'system'}` needs additive overrideAccess threading through the shared facade + reconciling 3 user types — a design-sensitive core change, not a pure wrapper. The wrong-shaped `ServiceOpts`/translator work was reverted; D35 gets its own brainstorm. **So P3 is not fully complete — D35 remains.**

## Test Plan
- [x] nextly unit baseline unchanged (405 failed / 32 files) → zero new failures; +5 new passing (secret 6 in sdk; config 2 + collector 3 in nextly)
- [x] SDK + nextly build + check-types clean
- [x] form-builder 16/16 unchanged

Stacked on `feat/plugin-p3b-client-gating`; retarget to `feat/plugin-platform` after the earlier P3 PRs merge. No changeset.