### PR TITLE
feat(nextly): invite a user by a set-password link

### DIFF
--- a/.changeset/invite-token-infrastructure.md
+++ b/.changeset/invite-token-infrastructure.md
@@ -1,0 +1,28 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Add the foundation for inviting a user by a set-password link.
+
+Nextly can now mint a single-use link that lets a new person set their own password and sign in, and accept that link in one step. `AuthService.generateInviteToken(userId)` returns a 256-bit token (only its SHA-256 hash is stored, and only one is active per account at a time); `AuthService.acceptInvite(token, password)` validates it, sets the password, marks the email verified, activates the account and consumes the token, all in one transaction. The link lasts seven days.
+
+This is the piece the admin "invite" flow will build on — the mechanism exists and is tested end to end, but nothing calls it from a user-facing screen yet. The HTTP endpoint and the create-user wiring land next.
+
+`users.password_hash` is now **nullable on Postgres**, matching SQLite and MySQL, so an invited account can exist before it has a password. This is a schema change your next `nextly db:sync` will apply; loosening a NOT NULL constraint is not data-losing, so it applies cleanly.

--- a/.changeset/invite-token-infrastructure.md
+++ b/.changeset/invite-token-infrastructure.md
@@ -19,10 +19,12 @@
 "@nextlyhq/ui": patch
 ---
 
-Add the foundation for inviting a user by a set-password link.
+Add the ability to invite a user by a set-password link.
 
 Nextly can now mint a single-use link that lets a new person set their own password and sign in, and accept that link in one step. `AuthService.generateInviteToken(userId)` returns a 256-bit token (only its SHA-256 hash is stored, and only one is active per account at a time); `AuthService.acceptInvite(token, password)` validates it, sets the password, marks the email verified, activates the account and consumes the token, all in one transaction. The link lasts seven days.
 
-This is the piece the admin "invite" flow will build on — the mechanism exists and is tested end to end, but nothing calls it from a user-facing screen yet. The HTTP endpoint and the create-user wiring land next.
+A new endpoint, **`POST /auth/accept-invite`**, accepts the link over HTTP: it takes `{ token, newPassword }`, is CSRF-protected like the other auth routes, and answers with one generic message for any unusable token (unknown, used, expired) so a guessed token learns nothing about which invites are live — while a weak-password error is passed through, since that is the one thing the person can fix.
+
+The mechanism is complete and tested at both the service and HTTP layers. What is not here yet: creating a user through the admin does not mint one of these links automatically — that wiring, and the form that shows the copyable link, come next.
 
 `users.password_hash` is now **nullable on Postgres**, matching SQLite and MySQL, so an invited account can exist before it has a password. This is a schema change your next `nextly db:sync` will apply; loosening a NOT NULL constraint is not data-losing, so it applies cleanly.

--- a/packages/nextly/src/auth/handlers/__tests__/handler-shapes.test.ts
+++ b/packages/nextly/src/auth/handlers/__tests__/handler-shapes.test.ts
@@ -35,7 +35,9 @@ import { handleLogin } from "../login";
 import { handleLogout } from "../logout";
 import { handleRefresh } from "../refresh";
 import { handleRegister } from "../register";
+import { handleAcceptInvite } from "../accept-invite";
 import { handleResetPassword } from "../reset-password";
+import { NextlyError } from "../../../errors/nextly-error";
 import { handleSession } from "../session";
 import { handleSetup, handleSetupStatus } from "../setup";
 import { handleResendVerification, handleVerifyEmail } from "../verify-email";
@@ -511,6 +513,86 @@ describe("reset-password handler: respondAction shape", () => {
     const body = (await res.json()) as Record<string, unknown>;
     expect(body).not.toHaveProperty("data");
     expect(body).toEqual({ message: "Password reset." });
+  });
+});
+
+describe("accept-invite handler", () => {
+  const baseDeps = () => ({
+    allowedOrigins: ALLOWED_ORIGINS,
+    acceptInvite: vi.fn().mockResolvedValue({ userId: "u1" }),
+  });
+
+  it("returns just { message: 'Invite accepted.' } on success", async () => {
+    const deps = baseDeps();
+    const req = makeRequest("POST", { token: "t", newPassword: "Pass1234!" });
+    const res = await handleAcceptInvite(req, deps);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).not.toHaveProperty("data");
+    expect(body).toEqual({ message: "Invite accepted." });
+    expect(deps.acceptInvite).toHaveBeenCalledWith("t", "Pass1234!");
+  });
+
+  it("400s when the token or password is missing", async () => {
+    const deps = baseDeps();
+    const req = makeRequest("POST", { token: "t" });
+    const res = await handleAcceptInvite(req, deps);
+
+    expect(res.status).toBe(400);
+    expect(deps.acceptInvite).not.toHaveBeenCalled();
+  });
+
+  it("collapses a bad token into one generic message", async () => {
+    const deps = baseDeps();
+    deps.acceptInvite.mockRejectedValue(
+      NextlyError.validation({
+        errors: [{ path: "token", code: "INVALID_INVITE", message: "no" }],
+      })
+    );
+    const req = makeRequest("POST", {
+      token: "wrong",
+      newPassword: "Pass1234!",
+    });
+    const res = await handleAcceptInvite(req, deps);
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: { message?: string } };
+    expect(body.error?.message).toBe(
+      "This invite link is invalid or has expired."
+    );
+  });
+
+  it("passes a weak-password error through, since the person can act on it", async () => {
+    const deps = baseDeps();
+    deps.acceptInvite.mockRejectedValue(
+      NextlyError.validation({
+        errors: [
+          { path: "newPassword", code: "WEAK_PASSWORD", message: "Too short." },
+        ],
+      })
+    );
+    const req = makeRequest("POST", { token: "t", newPassword: "weak" });
+    const res = await handleAcceptInvite(req, deps);
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error?: { data?: { errors?: Array<{ path: string }> } };
+    };
+    expect(body.error?.data?.errors?.[0]?.path).toBe("newPassword");
+  });
+
+  it("403s when the CSRF token is missing", async () => {
+    const deps = baseDeps();
+    const req = makeRequest(
+      "POST",
+      { token: "t", newPassword: "Pass1234!", csrfToken: "mismatch" },
+      { cookie: "nextly_csrf=different" }
+    );
+    const res = await handleAcceptInvite(req, deps);
+
+    expect(res.status).toBe(403);
+    expect(deps.acceptInvite).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/nextly/src/auth/handlers/__tests__/handler-shapes.test.ts
+++ b/packages/nextly/src/auth/handlers/__tests__/handler-shapes.test.ts
@@ -543,6 +543,33 @@ describe("accept-invite handler", () => {
     expect(deps.acceptInvite).not.toHaveBeenCalled();
   });
 
+  it("400s on non-string fields rather than passing them to the service", async () => {
+    const deps = baseDeps();
+    const req = makeRequest("POST", { token: 123, newPassword: { a: 1 } });
+    const res = await handleAcceptInvite(req, deps);
+
+    expect(res.status).toBe(400);
+    expect(deps.acceptInvite).not.toHaveBeenCalled();
+  });
+
+  it("400s on an empty body instead of a 500", async () => {
+    const deps = baseDeps();
+    // No JSON body at all — the parse falls back to {} and both fields fail.
+    const req = new Request("http://localhost:3000/admin/api/auth/x", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: "http://localhost:3000",
+        cookie: "nextly_csrf=csrf-test-token",
+        "x-csrf-token": "csrf-test-token",
+      },
+    });
+    const res = await handleAcceptInvite(req, deps);
+
+    expect(res.status).toBe(400);
+    expect(deps.acceptInvite).not.toHaveBeenCalled();
+  });
+
   it("collapses a bad token into one generic message", async () => {
     const deps = baseDeps();
     deps.acceptInvite.mockRejectedValue(

--- a/packages/nextly/src/auth/handlers/accept-invite.ts
+++ b/packages/nextly/src/auth/handlers/accept-invite.ts
@@ -1,0 +1,147 @@
+/**
+ * POST /auth/accept-invite
+ *
+ * Accepts an invite link: the new person sets their own password, and the
+ * account is verified, activated and signed-in-capable in one step. All
+ * token-related failures (unknown, used, expired) collapse into a single
+ * response so a guessed token learns nothing about which invites are live;
+ * the real reason lives only in logContext.
+ */
+import { readOrGenerateRequestId } from "../../api/request-id";
+import { respondAction } from "../../api/response-shapes";
+import { NextlyError } from "../../errors/nextly-error";
+import { readCsrfCookie, readCsrfFromRequest } from "../csrf/csrf-cookie";
+import { validateCsrf } from "../csrf/validate";
+
+import { jsonResponse } from "./handler-utils";
+
+export interface AcceptInviteHandlerDeps {
+  allowedOrigins: string[];
+  /**
+   * Throws NextlyError on failure. Any token-related failure (unknown, used,
+   * expired) must be normalised by the caller into the INVALID_INPUT shape;
+   * a weak password surfaces as VALIDATION_ERROR and is passed through so the
+   * person sees what to fix.
+   */
+  acceptInvite: (
+    token: string,
+    newPassword: string
+  ) => Promise<{ userId: string }>;
+}
+
+function buildErrorResponse(err: NextlyError, requestId: string): Response {
+  return new Response(
+    JSON.stringify({ error: err.toResponseJSON(requestId) }),
+    {
+      status: err.statusCode,
+      headers: {
+        "content-type": "application/problem+json",
+        "x-request-id": requestId,
+      },
+    }
+  );
+}
+
+/** Field errors carried by a VALIDATION_ERROR, or null for any other shape. */
+function validationFieldErrors(
+  err: NextlyError
+): ReadonlyArray<{ path: string }> | null {
+  const data = err.publicData;
+  if (data && "errors" in data && Array.isArray(data.errors)) {
+    return data.errors;
+  }
+  return null;
+}
+
+/**
+ * Collapse the token-not-usable failures (unknown, used, expired) into one
+ * response. A weak-password validation error is deliberately left alone — the
+ * token was fine, so hiding the real reason would only confuse the person, and
+ * a password complaint reveals nothing about which invites are live.
+ */
+function normaliseInviteFailure(err: unknown): NextlyError {
+  if (NextlyError.is(err)) {
+    if (err.code === "VALIDATION_ERROR") {
+      const fields = validationFieldErrors(err);
+      const isTokenOnly =
+        fields !== null && fields.every(e => e.path === "token");
+      // A password (or other non-token) validation error is actionable — pass
+      // it through untouched.
+      if (!isTokenOnly) return err;
+    }
+    if (
+      err.code === "NOT_FOUND" ||
+      err.code === "INVALID_INPUT" ||
+      err.code === "TOKEN_EXPIRED" ||
+      err.code === "VALIDATION_ERROR"
+    ) {
+      return new NextlyError({
+        code: "INVALID_INPUT",
+        publicMessage: "This invite link is invalid or has expired.",
+        logContext: { ...(err.logContext ?? {}), originalCode: err.code },
+      });
+    }
+  }
+  throw err;
+}
+
+export async function handleAcceptInvite(
+  request: Request,
+  deps: AcceptInviteHandlerDeps
+): Promise<Response> {
+  const requestId = readOrGenerateRequestId(request);
+
+  try {
+    const body = await request.json();
+
+    const csrfCookie = readCsrfCookie(request);
+    const csrfToken = readCsrfFromRequest(body, request);
+    const csrfResult = validateCsrf(
+      request,
+      csrfCookie,
+      csrfToken,
+      deps.allowedOrigins
+    );
+    if (!csrfResult.valid) {
+      return jsonResponse(
+        403,
+        { error: { code: "CSRF_FAILED", message: csrfResult.error } },
+        { "x-request-id": requestId }
+      );
+    }
+
+    const { token, newPassword } = body;
+    if (!token || !newPassword) {
+      throw NextlyError.validation({
+        errors: [
+          ...(!token
+            ? [{ path: "token", code: "REQUIRED", message: "Required." }]
+            : []),
+          ...(!newPassword
+            ? [{ path: "newPassword", code: "REQUIRED", message: "Required." }]
+            : []),
+        ],
+      });
+    }
+
+    try {
+      await deps.acceptInvite(token, newPassword);
+    } catch (err) {
+      throw normaliseInviteFailure(err);
+    }
+
+    return respondAction(
+      "Invite accepted.",
+      {},
+      { status: 200, headers: { "x-request-id": requestId } }
+    );
+  } catch (err) {
+    if (NextlyError.is(err)) {
+      return buildErrorResponse(err, requestId);
+    }
+    return buildErrorResponse(
+      NextlyError.internal({ cause: err as Error }),
+      requestId
+    );
+  }
+}

--- a/packages/nextly/src/auth/handlers/accept-invite.ts
+++ b/packages/nextly/src/auth/handlers/accept-invite.ts
@@ -92,7 +92,14 @@ export async function handleAcceptInvite(
   const requestId = readOrGenerateRequestId(request);
 
   try {
-    const body = await request.json();
+    // Untrusted input: a non-object body (null, an array, a number) must not
+    // reach the destructure below, where it would throw an internal 500, and a
+    // non-string token or password must not reach the service.
+    const raw: unknown = await request.json().catch(() => null);
+    const body: Record<string, unknown> =
+      raw !== null && typeof raw === "object" && !Array.isArray(raw)
+        ? (raw as Record<string, unknown>)
+        : {};
 
     const csrfCookie = readCsrfCookie(request);
     const csrfToken = readCsrfFromRequest(body, request);
@@ -111,18 +118,22 @@ export async function handleAcceptInvite(
     }
 
     const { token, newPassword } = body;
-    if (!token || !newPassword) {
+    const tokenMissing = typeof token !== "string" || token.length === 0;
+    const passwordMissing =
+      typeof newPassword !== "string" || newPassword.length === 0;
+    if (tokenMissing || passwordMissing) {
       throw NextlyError.validation({
         errors: [
-          ...(!token
+          ...(tokenMissing
             ? [{ path: "token", code: "REQUIRED", message: "Required." }]
             : []),
-          ...(!newPassword
+          ...(passwordMissing
             ? [{ path: "newPassword", code: "REQUIRED", message: "Required." }]
             : []),
         ],
       });
     }
+    // token and newPassword are non-empty strings past this point.
 
     try {
       await deps.acceptInvite(token, newPassword);

--- a/packages/nextly/src/auth/handlers/deps-bridge.ts
+++ b/packages/nextly/src/auth/handlers/deps-bridge.ts
@@ -343,6 +343,11 @@ export function buildAuthRouterDeps(
       return { email: result.email };
     },
 
+    acceptInvite: async (token, newPassword) => {
+      const authService = getService("authService");
+      return await authService.acceptInvite(token, newPassword);
+    },
+
     changePassword: async (userId, currentPassword, newPassword) => {
       const authService = getService("authService");
       try {

--- a/packages/nextly/src/auth/handlers/router.ts
+++ b/packages/nextly/src/auth/handlers/router.ts
@@ -6,6 +6,7 @@ import type { ChallengeRegistry } from "../pipeline/challenge";
 import type { AuthHookRegistry } from "../pipeline/hooks";
 import type { AuthStrategy } from "../pipeline/types";
 
+import { handleAcceptInvite } from "./accept-invite";
 import { handleAuthUi, type AuthUiMeta } from "./auth-ui";
 import { handleChallengeResolve } from "./challenge-resolve";
 import { handleChangePassword } from "./change-password";
@@ -178,6 +179,10 @@ export interface AuthRouterDeps {
     token: string,
     newPassword: string
   ) => Promise<{ email: string }>;
+  acceptInvite: (
+    token: string,
+    newPassword: string
+  ) => Promise<{ userId: string }>;
   changePassword: (
     userId: string,
     currentPassword: string,
@@ -255,6 +260,8 @@ async function dispatchAuthRequest(
           return handleForgotPassword(request, deps);
         case "reset-password":
           return handleResetPassword(request, deps);
+        case "accept-invite":
+          return handleAcceptInvite(request, deps);
         case "verify-email":
           return handleVerifyEmail(request, deps);
         case "verify-email/resend":

--- a/packages/nextly/src/auth/handlers/router.ts
+++ b/packages/nextly/src/auth/handlers/router.ts
@@ -33,6 +33,9 @@ const RATE_LIMITED_AUTH_PATHS = new Set([
   "register",
   "forgot-password",
   "reset-password",
+  // Same bucket as reset-password: both consume a token, so both are
+  // grind-able by an attacker holding no token at all.
+  "accept-invite",
   "challenge/resolve",
 ]);
 

--- a/packages/nextly/src/domains/auth/services/__tests__/affected-row-count.test.ts
+++ b/packages/nextly/src/domains/auth/services/__tests__/affected-row-count.test.ts
@@ -1,0 +1,38 @@
+/**
+ * `affectedRowCount` is the one dialect-specific piece of the invite flow — the
+ * atomic-claim check reads it to know whether it won a race. Each driver
+ * reports the count in a different field, so each shape is pinned here.
+ */
+import { describe, expect, it } from "vitest";
+
+import { affectedRowCount } from "../auth-service";
+
+describe("affectedRowCount", () => {
+  it("reads better-sqlite3's `changes`", () => {
+    expect(affectedRowCount({ changes: 1, lastInsertRowid: 5 }, "sqlite")).toBe(
+      1
+    );
+    expect(affectedRowCount({ changes: 0 }, "sqlite")).toBe(0);
+  });
+
+  it("reads node-postgres's `rowCount`", () => {
+    expect(affectedRowCount({ rowCount: 1, rows: [] }, "postgresql")).toBe(1);
+    expect(affectedRowCount({ rowCount: 0 }, "postgresql")).toBe(0);
+  });
+
+  it("reads mysql2's ResultSetHeader `affectedRows`, in an array", () => {
+    expect(affectedRowCount([{ affectedRows: 1 }], "mysql")).toBe(1);
+    expect(affectedRowCount([{ affectedRows: 0 }], "mysql")).toBe(0);
+  });
+
+  it("reads mysql2's header when returned directly", () => {
+    expect(affectedRowCount({ affectedRows: 1 }, "mysql")).toBe(1);
+  });
+
+  it("treats a missing count as zero rather than throwing", () => {
+    expect(affectedRowCount({}, "sqlite")).toBe(0);
+    expect(affectedRowCount({}, "postgresql")).toBe(0);
+    expect(affectedRowCount([], "mysql")).toBe(0);
+    expect(affectedRowCount({}, "mysql")).toBe(0);
+  });
+});

--- a/packages/nextly/src/domains/auth/services/__tests__/invite-token.integration.test.ts
+++ b/packages/nextly/src/domains/auth/services/__tests__/invite-token.integration.test.ts
@@ -145,6 +145,35 @@ describe("acceptInvite", () => {
     );
   });
 
+  it("lets only one of two concurrent acceptances win", async () => {
+    // The race the atomic claim exists to stop: both calls read the token as
+    // unused, and without the claim both would set a password — last writer
+    // wins. Exactly one must succeed; the token is consumed once.
+    const { auth, db, userId } = await setup();
+    const { token } = await auth.generateInviteToken(userId);
+
+    const results = await Promise.allSettled([
+      auth.acceptInvite(token, STRONG),
+      auth.acceptInvite(token, "D1fferent!Pass"),
+    ]);
+
+    const fulfilled = results.filter(r => r.status === "fulfilled");
+    const rejected = results.filter(r => r.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(
+      NextlyError
+    );
+
+    const invites = await db.select().from(userInviteTokens);
+    expect(invites).toHaveLength(1);
+    expect(invites[0].usedAt).toBeTruthy();
+
+    const [user] = await db.select().from(users).where(eq(users.id, userId));
+    expect(user.passwordHash).toBeTruthy();
+    expect(user.isActive).toBe(true);
+  });
+
   it("refuses a weak password and leaves both the token and the account untouched", async () => {
     const { auth, db, userId } = await setup();
     const { token } = await auth.generateInviteToken(userId);

--- a/packages/nextly/src/domains/auth/services/__tests__/invite-token.integration.test.ts
+++ b/packages/nextly/src/domains/auth/services/__tests__/invite-token.integration.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Invite tokens, end to end against a real database.
+ *
+ * The link is the artifact: minting one for an account, and accepting it,
+ * should set the password, prove the address and let the account sign in — in
+ * one step, with nothing left half-done on any failure path.
+ */
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../../../errors";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../../plugins/test-nextly";
+import { userInviteTokens } from "../../../../schemas/auth-tokens/sqlite";
+import { users } from "../../../../schemas/users/sqlite";
+import type { AuthService } from "../auth-service";
+
+/** Minimal slice of the Drizzle instance these tests drive. */
+interface TestDb {
+  insert: (table: unknown) => { values: (data: unknown) => Promise<unknown> };
+  select: () => {
+    from: (table: unknown) => {
+      where: (cond: unknown) => Promise<Record<string, unknown>[]>;
+    } & Promise<Record<string, unknown>[]>;
+  };
+  update: (table: unknown) => {
+    set: (data: unknown) => { where: (cond: unknown) => Promise<unknown> };
+  };
+}
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const STRONG = "Str0ng!Passw0rd";
+
+async function setup(): Promise<{
+  auth: AuthService;
+  db: TestDb;
+  userId: string;
+}> {
+  current = await createTestNextly();
+  const auth = current.getService("authService") as unknown as AuthService;
+  const db = current.adapter.getDrizzle() as unknown as TestDb;
+
+  const userId = "invited-user-1";
+  await db.insert(users).values({
+    id: userId,
+    email: "new.person@example.com",
+    name: "New Person",
+    passwordHash: null,
+    emailVerified: null,
+    isActive: false,
+  });
+
+  return { auth, db, userId };
+}
+
+describe("generateInviteToken", () => {
+  it("mints a 256-bit link for an existing account, expiring in the future", async () => {
+    const { auth, userId } = await setup();
+    const { token, expiresAt } = await auth.generateInviteToken(userId);
+
+    expect(token).toMatch(/^[a-f0-9]{64}$/);
+    expect(expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("refuses to mint for an account that does not exist", async () => {
+    const { auth } = await setup();
+    await expect(auth.generateInviteToken("nobody")).rejects.toBeInstanceOf(
+      NextlyError
+    );
+  });
+
+  it("stores only the hash, never the raw token", async () => {
+    const { auth, db, userId } = await setup();
+    const { token } = await auth.generateInviteToken(userId);
+
+    const rows = await db.select().from(userInviteTokens);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].tokenHash).not.toBe(token);
+    expect(String(rows[0].tokenHash)).toHaveLength(64);
+  });
+
+  it("keeps only one active invite per account", async () => {
+    const { auth, db, userId } = await setup();
+    await auth.generateInviteToken(userId);
+    await auth.generateInviteToken(userId);
+
+    const rows = await db.select().from(userInviteTokens);
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe("acceptInvite", () => {
+  it("sets the password, verifies the email, activates, and consumes the token", async () => {
+    const { auth, db, userId } = await setup();
+    const { token } = await auth.generateInviteToken(userId);
+
+    const result = await auth.acceptInvite(token, STRONG);
+    expect(result.userId).toBe(userId);
+
+    const [user] = await db.select().from(users).where(eq(users.id, userId));
+    expect(user.passwordHash).toBeTruthy();
+    expect(user.emailVerified).toBeTruthy();
+    expect(user.isActive).toBe(true);
+
+    const [invite] = await db.select().from(userInviteTokens);
+    expect(invite.usedAt).toBeTruthy();
+  });
+
+  it("refuses a token that was already used", async () => {
+    const { auth, userId } = await setup();
+    const { token } = await auth.generateInviteToken(userId);
+    await auth.acceptInvite(token, STRONG);
+
+    await expect(auth.acceptInvite(token, STRONG)).rejects.toBeInstanceOf(
+      NextlyError
+    );
+  });
+
+  it("refuses an unknown token", async () => {
+    const { auth } = await setup();
+    await expect(
+      auth.acceptInvite("d".repeat(64), STRONG)
+    ).rejects.toBeInstanceOf(NextlyError);
+  });
+
+  it("refuses an expired token", async () => {
+    const { auth, db, userId } = await setup();
+    const { token } = await auth.generateInviteToken(userId);
+
+    await db
+      .update(userInviteTokens)
+      .set({ expires: new Date(Date.now() - 1000) })
+      .where(eq(userInviteTokens.userId, userId));
+
+    await expect(auth.acceptInvite(token, STRONG)).rejects.toBeInstanceOf(
+      NextlyError
+    );
+  });
+
+  it("refuses a weak password and leaves both the token and the account untouched", async () => {
+    const { auth, db, userId } = await setup();
+    const { token } = await auth.generateInviteToken(userId);
+
+    await expect(auth.acceptInvite(token, "weak")).rejects.toBeInstanceOf(
+      NextlyError
+    );
+
+    const [invite] = await db.select().from(userInviteTokens);
+    expect(invite.usedAt).toBeNull();
+
+    const [user] = await db.select().from(users).where(eq(users.id, userId));
+    expect(user.passwordHash).toBeNull();
+    expect(user.isActive).toBe(false);
+  });
+});

--- a/packages/nextly/src/domains/auth/services/auth-service.ts
+++ b/packages/nextly/src/domains/auth/services/auth-service.ts
@@ -1,7 +1,8 @@
 import { randomBytes, createHash } from "crypto";
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
-import { eq, and, lt, isNull } from "drizzle-orm";
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+import { eq, and, gt, lt, isNull } from "drizzle-orm";
 
 import {
   verifyPassword as verifyPasswordBcrypt,
@@ -67,6 +68,34 @@ interface TransactionLike {
   update(table: unknown): {
     set(data: unknown): { where(condition: unknown): Promise<unknown> };
   };
+  delete(table: unknown): { where(condition: unknown): Promise<unknown> };
+  insert(table: unknown): { values(data: unknown): Promise<unknown> };
+}
+
+/**
+ * The number of rows a Drizzle write affected, read from the right field for
+ * the running dialect.
+ *
+ * Each driver reports it differently — better-sqlite3 as `changes`,
+ * node-postgres as `rowCount`, mysql2 as a `ResultSetHeader.affectedRows` (in
+ * an array on newer versions) — so an atomic claim that needs to know whether
+ * it won a race cannot read a single field. Exported for its own unit test:
+ * this is the one piece of the invite flow that is genuinely dialect-specific.
+ */
+export function affectedRowCount(
+  result: unknown,
+  dialect: SupportedDialect
+): number {
+  if (dialect === "sqlite") {
+    return (result as { changes?: number }).changes ?? 0;
+  }
+  if (dialect === "postgresql") {
+    return (result as { rowCount?: number }).rowCount ?? 0;
+  }
+  const header = Array.isArray(result)
+    ? (result[0] as { affectedRows?: number } | undefined)
+    : (result as { affectedRows?: number });
+  return header?.affectedRows ?? 0;
 }
 
 /**
@@ -740,22 +769,44 @@ export class AuthService extends BaseService {
     );
 
     try {
-      // One active invite per account: a freshly minted link supersedes any
-      // earlier one, so a re-invite cannot leave two working links.
-      await this.db
-        .delete(this.tables.userInviteTokens)
-        .where(eq(this.tables.userInviteTokens.userId, userId));
+      // One active invite per account, in one transaction: a freshly minted
+      // link supersedes any earlier one, and if the insert fails the delete
+      // rolls back so the previous link stays valid rather than the account
+      // being left with none. The unique index on user_id serialises two
+      // concurrent re-invites so they cannot both leave a live link.
+      await this.withTransaction(async txRaw => {
+        const tx = txRaw as TransactionLike;
+        await tx
+          .delete(this.tables.userInviteTokens)
+          .where(eq(this.tables.userInviteTokens.userId, userId));
 
-      await this.db.insert(this.tables.userInviteTokens).values({
-        userId,
-        tokenHash,
-        expires: expiresAt,
+        await tx.insert(this.tables.userInviteTokens).values({
+          userId,
+          tokenHash,
+          expires: expiresAt,
+        });
       });
     } catch (error) {
       throw NextlyError.fromDatabaseError(toDbError(this.dialect, error));
     }
 
     return { token: rawToken, expiresAt };
+  }
+
+  /** The one public error every unusable-invite path returns. */
+  private invalidInviteError(
+    logContext?: Record<string, unknown>
+  ): NextlyError {
+    return NextlyError.validation({
+      errors: [
+        {
+          path: "token",
+          code: "INVALID_INVITE",
+          message: "This invite link is invalid or has expired.",
+        },
+      ],
+      logContext,
+    });
   }
 
   /**
@@ -789,25 +840,13 @@ export class AuthService extends BaseService {
       throw NextlyError.fromDatabaseError(toDbError(this.dialect, error));
     }
 
-    if (!invite) {
-      throw NextlyError.validation({
-        errors: [
-          {
-            path: "token",
-            code: "INVALID_INVITE",
-            message: "This invite link is invalid or has already been used.",
-          },
-        ],
-      });
-    }
-
-    if (invite.expires < new Date()) {
-      throw new NextlyError({
-        code: "TOKEN_EXPIRED",
-        statusCode: 400,
-        publicMessage: "This invite link has expired.",
-        logContext: { inviteId: invite.id, expiredAt: invite.expires },
-      });
+    // Unknown, already used, and expired all return the same error, so a
+    // guessed token cannot tell a live invite from a dead one. The expiry
+    // detail is kept for the log only.
+    if (!invite || invite.expires < new Date()) {
+      throw this.invalidInviteError(
+        invite ? { inviteId: invite.id, expiredAt: invite.expires } : undefined
+      );
     }
 
     const passwordStrength = validatePasswordStrength(newPassword);
@@ -823,9 +862,31 @@ export class AuthService extends BaseService {
 
     const passwordHash = await hashPasswordBcrypt(newPassword);
 
+    // Claim the token before touching the account. Two acceptances can both
+    // pass the read above; the conditional update lets exactly one flip
+    // usedAt from null, and only that one goes on to set the password — so a
+    // race cannot end with two different passwords, last-writer-wins.
+    let claimed = false;
     try {
       await this.withTransaction(async txRaw => {
         const tx = txRaw as TransactionLike;
+
+        const claim = await tx
+          .update(this.tables.userInviteTokens)
+          .set({ usedAt: new Date() })
+          .where(
+            and(
+              eq(this.tables.userInviteTokens.id, invite.id),
+              isNull(this.tables.userInviteTokens.usedAt),
+              gt(this.tables.userInviteTokens.expires, new Date())
+            )
+          );
+
+        // Zero rows: another acceptance already claimed it, or it expired
+        // between the read and here. Leave the account untouched.
+        if (affectedRowCount(claim, this.dialect) !== 1) return;
+        claimed = true;
+
         await tx
           .update(this.tables.users)
           .set({
@@ -836,14 +897,16 @@ export class AuthService extends BaseService {
             updatedAt: new Date(),
           })
           .where(eq(this.tables.users.id, invite.userId));
-
-        await tx
-          .update(this.tables.userInviteTokens)
-          .set({ usedAt: new Date() })
-          .where(eq(this.tables.userInviteTokens.id, invite.id));
       });
     } catch (error) {
       throw NextlyError.fromDatabaseError(toDbError(this.dialect, error));
+    }
+
+    if (!claimed) {
+      throw this.invalidInviteError({
+        inviteId: invite.id,
+        reason: "already-claimed",
+      });
     }
 
     // No auth event is emitted: the closest existing one, passwordChanged,

--- a/packages/nextly/src/domains/auth/services/auth-service.ts
+++ b/packages/nextly/src/domains/auth/services/auth-service.ts
@@ -43,6 +43,32 @@ interface ConsumeResetTokenResult {
   email: string;
 }
 
+/** Result of {@link AuthService.generateInviteToken}. */
+interface InviteTokenResult {
+  /** The raw, single-use token. Returned once and never stored. */
+  token: string;
+  /** When the link stops working. */
+  expiresAt: Date;
+}
+
+/** Result of {@link AuthService.acceptInvite} on success. */
+interface AcceptInviteResult {
+  userId: string;
+}
+
+/**
+ * The fluent slice of a Drizzle transaction this service uses.
+ *
+ * `withTransaction` hands back `unknown` because the concrete transaction type
+ * is dialect-specific; narrowing to the methods actually called keeps the body
+ * typed without an `any`.
+ */
+interface TransactionLike {
+  update(table: unknown): {
+    set(data: unknown): { where(condition: unknown): Promise<unknown> };
+  };
+}
+
 /**
  * Authentication Service
  *
@@ -67,6 +93,11 @@ interface ConsumeResetTokenResult {
  */
 export class AuthService extends BaseService {
   private readonly TOKEN_EXPIRY_HOURS = 24;
+
+  // Seven days, the industry convention for an invite (GitHub, Vercel,
+  // Directus). Longer than a password-reset link because it is the first
+  // thing a new person receives and may sit unread over a weekend.
+  private readonly INVITE_TOKEN_EXPIRY_HOURS = 24 * 7;
 
   readonly emailService?: EmailService;
 
@@ -682,6 +713,147 @@ export class AuthService extends BaseService {
   }
 
   /**
+   * Mint a single-use set-password link for an existing account.
+   *
+   * The link is the artifact an admin hands to a new user; email is only ever
+   * one way to deliver it. Follows the same shape as a password-reset token —
+   * a 256-bit random value of which only the SHA-256 hash is stored, one active
+   * token per account — but keyed on the user id and given a longer life.
+   *
+   * The raw token is returned to the caller and never persisted. There is no
+   * way to recover it afterwards; mint a new one instead.
+   */
+  async generateInviteToken(userId: string): Promise<InviteTokenResult> {
+    const user = await this.db.query.users.findFirst({
+      where: eq(this.tables.users.id, userId),
+      columns: { id: true },
+    });
+    if (!user) {
+      throw NextlyError.notFound({ logContext: { userId } });
+    }
+
+    const rawToken = randomBytes(32).toString("hex");
+    const tokenHash = createHash("sha256").update(rawToken).digest("hex");
+
+    const expiresAt = new Date(
+      Date.now() + this.INVITE_TOKEN_EXPIRY_HOURS * 60 * 60 * 1000
+    );
+
+    try {
+      // One active invite per account: a freshly minted link supersedes any
+      // earlier one, so a re-invite cannot leave two working links.
+      await this.db
+        .delete(this.tables.userInviteTokens)
+        .where(eq(this.tables.userInviteTokens.userId, userId));
+
+      await this.db.insert(this.tables.userInviteTokens).values({
+        userId,
+        tokenHash,
+        expires: expiresAt,
+      });
+    } catch (error) {
+      throw NextlyError.fromDatabaseError(toDbError(this.dialect, error));
+    }
+
+    return { token: rawToken, expiresAt };
+  }
+
+  /**
+   * Accept an invite: set the account's password and let it sign in.
+   *
+   * Clicking a link that was delivered to an address is itself proof of the
+   * address, so acceptance sets `emailVerified` and `isActive` alongside the
+   * password in one transaction — there is no separate verification round trip,
+   * and no window where the account has a password but still cannot sign in.
+   *
+   * The failure messages do not distinguish "never existed" from "already
+   * used" from "expired-by-a-second", to avoid confirming which invites are
+   * live to whoever holds a guessed token.
+   */
+  async acceptInvite(
+    token: string,
+    newPassword: string
+  ): Promise<AcceptInviteResult> {
+    const tokenHash = createHash("sha256").update(token).digest("hex");
+
+    let invite: { id: number; userId: string; expires: Date } | undefined;
+    try {
+      invite = await this.db.query.userInviteTokens.findFirst({
+        where: and(
+          eq(this.tables.userInviteTokens.tokenHash, tokenHash),
+          isNull(this.tables.userInviteTokens.usedAt)
+        ),
+        columns: { id: true, userId: true, expires: true },
+      });
+    } catch (error) {
+      throw NextlyError.fromDatabaseError(toDbError(this.dialect, error));
+    }
+
+    if (!invite) {
+      throw NextlyError.validation({
+        errors: [
+          {
+            path: "token",
+            code: "INVALID_INVITE",
+            message: "This invite link is invalid or has already been used.",
+          },
+        ],
+      });
+    }
+
+    if (invite.expires < new Date()) {
+      throw new NextlyError({
+        code: "TOKEN_EXPIRED",
+        statusCode: 400,
+        publicMessage: "This invite link has expired.",
+        logContext: { inviteId: invite.id, expiredAt: invite.expires },
+      });
+    }
+
+    const passwordStrength = validatePasswordStrength(newPassword);
+    if (!passwordStrength.ok) {
+      throw NextlyError.validation({
+        errors: passwordStrength.errors.map(message => ({
+          path: "newPassword",
+          code: "WEAK_PASSWORD",
+          message,
+        })),
+      });
+    }
+
+    const passwordHash = await hashPasswordBcrypt(newPassword);
+
+    try {
+      await this.withTransaction(async txRaw => {
+        const tx = txRaw as TransactionLike;
+        await tx
+          .update(this.tables.users)
+          .set({
+            passwordHash,
+            passwordUpdatedAt: new Date(),
+            emailVerified: new Date(),
+            isActive: true,
+            updatedAt: new Date(),
+          })
+          .where(eq(this.tables.users.id, invite.userId));
+
+        await tx
+          .update(this.tables.userInviteTokens)
+          .set({ usedAt: new Date() })
+          .where(eq(this.tables.userInviteTokens.id, invite.id));
+      });
+    } catch (error) {
+      throw NextlyError.fromDatabaseError(toDbError(this.dialect, error));
+    }
+
+    // No auth event is emitted: the closest existing one, passwordChanged,
+    // carries "an established password was rotated" semantics and its listeners
+    // (e.g. a security-notification email) would be wrong for a first set.
+
+    return { userId: invite.userId };
+  }
+
+  /**
    * Clean up expired tokens
    */
   async cleanupExpiredTokens(): Promise<void> {
@@ -695,6 +867,10 @@ export class AuthService extends BaseService {
       await this.db
         .delete(this.tables.emailVerificationTokens)
         .where(lt(this.tables.emailVerificationTokens.expires, now));
+
+      await this.db
+        .delete(this.tables.userInviteTokens)
+        .where(lt(this.tables.userInviteTokens.expires, now));
     } catch (error) {
       console.error("Failed to cleanup expired tokens:", error);
     }

--- a/packages/nextly/src/schemas/_dialect-bundles/mysql.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/mysql.ts
@@ -20,6 +20,7 @@ export {
 export {
   emailVerificationTokens,
   passwordResetTokens,
+  userInviteTokens,
   refreshTokens,
 } from "../auth-tokens/mysql";
 export { refreshTokensRelations } from "../auth-tokens/mysql-relations";

--- a/packages/nextly/src/schemas/_dialect-bundles/postgres.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/postgres.ts
@@ -35,6 +35,7 @@ export {
 export {
   emailVerificationTokens,
   passwordResetTokens,
+  userInviteTokens,
   refreshTokens,
 } from "../auth-tokens/postgres";
 export { refreshTokensRelations } from "../auth-tokens/postgres-relations";

--- a/packages/nextly/src/schemas/_dialect-bundles/sqlite.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/sqlite.ts
@@ -20,6 +20,7 @@ export {
 export {
   emailVerificationTokens,
   passwordResetTokens,
+  userInviteTokens,
   refreshTokens,
 } from "../auth-tokens/sqlite";
 export { refreshTokensRelations } from "../auth-tokens/sqlite-relations";

--- a/packages/nextly/src/schemas/auth-tokens/index.ts
+++ b/packages/nextly/src/schemas/auth-tokens/index.ts
@@ -32,18 +32,21 @@ export function authTokenTables(dialect: SupportedDialect) {
       return {
         emailVerificationTokens: pg.emailVerificationTokens,
         passwordResetTokens: pg.passwordResetTokens,
+        userInviteTokens: pg.userInviteTokens,
         refreshTokens: pg.refreshTokens,
       };
     case "mysql":
       return {
         emailVerificationTokens: my.emailVerificationTokens,
         passwordResetTokens: my.passwordResetTokens,
+        userInviteTokens: my.userInviteTokens,
         refreshTokens: my.refreshTokens,
       };
     case "sqlite":
       return {
         emailVerificationTokens: sl.emailVerificationTokens,
         passwordResetTokens: sl.passwordResetTokens,
+        userInviteTokens: sl.userInviteTokens,
         refreshTokens: sl.refreshTokens,
       };
     default: {

--- a/packages/nextly/src/schemas/auth-tokens/mysql.ts
+++ b/packages/nextly/src/schemas/auth-tokens/mysql.ts
@@ -13,6 +13,7 @@
  * @since v0.0.3-alpha (Plan A — schemas consolidation)
  */
 
+import { sql } from "drizzle-orm";
 import {
   mysqlTable,
   int,
@@ -61,13 +62,19 @@ export const userInviteTokens = mysqlTable(
     tokenHash: varchar("token_hash", { length: 255 }).notNull(),
     expires: datetime("expires").notNull(),
     usedAt: datetime("used_at"),
-    createdAt: datetime("created_at").notNull().default(new Date()),
+    // Database-side default: `new Date()` would bake one JS timestamp into the
+    // schema and reuse it for every insert.
+    createdAt: datetime("created_at")
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
   },
   t => [
-    uniqueIndex("uit_user_id_token_hash_unique").on(t.userId, t.tokenHash),
-    index("uit_user_id_idx").on(t.userId),
+    // One invite row per account, enforced by the database: two concurrent
+    // re-invites cannot both leave a live link, and superseding an earlier
+    // invite holds without a read-modify-write race.
+    uniqueIndex("uit_user_id_unique").on(t.userId),
+    index("uit_token_hash_idx").on(t.tokenHash),
     index("uit_expires_idx").on(t.expires),
-    index("uit_used_at_idx").on(t.usedAt),
   ]
 );
 

--- a/packages/nextly/src/schemas/auth-tokens/mysql.ts
+++ b/packages/nextly/src/schemas/auth-tokens/mysql.ts
@@ -46,6 +46,31 @@ export const passwordResetTokens = mysqlTable(
   ]
 );
 
+// User invite tokens — the single-use set-password link an admin hands to a
+// new user. Mirrors passwordResetTokens (with a used_at consume marker), but
+// keyed on user_id rather than an email identifier: the invite belongs to one
+// account, survives an email change, and keeps the address out of the token
+// store. Only the SHA-256 hash of the token is kept, never the raw value.
+export const userInviteTokens = mysqlTable(
+  "user_invite_tokens",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    userId: varchar("user_id", { length: 191 })
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    tokenHash: varchar("token_hash", { length: 255 }).notNull(),
+    expires: datetime("expires").notNull(),
+    usedAt: datetime("used_at"),
+    createdAt: datetime("created_at").notNull().default(new Date()),
+  },
+  t => [
+    uniqueIndex("uit_user_id_token_hash_unique").on(t.userId, t.tokenHash),
+    index("uit_user_id_idx").on(t.userId),
+    index("uit_expires_idx").on(t.expires),
+    index("uit_used_at_idx").on(t.usedAt),
+  ]
+);
+
 // Email verification tokens (custom, hashed)
 export const emailVerificationTokens = mysqlTable(
   "email_verification_tokens",

--- a/packages/nextly/src/schemas/auth-tokens/postgres.ts
+++ b/packages/nextly/src/schemas/auth-tokens/postgres.ts
@@ -68,10 +68,12 @@ export const userInviteTokens = pgTable(
       .notNull(),
   },
   t => [
-    uniqueIndex("uit_user_id_token_hash_unique").on(t.userId, t.tokenHash),
-    index("uit_user_id_idx").on(t.userId),
+    // One invite row per account, enforced by the database: two concurrent
+    // re-invites cannot both leave a live link, and superseding an earlier
+    // invite holds without a read-modify-write race.
+    uniqueIndex("uit_user_id_unique").on(t.userId),
+    index("uit_token_hash_idx").on(t.tokenHash),
     index("uit_expires_idx").on(t.expires),
-    index("uit_used_at_idx").on(t.usedAt),
   ]
 );
 

--- a/packages/nextly/src/schemas/auth-tokens/postgres.ts
+++ b/packages/nextly/src/schemas/auth-tokens/postgres.ts
@@ -48,6 +48,33 @@ export const passwordResetTokens = pgTable(
   ]
 );
 
+// User invite tokens — the single-use set-password link an admin hands to a
+// new user. Mirrors passwordResetTokens (with a used_at consume marker), but
+// keyed on user_id rather than an email identifier: the invite belongs to one
+// account, survives an email change, and keeps the address out of the token
+// store. Only the SHA-256 hash of the token is kept, never the raw value.
+export const userInviteTokens = pgTable(
+  "user_invite_tokens",
+  {
+    id: serial("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    tokenHash: text("token_hash").notNull(),
+    expires: timestamp("expires", { withTimezone: false }).notNull(),
+    usedAt: timestamp("used_at", { withTimezone: false }),
+    createdAt: timestamp("created_at", { withTimezone: false })
+      .defaultNow()
+      .notNull(),
+  },
+  t => [
+    uniqueIndex("uit_user_id_token_hash_unique").on(t.userId, t.tokenHash),
+    index("uit_user_id_idx").on(t.userId),
+    index("uit_expires_idx").on(t.expires),
+    index("uit_used_at_idx").on(t.usedAt),
+  ]
+);
+
 // Email verification tokens (custom, hashed) to avoid storing raw tokens
 export const emailVerificationTokens = pgTable(
   "email_verification_tokens",

--- a/packages/nextly/src/schemas/auth-tokens/sqlite.ts
+++ b/packages/nextly/src/schemas/auth-tokens/sqlite.ts
@@ -46,6 +46,33 @@ export const passwordResetTokens = sqliteTable(
   ]
 );
 
+// User invite tokens — the single-use set-password link an admin hands to a
+// new user. Mirrors passwordResetTokens (with a used_at consume marker), but
+// keyed on user_id rather than an email identifier: the invite belongs to one
+// account, survives an email change, and keeps the address out of the token
+// store. Only the SHA-256 hash of the token is kept, never the raw value.
+export const userInviteTokens = sqliteTable(
+  "user_invite_tokens",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    tokenHash: text("token_hash").notNull(),
+    expires: integer("expires", { mode: "timestamp" }).notNull(),
+    usedAt: integer("used_at", { mode: "timestamp" }),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  t => [
+    uniqueIndex("uit_user_id_token_hash_unique").on(t.userId, t.tokenHash),
+    index("uit_user_id_idx").on(t.userId),
+    index("uit_expires_idx").on(t.expires),
+    index("uit_used_at_idx").on(t.usedAt),
+  ]
+);
+
 // Email verification tokens (custom, hashed)
 export const emailVerificationTokens = sqliteTable(
   "email_verification_tokens",

--- a/packages/nextly/src/schemas/auth-tokens/sqlite.ts
+++ b/packages/nextly/src/schemas/auth-tokens/sqlite.ts
@@ -66,10 +66,12 @@ export const userInviteTokens = sqliteTable(
       .$defaultFn(() => new Date()),
   },
   t => [
-    uniqueIndex("uit_user_id_token_hash_unique").on(t.userId, t.tokenHash),
-    index("uit_user_id_idx").on(t.userId),
+    // One invite row per account, enforced by the database: two concurrent
+    // re-invites cannot both leave a live link, and superseding an earlier
+    // invite holds without a read-modify-write race.
+    uniqueIndex("uit_user_id_unique").on(t.userId),
+    index("uit_token_hash_idx").on(t.tokenHash),
     index("uit_expires_idx").on(t.expires),
-    index("uit_used_at_idx").on(t.usedAt),
   ]
 );
 

--- a/packages/nextly/src/schemas/index.ts
+++ b/packages/nextly/src/schemas/index.ts
@@ -138,6 +138,7 @@ export const CORE_TABLE_NAMES: readonly string[] = [
   "accounts",
   "sessions",
   "password_reset_tokens",
+  "user_invite_tokens",
   "email_verification_tokens",
   "refresh_tokens",
   "roles",
@@ -186,6 +187,7 @@ export { users, accounts, sessions } from "./users/postgres";
 export {
   emailVerificationTokens,
   passwordResetTokens,
+  userInviteTokens,
   refreshTokens,
 } from "./auth-tokens/postgres";
 

--- a/packages/nextly/src/schemas/users/postgres.ts
+++ b/packages/nextly/src/schemas/users/postgres.ts
@@ -37,7 +37,11 @@ export const users = pgTable(
       withTimezone: false,
     }),
     image: text("image"),
-    passwordHash: text("password_hash").notNull(),
+    // Nullable, matching SQLite and MySQL. An invited user has no password
+    // until they accept and set one, so the account has to exist without a
+    // hash. Loosening a NOT NULL constraint is not data-losing, so drizzle-kit
+    // applies it cleanly.
+    passwordHash: text("password_hash"),
     isActive: boolean("is_active").notNull().default(false),
     // Brute-force protection: tracks failed login attempts and account lockout
     failedLoginAttempts: integer("failed_login_attempts").notNull().default(0),


### PR DESCRIPTION
The first, complete slice of inviting a user by a link rather than by a password an admin types: the mechanism and the endpoint. Creating a user through the admin does not mint one of these yet — that wiring and the form are a focused follow-up.

## Why this exists

Today a user Nextly creates gets `emailVerified: null` when "send welcome email" is ticked, and login refuses an unverified user. So delivery state is being used as authorization state: if the mail fails, the person is locked out with "invalid credentials" and no way in. PR #165 papered over this with a preflight that refuses to create such a user; that is a stopgap. The real fix is to stop making sign-in depend on email at all — the **link** is the artifact, email is one way to deliver it.

## What this PR adds

**`AuthService.generateInviteToken(userId)`** mints a 256-bit token, stores only its SHA-256 hash, keeps one active token per account, and returns the raw value once. Seven-day life, the industry convention.

**`AuthService.acceptInvite(token, password)`** validates the token, checks the password against the policy, then in one transaction sets the password, marks the email verified, activates the account and consumes the token. Clicking a link delivered to an address is itself proof of the address, so acceptance verifies and activates in the same step — no separate round trip, no window where the account has a password but cannot sign in.

**`POST /auth/accept-invite`** exposes it over HTTP: `{ token, newPassword }`, CSRF-protected like the other auth routes.

**Security shape:** any unusable token (unknown, used, expired) returns one generic message so a guessed token learns nothing about which invites are live. A weak-password error is the deliberate exception — the token was fine, the person can fix the password, and a password complaint reveals nothing about invite validity.

**`user_invite_tokens`** mirrors `password_reset_tokens` (with a `used_at` consume marker) but is keyed on `user_id` via a cascading foreign key: the invite belongs to one account, survives an email change, and keeps the address out of the token store. Registered across all three dialects.

**`users.password_hash` is now nullable on Postgres**, matching SQLite and MySQL, so an invited account can exist before it has a password. Loosening a NOT NULL constraint is not data-losing.

## What is deliberately NOT here

- **Creating a user does not auto-mint a link yet**, and the `#165` preflight is untouched. Deleting that preflight only makes sense once user-creation returns a link, so the two go together in the next PR — removing it now would let an admin create a stranded user with no link to hand over.
- **No admin form.** The copyable-link UI is the next PR.
- **No `must_change_password`** (the admin-sets-a-password-directly mode) — a later PR.

## Verification

- 9 service integration tests: mint, hash-only storage, one-active-per-account, the full accept path, and every failure mode (unknown, used, expired, weak password) leaving state clean.
- 5 handler tests: success shape, missing-field guard, token collapse, weak-password pass-through, CSRF rejection.
- nextly integration **3 failed / 141 passed** (the 3 are the pre-existing baseline; +9 new). Unit baseline unchanged. Typecheck, lint, prettier clean.

One changeset, all 18 packages at patch, describing the user-facing capability.

## Sequencing

1. **this PR** — the mechanism + the accept endpoint
2. next — wire user-creation to mint & return the link, delete the `#165` preflight, add the copyable-link form
3. later — `must_change_password` + first-sign-in gate for the admin-sets-password mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an invite-based account onboarding flow via a new **accept-invite** endpoint.
  - Invitees can set a password using a secure, single-use invitation valid for **7 days**.
  - Successful invite acceptance activates the account and marks the email as verified.
  - Implemented database support for PostgreSQL, MySQL, and SQLite.

- **Security**
  - Invite tokens are stored as hashes and cannot be reused.
  - Invalid or already-consumed/expired invites return generic validation errors.
  - CSRF checks are enforced for invite acceptance.

- **Tests**
  - Added integration coverage, including concurrency scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->