### PR TITLE
docs: add contributor skills

### DIFF
--- a/.claude/skills/adding-a-field-type/SKILL.md
+++ b/.claude/skills/adding-a-field-type/SKILL.md
@@ -65,7 +65,9 @@ Work through these in order; each layer has tests nearby to extend.
 
 - Unit tests at each touched layer (factory, guard, descriptor, zod, type
   generator) plus an integration test that creates a collection using the
-  type against at least sqlite.
+  type. Because this workflow changes per-dialect column mappings and DDL,
+  cover Postgres plus at least one of MySQL/SQLite (the CI matrix runs all
+  three).
 - `pnpm generate:types` output in the playground includes the new type
   correctly; the field renders in the playground admin (both light and dark).
 - Run the schema-hash and export tests; a new type that changes hashing

--- a/.claude/skills/adding-a-field-type/SKILL.md
+++ b/.claude/skills/adding-a-field-type/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: adding-a-field-type
+description: Use when adding a new field type to Nextly (a new entry in the FieldType union, a new field factory, or a new schema-builder picker type), or when a field type renders or stores incorrectly across the config, catalog, column-mapping, or admin layers.
+---
+
+# Adding a field type to Nextly
+
+## You might not need this
+
+If the field type belongs to ONE plugin, do not touch core. Declare it in the
+plugin's `contributes.fieldTypes` (`PluginFieldType`: type id, storage
+primitive `text|longText|boolean|number|timestamp|json`, admin `component`
+path, optional `surfaces`). The boot-time registry
+(`packages/nextly/src/domains/schema/field-types/field-type-registry.ts`)
+validates it, and the admin renders it via the component registry. The rest
+of this skill is for BUILT-IN types only.
+
+## The end-to-end recipe (built-in type)
+
+Work through these in order; each layer has tests nearby to extend.
+
+1. **Type union + config interface**
+   - Add the literal to `FieldType` in
+     `packages/nextly/src/collections/fields/types/base.ts`.
+   - Create `packages/nextly/src/collections/fields/types/<type>.ts` with the
+     config interface; export it from `types/index.ts` (this also feeds
+     `ALL_FIELD_TYPES`).
+2. **Factory**: add the helper in
+   `packages/nextly/src/collections/fields/helpers.ts` following the existing
+   `(config) => ({ ...config, type: "<type>" })` shape with a JSDoc example.
+3. **Type guard**: add it in `collections/fields/guards.ts` via
+   `createTypeGuard`, and decide membership in `isDataField` /
+   `isRelationalField` / `hasNestedFields`.
+4. **Catalog entry**: add to `FIELD_TYPE_CATALOG` in
+   `collections/fields/catalog.ts` (label, category, hint, Lucide icon NAME
+   as a string). Pickers render from the catalog automatically. If the type
+   should appear on the user-fields or form surfaces, add it to those
+   allow-lists too; if it is surface-only, do NOT add it to the canonical
+   union (see the catalog's comment block for why).
+5. **Column mapping (the single source of truth)**: add the per-dialect case
+   in `packages/nextly/src/domains/schema/services/field-column-descriptor.ts`.
+   Then verify the descriptor's `kind` is handled by
+   `runtime-schema-generator.ts`, `pipeline/diff/build-from-fields.ts`, and
+   the DDL emitters in `domains/schema/pipeline/ddl-emitter/`.
+6. **Validation**: add a validator under `collections/fields/validators/` and
+   the case in `domains/schema/services/zod-generator.ts` (the per-type
+   switch).
+7. **Type generation**: add the TS mapping in
+   `domains/schema/services/type-generator.ts` so `nextly generate:types`
+   emits the right property type.
+8. **Admin rendering**:
+   - Edit view: a component under
+     `packages/admin/src/components/features/entries/fields/` and its case in
+     `FieldRenderer.tsx`.
+   - List view: cell rendering in the EntryList table components
+     (`EntryTableCell.tsx` / `EntryTableColumns.tsx`).
+   - Builder config: if the type has builder-editable options, extend the
+     schema builder's field editor sheet under
+     `packages/admin/src/components/features/schema-builder/`.
+9. **Serialization extras** (check, usually small): the collection export
+   service (`domains/collections/services/collection-export-service.ts`) and
+   `domains/schema/services/schema-hash.ts`.
+
+## Verify before opening the PR
+
+- Unit tests at each touched layer (factory, guard, descriptor, zod, type
+  generator) plus an integration test that creates a collection using the
+  type against at least sqlite.
+- `pnpm generate:types` output in the playground includes the new type
+  correctly; the field renders in the playground admin (both light and dark).
+- Run the schema-hash and export tests; a new type that changes hashing
+  semantics needs a deliberate decision, not an accidental one.
+- One changeset covering all packages (patch, alpha rules) since this
+  touches published code.

--- a/.claude/skills/release-and-changesets/SKILL.md
+++ b/.claude/skills/release-and-changesets/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: release-and-changesets
+description: Use when adding a changeset to a PR, deciding whether a PR needs one, cutting or debugging a release, or when the Version PR / npm publish flow looks wrong.
+---
+
+# Changesets and releases in the Nextly monorepo
+
+## The changeset rules (non-negotiable)
+
+- **ONE changeset per PR**, not per commit.
+- It must list **ALL published packages** (they are a `fixed` lockstep group
+  in `.changeset/config.json`; the repo is in pre-release `alpha` mode via
+  `.changeset/pre.json`).
+- Always **`patch`** while in alpha.
+- The description is the USER-facing impact, one or two lines, not an
+  implementation note.
+- **No changeset** for PRs that touch only tests, CI/workflows, repo docs,
+  or other non-published files. When in doubt: does the change alter what a
+  user installs from npm? No -> no changeset.
+
+Create one with `pnpm changeset` (select all packages, patch) or write the
+file by hand under `.changeset/` following an existing one.
+
+## How releasing actually works (CI-only)
+
+1. PRs with changesets merge to `main`.
+2. The Changesets bot maintains a Version PR ("chore: version packages
+   (alpha)") that accumulates pending changesets, bumps every package in
+   lockstep, and updates changelogs.
+3. **Merging the Version PR publishes**: the release workflow builds and
+   publishes all packages to npm via trusted publishing (OIDC) in the
+   protected environment. There are no local publishes; never run
+   `changeset publish` or `npm publish` yourself.
+4. Tags (`vX.Y.Z-alpha.N`) and a consolidated GitHub Release are created by
+   the workflow.
+
+## Known gotchas (learned the hard way)
+
+- The release workflow pins an exact npm version on purpose (a floating
+  `npm@latest` once broke every release via an engines bump). Do not
+  "simplify" it back to latest.
+- Old branches can restore already-published changeset files on merge; if
+  the Version PR suddenly lists ancient entries, check for resurrected
+  `.changeset/*.md` files and delete them in a cleanup PR.
+- The npm `latest` dist-tag for the unscoped packages is managed manually
+  after publishes; a publish alone does not move it.
+- If the Version PR looks wrong, fix the inputs (changeset files on main);
+  never edit the Version PR's generated diff by hand.

--- a/.claude/skills/reviewing-a-pr/SKILL.md
+++ b/.claude/skills/reviewing-a-pr/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: reviewing-a-pr
+description: Use when reviewing a Nextly pull request, responding to review-bot feedback (CodeRabbit, Greptile), or preparing a PR to pass review.
+---
+
+# Reviewing a PR in the Nextly monorepo
+
+## The review bar
+
+- **Verify before you trust.** For every review-bot suggestion (CodeRabbit,
+  Greptile), check the claim against the actual code and, where cheap, run
+  the relevant test. Bots are frequently right about style and frequently
+  wrong about behavior; apply fixes for confirmed issues, and push back with
+  evidence (file/line, test output) when a suggestion is wrong. Never apply
+  a suggestion you cannot explain.
+- **Reply and resolve every thread.** Each bot comment gets a reply stating
+  what was done (fixed in <commit>, or why it is not a real issue), then the
+  thread is marked resolved so the bot can re-verify.
+- **Check the PR against the repo's invariants** (ARCHITECTURE.md "Key
+  invariants" and AGENTS.md conventions): envelope shapes, NextlyError
+  usage, Drizzle-only, token-driven admin styling in both modes, changeset
+  presence/absence, comment style (explains code, never references tasks or
+  conversations), no AI attribution anywhere.
+
+## Mechanical checks
+
+- PR title: Conventional Commits; scopes are package-based plus
+  `playground|root|ci|docs|deps|release`; subject starts lowercase. Fix the
+  title rather than bypassing the check.
+- Tests: the PR adds/extends tests for what it changes; no new failures
+  against the known baseline; integration-heavy changes name which dialect
+  legs cover them.
+- Changeset: exactly one for published-code changes (all packages, patch);
+  none for test/CI/docs-only PRs.
+
+## Recurring defect classes (look for these specifically)
+
+- Malformed Tailwind: stray spaces before `:` modifiers, duplicated opacity
+  suffixes, v4 `!` placement (suffix), raw black/white instead of theme
+  classes.
+- Table invariants: pagination not reset on search/page-size change, missing
+  `getRowId`, cross-page selection broken.
+- Date handling: UTC vs local drift in formatting or range boundaries.
+- Inputs: missing guards on user-controlled values (length, format,
+  numeric bounds), PII in logs, missing email preheader/text variants.
+- Admin visuals: light-mode-only styling, hardcoded colors, focus states
+  missing.
+- API: hand-rolled response shapes instead of response-shapes.ts helpers;
+  bare `Error` in packages/nextly; status codes inlined instead of
+  error-code mappings.
+
+## Merging
+
+Default policy: the founder merges. Only merge yourself when the founder has
+explicitly authorized it for the specific PR or program, and then only with
+all CI checks green and every review thread resolved.

--- a/.claude/skills/writing-integration-tests/SKILL.md
+++ b/.claude/skills/writing-integration-tests/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: writing-integration-tests
+description: Use when writing or debugging Nextly integration tests (*.integration.test.ts), when integration tests fail with self-import or connection errors, or when adding database-backed test coverage for a new feature.
+---
+
+# Writing integration tests in the Nextly monorepo
+
+## The rules that prevent 90% of the pain
+
+1. **Build first, always.** Integration tests import built package output.
+   Run from the repo ROOT (`pnpm test:integration...`) so turbo builds
+   dependencies; a direct `pnpm --filter nextly test:integration` on an
+   unbuilt tree fails 60+ files with self-import errors that look real.
+2. **Dialect URLs decide what runs.** Tests self-skip when the dialect's URL
+   is unset: `TEST_POSTGRES_URL`, `TEST_MYSQL_URL` (SQLite falls back to
+   in-memory). The root scripts wire the standard local ports:
+   - `pnpm test:integration:postgres17` -> localhost:5435
+   - `pnpm test:integration:postgres15` -> localhost:5434
+   - `pnpm test:integration:mysql` -> localhost:3307
+   - `pnpm test:integration:sqlite` -> no URL needed
+   Start the throwaway containers with `pnpm docker:test`. NEVER point a
+   TEST_* URL at a database you did not create for the run.
+3. **Isolation is per-file prefixes, not parallelism.** Use the canonical
+   helper (`packages/nextly/src/database/__tests__/integration/helpers/test-db.ts`)
+   which generates a random per-file table/schema prefix. In packages/nextly
+   the integration config runs files sequentially (`fileParallelism: false`,
+   single fork) because system-table suites share fixed table names like
+   `nextly_schema_events`. Do not re-enable parallelism to make runs faster.
+4. **System tables come from production DDL.** If a suite needs a Nextly
+   system table, create it with the production helper (for example
+   `getSchemaEventsDdl(dialect)`), never a hand-copied CREATE TABLE. Copies
+   drift; there is a parity test that will catch you.
+
+## Writing a new suite
+
+- Name it `<area>.integration.test.ts`; the unit config excludes that
+  pattern and the integration config picks it up.
+- Follow an existing suite in the same domain for setup/teardown shape.
+- Timeouts are 30s in integration configs; if a test needs more, the test is
+  usually doing too much.
+- Cover Postgres AND at least one of MySQL/SQLite when the behavior touches
+  SQL generation; the CI matrix runs all three dialects
+  (`.github/workflows/integration.yml`).
+
+## Debugging failures
+
+- "Cannot resolve nextly/testing" or self-import errors -> unbuilt tree,
+  build first.
+- Connection refused -> containers not up (`pnpm docker:test`), or wrong
+  port (see the mapping above).
+- A suite passes alone but fails in the full run -> table-name collision;
+  check the suite uses the prefix helper, and that it is not creating a
+  fixed-name system table directly.
+- Do not add retries or sleeps to mask ordering issues; fix the isolation.

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,10 @@ apps/playground/src/db/schemas/**/*
 apps/playground/src/db/schemas/dynamic/*.ts
 !apps/playground/src/db/schemas/dynamic/index.ts
 
-# Claude Code local config
-.claude/
+# Claude Code: local config stays ignored, shared rules/skills are committed
+.claude/*
+!.claude/rules/
+!.claude/skills/
 
 # Testing
 coverage


### PR DESCRIPTION
## What

Adds four contributor skills under `.claude/skills/` (the SKILL.md open standard, readable by Claude Code, Codex, Cursor, and Copilot; loaded on demand so they cost no context until triggered):

- **adding-a-field-type**: the end-to-end recipe across the union, factory, guard, catalog, column descriptor, zod/type generators, and admin renderers, with the plugin-path shortcut (`contributes.fieldTypes`) as the you-might-not-need-this preamble.
- **writing-integration-tests**: build-first rule, TEST_* URL skip behavior, docker:test ports, per-file prefixes, production-DDL reuse, sequential-by-design rationale, debugging map.
- **release-and-changesets**: the one-per-PR/all-packages/patch rules, when NOT to add a changeset, the CI-only Version PR publish flow, and known gotchas.
- **reviewing-a-pr**: verify-bot-suggestions-against-behavior, reply-and-resolve etiquette, invariant checklist, recurring defect classes.

Also applies the same `.gitignore` carve-out as #194 (`.claude/*` with `!rules/` and `!skills/` negations); the identical edit merges cleanly whichever PR lands first.

## Why

These are procedures too long for AGENTS.md (which stays operational and short). Each one encodes knowledge that spans multiple packages or was learned through real incidents, exactly the content that agents cannot derive by reading code.

## Notes

- The field-type skill was written against the current post-rework field system (#185-#192), not the older architecture.
- Docs-only PR: no changeset.

## Testing

Prettier-clean; skill frontmatter follows the spec minimum (name + trigger-phrased description); no source files touched; husky pre-push passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added end-to-end guidance for introducing built-in field types, including verification steps and admin/UI coverage.
  * Added instructions for managing Changesets and releases in the monorepo, including release flow rules and common pitfalls.
  * Added pull request review guidance for handling review-bot feedback and enforcing repo/style checks.
  * Added conventions for writing integration tests, including isolation rules and debugging tips.
* **Chores**
  * Updated ignore settings so Claude skills and repository rules remain tracked while still ignoring other Claude artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->