### PR TITLE
fix(nextly): forward user roles into role-based access checks

### DIFF
--- a/.changeset/forward-roles-role-based-access.md
+++ b/.changeset/forward-roles-role-based-access.md
@@ -1,0 +1,21 @@
+---
+"nextly": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"create-nextly-app": patch
+---
+
+Forward the authenticated user's roles into access-control evaluation so role-based rules work over REST.
+
+- Route-authenticated write requests (create/update/delete/duplicate/bulk) now carry the caller's role set to the service layer, so collection-level `role-based` rules and field-level `access.read` evaluate against the real roles instead of an empty context.
+- Role-based rules now match on ANY held role (documented OR-logic) for the many-to-many user/role model. The single `role` field is still honored, so existing single-role setups are unchanged.

--- a/packages/nextly/src/__tests__/routeHandler-direct-branches.test.ts
+++ b/packages/nextly/src/__tests__/routeHandler-direct-branches.test.ts
@@ -64,6 +64,7 @@ vi.mock("../services/lib/permissions", () => ({
   isSuperAdmin: vi.fn().mockResolvedValue(false),
   containsSuperAdminRole: vi.fn().mockResolvedValue(false),
   hasSuperAdminExcluding: vi.fn().mockResolvedValue(false),
+  listRoleSlugsForUser: vi.fn().mockResolvedValue([]),
 }));
 
 // Replace the ImageSizeService class with a vi.fn-backed constructor whose
@@ -106,7 +107,9 @@ const mockHandlerConfig: {
 
 vi.mock("../route-handler", async () => {
   const actual =
-    await vi.importActual<typeof import("../route-handler")>("../route-handler");
+    await vi.importActual<typeof import("../route-handler")>(
+      "../route-handler"
+    );
   return {
     ...actual,
     // Only the config getter is consulted by the admin-meta branch; the
@@ -128,7 +131,9 @@ import { container } from "../di/container";
 import {
   _handleAdminMetaRequestForTest,
   _handleAdminMetaSidebarGroupsForTest,
+  _setAuthenticatedRouteParamsForTest,
 } from "../routeHandler";
+import { listRoleSlugsForUser } from "../services/lib/permissions";
 import {
   createImageSize,
   deleteImageSize,
@@ -311,7 +316,10 @@ describe("createImageSize (POST /image-sizes)", () => {
     );
 
     expect(res.status).toBe(201);
-    const json = (await res.json()) as { message: string; item: { id: string } };
+    const json = (await res.json()) as {
+      message: string;
+      item: { id: string };
+    };
     expect(json).not.toHaveProperty("data");
     expect(json.message).toMatch(/created/i);
     expect(json.item.id).toBe("sz_2");
@@ -369,3 +377,74 @@ describe("deleteImageSize (DELETE /image-sizes/:id)", () => {
 // in any test branch (different SUTs reach them via the auth/middleware
 // barrel).
 void createJsonErrorResponse;
+
+describe("setAuthenticatedRouteParams", () => {
+  const listRoleSlugsMock = vi.mocked(listRoleSlugsForUser);
+
+  it("strips client-injected reserved params and forwards resolved session slugs", async () => {
+    listRoleSlugsMock.mockResolvedValue(["editor"]);
+    const routeParams: Record<string, string> = {
+      collectionName: "posts",
+      // Attacker-supplied copies of server-authored identity params.
+      _authenticatedUserId: "attacker",
+      _authenticatedUserRoles: JSON.stringify(["admin"]),
+    };
+
+    await _setAuthenticatedRouteParamsForTest(routeParams, {
+      userId: "u1",
+      roles: ["role-id-1"],
+      permissions: [],
+      authMethod: "session",
+    });
+
+    expect(routeParams._authenticatedUserId).toBe("u1");
+    // Injected roles are clobbered by the resolved slugs, not trusted.
+    expect(routeParams._authenticatedUserRoles).toBe(
+      JSON.stringify(["editor"])
+    );
+  });
+
+  it("uses API-key slugs as-is without resolving", async () => {
+    const routeParams: Record<string, string> = { collectionName: "posts" };
+
+    await _setAuthenticatedRouteParamsForTest(routeParams, {
+      userId: "u1",
+      roles: ["editor", "author"],
+      permissions: [],
+      authMethod: "api-key",
+    });
+
+    expect(listRoleSlugsMock).not.toHaveBeenCalled();
+    expect(routeParams._authenticatedUserRoles).toBe(
+      JSON.stringify(["editor", "author"])
+    );
+  });
+
+  it("writes an empty roles array (clobbering injection) when the user has none", async () => {
+    listRoleSlugsMock.mockResolvedValue([]);
+    const routeParams: Record<string, string> = {
+      _authenticatedUserRoles: JSON.stringify(["admin"]),
+    };
+
+    await _setAuthenticatedRouteParamsForTest(routeParams, {
+      userId: "u1",
+      roles: [],
+      permissions: [],
+      authMethod: "session",
+    });
+
+    expect(routeParams._authenticatedUserRoles).toBe("[]");
+  });
+
+  it("strips reserved params when there is no authorized user", async () => {
+    const routeParams: Record<string, string> = {
+      _authenticatedUserId: "attacker",
+      _authenticatedUserRoles: JSON.stringify(["admin"]),
+    };
+
+    await _setAuthenticatedRouteParamsForTest(routeParams, undefined);
+
+    expect(routeParams._authenticatedUserId).toBeUndefined();
+    expect(routeParams._authenticatedUserRoles).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/collections/fields/types/base.ts
+++ b/packages/nextly/src/collections/fields/types/base.ts
@@ -88,6 +88,11 @@ export interface RequestContext {
     email?: string;
     /** User's role (e.g., 'admin', 'editor', 'user') */
     role?: string;
+    /**
+     * User's roles (many-to-many). Role-based access rules match if ANY of
+     * these roles is allowed; `role` is folded in when present.
+     */
+    roles?: string[];
     /** Additional user properties */
     [key: string]: unknown;
   };

--- a/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-shapes.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-shapes.test.ts
@@ -478,6 +478,63 @@ describe("dispatchCollections, mutations (respondMutation)", () => {
     });
   });
 
+  it("createEntry decodes and forwards the authenticated roles", async () => {
+    const spy = vi.fn().mockResolvedValue({
+      success: true,
+      statusCode: 201,
+      message: "ok",
+      data: { id: "e1" },
+    });
+    const container = makeContainer({ createEntry: spy });
+
+    await dispatchCollections(
+      container,
+      "createEntry",
+      {
+        collectionName: "posts",
+        _authenticatedUserId: "u1",
+        // Route params are strings; roles arrive JSON-encoded.
+        _authenticatedUserRoles: JSON.stringify(["editor", "author"]),
+      },
+      { title: "Hello" }
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collectionName: "posts",
+        userId: "u1",
+        userRoles: ["editor", "author"],
+      }),
+      expect.anything()
+    );
+  });
+
+  it("createEntry degrades a malformed roles param to undefined", async () => {
+    const spy = vi.fn().mockResolvedValue({
+      success: true,
+      statusCode: 201,
+      message: "ok",
+      data: { id: "e1" },
+    });
+    const container = makeContainer({ createEntry: spy });
+
+    await dispatchCollections(
+      container,
+      "createEntry",
+      {
+        collectionName: "posts",
+        _authenticatedUserId: "u1",
+        _authenticatedUserRoles: "not-json",
+      },
+      { title: "Hello" }
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ userRoles: undefined }),
+      expect.anything()
+    );
+  });
+
   it("updateEntry returns { message, item } body and 200 status", async () => {
     const fakeEntry = { id: "e1", title: "Hello (updated)" };
     const fakeServiceResult = {

--- a/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-shapes.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-shapes.test.ts
@@ -509,31 +509,39 @@ describe("dispatchCollections, mutations (respondMutation)", () => {
     );
   });
 
-  it("createEntry degrades a malformed roles param to undefined", async () => {
-    const spy = vi.fn().mockResolvedValue({
-      success: true,
-      statusCode: 201,
-      message: "ok",
-      data: { id: "e1" },
-    });
-    const container = makeContainer({ createEntry: spy });
+  it.each([
+    ["non-JSON string", "not-json"],
+    ["a mixed-type array", JSON.stringify(["editor", 123])],
+    ["a non-array value", JSON.stringify({ role: "editor" })],
+    ["an empty array", JSON.stringify([])],
+  ])(
+    "createEntry degrades %s roles param to undefined",
+    async (_label, raw) => {
+      const spy = vi.fn().mockResolvedValue({
+        success: true,
+        statusCode: 201,
+        message: "ok",
+        data: { id: "e1" },
+      });
+      const container = makeContainer({ createEntry: spy });
 
-    await dispatchCollections(
-      container,
-      "createEntry",
-      {
-        collectionName: "posts",
-        _authenticatedUserId: "u1",
-        _authenticatedUserRoles: "not-json",
-      },
-      { title: "Hello" }
-    );
+      await dispatchCollections(
+        container,
+        "createEntry",
+        {
+          collectionName: "posts",
+          _authenticatedUserId: "u1",
+          _authenticatedUserRoles: raw,
+        },
+        { title: "Hello" }
+      );
 
-    expect(spy).toHaveBeenCalledWith(
-      expect.objectContaining({ userRoles: undefined }),
-      expect.anything()
-    );
-  });
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ userRoles: undefined }),
+        expect.anything()
+      );
+    }
+  );
 
   it("updateEntry returns { message, item } body and 200 status", async () => {
     const fakeEntry = { id: "e1", title: "Hello (updated)" };

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -132,9 +132,16 @@ function readAuthenticatedRoles(p: Params): string[] | undefined {
   if (!raw) return undefined;
   try {
     const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return undefined;
-    const roles = parsed.filter((r): r is string => typeof r === "string");
-    return roles.length > 0 ? roles : undefined;
+    // Require a non-empty array of only strings; a malformed or mixed-type
+    // value degrades to "no roles" rather than forwarding a partial set.
+    if (
+      !Array.isArray(parsed) ||
+      parsed.length === 0 ||
+      !parsed.every((role): role is string => typeof role === "string")
+    ) {
+      return undefined;
+    }
+    return parsed;
   } catch {
     return undefined;
   }

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -123,6 +123,23 @@ function formatToastSummary(summary: {
   return parts.length > 0 ? parts.join(", ") : "no changes";
 }
 
+// Decode the authenticated role set forwarded by the route handler. Route
+// params are strings, so roles arrive JSON-encoded; parse defensively and keep
+// only string entries so a malformed value degrades to "no roles" rather than
+// throwing.
+function readAuthenticatedRoles(p: Params): string[] | undefined {
+  const raw = p._authenticatedUserRoles;
+  if (!raw) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return undefined;
+    const roles = parsed.filter((r): r is string => typeof r === "string");
+    return roles.length > 0 ? roles : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 const COLLECTIONS_METHODS: Record<
   string,
   MethodHandler<CollectionsHandlerType>
@@ -794,6 +811,7 @@ const COLLECTIONS_METHODS: Record<
           userEmail: p._authenticatedUserEmail
             ? String(p._authenticatedUserEmail)
             : undefined,
+          userRoles: readAuthenticatedRoles(p),
         },
         body as Record<string, unknown>
       );
@@ -854,6 +872,7 @@ const COLLECTIONS_METHODS: Record<
           userEmail: p._authenticatedUserEmail
             ? String(p._authenticatedUserEmail)
             : undefined,
+          userRoles: readAuthenticatedRoles(p),
         },
         body as Record<string, unknown>
       );
@@ -882,6 +901,7 @@ const COLLECTIONS_METHODS: Record<
         userEmail: p._authenticatedUserEmail
           ? String(p._authenticatedUserEmail)
           : undefined,
+        userRoles: readAuthenticatedRoles(p),
       });
       const entry = unwrapServiceResult(result, {
         collectionName: p.collectionName,
@@ -916,6 +936,7 @@ const COLLECTIONS_METHODS: Record<
         userEmail: p._authenticatedUserEmail
           ? String(p._authenticatedUserEmail)
           : undefined,
+        userRoles: readAuthenticatedRoles(p),
       });
       // Compose a server-authored toast string. Total here is the
       // request's id count, not just the success count, so the message
@@ -958,6 +979,7 @@ const COLLECTIONS_METHODS: Record<
         userEmail: p._authenticatedUserEmail
           ? String(p._authenticatedUserEmail)
           : undefined,
+        userRoles: readAuthenticatedRoles(p),
       });
       const message =
         result.failures.length === 0
@@ -1009,6 +1031,7 @@ const COLLECTIONS_METHODS: Record<
           userEmail: p._authenticatedUserEmail
             ? String(p._authenticatedUserEmail)
             : undefined,
+          userRoles: readAuthenticatedRoles(p),
         },
         { limit: b.limit }
       );
@@ -1044,6 +1067,7 @@ const COLLECTIONS_METHODS: Record<
         userEmail: p._authenticatedUserEmail
           ? String(p._authenticatedUserEmail)
           : undefined,
+        userRoles: readAuthenticatedRoles(p),
       });
       const entry = unwrapServiceResult(result, {
         collectionName: p.collectionName,

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -50,6 +50,9 @@ export class CollectionAccessService extends BaseService {
       user: {
         id: user.id,
         role: user.role,
+        // Forward the full role set so role-based rules match on ANY role,
+        // not just a single primary role (the user/role model is many-to-many).
+        roles: user.roles,
         email: user.email,
       },
     };

--- a/packages/nextly/src/domains/collections/services/collection-types.ts
+++ b/packages/nextly/src/domains/collections/services/collection-types.ts
@@ -35,8 +35,13 @@ export interface CollectionServiceResult<T = unknown> {
 export interface UserContext {
   /** Unique user identifier */
   id: string;
-  /** User's role (required for role-based access rules) */
+  /** User's role (required for single-role role-based access rules) */
   role?: string;
+  /**
+   * User's roles (many-to-many). Role-based access rules match if ANY of
+   * these roles is allowed; `role` is folded in when present.
+   */
+  roles?: string[];
   /** User's display name (optional, for logging/auditing) */
   name?: string;
   /** User's email address (optional, for logging/auditing) */

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -86,6 +86,7 @@ import {
   isSuperAdmin,
   containsSuperAdminRole,
   hasSuperAdminExcluding,
+  listRoleSlugsForUser,
 } from "./services/lib/permissions";
 import {
   builderDisabledError,
@@ -807,21 +808,7 @@ async function handleServiceRequest(
   // are silently skipped.
   // NOTE: We use _authenticatedUserId (not userId) to avoid colliding with
   // the existing routeParams.userId which is the target user ID from URL params.
-  if (authorizedUser && routeParams) {
-    routeParams._authenticatedUserId = authorizedUser.userId;
-    if (authorizedUser.userName)
-      routeParams._authenticatedUserName = authorizedUser.userName;
-    if (authorizedUser.userEmail)
-      routeParams._authenticatedUserEmail = authorizedUser.userEmail;
-    // Forward the resolved role set so role-based access rules (collection and
-    // field-level) evaluate against the caller's actual roles, not undefined.
-    // routeParams values are strings, so the array is JSON-encoded here and
-    // decoded at the dispatcher boundary.
-    if (authorizedUser.roles && authorizedUser.roles.length > 0)
-      routeParams._authenticatedUserRoles = JSON.stringify(
-        authorizedUser.roles
-      );
-  }
+  await setAuthenticatedRouteParams(routeParams, authorizedUser);
 
   const dispatchRequest: DispatchRequest = {
     service,
@@ -1399,3 +1386,42 @@ export function getCollectionsHandler(): CollectionsHandler | undefined {
 export const _handleAdminMetaRequestForTest = handleAdminMetaRequest;
 export const _handleAdminMetaSidebarGroupsForTest =
   handleAdminMetaSidebarGroups;
+
+/**
+ * Populate the reserved `_authenticated*` route params from the authorized
+ * user so downstream services get the caller's identity and roles.
+ *
+ * `parseRestRoute` copies every query-string key into `routeParams`, so these
+ * reserved keys are stripped first: they are server-authored and a
+ * client-supplied copy (e.g. `?_authenticatedUserRoles=["admin"]`) must never
+ * be trusted. Roles are forwarded as SLUGS — session auth carries role IDs on
+ * `AuthContext.roles`, so those are resolved; API-key auth already carries
+ * key-scoped slugs.
+ */
+async function setAuthenticatedRouteParams(
+  routeParams: Record<string, string> | undefined,
+  authorizedUser: AuthContext | undefined
+): Promise<void> {
+  if (!routeParams) return;
+
+  delete routeParams._authenticatedUserId;
+  delete routeParams._authenticatedUserName;
+  delete routeParams._authenticatedUserEmail;
+  delete routeParams._authenticatedUserRoles;
+
+  if (!authorizedUser) return;
+
+  routeParams._authenticatedUserId = authorizedUser.userId;
+  if (authorizedUser.userName)
+    routeParams._authenticatedUserName = authorizedUser.userName;
+  if (authorizedUser.userEmail)
+    routeParams._authenticatedUserEmail = authorizedUser.userEmail;
+
+  const roleSlugs =
+    authorizedUser.authMethod === "api-key"
+      ? authorizedUser.roles
+      : await listRoleSlugsForUser(authorizedUser.userId);
+  routeParams._authenticatedUserRoles = JSON.stringify(roleSlugs ?? []);
+}
+
+export const _setAuthenticatedRouteParamsForTest = setAuthenticatedRouteParams;

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -813,6 +813,14 @@ async function handleServiceRequest(
       routeParams._authenticatedUserName = authorizedUser.userName;
     if (authorizedUser.userEmail)
       routeParams._authenticatedUserEmail = authorizedUser.userEmail;
+    // Forward the resolved role set so role-based access rules (collection and
+    // field-level) evaluate against the caller's actual roles, not undefined.
+    // routeParams values are strings, so the array is JSON-encoded here and
+    // decoded at the dispatcher boundary.
+    if (authorizedUser.roles && authorizedUser.roles.length > 0)
+      routeParams._authenticatedUserRoles = JSON.stringify(
+        authorizedUser.roles
+      );
   }
 
   const dispatchRequest: DispatchRequest = {

--- a/packages/nextly/src/services/access/access-control-service.test.ts
+++ b/packages/nextly/src/services/access/access-control-service.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+
+import type { RequestContext } from "@nextly/collections/fields/types/base";
+
+import { AccessControlService } from "./access-control-service";
+import type { CollectionAccessRules } from "./types";
+
+// Role-based rules use OR logic: access is granted if the user holds ANY of the
+// allowed roles. The user/role model is many-to-many, so evaluation reads the
+// full `roles` set and folds in the single `role` for backward compatibility.
+describe("AccessControlService role-based access (OR-membership)", () => {
+  const service = new AccessControlService();
+  const rules: CollectionAccessRules = {
+    read: { type: "role-based", allowedRoles: ["admin", "editor"] },
+  };
+
+  function evaluate(user: RequestContext["user"]) {
+    return service.evaluateAccess(rules, "read", { user });
+  }
+
+  it("grants when one of several held roles is allowed", async () => {
+    const result = await evaluate({ id: "u1", roles: ["viewer", "editor"] });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("denies when no held role is allowed", async () => {
+    const result = await evaluate({ id: "u1", roles: ["viewer", "guest"] });
+    expect(result.allowed).toBe(false);
+  });
+
+  it("still honors the single `role` field (backward compatibility)", async () => {
+    const result = await evaluate({ id: "u1", role: "editor" });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("folds `role` into the set when `roles` does not match", async () => {
+    const result = await evaluate({
+      id: "u1",
+      role: "admin",
+      roles: ["viewer"],
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("denies an authenticated user with no roles at all", async () => {
+    const result = await evaluate({ id: "u1" });
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe("User has no role assigned");
+  });
+
+  it("denies an unauthenticated request", async () => {
+    const result = await evaluate(undefined);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe("Authentication required");
+  });
+});

--- a/packages/nextly/src/services/access/access-control-service.ts
+++ b/packages/nextly/src/services/access/access-control-service.ts
@@ -247,18 +247,23 @@ export class AccessControlService {
     rule: StoredAccessRule,
     context: RequestContext
   ): AccessEvaluationResult {
-    const userRole = context.user?.role;
     const allowedRoles = rule.allowedRoles ?? [];
 
     if (!context.user) {
       return { allowed: false, reason: "Authentication required" };
     }
 
-    if (!userRole) {
+    // Collect every role the user holds: the many-to-many `roles` set plus the
+    // single `role` when present (deduped). Role-based rules use OR logic, so
+    // access is granted if ANY held role is in the allowed list.
+    const userRoles = new Set<string>(context.user.roles ?? []);
+    if (context.user.role) userRoles.add(context.user.role);
+
+    if (userRoles.size === 0) {
       return { allowed: false, reason: "User has no role assigned" };
     }
 
-    const allowed = allowedRoles.includes(userRole);
+    const allowed = allowedRoles.some(role => userRoles.has(role));
 
     return {
       allowed,

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -164,12 +164,13 @@ export class CollectionsHandler {
       userId?: string;
       userName?: string;
       userEmail?: string;
+      userRoles?: string[];
       user?: UserContext;
       overrideAccess?: boolean;
       routeAuthorized?: boolean;
     },
-  >(params: T): Omit<T, "userName" | "userEmail"> {
-    const { userName, userEmail, ...rest } = params;
+  >(params: T): Omit<T, "userName" | "userEmail" | "userRoles"> {
+    const { userName, userEmail, userRoles, ...rest } = params;
     if (!rest.user && rest.userId) {
       return {
         ...rest,
@@ -177,6 +178,9 @@ export class CollectionsHandler {
           id: rest.userId,
           name: userName,
           email: userEmail,
+          // Carry the authenticated role set so role-based access rules and
+          // field-level access.read evaluate against the real user.
+          roles: userRoles,
         },
         overrideAccess: true,
         routeAuthorized: true,
@@ -376,6 +380,8 @@ export class CollectionsHandler {
       userId?: string;
       userName?: string;
       userEmail?: string;
+      /** Authenticated role set, forwarded to role-based access rules. */
+      userRoles?: string[];
       /** Depth for relationship population in response (0-5) */
       depth?: number;
       /** User context for access control */
@@ -466,6 +472,8 @@ export class CollectionsHandler {
       userId?: string;
       userName?: string;
       userEmail?: string;
+      /** Authenticated role set, forwarded to role-based access rules. */
+      userRoles?: string[];
       /** Depth for relationship population in response (0-5) */
       depth?: number;
       /** User context for access control */
@@ -494,6 +502,8 @@ export class CollectionsHandler {
     userId?: string;
     userName?: string;
     userEmail?: string;
+    /** Authenticated role set, forwarded to role-based access rules. */
+    userRoles?: string[];
     /** User context for access control */
     user?: UserContext;
     /** When true, bypass all access control checks */
@@ -516,6 +526,8 @@ export class CollectionsHandler {
     userId?: string;
     userName?: string;
     userEmail?: string;
+    /** Authenticated role set, forwarded to role-based access rules. */
+    userRoles?: string[];
     /** User context for access control */
     user?: UserContext;
     /** When true, bypass all access control checks */
@@ -539,6 +551,8 @@ export class CollectionsHandler {
     userId?: string;
     userName?: string;
     userEmail?: string;
+    /** Authenticated role set, forwarded to role-based access rules. */
+    userRoles?: string[];
     /** User context for access control */
     user?: UserContext;
     /** When true, bypass all access control checks */
@@ -564,6 +578,8 @@ export class CollectionsHandler {
       userId?: string;
       userName?: string;
       userEmail?: string;
+      /** Authenticated role set, forwarded to role-based access rules. */
+      userRoles?: string[];
       /** User context for access control */
       user?: UserContext;
       /** When true, bypass all access control checks */
@@ -621,6 +637,8 @@ export class CollectionsHandler {
     userId?: string;
     userName?: string;
     userEmail?: string;
+    /** Authenticated role set, forwarded to role-based access rules. */
+    userRoles?: string[];
     /** Optional field overrides to apply to the duplicated entry */
     overrides?: Record<string, unknown>;
     /** User context for access control */


### PR DESCRIPTION
> **Stacked on #213.** Base is `fix/schema-p0-followup-round2`, so this PR shows only the roles diff. Merge #213 first; GitHub will retarget this to `main`.

## What

The third #209 finding: route-authenticated requests forwarded the caller's id but **not their roles**, so declarative `role-based` `access.read`/write rules and field-level `access.read` evaluated against an empty role set. On REST this meant role-based rules effectively always denied (fail-closed).

This forwards the authenticated role set end-to-end and makes role matching correct for the many-to-many user/role model.

## Changes

- **`routeHandler.ts`** — forward `AuthContext.roles` as `_authenticatedUserRoles` (JSON-encoded, since route params are strings).
- **`collection-dispatcher.ts`** — a small `readAuthenticatedRoles(p)` helper decodes it defensively (malformed -> `undefined`, never throws); every **write** dispatch site (create/update/delete/bulkDelete/bulkUpdate/bulkUpdateByQuery/duplicate) forwards it. Reads are intentionally untouched (see below).
- **`collections-handler.ts`** — `resolveUserParam` maps `userRoles` onto the built `user.roles`; write-method param types accept it.
- **`collection-types.ts` / `base.ts`** — `UserContext` and `RequestContext.user` gain `roles?: string[]`.
- **`collection-access-service.ts`** — `buildRequestContext` forwards `roles`.
- **`access-control-service.ts`** — `evaluateRoleBasedAccess` now grants when the user holds **any** allowed role (documented OR-logic), reading the full `roles` set and folding in the single `role` for backward compatibility. Single-role setups behave exactly as before.

## Tests
- New `access-control-service.test.ts`: OR-membership (any role matches, none matches, single `role` still works, `role` folded in, no-roles denies, unauthenticated denies).
- Extended `collection-dispatcher-shapes.test.ts`: `createEntry` decodes and forwards roles; a malformed roles param degrades to `undefined`.
- `check-types`, `lint`, `build` clean. Zero new test failures (the pre-existing #204 baseline failures in `collection-dispatcher-shapes` and `collection-access` are unrelated and present on the base branch).

## Deliberately out of scope
- **Reads (`listEntries`/`getEntry`/`countEntries`) forward no user at all** — a separate, larger gap (owner-only and role-based *read* filtering on the list/get path can't evaluate). Flagged for its own PR rather than conflated here.
- **Singles** role forwarding — the finding was collections-scoped (`resolveUserParam`); singles use RBAC keyed on `userId`. Can follow up for consistency if desired.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for users with multiple roles in access-control checks.
  * Access is granted when any of the user’s roles matches an allowed role.
  * Multi-role context is now preserved across create, update, delete, bulk, and duplicate operations.
  * Existing single-role authorization remains supported.

* **Bug Fixes**
  * Invalid role data is safely ignored instead of disrupting requests.
  * Access decisions now provide clearer handling when users have no assigned roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->