### PR TITLE
fix(nextly): stop component fields from creating an unwritten parent column

### DIFF
--- a/.changeset/component-no-parent-column.md
+++ b/.changeset/component-no-parent-column.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Fixed inserts failing on collections that use a component field.
+
+A component field created a column on the parent table, but component values are stored in their own table and stripped from the parent row before insert. That column was therefore never written: when the component field was required it became `NOT NULL` with no value and every insert failed, and even when optional it left a permanently empty column. Component fields no longer create a parent column.

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/dynamic-collection-schema-service.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/dynamic-collection-schema-service.test.ts
@@ -41,6 +41,25 @@ describe("DynamicCollectionSchemaService — index naming (snake_case)", () => {
   });
 });
 
+describe("DynamicCollectionSchemaService: component fields are column-less", () => {
+  it("emits no parent column and no index for a component field", () => {
+    const service = new DynamicCollectionSchemaService(undefined, "postgresql");
+    const sql = service.generateMigrationSQL("dc_pages", [
+      { name: "hero", type: "component", index: true } as FieldDefinition,
+    ]);
+    expect(sql).not.toContain('"hero"');
+    expect(sql).not.toContain("idx_dc_pages_hero");
+  });
+
+  it("keeps the system title column when a component field is named 'title'", () => {
+    const service = new DynamicCollectionSchemaService(undefined, "postgresql");
+    const sql = service.generateMigrationSQL("dc_pages", [
+      { name: "title", type: "component" } as FieldDefinition,
+    ]);
+    expect(sql).toContain('"title" text NOT NULL');
+  });
+});
+
 describe("DynamicCollectionSchemaService.generateAlterTableMigration — Phase D rename detection", () => {
   let service: DynamicCollectionSchemaService;
   let warnSpy: ReturnType<typeof vi.spyOn>;
@@ -134,9 +153,7 @@ describe("DynamicCollectionSchemaService.generateAlterTableMigration — Phase D
     // Old: { salary: text }, New: { compensation: number }.
     // Types differ → would lose data even with rename (varchar vs int).
     // Bail out and warn; let user do an explicit two-step migration.
-    const oldFields: FieldDefinition[] = [
-      { name: "salary", type: "text" },
-    ];
+    const oldFields: FieldDefinition[] = [{ name: "salary", type: "text" }];
     const newFields: FieldDefinition[] = [
       { name: "compensation", type: "number" },
     ];
@@ -247,9 +264,7 @@ describe("DynamicCollectionSchemaService.generateAlterTableMigration — Phase D
   });
 
   it("pure add (only added fields, no removed) does not trigger rename detection", () => {
-    const oldFields: FieldDefinition[] = [
-      { name: "title", type: "text" },
-    ];
+    const oldFields: FieldDefinition[] = [{ name: "title", type: "text" }];
     const newFields: FieldDefinition[] = [
       { name: "title", type: "text" },
       { name: "summary", type: "text" },
@@ -271,9 +286,7 @@ describe("DynamicCollectionSchemaService.generateAlterTableMigration — Phase D
       { name: "title", type: "text" },
       { name: "summary", type: "text" },
     ];
-    const newFields: FieldDefinition[] = [
-      { name: "title", type: "text" },
-    ];
+    const newFields: FieldDefinition[] = [{ name: "title", type: "text" }];
 
     const sql = service.generateAlterTableMigration(
       "dc_posts",
@@ -296,9 +309,7 @@ describe("DynamicCollectionSchemaService.detectFieldRename — direct unit", () 
 
   it("returns the from→to pair for a single compatible rename", () => {
     const service = new DynamicCollectionSchemaService(undefined, "postgresql");
-    const oldFields: FieldDefinition[] = [
-      { name: "salary", type: "number" },
-    ];
+    const oldFields: FieldDefinition[] = [{ name: "salary", type: "number" }];
     const newFields: FieldDefinition[] = [
       { name: "compensation", type: "number" },
     ];

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -98,6 +98,13 @@ export class DynamicCollectionSchemaService {
           return null;
         }
 
+        // Component fields store their data in a separate comp_{slug} table and
+        // are stripped from the parent row on write, so they get no parent
+        // column (a NOT NULL one would break every insert).
+        if (f.type === "component") {
+          return null;
+        }
+
         const type = this.mapFieldTypeToSQL(
           f.type,
           f.length,

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -222,8 +222,11 @@ export class DynamicCollectionSchemaService {
       );
     }
 
-    // title (only if not user-defined)
-    const hasTitleField = fields.some(f => f.name === "title");
+    // title (only if not user-defined). A component named "title" produces no
+    // column, so it must not suppress the system title column.
+    const hasTitleField = fields.some(
+      f => f.name === "title" && f.type !== "component"
+    );
     if (!hasTitleField) {
       if (this.dialect === "mysql") {
         allColumnDefs.push(
@@ -234,8 +237,10 @@ export class DynamicCollectionSchemaService {
       }
     }
 
-    // slug (only if not user-defined)
-    const hasSlugField = fields.some(f => f.name === "slug");
+    // slug (only if not user-defined). Same column-less exclusion as title.
+    const hasSlugField = fields.some(
+      f => f.name === "slug" && f.type !== "component"
+    );
     if (!hasSlugField) {
       if (this.dialect === "mysql") {
         allColumnDefs.push(
@@ -351,9 +356,10 @@ ${allColumnDefs.join(",\n")}
       }
     });
 
-    // Add manual indexes requested by the user
+    // Add manual indexes requested by the user. Component fields have no column
+    // to index, so skip them (an index on a nonexistent column fails).
     fields.forEach(f => {
-      if (f.index && f.type !== "relationship") {
+      if (f.index && f.type !== "relationship" && f.type !== "component") {
         const col = this.toSnakeCase(f.name);
         const indexName = `idx_${tableName}_${col}`;
         if (this.dialect === "mysql") {
@@ -512,6 +518,12 @@ ${allColumnDefs.join(",\n")}
           continue;
         }
 
+        // Component fields store their data in a separate comp_{slug} table, so
+        // adding one must not ADD COLUMN on the parent table.
+        if (field.type === "component") {
+          continue;
+        }
+
         const type = this.mapFieldTypeToSQL(field.type, field.length);
         const nullable = field.required ? "NOT NULL" : "";
 
@@ -564,6 +576,8 @@ ${allColumnDefs.join(",\n")}
 
     // Find fields that were modified to add/remove an index
     for (const field of newFields) {
+      // Component fields have no parent column, so there is no index to add/drop.
+      if (field.type === "component") continue;
       const oldField = oldFieldMap.get(field.name);
       if (oldField && oldField.index !== field.index) {
         const idxCol = this.toSnakeCase(field.name);
@@ -599,6 +613,9 @@ ${allColumnDefs.join(",\n")}
       // Phase D: skip the renamed source — it's already been handled
       // above as ALTER TABLE RENAME COLUMN.
       if (field.name === renamedFromName) continue;
+      // Component fields never had a parent column, so there is nothing to drop
+      // (and SQLite's DROP COLUMN has no IF EXISTS to tolerate the absence).
+      if (field.type === "component") continue;
       if (!newFieldMap.has(field.name)) {
         const dropCol = this.toSnakeCase(field.name);
         // SQLite doesn't support IF EXISTS on DROP COLUMN
@@ -619,6 +636,8 @@ ${allColumnDefs.join(",\n")}
     // For simplicity, we skip column modifications for SQLite
     if (this.dialect !== "sqlite") {
       for (const field of newFields) {
+        // Component fields have no parent column to alter.
+        if (field.type === "component") continue;
         const oldField = oldFieldMap.get(field.name);
         if (oldField && this.isFieldModified(oldField, field)) {
           const alterCol = this.toSnakeCase(field.name);

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields-indexes.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields-indexes.test.ts
@@ -39,6 +39,21 @@ describe("buildDesiredTableFromFields — indexes", () => {
     expect(idxNames(t)).not.toContain("idx_dc_posts_tags:n");
   });
 
+  it("never indexes a component field (it has no parent column)", () => {
+    const t = buildDesiredTableFromFields(
+      "dc_posts",
+      [
+        { name: "title", type: "text" },
+        { name: "hero", type: "component", unique: true, index: true },
+      ] as never,
+      "postgresql",
+      {}
+    );
+    expect(t.columns.some(c => c.name === "hero")).toBe(false);
+    expect(idxNames(t)).not.toContain("uq_dc_posts_hero:u");
+    expect(idxNames(t)).not.toContain("idx_dc_posts_hero:n");
+  });
+
   it("dedupes the slug index when a unique slug field collides with the system index", () => {
     // defineCollection injects a `slug` field with unique:true; the system also
     // adds idx_<t>_slug (unique). Only ONE unique slug index should result.

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields.test.ts
@@ -16,7 +16,6 @@ describe("canonical field types map to columns (widened ui-schema set)", () => {
     ["radio", "text"],
     ["repeater", "jsonb"],
     ["group", "jsonb"],
-    ["component", "jsonb"],
     ["json", "jsonb"],
     ["chips", "jsonb"],
   ];
@@ -31,6 +30,18 @@ describe("canonical field types map to columns (widened ui-schema set)", () => {
       expect(d?.dialectType).toBe(dialectType);
     });
   }
+
+  // component is storable but has no parent column: its values live in a
+  // separate comp_{slug} table, so the descriptor returns null (column-less).
+  it("maps component -> no parent column (stored in its own table)", () => {
+    const d = getColumnDescriptor(
+      { name: "f", type: "component", required: true } as unknown as Parameters<
+        typeof getColumnDescriptor
+      >[0],
+      "postgresql"
+    );
+    expect(d).toBeNull();
+  });
 });
 
 // Minimal FieldConfig shape used by the helper. The real type lives in

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields.test.ts
@@ -93,6 +93,21 @@ describe("buildDesiredTableFromFields - reserved columns", () => {
     expect(findColumn(table.columns, "updated_at")?.type).toBe("timestamp");
   });
 
+  it("keeps the system title column when a component field is named 'title'", () => {
+    // A component provides no column, so it must not suppress the system title
+    // column the way a real user 'title' field does.
+    const table = buildDesiredTableFromFields(
+      "dc_x",
+      [{ name: "title", type: "component" }] as never,
+      "postgresql"
+    );
+    expect(findColumn(table.columns, "title")).toEqual({
+      name: "title",
+      type: "text",
+      nullable: false,
+    });
+  });
+
   it("MySQL: id is varchar(36); title/slug varchar(255); timestamps", () => {
     const table = buildDesiredTableFromFields("dc_x", [], "mysql");
     expect(findColumn(table.columns, "id")?.type).toBe("varchar(36)");

--- a/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
@@ -160,8 +160,10 @@ export function buildDesiredTableFromFields(
   for (const field of fields) {
     const col = toSnakeCase(field.name);
     // Skip fields that materialize no column (e.g. component fields): a unique
-    // or plain index on a nonexistent column is invalid DDL.
-    if (!columns.some(c => c.name === col)) continue;
+    // or plain index on a nonexistent column is invalid DDL. Check the field
+    // directly (not column presence) so a component named after a system column
+    // like `title` does not index the system-injected column instead.
+    if (!producesColumn(field)) continue;
     const isSingleRelation =
       (field.type === "relationship" || field.type === "upload") &&
       field.hasMany !== true &&

--- a/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
@@ -88,11 +88,22 @@ export function buildDesiredTableFromFields(
 ): TableSpec {
   const columns: ColumnSpec[] = [];
 
+  // A field materializes a parent column unless the descriptor skips it (a
+  // component field stores its data in its own table). Column-less fields must
+  // not suppress the system title/slug column nor receive an index.
+  const producesColumn = (f: (typeof fields)[number]): boolean =>
+    getColumnDescriptor(
+      f as unknown as Parameters<typeof getColumnDescriptor>[0],
+      dialect
+    ) !== null;
+
   // Inject reserved system columns first - mirrors runtime-schema-generator's
-  // behavior. title/slug only when not user-defined (user wins). status only
-  // when the collection/single has Draft/Published enabled.
-  const hasTitleField = fields.some(f => f.name === "title");
-  const hasSlugField = fields.some(f => f.name === "slug");
+  // behavior. title/slug only when a column-producing user field replaces them
+  // (user wins). status only when Draft/Published is enabled.
+  const hasTitleField = fields.some(
+    f => f.name === "title" && producesColumn(f)
+  );
+  const hasSlugField = fields.some(f => f.name === "slug" && producesColumn(f));
   for (const reserved of getSystemColumnDescriptors(dialect, {
     hasTitleField,
     hasSlugField,
@@ -148,6 +159,9 @@ export function buildDesiredTableFromFields(
   }
   for (const field of fields) {
     const col = toSnakeCase(field.name);
+    // Skip fields that materialize no column (e.g. component fields): a unique
+    // or plain index on a nonexistent column is invalid DDL.
+    if (!columns.some(c => c.name === col)) continue;
     const isSingleRelation =
       (field.type === "relationship" || field.type === "upload") &&
       field.hasMany !== true &&

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -183,10 +183,15 @@ function classifyFieldKind(field: FieldDefinition): ColumnKind {
 
     case "repeater":
     case "group":
-    case "component":
     case "json":
     case "chips":
       return "json";
+
+    case "component":
+      // Component values live in their own comp_{slug} tables and are stripped
+      // from the parent row on write, so the parent needs no column. Emitting
+      // one (NOT NULL when required) produced an orphan that broke every insert.
+      return "skip";
 
     default: {
       // Plugin-contributed custom field type maps to its declared storage

--- a/packages/nextly/src/domains/schema/services/runtime-schema-generator.ts
+++ b/packages/nextly/src/domains/schema/services/runtime-schema-generator.ts
@@ -146,8 +146,14 @@ function buildDrizzleColumnRecord(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- as above
   const out: Record<string, any> = {};
 
-  const hasTitleField = fields.some(f => f.name === "title");
-  const hasSlugField = fields.some(f => f.name === "slug");
+  // A column-less field (e.g. a component, stored in its own table) must not
+  // suppress the system title/slug column, or the table would have neither.
+  const producesColumn = (f: FieldDefinition): boolean =>
+    getColumnDescriptor(f, dialect) !== null;
+  const hasTitleField = fields.some(
+    f => f.name === "title" && producesColumn(f)
+  );
+  const hasSlugField = fields.some(f => f.name === "slug" && producesColumn(f));
 
   // System columns first (id, created_at, updated_at; conditionally title,
   // slug, and status). Source-of-truth descriptor list lives in
@@ -184,8 +190,10 @@ function buildSystemDrizzleColumn(
 ): unknown {
   if (dialect === "postgresql") {
     if (sys.name === "id") return pgText("id").primaryKey();
-    if (sys.name === "created_at") return pgTimestamp("created_at").defaultNow();
-    if (sys.name === "updated_at") return pgTimestamp("updated_at").defaultNow();
+    if (sys.name === "created_at")
+      return pgTimestamp("created_at").defaultNow();
+    if (sys.name === "updated_at")
+      return pgTimestamp("updated_at").defaultNow();
     if (sys.name === "status") {
       // Why: 'draft' default ensures backfill on enable doesn't accidentally
       // publish anything. Length 20 leaves headroom over "published" (9 chars).

--- a/packages/nextly/src/domains/schema/utils/__tests__/missing-columns.test.ts
+++ b/packages/nextly/src/domains/schema/utils/__tests__/missing-columns.test.ts
@@ -89,6 +89,27 @@ describe("addMissingColumnsForFields", () => {
     expect(alter?.sql).toBe(`ALTER TABLE "dc_posts" ADD COLUMN "excerpt" TEXT`);
   });
 
+  it("never adds a parent column for a component field", async () => {
+    const { adapter, calls } = makeAdapter({
+      dialect: "postgresql",
+      existingColumns: ["id"],
+    });
+    const fields: FieldConfig[] = [
+      { name: "hero", type: "component" } as FieldConfig,
+    ];
+
+    const added = await addMissingColumnsForFields(
+      adapter as unknown as Parameters<typeof addMissingColumnsForFields>[0],
+      fakeLogger,
+      "dc_pages",
+      fields,
+      { timestamps: false }
+    );
+
+    expect(added).toEqual([]);
+    expect(calls.find(c => c.sql.startsWith("ALTER TABLE"))).toBeUndefined();
+  });
+
   it("uses backtick-quoted identifiers on MySQL", async () => {
     const { adapter, calls } = makeAdapter({
       dialect: "mysql",

--- a/packages/nextly/src/domains/schema/utils/missing-columns.ts
+++ b/packages/nextly/src/domains/schema/utils/missing-columns.ts
@@ -47,6 +47,12 @@ function fieldToColumnDef(field: FieldConfig, dialect: string): string | null {
     return null;
   }
 
+  // Component fields store their data in a separate comp_{slug} table and are
+  // stripped from the parent row on write, so they get no parent column.
+  if (field.type === "component") {
+    return null;
+  }
+
   const name = toSnakeCase(field.name);
   const required = "required" in field && field.required;
   const quotedName = dialect === "mysql" ? `\`${name}\`` : `"${name}"`;
@@ -121,7 +127,6 @@ function fieldToColumnDef(field: FieldConfig, dialect: string): string | null {
     case "repeater":
     case "group":
     case "chips":
-    case "component":
       columnType =
         dialect === "postgresql"
           ? "JSONB"


### PR DESCRIPTION
## Summary

A component field created a JSON column on the **parent** collection table, but component values are stored in their own `comp_{slug}` table and stripped from the parent row before write (`collection-mutation-service.ts`). That parent column was therefore never populated:

- **required** component field → `NOT NULL` column with no value → **every insert fails**
- **optional** component field → a permanently empty orphan column

This is finding **F-4** from the fields/schema audit, routed to (but not addressed by) the drizzle-v1 migration. See `tasks/drizzle-v1-findings-verification.md` for the full verification.

## Fix

Classify `component` fields as column-less in the shared column descriptor (`getColumnDescriptor` returns `null`). Both consumers of the descriptor already skip `null`:

- the runtime table builder (`runtime-schema-generator.ts`) - so the real insert table has no component column
- the diff snapshot (`build-from-fields.ts`) - so no phantom column diff

Component data continues to be stored and read from its `comp_{slug}` table, unchanged. `group`/`repeater`/`json`/`chips` still use their JSON column (their data really lives there); only `component` is stripped from the parent, so only it is made column-less.

## Migration note

On an existing database whose parent table already has the orphan component column, the next schema sync will propose dropping it. The column is always empty, so this is a safe cleanup (it goes through the normal destructive-drop acknowledgment).

## Verification

- New test: a required `component` field resolves to no parent column (`getColumnDescriptor(...) === null`). The stale `component -> jsonb` characterization case is replaced by this.
- `pnpm --filter nextly check-types` + `lint` clean.
- Pre-existing baseline: `build-from-fields.test.ts` carries 5 pre-existing failures on `main` (stale `number -> double/float8/real`, `json/repeater/group/blocks -> jsonb`, and a layout-skip test); this PR adds **0** new failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Component fields are now treated as column-less, preventing generation of unused parent-table columns and avoiding invalid/incorrect migration DDL.
  * Dynamic collection migrations now fully omit component fields from column/index/unique handling.
  * System `title`/`slug` columns are added or suppressed based on whether matching fields actually materialize as database columns.
* **Tests**
  * Expanded and adjusted coverage to verify component omission for columns, indexes/uniques, and reserved `title` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->