### PR TITLE
feat(plugin-form-builder): forms as a standalone main-rail destination

### DIFF
--- a/.changeset/forms-main-nav.md
+++ b/.changeset/forms-main-nav.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Forms moves into the main sidebar rail.
+
+The form builder now declares standalone placement: Forms gets its own icon right after Media, and clicking it opens a sub-sidebar with Forms and Submissions. "Forms" appears exactly once — the duplicate entries in the Plugins section and the Collections group are gone, and the redundant second builder that rendered at the plugin "settings" URL is removed (the Forms collection's edit view is the one and only builder). Hosts that prefer Forms under the Plugins section can override the placement in one config line.

--- a/e2e/tests/forms-nav.spec.ts
+++ b/e2e/tests/forms-nav.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Forms navigation: the plugin declares standalone placement, so Forms is a
+ * first-class main-rail item whose sub-sidebar lists the plugin's
+ * collections — and it appears exactly once (no Plugins-section duplicate,
+ * no Collections-group duplicate).
+ */
+import { expect, test } from "@playwright/test";
+
+import { gotoAdmin } from "./support/admin";
+
+test("Forms lives in the main rail exactly once, with its collections inside", async ({
+  page,
+}) => {
+  await gotoAdmin(page, "");
+
+  // The standalone rail item resolves to the forms collection; the rail is
+  // icon-only, so the assertion keys on the href. Exactly one such entry.
+  const rail = page.getByRole("navigation").first();
+  const railForms = rail.locator('a[href="/admin/collections/forms"]');
+  await expect(railForms).toHaveCount(1);
+
+  // The old duplicates are gone: the Collections sub-sidebar carries no
+  // Forms group (the plugin's collections moved into the standalone
+  // section wholesale).
+  await rail.locator('a[href="/admin/collections"]').click();
+  await expect(
+    page
+      .getByRole("link", { name: "Forms", exact: true })
+      .filter({ visible: true })
+  ).toHaveCount(0);
+
+  // The rail item opens the standalone sub-sidebar with the plugin's
+  // collections as links.
+  await railForms.click();
+  await expect(
+    page
+      .getByRole("link", { name: "Forms", exact: true })
+      .filter({ visible: true })
+  ).toBeVisible();
+  const submissionsLink = page
+    .getByRole("link", { name: "Submissions", exact: true })
+    .filter({ visible: true });
+  await expect(submissionsLink).toBeVisible();
+
+  // The links actually navigate to the collection surfaces.
+  await submissionsLink.first().click();
+  await expect(page).toHaveURL(/collections\/form-submissions/);
+});

--- a/packages/plugin-form-builder/src/__tests__/admin-contributions.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/admin-contributions.test.ts
@@ -4,25 +4,24 @@ import { submissionsCollection } from "../collections/submissions";
 import { formBuilder } from "../plugin";
 
 describe("form-builder contributes.admin (P5 dogfood)", () => {
-  it("declares a sidebar menu item linking to the forms collection", () => {
-    const admin = formBuilder().plugin.contributes?.admin;
-    expect(admin?.menu?.[0]).toMatchObject({
-      label: "Forms",
-      icon: "file-text",
+  it("declares standalone main-rail placement with a single Forms identity", () => {
+    const { plugin } = formBuilder();
+    // Forms lives in the main rail: standalone placement + appearance, with
+    // NO separate menu contribution — "Forms" must exist exactly once.
+    expect(plugin.admin).toMatchObject({
+      placement: "standalone",
+      after: "media",
+      appearance: { icon: "FileText", label: "Forms" },
     });
-    expect(admin?.menu?.[0]?.to).toContain("/admin/collections/");
-    expect(admin?.menu?.[0]?.requiredPermission).toMatch(/^read-/);
+    expect(plugin.contributes?.admin?.menu ?? []).toHaveLength(0);
   });
 
-  it("declares a settings component", () => {
+  it("registers no settings component, custom pages, or beforeList injections", () => {
+    // The collection Edit-view override is the single FormBuilderView mount;
+    // the old settings-component (a second full builder at /admin/plugins/…),
+    // the filter-widget-as-page, and the beforeList injection stay gone.
     const admin = formBuilder().plugin.contributes?.admin;
-    expect(admin?.settings?.component).toContain("#FormBuilderView");
-  });
-
-  it("registers no custom pages or beforeList injections", () => {
-    // The submissions experience lives in the List-view override; the old
-    // filter-widget-as-page and beforeList registrations must stay gone.
-    const admin = formBuilder().plugin.contributes?.admin;
+    expect(admin?.settings).toBeUndefined();
     expect(admin?.pages ?? []).toHaveLength(0);
     expect(admin?.views ?? {}).toEqual({});
   });

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -358,30 +358,21 @@ export function formBuilder(
             ),
         },
       ],
-      // Admin UI — the canonical contributes.admin example. Paths
-      // are the components form-builder's `/admin` module self-registers (kept
-      // as literals so this node entry stays React-free). menu links to
-      // the forms collection; settings renders the builder UI at
-      // /admin/plugins/<slug>; a custom page is gated by export-submissions;
-      // a submissions beforeList view injects the filter above the list.
-      admin: {
-        menu: [
-          {
-            label: "Forms",
-            to: `/admin/collections/${resolvedConfig.formOverrides.slug}`,
-            icon: "file-text",
-            order: 50,
-            requiredPermission: `read-${resolvedConfig.formOverrides.slug}`,
-          },
-        ],
-        settings: {
-          component: "@nextlyhq/plugin-form-builder/admin#FormBuilderView",
-        },
-      },
     },
 
+    // Forms is a first-class destination, not a plugin detail: standalone
+    // placement gives it its own main-rail icon after Media, and its
+    // sub-sidebar lists the plugin's collections (Forms, Submissions) —
+    // no separate menu contribution, so "Forms" exists exactly once.
+    // Hosts preferring the Plugins section override placement in config.
+    // (The old admin.settings.component that rendered a second full builder
+    // at /admin/plugins/<slug> is gone; the collection Edit-view override
+    // is the single FormBuilderView mount.)
     admin: {
+      placement: "standalone",
+      after: "media",
       order: 50,
+      appearance: { icon: "FileText", label: "Forms" },
       description: "Create and manage forms with submission tracking",
     },
 


### PR DESCRIPTION
## What

Tier-4 #10 sub-doc 4 (Navigation) — approved design D-N1..D-N4 (`nextly-integrations/tasks/admin-tasks/tier4-10-04-navigation-design.md`). One PR, as designed.

### Forms in the main rail (D-N1)
The plugin declares `admin.placement: "standalone"` with `appearance: { icon: "FileText", label: "Forms" }`, anchored after Media — all pre-existing admin machinery from the #11 plugins-nav work; zero new mechanism. The standalone sub-sidebar automatically lists the plugin's collections (Forms, Submissions), which is exactly the inner nav the design called for. Hosts preferring the old behavior set `placement: "plugins"` in `pluginOverrides`.

### One home (D-N2) and one registration (D-N3)
- The separate `contributes.admin.menu` entry is deleted; the Collections-sidebar "Forms" group disappears automatically (standalone collections are filtered out of both the Collections and Plugins sections). "Forms" now exists exactly once.
- `admin.settings.component` is deleted — `/admin/plugins/<slug>` no longer renders a second full builder pretending to be settings. The collection Edit-view override is the single `FormBuilderView` mount. (The collections keep `group: "Forms"` on purpose: it only matters if a host overrides placement back to `"plugins"`, where it nests them correctly.)

## Verification

- plugin-form-builder **60 passed** (contributions tests rewritten for the new shape); typecheck/lint clean
- E2E **24 passed** (baseline 23; new `forms-nav.spec.ts`: exactly one rail entry resolving to the forms collection, no Collections-group duplicate, sub-sidebar links navigate)
- Live walkthrough in **both themes** (screenshots in `nextly-integrations/tasks/admin-tasks/assets/tier4-10/tier4-nav-*`): rail icon + tooltip after Media, FORMS sub-sidebar with Forms/Submissions.

Design doc: `nextly-integrations/tasks/admin-tasks/tier4-10-04-navigation-design.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standalone **Forms** item to the admin navigation rail.
  * Added a Forms sub-sidebar with links to Forms and Submissions.
  * Selecting **Submissions** now navigates directly to form submissions.

* **Bug Fixes**
  * Removed duplicate Forms navigation entries from the Collections menu.
  * Simplified the Forms admin navigation to provide a single, consistent entry point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->