### PR TITLE
chore: keep every package version in lockstep

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,7 +16,12 @@
       "@nextlyhq/storage-uploadthing",
       "@nextlyhq/storage-vercel-blob",
       "@nextlyhq/plugin-form-builder",
-      "@nextlyhq/plugin-sdk"
+      "@nextlyhq/plugin-page-builder",
+      "@nextlyhq/plugin-sdk",
+      "@nextlyhq/eslint-config",
+      "@nextlyhq/prettier-config",
+      "@nextlyhq/telemetry",
+      "@nextlyhq/tsconfig"
     ]
   ],
   "linked": [],


### PR DESCRIPTION
Four packages have drifted behind the rest.

| package | version |
|---|---|
| @nextlyhq/eslint-config | 0.0.2-alpha.26 |
| @nextlyhq/prettier-config | 0.0.2-alpha.26 |
| @nextlyhq/telemetry | 0.0.2-alpha.26 |
| @nextlyhq/tsconfig | 0.0.2-alpha.26 |
| everything else | 0.0.2-alpha.34 |

## Why

The changeset `fixed` group — the set of packages changesets always versions together — listed **13 of 18**. The four above, plus `plugin-page-builder`, were outside it. A package outside the group only moves when it happens to be named in a changeset, so the four fell eight versions behind when they were missed. `plugin-page-builder` kept pace only by being listed every time.

## The fix

Put all 18 in `fixed`. Lockstep stops being something to remember and becomes structural — changesets versions them together, and no package can fall behind again.

## Verified, not assumed

Ran `changeset version` locally against the pending changesets with this config. The four laggards jump **0.0.2-alpha.26 → 0.0.2-alpha.35** in one step, exactly matching the group — not one patch at a time. Then reverted the dry run; only the config change remains.

No changeset in this PR: it changes release tooling, not a package, and the version correction lands automatically on the next release the group already drives.