### PR TITLE
feat(plugin-redirects): P7d — first-party redirects plugin (Payload pattern)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -17,7 +17,8 @@
       "@nextlyhq/storage-vercel-blob",
       "@nextlyhq/plugin-form-builder",
       "@nextlyhq/plugin-sdk",
-      "@nextlyhq/plugin-seo"
+      "@nextlyhq/plugin-seo",
+      "@nextlyhq/plugin-redirects"
     ]
   ],
   "linked": [],

--- a/packages/plugin-redirects/README.md
+++ b/packages/plugin-redirects/README.md
@@ -1,0 +1,80 @@
+# @nextlyhq/plugin-redirects
+
+> ⚠️ **Alpha.** Part of the Nextly plugin platform. The public surface is
+> `@experimental` and may change between alpha releases — pin a version.
+
+Admin-managed URL redirects for [Nextly](https://nextlyhq.com), modeled on
+Payload's `@payloadcms/plugin-redirects`. It:
+
+- adds a **`redirects` collection** (`fromPath` → `toPath`, with a `301`/`302`
+  `type`) you manage in the admin,
+- declares a **`manage-redirects`** permission,
+- exposes a **lookup route**, and
+- ships a **Next.js middleware helper** that applies the redirects at request
+  time.
+
+Because plugin routes are namespaced, the actual interception lives in your
+app's `middleware.ts` (same model as Payload) — the plugin owns the data + the
+helper.
+
+## Install
+
+```bash
+npm install @nextlyhq/plugin-redirects
+```
+
+## 1. Register the plugin
+
+```ts
+// nextly.config.ts
+import { defineConfig } from "nextly/config";
+import { redirects } from "@nextlyhq/plugin-redirects";
+
+export default defineConfig({
+  plugins: [redirects().plugin],
+});
+```
+
+Run `nextly migrate` to create the `redirects` collection, then manage redirects
+in the admin (each redirect is a `fromPath`, a `toPath`, and a `301`/`302` type).
+
+## 2. Wire the middleware
+
+```ts
+// middleware.ts
+import { createRedirectsMiddleware } from "@nextlyhq/plugin-redirects/middleware";
+
+export const middleware = createRedirectsMiddleware();
+
+// Skip API/static assets so only page requests are checked.
+export const config = {
+  matcher: ["/((?!api|_next|.*\\..*).*)"],
+};
+```
+
+On each request the middleware looks up the incoming path against the plugin's
+lookup route and issues a `301`/`302` when there's a match, otherwise passes
+through. Lookups are cached (Next `revalidate`, default 60s) and best-effort — a
+lookup failure never breaks the request.
+
+### Options
+
+`redirects(options?)`:
+
+| Option | Type     | Description                                                |
+| ------ | -------- | ---------------------------------------------------------- |
+| `slug` | `string` | Slug for the redirects collection (default `"redirects"`). |
+
+`createRedirectsMiddleware(options?)`:
+
+| Option       | Type     | Description                                                          |
+| ------------ | -------- | -------------------------------------------------------------------- |
+| `baseUrl`    | `string` | App origin serving the lookup route. Defaults to the request origin. |
+| `revalidate` | `number` | Seconds to cache the lookup (default `60`).                          |
+
+v1 matches on the **exact** `fromPath` (no wildcards/regex); `toPath` may be a
+path or an absolute URL.
+
+## License
+
+MIT

--- a/packages/plugin-redirects/package.json
+++ b/packages/plugin-redirects/package.json
@@ -1,0 +1,79 @@
+{
+  "name": "@nextlyhq/plugin-redirects",
+  "version": "0.0.2-alpha.22",
+  "description": "Redirects plugin for Nextly — admin-managed redirects + a Next.js middleware helper",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./middleware": {
+      "types": "./dist/middleware.d.ts",
+      "import": "./dist/middleware.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup src/index.ts src/middleware.ts --format esm --dts --watch",
+    "check-types": "tsc --noEmit",
+    "lint": "eslint . --max-warnings 0",
+    "lint:fix": "eslint . --fix",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "nextly": "0.0.2-alpha.22",
+    "@nextlyhq/plugin-sdk": "workspace:*",
+    "next": "^14.0.0 || ^15.0.0 || ^16.0.0"
+  },
+  "peerDependenciesMeta": {
+    "next": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "next": "^16.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.0",
+    "vitest": "^4.0.8",
+    "@nextlyhq/tsconfig": "workspace:*",
+    "nextly": "workspace:*",
+    "@nextlyhq/plugin-sdk": "workspace:*"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "keywords": [
+    "nextly",
+    "nextly-plugin",
+    "plugin",
+    "redirects",
+    "cms",
+    "headless-cms"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nextlyhq/nextly.git",
+    "directory": "packages/plugin-redirects"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
+  },
+  "homepage": "https://nextlyhq.com",
+  "bugs": {
+    "url": "https://github.com/nextlyhq/nextly/issues"
+  },
+  "author": "Nextly <contact@nextlyhq.com> (https://nextlyhq.com)"
+}

--- a/packages/plugin-redirects/src/__tests__/lookup.integration.test.ts
+++ b/packages/plugin-redirects/src/__tests__/lookup.integration.test.ts
@@ -1,0 +1,75 @@
+/**
+ * P7d/D56 — the lookup route resolves a source path to its redirect target by
+ * querying the redirects collection with a `where` filter (P7a) as system.
+ * End-to-end against a live boot, reading the PLUGIN-CONTRIBUTED `redirects`
+ * collection (works post-P7b2 harness fix).
+ */
+import { definePlugin } from "@nextlyhq/plugin-sdk";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "@nextlyhq/plugin-sdk/testing";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { redirects } from "../plugin";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+describe("redirects lookup route (P7d)", () => {
+  it("resolves a source path to {to,type}, and null when unknown", async () => {
+    const result = redirects();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let services: any;
+    const probe = definePlugin({
+      name: "@test/redirects-probe",
+      version: "1.0.0",
+      nextly: ">=0.0.0",
+      init: c => {
+        services = c.services;
+      },
+    });
+    current = await createTestNextly({ plugins: [result.plugin, probe] });
+
+    await current.nextly.create({
+      collection: "redirects",
+      data: {
+        title: "Old page",
+        slug: "old-page",
+        fromPath: "/old",
+        toPath: "/new",
+        type: "301",
+      },
+    });
+    await current.nextly.create({
+      collection: "redirects",
+      data: {
+        title: "External",
+        slug: "external",
+        fromPath: "/go",
+        toPath: "https://example.com",
+        type: "302",
+      },
+    });
+
+    const handler = result.plugin.contributes!.routes![0].handler;
+    const lookup = async (from: string): Promise<unknown> => {
+      const res = await handler(
+        new Request(`http://localhost/lookup?from=${encodeURIComponent(from)}`),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { services } as any
+      );
+      return res.json();
+    };
+
+    expect(await lookup("/old")).toEqual({ to: "/new", type: "301" });
+    expect(await lookup("/go")).toEqual({
+      to: "https://example.com",
+      type: "302",
+    });
+    expect(await lookup("/missing")).toBeNull();
+  });
+});

--- a/packages/plugin-redirects/src/__tests__/middleware.test.ts
+++ b/packages/plugin-redirects/src/__tests__/middleware.test.ts
@@ -1,0 +1,52 @@
+/**
+ * P7d — the Next.js middleware helper issues a 301/302 for a matched path and
+ * passes through otherwise. Unit test with real next/server + a mocked fetch
+ * (the lookup route).
+ */
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createRedirectsMiddleware } from "../middleware";
+
+afterEach(() => vi.restoreAllMocks());
+
+function request(path: string): NextRequest {
+  return new NextRequest(new URL(`https://app.test${path}`));
+}
+
+function mockLookup(body: unknown) {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  );
+}
+
+describe("createRedirectsMiddleware (P7d)", () => {
+  it("redirects to the matched target with the matched status (302)", async () => {
+    mockLookup({ to: "/new", type: "302" });
+    const res = await createRedirectsMiddleware()(request("/old"));
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("https://app.test/new");
+  });
+
+  it("defaults to 301 and supports absolute destinations", async () => {
+    mockLookup({ to: "https://example.com/", type: "301" });
+    const res = await createRedirectsMiddleware()(request("/go"));
+    expect(res.status).toBe(301);
+    expect(res.headers.get("location")).toBe("https://example.com/");
+  });
+
+  it("passes through when there is no match", async () => {
+    mockLookup(null);
+    const res = await createRedirectsMiddleware()(request("/keep"));
+    expect(res.headers.get("location")).toBeNull();
+  });
+
+  it("passes through (never throws) when the lookup fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
+    const res = await createRedirectsMiddleware()(request("/old"));
+    expect(res.headers.get("location")).toBeNull();
+  });
+});

--- a/packages/plugin-redirects/src/__tests__/plugin.test.ts
+++ b/packages/plugin-redirects/src/__tests__/plugin.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import { redirects } from "../plugin";
+
+const pkg = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf8")
+) as { version: string; keywords: string[] };
+
+describe("redirects() plugin (P7d)", () => {
+  it("defines the redirects collection + manage-redirects permission + lookup route", () => {
+    const { plugin } = redirects();
+
+    expect(plugin.name).toBe("@nextlyhq/plugin-redirects");
+
+    const col = plugin.contributes?.collections?.[0];
+    expect(col?.slug).toBe("redirects");
+    // defineCollection prepends the Nextly system fields (title, slug); assert
+    // the redirect-specific fields are present.
+    expect(col?.fields.map(f => (f as { name: string }).name)).toEqual(
+      expect.arrayContaining(["fromPath", "toPath", "type"])
+    );
+
+    expect(plugin.contributes?.permissions?.[0]).toMatchObject({
+      action: "manage",
+      resource: "redirects",
+    });
+
+    expect(plugin.contributes?.routes?.[0]).toMatchObject({
+      method: "GET",
+      path: "/lookup",
+      public: true,
+    });
+  });
+
+  it("version matches package.json + declares the nextly-plugin keyword", () => {
+    expect(redirects().plugin.version).toBe(pkg.version);
+    expect(pkg.keywords).toContain("nextly-plugin");
+  });
+
+  it("supports a custom collection slug", () => {
+    expect(
+      redirects({ slug: "url-redirects" }).plugin.contributes?.collections?.[0]
+        .slug
+    ).toBe("url-redirects");
+  });
+});

--- a/packages/plugin-redirects/src/collection.ts
+++ b/packages/plugin-redirects/src/collection.ts
@@ -1,0 +1,38 @@
+import { defineCollection, select, text, type CollectionConfig } from "nextly";
+
+/**
+ * The admin-managed redirects collection (mirrors Payload's plugin-redirects):
+ * `from` (unique source path) → `to` (destination URL/path), with a 301/302
+ * `type`. Editors manage entries in the admin; the Next.js middleware helper
+ * applies them at request time.
+ */
+export function redirectsCollection(slug = "redirects"): CollectionConfig {
+  return defineCollection({
+    slug,
+    labels: { singular: "Redirect", plural: "Redirects" },
+    fields: [
+      text({
+        name: "fromPath",
+        label: "From",
+        required: true,
+        unique: true,
+        admin: { description: "Source path, e.g. /old-page" },
+      }),
+      text({
+        name: "toPath",
+        label: "To",
+        required: true,
+        admin: { description: "Destination URL or path, e.g. /new-page" },
+      }),
+      select({
+        name: "type",
+        label: "Type",
+        defaultValue: "301",
+        options: [
+          { label: "301 (Permanent)", value: "301" },
+          { label: "302 (Temporary)", value: "302" },
+        ],
+      }),
+    ],
+  });
+}

--- a/packages/plugin-redirects/src/index.ts
+++ b/packages/plugin-redirects/src/index.ts
@@ -1,0 +1,5 @@
+export { redirects } from "./plugin";
+export type { RedirectsPluginOptions, RedirectsPluginResult } from "./plugin";
+export { redirectsCollection } from "./collection";
+export { findRedirect } from "./lookup";
+export type { RedirectServices, RedirectMatch } from "./lookup";

--- a/packages/plugin-redirects/src/lookup.ts
+++ b/packages/plugin-redirects/src/lookup.ts
@@ -1,0 +1,47 @@
+/**
+ * Redirect resolution for `@nextlyhq/plugin-redirects`.
+ *
+ * Resolves a source path to its redirect target through the secure managed
+ * service (D56 `where`, as system — redirects are public routing data). Pure
+ * given a services object, so it is unit/integration-testable.
+ */
+
+/** The slice of `ctx.services` the lookup needs. */
+export interface RedirectServices {
+  collections: {
+    listEntries(
+      slug: string,
+      query: {
+        where?: Record<string, unknown>;
+        pagination?: { limit?: number };
+      },
+      opts: { as: "system" }
+    ): Promise<{ data: Array<Record<string, unknown>> }>;
+  };
+}
+
+export interface RedirectMatch {
+  /** Destination URL or path. */
+  to: string;
+  /** HTTP redirect status as a string ("301" | "302"). */
+  type: string;
+}
+
+/** Find the redirect for a source path, or `null` if none. */
+export async function findRedirect(
+  services: RedirectServices,
+  slug: string,
+  from: string
+): Promise<RedirectMatch | null> {
+  const result = await services.collections.listEntries(
+    slug,
+    { where: { fromPath: { equals: from } }, pagination: { limit: 1 } },
+    { as: "system" }
+  );
+  const row = result.data?.[0];
+  if (!row || typeof row.toPath !== "string") return null;
+  return {
+    to: row.toPath,
+    type: typeof row.type === "string" ? row.type : "301",
+  };
+}

--- a/packages/plugin-redirects/src/middleware.ts
+++ b/packages/plugin-redirects/src/middleware.ts
@@ -1,0 +1,71 @@
+/**
+ * Next.js middleware helper for `@nextlyhq/plugin-redirects` — the
+ * `@nextlyhq/plugin-redirects/middleware` entry.
+ *
+ * Plugin routes are namespaced, so transparent root-path redirects live in the
+ * APP, not the plugin (same model as Payload's plugin-redirects). Drop this into
+ * your `middleware.ts`: it looks up the incoming path against the plugin's
+ * lookup route and issues a 301/302 when there's a match, otherwise passes
+ * through. Best-effort — a lookup failure never breaks the request.
+ *
+ * @example
+ * ```ts
+ * // middleware.ts
+ * import { createRedirectsMiddleware } from "@nextlyhq/plugin-redirects/middleware";
+ * export const middleware = createRedirectsMiddleware();
+ * export const config = { matcher: ["/((?!api|_next|.*\\..*).*)"] };
+ * ```
+ */
+import { NextResponse, type NextRequest } from "next/server";
+
+const LOOKUP_PATH = "/api/plugins/@nextlyhq/plugin-redirects/lookup";
+
+export interface RedirectsMiddlewareOptions {
+  /**
+   * Base URL of the Nextly app serving the plugin route. Defaults to the
+   * incoming request's origin (correct for single-origin apps).
+   */
+  baseUrl?: string;
+  /** Seconds to cache the lookup response (Next fetch revalidate; default 60). */
+  revalidate?: number;
+}
+
+/** Create a Next.js middleware that applies plugin-managed redirects. */
+export function createRedirectsMiddleware(
+  opts: RedirectsMiddlewareOptions = {}
+) {
+  const revalidate = opts.revalidate ?? 60;
+
+  return async function redirectsMiddleware(
+    request: NextRequest
+  ): Promise<NextResponse> {
+    const base = opts.baseUrl ?? request.nextUrl.origin;
+    const from = request.nextUrl.pathname;
+
+    try {
+      // `next.revalidate` is a Next.js fetch extension (not in the DOM
+      // RequestInit type) — declare it on a typed init so it stays type-clean.
+      const init: RequestInit & { next?: { revalidate?: number } } = {
+        next: { revalidate },
+      };
+      const res = await fetch(
+        `${base}${LOOKUP_PATH}?from=${encodeURIComponent(from)}`,
+        init
+      );
+      if (res.ok) {
+        const match = (await res.json()) as {
+          to?: string;
+          type?: string;
+        } | null;
+        if (match?.to) {
+          const status = match.type === "302" ? 302 : 301;
+          return NextResponse.redirect(new URL(match.to, base), status);
+        }
+      }
+    } catch {
+      // Best-effort: never break the request pipeline on a lookup failure.
+    }
+
+    return NextResponse.next();
+  };
+}

--- a/packages/plugin-redirects/src/plugin.ts
+++ b/packages/plugin-redirects/src/plugin.ts
@@ -1,0 +1,79 @@
+/**
+ * @nextlyhq/plugin-redirects — admin-managed redirects for Nextly.
+ *
+ * Mirrors Payload's `@payloadcms/plugin-redirects`: it owns a `redirects`
+ * collection (D12) + a `manage-redirects` permission (D36) and exposes a public
+ * lookup route (D25/D28) that resolves a path via the D56 `where` query. The
+ * actual interception is done by the app via the shipped Next.js middleware
+ * helper (`@nextlyhq/plugin-redirects/middleware`) — plugin routes are
+ * namespaced, so transparent root-path redirects live in the app, not the
+ * plugin (same model as Payload).
+ */
+import { definePlugin, type PluginDefinition } from "@nextlyhq/plugin-sdk";
+
+import { redirectsCollection } from "./collection";
+import { findRedirect } from "./lookup";
+
+export interface RedirectsPluginOptions {
+  /** Slug for the redirects collection (default `"redirects"`). */
+  slug?: string;
+}
+
+export interface RedirectsPluginResult {
+  /** Plugin definition — pass to `defineConfig({ plugins: [...] })`. */
+  plugin: PluginDefinition;
+}
+
+/**
+ * Create a redirects plugin instance.
+ *
+ * @example
+ * ```ts
+ * import { defineConfig } from "nextly/config";
+ * import { redirects } from "@nextlyhq/plugin-redirects";
+ *
+ * export default defineConfig({ plugins: [redirects().plugin] });
+ * ```
+ */
+export function redirects(
+  opts: RedirectsPluginOptions = {}
+): RedirectsPluginResult {
+  const slug = opts.slug ?? "redirects";
+
+  const plugin = definePlugin({
+    name: "@nextlyhq/plugin-redirects",
+    // Keep in sync with package.json `version` (guarded by package-metadata.test).
+    version: "0.0.2-alpha.22",
+    nextly: ">=0.0.2-alpha.21",
+    contributes: {
+      collections: [redirectsCollection(slug)],
+      permissions: [
+        {
+          action: "manage",
+          resource: "redirects",
+          label: "Manage Redirects",
+          description: "Manage URL redirects",
+          group: "Redirects",
+        },
+      ],
+      // Public lookup route (D25/D28): the middleware helper calls it with the
+      // incoming path; reads the redirects collection via the D56 `where`
+      // query as system. Redirects are public routing data, not secrets.
+      routes: [
+        {
+          method: "GET",
+          path: "/lookup",
+          public: true,
+          handler: async (req, ctx) => {
+            const from = new URL(req.url).searchParams.get("from");
+            if (!from) return Response.json(null);
+            const match = await findRedirect(ctx.services, slug, from);
+            return Response.json(match);
+          },
+        },
+      ],
+    },
+  });
+
+  return { plugin };
+}

--- a/packages/plugin-redirects/tsconfig.json
+++ b/packages/plugin-redirects/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@nextlyhq/tsconfig/base-bundler.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "baseUrl": "."
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts"]
+}

--- a/packages/plugin-redirects/tsup.config.ts
+++ b/packages/plugin-redirects/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  // Two entries: the `.` plugin (Next-free, safe to import in nextly.config.ts)
+  // and the `./middleware` Next.js helper (imports next/server).
+  entry: ["src/index.ts", "src/middleware.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  minify: false,
+  target: "es2022",
+  external: ["next", "next/server"],
+});


### PR DESCRIPTION
## P7d — Redirects plugin (`@nextlyhq/plugin-redirects`)

The third planned first-party plugin — **completes P7's plugin set (form-builder + SEO + redirects), 1:1 with Payload's official plugins.**

> ⚠️ **Stacks on P7b2 → P7c → P7b → P7a.** Review only P7d via `feat/plugin-p7b2-managed-path...feat/plugin-p7d-redirects`, or merge the stack in order.

### Design (OQ-P7d resolved by the benchmark)
Payload's redirects plugin doesn't intercept inside the plugin — it owns a redirects **collection** + API, and the **app wires Next.js `middleware.ts`** to apply them. So the "namespaced routes can't intercept root paths" concern was a non-issue; this plugin follows the same model. No new global-middleware capability needed.

### Shipped (4 tasks)
- **T1** scaffold `@nextlyhq/plugin-redirects` (`.` Next-free + `./middleware` entries). `redirects()` → `redirects` collection (D12) + `manage-redirects` permission (D36) + a public `GET /lookup?from=` route (D25/D28) resolving via the D56 `where` query.
- **T2** lookup integration — create redirects → the route resolves `/old`→`/new` (301), `/go`→`https://…` (302), null on miss (reads the plugin-contributed collection end-to-end).
- **T3** `createRedirectsMiddleware()` on `@nextlyhq/plugin-redirects/middleware` — issues 301/302 (else passthrough), best-effort. Unit-tested with real next/server + mocked fetch.
- **T4** README (register + `middleware.ts` snippet + options).

### Findings
- `from`/`to` are SQL reserved keywords (collection validator) → `fromPath`/`toPath`.
- `defineCollection` force-adds required system `title`/`slug` (Nextly convention) — leaned into it.
- `next.revalidate` fetch option typed via a local `init` (not in DOM `RequestInit`); `.` entry stays Next-free.

### Verification
- plugin-redirects **build (2 entries, ESM+DTS) + check-types clean + 8/8 tests**. No nextly/sdk source change → baselines unchanged.

No changeset (phase→base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)