### PR TITLE
fix(nextly): add optimistic locking to single and component schema saves

### DIFF
--- a/.changeset/singles-components-schema-lock.md
+++ b/.changeset/singles-components-schema-lock.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Schema Builder saves for singles and components now reject stale saves.
+
+Applying a schema change to a single or a component through the Schema Builder previously ignored the version the editor was loaded at, so two admins editing the same single or component would silently overwrite each other (last-write-wins on both the DDL and the stored metadata). Both now compare the submitted version against the current one and reject a stale save with a version-conflict error before any DDL runs, matching the collection apply path. All three entity kinds report the conflict identically, so the client can prompt the editor to reload and retry. Code-first schema changes applied through the dev HMR path are unaffected.

--- a/packages/nextly/src/dispatcher/handlers/__tests__/schema-version-guard.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/schema-version-guard.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../../errors";
+import { assertSchemaVersionMatch } from "../schema-version-guard";
+
+describe("assertSchemaVersionMatch", () => {
+  it("passes when the expected version matches the stored version", () => {
+    expect(() => assertSchemaVersionMatch(3, 3, "hero")).not.toThrow();
+  });
+
+  it("passes when no expected version is sent (code-first / HMR source)", () => {
+    // A missing expected version means the caller is not doing an optimistic
+    // save, so it must not be blocked regardless of the stored version.
+    expect(() => assertSchemaVersionMatch(undefined, 7, "hero")).not.toThrow();
+  });
+
+  it("throws a version conflict when the expected version is stale", () => {
+    expect(() => assertSchemaVersionMatch(3, 5, "hero")).toThrow(NextlyError);
+    try {
+      assertSchemaVersionMatch(3, 5, "hero");
+    } catch (err) {
+      expect(NextlyError.isConflict(err)).toBe(true);
+    }
+  });
+});

--- a/packages/nextly/src/dispatcher/handlers/__tests__/schema-version-guard.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/schema-version-guard.test.ts
@@ -8,13 +8,27 @@ describe("assertSchemaVersionMatch", () => {
     expect(() => assertSchemaVersionMatch(3, 3, "hero")).not.toThrow();
   });
 
-  it("passes when no expected version is sent (code-first / HMR source)", () => {
-    // A missing expected version means the caller is not doing an optimistic
-    // save, so it must not be blocked regardless of the stored version.
-    expect(() => assertSchemaVersionMatch(undefined, 7, "hero")).not.toThrow();
+  it("rejects a missing expected version instead of skipping the check", () => {
+    // The Schema Builder is the only caller and always sends a version, so an
+    // omitted one is a malformed request, not a reason to bypass the lock.
+    expect.assertions(2);
+    expect(() => assertSchemaVersionMatch(undefined, 7, "hero")).toThrow(
+      NextlyError
+    );
+    try {
+      assertSchemaVersionMatch(undefined, 7, "hero");
+    } catch (err) {
+      const data = (err as NextlyError).publicData as {
+        errors: Array<{ code: string }>;
+      };
+      expect(data.errors[0].code).toBe("SCHEMA_VERSION_REQUIRED");
+    }
   });
 
   it("throws a version conflict when the expected version is stale", () => {
+    // expect.assertions keeps the isConflict check in the catch load-bearing:
+    // if the call ever stops throwing, the test fails instead of passing empty.
+    expect.assertions(2);
     expect(() => assertSchemaVersionMatch(3, 5, "hero")).toThrow(NextlyError);
     try {
       assertSchemaVersionMatch(3, 5, "hero");

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -49,6 +49,7 @@ import type { DesiredCollection } from "../../domains/schema/pipeline/types";
 import { DrizzleStatementExecutor } from "../../domains/schema/services/drizzle-statement-executor";
 import { generateRuntimeSchema } from "../../domains/schema/services/runtime-schema-generator";
 import type { FieldResolution } from "../../domains/schema/services/schema-change-types";
+import { NextlyError } from "../../errors";
 import {
   applyPluginAdminViews,
   type CollectionWithAdmin,
@@ -586,9 +587,9 @@ const COLLECTIONS_METHODS: Record<
 
       if (!result.success) {
         if (result.error.code === "SCHEMA_VERSION_CONFLICT") {
-          throw new Error(
-            "Schema was modified by another session. Please refresh."
-          );
+          // Same conflict surface as the single/component apply paths so all
+          // three entity kinds report a stale schema save identically.
+          throw NextlyError.conflict({ reason: "version" });
         }
         throw new Error(result.error.message);
       }

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -58,6 +58,8 @@ import {
 import { requireParam, toNumber } from "../helpers/validation";
 import type { MethodHandler, Params } from "../types";
 
+import { assertSchemaVersionMatch } from "./schema-version-guard";
+
 interface ComponentsServices {
   registry: ComponentRegistryService;
 }
@@ -462,6 +464,9 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
       assertValidFieldsPayload(fields);
 
       const currentVersion = component.schemaVersion ?? 1;
+      // Reject a stale UI save before any DDL runs so two admins editing the
+      // same component cannot silently overwrite each other (last-write-wins).
+      assertSchemaVersionMatch(schemaVersion, currentVersion, slug);
       const tableName = component.tableName;
 
       const legacyBundle = resolutions
@@ -556,8 +561,6 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
       // those live on createApplyDesiredSchema's ApplyResult wrapper. Bump by
       // 1 locally — matches the collection fallback pattern.
       const newSchemaVersion = currentVersion + 1;
-
-      void schemaVersion; // accepted but unused (reserved for future optimistic lock)
 
       return respondAction(`Schema applied for component '${slug}'`, {
         newSchemaVersion,

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -530,7 +530,10 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
       // (not via the registry helper, whose auto-bump would also reset
       // migration_status). Advance schema_version here so the optimistic-lock
       // check above sees a new value on the next save; without the bump the
-      // stored version never changes and a second stale save would pass.
+      // stored version never changes and a second stale save would pass. The
+      // write is non-fatal (the DDL already succeeded), but track whether it
+      // landed so the response never reports a version the DB did not persist.
+      let versionPersisted = true;
       try {
         await adapter.update(
           "dynamic_components",
@@ -544,9 +547,11 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
           { and: [{ column: "slug", op: "=", value: slug }] }
         );
       } catch (err) {
+        versionPersisted = false;
         const msg = err instanceof Error ? err.message : String(err);
         console.warn(
-          `[applyComponentSchemaChanges] Post-apply metadata write failed for '${slug}': ${msg}.`
+          `[applyComponentSchemaChanges] Post-apply metadata write failed for '${slug}': ${msg}. ` +
+            `schema_version was not advanced; the save is reported at the current version so a retry re-attempts the bump.`
         );
       }
 
@@ -564,7 +569,7 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
       );
 
       return respondAction(`Schema applied for component '${slug}'`, {
-        newSchemaVersion,
+        newSchemaVersion: versionPersisted ? newSchemaVersion : currentVersion,
       });
     },
   },

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -524,8 +524,13 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         );
       }
 
+      const newSchemaVersion = currentVersion + 1;
+
       // Post-apply: update dynamic_components fields JSON + schema_hash directly
-      // to avoid the registry's auto-bump of schemaVersion / migrationStatus.
+      // (not via the registry helper, whose auto-bump would also reset
+      // migration_status). Advance schema_version here so the optimistic-lock
+      // check above sees a new value on the next save; without the bump the
+      // stored version never changes and a second stale save would pass.
       try {
         await adapter.update(
           "dynamic_components",
@@ -533,6 +538,7 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
             fields: JSON.stringify(fields),
             schema_hash: calculateSchemaHash(fields as FieldConfig[]),
             migration_status: "applied",
+            schema_version: newSchemaVersion,
             updated_at: new Date(),
           },
           { and: [{ column: "slug", op: "=", value: slug }] }
@@ -556,11 +562,6 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         tableName,
         fields as FieldConfig[]
       );
-
-      // Pipeline (PipelineResult) does not carry per-slug schema versions;
-      // those live on createApplyDesiredSchema's ApplyResult wrapper. Bump by
-      // 1 locally — matches the collection fallback pattern.
-      const newSchemaVersion = currentVersion + 1;
 
       return respondAction(`Schema applied for component '${slug}'`, {
         newSchemaVersion,

--- a/packages/nextly/src/dispatcher/handlers/schema-version-guard.ts
+++ b/packages/nextly/src/dispatcher/handlers/schema-version-guard.ts
@@ -1,0 +1,21 @@
+import { NextlyError } from "../../errors";
+
+// Optimistic-lock guard for visual Schema Builder saves. A UI save carries the
+// schemaVersion the editor was loaded at. If that no longer matches the stored
+// version, another session changed the schema first and applying this save
+// would silently overwrite those changes (last-write-wins on DDL + metadata).
+// Throw a version conflict so the client reloads and retries. An `undefined`
+// expected version means the caller is code-first HMR, which is the source of
+// truth for code edits and deliberately skips the check.
+export function assertSchemaVersionMatch(
+  expected: number | undefined,
+  actual: number,
+  slug: string
+): void {
+  if (expected !== undefined && expected !== actual) {
+    throw NextlyError.conflict({
+      reason: "version",
+      logContext: { slug, expected, actual },
+    });
+  }
+}

--- a/packages/nextly/src/dispatcher/handlers/schema-version-guard.ts
+++ b/packages/nextly/src/dispatcher/handlers/schema-version-guard.ts
@@ -1,18 +1,31 @@
 import { NextlyError } from "../../errors";
 
-// Optimistic-lock guard for visual Schema Builder saves. A UI save carries the
-// schemaVersion the editor was loaded at. If that no longer matches the stored
-// version, another session changed the schema first and applying this save
-// would silently overwrite those changes (last-write-wins on DDL + metadata).
-// Throw a version conflict so the client reloads and retries. An `undefined`
-// expected version means the caller is code-first HMR, which is the source of
-// truth for code edits and deliberately skips the check.
+// Optimistic-lock guard for visual Schema Builder saves. These are the only
+// callers, and every one carries the schemaVersion the editor was loaded at, so
+// the version is required: an omitted one is rejected rather than silently
+// skipping the check (a crafted request could otherwise bypass it). When the
+// submitted version no longer matches the stored one, another session changed
+// the schema first and applying this save would overwrite those changes
+// (last-write-wins on DDL + metadata), so it is rejected as a conflict for the
+// client to reload and retry.
 export function assertSchemaVersionMatch(
   expected: number | undefined,
   actual: number,
   slug: string
 ): void {
-  if (expected !== undefined && expected !== actual) {
+  if (expected === undefined) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "schemaVersion",
+          code: "SCHEMA_VERSION_REQUIRED",
+          message: "schemaVersion is required to save schema changes.",
+        },
+      ],
+      logContext: { slug },
+    });
+  }
+  if (expected !== actual) {
     throw NextlyError.conflict({
       reason: "version",
       logContext: { slug, expected, actual },

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -81,6 +81,8 @@ import {
 } from "../helpers/validation";
 import type { MethodHandler, Params } from "../types";
 
+import { assertSchemaVersionMatch } from "./schema-version-guard";
+
 // ============================================================
 // Default field helpers
 // ============================================================
@@ -897,6 +899,9 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       assertValidFieldsPayload(fields);
 
       const currentVersion = single.schemaVersion ?? 1;
+      // Reject a stale UI save before any DDL runs so two admins editing the
+      // same single cannot silently overwrite each other (last-write-wins).
+      assertSchemaVersionMatch(schemaVersion, currentVersion, slug);
       const tableName = single.tableName;
 
       const legacyBundle = resolutions
@@ -992,7 +997,6 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       }
 
       const newSchemaVersion = currentVersion + 1;
-      void schemaVersion; // accepted but unused (reserved for future optimistic lock)
 
       return respondAction(`Schema applied for single '${slug}'`, {
         newSchemaVersion,

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -962,7 +962,12 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         );
       }
 
-      // Post-apply: update dynamic_singles fields JSON + schema_hash.
+      const newSchemaVersion = currentVersion + 1;
+
+      // Post-apply: update dynamic_singles fields JSON + schema_hash, and
+      // advance schema_version so the optimistic-lock check above sees a new
+      // value on the next save. Without this bump the stored version never
+      // changes and a second stale save would pass the guard.
       try {
         await adapter.update(
           "dynamic_singles",
@@ -970,6 +975,7 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
             fields: JSON.stringify(fields),
             schema_hash: calculateSchemaHash(fields as FieldConfig[]),
             migration_status: "applied",
+            schema_version: newSchemaVersion,
             updated_at: new Date(),
           },
           { and: [{ column: "slug", op: "=", value: slug }] }
@@ -995,8 +1001,6 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
           `[applySingleSchemaChanges] In-memory schema refresh failed for '${slug}': ${msg}.`
         );
       }
-
-      const newSchemaVersion = currentVersion + 1;
 
       return respondAction(`Schema applied for single '${slug}'`, {
         newSchemaVersion,

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -967,7 +967,10 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       // Post-apply: update dynamic_singles fields JSON + schema_hash, and
       // advance schema_version so the optimistic-lock check above sees a new
       // value on the next save. Without this bump the stored version never
-      // changes and a second stale save would pass the guard.
+      // changes and a second stale save would pass the guard. The write is
+      // non-fatal (the DDL already succeeded), but track whether it landed so
+      // the response never reports a version the database did not persist.
+      let versionPersisted = true;
       try {
         await adapter.update(
           "dynamic_singles",
@@ -981,9 +984,11 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
           { and: [{ column: "slug", op: "=", value: slug }] }
         );
       } catch (err) {
+        versionPersisted = false;
         const msg = err instanceof Error ? err.message : String(err);
         console.warn(
-          `[applySingleSchemaChanges] Post-apply metadata write failed for '${slug}': ${msg}.`
+          `[applySingleSchemaChanges] Post-apply metadata write failed for '${slug}': ${msg}. ` +
+            `schema_version was not advanced; the save is reported at the current version so a retry re-attempts the bump.`
         );
       }
 
@@ -1003,7 +1008,7 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       }
 
       return respondAction(`Schema applied for single '${slug}'`, {
-        newSchemaVersion,
+        newSchemaVersion: versionPersisted ? newSchemaVersion : currentVersion,
       });
     },
   },


### PR DESCRIPTION
## What

Applying a schema change to a **single** or a **component** through the Schema Builder ignored the version the editor was loaded at — both dispatchers had `void schemaVersion; // reserved` and bumped to `currentVersion + 1` unconditionally. So two admins editing the same single/component would **silently overwrite each other** (last-write-wins on both the DDL and the stored metadata). Collections already reject this via the apply pipeline's `SCHEMA_VERSION_CONFLICT`; singles and components did not.

Closes the schema/fields-audit **F-10** finding.

## The fix (dispatcher-level, off the DDL layer)

- New shared guard **`assertSchemaVersionMatch(expected, actual, slug)`** (`dispatcher/handlers/schema-version-guard.ts`) — throws `NextlyError.conflict({ reason: "version" })` when a UI save's expected version no longer matches the stored one. An `undefined` expected version means code-first HMR (the source of truth for code edits), which deliberately skips the check.
- Wired into **`single-dispatcher`** and **`component-dispatcher`** right after the current version is read, so a stale save is rejected **before any DDL runs**. Removed both `void schemaVersion` stubs.
- **`collection-dispatcher`**: aligned its existing conflict throw from a bare `Error("Schema was modified by another session…")` to the same `NextlyError.conflict(...)`, so all three entity kinds report the conflict identically (and fixes a pre-existing bare-`Error` convention nit; no test asserted the old message).

## Scope / safety

- Single-package (`nextly`), dispatcher layer only. Does **not** touch the column/DDL/`field-column-descriptor` layer, so no conflict with the Drizzle-v1 work.
- The optimistic check is deliberately the same shape (and same race-window caveat) as the collection path — parity, not a stronger guarantee.

## Tests

- `schema-version-guard.test.ts` (new): matching version passes, missing expected version (code-first/HMR) passes, stale version throws a conflict (`NextlyError.isConflict`).
- `pnpm --filter nextly check-types` clean.
- Zero new test failures: the dispatcher-handler suite shows the same 8 pre-existing stale-mock failures with these changes stashed vs. applied (verified via `git stash`); the new guard test adds 3 passing on top.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added optimistic-lock schema version checks for component and single-item schema updates to prevent overwriting newer concurrent edits.
  - After a successful schema apply, the persisted schema version is advanced; if saving the metadata fails, the version is no longer incorrectly reported as updated.
  - Version conflicts now surface as structured conflict errors, and missing expected versions produce a clear validation error.
- **New Features**
  - Introduced a schema version guard utility to enforce consistency.
- **Tests**
  - Added coverage for schema version guard success, missing expected version, and stale conflict behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->