### PR TITLE
feat(nextly): form-surface field catalog and plugin field-type surfaces

### DIFF
--- a/.changeset/form-field-catalog.md
+++ b/.changeset/form-field-catalog.md
@@ -1,0 +1,26 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The shared field-type catalog now describes the form surface, and plugin field types can declare where they belong.
+
+`nextly/field-catalog` gains `FORM_FIELD_TYPE_CATALOG`: the form builder's thirteen field types described once in the same catalog the schema builder and user-profile pickers already read, including five form-surface types (url, phone, time, file, hidden) that are deliberately not part of the canonical collection field union — form fields live in a form's JSON, so these can never reach the schema pipeline. The url and phone descriptions are shared with the user-profile surface, so a "URL" field looks and reads the same everywhere.
+
+Plugin-contributed field types can now declare `surfaces` (entries, users, forms) on their registration. A type only appears in a surface's field picker when the surface admits it, the type declares it, and the host has not excluded it — each level can only remove types, never force one in. Omitting `surfaces` keeps today's behavior (the type appears on the entry editing surface only).

--- a/packages/nextly/src/collections/fields/catalog.test.ts
+++ b/packages/nextly/src/collections/fields/catalog.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   FIELD_TYPE_CATALOG,
+  FORM_FIELD_TYPE_CATALOG,
+  USER_FIELD_TYPE_CATALOG,
   getFieldTypeCatalogEntry,
   narrowFieldTypeCatalog,
 } from "./catalog";
@@ -42,5 +44,62 @@ describe("FIELD_TYPE_CATALOG", () => {
   it("narrows to a surface's subset in catalog order", () => {
     const subset = narrowFieldTypeCatalog(["date", "text", "select"]);
     expect(subset.map(entry => entry.type)).toEqual(["text", "date", "select"]);
+  });
+});
+
+describe("FORM_FIELD_TYPE_CATALOG", () => {
+  it("describes the form surface's thirteen types exactly once", () => {
+    const types = FORM_FIELD_TYPE_CATALOG.map(entry => entry.type);
+    expect(new Set(types).size).toBe(types.length);
+    expect([...types].sort()).toEqual(
+      [
+        "text",
+        "textarea",
+        "number",
+        "email",
+        "url",
+        "phone",
+        "select",
+        "radio",
+        "checkbox",
+        "date",
+        "time",
+        "file",
+        "hidden",
+      ].sort()
+    );
+  });
+
+  it("slots url and phone beside email, and time beside date", () => {
+    const types = FORM_FIELD_TYPE_CATALOG.map(entry => entry.type);
+    const email = types.indexOf("email");
+    expect(types[email + 1]).toBe("url");
+    expect(types[email + 2]).toBe("phone");
+    const date = types.indexOf("date");
+    expect(types[date + 1]).toBe("time");
+  });
+
+  it("keeps the surface-only types out of the canonical catalog", () => {
+    for (const surfaceOnly of ["time", "file", "hidden"]) {
+      expect(
+        FIELD_TYPE_CATALOG.find(entry => entry.type === surfaceOnly)
+      ).toBeUndefined();
+    }
+  });
+
+  it("shares the url and phone descriptions with the user surface", () => {
+    for (const shared of ["url", "phone"] as const) {
+      const formEntry = FORM_FIELD_TYPE_CATALOG.find(e => e.type === shared);
+      const userEntry = USER_FIELD_TYPE_CATALOG.find(e => e.type === shared);
+      expect(formEntry).toEqual(userEntry);
+    }
+  });
+
+  it("gives every entry a non-empty label, hint, and icon name", () => {
+    for (const entry of FORM_FIELD_TYPE_CATALOG) {
+      expect(entry.label.length).toBeGreaterThan(0);
+      expect(entry.hint.length).toBeGreaterThan(0);
+      expect(entry.icon.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/packages/nextly/src/collections/fields/catalog.test.ts
+++ b/packages/nextly/src/collections/fields/catalog.test.ts
@@ -79,6 +79,24 @@ describe("FORM_FIELD_TYPE_CATALOG", () => {
     expect(types[date + 1]).toBe("time");
   });
 
+  it("keeps categories in display order (Basic before Advanced before Media)", () => {
+    const order = ["Basic", "Advanced", "Media", "Relational", "Structured"];
+    const indices = FORM_FIELD_TYPE_CATALOG.map(entry =>
+      order.indexOf(entry.category)
+    );
+    for (let i = 1; i < indices.length; i++) {
+      expect(indices[i]).toBeGreaterThanOrEqual(indices[i - 1]);
+    }
+  });
+
+  it("gives every form-surface type an icon distinct from canonical entries", () => {
+    const canonicalIcons = new Set(FIELD_TYPE_CATALOG.map(e => e.icon));
+    for (const surfaceOnly of ["url", "phone", "time", "file", "hidden"]) {
+      const entry = FORM_FIELD_TYPE_CATALOG.find(e => e.type === surfaceOnly);
+      expect(entry && canonicalIcons.has(entry.icon)).toBe(false);
+    }
+  });
+
   it("keeps the surface-only types out of the canonical catalog", () => {
     for (const surfaceOnly of ["time", "file", "hidden"]) {
       expect(

--- a/packages/nextly/src/collections/fields/catalog.ts
+++ b/packages/nextly/src/collections/fields/catalog.ts
@@ -180,12 +180,60 @@ export const FIELD_TYPE_CATALOG: readonly FieldTypeCatalogEntry[] = [
 ];
 
 /**
- * Field types that exist only on the user-profile surface. They are NOT part
+ * Field types that exist only on specific admin surfaces. They are NOT part
  * of the canonical `FieldType` union: a collection cannot declare them, so
- * they can never reach the schema pipeline's column mappers. Both store as
- * text; their meaning is validation (a URL shape, a phone shape).
+ * they can never reach the schema pipeline's column mappers. Their storage
+ * is either text with validation semantics (url, phone, time, hidden) or the
+ * surface's own blob handling (file inside a form's JSON).
  */
 export type UserSurfaceFieldType = "url" | "phone";
+
+/** Field types that exist only on the form-builder surface. */
+export type FormSurfaceFieldType = "url" | "phone" | "file" | "time" | "hidden";
+
+/**
+ * Surface-only catalog entries, described once so every surface that admits
+ * them shares one label/icon/hint. Slotted into per-surface catalogs below.
+ */
+const URL_SURFACE_ENTRY = {
+  type: "url",
+  label: "URL",
+  category: "Basic",
+  hint: "Validated web address",
+  icon: "Link2",
+} as const satisfies FieldTypeCatalogEntry<"url">;
+
+const PHONE_SURFACE_ENTRY = {
+  type: "phone",
+  label: "Phone",
+  category: "Basic",
+  hint: "Phone number",
+  icon: "Phone",
+} as const satisfies FieldTypeCatalogEntry<"phone">;
+
+const TIME_SURFACE_ENTRY = {
+  type: "time",
+  label: "Time",
+  category: "Basic",
+  hint: "Time of day",
+  icon: "Clock",
+} as const satisfies FieldTypeCatalogEntry<"time">;
+
+const FILE_SURFACE_ENTRY = {
+  type: "file",
+  label: "File upload",
+  category: "Media",
+  hint: "File attached by the visitor",
+  icon: "Upload",
+} as const satisfies FieldTypeCatalogEntry<"file">;
+
+const HIDDEN_SURFACE_ENTRY = {
+  type: "hidden",
+  label: "Hidden",
+  category: "Advanced",
+  hint: "Invisible value submitted with the form",
+  icon: "EyeOff",
+} as const satisfies FieldTypeCatalogEntry<"hidden">;
 
 /** The user-profile surface's field types: flat scalars plus url/phone. */
 export type UserFieldCatalogType =
@@ -217,25 +265,62 @@ export const USER_FIELD_TYPE_CATALOG: readonly FieldTypeCatalogEntry<UserFieldCa
       "checkbox",
       "date",
     ] as const);
-    const url: FieldTypeCatalogEntry<UserFieldCatalogType> = {
-      type: "url",
-      label: "URL",
-      category: "Basic",
-      hint: "Validated web address",
-      icon: "Link2",
-    };
-    const phone: FieldTypeCatalogEntry<UserFieldCatalogType> = {
-      type: "phone",
-      label: "Phone",
-      category: "Basic",
-      hint: "Phone number",
-      icon: "Phone",
-    };
     const combined: FieldTypeCatalogEntry<UserFieldCatalogType>[] = [];
     for (const entry of scalars) {
       combined.push(entry);
-      if (entry.type === "email") combined.push(url, phone);
+      if (entry.type === "email") {
+        combined.push(URL_SURFACE_ENTRY, PHONE_SURFACE_ENTRY);
+      }
     }
+    return combined;
+  })();
+
+/** The form-builder surface's field types: flat inputs plus its own five. */
+export type FormFieldCatalogType =
+  | "text"
+  | "textarea"
+  | "number"
+  | "email"
+  | "url"
+  | "phone"
+  | "select"
+  | "radio"
+  | "checkbox"
+  | "date"
+  | "time"
+  | "file"
+  | "hidden";
+
+/**
+ * The form-builder picker's catalog: the flat-input subset of the shared
+ * catalog plus the form-surface types — url/phone beside email (contact
+ * shapes together, matching the user surface), time beside date, and
+ * file/hidden appended in their own categories. Form fields live in the
+ * form's JSON blob, so none of these touch the schema pipeline.
+ */
+export const FORM_FIELD_TYPE_CATALOG: readonly FieldTypeCatalogEntry<FormFieldCatalogType>[] =
+  (() => {
+    const scalars = narrowFieldTypeCatalog([
+      "text",
+      "textarea",
+      "number",
+      "email",
+      "select",
+      "radio",
+      "checkbox",
+      "date",
+    ] as const);
+    const combined: FieldTypeCatalogEntry<FormFieldCatalogType>[] = [];
+    for (const entry of scalars) {
+      combined.push(entry);
+      if (entry.type === "email") {
+        combined.push(URL_SURFACE_ENTRY, PHONE_SURFACE_ENTRY);
+      }
+      if (entry.type === "date") {
+        combined.push(TIME_SURFACE_ENTRY);
+      }
+    }
+    combined.push(FILE_SURFACE_ENTRY, HIDDEN_SURFACE_ENTRY);
     return combined;
   })();
 

--- a/packages/nextly/src/collections/fields/catalog.ts
+++ b/packages/nextly/src/collections/fields/catalog.ts
@@ -200,7 +200,7 @@ const URL_SURFACE_ENTRY = {
   label: "URL",
   category: "Basic",
   hint: "Validated web address",
-  icon: "Link2",
+  icon: "Globe",
 } as const satisfies FieldTypeCatalogEntry<"url">;
 
 const PHONE_SURFACE_ENTRY = {
@@ -214,7 +214,7 @@ const PHONE_SURFACE_ENTRY = {
 const TIME_SURFACE_ENTRY = {
   type: "time",
   label: "Time",
-  category: "Basic",
+  category: "Advanced",
   hint: "Time of day",
   icon: "Clock",
 } as const satisfies FieldTypeCatalogEntry<"time">;
@@ -224,7 +224,7 @@ const FILE_SURFACE_ENTRY = {
   label: "File upload",
   category: "Media",
   hint: "File attached by the visitor",
-  icon: "Upload",
+  icon: "Paperclip",
 } as const satisfies FieldTypeCatalogEntry<"file">;
 
 const HIDDEN_SURFACE_ENTRY = {
@@ -320,7 +320,7 @@ export const FORM_FIELD_TYPE_CATALOG: readonly FieldTypeCatalogEntry<FormFieldCa
         combined.push(TIME_SURFACE_ENTRY);
       }
     }
-    combined.push(FILE_SURFACE_ENTRY, HIDDEN_SURFACE_ENTRY);
+    combined.push(HIDDEN_SURFACE_ENTRY, FILE_SURFACE_ENTRY);
     return combined;
   })();
 

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -352,6 +352,7 @@ export {
   type PluginEmailProvider,
   type PluginEmailTemplate,
   type PluginFieldType,
+  type FieldSurface,
   type ScheduledTask,
   type PermissionSlug,
   type PluginHookRegistry,

--- a/packages/nextly/src/plugins/contributions.ts
+++ b/packages/nextly/src/plugins/contributions.ts
@@ -114,6 +114,14 @@ export interface PluginEmailTemplate {
  * the given admin `component`. Validation rides on the primitive + the field's
  * standard `validate` option. (Typed builders + Visual-Builder UI are full-M9.)
  */
+/**
+ * The admin surfaces a field type can appear on. Each surface narrows the
+ * visible type set independently: what a picker shows resolves as the
+ * surface's own capability set ∩ the type's declared surfaces ∩ the host's
+ * excludes — every level can only remove types, never force one in.
+ */
+export type FieldSurface = "entries" | "users" | "forms";
+
 export interface PluginFieldType {
   /** Field type id used as `field.type` (e.g. `"rating"`). Must not collide with a built-in. */
   type: string;
@@ -121,6 +129,14 @@ export interface PluginFieldType {
   storage: "text" | "longText" | "boolean" | "number" | "timestamp" | "json";
   /** Admin field-editor component path, resolved via the component registry. */
   component: ComponentPath;
+  /**
+   * Which admin surfaces may offer this type in their field pickers. Omitted
+   * means the entry/single editing surface only — a type never auto-appears
+   * on a surface its author did not opt into. Instances of a type that later
+   * stops being offered still render (read-only degradation), they are never
+   * dropped.
+   */
+  surfaces?: readonly FieldSurface[];
   /**
    * Layout hint for the entry/single form. `"takeover"`: when a visible field of
    * this type is present, the form body shows only that field plus the field that

--- a/packages/nextly/src/plugins/index.ts
+++ b/packages/nextly/src/plugins/index.ts
@@ -31,6 +31,7 @@ export type {
   PluginEmailProvider,
   PluginEmailTemplate,
   PluginFieldType,
+  FieldSurface,
   ScheduledTask,
   PermissionSlug,
 } from "./contributions";


### PR DESCRIPTION
## What & why

Tier-4 item #10 (Form Builder), PR B of the approved sub-doc 1 (`tier4-10-01-fields-design.md`, D-FB1 + D-FB2): the nextly-side contract the field-editor rebuild (PR C) consumes. Additive only — no UI or behavior change.

### One catalog for the form surface (D-FB1)

`nextly/field-catalog` gains **`FORM_FIELD_TYPE_CATALOG`** — the form builder's 13 types described in the same shared catalog the schema builder and user-field pickers already read. Construction mirrors #14's `USER_FIELD_TYPE_CATALOG` exactly:

- 8 canonical types narrowed via `narrowFieldTypeCatalog` (text, textarea, number, email, select, radio, checkbox, date);
- **url/phone** are now shared surface-entry constants used by BOTH the user and form catalogs (one label/icon/hint everywhere; a test locks the equality);
- **time, file, hidden** are new form-surface entries, deliberately NOT in the canonical `FieldType` union — form fields persist in the form's JSON blob, so these can never reach the schema pipeline's column mappers (the §5b Drizzle-v1 boundary holds: zero pipeline files touched).

This is the replacement for the plugin's five duplicate field-type lists, which PR C deletes when it rewires the builder.

### The §5c `surfaces` declaration (D-FB2)

`PluginFieldType` gains an optional **`surfaces?: readonly FieldSurface[]`** (`"entries" | "users" | "forms"`). Visibility semantics documented on the type: surface capability ∩ declared surfaces ∩ host excludes — each level only removes. Omitted = entry-editing surface only, i.e. exactly today's behavior, so every existing registration is unaffected. Duplicate-key loud failure already exists in the registry (`NEXTLY_FIELD_TYPE_COLLISION`) and is unchanged. The host-exclude *wiring* (the form plugin's enable/disable option) lands in PR C where its consumer lives.

## Verification

- 5 new catalog tests (13-types-once, ordering slots, surface-types-stay-out-of-canonical, url/phone shared with user surface, non-empty descriptions); nextly catalog suite 10/10.
- Typecheck + lint clean; full `nextly` build succeeds (the `field-catalog` subpath entry compiles and its dts rolls up).
- No consumer changes anywhere: additive exports only (`FORM_FIELD_TYPE_CATALOG`, `FormFieldCatalogType`, `FormSurfaceFieldType`, `FieldSurface`).

PR C (the card-list field editor rebuilt on the kit, host-exclude wiring, save-path routing) follows on top of this and PR #190.
