### PR TITLE
fix(admin): scan first-party plugin admin sources for css utilities

### DIFF
--- a/.changeset/admin-css-scans-plugin-sources.md
+++ b/.changeset/admin-css-scans-plugin-sources.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+First-party plugin admin UIs now render exactly as designed.
+
+The admin stylesheet build now scans the form-builder and page-builder admin sources, so utility classes used only by a plugin are no longer silently dropped from the compiled CSS. Most visibly: the form preview's desktop/mobile toggle now genuinely resizes the simulated pane (mobile was rendering full-width), and over a dozen other spacing, sizing, and border details across the builder, notifications, and submissions screens now apply as intended.

--- a/e2e/tests/form-builder.spec.ts
+++ b/e2e/tests/form-builder.spec.ts
@@ -176,9 +176,16 @@ test("the preview is an interactive simulation with real confirmation", async ({
   const desktopWidth = (await emailInput.boundingBox())?.width ?? 0;
   expect(desktopWidth).toBeGreaterThan(0);
   await page.getByRole("tab", { name: "Mobile" }).click();
+  // boundingBox() returns null while the pane is detached mid-transition; a
+  // null-to-zero fallback would let that transient state pass the narrower
+  // check, so only a real, positive measurement may satisfy the poll.
   await expect
-    .poll(async () => (await emailInput.boundingBox())?.width ?? 0, {
-      message: "mobile preview should be narrower than desktop",
-    })
-    .toBeLessThan(desktopWidth);
+    .poll(
+      async () => {
+        const box = await emailInput.boundingBox();
+        return box !== null && box.width > 0 && box.width < desktopWidth;
+      },
+      { message: "mobile preview should be narrower than desktop" }
+    )
+    .toBe(true);
 });

--- a/e2e/tests/form-builder.spec.ts
+++ b/e2e/tests/form-builder.spec.ts
@@ -167,4 +167,18 @@ test("the preview is an interactive simulation with real confirmation", async ({
   // Reset returns to a fresh form.
   await page.getByRole("button", { name: "Fill again" }).click();
   await expect(emailInput).toHaveValue("");
+
+  // The device toggle must genuinely resize the simulated pane. The pane
+  // widths come from utility classes in the compiled admin stylesheet, so a
+  // class the stylesheet fails to emit leaves both modes rendering at the
+  // same width — measure the pane (via its full-width input) instead of
+  // trusting the toggle state.
+  const desktopWidth = (await emailInput.boundingBox())?.width ?? 0;
+  expect(desktopWidth).toBeGreaterThan(0);
+  await page.getByRole("tab", { name: "Mobile" }).click();
+  await expect
+    .poll(async () => (await emailInput.boundingBox())?.width ?? 0, {
+      message: "mobile preview should be narrower than desktop",
+    })
+    .toBeLessThan(desktopWidth);
 });

--- a/packages/admin/src/styles/globals.css
+++ b/packages/admin/src/styles/globals.css
@@ -17,6 +17,13 @@
 /* Scan @nextlyhq/ui source so Tailwind includes utility classes used by extracted components */
 @source "../../../ui/src";
 
+/* First-party plugin admin components render inside the admin shell and rely on
+ * this compiled stylesheet — Tailwind cannot auto-detect sibling packages, so
+ * without these directives any utility used only by a plugin is silently
+ * dropped from the build and becomes a no-op at runtime. */
+@source "../../../plugin-form-builder/src/admin";
+@source "../../../plugin-page-builder/src/admin";
+
 /* Scope overflow fix to nextly-admin only */
 .nextly-admin {
   overflow-x: hidden;


### PR DESCRIPTION
## What

The admin's compiled stylesheet (`@nextlyhq/admin/style.css`) is the only CSS that styles plugin admin components, but its Tailwind build only scanned `admin/src` and `ui/src`. Any utility class used *only* by a plugin was silently dropped from the build and became a no-op at runtime.

Most visible symptom: the form preview's desktop/mobile toggle appeared inverted — `max-w-95` was never emitted, so the mobile pane rendered full-width (wider than the desktop pane's `max-w-2xl`).

A sweep of `plugin-form-builder/src/admin` against the compiled CSS found **14 missing utilities** across six components: `max-w-95`, `opacity-25`, `opacity-75`, `pb-12`, `min-w-[200px]`, `-top-2`, `-right-2`, `mx-1.5`, `max-w-64`, `py-14`, `min-w-36`, `max-w-200`, `gap-10`, `border-warning/20`, plus `wrap-break-word` in the submissions drawer. Badge offsets, sheet widths, spinner opacity, and spacing were all silently unstyled.

## Fix

Two `@source` directives in `packages/admin/src/styles/globals.css` so the stylesheet build scans the first-party plugin admin sources — the same mechanism already used for `ui/src`. All 15 utilities (and the page-builder's) now compile; the stylesheet grows ~1.8 KB.

## Regression test

`form-builder.spec.ts` now measures the preview pane across the device toggle and asserts mobile is genuinely narrower than desktop. Verified the test **fails** against a stylesheet built without this fix and passes with it.

## Verified

- All 15 previously-missing classes present in the rebuilt CSS; page-builder admin classes spot-checked clean.
- E2E full suite 25/25.
- Live walkthrough on the playground in **both themes**: desktop pane 672px, mobile pane 380px.

## Known limitation (follow-up, not this PR)

This covers **first-party** plugins only — they build and publish together with the admin, so scanning their sources is sound. Third-party plugins installed from npm still have no styling story: their utility classes won't be in the precompiled admin CSS. That needs a deliberate plugin-CSS mechanism (e.g. plugins shipping their own stylesheet the host imports, or a documented `@source` recipe for host apps) and is being filed as a platform follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved styling support for form builder and page builder admin components, ensuring their utility-based styles render correctly.
  * Strengthened interactive form preview validation so switching to Mobile reliably displays a narrower simulated preview.

* **Tests**
  * Added coverage confirming that preview dimensions visibly change when switching between desktop and mobile modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->