### PR TITLE
ci: run adapter integration tests against postgres, mysql, and sqlite

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,131 @@
+name: Integration
+
+# Real-database integration tests across every supported dialect. The unit
+# suites mock the drivers and the browser tests run on sqlite only, so
+# without this job a Postgres- or MySQL-specific regression in an adapter
+# ships silently. Runs as a sibling of `ci`, so it adds no wall-time to a
+# pull request.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+
+# Read-only: the job never writes through the GITHUB_TOKEN.
+permissions:
+  contents: read
+
+concurrency:
+  group: integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration:
+    name: Integration (${{ matrix.dialect }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    strategy:
+      # One dialect failing must not cancel the others: seeing that a change
+      # breaks only MySQL (and not all three) is exactly the signal that
+      # locates the bug.
+      fail-fast: false
+      matrix:
+        dialect: [postgres, mysql, sqlite]
+
+    # Both databases boot for every leg: GitHub cannot attach a `services:`
+    # entry conditionally per matrix value, and an idle container costs
+    # nothing. Each leg only connects to the one its dialect needs; sqlite
+    # runs in-process against a throwaway file.
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: nextly
+          POSTGRES_PASSWORD: nextly
+          POSTGRES_DB: nextly_test
+        ports:
+          - 5432:5432
+        # Health-gate so test steps never race a database that is still
+        # starting up.
+        options: >-
+          --health-cmd "pg_isready -U nextly"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: nextly
+          MYSQL_DATABASE: nextly_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h 127.0.0.1 -pnextly"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Cache Turbo
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The adapter suites read TEST_POSTGRES_URL / TEST_MYSQL_URL and fail
+      # (rather than skip) when their database is unreachable, so each leg
+      # runs only the packages its dialect covers. `test:integration`
+      # declares `dependsOn: ^build`, so turbo builds prerequisites itself.
+      #
+      # The core `nextly` integration suite is NOT gated yet, same policy as
+      # the unit `Test` step in ci.yml: it carries a pre-existing failing
+      # baseline (suites that import the absent `pg` package or a moved
+      # admin util fail at collection, and stale fixtures miss newer user
+      # columns). It joins the sqlite leg — and its pg-targeting files join
+      # the postgres leg — once that baseline is repaired.
+      - name: Run integration tests (postgres)
+        if: matrix.dialect == 'postgres'
+        run: pnpm turbo test:integration --filter=@nextlyhq/adapter-postgres
+        env:
+          TEST_POSTGRES_URL: postgres://nextly:nextly@localhost:5432/nextly_test
+          TURBO_CACHE_DIR: .turbo
+
+      - name: Run integration tests (mysql)
+        if: matrix.dialect == 'mysql'
+        run: pnpm turbo test:integration --filter=@nextlyhq/adapter-mysql
+        env:
+          TEST_MYSQL_URL: mysql://root:nextly@127.0.0.1:3306/nextly_test
+          TURBO_CACHE_DIR: .turbo
+
+      - name: Run integration tests (sqlite)
+        if: matrix.dialect == 'sqlite'
+        run: pnpm turbo test:integration --filter=@nextlyhq/adapter-sqlite
+        env:
+          TURBO_CACHE_DIR: .turbo

--- a/packages/adapter-sqlite/src/__tests__/adapter.integration.test.ts
+++ b/packages/adapter-sqlite/src/__tests__/adapter.integration.test.ts
@@ -10,7 +10,8 @@
 // WAL mode is enabled, foreign keys are enabled.
 
 import { existsSync, mkdirSync, rmSync } from "fs";
-import { resolve } from "path";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
 
 import BetterSqlite3 from "better-sqlite3";
 import { eq, and } from "drizzle-orm";
@@ -23,8 +24,12 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 // The directory is created in beforeAll and cleaned up in afterAll.
 // ============================================================
 
+// Resolved from this file's location so the test runs on any machine and
+// in CI, not just the checkout it was first written in.
 const TEST_DB_DIR = resolve(
-  "/Users/mobeen/Work/Products/nextly-integrations/nextly-dev/packages/adapter-sqlite",
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
   "test-data"
 );
 const TEST_DB_PATH = resolve(TEST_DB_DIR, "sqlite-integration-test.db");


### PR DESCRIPTION
## Summary

Part 2 of the CI/CD program (`nextly-integrations/tasks/ci-cd-implementation-plan.md`). Closes the audit's **#1 gap**: we ship 3 database adapters but no CI job ever ran their integration suites against a real server — the scripts (`test:integration:*`) existed since F18 but nothing invoked them.

New `integration.yml`:
- **Matrix `dialect: [postgres, mysql, sqlite]`**, `fail-fast: false` (a single-dialect failure stays visible as exactly that — the localization signal).
- **postgres:17 + mysql:8.4 as health-gated service containers** (both always boot — GitHub can't attach services conditionally per leg; idle containers cost nothing). SQLite in-process.
- Runs **parallel to `ci`** → zero added PR wall-time. Docs-only PRs skip via `paths-ignore`.
- SHA-pinned actions + `permissions: contents: read` from day one (consistent with #173).
- `turbo test:integration` has `dependsOn: ^build`, `cache: false`, and declares the `TEST_*_URL` env vars in `turbo.jsonc` — verified the task can never replay a stale cached pass.

## Verified locally (not just YAML-reviewed)

Ran each leg's **exact CI command** against throwaway Docker containers on unused ports (55432/33306, removed afterwards — no local project DB touched):
- postgres:17 → **13/13 pass**
- mysql:8.4 → **10/10 pass**
- sqlite → suite passes in-process

## Pre-existing issue found while verifying (NOT introduced here, NOT gated)

The **core `nextly` integration suite fails on a clean `main` checkout**: 10 files fail at collection (they import `pg`, which isn't a dependency of `packages/nextly`; one imports a moved `admin/src` util) and 3 tests fail on stale fixtures (`users` table missing `failed_login_attempts`). Same class as the known unit-test baseline. It is therefore **excluded from the gate**, with the same documented policy `ci.yml` already uses for unit tests — and should join the matrix (pg-targeting files on the postgres leg) once repaired. Recommend tracking that repair as its own task.

## Changeset

Skipped — workflow-only; no published package touched.

## Notes

- Deliberately **not** a required branch-protection check yet (`paths-ignore` + required checks = stuck "expected" states); revisit after a couple of stable weeks.
- Independent of #173; merges in any order (this file is born SHA-pinned).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated integration testing across PostgreSQL, MySQL, and SQLite.
  * Integration tests now run automatically for changes pushed to or proposed for the main branch.
  * Improved reliability with per-database health checks and isolated dialect-scoped test execution.
  * Made SQLite integration test database path resolution portable across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->