### PR TITLE
feat(plugins): P7a — service gaps (D56) — rich queries + count + createMany

### DIFF
--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -151,9 +151,7 @@ function partitionOutcomes<T>(
     } else {
       // Per-item closure rejected unexpectedly. Defensive: report as
       // INTERNAL_ERROR rather than silently swallowing the bug.
-      result.failures.push(
-        failureFromThrown(ids[index] ?? "", outcome.reason)
-      );
+      result.failures.push(failureFromThrown(ids[index] ?? "", outcome.reason));
       result.failedCount++;
     }
   });
@@ -296,37 +294,43 @@ export class CollectionBulkService extends BaseService {
     // single-item deleteEntry which preserves the full pipeline). The
     // db connection pool naturally throttles real DB concurrency.
     const outcomes = await Promise.allSettled(
-      params.ids.map(async (entryId): Promise<PerItemOutcome<{ id: string }>> => {
-        try {
-          const deleteResult = await this.mutationService.deleteEntry({
-            collectionName: params.collectionName,
-            entryId,
-            user: params.user,
-            overrideAccess: params.overrideAccess,
-            context: params.context,
-          });
+      params.ids.map(
+        async (entryId): Promise<PerItemOutcome<{ id: string }>> => {
+          try {
+            const deleteResult = await this.mutationService.deleteEntry({
+              collectionName: params.collectionName,
+              entryId,
+              user: params.user,
+              overrideAccess: params.overrideAccess,
+              context: params.context,
+            });
 
-          if (deleteResult.success) {
-            return { kind: "success", record: { id: entryId } };
+            if (deleteResult.success) {
+              return { kind: "success", record: { id: entryId } };
+            }
+            // Decompose the legacy envelope into the canonical per-item
+            // failure shape. The legacy `message` would leak driver/value
+            // text on the wire (§13.8 violation); we keep only the canonical
+            // code-to-publicMessage mapping and let the operator log carry
+            // the legacy text via the dispatcher's logger.
+            const { code, message } =
+              legacyEnvelopeToFailureFields(deleteResult);
+            return {
+              kind: "failure",
+              failure: { id: entryId, code, message },
+            };
+          } catch (error: unknown) {
+            // NextlyError thrown from below the boundary: preserve its code +
+            // publicMessage. Anything else is INTERNAL_ERROR with a generic
+            // public message; full detail goes to the operator log via the
+            // outer dispatcher when it logs the cause chain.
+            return {
+              kind: "failure",
+              failure: failureFromThrown(entryId, error),
+            };
           }
-          // Decompose the legacy envelope into the canonical per-item
-          // failure shape. The legacy `message` would leak driver/value
-          // text on the wire (§13.8 violation); we keep only the canonical
-          // code-to-publicMessage mapping and let the operator log carry
-          // the legacy text via the dispatcher's logger.
-          const { code, message } = legacyEnvelopeToFailureFields(deleteResult);
-          return {
-            kind: "failure",
-            failure: { id: entryId, code, message },
-          };
-        } catch (error: unknown) {
-          // NextlyError thrown from below the boundary: preserve its code +
-          // publicMessage. Anything else is INTERNAL_ERROR with a generic
-          // public message; full detail goes to the operator log via the
-          // outer dispatcher when it logs the cause chain.
-          return { kind: "failure", failure: failureFromThrown(entryId, error) };
         }
-      })
+      )
     );
 
     return partitionOutcomes(outcomes, params.ids);
@@ -377,13 +381,17 @@ export class CollectionBulkService extends BaseService {
                 record: updateResult.data as Record<string, unknown>,
               };
             }
-            const { code, message } = legacyEnvelopeToFailureFields(updateResult);
+            const { code, message } =
+              legacyEnvelopeToFailureFields(updateResult);
             return {
               kind: "failure",
               failure: { id: entryId, code, message },
             };
           } catch (error: unknown) {
-            return { kind: "failure", failure: failureFromThrown(entryId, error) };
+            return {
+              kind: "failure",
+              failure: failureFromThrown(entryId, error),
+            };
           }
         }
       )
@@ -743,7 +751,11 @@ export class CollectionBulkService extends BaseService {
    * ```
    */
   async createEntries(
-    params: { collectionName: string; user?: UserContext },
+    params: {
+      collectionName: string;
+      user?: UserContext;
+      overrideAccess?: boolean;
+    },
     entries: Record<string, unknown>[],
     options?: BulkOperationOptions
   ): Promise<BatchOperationResult> {
@@ -766,12 +778,19 @@ export class CollectionBulkService extends BaseService {
       return result;
     }
 
-    // 1. Check collection-level access FIRST (once for all entries)
+    // 1. Check collection-level access FIRST (once for all entries).
+    // `overrideAccess` (D35 system elevation) bypasses the check — mirrors the
+    // by-query bulk methods so `ctx.services.collections.createMany(..., {as:'system'})`
+    // can seed without an ambient user.
+    const accessUser = params.overrideAccess ? undefined : params.user;
     const accessDenied =
       await this.accessService.checkCollectionAccess<BatchOperationResult>(
         params.collectionName,
         "create",
-        params.user
+        accessUser,
+        undefined,
+        undefined,
+        params.overrideAccess
       );
     if (accessDenied) {
       // All entries fail due to access denial

--- a/packages/nextly/src/domains/collections/services/collection-service-d56.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service-d56.test.ts
@@ -1,0 +1,82 @@
+/**
+ * D56 (P7a) — the collection facade plumbs rich-query options + the new
+ * `count` / `createMany` methods through to the entry service. Focused unit
+ * tests with a spied entry service (the live `createTestNextly` path is proven
+ * end-to-end separately in `plugins/__tests__/service-d56.integration.test.ts`).
+ *
+ * Pre-P7a, the facade `listEntries` dropped `where`/`sort`/`depth`/`select` on
+ * the floor (only `page`/`limit` were forwarded) — so service-level filtering
+ * through `ctx.services.collections` was silently a no-op. These assert it
+ * forwards every option, and that `count`/`createMany` exist and delegate.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { CollectionService } from "./collection-service";
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+function make(entry: Record<string, unknown>): CollectionService {
+  return new CollectionService(
+    {} as never,
+    noopLogger as never,
+    {} as never,
+    entry as never
+  );
+}
+
+const listOk = {
+  success: true,
+  data: { docs: [], totalDocs: 0, limit: 10, hasNextPage: false },
+};
+
+describe("CollectionService.listEntries forwards rich-query options (D56, T1)", () => {
+  it("forwards `where` to the entry service", async () => {
+    const entry = { listEntries: vi.fn().mockResolvedValue(listOk) };
+    await make(entry).listEntries(
+      "posts",
+      { where: { status: { equals: "published" } } },
+      { overrideAccess: true }
+    );
+    expect(entry.listEntries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collectionName: "posts",
+        where: { status: { equals: "published" } },
+        overrideAccess: true,
+      })
+    );
+  });
+
+  it("converts SortOptions to the entry service's string format", async () => {
+    const entry = { listEntries: vi.fn().mockResolvedValue(listOk) };
+    await make(entry).listEntries(
+      "posts",
+      { sort: { field: "createdAt", direction: "desc" } },
+      {}
+    );
+    expect(entry.listEntries).toHaveBeenCalledWith(
+      expect.objectContaining({ sort: "-createdAt" })
+    );
+
+    await make(entry).listEntries(
+      "posts",
+      { sort: { field: "title", direction: "asc" } },
+      {}
+    );
+    expect(entry.listEntries).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sort: "title" })
+    );
+  });
+
+  it("forwards no `where`/`sort` when omitted (negative control)", async () => {
+    const entry = { listEntries: vi.fn().mockResolvedValue(listOk) };
+    await make(entry).listEntries("posts", {}, {});
+    const arg = entry.listEntries.mock.calls[0][0];
+    expect(arg.where).toBeUndefined();
+    expect(arg.sort).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-service-d56.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service-d56.test.ts
@@ -80,3 +80,25 @@ describe("CollectionService.listEntries forwards rich-query options (D56, T1)", 
     expect(arg.sort).toBeUndefined();
   });
 });
+
+describe("CollectionService.listEntries forwards relations/projection (D56, T2)", () => {
+  it("forwards `depth` and `select` to the entry service", async () => {
+    const entry = { listEntries: vi.fn().mockResolvedValue(listOk) };
+    await make(entry).listEntries(
+      "posts",
+      { depth: 2, select: { title: true } },
+      {}
+    );
+    expect(entry.listEntries).toHaveBeenCalledWith(
+      expect.objectContaining({ depth: 2, select: { title: true } })
+    );
+  });
+
+  it("leaves `depth`/`select` undefined when omitted (default depth preserved)", async () => {
+    const entry = { listEntries: vi.fn().mockResolvedValue(listOk) };
+    await make(entry).listEntries("posts", {}, {});
+    const arg = entry.listEntries.mock.calls[0][0];
+    expect(arg.depth).toBeUndefined();
+    expect(arg.select).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-service-d56.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service-d56.test.ts
@@ -102,3 +102,42 @@ describe("CollectionService.listEntries forwards relations/projection (D56, T2)"
     expect(arg.select).toBeUndefined();
   });
 });
+
+describe("CollectionService.count (D56, T3)", () => {
+  it("returns the scalar totalDocs and forwards where/search/overrideAccess", async () => {
+    const entry = {
+      countEntries: vi
+        .fn()
+        .mockResolvedValue({ success: true, data: { totalDocs: 7 } }),
+    };
+    const n = await make(entry).count(
+      "posts",
+      { where: { status: { equals: "published" } }, search: "hi" },
+      { overrideAccess: true }
+    );
+    expect(n).toBe(7);
+    expect(entry.countEntries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collectionName: "posts",
+        where: { status: { equals: "published" } },
+        search: "hi",
+        overrideAccess: true,
+      })
+    );
+  });
+
+  it("maps a failed count result to a thrown NextlyError", async () => {
+    const entry = {
+      countEntries: vi
+        .fn()
+        .mockResolvedValue({
+          success: false,
+          statusCode: 500,
+          message: "boom",
+        }),
+    };
+    await expect(make(entry).count("posts", {}, {})).rejects.toBeInstanceOf(
+      Error
+    );
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-service-d56.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service-d56.test.ts
@@ -128,16 +128,49 @@ describe("CollectionService.count (D56, T3)", () => {
 
   it("maps a failed count result to a thrown NextlyError", async () => {
     const entry = {
-      countEntries: vi
-        .fn()
-        .mockResolvedValue({
-          success: false,
-          statusCode: 500,
-          message: "boom",
-        }),
+      countEntries: vi.fn().mockResolvedValue({
+        success: false,
+        statusCode: 500,
+        message: "boom",
+      }),
     };
     await expect(make(entry).count("posts", {}, {})).rejects.toBeInstanceOf(
       Error
+    );
+  });
+});
+
+describe("CollectionService.createMany (D56, T4)", () => {
+  const batch = {
+    successful: 2,
+    failed: 1,
+    ids: ["a", "b"],
+    errors: [{ index: 2, error: "bad" }],
+  };
+
+  it("returns the BatchOperationResult and forwards user + overrideAccess", async () => {
+    const entry = { createEntries: vi.fn().mockResolvedValue(batch) };
+    const res = await make(entry).createMany(
+      "posts",
+      [{ t: 1 }, { t: 2 }, { t: 3 }],
+      { user: { id: "u1", email: "u@x.com", role: "", permissions: [] } }
+    );
+    expect(res).toEqual(batch);
+    expect(entry.createEntries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collectionName: "posts",
+        user: expect.objectContaining({ id: "u1" }),
+      }),
+      [{ t: 1 }, { t: 2 }, { t: 3 }]
+    );
+  });
+
+  it("forwards overrideAccess for system elevation", async () => {
+    const entry = { createEntries: vi.fn().mockResolvedValue(batch) };
+    await make(entry).createMany("posts", [{ t: 1 }], { overrideAccess: true });
+    expect(entry.createEntries).toHaveBeenCalledWith(
+      expect.objectContaining({ overrideAccess: true }),
+      [{ t: 1 }]
     );
   });
 });

--- a/packages/nextly/src/domains/collections/services/collection-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service.ts
@@ -70,6 +70,7 @@ import { BaseService } from "../../../shared/base-service";
 import type { WhereFilter } from "../query/query-operators";
 
 import type { CollectionMetadataService } from "./collection-metadata-service";
+import type { BatchOperationResult } from "./collection-types";
 
 /**
  * Convert the structured {@link SortOptions} into the entry service's string
@@ -419,6 +420,38 @@ export class CollectionService extends BaseService {
     });
 
     return result.data as CollectionEntry;
+  }
+
+  /**
+   * Bulk-create entries in a single transaction (D56).
+   *
+   * Returns an index-based {@link BatchOperationResult} — the natural shape for
+   * creates, which have no caller-supplied ids to key failures by (mirrors the
+   * existing batch ops `createEntries`/`updateEntries`/`deleteEntries`).
+   *
+   * @param collectionName - Name of the collection
+   * @param data - Array of entry payloads to create
+   * @param context - Request context (carries `overrideAccess` for elevation)
+   * @returns Per-batch result: counts, created ids, and index-keyed failures
+   */
+  async createMany(
+    collectionName: string,
+    data: Record<string, unknown>[],
+    context: RequestContext
+  ): Promise<BatchOperationResult> {
+    this.logger.debug("Creating entries (bulk)", {
+      collectionName,
+      count: data.length,
+    });
+
+    return this.entryService.createEntries(
+      {
+        collectionName,
+        user: context.user,
+        overrideAccess: context.overrideAccess,
+      },
+      data
+    );
   }
 
   /**

--- a/packages/nextly/src/domains/collections/services/collection-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service.ts
@@ -63,11 +63,23 @@ import type {
   RequestContext,
   PaginatedResult,
   QueryOptions,
+  SortOptions,
   Logger,
 } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
+import type { WhereFilter } from "../query/query-operators";
 
 import type { CollectionMetadataService } from "./collection-metadata-service";
+
+/**
+ * Convert the structured {@link SortOptions} into the entry service's string
+ * sort format (`-field` = desc, `field` = asc). Returns `undefined` when no
+ * sort is requested so the entry service keeps its default ordering.
+ */
+function serializeSort(sort: SortOptions | undefined): string | undefined {
+  if (!sort) return undefined;
+  return sort.direction === "desc" ? `-${sort.field}` : sort.field;
+}
 
 /**
  * Collection metadata returned from operations
@@ -435,6 +447,10 @@ export class CollectionService extends BaseService {
       overrideAccess: context.overrideAccess,
       page,
       limit,
+      // D56: forward the rich-query options the facade previously dropped, so
+      // filtering/sorting through `ctx.services.collections` actually applies.
+      where: options.where as WhereFilter | undefined,
+      sort: serializeSort(options.sort),
     });
 
     if (!result.success || !result.data) {

--- a/packages/nextly/src/domains/collections/services/collection-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service.ts
@@ -448,9 +448,13 @@ export class CollectionService extends BaseService {
       page,
       limit,
       // D56: forward the rich-query options the facade previously dropped, so
-      // filtering/sorting through `ctx.services.collections` actually applies.
+      // filtering/sorting/relation-population through `ctx.services.collections`
+      // actually applies. `depth`/`select` stay undefined when omitted so the
+      // entry service keeps its default depth.
       where: options.where as WhereFilter | undefined,
       sort: serializeSort(options.sort),
+      depth: options.depth,
+      select: options.select,
     });
 
     if (!result.success || !result.data) {

--- a/packages/nextly/src/domains/collections/services/collection-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service.ts
@@ -474,6 +474,41 @@ export class CollectionService extends BaseService {
   }
 
   /**
+   * Count entries matching an optional filter (D56 aggregation-lite).
+   *
+   * Lets plugins answer "how many?" without loading rows or dropping to raw
+   * `ctx.db`. For richer aggregations (sum/avg/group-by) use the raw `ctx.db`
+   * escape hatch (D33) — relational aggregation pipelines are out of scope.
+   *
+   * @param collectionName - Name of the collection
+   * @param options - Optional `where` filter and full-text `search`
+   * @param context - Request context (carries `overrideAccess` for elevation)
+   * @returns Number of matching entries
+   * @throws NextlyError if counting fails
+   */
+  async count(
+    collectionName: string,
+    options: { where?: Record<string, unknown>; search?: string } = {},
+    context: RequestContext
+  ): Promise<number> {
+    this.logger.debug("Counting entries", { collectionName });
+
+    const result = await this.entryService.countEntries({
+      collectionName,
+      user: context.user,
+      overrideAccess: context.overrideAccess,
+      where: options.where as WhereFilter | undefined,
+      search: options.search,
+    });
+
+    if (!result.success || !result.data) {
+      throw this.mapLegacyErrorToNextlyError(result);
+    }
+
+    return result.data.totalDocs;
+  }
+
+  /**
    * Find an entry by ID
    *
    * @param collectionName - Name of the collection

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -367,8 +367,17 @@ export {
 } from "./plugins";
 
 // Managed-services elevation (D35) — `ctx.services` ServiceOpts + the auth user.
-export type { ServiceOpts } from "./plugins/service-opts";
+export type {
+  ServiceOpts,
+  PluginCollectionService,
+} from "./plugins/service-opts";
 export type { AuthUser } from "./types/auth";
+
+// Managed data access (D56) — bulk-create result for
+// `ctx.services.collections.createMany`. Rich-query options (`QueryOptions`
+// with where/sort/depth/select) + `PaginatedResult` are exported with the other
+// shared service types above.
+export type { BatchOperationResult } from "./domains/collections/services/collection-types";
 
 // Plugin event bus (D8/D51) — `ctx.events` surface + types.
 export {

--- a/packages/nextly/src/plugins/__tests__/service-d56.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/service-d56.integration.test.ts
@@ -1,0 +1,100 @@
+/**
+ * D56 (P7a) end-to-end — the new `ctx.services.collections` surface (the
+ * ServiceOpts-wrapped facade) against a live in-memory SQLite boot.
+ *
+ * Harness scope (mirrors the P3-D35/P4 posture): the in-memory `createTestNextly`
+ * boot wires the high-level `nextly.create` path but NOT the lower entry-service
+ * hook seam that the facade's doc-read (`listEntries`) and bulk-create
+ * (`createMany`) paths call — both surface `hookRegistry.executeBeforeOperation
+ * is not a function` / an INTERNAL_ERROR there. That is a pre-existing harness
+ * limitation, not a P7a regression (a plain `listEntries` fails identically).
+ * So those two are covered by the focused facade/wrapper UNIT tests
+ * (`collection-service-d56.test.ts`, `service-opts-wrapper.test.ts`).
+ *
+ * What this file proves end-to-end through the wrapper:
+ *  - `count` with a `where` filter actually reaches the query layer (the filter
+ *    the facade used to DROP), under `{as:'system'}` elevation; and
+ *  - secure-by-default: `{as:'user'}` enforces RBAC (permission-less user denied)
+ *    and a missing user is rejected before any query (D35).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../config";
+import { definePlugin } from "../plugin-context";
+import { createTestNextly, type TestNextly } from "../test-nextly";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const widgets = () =>
+  defineCollection({
+    slug: "widgets",
+    fields: [text({ name: "title" }), text({ name: "kind" })],
+  });
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Services = any;
+
+async function bootWithServices(): Promise<Services> {
+  let services: Services;
+  const probe = definePlugin({
+    name: "@test/d56",
+    version: "1.0.0",
+    nextly: ">=0.0.0",
+    init: ctx => {
+      services = ctx.services;
+    },
+  });
+  current = await createTestNextly({
+    collections: [widgets()],
+    plugins: [probe],
+  });
+  return services;
+}
+
+describe("ctx.services.collections D56 surface (D56/D35)", () => {
+  it("count threads its `where` filter through {as:'system'} end-to-end", async () => {
+    const services = await bootWithServices();
+    for (const w of [
+      { title: "b", kind: "a" },
+      { title: "a", kind: "a" },
+      { title: "c", kind: "z" },
+    ]) {
+      await current!.nextly.create({ collection: "widgets", data: w });
+    }
+
+    // Unfiltered count, then a filtered count — the `where` clause is the exact
+    // option the facade used to drop before reaching the query layer.
+    expect(
+      await services.collections.count("widgets", {}, { as: "system" })
+    ).toBe(3);
+    expect(
+      await services.collections.count(
+        "widgets",
+        { where: { kind: { equals: "a" } } },
+        { as: "system" }
+      )
+    ).toBe(2);
+  });
+
+  it("{as:'user'} enforces RBAC — a permission-less user is denied (secure-by-default)", async () => {
+    const services = await bootWithServices();
+    await expect(
+      services.collections.count(
+        "widgets",
+        {},
+        { as: "user", user: { id: "u1", email: "u@x.com" } }
+      )
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("count as:'user' with no user rejects before any query (D35)", async () => {
+    const services = await bootWithServices();
+    await expect(
+      services.collections.count("widgets", {}, { as: "user" })
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+  });
+});

--- a/packages/nextly/src/plugins/service-opts-wrapper.test.ts
+++ b/packages/nextly/src/plugins/service-opts-wrapper.test.ts
@@ -7,6 +7,8 @@ function mockCollections() {
     createEntry: vi.fn().mockResolvedValue({ id: "1" }),
     findEntryById: vi.fn().mockResolvedValue({ id: "1" }),
     updateEntry: vi.fn().mockResolvedValue({ id: "1" }),
+    count: vi.fn().mockResolvedValue(3),
+    createMany: vi.fn().mockResolvedValue({ successful: 1, failed: 0 }),
     listCollections: vi.fn().mockResolvedValue([]), // non-access passthrough
   };
 }
@@ -91,6 +93,42 @@ describe("wrapCollectionsForPlugin (D35, Unit C)", () => {
       { title: "b" },
       SYSTEM_CTX
     );
+  });
+
+  it("count translates the trailing opts (index 2, D56)", async () => {
+    const m = mockCollections();
+    await wrapCollectionsForPlugin(m as never).count(
+      "vault",
+      { where: { a: { equals: 1 } } },
+      { as: "system" }
+    );
+    expect(m.count).toHaveBeenCalledWith(
+      "vault",
+      { where: { a: { equals: 1 } } },
+      SYSTEM_CTX
+    );
+  });
+
+  it("createMany translates the trailing opts (index 2, D56)", async () => {
+    const m = mockCollections();
+    await wrapCollectionsForPlugin(m as never).createMany(
+      "vault",
+      [{ title: "a" }],
+      { as: "system" }
+    );
+    expect(m.createMany).toHaveBeenCalledWith(
+      "vault",
+      [{ title: "a" }],
+      SYSTEM_CTX
+    );
+  });
+
+  it("count as:'user' with no user rejects before delegating (D56)", async () => {
+    const m = mockCollections();
+    await expect(
+      wrapCollectionsForPlugin(m as never).count("vault", {}, { as: "user" })
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+    expect(m.count).not.toHaveBeenCalled();
   });
 
   it("non-access methods pass through unchanged", async () => {

--- a/packages/nextly/src/plugins/service-opts.ts
+++ b/packages/nextly/src/plugins/service-opts.ts
@@ -52,7 +52,9 @@ type AccessMethod =
   | "listEntries"
   | "findEntryById"
   | "updateEntry"
-  | "deleteEntry";
+  | "deleteEntry"
+  | "count"
+  | "createMany";
 
 const CONTEXT_INDEX: Record<AccessMethod, number> = {
   createEntry: 2,
@@ -60,6 +62,9 @@ const CONTEXT_INDEX: Record<AccessMethod, number> = {
   findEntryById: 2,
   updateEntry: 3,
   deleteEntry: 2,
+  // D56 additions — trailing context at arg index 2.
+  count: 2,
+  createMany: 2,
 };
 
 /** Replace a method's trailing `RequestContext` arg with an optional `ServiceOpts`. */

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -297,7 +297,11 @@ export class CollectionEntryService extends BaseService {
   }
 
   async createEntries(
-    params: { collectionName: string; user?: UserContext },
+    params: {
+      collectionName: string;
+      user?: UserContext;
+      overrideAccess?: boolean;
+    },
     entries: Record<string, unknown>[],
     options?: BulkOperationOptions
   ): Promise<BatchOperationResult> {

--- a/packages/nextly/src/shared/types/index.ts
+++ b/packages/nextly/src/shared/types/index.ts
@@ -182,6 +182,16 @@ export interface QueryOptions {
   sort?: SortOptions;
   /** Filter conditions (key-value pairs) */
   where?: Record<string, unknown>;
+  /**
+   * Relation population depth (0–5). Omit to keep the service default depth.
+   * @experimental Plugin data-access option (D56).
+   */
+  depth?: number;
+  /**
+   * Field projection — return only the listed fields (`{ title: true }`).
+   * @experimental Plugin data-access option (D56).
+   */
+  select?: Record<string, boolean>;
 }
 
 /**

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -21,6 +21,18 @@ export type {
   AuthUser,
 } from "nextly";
 
+// Managed data access (D56) — the `ctx.services.collections` surface: rich
+// queries (filters/sort/pagination/relations via QueryOptions), `count`, and
+// `createMany`. Aggregations beyond `count` use the raw `ctx.db` escape hatch
+// (D33). `ctx.services` is the highest-scrutiny surface (D55) and stays
+// experimental the longest.
+export type {
+  PluginCollectionService,
+  QueryOptions,
+  PaginatedResult,
+  BatchOperationResult,
+} from "nextly";
+
 // Plugin HTTP routes (P4, D25/D26/D27) — `contributes.routes` author surface.
 export type {
   PluginRoute,

--- a/packages/plugin-sdk/src/service-types.test-d.ts
+++ b/packages/plugin-sdk/src/service-types.test-d.ts
@@ -1,0 +1,40 @@
+import type {
+  PluginCollectionService,
+  QueryOptions,
+  PaginatedResult,
+  BatchOperationResult,
+  ServiceOpts,
+} from "@nextlyhq/plugin-sdk";
+
+// QueryOptions carries the rich-query options the facade now threads (D56):
+// filters, sort, pagination, relation depth, and field projection.
+const q: QueryOptions = {
+  where: { status: { equals: "published" } },
+  sort: { field: "createdAt", direction: "desc" },
+  pagination: { limit: 10, page: 1 },
+  depth: 1,
+  select: { title: true },
+};
+
+declare const svc: PluginCollectionService;
+const sys: ServiceOpts = { as: "system" };
+
+// listEntries accepts the rich QueryOptions + a trailing ServiceOpts (D35/D56).
+const list: Promise<PaginatedResult<unknown>> = svc.listEntries(
+  "posts",
+  q,
+  sys
+);
+
+// count(slug, { where?, search? }, ServiceOpts?) => Promise<number> (D56).
+const total: Promise<number> = svc.count("posts", { where: q.where }, sys);
+
+// createMany(slug, data[], ServiceOpts?) => Promise<BatchOperationResult> (D56).
+const bulk: Promise<BatchOperationResult> = svc.createMany(
+  "posts",
+  [{ title: "a" }, { title: "b" }],
+  sys
+);
+
+// Exported so eslint does not flag the assertions as unused.
+export const __d56TypeCheck = { q, list, total, bulk };


### PR DESCRIPTION
## P7a — Service gaps (D56)

First slice of **P7** (first-party plugins). Makes `ctx.services.collections` deliver D56 rich queries + bulk + count so plugins rarely need raw `ctx.db`.

**Root cause fixed:** the collection facade `listEntries` silently **dropped `where`/`sort`/`depth`/`select`** (only `page`/`limit` were forwarded) — so service-level filtering through `ctx.services.collections` was a no-op (this is why form-builder filters client-side; adopted in P7b).

### Shipped (7 TDD tasks)
- **T1** facade `listEntries` forwards `where` + serialized `sort`
- **T2** `QueryOptions` gains `depth`/`select`; facade forwards them (relations/projection)
- **T3** facade `count(slug, {where?,search?}, ctx): number`
- **T4** facade `createMany(slug, data[], ctx): BatchOperationResult` + threads `overrideAccess` through the bulk create path (`{as:'system'}` elevation)
- **T5** plugin wrapper translates `ServiceOpts` for `count`/`createMany`
- **T6** end-to-end integration: `count` filtering + secure-by-default RBAC
- **T7** exports the D56 surface from `@nextlyhq/plugin-sdk` (`@experimental`) + compile-time `test-d` guard

### Decisions
- `createMany` returns `BatchOperationResult` (index-based — natural for creates; matches existing batch ops).
- `aggregate` **deferred** (no relational substrate, no first-party driver, raw `ctx.db` escape hatch — D56 relaxed).
- `listEntries` doc-read + `createMany` persistence aren't exercisable in the in-memory harness (pre-existing hook-wiring gap) — unit-covered; integration proves `count` filtering + secure-by-default.

### Verification
- nextly **unit: 405 failed/32 files = documented baseline → zero new** (2714 passed, +12 new)
- nextly **integration: only the 3 pre-existing/environmental failures**; new D56 integration green
- **build + check-types clean** across `nextly` + `@nextlyhq/plugin-sdk`; **form-builder unchanged** (23/23)

No changeset (phase→base PR releases nothing; changesets land once on base→main after P9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)