### PR TITLE
feat(nextly): webhook event envelope + filter matching

### DIFF
--- a/.changeset/webhook-envelope-filter.md
+++ b/.changeset/webhook-envelope-filter.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Add the webhook event envelope and filter-matching primitives.
+
+Pure, storage-agnostic building blocks for the webhook system: the versioned `WebhookEvent` envelope (with computed `changedFields` and mandatory sensitive-field stripping), the endpoint and filter-spec types, `buildEnvelope()` for assembling an envelope from a resource's current and prior state, and `matchesFilter()` for evaluating a per-webhook filter at fan-out time. No delivery behavior yet; these feed the outbox-capture and delivery slices.

--- a/packages/nextly/src/domains/webhooks/__tests__/envelope.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/envelope.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 
 import { buildEnvelope, type BuildEnvelopeInput } from "../envelope";
 
+// A fixed Date fixture so every timestamp assertion is deterministic.
 const base: BuildEnvelopeInput = {
   id: "evt_1",
   type: "entry.updated",
@@ -23,6 +24,7 @@ describe("buildEnvelope", () => {
     });
   });
 
+  // The envelope boundary owns time formatting: a Date in, an ISO string out.
   it("normalizes the Date timestamp to an ISO-8601 string", () => {
     const env = buildEnvelope({
       ...base,
@@ -96,6 +98,8 @@ describe("buildEnvelope", () => {
     expect(env.data).toEqual({ id: "p1", title: "World" });
   });
 
+  // Secrets can live inside groups/repeaters, so stripping must remove the
+  // named fields recursively before the payload is ever exposed.
   it("strips sensitive fields nested inside groups and arrays, at any depth", () => {
     const env = buildEnvelope({
       ...base,
@@ -114,6 +118,8 @@ describe("buildEnvelope", () => {
     });
   });
 
+  // Date instances have no enumerable keys, so the diff must compare them by
+  // value; otherwise a date-only change would be missed.
   it("detects a Date-only change and treats equal Dates as unchanged", () => {
     const changed = buildEnvelope({
       ...base,

--- a/packages/nextly/src/domains/webhooks/__tests__/envelope.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/envelope.test.ts
@@ -5,7 +5,7 @@ import { buildEnvelope, type BuildEnvelopeInput } from "../envelope";
 const base: BuildEnvelopeInput = {
   id: "evt_1",
   type: "entry.updated",
-  timestamp: "2026-07-18T00:00:00.000Z",
+  timestamp: new Date("2026-07-18T00:00:00.000Z"),
   resource: { kind: "entry", collection: "posts", id: "p1" },
   data: { id: "p1", title: "Hello", status: "published" },
 };
@@ -23,15 +23,12 @@ describe("buildEnvelope", () => {
     });
   });
 
-  it("normalizes a Date timestamp to ISO-8601 and passes a string through", () => {
-    const fromDate = buildEnvelope({
+  it("normalizes the Date timestamp to an ISO-8601 string", () => {
+    const env = buildEnvelope({
       ...base,
       timestamp: new Date("2026-07-18T12:34:56.000Z"),
     });
-    expect(fromDate.timestamp).toBe("2026-07-18T12:34:56.000Z");
-
-    const fromString = buildEnvelope({ ...base, timestamp: "not-parsed" });
-    expect(fromString.timestamp).toBe("not-parsed");
+    expect(env.timestamp).toBe("2026-07-18T12:34:56.000Z");
   });
 
   it("on create (no previous) reports previous=null and all keys changed", () => {
@@ -97,6 +94,40 @@ describe("buildEnvelope", () => {
     expect(env.data).not.toHaveProperty("password");
     expect(env.previous).not.toHaveProperty("password");
     expect(env.data).toEqual({ id: "p1", title: "World" });
+  });
+
+  it("strips sensitive fields nested inside groups and arrays, at any depth", () => {
+    const env = buildEnvelope({
+      ...base,
+      previous: null,
+      data: {
+        id: "p1",
+        profile: { name: "A", apiSecret: "s1" },
+        items: [{ label: "x", token: "t1" }],
+      },
+      sensitiveFields: ["apiSecret", "token"],
+    });
+    expect(env.data).toEqual({
+      id: "p1",
+      profile: { name: "A" },
+      items: [{ label: "x" }],
+    });
+  });
+
+  it("detects a Date-only change and treats equal Dates as unchanged", () => {
+    const changed = buildEnvelope({
+      ...base,
+      previous: { publishedAt: new Date("2026-01-01T00:00:00.000Z") },
+      data: { publishedAt: new Date("2026-02-01T00:00:00.000Z") },
+    });
+    expect(changed.changedFields).toEqual(["publishedAt"]);
+
+    const same = buildEnvelope({
+      ...base,
+      previous: { publishedAt: new Date("2026-01-01T00:00:00.000Z") },
+      data: { publishedAt: new Date("2026-01-01T00:00:00.000Z") },
+    });
+    expect(same.changedFields).toEqual([]);
   });
 
   it("strips before diffing, so a secret-only change never appears in changedFields", () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/envelope.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/envelope.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+
+import { buildEnvelope, type BuildEnvelopeInput } from "../envelope";
+
+const base: BuildEnvelopeInput = {
+  id: "evt_1",
+  type: "entry.updated",
+  timestamp: "2026-07-18T00:00:00.000Z",
+  resource: { kind: "entry", collection: "posts", id: "p1" },
+  data: { id: "p1", title: "Hello", status: "published" },
+};
+
+describe("buildEnvelope", () => {
+  it("stamps the fixed envelope shape", () => {
+    const env = buildEnvelope(base);
+    expect(env.specversion).toBe("1");
+    expect(env.id).toBe("evt_1");
+    expect(env.type).toBe("entry.updated");
+    expect(env.resource).toEqual({
+      kind: "entry",
+      collection: "posts",
+      id: "p1",
+    });
+  });
+
+  it("normalizes a Date timestamp to ISO-8601 and passes a string through", () => {
+    const fromDate = buildEnvelope({
+      ...base,
+      timestamp: new Date("2026-07-18T12:34:56.000Z"),
+    });
+    expect(fromDate.timestamp).toBe("2026-07-18T12:34:56.000Z");
+
+    const fromString = buildEnvelope({ ...base, timestamp: "not-parsed" });
+    expect(fromString.timestamp).toBe("not-parsed");
+  });
+
+  it("on create (no previous) reports previous=null and all keys changed", () => {
+    const env = buildEnvelope({
+      ...base,
+      type: "entry.created",
+      data: { id: "p1", title: "Hello", status: "draft" },
+      previous: null,
+    });
+    expect(env.previous).toBeNull();
+    expect(env.changedFields).toEqual(["id", "status", "title"]);
+  });
+
+  it("treats an undefined previous the same as create", () => {
+    const env = buildEnvelope({ ...base, previous: undefined });
+    expect(env.previous).toBeNull();
+    expect(env.changedFields).toEqual(["id", "status", "title"]);
+  });
+
+  it("computes changedFields as only the top-level keys that differ", () => {
+    const env = buildEnvelope({
+      ...base,
+      previous: { id: "p1", title: "Hello", status: "draft" },
+      data: { id: "p1", title: "Hello", status: "published" },
+    });
+    expect(env.changedFields).toEqual(["status"]);
+  });
+
+  it("registers a top-level key when a nested value or array changes", () => {
+    const env = buildEnvelope({
+      ...base,
+      previous: { seo: { title: "a" }, tags: ["x"] },
+      data: { seo: { title: "b" }, tags: ["x", "y"] },
+    });
+    expect(env.changedFields).toEqual(["seo", "tags"]);
+  });
+
+  it("counts a key present on only one side as changed", () => {
+    const env = buildEnvelope({
+      ...base,
+      previous: { id: "p1", removed: "gone" },
+      data: { id: "p1", added: "new" },
+    });
+    expect(env.changedFields).toEqual(["added", "removed"]);
+  });
+
+  it("does NOT flag a key whose nested object differs only in key order", () => {
+    const env = buildEnvelope({
+      ...base,
+      previous: { seo: { a: 1, b: 2 } },
+      data: { seo: { b: 2, a: 1 } },
+    });
+    expect(env.changedFields).toEqual([]);
+  });
+
+  it("strips sensitive fields from both data and previous", () => {
+    const env = buildEnvelope({
+      ...base,
+      previous: { id: "p1", password: "old-hash", title: "Hello" },
+      data: { id: "p1", password: "new-hash", title: "World" },
+      sensitiveFields: ["password"],
+    });
+    expect(env.data).not.toHaveProperty("password");
+    expect(env.previous).not.toHaveProperty("password");
+    expect(env.data).toEqual({ id: "p1", title: "World" });
+  });
+
+  it("strips before diffing, so a secret-only change never appears in changedFields", () => {
+    const env = buildEnvelope({
+      ...base,
+      previous: { id: "p1", apiSecret: "s1", title: "Hello" },
+      data: { id: "p1", apiSecret: "s2", title: "Hello" },
+      sensitiveFields: ["apiSecret"],
+    });
+    expect(env.changedFields).toEqual([]);
+  });
+
+  it("attaches site only when provided", () => {
+    expect(buildEnvelope(base).site).toBeUndefined();
+    expect(buildEnvelope({ ...base, site: "https://acme.com" }).site).toBe(
+      "https://acme.com"
+    );
+  });
+
+  it("attaches actor only when non-null", () => {
+    expect(buildEnvelope(base).actor).toBeUndefined();
+    expect(buildEnvelope({ ...base, actor: null }).actor).toBeUndefined();
+    expect(
+      buildEnvelope({ ...base, actor: { type: "user", id: "u1" } }).actor
+    ).toEqual({ type: "user", id: "u1" });
+  });
+
+  it("does not mutate the caller's data/previous objects", () => {
+    const data = { id: "p1", password: "x" };
+    const previous = { id: "p1", password: "y" };
+    buildEnvelope({ ...base, data, previous, sensitiveFields: ["password"] });
+    expect(data).toHaveProperty("password");
+    expect(previous).toHaveProperty("password");
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/filter.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/filter.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+
+import { matchesFilter } from "../filter";
+import type { FilterSpec, WebhookEvent } from "../types";
+
+function envelope(overrides: Partial<WebhookEvent> = {}): WebhookEvent {
+  return {
+    id: "evt_1",
+    type: "entry.updated",
+    specversion: "1",
+    timestamp: "2026-07-18T00:00:00.000Z",
+    resource: { kind: "entry", collection: "posts", id: "p1" },
+    data: { id: "p1" },
+    previous: null,
+    changedFields: ["status"],
+    ...overrides,
+  };
+}
+
+describe("matchesFilter", () => {
+  it("matches everything when the filter is null or undefined", () => {
+    expect(matchesFilter(null, envelope())).toBe(true);
+    expect(matchesFilter(undefined, envelope())).toBe(true);
+  });
+
+  it("fails closed on an unknown filter version", () => {
+    const v2 = {
+      version: 2,
+      type: "expression",
+      expr: "true",
+    } as FilterSpec;
+    expect(matchesFilter(v2, envelope())).toBe(false);
+  });
+
+  describe("eventTypes (OR)", () => {
+    it("matches when the envelope type is listed", () => {
+      const f: FilterSpec = {
+        version: 1,
+        eventTypes: ["entry.created", "entry.updated"],
+      };
+      expect(matchesFilter(f, envelope({ type: "entry.updated" }))).toBe(true);
+    });
+
+    it("rejects when the envelope type is not listed", () => {
+      const f: FilterSpec = { version: 1, eventTypes: ["entry.created"] };
+      expect(matchesFilter(f, envelope({ type: "entry.updated" }))).toBe(false);
+    });
+
+    it("treats an absent or empty eventTypes as any type", () => {
+      expect(matchesFilter({ version: 1 }, envelope())).toBe(true);
+      expect(matchesFilter({ version: 1, eventTypes: [] }, envelope())).toBe(
+        true
+      );
+    });
+  });
+
+  describe("collections", () => {
+    it("matches all collections when null or absent", () => {
+      expect(matchesFilter({ version: 1, collections: null }, envelope())).toBe(
+        true
+      );
+      expect(matchesFilter({ version: 1 }, envelope())).toBe(true);
+    });
+
+    it("matches only a listed collection", () => {
+      const f: FilterSpec = { version: 1, collections: ["posts", "pages"] };
+      expect(
+        matchesFilter(
+          f,
+          envelope({ resource: { kind: "entry", collection: "posts" } })
+        )
+      ).toBe(true);
+      expect(
+        matchesFilter(
+          f,
+          envelope({ resource: { kind: "entry", collection: "authors" } })
+        )
+      ).toBe(false);
+    });
+
+    it("rejects a collection filter when the envelope has no collection", () => {
+      const f: FilterSpec = { version: 1, collections: ["posts"] };
+      expect(matchesFilter(f, envelope({ resource: { kind: "single" } }))).toBe(
+        false
+      );
+    });
+  });
+
+  describe("changedFields", () => {
+    it("has no effect when null, absent, or empty", () => {
+      expect(
+        matchesFilter({ version: 1, changedFields: null }, envelope())
+      ).toBe(true);
+      expect(matchesFilter({ version: 1 }, envelope())).toBe(true);
+      expect(matchesFilter({ version: 1, changedFields: [] }, envelope())).toBe(
+        true
+      );
+    });
+
+    it("matches when any listed field changed", () => {
+      const f: FilterSpec = { version: 1, changedFields: ["status", "title"] };
+      expect(matchesFilter(f, envelope({ changedFields: ["status"] }))).toBe(
+        true
+      );
+    });
+
+    it("rejects when none of the listed fields changed", () => {
+      const f: FilterSpec = { version: 1, changedFields: ["status"] };
+      expect(matchesFilter(f, envelope({ changedFields: ["title"] }))).toBe(
+        false
+      );
+    });
+  });
+
+  it("requires every present constraint to hold (conjunction)", () => {
+    const f: FilterSpec = {
+      version: 1,
+      eventTypes: ["entry.updated"],
+      collections: ["posts"],
+      changedFields: ["status"],
+    };
+    // All three hold.
+    expect(
+      matchesFilter(
+        f,
+        envelope({
+          type: "entry.updated",
+          resource: { kind: "entry", collection: "posts" },
+          changedFields: ["status"],
+        })
+      )
+    ).toBe(true);
+    // Right type + collection, but the changed field misses.
+    expect(
+      matchesFilter(
+        f,
+        envelope({
+          type: "entry.updated",
+          resource: { kind: "entry", collection: "posts" },
+          changedFields: ["title"],
+        })
+      )
+    ).toBe(false);
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/filter.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/filter.test.ts
@@ -55,11 +55,15 @@ describe("matchesFilter", () => {
   });
 
   describe("collections", () => {
-    it("matches all collections when null or absent", () => {
+    it("matches all collections when null, absent, or empty", () => {
       expect(matchesFilter({ version: 1, collections: null }, envelope())).toBe(
         true
       );
       expect(matchesFilter({ version: 1 }, envelope())).toBe(true);
+      // An empty array means "no collection constraint", not "match nothing".
+      expect(matchesFilter({ version: 1, collections: [] }, envelope())).toBe(
+        true
+      );
     });
 
     it("matches only a listed collection", () => {

--- a/packages/nextly/src/domains/webhooks/envelope.ts
+++ b/packages/nextly/src/domains/webhooks/envelope.ts
@@ -118,9 +118,16 @@ export interface BuildEnvelopeInput {
   timestamp: Date;
   site?: string;
   resource: WebhookResource;
-  /** Current state of the resource. */
+  /**
+   * Current state of the resource as the DESERIALIZED document — group/repeater
+   * and other JSON container fields parsed back to objects/arrays, i.e. the
+   * shape the API returns, not the raw persisted row. Recursive secret
+   * stripping only reaches a nested field when it is a real object, so callers
+   * must pass the parsed document (the write paths already parse it for their
+   * response); a field still held as a JSON string would not be traversed.
+   */
   data: Record<string, unknown>;
-  /** Prior state on update/delete/status-change; null/undefined on create. */
+  /** Prior state on update/delete/status-change; null/undefined on create. Same deserialized-document requirement as `data`. */
   previous?: Record<string, unknown> | null;
   actor?: WebhookActor | null;
   /** Field names to strip from both `data` and `previous` before shipping. */

--- a/packages/nextly/src/domains/webhooks/envelope.ts
+++ b/packages/nextly/src/domains/webhooks/envelope.ts
@@ -27,6 +27,15 @@ function deepEqual(a: unknown, b: unknown): boolean {
   if (a === null || b === null) return false;
   if (typeof a !== "object" || typeof b !== "object") return false;
 
+  // Dates have no enumerable keys, so the object branch below would treat any
+  // two of them as equal; compare by instant instead. A date-only change must
+  // still register in changedFields.
+  if (a instanceof Date || b instanceof Date) {
+    return (
+      a instanceof Date && b instanceof Date && a.getTime() === b.getTime()
+    );
+  }
+
   const aIsArray = Array.isArray(a);
   const bIsArray = Array.isArray(b);
   if (aIsArray !== bIsArray) return false;
@@ -47,21 +56,37 @@ function deepEqual(a: unknown, b: unknown): boolean {
 }
 
 /**
- * Return a shallow copy of `doc` without the sensitive field names. A missing
- * field name is a no-op, so callers can pass a superset (e.g. every secret
- * field of the collection) safely.
+ * Recursively drop every key named in `denied` from a value, descending into
+ * nested objects and arrays (Nextly allows secret fields at any depth, e.g. a
+ * password inside a group or repeater). Dates are treated as leaves. Returns a
+ * fresh structure so the caller's objects are never mutated.
+ */
+function stripValue(value: unknown, denied: Set<string>): unknown {
+  if (Array.isArray(value)) {
+    return value.map(v => stripValue(v, denied));
+  }
+  if (value !== null && typeof value === "object" && !(value instanceof Date)) {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (denied.has(k)) continue;
+      out[k] = stripValue(v, denied);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Return a deep copy of `doc` without the sensitive field names, at any depth.
+ * A missing field name is a no-op, so callers can pass a superset (e.g. every
+ * secret field of the collection) safely.
  */
 function stripSensitive(
   doc: Record<string, unknown>,
   sensitiveFields: readonly string[]
 ): Record<string, unknown> {
   if (sensitiveFields.length === 0) return { ...doc };
-  const out: Record<string, unknown> = {};
-  const denied = new Set(sensitiveFields);
-  for (const [k, v] of Object.entries(doc)) {
-    if (!denied.has(k)) out[k] = v;
-  }
-  return out;
+  return stripValue(doc, new Set(sensitiveFields)) as Record<string, unknown>;
 }
 
 /**
@@ -89,8 +114,8 @@ export interface BuildEnvelopeInput {
   /** ULID; caller-generated so the envelope stays deterministic. */
   id: string;
   type: WebhookEventType;
-  /** Event time; a Date is normalized to ISO-8601, a string is passed through. */
-  timestamp: Date | string;
+  /** Event time as a Date; normalized to an ISO-8601 string on the envelope. */
+  timestamp: Date;
   site?: string;
   resource: WebhookResource;
   /** Current state of the resource. */
@@ -119,10 +144,7 @@ export function buildEnvelope(input: BuildEnvelopeInput): WebhookEvent {
     id: input.id,
     type: input.type,
     specversion: "1",
-    timestamp:
-      input.timestamp instanceof Date
-        ? input.timestamp.toISOString()
-        : input.timestamp,
+    timestamp: input.timestamp.toISOString(),
     resource: input.resource,
     data,
     previous,

--- a/packages/nextly/src/domains/webhooks/envelope.ts
+++ b/packages/nextly/src/domains/webhooks/envelope.ts
@@ -1,0 +1,138 @@
+/**
+ * Webhook domain — envelope construction (pure).
+ *
+ * `buildEnvelope` assembles the delivery envelope from a resource's current and
+ * prior state: it strips sensitive fields, computes the changed-field diff, and
+ * normalizes the timestamp. Deterministic (id + timestamp are passed in, never
+ * generated here) so it is trivially unit-testable and safe to call inside the
+ * write transaction.
+ *
+ * @module domains/webhooks/envelope
+ */
+
+import type {
+  WebhookActor,
+  WebhookEvent,
+  WebhookEventType,
+  WebhookResource,
+} from "./types";
+
+/**
+ * Structural deep-equal for JSON-serializable values (null, primitives,
+ * arrays, plain objects). Used to decide whether a top-level field's value
+ * actually changed. Key order is irrelevant; array order is significant.
+ */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+
+  const aIsArray = Array.isArray(a);
+  const bIsArray = Array.isArray(b);
+  if (aIsArray !== bIsArray) return false;
+
+  if (aIsArray && bIsArray) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+
+  const aObj = a as Record<string, unknown>;
+  const bObj = b as Record<string, unknown>;
+  const aKeys = Object.keys(aObj);
+  const bKeys = Object.keys(bObj);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every(
+    k => Object.hasOwn(bObj, k) && deepEqual(aObj[k], bObj[k])
+  );
+}
+
+/**
+ * Return a shallow copy of `doc` without the sensitive field names. A missing
+ * field name is a no-op, so callers can pass a superset (e.g. every secret
+ * field of the collection) safely.
+ */
+function stripSensitive(
+  doc: Record<string, unknown>,
+  sensitiveFields: readonly string[]
+): Record<string, unknown> {
+  if (sensitiveFields.length === 0) return { ...doc };
+  const out: Record<string, unknown> = {};
+  const denied = new Set(sensitiveFields);
+  for (const [k, v] of Object.entries(doc)) {
+    if (!denied.has(k)) out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Top-level keys whose value differs between `previous` and `next`. A key
+ * present in only one side counts as changed. Returned sorted for stable,
+ * comparable output. On create (`previous` null) every present key is
+ * considered changed, so a changed-field filter still matches a create that
+ * sets the field.
+ */
+function computeChangedFields(
+  previous: Record<string, unknown> | null,
+  next: Record<string, unknown>
+): string[] {
+  if (previous === null) return Object.keys(next).sort();
+  const keys = new Set([...Object.keys(previous), ...Object.keys(next)]);
+  const changed: string[] = [];
+  for (const k of keys) {
+    if (!deepEqual(previous[k], next[k])) changed.push(k);
+  }
+  return changed.sort();
+}
+
+/** Input to {@link buildEnvelope}. All identity/time values are caller-supplied. */
+export interface BuildEnvelopeInput {
+  /** ULID; caller-generated so the envelope stays deterministic. */
+  id: string;
+  type: WebhookEventType;
+  /** Event time; a Date is normalized to ISO-8601, a string is passed through. */
+  timestamp: Date | string;
+  site?: string;
+  resource: WebhookResource;
+  /** Current state of the resource. */
+  data: Record<string, unknown>;
+  /** Prior state on update/delete/status-change; null/undefined on create. */
+  previous?: Record<string, unknown> | null;
+  actor?: WebhookActor | null;
+  /** Field names to strip from both `data` and `previous` before shipping. */
+  sensitiveFields?: readonly string[];
+}
+
+/**
+ * Build a delivery envelope. Sensitive fields are stripped from both `data` and
+ * `previous` first, so `changedFields` is computed over the sanitized documents
+ * and a stripped field never leaks (not even as a name).
+ */
+export function buildEnvelope(input: BuildEnvelopeInput): WebhookEvent {
+  const sensitiveFields = input.sensitiveFields ?? [];
+  const data = stripSensitive(input.data, sensitiveFields);
+  const previous =
+    input.previous == null
+      ? null
+      : stripSensitive(input.previous, sensitiveFields);
+
+  const envelope: WebhookEvent = {
+    id: input.id,
+    type: input.type,
+    specversion: "1",
+    timestamp:
+      input.timestamp instanceof Date
+        ? input.timestamp.toISOString()
+        : input.timestamp,
+    resource: input.resource,
+    data,
+    previous,
+    changedFields: computeChangedFields(previous, data),
+  };
+
+  // Only attach optional identity fields when present, so the serialized
+  // payload stays clean (no `site: undefined` / `actor: null`).
+  if (input.site !== undefined) envelope.site = input.site;
+  if (input.actor != null) envelope.actor = input.actor;
+
+  return envelope;
+}

--- a/packages/nextly/src/domains/webhooks/filter.ts
+++ b/packages/nextly/src/domains/webhooks/filter.ts
@@ -1,0 +1,57 @@
+/**
+ * Webhook domain — filter matching (pure).
+ *
+ * `matchesFilter` decides whether one endpoint's filter accepts one envelope.
+ * Run at fan-out time for every (envelope, endpoint) pair, so it stays a small
+ * allocation-free predicate.
+ *
+ * @module domains/webhooks/filter
+ */
+
+import type { FilterSpec, WebhookEvent } from "./types";
+
+/**
+ * Whether `filter` accepts `envelope`.
+ *
+ * A null/undefined filter matches everything (the endpoint's subscribed event
+ * types are enforced separately at fan-out). For the v1 spec, all present
+ * constraints must hold (a conjunction):
+ * - `eventTypes`: OR across the listed types; absent/empty = any type.
+ * - `collections`: envelope's collection must be listed; null/absent = all.
+ * - `changedFields`: at least one listed field must appear in the envelope's
+ *   `changedFields`; null/absent = no constraint.
+ *
+ * An unknown/unsupported filter version fails closed (returns false): we never
+ * deliver against a filter we cannot evaluate.
+ */
+export function matchesFilter(
+  filter: FilterSpec | null | undefined,
+  envelope: WebhookEvent
+): boolean {
+  if (filter == null) return true;
+  if (filter.version !== 1) return false;
+
+  const { eventTypes, collections, changedFields } = filter;
+
+  if (
+    eventTypes != null &&
+    eventTypes.length > 0 &&
+    !eventTypes.includes(envelope.type)
+  ) {
+    return false;
+  }
+
+  if (collections != null) {
+    const collection = envelope.resource.collection;
+    if (collection === undefined || !collections.includes(collection)) {
+      return false;
+    }
+  }
+
+  if (changedFields != null && changedFields.length > 0) {
+    const changed = new Set(envelope.changedFields);
+    if (!changedFields.some(f => changed.has(f))) return false;
+  }
+
+  return true;
+}

--- a/packages/nextly/src/domains/webhooks/filter.ts
+++ b/packages/nextly/src/domains/webhooks/filter.ts
@@ -41,7 +41,7 @@ export function matchesFilter(
     return false;
   }
 
-  if (collections != null) {
+  if (collections != null && collections.length > 0) {
     const collection = envelope.resource.collection;
     if (collection === undefined || !collections.includes(collection)) {
       return false;

--- a/packages/nextly/src/domains/webhooks/index.ts
+++ b/packages/nextly/src/domains/webhooks/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Webhook domain — public barrel.
+ *
+ * Pure envelope + filter primitives shared by the capture and delivery slices.
+ *
+ * @module domains/webhooks
+ */
+
+export { buildEnvelope, type BuildEnvelopeInput } from "./envelope";
+export { matchesFilter } from "./filter";
+export {
+  WEBHOOK_EVENT_TYPES,
+  type WebhookEventType,
+  type WebhookResourceKind,
+  type WebhookActorType,
+  type WebhookResource,
+  type WebhookActor,
+  type WebhookEvent,
+  type DeliveryStatus,
+  type FilterSpec,
+  type FilterSpecV1,
+  type FilterSpecExpression,
+  type WebhookEndpoint,
+} from "./types";

--- a/packages/nextly/src/domains/webhooks/types.ts
+++ b/packages/nextly/src/domains/webhooks/types.ts
@@ -54,13 +54,18 @@ export type WebhookResourceKind =
 /** What triggered an event; feeds the audit trail. */
 export type WebhookActorType = "user" | "apiKey" | "system";
 
-/** The resource an event is about. `collection` is omitted for non-entry kinds. */
-export interface WebhookResource {
-  kind: WebhookResourceKind;
-  /** Collection slug; present for entries, omitted for singles/media/user. */
-  collection?: string;
-  id?: string;
-}
+/**
+ * The resource an event is about. Modeled as a discriminated union so the
+ * collection invariant is enforced by the type system: an `entry` always
+ * carries its collection slug, and every other kind forbids one.
+ */
+export type WebhookResource =
+  | { kind: "entry"; collection: string; id?: string }
+  | {
+      kind: "single" | "media" | "user" | "form";
+      collection?: never;
+      id?: string;
+    };
 
 /** Who triggered the event. */
 export interface WebhookActor {
@@ -128,8 +133,9 @@ export type FilterSpec = FilterSpecV1 | FilterSpecExpression;
 
 /**
  * The outbound endpoint registry shape (mirrors `nextly_webhooks`). Secrets are
- * never held raw: `secretHashes` is the list of active-secret hashes (list for
- * zero-downtime rotation) and `secretPrefix` is a display-only prefix.
+ * never held raw: `secretHash` is the list of active-secret hashes (a list for
+ * zero-downtime rotation) and `secretPrefix` is a display-only prefix. The
+ * property name matches the Drizzle column so a hydrated row maps directly.
  */
 export interface WebhookEndpoint {
   id: string;
@@ -142,7 +148,8 @@ export interface WebhookEndpoint {
   filter: FilterSpec | null;
   /** Static request headers merged into every delivery. */
   headers: Record<string, string> | null;
-  secretHashes: string[];
+  /** List of active signing-secret hashes (list-shaped for rotation). */
+  secretHash: string[];
   secretPrefix: string;
   /** Reserved per-endpoint field projection; not applied yet. */
   fieldAllowlist: string[] | null;

--- a/packages/nextly/src/domains/webhooks/types.ts
+++ b/packages/nextly/src/domains/webhooks/types.ts
@@ -1,0 +1,152 @@
+/**
+ * Webhook domain — pure types.
+ *
+ * The public delivery contract for the durable-outbox webhook system: the
+ * event envelope that ships to endpoints, the endpoint registry shape, and the
+ * structured filter spec. These are storage-agnostic; the per-dialect Drizzle
+ * tables (`schemas/webhooks/*`) persist them, and the delivery engine (later
+ * slices) reads them back. No I/O lives here.
+ *
+ * @module domains/webhooks/types
+ */
+
+/**
+ * Canonical webhook event types, grouped by resource. Stable string ids; the
+ * envelope's `specversion` (not renames) carries breaking changes. A webhook
+ * subscribes to a set of these. Distinct from the internal event-bus names
+ * (`document.*`, `collection.<slug>.*`); the bus -> webhook-type mapping is
+ * wired in the capture slice.
+ */
+export const WEBHOOK_EVENT_TYPES = [
+  // Entries (per collection).
+  "entry.created",
+  "entry.updated",
+  "entry.deleted",
+  "entry.published",
+  "entry.unpublished",
+  "entry.status_changed",
+  // Singles.
+  "single.updated",
+  "single.published",
+  "single.unpublished",
+  // Media.
+  "media.uploaded",
+  "media.updated",
+  "media.deleted",
+  // Users (opt-in, sensitive; never carries password fields).
+  "user.created",
+  "user.deleted",
+  // Forms (via plugin-form-builder).
+  "form.submission.created",
+] as const;
+
+/** A canonical webhook event type. */
+export type WebhookEventType = (typeof WEBHOOK_EVENT_TYPES)[number];
+
+/** Resource families an event can be about. */
+export type WebhookResourceKind =
+  | "entry"
+  | "single"
+  | "media"
+  | "user"
+  | "form";
+
+/** What triggered an event; feeds the audit trail. */
+export type WebhookActorType = "user" | "apiKey" | "system";
+
+/** The resource an event is about. `collection` is omitted for non-entry kinds. */
+export interface WebhookResource {
+  kind: WebhookResourceKind;
+  /** Collection slug; present for entries, omitted for singles/media/user. */
+  collection?: string;
+  id?: string;
+}
+
+/** Who triggered the event. */
+export interface WebhookActor {
+  type: WebhookActorType;
+  id?: string;
+}
+
+/**
+ * The event envelope delivered to endpoints. One shape for every event: thin
+ * identity plus a full `data` section so any current or future filter/consumer
+ * has what it needs. Modeled on Standard Webhooks / CloudEvents.
+ */
+export interface WebhookEvent {
+  /** ULID; stable across retries; doubles as the idempotency / webhook-id key. */
+  id: string;
+  type: WebhookEventType;
+  /** Envelope schema version; bumped only on a breaking envelope change. */
+  specversion: "1";
+  /** Event time (not delivery time), ISO-8601. */
+  timestamp: string;
+  /** Origin site (from config), for multi-endpoint disambiguation. */
+  site?: string;
+  resource: WebhookResource;
+  /** Current state, with access-denied/secret fields already stripped. */
+  data: Record<string, unknown>;
+  /** Prior state on update/delete/status-change; null on create. */
+  previous: Record<string, unknown> | null;
+  /** Top-level keys whose value changed; drives changed-field filtering. */
+  changedFields: string[];
+  actor?: WebhookActor;
+}
+
+/** Lifecycle of one delivery row in the outbox ledger. */
+export type DeliveryStatus =
+  | "pending"
+  | "processing"
+  | "delivered"
+  | "retrying"
+  | "failed";
+
+/**
+ * Structured, extensible per-webhook filter. v1 is a plain conjunction of
+ * optional constraints; a future expression filter is an additive
+ * discriminated member on the same `version` column, so v1 -> v2 needs no
+ * migration. Evaluated by the pure `matchesFilter`.
+ */
+export interface FilterSpecV1 {
+  version: 1;
+  /** OR across types; absent/empty = every subscribed type matches. */
+  eventTypes?: WebhookEventType[];
+  /** null/absent = all collections. */
+  collections?: string[] | null;
+  /** Fire only if any listed field changed; null/absent = no constraint. */
+  changedFields?: string[] | null;
+}
+
+/** Reserved for the future expression filter (not yet evaluated). */
+export interface FilterSpecExpression {
+  version: 2;
+  type: "expression";
+  expr: string;
+}
+
+export type FilterSpec = FilterSpecV1 | FilterSpecExpression;
+
+/**
+ * The outbound endpoint registry shape (mirrors `nextly_webhooks`). Secrets are
+ * never held raw: `secretHashes` is the list of active-secret hashes (list for
+ * zero-downtime rotation) and `secretPrefix` is a display-only prefix.
+ */
+export interface WebhookEndpoint {
+  id: string;
+  name: string;
+  url: string;
+  enabled: boolean;
+  /** Subscribed event types. */
+  eventTypes: WebhookEventType[];
+  /** Structured filter, or null for "match every subscribed type". */
+  filter: FilterSpec | null;
+  /** Static request headers merged into every delivery. */
+  headers: Record<string, string> | null;
+  secretHashes: string[];
+  secretPrefix: string;
+  /** Reserved per-endpoint field projection; not applied yet. */
+  fieldAllowlist: string[] | null;
+  createdBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}


### PR DESCRIPTION
## What

P1b of the webhooks program (roadmap item 6): the pure, storage-agnostic building blocks the capture and delivery slices will call. No I/O, no delivery behavior yet.

New `packages/nextly/src/domains/webhooks/`:
- **`types.ts`** — the versioned `WebhookEvent` envelope, `WebhookResource`/`WebhookActor`, the `WEBHOOK_EVENT_TYPES` catalog + `WebhookEventType` union, `FilterSpec` (v1 conjunction + reserved v2 expression member), `WebhookEndpoint` (mirrors `nextly_webhooks`), and `DeliveryStatus`.
- **`envelope.ts`** — `buildEnvelope()`: strips sensitive fields from `data` **and** `previous`, computes `changedFields` over the sanitized docs (so a secret-only change never leaks, not even as a name), normalizes the timestamp, and attaches `site`/`actor` only when present. Deterministic: id + timestamp are passed in, never generated here.
- **`filter.ts`** — `matchesFilter()`: null filter = match-all; v1 conjunction of eventTypes (OR) + collections (null = all) + changedFields (any-listed-changed); unknown version **fails closed**.

## Design decisions honored

- Envelope shape, taxonomy, and filter-spec follow `tasks/webhooks-design.md` §2/§3/§5.
- Field-stripping is caller-driven: `buildEnvelope` takes an explicit `sensitiveFields` list, so the pure function stays testable and the "which fields are secret/hidden" wiring (field-config flags) lands with the capture slice that has the collection config.
- `v1 -> v2` filter is additive (same `version` column), so no migration when the expression filter ships.

## Tests

25 pure unit tests (`envelope.test.ts` 13, `filter.test.ts` 12): changedFields diff (create/update/nested/array/added-removed/key-order), sensitive stripping + strip-before-diff, no caller mutation, timestamp normalization, and every filter branch incl. fail-closed and conjunction. Fast, no baseline risk.

## Notes

- Pure functions only — no dispatcher, DB, or event-bus wiring (that is P1c capture).
- `check-types`, `eslint`, and the 25 unit tests pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic webhook event envelope building with standardized identity metadata, ISO-8601 timestamp normalization, resource/actor/site binding, and conditional optional fields.
  * Implemented change detection that redacts sensitive fields and computes top-level `changedFields`, handling nested differences correctly.
  * Added webhook filtering via event types, collection constraints, and changed-field requirements, plus published webhook domain types through a public barrel API.
* **Tests**
  * Added comprehensive test suites covering envelope construction and filter-matching semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->