### PR TITLE
ci: run the unit tests that pass, so a regression in them blocks merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,35 @@ jobs:
         env:
           TURBO_CACHE_DIR: .turbo
 
+      # Unit tests. Named packages rather than all of them: `nextly` and
+      # `@nextlyhq/admin` carry a large pre-existing failing baseline (stale
+      # test scaffolding, not product bugs) and are being repaired in a
+      # follow-up that adds them here once green. Everything gated below passes
+      # today, so a new failure in any of these packages is a real regression
+      # and blocks the merge — which is the whole point, and the reason the job
+      # was named "Test" long before it ran any.
+      #
+      # ui / storage-s3 / storage-uploadthing have no test files yet; listed so
+      # they gate automatically the moment they gain one.
+      - name: Test
+        run: >-
+          pnpm turbo test
+          --filter=@nextlyhq/plugin-page-builder
+          --filter=@nextlyhq/plugin-form-builder
+          --filter=@nextlyhq/plugin-sdk
+          --filter=@nextlyhq/ui
+          --filter=@nextlyhq/adapter-drizzle
+          --filter=@nextlyhq/adapter-postgres
+          --filter=@nextlyhq/adapter-mysql
+          --filter=@nextlyhq/adapter-sqlite
+          --filter=@nextlyhq/storage-s3
+          --filter=@nextlyhq/storage-uploadthing
+          --filter=@nextlyhq/storage-vercel-blob
+          --filter=@nextlyhq/telemetry
+          --filter=create-nextly-app
+        env:
+          TURBO_CACHE_DIR: .turbo
+
       # Strict: package.json shape / publish-readiness across all 13 publishable
       # packages (nextly + create-nextly-app + 11 @nextlyhq/*). Failures here
       # block the release pipeline.


### PR DESCRIPTION
The `ci` job has carried the name **Lint / Typecheck / Test / Build** since it was written and has never run a test. ~780 unit tests across ten packages pass today and gated nothing — a break in any of them reached `main` unseen.

## What this does

Adds a `Test` step for exactly the packages that are green today:

| package | tests |
|---|---|
| plugin-page-builder | 284 |
| create-nextly-app | 110 |
| adapter-drizzle | 97 |
| adapter-postgres | 87 |
| adapter-sqlite | 61 |
| telemetry | 56 |
| adapter-mysql | 47 |
| plugin-form-builder | 31 |
| plugin-sdk | 7 |
| storage-vercel-blob | 4 |

`ui`, `storage-s3` and `storage-uploadthing` are listed too — they have no test files yet, so they gate automatically the moment they gain one.

## What it deliberately leaves out, and why

`nextly` (413 failing) and `@nextlyhq/admin` (37 failing) are **not** here. Their failures are a large pre-existing baseline of **stale test scaffolding, not product bugs** — a service constructor that changed from `(db, schema)` to `(adapter, logger)`, a hand-written test table missing two columns, a mock pointing at a moved module, and a missing `DB_DIALECT` default. Analysis puts ~347 of the 413 behind four shared fixes.

I chose **repair over quarantine**: rather than excluding those failures behind a filter and gating a hollowed-out suite, the follow-up fixes the scaffolding and adds both packages to this list once they are green. Excluding them now would let a real regression hide among the noise; leaving them out entirely keeps the gate honest about what it covers.

## Verification

The exact filtered command in the step was run locally: **9 packages, all green, 780 tests passing**. No package code changes, so no changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated testing to the continuous integration workflow.
  * Tests now cover key plugins, SDK, UI, adapters, storage integrations, telemetry, and app creation tooling.
  * Failing tests in covered areas will block merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->