### PR TITLE
fix(nextly): fall back for empty slugs and re-sanitize hook-set slugs

### DIFF
--- a/.changeset/slug-empty-generation-fallback.md
+++ b/.changeset/slug-empty-generation-fallback.md
@@ -1,0 +1,20 @@
+---
+"nextly": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"create-nextly-app": patch
+---
+
+Populate a valid `slug` when a title has no URL-safe characters, and re-sanitize hook-set slugs.
+
+Creating an entry whose title is entirely non-ASCII, emoji, or punctuation (for example `create({ data: { title: "你好世界" } })`) previously produced an empty slug and failed required-field validation, because slug derivation stripped every character. It now falls back to a unique generated token so the required, unique `slug` column stays populated. Additionally, a slug set by a field-level `beforeValidate` hook is re-sanitized before validation and storage, so hook-provided values stay URL-safe.

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -391,14 +391,16 @@ export class CollectionMutationService extends BaseService {
       typeof finalData.slug === "string" && finalData.slug.trim() !== "";
     if (provided) {
       // Explicit slug: sanitize only, never dedupe — respect the caller's value.
-      finalData.slug = generateSlug(finalData.slug as string);
+      const sanitized = generateSlug(finalData.slug as string);
+      // generateSlug strips everything outside [\w-], so an explicit slug of
+      // only non-ASCII/punctuation (e.g. "你好") sanitizes to empty. Treat that
+      // as unset and derive a valid, unique slug instead of persisting "".
+      finalData.slug =
+        sanitized !== ""
+          ? sanitized
+          : await this.deriveSlug(finalData, isSlugTaken);
     } else {
-      const titleValue = finalData.title ?? finalData.name ?? "";
-      const baseSlug =
-        typeof titleValue === "string" && titleValue.trim()
-          ? generateSlug(titleValue)
-          : `entry-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
-      finalData.slug = await this.dedupeSlug(baseSlug, isSlugTaken);
+      finalData.slug = await this.deriveSlug(finalData, isSlugTaken);
     }
 
     // The `title` column is NOT NULL: fall back to the name, then the slug.
@@ -408,6 +410,45 @@ export class CollectionMutationService extends BaseService {
         typeof nameValue === "string" && nameValue.trim()
           ? nameValue.trim()
           : finalData.slug;
+    }
+  }
+
+  /**
+   * Derive a unique slug from the title (or name), falling back to a
+   * collision-proof token. `generateSlug` strips everything outside [\w-], so a
+   * CJK/emoji/punctuation-only title (or a missing one) yields an empty base;
+   * the `entry-<ts>-<rand>` fallback keeps the required, unique `slug` column
+   * populated instead of failing required-field validation.
+   */
+  private async deriveSlug(
+    finalData: Record<string, unknown>,
+    isSlugTaken: (slug: string) => Promise<boolean>
+  ): Promise<string> {
+    const titleValue = finalData.title ?? finalData.name ?? "";
+    const derived =
+      typeof titleValue === "string" && titleValue.trim()
+        ? generateSlug(titleValue)
+        : "";
+    const baseSlug =
+      derived !== ""
+        ? derived
+        : `entry-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
+    return this.dedupeSlug(baseSlug, isSlugTaken);
+  }
+
+  /**
+   * Re-sanitize `slug` after field-level beforeValidate hooks run. Those hooks
+   * execute after slug generation, so a hook that sets `slug` (for example from
+   * the title) could introduce an unsanitized value that would otherwise be
+   * validated and stored verbatim. Normalizing here keeps the stored slug
+   * URL-safe; it is idempotent for an already-clean slug and only overwrites
+   * when sanitization yields a non-empty value, so a hook that clears the slug
+   * still surfaces as the normal required-field validation error.
+   */
+  private reSanitizeSlug(finalData: Record<string, unknown>): void {
+    if (typeof finalData.slug === "string" && finalData.slug.trim() !== "") {
+      const sanitized = generateSlug(finalData.slug);
+      if (sanitized !== "") finalData.slug = sanitized;
     }
   }
 
@@ -593,6 +634,10 @@ export class CollectionMutationService extends BaseService {
         operation: "create",
         user: params.user,
       });
+
+      // A beforeValidate hook can set `slug` after generation ran; re-sanitize
+      // so the validated and stored value stays URL-safe.
+      this.reSanitizeSlug(finalData);
 
       {
         const validationIssues = await validateEntryData(
@@ -1964,6 +2009,10 @@ export class CollectionMutationService extends BaseService {
         user: params.user,
       });
 
+      // A beforeValidate hook can set `slug` after generation ran; re-sanitize
+      // so the validated and stored value stays URL-safe.
+      this.reSanitizeSlug(finalData);
+
       {
         const validationIssues = await validateEntryData(
           finalData,
@@ -2823,6 +2872,10 @@ export class CollectionMutationService extends BaseService {
           user: params.user,
         });
       }
+
+      // A beforeValidate hook can set `slug` after generation ran; re-sanitize
+      // so the validated and stored value stays URL-safe.
+      this.reSanitizeSlug(finalData);
 
       {
         const validationIssues = await validateEntryData(

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -441,14 +441,22 @@ export class CollectionMutationService extends BaseService {
    * execute after slug generation, so a hook that sets `slug` (for example from
    * the title) could introduce an unsanitized value that would otherwise be
    * validated and stored verbatim. Normalizing here keeps the stored slug
-   * URL-safe; it is idempotent for an already-clean slug and only overwrites
-   * when sanitization yields a non-empty value, so a hook that clears the slug
-   * still surfaces as the normal required-field validation error.
+   * URL-safe; it is idempotent for an already-clean slug. When the hook value
+   * sanitizes to empty (a CJK/emoji/punctuation-only string), it derives a
+   * valid slug from the title just like `applyGeneratedSlugAndTitle` does for
+   * an explicit slug that sanitizes away, rather than leaving the un-sanitized
+   * value to be stored verbatim.
    */
-  private reSanitizeSlug(finalData: Record<string, unknown>): void {
+  private async reSanitizeSlug(
+    finalData: Record<string, unknown>,
+    isSlugTaken: (slug: string) => Promise<boolean>
+  ): Promise<void> {
     if (typeof finalData.slug === "string" && finalData.slug.trim() !== "") {
       const sanitized = generateSlug(finalData.slug);
-      if (sanitized !== "") finalData.slug = sanitized;
+      finalData.slug =
+        sanitized !== ""
+          ? sanitized
+          : await this.deriveSlug(finalData, isSlugTaken);
     }
   }
 
@@ -609,9 +617,9 @@ export class CollectionMutationService extends BaseService {
       // without a manual slug. Running before write access means a field the
       // caller may not create is not reintroduced; the uniqueness check uses
       // the shared connection (a plain, non-transactional create).
-      await this.applyGeneratedSlugAndTitle(finalData, slug =>
-        this.checkFieldUniqueness(params.collectionName, "slug", slug)
-      );
+      const isSlugTaken = (slug: string) =>
+        this.checkFieldUniqueness(params.collectionName, "slug", slug);
+      await this.applyGeneratedSlugAndTitle(finalData, isSlugTaken);
 
       // Field-level access: fields the caller may not create are stripped
       // silently (Payload parity); overrideAccess bypasses.
@@ -637,7 +645,7 @@ export class CollectionMutationService extends BaseService {
 
       // A beforeValidate hook can set `slug` after generation ran; re-sanitize
       // so the validated and stored value stays URL-safe.
-      this.reSanitizeSlug(finalData);
+      await this.reSanitizeSlug(finalData, isSlugTaken);
 
       {
         const validationIssues = await validateEntryData(
@@ -663,6 +671,10 @@ export class CollectionMutationService extends BaseService {
         operation: "create",
         user: params.user,
       });
+
+      // A beforeChange hook runs after validation and can also set `slug`;
+      // re-sanitize once more so the stored value stays URL-safe.
+      await this.reSanitizeSlug(finalData, isSlugTaken);
 
       await hashPasswordFieldValues(finalData, fields);
 
@@ -1976,7 +1988,7 @@ export class CollectionMutationService extends BaseService {
       // validation (see createEntry). The uniqueness check runs on the
       // transaction so same-title creates within one uncommitted tx still
       // dedupe — the tx sees its own pending rows.
-      await this.applyGeneratedSlugAndTitle(finalData, async slug => {
+      const isSlugTaken = async (slug: string) => {
         const existing = await tx.selectOne<Record<string, unknown>>(
           tableName,
           {
@@ -1984,7 +1996,8 @@ export class CollectionMutationService extends BaseService {
           }
         );
         return existing != null;
-      });
+      };
+      await this.applyGeneratedSlugAndTitle(finalData, isSlugTaken);
 
       // Field-level write access: fields the caller may not create are
       // stripped (Payload parity); a system write (no user) or an
@@ -2011,7 +2024,7 @@ export class CollectionMutationService extends BaseService {
 
       // A beforeValidate hook can set `slug` after generation ran; re-sanitize
       // so the validated and stored value stays URL-safe.
-      this.reSanitizeSlug(finalData);
+      await this.reSanitizeSlug(finalData, isSlugTaken);
 
       {
         const validationIssues = await validateEntryData(
@@ -2037,6 +2050,10 @@ export class CollectionMutationService extends BaseService {
         operation: "create",
         user: params.user,
       });
+
+      // A beforeChange hook runs after validation and can also set `slug`;
+      // re-sanitize once more so the stored value stays URL-safe.
+      await this.reSanitizeSlug(finalData, isSlugTaken);
 
       await hashPasswordFieldValues(finalData, fields);
 
@@ -2838,7 +2855,7 @@ export class CollectionMutationService extends BaseService {
       // entry that omits slug/title must still receive them. The uniqueness
       // check runs on the transaction so entries created earlier in the same
       // bulk batch are seen.
-      await this.applyGeneratedSlugAndTitle(finalData, async slug => {
+      const isSlugTaken = async (slug: string) => {
         const existing = await tx.selectOne<Record<string, unknown>>(
           tableName,
           {
@@ -2846,7 +2863,8 @@ export class CollectionMutationService extends BaseService {
           }
         );
         return existing != null;
-      });
+      };
+      await this.applyGeneratedSlugAndTitle(finalData, isSlugTaken);
 
       // Field-level write access: fields the caller may not create are
       // stripped (Payload parity); a system write (no user) or an
@@ -2861,7 +2879,10 @@ export class CollectionMutationService extends BaseService {
       });
 
       // Field-level beforeValidate hooks transform values ahead of the
-      // validation gate (functions resolved via the field-level registry).
+      // validation gate (functions resolved via the field-level registry). A
+      // hook can set `slug`, so re-sanitize after it so the validated and
+      // stored value stays URL-safe. When hooks are skipped the slug is still
+      // the (already-sanitized) generated value, so no pass is needed.
       if (!skipHooks) {
         await runFieldHooks({
           kind: "collection",
@@ -2871,11 +2892,8 @@ export class CollectionMutationService extends BaseService {
           operation: "create",
           user: params.user,
         });
+        await this.reSanitizeSlug(finalData, isSlugTaken);
       }
-
-      // A beforeValidate hook can set `slug` after generation ran; re-sanitize
-      // so the validated and stored value stays URL-safe.
-      this.reSanitizeSlug(finalData);
 
       {
         const validationIssues = await validateEntryData(
@@ -2892,7 +2910,8 @@ export class CollectionMutationService extends BaseService {
       }
 
       // Field-level beforeChange hooks transform the final stored value
-      // (runs after validation, before hashing/serialization).
+      // (runs after validation, before hashing/serialization). This hook can
+      // also set `slug`, so re-sanitize once more before storage.
       if (!skipHooks) {
         await runFieldHooks({
           kind: "collection",
@@ -2902,6 +2921,7 @@ export class CollectionMutationService extends BaseService {
           operation: "create",
           user: params.user,
         });
+        await this.reSanitizeSlug(finalData, isSlugTaken);
       }
 
       await hashPasswordFieldValues(finalData, fields);

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -451,13 +451,16 @@ export class CollectionMutationService extends BaseService {
     finalData: Record<string, unknown>,
     isSlugTaken: (slug: string) => Promise<boolean>
   ): Promise<void> {
-    if (typeof finalData.slug === "string" && finalData.slug.trim() !== "") {
-      const sanitized = generateSlug(finalData.slug);
-      finalData.slug =
-        sanitized !== ""
-          ? sanitized
-          : await this.deriveSlug(finalData, isSlugTaken);
-    }
+    if (typeof finalData.slug !== "string") return;
+    // A blank/whitespace slug and a non-URL-safe one both sanitize to "".
+    // Either way derive a valid slug rather than leaving an empty or
+    // un-sanitized value: the post-beforeChange call runs after validation, so
+    // nothing downstream catches a blank slug the hook may have set.
+    const sanitized = generateSlug(finalData.slug);
+    finalData.slug =
+      sanitized !== ""
+        ? sanitized
+        : await this.deriveSlug(finalData, isSlugTaken);
   }
 
   /**

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -451,12 +451,13 @@ export class CollectionMutationService extends BaseService {
     finalData: Record<string, unknown>,
     isSlugTaken: (slug: string) => Promise<boolean>
   ): Promise<void> {
-    if (typeof finalData.slug !== "string") return;
-    // A blank/whitespace slug and a non-URL-safe one both sanitize to "".
-    // Either way derive a valid slug rather than leaving an empty or
-    // un-sanitized value: the post-beforeChange call runs after validation, so
-    // nothing downstream catches a blank slug the hook may have set.
-    const sanitized = generateSlug(finalData.slug);
+    // `applyGeneratedSlugAndTitle` always sets a string slug before hooks run,
+    // so any blank, non-URL-safe, or non-string value here means a hook set it.
+    // All of those sanitize to "" (a non-string yields ""), and each is derived
+    // back to a valid slug: the post-beforeChange call runs after validation,
+    // so nothing downstream catches an empty or invalid slug a hook may leave.
+    const current = finalData.slug;
+    const sanitized = typeof current === "string" ? generateSlug(current) : "";
     finalData.slug =
       sanitized !== ""
         ? sanitized

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -451,11 +451,19 @@ export class CollectionMutationService extends BaseService {
     finalData: Record<string, unknown>,
     isSlugTaken: (slug: string) => Promise<boolean>
   ): Promise<void> {
-    // `applyGeneratedSlugAndTitle` always sets a string slug before hooks run,
-    // so any blank, non-URL-safe, or non-string value here means a hook set it.
-    // All of those sanitize to "" (a non-string yields ""), and each is derived
-    // back to a valid slug: the post-beforeChange call runs after validation,
-    // so nothing downstream catches an empty or invalid slug a hook may leave.
+    // Respect an ABSENT slug. Field-level write access deletes the key when it
+    // denies the write, so `undefined` means "stripped by access" (or never
+    // set): leave it so access control holds and required validation applies —
+    // deriving would smuggle a slug back past access. Slug generation for a
+    // create with no user-supplied slug already ran in applyGeneratedSlugAndTitle
+    // (before write access), so a legitimately-absent-here slug is intentional.
+    if (finalData.slug === undefined) return;
+    // The field is PRESENT (a user provided it and passed access, or a hook set
+    // it). Normalize a string; a non-string or empty/non-URL-safe value (e.g.
+    // "你好", "   ", null) sanitizes to "" and is derived from the title rather
+    // than persisting an invalid slug — required validation permits empty
+    // strings, so it would not catch it, and this mirrors the empty fallback in
+    // applyGeneratedSlugAndTitle.
     const current = finalData.slug;
     const sanitized = typeof current === "string" ? generateSlug(current) : "";
     finalData.slug =

--- a/packages/nextly/src/plugins/__tests__/slug-autogen.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/slug-autogen.integration.test.ts
@@ -183,4 +183,28 @@ describe("slug auto-generation on create", () => {
 
     expect((created.item as { slug?: string }).slug).toBe("changed-by-hook");
   });
+
+  it("derives a slug when a beforeChange hook blanks it", async () => {
+    const posts = defineCollection({
+      slug: "posts",
+      fields: [
+        text({ name: "title" }),
+        text({
+          name: "slug",
+          unique: true,
+          // A beforeChange hook that clears the slug runs after validation, so
+          // nothing else catches the blank value — it must be re-derived.
+          hooks: { beforeChange: [() => "   "] },
+        }),
+      ],
+    });
+    current = await createTestNextly({ collections: [posts] });
+
+    const created = await current.nextly.create({
+      collection: "posts",
+      data: { title: "Fallback Title" },
+    });
+
+    expect((created.item as { slug?: string }).slug).toBe("fallback-title");
+  });
 });

--- a/packages/nextly/src/plugins/__tests__/slug-autogen.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/slug-autogen.integration.test.ts
@@ -134,4 +134,53 @@ describe("slug auto-generation on create", () => {
 
     expect((created.item as { slug?: string }).slug).toBe("hooked-slug-value");
   });
+
+  it("does not store a beforeValidate hook slug that sanitizes to empty", async () => {
+    const posts = defineCollection({
+      slug: "posts",
+      fields: [
+        text({ name: "title" }),
+        text({
+          name: "slug",
+          unique: true,
+          // A hook returning a CJK/emoji-only value sanitizes to "". It must be
+          // replaced with a derived slug, never stored verbatim.
+          hooks: { beforeValidate: [() => "你好世界"] },
+        }),
+      ],
+    });
+    current = await createTestNextly({ collections: [posts] });
+
+    const created = await current.nextly.create({
+      collection: "posts",
+      data: { title: "Readable Title" },
+    });
+
+    // Derived from the title, not the un-sanitizable hook value.
+    expect((created.item as { slug?: string }).slug).toBe("readable-title");
+  });
+
+  it("re-sanitizes a slug set by a field beforeChange hook", async () => {
+    const posts = defineCollection({
+      slug: "posts",
+      fields: [
+        text({ name: "title" }),
+        text({
+          name: "slug",
+          unique: true,
+          // A beforeChange hook runs after validation, right before storage;
+          // its value must still be normalized.
+          hooks: { beforeChange: [() => "Changed By Hook"] },
+        }),
+      ],
+    });
+    current = await createTestNextly({ collections: [posts] });
+
+    const created = await current.nextly.create({
+      collection: "posts",
+      data: { title: "Ignored" },
+    });
+
+    expect((created.item as { slug?: string }).slug).toBe("changed-by-hook");
+  });
 });

--- a/packages/nextly/src/plugins/__tests__/slug-autogen.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/slug-autogen.integration.test.ts
@@ -90,4 +90,48 @@ describe("slug auto-generation on create", () => {
 
     expect((created.item as { slug?: string }).slug).toBe("custom-slug");
   });
+
+  it("falls back to a generated token when the title has no slug-safe characters", async () => {
+    const posts = defineCollection({
+      slug: "posts",
+      fields: [text({ name: "title" })],
+    });
+    current = await createTestNextly({ collections: [posts] });
+
+    // generateSlug strips everything outside [\w-], so a CJK/emoji/punctuation
+    // -only title sanitizes to an empty base. The required, unique slug must
+    // still be populated via the `entry-<ts>-<rand>` fallback instead of "".
+    const created = await current.nextly.create({
+      collection: "posts",
+      data: { title: "你好世界" },
+    });
+
+    const slug = (created.item as { slug?: string }).slug;
+    expect(slug).toBeTruthy();
+    expect(slug).toMatch(/^entry-/);
+  });
+
+  it("re-sanitizes a slug set by a field beforeValidate hook", async () => {
+    const posts = defineCollection({
+      slug: "posts",
+      fields: [
+        text({ name: "title" }),
+        text({
+          name: "slug",
+          unique: true,
+          // A field hook runs after slug generation and can set an unsanitized
+          // value; the create path must normalize it before storing.
+          hooks: { beforeValidate: [() => "Hooked Slug Value"] },
+        }),
+      ],
+    });
+    current = await createTestNextly({ collections: [posts] });
+
+    const created = await current.nextly.create({
+      collection: "posts",
+      data: { title: "Ignored" },
+    });
+
+    expect((created.item as { slug?: string }).slug).toBe("hooked-slug-value");
+  });
 });

--- a/packages/nextly/src/plugins/__tests__/slug-autogen.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/slug-autogen.integration.test.ts
@@ -207,4 +207,28 @@ describe("slug auto-generation on create", () => {
 
     expect((created.item as { slug?: string }).slug).toBe("fallback-title");
   });
+
+  it("derives a slug when a beforeChange hook returns a non-string", async () => {
+    const posts = defineCollection({
+      slug: "posts",
+      fields: [
+        text({ name: "title" }),
+        text({
+          name: "slug",
+          unique: true,
+          // A hook returning null (or any non-string) must not leave a
+          // non-string slug on the required column.
+          hooks: { beforeChange: [() => null] },
+        }),
+      ],
+    });
+    current = await createTestNextly({ collections: [posts] });
+
+    const created = await current.nextly.create({
+      collection: "posts",
+      data: { title: "Recovered Title" },
+    });
+
+    expect((created.item as { slug?: string }).slug).toBe("recovered-title");
+  });
 });


### PR DESCRIPTION
## What

Two follow-up fixes for slug auto-generation, surfaced by Codex's post-merge review of #222.

### 1. Empty slug when the title has no URL-safe characters
`generateSlug` strips everything outside `[\w-]`, so a title that is entirely non-ASCII, emoji, or punctuation (e.g. `create({ data: { title: "你好世界" } })`) sanitized to `""`. The previous fallback token only fired when the title/name was *missing*, not when derivation *yielded* empty, so the create failed required-field validation with an empty `slug`.

Now derivation falls back to a unique `entry-<ts>-<rand>` token whenever the sanitized base is empty. This also covers an **explicit** slug that sanitizes away (e.g. `slug: "你好"`), which is treated as unset and derived instead of persisting `""`.

### 2. Re-sanitize a slug set by a field `beforeValidate` hook
#222 moved slug generation ahead of field-level write access + validation. Field-level `beforeValidate` hooks run *after* that step, so a slug field hook could set an unsanitized value (`"Hello World"`) that was then validated and stored verbatim — a regression from the pre-#222 ordering, which sanitized after those hooks. All three create paths (`createEntry`, `createEntryInTransaction`, `createSingleEntryInTransaction`) now re-sanitize `slug` after `beforeValidate` hooks and before validation. The pass is idempotent for an already-clean slug and only overwrites when sanitization yields a non-empty value, so a hook that clears the slug still surfaces as the normal required-field error.

## Tests
Two integration tests added to `slug-autogen.integration.test.ts`:
- CJK-only title falls back to an `entry-` token.
- A slug field `beforeValidate` hook returning `"Hooked Slug Value"` is stored as `hooked-slug-value`.

Full slug suite (6) + plugin integration suite (37 files / 86 tests) green; `check-types` + `lint` clean.

## Not in this PR
A third Codex finding — the adapters' `TransactionContext` read methods (`selectOne`/`select`/…) delegate to the main connection rather than the transaction, so tx-scoped slug dedupe is only effective on SQLite — is an adapter-layer change tracked as a separate follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slug auto-generation so slugs that sanitize to empty (including non-string results) are treated as unset and never stored as `""`; a unique fallback is derived instead.
  * Re-sanitizes/normalizes `slug` after both validation and change hooks during create flows, including transactional paths, to ensure consistent URL-safe storage.
* **Tests**
  * Expanded integration coverage for slug sanitization and hook edge cases across create scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->