### PR TITLE
docs: add package agent guides and integration-test rule

### DIFF
--- a/.claude/rules/integration-tests.md
+++ b/.claude/rules/integration-tests.md
@@ -15,6 +15,7 @@ Integration tests in this repo must:
   `packages/nextly/src/database/__tests__/integration/helpers/test-db.ts`)
   so files stay independent.
 - Never target an existing database. Use the throwaway containers from
-  `pnpm docker:test` (Postgres on 5434/5435, MySQL on 3307).
+  `pnpm docker:test` (Postgres 15 on 5434, Postgres 17 on 5435, MySQL on
+  3307; these are the matrix-tested versions).
 - Run from the repo root so turbo builds dependencies first; a direct
   package-level run on an unbuilt tree produces dozens of false failures.

--- a/.claude/rules/integration-tests.md
+++ b/.claude/rules/integration-tests.md
@@ -1,0 +1,20 @@
+---
+paths:
+  - "**/*.integration.test.ts"
+---
+
+Integration tests in this repo must:
+
+- Reuse the production DDL helpers for system tables (for example
+  `getSchemaEventsDdl`); never hand-copy CREATE TABLE statements into
+  fixtures, they drift.
+- Self-skip when the dialect's connection URL (`TEST_POSTGRES_URL`,
+  `TEST_MYSQL_URL`) is unset instead of failing; SQLite may fall back to
+  in-memory.
+- Use a unique per-file table or schema prefix (see
+  `packages/nextly/src/database/__tests__/integration/helpers/test-db.ts`)
+  so files stay independent.
+- Never target an existing database. Use the throwaway containers from
+  `pnpm docker:test` (Postgres on 5434/5435, MySQL on 3307).
+- Run from the repo root so turbo builds dependencies first; a direct
+  package-level run on an unbuilt tree produces dozens of false failures.

--- a/.claude/rules/integration-tests.md
+++ b/.claude/rules/integration-tests.md
@@ -11,9 +11,12 @@ Integration tests in this repo must:
 - Self-skip when the dialect's connection URL (`TEST_POSTGRES_URL`,
   `TEST_MYSQL_URL`) is unset instead of failing; SQLite may fall back to
   in-memory.
-- Use a unique per-file table or schema prefix (see
+- Use a unique per-file table or schema prefix for TEST-OWNED tables (see
   `packages/nextly/src/database/__tests__/integration/helpers/test-db.ts`)
-  so files stay independent.
+  so files stay independent. Fixed-name SYSTEM tables (for example
+  `nextly_schema_events`) cannot be prefixed; suites that create them rely on
+  the sequential integration run (`fileParallelism: false`) for isolation,
+  which is why parallelism must never be re-enabled.
 - Never target an existing database. Use the throwaway containers from
   `pnpm docker:test` (Postgres 15 on 5434, Postgres 17 on 5435, MySQL on
   3307; these are the matrix-tested versions).

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,10 @@ apps/playground/src/db/schemas/**/*
 apps/playground/src/db/schemas/dynamic/*.ts
 !apps/playground/src/db/schemas/dynamic/index.ts
 
-# Claude Code local config
-.claude/
+# Claude Code: local config stays ignored, shared rules/skills are committed
+.claude/*
+!.claude/rules/
+!.claude/skills/
 
 # Testing
 coverage

--- a/packages/admin/AGENTS.md
+++ b/packages/admin/AGENTS.md
@@ -1,0 +1,39 @@
+# packages/admin: Agent Guide
+
+Admin panel UI. Read the root AGENTS.md first; this file adds what only
+matters inside `packages/admin`.
+
+## Styling rules (strict)
+
+- All admin styles are scoped under the `.nextly-admin` wrapper by a
+  build-time CSS scoper (`scripts/build-css.mjs`; the scoper has its own
+  tests in `scripts/*.test.mjs`).
+- Design tokens only: `--nx-*` custom properties defined in
+  `packages/ui/src/styles/theme.css` for light AND dark. Zero hardcoded
+  colors. Every visual change must be checked in both modes; there are no
+  single-mode changes.
+
+## Data and errors
+
+- Parse API errors with `src/lib/api/parseApiError.ts` against the canonical
+  `{ error: { code, message, requestId, data? } }` envelope. Do not throw or
+  expect `NextlyError` here; that class belongs to the core package.
+- Prefer type-only imports from `nextly/config` (field types and guards) so
+  admin does not pull Next-coupled runtime code. The serializable field-type
+  catalog is imported from `nextly/field-catalog`.
+- `@tanstack/react-query` is externalized from the bundle and resolved from
+  the consumer's node_modules. Keep it (and the other externals listed in
+  `tsup.config.ts`) out of the bundle.
+
+## Component conventions
+
+- Tables: reset pagination when search or page size changes, set `getRowId`,
+  and preserve cross-page selection semantics (follow the existing table
+  components).
+- Field editors: the shared field-UI kit lives in `src/components/field-ui/`
+  (`FieldTypePicker`, `FieldDefaultValueInput`, `FieldOptionsEditor`) and is
+  re-exported through the plugin SDK as experimental surface. New field
+  pickers must render from the catalog, never from a hand-written type list.
+- Entry field rendering goes through
+  `src/components/features/entries/fields/FieldRenderer.tsx`; list cells
+  through the EntryList table components.

--- a/packages/nextly/AGENTS.md
+++ b/packages/nextly/AGENTS.md
@@ -43,9 +43,11 @@ inside `packages/nextly`.
 
 - Unit: `vitest run` (excludes `*.integration.test.ts`).
 - Integration: separate config (`vitest.integration.config.ts`), forks pool,
-  single fork, `fileParallelism: false`. Suites that create system tables
-  must use the production DDL helpers and a unique per-file prefix (see
-  `src/database/__tests__/integration/helpers/test-db.ts`).
+  single fork, `fileParallelism: false`. Test-owned tables use a unique
+  per-file prefix (see
+  `src/database/__tests__/integration/helpers/test-db.ts`); fixed-name
+  system tables (created via the production DDL helpers) cannot be prefixed
+  and rely on the sequential run for isolation.
 - Integration tests self-skip when `TEST_POSTGRES_URL` / `TEST_MYSQL_URL` is
   unset; SQLite falls back to in-memory. Run from the repo root so turbo
   builds first.

--- a/packages/nextly/AGENTS.md
+++ b/packages/nextly/AGENTS.md
@@ -1,0 +1,51 @@
+# packages/nextly: Agent Guide
+
+Core package. Read the root AGENTS.md first; this file adds what only matters
+inside `packages/nextly`.
+
+## Entry points
+
+- Config surface: `src/config.ts` (field factories, `defineCollection`,
+  `defineSingle`, `defineConfig`, type guards). Field factories live in
+  `src/collections/fields/helpers.ts`.
+- Field-type catalog: `src/collections/fields/catalog.ts`, published as the
+  `nextly/field-catalog` subpath. Pure serializable data (labels, categories,
+  hints, Lucide icon NAMES); admin pickers, the user-fields page, and the
+  form builder all render from it. Surfaces narrow it with
+  `narrowFieldTypeCatalog`; they never redeclare type lists.
+- Direct API: `src/direct-api/nextly.ts`. REST dispatcher: `src/routeHandler.ts`
+  plus `src/dispatcher/`. CLI: `src/cli/program.ts`.
+
+## Facts agents get wrong without help
+
+- Direct API lists return `{ items, meta }`; mutations return a result with
+  `.item`. There is no `docs`/`totalDocs` shape anywhere.
+- `overrideAccess` defaults to `true` (trusted server context). Enforcing
+  access control requires `overrideAccess: false` plus a `user`.
+- The canonical `FieldType` union has 18 members and the structured-array
+  type is `repeater`; the `array()` factory is a backward-compat alias, use
+  `repeater()` in new code. Surface-only types (`url`, `phone` for users;
+  plus `file`, `time`, `hidden` for forms) are intentionally NOT in the
+  union so they can never reach the schema pipeline's column mappers.
+- Field-to-column mapping has ONE source of truth:
+  `src/domains/schema/services/field-column-descriptor.ts` (per-dialect).
+  The adapters do not map field types; do not add mapping logic there.
+- Error codes live in `src/errors/error-codes.ts` with canonical HTTP
+  statuses. Add new codes there; never inline status numbers. Throw via
+  `NextlyError` factories.
+- The CLI has no `dev` command on purpose (user apps run `next dev`; schema
+  applies via the HMR listener in `src/runtime/hmr-listener.ts`).
+  `generate:schema` is a stub. `migrate:down` exists (single-step rollback);
+  `migrate:reset`/`migrate:rollback`/`migrate:refresh` were deliberately
+  deleted. Do not resurrect removed commands.
+
+## Testing in this package
+
+- Unit: `vitest run` (excludes `*.integration.test.ts`).
+- Integration: separate config (`vitest.integration.config.ts`), forks pool,
+  single fork, `fileParallelism: false`. Suites that create system tables
+  must use the production DDL helpers and a unique per-file prefix (see
+  `src/database/__tests__/integration/helpers/test-db.ts`).
+- Integration tests self-skip when `TEST_POSTGRES_URL` / `TEST_MYSQL_URL` is
+  unset; SQLite falls back to in-memory. Run from the repo root so turbo
+  builds first.


### PR DESCRIPTION
## What

- Nested `AGENTS.md` for `packages/nextly` and `packages/admin`: package-specific guidance that loads only when an agent works in those directories (nearest-file-wins is native behavior in Claude Code, Cursor, Codex, and Copilot).
- `.claude/rules/integration-tests.md`: a path-scoped rule (glob `**/*.integration.test.ts`) encoding the integration-test invariants (production DDL reuse, self-skip without TEST_* URLs, per-file prefixes, throwaway DBs only).
- `.gitignore`: `.claude/` was fully ignored as local config; switched to `.claude/*` with negations for `rules/` and `skills/` so shared team files are committable while local settings stay ignored.

## Why

The root guide (#193) carries universal rules; these files carry what only matters inside each package (the field-catalog architecture, the single column-mapping source of truth, admin token/scoping rules) without inflating the root file every session pays for.

## Notes

- Content verified against main after the field-system rework (#185-#192): references the `nextly/field-catalog` subpath, `field-column-descriptor.ts` as the single mapping source, the field-ui kit, and the current CLI command set (`migrate:down` exists; `generate:schema` is a stub).
- Docs-only PR: no changeset.
- Independent of #193 (disjoint files); can merge in any order.

## Testing

Prettier-clean; no source files touched; husky pre-push (lint + build) passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added/updated integration-test rules to standardize how system tables and schema setup are performed, enforce environment-based self-skipping when test DB URLs aren’t set, and constrain how integration tests are run (targeting throwaway containers and running from the repo root).
  * Added package-specific agent guidelines for the admin and nextly packages, including UI styling/token conventions, API/error parsing expectations, field configuration practices, and test-running notes.
* **Chores**
  * Updated local assistant ignore settings to ignore all `.claude/` content except committed rules/guides directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->