### PR TITLE
P4 — API & routes: contributes.routes (D25–D28)

### DIFF
--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -60,6 +60,8 @@ import type {
 } from "../plugins/plugin-context";
 import { createPluginContext } from "../plugins/plugin-context";
 import { resolvePlugins } from "../plugins/resolve";
+import { collectPluginRoutes } from "../plugins/routes/collect-routes";
+import { getPluginRouteRegistry } from "../plugins/routes/route-registry";
 import { applyPluginSchemaContributions } from "../plugins/schema/apply-contributions";
 import {
   validateCrossPluginRelations,
@@ -1514,6 +1516,10 @@ async function initializePlugins(
   const plugins = transformedConfig.plugins ?? [];
   if (plugins.length === 0) return [];
 
+  // Collect + validate contributed routes BEFORE any init runs so a route
+  // collision / invalid path fails the boot fast (D25/D7), before side effects.
+  const collectedRoutes = collectPluginRoutes(plugins);
+
   const pluginHookRegistry = hookRegistry ?? getHookRegistry();
 
   const getServiceForPlugin = <
@@ -1616,6 +1622,25 @@ async function initializePlugins(
       name: plugin.name,
       version: plugin.version,
     });
+  }
+
+  // Register contributed routes into the global registry (D25). Rebuilt every
+  // boot (cleared first) so HMR / re-registration never accumulates. Each route
+  // carries its plugin's boot-built context; the dispatcher adds per-request
+  // user/params at call time.
+  const routeRegistry = getPluginRouteRegistry();
+  routeRegistry.clear();
+  if (collectedRoutes.length > 0) {
+    const contextByPlugin = new Map(
+      teardown.map(t => [t.plugin.name, t.context])
+    );
+    for (const collected of collectedRoutes) {
+      const context = contextByPlugin.get(collected.pluginName);
+      if (context) {
+        routeRegistry.register(collected.pluginName, collected.route, context);
+      }
+    }
+    logger.info?.(`Registered ${collectedRoutes.length} plugin route(s)`);
   }
 
   return teardown;

--- a/packages/nextly/src/errors/error-codes.ts
+++ b/packages/nextly/src/errors/error-codes.ts
@@ -55,6 +55,9 @@ export const NEXTLY_ERROR_STATUS = {
   NEXTLY_SCHEMA_RENAME_UNKNOWN_TARGET: 400,
   // Plugin platform (P0) — boot-time plugin dependency/version resolution.
   PLUGIN_RESOLUTION_ERROR: 500,
+  // Plugin platform (P4) — contributes.routes collection (D25).
+  NEXTLY_ROUTE_COLLISION: 409,
+  NEXTLY_ROUTE_INVALID_PATH: 400,
 } as const;
 
 export type NextlyErrorCode = keyof typeof NEXTLY_ERROR_STATUS;

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -353,6 +353,11 @@ export {
   type PluginHookRegistry,
   type PluginFilterRegistry,
   type PluginActionRegistry,
+  type PluginRoute,
+  type PluginRouteContext,
+  type PluginRouteHandler,
+  type Middleware,
+  type RouteMethod,
 } from "./plugins";
 
 // Managed-services elevation (D35) — `ctx.services` ServiceOpts + the auth user.

--- a/packages/nextly/src/plugins/contributions.ts
+++ b/packages/nextly/src/plugins/contributions.ts
@@ -3,6 +3,8 @@ import type { FieldConfig } from "../collections/fields/types";
 import type { ComponentConfig } from "../components/config/types";
 import type { SingleConfig } from "../singles/config/types";
 
+import type { PluginRoute } from "./routes/route-types";
+
 /**
  * @experimental A plugin-declared custom permission (D36). CRUD permissions are
  * auto-seeded per collection/single slug separately — declare only NON-CRUD
@@ -27,9 +29,9 @@ export type PermissionSlug = string;
  * Declarative, introspectable plugin contributions (D1). The host can read these
  * WITHOUT running the plugin.
  *
- * @experimental Contract surface only in P0 — each key is *consumed* by a later
- * phase: collections/singles/components/extend → P2 (merge pipeline); permissions
- * → P3; events → P1. `routes` (P4) and `admin` (P5) keys are added in those phases.
+ * @experimental Each key is *consumed* by a phase: collections/singles/components/
+ * extend → P2 (merge pipeline); permissions → P3; events → P1; routes → P4. The
+ * `admin` (P5) key is added in that phase.
  */
 export interface PluginContributions {
   /** @experimental New plugin-owned collections. Merged by the schema pipeline (P2, D3/D12). */
@@ -44,4 +46,6 @@ export interface PluginContributions {
   permissions?: PluginPermission[];
   /** @experimental Custom event names this plugin may emit (P1, D9). */
   events?: Array<{ name: string }>;
+  /** @experimental HTTP routes, namespaced under /api/plugins/<name> (P4, D25). */
+  routes?: PluginRoute[];
 }

--- a/packages/nextly/src/plugins/index.ts
+++ b/packages/nextly/src/plugins/index.ts
@@ -28,3 +28,12 @@ export type {
   PluginPermission,
   PermissionSlug,
 } from "./contributions";
+
+// Plugin HTTP routes (P4, D25/D26/D27) — `contributes.routes` surface.
+export type {
+  PluginRoute,
+  PluginRouteContext,
+  PluginRouteHandler,
+  Middleware,
+  RouteMethod,
+} from "./routes/route-types";

--- a/packages/nextly/src/plugins/routes/collect-routes.test.ts
+++ b/packages/nextly/src/plugins/routes/collect-routes.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../errors/nextly-error";
+import type { PluginDefinition } from "../plugin-context";
+
+import { collectPluginRoutes } from "./collect-routes";
+
+const h = () => new Response("");
+
+/** Capture the NextlyError a thunk throws and return its `code`. */
+function thrownCode(fn: () => unknown): string {
+  try {
+    fn();
+  } catch (e) {
+    return (e as NextlyError).code as string;
+  }
+  throw new Error("expected the function to throw");
+}
+
+function plugin(
+  name: string,
+  routes: Array<{ method: "GET" | "POST"; path: string }>,
+  enabled?: boolean
+): PluginDefinition {
+  return {
+    name,
+    version: "1.0.0",
+    nextly: ">=0.0.1",
+    ...(enabled === undefined ? {} : { enabled }),
+    contributes: { routes: routes.map(r => ({ ...r, handler: h })) },
+  } as PluginDefinition;
+}
+
+describe("collectPluginRoutes", () => {
+  it("collects enabled plugins' routes, namespaced; skips disabled (D49)", () => {
+    const collected = collectPluginRoutes([
+      plugin("@a/x", [{ method: "GET", path: "/p" }]),
+      plugin("@a/y", [{ method: "GET", path: "/q" }], false),
+    ]);
+    expect(collected.map(r => r.fullPath)).toEqual(["/plugins/@a/x/p"]);
+    expect(collected[0].pluginName).toBe("@a/x");
+  });
+
+  it("throws on a (method, path) collision across plugins", () => {
+    expect(
+      thrownCode(() =>
+        collectPluginRoutes([
+          plugin("@a/x", [{ method: "GET", path: "/p" }]),
+          plugin("@a/x", [{ method: "GET", path: "/p" }]),
+        ])
+      )
+    ).toBe("NEXTLY_ROUTE_COLLISION");
+  });
+
+  it("allows the same path with different methods", () => {
+    const collected = collectPluginRoutes([
+      plugin("@a/x", [
+        { method: "GET", path: "/p" },
+        { method: "POST", path: "/p" },
+      ]),
+    ]);
+    expect(collected).toHaveLength(2);
+  });
+
+  it("rejects a path without a leading slash", () => {
+    expect(
+      thrownCode(() =>
+        collectPluginRoutes([plugin("@a/x", [{ method: "GET", path: "bad" }])])
+      )
+    ).toBe("NEXTLY_ROUTE_INVALID_PATH");
+  });
+
+  it("returns an empty list when no plugin contributes routes", () => {
+    expect(
+      collectPluginRoutes([
+        { name: "@a/z", version: "1", nextly: ">=0" } as PluginDefinition,
+      ])
+    ).toEqual([]);
+  });
+});

--- a/packages/nextly/src/plugins/routes/collect-routes.ts
+++ b/packages/nextly/src/plugins/routes/collect-routes.ts
@@ -1,0 +1,62 @@
+import type { PluginDefinition } from "../plugin-context";
+
+import { routeCollisionError, routeInvalidPathError } from "./route-error";
+import type { PluginRoute } from "./route-types";
+
+/** A route collected from a plugin, namespaced and ready to register. */
+export interface CollectedRoute {
+  pluginName: string;
+  method: PluginRoute["method"];
+  /** The plugin-declared path (within its namespace). */
+  path: string;
+  /** Namespaced path: `/plugins/<pluginName><path>`. */
+  fullPath: string;
+  route: PluginRoute;
+}
+
+/**
+ * Pure fold of every ENABLED plugin's `contributes.routes` into namespaced,
+ * collision-checked routes (D25). Disabled plugins (`enabled: false`) skip
+ * behavior — including routes — while their schema is still applied (D49).
+ *
+ * Throws {@link routeInvalidPathError} for a path without a leading slash and
+ * {@link routeCollisionError} when two routes share a `(method, full path)`.
+ */
+export function collectPluginRoutes(
+  plugins: PluginDefinition[]
+): CollectedRoute[] {
+  const collected: CollectedRoute[] = [];
+  // Tracks the first owner of each (method, fullPath) for collision reporting.
+  const seen = new Map<string, string>();
+
+  for (const plugin of plugins) {
+    if (plugin.enabled === false) continue;
+    const routes = plugin.contributes?.routes;
+    if (!routes || routes.length === 0) continue;
+
+    for (const route of routes) {
+      if (!route.path.startsWith("/")) {
+        throw routeInvalidPathError(plugin.name, route.path);
+      }
+      const fullPath = `/plugins/${plugin.name}${route.path}`;
+      const key = `${route.method} ${fullPath}`;
+      const existingOwner = seen.get(key);
+      if (existingOwner !== undefined) {
+        throw routeCollisionError(route.method, fullPath, [
+          existingOwner,
+          plugin.name,
+        ]);
+      }
+      seen.set(key, plugin.name);
+      collected.push({
+        pluginName: plugin.name,
+        method: route.method,
+        path: route.path,
+        fullPath,
+        route,
+      });
+    }
+  }
+
+  return collected;
+}

--- a/packages/nextly/src/plugins/routes/dispatch-auth.test.ts
+++ b/packages/nextly/src/plugins/routes/dispatch-auth.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the auth middleware so we drive the secure-by-default branches without a
+// real session. isErrorResponse/createJsonErrorResponse keep their real shape.
+vi.mock("../../auth/middleware", () => ({
+  requireAuthentication: vi.fn(),
+  requirePermission: vi.fn(),
+  isErrorResponse: (x: unknown) =>
+    !!x && typeof x === "object" && "statusCode" in x,
+  createJsonErrorResponse: (e: { statusCode: number; error?: string }) =>
+    new Response(JSON.stringify({ error: e }), { status: e.statusCode }),
+}));
+
+import {
+  requireAuthentication,
+  requirePermission,
+} from "../../auth/middleware";
+import type { PluginContext } from "../plugin-context";
+
+import { runPluginRoute } from "./dispatch";
+import type { RouteMatch } from "./route-registry";
+import type { PluginRoute } from "./route-types";
+
+const reqAuth = vi.mocked(requireAuthentication);
+const reqPerm = vi.mocked(requirePermission);
+
+const baseCtx = {
+  self: { name: "@a/x", collections: {}, singles: {} },
+  logger: { info() {}, warn() {}, error() {} },
+} as unknown as PluginContext;
+
+let handlerCalls = 0;
+function route(extra: Partial<PluginRoute>): PluginRoute {
+  return {
+    method: "GET",
+    path: "/r",
+    handler: (_req, ctx) => {
+      handlerCalls++;
+      return Response.json({ user: ctx.user });
+    },
+    ...extra,
+  } as PluginRoute;
+}
+function match(r: PluginRoute): RouteMatch {
+  return { pluginName: "@a/x", route: r, baseCtx, params: {} };
+}
+const req = () => new Request("http://x/api/plugins/@a/x/r");
+const okAuth = { userId: "u1", userEmail: "u1@x.com", userName: "U" };
+
+beforeEach(() => {
+  handlerCalls = 0;
+  reqAuth.mockReset();
+  reqPerm.mockReset();
+});
+
+describe("secure-by-default plugin route dispatch (D28)", () => {
+  it("public route runs the handler without calling auth; user is null", async () => {
+    const res = await runPluginRoute(req(), match(route({ public: true })));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ user: null });
+    expect(reqAuth).not.toHaveBeenCalled();
+    expect(handlerCalls).toBe(1);
+  });
+
+  it("protected route returns 401 when unauthenticated; handler not called", async () => {
+    reqAuth.mockResolvedValue({ statusCode: 401 } as never);
+    const res = await runPluginRoute(req(), match(route({})));
+    expect(res.status).toBe(401);
+    expect(handlerCalls).toBe(0);
+  });
+
+  it("protected route runs with a mapped ctx.user when authenticated", async () => {
+    reqAuth.mockResolvedValue(okAuth as never);
+    const res = await runPluginRoute(req(), match(route({})));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      user: { id: "u1", email: "u1@x.com", name: "U" },
+    });
+    expect(handlerCalls).toBe(1);
+  });
+
+  it("requiredPermission route returns 403 when denied; handler not called", async () => {
+    reqPerm.mockResolvedValue({ statusCode: 403 } as never);
+    const res = await runPluginRoute(
+      req(),
+      match(route({ requiredPermission: "export-submissions" }))
+    );
+    expect(res.status).toBe(403);
+    expect(reqPerm).toHaveBeenCalledWith(
+      expect.anything(),
+      "export",
+      "submissions"
+    );
+    expect(handlerCalls).toBe(0);
+  });
+
+  it("requiredPermission route runs when permission is granted", async () => {
+    reqPerm.mockResolvedValue(okAuth as never);
+    const res = await runPluginRoute(
+      req(),
+      match(route({ requiredPermission: "export-submissions" }))
+    );
+    expect(res.status).toBe(200);
+    expect(handlerCalls).toBe(1);
+    expect(reqAuth).not.toHaveBeenCalled(); // requirePermission covers auth
+  });
+});

--- a/packages/nextly/src/plugins/routes/dispatch.test.ts
+++ b/packages/nextly/src/plugins/routes/dispatch.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../errors/nextly-error";
+import type { PluginContext } from "../plugin-context";
+
+import { runPluginRoute } from "./dispatch";
+import type { RouteMatch } from "./route-registry";
+import type { PluginRoute } from "./route-types";
+
+const baseCtx = {
+  self: { name: "@a/x", collections: {}, singles: {} },
+  logger: { info() {}, warn() {}, error() {} },
+} as unknown as PluginContext;
+
+function match(
+  route: PluginRoute,
+  params: Record<string, string> = {}
+): RouteMatch {
+  return { pluginName: "@a/x", route, baseCtx, params };
+}
+
+describe("runPluginRoute", () => {
+  it("invokes the handler with a per-request ctx (user + params) and returns its Response", async () => {
+    const route: PluginRoute = {
+      method: "GET",
+      path: "/i/:id",
+      public: true,
+      handler: (_req, ctx) =>
+        Response.json({
+          id: ctx.params.id,
+          who: ctx.self.name,
+          user: ctx.user,
+        }),
+    };
+    const res = await runPluginRoute(
+      new Request("http://x/api/plugins/@a/x/i/7"),
+      match(route, { id: "7" })
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: "7", who: "@a/x", user: null });
+  });
+
+  it("maps a handler-thrown NextlyError to an error Response with its status", async () => {
+    const route: PluginRoute = {
+      method: "GET",
+      path: "/boom",
+      public: true,
+      handler: () => {
+        throw new NextlyError({
+          code: "NOT_FOUND",
+          statusCode: 404,
+          publicMessage: "nope",
+        });
+      },
+    };
+    const res = await runPluginRoute(
+      new Request("http://x/api/plugins/@a/x/boom"),
+      match(route)
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("maps an unknown thrown error to a 500 (never crashes the dispatcher)", async () => {
+    const route: PluginRoute = {
+      method: "GET",
+      path: "/explode",
+      public: true,
+      handler: () => {
+        throw new Error("kaboom");
+      },
+    };
+    const res = await runPluginRoute(
+      new Request("http://x/api/plugins/@a/x/explode"),
+      match(route)
+    );
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/nextly/src/plugins/routes/dispatch.ts
+++ b/packages/nextly/src/plugins/routes/dispatch.ts
@@ -8,6 +8,7 @@ import {
 import { NextlyError } from "../../errors/nextly-error";
 import type { AuthUser } from "../../types/auth";
 
+import { composeMiddleware } from "./middleware";
 import { parsePermissionSlug } from "./permission-slug";
 import type { RouteMatch } from "./route-registry";
 import type { PluginRoute, PluginRouteContext } from "./route-types";
@@ -87,8 +88,13 @@ export async function runPluginRoute(
     params: matched.params,
   };
 
+  const run = composeMiddleware(
+    matched.route.middleware ?? [],
+    matched.route.handler
+  );
+
   try {
-    return await matched.route.handler(req, ctx);
+    return await run(req, ctx);
   } catch (err) {
     return toErrorResponse(req, err);
   }

--- a/packages/nextly/src/plugins/routes/dispatch.ts
+++ b/packages/nextly/src/plugins/routes/dispatch.ts
@@ -1,8 +1,16 @@
 import { readOrGenerateRequestId } from "../../api/request-id";
+import {
+  createJsonErrorResponse,
+  isErrorResponse,
+  requireAuthentication,
+  requirePermission,
+} from "../../auth/middleware";
 import { NextlyError } from "../../errors/nextly-error";
+import type { AuthUser } from "../../types/auth";
 
+import { parsePermissionSlug } from "./permission-slug";
 import type { RouteMatch } from "./route-registry";
-import type { PluginRouteContext } from "./route-types";
+import type { PluginRoute, PluginRouteContext } from "./route-types";
 
 /**
  * Map an error thrown by a plugin route handler to a JSON error Response,
@@ -26,19 +34,56 @@ function toErrorResponse(req: Request, err: unknown): Response {
 }
 
 /**
- * Run a matched plugin route (D25/D26). Builds the per-request
- * {@link PluginRouteContext} (the plugin's boot context plus `user`/`params`)
- * and invokes the handler, isolating any thrown error into a Response.
- *
- * Secure-by-default auth (D28) is layered on in {@link resolvePluginRouteAuth}.
+ * Resolve secure-by-default auth for a route (D28). `public: true` skips auth
+ * (`user` is `null`). Otherwise the request must be authenticated; if the route
+ * declares `requiredPermission`, that permission is enforced too. Returns either
+ * the resolved `user` or a ready-to-return error Response (401/403).
+ */
+async function resolvePluginRouteAuth(
+  req: Request,
+  route: PluginRoute
+): Promise<{ user: AuthUser | null } | { errorResponse: Response }> {
+  if (route.public === true) return { user: null };
+
+  // requirePermission already enforces authentication, so the permission-gated
+  // path needs a single call (avoids verifying the session twice).
+  const authResult = route.requiredPermission
+    ? await requirePermission(req, ...permissionArgs(route.requiredPermission))
+    : await requireAuthentication(req);
+
+  if (isErrorResponse(authResult)) {
+    return { errorResponse: createJsonErrorResponse(authResult) };
+  }
+
+  const user: AuthUser = {
+    id: authResult.userId as AuthUser["id"],
+    email: authResult.userEmail ?? "",
+    name: authResult.userName ?? null,
+  };
+  return { user };
+}
+
+function permissionArgs(slug: string): [string, string] {
+  const { action, resource } = parsePermissionSlug(slug);
+  return [action, resource];
+}
+
+/**
+ * Run a matched plugin route (D25/D26). Enforces secure-by-default auth (D28),
+ * builds the per-request {@link PluginRouteContext} (the plugin's boot context
+ * plus `user`/`params`), and invokes the handler, isolating any thrown error
+ * into a Response.
  */
 export async function runPluginRoute(
   req: Request,
   matched: RouteMatch
 ): Promise<Response> {
+  const auth = await resolvePluginRouteAuth(req, matched.route);
+  if ("errorResponse" in auth) return auth.errorResponse;
+
   const ctx: PluginRouteContext = {
     ...matched.baseCtx,
-    user: null,
+    user: auth.user,
     params: matched.params,
   };
 

--- a/packages/nextly/src/plugins/routes/dispatch.ts
+++ b/packages/nextly/src/plugins/routes/dispatch.ts
@@ -1,0 +1,50 @@
+import { readOrGenerateRequestId } from "../../api/request-id";
+import { NextlyError } from "../../errors/nextly-error";
+
+import type { RouteMatch } from "./route-registry";
+import type { PluginRouteContext } from "./route-types";
+
+/**
+ * Map an error thrown by a plugin route handler to a JSON error Response,
+ * reusing the dispatcher's `{ error: ... }` / problem+json convention. A
+ * non-NextlyError becomes a generic 500 — a handler failure must never crash
+ * the server (D28-adjacent robustness).
+ */
+function toErrorResponse(req: Request, err: unknown): Response {
+  const requestId = readOrGenerateRequestId(req);
+  const nextlyErr = NextlyError.is(err) ? err : NextlyError.internal();
+  return new Response(
+    JSON.stringify({ error: nextlyErr.toResponseJSON(requestId) }),
+    {
+      status: nextlyErr.statusCode,
+      headers: {
+        "content-type": "application/problem+json",
+        "x-request-id": requestId,
+      },
+    }
+  );
+}
+
+/**
+ * Run a matched plugin route (D25/D26). Builds the per-request
+ * {@link PluginRouteContext} (the plugin's boot context plus `user`/`params`)
+ * and invokes the handler, isolating any thrown error into a Response.
+ *
+ * Secure-by-default auth (D28) is layered on in {@link resolvePluginRouteAuth}.
+ */
+export async function runPluginRoute(
+  req: Request,
+  matched: RouteMatch
+): Promise<Response> {
+  const ctx: PluginRouteContext = {
+    ...matched.baseCtx,
+    user: null,
+    params: matched.params,
+  };
+
+  try {
+    return await matched.route.handler(req, ctx);
+  } catch (err) {
+    return toErrorResponse(req, err);
+  }
+}

--- a/packages/nextly/src/plugins/routes/middleware.test.ts
+++ b/packages/nextly/src/plugins/routes/middleware.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import type { PluginRouteContext } from "./route-types";
+import { composeMiddleware } from "./middleware";
+
+const ctx = {} as PluginRouteContext;
+const req = () => new Request("http://x");
+
+describe("composeMiddleware", () => {
+  it("runs middleware in order, wrapping the handler (onion model)", async () => {
+    const calls: string[] = [];
+    const run = composeMiddleware(
+      [
+        async (_r, _c, next) => {
+          calls.push("a:in");
+          const res = await next();
+          calls.push("a:out");
+          return res;
+        },
+        async (_r, _c, next) => {
+          calls.push("b");
+          return next();
+        },
+      ],
+      () => {
+        calls.push("handler");
+        return new Response("h");
+      }
+    );
+    const res = await run(req(), ctx);
+    expect(await res.text()).toBe("h");
+    expect(calls).toEqual(["a:in", "b", "handler", "a:out"]);
+  });
+
+  it("lets a middleware short-circuit without calling next", async () => {
+    let handlerRan = false;
+    const run = composeMiddleware(
+      [async () => new Response("blocked", { status: 403 })],
+      () => {
+        handlerRan = true;
+        return new Response("h");
+      }
+    );
+    const res = await run(req(), ctx);
+    expect(res.status).toBe(403);
+    expect(handlerRan).toBe(false);
+  });
+
+  it("runs the handler directly when there is no middleware", async () => {
+    const run = composeMiddleware([], () => new Response("h"));
+    expect(await (await run(req(), ctx)).text()).toBe("h");
+  });
+
+  it("propagates a thrown error (runPluginRoute maps it to a Response)", async () => {
+    const run = composeMiddleware(
+      [
+        async () => {
+          throw new Error("boom");
+        },
+      ],
+      () => new Response("h")
+    );
+    await expect(run(req(), ctx)).rejects.toThrow("boom");
+  });
+});

--- a/packages/nextly/src/plugins/routes/middleware.ts
+++ b/packages/nextly/src/plugins/routes/middleware.ts
@@ -1,0 +1,27 @@
+import type { Middleware, PluginRouteContext } from "./route-types";
+
+/** The terminal of a middleware chain — the plugin's route handler. */
+type TerminalHandler = (
+  req: Request,
+  ctx: PluginRouteContext
+) => Response | Promise<Response>;
+
+/**
+ * Compose an ordered, typed route-level middleware chain (D27, onion model).
+ * Each middleware may transform the request/response, short-circuit by returning
+ * a Response without calling `next`, or call `next()` to continue. Thrown errors
+ * propagate to the caller ({@link runPluginRoute} maps them to a Response).
+ */
+export function composeMiddleware(
+  middleware: Middleware[],
+  handler: TerminalHandler
+): (req: Request, ctx: PluginRouteContext) => Promise<Response> {
+  return (req, ctx) => {
+    const dispatch = (index: number): Promise<Response> => {
+      const mw = middleware[index];
+      if (!mw) return Promise.resolve(handler(req, ctx));
+      return mw(req, ctx, () => dispatch(index + 1));
+    };
+    return dispatch(0);
+  };
+}

--- a/packages/nextly/src/plugins/routes/permission-slug.test.ts
+++ b/packages/nextly/src/plugins/routes/permission-slug.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { parsePermissionSlug } from "./permission-slug";
+
+describe("parsePermissionSlug", () => {
+  it("splits a slug into action and resource on the first hyphen", () => {
+    expect(parsePermissionSlug("export-submissions")).toEqual({
+      action: "export",
+      resource: "submissions",
+    });
+    expect(parsePermissionSlug("read-posts")).toEqual({
+      action: "read",
+      resource: "posts",
+    });
+  });
+
+  it("keeps later hyphens in the resource (action has no hyphen)", () => {
+    expect(parsePermissionSlug("export-form-submissions")).toEqual({
+      action: "export",
+      resource: "form-submissions",
+    });
+  });
+
+  it("treats a slug without a hyphen as an action with an empty resource", () => {
+    expect(parsePermissionSlug("manage")).toEqual({
+      action: "manage",
+      resource: "",
+    });
+  });
+});

--- a/packages/nextly/src/plugins/routes/permission-slug.ts
+++ b/packages/nextly/src/plugins/routes/permission-slug.ts
@@ -1,0 +1,17 @@
+/**
+ * Split a permission slug into its `action` and `resource` (D28/D36).
+ *
+ * Permission slugs are canonically `${action}-${resource}` (e.g.
+ * `"export-submissions"`). Actions are single tokens with no hyphen, so we split
+ * on the FIRST hyphen — any further hyphens belong to the resource (e.g.
+ * `"export-form-submissions"` → `{ action: "export", resource: "form-submissions" }`).
+ * A slug with no hyphen is treated as an action with an empty resource.
+ */
+export function parsePermissionSlug(slug: string): {
+  action: string;
+  resource: string;
+} {
+  const idx = slug.indexOf("-");
+  if (idx === -1) return { action: slug, resource: "" };
+  return { action: slug.slice(0, idx), resource: slug.slice(idx + 1) };
+}

--- a/packages/nextly/src/plugins/routes/plugin-routes.integration.test.ts
+++ b/packages/nextly/src/plugins/routes/plugin-routes.integration.test.ts
@@ -1,0 +1,116 @@
+/**
+ * End-to-end secure-by-default proof for plugin routes (D28), driven through the
+ * REAL catch-all dispatcher (`createDynamicHandlers`) with REAL JWT auth.
+ *
+ * Coverage split (documented): auth is stateless JWT verification, so a signed
+ * `nextly_session` cookie exercises the real auth path here — proving routes are
+ * closed by default (401), `public` opts out (200), and `requiredPermission`
+ * blocks the unprivileged (403). The `requiredPermission`-GRANTED path is DB-RBAC
+ * backed (`isSuperAdmin`/`hasPermission` resolve by userId from the DB) and the
+ * harness does not seed a privileged user, so that positive branch is covered by
+ * the unit test `dispatch-auth.test.ts` (requirePermission → AuthContext → handler).
+ */
+
+// Must be set before the harness boots (env validation) and to sign test tokens.
+process.env.NEXTLY_SECRET =
+  process.env.NEXTLY_SECRET ??
+  "test-secret-must-be-at-least-32-characters-long!!";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { buildClaims } from "../../auth/jwt/claims";
+import { signAccessToken } from "../../auth/jwt/sign";
+import { createDynamicHandlers } from "../../routeHandler";
+import { definePlugin } from "../plugin-context";
+import type { TestNextly } from "../test-nextly";
+import { createTestNextly } from "../test-nextly";
+
+const PLUGIN = "@test/routes-e2e";
+
+const e2ePlugin = definePlugin({
+  name: PLUGIN,
+  version: "1.0.0",
+  nextly: ">=0.0.1",
+  contributes: {
+    routes: [
+      {
+        method: "GET",
+        path: "/open",
+        public: true,
+        handler: () => Response.json({ ok: true }),
+      },
+      {
+        method: "GET",
+        path: "/whoami",
+        handler: (_req, ctx) => Response.json({ id: ctx.user?.id ?? null }),
+      },
+      {
+        method: "GET",
+        path: "/privileged",
+        requiredPermission: "manage-things",
+        handler: () => Response.json({ secret: true }),
+      },
+    ],
+  },
+});
+
+async function cookie(roleIds: string[] = []): Promise<string> {
+  const token = await signAccessToken(
+    buildClaims({
+      userId: "u1",
+      email: "u1@example.com",
+      name: "U1",
+      image: null,
+      roleIds,
+    }),
+    process.env.NEXTLY_SECRET!
+  );
+  return `nextly_session=${token}`;
+}
+
+/** Call the real catch-all for GET /api/plugins/<PLUGIN>/<sub>. */
+function get(
+  sub: string,
+  headers: Record<string, string> = {}
+): Promise<Response> {
+  const handlers = createDynamicHandlers();
+  const url = `http://localhost/api/plugins/${PLUGIN}/${sub}`;
+  const params = ["plugins", ...PLUGIN.split("/"), sub];
+  return handlers.GET(new Request(url, { headers }), {
+    params: Promise.resolve({ params }),
+  });
+}
+
+let handle: TestNextly | undefined;
+afterEach(async () => {
+  await handle?.destroy();
+  handle = undefined;
+});
+
+describe("plugin routes — secure by default (D28, end-to-end)", () => {
+  it("a public route is reachable without auth", async () => {
+    handle = await createTestNextly({ plugins: [e2ePlugin] });
+    const res = await get("open");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("a non-public route returns 401 without a session", async () => {
+    handle = await createTestNextly({ plugins: [e2ePlugin] });
+    expect((await get("whoami")).status).toBe(401);
+  });
+
+  it("a non-public route runs with the authed user when a session is present", async () => {
+    handle = await createTestNextly({ plugins: [e2ePlugin] });
+    const res = await get("whoami", { cookie: await cookie() });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: "u1" });
+  });
+
+  it("a requiredPermission route returns 403 for a user lacking the permission", async () => {
+    handle = await createTestNextly({ plugins: [e2ePlugin] });
+    expect((await get("privileged", { cookie: await cookie() })).status).toBe(
+      403
+    );
+  });
+});

--- a/packages/nextly/src/plugins/routes/route-boot.integration.test.ts
+++ b/packages/nextly/src/plugins/routes/route-boot.integration.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { definePlugin } from "../plugin-context";
+import type { TestNextly } from "../test-nextly";
+import { createTestNextly } from "../test-nextly";
+
+import { getPluginRouteRegistry } from "./route-registry";
+
+const routePlugin = definePlugin({
+  name: "@test/routes-boot",
+  version: "1.0.0",
+  nextly: ">=0.0.1",
+  contributes: {
+    routes: [
+      {
+        method: "GET",
+        path: "/ping",
+        public: true,
+        handler: () => Response.json({ pong: true }),
+      },
+    ],
+  },
+});
+
+let handle: TestNextly | undefined;
+afterEach(async () => {
+  await handle?.destroy();
+  handle = undefined;
+});
+
+describe("plugin route registration at boot", () => {
+  it("registers a contributed route with the plugin's base context", async () => {
+    handle = await createTestNextly({ plugins: [routePlugin] });
+    const match = getPluginRouteRegistry().match(
+      "GET",
+      "/plugins/@test/routes-boot/ping"
+    );
+    expect(match).not.toBeNull();
+    expect(match?.pluginName).toBe("@test/routes-boot");
+    expect(match?.baseCtx.self.name).toBe("@test/routes-boot");
+  });
+
+  it("does not accumulate routes across boots (registry reset)", async () => {
+    handle = await createTestNextly({ plugins: [routePlugin] });
+    await handle.destroy();
+    handle = await createTestNextly({ plugins: [routePlugin] });
+    expect(getPluginRouteRegistry().list()).toHaveLength(1);
+  });
+});

--- a/packages/nextly/src/plugins/routes/route-error.ts
+++ b/packages/nextly/src/plugins/routes/route-error.ts
@@ -1,0 +1,38 @@
+import { NextlyError } from "../../errors/nextly-error";
+
+/**
+ * Fail-fast boot error when two contributed routes resolve to the same
+ * `(method, full path)` (D25). Mirrors {@link ../schema-error}: a generic public
+ * message; the specific detail lives in `logContext` for operators.
+ */
+export function routeCollisionError(
+  method: string,
+  fullPath: string,
+  owners: string[]
+): NextlyError {
+  return new NextlyError({
+    code: "NEXTLY_ROUTE_COLLISION",
+    statusCode: 409,
+    publicMessage: "Route configuration is invalid.",
+    logMessage: `Duplicate route ${method} ${fullPath} contributed by ${owners.join(" and ")}`,
+    logContext: { reason: "route-collision", method, fullPath, owners },
+  });
+}
+
+/**
+ * Fail-fast boot error when a contributed route's `path` does not start with
+ * "/" (D25). Paths are mounted under `/api/plugins/<name>` and must be absolute
+ * within the plugin namespace.
+ */
+export function routeInvalidPathError(
+  pluginName: string,
+  path: string
+): NextlyError {
+  return new NextlyError({
+    code: "NEXTLY_ROUTE_INVALID_PATH",
+    statusCode: 400,
+    publicMessage: "Route configuration is invalid.",
+    logMessage: `Plugin "${pluginName}" declares a route path "${path}" that does not start with "/"`,
+    logContext: { reason: "route-invalid-path", pluginName, path },
+  });
+}

--- a/packages/nextly/src/plugins/routes/route-registry.test.ts
+++ b/packages/nextly/src/plugins/routes/route-registry.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  getPluginRouteRegistry,
+  resetPluginRouteRegistry,
+} from "./route-registry";
+import type { PluginRoute } from "./route-types";
+
+const handler: PluginRoute["handler"] = () => new Response("ok");
+const baseCtx = {} as never;
+
+beforeEach(() => resetPluginRouteRegistry());
+
+describe("PluginRouteRegistry", () => {
+  it("matches a static namespaced route", () => {
+    const reg = getPluginRouteRegistry();
+    reg.register("@acme/x", { method: "GET", path: "/ping", handler }, baseCtx);
+    const m = reg.match("GET", "/plugins/@acme/x/ping");
+    expect(m?.pluginName).toBe("@acme/x");
+    expect(m?.params).toEqual({});
+    expect(m?.route.path).toBe("/ping");
+  });
+
+  it("captures :params and ignores the wrong method", () => {
+    const reg = getPluginRouteRegistry();
+    reg.register(
+      "@acme/x",
+      { method: "GET", path: "/items/:id", handler },
+      baseCtx
+    );
+    expect(reg.match("GET", "/plugins/@acme/x/items/42")?.params).toEqual({
+      id: "42",
+    });
+    expect(reg.match("POST", "/plugins/@acme/x/items/42")).toBeNull();
+  });
+
+  it("returns null for an unknown plugin/path and clears", () => {
+    const reg = getPluginRouteRegistry();
+    reg.register("@acme/x", { method: "GET", path: "/ping", handler }, baseCtx);
+    expect(reg.match("GET", "/plugins/@acme/y/ping")).toBeNull();
+    expect(reg.match("GET", "/plugins/@acme/x/ping/extra")).toBeNull();
+    resetPluginRouteRegistry();
+    expect(getPluginRouteRegistry().list()).toHaveLength(0);
+  });
+
+  it("exposes registered routes via list()", () => {
+    const reg = getPluginRouteRegistry();
+    reg.register("@acme/x", { method: "GET", path: "/ping", handler }, baseCtx);
+    reg.register(
+      "@acme/x",
+      { method: "POST", path: "/ping", handler },
+      baseCtx
+    );
+    expect(reg.list().map(r => `${r.method} ${r.fullPath}`)).toEqual([
+      "GET /plugins/@acme/x/ping",
+      "POST /plugins/@acme/x/ping",
+    ]);
+  });
+});

--- a/packages/nextly/src/plugins/routes/route-registry.ts
+++ b/packages/nextly/src/plugins/routes/route-registry.ts
@@ -1,0 +1,118 @@
+import type {
+  PluginRouteContext,
+  PluginRoute,
+  RouteMethod,
+} from "./route-types";
+
+/**
+ * A route registered at boot: the plugin's declared {@link PluginRoute}, its
+ * namespaced full path, and the plugin's boot-built base context (cloned per
+ * request with `user`/`params` added by the dispatcher).
+ */
+export interface RegisteredRoute {
+  pluginName: string;
+  method: RouteMethod;
+  /** Namespaced path: `/plugins/<pluginName><route.path>`. */
+  fullPath: string;
+  route: PluginRoute;
+  baseCtx: PluginRouteContext;
+  /** Pre-split path segments (literal, or `:name` capture) for matching. */
+  segments: string[];
+}
+
+/** A successful match: the route plus the captured path params. */
+export interface RouteMatch {
+  pluginName: string;
+  route: PluginRoute;
+  baseCtx: PluginRouteContext;
+  params: Record<string, string>;
+}
+
+function splitPath(path: string): string[] {
+  return path.split("/").filter(Boolean);
+}
+
+/**
+ * Registry of plugin-contributed HTTP routes (D25). globalThis-backed singleton
+ * mirroring the hook/event/filter registries so registration survives Next.js/
+ * Turbopack ESM re-evaluation.
+ */
+export class PluginRouteRegistry {
+  private routes: RegisteredRoute[] = [];
+
+  register(
+    pluginName: string,
+    route: PluginRoute,
+    baseCtx: PluginRouteContext
+  ): void {
+    const fullPath = `/plugins/${pluginName}${route.path}`;
+    this.routes.push({
+      pluginName,
+      method: route.method,
+      fullPath,
+      route,
+      baseCtx,
+      segments: splitPath(fullPath),
+    });
+  }
+
+  /** Match an incoming (method, path) against registered routes. */
+  match(method: string, path: string): RouteMatch | null {
+    const pathSegments = splitPath(path);
+    for (const entry of this.routes) {
+      if (entry.method !== method) continue;
+      if (entry.segments.length !== pathSegments.length) continue;
+      const params: Record<string, string> = {};
+      let matched = true;
+      for (let i = 0; i < entry.segments.length; i++) {
+        const seg = entry.segments[i];
+        if (seg.startsWith(":")) {
+          params[seg.slice(1)] = pathSegments[i];
+        } else if (seg !== pathSegments[i]) {
+          matched = false;
+          break;
+        }
+      }
+      if (matched) {
+        return {
+          pluginName: entry.pluginName,
+          route: entry.route,
+          baseCtx: entry.baseCtx,
+          params,
+        };
+      }
+    }
+    return null;
+  }
+
+  list(): RegisteredRoute[] {
+    return [...this.routes];
+  }
+
+  clear(): void {
+    this.routes = [];
+  }
+}
+
+// Use globalThis to survive ESM module duplication in Next.js/Turbopack — the
+// same guard the hook/event/filter registries use.
+const globalForRoutes = globalThis as unknown as {
+  __nextly_pluginRouteRegistry?: PluginRouteRegistry;
+};
+
+if (!globalForRoutes.__nextly_pluginRouteRegistry) {
+  globalForRoutes.__nextly_pluginRouteRegistry = new PluginRouteRegistry();
+}
+
+const globalRegistry: PluginRouteRegistry =
+  globalForRoutes.__nextly_pluginRouteRegistry;
+
+/** Get the global plugin route registry singleton. */
+export function getPluginRouteRegistry(): PluginRouteRegistry {
+  return globalRegistry;
+}
+
+/** Reset the global plugin route registry (testing + per-boot). */
+export function resetPluginRouteRegistry(): void {
+  globalRegistry.clear();
+}

--- a/packages/nextly/src/plugins/routes/route-registry.ts
+++ b/packages/nextly/src/plugins/routes/route-registry.ts
@@ -1,13 +1,11 @@
-import type {
-  PluginRouteContext,
-  PluginRoute,
-  RouteMethod,
-} from "./route-types";
+import type { PluginContext } from "../plugin-context";
+
+import type { PluginRoute, RouteMethod } from "./route-types";
 
 /**
  * A route registered at boot: the plugin's declared {@link PluginRoute}, its
- * namespaced full path, and the plugin's boot-built base context (cloned per
- * request with `user`/`params` added by the dispatcher).
+ * namespaced full path, and the plugin's boot-built base {@link PluginContext}
+ * (the dispatcher clones it per request, adding `user`/`params`).
  */
 export interface RegisteredRoute {
   pluginName: string;
@@ -15,7 +13,7 @@ export interface RegisteredRoute {
   /** Namespaced path: `/plugins/<pluginName><route.path>`. */
   fullPath: string;
   route: PluginRoute;
-  baseCtx: PluginRouteContext;
+  baseCtx: PluginContext;
   /** Pre-split path segments (literal, or `:name` capture) for matching. */
   segments: string[];
 }
@@ -24,7 +22,7 @@ export interface RegisteredRoute {
 export interface RouteMatch {
   pluginName: string;
   route: PluginRoute;
-  baseCtx: PluginRouteContext;
+  baseCtx: PluginContext;
   params: Record<string, string>;
 }
 
@@ -43,7 +41,7 @@ export class PluginRouteRegistry {
   register(
     pluginName: string,
     route: PluginRoute,
-    baseCtx: PluginRouteContext
+    baseCtx: PluginContext
   ): void {
     const fullPath = `/plugins/${pluginName}${route.path}`;
     this.routes.push({

--- a/packages/nextly/src/plugins/routes/route-types.test-d.ts
+++ b/packages/nextly/src/plugins/routes/route-types.test-d.ts
@@ -1,0 +1,43 @@
+import { expectTypeOf } from "vitest";
+
+import { definePlugin } from "../plugin-context";
+
+import type {
+  PluginRoute,
+  PluginRouteContext,
+  Middleware,
+} from "./route-types";
+
+// PluginRouteContext extends PluginContext with per-request user + params.
+expectTypeOf<PluginRouteContext>().toHaveProperty("services");
+expectTypeOf<PluginRouteContext>().toHaveProperty("db");
+expectTypeOf<PluginRouteContext>().toHaveProperty("self");
+expectTypeOf<PluginRouteContext>().toHaveProperty("user");
+expectTypeOf<PluginRouteContext>().toHaveProperty("params");
+
+// A plugin can declare contributes.routes via definePlugin.
+definePlugin({
+  name: "@acme/x",
+  version: "1.0.0",
+  nextly: ">=0.0.1",
+  contributes: {
+    routes: [
+      {
+        method: "GET",
+        path: "/ping",
+        public: true,
+        handler: (_req, ctx) => Response.json({ ok: ctx.self.name }),
+      },
+      {
+        method: "POST",
+        path: "/export",
+        requiredPermission: "export-submissions",
+        handler: () => new Response(null, { status: 204 }),
+      },
+    ] satisfies PluginRoute[],
+  },
+});
+
+// Middleware is a (req, ctx, next) => Promise<Response> function.
+const mw: Middleware = (_req, _ctx, next) => next();
+expectTypeOf(mw).toBeFunction();

--- a/packages/nextly/src/plugins/routes/route-types.ts
+++ b/packages/nextly/src/plugins/routes/route-types.ts
@@ -1,0 +1,64 @@
+import type { AuthUser } from "../../types/auth";
+import type { PermissionSlug } from "../contributions";
+import type { PluginContext } from "../plugin-context";
+
+/**
+ * @experimental HTTP methods a plugin route may declare.
+ */
+export type RouteMethod = "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+
+/**
+ * @experimental Per-request context handed to a plugin route handler (D26).
+ *
+ * It is the plugin's boot-built {@link PluginContext} (services/db/logger/events/
+ * hooks/filters/actions/self/config) plus the per-request `user` and path `params`.
+ */
+export interface PluginRouteContext extends PluginContext {
+  /**
+   * The authenticated user, or `null` for a `public` route reached without a
+   * session. Pass it to secure-by-default services as `{ as: 'user', user }`.
+   */
+  user: AuthUser | null;
+  /** Path parameters captured from `:param` segments in the route's path. */
+  params: Record<string, string>;
+}
+
+/**
+ * @experimental A plugin route handler. Receives the raw web `Request` (body/
+ * query/headers) plus the per-request {@link PluginRouteContext} (D26).
+ */
+export type PluginRouteHandler = (
+  req: Request,
+  ctx: PluginRouteContext
+) => Response | Promise<Response>;
+
+/**
+ * @experimental Typed, ordered route-level middleware (onion model, D27). Call
+ * `next()` to continue the chain, or return a `Response` to short-circuit.
+ */
+export type Middleware = (
+  req: Request,
+  ctx: PluginRouteContext,
+  next: () => Promise<Response>
+) => Promise<Response>;
+
+/**
+ * @experimental A single HTTP route contributed by a plugin (D25). Mounted at
+ * `/api/plugins/<plugin-name><path>` under the existing catch-all and secure by
+ * default (auth + RBAC) unless `public: true` (D28).
+ */
+export interface PluginRoute {
+  method: RouteMethod;
+  /**
+   * Path within the plugin namespace; MUST start with `"/"`. Supports `:param`
+   * segments (e.g. `"/items/:id"`). Final URL: `/api/plugins/<plugin-name><path>`.
+   */
+  path: string;
+  handler: PluginRouteHandler;
+  /** Secure-by-default: the permission slug required to call this route (D28). */
+  requiredPermission?: PermissionSlug;
+  /** Opt out of auth — the route is publicly callable (D28). */
+  public?: boolean;
+  /** Ordered, typed route-level middleware chain (D27). */
+  middleware?: Middleware[];
+}

--- a/packages/nextly/src/plugins/test-nextly.ts
+++ b/packages/nextly/src/plugins/test-nextly.ts
@@ -30,6 +30,7 @@ import type { SingleConfig } from "../singles/config/types";
 import { getImageProcessor } from "../storage/image-processor";
 
 import type { PluginDefinition } from "./plugin-context";
+import { resetPluginRouteRegistry } from "./routes/route-registry";
 
 type TestAdapter = Awaited<ReturnType<typeof createAdapter>>;
 
@@ -90,6 +91,7 @@ export async function createTestNextly(
   resetHookRegistry();
   resetEventBus();
   resetFilterRegistry();
+  resetPluginRouteRegistry();
   resetNextlyInstance();
   // Each boot is a fresh, distinct in-memory database. The schema-snapshot
   // cache (D52) is a globalThis singleton scoped to a single live DB; if left
@@ -144,6 +146,7 @@ export async function createTestNextly(
       resetHookRegistry();
       resetEventBus();
       resetFilterRegistry();
+      resetPluginRouteRegistry();
       resetNextlyInstance();
       clearCachedSnapshot();
       clearLiveSnapshots();

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -66,6 +66,8 @@ import { createCorsMiddleware } from "./middleware/cors";
 import { createRateLimiter } from "./middleware/rate-limit";
 import { createSecurityHeadersMiddleware } from "./middleware/security-headers";
 import { pluginCollectionSlugs } from "./plugins/plugin-admin-meta";
+import { runPluginRoute } from "./plugins/routes/dispatch";
+import { getPluginRouteRegistry } from "./plugins/routes/route-registry";
 import {
   parseRestRoute,
   getActionFromMethod,
@@ -599,6 +601,18 @@ async function handleServiceRequest(
   // Extract search parameters from the request URL
   const url = new URL(req.url);
   const searchParams = url.searchParams;
+
+  // Plugin-contributed routes (D25), namespaced under /plugins/<name>. They own
+  // their secure-by-default auth (D28) and are matched BEFORE the built-in REST
+  // router (which would 400 on these paths). The verb wrappers' withSecurity()
+  // already applies CORS/rate-limit/headers around this.
+  const pluginRouteMatch = getPluginRouteRegistry().match(
+    httpMethod,
+    "/" + params.join("/")
+  );
+  if (pluginRouteMatch) {
+    return runPluginRoute(req, pluginRouteMatch);
+  }
 
   const { service, operation, method, routeParams } = parseRestRoute(
     params,

--- a/packages/plugin-form-builder/src/__tests__/route.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/route.integration.test.ts
@@ -1,0 +1,63 @@
+/**
+ * form-builder HTTP route (R4, P4/D25/D28).
+ *
+ * Proves the flagship plugin CONTRIBUTES a real HTTP route and that it mounts
+ * under the catch-all, secured by default — the canonical `contributes.routes`
+ * example third-party authors copy. The 403-denied / 200-granted RBAC branches
+ * are DB-backed and proven generically in the `nextly` package (route auth-matrix
+ * + dispatch-auth unit tests); a plugin package only sees the public surface.
+ */
+import {
+  createTestNextly,
+  type TestNextly,
+} from "@nextlyhq/plugin-sdk/testing";
+import { createDynamicHandlers } from "nextly/runtime";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { formBuilder } from "../plugin";
+
+const ROUTE_PARAMS = [
+  "plugins",
+  "@nextlyhq",
+  "plugin-form-builder",
+  "submissions",
+  "export",
+];
+
+let current: TestNextly | undefined;
+
+beforeEach(() => {
+  delete (globalThis as Record<string, unknown>)[
+    "__formBuilder_afterCreate_form-submissions"
+  ];
+});
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+describe("form-builder export route (R4, D25)", () => {
+  it("contributes the submissions export route", () => {
+    const { plugin } = formBuilder();
+    expect(plugin.contributes?.routes).toContainEqual(
+      expect.objectContaining({
+        method: "GET",
+        path: "/submissions/export",
+        requiredPermission: "export-submissions",
+      })
+    );
+  });
+
+  it("mounts the route under the catch-all, secured by default (401 without a session)", async () => {
+    current = await createTestNextly({ plugins: [formBuilder().plugin] });
+    const handlers = createDynamicHandlers();
+    const res = await handlers.GET(
+      new Request(
+        "http://localhost/api/plugins/@nextlyhq/plugin-form-builder/submissions/export"
+      ),
+      { params: Promise.resolve({ params: ROUTE_PARAMS }) }
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -193,6 +193,29 @@ export function formBuilder(
           group: "Form Builder",
         },
       ],
+      // HTTP route (P4/D25) — exported at
+      // /api/plugins/@nextlyhq/plugin-form-builder/submissions/export. Secure by
+      // default (D28): gated by the custom `export-submissions` permission. Reads
+      // via the secure-by-default service path as the authed user (D35) and
+      // resolves its OWN slug through `ctx.self` (D54). The canonical
+      // contributes.routes example for third-party authors.
+      routes: [
+        {
+          method: "GET",
+          path: "/submissions/export",
+          requiredPermission: "export-submissions",
+          handler: async (_req, ctx) => {
+            const declaredSlug = resolvedConfig.formSubmissionOverrides.slug;
+            const slug = ctx.self.collections[declaredSlug] ?? declaredSlug;
+            const result = await ctx.services.collections.listEntries(
+              slug,
+              {},
+              { as: "user", user: ctx.user ?? undefined }
+            );
+            return Response.json({ items: result.data });
+          },
+        },
+      ],
     },
 
     admin: {

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -21,6 +21,15 @@ export type {
   AuthUser,
 } from "nextly";
 
+// Plugin HTTP routes (P4, D25/D26/D27) — `contributes.routes` author surface.
+export type {
+  PluginRoute,
+  PluginRouteContext,
+  PluginRouteHandler,
+  Middleware,
+  RouteMethod,
+} from "nextly";
+
 export type { HookType, HookHandler, HookContext } from "nextly";
 
 // Event bus (D8/D51) — `ctx.events` surface + types.

--- a/packages/plugin-sdk/src/route-types.test-d.ts
+++ b/packages/plugin-sdk/src/route-types.test-d.ts
@@ -1,0 +1,31 @@
+import type {
+  Middleware,
+  PluginRoute,
+  PluginRouteContext,
+  RouteMethod,
+} from "@nextlyhq/plugin-sdk";
+
+// PluginRoute: method + path + handler, with optional security + middleware.
+const route: PluginRoute = {
+  method: "GET",
+  path: "/export",
+  requiredPermission: "export-submissions",
+  handler: (_req, ctx: PluginRouteContext) =>
+    Response.json({ who: ctx.self.name, user: ctx.user, id: ctx.params.id }),
+};
+
+// A public route opts out of auth.
+const publicRoute: PluginRoute = {
+  method: "POST",
+  path: "/webhook",
+  public: true,
+  handler: () => new Response(null, { status: 204 }),
+};
+
+// Middleware is a (req, ctx, next) => Promise<Response> function.
+const mw: Middleware = (_req, _ctx, next) => next();
+
+const method: RouteMethod = "PATCH";
+
+// Exported so eslint does not flag the assertions as unused.
+export const __routeTypeCheck = { route, publicRoute, mw, method };


### PR DESCRIPTION
## Summary
- `contributes.routes` — plugin HTTP endpoints namespaced under `/api/plugins/<name>` (D25), handlers receive `(req, ctx)` (D26).
- Secure-by-default: auth + RBAC via `requiredPermission`, `public: true` opt-out; inherits CORS/rate-limit/headers (D28).
- Typed, ordered route-level middleware chain (D27).
- `@experimental` SDK exports; form-builder dogfoods an export route (R4).

## Notes
- T11 (wire the dead collection `endpoints` field) trimmed + documented as a follow-up.

## Test plan
- Unit: 405 failed / 32 files = exact documented baseline (zero new) + 24 new route tests passing.
- Integration: same 3 pre-existing/environmental failures; new route auth-matrix + boot tests pass.
- check-types + build green across `nextly`, `@nextlyhq/plugin-sdk`, `@nextlyhq/plugin-form-builder`; form-builder 18/18.
