### PR TITLE
feat(form-builder): P7b — finalize on the D56 managed path (R4)

### DIFF
--- a/packages/nextly/src/plugins/__tests__/service-d56-reads.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/service-d56-reads.integration.test.ts
@@ -1,0 +1,88 @@
+/**
+ * D56 reads/writes end-to-end through `ctx.services.collections`, enabled by the
+ * P7b harness hook-registry fix.
+ *
+ * Before P7b, `createTestNextly` called `registerServices` WITHOUT a
+ * `hookRegistry`, so the collection services got `hookRegistry: undefined` and
+ * the facade read/single-write paths threw `executeBeforeOperation is not a
+ * function` (P7a documented this as a harness limitation, covering those via
+ * unit tests). Now the harness wires the (freshly reset) global registry, so
+ * `listEntries` (where/sort) and single `createEntry` run end-to-end via the
+ * ServiceOpts wrapper. (Bulk `createMany` has a separate, pre-existing
+ * column-mapping issue in the bulk path — out of scope; P7a follow-up.)
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../config";
+import { definePlugin } from "../plugin-context";
+import { createTestNextly, type TestNextly } from "../test-nextly";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const widgets = () =>
+  defineCollection({
+    slug: "widgets",
+    fields: [text({ name: "title" }), text({ name: "kind" })],
+  });
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function boot(): Promise<any> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let services: any;
+  const probe = definePlugin({
+    name: "@test/d56-reads",
+    version: "1.0.0",
+    nextly: ">=0.0.0",
+    init: c => {
+      services = c.services;
+    },
+  });
+  current = await createTestNextly({
+    collections: [widgets()],
+    plugins: [probe],
+  });
+  return services;
+}
+
+describe("ctx.services.collections reads/writes (D56, harness hook-wired)", () => {
+  it("listEntries applies where + sort end-to-end via {as:'system'}", async () => {
+    const services = await boot();
+    for (const w of [
+      { title: "b", kind: "a" },
+      { title: "a", kind: "a" },
+      { title: "c", kind: "z" },
+    ]) {
+      await current!.nextly.create({ collection: "widgets", data: w });
+    }
+
+    const list = await services.collections.listEntries(
+      "widgets",
+      {
+        where: { kind: { equals: "a" } },
+        sort: { field: "title", direction: "asc" },
+      },
+      { as: "system" }
+    );
+    expect(list.data.map((e: { title: string }) => e.title)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("single createEntry persists via {as:'system'}", async () => {
+    const services = await boot();
+    const created = await services.collections.createEntry(
+      "widgets",
+      { title: "x", kind: "q" },
+      { as: "system" }
+    );
+    expect((created as { id: string }).id).toBeDefined();
+    expect(
+      await services.collections.count("widgets", {}, { as: "system" })
+    ).toBe(1);
+  });
+});

--- a/packages/nextly/src/plugins/test-nextly.ts
+++ b/packages/nextly/src/plugins/test-nextly.ts
@@ -123,6 +123,12 @@ export async function createTestNextly(
     adapter,
     imageProcessor: getImageProcessor(),
     logger,
+    // Wire the (freshly reset) global hook registry into the collection
+    // services so the entry/query/mutation/bulk paths run hooks — without it
+    // those services get `hookRegistry: undefined` and any read/bulk-write
+    // through `ctx.services.collections` throws "executeBeforeOperation is not
+    // a function". Mirrors production boot (registerServices always gets one).
+    hookRegistry: getHookRegistry(),
     plugins: opts.plugins,
     collections: opts.collections,
     singles: opts.singles,

--- a/packages/plugin-form-builder/package.json
+++ b/packages/plugin-form-builder/package.json
@@ -73,6 +73,7 @@
   },
   "keywords": [
     "nextly",
+    "nextly-plugin",
     "plugin",
     "forms",
     "form-builder",

--- a/packages/plugin-form-builder/src/__tests__/fetch-form-by-slug.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/fetch-form-by-slug.test.ts
@@ -1,0 +1,46 @@
+/**
+ * R4/D56 — `fetchFormBySlug` resolves a form via a service-level `where` query
+ * (P7a) + `{as:'system'}` instead of fetching every form and filtering
+ * client-side. Focused unit test with a spied collections service.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { fetchFormBySlug } from "../handlers/submit-form";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function ctxWith(listEntries: any) {
+  return {
+    services: { collections: { listEntries } },
+    logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+const config = {
+  formOverrides: { slug: "forms" },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;
+
+describe("fetchFormBySlug (R4/D56)", () => {
+  it("queries by slug with a where filter under {as:'system'}", async () => {
+    const listEntries = vi
+      .fn()
+      .mockResolvedValue({ data: [{ id: "1", slug: "contact" }] });
+
+    const form = await fetchFormBySlug("contact", config, ctxWith(listEntries));
+
+    expect(listEntries).toHaveBeenCalledWith(
+      "forms",
+      { where: { slug: { equals: "contact" } }, pagination: { limit: 1 } },
+      { as: "system" }
+    );
+    expect(form).toMatchObject({ slug: "contact" });
+  });
+
+  it("returns null when no match", async () => {
+    const listEntries = vi.fn().mockResolvedValue({ data: [] });
+    expect(
+      await fetchFormBySlug("missing", config, ctxWith(listEntries))
+    ).toBeNull();
+  });
+});

--- a/packages/plugin-form-builder/src/__tests__/package-metadata.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/package-metadata.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import { formBuilder } from "../plugin";
+
+const pkg = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf8")
+) as { version: string; keywords: string[] };
+
+describe("form-builder package metadata", () => {
+  it("definePlugin version matches package.json (no hardcoded drift)", () => {
+    expect(formBuilder().plugin.version).toBe(pkg.version);
+  });
+
+  it("declares the nextly-plugin keyword for discoverability", () => {
+    expect(pkg.keywords).toContain("nextly-plugin");
+  });
+});

--- a/packages/plugin-form-builder/src/__tests__/submission-stats.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/submission-stats.test.ts
@@ -1,0 +1,57 @@
+/**
+ * R4/D56 — `getFormSubmissionStats` counts submissions per status via the
+ * service-level `count` (P7a) under `{as:'system'}`, instead of listing every
+ * submission and counting client-side. Focused unit test with a spied service.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { getFormSubmissionStats } from "../handlers/submit-form";
+
+describe("getFormSubmissionStats (R4/D56)", () => {
+  it("counts per status with where filters and assembles the totals", async () => {
+    // fetchFormBySlug resolves the parent form via listEntries.
+    const listEntries = vi
+      .fn()
+      .mockResolvedValue({ data: [{ id: "form1", slug: "contact" }] });
+    // total, new, read, archived (Promise.all order).
+    const count = vi
+      .fn()
+      .mockResolvedValueOnce(10)
+      .mockResolvedValueOnce(4)
+      .mockResolvedValueOnce(3)
+      .mockResolvedValueOnce(3);
+
+    const context = {
+      pluginContext: {
+        services: { collections: { listEntries, count } },
+        logger: {
+          warn: vi.fn(),
+          error: vi.fn(),
+          info: vi.fn(),
+          debug: vi.fn(),
+        },
+      },
+      pluginConfig: {
+        formOverrides: { slug: "forms" },
+        formSubmissionOverrides: { slug: "form-submissions" },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const stats = await getFormSubmissionStats("contact", context);
+
+    expect(stats).toEqual({ total: 10, new: 4, read: 3, archived: 3 });
+    // Every count runs as system, scoped to the form, with the right status.
+    expect(count).toHaveBeenCalledWith(
+      "form-submissions",
+      { where: { form: { equals: "form1" } } },
+      { as: "system" }
+    );
+    expect(count).toHaveBeenCalledWith(
+      "form-submissions",
+      { where: { form: { equals: "form1" }, status: { equals: "new" } } },
+      { as: "system" }
+    );
+    expect(count).toHaveBeenCalledTimes(4);
+  });
+});

--- a/packages/plugin-form-builder/src/admin/index.ts
+++ b/packages/plugin-form-builder/src/admin/index.ts
@@ -115,26 +115,6 @@ export const FORM_BUILDER_VIEW_PATH: ComponentPath =
 export const SUBMISSIONS_FILTER_PATH: ComponentPath =
   "@nextlyhq/plugin-form-builder/admin#SubmissionsFilter";
 
-/**
- * Register Form Builder admin components with the Nextly admin panel.
- *
- * @deprecated This function is no longer needed. Components are auto-registered
- * when the admin detects the Form Builder plugin's component paths in collection configs.
- *
- * @example
- * ```typescript
- * // No manual registration needed! Just add the plugin to your config:
- * export default defineConfig({
- *   plugins: [formBuilderPlugin.plugin],
- * });
- * ```
- */
-export function registerFormBuilderAdminComponents(): void {
-  registerComponents({
-    [FORM_BUILDER_VIEW_PATH]: FormBuilderView,
-  });
-}
-
 // ============================================================================
 // Auto-Registration with Admin
 // ============================================================================

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -218,7 +218,9 @@ export async function submitForm(
     const submission = await collections.createEntry(
       pluginConfig.formSubmissionOverrides.slug,
       submissionData,
-      {} // Empty context - submission creation is public
+      // Public form submission — create as system (D35). No ambient user; an
+      // empty context already resolves to system, but be explicit.
+      { as: "system" }
     );
 
     logger.info?.("Form submission created successfully", {

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -255,18 +255,14 @@ export async function submitForm(
 // ============================================================
 
 /**
- * Fetch a form by its slug.
- *
- * Uses listEntries and filters by slug client-side.
- * Note: For production with large numbers of forms, consider using
- * direct database queries with WHERE clause support.
+ * Fetch a form by its slug via a service-level `where` query (D56).
  *
  * @param slug - Form slug
  * @param pluginConfig - Plugin configuration
  * @param pluginContext - Plugin context
  * @returns Form document or null if not found
  */
-async function fetchFormBySlug(
+export async function fetchFormBySlug(
   slug: string,
   pluginConfig: ResolvedFormBuilderConfig,
   pluginContext: PluginContext
@@ -274,26 +270,16 @@ async function fetchFormBySlug(
   try {
     const { collections } = pluginContext.services;
 
-    // List all forms and filter by slug
-    // Note: This approach works for small-medium form counts.
-    // For large-scale deployments, use direct database queries.
+    // D56: resolve the form by slug via a service-level `where` query (P7a)
+    // instead of fetching every form and filtering client-side. Forms are
+    // public config the plugin owns, so the read runs as system.
     const result = await collections.listEntries(
       pluginConfig.formOverrides.slug,
-      {
-        pagination: { limit: 100 }, // Fetch enough to find the form
-      },
-      {} // Empty context for public access
+      { where: { slug: { equals: slug } }, pagination: { limit: 1 } },
+      { as: "system" }
     );
 
-    if (!result.data || result.data.length === 0) {
-      return null;
-    }
-
-    // Find form by slug
-    const form = result.data.find(
-      (entry: unknown) => (entry as FormDocument).slug === slug
-    );
-
+    const form = result.data?.[0];
     return form ? (form as unknown as FormDocument) : null;
   } catch {
     return null;

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -497,40 +497,33 @@ export async function getFormSubmissionStats(
   }
 
   try {
-    // Fetch all submissions for this form
-    // Note: For large-scale use, implement pagination or direct DB queries
-    const result = await collections.listEntries(
-      pluginConfig.formSubmissionOverrides.slug,
-      {
-        pagination: { limit: 1000 }, // Reasonable limit for stats
-      },
-      {}
-    );
+    const submissionsSlug = pluginConfig.formSubmissionOverrides.slug;
+    const sys = { as: "system" } as const;
+    const base = { form: { equals: form.id } };
 
-    if (!result.data) {
-      return { total: 0, new: 0, read: 0, archived: 0 };
-    }
+    // D56: count per status server-side (P7a) instead of listing every
+    // submission and counting client-side. Stats run as system (plugin-owned
+    // aggregate over submissions for this form).
+    const [total, newCount, read, archived] = await Promise.all([
+      collections.count(submissionsSlug, { where: base }, sys),
+      collections.count(
+        submissionsSlug,
+        { where: { ...base, status: { equals: "new" } } },
+        sys
+      ),
+      collections.count(
+        submissionsSlug,
+        { where: { ...base, status: { equals: "read" } } },
+        sys
+      ),
+      collections.count(
+        submissionsSlug,
+        { where: { ...base, status: { equals: "archived" } } },
+        sys
+      ),
+    ]);
 
-    // Filter submissions for this form and count by status
-    const submissions = result.data.filter(
-      (entry: unknown) => (entry as { form: string }).form === form.id
-    );
-
-    const stats = {
-      total: submissions.length,
-      new: 0,
-      read: 0,
-      archived: 0,
-    };
-
-    for (const sub of submissions) {
-      const status = (sub as unknown as { status: string }).status;
-      if (status === "new") stats.new++;
-      else if (status === "read") stats.read++;
-      else if (status === "archived") stats.archived++;
-    }
-
-    return stats;
+    return { total, new: newCount, read, archived };
   } catch {
     return null;
   }

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -175,7 +175,8 @@ export function formBuilder(
 
   const plugin = definePlugin({
     name: "@nextlyhq/plugin-form-builder",
-    version: "0.0.8",
+    // Keep in sync with package.json `version` (guarded by package-metadata.test).
+    version: "0.0.2-alpha.22",
     nextly: ">=0.0.2-alpha.21",
 
     // Declarative schema (P2/D12): the merged pipeline folds these into the

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -49,10 +49,8 @@ type NextlyWithFormBuilderConfig = NextlyInstance & {
 function resolveConfig(
   options: FormBuilderPluginOptions
 ): ResolvedFormBuilderConfig {
-  const formOverrides =
-    options.formOverrides || options.collections?.forms || {};
-  const submissionOverrides =
-    options.formSubmissionOverrides || options.collections?.submissions || {};
+  const formOverrides = options.formOverrides || {};
+  const submissionOverrides = options.formSubmissionOverrides || {};
 
   return {
     formOverrides: {

--- a/packages/plugin-form-builder/src/types.ts
+++ b/packages/plugin-form-builder/src/types.ts
@@ -244,27 +244,6 @@ export interface FormBuilderPluginOptions {
   };
 
   /**
-   * @deprecated Use `formOverrides` and `formSubmissionOverrides` instead.
-   * This option is kept for backward compatibility.
-   */
-  collections?: {
-    forms?: Partial<CollectionConfig> & {
-      slug?: string;
-      labels?: {
-        singular?: string;
-        plural?: string;
-      };
-    };
-    submissions?: Partial<CollectionConfig> & {
-      slug?: string;
-      labels?: {
-        singular?: string;
-        plural?: string;
-      };
-    };
-  };
-
-  /**
    * Configure which field types are available in the form builder.
    *
    * Set to `false` to disable a field type, or provide partial configuration


### PR DESCRIPTION
## P7b — Form-builder finalize (R4)

Second slice of **P7**. Form-builder now consumes the **P7a D56 managed service path** instead of client-side filtering, plus version/keyword/deprecation cleanup.

> ⚠️ **Stacks on P7a** (`feat/plugin-p7a-service-gaps`) — needs the D56 surface. Until P7a merges, this PR's diff includes P7a's commits; review only P7b via `feat/plugin-p7a-service-gaps...feat/plugin-p7b-form-builder-finalize`, or merge P7a first.

### Shipped (7 tasks)
- **T1** harness fix: `createTestNextly` wires `hookRegistry` into `registerServices` → `ctx.services.collections` read/single-write run hooks (code-first collections). Verified zero regressions.
- **T2** sync plugin `version` to package.json (`0.0.8`→`0.0.2-alpha.22`) + `nextly-plugin` keyword (drift-guard test).
- **T3** `fetchFormBySlug` → D56 `where` query (was fetch-all + client `.find`).
- **T4** `getFormSubmissionStats` → D56 `count` per status (was list-all + client filter).
- **T5** public submission `createEntry` → explicit `{as:'system'}` (behavior-identical clarity).
- **T7** drop deprecated `collections` option.
- **T8** drop deprecated `registerFormBuilderAdminComponents`.

### Deviations
- **T6 (migrate `fetchParentForm` off `getCollectionsHandler`) — reverted.** Facade reads on **plugin-contributed** collections (`forms`) throw INTERNAL in `createTestNextly` (FileManager dynamic-schema registry isn't populated for them in-harness), breaking the passing email-filter test. Kept on `getCollectionsHandler`; follow-up = register plugin-collection schemas in the harness.
- **T9 (e2e submitForm) — dropped:** infeasible in-harness for the same reason; T3/T4 are unit-tested (query-shape changes) + the email-filter integration test stays green.

### Verification
- nextly **unit 405/32 = documented baseline → zero new** (2714 passed); **integration = the 3 pre-existing failures** (+1 new passing file).
- **build + check-types clean** across `nextly` / `@nextlyhq/plugin-sdk` / `@nextlyhq/plugin-form-builder`; **form-builder 28/28**.

No changeset (phase→base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)