### PR TITLE
feat(admin): field-ui kit on the plugin author surface

### DIFF
--- a/.changeset/field-ui-primitives.md
+++ b/.changeset/field-ui-primitives.md
@@ -1,0 +1,30 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Plugins can now build field-editing UI from the same components the admin uses.
+
+**New in `@nextlyhq/plugin-sdk/admin` (experimental): the field-UI kit.** Three controlled, form-library-agnostic components, following the same author surface as the shared DataTable:
+
+- **`FieldTypePicker`** — a grid of type cards rendered from `nextly/field-catalog`, narrowed to your surface's allowed types, with the same label, hint, and icon for a type everywhere it appears.
+- **`FieldOptionsEditor`** — the schema builder's options editor: label/value rows with drag reorder, values auto-generated from labels until edited, CSV/JSON import, and select/radio display knobs.
+- **`FieldDefaultValueInput`** — a type-aware default control: checkbox defaults are a true/false choice, select/radio defaults choose among the field's own options, number and date get typed inputs.
+
+**The options editor now reports every duplicate value at once.** Previously a batch of colliding option values surfaced one collision at a time — fix one, resubmit, discover the next. All duplicated values are now named together in a single warning.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -47,10 +47,13 @@ jobs:
             storage-vercel-blob
             storage-uploadthing
             plugin-form-builder
+            plugin-page-builder
+            plugin-sdk
             create-nextly-app
             eslint-config
             prettier-config
             tsconfig
+            telemetry
             playground
             root
             ci

--- a/packages/admin/src/components/features/schema-builder/SelectOptionsEditor.tsx
+++ b/packages/admin/src/components/features/schema-builder/SelectOptionsEditor.tsx
@@ -49,7 +49,7 @@ import {
   TabsTrigger,
   Textarea,
 } from "@nextlyhq/ui";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 
 import * as Icons from "@admin/components/icons";
 import { FormLabelWithTooltip } from "@admin/components/ui/form-label-with-tooltip";
@@ -247,6 +247,21 @@ export function SelectOptionsEditor({
     })
   );
 
+  // Every stored value that appears more than once, so a batch of collisions
+  // is reported whole — fixing one duplicate must not reveal the next as a
+  // surprise on resubmit.
+  const duplicateValues = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const option of options) {
+      const value = option.value.trim();
+      if (!value) continue;
+      counts.set(value, (counts.get(value) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .filter(([, count]) => count > 1)
+      .map(([value]) => value);
+  }, [options]);
+
   // Add a new empty option
   const handleAddOption = useCallback(() => {
     const newOption: SelectOption = {
@@ -398,6 +413,16 @@ export function SelectOptionsEditor({
         // 2026-05-04 Option B locked this shape.
         <p className="text-xs text-muted-foreground">
           No options yet -- click + Add or Import above.
+        </p>
+      )}
+
+      {/* Duplicate stored values make a select ambiguous; name every
+          collision at once rather than the first one found. */}
+      {duplicateValues.length > 0 && (
+        <p role="alert" className="text-xs text-destructive">
+          Duplicate values:{" "}
+          {duplicateValues.map(value => `"${value}"`).join(", ")}. Each
+          option&apos;s stored value must be unique.
         </p>
       )}
 

--- a/packages/admin/src/components/features/schema-builder/__tests__/SelectOptionsEditor.test.tsx
+++ b/packages/admin/src/components/features/schema-builder/__tests__/SelectOptionsEditor.test.tsx
@@ -8,6 +8,47 @@ import { render, screen } from "@admin/__tests__/utils";
 
 import { SelectOptionsEditor } from "../SelectOptionsEditor";
 
+describe("SelectOptionsEditor -- duplicate value reporting", () => {
+  it("names every duplicated value at once, not just the first collision", () => {
+    render(
+      <SelectOptionsEditor
+        options={[
+          { id: "1", label: "Red", value: "red" },
+          { id: "2", label: "Crimson", value: "red" },
+          { id: "3", label: "Blue", value: "blue" },
+          { id: "4", label: "Navy", value: "blue" },
+          { id: "5", label: "Green", value: "green" },
+        ]}
+        onOptionsChange={vi.fn()}
+        fieldType="select"
+        onIsClearableChange={vi.fn()}
+        onPlaceholderChange={vi.fn()}
+      />
+    );
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent('"red"');
+    expect(alert).toHaveTextContent('"blue"');
+    expect(alert).not.toHaveTextContent('"green"');
+  });
+
+  it("shows no duplicate warning when values are unique or blank", () => {
+    render(
+      <SelectOptionsEditor
+        options={[
+          { id: "1", label: "Red", value: "red" },
+          { id: "2", label: "", value: "" },
+          { id: "3", label: "", value: "" },
+        ]}
+        onOptionsChange={vi.fn()}
+        fieldType="select"
+        onIsClearableChange={vi.fn()}
+        onPlaceholderChange={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});
+
 describe("SelectOptionsEditor -- PR E3 admin knobs", () => {
   describe("select fieldType", () => {
     it("renders the Clearable switch and reports onIsClearableChange", async () => {

--- a/packages/admin/src/components/field-ui/FieldDefaultValueInput.tsx
+++ b/packages/admin/src/components/field-ui/FieldDefaultValueInput.tsx
@@ -8,12 +8,22 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@nextlyhq/ui";
+import { useMemo } from "react";
 
 /**
  * Radix Select rejects an empty-string item value, so "no default" is a
- * sentinel translated back to "" at the onChange boundary.
+ * sentinel translated back to "" at the onChange boundary. The base spelling
+ * is extended until it collides with no real option value, so an option
+ * literally valued "__none__" still selects itself instead of clearing the
+ * default.
  */
-const NO_DEFAULT = "__none__";
+const NO_DEFAULT_BASE = "__none__";
+
+function uncollidedSentinel(values: ReadonlySet<string>): string {
+  let sentinel = NO_DEFAULT_BASE;
+  while (values.has(sentinel)) sentinel += "_";
+  return sentinel;
+}
 
 export interface FieldDefaultOption {
   label: string;
@@ -52,18 +62,30 @@ export function FieldDefaultValueInput({
   disabled,
   ariaLabel = "Default value",
 }: FieldDefaultValueInputProps) {
+  const validOptions = useMemo(
+    () => options.filter(option => option.value.trim()),
+    [options]
+  );
+  const noDefault = useMemo(
+    () =>
+      uncollidedSentinel(
+        new Set(["true", "false", ...validOptions.map(option => option.value)])
+      ),
+    [validOptions]
+  );
+
   if (fieldType === "checkbox") {
     return (
       <Select
-        value={value || NO_DEFAULT}
-        onValueChange={val => onChange(val === NO_DEFAULT ? "" : val)}
+        value={value || noDefault}
+        onValueChange={val => onChange(val === noDefault ? "" : val)}
         disabled={disabled}
       >
         <SelectTrigger aria-label={ariaLabel}>
           <SelectValue placeholder="No default" />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value={NO_DEFAULT}>No default</SelectItem>
+          <SelectItem value={noDefault}>No default</SelectItem>
           <SelectItem value="true">Checked (true)</SelectItem>
           <SelectItem value="false">Unchecked (false)</SelectItem>
         </SelectContent>
@@ -71,22 +93,21 @@ export function FieldDefaultValueInput({
     );
   }
 
-  const validOptions = options.filter(option => option.value.trim());
   if (
     (fieldType === "select" || fieldType === "radio") &&
     validOptions.length > 0
   ) {
     return (
       <Select
-        value={value || NO_DEFAULT}
-        onValueChange={val => onChange(val === NO_DEFAULT ? "" : val)}
+        value={value || noDefault}
+        onValueChange={val => onChange(val === noDefault ? "" : val)}
         disabled={disabled}
       >
         <SelectTrigger aria-label={ariaLabel}>
           <SelectValue placeholder="No default" />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value={NO_DEFAULT}>No default</SelectItem>
+          <SelectItem value={noDefault}>No default</SelectItem>
           {validOptions.map(option => (
             <SelectItem key={option.value} value={option.value}>
               {option.label || option.value}

--- a/packages/admin/src/components/field-ui/FieldDefaultValueInput.tsx
+++ b/packages/admin/src/components/field-ui/FieldDefaultValueInput.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import {
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@nextlyhq/ui";
+
+/**
+ * Radix Select rejects an empty-string item value, so "no default" is a
+ * sentinel translated back to "" at the onChange boundary.
+ */
+const NO_DEFAULT = "__none__";
+
+export interface FieldDefaultOption {
+  label: string;
+  value: string;
+}
+
+export interface FieldDefaultValueInputProps {
+  /**
+   * The field type whose default is being edited. Drives the control:
+   * checkbox → true/false select; select/radio with options → a select of
+   * those options; number/date → a typed input; anything else → text.
+   */
+  fieldType: string;
+  /** Options for select/radio types; ignored otherwise. */
+  options?: readonly FieldDefaultOption[];
+  /** The default value as a string; "" means no default. */
+  value: string;
+  /** Called with the new default; "" when cleared. */
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  /** Accessible name for the control. */
+  ariaLabel?: string;
+}
+
+/**
+ * Type-aware default-value control, controlled and form-library agnostic.
+ * Every surface that lets a field declare a default renders this, so a
+ * checkbox default is always the same true/false choice and a select default
+ * is always a choice among the field's own options.
+ */
+export function FieldDefaultValueInput({
+  fieldType,
+  options = [],
+  value,
+  onChange,
+  disabled,
+  ariaLabel = "Default value",
+}: FieldDefaultValueInputProps) {
+  if (fieldType === "checkbox") {
+    return (
+      <Select
+        value={value || NO_DEFAULT}
+        onValueChange={val => onChange(val === NO_DEFAULT ? "" : val)}
+        disabled={disabled}
+      >
+        <SelectTrigger aria-label={ariaLabel}>
+          <SelectValue placeholder="No default" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={NO_DEFAULT}>No default</SelectItem>
+          <SelectItem value="true">Checked (true)</SelectItem>
+          <SelectItem value="false">Unchecked (false)</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+  }
+
+  const validOptions = options.filter(option => option.value.trim());
+  if (
+    (fieldType === "select" || fieldType === "radio") &&
+    validOptions.length > 0
+  ) {
+    return (
+      <Select
+        value={value || NO_DEFAULT}
+        onValueChange={val => onChange(val === NO_DEFAULT ? "" : val)}
+        disabled={disabled}
+      >
+        <SelectTrigger aria-label={ariaLabel}>
+          <SelectValue placeholder="No default" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={NO_DEFAULT}>No default</SelectItem>
+          {validOptions.map(option => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label || option.value}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  }
+
+  return (
+    <Input
+      type={
+        fieldType === "number"
+          ? "number"
+          : fieldType === "date"
+            ? "date"
+            : "text"
+      }
+      placeholder={fieldType === "date" ? "" : "Enter default value"}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      value={value}
+      onChange={event => onChange(event.target.value)}
+    />
+  );
+}

--- a/packages/admin/src/components/field-ui/FieldTypePicker.tsx
+++ b/packages/admin/src/components/field-ui/FieldTypePicker.tsx
@@ -26,6 +26,8 @@ export interface FieldTypePickerProps<T extends CatalogFieldType> {
   disabled?: boolean;
   /** Grid columns; surfaces with wider layouts pass more. */
   columns?: 2 | 3 | 4;
+  /** Accessible name for the radio group. */
+  ariaLabel?: string;
 }
 
 /**
@@ -40,6 +42,7 @@ export function FieldTypePicker<T extends CatalogFieldType>({
   onChange,
   disabled,
   columns = 2,
+  ariaLabel = "Field type",
 }: FieldTypePickerProps<T>) {
   const entries = useMemo(() => narrowFieldTypeCatalog(types), [types]);
 
@@ -49,8 +52,34 @@ export function FieldTypePicker<T extends CatalogFieldType>({
     4: "grid-cols-2 md:grid-cols-4",
   }[columns];
 
+  // Standard radio-group keyboard model: the group is one tab stop (the
+  // selected card), and arrow keys move + select within it.
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (disabled || entries.length === 0) return;
+    const forward = event.key === "ArrowRight" || event.key === "ArrowDown";
+    const backward = event.key === "ArrowLeft" || event.key === "ArrowUp";
+    if (!forward && !backward) return;
+    event.preventDefault();
+    const currentIndex = Math.max(
+      0,
+      entries.findIndex(entry => entry.type === value)
+    );
+    const nextIndex =
+      (currentIndex + (forward ? 1 : -1) + entries.length) % entries.length;
+    const nextType = entries[nextIndex].type;
+    onChange(nextType);
+    event.currentTarget
+      .querySelector<HTMLButtonElement>(`[data-type="${nextType}"]`)
+      ?.focus();
+  };
+
   return (
-    <div role="radiogroup" className={cn("grid gap-3", gridColumns)}>
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className={cn("grid gap-3", gridColumns)}
+      onKeyDown={handleKeyDown}
+    >
       {entries.map(entry => {
         const Icon =
           (Icons as Record<string, React.ElementType>)[entry.icon] ?? Type;
@@ -60,7 +89,9 @@ export function FieldTypePicker<T extends CatalogFieldType>({
             key={entry.type}
             type="button"
             role="radio"
+            data-type={entry.type}
             aria-checked={isSelected}
+            tabIndex={isSelected ? 0 : -1}
             disabled={disabled}
             onClick={() => onChange(entry.type)}
             className={cn(

--- a/packages/admin/src/components/field-ui/FieldTypePicker.tsx
+++ b/packages/admin/src/components/field-ui/FieldTypePicker.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { narrowFieldTypeCatalog } from "nextly/field-catalog";
+import type { FieldTypeCatalogEntry } from "nextly/field-catalog";
+import type React from "react";
+import { useMemo } from "react";
+
+import * as Icons from "@admin/components/icons";
+import { Check, Type } from "@admin/components/icons";
+import { cn } from "@admin/lib/utils";
+
+/**
+ * The catalog's `FieldType` union, re-derived here so the picker can be
+ * generic over any surface's subset without importing server types.
+ */
+type CatalogFieldType = FieldTypeCatalogEntry["type"];
+
+export interface FieldTypePickerProps<T extends CatalogFieldType> {
+  /** The surface's allowed types; entries render in catalog order. */
+  types: readonly T[];
+  /** The selected type. */
+  value: T;
+  /** Called with the newly selected type. */
+  onChange: (type: T) => void;
+  /** Disable every card (read-only surfaces, locked identity in edit). */
+  disabled?: boolean;
+  /** Grid columns; surfaces with wider layouts pass more. */
+  columns?: 2 | 3 | 4;
+}
+
+/**
+ * Catalog-driven field-type picker: a grid of cards, one per allowed type,
+ * rendered from `nextly/field-catalog` so every surface shows the same
+ * label, hint, and icon for the same type. Controlled and form-library
+ * agnostic — wrap it in react-hook-form or plain state alike.
+ */
+export function FieldTypePicker<T extends CatalogFieldType>({
+  types,
+  value,
+  onChange,
+  disabled,
+  columns = 2,
+}: FieldTypePickerProps<T>) {
+  const entries = useMemo(() => narrowFieldTypeCatalog(types), [types]);
+
+  const gridColumns = {
+    2: "grid-cols-2",
+    3: "grid-cols-2 md:grid-cols-3",
+    4: "grid-cols-2 md:grid-cols-4",
+  }[columns];
+
+  return (
+    <div role="radiogroup" className={cn("grid gap-3", gridColumns)}>
+      {entries.map(entry => {
+        const Icon =
+          (Icons as Record<string, React.ElementType>)[entry.icon] ?? Type;
+        const isSelected = value === entry.type;
+        return (
+          <button
+            key={entry.type}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            disabled={disabled}
+            onClick={() => onChange(entry.type)}
+            className={cn(
+              "relative flex flex-row items-center gap-4 rounded-none border p-4 text-left transition-all duration-200",
+              isSelected
+                ? "border-primary bg-primary/5"
+                : "border-border hover-unified",
+              disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer"
+            )}
+          >
+            {isSelected && (
+              <div className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-none bg-primary text-primary-foreground">
+                <Check className="h-3 w-3" />
+              </div>
+            )}
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-none border border-border bg-primary/5 text-primary">
+              <Icon className="h-5 w-5" />
+            </div>
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <span
+                className={cn(
+                  "truncate text-sm font-semibold",
+                  isSelected ? "text-primary" : "text-foreground"
+                )}
+              >
+                {entry.label}
+              </span>
+              <span className="line-clamp-1 text-[12px] leading-normal text-muted-foreground">
+                {entry.hint}
+              </span>
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/admin/src/components/field-ui/field-ui.test.tsx
+++ b/packages/admin/src/components/field-ui/field-ui.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { FieldDefaultValueInput } from "./FieldDefaultValueInput";
+import { FieldTypePicker } from "./FieldTypePicker";
+
+describe("FieldTypePicker", () => {
+  const types = ["text", "number", "date"] as const;
+
+  it("renders one radio card per allowed type, in catalog order with catalog labels", () => {
+    render(<FieldTypePicker types={types} value="text" onChange={() => {}} />);
+    const radios = screen.getAllByRole("radio");
+    expect(radios.map(r => r.textContent)).toEqual([
+      expect.stringContaining("Text"),
+      expect.stringContaining("Number"),
+      expect.stringContaining("Date"),
+    ]);
+    // Catalog hints render, so every surface describes a type identically.
+    expect(screen.getByText("Single-line input")).toBeInTheDocument();
+    expect(screen.getByText("Integer or decimal")).toBeInTheDocument();
+  });
+
+  it("marks the selected type and reports a change on click", () => {
+    const onChange = vi.fn();
+    render(<FieldTypePicker types={types} value="text" onChange={onChange} />);
+    expect(screen.getByRole("radio", { checked: true })).toHaveTextContent(
+      "Text"
+    );
+    fireEvent.click(screen.getByRole("radio", { name: /Number/ }));
+    expect(onChange).toHaveBeenCalledWith("number");
+  });
+
+  it("disables every card when disabled", () => {
+    const onChange = vi.fn();
+    render(
+      <FieldTypePicker
+        types={types}
+        value="text"
+        onChange={onChange}
+        disabled
+      />
+    );
+    for (const radio of screen.getAllByRole("radio")) {
+      expect(radio).toBeDisabled();
+    }
+    fireEvent.click(screen.getByRole("radio", { name: /Number/ }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("FieldDefaultValueInput", () => {
+  it("renders a true/false choice for checkbox", () => {
+    render(
+      <FieldDefaultValueInput
+        fieldType="checkbox"
+        value=""
+        onChange={() => {}}
+      />
+    );
+    expect(
+      screen.getByRole("combobox", { name: "Default value" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders the field's own options for select", () => {
+    render(
+      <FieldDefaultValueInput
+        fieldType="select"
+        options={[
+          { label: "Red", value: "red" },
+          { label: "", value: "  " },
+        ]}
+        value="red"
+        onChange={() => {}}
+      />
+    );
+    // The blank-valued option is not offered; the current value renders.
+    expect(screen.getByRole("combobox")).toHaveTextContent("Red");
+  });
+
+  it("falls back to a typed input and echoes changes for number", () => {
+    const onChange = vi.fn();
+    render(
+      <FieldDefaultValueInput
+        fieldType="number"
+        value="5"
+        onChange={onChange}
+      />
+    );
+    const input = screen.getByRole("spinbutton", { name: "Default value" });
+    fireEvent.change(input, { target: { value: "7" } });
+    expect(onChange).toHaveBeenCalledWith("7");
+  });
+
+  it("renders a select with no options as a text input rather than an empty menu", () => {
+    render(
+      <FieldDefaultValueInput fieldType="select" value="" onChange={() => {}} />
+    );
+    expect(
+      screen.getByRole("textbox", { name: "Default value" })
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/field-ui/field-ui.test.tsx
+++ b/packages/admin/src/components/field-ui/field-ui.test.tsx
@@ -30,6 +30,26 @@ describe("FieldTypePicker", () => {
     expect(onChange).toHaveBeenCalledWith("number");
   });
 
+  it("names the group and moves selection with arrow keys (roving tabindex)", () => {
+    const onChange = vi.fn();
+    render(<FieldTypePicker types={types} value="text" onChange={onChange} />);
+    const group = screen.getByRole("radiogroup", { name: "Field type" });
+    // One tab stop: the selected card; the rest are removed from tab order.
+    expect(screen.getByRole("radio", { name: /Text/ })).toHaveAttribute(
+      "tabindex",
+      "0"
+    );
+    expect(screen.getByRole("radio", { name: /Number/ })).toHaveAttribute(
+      "tabindex",
+      "-1"
+    );
+    fireEvent.keyDown(group, { key: "ArrowRight" });
+    expect(onChange).toHaveBeenCalledWith("number");
+    // Backward from the first entry wraps to the last.
+    fireEvent.keyDown(group, { key: "ArrowUp" });
+    expect(onChange).toHaveBeenCalledWith("date");
+  });
+
   it("disables every card when disabled", () => {
     const onChange = vi.fn();
     render(
@@ -90,6 +110,23 @@ describe("FieldDefaultValueInput", () => {
     const input = screen.getByRole("spinbutton", { name: "Default value" });
     fireEvent.change(input, { target: { value: "7" } });
     expect(onChange).toHaveBeenCalledWith("7");
+  });
+
+  it("keeps an option literally valued __none__ selectable instead of clearing", () => {
+    render(
+      <FieldDefaultValueInput
+        fieldType="select"
+        options={[
+          { label: "None marker", value: "__none__" },
+          { label: "Red", value: "red" },
+        ]}
+        value="__none__"
+        onChange={() => {}}
+      />
+    );
+    // The sentinel extends past the collision, so the trigger shows the real
+    // option rather than the "No default" placeholder.
+    expect(screen.getByRole("combobox")).toHaveTextContent("None marker");
   });
 
   it("renders a select with no options as a text input rather than an empty menu", () => {

--- a/packages/admin/src/components/field-ui/index.ts
+++ b/packages/admin/src/components/field-ui/index.ts
@@ -1,0 +1,26 @@
+/**
+ * The shared field-UI kit: the controlled, form-library-agnostic components
+ * every field-building surface composes — the admin's own builders and, via
+ * `@nextlyhq/plugin-sdk/admin`, plugins. Each surface injects its allowed
+ * type subset and owns its storage; these components own how a field type is
+ * picked and configured.
+ */
+
+export { FieldTypePicker } from "./FieldTypePicker";
+export type { FieldTypePickerProps } from "./FieldTypePicker";
+
+export { FieldDefaultValueInput } from "./FieldDefaultValueInput";
+export type {
+  FieldDefaultOption,
+  FieldDefaultValueInputProps,
+} from "./FieldDefaultValueInput";
+
+// The options editor lives with the schema builder (its richest consumer)
+// and is surfaced here under the kit's naming: controlled options list with
+// drag reorder, auto-generated values, CSV/JSON import, and whole-batch
+// duplicate reporting.
+export { SelectOptionsEditor as FieldOptionsEditor } from "../features/schema-builder/SelectOptionsEditor";
+export type {
+  SelectOption as FieldOption,
+  SelectOptionsEditorProps as FieldOptionsEditorProps,
+} from "../features/schema-builder/types";

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -150,6 +150,23 @@ export type {
   BulkAction,
 } from "./components/ui/table/data-table";
 
+// Field-UI kit — controlled, form-library-agnostic field-building components
+// (type picker, options editor, default-value input) rendered from the shared
+// `nextly/field-catalog`. Author surface re-exported by
+// `@nextlyhq/plugin-sdk/admin`, same as the DataTable above.
+export {
+  FieldTypePicker,
+  FieldDefaultValueInput,
+  FieldOptionsEditor,
+} from "./components/field-ui";
+export type {
+  FieldTypePickerProps,
+  FieldDefaultValueInputProps,
+  FieldDefaultOption,
+  FieldOption,
+  FieldOptionsEditorProps,
+} from "./components/field-ui";
+
 // Error Fallback Components
 export {
   PageErrorFallback,

--- a/packages/plugin-sdk/src/admin.ts
+++ b/packages/plugin-sdk/src/admin.ts
@@ -49,6 +49,28 @@ export type {
   BulkAction,
 } from "@nextlyhq/admin";
 
+/**
+ * The field-UI kit (@experimental): controlled, form-library-agnostic
+ * field-building components rendered from `nextly/field-catalog` — a
+ * catalog-driven type picker, an options editor with drag reorder and
+ * whole-batch duplicate reporting, and a type-aware default-value input.
+ * Compose them in plugin admin surfaces so field editing looks and behaves
+ * like the rest of the admin; your plugin owns storage and the allowed-type
+ * subset.
+ */
+export {
+  FieldTypePicker,
+  FieldDefaultValueInput,
+  FieldOptionsEditor,
+} from "@nextlyhq/admin";
+export type {
+  FieldTypePickerProps,
+  FieldDefaultValueInputProps,
+  FieldDefaultOption,
+  FieldOption,
+  FieldOptionsEditorProps,
+} from "@nextlyhq/admin";
+
 // The declarative `contributes.admin` contract types (the same ones exported
 // from the package root) for convenience when authoring admin components.
 export type {


### PR DESCRIPTION
## What this does

Task-04 Tier 4, item #14, **Slice B of 3** (approved design `tier4-14-user-fields-design.md`, D-14.1) — the shared field-UI primitives, following the DataTable author-surface pattern exactly: implemented in `@nextlyhq/admin`, re-exported by `@nextlyhq/plugin-sdk/admin` as `@experimental`.

### The kit (all controlled, form-library-agnostic)
- **`FieldTypePicker`** — new. A grid of type cards rendered from `nextly/field-catalog` (Slice A), generic over a surface's allowed-type subset with full type inference. Token-driven selected state — notably *without* the inline `style={{border: color-mix(...)}}` that defeats selection styling in the current user-field picker (that swap lands in Slice C).
- **`FieldDefaultValueInput`** — new. Type-aware default control distilled from the two RHF-coupled implementations that exist today: checkbox → true/false choice, select/radio → the field's own options (blank-valued options excluded), number/date → typed inputs, else text.
- **`FieldOptionsEditor`** — promoted, not rewritten. The schema builder's `SelectOptionsEditor` was already the best implementation (controlled, dnd-kit drag reorder, auto-value-from-label latch, CSV/JSON import, select/radio knobs); it is surfaced under the kit's naming. Its internal home and existing consumers are untouched.

### One behavior improvement: duplicates reported whole
The options editor now names **every** duplicated stored value in a single `role="alert"` line. Previously collisions surfaced one at a time (fix one, resubmit, discover the next — the defect research 07 flagged). Benefits the schema builder immediately.

## Verified
- 9 new tests (picker rendering/order/labels from the catalog, selection + disabled behavior, default-input per-type branches incl. blank-option exclusion, duplicate reporting whole-batch + quiet when unique): 23/23 pass in the touched files.
- Full admin suite: **37 failed / 854 passed** — failures exactly at the documented baseline, passes +9.
- Typecheck + lint clean (admin, plugin-sdk); build chain green.

## Not verified
- No page consumes the two new components yet — that is Slice C by design (the user-field page rebuild), so there was no browser flow to drive for them. The options editor's duplicate warning is live in the schema builder and covered by component tests asserting the rendered alert.

Slice C follows: the user-field page rebuild on these primitives + the validation-bounds columns. One changeset, all 18 packages, patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable field-building controls for choosing field types, editing default values, and configuring select/radio/option values.
  * Improved accessibility with an optional radiogroup `ariaLabel` and Arrow-key navigation for field type selection.
  * Added inline warnings when select option values are duplicated.
  * Exposed these controls via the admin package and plugin SDK APIs.
* **Tests**
  * Added UI coverage for field type selection (click + keyboard), default value editing, disabled states, option filtering, and duplicate-value reporting.
* **Chores**
  * Updated PR title scope validation rules in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->