### PR TITLE
fix(nextly): fix media bulk delete route

### DIFF
--- a/.changeset/young-papers-leave.md
+++ b/.changeset/young-papers-leave.md
@@ -1,0 +1,21 @@
+---
+"nextly": patch
+"playground": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+parseMediaRoute had no case for the 'bulk' segment, so DELETE /api/media/bulk fell through to the single-item path and treated 'bulk' as a mediaId, causing a 404 from the database.

--- a/packages/nextly/src/api/media-bulk.ts
+++ b/packages/nextly/src/api/media-bulk.ts
@@ -45,10 +45,6 @@ import { withErrorHandler } from "./with-error-handler";
 
 function getMediaService(): MediaService {
   if (!isServicesRegistered()) {
-    // Surface initialization failures via the canonical 503 factory so the
-    // public response sticks to the spec §13.8-canonical sentence emitted by
-    // `serviceUnavailable()`. The setup hint goes to `logContext` so operators
-    // see it without leaking into the wire.
     throw NextlyError.serviceUnavailable({
       logMessage: "Media bulk handler called before registerServices()",
       logContext: {
@@ -74,6 +70,50 @@ function createAuthenticatedContext(userId: string | null): RequestContext {
       permissions: [],
     },
   };
+}
+
+/**
+ * Shared bulk-delete execution logic.
+ *
+ * Validates the `mediaIds` payload, delegates to `mediaService.bulkDelete`,
+ * and returns the canonical `respondBulk` envelope. Extracted here so both
+ * the standalone `DELETE` export (sync `getMediaService`) and the catch-all
+ * `handleBulkDeleteMedia` in `media-handlers.ts` (async `getMediaService`
+ * that bootstraps storage plugins) share one implementation — preventing
+ * silent drift between validation rules, message format, and error shape.
+ *
+ * @param request - The incoming HTTP request containing `{ mediaIds: string[] }`
+ * @param mediaService - Already-resolved MediaService instance
+ * @param context - RequestContext for the operation
+ */
+export async function executeBulkDelete(
+  request: Request,
+  mediaService: MediaService,
+  context: RequestContext
+): Promise<Response> {
+  const body = await readJsonBody<Record<string, unknown>>(request);
+  const mediaIds = body.mediaIds;
+
+  if (!Array.isArray(mediaIds) || mediaIds.length === 0) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "mediaIds",
+          code: "required_array",
+          message: "mediaIds must be a non-empty array.",
+        },
+      ],
+    });
+  }
+
+  const result = await mediaService.bulkDelete(mediaIds as string[], context);
+
+  const message =
+    result.failures.length === 0
+      ? `Deleted ${result.successCount} ${result.successCount === 1 ? "file" : "files"}.`
+      : `Deleted ${result.successCount} of ${result.total} files.`;
+
+  return respondBulk(message, result.successes, result.failures);
 }
 
 /**
@@ -210,7 +250,9 @@ export const POST = withErrorHandler(
     // doesn't need it, but we use it below to remap service failures
     // (which are 0-indexed in validatedFiles) back to the caller's
     // original payload indices.
-    const serviceInputs = validatedFiles.map(({ originalIndex: _, ...rest }) => rest);
+    const serviceInputs = validatedFiles.map(
+      ({ originalIndex: _, ...rest }) => rest
+    );
     const result = await mediaService.bulkUpload(serviceInputs, context);
 
     // Remap service-side failure indices back to the caller's original
@@ -230,9 +272,7 @@ export const POST = withErrorHandler(
     const successCount = result.successCount;
     const message =
       failures.length === 0
-        ? `Uploaded ${successCount} ${
-            successCount === 1 ? "file" : "files"
-          }.`
+        ? `Uploaded ${successCount} ${successCount === 1 ? "file" : "files"}.`
         : `Uploaded ${successCount} of ${totalRequested} files.`;
 
     return respondBulkUpload(message, result.successes, failures);
@@ -255,31 +295,6 @@ export const POST = withErrorHandler(
 export const DELETE = withErrorHandler(
   async (request: Request): Promise<Response> => {
     const mediaService = getMediaService();
-    const body = await readJsonBody<Record<string, unknown>>(request);
-    const mediaIds = body.mediaIds;
-
-    if (!Array.isArray(mediaIds) || mediaIds.length === 0) {
-      throw NextlyError.validation({
-        errors: [
-          {
-            path: "mediaIds",
-            code: "required_array",
-            message: "mediaIds must be a non-empty array.",
-          },
-        ],
-      });
-    }
-
-    const context: RequestContext = {};
-    const result = await mediaService.bulkDelete(mediaIds as string[], context);
-
-    const message =
-      result.failures.length === 0
-        ? `Deleted ${result.successCount} ${
-            result.successCount === 1 ? "file" : "files"
-          }.`
-        : `Deleted ${result.successCount} of ${result.total} files.`;
-
-    return respondBulk(message, result.successes, result.failures);
+    return executeBulkDelete(request, mediaService, {});
   }
 );

--- a/packages/nextly/src/api/media-handlers.ts
+++ b/packages/nextly/src/api/media-handlers.ts
@@ -66,10 +66,10 @@ import type {
 import type { RequestContext } from "../services/shared";
 import { UploadMediaInputSchema, UpdateMediaInputSchema } from "../types/media";
 
+import { executeBulkDelete } from "./media-bulk";
 import { readJsonBody } from "./read-json-body";
 import {
   respondAction,
-  respondBulk,
   respondData,
   respondDoc,
   respondList,
@@ -412,30 +412,7 @@ async function handleMoveMedia(
 
 async function handleBulkDeleteMedia(request: Request): Promise<Response> {
   const mediaService = await getMediaService();
-  const body = await readJsonBody<Record<string, unknown>>(request);
-  const mediaIds = body.mediaIds;
-
-  if (!Array.isArray(mediaIds) || mediaIds.length === 0) {
-    throw NextlyError.validation({
-      errors: [
-        {
-          path: "mediaIds",
-          code: "required_array",
-          message: "mediaIds must be a non-empty array.",
-        },
-      ],
-    });
-  }
-
-  const context = createRequestContext();
-  const result = await mediaService.bulkDelete(mediaIds as string[], context);
-
-  const message =
-    result.failures.length === 0
-      ? `Deleted ${result.successCount} ${result.successCount === 1 ? "file" : "files"}.`
-      : `Deleted ${result.successCount} of ${result.total} files.`;
-
-  return respondBulk(message, result.successes, result.failures);
+  return executeBulkDelete(request, mediaService, createRequestContext());
 }
 
 // ============================================================

--- a/packages/nextly/src/api/media-handlers.ts
+++ b/packages/nextly/src/api/media-handlers.ts
@@ -57,11 +57,7 @@ import { z } from "zod";
 import type { SanitizedNextlyConfig } from "../collections/config/define-config";
 import { getService } from "../di";
 import { NextlyError } from "../errors/nextly-error";
-import {
-  getCachedNextly,
-  getNextly,
-  type GetNextlyOptions,
-} from "../init";
+import { getCachedNextly, getNextly, type GetNextlyOptions } from "../init";
 import { withTimezoneFormatting } from "../lib/date-formatting";
 import type {
   MediaService,
@@ -73,6 +69,7 @@ import { UploadMediaInputSchema, UpdateMediaInputSchema } from "../types/media";
 import { readJsonBody } from "./read-json-body";
 import {
   respondAction,
+  respondBulk,
   respondData,
   respondDoc,
   respondList,
@@ -151,6 +148,7 @@ interface ParsedMediaRoute {
     | "update-media"
     | "delete-media"
     | "move-media"
+    | "bulk-delete-media"
     | "list-folders"
     | "create-folder"
     | "get-folder"
@@ -172,6 +170,13 @@ function parseMediaRoute(
   if (segments.length === 0) {
     if (method === "GET") return { type: "list-media" };
     if (method === "POST") return { type: "upload-media" };
+    return { type: "not-found" };
+  }
+
+  // "bulk" must be matched before the generic segments.length === 1 block
+  // so it is never mistaken for a media ID.
+  if (segments[0] === "bulk" && segments.length === 1) {
+    if (method === "DELETE") return { type: "bulk-delete-media" };
     return { type: "not-found" };
   }
 
@@ -253,9 +258,7 @@ async function handleListMedia(request: Request): Promise<Response> {
   const folderIdParam = searchParams.get("folderId");
   const options: ListMediaOptions = {
     page: searchParams.get("page") ? Number(searchParams.get("page")) : 1,
-    limit: searchParams.get("limit")
-      ? Number(searchParams.get("limit"))
-      : 24,
+    limit: searchParams.get("limit") ? Number(searchParams.get("limit")) : 24,
     search: searchParams.get("search") || undefined,
     type: (searchParams.get("type") as ListMediaOptions["type"]) || undefined,
     folderId: folderIdParam === "root" ? "root" : folderIdParam || undefined,
@@ -401,7 +404,38 @@ async function handleMoveMedia(
 
   // Service returns void; echo the target ids so the admin can update the
   // moved record locally without re-fetching the affected folders.
-  return respondAction("Media moved.", { id: mediaId, folderId: folderId ?? null });
+  return respondAction("Media moved.", {
+    id: mediaId,
+    folderId: folderId ?? null,
+  });
+}
+
+async function handleBulkDeleteMedia(request: Request): Promise<Response> {
+  const mediaService = await getMediaService();
+  const body = await readJsonBody<Record<string, unknown>>(request);
+  const mediaIds = body.mediaIds;
+
+  if (!Array.isArray(mediaIds) || mediaIds.length === 0) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "mediaIds",
+          code: "required_array",
+          message: "mediaIds must be a non-empty array.",
+        },
+      ],
+    });
+  }
+
+  const context = createRequestContext();
+  const result = await mediaService.bulkDelete(mediaIds as string[], context);
+
+  const message =
+    result.failures.length === 0
+      ? `Deleted ${result.successCount} ${result.successCount === 1 ? "file" : "files"}.`
+      : `Deleted ${result.successCount} of ${result.total} files.`;
+
+  return respondBulk(message, result.successes, result.failures);
 }
 
 // ============================================================
@@ -631,6 +665,9 @@ export function createMediaHandlers(options?: MediaHandlerOptions) {
             break;
           case "delete-folder":
             response = await handleDeleteFolder(request, route.folderId!);
+            break;
+          case "bulk-delete-media":
+            response = await handleBulkDeleteMedia(request);
             break;
           default:
             throwUnmatchedRoute(resolvedParams.path, "DELETE");


### PR DESCRIPTION
## Summary

Fixes issues bulk media deletion caused by stacked problem:

###  Server 404 on `DELETE /api/media/bulk`

`parseMediaRoute` in `media-handlers.ts` did not handle the `"bulk"` path segment. When a request came in with `path = ["bulk"]`, it incorrectly fell through to the single-item handler and attempted to fetch a media record with `id = "bulk"`, resulting in a 404 from the database.

**Fix:**

* Added a `"bulk"` guard before the generic `segments.length === 1` condition.
* Implemented `handleBulkDeleteMedia` handler:

  * Reads `mediaIds[]` from the request body.
  * Calls `mediaService.bulkDelete()` with proper concurrency.
* Wired the handler into the `DELETE` switch.

---


## Type of Change

* Bug fix (non-breaking change that resolves existing issues)

---

## Changeset

* I added a changeset (or this PR only touches non-publishable code such as docs, tests, internal tooling, apps/*)
* I selected the correct semver bump (patch / minor / major)

---

## Test Plan

* Open the Media Library
* Delete a single image → confirm → verify removal and list refresh
* Delete multiple images → confirm → verify all are removed (or partial failures are reported via toast)
* Verify `DELETE /api/media/bulk` returns 200 (not 404) in the network tab

### Commands

* `pnpm lint`

* `pnpm check-types`

* `pnpm build`

* Manually verified the changes

---

## Checklist

* I read CONTRIBUTING (if available)
* My commits follow the Conventional Commits spec (commitlint enforced)
* I targeted the `main` branch
* I updated relevant documentation

