### PR TITLE
feat(plugin-form-builder): canonical form settings that all do something

### DIFF
--- a/.changeset/form-settings-canonical.md
+++ b/.changeset/form-settings-canonical.md
@@ -1,0 +1,28 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Form settings are one honest shape, and every setting shown now does something.
+
+**One canonical shape.** The builder previously saved settings keys the collection schema never declared, while the schema declared keys the builder never wrote. Now there is one `FormSettings` (the message-vs-redirect confirmation radio included), one reader (`normalizeFormSettings`) that every consumer goes through, and migration-on-read for legacy keys (`confirmationMessage` becomes the success message; the old nested `captcha` object becomes the flat fields) — saved forms lose nothing.
+
+**Settings that do things.** "Allow multiple submissions" is now real: turn it off and the same visitor (by IP) can submit once, with an honest "You have already submitted this form." on repeats. The per-form honeypot and reCAPTCHA toggles are now real overrides of the plugin's global spam config — tri-state selects where "Inherit" shows what the plugin default actually is, and the form wins where set.
+
+**Settings that did nothing are gone.** `showResetButton`, `resetButtonText`, `storeSubmissions`, and `submissionLimit` had no consumer anywhere; they no longer appear in the UI or the shape.

--- a/packages/plugin-form-builder/src/__tests__/submit-form.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/submit-form.integration.test.ts
@@ -129,6 +129,72 @@ describe("submitForm end-to-end", () => {
     ).toBe(0);
   });
 
+  it("rejects a second submission from the same IP on single-submission forms", async () => {
+    const fb = formBuilder({
+      spamProtection: { honeypot: false, recaptcha: { enabled: false } },
+    });
+    const probe = contextProbe("@test/fb-single");
+    current = await createTestNextly({ plugins: [fb.plugin, probe.plugin] });
+
+    await current.nextly.create({
+      collection: "forms",
+      data: {
+        name: "RSVP",
+        slug: "rsvp",
+        status: "published",
+        fields: [{ type: "text", name: "name", label: "Name" }],
+        settings: { allowMultipleSubmissions: false },
+      },
+    });
+
+    const submit = () =>
+      submitForm(
+        {
+          formSlug: "rsvp",
+          data: { name: "Ada" },
+          metadata: { ipAddress: "203.0.113.9" },
+        },
+        { pluginContext: probe.get(), pluginConfig: fb.config }
+      );
+
+    expect((await submit()).success).toBe(true);
+    const second = await submit();
+    expect(second.success).toBe(false);
+    expect(second.error).toContain("already submitted");
+  });
+
+  it("lets a per-form honeypot override disable the plugin-level trap", async () => {
+    const fb = formBuilder({
+      spamProtection: { honeypot: true, recaptcha: { enabled: false } },
+    });
+    const probe = contextProbe("@test/fb-hp-override");
+    current = await createTestNextly({ plugins: [fb.plugin, probe.plugin] });
+
+    await current.nextly.create({
+      collection: "forms",
+      data: {
+        name: "Open",
+        slug: "open",
+        status: "published",
+        fields: [{ type: "text", name: "message", label: "Message" }],
+        // The form opts out of the honeypot even though the plugin has it on.
+        settings: { honeypotEnabled: false },
+      },
+    });
+
+    const result = await submitForm(
+      { formSlug: "open", data: { message: "hi", _hp: "filled" } },
+      { pluginContext: probe.get(), pluginConfig: fb.config }
+    );
+
+    expect(result.success).toBe(true);
+    const stored = await current.nextly.find({
+      collection: "form-submissions",
+      where: { status: { equals: "new" } },
+    });
+    expect(stored.items).toHaveLength(1);
+  });
+
   it("gives a honeypot bot the same fake success even when validation would fail", async () => {
     const fb = formBuilder({
       spamProtection: { honeypot: true, recaptcha: { enabled: false } },

--- a/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
+++ b/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
@@ -38,7 +38,10 @@ import {
   type NotificationDefaults,
 } from "./components/builder/FormNotificationsTab";
 import { FormPreview } from "./components/builder/FormPreview";
-import { FormSettingsTab } from "./components/builder/FormSettingsTab";
+import {
+  FormSettingsTab,
+  type SpamDefaults,
+} from "./components/builder/FormSettingsTab";
 import {
   FormBuilderProvider,
   useFormBuilder,
@@ -141,6 +144,10 @@ function FormBuilderViewInner({
   const [notificationDefaults, setNotificationDefaults] =
     useState<NotificationDefaults | null>(null);
 
+  // Plugin-level spam defaults, so the Settings tab can show what
+  // "inherit" resolves to. `null` while the config request settles.
+  const [spamDefaults, setSpamDefaults] = useState<SpamDefaults | null>(null);
+
   useEffect(() => {
     let cancelled = false;
     const allTypes = FORM_FIELD_TYPE_CATALOG.map(entry => entry.type);
@@ -154,6 +161,7 @@ function FormBuilderViewInner({
           config: {
             fields?: Record<string, boolean>;
             notifications?: NotificationDefaults;
+            spamProtection?: SpamDefaults;
           } | null
         ) => {
           if (cancelled) return;
@@ -163,12 +171,14 @@ function FormBuilderViewInner({
               : allTypes
           );
           setNotificationDefaults(config?.notifications ?? {});
+          setSpamDefaults(config?.spamProtection ?? {});
         }
       )
       .catch(() => {
         if (cancelled) return;
         setEnabledTypes(allTypes);
         setNotificationDefaults({});
+        setSpamDefaults({});
       });
     return () => {
       cancelled = true;
@@ -528,7 +538,7 @@ function FormBuilderViewInner({
             {/* Settings tab */}
             {activeTab === "settings" && (
               <div className="w-full">
-                <FormSettingsTab />
+                <FormSettingsTab spamDefaults={spamDefaults} />
               </div>
             )}
 

--- a/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
@@ -158,7 +158,7 @@ export function FormSettingsTab({ spamDefaults }: FormSettingsTabProps) {
 
           <SettingRow
             label="Allow multiple submissions"
-            description="When off, the same visitor (by IP) can submit this form only once"
+            description="When off, the same visitor (by IP) can submit this form only once. Best-effort: IP-based, so shared networks count as one visitor."
             htmlFor="settings-multiple"
           >
             <Switch
@@ -176,6 +176,12 @@ export function FormSettingsTab({ spamDefaults }: FormSettingsTabProps) {
       <section>
         <SectionHeading>After submission</SectionHeading>
         <div className="flex flex-col gap-4 pt-4">
+          {settings.confirmationType === "relationship" && (
+            <p className="border border-border bg-muted/40 p-3 text-sm text-muted-foreground">
+              This form redirects to a linked page (configured via the API).
+              Picking an option below replaces that behavior.
+            </p>
+          )}
           <RadioGroup
             value={settings.confirmationType ?? "message"}
             onValueChange={value =>

--- a/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
@@ -1,301 +1,291 @@
 "use client";
 
+/**
+ * Form Settings Tab
+ *
+ * Per-form behavior on the canonical settings shape: every control here is
+ * consumed somewhere (the submit handler or the confirmation flow) — a
+ * setting that does nothing does not get a toggle. Spam controls are
+ * per-form OVERRIDES of the plugin's global config: blank means inherit,
+ * and the inherited value is shown rather than hidden.
+ *
+ * @module admin/components/builder/FormSettingsTab
+ */
+
 import {
   Input,
-  Textarea,
-  Tabs,
-  TabsList,
-  TabsTrigger,
+  Label,
+  RadioGroup,
+  RadioGroupItem,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Switch,
+  Textarea,
 } from "@nextlyhq/ui";
 import type React from "react";
 
 import { useFormBuilder } from "../../context/FormBuilderContext";
 
-// ============================================================================
-// Helper Components
-// ============================================================================
+// ---------------------------------------------------------------------------
+// Layout helpers
+// ---------------------------------------------------------------------------
 
-/**
- * SettingRow - A layout component for a single setting with label and description on the left,
- * and the control/input on the right.
- */
 function SettingRow({
   label,
   description,
+  htmlFor,
   children,
-  className = "",
 }: {
   label: string;
   description?: string;
+  htmlFor?: string;
   children: React.ReactNode;
-  className?: string;
 }) {
   return (
-    <div
-      className={`flex flex-col sm:flex-row sm:items-center justify-between gap-6 py-2 ${className}`}
-    >
+    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-6 py-2">
       <div className="space-y-1 max-w-xl">
-        <h4 className="text-[13px] font-semibold text-foreground tracking-tight">
+        <Label
+          htmlFor={htmlFor}
+          className="text-[13px] font-semibold text-foreground tracking-tight"
+        >
           {label}
-        </h4>
+        </Label>
         {description && (
           <p className="text-[12px] text-muted-foreground leading-relaxed">
             {description}
           </p>
         )}
       </div>
-      <div className="flex-shrink-0 flex items-center justify-end min-w-[100px]">
+      <div className="shrink-0 flex items-center justify-end min-w-25">
         {children}
       </div>
     </div>
   );
 }
 
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="border-b border-border pb-3">
+      <h3 className="text-[16px] font-bold text-foreground tracking-tight">
+        {children}
+      </h3>
+    </div>
+  );
+}
+
 /**
- * FormSettingsTab - Form settings configuration panel
- *
- * Refined for Antigravity standard:
- * - Two-column layout for better space utilization.
- * - Title Case headings with improved hierarchy.
- * - Robust state management for action tabs.
+ * Tri-state override select: inherit from the plugin config (showing the
+ * effective value), or force on/off for this form.
  */
-export function FormSettingsTab() {
+function InheritToggle({
+  id,
+  value,
+  inherited,
+  onChange,
+}: {
+  id: string;
+  value: boolean | undefined;
+  inherited: boolean | undefined;
+  onChange: (value: boolean | undefined) => void;
+}) {
+  const inheritedLabel =
+    inherited === undefined
+      ? "Inherit"
+      : `Inherit (${inherited ? "on" : "off"})`;
+  return (
+    <Select
+      value={value === undefined ? "inherit" : value ? "on" : "off"}
+      onValueChange={selected =>
+        onChange(selected === "inherit" ? undefined : selected === "on")
+      }
+    >
+      <SelectTrigger
+        id={id}
+        className="w-40 bg-transparent border-input dark:bg-muted/50"
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="inherit">{inheritedLabel}</SelectItem>
+        <SelectItem value="on">On</SelectItem>
+        <SelectItem value="off">Off</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface SpamDefaults {
+  honeypot?: boolean;
+  recaptchaEnabled?: boolean;
+}
+
+interface FormSettingsTabProps {
+  /** Plugin-level spam defaults (from builder-config); null while loading. */
+  spamDefaults: SpamDefaults | null;
+}
+
+export function FormSettingsTab({ spamDefaults }: FormSettingsTabProps) {
   const { settings, updateSettings } = useFormBuilder();
 
-  // Handle tab switch for After Submission
-  // We check for undefined specifically so empty strings "" are treated as "redirect"
-  const currentActionTab =
-    settings.redirectUrl !== undefined ? "redirect" : "message";
-
   return (
-    <div className="w-full flex flex-row gap-8">
-      {/* Left Column: Submission & After Submission */}
-      <div className="w-full flex flex-col gap-8">
-        {/* Submission Settings */}
-        <section className="mb-12">
-          <div className="border-b border-primary/5 pb-3">
-            <h3 className="text-[16px] font-bold text-foreground tracking-tight">
-              Submission Settings
-            </h3>
-          </div>
+    <div className="w-full max-w-3xl flex flex-col gap-10">
+      {/* Submission */}
+      <section>
+        <SectionHeading>Submission</SectionHeading>
+        <div className="flex flex-col gap-1 pt-2">
+          <SettingRow
+            label="Submit button text"
+            description="Label on the form's primary action button"
+            htmlFor="settings-submit-text"
+          >
+            <Input
+              id="settings-submit-text"
+              type="text"
+              className="w-56"
+              value={settings.submitButtonText ?? ""}
+              onChange={e =>
+                updateSettings({ submitButtonText: e.target.value })
+              }
+            />
+          </SettingRow>
 
-          <div className="flex flex-col gap-1">
+          <SettingRow
+            label="Allow multiple submissions"
+            description="When off, the same visitor (by IP) can submit this form only once"
+            htmlFor="settings-multiple"
+          >
+            <Switch
+              id="settings-multiple"
+              checked={settings.allowMultipleSubmissions ?? true}
+              onCheckedChange={checked =>
+                updateSettings({ allowMultipleSubmissions: checked })
+              }
+            />
+          </SettingRow>
+        </div>
+      </section>
+
+      {/* After submission */}
+      <section>
+        <SectionHeading>After submission</SectionHeading>
+        <div className="flex flex-col gap-4 pt-4">
+          <RadioGroup
+            value={settings.confirmationType ?? "message"}
+            onValueChange={value =>
+              updateSettings({
+                confirmationType: value as "message" | "redirect",
+              })
+            }
+            className="flex flex-col gap-3"
+          >
+            <div className="flex items-start gap-3">
+              <RadioGroupItem
+                value="message"
+                id="settings-confirm-message"
+                className="mt-0.5"
+              />
+              <div className="w-full space-y-2">
+                <Label htmlFor="settings-confirm-message">Show a message</Label>
+                {(settings.confirmationType ?? "message") === "message" && (
+                  <Textarea
+                    aria-label="Success message"
+                    value={settings.successMessage ?? ""}
+                    onChange={e =>
+                      updateSettings({ successMessage: e.target.value })
+                    }
+                    rows={3}
+                    placeholder="Thank you for your submission!"
+                  />
+                )}
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <RadioGroupItem
+                value="redirect"
+                id="settings-confirm-redirect"
+                className="mt-0.5"
+              />
+              <div className="w-full space-y-2">
+                <Label htmlFor="settings-confirm-redirect">
+                  Redirect to a URL
+                </Label>
+                {settings.confirmationType === "redirect" && (
+                  <Input
+                    aria-label="Redirect URL"
+                    type="url"
+                    value={settings.redirectUrl ?? ""}
+                    onChange={e =>
+                      updateSettings({
+                        redirectUrl: e.target.value || undefined,
+                      })
+                    }
+                    placeholder="https://example.com/thanks"
+                  />
+                )}
+              </div>
+            </div>
+          </RadioGroup>
+        </div>
+      </section>
+
+      {/* Spam protection */}
+      <section>
+        <SectionHeading>Spam protection</SectionHeading>
+        <div className="flex flex-col gap-1 pt-2">
+          <SettingRow
+            label="Honeypot"
+            description="Invisible trap field for bots. Inherits the plugin default unless overridden here."
+            htmlFor="settings-honeypot"
+          >
+            <InheritToggle
+              id="settings-honeypot"
+              value={settings.honeypotEnabled}
+              inherited={spamDefaults?.honeypot}
+              onChange={honeypotEnabled => updateSettings({ honeypotEnabled })}
+            />
+          </SettingRow>
+
+          <SettingRow
+            label="reCAPTCHA"
+            description="Challenge-based bot check. Inherits the plugin default unless overridden here."
+            htmlFor="settings-captcha"
+          >
+            <InheritToggle
+              id="settings-captcha"
+              value={settings.captchaEnabled}
+              inherited={spamDefaults?.recaptchaEnabled}
+              onChange={captchaEnabled => updateSettings({ captchaEnabled })}
+            />
+          </SettingRow>
+
+          {settings.captchaEnabled === true && (
             <SettingRow
-              label="Submit Button Text"
-              description="Label on the primary action button"
+              label="reCAPTCHA site key"
+              description="The client-facing site key for this form"
+              htmlFor="settings-captcha-key"
             >
               <Input
+                id="settings-captcha-key"
                 type="text"
-                value={settings.submitButtonText}
+                className="w-72 font-mono"
+                value={settings.captchaSiteKey ?? ""}
                 onChange={e =>
-                  updateSettings({ submitButtonText: e.target.value })
-                }
-                placeholder="Submit"
-                className="bg-transparent h-8 w-40 text-right pr-2 focus-visible:ring-1 border-primary/5 text-[13px]"
-              />
-            </SettingRow>
-
-            <SettingRow
-              label="Show Reset Button"
-              description="Lets users clear all fields at once"
-            >
-              <Switch
-                checked={settings.showResetButton}
-                onCheckedChange={(checked: boolean) =>
-                  updateSettings({ showResetButton: checked })
+                  updateSettings({
+                    captchaSiteKey: e.target.value || undefined,
+                  })
                 }
               />
             </SettingRow>
-
-            {settings.showResetButton && (
-              <SettingRow
-                label="Reset Button Text"
-                description="Label on the secondary action button"
-                className="animate-in fade-in slide-in-from-top-2 duration-300"
-              >
-                <Input
-                  type="text"
-                  value={settings.resetButtonText}
-                  onChange={e =>
-                    updateSettings({ resetButtonText: e.target.value })
-                  }
-                  placeholder="Reset"
-                  className="bg-transparent h-8 w-40 text-right pr-2 focus-visible:ring-1 border-primary/5 text-[13px]"
-                />
-              </SettingRow>
-            )}
-          </div>
-        </section>
-
-        {/* After Submission */}
-        <section className="mb-12">
-          <div className="border-b border-primary/5 pb-3">
-            <h3 className="text-[16px] font-bold text-foreground tracking-tight">
-              After Submission
-            </h3>
-          </div>
-
-          <div className="flex flex-col gap-4">
-            <SettingRow
-              label="Action"
-              description="What happens after the form is submitted"
-            >
-              <Tabs
-                value={currentActionTab}
-                onValueChange={v => {
-                  if (v === "message") {
-                    updateSettings({ redirectUrl: undefined });
-                  } else if (v === "redirect") {
-                    updateSettings({ redirectUrl: "" });
-                  }
-                }}
-              >
-                <TabsList className="bg-primary/5 p-1 h-8">
-                  <TabsTrigger
-                    value="message"
-                    className="px-4 py-1 text-[11px] font-medium data-[state=active]:bg-background data-[state=active]:shadow-sm"
-                  >
-                    Message
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="redirect"
-                    className="px-4 py-1 text-[11px] font-medium data-[state=active]:bg-background data-[state=active]:shadow-sm"
-                  >
-                    Redirect
-                  </TabsTrigger>
-                </TabsList>
-              </Tabs>
-            </SettingRow>
-
-            {currentActionTab === "message" ? (
-              <div className="pt-2 animate-in fade-in duration-300">
-                <div className="space-y-1.5 mb-4">
-                  <h4 className="text-[13px] font-semibold text-foreground tracking-tight">
-                    Confirmation Message
-                  </h4>
-                  <p className="text-[12px] text-muted-foreground leading-relaxed">
-                    Message shown to user after successful submission
-                  </p>
-                </div>
-                <Textarea
-                  id="confirmationMessage"
-                  value={settings.confirmationMessage}
-                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                    updateSettings({ confirmationMessage: e.target.value })
-                  }
-                  placeholder="Thank you for your submission!"
-                  rows={4}
-                  className="bg-transparent text-[13px] leading-relaxed w-full border-primary/5 focus-visible:ring-1"
-                />
-              </div>
-            ) : (
-              <div className="pt-2 animate-in fade-in duration-300">
-                <SettingRow
-                  label="Redirect URL"
-                  description="User will be redirected to this URL after submission"
-                >
-                  <Input
-                    type="url"
-                    value={settings.redirectUrl || ""}
-                    onChange={e =>
-                      updateSettings({ redirectUrl: e.target.value })
-                    }
-                    placeholder="https://example.com/thank-you"
-                    className="bg-transparent h-8 w-56 text-right pr-2 focus-visible:ring-1 border-primary/5 text-[13px]"
-                  />
-                </SettingRow>
-              </div>
-            )}
-          </div>
-        </section>
-      </div>
-
-      {/* Right Column: Spam Protection & Data Storage */}
-      <div className="w-full flex flex-col gap-8">
-        {/* Spam Protection */}
-        <section>
-          <div className="border-b border-primary/5 pb-3">
-            <h3 className="text-[16px] font-bold text-foreground tracking-tight">
-              Spam Protection
-            </h3>
-          </div>
-
-          <div className="flex flex-col gap-1">
-            <SettingRow
-              label="Honeypot Field"
-              description="Hidden field that silently catches bots"
-            >
-              <Switch
-                checked={settings.honeypotEnabled}
-                onCheckedChange={(checkedValue: boolean) =>
-                  updateSettings({ honeypotEnabled: checkedValue })
-                }
-              />
-            </SettingRow>
-
-            <SettingRow
-              label="CAPTCHA Challenge"
-              description="Human verification before submitting"
-            >
-              <Switch
-                checked={settings.captchaEnabled}
-                onCheckedChange={(checkedValue: boolean) =>
-                  updateSettings({ captchaEnabled: checkedValue })
-                }
-              />
-            </SettingRow>
-          </div>
-        </section>
-
-        {/* Data Storage */}
-        <section>
-          <div className="border-b border-primary/5 pb-3">
-            <h3 className="text-[16px] font-bold text-foreground tracking-tight">
-              Data Storage
-            </h3>
-          </div>
-
-          <div className="flex flex-col gap-1">
-            <SettingRow
-              label="Store Submissions"
-              description="Save responses to the database"
-            >
-              <Switch
-                checked={settings.storeSubmissions}
-                onCheckedChange={(checkedValue: boolean) =>
-                  updateSettings({ storeSubmissions: checkedValue })
-                }
-              />
-            </SettingRow>
-
-            <SettingRow
-              label="Submission Limit"
-              description="Max number of entries to store"
-            >
-              <div className="flex items-center gap-3">
-                <Input
-                  type="number"
-                  value={settings.submissionLimit || ""}
-                  onChange={e =>
-                    updateSettings({
-                      submissionLimit: e.target.value
-                        ? parseInt(e.target.value, 10)
-                        : undefined,
-                    })
-                  }
-                  placeholder="Unlimited"
-                  min={1}
-                  className="bg-transparent h-8 w-28 text-right pr-2 focus-visible:ring-1 border-primary/5 text-[13px]"
-                />
-                <span className="text-[12px] text-muted-foreground font-medium">
-                  Entries
-                </span>
-              </div>
-            </SettingRow>
-          </div>
-        </section>
-      </div>
+          )}
+        </div>
+      </section>
     </div>
   );
 }

--- a/packages/plugin-form-builder/src/admin/context/FormBuilderContext.tsx
+++ b/packages/plugin-form-builder/src/admin/context/FormBuilderContext.tsx
@@ -22,33 +22,27 @@ import {
   type ReactNode,
 } from "react";
 
-import type { FormField, FormFieldType, FormNotification } from "../../types";
+import type {
+  FormField,
+  FormFieldType,
+  FormNotification,
+  FormSettings,
+} from "../../types";
+import {
+  DEFAULT_FORM_SETTINGS,
+  normalizeFormSettings,
+} from "../../utils/form-settings";
 
 // ============================================================================
 // Types
 // ============================================================================
 
-/** Form settings configuration */
-export interface FormSettings {
-  /** Submit button text */
-  submitButtonText: string;
-  /** Show reset button */
-  showResetButton: boolean;
-  /** Reset button text */
-  resetButtonText: string;
-  /** Success message after submission */
-  confirmationMessage: string;
-  /** Redirect URL after submission (optional) */
-  redirectUrl?: string;
-  /** Enable honeypot spam protection */
-  honeypotEnabled: boolean;
-  /** Enable CAPTCHA */
-  captchaEnabled: boolean;
-  /** Store submissions in database */
-  storeSubmissions: boolean;
-  /** Limit submissions per user/IP */
-  submissionLimit?: number;
-}
+/**
+ * The canonical settings shape lives in `types.ts` (the same shape the
+ * collection group declares and the submit handler consumes); re-exported
+ * here so admin components keep one import site.
+ */
+export type { FormSettings } from "../../types";
 
 /**
  * The notification rule type lives in `types.ts` (the same shape the send
@@ -136,18 +130,8 @@ export interface FormBuilderProviderProps {
   children: ReactNode;
 }
 
-/** Default form settings */
-export const DEFAULT_SETTINGS: FormSettings = {
-  submitButtonText: "Submit",
-  showResetButton: false,
-  resetButtonText: "Reset",
-  confirmationMessage: "Thank you for your submission!",
-  redirectUrl: undefined,
-  honeypotEnabled: true,
-  captchaEnabled: false,
-  storeSubmissions: true,
-  submissionLimit: undefined,
-};
+/** Default form settings (the canonical defaults from the settings reader) */
+export const DEFAULT_SETTINGS: FormSettings = DEFAULT_FORM_SETTINGS;
 
 /** Create a new notification rule with default values */
 export function createNotification(): FormNotification {
@@ -311,10 +295,11 @@ export function FormBuilderProvider({
     description: initialData?.description,
     status: initialData?.status || "draft",
   });
-  const [settings, setSettings] = useState<FormSettings>({
-    ...DEFAULT_SETTINGS,
-    ...initialData?.settings,
-  });
+  // Stored settings may carry legacy keys from earlier builder versions —
+  // the normalizer migrates them on read (nothing rewrites until save).
+  const [settings, setSettings] = useState<FormSettings>(() =>
+    normalizeFormSettings(initialData?.settings)
+  );
   const [notifications, setNotifications] = useState<FormNotification[]>(
     initialData?.notifications || []
   );

--- a/packages/plugin-form-builder/src/collections/forms.ts
+++ b/packages/plugin-form-builder/src/collections/forms.ts
@@ -177,11 +177,20 @@ export function formsCollection(
     }),
 
     checkbox({
+      name: "honeypotEnabled",
+      label: "Honeypot",
+      admin: {
+        description:
+          "Per-form honeypot override; unset inherits the plugin default",
+      },
+    }),
+
+    checkbox({
       name: "captchaEnabled",
       label: "Enable reCAPTCHA",
-      defaultValue: false,
       admin: {
-        description: "Protect this form with Google reCAPTCHA v3",
+        description:
+          "Per-form reCAPTCHA override; unset inherits the plugin default",
       },
     }),
 

--- a/packages/plugin-form-builder/src/config/defaults.ts
+++ b/packages/plugin-form-builder/src/config/defaults.ts
@@ -184,7 +184,9 @@ export function applyFormDefaults(config: FormConfig): FormConfig {
       // Preserve other settings that don't have defaults
       redirectUrl: config.settings?.redirectUrl,
       redirectRelation: config.settings?.redirectRelation,
-      captcha: config.settings?.captcha,
+      honeypotEnabled: config.settings?.honeypotEnabled,
+      captchaEnabled: config.settings?.captchaEnabled,
+      captchaSiteKey: config.settings?.captchaSiteKey,
     },
 
     // Apply notification defaults if notifications are configured

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -16,6 +16,7 @@ import type {
   ResolvedFormBuilderConfig,
   FormField,
 } from "../types";
+import { normalizeFormSettings } from "../utils/form-settings";
 import {
   generateZodSchema,
   transformFormData,
@@ -158,6 +159,37 @@ export async function submitForm(
       };
     }
 
+    // 2b. Settings come through the one canonical reader — stored settings
+    // may carry legacy keys from earlier builder versions.
+    const settings = normalizeFormSettings(form.settings);
+
+    // 2c. Single-submission forms: the same visitor (by IP) submits once.
+    // Checked before spam so a repeat visitor gets the honest message
+    // instead of an inexplicable success that stored nothing new.
+    if (settings.allowMultipleSubmissions === false && metadata?.ipAddress) {
+      const existing = await collections.count(
+        pluginConfig.formSubmissionOverrides.slug,
+        {
+          where: {
+            form: { equals: form.id },
+            ipAddress: { equals: metadata.ipAddress },
+            status: { not_equals: "spam" },
+          },
+        },
+        { as: "system" }
+      );
+      if (existing > 0) {
+        logger.info?.("Repeat submission rejected (single-submission form)", {
+          formSlug,
+          ipAddress: metadata.ipAddress,
+        });
+        return {
+          success: false,
+          error: "You have already submitted this form.",
+        };
+      }
+    }
+
     // 3. Spam detection — BEFORE validation, so a bot that trips the trap
     // while also failing validation still receives the same fake success as
     // any other bot instead of a distinguishable validation error.
@@ -174,9 +206,17 @@ export async function submitForm(
       ipAddress: metadata?.ipAddress,
       formSlug,
       config: {
-        honeypot: pluginConfig.spamProtection.honeypot,
+        // Per-form overrides win where set; blank inherits the plugin config.
+        honeypot:
+          settings.honeypotEnabled ?? pluginConfig.spamProtection.honeypot,
         rateLimit: pluginConfig.spamProtection.rateLimit,
-        recaptcha: pluginConfig.spamProtection.recaptcha,
+        recaptcha: {
+          ...pluginConfig.spamProtection.recaptcha,
+          enabled:
+            settings.captchaEnabled ??
+            pluginConfig.spamProtection.recaptcha?.enabled ??
+            false,
+        },
       },
     });
 

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -165,7 +165,20 @@ export async function submitForm(
 
     // 2c. Single-submission forms: the same visitor (by IP) submits once.
     // Checked before spam so a repeat visitor gets the honest message
-    // instead of an inexplicable success that stored nothing new.
+    // instead of an inexplicable success that stored nothing new. This is a
+    // best-effort deterrent, not a guarantee: IPs are shared (NAT/proxies),
+    // and the check-then-create pair is not atomic, so two truly concurrent
+    // submissions can both pass — an airtight version needs a partial
+    // unique index the portable field config cannot express yet.
+    if (settings.allowMultipleSubmissions === false && !metadata?.ipAddress) {
+      // Without an identifier there is nothing to deduplicate on. Failing
+      // closed would block every server-to-server integration, so the gate
+      // stays open — loudly.
+      logger.warn?.(
+        "Single-submission form received a submission without an IP — the restriction cannot apply",
+        { formSlug }
+      );
+    }
     if (settings.allowMultipleSubmissions === false && metadata?.ipAddress) {
       const existing = await collections.count(
         pluginConfig.formSubmissionOverrides.slug,

--- a/packages/plugin-form-builder/src/plugin.ts
+++ b/packages/plugin-form-builder/src/plugin.ts
@@ -342,6 +342,13 @@ export function formBuilder(
                   defaultFrom: resolvedConfig.notifications.defaultFrom,
                   defaultToEmail: resolvedConfig.notifications.defaultToEmail,
                 },
+                // Spam defaults the Settings tab surfaces, so per-form
+                // override selects can show what "inherit" resolves to.
+                spamProtection: {
+                  honeypot: resolvedConfig.spamProtection.honeypot,
+                  recaptchaEnabled:
+                    resolvedConfig.spamProtection.recaptcha?.enabled ?? false,
+                },
                 // Runtime-resolved collection slugs (through ctx.self, so a
                 // framework .rename() is honored too) — admin components
                 // never hardcode "forms"/"form-submissions".

--- a/packages/plugin-form-builder/src/types.ts
+++ b/packages/plugin-form-builder/src/types.ts
@@ -813,11 +813,20 @@ export interface FormSettings {
   /**
    * Confirmation type after successful submission.
    * - "message": Display a success message
-   * - "redirect": Redirect to a URL or linked document
+   * - "redirect": Redirect to a URL
+   * - "relationship": Redirect to a linked document (requires
+   *   `redirectRelationships` in the plugin options)
    *
    * @default "message"
    */
-  confirmationType?: "message" | "redirect";
+  confirmationType?: "message" | "redirect" | "relationship";
+
+  /**
+   * Linked document for relationship-based redirects (the collection's
+   * `redirectPage` relationship value). Preserved verbatim — resolution
+   * happens where the relationship is rendered.
+   */
+  redirectPage?: unknown;
 
   /** Success message (supports HTML) - used when confirmationType is "message" */
   successMessage?: string;

--- a/packages/plugin-form-builder/src/types.ts
+++ b/packages/plugin-form-builder/src/types.ts
@@ -834,14 +834,23 @@ export interface FormSettings {
     value: string; // Document ID
   };
 
-  /** Allow multiple submissions from same user/IP */
+  /** Allow multiple submissions from same IP (default true) */
   allowMultipleSubmissions?: boolean;
 
-  /** reCAPTCHA configuration */
-  captcha?: {
-    enabled: boolean;
-    siteKey?: string;
-  };
+  /**
+   * Per-form honeypot override. Unset inherits the plugin's
+   * `spamProtection.honeypot`; the form wins where set.
+   */
+  honeypotEnabled?: boolean;
+
+  /**
+   * Per-form reCAPTCHA override. Unset inherits the plugin's
+   * `spamProtection.recaptcha.enabled`; the form wins where set.
+   */
+  captchaEnabled?: boolean;
+
+  /** reCAPTCHA site key (client-facing) when captcha is enabled per-form */
+  captchaSiteKey?: string;
 }
 
 // ============================================================

--- a/packages/plugin-form-builder/src/utils/form-settings.test.ts
+++ b/packages/plugin-form-builder/src/utils/form-settings.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeFormSettings } from "./form-settings";
+
+describe("normalizeFormSettings", () => {
+  it("returns the canonical defaults for empty or non-object input", () => {
+    for (const raw of [undefined, null, "x", 42, []]) {
+      expect(normalizeFormSettings(raw)).toMatchObject({
+        submitButtonText: "Submit",
+        confirmationType: "message",
+        successMessage: "Thank you for your submission!",
+        allowMultipleSubmissions: true,
+      });
+    }
+  });
+
+  it("migrates the legacy confirmationMessage key on read", () => {
+    const settings = normalizeFormSettings({
+      confirmationMessage: "Thanks, we got it!",
+    });
+    expect(settings.confirmationType).toBe("message");
+    expect(settings.successMessage).toBe("Thanks, we got it!");
+  });
+
+  it("prefers the declared successMessage over the legacy key", () => {
+    const settings = normalizeFormSettings({
+      successMessage: "New copy",
+      confirmationMessage: "Old copy",
+    });
+    expect(settings.successMessage).toBe("New copy");
+  });
+
+  it("migrates the legacy nested captcha object to the flat keys", () => {
+    const settings = normalizeFormSettings({
+      captcha: { enabled: true, siteKey: "site_123" },
+    });
+    expect(settings.captchaEnabled).toBe(true);
+    expect(settings.captchaSiteKey).toBe("site_123");
+  });
+
+  it("drops settings that have no consumer", () => {
+    const settings = normalizeFormSettings({
+      showResetButton: true,
+      resetButtonText: "Reset",
+      storeSubmissions: false,
+      submissionLimit: 5,
+    }) as Record<string, unknown>;
+    expect(settings.showResetButton).toBeUndefined();
+    expect(settings.resetButtonText).toBeUndefined();
+    expect(settings.storeSubmissions).toBeUndefined();
+    expect(settings.submissionLimit).toBeUndefined();
+  });
+
+  it("keeps spam overrides tri-state: unset means inherit", () => {
+    expect(normalizeFormSettings({}).honeypotEnabled).toBeUndefined();
+    expect(normalizeFormSettings({}).captchaEnabled).toBeUndefined();
+    expect(
+      normalizeFormSettings({ honeypotEnabled: false }).honeypotEnabled
+    ).toBe(false);
+  });
+
+  it("keeps redirect configuration intact", () => {
+    const settings = normalizeFormSettings({
+      confirmationType: "redirect",
+      redirectUrl: "https://example.com/thanks",
+    });
+    expect(settings.confirmationType).toBe("redirect");
+    expect(settings.redirectUrl).toBe("https://example.com/thanks");
+  });
+});

--- a/packages/plugin-form-builder/src/utils/form-settings.test.ts
+++ b/packages/plugin-form-builder/src/utils/form-settings.test.ts
@@ -60,12 +60,22 @@ describe("normalizeFormSettings", () => {
   });
 
   it("preserves relationship-based redirects verbatim", () => {
+    // Relationship references may be plain IDs or structured values — both
+    // must survive normalization byte-for-byte, never coerced.
+    const structuredRef = { relationTo: "pages", value: "page_123" };
     const settings = normalizeFormSettings({
       confirmationType: "relationship",
-      redirectPage: "page_123",
+      redirectPage: structuredRef,
     });
     expect(settings.confirmationType).toBe("relationship");
-    expect(settings.redirectPage).toBe("page_123");
+    expect(settings.redirectPage).toBe(structuredRef);
+
+    expect(
+      normalizeFormSettings({
+        confirmationType: "relationship",
+        redirectPage: "page_123",
+      }).redirectPage
+    ).toBe("page_123");
   });
 
   it("keeps redirect configuration intact", () => {

--- a/packages/plugin-form-builder/src/utils/form-settings.test.ts
+++ b/packages/plugin-form-builder/src/utils/form-settings.test.ts
@@ -59,6 +59,15 @@ describe("normalizeFormSettings", () => {
     ).toBe(false);
   });
 
+  it("preserves relationship-based redirects verbatim", () => {
+    const settings = normalizeFormSettings({
+      confirmationType: "relationship",
+      redirectPage: "page_123",
+    });
+    expect(settings.confirmationType).toBe("relationship");
+    expect(settings.redirectPage).toBe("page_123");
+  });
+
   it("keeps redirect configuration intact", () => {
     const settings = normalizeFormSettings({
       confirmationType: "redirect",

--- a/packages/plugin-form-builder/src/utils/form-settings.ts
+++ b/packages/plugin-form-builder/src/utils/form-settings.ts
@@ -1,0 +1,74 @@
+/**
+ * The ONE reader for stored form settings. Settings were historically
+ * written in two shapes (the builder's old context shape and the collection
+ * group's declared shape), so every consumer — the builder UI and the
+ * submit handler alike — normalizes through here instead of trusting the
+ * stored keys.
+ */
+
+import { DEFAULT_FORM_SETTINGS } from "../config/defaults";
+import type { FormSettings } from "../types";
+
+export { DEFAULT_FORM_SETTINGS };
+
+function asOptionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function asOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+/**
+ * Normalize a stored settings value into the canonical {@link FormSettings}.
+ *
+ * Legacy keys are migrated on read (no data is lost, nothing is rewritten
+ * until the form is next saved):
+ * - `confirmationMessage` → `successMessage` + `confirmationType: "message"`
+ * - nested `captcha: { enabled, siteKey }` → flat `captchaEnabled`/`captchaSiteKey`
+ *
+ * Keys with no consumer (`showResetButton`, `resetButtonText`,
+ * `storeSubmissions`, `submissionLimit`) are dropped: a setting that does
+ * nothing must not survive into the UI.
+ */
+export function normalizeFormSettings(raw: unknown): FormSettings {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return { ...DEFAULT_FORM_SETTINGS };
+  }
+  const source = raw as Record<string, unknown>;
+
+  const legacyMessage = asOptionalString(source.confirmationMessage);
+  const legacyCaptcha =
+    source.captcha && typeof source.captcha === "object"
+      ? (source.captcha as { enabled?: unknown; siteKey?: unknown })
+      : undefined;
+
+  const confirmationType =
+    source.confirmationType === "redirect" ? "redirect" : "message";
+
+  return {
+    submitButtonText:
+      asOptionalString(source.submitButtonText) ??
+      DEFAULT_FORM_SETTINGS.submitButtonText,
+    confirmationType,
+    successMessage:
+      asOptionalString(source.successMessage) ??
+      legacyMessage ??
+      DEFAULT_FORM_SETTINGS.successMessage,
+    redirectUrl: asOptionalString(source.redirectUrl),
+    redirectRelation:
+      source.redirectRelation && typeof source.redirectRelation === "object"
+        ? (source.redirectRelation as FormSettings["redirectRelation"])
+        : undefined,
+    allowMultipleSubmissions:
+      asOptionalBoolean(source.allowMultipleSubmissions) ??
+      DEFAULT_FORM_SETTINGS.allowMultipleSubmissions,
+    honeypotEnabled: asOptionalBoolean(source.honeypotEnabled),
+    captchaEnabled:
+      asOptionalBoolean(source.captchaEnabled) ??
+      asOptionalBoolean(legacyCaptcha?.enabled),
+    captchaSiteKey:
+      asOptionalString(source.captchaSiteKey) ??
+      asOptionalString(legacyCaptcha?.siteKey),
+  };
+}

--- a/packages/plugin-form-builder/src/utils/form-settings.ts
+++ b/packages/plugin-form-builder/src/utils/form-settings.ts
@@ -43,8 +43,14 @@ export function normalizeFormSettings(raw: unknown): FormSettings {
       ? (source.captcha as { enabled?: unknown; siteKey?: unknown })
       : undefined;
 
+  // "relationship" is a real stored value (redirect to a linked document) —
+  // coercing it to "message" would disable the form's redirect on the next
+  // save. Only genuinely unknown values fall back to "message".
   const confirmationType =
-    source.confirmationType === "redirect" ? "redirect" : "message";
+    source.confirmationType === "redirect" ||
+    source.confirmationType === "relationship"
+      ? source.confirmationType
+      : "message";
 
   return {
     submitButtonText:
@@ -56,6 +62,7 @@ export function normalizeFormSettings(raw: unknown): FormSettings {
       legacyMessage ??
       DEFAULT_FORM_SETTINGS.successMessage,
     redirectUrl: asOptionalString(source.redirectUrl),
+    redirectPage: source.redirectPage ?? undefined,
     redirectRelation:
       source.redirectRelation && typeof source.redirectRelation === "object"
         ? (source.redirectRelation as FormSettings["redirectRelation"])


### PR DESCRIPTION
## What

Tier-4 #10 sub-doc 5 (Settings + Preview), **PR A of 2** — the settings half of the approved design D-P1/D-P2 (`nextly-integrations/tasks/admin-tasks/tier4-10-05-settings-preview-design.md`). PR B (interactive preview, approved option b) follows.

### One canonical shape (D-P1)
Settings existed as three disconnected shapes: the builder saved keys the collection group never declared, the group declared keys the builder never wrote, and `types.ts` held a third. Now:
- **One `FormSettings`** in `types.ts` (message-vs-redirect `confirmationType` radio included — the universal pattern: Payload, HubSpot, WPForms, Formspree, Gravity). The context re-exports it; the collection group declares exactly its keys; the submit handler consumes it.
- **One reader**: `normalizeFormSettings` — every consumer (builder UI and submit handler) goes through it. Legacy keys migrate on read (`confirmationMessage` → `successMessage` + message type; nested `captcha` object → flat keys), so saved forms lose nothing and nothing is rewritten until save.
- **Rule enforced: a setting only exists if something consumes it.** `showResetButton`, `resetButtonText`, `storeSubmissions`, `submissionLimit` had no consumer anywhere — dropped from the shape and the tab.

### Settings that now do things (D-P1/D-P2)
- **Allow multiple submissions** is wired: off = one submission per IP, checked before the spam gate, with an honest "You have already submitted this form." (Gravity's restriction pattern, message included).
- **Per-form honeypot/reCAPTCHA** are tri-state overrides of the plugin's global spam config (the §D consensus: per-form wins, inheritance visible). The Settings tab's selects show what "Inherit" resolves to — builder-config now returns the plugin spam defaults.
- The rebuilt tab is a11y-correct (labels wired via htmlFor) and token-only.

## Verification

- plugin-form-builder **69 passed** on the rebased head (SD4 baseline 59; +7 normalizer tests incl. both legacy migrations and the dropped-keys rule, +2 integration: single-submission rejection round trip, per-form honeypot override letting a trap payload through as clean, +1 restructure)
- typecheck/lint clean; E2E **24 passed** on the rebased head
- E2E count verified post-rebase (24/24).
- Live browser verification of the rebuilt tab in both themes rides with PR B (the Preview rebuild changes the same screen's neighborhood; one pass covers both).

Design doc: `nextly-integrations/tasks/admin-tasks/tier4-10-05-settings-preview-design.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned form settings for submissions, confirmation (message/redirect/relationship), and spam protection.
  * Added per-form spam protection overrides for honeypot and reCAPTCHA with inherit/on/off controls.
  * Added relationship-based confirmation and relationship redirect support.
* **Bug Fixes**
  * Strengthened single-submission enforcement by blocking repeat submissions from the same IP (unless marked spam).
  * Improved compatibility by auto-migrating legacy confirmation and captcha settings.
* **Tests**
  * Added integration and normalization test coverage for overrides and legacy migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->