### PR TITLE
test(nextly): cover user-fields validation, url/phone columns, hasMany lock

### DIFF
--- a/packages/nextly/src/domains/users/services/__tests__/user-ext-builtin-columns.test.ts
+++ b/packages/nextly/src/domains/users/services/__tests__/user-ext-builtin-columns.test.ts
@@ -56,6 +56,7 @@ describe("UserExtSchemaService — built-in url/phone runtime columns", () => {
   });
 
   it("builds text runtime columns for url and phone on sqlite", () => {
+    // SQLite stores these text-family fields as text, matching the generated DDL.
     const table = new UserExtSchemaService("sqlite").generateRuntimeSchema([
       field("website", "url"),
       field("mobile", "phone"),

--- a/packages/nextly/src/domains/users/services/__tests__/user-ext-builtin-columns.test.ts
+++ b/packages/nextly/src/domains/users/services/__tests__/user-ext-builtin-columns.test.ts
@@ -1,19 +1,29 @@
 /**
  * The url and phone user field types are validated as text but must still get a
- * real text column in user_ext (they are stored, not skipped or defaulted to a
- * different primitive).
+ * real text-family column in user_ext (not skipped, not defaulted to another
+ * primitive). Two independent code paths build that column and must not
+ * diverge: the DDL string from generateMigrationSQL (getColumnType) and the
+ * Drizzle runtime table from generateRuntimeSchema (mapFieldTo*Column). Both
+ * are asserted below.
  */
 import { describe, expect, it } from "vitest";
 
 import type { UserFieldConfig } from "../../../../users/config/types";
 import { UserExtSchemaService } from "../user-ext-schema-service";
 
+// A user field of the given built-in type; only name/type drive the mapping.
 function field(name: string, type: string): UserFieldConfig {
   return { name, label: name, type } as unknown as UserFieldConfig;
 }
 
-describe("UserExtSchemaService — built-in url/phone columns", () => {
+// Read a generated Drizzle column's SQL type (e.g. "varchar(255)", "text").
+function sqlType(table: Record<string, unknown>, name: string): string {
+  return (table[name] as { getSQLType: () => string }).getSQLType();
+}
+
+describe("UserExtSchemaService — built-in url/phone DDL columns", () => {
   it("maps url and phone to varchar columns on postgres", () => {
+    // Postgres sizes these text-family columns as varchar(maxLength ?? 255).
     const sql = new UserExtSchemaService("postgresql").generateMigrationSQL([
       field("website", "url"),
       field("mobile", "phone"),
@@ -23,11 +33,34 @@ describe("UserExtSchemaService — built-in url/phone columns", () => {
   });
 
   it("maps url and phone to text columns on sqlite", () => {
+    // SQLite has no varchar sizing, so the same fields land as TEXT.
     const sql = new UserExtSchemaService("sqlite").generateMigrationSQL([
       field("website", "url"),
       field("mobile", "phone"),
     ]);
     expect(sql).toMatch(/"website"\s+TEXT/i);
     expect(sql).toMatch(/"mobile"\s+TEXT/i);
+  });
+});
+
+describe("UserExtSchemaService — built-in url/phone runtime columns", () => {
+  it("builds varchar(255) runtime columns for url and phone on postgres", () => {
+    // The Drizzle table used for live queries must match the DDL above, or
+    // reads/writes would target a column shape the migration never created.
+    const table = new UserExtSchemaService("postgresql").generateRuntimeSchema([
+      field("website", "url"),
+      field("mobile", "phone"),
+    ]);
+    expect(sqlType(table, "website")).toBe("varchar(255)");
+    expect(sqlType(table, "mobile")).toBe("varchar(255)");
+  });
+
+  it("builds text runtime columns for url and phone on sqlite", () => {
+    const table = new UserExtSchemaService("sqlite").generateRuntimeSchema([
+      field("website", "url"),
+      field("mobile", "phone"),
+    ]);
+    expect(sqlType(table, "website")).toBe("text");
+    expect(sqlType(table, "mobile")).toBe("text");
   });
 });

--- a/packages/nextly/src/domains/users/services/__tests__/user-ext-builtin-columns.test.ts
+++ b/packages/nextly/src/domains/users/services/__tests__/user-ext-builtin-columns.test.ts
@@ -1,0 +1,33 @@
+/**
+ * The url and phone user field types are validated as text but must still get a
+ * real text column in user_ext (they are stored, not skipped or defaulted to a
+ * different primitive).
+ */
+import { describe, expect, it } from "vitest";
+
+import type { UserFieldConfig } from "../../../../users/config/types";
+import { UserExtSchemaService } from "../user-ext-schema-service";
+
+function field(name: string, type: string): UserFieldConfig {
+  return { name, label: name, type } as unknown as UserFieldConfig;
+}
+
+describe("UserExtSchemaService — built-in url/phone columns", () => {
+  it("maps url and phone to varchar columns on postgres", () => {
+    const sql = new UserExtSchemaService("postgresql").generateMigrationSQL([
+      field("website", "url"),
+      field("mobile", "phone"),
+    ]);
+    expect(sql).toMatch(/"website"\s+VARCHAR\(255\)/i);
+    expect(sql).toMatch(/"mobile"\s+VARCHAR\(255\)/i);
+  });
+
+  it("maps url and phone to text columns on sqlite", () => {
+    const sql = new UserExtSchemaService("sqlite").generateMigrationSQL([
+      field("website", "url"),
+      field("mobile", "phone"),
+    ]);
+    expect(sql).toMatch(/"website"\s+TEXT/i);
+    expect(sql).toMatch(/"mobile"\s+TEXT/i);
+  });
+});

--- a/packages/nextly/src/domains/users/services/__tests__/user-field-guards.integration.test.ts
+++ b/packages/nextly/src/domains/users/services/__tests__/user-field-guards.integration.test.ts
@@ -144,6 +144,37 @@ describe("updateField — name and type are fixed at creation", () => {
     expect(updated.name).toBe("phoneNumber");
   });
 
+  it("refuses to change whether a field stores multiple values", async () => {
+    // hasMany picks a scalar vs a json column, so it is as fixed as the type.
+    const service = await bootService();
+    const field = await service.createField(validField);
+
+    const error = await service
+      .updateField(field.id, { hasMany: true })
+      .catch((e: unknown) => e);
+
+    expect(NextlyError.is(error)).toBe(true);
+    const data = (error as NextlyError).publicData as {
+      errors: Array<{ path: string; code: string; message: string }>;
+    };
+    expect(data.errors[0].path).toBe("hasMany");
+    expect(data.errors[0].code).toBe("USER_FIELD_HAS_MANY_IMMUTABLE");
+  });
+
+  it("accepts hasMany echoed back unchanged", async () => {
+    // An unset field stores hasMany as null, which is equivalent to false, so
+    // echoing false must not fire the guard.
+    const service = await bootService();
+    const field = await service.createField(validField);
+
+    const updated = await service.updateField(field.id, {
+      hasMany: false,
+      label: "Still Single-Valued",
+    });
+
+    expect(updated.label).toBe("Still Single-Valued");
+  });
+
   it("still updates everything that is not the field's identity", async () => {
     const service = await bootService();
     const field = await service.createField(validField);

--- a/packages/nextly/src/schemas/__tests__/user-fields.test.ts
+++ b/packages/nextly/src/schemas/__tests__/user-fields.test.ts
@@ -27,6 +27,9 @@ function userField(cfg: FieldFixture): UserFieldConfig {
   return cfg as unknown as UserFieldConfig;
 }
 
+// buildUserFieldsSchema turns each field config into the zod schema that guards
+// a user's value for that field, so these cases pin the per-type value rules
+// (fieldConfigToZod) that the write path relies on.
 describe("buildUserFieldsSchema value validation", () => {
   it("validates a url field and enforces its length bounds", () => {
     const schema = buildUserFieldsSchema([
@@ -53,6 +56,7 @@ describe("buildUserFieldsSchema value validation", () => {
   });
 
   it("enforces text minLength and maxLength", () => {
+    // A text field's declared length bounds become zod min/max on the string.
     const schema = buildUserFieldsSchema([
       userField({
         name: "bio",
@@ -68,6 +72,7 @@ describe("buildUserFieldsSchema value validation", () => {
   });
 
   it("enforces number min and max", () => {
+    // A number field's min/max bound the numeric value, not its length.
     const schema = buildUserFieldsSchema([
       userField({
         name: "age",
@@ -83,6 +88,7 @@ describe("buildUserFieldsSchema value validation", () => {
   });
 
   it("validates an email field", () => {
+    // An email field must parse as an email address, not just any string.
     const schema = buildUserFieldsSchema([
       userField({ name: "work", type: "email", required: true }),
     ]);
@@ -109,6 +115,7 @@ describe("buildUserFieldsSchema value validation", () => {
   });
 
   it("accepts an array of option values for a hasMany select and rejects a bare value", () => {
+    // hasMany wraps the option enum in an array, so a scalar value is rejected.
     const schema = buildUserFieldsSchema([
       userField({
         name: "tags",
@@ -138,6 +145,8 @@ describe("buildUserFieldsSchema value validation", () => {
   });
 
   it("treats a non-required field as nullable and optional", () => {
+    // An optional field wraps its schema in nullable().optional(), so a missing
+    // key, an explicit null, and a value are all accepted.
     const schema = buildUserFieldsSchema([
       userField({ name: "note", type: "text" }),
     ]);
@@ -147,7 +156,10 @@ describe("buildUserFieldsSchema value validation", () => {
   });
 });
 
+// The create and update schemas merge the same custom fields onto the core user
+// schema but treat `required` differently, so these pin that difference.
 describe("buildCreateUserSchema vs buildUpdateUserSchema", () => {
+  // A required custom field, reused across both create and update expectations.
   const requiredCustom = userField({
     name: "company",
     type: "text",
@@ -166,6 +178,7 @@ describe("buildCreateUserSchema vs buildUpdateUserSchema", () => {
   });
 
   it("makes the same required custom field optional on update (partial saves)", () => {
+    // Updates are partial, so even a required custom field may be omitted.
     const schema = buildUpdateUserSchema([requiredCustom]);
     expect(schema.safeParse({}).success).toBe(true);
   });

--- a/packages/nextly/src/schemas/__tests__/user-fields.test.ts
+++ b/packages/nextly/src/schemas/__tests__/user-fields.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+
+import type { UserFieldConfig } from "../../users/config/types";
+
+import {
+  buildCreateUserSchema,
+  buildUpdateUserSchema,
+  buildUserFieldsSchema,
+} from "../user-fields";
+
+// UserFieldConfig is a broad discriminated union; the value-mapping under test
+// keys off `type` and reads bounds/options structurally, so a single typed
+// helper keeps the fixtures readable without repeating the cast per field.
+type FieldFixture = {
+  name: string;
+  type: string;
+  required?: boolean;
+  minLength?: number;
+  maxLength?: number;
+  min?: number;
+  max?: number;
+  hasMany?: boolean;
+  options?: { label: string; value: string }[];
+};
+
+function userField(cfg: FieldFixture): UserFieldConfig {
+  return cfg as unknown as UserFieldConfig;
+}
+
+describe("buildUserFieldsSchema value validation", () => {
+  it("validates a url field and enforces its length bounds", () => {
+    const schema = buildUserFieldsSchema([
+      userField({ name: "site", type: "url", required: true, maxLength: 20 }),
+    ]);
+    expect(schema.safeParse({ site: "https://nextly.dev" }).success).toBe(true);
+    expect(schema.safeParse({ site: "not-a-url" }).success).toBe(false);
+    // A valid URL that exceeds maxLength is still rejected.
+    expect(
+      schema.safeParse({ site: "https://example.com/very/long/path" }).success
+    ).toBe(false);
+  });
+
+  it("accepts a well-formed phone and rejects separator-only or out-of-range values", () => {
+    const schema = buildUserFieldsSchema([
+      userField({ name: "tel", type: "phone", required: true }),
+    ]);
+    expect(schema.safeParse({ tel: "+1 (312) 847-1928" }).success).toBe(true);
+    // The digit lookahead rejects a separators-only string.
+    expect(schema.safeParse({ tel: "---" }).success).toBe(false);
+    // Default bounds are 3..32 characters.
+    expect(schema.safeParse({ tel: "12" }).success).toBe(false);
+    expect(schema.safeParse({ tel: "1".repeat(40) }).success).toBe(false);
+  });
+
+  it("enforces text minLength and maxLength", () => {
+    const schema = buildUserFieldsSchema([
+      userField({
+        name: "bio",
+        type: "text",
+        required: true,
+        minLength: 2,
+        maxLength: 5,
+      }),
+    ]);
+    expect(schema.safeParse({ bio: "hey" }).success).toBe(true);
+    expect(schema.safeParse({ bio: "a" }).success).toBe(false);
+    expect(schema.safeParse({ bio: "toolong" }).success).toBe(false);
+  });
+
+  it("enforces number min and max", () => {
+    const schema = buildUserFieldsSchema([
+      userField({
+        name: "age",
+        type: "number",
+        required: true,
+        min: 18,
+        max: 65,
+      }),
+    ]);
+    expect(schema.safeParse({ age: 30 }).success).toBe(true);
+    expect(schema.safeParse({ age: 10 }).success).toBe(false);
+    expect(schema.safeParse({ age: 99 }).success).toBe(false);
+  });
+
+  it("validates an email field", () => {
+    const schema = buildUserFieldsSchema([
+      userField({ name: "work", type: "email", required: true }),
+    ]);
+    expect(schema.safeParse({ work: "a@b.com" }).success).toBe(true);
+    expect(schema.safeParse({ work: "nope" }).success).toBe(false);
+  });
+
+  it("restricts a single select to its option values", () => {
+    const schema = buildUserFieldsSchema([
+      userField({
+        name: "dept",
+        type: "select",
+        required: true,
+        options: [
+          { label: "Eng", value: "eng" },
+          { label: "Sales", value: "sales" },
+        ],
+      }),
+    ]);
+    expect(schema.safeParse({ dept: "eng" }).success).toBe(true);
+    expect(schema.safeParse({ dept: "marketing" }).success).toBe(false);
+    // A single select is a scalar, not an array.
+    expect(schema.safeParse({ dept: ["eng"] }).success).toBe(false);
+  });
+
+  it("accepts an array of option values for a hasMany select and rejects a bare value", () => {
+    const schema = buildUserFieldsSchema([
+      userField({
+        name: "tags",
+        type: "select",
+        required: true,
+        hasMany: true,
+        options: [
+          { label: "A", value: "a" },
+          { label: "B", value: "b" },
+        ],
+      }),
+    ]);
+    expect(schema.safeParse({ tags: ["a", "b"] }).success).toBe(true);
+    expect(schema.safeParse({ tags: ["a", "c"] }).success).toBe(false);
+    expect(schema.safeParse({ tags: "a" }).success).toBe(false);
+  });
+
+  it("enforces required on a plugin field type whose value shape is unknown", () => {
+    // The default branch accepts any value but still rejects a missing/empty
+    // one for a required plugin field (z.unknown() alone would let it through).
+    const schema = buildUserFieldsSchema([
+      userField({ name: "rating", type: "stars", required: true }),
+    ]);
+    expect(schema.safeParse({ rating: 4 }).success).toBe(true);
+    expect(schema.safeParse({ rating: "" }).success).toBe(false);
+    expect(schema.safeParse({}).success).toBe(false);
+  });
+
+  it("treats a non-required field as nullable and optional", () => {
+    const schema = buildUserFieldsSchema([
+      userField({ name: "note", type: "text" }),
+    ]);
+    expect(schema.safeParse({}).success).toBe(true);
+    expect(schema.safeParse({ note: null }).success).toBe(true);
+    expect(schema.safeParse({ note: "hi" }).success).toBe(true);
+  });
+});
+
+describe("buildCreateUserSchema vs buildUpdateUserSchema", () => {
+  const requiredCustom = userField({
+    name: "company",
+    type: "text",
+    required: true,
+  });
+
+  it("enforces a required custom field on create", () => {
+    const schema = buildCreateUserSchema([requiredCustom]);
+    expect(
+      schema.safeParse({ email: "a@b.com", name: "A", company: "Acme" }).success
+    ).toBe(true);
+    // Missing the required custom field fails create validation.
+    expect(schema.safeParse({ email: "a@b.com", name: "A" }).success).toBe(
+      false
+    );
+  });
+
+  it("makes the same required custom field optional on update (partial saves)", () => {
+    const schema = buildUpdateUserSchema([requiredCustom]);
+    expect(schema.safeParse({}).success).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Backfills unit coverage for the user-fields server logic (shipped in #187 with no tests), closing the schema/fields-audit **F-17** finding. **Test-only — no product code changes, no changeset.**

## Coverage added

**`schemas/__tests__/user-fields.test.ts` (new, 11 cases)** — the value schema built from user field configs (`buildUserFieldsSchema` / `buildCreateUserSchema` / `buildUpdateUserSchema`, exercising the internal `fieldConfigToZod`):
- **url** — valid URL passes, non-URL rejected, `maxLength` still enforced on a valid URL.
- **phone** — a well-formed number passes; a separators-only string (`"---"`) is rejected by the digit lookahead; the default 3..32 bounds are enforced.
- **text** min/max, **number** min/max, **email** validity.
- **select** — a single select restricts to its option values and rejects an array; a `hasMany` select accepts an array of option values and rejects a bare value / an unknown value.
- **required plugin field** — a required field of an unknown (plugin) type rejects missing/empty; a non-required field is nullable + optional.
- **create vs update** — a required custom field is enforced on create but optional on update (partial saves).

**`domains/users/services/__tests__/user-ext-builtin-columns.test.ts` (new, 2 cases)** — url/phone are validated as text but must still get a real text-family column: `VARCHAR(255)` on postgres, `TEXT` on sqlite (not skipped, not defaulted to another primitive).

**`domains/users/services/__tests__/user-field-guards.integration.test.ts` (+2 cases)** — the `hasMany` immutability guard on `updateField`: toggling `hasMany` after creation is rejected with `USER_FIELD_HAS_MANY_IMMUTABLE` (keyed to the `hasMany` path), while echoing the unchanged value passes.

## Verification
- Unit files: **13/13 green**; guards integration file **19/19 green** (`vitest.integration.config.ts`, sqlite).
- `pnpm --filter nextly check-types` clean.
- Zero new failures: the `src/schemas` and `src/domains/users/services` unit dirs show the same pre-existing baseline (1 unrelated `ui-schema.test.ts` failure) with these files stashed vs. applied.

## Scope note
The `createFieldSchema` bounds-inversion `superRefine` (`minLength > maxLength` / `minValue > maxValue`) in `api/user-fields.ts` is **not** covered here: it is an unexported route-handler schema, so testing it directly would require a source export. Left out to keep this PR strictly test-only; happy to add a small export + test as a follow-up if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened custom user-field validation coverage for URL, phone, text, numbers, email, and select options (including option whitelisting and has-many handling).

- **Tests**
  - Added guard coverage to ensure a field’s multiple-values setting can’t be changed after creation.
  - Expanded schema tests for create vs update behavior and detailed value-shape/required/optional rules.
  - Verified built-in `url`/`phone` column types match expectations for both migration output and runtime schemas across PostgreSQL and SQLite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->