### PR TITLE
fix(form-builder): complete managed-path migration + correct P7b stale-dist misdiagnosis

### DIFF
--- a/packages/plugin-form-builder/src/__tests__/fetch-parent-form.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/fetch-parent-form.test.ts
@@ -1,0 +1,48 @@
+/**
+ * R4/D35 — `fetchParentForm` (used by the afterCreate notification hook) reads
+ * the parent form through the secure managed service as system, instead of the
+ * legacy `getCollectionsHandler()` + `overrideAccess` runtime path. (The
+ * end-to-end path is covered by `before-email-filter.integration.test.ts`.)
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { fetchParentForm } from "../plugin";
+
+const config = {
+  formOverrides: { slug: "forms" },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;
+
+function nextlyWith(findEntryById: ReturnType<typeof vi.fn>) {
+  return {
+    services: { collections: { findEntryById } },
+    logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe("fetchParentForm (R4/D35)", () => {
+  it("reads the form via findEntryById as system", async () => {
+    const findEntryById = vi
+      .fn()
+      .mockResolvedValue({ id: "form1", slug: "contact" });
+
+    const form = await fetchParentForm(
+      config,
+      "form1",
+      nextlyWith(findEntryById)
+    );
+
+    expect(findEntryById).toHaveBeenCalledWith("forms", "form1", {
+      as: "system",
+    });
+    expect(form).toMatchObject({ id: "form1" });
+  });
+
+  it("returns null (not throws) when the form is missing", async () => {
+    const findEntryById = vi.fn().mockRejectedValue(new Error("not found"));
+    expect(
+      await fetchParentForm(config, "missing", nextlyWith(findEntryById))
+    ).toBeNull();
+  });
+});

--- a/packages/plugin-form-builder/src/__tests__/rename.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/rename.integration.test.ts
@@ -38,9 +38,14 @@ describe("form-builder framework .rename() (D54 / R4)", () => {
 
     // init() resolved the submissions slug via ctx.self, so the afterCreate
     // hook is registered on the RENAMED slug — proving the canonical pattern.
-    expect(current.hooks.hasHooks("afterCreate", "leads")).toBe(true);
-    expect(current.hooks.hasHooks("afterCreate", "form-submissions")).toBe(
-      false
+    // Use getHookCount (specific-slug only) rather than hasHooks: the harness
+    // now registers a global `afterCreate` "*" activity-log hook (matching
+    // production), which hasHooks would conflate with a per-slug hook.
+    expect(current.hooks.getHookCount("afterCreate", "leads")).toBeGreaterThan(
+      0
+    );
+    expect(current.hooks.getHookCount("afterCreate", "form-submissions")).toBe(
+      0
     );
   });
 });

--- a/packages/plugin-form-builder/src/__tests__/submit-form.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/submit-form.integration.test.ts
@@ -1,0 +1,65 @@
+/**
+ * R4/D56 — full submission flow end-to-end through the harness: `submitForm`
+ * resolves the form via the D56 `where` query, validates, and persists a
+ * submission via the secure managed service. Proves a plugin that OWNS its
+ * collections (forms/form-submissions) is fully testable with `createTestNextly`
+ * (the case P7b mistakenly believed was blocked — it was a stale-dist artifact).
+ */
+import { definePlugin } from "@nextlyhq/plugin-sdk";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "@nextlyhq/plugin-sdk/testing";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { submitForm } from "../handlers/submit-form";
+import { formBuilder } from "../plugin";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+describe("submitForm end-to-end (R4/D56)", () => {
+  it("resolves the form, validates, and persists a submission", async () => {
+    const fb = formBuilder({
+      spamProtection: { honeypot: false, recaptcha: { enabled: false } },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let services: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let logger: any;
+    const probe = definePlugin({
+      name: "@test/fb-submit",
+      version: "1.0.0",
+      nextly: ">=0.0.0",
+      init: c => {
+        services = c.services;
+        logger = c.logger;
+      },
+    });
+    current = await createTestNextly({ plugins: [fb.plugin, probe] });
+
+    await current.nextly.create({
+      collection: "forms",
+      data: {
+        name: "Contact",
+        slug: "contact",
+        status: "published",
+        fields: [{ type: "text", name: "message", label: "Message" }],
+      },
+    });
+
+    const result = await submitForm(
+      { formSlug: "contact", data: { message: "hello" } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { pluginContext: { services, logger } as any, pluginConfig: fb.config }
+    );
+
+    expect(result.success).toBe(true);
+    expect(
+      await services.collections.count("form-submissions", {}, { as: "system" })
+    ).toBe(1);
+  });
+});

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -10,11 +10,6 @@
 
 import { definePlugin, type PluginDefinition } from "@nextlyhq/plugin-sdk";
 import type { CollectionConfig } from "nextly";
-// `getCollectionsHandler` runs inside Next.js request handlers, so it
-// lives behind the runtime subpath. Importing from
-// the root would drag Next.js subpaths into Node-only contexts (CLI,
-// config loaders) that pull this plugin via `nextly.config.ts`.
-import { getCollectionsHandler } from "nextly/runtime";
 // Author against the SDK — the stable, experimental plugin boundary (D43).
 
 import { formsCollection } from "./collections/forms";
@@ -525,31 +520,21 @@ async function handleSubmissionCreated(
 /**
  * Fetch the parent form document for a submission.
  */
-async function fetchParentForm(
+export async function fetchParentForm(
   config: ResolvedFormBuilderConfig,
   formId: string,
   nextly: NextlyInstance
 ): Promise<Record<string, unknown> | null> {
   try {
-    const handler = getCollectionsHandler();
-    if (!handler) {
-      nextly.logger.warn?.(
-        "Form Builder: CollectionsHandler unavailable, skipping notifications"
-      );
-      return null;
-    }
-    const result = await handler.getEntry({
-      collectionName: config.formOverrides.slug,
-      entryId: formId,
-      overrideAccess: true,
-    });
-    const fromData = result?.data;
-    if (fromData) return fromData as Record<string, unknown>;
-    const fromDoc = (result as { doc?: unknown } | undefined)?.doc;
-    if (fromDoc && typeof fromDoc === "object") {
-      return fromDoc as Record<string, unknown>;
-    }
-    return null;
+    // D35/D56: read the parent form through the secure managed service as
+    // system — the afterCreate hook runs without an ambient user. Replaces the
+    // legacy `getCollectionsHandler()` + `overrideAccess` runtime path.
+    const form = await nextly.services.collections.findEntryById(
+      config.formOverrides.slug,
+      formId,
+      { as: "system" }
+    );
+    return form;
   } catch (err) {
     nextly.logger.error?.("Form Builder: failed to fetch form", {
       formId,


### PR DESCRIPTION
## P7b2 — Form-builder managed-path completion + P7b correction

A follow-up that **corrects a P7b misdiagnosis** and finishes form-builder's R4 migration.

> ⚠️ **Stacks on P7c → P7b → P7a.** Review only P7b2 via `feat/plugin-p7c-seo...feat/plugin-p7b2-managed-path`, or merge the stack in order.

### The correction (root-caused via systematic debugging)
P7b concluded there was a harness "FileManager gap", reverted the `fetchParentForm` migration, and dropped the submitForm e2e. **That was wrong.** The real cause was a **stale `nextly` dist**: form-builder's harness tests consume `nextly` via its built dist, and during P7b it hadn't been rebuilt after T1's fix. With the dist current, facade reads on plugin-owned collections work.

### Shipped
- **F1** `fetchParentForm` via `findEntryById(...,{as:'system'})` — drops `getCollectionsHandler`; form-builder fully on the managed path (R4/D35).
- **F2** submitForm e2e — plugin-owned collections testable via `createTestNextly`.
- **F3** corrected the phase-log misdiagnosis.
- **F4** fixed a T1-induced rename-test regression (getHookCount). ⚠️ The regression lives in P7b's T1 — merge the stack in order or fold F4 into P7b.

### Verification
form-builder check-types clean + 31/31. No nextly/sdk source change.

No changeset (phase→base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)