### PR TITLE
feat(nextly): add webhook and event system tables

### DIFF
--- a/.changeset/webhook-system-tables.md
+++ b/.changeset/webhook-system-tables.md
@@ -1,0 +1,24 @@
+---
+
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+
+Add the webhook and event system tables (nextly_events, nextly_webhooks, nextly_webhook_deliveries).
+
+These three per-dialect core tables back the durable-outbox webhook system: an append-only event ledger (also the substrate for audit logging and workflows), the outbound-webhook endpoint registry (hashed secrets, subscribed events, structured filter), and the per-endpoint delivery ledger with retry state and an attempt log. They are registered as first-class managed tables, so the schema pipeline creates them on boot. No delivery behavior yet; this is the data model only.

--- a/.changeset/webhook-system-tables.md
+++ b/.changeset/webhook-system-tables.md
@@ -1,5 +1,4 @@
 ---
-
 "@nextlyhq/adapter-drizzle": patch
 "@nextlyhq/adapter-mysql": patch
 "@nextlyhq/adapter-postgres": patch
@@ -18,6 +17,7 @@
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/ui": patch
+---
 
 Add the webhook and event system tables (nextly_events, nextly_webhooks, nextly_webhook_deliveries).
 

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
@@ -93,11 +93,19 @@ const POST_045_TABLES = [
   "nextly_webhook_deliveries",
 ];
 
+// The post-045 names are static identifiers, but escape defensively so the
+// generated RegExp can never carry a metacharacter (also silences the
+// variable-in-regex lint).
+const escapeRegExp = (s: string): string =>
+  s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 // Whole-identifier match tolerant of the per-dialect quoting drizzle-kit emits
 // ("pg" / `mysql` / bare), so a table whose name merely contains an allowlisted
 // name cannot slip through on a substring.
 const namesPost045Table = (stmt: string): boolean =>
-  POST_045_TABLES.some(t => new RegExp(`[\`"\\s(]${t}[\`"\\s)(]`).test(stmt));
+  POST_045_TABLES.some(t =>
+    new RegExp(`[\`"\\s(]${escapeRegExp(t)}[\`"\\s)(]`).test(stmt)
+  );
 
 // Only additive DDL is acceptable in the upgrade sim: CREATE TABLE, CREATE
 // [UNIQUE] INDEX, or ALTER TABLE ... ADD (the shape drizzle-kit emits for a
@@ -115,8 +123,10 @@ const isPost045TableStatement = (stmt: string): boolean =>
 // pass would otherwise satisfy the additive-only check vacuously).
 const hasCreateTableFor = (stmts: string[], table: string): boolean =>
   stmts.some(s =>
+    // Trailing `[\s(]` requires a real identifier boundary after the name, so
+    // `nextly_webhooks` does not match `CREATE TABLE nextly_webhooks_archive`.
     new RegExp(
-      `^CREATE TABLE\\s+(IF NOT EXISTS\\s+)?[\`"]?${table}[\`"]?`,
+      `^CREATE TABLE\\s+(IF NOT EXISTS\\s+)?[\`"]?${escapeRegExp(table)}[\`"]?[\\s(]`,
       "i"
     ).test(s.trim())
   );

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
@@ -81,6 +81,20 @@ function onlyTables(bundle: Record<string, unknown>): Record<string, unknown> {
   return out;
 }
 
+// Core tables that did not exist when fixtures-045 was captured, so an
+// existing user upgrading legitimately gets them created. Their creation is
+// additive/non-destructive; every OTHER table must still diff to zero. After
+// applying the additive statements, a second pass must be zero too, which is
+// what proves these new tables themselves round-trip cleanly (no phantom diffs
+// forever, the same contract the pre-existing tables are held to).
+const POST_045_TABLES = [
+  "nextly_events",
+  "nextly_webhooks",
+  "nextly_webhook_deliveries",
+];
+const isPost045TableStatement = (stmt: string): boolean =>
+  POST_045_TABLES.some(t => stmt.includes(t));
+
 describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
   it("sqlite: one data-preserving reconcile, then zero", async () => {
     const fixture = loadFixture("sqlite");
@@ -140,7 +154,7 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
   });
 
   it.skipIf(!process.env.TEST_POSTGRES_URL)(
-    "postgres: strict zero — v1 proposes nothing over a 0.31-created schema",
+    "postgres: only additive new-table creates, then zero",
     async () => {
       const fixture = loadFixture("postgres");
       const admin = new Pool({
@@ -160,13 +174,27 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
           fixture.dynamicFields,
           "postgresql"
         );
-        const result = await kit.pushSchema(
-          { ...onlyTables(pgTables as never), ...schemaRecord },
-          db,
-          { schemas: ["public"] }
-        );
-        expect(result.sqlStatements).toEqual([]);
-        expect(result.hints).toEqual([]);
+        const desired = { ...onlyTables(pgTables as never), ...schemaRecord };
+
+        // Pass 1: v1 proposes NOTHING for the pre-existing 0.31 schema — the
+        // only statements are the additive creates for tables added after the
+        // fixture was captured. Any statement touching an untouched table is a
+        // phantom diff and fails here.
+        const first = await kit.pushSchema(desired, db, {
+          schemas: ["public"],
+        });
+        for (const s of first.sqlStatements) {
+          expect(isPost045TableStatement(s), `phantom diff: ${s}`).toBe(true);
+        }
+        expect(first.hints).toEqual([]);
+        await first.apply();
+
+        // Pass 2: silence — the new tables round-trip with no phantom diffs.
+        const second = await kit.pushSchema(desired, db, {
+          schemas: ["public"],
+        });
+        expect(second.sqlStatements).toEqual([]);
+        expect(second.hints).toEqual([]);
       } finally {
         await pool.end();
         await admin.query("DROP DATABASE IF EXISTS nextly_upgrade_v1");
@@ -207,14 +235,20 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
           ...schemaRecord,
         };
 
-        // Pass 1: ONLY the literal-default → CURRENT_TIMESTAMP MODIFYs
-        // (metadata-only; instant; non-destructive).
+        // Pass 1: the literal-default → CURRENT_TIMESTAMP MODIFYs (metadata
+        // only; instant; non-destructive), plus the additive creates for
+        // tables added after the fixture was captured. Nothing else.
         const first = await kit.pushSchema(desired, db, "nextly_upgrade_v1");
         expect(first.hints).toEqual([]);
         for (const s of first.sqlStatements) {
-          expect(s, "unexpected reconcile statement shape").toMatch(
-            /^ALTER TABLE `[^`]+` MODIFY COLUMN `[^`]+` datetime DEFAULT \(?CURRENT_TIMESTAMP\)? NOT NULL;?$/
-          );
+          const isDefaultReconcile =
+            /^ALTER TABLE `[^`]+` MODIFY COLUMN `[^`]+` datetime DEFAULT \(?CURRENT_TIMESTAMP\)? NOT NULL;?$/.test(
+              s
+            );
+          expect(
+            isDefaultReconcile || isPost045TableStatement(s),
+            `unexpected reconcile statement shape: ${s}`
+          ).toBe(true);
         }
         await first.apply();
 

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
@@ -92,8 +92,34 @@ const POST_045_TABLES = [
   "nextly_webhooks",
   "nextly_webhook_deliveries",
 ];
+
+// Whole-identifier match tolerant of the per-dialect quoting drizzle-kit emits
+// ("pg" / `mysql` / bare), so a table whose name merely contains an allowlisted
+// name cannot slip through on a substring.
+const namesPost045Table = (stmt: string): boolean =>
+  POST_045_TABLES.some(t => new RegExp(`[\`"\\s(]${t}[\`"\\s)(]`).test(stmt));
+
+// Only additive DDL is acceptable in the upgrade sim: CREATE TABLE, CREATE
+// [UNIQUE] INDEX, or ALTER TABLE ... ADD (the shape drizzle-kit emits for a
+// new table's FK constraints). A destructive statement (DROP/RENAME/ALTER
+// COLUMN) never starts with one of these prefixes, so the positive allowlist
+// rejects it without a separate blocklist -- which also avoids false-flagging
+// the word DELETE inside a legitimate `... ADD CONSTRAINT ... ON DELETE ...`.
+const ADDITIVE_STATEMENT =
+  /^(CREATE TABLE|CREATE UNIQUE INDEX|CREATE INDEX|ALTER TABLE .+ ADD\b)/i;
+
 const isPost045TableStatement = (stmt: string): boolean =>
-  POST_045_TABLES.some(t => stmt.includes(t));
+  ADDITIVE_STATEMENT.test(stmt.trim()) && namesPost045Table(stmt);
+
+// Positive guard: the sim must actually create each new table (an empty first
+// pass would otherwise satisfy the additive-only check vacuously).
+const hasCreateTableFor = (stmts: string[], table: string): boolean =>
+  stmts.some(s =>
+    new RegExp(
+      `^CREATE TABLE\\s+(IF NOT EXISTS\\s+)?[\`"]?${table}[\`"]?`,
+      "i"
+    ).test(s.trim())
+  );
 
 describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
   it("sqlite: one data-preserving reconcile, then zero", async () => {
@@ -186,6 +212,12 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
         for (const s of first.sqlStatements) {
           expect(isPost045TableStatement(s), `phantom diff: ${s}`).toBe(true);
         }
+        for (const t of POST_045_TABLES) {
+          expect(
+            hasCreateTableFor(first.sqlStatements, t),
+            `missing CREATE TABLE for ${t}`
+          ).toBe(true);
+        }
         expect(first.hints).toEqual([]);
         await first.apply();
 
@@ -248,6 +280,12 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
           expect(
             isDefaultReconcile || isPost045TableStatement(s),
             `unexpected reconcile statement shape: ${s}`
+          ).toBe(true);
+        }
+        for (const t of POST_045_TABLES) {
+          expect(
+            hasCreateTableFor(first.sqlStatements, t),
+            `missing CREATE TABLE for ${t}`
           ).toBe(true);
         }
         await first.apply();

--- a/packages/nextly/src/schemas/_dialect-bundles/mysql.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/mysql.ts
@@ -46,3 +46,11 @@ export { emailProvidersMysql as emailProviders } from "../email-providers/mysql"
 export { emailTemplatesMysql as emailTemplates } from "../email-templates/mysql";
 
 export { nextlySchemaEventsMysql as nextlySchemaEvents } from "../schema-events/mysql";
+
+// Webhook + event system tables. Must be in this flat bundle (not just
+// getCoreSchema) so freshPushSchema creates them on a fresh database.
+export {
+  nextlyEvents,
+  nextlyWebhooks,
+  nextlyWebhookDeliveries,
+} from "../webhooks/mysql";

--- a/packages/nextly/src/schemas/_dialect-bundles/postgres.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/postgres.ts
@@ -71,3 +71,11 @@ export { emailProvidersPg as emailProviders } from "../email-providers/postgres"
 export { emailTemplatesPg as emailTemplates } from "../email-templates/postgres";
 
 export { nextlySchemaEventsPg as nextlySchemaEvents } from "../schema-events/postgres";
+
+// Webhook + event system tables. Must be in this flat bundle (not just
+// getCoreSchema) so freshPushSchema creates them on a fresh database.
+export {
+  nextlyEvents,
+  nextlyWebhooks,
+  nextlyWebhookDeliveries,
+} from "../webhooks/postgres";

--- a/packages/nextly/src/schemas/_dialect-bundles/sqlite.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/sqlite.ts
@@ -46,3 +46,11 @@ export { emailProvidersSqlite as emailProviders } from "../email-providers/sqlit
 export { emailTemplatesSqlite as emailTemplates } from "../email-templates/sqlite";
 
 export { nextlySchemaEventsSqlite as nextlySchemaEvents } from "../schema-events/sqlite";
+
+// Webhook + event system tables. Must be in this flat bundle (not just
+// getCoreSchema) so freshPushSchema creates them on a fresh database.
+export {
+  nextlyEvents,
+  nextlyWebhooks,
+  nextlyWebhookDeliveries,
+} from "../webhooks/sqlite";

--- a/packages/nextly/src/schemas/index.ts
+++ b/packages/nextly/src/schemas/index.ts
@@ -54,6 +54,7 @@ import { userFieldDefinitionsMysql } from "./user-field-definitions/mysql";
 import { userFieldDefinitionsPg } from "./user-field-definitions/postgres";
 import { userFieldDefinitionsSqlite } from "./user-field-definitions/sqlite";
 import { userTables } from "./users";
+import { webhookTables } from "./webhooks";
 
 // =============================================================================
 // Public API — populated incrementally by Plan A tasks 4–14.
@@ -84,6 +85,7 @@ export function getCoreSchema(dialect: SupportedDialect): NextlySchemaSnapshot {
     // drizzle-kit 0.31.10 can't round-trip one, drizzle-team/drizzle-orm#4688),
     // so declaring it here is a no-op when the on-disk table already matches.
     ...Object.values(schemaEventsTables(dialect)),
+    ...Object.values(webhookTables(dialect)),
   ];
 
   // Per-dialect tables for feature groups whose dialect subdirs predate Plan A.
@@ -162,6 +164,9 @@ export const CORE_TABLE_NAMES: readonly string[] = [
   "email_providers",
   "email_templates",
   "nextly_schema_events",
+  "nextly_events",
+  "nextly_webhooks",
+  "nextly_webhook_deliveries",
 ] as const;
 
 /** Prefixes that identify managed user tables (dc_, single_, comp_). */

--- a/packages/nextly/src/schemas/index.ts
+++ b/packages/nextly/src/schemas/index.ts
@@ -224,4 +224,12 @@ export * from "./dynamic-components"; // kept; unchanged
 // schemas/_zod/api-keys.ts and are re-exported via `export * from "./_zod"`
 // at the top of this file.
 export { apiKeys } from "./api-keys/postgres";
+// Webhook + event system tables. PG re-exports for direct-query callers who
+// want to inspect the event/webhook/delivery ledger via the `nextly/schemas`
+// subpath; other dialects are reachable through getCoreSchema(dialect).
+export {
+  nextlyEvents,
+  nextlyWebhooks,
+  nextlyWebhookDeliveries,
+} from "./webhooks/postgres";
 export * from "./security-config"; // Zod — review in Task 19

--- a/packages/nextly/src/schemas/webhooks/__tests__/tables.test.ts
+++ b/packages/nextly/src/schemas/webhooks/__tests__/tables.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+
+import { CORE_TABLE_NAMES, getCoreSchema } from "../../index";
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+const DIALECTS: SupportedDialect[] = ["postgresql", "mysql", "sqlite"];
+const WEBHOOK_TABLES = [
+  "nextly_events",
+  "nextly_webhooks",
+  "nextly_webhook_deliveries",
+];
+
+// The webhook system tables must be registered as first-class managed tables so
+// the introspect-diff pipeline creates them on boot, exactly like the other
+// core system tables (api_keys, audit_log, nextly_schema_events).
+describe("webhook system tables", () => {
+  it("registers all three tables in CORE_TABLE_NAMES", () => {
+    for (const name of WEBHOOK_TABLES) {
+      expect(CORE_TABLE_NAMES).toContain(name);
+    }
+  });
+
+  for (const dialect of DIALECTS) {
+    it(`includes the three webhook tables in getCoreSchema(${dialect})`, () => {
+      const names = getCoreSchema(dialect).tables.map(t => t.name);
+      for (const name of WEBHOOK_TABLES) {
+        expect(names).toContain(name);
+      }
+    });
+  }
+
+  it("gives the delivery ledger its retry/lease columns (sqlite)", () => {
+    // Guards against a column being dropped from one dialect: the drain relies
+    // on status + next_attempt_at, and the fallback claim relies on the lease.
+    const deliveries = getCoreSchema("sqlite").tables.find(
+      t => t.name === "nextly_webhook_deliveries"
+    );
+    const cols = deliveries?.columns.map(c => c.name) ?? [];
+    for (const col of [
+      "status",
+      "attempt_count",
+      "next_attempt_at",
+      "locked_by",
+      "locked_until",
+      "webhook_id",
+      "event_id",
+    ]) {
+      expect(cols).toContain(col);
+    }
+  });
+
+  it("stores the full envelope on the event ledger (postgres)", () => {
+    const events = getCoreSchema("postgresql").tables.find(
+      t => t.name === "nextly_events"
+    );
+    const cols = events?.columns.map(c => c.name) ?? [];
+    for (const col of ["id", "type", "payload", "resource_kind"]) {
+      expect(cols).toContain(col);
+    }
+  });
+});

--- a/packages/nextly/src/schemas/webhooks/__tests__/tables.test.ts
+++ b/packages/nextly/src/schemas/webhooks/__tests__/tables.test.ts
@@ -1,6 +1,8 @@
+import { getTableConfig } from "drizzle-orm/pg-core";
 import { describe, it, expect } from "vitest";
 
 import { CORE_TABLE_NAMES, getCoreSchema } from "../../index";
+import { nextlyWebhookDeliveries } from "../postgres";
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
 const DIALECTS: SupportedDialect[] = ["postgresql", "mysql", "sqlite"];
@@ -47,6 +49,17 @@ describe("webhook system tables", () => {
     ]) {
       expect(cols).toContain(col);
     }
+  });
+
+  it("enforces one delivery per (webhook, event) with a unique index", () => {
+    // The DB constraint is what makes capture idempotent: fan-out and retry
+    // insert with ON CONFLICT DO NOTHING, so a duplicate can never double-send.
+    const { indexes } = getTableConfig(nextlyWebhookDeliveries);
+    const unique = indexes.find(i => i.config.unique);
+    expect(unique).toBeDefined();
+    expect(
+      unique?.config.columns.map(c => (c as { name: string }).name)
+    ).toEqual(["webhook_id", "event_id"]);
   });
 
   it("stores the full envelope on the event ledger (postgres)", () => {

--- a/packages/nextly/src/schemas/webhooks/__tests__/tables.test.ts
+++ b/packages/nextly/src/schemas/webhooks/__tests__/tables.test.ts
@@ -1,6 +1,7 @@
 import { getTableConfig } from "drizzle-orm/pg-core";
 import { describe, it, expect } from "vitest";
 
+import { getDialectTables } from "../../../database/index";
 import { CORE_TABLE_NAMES, getCoreSchema } from "../../index";
 import { nextlyWebhookDeliveries } from "../postgres";
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
@@ -27,6 +28,22 @@ describe("webhook system tables", () => {
       const names = getCoreSchema(dialect).tables.map(t => t.name);
       for (const name of WEBHOOK_TABLES) {
         expect(names).toContain(name);
+      }
+    });
+  }
+
+  for (const dialect of DIALECTS) {
+    it(`exports the webhook tables from the ${dialect} dialect bundle`, () => {
+      // getCoreSchema registration is not enough: freshPushSchema creates a
+      // fresh database from getDialectTables (the flat bundle), so the tables
+      // must be present there too or they never materialize on first boot.
+      const tables = getDialectTables(dialect) as Record<string, unknown>;
+      for (const key of [
+        "nextlyEvents",
+        "nextlyWebhooks",
+        "nextlyWebhookDeliveries",
+      ]) {
+        expect(tables[key]).toBeDefined();
       }
     });
   }

--- a/packages/nextly/src/schemas/webhooks/index.ts
+++ b/packages/nextly/src/schemas/webhooks/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Webhook + event system tables — dialect-aware barrel.
+ *
+ * Re-exports the per-dialect `nextly_events`, `nextly_webhooks`, and
+ * `nextly_webhook_deliveries` Drizzle tables. The runtime dialect determines
+ * which table objects a caller sees.
+ *
+ * @module schemas/webhooks
+ */
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+import * as my from "./mysql";
+import * as pg from "./postgres";
+import * as sl from "./sqlite";
+
+export { pg, my, sl };
+
+/**
+ * Returns the webhook + event Drizzle tables for the requested dialect.
+ */
+export function webhookTables(dialect: SupportedDialect) {
+  switch (dialect) {
+    case "postgresql":
+      return {
+        nextlyEvents: pg.nextlyEvents,
+        nextlyWebhooks: pg.nextlyWebhooks,
+        nextlyWebhookDeliveries: pg.nextlyWebhookDeliveries,
+      };
+    case "mysql":
+      return {
+        nextlyEvents: my.nextlyEvents,
+        nextlyWebhooks: my.nextlyWebhooks,
+        nextlyWebhookDeliveries: my.nextlyWebhookDeliveries,
+      };
+    case "sqlite":
+      return {
+        nextlyEvents: sl.nextlyEvents,
+        nextlyWebhooks: sl.nextlyWebhooks,
+        nextlyWebhookDeliveries: sl.nextlyWebhookDeliveries,
+      };
+    default: {
+      // Exhaustiveness check — TypeScript flags any missing dialect.
+      const _exhaustive: never = dialect;
+      throw new Error(`Unsupported dialect: ${String(_exhaustive)}`);
+    }
+  }
+}

--- a/packages/nextly/src/schemas/webhooks/index.ts
+++ b/packages/nextly/src/schemas/webhooks/index.ts
@@ -10,6 +10,8 @@
 
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
+import { NextlyError } from "../../errors";
+
 import * as my from "./mysql";
 import * as pg from "./postgres";
 import * as sl from "./sqlite";
@@ -40,9 +42,13 @@ export function webhookTables(dialect: SupportedDialect) {
         nextlyWebhookDeliveries: sl.nextlyWebhookDeliveries,
       };
     default: {
-      // Exhaustiveness check — TypeScript flags any missing dialect.
+      // `never` gives a compile-time exhaustiveness guarantee for typed
+      // callers; the throw handles an invalid dialect reaching here at runtime
+      // from an untyped/JS caller (e.g. a string from config).
       const _exhaustive: never = dialect;
-      throw new Error(`Unsupported dialect: ${String(_exhaustive)}`);
+      throw NextlyError.internal({
+        logContext: { dialect: String(_exhaustive) },
+      });
     }
   }
 }

--- a/packages/nextly/src/schemas/webhooks/mysql.ts
+++ b/packages/nextly/src/schemas/webhooks/mysql.ts
@@ -19,6 +19,7 @@ import {
   json,
   datetime,
   index,
+  uniqueIndex,
 } from "drizzle-orm/mysql-core";
 
 import { users } from "../users/mysql";
@@ -100,6 +101,15 @@ export const nextlyWebhookDeliveries = mysqlTable(
       t.status,
       t.nextAttemptAt
     ),
-    index("nextly_webhook_deliveries_webhook_idx").on(t.webhookId),
+    // One delivery per (webhook, event): fan-out and retry both insert with
+    // ON CONFLICT DO NOTHING, so a duplicate capture can never double-send.
+    // The leading webhook_id column also serves lookups scoped to an endpoint.
+    uniqueIndex("nextly_webhook_deliveries_webhook_event_unique").on(
+      t.webhookId,
+      t.eventId
+    ),
+    // MySQL auto-indexes FK columns, but declare event_id explicitly so the
+    // schema is identical across dialects and the diff pipeline round-trips.
+    index("nextly_webhook_deliveries_event_idx").on(t.eventId),
   ]
 );

--- a/packages/nextly/src/schemas/webhooks/mysql.ts
+++ b/packages/nextly/src/schemas/webhooks/mysql.ts
@@ -1,0 +1,105 @@
+/**
+ * Webhook + event system tables — MySQL.
+ *
+ * See `./postgres.ts` for the full documentation of the three tables. MySQL
+ * differences: `varchar(191)` for id/FK columns (utf8mb4 index-length limit),
+ * `datetime` for timestamps with a DDL-side `CURRENT_TIMESTAMP` default, and
+ * `json` for JSON columns.
+ *
+ * @module schemas/webhooks/mysql
+ */
+
+import { sql } from "drizzle-orm";
+import {
+  mysqlTable,
+  varchar,
+  text,
+  boolean,
+  int,
+  json,
+  datetime,
+  index,
+} from "drizzle-orm/mysql-core";
+
+import { users } from "../users/mysql";
+
+export const nextlyEvents = mysqlTable(
+  "nextly_events",
+  {
+    id: varchar("id", { length: 191 }).primaryKey(),
+    type: varchar("type", { length: 100 }).notNull(),
+    resourceKind: varchar("resource_kind", { length: 20 }).notNull(),
+    resourceCollection: varchar("resource_collection", { length: 255 }),
+    resourceId: varchar("resource_id", { length: 191 }),
+    payload: json("payload").notNull(),
+    actorType: varchar("actor_type", { length: 20 }),
+    actorId: varchar("actor_id", { length: 191 }),
+    createdAt: datetime("created_at")
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  t => [index("nextly_events_type_created_at_idx").on(t.type, t.createdAt)]
+);
+
+export const nextlyWebhooks = mysqlTable(
+  "nextly_webhooks",
+  {
+    id: varchar("id", { length: 191 }).primaryKey(),
+    name: varchar("name", { length: 255 }).notNull(),
+    url: text("url").notNull(),
+    enabled: boolean("enabled").notNull().default(true),
+    eventTypes: json("event_types").notNull(),
+    filter: json("filter"),
+    headers: json("headers"),
+    secretHash: json("secret_hash").notNull(),
+    secretPrefix: varchar("secret_prefix", { length: 16 }).notNull(),
+    fieldAllowlist: json("field_allowlist"),
+    createdBy: varchar("created_by", { length: 191 }).references(
+      () => users.id,
+      { onDelete: "set null" }
+    ),
+    createdAt: datetime("created_at")
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: datetime("updated_at")
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  t => [index("nextly_webhooks_enabled_idx").on(t.enabled)]
+);
+
+export const nextlyWebhookDeliveries = mysqlTable(
+  "nextly_webhook_deliveries",
+  {
+    id: varchar("id", { length: 191 }).primaryKey(),
+    webhookId: varchar("webhook_id", { length: 191 })
+      .notNull()
+      .references(() => nextlyWebhooks.id, { onDelete: "cascade" }),
+    eventId: varchar("event_id", { length: 191 })
+      .notNull()
+      .references(() => nextlyEvents.id, { onDelete: "cascade" }),
+    status: varchar("status", { length: 20 }).notNull().default("pending"),
+    attemptCount: int("attempt_count").notNull().default(0),
+    nextAttemptAt: datetime("next_attempt_at"),
+    lockedBy: varchar("locked_by", { length: 191 }),
+    lockedUntil: datetime("locked_until"),
+    lastStatusCode: int("last_status_code"),
+    lastLatencyMs: int("last_latency_ms"),
+    lastError: text("last_error"),
+    lastResponseSnippet: text("last_response_snippet"),
+    attempts: json("attempts"),
+    createdAt: datetime("created_at")
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: datetime("updated_at")
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  t => [
+    index("nextly_webhook_deliveries_status_next_idx").on(
+      t.status,
+      t.nextAttemptAt
+    ),
+    index("nextly_webhook_deliveries_webhook_idx").on(t.webhookId),
+  ]
+);

--- a/packages/nextly/src/schemas/webhooks/postgres.ts
+++ b/packages/nextly/src/schemas/webhooks/postgres.ts
@@ -1,0 +1,145 @@
+/**
+ * Webhook + event system tables — PostgreSQL.
+ *
+ * Three tables back the durable-outbox webhook system:
+ * - `nextly_events` — the durable event ledger (outbox). One row per content
+ *   event; the JSON payload is the full delivery envelope. Also the substrate
+ *   the audit-log and workflow features reuse.
+ * - `nextly_webhooks` — the endpoint registry (URL, subscribed events, filter,
+ *   hashed secret). Mirrors the api-keys security model (secret never stored
+ *   raw; only a hash + a display prefix).
+ * - `nextly_webhook_deliveries` — the per-endpoint delivery ledger: retry
+ *   state, lease columns for concurrent drain workers, and an attempt log.
+ *
+ * Drizzle table objects flow through `getCoreSchema` and are created/reconciled
+ * by the introspect-diff pipeline, so no hand-written migration is needed.
+ *
+ * @module schemas/webhooks/postgres
+ */
+
+import {
+  pgTable,
+  text,
+  varchar,
+  boolean,
+  integer,
+  jsonb,
+  timestamp,
+  index,
+} from "drizzle-orm/pg-core";
+
+import { users } from "../users/postgres";
+
+/**
+ * Durable event ledger (outbox). Rows are written inside the same transaction
+ * as the content change, so an event can never be lost or fired for a
+ * rolled-back change. `id` is the envelope id and doubles as the idempotency
+ * key; it is the primary key, so uniqueness is enforced on every dialect.
+ */
+export const nextlyEvents = pgTable(
+  "nextly_events",
+  {
+    id: text("id").primaryKey(),
+    // Canonical event type, e.g. "entry.published".
+    type: varchar("type", { length: 100 }).notNull(),
+    // Resource the event is about.
+    resourceKind: varchar("resource_kind", { length: 20 }).notNull(),
+    resourceCollection: varchar("resource_collection", { length: 255 }),
+    resourceId: text("resource_id"),
+    // The full delivery envelope (data/previous/changedFields/actor/...).
+    payload: jsonb("payload").notNull(),
+    // Denormalized actor for audit-log reuse.
+    actorType: varchar("actor_type", { length: 20 }),
+    actorId: text("actor_id"),
+    createdAt: timestamp("created_at", { withTimezone: false })
+      .defaultNow()
+      .notNull(),
+  },
+  t => [
+    // Drain/reporting scans by type and recency.
+    index("nextly_events_type_created_at_idx").on(t.type, t.createdAt),
+  ]
+);
+
+/**
+ * Outbound webhook endpoint registry. Secrets follow the api-keys pattern:
+ * only the hash and a short display prefix are stored; the raw secret is shown
+ * once at creation. `secretHash` is a JSON array of active-secret hashes so
+ * zero-downtime rotation can be added later without a migration.
+ */
+export const nextlyWebhooks = pgTable(
+  "nextly_webhooks",
+  {
+    id: text("id").primaryKey(),
+    name: varchar("name", { length: 255 }).notNull(),
+    url: text("url").notNull(),
+    enabled: boolean("enabled").notNull().default(true),
+    // JSON array of subscribed event types.
+    eventTypes: jsonb("event_types").notNull(),
+    // Structured, versioned filter spec (collections, changedFields, ...).
+    filter: jsonb("filter"),
+    // Static request headers merged into every delivery.
+    headers: jsonb("headers"),
+    // JSON array of active signing-secret hashes (list-shaped for rotation).
+    secretHash: jsonb("secret_hash").notNull(),
+    // Short prefix of the current secret for display, never the raw secret.
+    secretPrefix: varchar("secret_prefix", { length: 16 }).notNull(),
+    // Optional per-endpoint field allowlist (projection; reserved for later).
+    fieldAllowlist: jsonb("field_allowlist"),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: timestamp("created_at", { withTimezone: false })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: false })
+      .defaultNow()
+      .notNull(),
+  },
+  t => [index("nextly_webhooks_enabled_idx").on(t.enabled)]
+);
+
+/**
+ * Per-endpoint delivery ledger. One row per (event, matching webhook). Carries
+ * the retry state, a lease (`lockedBy`/`lockedUntil`) for concurrent drain
+ * workers, and a JSON attempt log for observability.
+ */
+export const nextlyWebhookDeliveries = pgTable(
+  "nextly_webhook_deliveries",
+  {
+    id: text("id").primaryKey(),
+    webhookId: text("webhook_id")
+      .notNull()
+      .references(() => nextlyWebhooks.id, { onDelete: "cascade" }),
+    eventId: text("event_id")
+      .notNull()
+      .references(() => nextlyEvents.id, { onDelete: "cascade" }),
+    // pending | processing | delivered | retrying | failed
+    status: varchar("status", { length: 20 }).notNull().default("pending"),
+    attemptCount: integer("attempt_count").notNull().default(0),
+    nextAttemptAt: timestamp("next_attempt_at", { withTimezone: false }),
+    // Lease for the claim-fallback dialects (SQLite / MySQL < 8).
+    lockedBy: text("locked_by"),
+    lockedUntil: timestamp("locked_until", { withTimezone: false }),
+    lastStatusCode: integer("last_status_code"),
+    lastLatencyMs: integer("last_latency_ms"),
+    lastError: text("last_error"),
+    lastResponseSnippet: text("last_response_snippet"),
+    // JSON array of per-attempt records (timestamp, status, latency, error).
+    attempts: jsonb("attempts"),
+    createdAt: timestamp("created_at", { withTimezone: false })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: false })
+      .defaultNow()
+      .notNull(),
+  },
+  t => [
+    // The drain query claims due rows by (status, next_attempt_at).
+    index("nextly_webhook_deliveries_status_next_idx").on(
+      t.status,
+      t.nextAttemptAt
+    ),
+    index("nextly_webhook_deliveries_webhook_idx").on(t.webhookId),
+  ]
+);

--- a/packages/nextly/src/schemas/webhooks/postgres.ts
+++ b/packages/nextly/src/schemas/webhooks/postgres.ts
@@ -26,6 +26,7 @@ import {
   jsonb,
   timestamp,
   index,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
 
 import { users } from "../users/postgres";
@@ -140,6 +141,15 @@ export const nextlyWebhookDeliveries = pgTable(
       t.status,
       t.nextAttemptAt
     ),
-    index("nextly_webhook_deliveries_webhook_idx").on(t.webhookId),
+    // One delivery per (webhook, event): fan-out and retry both insert with
+    // ON CONFLICT DO NOTHING, so a duplicate capture can never double-send.
+    // The leading webhook_id column also serves lookups scoped to an endpoint.
+    uniqueIndex("nextly_webhook_deliveries_webhook_event_unique").on(
+      t.webhookId,
+      t.eventId
+    ),
+    // Postgres does not auto-index FK columns, so index event_id explicitly for
+    // the event -> deliveries cascade delete and event-scoped admin queries.
+    index("nextly_webhook_deliveries_event_idx").on(t.eventId),
   ]
 );

--- a/packages/nextly/src/schemas/webhooks/sqlite.ts
+++ b/packages/nextly/src/schemas/webhooks/sqlite.ts
@@ -1,0 +1,95 @@
+/**
+ * Webhook + event system tables — SQLite.
+ *
+ * See `./postgres.ts` for the full documentation of the three tables. SQLite
+ * differences: `text` for all string and JSON columns (JSON is stored as text),
+ * `integer { mode: "timestamp" }` for datetimes, and `integer { mode: "boolean" }`
+ * for booleans.
+ *
+ * @module schemas/webhooks/sqlite
+ */
+
+import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+
+import { users } from "../users/sqlite";
+
+export const nextlyEvents = sqliteTable(
+  "nextly_events",
+  {
+    id: text("id").primaryKey(),
+    type: text("type").notNull(),
+    resourceKind: text("resource_kind").notNull(),
+    resourceCollection: text("resource_collection"),
+    resourceId: text("resource_id"),
+    // JSON stored as text on SQLite.
+    payload: text("payload").notNull(),
+    actorType: text("actor_type"),
+    actorId: text("actor_id"),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  t => [index("nextly_events_type_created_at_idx").on(t.type, t.createdAt)]
+);
+
+export const nextlyWebhooks = sqliteTable(
+  "nextly_webhooks",
+  {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    url: text("url").notNull(),
+    enabled: integer("enabled", { mode: "boolean" }).notNull().default(true),
+    eventTypes: text("event_types").notNull(),
+    filter: text("filter"),
+    headers: text("headers"),
+    secretHash: text("secret_hash").notNull(),
+    secretPrefix: text("secret_prefix").notNull(),
+    fieldAllowlist: text("field_allowlist"),
+    createdBy: text("created_by").references(() => users.id, {
+      onDelete: "set null",
+    }),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  t => [index("nextly_webhooks_enabled_idx").on(t.enabled)]
+);
+
+export const nextlyWebhookDeliveries = sqliteTable(
+  "nextly_webhook_deliveries",
+  {
+    id: text("id").primaryKey(),
+    webhookId: text("webhook_id")
+      .notNull()
+      .references(() => nextlyWebhooks.id, { onDelete: "cascade" }),
+    eventId: text("event_id")
+      .notNull()
+      .references(() => nextlyEvents.id, { onDelete: "cascade" }),
+    status: text("status").notNull().default("pending"),
+    attemptCount: integer("attempt_count").notNull().default(0),
+    nextAttemptAt: integer("next_attempt_at", { mode: "timestamp" }),
+    lockedBy: text("locked_by"),
+    lockedUntil: integer("locked_until", { mode: "timestamp" }),
+    lastStatusCode: integer("last_status_code"),
+    lastLatencyMs: integer("last_latency_ms"),
+    lastError: text("last_error"),
+    lastResponseSnippet: text("last_response_snippet"),
+    attempts: text("attempts"),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  t => [
+    index("nextly_webhook_deliveries_status_next_idx").on(
+      t.status,
+      t.nextAttemptAt
+    ),
+    index("nextly_webhook_deliveries_webhook_idx").on(t.webhookId),
+  ]
+);

--- a/packages/nextly/src/schemas/webhooks/sqlite.ts
+++ b/packages/nextly/src/schemas/webhooks/sqlite.ts
@@ -9,7 +9,13 @@
  * @module schemas/webhooks/sqlite
  */
 
-import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+import {
+  sqliteTable,
+  text,
+  integer,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
 
 import { users } from "../users/sqlite";
 
@@ -90,6 +96,15 @@ export const nextlyWebhookDeliveries = sqliteTable(
       t.status,
       t.nextAttemptAt
     ),
-    index("nextly_webhook_deliveries_webhook_idx").on(t.webhookId),
+    // One delivery per (webhook, event): fan-out and retry both insert with
+    // ON CONFLICT DO NOTHING, so a duplicate capture can never double-send.
+    // The leading webhook_id column also serves lookups scoped to an endpoint.
+    uniqueIndex("nextly_webhook_deliveries_webhook_event_unique").on(
+      t.webhookId,
+      t.eventId
+    ),
+    // Index event_id for the event -> deliveries cascade delete and
+    // event-scoped admin queries.
+    index("nextly_webhook_deliveries_event_idx").on(t.eventId),
   ]
 );

--- a/packages/nextly/src/schemas/webhooks/sqlite.ts
+++ b/packages/nextly/src/schemas/webhooks/sqlite.ts
@@ -27,8 +27,10 @@ export const nextlyEvents = sqliteTable(
     resourceKind: text("resource_kind").notNull(),
     resourceCollection: text("resource_collection"),
     resourceId: text("resource_id"),
-    // JSON stored as text on SQLite.
-    payload: text("payload").notNull(),
+    // JSON stored as TEXT on SQLite; `mode: "json"` gives Drizzle the same
+    // object-in/object-out interface as the PG jsonb / MySQL json columns, so
+    // delivery code never special-cases SQLite. Same TEXT DDL either way.
+    payload: text("payload", { mode: "json" }).notNull(),
     actorType: text("actor_type"),
     actorId: text("actor_id"),
     createdAt: integer("created_at", { mode: "timestamp" })
@@ -45,12 +47,14 @@ export const nextlyWebhooks = sqliteTable(
     name: text("name").notNull(),
     url: text("url").notNull(),
     enabled: integer("enabled", { mode: "boolean" }).notNull().default(true),
-    eventTypes: text("event_types").notNull(),
-    filter: text("filter"),
-    headers: text("headers"),
-    secretHash: text("secret_hash").notNull(),
+    // JSON columns use `mode: "json"` for parity with the PG/MySQL
+    // jsonb/json columns (same TEXT DDL on SQLite).
+    eventTypes: text("event_types", { mode: "json" }).notNull(),
+    filter: text("filter", { mode: "json" }),
+    headers: text("headers", { mode: "json" }),
+    secretHash: text("secret_hash", { mode: "json" }).notNull(),
     secretPrefix: text("secret_prefix").notNull(),
-    fieldAllowlist: text("field_allowlist"),
+    fieldAllowlist: text("field_allowlist", { mode: "json" }),
     createdBy: text("created_by").references(() => users.id, {
       onDelete: "set null",
     }),
@@ -83,7 +87,8 @@ export const nextlyWebhookDeliveries = sqliteTable(
     lastLatencyMs: integer("last_latency_ms"),
     lastError: text("last_error"),
     lastResponseSnippet: text("last_response_snippet"),
-    attempts: text("attempts"),
+    // JSON array of per-attempt records; `mode: "json"` matches PG/MySQL.
+    attempts: text("attempts", { mode: "json" }),
     createdAt: integer("created_at", { mode: "timestamp" })
       .notNull()
       .$defaultFn(() => new Date()),


### PR DESCRIPTION
## What

**P1a** of the webhooks program (design: `tasks/webhooks-design.md`, plan: `tasks/webhooks-implementation-plan.md`). This PR adds **only the data model** — the three per-dialect core system tables the durable-outbox webhook system is built on. No delivery behavior yet.

- **`nextly_events`** — the durable event ledger (outbox). One row per content event; `payload` (JSON) holds the full delivery envelope. `id` is the envelope id + idempotency key (primary key → unique on every dialect). This ledger is also the substrate the audit-log (roadmap item 7) and workflows (item 9) will reuse.
- **`nextly_webhooks`** — the outbound endpoint registry. Mirrors the api-keys security model: only a hashed secret + a display prefix are stored (`secret_hash` is a JSON list so zero-downtime rotation can be added later without a migration). Carries subscribed `event_types`, a structured `filter`, static `headers`, and a reserved `field_allowlist`.
- **`nextly_webhook_deliveries`** — the per-endpoint delivery ledger: `status`/`attempt_count`/`next_attempt_at` retry state, `locked_by`/`locked_until` lease columns for concurrent drain workers on the fallback dialects, and a JSON `attempts` log.

All three are registered in `getCoreSchema` + `CORE_TABLE_NAMES`, so the existing introspect-diff pipeline creates them on boot — no hand-written migration.

## Patterns followed
- Per-dialect files (`postgres`/`mysql`/`sqlite`) + a `webhookTables(dialect)` barrel, cloning `schemas/api-keys/*`.
- Postgres `jsonb` / MySQL `json` / SQLite `text` for JSON columns; MySQL `varchar(191)` ids; SQLite `integer` timestamp/boolean modes — matching the surrounding schema conventions.
- Real FK constraints (deliveries → webhooks/events cascade; webhooks.created_by → users set-null), like api-keys.

## Tests
- New `schemas/webhooks/__tests__/tables.test.ts`: all three tables present in `getCoreSchema` for all three dialects + in `CORE_TABLE_NAMES`; delivery ledger keeps its retry/lease columns; event ledger keeps its envelope columns. **6/6 green.**
- `check-types` clean; `public-api` + migrate (`core-reconcile`/`resolve`) suites that consume `getCoreSchema` still pass (27/27) — zero regression.

## Next in the program
P1b (event envelope + filter matching, pure) → P1c (transactional-outbox capture in the write path) → P1e (Standard-Webhooks signing + SSRF DNS-rebinding fix) → P1f (delivery engine + drain route) → P1g (reconcile the two existing half-built webhook impls). Admin UI + `after()`/cron triggers = P2; the in-app `revalidate` helper = P3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added webhook/event durable storage tables for PostgreSQL, MySQL, and SQLite (event envelopes, webhook configuration, and delivery-attempt tracking with retries and locking).
  * Extended the framework-managed core schema so these webhook subsystem tables are included for all supported dialects.
  * Updated the exported core table names to include `nextly_events`, `nextly_webhooks`, and `nextly_webhook_deliveries`, with transitional Postgres re-exports (`nextlyEvents`, `nextlyWebhooks`, `nextlyWebhookDeliveries`).

* **Tests**
  * Added schema tests covering required columns, indexes/uniqueness, and dialect-specific exports for webhook tables.
  * Updated upgrade-simulation golden expectations to allow the newly introduced “post-045” tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->