### PR TITLE
fix(nextly): make the collection schema-apply lock effective and consistent

### DIFF
--- a/.changeset/collection-schema-lock.md
+++ b/.changeset/collection-schema-lock.md
@@ -1,0 +1,33 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Schema Builder saves for collections now reject stale saves reliably.
+
+The collection schema apply had an optimistic-lock check, but the stored
+schema_version was never advanced on apply, so the check compared against a
+value that never changed and a second admin editing the same collection could
+still overwrite the first (last-write-wins). The apply now persists the bumped
+schema_version, and the check runs through the same guard as singles and
+components: an omitted version is rejected and a stale version is reported as a
+conflict for the client to reload and retry. All three entity kinds now share
+one optimistic-lock behavior and error surface. If the post-apply metadata
+write fails, the response reports the current version rather than the bumped
+one so a retry re-attempts the bump.

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -86,6 +86,8 @@ import {
 } from "../helpers/validation";
 import type { MethodHandler, Params } from "../types";
 
+// Shared guard that centralizes required + stale schema-version validation for
+// all three entity kinds, so a stale UI save is rejected before any DDL runs.
 import { assertSchemaVersionMatch } from "./schema-version-guard";
 
 type CollectionsHandlerType = CollectionsHandler;
@@ -463,7 +465,11 @@ const COLLECTIONS_METHODS: Record<
         );
       }
 
-      const currentVersion = collection.schemaVersion;
+      // Default legacy rows (schema_version NULL) to 1 so a first save is not
+      // rejected as version-less. The registry types schemaVersion as `number`
+      // via a type assertion, but the DB column is nullable, so the value can
+      // be null at runtime; singles/components apply the same `?? 1` fallback.
+      const currentVersion = collection.schemaVersion ?? 1;
       // Reject a stale or version-less UI save before any DDL runs. The shared
       // guard gives all three entity kinds (collections, singles, components)
       // one optimistic-lock behavior and one error surface.

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -49,7 +49,6 @@ import type { DesiredCollection } from "../../domains/schema/pipeline/types";
 import { DrizzleStatementExecutor } from "../../domains/schema/services/drizzle-statement-executor";
 import { generateRuntimeSchema } from "../../domains/schema/services/runtime-schema-generator";
 import type { FieldResolution } from "../../domains/schema/services/schema-change-types";
-import { NextlyError } from "../../errors";
 import {
   applyPluginAdminViews,
   type CollectionWithAdmin,
@@ -86,6 +85,8 @@ import {
   toNumber,
 } from "../helpers/validation";
 import type { MethodHandler, Params } from "../types";
+
+import { assertSchemaVersionMatch } from "./schema-version-guard";
 
 type CollectionsHandlerType = CollectionsHandler;
 
@@ -463,6 +464,10 @@ const COLLECTIONS_METHODS: Record<
       }
 
       const currentVersion = collection.schemaVersion;
+      // Reject a stale or version-less UI save before any DDL runs. The shared
+      // guard gives all three entity kinds (collections, singles, components)
+      // one optimistic-lock behavior and one error surface.
+      assertSchemaVersionMatch(schemaVersion, currentVersion, p.collectionName);
       const tableName = collection.tableName;
 
       // Legacy per-field resolutions get translated to typed
@@ -557,10 +562,9 @@ const COLLECTIONS_METHODS: Record<
             uiTargetSlug: p.collectionName,
           });
         },
-        // Optimistic-lock: only the slug being saved has a known
-        // currentVersion (we pre-fetched it above). For sibling
-        // collections in the snapshot, return null = no version check
-        // needed (caller didn't pass schemaVersions for them either).
+        // The optimistic-lock check now runs up front via
+        // assertSchemaVersionMatch, so no schemaVersions are passed below and
+        // this callback is unused; it is retained to satisfy the deps contract.
         readSchemaVersionForSlug: (slug: string) =>
           Promise.resolve(slug === p.collectionName ? currentVersion : null),
         // Read post-apply versions for the saved slug from the registry.
@@ -575,22 +579,13 @@ const COLLECTIONS_METHODS: Record<
         },
       });
 
-      const schemaVersionsCtx: Record<string, number> = {};
-      if (schemaVersion !== undefined) {
-        schemaVersionsCtx[p.collectionName] = schemaVersion;
-      }
-
       const result = await apply(desired, "ui", {
-        schemaVersions: schemaVersionsCtx,
         promptChannel: "auto",
       });
 
       if (!result.success) {
-        if (result.error.code === "SCHEMA_VERSION_CONFLICT") {
-          // Same conflict surface as the single/component apply paths so all
-          // three entity kinds report a stale schema save identically.
-          throw NextlyError.conflict({ reason: "version" });
-        }
+        // The stale-version case is already rejected up front by
+        // assertSchemaVersionMatch, so any failure here is a real apply error.
         throw new Error(result.error.message);
       }
 
@@ -604,29 +599,35 @@ const COLLECTIONS_METHODS: Record<
       // every list query 500s.
       //
       // Use `adapter.update` directly (not `registry.updateCollection`)
-      // because the registry helper auto-bumps `schema_version` and
-      // resets `migration_status` to `"pending"` on any `fields`
-      // change; both wrong here. The pipeline already bumped the schema
-      // version (see bumpSchemaVersion below plus the journal record),
-      // and the migration status is now `applied`, not `pending`.
-      // Surgical write of just the `fields` column keeps invariants
-      // intact.
+      // because the registry helper resets `migration_status` to `"pending"`
+      // on any `fields` change, which is wrong here (the migration is now
+      // `applied`). Advance `schema_version` in this same write so the
+      // optimistic-lock check above sees a new value on the next save;
+      // nothing else persists it, so without this bump the stored version
+      // never changes and a second stale save would pass the guard. The
+      // write is non-fatal (the DDL already succeeded), but track whether it
+      // landed so the response never reports a version the DB did not persist.
+      const newSchemaVersion = currentVersion + 1;
+      let versionPersisted = true;
       try {
         await adapter.update(
           "dynamic_collections",
           {
             fields: JSON.stringify(fields),
+            schema_version: newSchemaVersion,
             updated_at: new Date(),
           },
           { and: [{ column: "slug", op: "=", value: p.collectionName }] }
         );
       } catch (err) {
+        versionPersisted = false;
         const msg = err instanceof Error ? err.message : String(err);
         // Non-fatal: the schema apply itself already succeeded. If the
         // metadata write fails, the actual DB column was already
         // renamed and the collection is in a good state structurally;
-        // only the admin's view of the field name is stale. Log so an
-        // operator can diagnose, but don't block the response.
+        // only the admin's view of the field name is stale, and the version
+        // was not advanced (the response reports the current version so a
+        // retry re-attempts the bump). Log so an operator can diagnose.
         console.warn(
           `[applySchemaChanges] Post-apply metadata write failed for ` +
             `'${p.collectionName}': ${msg}. Live DB schema is correct ` +
@@ -685,8 +686,7 @@ const COLLECTIONS_METHODS: Record<
       // pipeline didn't emit diff counts; the conditional spread drops
       // undefined fields silently.
       return respondAction(`Schema applied for '${p.collectionName}'`, {
-        newSchemaVersion:
-          result.newSchemaVersions[p.collectionName] ?? currentVersion + 1,
+        newSchemaVersion: versionPersisted ? newSchemaVersion : currentVersion,
         ...(result.summary
           ? { toastSummary: formatToastSummary(result.summary) }
           : {}),

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -384,7 +384,11 @@ const COLLECTIONS_METHODS: Record<
       return respondData({
         ...legacyAsRecord,
         renamed,
-        schemaVersion: collection.schemaVersion,
+        // Normalize legacy rows (schema_version NULL) to 1 so the editor always
+        // receives a concrete version to echo back on apply; otherwise JSON
+        // omits an undefined value and the guard rejects the first save as
+        // version-less. Mirrors the single-dispatcher preview.
+        schemaVersion: collection.schemaVersion ?? 1,
       });
     },
   },


### PR DESCRIPTION
## What

Follow-up to #215 (which fixed singles/components), flagged during that review. The collection schema apply had an optimistic-lock check, but it was **ineffective**: the stored `schema_version` was never advanced on apply (nothing persisted it — the registry auto-bump is deliberately avoided, and `readSchemaVersionForSlug` just returns the request-start value), so the check compared the client version against a value that never changed. A second admin editing the same collection could still overwrite the first (last-write-wins). It also accepted an omitted `schemaVersion` (bypass).

This brings collections to parity with singles/components and unifies all three on one mechanism.

## Changes (collection-dispatcher only)

- **Persist the version:** the post-apply `dynamic_collections` write now advances `schema_version` (with truthful-version tracking, matching #215), so the next request reads the bumped value and a stale save is rejected. Corrected the stale comment that claimed "the pipeline already bumped the schema version" (it never did).
- **Use the shared guard:** the check now runs through `assertSchemaVersionMatch(schemaVersion, currentVersion, slug)` up front — the same guard singles and components use — so an omitted version is rejected (`SCHEMA_VERSION_REQUIRED`) and a stale one is a `NextlyError.conflict`. All three entity kinds now share one optimistic-lock behavior and error surface.
- **Removed the now-redundant plumbing:** the guard replaces the `apply.ts` `schemaVersions` check, so the dispatcher no longer builds/passes `schemaVersionsCtx`, the (now-dead) `SCHEMA_VERSION_CONFLICT` re-throw branch is gone, and the unused `NextlyError` import was removed. (`apply.ts` itself is untouched; its own tests still cover its version-conflict logic.)
- **Truthful response:** if the post-apply write fails, the response reports the current version rather than the bumped one, so a retry re-attempts the bump.

## Scope / safety
- Single-package (`nextly`), dispatcher layer only; no DDL/column-layer changes.
- Reuses the shared `assertSchemaVersionMatch` guard (unit-tested on `main` via `schema-version-guard.test.ts`).

## Tests
- `pnpm --filter nextly check-types` clean.
- Zero new failures: the dispatcher-handler suite + `apply.test.ts` show the same pre-existing baseline (8 failed) with these changes stashed vs. applied (verified via `git stash`).
- No new test file: the change reuses the already-tested shared guard and the same persist pattern reviewed in #215; there is no collection-apply integration harness today (the existing `apply.test.ts` covers `createApplyDesiredSchema` directly).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented missing or null schema versions from overwriting newer changes by defaulting to a concrete version and enforcing optimistic-lock validation up front.
  * Improved schema version reporting after updates, including conditional version increment only when metadata persistence succeeds.
  * Simplified post-apply handling by removing schema-version conflict special-casing after pipeline completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->