### PR TITLE
chore: enable automatic qodo pr reviews

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -14,6 +14,11 @@
 # (no `/agentic_describe`) so Qodo never overwrites a PR description authored
 # by the team.
 pr_commands = ["/agentic_review"]
+# Refresh the review when new commits are pushed to an open PR. `push_commands`
+# requires `handle_push_trigger = true`; Qodo updates its existing review
+# rather than stacking a new comment each push.
+handle_push_trigger = true
+push_commands = ["/agentic_review"]
 
 [review_agent]
 # Post both an inline, line-anchored review and a summary comment, matching how

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,21 @@
+# Qodo (qodo.ai) code-review configuration.
+# Docs: https://docs.qodo.ai/install-and-configure/configuration-overview/configuration-file
+#
+# nextlyhq/nextly qualifies for Qodo's free open-source plan. This file makes
+# Qodo run an agentic code review automatically when a pull request is opened,
+# and refresh its review as new commits are pushed. You can also trigger a
+# review at any time by commenting `/agentic_review` on a PR.
+#
+# NOTE: this config only takes effect for pull requests opened AFTER it lands
+# on the default branch (`main`). Open PRs need a manual `/agentic_review`.
+
+[github_app]
+# Commands Qodo runs automatically on pull-request open. Kept to review only
+# (no `/agentic_describe`) so Qodo never overwrites a PR description authored
+# by the team.
+pr_commands = ["/agentic_review"]
+
+[review_agent]
+# Post both an inline, line-anchored review and a summary comment, matching how
+# our other review bots surface findings.
+comments_location_policy = "both"


### PR DESCRIPTION
## What

Adds `.pr_agent.toml` so **Qodo** (qodo.ai, on the free OSS plan for this repo) runs an agentic code review **automatically on every pull request**, alongside CodeRabbit and Greptile.

## Config

```toml
[github_app]
pr_commands = ["/agentic_review"]

[review_agent]
comments_location_policy = "both"
```

- `pr_commands = ["/agentic_review"]` — auto-runs a review when a PR is opened; Qodo refreshes it as new commits are pushed.
- Deliberately **no `/agentic_describe`** — so Qodo never overwrites a PR description the team wrote.
- `comments_location_policy = "both"` — posts inline (line-anchored) findings plus a summary, matching how our other review bots behave.

## Important: activation timing

Per Qodo's docs, this file only takes effect for PRs opened **after** it merges to `main`. So:
- **Merge this first** to turn on auto-review for all future PRs.
- **Open PRs** (including the schema-P0 security PR) won't be picked up retroactively — comment `/agentic_review` on them to trigger Qodo manually. I've already done that on the open PRs.

Prerequisite (already done): the Qodo GitHub App is installed on the repo, and the account is on the OSS plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated pull request reviews with both inline line-anchored feedback and a summary comment.
  * Reviews now run automatically when pull requests are opened and when new commits are pushed, once the configuration is available on the main branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->