### PR TITLE
ci: publish per-pr preview packages via pkg.pr.new

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -63,5 +63,9 @@ jobs:
       # `--pnpm` makes pkg-pr-new pack with pnpm so workspace:* protocol
       # ranges in package.json resolve to real versions in the tarballs,
       # exactly as `changeset publish` does for npm releases.
+      # `--commentWithSha` puts the commit sha in the comment's install
+      # links instead of the PR number: a sha URL is immutable, so a
+      # consumer app testing a preview cannot silently drift onto a newer
+      # push to the same PR.
       - name: Publish to pkg.pr.new
-        run: pnpm dlx pkg-pr-new publish --pnpm './packages/*'
+        run: pnpm dlx pkg-pr-new publish --pnpm --commentWithSha './packages/*'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,67 @@
+name: Preview release
+
+# Publishes every PR's packages to pkg.pr.new (StackBlitz's continuous-release
+# CDN) and comments install URLs on the PR. A consumer app can then install a
+# PR's exact build — `npm i https://pkg.pr.new/nextlyhq/nextly/nextly@<sha>` —
+# and verify it against real projects before the PR merges. Nothing is
+# published to the npm registry and the URLs expire on their own, so there is
+# no version pollution and nothing to clean up.
+#
+# Requires the pkg.pr.new GitHub App (github.com/apps/pkg-pr-new) to be
+# installed on this repository; publishing authenticates through the app, not
+# through repo secrets.
+
+on:
+  pull_request:
+    branches: [main]
+
+# The GITHUB_TOKEN is unused: the pkg.pr.new app authenticates the publish
+# and writes the PR comment itself.
+permissions: {}
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Publish preview packages
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Cache Turbo
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm turbo build --filter='./packages/*'
+        env:
+          TURBO_CACHE_DIR: .turbo
+
+      # `--pnpm` makes pkg-pr-new pack with pnpm so workspace:* protocol
+      # ranges in package.json resolve to real versions in the tarballs,
+      # exactly as `changeset publish` does for npm releases.
+      - name: Publish to pkg.pr.new
+        run: pnpm dlx pkg-pr-new publish --pnpm './packages/*'


### PR DESCRIPTION
## Summary

Part 4 of the CI/CD program (`nextly-integrations/tasks/ci-cd-implementation-plan.md`). Every PR now publishes its packages to **pkg.pr.new** (StackBlitz's continuous-release CDN) and gets an automatic comment with install URLs:

```bash
npm i https://pkg.pr.new/nextlyhq/nextly/nextly@<sha>
```

**Why this matters for us specifically:** we dogfood Nextly in separate consumer repos (mobeen-site, nextly-site, rext-site). This lets us install a PR's exact code into a real consumer **before merge** — the class of cross-repo integration break no in-repo test can catch. Keystone runs the identical setup (`publish_preview.yml`).

- Nothing is published to the npm registry; URLs auto-expire → zero version pollution.
- `--pnpm` packing resolves `workspace:*` ranges to concrete versions, matching `changeset publish` behavior.
- `permissions: {}` — the GITHUB_TOKEN is never used; the pkg.pr.new app authenticates.
- Runs parallel to `ci` (~3–5 min) → no added PR wall-time.

## ⚠️ One-time manual step (required before this works)

**Install the pkg.pr.new GitHub App on this repo:** https://github.com/apps/pkg-pr-new → Install → select `nextlyhq/nextly`. Until installed, the job fails with a clear "app is not installed" error — it cannot break anything else. I can't do this step; it needs org admin.

## Test plan

- YAML validated; actions SHA-pinned; permissions empty by design.
- This PR itself will exercise the workflow: after the app is installed, re-run the job and it should comment install URLs right here.

## Changeset

Skipped — workflow-only; `pkg-pr-new` is invoked via `pnpm dlx`, no dependency added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated **Preview release** workflow that runs on pull requests targeting the main branch.
  * The workflow builds the workspace packages and publishes them to a temporary preview registry for testing.
  * Preview builds generate commit-specific package install links to help validate changes before release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->