### PR TITLE
test(nextly): repair the integration-test baseline

### DIFF
--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -213,6 +213,7 @@
     "acorn-walk": "^8.3.4",
     "better-sqlite3": "^12.5.0",
     "eslint": "^9.34.0",
+    "pg": "^8.13.0",
     "rimraf": "^6.1.3",
     "rollup": "^4.60.1",
     "rollup-plugin-dts": "^6.4.1",

--- a/packages/nextly/src/database/__tests__/integration/schema-push.integration.test.ts
+++ b/packages/nextly/src/database/__tests__/integration/schema-push.integration.test.ts
@@ -21,19 +21,21 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 // `pipeline/__tests__/preview.test.ts`. F8 PR 7's cross-dialect
 // integration matrix exercises the new preview/apply paths end-to-end
 // against real PG/MySQL/SQLite.
-import { generateRuntimeSchema } from "../../../../domains/schema/services/runtime-schema-generator";
+import { generateRuntimeSchema } from "../../../domains/schema/services/runtime-schema-generator";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import { SchemaRegistry } from "../../schema-registry";
 
-// F18 canonical env var: TEST_POSTGRES_URL.
-// Falls back to legacy TEST_DATABASE_URL, then to the dev default.
+// F18 canonical env var: TEST_POSTGRES_URL (legacy TEST_DATABASE_URL also
+// honored). No dev-default fallback on purpose: probing a hardcoded
+// localhost DB would run this suite's DROP/CREATE DDL against whatever
+// database happens to be listening there. The suite skips unless a test URL
+// is explicitly provided.
 const TEST_DB_URL =
-  process.env.TEST_POSTGRES_URL ??
-  process.env.TEST_DATABASE_URL ??
-  "postgres://postgres:postgres@localhost:5433/nextly_test";
+  process.env.TEST_POSTGRES_URL ?? process.env.TEST_DATABASE_URL ?? "";
 
-// Check if test database is available
+// Check if the test database is available (only when a URL was provided).
 const canConnect = async (): Promise<boolean> => {
+  if (!TEST_DB_URL) return false;
   const pool = new Pool({ connectionString: TEST_DB_URL });
   try {
     await pool.query("SELECT 1");

--- a/packages/nextly/src/domains/users/__tests__/user-mutation-service.transaction.integration.test.ts
+++ b/packages/nextly/src/domains/users/__tests__/user-mutation-service.transaction.integration.test.ts
@@ -61,11 +61,11 @@ const TEST_DB_URL = `file:${TEST_DB_PATH}`;
 process.env.DB_DIALECT = "sqlite";
 process.env.DATABASE_URL = TEST_DB_URL;
 
-// Minimal DDL matching the Drizzle sqliteTable definitions in
-// packages/nextly/src/database/schema/sqlite.ts. Only the tables that
+// Minimal DDL matching the Drizzle sqliteTable definition in
+// packages/nextly/src/schemas/users/sqlite.ts. Only the tables that
 // createLocalUser actually touches are created here — keeping the DDL
 // explicit makes the test fast and keeps the failure mode obvious if the
-// schema drifts. If you add a column to `users` in sqlite.ts and this test
+// schema drifts. If you add a column to `users` in that file and this test
 // starts failing, update the CREATE TABLE here to match.
 const CREATE_USERS_TABLE = `
   CREATE TABLE IF NOT EXISTS users (
@@ -77,6 +77,8 @@ const CREATE_USERS_TABLE = `
     image                TEXT,
     password_hash        TEXT,
     is_active            INTEGER NOT NULL DEFAULT 0,
+    failed_login_attempts INTEGER NOT NULL DEFAULT 0,
+    locked_until         INTEGER,
     created_at           INTEGER NOT NULL,
     updated_at           INTEGER NOT NULL
   )

--- a/packages/nextly/src/lib/date-formatting.integration.test.ts
+++ b/packages/nextly/src/lib/date-formatting.integration.test.ts
@@ -1,9 +1,5 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it, beforeEach } from "vitest";
 
-import {
-  formatGlobalDateTime,
-  setGlobalDateTimeConfig,
-} from "../../../admin/src/utils/globalDateTime";
 import { container } from "../di/container";
 
 import {
@@ -11,112 +7,95 @@ import {
   withTimezoneFormatting,
 } from "./date-formatting";
 
-describe("date formatting integration (API -> admin)", () => {
+// This suite exercises the API-side timestamp contract that nextly owns.
+// The admin panel has its own formatter tests in the admin package; nextly
+// must not import admin source, so the assertions here verify nextly's real
+// behavior with timezone-independent epoch/string checks rather than a
+// display formatter.
+//
+// The contract (see `normalizeTimestampsInPayload`): a naive wall-clock
+// string is read as UTC, and the value is re-rendered carrying the target
+// timezone's offset. The instant it denotes never changes — only the offset
+// suffix does — so a client knows which offset to display without the stored
+// moment being shifted.
+
+describe("date formatting (API normalization contract)", () => {
   beforeEach(() => {
-    // Keep tests deterministic and avoid cross-test config bleed.
-    setGlobalDateTimeConfig({});
     container.clear();
   });
 
-  it("keeps admin display consistent for the same payload after API normalization", () => {
+  it("re-renders a naive timestamp with the timezone's offset without moving the instant", () => {
     const payload = {
       createdAt: "2026-04-03T12:34:56",
-      nested: {
-        updatedAt: "2026-04-03 18:00:00",
-      },
+      nested: { updatedAt: "2026-04-03 18:00:00" },
     };
+    const normalized = normalizeTimestampsInPayload(
+      payload,
+      "America/New_York"
+    ) as { createdAt: string; nested: { updatedAt: string } };
 
-    const timezone = "America/New_York";
-
-    const normalized = normalizeTimestampsInPayload(payload, timezone) as {
-      createdAt: string;
-      nested: { updatedAt: string };
-    };
-
-    setGlobalDateTimeConfig({
-      timezone,
-      dateFormat: "YYYY-MM-DD",
-      timeFormat: "24h",
-      locale: "en-US",
-    });
-
-    const fromOriginalCreatedAt = formatGlobalDateTime(payload.createdAt);
-    const fromNormalizedCreatedAt = formatGlobalDateTime(normalized.createdAt);
-    const fromOriginalUpdatedAt = formatGlobalDateTime(
-      payload.nested.updatedAt
-    );
-    const fromNormalizedUpdatedAt = formatGlobalDateTime(
-      normalized.nested.updatedAt
-    );
-
+    // Carries an explicit offset (or Z), so it is an unambiguous instant.
     expect(normalized.createdAt).toMatch(/[+-]\d{2}:\d{2}|Z$/);
     expect(normalized.nested.updatedAt).toMatch(/[+-]\d{2}:\d{2}|Z$/);
 
-    expect(fromNormalizedCreatedAt).toBe(fromOriginalCreatedAt);
-    expect(fromNormalizedUpdatedAt).toBe(fromOriginalUpdatedAt);
+    // The instant equals the source read as UTC (naive input is treated as
+    // UTC; only the rendered offset changes).
+    expect(new Date(normalized.createdAt).getTime()).toBe(
+      Date.parse("2026-04-03T12:34:56Z")
+    );
+    expect(new Date(normalized.nested.updatedAt).getTime()).toBe(
+      Date.parse("2026-04-03T18:00:00Z")
+    );
+
+    // And it renders with New York's offset in early April (EDT, -04:00).
+    expect(normalized.createdAt).toContain("-04:00");
   });
 
-  it("applies localization/time settings changes immediately", () => {
-    const value = "2026-04-03T12:34:56";
+  it("changes the rendered offset per timezone while preserving the instant", () => {
+    const value = { createdAt: "2026-04-03T12:34:56" };
 
-    setGlobalDateTimeConfig({
-      timezone: "America/New_York",
-      dateFormat: "YYYY-MM-DD",
-      timeFormat: "24h",
-      locale: "en-US",
-    });
-    const firstRender = formatGlobalDateTime(value);
+    const inNewYork = normalizeTimestampsInPayload(
+      value,
+      "America/New_York"
+    ) as { createdAt: string };
+    const inTokyo = normalizeTimestampsInPayload(value, "Asia/Tokyo") as {
+      createdAt: string;
+    };
 
-    setGlobalDateTimeConfig({
-      timezone: "Asia/Tokyo",
-      dateFormat: "MM/DD/YYYY",
-      timeFormat: "12h",
-      locale: "en-US",
-    });
-    const secondRender = formatGlobalDateTime(value);
-
-    expect(secondRender).not.toBe(firstRender);
+    // Same moment in time, different offset labels.
+    expect(new Date(inNewYork.createdAt).getTime()).toBe(
+      new Date(inTokyo.createdAt).getTime()
+    );
+    expect(inNewYork.createdAt).not.toBe(inTokyo.createdAt);
+    expect(inNewYork.createdAt).toContain("-04:00");
+    expect(inTokyo.createdAt).toContain("+09:00");
   });
 
-  it("keeps displayed UI value consistent with API returned timestamp", async () => {
+  it("transforms nested timestamps on a Response using the configured timezone", async () => {
     let activeTimezone = "America/New_York";
     container.registerSingleton("generalSettingsService", () => ({
       getTimezone: async () => activeTimezone,
     }));
 
     const originalPayload = {
-      data: {
-        data: {
-          createdAt: "2026-04-03T12:34:56",
-        },
-      },
+      data: { data: { createdAt: "2026-04-03T12:34:56" } },
     };
 
-    const apiResponse = new Response(JSON.stringify(originalPayload), {
-      headers: { "Content-Type": "application/json" },
-      status: 200,
-    });
-
-    const transformedResponse = await withTimezoneFormatting(apiResponse);
-    const transformedJson = (await transformedResponse.json()) as {
+    const transformed = await withTimezoneFormatting(
+      new Response(JSON.stringify(originalPayload), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      })
+    );
+    const json = (await transformed.json()) as {
       data: { data: { createdAt: string } };
     };
 
-    setGlobalDateTimeConfig({
-      timezone: activeTimezone,
-      dateFormat: "YYYY-MM-DD",
-      timeFormat: "24h",
-      locale: "en-US",
-    });
+    expect(json.data.data.createdAt).toMatch(/[+-]\d{2}:\d{2}|Z$/);
+    expect(json.data.data.createdAt).toContain("-04:00");
 
-    const uiFromOriginal = formatGlobalDateTime(
-      originalPayload.data.data.createdAt
-    );
-    const uiFromApi = formatGlobalDateTime(transformedJson.data.data.createdAt);
-
-    expect(transformedJson.data.data.createdAt).toMatch(/[+-]\d{2}:\d{2}|Z$/);
-    expect(uiFromApi).toBe(uiFromOriginal);
-
+    // Switching the configured timezone re-renders the same instant with a
+    // different offset.
     activeTimezone = "Asia/Tokyo";
     const transformedAgain = await withTimezoneFormatting(
       new Response(JSON.stringify(originalPayload), {
@@ -124,25 +103,23 @@ describe("date formatting integration (API -> admin)", () => {
         status: 200,
       })
     );
-    const transformedAgainJson = (await transformedAgain.json()) as {
+    const jsonAgain = (await transformedAgain.json()) as {
       data: { data: { createdAt: string } };
     };
 
-    expect(transformedAgainJson.data.data.createdAt).not.toBe(
-      transformedJson.data.data.createdAt
+    expect(new Date(jsonAgain.data.data.createdAt).getTime()).toBe(
+      new Date(json.data.data.createdAt).getTime()
     );
+    expect(jsonAgain.data.data.createdAt).not.toBe(json.data.data.createdAt);
+    expect(jsonAgain.data.data.createdAt).toContain("+09:00");
   });
 
-  it("keeps unset timezone payloads in UTC", async () => {
+  it("keeps unset-timezone payloads in UTC", async () => {
     container.registerSingleton("generalSettingsService", () => ({
       getTimezone: async () => null,
     }));
 
-    const payload = {
-      data: {
-        uploadedAt: "2026-04-03T12:34:56",
-      },
-    };
+    const payload = { data: { uploadedAt: "2026-04-03T12:34:56" } };
 
     const transformed = await withTimezoneFormatting(
       new Response(JSON.stringify(payload), {
@@ -150,7 +127,6 @@ describe("date formatting integration (API -> admin)", () => {
         status: 200,
       })
     );
-
     const json = (await transformed.json()) as { data: { uploadedAt: string } };
 
     expect(json.data.uploadedAt).toBe("2026-04-03T12:34:56.000Z");

--- a/packages/nextly/src/plugins/__tests__/builder-extend-pg.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/builder-extend-pg.integration.test.ts
@@ -17,10 +17,11 @@ import { createAdapter } from "../../database/factory";
 import { addMissingColumnsForFields } from "../../domains/schema/utils/missing-columns";
 import type { Logger } from "../../services/shared";
 
+// No dev-default fallback on purpose: this suite creates and drops a real
+// table, so probing a hardcoded localhost DB would mutate whatever database
+// happens to be listening there. It skips unless a test URL is explicit.
 const PG_URL =
-  process.env.TEST_POSTGRES_URL ??
-  process.env.TEST_DATABASE_URL ??
-  "postgres://postgres:postgres@localhost:5433/nextly_test";
+  process.env.TEST_POSTGRES_URL ?? process.env.TEST_DATABASE_URL ?? "";
 
 const silentLogger: Logger = {
   debug() {},
@@ -35,6 +36,7 @@ const TABLE = "dc_pg_builder_extend";
 async function connectIfAvailable(): Promise<Awaited<
   ReturnType<typeof createAdapter>
 > | null> {
+  if (!PG_URL) return null;
   process.env.DB_DIALECT = "postgresql";
   try {
     const adapter = await createAdapter({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,7 +198,7 @@ importers:
         version: 9.39.1(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.7.0)))(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.2.6(@typescript-eslint/parser@8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.7.0)))(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4
         version: 4.1.17
@@ -945,6 +945,9 @@ importers:
       eslint:
         specifier: ^9.34.0
         version: 9.39.1(jiti@2.6.1)
+      pg:
+        specifier: ^8.13.0
+        version: 8.16.3
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -13786,13 +13789,13 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.2.6(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.7.0)))(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3):
+  eslint-config-next@16.2.6(@typescript-eslint/parser@8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.7.0)))(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 9.39.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint@9.39.1(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.1(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1(jiti@2.7.0))
@@ -13852,7 +13855,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint@9.39.1(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.1(jiti@2.7.0))
       eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
@@ -13869,10 +13872,11 @@ snapshots:
       - supports-color
     optional: true
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.7.0)))(eslint@9.39.1(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.7.0)))(eslint@9.39.1(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.7.0))
@@ -13948,7 +13952,7 @@ snapshots:
       - supports-color
     optional: true
 
-  eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.1(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -13959,7 +13963,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.7.0)))(eslint@9.39.1(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.7.0)))(eslint@9.39.1(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13970,6 +13974,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.59.0(eslint@9.39.1(jiti@2.7.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
## Summary

Follow-up 1 of 2 from the CI/CD program. The `nextly` integration suite errored on a clean checkout (which is why #174 kept it off the CI matrix) and — worse — could **mutate a real dev database** when run locally. This repairs it to pass in its normal no-database mode and removes the hazards.

**Before:** `pnpm --filter nextly test:integration` → **11 files failed** (9 collection failures, 1 stale cross-package import, 1 stale fixture).
**After:** **54 passed, 10 skipped, 0 failed** (the 10 skips are the postgres/oracle suites, which correctly skip when no test DB is provided).

## What changed

1. **Add `pg` as a devDependency** (`^8.13.0`, matching adapter-postgres — no new version drift). The 9 postgres integration suites imported `pg`, which wasn't installed, so they failed at *collection* before their existing skip-guards could fire.
2. **Removed a genuine hazard** in `schema-push` and `builder-extend-pg`: both defaulted to `postgres://…@localhost:5433/nextly_test` and *probed* it, then ran `DROP/CREATE` DDL against whatever database answered. On a dev machine, `:5433` is a real project's database (e.g. mobeen-site's). They now default to empty and **skip unless `TEST_POSTGRES_URL` is set**, matching every other pg suite.
3. **Fixed a stale import** in `schema-push` (`runtime-schema-generator` was one directory level too deep, failing the whole file load).
4. **Synced the `users` fixture** in the transaction test with the current schema (`failed_login_attempts`, `locked_until`) so `createLocalUser` inserts succeed.
5. **Removed a cross-package `admin/src` import** from the date-formatting suite — a path that no longer exists *and* a dependency direction nextly must not have (nextly must not import admin). It now asserts nextly's own normalization contract directly (verified against the real behavior: naive input is read as UTC and re-rendered with the target timezone's offset, preserving the instant).

## Test plan

- `pnpm --filter nextly test:integration` (no DB): **54 passed / 10 skipped / 0 failed**.
- `pnpm turbo check-types lint --filter=nextly`: pass.
- `pnpm lint:workspace` (sherif): clean (the `pg` range matches adapter-postgres, so no new `multiple-dependency-versions`).
- Ran the suite against a **throwaway postgres:17** (unused port, removed after) to confirm the pg suites actually execute rather than always-skip — see the important note below.

## ⚠️ Discovered — recommended as its own follow-up (NOT fixed here)

When the postgres suites *do* run against a live DB, **18 tests fail on a real schema drift**: the tests create `nextly_schema_events` via its DDL helper, but the DDL is missing the `note` column (and the read query selects it) → `column "note" does not exist`. This is the same *class* as the fixture drift, but it lives in the schema-events subsystem and may indicate the production ledger DDL is behind its Drizzle schema — a real fix worth its own PR. Because of it, this PR deliberately **does not wire `nextly` into #174's postgres CI leg** yet (that would make CI red). Recommend a dedicated `fix(schema-events)` task to reconcile the DDL, after which nextly can join the postgres matrix.

## Changeset

Skipped — test files + a devDependency only; the published package ships `dist/` (no test files, no devDeps), so there is no user-facing change. Consistent with #174.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp formatting tests to verify timezone handling, nested responses, and UTC behavior more reliably.
  * Updated transaction test schemas to include login-attempt and account-lock fields.

* **Tests**
  * PostgreSQL integration tests now require an explicitly configured test database and skip safely when unavailable.
  * Updated test imports and database connectivity configuration.
  * Added PostgreSQL tooling required by the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->