### PR TITLE
refactor(nextly): stop generating orphan Drizzle schema files

### DIFF
--- a/.changeset/drop-collection-drizzle-schema-files.md
+++ b/.changeset/drop-collection-drizzle-schema-files.md
@@ -1,0 +1,33 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Stop collections from generating orphan Drizzle `.ts` schema files.
+
+Creating or updating a collection (via the admin UI or `nextly db:sync`) used to write a Drizzle `.ts` schema into `src/db/schemas/dynamic/` and maintain an `index.ts` barrel. Nothing imported these files: the runtime resolves each table's Drizzle schema from the `dynamic_collections` metadata via `generateRuntimeSchema`, exactly as singles and components already do (those never generated `.ts` files). The only consumer was the raw `drizzle-kit` binary via `merge-schemas` / `drizzle-kit-entry`, which requires a `drizzle.config.ts` that the framework's own commands never invoke. The generated files therefore drifted from the database and read as dead code.
+
+Collections now behave like singles and components: the data table is created, the field definitions are stored in `dynamic_collections`, an in-memory runtime schema is registered, and the SQL migration is still written to `src/db/migrations/dynamic/` (it remains the durable DDL applied by `nextly migrate`). No `.ts` schema file is written.
+
+Changes:
+
+- `CollectionFileManager`: replaced `saveArtifacts`/`saveUpdateArtifacts` with a migration-only `saveMigration`; removed `updateSchemaIndex`, `removeFromSchemaIndex`, and the disk-based `reloadSchema` hot-reload.
+- `CollectionMetadataService`: create/update/delete now persist only the SQL migration. The update path relies on the existing `registerRuntimeSchema` call to refresh the in-memory table, so no on-disk reload is needed.
+- Removed the now-unused `generateSchemaCode` Drizzle code generator from `DynamicCollectionSchemaService` and the `schemaCode`/`schemaFileName` fields from `CollectionArtifacts`.
+- `nextly db:sync --schemas` no longer writes Drizzle `.ts` files; the flag now only generates Zod validation schemas.
+
+Also removed the unused `NEXTLY_SKIP_SCHEMA_FILES` environment toggle (it was set nowhere and only gated the now-removed file writes).

--- a/packages/nextly/src/cli/commands/db-sync.ts
+++ b/packages/nextly/src/cli/commands/db-sync.ts
@@ -112,7 +112,9 @@ export interface DbSyncCommandOptions {
   types?: boolean;
 
   /**
-   * Generate Drizzle schema files to src/db/schemas/dynamic/
+   * Generate Zod validation schema files to src/db/schemas/zod/.
+   * Drizzle `.ts` schema generation was removed (orphan output, unused by the
+   * runtime), so this flag no longer writes Drizzle schemas.
    * @default false (schemas are not generated unless explicitly requested)
    */
   schemas?: boolean;
@@ -356,7 +358,7 @@ export function registerDbSyncCommand(program: Command): void {
     .option("--types", "Generate TypeScript types (payload-types.ts)", false)
     .option(
       "--schemas",
-      "Generate Drizzle schema files to src/db/schemas/dynamic/",
+      "Generate Zod validation schema files to src/db/schemas/zod/",
       false
     )
     .option(

--- a/packages/nextly/src/cli/commands/dev-build.ts
+++ b/packages/nextly/src/cli/commands/dev-build.ts
@@ -88,15 +88,16 @@ export async function syncCollections(
     serviceLogger
   );
 
-  // Determine what to generate (opt-in: only generate when explicitly requested)
+  // Determine what to generate (opt-in: only generate when explicitly
+  // requested). Drizzle `.ts` schema generation was removed (orphan output);
+  // the `--schemas` flag now only drives Zod validation schema generation.
   const generateTypes = options.types === true;
-  const generateSchemas = options.schemas === true;
+  const generateZodSchemas = options.schemas === true;
 
   let result: CollectionSyncResultWithValidation;
   try {
     result = await syncService.syncWithValidation(config, {
-      generateSchemas,
-      generateZodSchemas: generateSchemas,
+      generateZodSchemas,
       generateTypes,
       dialect: adapter.getCapabilities().dialect,
       cwd: options.cwd ?? process.cwd(),
@@ -599,9 +600,7 @@ export async function performPermissionSeeding(
       errorMsg.includes("relation") ||
       errorMsg.includes("doesn't exist")
     ) {
-      logger.debug(
-        "Skipping permission seeding (tables may not exist yet)"
-      );
+      logger.debug("Skipping permission seeding (tables may not exist yet)");
     } else {
       logger.warn(`Permission seeding failed: ${errorMsg}`);
     }

--- a/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
@@ -246,15 +246,6 @@ export class CollectionMetadataService extends BaseService {
   }
 
   /**
-   * Check if schema file generation should be skipped.
-   * Set NEXTLY_SKIP_SCHEMA_FILES=true to skip generating schema/migration files.
-   * Useful for testing runtime schema generation without file artifacts.
-   */
-  private shouldSkipSchemaFiles(): boolean {
-    return process.env.NEXTLY_SKIP_SCHEMA_FILES === "true";
-  }
-
-  /**
    * Register dynamic schemas with the file manager.
    *
    * @param schemas - Map of schema names to schema objects
@@ -294,10 +285,13 @@ export class CollectionMetadataService extends BaseService {
     try {
       const artifacts = await this.collectionService.generateCollection(data);
 
-      // Save files (skip if NEXTLY_SKIP_SCHEMA_FILES=true)
-      if (!this.shouldSkipSchemaFiles()) {
-        await this.fileManager.saveArtifacts(artifacts);
-      }
+      // Persist the SQL migration. The Drizzle `.ts` schema is no longer
+      // written — the runtime builds it from dynamic_collections metadata,
+      // matching singles/components (see CollectionFileManager.saveMigration).
+      await this.fileManager.saveMigration(
+        artifacts.migrationSQL,
+        artifacts.migrationFileName
+      );
 
       if (this.isDevelopment()) {
         try {
@@ -630,16 +624,14 @@ export class CollectionMetadataService extends BaseService {
           body
         );
 
-      // If schema changed, save migration and schema files (skip if NEXTLY_SKIP_SCHEMA_FILES=true)
-      if (updateArtifacts.migrationSQL && updateArtifacts.schemaCode) {
-        if (!this.shouldSkipSchemaFiles()) {
-          await this.fileManager.saveUpdateArtifacts(
-            updateArtifacts.migrationSQL,
-            updateArtifacts.migrationFileName!,
-            updateArtifacts.schemaCode,
-            updateArtifacts.schemaFileName!
-          );
-        }
+      // If the data table changed, persist the SQL migration. No Drizzle
+      // `.ts` schema is written — the runtime regenerates it from the
+      // dynamic_collections metadata, matching singles/components.
+      if (updateArtifacts.migrationSQL) {
+        await this.fileManager.saveMigration(
+          updateArtifacts.migrationSQL,
+          updateArtifacts.migrationFileName!
+        );
 
         if (this.isDevelopment()) {
           try {
@@ -680,20 +672,8 @@ export class CollectionMetadataService extends BaseService {
             );
           }
 
-          // Only hot-reload if migration succeeded (skip if files disabled)
-          if (
-            updateArtifacts.metadataUpdates.migrationStatus === "applied" &&
-            !this.shouldSkipSchemaFiles()
-          ) {
-            try {
-              await this.fileManager.reloadSchema(params.collectionName);
-            } catch (reloadError) {
-              console.warn(
-                `Schema hot-reload failed, restart may be needed:`,
-                reloadError
-              );
-            }
-          }
+          // No on-disk hot-reload needed: registerRuntimeSchema above already
+          // refreshed the in-memory Drizzle table from the new field list.
         }
       }
 
@@ -766,25 +746,16 @@ export class CollectionMetadataService extends BaseService {
         collection.tableName
       );
 
-      // Save drop migration (skip if NEXTLY_SKIP_SCHEMA_FILES=true)
-      if (!this.shouldSkipSchemaFiles()) {
-        await this.fileManager.saveDropMigration(
-          dropArtifacts.migrationSQL,
-          dropArtifacts.migrationFileName
-        );
-      }
+      // Persist the drop migration. It is the durable DDL record applied by
+      // `nextly migrate` in non-dev/deploy flows.
+      await this.fileManager.saveDropMigration(
+        dropArtifacts.migrationSQL,
+        dropArtifacts.migrationFileName
+      );
 
       // Run drop migration in development
       if (this.isDevelopment()) {
         await this.fileManager.runMigration(dropArtifacts.migrationSQL);
-      }
-
-      // Delete schema file (skip if NEXTLY_SKIP_SCHEMA_FILES=true)
-      if (!this.shouldSkipSchemaFiles()) {
-        await this.fileManager.deleteSchemaFile(
-          `${params.collectionName}.ts`,
-          collection.tableName
-        );
       }
 
       // Unregister from metadata

--- a/packages/nextly/src/domains/collections/services/collection-sync-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-sync-service.ts
@@ -48,7 +48,6 @@ import {
   toPluralLabel,
 } from "../../../shared/lib/pluralization";
 import {
-  SchemaGenerator,
   ZodGenerator,
   TypeGenerator,
   type SupportedDialect,
@@ -64,12 +63,6 @@ import {
  * Options for the sync operation.
  */
 export interface SyncOptions {
-  /**
-   * Generate Drizzle schema files to src/db/schemas/dynamic/.
-   * @default false (opt-in: only generate when explicitly requested)
-   */
-  generateSchemas?: boolean;
-
   /**
    * Generate Zod validation schemas.
    * @default false (opt-in: only generate when explicitly requested)
@@ -268,7 +261,6 @@ export class CollectionSyncService extends BaseService {
    * ```typescript
    * const result = await syncService.sync(config, {
    *   dialect: 'postgresql',
-   *   generateSchemas: true,
    *   generateZodSchemas: true,
    *   generateTypes: true,
    * });
@@ -287,7 +279,6 @@ export class CollectionSyncService extends BaseService {
     const startTime = Date.now();
 
     const opts = {
-      generateSchemas: options.generateSchemas ?? false,
       generateZodSchemas: options.generateZodSchemas ?? false,
       generateTypes: options.generateTypes ?? false,
       onRemoved: options.onRemoved ?? "warn",
@@ -342,28 +333,11 @@ export class CollectionSyncService extends BaseService {
         ...result.sync.updated,
       ]);
 
-      // Code-first schemas are generated to the dynamic folder (sibling to schemasDir)
-      const baseSchemasDir = resolve(opts.cwd, config.db.schemasDir, "..");
-      const dynamicDir = join(baseSchemasDir, "dynamic");
-      const missingSchemaCollections = config.collections.filter(c => {
-        const schemaPath = join(dynamicDir, `${c.slug}.ts`);
-        return !existsSync(schemaPath);
-      });
-
-      const collectionsForSchemaGen = [
-        ...config.collections.filter(c => changedSlugs.has(c.slug)),
-        ...missingSchemaCollections.filter(c => !changedSlugs.has(c.slug)),
-      ];
-
-      if (opts.generateSchemas && collectionsForSchemaGen.length > 0) {
-        const schemas = await this.generateDrizzleSchemas(
-          collectionsForSchemaGen,
-          config.db.schemasDir,
-          opts
-        );
-        result.generatedSchemas = schemas;
-      }
-
+      // Drizzle `.ts` schema generation was removed: nothing imports the
+      // generated files (the runtime builds its Drizzle table from
+      // dynamic_collections metadata via generateRuntimeSchema), so they
+      // were orphan output. `result.generatedSchemas` stays an empty array
+      // for backward compatibility with consumers that read it.
       const zodDir = resolve(opts.cwd, config.db.schemasDir, "zod");
       const missingZodCollections = config.collections.filter(c => {
         const zodPath = join(zodDir, `${c.slug}.zod.ts`);
@@ -772,103 +746,6 @@ export class CollectionSyncService extends BaseService {
   private detectDialect(): SupportedDialect {
     const capabilities = this.adapter.getCapabilities();
     return capabilities.dialect;
-  }
-
-  /**
-   * Generate Drizzle schema files for collections.
-   *
-   * Code-first collection schemas are generated to the `dynamic` folder
-   * (sibling to the configured schemasDir) to be consistent with UI-created
-   * collections. This ensures they can be registered in the schema registry.
-   */
-  private async generateDrizzleSchemas(
-    collections: CollectionConfig[],
-    schemasDir: string,
-    opts: { dialect: SupportedDialect; cwd: string; dryRun: boolean }
-  ): Promise<string[]> {
-    if (collections.length === 0) {
-      return [];
-    }
-
-    const generator = new SchemaGenerator({ dialect: opts.dialect });
-    const generatedFiles: string[] = [];
-
-    const records = this.convertToRecords(collections);
-
-    const schemas = generator.generateAllSchemas(records);
-
-    // Output to dynamic folder (sibling to schemasDir) to match UI-created collections
-    const baseSchemasDir = resolve(opts.cwd, schemasDir, "..");
-    const dynamicDir = join(baseSchemasDir, "dynamic");
-
-    if (!opts.dryRun) {
-      if (!existsSync(dynamicDir)) {
-        mkdirSync(dynamicDir, { recursive: true });
-      }
-
-      for (const schema of schemas) {
-        const filename = `${schema.collectionSlug}.ts`;
-        const filePath = join(dynamicDir, filename);
-        writeFileSync(filePath, schema.code, "utf-8");
-        generatedFiles.push(filePath);
-        this.logger.debug(`Generated schema: ${filePath}`);
-      }
-
-      await this.updateDynamicIndexFile(dynamicDir, collections);
-    } else {
-      for (const schema of schemas) {
-        const filename = `${schema.collectionSlug}.ts`;
-        generatedFiles.push(join(dynamicDir, filename));
-      }
-    }
-
-    return generatedFiles;
-  }
-
-  /**
-   * Update the dynamic/index.ts file to include exports for code-first collections.
-   *
-   * This method reads the existing index file, checks which exports are already
-   * present, and adds any missing exports for code-first collections.
-   */
-  private async updateDynamicIndexFile(
-    dynamicDir: string,
-    collections: CollectionConfig[]
-  ): Promise<void> {
-    const indexPath = join(dynamicDir, "index.ts");
-
-    let content: string;
-    if (existsSync(indexPath)) {
-      const { readFileSync } = await import("node:fs");
-      content = readFileSync(indexPath, "utf-8");
-    } else {
-      content = `// This file exports all dynamic collection schemas
-// Schema exports are auto-generated when you create collections via the UI
-// Example: export { dc_products } from './products';
-
-// Empty export to make this a valid TypeScript module
-export {};
-`;
-    }
-
-    let modified = false;
-    for (const collection of collections) {
-      const exportName = `dc_${collection.slug.replace(/-/g, "_")}`;
-      const exportStatement = `export { ${exportName} } from './${collection.slug}';`;
-
-      if (!content.includes(exportStatement)) {
-        content = content.trimEnd() + "\n" + exportStatement + "\n";
-        modified = true;
-        this.logger.debug(`Added export for ${exportName} to dynamic/index.ts`);
-      }
-    }
-
-    if (modified) {
-      writeFileSync(indexPath, content, "utf-8");
-      this.logger.debug(
-        `Updated dynamic/index.ts with code-first collection exports`
-      );
-    }
   }
 
   /**

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -1,11 +1,15 @@
 /**
  * DynamicCollectionSchemaService
  *
- * Handles all code and SQL generation for dynamic collections:
+ * Handles SQL generation for dynamic collections:
  * - SQL migration generation (CREATE TABLE, ALTER TABLE, DROP TABLE)
- * - TypeScript/Drizzle schema code generation
  * - Junction table generation for many-to-many relationships
- * - Type mapping between field types and SQL/Drizzle types
+ * - Type mapping between field types and SQL types
+ *
+ * Drizzle `.ts` schema-code generation was removed: nothing imports the
+ * generated files (the runtime builds its Drizzle table from
+ * dynamic_collections metadata via generateRuntimeSchema), so they were
+ * orphan output. Singles and components never generated them.
  *
  * Supports multiple database dialects: postgresql, mysql, sqlite
  *
@@ -13,7 +17,6 @@
  * ```typescript
  * const schemaService = new DynamicCollectionSchemaService(validationService, 'sqlite');
  * const sql = schemaService.generateMigrationSQL('dc_posts', fields);
- * const code = schemaService.generateSchemaCode('dc_posts', 'posts', fields);
  * ```
  */
 
@@ -757,258 +760,6 @@ ${allColumnDefs.join(",\n")}
   }
 
   /**
-   * Generate TypeScript/Drizzle schema code for a collection. Pass
-   * `hasStatus: true` for Draft/Published collections so the generated
-   * file includes the `status` column — without it, `drizzle-kit
-   * pushSchema` later sees the live `status` column as extra and drops it.
-   */
-  generateSchemaCode(
-    tableName: string,
-    collectionName: string,
-    fields: FieldDefinition[],
-    options?: { hasStatus?: boolean }
-  ): string {
-    // Determine dialect-specific imports and table function
-    const dialectConfig = this.getDialectConfig();
-    // Check for any field type that uses jsonb in PostgreSQL
-    const jsonbFieldTypes = [
-      "json",
-      "repeater",
-      "group",
-      "blocks",
-      "point",
-      "group",
-      "blocks",
-      "point",
-      "chips",
-    ];
-    const hasJsonField = fields.some(f => jsonbFieldTypes.includes(f.type));
-    const hasRelation = fields.some(f => f.type === "relationship");
-
-    // Build base imports based on dialect
-    const baseImports = ["text", "index", "uniqueIndex"];
-    if (this.dialect !== "sqlite") {
-      baseImports.push("varchar", "decimal", "boolean", "timestamp", "integer");
-    } else {
-      // SQLite uses integer for boolean and timestamp
-      baseImports.push("integer", "real");
-    }
-    if (hasJsonField) {
-      if (this.dialect === "postgresql") {
-        baseImports.push("jsonb");
-      }
-      // SQLite and MySQL use text/json which is already covered
-    }
-
-    let imports = `import { ${dialectConfig.tableFunction}, ${baseImports.join(", ")} } from '${dialectConfig.importPath}';`;
-
-    if (hasRelation) {
-      imports += `\nimport { relations } from 'drizzle-orm';`;
-    }
-
-    const columns = fields
-      .filter(
-        f =>
-          !(
-            f.type === "relationship" &&
-            f.options?.relationType === "manyToMany"
-          )
-      )
-      .map(f => {
-        const drizzleType = this.mapFieldTypeToDrizzleDialectAware(f);
-        const modifiers = [];
-        if (f.required) modifiers.push(".notNull()");
-
-        // Auto-add unique for one-to-one relationships
-        if (
-          f.unique ||
-          (f.type === "relationship" && f.options?.relationType === "oneToOne")
-        ) {
-          modifiers.push(".unique()");
-        }
-
-        const defaultValue = f.default;
-        if (defaultValue !== undefined && defaultValue !== null) {
-          if (f.type === "json") {
-            modifiers.push(`.default(${JSON.stringify(defaultValue)})`);
-          } else if (typeof defaultValue === "string") {
-            modifiers.push(`.default('${defaultValue}')`);
-          } else {
-            // eslint-disable-next-line @typescript-eslint/no-base-to-string
-            modifiers.push(`.default(${String(defaultValue)})`);
-          }
-        }
-
-        // Add references for foreign keys
-        if (
-          f.type === "relationship" &&
-          f.options?.target &&
-          f.options?.relationType !== "manyToMany"
-        ) {
-          const targetTable = `dc_${f.options.target}`;
-          const onDelete = f.options.onDelete || "set null";
-          const onUpdate = f.options.onUpdate || "no action";
-          modifiers.push(
-            `.references(() => ${targetTable}.id, { onDelete: "${onDelete}", onUpdate: "${onUpdate}" })`
-          );
-        }
-
-        return `  ${f.name}: ${drizzleType}${modifiers.join("")},`;
-      })
-      .join("\n");
-
-    // Generate relation definitions for Drizzle ORM
-    const relationDefs = this.generateRelationDefinitions(tableName, fields);
-
-    // Generate index definitions (including manual indexes and relations)
-    const fieldIndexes = fields
-      .filter(
-        f =>
-          f.index ||
-          (f.type === "relationship" &&
-            f.options?.relationType !== "manyToMany")
-      )
-      .map(
-        f =>
-          `  ${f.name}Idx: index('idx_${tableName}_${f.name}').on(table.${f.name}),`
-      )
-      .join("\n");
-
-    const allIndexes = fieldIndexes
-      ? `  createdAtIdx: index('idx_${tableName}_created_at').on(table.createdAt),\n${fieldIndexes}`
-      : `  createdAtIdx: index('idx_${tableName}_created_at').on(table.createdAt),`;
-
-    // Generate dialect-specific timestamp columns
-    const timestampColumns = this.generateTimestampColumnsForDialect();
-
-    // Placed between user columns and timestamps to match the CREATE TABLE
-    // SQL column order, so drizzle-kit diffs don't see a fake reorder.
-    const statusColumn = options?.hasStatus
-      ? this.dialect === "sqlite"
-        ? `  status: text('status').notNull().default('draft'),\n`
-        : `  status: varchar('status', { length: 20 }).notNull().default('draft'),\n`
-      : "";
-
-    return `${imports}
-
-/**
- * Dynamic collection: ${collectionName}
- * Generated by nextly
- */
-export const ${tableName} = ${dialectConfig.tableFunction}('${tableName}', {
-  id: text('id').primaryKey().notNull(),
-  title: text('title').notNull(),
-  slug: text('slug').notNull(),
-${columns}
-${statusColumn}${timestampColumns}
-}, (table) => ({
-  slugIdx: uniqueIndex('idx_${tableName}_slug').on(table.slug),
-${allIndexes}
-}));
-${relationDefs}
-export type ${this.toPascalCase(collectionName)} = typeof ${tableName}.$inferSelect;
-export type New${this.toPascalCase(collectionName)} = typeof ${tableName}.$inferInsert;
-`;
-  }
-
-  /**
-   * Get dialect-specific configuration for schema generation
-   */
-  private getDialectConfig(): { tableFunction: string; importPath: string } {
-    switch (this.dialect) {
-      case "mysql":
-        return {
-          tableFunction: "mysqlTable",
-          importPath: "drizzle-orm/mysql-core",
-        };
-      case "sqlite":
-        return {
-          tableFunction: "sqliteTable",
-          importPath: "drizzle-orm/sqlite-core",
-        };
-      case "postgresql":
-      default:
-        return {
-          tableFunction: "pgTable",
-          importPath: "drizzle-orm/pg-core",
-        };
-    }
-  }
-
-  /**
-   * Generate dialect-specific timestamp column definitions
-   */
-  private generateTimestampColumnsForDialect(): string {
-    if (this.dialect === "sqlite") {
-      return `  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()).$onUpdate(() => new Date()),`;
-    }
-
-    // PostgreSQL and MySQL
-    return `  createdAt: timestamp('created_at').defaultNow().notNull(),
-  updatedAt: timestamp('updated_at').defaultNow().notNull(),`;
-  }
-
-  /**
-   * Map field type to Drizzle ORM column definition (dialect-aware)
-   */
-  private mapFieldTypeToDrizzleDialectAware(field: FieldDefinition): string {
-    if (this.dialect === "sqlite") {
-      // SQLite-specific mapping
-      const sqliteTypeMap: Record<string, (f: FieldDefinition) => string> = {
-        string: f => `text('${f.name}')`,
-        text: f => `text('${f.name}')`,
-        number: f =>
-          f.options?.format === "float"
-            ? `real('${f.name}')`
-            : `integer('${f.name}')`,
-        decimal: f => `real('${f.name}')`,
-        boolean: f => `integer('${f.name}', { mode: 'boolean' })`,
-        date: f => `integer('${f.name}', { mode: 'timestamp' })`,
-        email: f => `text('${f.name}')`,
-        password: f => `text('${f.name}')`,
-        richtext: f => `text('${f.name}')`,
-        json: f => `text('${f.name}', { mode: 'json' })`,
-        chips: f => `text('${f.name}', { mode: 'json' })`,
-        relation: f => `text('${f.name}')`,
-      };
-      const mapper = sqliteTypeMap[field.type];
-      return mapper ? mapper(field) : `text('${field.name}')`;
-    }
-
-    if (this.dialect === "mysql") {
-      // MySQL-specific mapping
-      const mysqlTypeMap: Record<string, (f: FieldDefinition) => string> = {
-        string: f => `varchar('${f.name}', { length: ${f.length || 255} })`,
-        text: f =>
-          f.options?.variant === "short"
-            ? `varchar('${f.name}', { length: ${f.validation?.maxLength || 255} })`
-            : `text('${f.name}')`,
-        number: f =>
-          f.options?.format === "float"
-            ? `decimal('${f.name}', { precision: 10, scale: 2 })`
-            : `int('${f.name}')`,
-        decimal: f => `decimal('${f.name}', { precision: 10, scale: 2 })`,
-        boolean: f => `boolean('${f.name}')`,
-        date: f => `timestamp('${f.name}')`,
-        email: f =>
-          `varchar('${f.name}', { length: ${f.validation?.maxLength || 255} })`,
-        password: f =>
-          `varchar('${f.name}', { length: ${f.validation?.maxLength || 255} })`,
-        richtext: f => `text('${f.name}')`,
-        json: f => `json('${f.name}')`,
-        chips: f => `json('${f.name}')`,
-        relation: f => `varchar('${f.name}', { length: 36 })`,
-      };
-      const mapper = mysqlTypeMap[field.type];
-      return mapper ? mapper(field) : `text('${field.name}')`;
-    }
-
-    // PostgreSQL (default) - use existing mapping
-    return this.mapFieldTypeToDrizzle(field);
-  }
-
-  /**
    * Generate DROP TABLE migration SQL
    */
   generateDropTableMigration(
@@ -1105,63 +856,6 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
     return `${tables[0]}_${tables[1]}_${fieldName}`;
   }
 
-  /**
-   * Generate Drizzle ORM relation definitions
-   */
-  generateRelationDefinitions(
-    tableName: string,
-    fields: FieldDefinition[]
-  ): string {
-    const relationFields = fields.filter(f => f.type === "relationship");
-    if (relationFields.length === 0) {
-      return "";
-    }
-
-    const relationDefs = relationFields
-      .map(f => {
-        const targetTable = `dc_${f.options!.target!}`;
-        const relationType = f.options!.relationType!;
-
-        switch (relationType) {
-          case "oneToOne":
-            return `    ${f.name}: one(${targetTable}, {
-      fields: [${tableName}.${f.name}],
-      references: [${targetTable}.id],
-    }),`;
-
-          case "manyToOne":
-            return `    ${f.name}: one(${targetTable}, {
-      fields: [${tableName}.${f.name}],
-      references: [${targetTable}.id],
-    }),`;
-
-          case "oneToMany":
-            // oneToMany is typically defined on the "one" side, referencing the "many" side
-            // This assumes the target collection has a foreign key back to this collection
-            return `    ${f.name}: many(${targetTable}),`;
-
-          case "manyToMany": {
-            const junctionTableName =
-              f.options?.junctionTable ||
-              this.generateJunctionTableName(tableName, targetTable, f.name);
-            return `    ${f.name}: many(${targetTable}), // Through ${junctionTableName}`;
-          }
-
-          default:
-            return "";
-        }
-      })
-      .filter(Boolean)
-      .join("\n");
-
-    return `
-// Drizzle ORM Relations
-export const ${tableName}Relations = relations(${tableName}, ({ one, many }) => ({
-${relationDefs}
-}));
-`;
-  }
-
   // ==================== TYPE MAPPING METHODS ====================
 
   /**
@@ -1233,36 +927,6 @@ ${relationDefs}
       relationship: "text", // Store foreign key as text (UUID or ID)
     };
     return typeMap[type] || "text";
-  }
-
-  /**
-   * Map field type to Drizzle ORM column definition
-   */
-  mapFieldTypeToDrizzle(field: FieldDefinition): string {
-    const typeMap: Record<string, (f: FieldDefinition) => string> = {
-      string: f => `varchar('${f.name}', { length: ${f.length || 255} })`,
-      text: f =>
-        f.options?.variant === "short"
-          ? `varchar('${f.name}', { length: ${f.validation?.maxLength || 255} })`
-          : `text('${f.name}')`,
-      number: f =>
-        f.options?.format === "float"
-          ? `decimal('${f.name}', { precision: 10, scale: 2 })`
-          : `integer('${f.name}')`,
-      decimal: f => `decimal('${f.name}', { precision: 10, scale: 2 })`,
-      boolean: f => `boolean('${f.name}')`,
-      date: f => `timestamp('${f.name}')`,
-      email: f =>
-        `varchar('${f.name}', { length: ${f.validation?.maxLength || 255} })`,
-      password: f =>
-        `varchar('${f.name}', { length: ${f.validation?.maxLength || 255} })`,
-      richtext: f => `text('${f.name}')`,
-      json: f => `jsonb('${f.name}')`,
-      chips: f => `jsonb('${f.name}')`,
-      relation: f => `text('${f.name}')`, // Foreign key
-    };
-    const mapper = typeMap[field.type];
-    return mapper ? mapper(field) : `text('${field.name}')`;
   }
 
   /**
@@ -1365,16 +1029,6 @@ ${relationDefs}
   }
 
   // ==================== UTILITY METHODS ====================
-
-  /**
-   * Convert snake_case to PascalCase
-   */
-  toPascalCase(str: string): string {
-    return str
-      .charAt(0)
-      .toUpperCase()
-      .concat(str.slice(1).replace(/_([a-z])/g, (_, c) => c.toUpperCase()));
-  }
 
   /**
    * Convert snake_case to camelCase

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -24,8 +24,6 @@ import { DynamicCollectionValidationService } from "./dynamic-collection-validat
 export interface CollectionArtifacts {
   migrationSQL: string;
   migrationFileName: string;
-  schemaCode: string;
-  schemaFileName: string;
   tableName: string;
   metadata: {
     id: string;
@@ -149,12 +147,6 @@ export class DynamicCollectionService extends BaseService {
       userDefinedFields,
       { hasStatus: data.status === true }
     );
-    const schemaCode = this.schemaService.generateSchemaCode(
-      tableName,
-      normalizedName,
-      userDefinedFields,
-      { hasStatus: data.status === true }
-    );
 
     const schemaHash = this.generateSchemaHash(userDefinedFields);
 
@@ -192,8 +184,6 @@ export class DynamicCollectionService extends BaseService {
     return {
       migrationSQL,
       migrationFileName: `${Date.now()}_create_${normalizedName}.sql`,
-      schemaCode,
-      schemaFileName: `${normalizedName}.ts`,
       tableName,
       metadata,
     };
@@ -213,8 +203,6 @@ export class DynamicCollectionService extends BaseService {
   ): Promise<{
     migrationSQL: string | null;
     migrationFileName: string | null;
-    schemaCode: string | null;
-    schemaFileName: string | null;
     metadataUpdates: Record<string, unknown>;
   }> {
     const collection = (await this.registryService.getCollection(
@@ -267,8 +255,6 @@ export class DynamicCollectionService extends BaseService {
 
     let migrationSQL: string | null = null;
     let migrationFileName: string | null = null;
-    let schemaCode: string | null = null;
-    let schemaFileName: string | null = null;
 
     // Why: the alter-table block runs when fields change, but a status-only
     // flip also needs a migration (ADD/DROP status column) so the data
@@ -322,14 +308,6 @@ export class DynamicCollectionService extends BaseService {
       );
       migrationFileName = `${Date.now()}_update_${collectionName}.sql`;
 
-      schemaCode = this.schemaService.generateSchemaCode(
-        collection.tableName,
-        collectionName,
-        userDefinedFields,
-        { hasStatus }
-      );
-      schemaFileName = `${collectionName}.ts`;
-
       metadataUpdates.fields = userDefinedFields;
       metadataUpdates.schemaHash = this.generateSchemaHash(userDefinedFields);
     } else if (statusFlipped) {
@@ -362,8 +340,6 @@ export class DynamicCollectionService extends BaseService {
     return {
       migrationSQL,
       migrationFileName,
-      schemaCode,
-      schemaFileName,
       metadataUpdates,
     };
   }

--- a/packages/nextly/src/services/collection-file-manager.ts
+++ b/packages/nextly/src/services/collection-file-manager.ts
@@ -1,11 +1,9 @@
 import { promises as fs } from "node:fs";
-import { createRequire } from "node:module";
 import * as path from "node:path";
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import { sql } from "drizzle-orm";
 
-import type { CollectionArtifacts } from "../domains/dynamic-collections";
 import { generateRuntimeSchema } from "../domains/schema/services/runtime-schema-generator";
 import type { FieldDefinition } from "../schemas/dynamic-collections";
 import type { DatabaseInstance } from "../types/database-operations";
@@ -35,7 +33,6 @@ export type CollectionMetadataFetcher = (collectionName: string) => Promise<{
 } | null>;
 
 export class CollectionFileManager {
-  private schemasDir: string;
   private migrationsDir: string;
   private db: DatabaseInstance;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -43,12 +40,8 @@ export class CollectionFileManager {
   private adapter?: DrizzleAdapter;
   private metadataFetcher?: CollectionMetadataFetcher;
 
-  // Node require loader (safe in Next.js)
-  private requireModule = createRequire(import.meta.url);
-
   constructor(db: DatabaseInstance, config: FileManagerConfig) {
     this.db = db;
-    this.schemasDir = config.schemasDir;
     this.migrationsDir = config.migrationsDir;
   }
 
@@ -112,47 +105,19 @@ export class CollectionFileManager {
     this.schemaRegistry.delete(schemaKey);
   }
 
-  async saveArtifacts(artifacts: CollectionArtifacts): Promise<void> {
-    await fs.mkdir(this.schemasDir, { recursive: true });
-    await fs.mkdir(this.migrationsDir, { recursive: true });
-
-    const migrationPath = path.join(
-      this.migrationsDir,
-      artifacts.migrationFileName
-    );
-    await fs.writeFile(migrationPath, artifacts.migrationSQL);
-
-    const schemaPath = path.join(this.schemasDir, artifacts.schemaFileName);
-    await fs.writeFile(schemaPath, artifacts.schemaCode);
-
-    await this.updateSchemaIndex(artifacts.schemaFileName, artifacts.tableName);
-  }
-
-  async saveUpdateArtifacts(
+  // Persist only the SQL migration for a created/updated collection. The
+  // Drizzle `.ts` schema is no longer generated: nothing at runtime imports
+  // it (the runtime builds its Drizzle table from `dynamic_collections`
+  // metadata via generateRuntimeSchema), so writing it produced orphan files
+  // that drift from the database. This matches how singles and components
+  // already work — they persist no schema file at all, only run their DDL.
+  async saveMigration(
     migrationSQL: string,
-    migrationFileName: string,
-    schemaCode: string,
-    schemaFileName: string
+    migrationFileName: string
   ): Promise<void> {
+    await fs.mkdir(this.migrationsDir, { recursive: true });
     const migrationPath = path.join(this.migrationsDir, migrationFileName);
     await fs.writeFile(migrationPath, migrationSQL);
-
-    const schemaPath = path.join(this.schemasDir, schemaFileName);
-    await fs.writeFile(schemaPath, schemaCode);
-  }
-
-  async deleteSchemaFile(
-    schemaFileName: string,
-    tableName: string
-  ): Promise<void> {
-    const schemaPath = path.join(this.schemasDir, schemaFileName);
-
-    try {
-      await fs.unlink(schemaPath);
-      await this.removeFromSchemaIndex(schemaFileName, tableName);
-    } catch (_error) {
-      console.warn(`Could not delete schema file: ${schemaPath}`);
-    }
   }
 
   async saveDropMigration(
@@ -206,45 +171,6 @@ export class CollectionFileManager {
       throw new Error(
         `Migration failed: ${error instanceof Error ? error.message : String(error)}`
       );
-    }
-  }
-
-  private async updateSchemaIndex(
-    fileName: string,
-    tableName: string
-  ): Promise<void> {
-    const indexPath = path.join(this.schemasDir, "index.ts");
-    const exportLine = `export { ${tableName} } from './${fileName.replace(".ts", "")}';\n`;
-
-    try {
-      const content = await fs.readFile(indexPath, "utf-8");
-      if (content.includes(exportLine.trim())) {
-        return;
-      }
-      await fs.appendFile(indexPath, exportLine);
-    } catch (_error) {
-      // Create index file if it doesn't exist
-      await fs.writeFile(indexPath, exportLine);
-    }
-  }
-
-  private async removeFromSchemaIndex(
-    fileName: string,
-    tableName: string
-  ): Promise<void> {
-    const indexPath = path.join(this.schemasDir, "index.ts");
-    const exportLine = `export { ${tableName} } from './${fileName.replace(".ts", "")}';`;
-
-    try {
-      const content = await fs.readFile(indexPath, "utf-8");
-      const filtered = content
-        .split("\n")
-        .filter(line => !line.includes(exportLine))
-        .join("\n");
-
-      await fs.writeFile(indexPath, filtered);
-    } catch {
-      console.warn(`Could not update index file: ${indexPath}`);
     }
   }
 
@@ -332,60 +258,5 @@ export class CollectionFileManager {
     throw new Error(
       `Schema for collection "${collectionName}" not found in registry. ${guidance}`
     );
-  }
-
-  /**
-   * Hot-reload a schema from disk (development only)
-   * Useful after schema updates to avoid app restart
-   */
-  // eslint-disable-next-line @typescript-eslint/require-await
-  async reloadSchema(collectionName: string): Promise<void> {
-    const schemaFileName = `${collectionName}.ts`;
-    const schemaPath = path.resolve(path.join(this.schemasDir, schemaFileName));
-    const schemaKey = `dc_${collectionName.replace(/-/g, "_")}`;
-
-    try {
-      try {
-        const resolved = this.requireModule.resolve(schemaPath);
-        delete this.requireModule.cache[resolved];
-      } catch (innerError: unknown) {
-        console.warn(
-          `Failed to clear require cache for schema "${collectionName}"`,
-          {
-            schemaPath,
-            error:
-              innerError instanceof Error
-                ? innerError.message
-                : String(innerError),
-            stack: innerError instanceof Error ? innerError.stack : undefined,
-          }
-        );
-      }
-
-      const schemaModule = this.requireModule(schemaPath);
-      const schema = schemaModule[schemaKey];
-
-      if (!schema) {
-        throw new Error(
-          `Schema export "${schemaKey}" not found in ${schemaFileName}`
-        );
-      }
-
-      this.schemaRegistry.set(schemaKey, schema);
-
-      console.log(`Hot-reloaded schema for collection: ${collectionName}`);
-    } catch (error: unknown) {
-      console.error(`Failed to reload schema for ${collectionName}`, {
-        schemaName: collectionName,
-        filePath: schemaPath,
-        expectedExport: schemaKey,
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-      });
-
-      throw new Error(
-        `Failed to reload schema: ${error instanceof Error ? error.message : String(error)}`
-      );
-    }
   }
 }


### PR DESCRIPTION
## Summary

Collections behave like singles/components: create/update/delete persist only the SQL migration; the runtime builds the Drizzle table from dynamic_collections metadata.

Also removes the unused NEXTLY_SKIP_SCHEMA_FILES env toggle, the db:sync Drizzle .ts output (--schemas now drives only Zod), and dead schema-code generator helpers.

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [X] Refactor/chore (no user-facing change)

## Related issues

<!-- e.g. Closes #123, Refs #456 -->

## Changeset

This repo uses [Changesets](https://github.com/changesets/changesets). If your PR changes any publishable package under `packages/*`, you **must** include a changeset:

```bash
pnpm changeset
```

Then commit the generated `.changeset/*.md` file.

- [X] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [ ] I selected the correct semver bump (patch / minor / major)

> The `changeset-check` CI job will fail if a publishable package is modified without a changeset.

## Test plan

<!-- How did you verify this works? Commands run, scenarios tested, screenshots, etc. -->

- [X] `pnpm lint`
- [X] `pnpm check-types`
- [X] `pnpm build`
- [ ] Manually verified the change

## Checklist

- [ ] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [X] I targeted the `main` branch
- [ ] I updated relevant documentation

## Screenshots / recordings

<!-- Optional. Drag images or videos here for UI changes. -->

## Notes for reviewers

<!-- Anything reviewers should pay extra attention to? Migration risks, perf concerns, etc. -->
