### PR TITLE
feat(admin): per-file media upload queue with honest partial-batch reporting

### DIFF
--- a/.changeset/media-upload-queue.md
+++ b/.changeset/media-upload-queue.md
@@ -1,0 +1,30 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Media bulk uploads now report every file honestly, and one bad file no longer sabotages the batch.
+
+**Dropping more than 10 files no longer rejects the whole batch.** Previously a drop of 11 valid files uploaded nothing and labeled every file "Too many files". Now the first 10 upload and the rest are listed as skipped, each saying so.
+
+**A batch with an oversized file now reads as what it is: a partial success.** Previously 9 valid files uploaded silently behind a full-width red "Invalid file type or size" panel, and the 9 success rows vanished after 2 seconds while the error stayed. Now every file gets its own row in one upload queue: per-file progress while uploading, a green check per success, and a persistent human-readable reason per failure ("File is too large (max 10 MB)" instead of "File is larger than 5242880 bytes"). The summary line reports "9 uploaded, 1 failed" and the queue stays until dismissed whenever anything failed; all-success queues dismiss themselves.
+
+**The upload drop target now closes itself when an upload starts** — no more hunting for the close icon — while the queue stays visible. Files that fail on the server get a one-click Retry.
+
+Also: the client-side size limit default now matches the server's 10MB default (it was 5MB, so files between 5 and 10MB were refused by the client that the server would have accepted), the dropzone no longer nests interactive buttons (invalid markup), and its status colors now use the design system's semantic tokens.

--- a/e2e/tests/media-upload.spec.ts
+++ b/e2e/tests/media-upload.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * Bulk upload against a real server: the failure classes here are exactly the
+ * ones unit tests cannot see. A batch with one oversized file must upload the
+ * valid files and report the bad one per-file (the old dropzone painted the
+ * whole zone red and let the successes vanish), and a batch over the 10-file
+ * cap must upload the first 10 and mark the rest skipped (react-dropzone's
+ * `maxFiles` used to reject the entire batch as "Too many files").
+ */
+import { deflateSync } from "node:zlib";
+
+import { expect, test } from "@playwright/test";
+
+import { gotoAdmin } from "./support/admin";
+
+/**
+ * A minimal valid grayscale PNG. Real image bytes, not a fixture on disk: the
+ * server decodes uploads for dimensions, so the content has to parse, and
+ * generating it keeps the suite free of binary files.
+ */
+function pngBuffer(shade: number, padToBytes = 0): Buffer {
+  const crcTable = Array.from({ length: 256 }, (_, n) => {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    return c >>> 0;
+  });
+  const crc32 = (buf: Buffer) => {
+    let c = 0xffffffff;
+    for (const b of buf) c = crcTable[(c ^ b) & 0xff] ^ (c >>> 8);
+    return (c ^ 0xffffffff) >>> 0;
+  };
+  const chunk = (type: string, data: Buffer) => {
+    const len = Buffer.alloc(4);
+    len.writeUInt32BE(data.length);
+    const td = Buffer.concat([Buffer.from(type), data]);
+    const crc = Buffer.alloc(4);
+    crc.writeUInt32BE(crc32(td));
+    return Buffer.concat([len, td, crc]);
+  };
+
+  const size = 8;
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(size, 0);
+  ihdr.writeUInt32BE(size, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 0; // grayscale
+  const raw = Buffer.alloc((size + 1) * size, shade);
+  for (let y = 0; y < size; y++) raw[y * (size + 1)] = 0; // filter byte per row
+
+  const png = Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    chunk("IHDR", ihdr),
+    chunk("IDAT", deflateSync(raw)),
+    chunk("IEND", Buffer.alloc(0)),
+  ]);
+
+  // Decoders ignore trailing bytes after IEND, so padding inflates the file
+  // size (to trip the client's max-size check) while staying a valid image.
+  if (padToBytes > png.length) {
+    return Buffer.concat([png, Buffer.alloc(padToBytes - png.length)]);
+  }
+  return png;
+}
+
+async function dropFiles(
+  page: import("@playwright/test").Page,
+  files: { name: string; buffer: Buffer }[]
+) {
+  await page.getByRole("button", { name: "Upload Files" }).click();
+
+  const chooserPromise = page.waitForEvent("filechooser");
+  await page
+    .getByRole("button", { name: /Upload files\. Drag and drop/ })
+    .click();
+  const chooser = await chooserPromise;
+
+  await chooser.setFiles(
+    files.map(f => ({ name: f.name, mimeType: "image/png", buffer: f.buffer }))
+  );
+}
+
+test("a batch with one oversized file uploads the rest and reports the failure per file", async ({
+  page,
+}) => {
+  await gotoAdmin(page, "/media");
+
+  await dropFiles(page, [
+    { name: "ok-1.png", buffer: pngBuffer(40) },
+    { name: "ok-2.png", buffer: pngBuffer(80) },
+    { name: "ok-3.png", buffer: pngBuffer(120) },
+    // 11MB against the 10MB client limit
+    { name: "huge.png", buffer: pngBuffer(160, 11 * 1024 * 1024) },
+  ]);
+
+  // Partial success is reported as such, never as a whole-batch error. The
+  // summary is asserted via its status role because an sr-only live region
+  // announces the same text. The dev server compiles routes on first hit, so
+  // the settled summary can take a while on a cold run.
+  await expect(
+    page.getByRole("status").filter({ hasText: /uploaded/ })
+  ).toHaveText("3 uploaded, 1 failed", {
+    timeout: 30_000,
+  });
+
+  // The failed row carries human copy with the limit, not raw byte counts.
+  await expect(page.getByText("File is too large (max 10 MB)")).toBeVisible();
+  await expect(page.getByText(/larger than \d+ bytes/)).toHaveCount(0);
+
+  // The drop target auto-collapsed when the upload started; the queue is the
+  // surviving surface.
+  await expect(
+    page.getByRole("button", { name: /Upload files\. Drag and drop/ })
+  ).toHaveCount(0);
+
+  // The successes really landed: the grid shows the uploaded files.
+  await expect(
+    page.getByRole("button", { name: /ok-1\.png/ }).first()
+  ).toBeVisible();
+});
+
+test("a batch over the 10-file cap uploads the first 10 and marks the rest skipped", async ({
+  page,
+}) => {
+  await gotoAdmin(page, "/media");
+
+  await dropFiles(
+    page,
+    Array.from({ length: 12 }, (_, i) => ({
+      name: `cap-${i + 1}.png`,
+      buffer: pngBuffer((i * 20) % 255),
+    }))
+  );
+
+  // Nothing valid is refused outright ("Too many files" is gone): the first
+  // 10 upload, the overflow is skipped and says so.
+  await expect(
+    page.getByRole("status").filter({ hasText: /uploaded/ })
+  ).toHaveText("10 uploaded, 2 skipped", {
+    timeout: 30_000,
+  });
+  await expect(
+    page.getByText("Skipped: only 10 files can be uploaded at once")
+  ).toHaveCount(2);
+  await expect(page.getByText("Too many files")).toHaveCount(0);
+});

--- a/e2e/tests/media-upload.spec.ts
+++ b/e2e/tests/media-upload.spec.ts
@@ -92,12 +92,13 @@ test("a batch with one oversized file uploads the rest and reports the failure p
   ]);
 
   // Partial success is reported as such, never as a whole-batch error. The
-  // summary is asserted via its status role because an sr-only live region
-  // announces the same text. The dev server compiles routes on first hit, so
-  // the settled summary can take a while on a cold run.
+  // sr-only live region is the queue's single status source; the media
+  // grid's loading skeleton also carries role=status, hence the filter. The
+  // dev server compiles routes on first hit, so the settled summary can take
+  // a while on a cold run.
   await expect(
     page.getByRole("status").filter({ hasText: /uploaded/ })
-  ).toHaveText("3 uploaded, 1 failed", {
+  ).toContainText("3 uploaded, 1 failed", {
     timeout: 30_000,
   });
 
@@ -134,7 +135,7 @@ test("a batch over the 10-file cap uploads the first 10 and marks the rest skipp
   // 10 upload, the overflow is skipped and says so.
   await expect(
     page.getByRole("status").filter({ hasText: /uploaded/ })
-  ).toHaveText("10 uploaded, 2 skipped", {
+  ).toContainText("10 uploaded, 2 skipped", {
     timeout: 30_000,
   });
   await expect(

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/MediaUploadDropzone.test.ts
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/MediaUploadDropzone.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+
+import { describeFileError, buildQueueFromDrop } from "./index";
+
+const MB = 1024 * 1024;
+
+function makeFile(name: string, size: number): File {
+  const file = new File(["x"], name, { type: "image/png" });
+  // File size is read-only; tests only need the reported value, not content.
+  Object.defineProperty(file, "size", { value: size });
+  return file;
+}
+
+describe("describeFileError", () => {
+  it("maps file-too-large to human copy with the formatted limit", () => {
+    const message = describeFileError(
+      { code: "file-too-large", message: "File is larger than 5242880 bytes" },
+      5 * MB
+    );
+    expect(message).toBe("File is too large (max 5 MB)");
+    expect(message).not.toContain("bytes");
+  });
+
+  it("maps file-invalid-type to human copy", () => {
+    expect(
+      describeFileError(
+        { code: "file-invalid-type", message: "File type must be image/*" },
+        5 * MB
+      )
+    ).toBe("File type is not supported");
+  });
+
+  it("maps too-many-files to the batch-cap copy", () => {
+    expect(
+      describeFileError(
+        { code: "too-many-files", message: "Too many files" },
+        5 * MB
+      )
+    ).toBe("Only 10 files can be uploaded at once");
+  });
+
+  it("falls through to the library message for unknown codes", () => {
+    expect(
+      describeFileError(
+        { code: "custom-check", message: "Custom reason" },
+        5 * MB
+      )
+    ).toBe("Custom reason");
+  });
+});
+
+describe("buildQueueFromDrop", () => {
+  it("uploads all accepted files and rows every client rejection with its reason", () => {
+    const accepted = Array.from({ length: 9 }, (_, i) =>
+      makeFile(`small-${i + 1}.png`, 100)
+    );
+    const rejections = [
+      {
+        file: makeFile("big.png", 7 * MB),
+        errors: [
+          {
+            code: "file-too-large",
+            message: "File is larger than 5242880 bytes",
+          },
+        ],
+      },
+    ];
+
+    const { toUpload, failed } = buildQueueFromDrop(
+      accepted,
+      rejections,
+      5 * MB
+    );
+
+    expect(toUpload).toHaveLength(9);
+    expect(toUpload.every(row => row.status === "pending")).toBe(true);
+    expect(failed).toHaveLength(1);
+    expect(failed[0]).toMatchObject({
+      filename: "big.png",
+      status: "rejected",
+      error: "File is too large (max 5 MB)",
+    });
+    // Validation failures are real failures, not batch-cap skips
+    expect(failed[0].skipped).toBeUndefined();
+  });
+
+  it("takes the first 10 of an over-cap drop and marks the rest skipped", () => {
+    const accepted = Array.from({ length: 14 }, (_, i) =>
+      makeFile(`file-${i + 1}.png`, 100)
+    );
+
+    const { toUpload, failed } = buildQueueFromDrop(accepted, [], 5 * MB);
+
+    expect(toUpload).toHaveLength(10);
+    expect(toUpload.map(row => row.filename)).toEqual(
+      accepted.slice(0, 10).map(f => f.name)
+    );
+    expect(failed).toHaveLength(4);
+    expect(
+      failed.every(row => row.status === "rejected" && row.skipped === true)
+    ).toBe(true);
+    expect(failed[0].error).toBe(
+      "Skipped: only 10 files can be uploaded at once"
+    );
+  });
+
+  it("produces no upload rows for an all-rejected drop", () => {
+    const rejections = [
+      {
+        file: makeFile("bad.exe", 100),
+        errors: [{ code: "file-invalid-type", message: "" }],
+      },
+    ];
+
+    const { toUpload, failed } = buildQueueFromDrop([], rejections, 5 * MB);
+
+    expect(toUpload).toHaveLength(0);
+    expect(failed).toHaveLength(1);
+    expect(failed[0].error).toBe("File type is not supported");
+  });
+
+  it("assigns each row a unique id", () => {
+    const accepted = Array.from({ length: 12 }, (_, i) =>
+      makeFile(`f-${i}.png`, 1)
+    );
+    const { toUpload, failed } = buildQueueFromDrop(accepted, [], 5 * MB);
+    const ids = [...toUpload, ...failed].map(row => row.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("joins multiple rejection reasons on one row", () => {
+    const rejections = [
+      {
+        file: makeFile("bad.bmp", 20 * MB),
+        errors: [
+          { code: "file-invalid-type", message: "" },
+          { code: "file-too-large", message: "" },
+        ],
+      },
+    ];
+
+    const { failed } = buildQueueFromDrop([], rejections, 10 * MB);
+    expect(failed[0].error).toBe(
+      "File type is not supported, File is too large (max 10 MB)"
+    );
+  });
+});

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/MediaUploadDropzone.test.ts
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/MediaUploadDropzone.test.ts
@@ -69,7 +69,8 @@ describe("buildQueueFromDrop", () => {
     const { toUpload, failed } = buildQueueFromDrop(
       accepted,
       rejections,
-      5 * MB
+      5 * MB,
+      null
     );
 
     expect(toUpload).toHaveLength(9);
@@ -84,12 +85,58 @@ describe("buildQueueFromDrop", () => {
     expect(failed[0].skipped).toBeUndefined();
   });
 
+  it("lets rejected files never consume batch-cap slots (mixed rejection + overflow)", () => {
+    // 11 valid + 1 oversized: the cap applies to VALID files, so 10 upload,
+    // 1 valid file is skipped, and the oversized one fails on its own row.
+    // A rejected file "ahead of" valid files in the drop must not push a
+    // valid file out of the batch.
+    const accepted = Array.from({ length: 11 }, (_, i) =>
+      makeFile(`valid-${i + 1}.png`, 100)
+    );
+    const rejections = [
+      {
+        file: makeFile("big.png", 7 * MB),
+        errors: [{ code: "file-too-large", message: "" }],
+      },
+    ];
+
+    const { toUpload, failed } = buildQueueFromDrop(
+      accepted,
+      rejections,
+      5 * MB,
+      null
+    );
+
+    expect(toUpload).toHaveLength(10);
+    expect(failed).toHaveLength(2);
+    expect(failed.filter(row => row.skipped)).toHaveLength(1);
+    expect(failed.find(row => row.skipped)?.filename).toBe("valid-11.png");
+    expect(failed.find(row => !row.skipped)?.filename).toBe("big.png");
+  });
+
+  it("snapshots the drop-time folder on every row", () => {
+    const { toUpload, failed } = buildQueueFromDrop(
+      [makeFile("a.png", 1)],
+      [
+        {
+          file: makeFile("bad.exe", 1),
+          errors: [{ code: "file-invalid-type", message: "" }],
+        },
+      ],
+      5 * MB,
+      "folder-123"
+    );
+
+    expect(toUpload[0].folderId).toBe("folder-123");
+    expect(failed[0].folderId).toBe("folder-123");
+  });
+
   it("takes the first 10 of an over-cap drop and marks the rest skipped", () => {
     const accepted = Array.from({ length: 14 }, (_, i) =>
       makeFile(`file-${i + 1}.png`, 100)
     );
 
-    const { toUpload, failed } = buildQueueFromDrop(accepted, [], 5 * MB);
+    const { toUpload, failed } = buildQueueFromDrop(accepted, [], 5 * MB, null);
 
     expect(toUpload).toHaveLength(10);
     expect(toUpload.map(row => row.filename)).toEqual(
@@ -112,7 +159,12 @@ describe("buildQueueFromDrop", () => {
       },
     ];
 
-    const { toUpload, failed } = buildQueueFromDrop([], rejections, 5 * MB);
+    const { toUpload, failed } = buildQueueFromDrop(
+      [],
+      rejections,
+      5 * MB,
+      null
+    );
 
     expect(toUpload).toHaveLength(0);
     expect(failed).toHaveLength(1);
@@ -123,7 +175,7 @@ describe("buildQueueFromDrop", () => {
     const accepted = Array.from({ length: 12 }, (_, i) =>
       makeFile(`f-${i}.png`, 1)
     );
-    const { toUpload, failed } = buildQueueFromDrop(accepted, [], 5 * MB);
+    const { toUpload, failed } = buildQueueFromDrop(accepted, [], 5 * MB, null);
     const ids = [...toUpload, ...failed].map(row => row.id);
     expect(new Set(ids).size).toBe(ids.length);
   });
@@ -139,7 +191,7 @@ describe("buildQueueFromDrop", () => {
       },
     ];
 
-    const { failed } = buildQueueFromDrop([], rejections, 10 * MB);
+    const { failed } = buildQueueFromDrop([], rejections, 10 * MB, null);
     expect(failed[0].error).toBe(
       "File type is not supported, File is too large (max 10 MB)"
     );

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
@@ -590,8 +590,13 @@ export function MediaUploadDropzone({
   ]
     .filter(Boolean)
     .join(", ");
+  // The live denominator counts only rows that will actually upload;
+  // pre-rejected rows sit in the same queue but were never attempted.
+  const uploadableCount = uploadQueue.filter(
+    item => item.status !== "rejected"
+  ).length;
   const queueSummary = isUploading
-    ? `Uploading ${inProgressCount} of ${uploadQueue.length} files...`
+    ? `Uploading ${inProgressCount} of ${uploadableCount} files...`
     : settledSummary;
 
   return (

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
@@ -3,70 +3,52 @@
 /**
  * MediaUploadDropzone Component
  *
- * Drag-and-drop file upload area with react-dropzone for media library.
- * Supports multi-file upload with progress tracking, file validation, and error handling.
+ * Drag-and-drop upload area for the media library and the media picker.
  *
- * ## Design Specifications
+ * Upload feedback is a single per-file queue: every file in a drop gets a row
+ * with its own progress, status, and (for failures) a persistent human-readable
+ * reason. Files the client rejects (too large, wrong type, over the batch cap)
+ * appear as rows in the same queue rather than a separate alert, so a batch
+ * with one bad file still reads as "9 uploaded, 1 failed" instead of an
+ * all-red error state.
  *
- * **Desktop Size**:
- * - Height: 256px (h-64) expanded, 64px (h-16) collapsed
- * - Width: Full width (w-full)
+ * Batch cap: drops larger than {@link MAX_FILES} upload the first
+ * {@link MAX_FILES} files and mark the rest as skipped. The cap is enforced in
+ * `onDrop` instead of react-dropzone's `maxFiles`, because `maxFiles` rejects
+ * the ENTIRE batch with `too-many-files` when exceeded - valid files included.
  *
- * **Mobile Size**:
- * - Height: 176px (h-44) expanded, 64px (h-16) collapsed
- * - Width: Full width (w-full)
+ * The queue outlives the drop target: when `isCollapsed` is true only the drop
+ * target hides, so a parent can collapse the zone the moment an upload starts
+ * (via `onUploadStart`) while progress stays visible.
  *
- * **Visual States**:
- * - Default: Dashed  border border-border (border-2 border-dashed border-border)
- * - Hover: Primary  border border-border (border-primary-300 bg-accent/50)
- * - Active (dragging): Primary  border border-border (border-primary-500 bg-primary-50)
- * - Uploading: Progress bars for each file
- * - Error: Red  border border-border (border-destructive bg-destructive/10)
- * - Collapsed: Compact 64px height with small icon
+ * ## Visual states (drop target)
  *
- * **Supported File Types**:
- * - Images: PNG, JPG, JPEG, GIF, WebP
- * - Videos: MP4, MOV, AVI
- * - Documents: PDF
+ * - Default: dashed `border-border`
+ * - Drag active: `border-primary`
+ * - Drag reject: `border-destructive` (live feedback while dragging only)
+ * - Uploading: spinner + count (shown where the target stays open, e.g. the picker)
  *
- * **File Size Limit**: 5MB per file
- * **Max Files**: 10 files per upload
+ * **Supported file types** (default): PNG, JPG, JPEG, GIF, WebP, MP4, MOV, AVI, PDF
+ * **File size limit**: 10MB per file by default (server default; overridable via `maxFileSize`)
+ * **Batch cap**: 10 files per drop
  *
  * ## Accessibility
  *
- * - WCAG 2.2 AA compliant
- * - Keyboard navigation (Tab, Enter, Space)
- * - Screen reader support (ARIA labels, live regions)
- * - Focus indicators (ring-2 ring-primary-500)
- * - Touch targets: 44×44px minimum on mobile
- *
- * ## Usage Examples
- *
- * ### Basic usage
- * ```tsx
- * <MediaUploadDropzone
- *   onUploadComplete={(media) => {
- *     console.log('Uploaded:', media);
- *   }}
- * />
- * ```
- *
- * ### Controlled collapsed state
- * ```tsx
- * const [isCollapsed, setIsCollapsed] = useState(false);
- *
- * <MediaUploadDropzone
- *   isCollapsed={isCollapsed}
- *   onToggleCollapse={() => setIsCollapsed(!isCollapsed)}
- * />
- * ```
- *
+ * - Keyboard: Tab to the target, Enter/Space to browse
+ * - The browse hint is plain text inside the single `role="button"` target
+ *   (no nested interactive elements)
+ * - ARIA live region announces progress and results
  */
 
-import { Alert, AlertDescription, Progress, Button } from "@nextlyhq/ui";
+import { Progress, Button } from "@nextlyhq/ui";
 import { useQueryClient } from "@tanstack/react-query";
 import * as React from "react";
-import { useDropzone, type Accept } from "react-dropzone";
+import {
+  useDropzone,
+  type Accept,
+  type FileRejection,
+  type FileError,
+} from "react-dropzone";
 
 import {
   Upload,
@@ -74,6 +56,7 @@ import {
   AlertTriangle,
   X,
   Check,
+  RefreshCw,
 } from "@admin/components/icons";
 import { useUploadMedia } from "@admin/hooks/queries/useMedia";
 import { formatFileSize } from "@admin/lib/media-utils";
@@ -88,52 +71,40 @@ export interface MediaUploadDropzoneProps {
    * Callback when upload completes successfully
    *
    * @param media - Array of uploaded Media objects
-   *
-   * @example
-   * ```tsx
-   * <MediaUploadDropzone
-   *   onUploadComplete={(media) => {
-   *     console.log(`Uploaded ${media.length} files`);
-   *     toast.success(`${media.length} files uploaded`);
-   *   }}
-   * />
-   * ```
    */
   onUploadComplete?: (media: Media[]) => void;
 
   /**
-   * Controlled collapsed state
+   * Callback fired when at least one accepted file begins uploading.
+   * Parents use this to auto-collapse the drop target; the queue stays
+   * visible independently of `isCollapsed`.
+   */
+  onUploadStart?: () => void;
+
+  /**
+   * Controlled collapsed state. Hides the drop target only; an in-flight or
+   * settled upload queue keeps rendering so results are never lost.
    *
-   * @default undefined (uncontrolled)
+   * @default undefined (uncontrolled, target visible)
    */
   isCollapsed?: boolean;
 
   /**
-   * Callback when collapse button is clicked
-   *
-   * @example
-   * ```tsx
-   * const [isCollapsed, setIsCollapsed] = useState(false);
-   *
-   * <MediaUploadDropzone
-   *   isCollapsed={isCollapsed}
-   *   onToggleCollapse={() => setIsCollapsed(!isCollapsed)}
-   * />
-   * ```
+   * Callback when the close button is clicked
    */
   onToggleCollapse?: () => void;
 
   /**
    * MIME type filter pattern for allowed uploads (e.g., "image/*", "image/png,image/jpeg")
    *
-   * @default undefined (accepts all file types defined in ACCEPTED_FILE_TYPES)
+   * @default undefined (accepts all file types defined in DEFAULT_ACCEPTED_FILE_TYPES)
    */
   accept?: string;
 
   /**
    * Maximum file size in bytes
    *
-   * @default 5242880 (5MB)
+   * @default 10485760 (10MB, matching the server's default `limits.fileSize`)
    */
   maxFileSize?: number;
 
@@ -167,9 +138,24 @@ const DEFAULT_ACCEPTED_FILE_TYPES: Accept = {
 };
 
 /**
- * Default maximum file size (5MB)
+ * Default maximum file size. Matches the server's default `limits.fileSize`
+ * (10MB) so the client pre-check and the server agree; the server stays
+ * authoritative and its per-file errors render on the queue rows either way.
  */
-const DEFAULT_MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB in bytes
+const DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB in bytes
+
+/**
+ * Maximum number of files per drop. Enforced by slicing in `onDrop` (first
+ * MAX_FILES upload, the rest are marked skipped) - see the header comment for
+ * why react-dropzone's `maxFiles` is not used.
+ */
+const MAX_FILES = 10;
+
+/**
+ * How long an all-success queue stays visible before auto-dismissing.
+ * Queues containing any failure persist until explicitly dismissed.
+ */
+const UPLOAD_SUCCESS_DISPLAY_DURATION_MS = 4000;
 
 /**
  * Convert MIME type string to react-dropzone Accept format
@@ -215,10 +201,11 @@ function parseAcceptString(acceptString?: string): Accept | undefined {
 /**
  * Get human-readable file type description from accept string
  */
-function getAcceptDescription(acceptString?: string, maxSize?: number): string {
-  const sizeLimit = maxSize
-    ? ` up to ${formatFileSize(maxSize)}`
-    : " up to 5MB";
+function getAcceptDescription(
+  acceptString: string | undefined,
+  maxSize: number
+): string {
+  const sizeLimit = ` up to ${formatFileSize(maxSize)}`;
 
   if (!acceptString) {
     return `PNG, JPG, GIF, WebP, MP4, MOV, PDF${sizeLimit}`;
@@ -248,25 +235,93 @@ function getAcceptDescription(acceptString?: string, maxSize?: number): string {
 }
 
 /**
- * Maximum number of files per upload
+ * Map react-dropzone rejection codes to human-readable copy. Raw library
+ * defaults leak byte counts ("File is larger than 5242880 bytes"), so every
+ * known code gets explicit wording; unknown codes fall through to the
+ * library's message rather than hiding it.
  */
-const MAX_FILES = 10;
+export function describeFileError(error: FileError, maxSize: number): string {
+  switch (error.code) {
+    case "file-too-large":
+      return `File is too large (max ${formatFileSize(maxSize)})`;
+    case "file-invalid-type":
+      return "File type is not supported";
+    case "file-too-small":
+      return "File is too small";
+    case "too-many-files":
+      return `Only ${MAX_FILES} files can be uploaded at once`;
+    default:
+      return error.message;
+  }
+}
+
+/** Row reason for files beyond the batch cap. */
+const BATCH_SKIP_MESSAGE = `Skipped: only ${MAX_FILES} files can be uploaded at once`;
+
+/** A queue row: upload progress plus a stable identity for updates/retry. */
+type UploadQueueItem = UploadProgress & { id: string };
+
+// Stable row ids for React keys and targeted state updates; a module counter
+// avoids collisions across drops without needing crypto APIs.
+let queueItemSeq = 0;
+function nextQueueItemId(): string {
+  queueItemSeq += 1;
+  return `upload-${queueItemSeq}`;
+}
 
 /**
- * Duration to display upload success/error state before clearing queue (milliseconds)
+ * Split a drop into uploadable rows and pre-failed rows (client rejections
+ * and over-cap skips). Pure so the batch semantics are unit-testable.
  */
-const UPLOAD_SUCCESS_DISPLAY_DURATION_MS = 2000;
+export function buildQueueFromDrop(
+  acceptedFiles: File[],
+  fileRejections: Pick<FileRejection, "file" | "errors">[],
+  maxSize: number
+): { toUpload: UploadQueueItem[]; failed: UploadQueueItem[] } {
+  const withinCap = acceptedFiles.slice(0, MAX_FILES);
+  const overCap = acceptedFiles.slice(MAX_FILES);
+
+  const toUpload: UploadQueueItem[] = withinCap.map(file => ({
+    id: nextQueueItemId(),
+    file,
+    filename: file.name,
+    status: "pending",
+    progress: 0,
+  }));
+
+  const failed: UploadQueueItem[] = [
+    ...fileRejections.map(({ file, errors }) => ({
+      id: nextQueueItemId(),
+      file,
+      filename: file.name,
+      status: "rejected" as const,
+      error: errors.map(e => describeFileError(e, maxSize)).join(", "),
+    })),
+    ...overCap.map(file => ({
+      id: nextQueueItemId(),
+      file,
+      filename: file.name,
+      status: "rejected" as const,
+      skipped: true,
+      error: BATCH_SKIP_MESSAGE,
+    })),
+  ];
+
+  return { toUpload, failed };
+}
 
 /**
  * MediaUploadDropzone component
  *
- * Drag-and-drop upload area with file validation, progress tracking, and error handling.
+ * Drag-and-drop upload area with per-file validation, progress, retry, and
+ * partial-success reporting.
  *
  * @param props - MediaUploadDropzone props
  * @returns MediaUploadDropzone component
  */
 export function MediaUploadDropzone({
   onUploadComplete,
+  onUploadStart,
   isCollapsed: controlledIsCollapsed,
   onToggleCollapse,
   accept,
@@ -290,12 +345,12 @@ export function MediaUploadDropzone({
 
   // Get human-readable description
   const fileTypeDescription = React.useMemo(
-    () => getAcceptDescription(accept, maxFileSize),
-    [accept, maxFileSize]
+    () => getAcceptDescription(accept, maxSize),
+    [accept, maxSize]
   );
 
-  // Upload queue state
-  const [uploadQueue, setUploadQueue] = React.useState<UploadProgress[]>([]);
+  // Upload queue state (uploadable rows and pre-failed rows together)
+  const [uploadQueue, setUploadQueue] = React.useState<UploadQueueItem[]>([]);
 
   // Upload mutation (disable auto-invalidate for batch uploads)
   const { mutateAsync: uploadMediaAsync } = useUploadMedia({
@@ -305,68 +360,72 @@ export function MediaUploadDropzone({
   // Query client for manual cache invalidation after batch upload
   const queryClient = useQueryClient();
 
-  // Handle file drop
-  const handleDrop = React.useCallback(
-    async (acceptedFiles: File[]) => {
-      // Initialize upload queue
-      const initialQueue: UploadProgress[] = acceptedFiles.map(file => ({
-        file,
-        filename: file.name,
-        status: "pending",
-        progress: 0,
-      }));
-
-      setUploadQueue(initialQueue);
-
-      // Upload files in parallel
-      const uploadPromises = acceptedFiles.map((file, index) => {
-        return uploadMediaAsync({
-          file,
-          folderId: activeFolderId,
-          onProgress: progress => {
-            // Update progress for this file
-            setUploadQueue(prevQueue =>
-              prevQueue.map((item, i) =>
-                i === index ? { ...item, status: "uploading", progress } : item
-              )
-            );
-          },
+  // Upload a single queue row, updating only that row by id. Shared by the
+  // initial batch and per-row retry.
+  const uploadQueueItem = React.useCallback(
+    (item: UploadQueueItem): Promise<Media | null> => {
+      return uploadMediaAsync({
+        file: item.file,
+        folderId: activeFolderId,
+        onProgress: progress => {
+          setUploadQueue(prevQueue =>
+            prevQueue.map(row =>
+              row.id === item.id
+                ? { ...row, status: "uploading", progress }
+                : row
+            )
+          );
+        },
+      })
+        .then(media => {
+          setUploadQueue(prevQueue =>
+            prevQueue.map(row =>
+              row.id === item.id
+                ? {
+                    ...row,
+                    status: "success",
+                    progress: 100,
+                    mediaId: media.id,
+                  }
+                : row
+            )
+          );
+          return media;
         })
-          .then(media => {
-            // Mark as success
-            setUploadQueue(prevQueue =>
-              prevQueue.map((item, i) =>
-                i === index
-                  ? {
-                      ...item,
-                      status: "success",
-                      progress: 100,
-                      mediaId: media.id,
-                    }
-                  : item
-              )
-            );
-            return media;
-          })
-          .catch(error => {
-            // Mark as error
-            setUploadQueue(prevQueue =>
-              prevQueue.map((item, i) =>
-                i === index
-                  ? {
-                      ...item,
-                      status: "error",
-                      error: error.message,
-                    }
-                  : item
-              )
-            );
-            return null; // Return null for failed uploads
-          });
-      });
+        .catch((error: Error) => {
+          setUploadQueue(prevQueue =>
+            prevQueue.map(row =>
+              row.id === item.id
+                ? { ...row, status: "error", error: error.message }
+                : row
+            )
+          );
+          return null; // Return null for failed uploads
+        });
+    },
+    [uploadMediaAsync, activeFolderId]
+  );
 
-      // Wait for all uploads to complete
-      const results = await Promise.all(uploadPromises);
+  // Handle file drop: build the queue (including pre-failed rows), then
+  // upload the valid files in parallel.
+  const handleDrop = React.useCallback(
+    async (acceptedFiles: File[], fileRejections: FileRejection[]) => {
+      const { toUpload, failed } = buildQueueFromDrop(
+        acceptedFiles,
+        fileRejections,
+        maxSize
+      );
+
+      // Starting a new drop replaces the previous batch's results
+      setUploadQueue([...toUpload, ...failed]);
+
+      if (toUpload.length === 0) return;
+
+      // Collapse-on-start only fires when something actually uploads; an
+      // all-rejected drop keeps the target open next to the failure rows.
+      onUploadStart?.();
+
+      const results = await Promise.all(toUpload.map(uploadQueueItem));
       const successfulUploads = results.filter(
         (media): media is Media => media !== null
       );
@@ -379,10 +438,29 @@ export function MediaUploadDropzone({
         // Call onUploadComplete callback after cache invalidation
         onUploadComplete?.(successfulUploads);
       }
-
-      // Note: Queue will be cleared by useEffect after display duration
     },
-    [uploadMediaAsync, queryClient, onUploadComplete, activeFolderId]
+    [maxSize, onUploadStart, uploadQueueItem, queryClient, onUploadComplete]
+  );
+
+  // Retry a server-failed row in place. Client-rejected rows never retry
+  // (the file would just fail validation again).
+  const handleRetry = React.useCallback(
+    async (item: UploadQueueItem) => {
+      setUploadQueue(prevQueue =>
+        prevQueue.map(row =>
+          row.id === item.id
+            ? { ...row, status: "pending", progress: 0, error: undefined }
+            : row
+        )
+      );
+
+      const media = await uploadQueueItem(item);
+      if (media) {
+        await queryClient.invalidateQueries({ queryKey: ["media"] });
+        onUploadComplete?.([media]);
+      }
+    },
+    [uploadQueueItem, queryClient, onUploadComplete]
   );
 
   // react-dropzone hook
@@ -394,32 +472,28 @@ export function MediaUploadDropzone({
   // "onDragOver" | "onDragLeave"> & {...}` and against the React 19
   // ambient types those four arrive as required. The hook still works
   // without user-side handlers — drag events are handled internally — so
-  // we set `multiple` to the semantically correct value (MAX_FILES > 1)
-  // and pass through `undefined` for the drag callbacks. Casting via
-  // `as DropzoneOptions` would hide the type contract; explicit values
-  // keep the intent visible.
-  const {
-    getRootProps,
-    getInputProps,
-    isDragActive,
-    isDragReject,
-    fileRejections,
-    open,
-  } = useDropzone({
-    accept: acceptedFileTypes,
-    maxSize: maxSize,
-    maxFiles: MAX_FILES,
-    multiple: MAX_FILES > 1,
-    disabled: uploadQueue.some(item => item.status === "uploading"),
-    onDrop: acceptedFiles => {
-      void handleDrop(acceptedFiles);
-    },
-    onDragEnter: undefined,
-    onDragOver: undefined,
-    onDragLeave: undefined,
-    noClick: true,
-    noKeyboard: true,
-  });
+  // we set `multiple: true` and pass through `undefined` for the drag
+  // callbacks. Casting via `as DropzoneOptions` would hide the type
+  // contract; explicit values keep the intent visible.
+  //
+  // No `maxFiles` here on purpose: the batch cap is handled in onDrop.
+  const { getRootProps, getInputProps, isDragActive, isDragReject, open } =
+    useDropzone({
+      accept: acceptedFileTypes,
+      maxSize: maxSize,
+      multiple: true,
+      disabled: uploadQueue.some(
+        item => item.status === "uploading" || item.status === "pending"
+      ),
+      onDrop: (acceptedFiles, fileRejections) => {
+        void handleDrop(acceptedFiles, fileRejections);
+      },
+      onDragEnter: undefined,
+      onDragOver: undefined,
+      onDragLeave: undefined,
+      noClick: true,
+      noKeyboard: true,
+    });
 
   // Count items by status
   const pendingCount = uploadQueue.filter(
@@ -431,7 +505,13 @@ export function MediaUploadDropzone({
   const successCount = uploadQueue.filter(
     item => item.status === "success"
   ).length;
-  const errorCount = uploadQueue.filter(item => item.status === "error").length;
+  const skippedCount = uploadQueue.filter(
+    item => item.status === "rejected" && item.skipped
+  ).length;
+  const failureCount =
+    uploadQueue.filter(
+      item => item.status === "error" || item.status === "rejected"
+    ).length - skippedCount;
 
   // Check if currently uploading (any pending or actively uploading)
   const isUploading = pendingCount > 0 || uploadingCount > 0;
@@ -439,13 +519,14 @@ export function MediaUploadDropzone({
   // Count of files still in progress (pending + uploading)
   const inProgressCount = pendingCount + uploadingCount;
 
-  // Clear upload queue after success/error display duration
-  // This effect prevents memory leaks by cleaning up the timeout on unmount
+  // A settled all-success queue dismisses itself; any failure or skip keeps
+  // the queue on screen until the user dismisses it, so errors are never lost.
   React.useEffect(() => {
     if (
       uploadQueue.length > 0 &&
       !isUploading &&
-      (successCount > 0 || errorCount > 0)
+      failureCount === 0 &&
+      skippedCount === 0
     ) {
       const timeoutId = setTimeout(() => {
         setUploadQueue([]);
@@ -453,15 +534,15 @@ export function MediaUploadDropzone({
 
       return () => clearTimeout(timeoutId);
     }
-  }, [uploadQueue.length, isUploading, successCount, errorCount]);
+  }, [uploadQueue.length, isUploading, failureCount, skippedCount]);
 
-  // Determine visual state
+  // Drop-target visual state. Result states (success/error) live on the
+  // queue rows, not the target, so partial success never paints the whole
+  // zone red; `reject` is live drag feedback only.
   const getVisualState = () => {
     if (isDragReject) return "reject";
     if (isDragActive) return "active";
     if (isUploading) return "uploading";
-    if (errorCount > 0) return "error";
-    if (successCount > 0) return "success";
     return "default";
   };
 
@@ -469,25 +550,18 @@ export function MediaUploadDropzone({
 
   // Border styles — border-2 dashed, prominent, mode-aware
   const borderStyles = {
-    default:
-      "border-2 border-dashed border-border hover:border-primary/50 dark:border-border-foreground/40 dark:hover:border-primary/60",
+    default: "border-2 border-dashed border-border hover:border-primary/50",
     active: "border-2 border-dashed border-primary",
     reject: "border-2 border-dashed border-destructive",
     uploading: "border-2 border-dashed border-primary/80",
-    error: "border-2 border-dashed border-destructive",
-    success:
-      "border-2 border-dashed border-success-500 dark:border-success-400",
   };
 
   // Background styles — use CSS variables (bg-card) so both light and dark modes resolve correctly.
-  // Avoid bg-card: it's a fixed color that wins over dark:bg-card due to Tailwind specificity.
   const backgroundStyles = {
     default: "bg-card",
     active: "bg-primary/5 dark:bg-primary/5",
     reject: "bg-destructive/5 dark:bg-destructive/10",
     uploading: "bg-card",
-    error: "bg-destructive/5 dark:bg-destructive/10",
-    success: "bg-success-500/5 dark:bg-success-500/10",
   };
 
   // Icon component based on state
@@ -496,8 +570,6 @@ export function MediaUploadDropzone({
     active: Upload,
     reject: AlertTriangle,
     uploading: Loader2,
-    error: AlertTriangle,
-    success: Check,
   }[visualState];
 
   // Icon color based on state — default always uses primary for the circle contrast
@@ -506,216 +578,242 @@ export function MediaUploadDropzone({
     active: "text-primary",
     reject: "text-destructive",
     uploading: "text-primary",
-    error: "text-destructive",
-    success: "text-success-500 dark:text-success-400",
   };
 
-  if (isCollapsed) return null;
+  // Queue summary copy: live count while uploading, outcome once settled.
+  // Failures (validation/server errors) and batch-cap skips are reported
+  // separately so a skipped file is never announced as a failed one.
+  const settledSummary = [
+    `${successCount} uploaded`,
+    failureCount > 0 ? `${failureCount} failed` : null,
+    skippedCount > 0 ? `${skippedCount} skipped` : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
+  const queueSummary = isUploading
+    ? `Uploading ${inProgressCount} of ${uploadQueue.length} files...`
+    : settledSummary;
 
   return (
     <div className={cn("w-full relative group/dropzone", className)}>
-      {/* Close Button */}
-      {onToggleCollapse && (
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          onClick={e => {
-            e.stopPropagation();
-            onToggleCollapse();
-          }}
-          className="absolute right-2 top-2 z-10 rounded-none bg-background/50 hover:bg-background/80 backdrop-blur-sm transition-colors"
-          aria-label="Close upload zone"
-        >
-          <X className="h-4 w-4" />
-        </Button>
-      )}
-
-      {/* Dropzone */}
-      <div
-        {...getRootProps()}
-        onClick={isUploading ? undefined : open}
-        onKeyDown={e => {
-          if (!isUploading && (e.key === "Enter" || e.key === " ")) {
-            e.preventDefault();
-            open();
-          }
-        }}
-        className={cn(
-          "relative flex flex-col items-center justify-center rounded-none transition-all duration-200 group",
-          borderStyles[visualState],
-          backgroundStyles[visualState],
-          "min-h-48 md:min-h-56 py-16 px-8",
-          !isUploading &&
-            "cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary/40 focus:ring-offset-2",
-          isUploading && "cursor-not-allowed"
-        )}
-        role="button"
-        aria-label="Upload files. Drag and drop files here, or press Enter to browse."
-        aria-describedby="upload-instructions"
-        tabIndex={isUploading ? -1 : 0}
-      >
-        <input {...getInputProps()} aria-hidden="true" />
-
-        {/* Icon circle — solid filled, primary light color background */}
-        <div
-          className={cn(
-            "flex items-center justify-center rounded-none mb-5 transition-all duration-200",
-            "w-16 h-16",
-            // Solid filled circle — no ring/outline, just a clean bg fill
-            visualState === "default" &&
-              "bg-primary/20 dark:bg-primary/30 group-hover:bg-primary/30 dark:group-hover:bg-primary/40",
-            visualState === "active" && "bg-primary/20 dark:bg-primary/25",
-            visualState === "uploading" && "bg-primary/15 dark:bg-primary/20",
-            (visualState === "reject" || visualState === "error") &&
-              "bg-destructive/15 dark:bg-destructive/20",
-            visualState === "success" &&
-              "bg-success-500/15 dark:bg-success-500/20"
+      {!isCollapsed && (
+        <>
+          {/* Close Button */}
+          {onToggleCollapse && (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={e => {
+                e.stopPropagation();
+                onToggleCollapse();
+              }}
+              className="absolute right-2 top-2 z-10 rounded-none bg-background/50 hover:bg-background/80 backdrop-blur-sm transition-colors"
+              aria-label="Close upload zone"
+            >
+              <X className="h-4 w-4" />
+            </Button>
           )}
-        >
-          <IconComponent
+
+          {/* Dropzone */}
+          <div
+            {...getRootProps()}
+            onClick={isUploading ? undefined : open}
+            onKeyDown={e => {
+              if (!isUploading && (e.key === "Enter" || e.key === " ")) {
+                e.preventDefault();
+                open();
+              }
+            }}
             className={cn(
-              iconColorStyles[visualState],
-              "h-7 w-7 transition-colors duration-200",
-              isUploading && "animate-spin"
+              "relative flex flex-col items-center justify-center rounded-none transition-all duration-200 group",
+              borderStyles[visualState],
+              backgroundStyles[visualState],
+              "min-h-48 md:min-h-56 py-16 px-8",
+              !isUploading &&
+                "cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary/40 focus:ring-offset-2",
+              isUploading && "cursor-not-allowed"
             )}
-          />
-        </div>
-
-        {/* Text content */}
-        <div className="flex flex-col items-center gap-0.5 text-center">
-          {/* Folder indicator */}
-          {activeFolderId && activeFolderName && (
-            <p className="mb-1 text-xs text-muted-foreground">
-              Uploading to:{" "}
-              <span className="font-medium">{activeFolderName}</span>
-            </p>
-          )}
-          {/* Primary message */}
-          {visualState === "default" && (
-            <>
-              <p className="text-sm font-semibold text-foreground">
-                Drag &amp; drop files here
-              </p>
-              <button
-                type="button"
-                onClick={e => {
-                  e.stopPropagation();
-                  open();
-                }}
-                className="mt-1 text-sm font-medium text-primary hover-unified underline underline-offset-2"
-              >
-                or click to browse
-              </button>
-            </>
-          )}
-          {visualState !== "default" && (
-            <p className="text-sm font-semibold text-foreground">
-              {visualState === "active" && "Drop files here..."}
-              {visualState === "uploading" &&
-                `Uploading ${inProgressCount} file(s)...`}
-              {visualState === "success" &&
-                `${successCount} file(s) uploaded successfully`}
-              {(visualState === "error" || visualState === "reject") &&
-                (errorCount > 0
-                  ? `${errorCount} file(s) failed`
-                  : "Invalid file type or size")}
-            </p>
-          )}
-
-          {/* File type hint */}
-          <p
-            id="upload-instructions"
-            className="mt-2 text-xs text-muted-foreground dark:text-muted-foreground/80"
+            role="button"
+            aria-label="Upload files. Drag and drop files here, or press Enter to browse."
+            aria-describedby="upload-instructions"
+            tabIndex={isUploading ? -1 : 0}
           >
-            {fileTypeDescription}
-          </p>
-        </div>
+            <input {...getInputProps()} aria-hidden="true" tabIndex={-1} />
 
-        {/* Screen reader-only instructions */}
-        <span className="sr-only">
-          {fileTypeDescription}. Maximum files: {MAX_FILES} files per upload.
-        </span>
-      </div>
+            {/* Icon circle — solid filled, primary light color background */}
+            <div
+              className={cn(
+                "flex items-center justify-center rounded-none mb-5 transition-all duration-200",
+                "w-16 h-16",
+                // Solid filled square — no ring/outline, just a clean bg fill
+                visualState === "default" &&
+                  "bg-primary/20 dark:bg-primary/30 group-hover:bg-primary/30 dark:group-hover:bg-primary/40",
+                visualState === "active" && "bg-primary/20 dark:bg-primary/25",
+                visualState === "uploading" &&
+                  "bg-primary/15 dark:bg-primary/20",
+                visualState === "reject" &&
+                  "bg-destructive/15 dark:bg-destructive/20"
+              )}
+            >
+              <IconComponent
+                className={cn(
+                  iconColorStyles[visualState],
+                  "h-7 w-7 transition-colors duration-200",
+                  isUploading && "animate-spin"
+                )}
+              />
+            </div>
+
+            {/* Text content */}
+            <div className="flex flex-col items-center gap-0.5 text-center">
+              {/* Folder indicator */}
+              {activeFolderId && activeFolderName && (
+                <p className="mb-1 text-xs text-muted-foreground">
+                  Uploading to:{" "}
+                  <span className="font-medium">{activeFolderName}</span>
+                </p>
+              )}
+              {/* Primary message. The browse hint is plain text: the whole
+                  target is the interactive element, and a nested <button>
+                  inside role="button" is invalid markup. */}
+              {visualState === "default" && (
+                <>
+                  <p className="text-sm font-semibold text-foreground">
+                    Drag &amp; drop files here
+                  </p>
+                  <span className="mt-1 text-sm font-medium text-primary underline underline-offset-2">
+                    or click to browse
+                  </span>
+                </>
+              )}
+              {visualState !== "default" && (
+                <p className="text-sm font-semibold text-foreground">
+                  {visualState === "active" && "Drop files here..."}
+                  {visualState === "reject" &&
+                    "Some of these files can't be uploaded here"}
+                  {visualState === "uploading" &&
+                    `Uploading ${inProgressCount} file(s)...`}
+                </p>
+              )}
+
+              {/* File type hint */}
+              <p
+                id="upload-instructions"
+                className="mt-2 text-xs text-muted-foreground dark:text-muted-foreground/80"
+              >
+                {fileTypeDescription}
+              </p>
+            </div>
+
+            {/* Screen reader-only instructions */}
+            <span className="sr-only">
+              {fileTypeDescription}. Maximum files: {MAX_FILES} files per
+              upload.
+            </span>
+          </div>
+        </>
+      )}
 
       {/* ARIA live region for upload status */}
       <div aria-live="polite" aria-atomic="true" className="sr-only">
         {isUploading && `Uploading ${inProgressCount} files...`}
-        {successCount > 0 &&
-          !isUploading &&
-          `Upload complete. ${successCount} files uploaded successfully.`}
-        {errorCount > 0 &&
-          !isUploading &&
-          `Upload failed. ${errorCount} files failed to upload.`}
+        {!isUploading &&
+          uploadQueue.length > 0 &&
+          `Upload finished. ${settledSummary}.`}
       </div>
 
-      {/* Upload progress */}
-      {uploadQueue.length > 0 && !isCollapsed && (
-        <div className="mt-4 space-y-3">
-          {uploadQueue.map((item, index) => (
-            <div key={index} className="flex items-center gap-3">
-              {/* Status icon */}
-              <div className="flex-shrink-0">
-                {item.status === "uploading" && (
-                  <Loader2 className="h-4 w-4 animate-spin text-primary-500" />
-                )}
-                {item.status === "success" && (
-                  <Check className="h-4 w-4 text-success-500" />
-                )}
-                {item.status === "error" && (
-                  <X className="h-4 w-4 text-destructive" />
-                )}
-                {item.status === "pending" && (
-                  <div className="h-4 w-4 rounded-none border-2 border-border-foreground" />
-                )}
-              </div>
+      {/* Upload queue: renders regardless of isCollapsed so progress and
+          failures stay visible after the drop target auto-collapses. */}
+      {uploadQueue.length > 0 && (
+        <div
+          className={cn(
+            "border border-border bg-card",
+            isCollapsed ? "mt-0" : "mt-4"
+          )}
+        >
+          <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-2.5">
+            <p className="text-sm font-medium text-foreground" role="status">
+              {queueSummary}
+            </p>
+            {!isUploading && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setUploadQueue([])}
+                className="rounded-none"
+              >
+                Dismiss
+              </Button>
+            )}
+          </div>
 
-              {/* File info and progress */}
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center justify-between gap-2">
-                  <p className="truncate text-sm font-medium text-foreground">
-                    {item.filename}
-                  </p>
-                  <span className="flex-shrink-0 text-xs text-muted-foreground">
-                    {formatFileSize(item.file.size)}
-                  </span>
+          <div className="space-y-3 px-4 py-3">
+            {uploadQueue.map(item => (
+              <div key={item.id} className="flex items-center gap-3">
+                {/* Status icon */}
+                <div className="shrink-0">
+                  {item.status === "uploading" && (
+                    <Loader2 className="h-4 w-4 animate-spin text-primary" />
+                  )}
+                  {item.status === "success" && (
+                    <Check className="h-4 w-4 text-success" />
+                  )}
+                  {(item.status === "error" || item.status === "rejected") && (
+                    <X className="h-4 w-4 text-destructive" />
+                  )}
+                  {item.status === "pending" && (
+                    <div className="h-4 w-4 rounded-none border-2 border-border" />
+                  )}
                 </div>
 
-                {/* Progress bar */}
-                {(item.status === "uploading" || item.status === "pending") && (
-                  <Progress
-                    value={item.progress || 0}
-                    variant="default"
-                    className="mt-1"
-                    aria-label={`Uploading ${item.filename}: ${item.progress || 0}%`}
-                  />
-                )}
+                {/* File info and progress */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="truncate text-sm font-medium text-foreground">
+                      {item.filename}
+                    </p>
+                    <span className="shrink-0 text-xs text-muted-foreground">
+                      {formatFileSize(item.file.size)}
+                    </span>
+                  </div>
 
-                {/* Error message */}
-                {item.status === "error" && item.error && (
-                  <p className="mt-1 text-xs text-destructive">{item.error}</p>
+                  {/* Progress bar */}
+                  {(item.status === "uploading" ||
+                    item.status === "pending") && (
+                    <Progress
+                      value={item.progress || 0}
+                      variant="default"
+                      className="mt-1"
+                      aria-label={`Uploading ${item.filename}: ${item.progress || 0}%`}
+                    />
+                  )}
+
+                  {/* Failure reason */}
+                  {(item.status === "error" || item.status === "rejected") &&
+                    item.error && (
+                      <p className="mt-1 text-xs text-destructive">
+                        {item.error}
+                      </p>
+                    )}
+                </div>
+
+                {/* Retry applies to server failures only; a client-rejected
+                    file would fail the same validation again. */}
+                {item.status === "error" && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void handleRetry(item)}
+                    className="rounded-none shrink-0"
+                  >
+                    <RefreshCw className="h-3.5 w-3.5" />
+                    Retry
+                  </Button>
                 )}
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
-      )}
-
-      {/* File rejection errors */}
-      {fileRejections.length > 0 && (
-        <Alert variant="destructive" className="mt-4">
-          <AlertTriangle className="h-4 w-4" />
-          <AlertDescription>
-            <p className="font-medium">Some files were rejected:</p>
-            <ul className="mt-2 list-inside list-disc space-y-1 text-sm">
-              {fileRejections.map(({ file, errors }) => (
-                <li key={file.name}>
-                  <span className="font-medium">{file.name}</span>:{" "}
-                  {errors.map(e => e.message).join(", ")}
-                </li>
-              ))}
-            </ul>
-          </AlertDescription>
-        </Alert>
       )}
     </div>
   );

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
@@ -258,8 +258,16 @@ export function describeFileError(error: FileError, maxSize: number): string {
 /** Row reason for files beyond the batch cap. */
 const BATCH_SKIP_MESSAGE = `Skipped: only ${MAX_FILES} files can be uploaded at once`;
 
-/** A queue row: upload progress plus a stable identity for updates/retry. */
-type UploadQueueItem = UploadProgress & { id: string };
+/**
+ * A queue row: upload progress plus a stable identity for updates/retry and
+ * the folder the file was dropped into. The folder is snapshotted at drop
+ * time so a retry lands in the folder the user originally targeted, even if
+ * they navigated elsewhere while the failure sat in the queue.
+ */
+type UploadQueueItem = UploadProgress & {
+  id: string;
+  folderId: string | null;
+};
 
 // Stable row ids for React keys and targeted state updates; a module counter
 // avoids collisions across drops without needing crypto APIs.
@@ -276,8 +284,11 @@ function nextQueueItemId(): string {
 export function buildQueueFromDrop(
   acceptedFiles: File[],
   fileRejections: Pick<FileRejection, "file" | "errors">[],
-  maxSize: number
+  maxSize: number,
+  folderId: string | null
 ): { toUpload: UploadQueueItem[]; failed: UploadQueueItem[] } {
+  // The cap applies to VALID files: a batch with rejections still uploads up
+  // to MAX_FILES valid files (rejected files never consume cap slots).
   const withinCap = acceptedFiles.slice(0, MAX_FILES);
   const overCap = acceptedFiles.slice(MAX_FILES);
 
@@ -287,6 +298,7 @@ export function buildQueueFromDrop(
     filename: file.name,
     status: "pending",
     progress: 0,
+    folderId,
   }));
 
   const failed: UploadQueueItem[] = [
@@ -296,6 +308,7 @@ export function buildQueueFromDrop(
       filename: file.name,
       status: "rejected" as const,
       error: errors.map(e => describeFileError(e, maxSize)).join(", "),
+      folderId,
     })),
     ...overCap.map(file => ({
       id: nextQueueItemId(),
@@ -304,6 +317,7 @@ export function buildQueueFromDrop(
       status: "rejected" as const,
       skipped: true,
       error: BATCH_SKIP_MESSAGE,
+      folderId,
     })),
   ];
 
@@ -361,12 +375,13 @@ export function MediaUploadDropzone({
   const queryClient = useQueryClient();
 
   // Upload a single queue row, updating only that row by id. Shared by the
-  // initial batch and per-row retry.
+  // initial batch and per-row retry; the destination is the row's own
+  // drop-time folder, never the folder currently open in the UI.
   const uploadQueueItem = React.useCallback(
     (item: UploadQueueItem): Promise<Media | null> => {
       return uploadMediaAsync({
         file: item.file,
-        folderId: activeFolderId,
+        folderId: item.folderId,
         onProgress: progress => {
           setUploadQueue(prevQueue =>
             prevQueue.map(row =>
@@ -403,7 +418,7 @@ export function MediaUploadDropzone({
           return null; // Return null for failed uploads
         });
     },
-    [uploadMediaAsync, activeFolderId]
+    [uploadMediaAsync]
   );
 
   // Handle file drop: build the queue (including pre-failed rows), then
@@ -413,7 +428,8 @@ export function MediaUploadDropzone({
       const { toUpload, failed } = buildQueueFromDrop(
         acceptedFiles,
         fileRejections,
-        maxSize
+        maxSize,
+        activeFolderId ?? null
       );
 
       // Starting a new drop replaces the previous batch's results
@@ -439,7 +455,14 @@ export function MediaUploadDropzone({
         onUploadComplete?.(successfulUploads);
       }
     },
-    [maxSize, onUploadStart, uploadQueueItem, queryClient, onUploadComplete]
+    [
+      maxSize,
+      activeFolderId,
+      onUploadStart,
+      uploadQueueItem,
+      queryClient,
+      onUploadComplete,
+    ]
   );
 
   // Retry a server-failed row in place. Client-rejected rows never retry
@@ -591,12 +614,15 @@ export function MediaUploadDropzone({
     .filter(Boolean)
     .join(", ");
   // The live denominator counts only rows that will actually upload;
-  // pre-rejected rows sit in the same queue but were never attempted.
+  // pre-rejected rows sit in the same queue but were never attempted. The
+  // numerator counts finished rows so the label climbs (0 -> N) instead of
+  // counting down the remaining work.
   const uploadableCount = uploadQueue.filter(
     item => item.status !== "rejected"
   ).length;
+  const finishedCount = uploadableCount - inProgressCount;
   const queueSummary = isUploading
-    ? `Uploading ${inProgressCount} of ${uploadableCount} files...`
+    ? `Uploading files: ${finishedCount} of ${uploadableCount} done`
     : settledSummary;
 
   return (
@@ -719,12 +745,18 @@ export function MediaUploadDropzone({
         </>
       )}
 
-      {/* ARIA live region for upload status */}
-      <div aria-live="polite" aria-atomic="true" className="sr-only">
-        {isUploading && `Uploading ${inProgressCount} files...`}
-        {!isUploading &&
-          uploadQueue.length > 0 &&
-          `Upload finished. ${settledSummary}.`}
+      {/* The single ARIA live region for upload status. Always mounted so
+          screen readers announce the first status too; the visible summary
+          below is deliberately NOT a live region, so each state change is
+          announced exactly once. */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {uploadQueue.length > 0 &&
+          (isUploading ? queueSummary : `Upload finished. ${settledSummary}.`)}
       </div>
 
       {/* Upload queue: renders regardless of isCollapsed so progress and
@@ -737,7 +769,7 @@ export function MediaUploadDropzone({
           )}
         >
           <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-2.5">
-            <p className="text-sm font-medium text-foreground" role="status">
+            <p className="text-sm font-medium text-foreground">
               {queueSummary}
             </p>
             {!isUploading && (

--- a/packages/admin/src/components/features/media-library/index.tsx
+++ b/packages/admin/src/components/features/media-library/index.tsx
@@ -286,8 +286,7 @@ export function MediaLibrary({
 
   // Handlers: Upload
   const handleUploadComplete = React.useCallback(
-    (media: Media[]) => {
-      console.log("[MediaLibrary] Upload complete:", media.length, "files");
+    (_media: Media[]) => {
       // Refetch to show new uploads
       void refetch();
       // Clear selection
@@ -295,6 +294,12 @@ export function MediaLibrary({
     },
     [refetch]
   );
+
+  // Collapse the drop target as soon as files start uploading; the dropzone's
+  // queue keeps rendering while collapsed, so progress stays visible.
+  const handleUploadStart = React.useCallback(() => {
+    setIsUploadCollapsed(true);
+  }, []);
 
   // Handlers: Delete
   const handleDeleteItem = React.useCallback((media: Media) => {
@@ -541,7 +546,7 @@ export function MediaLibrary({
             <Button
               onClick={() => setIsUploadCollapsed(!isUploadCollapsed)}
               className={cn(
-                "flex items-center gap-2 px-5 h-10 shrink-0 font-medium tracking-tight rounded-none shadow-sm",
+                "flex items-center gap-2 px-5 h-10 shrink-0 font-medium tracking-tight rounded-none",
                 !isUploadCollapsed ? "opacity-90" : ""
               )}
             >
@@ -557,6 +562,7 @@ export function MediaLibrary({
           isCollapsed={isUploadCollapsed}
           onToggleCollapse={() => setIsUploadCollapsed(!isUploadCollapsed)}
           onUploadComplete={handleUploadComplete}
+          onUploadStart={handleUploadStart}
           activeFolderId={activeFolderId}
           activeFolderName={activeFolderName}
           className={cn(!isUploadCollapsed && "mb-8")}

--- a/packages/admin/src/types/media.ts
+++ b/packages/admin/src/types/media.ts
@@ -217,7 +217,17 @@ export interface MediaListResponse {
 export interface UploadProgress {
   file: File;
   filename: string;
-  status: "pending" | "uploading" | "success" | "error";
+  /**
+   * `error` is a server-side failure (retryable); `rejected` is a client-side
+   * validation failure (too large, wrong type, over the batch cap) that would
+   * fail identically on retry.
+   */
+  status: "pending" | "uploading" | "success" | "error" | "rejected";
+  /**
+   * True for rejected rows that were dropped only because the batch exceeded
+   * the per-upload file cap (reported as "skipped", not "failed").
+   */
+  skipped?: boolean;
   progress?: number; // 0-100
   error?: string;
   mediaId?: string; // Set on success


### PR DESCRIPTION
## What & why

Tier-4 item #7 (Media page), PR 1 of 2 per the approved design doc (`tier4-07-media-design.md`, D-M1..D-M4): the bulk-upload error path had four distinct defects, all reproduced live before the fix.

1. **All-or-nothing batch rejection.** `maxFiles: 10` on `useDropzone` made react-dropzone reject an 11-file batch entirely: nothing uploaded and every valid file was labeled "Too many files".
2. **Raw library error copy.** Rejections rendered react-dropzone defaults, e.g. "File is larger than 5242880 bytes".
3. **Aggregate error state masked partial success.** One oversized file in a 10-file drop painted the whole dropzone as a full-height red "Invalid file type or size" panel while 9 files uploaded successfully behind it.
4. **Successes vanished, errors persisted.** The queue auto-cleared after 2s; the surviving UI showed only failure.

## The fix

- **One per-file upload queue.** Every dropped file gets a row: progress bar, status icon, and a persistent human reason on failure. Client rejections join the same list as rows, not a separate alert.
- **Batch cap = first 10 accepted.** `maxFiles` removed; `onDrop` slices the batch, uploads the first 10, and marks the overflow "Skipped: only 10 files can be uploaded at once". Enforced in `buildQueueFromDrop` (pure, unit-tested).
- **Human error copy** via an explicit code map: "File is too large (max 10 MB)", "File type is not supported". Unknown codes fall through to the library message.
- **Honest summary** that separates outcomes: "10 uploaded, 1 failed, 3 skipped". All-success queues auto-dismiss after 4s; any failure keeps the queue until dismissed.
- **Auto-collapse on upload start** (`onUploadStart`): the drop target closes itself when files begin uploading; the queue renders independently of `isCollapsed` so progress is never hidden.
- **Retry** on server-failed rows (file still in memory); client-rejected rows get no retry since revalidation would fail identically.
- **Client size default aligned to the server's 10MB** (`limits.fileSize` default). It was 5MB, so 5-10MB files were refused client-side that the server would have accepted. The server stays authoritative; its errors render per row.
- **A11y**: the "or click to browse" hint is no longer a `<button>` nested inside the `role="button"` drop target.
- **Tokens**: dropzone `success-500`/`text-primary-500`/`border-border-foreground` raw-scale classes replaced with semantic tokens; non-token `shadow-sm` dropped from the Upload button.

## Verification

- Unit: 9 new tests for `describeFileError` + `buildQueueFromDrop` (admin suite: 865 passed, 37 failed = exact pre-existing baseline).
- E2E: 2 new Playwright specs (partial failure + batch cap) against the real server; full suite 17/17 (baseline 15 + 2 new).
- Browser (light + dark): reproduced the old bugs on main, then verified live on this branch: 9+1-oversized drop reads "9 uploaded, 1 failed" with the 9 visible in the grid; 14-file drop reads "10 uploaded, 1 failed, 3 skipped"; all-success queue auto-dismisses; drop target auto-collapses.
- `MediaPickerDialog` consumes the same component with unchanged props (`isCollapsed={false}`, no `onUploadStart`), so its upload tab keeps the target open during upload by construction; picker flows re-verified in browser in PR 2 alongside the folder work.

PR 2 (folders model, table default, persistence, sort control, remaining token sweep) follows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Media uploads now use a per-file queue with partial success/failure reporting.
  - Client-side validation failures appear directly in the queue (including “rejected” vs “skipped” when over the 10-file cap).
  - Uploads exceeding the 10-file limit are marked as skipped, while valid files still upload.
  - Failed items can be retried from the queue; results remain visible even when the upload area collapses.
  - Added “Dismiss” for clearing settled results.

- **Bug Fixes**
  - More accurate, user-friendly error messages for invalid type, oversized files, and upload limits.

- **Tests**
  - Added end-to-end coverage for mixed and over-cap uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->