### PR TITLE
feat(admin): read-only, config-sourced title & slug for singles

### DIFF
--- a/.changeset/singles-readonly-title-slug.md
+++ b/.changeset/singles-readonly-title-slug.md
@@ -1,0 +1,18 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/ui": patch
+---
+
+Single edit forms no longer ask for a title and slug. A Single is a one-instance document whose identity is fixed by its config (`label` + `slug`), but the admin previously rendered title and slug as editable, required inputs — forcing redundant input for values already determined by the definition.
+
+The single edit form now shows the title (from the single's `label`) and slug (from the configured `slug`) as read-only, non-editable fields, and submitting never errors on them. `EntrySystemHeader` and `EntryMetaStrip` gain opt-in `lockIdentity`/`lockSlug` flags (default off, so collection entry forms are unchanged); for singles the title/slug are seeded from config, the client validation for those two fields is relaxed, and slug auto-generation is disabled.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryMetaStrip.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryMetaStrip.tsx
@@ -23,6 +23,10 @@ export interface EntryMetaStripProps {
   /** Whether the rail is currently collapsed. Pill only renders when true,
    *  since DocumentPanel takes over that role when the rail is expanded. */
   isRailCollapsed: boolean;
+  /** When true (Singles), the slug is fixed by the single's config: render it
+   *  as read-only text with no inline-edit affordance. Defaults to false so
+   *  collection entry forms keep the editable slug. */
+  lockSlug?: boolean;
 }
 
 export function EntryMetaStrip({
@@ -30,6 +34,7 @@ export function EntryMetaStrip({
   hasStatus,
   status,
   isRailCollapsed,
+  lockSlug = false,
 }: EntryMetaStripProps) {
   const showStatusPill = hasStatus && isRailCollapsed && !!status;
   const showSlug = !!slugField;
@@ -39,7 +44,9 @@ export function EntryMetaStrip({
   return (
     <div className="px-6 py-2 border-b border-primary/5 flex items-center gap-3 text-xs text-muted-foreground">
       {showStatusPill && <StatusPill status={status} />}
-      {showSlug && <SlugInlineEditor slugField={slugField} />}
+      {showSlug && (
+        <SlugInlineEditor slugField={slugField} readOnly={lockSlug} />
+      )}
     </div>
   );
 }
@@ -63,7 +70,13 @@ function StatusPill({ status }: { status: string }) {
   );
 }
 
-function SlugInlineEditor({ slugField }: { slugField: FieldConfig }) {
+function SlugInlineEditor({
+  slugField,
+  readOnly = false,
+}: {
+  slugField: FieldConfig;
+  readOnly?: boolean;
+}) {
   const form = useFormContext();
   const slugName = "name" in slugField ? (slugField.name as string) : "slug";
   const liveValue = form?.watch(slugName) as string | undefined;
@@ -80,6 +93,19 @@ function SlugInlineEditor({ slugField }: { slugField: FieldConfig }) {
   }, [editing]);
 
   if (!form) return null;
+
+  // Singles: slug is fixed by the single's config. Render it as plain
+  // read-only text with no pencil-to-edit affordance.
+  if (readOnly) {
+    return (
+      <div className="flex items-center gap-1.5 min-w-0 flex-1">
+        <span className="text-muted-foreground/70 shrink-0">slug:</span>
+        <code className="text-foreground/80 font-mono text-xs whitespace-nowrap truncate">
+          {liveValue || "(unset)"}
+        </code>
+      </div>
+    );
+  }
 
   const startEdit = () => {
     setDraft(liveValue ?? "");

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -104,6 +104,13 @@ export interface EntrySystemHeaderProps {
    */
   scope?: "collection" | "single";
 
+  /**
+   * When true (Singles), the title is fixed by the single's config: render the
+   * title input read-only and drop its required validation. Defaults to false
+   * so collection entry forms keep the editable, optionally-required title.
+   */
+  lockIdentity?: boolean;
+
   /** Rail collapsed state. */
   isRailCollapsed?: boolean;
   /** Rail toggle handler. */
@@ -130,6 +137,7 @@ export function EntrySystemHeader({
   onViewApi,
   showJson = true,
   scope = "collection",
+  lockIdentity = false,
   isRailCollapsed = false,
   onToggleRail,
 }: EntrySystemHeaderProps) {
@@ -158,7 +166,7 @@ export function EntrySystemHeader({
     (titleField as { label?: string } | undefined)?.label ?? "Title";
 
   const { ref: rhfRef, ...rhfRegister } = form.register(titleName, {
-    required: titleRequired ? "Title is required" : false,
+    required: !lockIdentity && titleRequired ? "Title is required" : false,
   });
 
   const showEditMenuItems = mode === "edit" && entry?.id;
@@ -190,10 +198,12 @@ export function EntrySystemHeader({
           placeholder="Untitled"
           aria-label={titleLabel}
           disabled={isSubmitting}
+          readOnly={lockIdentity}
           className={cn(
             "w-full text-[19px] font-semibold tracking-tight text-foreground",
             "bg-transparent outline-none placeholder:text-muted-foreground/50",
-            isSubmitting && "opacity-60 cursor-not-allowed"
+            isSubmitting && "opacity-60 cursor-not-allowed",
+            lockIdentity && "cursor-default text-foreground/80"
           )}
         />
       </div>

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntryMetaStrip.lock-slug.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntryMetaStrip.lock-slug.test.tsx
@@ -1,0 +1,44 @@
+import type { FieldConfig } from "nextly/config";
+import { useForm, FormProvider } from "react-hook-form";
+import { describe, it, expect } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+import { EntryMetaStrip } from "../EntryMetaStrip";
+
+const slugField = {
+  type: "text",
+  name: "slug",
+  label: "Slug",
+} as unknown as FieldConfig;
+
+function Harness({ lockSlug }: { lockSlug?: boolean }) {
+  const methods = useForm({ defaultValues: { slug: "homepage" } });
+  return (
+    <FormProvider {...methods}>
+      <EntryMetaStrip
+        slugField={slugField}
+        hasStatus={false}
+        isRailCollapsed={false}
+        lockSlug={lockSlug}
+      />
+    </FormProvider>
+  );
+}
+
+describe("EntryMetaStrip — lockSlug", () => {
+  it("shows the slug read-only with no edit affordance when lockSlug is set", () => {
+    render(<Harness lockSlug />);
+    expect(screen.getByText("homepage")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /edit slug/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the inline edit affordance when lockSlug is not set", () => {
+    render(<Harness />);
+    expect(
+      screen.getByRole("button", { name: /edit slug/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.lock-identity.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.lock-identity.test.tsx
@@ -1,0 +1,42 @@
+import { useForm, FormProvider } from "react-hook-form";
+import { describe, it, expect, vi } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+import { EntrySystemHeader } from "../EntrySystemHeader";
+
+function Harness({ lockIdentity }: { lockIdentity?: boolean }) {
+  const methods = useForm({ defaultValues: { title: "Homepage" } });
+  return (
+    <FormProvider {...methods}>
+      <EntrySystemHeader
+        mode="edit"
+        hasStatus
+        entry={{ id: "homepage", status: "draft", title: "Homepage" }}
+        collectionSlug="homepage"
+        scope="single"
+        lockIdentity={lockIdentity}
+        onSaveDraft={vi.fn()}
+        onPublish={vi.fn()}
+        onSaveChanges={vi.fn()}
+        onUnpublish={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    </FormProvider>
+  );
+}
+
+describe("EntrySystemHeader — lockIdentity", () => {
+  it("renders the title read-only with the config value when lockIdentity is set", () => {
+    render(<Harness lockIdentity />);
+    const input = screen.getByLabelText("Title") as HTMLInputElement;
+    expect(input.readOnly).toBe(true);
+    expect(input.value).toBe("Homepage");
+  });
+
+  it("renders an editable title when lockIdentity is not set", () => {
+    render(<Harness />);
+    const input = screen.getByLabelText("Title") as HTMLInputElement;
+    expect(input.readOnly).toBe(false);
+  });
+});

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -44,6 +44,8 @@ import { useEntryFormShortcuts } from "@admin/hooks/useKeyboardShortcuts";
 import { generateClientSchema } from "@admin/lib/field-validation";
 import { cn } from "@admin/lib/utils";
 
+import { relaxIdentityRequired } from "./identity-fields";
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -297,20 +299,27 @@ export function SingleForm({
   onViewApi,
   className,
 }: SingleFormProps) {
-  // Generate Zod schema from field configurations
+  // Generate Zod schema from field configurations. Singles render title/slug
+  // read-only from config, so relax their required rule — submitting must not
+  // error when they aren't user-entered.
   const zodSchema = useMemo(() => {
     try {
-      return generateClientSchema(schema.fields);
+      return generateClientSchema(relaxIdentityRequired(schema.fields));
     } catch (error) {
       console.error("Failed to generate schema:", error);
       return z.record(z.string(), z.unknown());
     }
   }, [schema.fields]);
 
-  // Generate default values from document data
+  // Generate default values from document data, then pin the single's identity
+  // (title/slug) to its config so the read-only display and the submitted
+  // payload always reflect the definition rather than any stale stored value.
   const defaultValues = useMemo(() => {
-    return getDefaultValues(schema.fields, document);
-  }, [schema.fields, document]);
+    const values = getDefaultValues(schema.fields, document);
+    values.title = schema.label;
+    values.slug = schema.slug;
+    return values;
+  }, [schema.fields, schema.label, schema.slug, document]);
 
   // Initialize form
   //
@@ -419,11 +428,14 @@ export function SingleForm({
     titleField && "name" in titleField ? (titleField.name as string) : "title";
   const slugFieldName =
     slugField && "name" in slugField ? (slugField.name as string) : "slug";
+  // Singles never auto-generate the slug — it's fixed by the single's config
+  // and rendered read-only. Keep the hook mounted (stable hook order) but
+  // disabled so it never writes to the slug field.
   useAutoSlug({
     form,
     titleFieldName,
     slugFieldName,
-    enabled: !!titleField && !!slugField,
+    enabled: false,
   });
   const documentStatus =
     (document as { status?: string } | undefined)?.status ?? "draft";
@@ -488,6 +500,7 @@ export function SingleForm({
                  `scope="single"` routes the dialog through singleApi
                  instead of entryApi. */
               scope="single"
+              lockIdentity
               isRailCollapsed={railCollapsed}
               onToggleRail={toggleRail}
             />
@@ -496,6 +509,7 @@ export function SingleForm({
               hasStatus={hasStatus}
               status={documentStatus}
               isRailCollapsed={railCollapsed}
+              lockSlug
             />
 
             {mainFields.length > 0 && (

--- a/packages/admin/src/components/features/singles/__tests__/SingleForm.identity-readonly.test.tsx
+++ b/packages/admin/src/components/features/singles/__tests__/SingleForm.identity-readonly.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+import {
+  SingleForm,
+  type SingleSchema,
+  type SingleDocumentData,
+} from "../SingleForm";
+
+const schema = {
+  slug: "homepage",
+  label: "Homepage",
+  fields: [
+    { type: "text", name: "title", label: "Title", required: true },
+    { type: "text", name: "slug", label: "Slug", required: true, unique: true },
+    { type: "text", name: "heroTitle", label: "Hero Title" },
+  ],
+} as unknown as SingleSchema;
+
+const document = {
+  id: "homepage",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  title: "Homepage",
+  slug: "homepage",
+  heroTitle: "",
+} as unknown as SingleDocumentData;
+
+describe("SingleForm — read-only identity", () => {
+  it("renders title and slug read-only, sourced from the single config", () => {
+    render(
+      <SingleForm schema={schema} document={document} onSubmit={vi.fn()} />
+    );
+
+    const title = screen.getByLabelText("Title") as HTMLInputElement;
+    expect(title.readOnly).toBe(true);
+    expect(title.value).toBe("Homepage");
+
+    // slug shown as read-only text (value rendered, possibly also in the
+    // sidebar), with no inline editor affordance in the meta strip.
+    expect(screen.getAllByText("homepage").length).toBeGreaterThan(0);
+    expect(
+      screen.queryByRole("button", { name: /edit slug/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/features/singles/__tests__/identity-fields.test.ts
+++ b/packages/admin/src/components/features/singles/__tests__/identity-fields.test.ts
@@ -1,0 +1,37 @@
+import type { FieldConfig } from "nextly/config";
+import { describe, it, expect } from "vitest";
+
+import { relaxIdentityRequired } from "../identity-fields";
+
+describe("relaxIdentityRequired", () => {
+  it("marks title and slug not-required, leaving other fields untouched", () => {
+    const out = relaxIdentityRequired([
+      { type: "text", name: "title", required: true },
+      { type: "text", name: "slug", required: true },
+      { type: "text", name: "heroTitle", required: true },
+    ] as unknown as FieldConfig[]);
+
+    const byName = Object.fromEntries(
+      out.map(f => [(f as { name: string }).name, f as { required?: boolean }])
+    );
+    expect(byName.title.required).toBe(false);
+    expect(byName.slug.required).toBe(false);
+    expect(byName.heroTitle.required).toBe(true);
+  });
+
+  it("clears nested validation.required for identity fields but keeps other rules", () => {
+    const [title] = relaxIdentityRequired([
+      {
+        type: "text",
+        name: "title",
+        validation: { required: true, maxLength: 80 },
+      },
+    ] as unknown as FieldConfig[]);
+
+    const v = (
+      title as { validation: { required?: boolean; maxLength?: number } }
+    ).validation;
+    expect(v.required).toBe(false);
+    expect(v.maxLength).toBe(80);
+  });
+});

--- a/packages/admin/src/components/features/singles/identity-fields.ts
+++ b/packages/admin/src/components/features/singles/identity-fields.ts
@@ -1,0 +1,33 @@
+import type { FieldConfig } from "nextly/config";
+
+/**
+ * A Single's "identity" fields. These are auto-injected by `defineSingle`
+ * (or, for visual singles, by the system schema) and are fixed by the
+ * single's config — they are rendered read-only in the admin and must not be
+ * required-validated.
+ */
+const IDENTITY_FIELD_NAMES = new Set(["title", "slug"]);
+
+/**
+ * Return a copy of `fields` with the Single identity fields (`title`, `slug`)
+ * marked not-required, at both the flat (`field.required`) and nested
+ * (`field.validation.required`) shapes that `generateClientSchema` reads.
+ *
+ * Singles render title/slug read-only from config, so the client validation
+ * schema must accept a submission that doesn't carry them. All other fields
+ * pass through unchanged.
+ */
+export function relaxIdentityRequired(fields: FieldConfig[]): FieldConfig[] {
+  return fields.map(field => {
+    if (!("name" in field) || !IDENTITY_FIELD_NAMES.has(field.name as string)) {
+      return field;
+    }
+    const validation = (field as { validation?: Record<string, unknown> })
+      .validation;
+    return {
+      ...field,
+      required: false,
+      ...(validation ? { validation: { ...validation, required: false } } : {}),
+    } as FieldConfig;
+  });
+}


### PR DESCRIPTION
Single edit forms no longer require typing a title and slug. The single's title (from its `label`) and slug (from the configured `slug`) now render read-only, and submitting never errors on them.

EntrySystemHeader and EntryMetaStrip gain opt-in `lockIdentity`/`lockSlug` flags (default off, so collection entry forms are unchanged). SingleForm seeds title/slug from config, relaxes their client validation via relaxIdentityRequired, and disables slug auto-generation.

## Summary

<!-- What does this PR do and why? Keep it short. -->

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [ ] Refactor / chore (no user-facing change)

## Related issues

<!-- e.g. Closes #123, Refs #456 -->

## Changeset

This repo uses [Changesets](https://github.com/changesets/changesets). If your PR changes any publishable package under `packages/*`, you **must** include a changeset:

```bash
pnpm changeset
```

Then commit the generated `.changeset/*.md` file.

- [ ] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [ ] I selected the correct semver bump (patch / minor / major)

> The `changeset-check` CI job will fail if a publishable package is modified without a changeset.

## Test plan

<!-- How did you verify this works? Commands run, scenarios tested, screenshots, etc. -->

- [ ] `pnpm lint`
- [ ] `pnpm check-types`
- [ ] `pnpm build`
- [ ] Manually verified the change

## Checklist

- [ ] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [ ] I targeted the `main` branch
- [ ] I updated relevant documentation

## Screenshots / recordings

<!-- Optional. Drag images or videos here for UI changes. -->

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to? Migration risks, perf concerns, etc. -->
