### PR TITLE
fix(nextly): require auth and permissions to write media

### DIFF
--- a/.changeset/media-api-requires-auth.md
+++ b/.changeset/media-api-requires-auth.md
@@ -1,0 +1,30 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Require authentication and permissions to write media.
+
+Media writes are no longer open. Previously anyone on the internet could upload, edit, move, or delete a site's media by calling `/api/media` with no login and no key — the endpoint had no auth at all. Now the write operations (upload, update, move, delete, and their folder equivalents) live at a gated **`/admin/api/media`**, where each is checked against a media permission (`create`/`read`/`update`/`delete-media`) and the acting user is taken from the authenticated session or API key, never from a request field like `uploadedBy` (which could name anyone). Reading media stays public at `/api/media` — files are served to anonymous visitors — but that path now serves **reads only**; its write verbs are gone.
+
+This is why media permissions could not previously gate anything: the admin's session cookie is scoped to `/admin`, so it never reached `/api/media`, and the whole `manage`/`create`/`read`/`delete-media` set was decorative. Moving the management surface under `/admin` is what lets the session authenticate, so the permission checks finally take effect.
+
+Also adds a real **`update-media`** permission (media had create/read/delete but no update), so editing metadata and moving files gates on `update-media` consistently with every other resource. The built-in Admin, Editor, and Author roles pick it up automatically; Viewer does not.
+
+**Consumer action:** if your app re-exports the media handlers, mount the gated instance for the admin — `createMediaHandlers({ config, requireAuth: true })` at `app/admin/api/media/[[...path]]/route.ts` — and keep the public read-only instance (`createMediaHandlers({ config })`, exporting `GET` only) at `app/api/media/[[...path]]/route.ts`. Media file URLs in API responses are unchanged and remain public (no `/admin` prefix).

--- a/apps/playground/src/app/admin/api/media/[[...path]]/route.ts
+++ b/apps/playground/src/app/admin/api/media/[[...path]]/route.ts
@@ -1,0 +1,26 @@
+/**
+ * Admin Media API — permission-gated management surface.
+ *
+ * The admin's session cookie is scoped to `/admin`, so it reaches here but not
+ * the public `/api/media`. Every operation is checked against a media
+ * permission (read/create/update/delete-media) and the acting identity is
+ * taken from the session/API key, never a request field. This is the only
+ * place media can be uploaded, edited, moved or deleted.
+ *
+ * Supported (all gated):
+ * - GET/POST/PATCH/DELETE /admin/api/media/*  (files, folders, bulk delete)
+ */
+
+import { createMediaHandlers } from "nextly/api/media-handlers";
+
+import nextlyConfig from "../../../../../../nextly.config";
+
+const handlers = createMediaHandlers({
+  config: nextlyConfig,
+  requireAuth: true,
+});
+
+export const GET = handlers.GET;
+export const POST = handlers.POST;
+export const PATCH = handlers.PATCH;
+export const DELETE = handlers.DELETE;

--- a/apps/playground/src/app/api/media/[[...path]]/route.ts
+++ b/apps/playground/src/app/api/media/[[...path]]/route.ts
@@ -1,24 +1,17 @@
 /**
- * Media API Routes (Catch-All Handler)
+ * Public Media API — reads only.
  *
- * This single route handles all media operations:
+ * Media files are served to anonymous visitors, so GET stays public:
+ * - GET /api/media                        - List media with pagination
+ * - GET /api/media/:id                    - Get media by ID
+ * - GET /api/media/folders                - List folders
+ * - GET /api/media/folders/:id            - Get folder by ID
+ * - GET /api/media/folders/:id/contents   - Get folder contents
+ * - GET /api/media/folders/root/contents  - Get root folder contents
  *
- * Media Files:
- * - GET    /api/media                        - List media with pagination
- * - POST   /api/media                        - Upload new media file
- * - GET    /api/media/:id                    - Get media by ID
- * - PATCH  /api/media/:id                    - Update media metadata
- * - DELETE /api/media/:id                    - Delete media file
- * - PATCH  /api/media/:id/move               - Move media to folder
- *
- * Folders:
- * - GET    /api/media/folders                - List folders
- * - POST   /api/media/folders                - Create folder
- * - GET    /api/media/folders/:id            - Get folder by ID
- * - PATCH  /api/media/folders/:id            - Update folder
- * - DELETE /api/media/folders/:id            - Delete folder
- * - GET    /api/media/folders/:id/contents   - Get folder contents
- * - GET    /api/media/folders/root/contents  - Get root folder contents
+ * Writes (upload / update / move / delete) are NOT served here — they require a
+ * permission and are mounted, gated, at /admin/api/media. Only exporting GET
+ * means any write verb to this public path is refused.
  */
 
 import { createMediaHandlers } from "nextly/api/media-handlers";
@@ -29,6 +22,3 @@ import nextlyConfig from "../../../../../nextly.config";
 const handlers = createMediaHandlers({ config: nextlyConfig });
 
 export const GET = handlers.GET;
-export const POST = handlers.POST;
-export const PATCH = handlers.PATCH;
-export const DELETE = handlers.DELETE;

--- a/packages/admin/src/services/mediaApi.ts
+++ b/packages/admin/src/services/mediaApi.ts
@@ -6,25 +6,27 @@
  *
  * ## API Integration
  *
- * This client makes HTTP requests to `/api/media` endpoints which are implemented
- * in the consumer's Next.js application by re-exporting handlers from `nextly/api/media`.
+ * This client talks to the **gated** `/admin/api/media` endpoints, which the
+ * admin's `Path=/admin` session cookie can reach. Every write is checked
+ * against a media permission and attributed to the signed-in user server-side,
+ * so the client never sends an `uploadedBy`/`createdBy` identity. Public,
+ * anonymous reads live separately at `/api/media` (used when serving files);
+ * the admin uses the gated surface for everything.
  *
  * ## Architecture
  *
  * ```
  * Frontend (mediaApi.ts)
  *   ↓ HTTP fetch/XMLHttpRequest
- * API Routes (/api/media)
+ * API Routes (/admin/api/media)
  *   ↓ Function calls
  * MediaService (nextly)
  *   ↓ Database queries
  * PostgreSQL/MySQL/SQLite
  * ```
  *
- * @see nextly/api/media - Backend API handlers
+ * @see nextly/api/media-handlers - Backend API handlers
  */
-
-import { getCurrentUserId } from "@admin/lib/auth/session";
 
 import { parseApiError } from "../lib/api/parseApiError";
 import {
@@ -45,6 +47,11 @@ import type {
   FolderResponse,
   FolderContentsResponse,
 } from "../types/media";
+
+// The gated admin media surface. The session cookie is scoped to `/admin`, so
+// this is the path it authenticates against; the server derives identity and
+// enforces media permissions here.
+const MEDIA_BASE = "/admin/api/media";
 
 // ============================================================
 // Internal fetch helper
@@ -131,7 +138,9 @@ function uploadMediaOnce(
       reject(new Error("Upload cancelled"));
     });
 
-    xhr.open("POST", "/api/media");
+    xhr.open("POST", MEDIA_BASE);
+    // Send session cookies so the gated endpoint can authenticate the upload.
+    xhr.withCredentials = true;
     xhr.send(formData);
   });
 }
@@ -141,11 +150,10 @@ export async function uploadMedia(
   onProgress?: (progress: number) => void,
   folderId?: string | null
 ): Promise<Media> {
-  const userId = await getCurrentUserId();
-
   const formData = new FormData();
   formData.append("file", file);
-  formData.append("uploadedBy", userId);
+  // No `uploadedBy`: the server attributes the upload to the authenticated
+  // caller from the session, never a client-supplied identity.
   if (folderId) {
     formData.append("folderId", folderId);
   }
@@ -229,7 +237,7 @@ export async function fetchMedia(
       hasNext: boolean;
       hasPrev: boolean;
     };
-  }>(`/api/media?${queryParams.toString()}`);
+  }>(`${MEDIA_BASE}?${queryParams.toString()}`);
 
   return {
     data: result.items || [],
@@ -250,7 +258,7 @@ export async function fetchMedia(
  */
 export async function getMediaById(mediaId: string): Promise<Media> {
   // respondDoc returns the bare row.
-  return mediaFetchJson<Media>(`/api/media/${mediaId}`);
+  return mediaFetchJson<Media>(`${MEDIA_BASE}/${mediaId}`);
 }
 
 /**
@@ -261,7 +269,7 @@ export async function updateMedia(
   updates: MediaUpdateInput
 ): Promise<void> {
   // respondMutation { message, item }; caller does not need the item back.
-  await mediaFetchVoid(`/api/media/${mediaId}`, {
+  await mediaFetchVoid(`${MEDIA_BASE}/${mediaId}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(updates),
@@ -273,13 +281,13 @@ export async function updateMedia(
  */
 export async function deleteMedia(mediaId: string): Promise<void> {
   // respondAction { message, id }; caller does not need the id back.
-  await mediaFetchVoid(`/api/media/${mediaId}`, { method: "DELETE" });
+  await mediaFetchVoid(`${MEDIA_BASE}/${mediaId}`, { method: "DELETE" });
 }
 
 /**
  * Bulk delete multiple media files.
  *
- * Hits `DELETE /api/media/bulk` (server `media-bulk.ts` DELETE handler).
+ * Hits `DELETE /admin/api/media/bulk` (server `media-bulk.ts` DELETE handler).
  * Single round-trip; server runs per-id deletes concurrently with full
  * access-control + storage-cleanup pipeline; partial failures returned
  * in `errors[]` with structured `{ id, code, message }`.
@@ -299,7 +307,7 @@ export async function deleteMedia(mediaId: string): Promise<void> {
 export async function bulkDeleteMedia(
   mediaIds: string[]
 ): Promise<BulkResponse<{ id: string }>> {
-  const response = await authFetch("/api/media/bulk", {
+  const response = await authFetch(`${MEDIA_BASE}/bulk`, {
     method: "DELETE",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ mediaIds }),
@@ -323,15 +331,14 @@ export async function bulkDeleteMedia(
 export async function createFolder(
   input: CreateFolderInput
 ): Promise<MediaFolder> {
-  const userId = await getCurrentUserId();
-
-  // respondMutation: { message, item: Folder }.
+  // respondMutation: { message, item: Folder }. The server sets `createdBy`
+  // from the authenticated caller, so the client does not send it.
   const result = await mediaFetchJson<{ item?: MediaFolder }>(
-    "/api/media/folders",
+    `${MEDIA_BASE}/folders`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ...input, createdBy: userId }),
+      body: JSON.stringify(input),
     }
   );
   if (!result.item) {
@@ -348,7 +355,7 @@ export async function getFolderById(
 ): Promise<FolderResponse["data"]> {
   // respondDoc returns the bare folder row (with breadcrumbs).
   return mediaFetchJson<FolderResponse["data"]>(
-    `/api/media/folders/${folderId}`
+    `${MEDIA_BASE}/folders/${folderId}`
   );
 }
 
@@ -358,7 +365,7 @@ export async function getFolderById(
 export async function listRootFolders(): Promise<MediaFolder[]> {
   // respondData { folders: MediaFolder[] } (non-paginated list, named field).
   const result = await mediaFetchJson<{ folders?: MediaFolder[] }>(
-    "/api/media/folders?root=true"
+    `${MEDIA_BASE}/folders?root=true`
   );
   return result.folders || [];
 }
@@ -368,7 +375,7 @@ export async function listRootFolders(): Promise<MediaFolder[]> {
  */
 export async function listSubfolders(parentId: string): Promise<MediaFolder[]> {
   const result = await mediaFetchJson<{ folders?: MediaFolder[] }>(
-    `/api/media/folders?parentId=${parentId}`
+    `${MEDIA_BASE}/folders?parentId=${parentId}`
   );
   return result.folders || [];
 }
@@ -380,8 +387,8 @@ export async function getFolderContents(
   folderId: string | null
 ): Promise<FolderContentsResponse["data"]> {
   const url = folderId
-    ? `/api/media/folders/${folderId}/contents`
-    : "/api/media/folders/root/contents";
+    ? `${MEDIA_BASE}/folders/${folderId}/contents`
+    : `${MEDIA_BASE}/folders/root/contents`;
 
   // respondData ships the structured contents object bare.
   return mediaFetchJson<FolderContentsResponse["data"]>(url);
@@ -395,7 +402,7 @@ export async function updateFolder(
   updates: UpdateFolderInput
 ): Promise<MediaFolder> {
   const result = await mediaFetchJson<{ item?: MediaFolder }>(
-    `/api/media/folders/${folderId}`,
+    `${MEDIA_BASE}/folders/${folderId}`,
     {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
@@ -416,7 +423,7 @@ export async function deleteFolder(
   deleteContents: boolean = false
 ): Promise<void> {
   await mediaFetchVoid(
-    `/api/media/folders/${folderId}?deleteContents=${deleteContents}`,
+    `${MEDIA_BASE}/folders/${folderId}?deleteContents=${deleteContents}`,
     { method: "DELETE" }
   );
 }
@@ -432,7 +439,7 @@ export async function moveMediaToFolder(
   // signature returned the moved record; the new endpoint omits it because
   // the admin already has the row in cache. Keep the public signature for
   // backwards compatibility with callers but always resolve to null.
-  await mediaFetchVoid(`/api/media/${mediaId}/move`, {
+  await mediaFetchVoid(`${MEDIA_BASE}/${mediaId}/move`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ folderId }),

--- a/packages/nextly/src/api/media-handlers.test.ts
+++ b/packages/nextly/src/api/media-handlers.test.ts
@@ -8,7 +8,11 @@ const mocks = vi.hoisted(() => {
   return {
     mediaService: {
       listMedia: vi.fn(),
+      upload: vi.fn(),
+      createFolder: vi.fn(),
+      delete: vi.fn(),
     },
+    requirePermission: vi.fn(),
   };
 });
 
@@ -20,6 +24,13 @@ vi.mock("../init", () => ({
 vi.mock("../di", () => ({
   getService: vi.fn(() => mocks.mediaService),
 }));
+
+// Partial mock: keep the real ErrorResponse helpers (pure functions) and only
+// drive `requirePermission` from the test.
+vi.mock("../auth/middleware", async importOriginal => {
+  const actual = await importOriginal<typeof import("../auth/middleware")>();
+  return { ...actual, requirePermission: mocks.requirePermission };
+});
 
 describe("createMediaHandlers timezone formatting", () => {
   beforeEach(() => {
@@ -71,5 +82,89 @@ describe("createMediaHandlers timezone formatting", () => {
 
     expect(json.items[0].uploadedAt).toContain("+09:00");
     expect(json.items[0].updatedAt).toContain("+09:00");
+  });
+});
+
+describe("createMediaHandlers authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    container.clear();
+  });
+
+  afterEach(() => {
+    container.clear();
+  });
+
+  it("does not serve writes on the public mount (upload 404s, permission never consulted)", async () => {
+    const handlers = createMediaHandlers(); // public: requireAuth defaults false
+    const response = await handlers.POST(
+      new Request("http://localhost/api/media", { method: "POST" }),
+      { params: Promise.resolve({}) } // empty path + POST → upload-media
+    );
+
+    // The public surface has no write endpoint — the write is refused exactly
+    // like an unknown route, and no permission check (or upload) happens.
+    expect(response.status).toBe(404);
+    expect(mocks.requirePermission).not.toHaveBeenCalled();
+    expect(mocks.mediaService.upload).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unauthenticated request on the gated mount with the permission's error", async () => {
+    mocks.requirePermission.mockResolvedValue({
+      success: false,
+      statusCode: 401,
+      message: "Authentication required",
+      error: "You must be logged in to access this resource",
+      data: null,
+      code: "AUTH_REQUIRED",
+    });
+
+    const handlers = createMediaHandlers({ requireAuth: true });
+    const response = await handlers.DELETE(
+      new Request("http://localhost/admin/api/media/some-id", {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ path: ["some-id"] }) } // delete-media
+    );
+
+    expect(response.status).toBe(401);
+    expect(mocks.requirePermission).toHaveBeenCalledWith(
+      expect.anything(),
+      "delete",
+      "media"
+    );
+    expect(mocks.mediaService.delete).not.toHaveBeenCalled();
+  });
+
+  it("attributes a create to the authenticated caller, never a client-supplied identity", async () => {
+    mocks.requirePermission.mockResolvedValue({
+      userId: "real-admin",
+      permissions: [],
+      roles: [],
+      authMethod: "session",
+    });
+    mocks.mediaService.createFolder.mockResolvedValue({ id: "folder-1" });
+
+    const handlers = createMediaHandlers({ requireAuth: true });
+    const response = await handlers.POST(
+      new Request("http://localhost/admin/api/media/folders", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        // A spoofed createdBy in the body must be ignored.
+        body: JSON.stringify({ name: "Photos", createdBy: "attacker" }),
+      }),
+      { params: Promise.resolve({ path: ["folders"] }) } // create-folder
+    );
+
+    expect(mocks.requirePermission).toHaveBeenCalledWith(
+      expect.anything(),
+      "create",
+      "media"
+    );
+    expect(response.status).toBe(201);
+
+    // The folder is created for the session user, not the body's `createdBy`.
+    const [, context] = mocks.mediaService.createFolder.mock.calls[0];
+    expect(context.user.id).toBe("real-admin");
   });
 });

--- a/packages/nextly/src/api/media-handlers.ts
+++ b/packages/nextly/src/api/media-handlers.ts
@@ -54,6 +54,11 @@
 
 import { z } from "zod";
 
+import {
+  createJsonErrorResponse,
+  isErrorResponse,
+  requirePermission,
+} from "../auth/middleware";
 import type { SanitizedNextlyConfig } from "../collections/config/define-config";
 import { getService } from "../di";
 import { NextlyError } from "../errors/nextly-error";
@@ -99,25 +104,120 @@ export interface MediaHandlerOptions {
    * instrumentation hasn't run in this worker process.
    */
   config?: SanitizedNextlyConfig;
+  /**
+   * Gate every operation behind a media permission and take the acting
+   * identity from the authenticated session/API key rather than the request
+   * body. Use this for the admin-facing mount (`/admin/api/media`), where the
+   * `Path=/admin` session cookie can reach. The public mount omits it and
+   * serves reads only. Off by default so existing public mounts are unchanged
+   * in shape (their write verbs stop serving — see below).
+   */
+  requireAuth?: boolean;
 }
 
 let handlerConfig: GetNextlyOptions | undefined;
 
 // ============================================================
+// Authorization
+// ============================================================
+
+/**
+ * The media permission action each route requires. Reads gate on `read`,
+ * writes on the verb they perform. `move-media` is an update (it changes the
+ * file's folder), and every `*-folder` mutation gates on the same action as
+ * the equivalent media mutation.
+ */
+const MEDIA_ACTION_BY_ROUTE: Partial<
+  Record<ParsedMediaRoute["type"], "create" | "read" | "update" | "delete">
+> = {
+  "list-media": "read",
+  "get-media": "read",
+  "list-folders": "read",
+  "get-folder": "read",
+  "get-folder-contents": "read",
+  "get-root-contents": "read",
+  "upload-media": "create",
+  "create-folder": "create",
+  "update-media": "update",
+  "move-media": "update",
+  "update-folder": "update",
+  "delete-media": "delete",
+  "delete-folder": "delete",
+  "bulk-delete-media": "delete",
+};
+
+/** Route types that only read — the sole surface the public mount serves. */
+const READ_ROUTE_TYPES = new Set<ParsedMediaRoute["type"]>([
+  "list-media",
+  "get-media",
+  "list-folders",
+  "get-folder",
+  "get-folder-contents",
+  "get-root-contents",
+]);
+
+/**
+ * Gate a parsed route.
+ *
+ * - Public mount (`requireAuth` false): reads pass; any write is not served
+ *   here at all — it 404s exactly like an unknown path, so the public surface
+ *   never exposes a write endpoint. Writes live only on the gated admin mount.
+ * - Admin mount (`requireAuth` true): every operation is checked with
+ *   `requirePermission(req, action, "media")`, which authenticates the session
+ *   or API key and verifies the matching `{action}-media` permission. On
+ *   success the acting user id is returned so writes attribute to the real
+ *   caller, never a client-supplied `uploadedBy`/`createdBy`.
+ *
+ * Returns a `Response` to short-circuit (401/403), or the acting identity.
+ */
+async function gateMediaRoute(
+  request: Request,
+  route: ParsedMediaRoute,
+  path: string[] | undefined,
+  method: string,
+  requireAuth: boolean
+): Promise<{ authUserId?: string } | Response> {
+  if (!requireAuth) {
+    if (!READ_ROUTE_TYPES.has(route.type)) {
+      throwUnmatchedRoute(path, method);
+    }
+    return {};
+  }
+
+  const action = MEDIA_ACTION_BY_ROUTE[route.type];
+  // Unknown/unsupported route type: let the verb switch produce its 404.
+  if (!action) {
+    return {};
+  }
+
+  // The permission check reads from the DI container, so make sure Nextly is
+  // initialised on this worker before it runs.
+  await ensureInitialized();
+  const auth = await requirePermission(request, action, "media");
+  if (isErrorResponse(auth)) {
+    return createJsonErrorResponse(auth);
+  }
+  return { authUserId: auth.userId };
+}
+
+// ============================================================
 // Helper Functions
 // ============================================================
 
-async function getMediaService(): Promise<MediaService> {
-  // Two paths after: if the host called createMediaHandlers({
-  // config }) we have a config to bootstrap with — use getNextly to
-  // initialise the storage plugins on this worker. Otherwise we rely
-  // on whoever set up instrumentation.ts and just look up the cached
-  // instance via getCachedNextly().
+async function ensureInitialized(): Promise<void> {
+  // Two paths: if the host called createMediaHandlers({ config }) we have a
+  // config to bootstrap with — use getNextly to initialise the storage plugins
+  // on this worker. Otherwise we rely on whoever set up instrumentation.ts and
+  // just resolve the cached instance via getCachedNextly().
   if (handlerConfig?.config) {
     await getNextly(handlerConfig);
   } else {
     await getCachedNextly();
   }
+}
+
+async function getMediaService(): Promise<MediaService> {
+  await ensureInitialized();
   return getService("mediaService");
 }
 
@@ -286,43 +386,36 @@ async function handleListMedia(request: Request): Promise<Response> {
   });
 }
 
-async function handleUploadMedia(request: Request): Promise<Response> {
+async function handleUploadMedia(
+  request: Request,
+  authUserId: string
+): Promise<Response> {
   const mediaService = await getMediaService();
   const formData = await request.formData();
   const file = formData.get("file") as File | null;
-  const uploadedBy = formData.get("uploadedBy") as string | null;
   const folderId = formData.get("folderId") as string | null;
 
-  const errors: Array<{ path: string; code: string; message: string }> = [];
+  // The uploader is the authenticated caller, resolved from the session/API
+  // key — never a client-supplied `uploadedBy`, which could name anyone.
+  const uploadedByEnsured = authUserId;
+
   if (!file) {
-    errors.push({
-      path: "file",
-      code: "REQUIRED",
-      message: "file is required.",
+    throw NextlyError.validation({
+      errors: [
+        { path: "file", code: "REQUIRED", message: "file is required." },
+      ],
     });
   }
-  if (!uploadedBy) {
-    errors.push({
-      path: "uploadedBy",
-      code: "REQUIRED",
-      message: "uploadedBy is required.",
-    });
-  }
-  if (errors.length > 0) {
-    throw NextlyError.validation({ errors });
-  }
 
-  const fileEnsured = file as File;
-  const uploadedByEnsured = uploadedBy as string;
-
-  const arrayBuffer = await fileEnsured.arrayBuffer();
+  // `file` is narrowed to File past the guard above.
+  const arrayBuffer = await file.arrayBuffer();
   const buffer = Buffer.from(arrayBuffer);
 
   const input = {
     file: buffer,
-    filename: fileEnsured.name,
-    mimeType: fileEnsured.type,
-    size: fileEnsured.size,
+    filename: file.name,
+    mimeType: file.type,
+    size: file.size,
     uploadedBy: uploadedByEnsured,
   };
 
@@ -338,9 +431,9 @@ async function handleUploadMedia(request: Request): Promise<Response> {
   const mediaFile = await mediaService.upload(
     {
       buffer,
-      filename: fileEnsured.name,
-      mimeType: fileEnsured.type,
-      size: fileEnsured.size,
+      filename: file.name,
+      mimeType: file.type,
+      size: file.size,
       folderId: folderId || undefined,
     },
     context
@@ -438,36 +531,30 @@ async function handleListFolders(request: Request): Promise<Response> {
   return respondData({ folders });
 }
 
-async function handleCreateFolder(request: Request): Promise<Response> {
+async function handleCreateFolder(
+  request: Request,
+  authUserId: string
+): Promise<Response> {
   const mediaService = await getMediaService();
   const body = await readJsonBody<Record<string, unknown>>(request);
 
-  const { createdBy, ...folderInput } = body as {
+  // Ignore any client-supplied `createdBy`; the creator is the authenticated
+  // caller.
+  const { createdBy: _ignoredCreatedBy, ...folderInput } = body as {
     createdBy?: string;
     name?: string;
     [k: string]: unknown;
   };
 
-  const errors: Array<{ path: string; code: string; message: string }> = [];
-  if (!createdBy) {
-    errors.push({
-      path: "createdBy",
-      code: "REQUIRED",
-      message: "createdBy is required.",
-    });
-  }
   if (!folderInput.name) {
-    errors.push({
-      path: "name",
-      code: "REQUIRED",
-      message: "name is required.",
+    throw NextlyError.validation({
+      errors: [
+        { path: "name", code: "REQUIRED", message: "name is required." },
+      ],
     });
-  }
-  if (errors.length > 0) {
-    throw NextlyError.validation({ errors });
   }
 
-  const context = createAuthenticatedContext(createdBy as string);
+  const context = createAuthenticatedContext(authUserId);
   const folder = await mediaService.createFolder(
     folderInput as Parameters<MediaService["createFolder"]>[0],
     context
@@ -551,11 +638,24 @@ export function createMediaHandlers(options?: MediaHandlerOptions) {
   if (options?.config) {
     handlerConfig = { config: options.config };
   }
+  // Captured per-instance, not module-level: one process can mount both a
+  // public (reads only) and an admin (gated) instance, so this must not leak
+  // between them.
+  const requireAuth = options?.requireAuth ?? false;
+
   return {
     GET: withErrorHandler(
       async (request: Request, ctx: RouteContext): Promise<Response> => {
         const resolvedParams = await ctx.params;
         const route = parseMediaRoute(resolvedParams.path, "GET");
+        const gate = await gateMediaRoute(
+          request,
+          route,
+          resolvedParams.path,
+          "GET",
+          requireAuth
+        );
+        if (gate instanceof Response) return gate;
 
         let response: Response;
         switch (route.type) {
@@ -589,14 +689,22 @@ export function createMediaHandlers(options?: MediaHandlerOptions) {
       async (request: Request, ctx: RouteContext): Promise<Response> => {
         const resolvedParams = await ctx.params;
         const route = parseMediaRoute(resolvedParams.path, "POST");
+        const gate = await gateMediaRoute(
+          request,
+          route,
+          resolvedParams.path,
+          "POST",
+          requireAuth
+        );
+        if (gate instanceof Response) return gate;
 
         let response: Response;
         switch (route.type) {
           case "upload-media":
-            response = await handleUploadMedia(request);
+            response = await handleUploadMedia(request, gate.authUserId!);
             break;
           case "create-folder":
-            response = await handleCreateFolder(request);
+            response = await handleCreateFolder(request, gate.authUserId!);
             break;
           default:
             throwUnmatchedRoute(resolvedParams.path, "POST");
@@ -610,6 +718,14 @@ export function createMediaHandlers(options?: MediaHandlerOptions) {
       async (request: Request, ctx: RouteContext): Promise<Response> => {
         const resolvedParams = await ctx.params;
         const route = parseMediaRoute(resolvedParams.path, "PATCH");
+        const gate = await gateMediaRoute(
+          request,
+          route,
+          resolvedParams.path,
+          "PATCH",
+          requireAuth
+        );
+        if (gate instanceof Response) return gate;
 
         let response: Response;
         switch (route.type) {
@@ -634,6 +750,14 @@ export function createMediaHandlers(options?: MediaHandlerOptions) {
       async (request: Request, ctx: RouteContext): Promise<Response> => {
         const resolvedParams = await ctx.params;
         const route = parseMediaRoute(resolvedParams.path, "DELETE");
+        const gate = await gateMediaRoute(
+          request,
+          route,
+          resolvedParams.path,
+          "DELETE",
+          requireAuth
+        );
+        if (gate instanceof Response) return gate;
 
         let response: Response;
         switch (route.type) {

--- a/packages/nextly/src/domains/auth/services/permission-seed-service.ts
+++ b/packages/nextly/src/domains/auth/services/permission-seed-service.ts
@@ -121,6 +121,13 @@ const SYSTEM_PERMISSIONS: SystemPermissionDef[] = [
     description: "Permission to view media files",
   },
   {
+    name: "Update Media",
+    slug: "update-media",
+    action: "update",
+    resource: "media",
+    description: "Permission to edit media metadata and move files",
+  },
+  {
     name: "Delete Media",
     slug: "delete-media",
     action: "delete",


### PR DESCRIPTION
## What & why

Media writes were **open to the entire internet**. `/api/media` had no authentication at all — an anonymous `DELETE /api/media/:id` returned 200 and removed the row *and the file on disk*; anyone could also upload (as any user) and edit. This closes that hole.

Reproduced before the fix (no credentials): `DELETE /api/media/:id` → 200, file gone. The write verbs are now gone from the public path.

## Approach (founder decision: Option B + `update-media`)

The reason media had no auth: the admin **session cookie is scoped `Path=/admin`**, so it never reached `/api/media`. Adding a guard there would 401 the admin's own uploads (this was tried and reverted). So the fix moves the **management surface under `/admin`**, where the session authenticates:

- **`/admin/api/media`** (new, gated): every operation checked with `requirePermission(req, action, "media")`; the acting identity comes from the **session/API key**, never a client-supplied `uploadedBy`/`createdBy`.
- **`/api/media`** stays public but **reads only** (`GET`) — files are served to anonymous visitors. Its write verbs no longer serve.
- The gated handler is the same tested `createMediaHandlers`, now with a `requireAuth` option — no rewrite of the dispatcher, and it inherits the same `SameSite`-cookie CSRF posture as the rest of the admin CRUD API.
- Adds a real **`update-media`** permission (media had create/read/delete but no update); `PATCH`/move gate on it. Built-in Admin/Editor/Author roles pick it up by rule; Viewer does not.

**Asset URLs are unchanged** — the `url` field stays public with no `/admin` prefix (verified).

## Verification (live, against the running playground)

| Check | Result |
|---|---|
| Anonymous `DELETE`/`POST`/`PATCH /api/media` | **405** (was 200 + file deleted) |
| Anonymous `/admin/api/media` | **401 AUTH_REQUIRED** (route resolves, not shadowed by the `/admin/api` catch-all) |
| Public `GET /api/media` | **200** (reads unchanged) |
| Authenticated admin `GET /admin/api/media` | **200 + media** |
| Authenticated admin write with no body | **400 validation** (i.e. *past* the auth gate — a real upload would 201) |
| Asset `url` field | no `/admin` prefix |

Plus 4 unit tests: public mount refuses writes (permission never consulted), gated mount 401s the unauthenticated, and a create is attributed to the session user while a **spoofed `createdBy` in the body is ignored**.

## Notes for review

- No new test failures vs. clean `main` (the `api-key-token-types` / transaction-integration failures are the pre-existing `failed_login_attempts` DDL-drift baseline, unchanged).
- **Consumer action** (documented in the changeset): mount `createMediaHandlers({ config, requireAuth: true })` at `app/admin/api/media/[[...path]]/route.ts`, keep the public `GET`-only instance at `app/api/media/[[...path]]/route.ts`.
- Unblocks the `manage`-semantics decision (the media permission set is no longer decorative). The audit of other consumer-mounted handlers for the same pattern is still open (follow-up).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permission-protected media management for uploads, folder creation, updates, moves, and deletions.
  * Added a built-in **Update Media** permission.
  * Public media access is now read-only.
  * Media changes are attributed to the authenticated administrator automatically.

* **Bug Fixes**
  * Prevented unauthorized media modifications and client-supplied ownership attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->