### PR TITLE
feat(plugin-seo): P7c — first-party SEO plugin (extend + sitemap)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,7 +16,8 @@
       "@nextlyhq/storage-uploadthing",
       "@nextlyhq/storage-vercel-blob",
       "@nextlyhq/plugin-form-builder",
-      "@nextlyhq/plugin-sdk"
+      "@nextlyhq/plugin-sdk",
+      "@nextlyhq/plugin-seo"
     ]
   ],
   "linked": [],

--- a/packages/plugin-seo/README.md
+++ b/packages/plugin-seo/README.md
@@ -1,0 +1,82 @@
+# @nextlyhq/plugin-seo
+
+> ⚠️ **Alpha.** Part of the Nextly plugin platform. The public surface is
+> `@experimental` and may change between alpha releases — pin a version.
+
+A first-party SEO plugin for [Nextly](https://nextlyhq.com). It:
+
+- **Adds SEO meta fields** (`metaTitle`, `metaDescription`) to the content
+  collections you choose, via `contributes.extend`.
+- Declares a **`manage-seo`** permission (define-but-never-grant; assign it to
+  roles yourself).
+- Serves a **sitemap** of your published entries, cached and automatically
+  invalidated whenever a target collection changes.
+
+## Install
+
+```bash
+npm install @nextlyhq/plugin-seo
+```
+
+## Usage
+
+```ts
+// nextly.config.ts
+import { defineConfig } from "nextly/config";
+import { seo } from "@nextlyhq/plugin-seo";
+
+export default defineConfig({
+  plugins: [
+    seo({
+      collections: ["pages", "posts"],
+      baseUrl: "https://example.com",
+    }).plugin,
+  ],
+});
+```
+
+Then run `nextly migrate` — `collections: ["pages", "posts"]` get the SEO meta
+fields added to their schema.
+
+### Options
+
+| Option        | Type                            | Description                                                                   |
+| ------------- | ------------------------------- | ----------------------------------------------------------------------------- |
+| `collections` | `string[]`                      | Collections to extend with SEO fields **and** include in the sitemap.         |
+| `baseUrl`     | `string`                        | Absolute base URL for sitemap `<loc>` (e.g. `https://example.com`).           |
+| `urlFor?`     | `(entry, collection) => string` | Build an entry's path. Defaults to `/<collection>/<entry.slug>`.              |
+| `fields?`     | `FieldConfig[]`                 | Override the contributed fields (e.g. add a `metaImage` upload or canonical). |
+
+Target collections should have a `slug` field (for URLs) and a `status` field
+(only `status: "published"` entries appear in the sitemap).
+
+## Sitemap
+
+Plugin routes are namespaced, so the sitemap is served at:
+
+```
+/api/plugins/@nextlyhq/plugin-seo/sitemap.xml
+```
+
+Expose it at the conventional root path with a Next.js rewrite:
+
+```ts
+// next.config.ts
+export default {
+  async rewrites() {
+    return [
+      {
+        source: "/sitemap.xml",
+        destination: "/api/plugins/@nextlyhq/plugin-seo/sitemap.xml",
+      },
+    ];
+  },
+};
+```
+
+The sitemap is generated on demand, cached in memory, and invalidated when any
+target collection emits a `created` / `updated` / `deleted` event.
+
+## License
+
+MIT

--- a/packages/plugin-seo/package.json
+++ b/packages/plugin-seo/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@nextlyhq/plugin-seo",
+  "version": "0.0.2-alpha.22",
+  "description": "SEO plugin for Nextly — meta fields + sitemap for first-party content collections",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup src/index.ts --format esm --dts --watch",
+    "check-types": "tsc --noEmit",
+    "lint": "eslint . --max-warnings 0",
+    "lint:fix": "eslint . --fix",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "nextly": "0.0.2-alpha.22",
+    "@nextlyhq/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.0",
+    "vitest": "^4.0.8",
+    "@nextlyhq/tsconfig": "workspace:*",
+    "nextly": "workspace:*",
+    "@nextlyhq/plugin-sdk": "workspace:*"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "keywords": [
+    "nextly",
+    "nextly-plugin",
+    "plugin",
+    "seo",
+    "sitemap",
+    "cms",
+    "headless-cms"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nextlyhq/nextly.git",
+    "directory": "packages/plugin-seo"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
+  },
+  "homepage": "https://nextlyhq.com",
+  "bugs": {
+    "url": "https://github.com/nextlyhq/nextly/issues"
+  },
+  "author": "Nextly <contact@nextlyhq.com> (https://nextlyhq.com)"
+}

--- a/packages/plugin-seo/src/__tests__/extend.integration.test.ts
+++ b/packages/plugin-seo/src/__tests__/extend.integration.test.ts
@@ -1,0 +1,55 @@
+/**
+ * P7c — `seo({ collections })` adds its SEO fields to the target collections via
+ * `contributes.extend` (D12). Proven end-to-end on a code-first collection: a
+ * created entry carries the contributed `metaTitle`/`metaDescription` fields.
+ */
+import {
+  createTestNextly,
+  type TestNextly,
+} from "@nextlyhq/plugin-sdk/testing";
+import { defineCollection, text } from "nextly";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { seo } from "../plugin";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const pages = () =>
+  defineCollection({
+    slug: "pages",
+    fields: [
+      text({ name: "slug" }),
+      text({ name: "title" }),
+      text({ name: "status" }),
+    ],
+  });
+
+describe("seo extend (P7c)", () => {
+  it("adds metaTitle/metaDescription to the target collection", async () => {
+    current = await createTestNextly({
+      collections: [pages()],
+      plugins: [
+        seo({ collections: ["pages"], baseUrl: "https://example.com" }).plugin,
+      ],
+    });
+
+    const created = await current.nextly.create({
+      collection: "pages",
+      data: {
+        slug: "home",
+        title: "Home",
+        status: "published",
+        metaTitle: "Home — Meta",
+        metaDescription: "Welcome",
+      },
+    });
+
+    const item = created.item as Record<string, unknown>;
+    expect(item.metaTitle).toBe("Home — Meta");
+    expect(item.metaDescription).toBe("Welcome");
+  });
+});

--- a/packages/plugin-seo/src/__tests__/plugin.test.ts
+++ b/packages/plugin-seo/src/__tests__/plugin.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import { seo } from "../plugin";
+
+const pkg = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf8")
+) as { version: string; keywords: string[] };
+
+describe("seo() plugin (P7c)", () => {
+  it("defines the plugin with extend + manage-seo permission", () => {
+    const { plugin } = seo({
+      collections: ["pages", "posts"],
+      baseUrl: "https://example.com",
+    });
+
+    expect(plugin.name).toBe("@nextlyhq/plugin-seo");
+    expect(plugin.contributes?.extend?.[0].target).toEqual(["pages", "posts"]);
+
+    const fieldNames = plugin.contributes?.extend?.[0].fields.map(
+      f => (f as { name: string }).name
+    );
+    expect(fieldNames).toEqual(["metaTitle", "metaDescription"]);
+
+    expect(plugin.contributes?.permissions?.[0]).toMatchObject({
+      action: "manage",
+      resource: "seo",
+    });
+  });
+
+  it("lets the caller override the contributed fields", () => {
+    const { plugin } = seo({
+      collections: ["pages"],
+      baseUrl: "https://example.com",
+      fields: [],
+    });
+    expect(plugin.contributes?.extend?.[0].fields).toEqual([]);
+  });
+
+  it("plugin version matches package.json + declares nextly-plugin keyword", () => {
+    expect(seo({ collections: ["pages"], baseUrl: "x" }).plugin.version).toBe(
+      pkg.version
+    );
+    expect(pkg.keywords).toContain("nextly-plugin");
+  });
+});

--- a/packages/plugin-seo/src/__tests__/route.integration.test.ts
+++ b/packages/plugin-seo/src/__tests__/route.integration.test.ts
@@ -1,0 +1,91 @@
+/**
+ * P7c — the public sitemap route serves XML, and collection change events
+ * invalidate the cache so the sitemap reflects new published entries. Drives the
+ * `contributes.routes` handler directly against a live boot (D25/D28 + D8/D51).
+ */
+import { definePlugin } from "@nextlyhq/plugin-sdk";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "@nextlyhq/plugin-sdk/testing";
+import { defineCollection, text } from "nextly";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { seo } from "../plugin";
+
+let current: TestNextly | undefined;
+
+beforeEach(() => {
+  // init subscribes to events once per (collections) via a globalThis guard;
+  // clear it so each boot re-subscribes.
+  delete (globalThis as Record<string, unknown>)["__seo_events_pages"];
+});
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const pages = () =>
+  defineCollection({
+    slug: "pages",
+    fields: [text({ name: "slug" }), text({ name: "status" })],
+  });
+
+describe("seo sitemap route + event invalidation (P7c)", () => {
+  it("declares a public GET /sitemap.xml route", () => {
+    const route = seo({ collections: ["pages"], baseUrl: "https://x.com" })
+      .plugin.contributes?.routes?.[0];
+    expect(route).toMatchObject({
+      method: "GET",
+      path: "/sitemap.xml",
+      public: true,
+    });
+  });
+
+  it("serves XML and reflects new published entries after change events", async () => {
+    const seoResult = seo({ collections: ["pages"], baseUrl: "https://x.com" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let services: any;
+    const probe = definePlugin({
+      name: "@test/seo-route-probe",
+      version: "1.0.0",
+      nextly: ">=0.0.0",
+      init: c => {
+        services = c.services;
+      },
+    });
+    current = await createTestNextly({
+      collections: [pages()],
+      plugins: [seoResult.plugin, probe],
+    });
+
+    const handler = seoResult.plugin.contributes!.routes![0].handler;
+    const call = async (): Promise<string> => {
+      const res = await handler(
+        new Request("http://localhost/sitemap.xml"),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { services } as any
+      );
+      expect(res.headers.get("content-type")).toContain("xml");
+      return res.text();
+    };
+
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "a", status: "published" },
+    });
+    await current.events.settle();
+    expect(await call()).toContain("/pages/a");
+
+    // A new entry fires collection.pages.created → cache invalidated → the next
+    // request regenerates and includes it (would be stale "a"-only otherwise).
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "b", status: "published" },
+    });
+    await current.events.settle();
+    const xml = await call();
+    expect(xml).toContain("/pages/a");
+    expect(xml).toContain("/pages/b");
+  });
+});

--- a/packages/plugin-seo/src/__tests__/sitemap.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.test.ts
@@ -14,7 +14,11 @@ import { defineCollection, text } from "nextly";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { seo } from "../plugin";
-import { generateSitemap, type SitemapServices } from "../sitemap";
+import {
+  createSitemapCache,
+  generateSitemap,
+  type SitemapServices,
+} from "../sitemap";
 
 let current: TestNextly | undefined;
 afterEach(async () => {
@@ -96,5 +100,28 @@ describe("generateSitemap (P7c, integration)", () => {
 
     expect(xml).toContain("<loc>https://x.com/pages/live</loc>");
     expect(xml).not.toContain("/pages/wip");
+  });
+});
+
+describe("createSitemapCache (P7c, unit)", () => {
+  it("caches the result until invalidated", async () => {
+    const listEntries = vi
+      .fn()
+      .mockResolvedValue({ data: [{ slug: "a", updatedAt: null }] });
+    const services = {
+      collections: { listEntries },
+    } as unknown as SitemapServices;
+    const cache = createSitemapCache({
+      collections: ["pages"],
+      baseUrl: "https://x.com",
+    });
+
+    await cache.get(services);
+    await cache.get(services);
+    expect(listEntries).toHaveBeenCalledTimes(1); // second get served from cache
+
+    cache.invalidate();
+    await cache.get(services);
+    expect(listEntries).toHaveBeenCalledTimes(2); // regenerated after invalidate
   });
 });

--- a/packages/plugin-seo/src/__tests__/sitemap.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.test.ts
@@ -1,0 +1,100 @@
+/**
+ * P7c — sitemap generation: published-only via the D56 `where` query, correct
+ * `<loc>`/`<lastmod>`, XML-escaped. Unit (mock service: covers lastmod +
+ * escaping + the exact query) + integration (real published filter on a
+ * code-first collection — harness entries have null `updatedAt`, so lastmod is
+ * covered by the unit test).
+ */
+import {
+  createTestNextly,
+  type TestNextly,
+} from "@nextlyhq/plugin-sdk/testing";
+import { definePlugin } from "@nextlyhq/plugin-sdk";
+import { defineCollection, text } from "nextly";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { seo } from "../plugin";
+import { generateSitemap, type SitemapServices } from "../sitemap";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const pages = () =>
+  defineCollection({
+    slug: "pages",
+    fields: [
+      text({ name: "slug" }),
+      text({ name: "title" }),
+      text({ name: "status" }),
+    ],
+  });
+
+describe("generateSitemap (P7c, unit)", () => {
+  it("queries published entries and renders escaped loc + lastmod", async () => {
+    const listEntries = vi.fn().mockResolvedValue({
+      data: [{ slug: "a&b", updatedAt: "2026-01-02T03:04:05.000Z" }],
+    });
+
+    const xml = await generateSitemap(
+      { collections: { listEntries } } as unknown as SitemapServices,
+      { collections: ["pages"], baseUrl: "https://x.com" }
+    );
+
+    expect(listEntries).toHaveBeenCalledWith(
+      "pages",
+      {
+        where: { status: { equals: "published" } },
+        depth: 0,
+        pagination: { limit: 1000 },
+      },
+      { as: "system" }
+    );
+    expect(xml).toContain(
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+    );
+    expect(xml).toContain("<loc>https://x.com/pages/a&amp;b</loc>");
+    expect(xml).toContain("<lastmod>2026-01-02T03:04:05.000Z</lastmod>");
+  });
+});
+
+describe("generateSitemap (P7c, integration)", () => {
+  it("lists only published entries end-to-end", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let services: any;
+    const probe = definePlugin({
+      name: "@test/seo-probe",
+      version: "1.0.0",
+      nextly: ">=0.0.0",
+      init: c => {
+        services = c.services;
+      },
+    });
+    current = await createTestNextly({
+      collections: [pages()],
+      plugins: [
+        seo({ collections: ["pages"], baseUrl: "https://x.com" }).plugin,
+        probe,
+      ],
+    });
+
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "live", title: "Live", status: "published" },
+    });
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "wip", title: "WIP", status: "draft" },
+    });
+
+    const xml = await generateSitemap(services as SitemapServices, {
+      collections: ["pages"],
+      baseUrl: "https://x.com",
+    });
+
+    expect(xml).toContain("<loc>https://x.com/pages/live</loc>");
+    expect(xml).not.toContain("/pages/wip");
+  });
+});

--- a/packages/plugin-seo/src/fields.ts
+++ b/packages/plugin-seo/src/fields.ts
@@ -1,0 +1,18 @@
+import { text, textarea, type FieldConfig } from "nextly";
+
+/**
+ * The default SEO fields contributed onto each target collection (D12 extend).
+ * Matches the RFC §7.1 example (`metaTitle` + `metaDescription`). Integrators
+ * can override the whole set via `seo({ fields })` — e.g. to add an `metaImage`
+ * upload (relationTo: "media") or canonical/robots fields.
+ */
+export function defaultSeoFields(): FieldConfig[] {
+  return [
+    text({ name: "metaTitle", label: "Meta Title", maxLength: 60 }),
+    textarea({
+      name: "metaDescription",
+      label: "Meta Description",
+      maxLength: 160,
+    }),
+  ];
+}

--- a/packages/plugin-seo/src/index.ts
+++ b/packages/plugin-seo/src/index.ts
@@ -1,0 +1,3 @@
+export { seo, defaultUrlFor } from "./plugin";
+export type { SeoPluginOptions, SeoPluginResult, SeoEntry } from "./plugin";
+export { defaultSeoFields } from "./fields";

--- a/packages/plugin-seo/src/index.ts
+++ b/packages/plugin-seo/src/index.ts
@@ -1,3 +1,5 @@
 export { seo, defaultUrlFor } from "./plugin";
 export type { SeoPluginOptions, SeoPluginResult, SeoEntry } from "./plugin";
 export { defaultSeoFields } from "./fields";
+export { generateSitemap, escapeXml } from "./sitemap";
+export type { SitemapServices } from "./sitemap";

--- a/packages/plugin-seo/src/plugin.ts
+++ b/packages/plugin-seo/src/plugin.ts
@@ -13,6 +13,7 @@ import { definePlugin, type PluginDefinition } from "@nextlyhq/plugin-sdk";
 import type { FieldConfig } from "nextly";
 
 import { defaultSeoFields } from "./fields";
+import { createSitemapCache } from "./sitemap";
 
 /** A content document as seen by the sitemap builder (loose by design). */
 export type SeoEntry = Record<string, unknown> & {
@@ -59,6 +60,9 @@ export function defaultUrlFor(entry: SeoEntry, collection: string): string {
  */
 export function seo(opts: SeoPluginOptions): SeoPluginResult {
   const fields = opts.fields ?? defaultSeoFields();
+  // One cache per plugin instance, shared by the route handler (reads it) and
+  // the change-event subscriptions (invalidate it).
+  const sitemap = createSitemapCache(opts);
 
   const plugin = definePlugin({
     name: "@nextlyhq/plugin-seo",
@@ -78,6 +82,36 @@ export function seo(opts: SeoPluginOptions): SeoPluginResult {
           group: "SEO",
         },
       ],
+      // D25/D28: public sitemap, namespaced under
+      // /api/plugins/@nextlyhq/plugin-seo/sitemap.xml. Apps expose it at the
+      // root via a next.config rewrite (see README).
+      routes: [
+        {
+          method: "GET",
+          path: "/sitemap.xml",
+          public: true,
+          handler: async (_req, ctx) => {
+            const xml = await sitemap.get(ctx.services);
+            return new Response(xml, {
+              headers: { "content-type": "application/xml; charset=utf-8" },
+            });
+          },
+        },
+      ],
+    },
+    // D8/D51: invalidate the cached sitemap when any target collection changes.
+    init(ctx) {
+      const guardKey = `__seo_events_${opts.collections.join(",")}`;
+      const g = globalThis as Record<string, unknown>;
+      if (g[guardKey]) return; // dev-mode HMR: subscribe once
+      g[guardKey] = true;
+      for (const slug of opts.collections) {
+        for (const action of ["created", "updated", "deleted"] as const) {
+          ctx.events.on(`collection.${slug}.${action}`, () =>
+            sitemap.invalidate()
+          );
+        }
+      }
     },
   });
 

--- a/packages/plugin-seo/src/plugin.ts
+++ b/packages/plugin-seo/src/plugin.ts
@@ -1,0 +1,85 @@
+/**
+ * @nextlyhq/plugin-seo — a first-party SEO plugin for Nextly.
+ *
+ * - Extends the named content collections with SEO meta fields (D12).
+ * - Declares a `manage-seo` permission (D36).
+ * - Serves a public sitemap of published entries, namespaced under
+ *   `/api/plugins/@nextlyhq/plugin-seo/sitemap.xml` (D25/D28), cached and
+ *   invalidated on collection change events (D8/D51).
+ *
+ * Authored against `@nextlyhq/plugin-sdk` — the stable, experimental boundary.
+ */
+import { definePlugin, type PluginDefinition } from "@nextlyhq/plugin-sdk";
+import type { FieldConfig } from "nextly";
+
+import { defaultSeoFields } from "./fields";
+
+/** A content document as seen by the sitemap builder (loose by design). */
+export type SeoEntry = Record<string, unknown> & {
+  slug?: string;
+  updatedAt?: string | Date | null;
+};
+
+export interface SeoPluginOptions {
+  /** Collections to extend with SEO fields AND include in the sitemap. */
+  collections: string[];
+  /** Absolute base URL for sitemap `<loc>` (e.g. "https://example.com"). */
+  baseUrl: string;
+  /**
+   * Build the path for an entry. Defaults to `/<collection>/<entry.slug>`.
+   * Return a leading-slash path; it is appended to `baseUrl`.
+   */
+  urlFor?: (entry: SeoEntry, collection: string) => string;
+  /** Override the contributed SEO fields (defaults to metaTitle + metaDescription). */
+  fields?: FieldConfig[];
+}
+
+export interface SeoPluginResult {
+  /** Plugin definition — pass to `defineConfig({ plugins: [...] })`. */
+  plugin: PluginDefinition;
+}
+
+/** Default URL builder: `/<collection>/<slug>`. */
+export function defaultUrlFor(entry: SeoEntry, collection: string): string {
+  return `/${collection}/${entry.slug ?? ""}`;
+}
+
+/**
+ * Create an SEO plugin instance.
+ *
+ * @example
+ * ```ts
+ * import { defineConfig } from "nextly/config";
+ * import { seo } from "@nextlyhq/plugin-seo";
+ *
+ * export default defineConfig({
+ *   plugins: [seo({ collections: ["pages", "posts"], baseUrl: "https://example.com" }).plugin],
+ * });
+ * ```
+ */
+export function seo(opts: SeoPluginOptions): SeoPluginResult {
+  const fields = opts.fields ?? defaultSeoFields();
+
+  const plugin = definePlugin({
+    name: "@nextlyhq/plugin-seo",
+    // Keep in sync with package.json `version` (guarded by package-metadata.test).
+    version: "0.0.2-alpha.22",
+    nextly: ">=0.0.2-alpha.21",
+    contributes: {
+      // D12: add the same SEO fields to every target collection.
+      extend: [{ target: opts.collections, fields }],
+      // D36: a custom permission for SEO management (defined, never granted).
+      permissions: [
+        {
+          action: "manage",
+          resource: "seo",
+          label: "Manage SEO",
+          description: "Manage SEO metadata and the sitemap",
+          group: "SEO",
+        },
+      ],
+    },
+  });
+
+  return { plugin };
+}

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -1,0 +1,74 @@
+/**
+ * Sitemap generation for `@nextlyhq/plugin-seo`.
+ *
+ * Lists each target collection's PUBLISHED entries through the secure managed
+ * service (D56 `where` + `depth:0`, as system — sitemaps are public derived
+ * data) and renders a sitemaps.org `<urlset>`. Pure given a services object, so
+ * it is unit-testable with a stub and integration-testable against a real boot.
+ */
+import type { SeoPluginOptions } from "./plugin";
+import { defaultUrlFor } from "./plugin";
+
+/** The slice of `ctx.services` the sitemap builder needs. */
+export interface SitemapServices {
+  collections: {
+    listEntries(
+      slug: string,
+      query: {
+        where?: Record<string, unknown>;
+        depth?: number;
+        pagination?: { limit?: number };
+      },
+      opts: { as: "system" }
+    ): Promise<{ data: Array<Record<string, unknown>> }>;
+  };
+}
+
+/** XML-escape a text value for safe inclusion in `<loc>`. */
+export function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function toLastmod(value: unknown): string | undefined {
+  if (value === null || value === undefined || value === "") return undefined;
+  const d = new Date(value as string | number | Date);
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
+}
+
+/**
+ * Build the sitemap XML for the configured collections (published entries only).
+ */
+export async function generateSitemap(
+  services: SitemapServices,
+  opts: SeoPluginOptions
+): Promise<string> {
+  const urlFor = opts.urlFor ?? defaultUrlFor;
+  const urls: string[] = [];
+
+  for (const collection of opts.collections) {
+    const result = await services.collections.listEntries(
+      collection,
+      {
+        where: { status: { equals: "published" } },
+        depth: 0,
+        pagination: { limit: 1000 },
+      },
+      { as: "system" }
+    );
+
+    for (const entry of result.data) {
+      const loc = escapeXml(`${opts.baseUrl}${urlFor(entry, collection)}`);
+      const lastmod = toLastmod(entry.updatedAt);
+      urls.push(
+        `  <url><loc>${loc}</loc>${lastmod ? `<lastmod>${lastmod}</lastmod>` : ""}</url>`
+      );
+    }
+  }
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.join("\n")}\n</urlset>`;
+}

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -72,3 +72,25 @@ export async function generateSitemap(
 
   return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.join("\n")}\n</urlset>`;
 }
+
+/** Lazily-generated, cached sitemap. Invalidated on collection change events. */
+export interface SitemapCache {
+  /** Return the cached sitemap, generating it on first access (or after invalidate). */
+  get(services: SitemapServices): Promise<string>;
+  /** Drop the cached sitemap so the next `get` regenerates. */
+  invalidate(): void;
+}
+
+/** Create a per-plugin sitemap cache (one closure per `seo()` instance). */
+export function createSitemapCache(opts: SeoPluginOptions): SitemapCache {
+  let cached: string | null = null;
+  return {
+    async get(services) {
+      if (cached === null) cached = await generateSitemap(services, opts);
+      return cached;
+    },
+    invalidate() {
+      cached = null;
+    },
+  };
+}

--- a/packages/plugin-seo/tsconfig.json
+++ b/packages/plugin-seo/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@nextlyhq/tsconfig/base-bundler.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "baseUrl": "."
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts"]
+}

--- a/packages/plugin-seo/tsup.config.ts
+++ b/packages/plugin-seo/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  minify: false,
+  target: "es2022",
+});


### PR DESCRIPTION
## P7c — SEO plugin (`@nextlyhq/plugin-seo`)

Third slice of **P7** — a new first-party plugin proving the extend + events + route APIs.

> ⚠️ **Stacks on P7b** (`feat/plugin-p7b-form-builder-finalize`) — needs P7a's D56 `where`/`depth` **and** P7b's T1 harness hook fix. Until the stack merges, this PR's diff includes P7a+P7b; review only P7c via `feat/plugin-p7b-form-builder-finalize...feat/plugin-p7c-seo`, or merge the stack in order.

### Shipped (5 tasks)
- **T1** scaffold `@nextlyhq/plugin-seo` (server-only; peers `nextly` + `@nextlyhq/plugin-sdk`). `seo({collections, baseUrl, urlFor?, fields?})` → `contributes.extend` (metaTitle/metaDescription, D12) + `manage-seo` permission (D36). Added to the changeset fixed group.
- **T2** extend integration — SEO fields land on a code-first collection (create-path proof).
- **T3** sitemap generation via the **D56** service (published-only, `where`+`depth:0`, escaped `<loc>`, `<lastmod>`).
- **T4** public `GET /sitemap.xml` route (D25/D28) with an in-memory cache **invalidated by `collection.*` change events** (D8) — proven end-to-end (route reflects new published entries after events).
- **T5** README (usage, options, the `/sitemap.xml` next.config rewrite).

### Notes
- Routes are namespaced (`/api/plugins/@nextlyhq/plugin-seo/sitemap.xml`); apps expose `/sitemap.xml` via a next.config rewrite (documented).
- `metaImage` (upload→media) left to the `fields` override (avoids a media-table dependency in the harness).

### Verification
- plugin-seo **build (ESM+DTS) + check-types clean + 9/9 tests** (extend, sitemap unit+integration, route+events integration).
- No source changes outside `packages/plugin-seo/` + `.changeset/config.json` — nextly/sdk/form-builder baselines unchanged.

No changeset (phase→base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)