### PR TITLE
test(nextly): make schema-events journal fixtures use the production DDL

### DIFF
--- a/packages/nextly/src/domains/schema/journal/__tests__/migration-journal-roundtrip.integration.test.ts
+++ b/packages/nextly/src/domains/schema/journal/__tests__/migration-journal-roundtrip.integration.test.ts
@@ -10,6 +10,7 @@ import { Pool } from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { makeTestContext } from "../../../../database/__tests__/integration/helpers/test-db";
+import { getSchemaEventsDdl } from "../../events/schema-events-ddl";
 import { SchemaEventsRepository } from "../../events/schema-events-repository";
 import { DrizzleMigrationJournal } from "../migration-journal";
 
@@ -28,33 +29,11 @@ describe("DrizzleMigrationJournal → nextly_schema_events roundtrip (real PG)",
     pool = new Pool({ connectionString: ctx.url ?? undefined });
     db = drizzle(pool);
 
-    // Create the events table from raw SQL mirroring schema-events/postgres.ts.
+    // Create the events table via the production DDL so this fixture can
+    // never drift from the real schema (a hand-copy previously dropped the
+    // `note` column and the suite failed against a real Postgres).
     await pool.query('DROP TABLE IF EXISTS "nextly_schema_events"');
-    await pool.query(`
-      CREATE TABLE "nextly_schema_events" (
-        "id" text PRIMARY KEY,
-        "event_type" text NOT NULL,
-        "status" text NOT NULL,
-        "source" text NOT NULL,
-        "filename" text,
-        "sha256" text,
-        "scope_kind" text,
-        "scope_slug" text,
-        "started_at" timestamptz NOT NULL DEFAULT NOW(),
-        "ended_at" timestamptz,
-        "duration_ms" integer,
-        "applied_by" text,
-        "statements_planned" integer,
-        "statements_executed" integer,
-        "renames_applied" integer,
-        "error_code" text,
-        "error_message" text,
-        "error_json" jsonb,
-        "superseded_event_ids" jsonb,
-        "superseded_at" timestamptz,
-        "superseded_by" text
-      )
-    `);
+    for (const stmt of getSchemaEventsDdl("postgresql")) await pool.query(stmt);
   });
 
   afterAll(async () => {
@@ -96,7 +75,9 @@ describe("DrizzleMigrationJournal → nextly_schema_events roundtrip (real PG)",
     expect(row?.scopeSlug).toBe("posts");
     expect(row?.statementsExecuted).toBe(3);
     // Only renames are carried over from the journal summary (§4.3).
-    expect((row as { renamesApplied?: number } | undefined)?.renamesApplied).toBe(1);
+    expect(
+      (row as { renamesApplied?: number } | undefined)?.renamesApplied
+    ).toBe(1);
   });
 
   it("maps fresh-push scope → global (events has no fresh-push kind)", async () => {

--- a/packages/nextly/src/domains/schema/journal/__tests__/read-journal.integration.test.ts
+++ b/packages/nextly/src/domains/schema/journal/__tests__/read-journal.integration.test.ts
@@ -13,6 +13,7 @@ import { Pool } from "pg";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { makeTestContext } from "../../../../database/__tests__/integration/helpers/test-db";
+import { getSchemaEventsDdl } from "../../events/schema-events-ddl";
 import { readJournal } from "../read-journal";
 
 const ctx = makeTestContext("postgresql");
@@ -30,32 +31,11 @@ describe("readJournal — real-PG integration (nextly_schema_events)", () => {
     pool = new Pool({ connectionString: ctx.url ?? undefined });
     db = drizzle(pool);
 
+    // Create the events table via the production DDL so this fixture can
+    // never drift from the real schema (a hand-copy previously dropped the
+    // `note` column and this suite failed against a real Postgres).
     await pool.query('DROP TABLE IF EXISTS "nextly_schema_events"');
-    await pool.query(`
-      CREATE TABLE "nextly_schema_events" (
-        "id" text PRIMARY KEY,
-        "event_type" text NOT NULL,
-        "status" text NOT NULL,
-        "source" text NOT NULL,
-        "filename" text,
-        "sha256" text,
-        "scope_kind" text,
-        "scope_slug" text,
-        "started_at" timestamptz NOT NULL,
-        "ended_at" timestamptz,
-        "duration_ms" integer,
-        "applied_by" text,
-        "statements_planned" integer,
-        "statements_executed" integer,
-        "renames_applied" integer,
-        "error_code" text,
-        "error_message" text,
-        "error_json" jsonb,
-        "superseded_event_ids" jsonb,
-        "superseded_at" timestamptz,
-        "superseded_by" text
-      )
-    `);
+    for (const stmt of getSchemaEventsDdl("postgresql")) await pool.query(stmt);
   });
 
   afterAll(async () => {
@@ -136,7 +116,10 @@ describe("readJournal — real-PG integration (nextly_schema_events)", () => {
   });
 
   it("hasMore=false when total rows fit in one page", async () => {
-    await seedRows({ count: 5, baseTime: new Date("2026-04-29T18:00:00.000Z") });
+    await seedRows({
+      count: 5,
+      baseTime: new Date("2026-04-29T18:00:00.000Z"),
+    });
     const result = await readJournal({ db, dialect: "postgresql", limit: 20 });
     expect(result.rows).toHaveLength(5);
     expect(result.hasMore).toBe(false);

--- a/packages/nextly/src/schemas/schema-events/__tests__/columns.test.ts
+++ b/packages/nextly/src/schemas/schema-events/__tests__/columns.test.ts
@@ -5,7 +5,26 @@
 import { getTableColumns, getTableName } from "drizzle-orm";
 import { describe, it, expect } from "vitest";
 
+import { getSchemaEventsDdl } from "../../../domains/schema/events/schema-events-ddl";
 import { nextlySchemaEventsPg } from "../postgres";
+
+/**
+ * Pull the column names out of a `CREATE TABLE ( ... )` statement: the first
+ * token on each line inside the parentheses. Good enough for our own DDL,
+ * whose column list is one-per-line.
+ */
+function ddlColumnNames(createTableStmt: string): string[] {
+  const body = createTableStmt.slice(
+    createTableStmt.indexOf("(") + 1,
+    createTableStmt.lastIndexOf(")")
+  );
+  return body
+    .split("\n")
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => line.split(/[\s(]/)[0].replace(/["`]/g, ""))
+    .filter(tok => /^[a-z_][a-z0-9_]*$/.test(tok));
+}
 
 const EXPECTED_COLUMNS = [
   "id",
@@ -62,3 +81,18 @@ describe.each([
     expect(names).toEqual(EXPECTED_COLUMNS);
   });
 });
+
+// The raw DDL (getSchemaEventsDdl) is a second, hand-written copy of the
+// table used by `nextly upgrade` and by integration-test setup. It once
+// drifted from the model (a missing `note` column), so pin it to the same
+// canonical column set per dialect — any divergence now fails CI here, in a
+// unit test that needs no database.
+describe.each(["postgresql", "mysql", "sqlite"] as const)(
+  "getSchemaEventsDdl — %s stays in sync with the model",
+  dialect => {
+    it("creates exactly the canonical columns", () => {
+      const createTable = getSchemaEventsDdl(dialect)[0];
+      expect(ddlColumnNames(createTable).sort()).toEqual(EXPECTED_COLUMNS);
+    });
+  }
+);

--- a/packages/nextly/vitest.integration.config.ts
+++ b/packages/nextly/vitest.integration.config.ts
@@ -36,5 +36,13 @@ export default defineConfig({
         singleFork: true,
       },
     },
+    // singleFork keeps everything in one process, but vitest still interleaves
+    // test files within it by default. The suites that exercise system tables
+    // with a fixed name (`nextly_schema_events`) cannot use the per-file table
+    // prefix, so two of them running at once drop and recreate the same table
+    // out from under each other. Running files sequentially is the "conservative"
+    // behavior the note above intends and makes that class of collision
+    // impossible.
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
## Summary

Follow-up flagged in #179: the `nextly_schema_events` "DDL drift." I researched it first (single-source-of-truth for schema; DRY) — and the honest diagnosis is **not** a production bug. `getSchemaEventsDdl()` (the DDL production uses) is correct. The drift lived in **test fixtures**: two journal integration tests hand-copied their own `CREATE TABLE nextly_schema_events (...)` and it went stale (missing the `note` column), so they failed against a real Postgres while passing with none.

Per the research (and matching what the other event suites already do), the fix is to **reuse the production DDL, not re-type it** — adding `note` back would just reset the drift clock.

## What changed

1. **Both journal fixtures now call `getSchemaEventsDdl("postgresql")`** instead of a hand-written `CREATE TABLE`. Three copies of the table definition → two, and this copy can no longer drift. (Three other event suites already do exactly this.)

2. **`fileParallelism: false`** in the integration vitest config. Fixing #1 *revealed* a pre-existing isolation bug it had masked: vitest still interleaves test files inside the single fork, and the suites keyed on the fixed `nextly_schema_events` name (which can't use the per-file table prefix the other tests use) drop/recreate the table out from under each other. The config comment already said *"Sequential is conservative"* — but only `singleFork` was set, which doesn't stop file interleaving. This completes that intent.

3. **A parity guard** (`columns.test.ts`, runs with no database): asserts `getSchemaEventsDdl` emits exactly the model's column set **for every dialect**, so the remaining hand-written copy can't drift from the Drizzle model either. Verified it *catches* the drift (re-dropping `note` fails it).

## Verified

- Both journal suites pass against a real **postgres:17** (throwaway container); with sequential files the full nextly integration suite is **60 passed / 3 failed / 2 skipped** vs pg — down from many-broken.
- Integration suite with **no DB**: 55 passed / 10 skipped / 0 failed.
- `columns.test.ts`: 8 passing (incl. the 3 new per-dialect DDL-parity assertions); proven to fail when the DDL drifts.
- `pnpm turbo check-types lint --filter=nextly`: pass.

## Deliberately NOT in this PR (the real blocker to wiring nextly into the CI postgres leg)

The 3 remaining pg failures are **pre-existing and unrelated to schema-events** (confirmed by stashing my changes on clean `main`):
- `pushschema-pipeline.integration.test.ts` + `pushschema-pipeline-option-e.integration.test.ts` — fail with *"Interactive prompts require a TTY terminal"*: they drive the interactive push pipeline, which needs a non-interactive PromptDispatcher injected before it can run in CI.
- `notifications-pipeline.integration.test.ts` — one test (`fires a failure event when the executor throws`) fails a real assertion (`expected true to be false`).

Wiring nextly's full integration suite into the postgres CI leg is blocked on those. Recommend a dedicated follow-up for the interactive-pipeline tests + that one assertion; this PR removes the schema-events drift and its guard so that work starts from a clean base.

## Changeset

Skipped — test + test-config only; the published package ships `dist/` (no tests). Consistent with #179.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration tests to use the production schema definition when creating test tables.
  * Added coverage to verify schema columns remain consistent across PostgreSQL, MySQL, and SQLite.
  * Improved integration test stability by preventing conflicting test files from running in parallel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->