### PR TITLE
feat(plugin-form-builder): interactive form preview simulation

### DIFF
--- a/.changeset/form-preview-interactive.md
+++ b/.changeset/form-preview-interactive.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The form preview is now an interactive simulation instead of a static mock.
+
+Type into real inputs and conditional logic reacts live (the same evaluator the runtime uses), hit the form's actual submit button and the configured confirmation plays out — the success message, or an honest "the visitor would now be redirected to …". A desktop/mobile width toggle, a reset button, required markers, help text, and a note about invisible hidden fields complete it. The preview is explicit about what it is: a simulation inside the admin — nothing submits anywhere.

--- a/e2e/tests/form-builder.spec.ts
+++ b/e2e/tests/form-builder.spec.ts
@@ -139,3 +139,24 @@ test("seeds a default notification, edits it in the sheet, and guards referenced
   });
   await expect(page.getByText("Conditional")).toBeVisible();
 });
+
+test("the preview is an interactive simulation with real confirmation", async ({
+  page,
+}) => {
+  await gotoAdmin(page, "/collections/forms");
+  await page.getByRole("button", { name: /E2E Notifications Form/ }).click();
+  await page.getByRole("tab", { name: "Preview" }).click();
+
+  // Inputs are enabled — this is a simulation, not a screenshot.
+  const emailInput = page.getByRole("textbox", { name: /^Email/ });
+  await expect(emailInput).toBeEnabled();
+  await emailInput.fill("visitor@example.com");
+
+  // The simulated submit shows the form's real confirmation behavior.
+  await page.getByRole("button", { name: "Submit", exact: true }).click();
+  await expect(page.getByText("Thank you for your submission!")).toBeVisible();
+
+  // Reset returns to a fresh form.
+  await page.getByRole("button", { name: "Fill again" }).click();
+  await expect(emailInput).toHaveValue("");
+});

--- a/e2e/tests/form-builder.spec.ts
+++ b/e2e/tests/form-builder.spec.ts
@@ -143,8 +143,16 @@ test("seeds a default notification, edits it in the sheet, and guards referenced
 test("the preview is an interactive simulation with real confirmation", async ({
   page,
 }) => {
-  await gotoAdmin(page, "/collections/forms");
-  await page.getByRole("button", { name: /E2E Notifications Form/ }).click();
+  // Self-sufficient: the preview needs no saved form — the builder state
+  // previews live, so an unsaved form with one field is enough.
+  await gotoAdmin(page, "/collections/forms/create");
+  await page
+    .getByRole("textbox", { name: "Form Name" })
+    .fill("E2E Preview Form");
+  await page.getByRole("button", { name: "Add field" }).first().click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByRole("radio", { name: /^Email/ }).click();
+  await dialog.getByRole("button", { name: "Add field" }).click();
   await page.getByRole("tab", { name: "Preview" }).click();
 
   // Inputs are enabled — this is a simulation, not a screenshot.

--- a/packages/plugin-form-builder/src/admin/components/builder/FormPreview.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormPreview.tsx
@@ -16,6 +16,7 @@
 import {
   Badge,
   Button,
+  Checkbox,
   Input,
   Label,
   RadioGroup,
@@ -25,7 +26,6 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Switch,
   Tabs,
   TabsList,
   TabsTrigger,
@@ -64,8 +64,14 @@ function PreviewFieldInput({
         />
       );
     case "checkbox":
+      // A real checkbox, not a toggle switch — the preview should look like
+      // what a frontend form renders for this type.
       return (
-        <Switch id={id} checked={Boolean(value)} onCheckedChange={onChange} />
+        <Checkbox
+          id={id}
+          checked={Boolean(value)}
+          onCheckedChange={checked => onChange(checked === true)}
+        />
       );
     case "select": {
       const options = "options" in field ? (field.options ?? []) : [];
@@ -187,24 +193,55 @@ export function FormPreview({ fields, formData }: FormPreviewProps) {
   const [values, setValues] = useState<Record<string, unknown>>({});
   const [device, setDevice] = useState<"desktop" | "mobile">("desktop");
   const [confirmed, setConfirmed] = useState(false);
+  const [missingRequired, setMissingRequired] = useState<Set<string>>(
+    new Set()
+  );
 
   // Conditional logic runs against the live values with the SAME evaluator
   // the runtime uses — typing into the preview shows/hides fields for real.
-  const visibleFields = useMemo(
-    () =>
-      fields.filter(field => {
-        if (field.type === "hidden") return false;
-        if (!field.conditionalLogic?.enabled) return true;
-        return evaluateConditions(field.conditionalLogic, values);
-      }),
-    [fields, values]
-  );
+  // Visibility is computed in field order against the values of fields that
+  // are themselves visible: a hidden field's leftover value must not keep
+  // satisfying a downstream condition (chained show/hide would misbehave).
+  const visibleFields = useMemo(() => {
+    const effectiveValues: Record<string, unknown> = {};
+    const visible: FormField[] = [];
+    for (const field of fields) {
+      if (field.type === "hidden") continue;
+      const isVisible =
+        !field.conditionalLogic?.enabled ||
+        evaluateConditions(field.conditionalLogic, effectiveValues);
+      if (isVisible) {
+        visible.push(field);
+        if (field.name in values) {
+          effectiveValues[field.name] = values[field.name];
+        }
+      }
+    }
+    return visible;
+  }, [fields, values]);
 
   const hiddenCount = fields.filter(field => field.type === "hidden").length;
 
   const reset = () => {
     setValues({});
     setConfirmed(false);
+    setMissingRequired(new Set());
+  };
+
+  // The real form would refuse an empty required field, so the simulation
+  // does too — an admin previewing required fields sees the requirement.
+  const simulateSubmit = () => {
+    const missing = new Set(
+      visibleFields
+        .filter(field => {
+          if (!field.required || field.type === "file") return false;
+          const value = values[field.name];
+          return value === undefined || value === "" || value === false;
+        })
+        .map(field => field.name)
+    );
+    setMissingRequired(missing);
+    if (missing.size === 0) setConfirmed(true);
   };
 
   return (
@@ -306,6 +343,9 @@ export function FormPreview({ fields, formData }: FormPreviewProps) {
                       />
                       <Label htmlFor={`preview-${field.name}`}>
                         {field.label || field.name}
+                        {field.required && (
+                          <span className="ml-1 text-destructive">*</span>
+                        )}
                       </Label>
                     </div>
                   ) : (
@@ -322,12 +362,17 @@ export function FormPreview({ fields, formData }: FormPreviewProps) {
                       {field.helpText}
                     </p>
                   )}
+                  {missingRequired.has(field.name) && (
+                    <p className="text-xs text-destructive">
+                      This field is required.
+                    </p>
+                  )}
                 </div>
               ))}
 
               <Button
                 type="button"
-                onClick={() => setConfirmed(true)}
+                onClick={simulateSubmit}
                 disabled={visibleFields.length === 0}
               >
                 {settings.submitButtonText || "Submit"}

--- a/packages/plugin-form-builder/src/admin/components/builder/FormPreview.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormPreview.tsx
@@ -1,24 +1,175 @@
+"use client";
+
 /**
  * Form Preview
  *
- * Renders a preview of how the form will appear to end users.
- * Shows the form layout with input fields rendered in a disabled
- * (read-only) state so submissions cannot be made from the preview.
+ * An interactive simulation of the form: real enabled inputs, conditional
+ * logic evaluated live against what you type (the same evaluator the
+ * runtime uses), the form's actual settings (button text, confirmation
+ * behavior), and a device-width toggle. It is honest about what it is —
+ * a faithful simulation inside the admin, not the published form; nothing
+ * here submits anywhere.
  *
  * @module admin/components/builder/FormPreview
- * @since 0.1.0
  */
 
-"use client";
-
-import { Input, Button } from "@nextlyhq/ui";
-import type React from "react";
+import {
+  Badge,
+  Button,
+  Input,
+  Label,
+  RadioGroup,
+  RadioGroupItem,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  Textarea,
+} from "@nextlyhq/ui";
+import { Eye, Monitor, Paperclip, RotateCcw, Smartphone } from "lucide-react";
+import { useMemo, useState } from "react";
 
 import type { FormField } from "../../../types";
+import { evaluateConditions } from "../../../utils/evaluate-conditions";
+import { useFormBuilder } from "../../context/FormBuilderContext";
 
-// ============================================================================
-// Types
-// ============================================================================
+// ---------------------------------------------------------------------------
+// Field rendering
+// ---------------------------------------------------------------------------
+
+function PreviewFieldInput({
+  field,
+  value,
+  onChange,
+}: {
+  field: FormField;
+  value: unknown;
+  onChange: (value: unknown) => void;
+}) {
+  const id = `preview-${field.name}`;
+  switch (field.type) {
+    case "textarea":
+      return (
+        <Textarea
+          id={id}
+          value={typeof value === "string" ? value : ""}
+          onChange={e => onChange(e.target.value)}
+          rows={"rows" in field ? (field.rows ?? 4) : 4}
+          placeholder={field.placeholder}
+        />
+      );
+    case "checkbox":
+      return (
+        <Switch id={id} checked={Boolean(value)} onCheckedChange={onChange} />
+      );
+    case "select": {
+      const options = "options" in field ? (field.options ?? []) : [];
+      return (
+        <Select
+          value={typeof value === "string" ? value : ""}
+          onValueChange={onChange}
+        >
+          <SelectTrigger
+            id={id}
+            className="w-full bg-transparent border-input dark:bg-muted/50"
+          >
+            <SelectValue placeholder={field.placeholder ?? "Select…"} />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map(option => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      );
+    }
+    case "radio": {
+      const options = "options" in field ? (field.options ?? []) : [];
+      return (
+        <RadioGroup
+          value={typeof value === "string" ? value : ""}
+          onValueChange={onChange}
+          className="flex flex-col gap-2"
+        >
+          {options.map(option => (
+            <div key={option.value} className="flex items-center gap-2">
+              <RadioGroupItem
+                value={option.value}
+                id={`${id}-${option.value}`}
+              />
+              <Label htmlFor={`${id}-${option.value}`} className="font-normal">
+                {option.label}
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+      );
+    }
+    case "number":
+      return (
+        <Input
+          id={id}
+          type="number"
+          value={
+            typeof value === "number" || typeof value === "string"
+              ? String(value)
+              : ""
+          }
+          onChange={e =>
+            onChange(e.target.value === "" ? "" : Number(e.target.value))
+          }
+          placeholder={field.placeholder}
+        />
+      );
+    case "date":
+    case "time":
+      return (
+        <Input
+          id={id}
+          type={field.type}
+          value={typeof value === "string" ? value : ""}
+          onChange={e => onChange(e.target.value)}
+        />
+      );
+    case "file":
+      // Nothing uploads from a preview; the affordance is shown, disabled.
+      return (
+        <div className="flex items-center gap-2 border border-dashed border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+          <Paperclip className="h-4 w-4" aria-hidden="true" />
+          File upload (disabled in preview)
+        </div>
+      );
+    default:
+      return (
+        <Input
+          id={id}
+          type={
+            field.type === "email"
+              ? "email"
+              : field.type === "url"
+                ? "url"
+                : field.type === "phone"
+                  ? "tel"
+                  : "text"
+          }
+          value={typeof value === "string" ? value : ""}
+          onChange={e => onChange(e.target.value)}
+          placeholder={field.placeholder}
+        />
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
 
 export interface FormPreviewProps {
   /** Array of form fields to preview */
@@ -28,199 +179,178 @@ export interface FormPreviewProps {
     name?: string;
     slug?: string;
     description?: string;
-    status?: string;
   };
 }
 
-// ============================================================================
-// Component
-// ============================================================================
-
-/**
- * FormPreview - Visual form preview
- *
- * This is a stub component that shows a preview of the form.
- * The full implementation will include:
- * - Rendered form fields with proper styling
- * - Responsive preview modes (desktop, tablet, mobile)
- * - Theme preview options
- * - Conditional logic simulation
- *
- * @example
- * ```tsx
- * <FormPreview fields={fields} formData={formData} />
- * ```
- */
 export function FormPreview({ fields, formData }: FormPreviewProps) {
-  if (fields.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center p-12 bg-muted rounded-none border-2 border-dashed border-primary/5 text-center">
-        <div className="text-4xl mb-3">📝</div>
-        <p className="text-sm font-medium text-muted-foreground">
-          Add some fields to preview your form
-        </p>
-      </div>
-    );
-  }
+  const { settings } = useFormBuilder();
+  const [values, setValues] = useState<Record<string, unknown>>({});
+  const [device, setDevice] = useState<"desktop" | "mobile">("desktop");
+  const [confirmed, setConfirmed] = useState(false);
+
+  // Conditional logic runs against the live values with the SAME evaluator
+  // the runtime uses — typing into the preview shows/hides fields for real.
+  const visibleFields = useMemo(
+    () =>
+      fields.filter(field => {
+        if (field.type === "hidden") return false;
+        if (!field.conditionalLogic?.enabled) return true;
+        return evaluateConditions(field.conditionalLogic, values);
+      }),
+    [fields, values]
+  );
+
+  const hiddenCount = fields.filter(field => field.type === "hidden").length;
+
+  const reset = () => {
+    setValues({});
+    setConfirmed(false);
+  };
 
   return (
-    <div className="bg-background max-w-2xl mt-8">
-      <div className="mb-8">
-        <h2 className="text-2xl font-bold text-foreground">
-          {formData?.name || "Untitled Form"}
-        </h2>
-        {formData?.description && (
-          <p className="text-sm text-muted-foreground mt-2">
-            {formData.description}
-          </p>
-        )}
+    <div className="space-y-4">
+      {/* Preview chrome: honest framing + device toggle + reset */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Eye className="h-4 w-4" aria-hidden="true" />
+          Preview — a simulation of this form. Nothing here submits anywhere.
+        </div>
+        <div className="flex items-center gap-2">
+          <Tabs
+            value={device}
+            onValueChange={value => setDevice(value as "desktop" | "mobile")}
+          >
+            <TabsList className="rounded-none">
+              <TabsTrigger value="desktop" className="rounded-none gap-1.5">
+                <Monitor className="h-3.5 w-3.5" aria-hidden="true" />
+                Desktop
+              </TabsTrigger>
+              <TabsTrigger value="mobile" className="rounded-none gap-1.5">
+                <Smartphone className="h-3.5 w-3.5" aria-hidden="true" />
+                Mobile
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+          <Button type="button" variant="outline" size="sm" onClick={reset}>
+            <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
+            Reset
+          </Button>
+        </div>
       </div>
 
-      <div className="space-y-6">
-        {fields.map(field => (
-          <div key={field.name} className="flex flex-col gap-1.5">
-            <label className="text-sm font-medium text-foreground">
-              {field.label}
-              {field.required && (
-                <span className="text-destructive ml-1">*</span>
-              )}
-            </label>
-
-            {renderFieldPreview(field)}
-
-            {field.helpText && (
-              <p className="text-xs text-muted-foreground mt-1">
-                {field.helpText}
+      {/* The simulated form */}
+      <div className="flex justify-center border border-border bg-muted/30 p-6">
+        <div
+          className={`w-full space-y-5 border border-border bg-background p-6 ${
+            device === "mobile" ? "max-w-95" : "max-w-2xl"
+          }`}
+        >
+          <div>
+            <h3 className="text-lg font-semibold text-foreground">
+              {formData?.name || "Untitled form"}
+            </h3>
+            {formData?.description && (
+              <p className="mt-1 text-sm text-muted-foreground">
+                {formData.description}
               </p>
             )}
           </div>
-        ))}
-      </div>
 
-      <div className="mt-8 pt-6 border-t border-primary/5 flex items-center gap-4">
-        <Button type="button" disabled>
-          Submit
-        </Button>
-        <p className="text-xs text-muted-foreground">
-          This is a preview. Submissions are disabled.
-        </p>
+          {confirmed ? (
+            <div className="space-y-4">
+              {settings.confirmationType === "redirect" ? (
+                <p className="border border-border bg-muted/40 p-4 text-sm text-foreground">
+                  The visitor would now be redirected to{" "}
+                  <span className="font-mono">
+                    {settings.redirectUrl || "(no redirect URL set)"}
+                  </span>
+                  .
+                </p>
+              ) : (
+                <p className="border border-border bg-muted/40 p-4 text-sm text-foreground">
+                  {settings.successMessage || "Thank you for your submission!"}
+                </p>
+              )}
+              <Button type="button" variant="outline" onClick={reset}>
+                Fill again
+              </Button>
+            </div>
+          ) : (
+            <>
+              {visibleFields.length === 0 && (
+                <p className="text-sm text-muted-foreground">
+                  No visible fields — add fields in the Builder tab.
+                </p>
+              )}
+              {visibleFields.map(field => (
+                <div key={field.name} className="space-y-1.5">
+                  {field.type !== "checkbox" && (
+                    <Label htmlFor={`preview-${field.name}`}>
+                      {field.label || field.name}
+                      {field.required && (
+                        <span className="ml-1 text-destructive">*</span>
+                      )}
+                    </Label>
+                  )}
+                  {field.type === "checkbox" ? (
+                    <div className="flex items-center gap-2">
+                      <PreviewFieldInput
+                        field={field}
+                        value={values[field.name]}
+                        onChange={value =>
+                          setValues(prev => ({
+                            ...prev,
+                            [field.name]: value,
+                          }))
+                        }
+                      />
+                      <Label htmlFor={`preview-${field.name}`}>
+                        {field.label || field.name}
+                      </Label>
+                    </div>
+                  ) : (
+                    <PreviewFieldInput
+                      field={field}
+                      value={values[field.name]}
+                      onChange={value =>
+                        setValues(prev => ({ ...prev, [field.name]: value }))
+                      }
+                    />
+                  )}
+                  {field.helpText && (
+                    <p className="text-xs text-muted-foreground">
+                      {field.helpText}
+                    </p>
+                  )}
+                </div>
+              ))}
+
+              <Button
+                type="button"
+                onClick={() => setConfirmed(true)}
+                disabled={visibleFields.length === 0}
+              >
+                {settings.submitButtonText || "Submit"}
+              </Button>
+            </>
+          )}
+
+          {hiddenCount > 0 && !confirmed && (
+            <p className="text-xs text-muted-foreground">
+              <Badge
+                variant="outline"
+                className="mr-1.5 rounded-none border-border px-1 py-0 text-[10px]"
+              >
+                {hiddenCount}
+              </Badge>
+              hidden {hiddenCount === 1 ? "field" : "fields"} will be submitted
+              invisibly.
+            </p>
+          )}
+        </div>
       </div>
     </div>
   );
-}
-
-/**
- * Render a preview of a field based on its type
- */
-function renderFieldPreview(field: FormField): React.ReactNode {
-  switch (field.type) {
-    case "text":
-    case "email":
-    case "phone":
-    case "url":
-      return (
-        <Input
-          type={field.type === "email" ? "email" : "text"}
-          placeholder={
-            field.placeholder || `Enter ${field.label.toLowerCase()}`
-          }
-          disabled
-        />
-      );
-
-    case "number":
-      return (
-        <Input
-          type="number"
-          placeholder={field.placeholder || "Enter a number"}
-          disabled
-        />
-      );
-
-    case "textarea":
-      return (
-        <textarea
-          className="flex w-full rounded-none border border-input bg-transparent px-3 py-2 text-sm shadow-none placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-          placeholder={
-            field.placeholder || `Enter ${field.label.toLowerCase()}`
-          }
-          rows={field.rows || 4}
-          disabled
-        />
-      );
-
-    case "select":
-      return (
-        <select
-          className="flex h-9 w-full items-center justify-between rounded-none border border-input bg-transparent px-3 py-2 text-sm shadow-none focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-          disabled
-        >
-          <option value="">Select an option</option>
-          {field.options?.map(opt => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-      );
-
-    case "checkbox":
-      return (
-        <div className="flex items-center space-x-2">
-          <input
-            type="checkbox"
-            className="h-4 w-4 rounded border-input text-primary focus:ring-primary"
-            disabled
-          />
-          <span className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-            {field.label}
-          </span>
-        </div>
-      );
-
-    case "radio":
-      return (
-        <div className="flex flex-col space-y-2">
-          {field.options?.map(opt => (
-            <div key={opt.value} className="flex items-center space-x-2">
-              <input
-                type="radio"
-                name={field.name}
-                className="h-4 w-4 rounded-full border border-input text-primary focus:ring-primary"
-                disabled
-              />
-              <span className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-                {opt.label}
-              </span>
-            </div>
-          ))}
-        </div>
-      );
-
-    case "file":
-      return (
-        <div className="flex items-center">
-          <Input type="file" disabled />
-        </div>
-      );
-
-    case "date":
-      return <Input type="date" disabled />;
-
-    case "time":
-      return <Input type="time" disabled />;
-
-    case "hidden":
-      return (
-        <div className="flex items-center gap-2 p-3 text-sm text-muted-foreground bg-muted border-2 border-dashed border-primary/5 rounded-none">
-          <span className="text-lg">👁️</span>
-          <span>Hidden field</span>
-        </div>
-      );
-
-    default:
-      return <Input type="text" placeholder="Unknown field type" disabled />;
-  }
 }
 
 export default FormPreview;


### PR DESCRIPTION
## What

Tier-4 #10 sub-doc 5, **PR B of 2** — the preview half, per the founder-selected **option (b)**: an interactive admin-side simulation now, with the real frontend `FormRenderer` filed as its own post-Tier-4 product feature (`nextly-integrations/tasks/admin-tasks/tier4-10-05-settings-preview-design.md` §3c). Stacked on #201 (settings) — merge that first.

### From stub to simulation
The old Preview tab was a self-described stub: static disabled inputs, emoji glyphs, no conditional logic. Now:
- **Real enabled inputs** per field type (text/email/url/phone/number/textarea/select/radio/checkbox/date/time; file shows a disabled affordance — nothing uploads from a preview).
- **Conditional logic reacts live** to what you type, using the same `evaluate-conditions` the runtime uses.
- **The confirmation flow plays out**: the form's actual submit button text, then the configured success message — or an honest "the visitor would now be redirected to `<url>`" for redirect forms. "Fill again" resets.
- **Device toggle** (desktop/mobile width), reset button, required markers, help text, and a count of hidden fields that would submit invisibly.
- **Honest framing** in the chrome: "Preview — a simulation of this form. Nothing here submits anywhere."

### Scope note
Per the sign-off, Formbricks-grade fidelity (rendering the actual published component) needs the frontend `FormRenderer` the plugin doesn't ship yet; that's filed as follow-up product work, and this preview swaps to it behind the same tab when it exists.

## Verification

- plugin-form-builder **69 passed**, typecheck/lint clean; E2E **25 passed** (baseline 24; new preview test: enabled inputs → simulated submit → real success message → reset)
- Live walkthrough in **both themes** for BOTH sub-doc-5 tabs (screenshots `assets/tier4-10/tier4-settings-*`, `tier4-preview-*`), including the settings tab's live "Inherit (on)" / "Inherit (off)" resolution from plugin config.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Form previews are now interactive simulations with enabled inputs and real submit/confirmation behavior.
  * Supports conditional field visibility based on typed values, including hidden-field warnings.
  * Preview includes desktop/mobile modes, reset (“Fill again”), and confirmation messaging/redirects based on settings.
  * Inline required-field validation is shown during preview submission.
* **Bug Fixes**
  * “Fill again” now clears typed values and restores a fresh preview state after submission.
* **Tests**
  * Added an end-to-end test covering interactive preview submission and confirmation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->