### PR TITLE
fix(adapter-drizzle): run transaction context CRUD inside the transaction

### DIFF
--- a/.changeset/tx-scoped-context-crud.md
+++ b/.changeset/tx-scoped-context-crud.md
@@ -1,0 +1,20 @@
+---
+"nextly": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"create-nextly-app": patch
+---
+
+Run a transaction's `select`/`selectOne`/`update`/`delete`/`upsert` inside the transaction.
+
+The `TransactionContext` CRUD methods delegated to the adapter's pool-bound Drizzle instance, so on the pooled adapters (Postgres, MySQL) a read inside a transaction ran on a different connection and could not see rows written earlier in the same uncommitted transaction. Two same-title creates in one transaction (or bulk batch) both chose the base slug and the second hit the unique constraint instead of receiving `-2`. The base CRUD methods now accept an optional transaction-bound executor, and each dialect binds a Drizzle instance to its checked-out connection so context CRUD reads its own writes. SQLite was already correct by virtue of being single-connection; the fix makes all three dialects consistent.

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -89,17 +89,6 @@ import { createDatabaseError, isDatabaseError } from "./types";
  *
  * @public
  */
-/**
- * A dialect-specific Drizzle instance used to run a CRUD query. The CRUD
- * methods default to the pooled instance from `getDrizzle()`; a transaction
- * passes one bound to its checked-out connection so context CRUD executes
- * inside the transaction (and sees its uncommitted rows) instead of on the
- * pool. Drizzle's fluent query builder has no shared cross-dialect type, so
- * this mirrors the `any` that `getDrizzle<any>()` already returns everywhere.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type DrizzleExecutor = any;
-
 export abstract class DrizzleAdapter {
   // ============================================================
   // Abstract Methods (MUST be implemented by subclasses)
@@ -478,7 +467,7 @@ export abstract class DrizzleAdapter {
   async select<T = unknown>(
     table: string,
     options?: SelectOptions,
-    executor?: DrizzleExecutor
+    executor?: unknown
   ): Promise<T[]> {
     // Drizzle query API path: use when table resolver has a Drizzle table object
     const tableObj = this.getTableObject(table);
@@ -487,7 +476,9 @@ export abstract class DrizzleAdapter {
         // Run on the transaction's executor when one is supplied, otherwise the
         // pooled instance. Without this, a read inside a transaction would use
         // the pool and miss rows written earlier in the same uncommitted tx.
-        const db = executor ?? this.getDrizzle<DrizzleExecutor>();
+        // getDrizzle() returns unknown - explicit any generic for dialect-specific Drizzle API
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const db = executor ?? this.getDrizzle<any>();
         let query = db.select().from(tableObj);
 
         if (options?.where) {
@@ -559,7 +550,7 @@ export abstract class DrizzleAdapter {
   async selectOne<T = unknown>(
     table: string,
     options?: SelectOptions,
-    executor?: DrizzleExecutor
+    executor?: unknown
   ): Promise<T | null> {
     const results = await this.select<T>(
       table,
@@ -711,14 +702,16 @@ export abstract class DrizzleAdapter {
     data: Record<string, unknown>,
     where: WhereClause,
     options?: UpdateOptions,
-    executor?: DrizzleExecutor
+    executor?: unknown
   ): Promise<T[]> {
     // Drizzle query API path
     const tableObj = this.getTableObject(table);
     if (tableObj) {
       try {
         // Transaction executor when supplied, otherwise the pooled instance.
-        const db = executor ?? this.getDrizzle<DrizzleExecutor>();
+        // getDrizzle() returns unknown - explicit any generic for dialect-specific Drizzle API
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const db = executor ?? this.getDrizzle<any>();
         const caps = this.getCapabilities();
         // Map snake_case keys to Drizzle JS property names
         const mappedData = this.mapDataToColumnNames(tableObj, data);
@@ -780,14 +773,16 @@ export abstract class DrizzleAdapter {
     table: string,
     where: WhereClause,
     _options?: DeleteOptions,
-    executor?: DrizzleExecutor
+    executor?: unknown
   ): Promise<number> {
     // Drizzle query API path
     const tableObj = this.getTableObject(table);
     if (tableObj) {
       try {
         // Transaction executor when supplied, otherwise the pooled instance.
-        const db = executor ?? this.getDrizzle<DrizzleExecutor>();
+        // getDrizzle() returns unknown - explicit any generic for dialect-specific Drizzle API
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const db = executor ?? this.getDrizzle<any>();
         let query = db.delete(tableObj);
 
         const whereCondition = buildDrizzleWhere(tableObj as never, where);
@@ -845,14 +840,16 @@ export abstract class DrizzleAdapter {
     table: string,
     data: Record<string, unknown>,
     options: UpsertOptions,
-    executor?: DrizzleExecutor
+    executor?: unknown
   ): Promise<T> {
     // Drizzle query API path
     const tableObj = this.getTableObject(table);
     if (tableObj) {
       try {
         // Transaction executor when supplied, otherwise the pooled instance.
-        const db = executor ?? this.getDrizzle<DrizzleExecutor>();
+        // getDrizzle() returns unknown - explicit any generic for dialect-specific Drizzle API
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const db = executor ?? this.getDrizzle<any>();
         const caps = this.getCapabilities();
         const columns = getColumns(tableObj as never);
 

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -89,6 +89,17 @@ import { createDatabaseError, isDatabaseError } from "./types";
  *
  * @public
  */
+/**
+ * A dialect-specific Drizzle instance used to run a CRUD query. The CRUD
+ * methods default to the pooled instance from `getDrizzle()`; a transaction
+ * passes one bound to its checked-out connection so context CRUD executes
+ * inside the transaction (and sees its uncommitted rows) instead of on the
+ * pool. Drizzle's fluent query builder has no shared cross-dialect type, so
+ * this mirrors the `any` that `getDrizzle<any>()` already returns everywhere.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DrizzleExecutor = any;
+
 export abstract class DrizzleAdapter {
   // ============================================================
   // Abstract Methods (MUST be implemented by subclasses)
@@ -466,15 +477,17 @@ export abstract class DrizzleAdapter {
    */
   async select<T = unknown>(
     table: string,
-    options?: SelectOptions
+    options?: SelectOptions,
+    executor?: DrizzleExecutor
   ): Promise<T[]> {
     // Drizzle query API path: use when table resolver has a Drizzle table object
     const tableObj = this.getTableObject(table);
     if (tableObj) {
       try {
-        // getDrizzle() returns unknown - explicit any generic for dialect-specific Drizzle API
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const db = this.getDrizzle<any>();
+        // Run on the transaction's executor when one is supplied, otherwise the
+        // pooled instance. Without this, a read inside a transaction would use
+        // the pool and miss rows written earlier in the same uncommitted tx.
+        const db = executor ?? this.getDrizzle<DrizzleExecutor>();
         let query = db.select().from(tableObj);
 
         if (options?.where) {
@@ -545,9 +558,14 @@ export abstract class DrizzleAdapter {
    */
   async selectOne<T = unknown>(
     table: string,
-    options?: SelectOptions
+    options?: SelectOptions,
+    executor?: DrizzleExecutor
   ): Promise<T | null> {
-    const results = await this.select<T>(table, { ...options, limit: 1 });
+    const results = await this.select<T>(
+      table,
+      { ...options, limit: 1 },
+      executor
+    );
     return results.length > 0 ? results[0] : null;
   }
 
@@ -692,15 +710,15 @@ export abstract class DrizzleAdapter {
     table: string,
     data: Record<string, unknown>,
     where: WhereClause,
-    options?: UpdateOptions
+    options?: UpdateOptions,
+    executor?: DrizzleExecutor
   ): Promise<T[]> {
     // Drizzle query API path
     const tableObj = this.getTableObject(table);
     if (tableObj) {
       try {
-        // getDrizzle() returns unknown - explicit any generic for dialect-specific Drizzle API
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const db = this.getDrizzle<any>();
+        // Transaction executor when supplied, otherwise the pooled instance.
+        const db = executor ?? this.getDrizzle<DrizzleExecutor>();
         const caps = this.getCapabilities();
         // Map snake_case keys to Drizzle JS property names
         const mappedData = this.mapDataToColumnNames(tableObj, data);
@@ -717,9 +735,10 @@ export abstract class DrizzleAdapter {
 
         await query;
 
-        // For databases without RETURNING: select back the updated records
+        // For databases without RETURNING: select back the updated records on
+        // the same executor so a transactional update reads its own writes.
         if (!caps.supportsReturning && options?.returning) {
-          return await this.select<T>(table, { where });
+          return await this.select<T>(table, { where }, executor);
         }
 
         return [] as T[];
@@ -760,15 +779,15 @@ export abstract class DrizzleAdapter {
   async delete(
     table: string,
     where: WhereClause,
-    _options?: DeleteOptions
+    _options?: DeleteOptions,
+    executor?: DrizzleExecutor
   ): Promise<number> {
     // Drizzle query API path
     const tableObj = this.getTableObject(table);
     if (tableObj) {
       try {
-        // getDrizzle() returns unknown - explicit any generic for dialect-specific Drizzle API
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const db = this.getDrizzle<any>();
+        // Transaction executor when supplied, otherwise the pooled instance.
+        const db = executor ?? this.getDrizzle<DrizzleExecutor>();
         let query = db.delete(tableObj);
 
         const whereCondition = buildDrizzleWhere(tableObj as never, where);
@@ -825,15 +844,15 @@ export abstract class DrizzleAdapter {
   async upsert<T = unknown>(
     table: string,
     data: Record<string, unknown>,
-    options: UpsertOptions
+    options: UpsertOptions,
+    executor?: DrizzleExecutor
   ): Promise<T> {
     // Drizzle query API path
     const tableObj = this.getTableObject(table);
     if (tableObj) {
       try {
-        // getDrizzle() returns unknown - explicit any generic for dialect-specific Drizzle API
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const db = this.getDrizzle<any>();
+        // Transaction executor when supplied, otherwise the pooled instance.
+        const db = executor ?? this.getDrizzle<DrizzleExecutor>();
         const caps = this.getCapabilities();
         const columns = getColumns(tableObj as never);
 
@@ -873,21 +892,26 @@ export abstract class DrizzleAdapter {
         await query;
 
         // For databases without RETURNING: select back using conflict columns
+        // on the same executor so a transactional upsert reads its own write.
         if (
           options.conflictColumns.length &&
           data[options.conflictColumns[0]] !== undefined
         ) {
-          return (await this.selectOne<T>(table, {
-            where: {
-              and: [
-                {
-                  column: options.conflictColumns[0],
-                  op: "=",
-                  value: data[options.conflictColumns[0]] as SqlParam,
-                },
-              ],
+          return (await this.selectOne<T>(
+            table,
+            {
+              where: {
+                and: [
+                  {
+                    column: options.conflictColumns[0],
+                    op: "=",
+                    value: data[options.conflictColumns[0]] as SqlParam,
+                  },
+                ],
+              },
             },
-          })) as T;
+            executor
+          )) as T;
         }
 
         return data as T;

--- a/packages/adapter-mysql/src/__tests__/transaction-read-your-writes.integration.test.ts
+++ b/packages/adapter-mysql/src/__tests__/transaction-read-your-writes.integration.test.ts
@@ -22,13 +22,14 @@ const posts = mysqlTable(TABLE, {
 });
 
 const canConnect = async (url: string): Promise<boolean> => {
-  let conn: mysql.Connection | undefined;
   // Bound the probe so an unreachable TEST_MYSQL_URL cannot hang the suite for
   // the OS-level connect timeout (often minutes); mysql2 has no simple connect
   // timeout when given a URL string, so race the attempt against a short timer.
+  const connPromise = mysql.createConnection(url).catch(() => undefined);
   const attempt = (async () => {
+    const conn = await connPromise;
+    if (!conn) return false;
     try {
-      conn = await mysql.createConnection(url);
       await conn.query("SELECT 1");
       return true;
     } catch {
@@ -39,7 +40,9 @@ const canConnect = async (url: string): Promise<boolean> => {
     setTimeout(() => resolve(false), 5000)
   );
   const ok = await Promise.race([attempt, timeout]);
-  await conn?.end().catch(() => {});
+  // Close the connection whenever it resolves, even if the timeout won the race
+  // while createConnection was still pending — otherwise it would leak.
+  void connPromise.then(conn => conn?.end().catch(() => {}));
   return ok;
 };
 

--- a/packages/adapter-mysql/src/__tests__/transaction-read-your-writes.integration.test.ts
+++ b/packages/adapter-mysql/src/__tests__/transaction-read-your-writes.integration.test.ts
@@ -1,0 +1,98 @@
+// Verifies that the TransactionContext's Drizzle-path CRUD (select/selectOne)
+// runs inside the open transaction and observes rows written earlier in the
+// same uncommitted transaction. MySQL is pool-based: before the fix the
+// delegated select/selectOne ran on the pool (a different connection) and could
+// NOT see the transaction's uncommitted rows, so these assertions failed.
+//
+// Self-skips when TEST_MYSQL_URL is unset.
+
+import { mysqlTable, varchar } from "drizzle-orm/mysql-core";
+import mysql from "mysql2/promise";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createMySqlAdapter, type MySqlAdapter } from "../index";
+
+const TABLE = "int_txmysql_ryw";
+const TEST_DB_URL = process.env.TEST_MYSQL_URL;
+
+// Drizzle table definition backing the resolver so the adapter's Drizzle CRUD
+// path (used by ctx.select / ctx.selectOne) can resolve this table.
+const posts = mysqlTable(TABLE, {
+  id: varchar("id", { length: 36 }).primaryKey(),
+  slug: varchar("slug", { length: 255 }).notNull(),
+});
+
+const canConnect = async (url: string): Promise<boolean> => {
+  let conn: mysql.Connection | undefined;
+  try {
+    conn = await mysql.createConnection(url);
+    await conn.query("SELECT 1");
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await conn?.end().catch(() => {});
+  }
+};
+
+describe("MySQL transaction read-your-writes", async () => {
+  const available = TEST_DB_URL ? await canConnect(TEST_DB_URL) : false;
+
+  if (!available) {
+    it.skip("Skipping: TEST_MYSQL_URL not set or unreachable", () => {});
+    return;
+  }
+
+  let adapter: MySqlAdapter;
+
+  beforeAll(async () => {
+    adapter = createMySqlAdapter({ url: TEST_DB_URL });
+    await adapter.connect();
+    await adapter.executeQuery(`DROP TABLE IF EXISTS ${TABLE}`);
+    await adapter.executeQuery(
+      `CREATE TABLE ${TABLE} (id varchar(36) PRIMARY KEY, slug varchar(255) NOT NULL UNIQUE)`
+    );
+    adapter.setTableResolver({
+      getTable: (name: string) => (name === TABLE ? posts : null),
+    });
+  });
+
+  afterAll(async () => {
+    await adapter.executeQuery(`DROP TABLE IF EXISTS ${TABLE}`);
+    await adapter.disconnect();
+  });
+
+  it("selectOne sees a row inserted earlier in the same transaction", async () => {
+    const found = await adapter.transaction(async ctx => {
+      await ctx.insert(TABLE, { id: "a", slug: "hello" });
+      return ctx.selectOne<{ slug: string }>(TABLE, {
+        where: { and: [{ column: "slug", op: "=", value: "hello" }] },
+      });
+    });
+
+    expect(found).not.toBeNull();
+    expect(found?.slug).toBe("hello");
+  });
+
+  it("dedupes generated slugs within a single transaction", async () => {
+    const chosen = await adapter.transaction(async ctx => {
+      const results: string[] = [];
+      for (const base of ["dup", "dup"]) {
+        let candidate = base;
+        let suffix = 2;
+        while (
+          await ctx.selectOne(TABLE, {
+            where: { and: [{ column: "slug", op: "=", value: candidate }] },
+          })
+        ) {
+          candidate = `${base}-${suffix++}`;
+        }
+        await ctx.insert(TABLE, { id: `id-${candidate}`, slug: candidate });
+        results.push(candidate);
+      }
+      return results;
+    });
+
+    expect(chosen).toEqual(["dup", "dup-2"]);
+  });
+});

--- a/packages/adapter-mysql/src/__tests__/transaction-read-your-writes.integration.test.ts
+++ b/packages/adapter-mysql/src/__tests__/transaction-read-your-writes.integration.test.ts
@@ -1,8 +1,7 @@
-// Verifies that the TransactionContext's Drizzle-path CRUD (select/selectOne)
-// runs inside the open transaction and observes rows written earlier in the
-// same uncommitted transaction. MySQL is pool-based: before the fix the
-// delegated select/selectOne ran on the pool (a different connection) and could
-// NOT see the transaction's uncommitted rows, so these assertions failed.
+// The TransactionContext's Drizzle-path CRUD (select/selectOne) runs inside the
+// open transaction and observes rows written earlier in the same uncommitted
+// transaction. On the pool-based MySQL adapter this requires the delegated
+// reads to run on the transaction's checked-out connection, not the pool.
 //
 // Self-skips when TEST_MYSQL_URL is unset.
 
@@ -24,15 +23,24 @@ const posts = mysqlTable(TABLE, {
 
 const canConnect = async (url: string): Promise<boolean> => {
   let conn: mysql.Connection | undefined;
-  try {
-    conn = await mysql.createConnection(url);
-    await conn.query("SELECT 1");
-    return true;
-  } catch {
-    return false;
-  } finally {
-    await conn?.end().catch(() => {});
-  }
+  // Bound the probe so an unreachable TEST_MYSQL_URL cannot hang the suite for
+  // the OS-level connect timeout (often minutes); mysql2 has no simple connect
+  // timeout when given a URL string, so race the attempt against a short timer.
+  const attempt = (async () => {
+    try {
+      conn = await mysql.createConnection(url);
+      await conn.query("SELECT 1");
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+  const timeout = new Promise<boolean>(resolve =>
+    setTimeout(() => resolve(false), 5000)
+  );
+  const ok = await Promise.race([attempt, timeout]);
+  await conn?.end().catch(() => {});
+  return ok;
 };
 
 describe("MySQL transaction read-your-writes", async () => {

--- a/packages/adapter-mysql/src/index.ts
+++ b/packages/adapter-mysql/src/index.ts
@@ -65,7 +65,10 @@ import {
 import { checkDialectVersion } from "@nextlyhq/adapter-drizzle/version-check";
 import type { AnyRelations } from "drizzle-orm";
 import { drizzle, type MySql2Database } from "drizzle-orm/mysql2";
-import type { Pool as CallbackPool } from "mysql2";
+import type {
+  Pool as CallbackPool,
+  Connection as CallbackConnection,
+} from "mysql2";
 import mysql from "mysql2/promise";
 import type {
   PoolOptions,
@@ -750,6 +753,21 @@ export class MySqlAdapter extends DrizzleAdapter {
   private createTransactionContext(
     connection: PoolConnection
   ): TransactionContext {
+    // Bind a Drizzle instance to this transaction's checked-out connection so
+    // the delegated CRUD methods run inside the transaction and see its
+    // uncommitted rows. drizzle's mysql2 driver needs the underlying CALLBACK
+    // connection, which the mysql2/promise wrapper exposes on `.connection`
+    // (mirrors the `.pool` unwrap in getDrizzle()); getDrizzle() itself wraps
+    // the pool, which would use a different connection. Built lazily and
+    // memoized: transactions that use only raw execute/insert never construct
+    // it.
+    const buildTxExecutor = () =>
+      drizzle({
+        client: (connection as unknown as { connection: CallbackConnection })
+          .connection,
+      });
+    let txExecutor: ReturnType<typeof buildTxExecutor> | undefined;
+    const txDb = () => (txExecutor ??= buildTxExecutor());
     return {
       execute: async <T = unknown>(
         sql: string,
@@ -842,20 +860,21 @@ export class MySqlAdapter extends DrizzleAdapter {
         return [];
       },
 
-      // TransactionContext CRUD methods delegate to the adapter's CRUD
-      // which uses Drizzle query API via the TableResolver.
+      // TransactionContext CRUD methods delegate to the adapter's Drizzle CRUD
+      // but pass the transaction-bound executor so they run inside this
+      // transaction rather than on the pool.
       select: async <T = unknown>(
         table: string,
         options?: SelectOptions
       ): Promise<T[]> => {
-        return this.select<T>(table, options);
+        return this.select<T>(table, options, txDb());
       },
 
       selectOne: async <T = unknown>(
         table: string,
         options?: SelectOptions
       ): Promise<T | null> => {
-        return this.selectOne<T>(table, options);
+        return this.selectOne<T>(table, options, txDb());
       },
 
       update: async <T = unknown>(
@@ -864,15 +883,15 @@ export class MySqlAdapter extends DrizzleAdapter {
         where: WhereClause,
         options?: UpdateOptions
       ): Promise<T[]> => {
-        return this.update<T>(table, data, where, options);
+        return this.update<T>(table, data, where, options, txDb());
       },
 
       delete: async (
         table: string,
         where: WhereClause,
-        _options?: DeleteOptions
+        options?: DeleteOptions
       ): Promise<number> => {
-        return this.delete(table, where);
+        return this.delete(table, where, options, txDb());
       },
 
       upsert: async <T = unknown>(
@@ -880,7 +899,7 @@ export class MySqlAdapter extends DrizzleAdapter {
         data: Record<string, unknown>,
         options: UpsertOptions
       ): Promise<T> => {
-        return this.upsert<T>(table, data, options);
+        return this.upsert<T>(table, data, options, txDb());
       },
 
       // Savepoints disabled per approved approach

--- a/packages/adapter-postgres/src/__tests__/transaction-read-your-writes.integration.test.ts
+++ b/packages/adapter-postgres/src/__tests__/transaction-read-your-writes.integration.test.ts
@@ -1,0 +1,98 @@
+// Verifies that the TransactionContext's Drizzle-path CRUD (select/selectOne)
+// runs inside the open transaction and observes rows written earlier in the
+// same uncommitted transaction. Postgres is pool-based: before the fix the
+// delegated select/selectOne ran on the pool (a different connection) and could
+// NOT see the transaction's uncommitted rows, so these assertions failed.
+//
+// Self-skips when TEST_POSTGRES_URL is unset.
+
+import { pgTable, text } from "drizzle-orm/pg-core";
+import pg from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createPostgresAdapter, type PostgresAdapter } from "../index";
+
+const TABLE = "int_txpg_ryw";
+const TEST_DB_URL = process.env.TEST_POSTGRES_URL;
+
+// Drizzle table definition backing the resolver so the adapter's Drizzle CRUD
+// path (used by ctx.select / ctx.selectOne) can resolve this table.
+const posts = pgTable(TABLE, {
+  id: text("id").primaryKey(),
+  slug: text("slug").notNull(),
+});
+
+const canConnect = async (url: string): Promise<boolean> => {
+  const client = new pg.Client({ connectionString: url });
+  try {
+    await client.connect();
+    await client.query("SELECT 1");
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await client.end().catch(() => {});
+  }
+};
+
+describe("PostgreSQL transaction read-your-writes", async () => {
+  const available = TEST_DB_URL ? await canConnect(TEST_DB_URL) : false;
+
+  if (!available) {
+    it.skip("Skipping: TEST_POSTGRES_URL not set or unreachable", () => {});
+    return;
+  }
+
+  let adapter: PostgresAdapter;
+
+  beforeAll(async () => {
+    adapter = createPostgresAdapter({ url: TEST_DB_URL });
+    await adapter.connect();
+    await adapter.executeQuery(`DROP TABLE IF EXISTS ${TABLE}`);
+    await adapter.executeQuery(
+      `CREATE TABLE ${TABLE} (id text PRIMARY KEY, slug text NOT NULL UNIQUE)`
+    );
+    adapter.setTableResolver({
+      getTable: (name: string) => (name === TABLE ? posts : null),
+    });
+  });
+
+  afterAll(async () => {
+    await adapter.executeQuery(`DROP TABLE IF EXISTS ${TABLE}`);
+    await adapter.disconnect();
+  });
+
+  it("selectOne sees a row inserted earlier in the same transaction", async () => {
+    const found = await adapter.transaction(async ctx => {
+      await ctx.insert(TABLE, { id: "a", slug: "hello" });
+      return ctx.selectOne<{ slug: string }>(TABLE, {
+        where: { and: [{ column: "slug", op: "=", value: "hello" }] },
+      });
+    });
+
+    expect(found).not.toBeNull();
+    expect(found?.slug).toBe("hello");
+  });
+
+  it("dedupes generated slugs within a single transaction", async () => {
+    const chosen = await adapter.transaction(async ctx => {
+      const results: string[] = [];
+      for (const base of ["dup", "dup"]) {
+        let candidate = base;
+        let suffix = 2;
+        while (
+          await ctx.selectOne(TABLE, {
+            where: { and: [{ column: "slug", op: "=", value: candidate }] },
+          })
+        ) {
+          candidate = `${base}-${suffix++}`;
+        }
+        await ctx.insert(TABLE, { id: `id-${candidate}`, slug: candidate });
+        results.push(candidate);
+      }
+      return results;
+    });
+
+    expect(chosen).toEqual(["dup", "dup-2"]);
+  });
+});

--- a/packages/adapter-postgres/src/__tests__/transaction-read-your-writes.integration.test.ts
+++ b/packages/adapter-postgres/src/__tests__/transaction-read-your-writes.integration.test.ts
@@ -1,8 +1,7 @@
-// Verifies that the TransactionContext's Drizzle-path CRUD (select/selectOne)
-// runs inside the open transaction and observes rows written earlier in the
-// same uncommitted transaction. Postgres is pool-based: before the fix the
-// delegated select/selectOne ran on the pool (a different connection) and could
-// NOT see the transaction's uncommitted rows, so these assertions failed.
+// The TransactionContext's Drizzle-path CRUD (select/selectOne) runs inside the
+// open transaction and observes rows written earlier in the same uncommitted
+// transaction. On the pool-based Postgres adapter this requires the delegated
+// reads to run on the transaction's checked-out connection, not the pool.
 //
 // Self-skips when TEST_POSTGRES_URL is unset.
 
@@ -23,7 +22,11 @@ const posts = pgTable(TABLE, {
 });
 
 const canConnect = async (url: string): Promise<boolean> => {
-  const client = new pg.Client({ connectionString: url });
+  // Bounded connect so an unreachable TEST_POSTGRES_URL cannot hang the suite.
+  const client = new pg.Client({
+    connectionString: url,
+    connectionTimeoutMillis: 5000,
+  });
   try {
     await client.connect();
     await client.query("SELECT 1");

--- a/packages/adapter-postgres/src/index.ts
+++ b/packages/adapter-postgres/src/index.ts
@@ -919,6 +919,14 @@ export class PostgresAdapter extends DrizzleAdapter {
    * Creates a TransactionContext for the given client.
    */
   private createTransactionContext(client: PoolClient): TransactionContext {
+    // Bind a Drizzle instance to this transaction's checked-out client so the
+    // delegated CRUD methods run inside the transaction and see its uncommitted
+    // rows. getDrizzle() wraps the pool, which would use a different connection.
+    // Built lazily and memoized: transactions that use only raw execute/insert
+    // never construct it.
+    const buildTxExecutor = () => drizzle({ client });
+    let txExecutor: ReturnType<typeof buildTxExecutor> | undefined;
+    const txDb = () => (txExecutor ??= buildTxExecutor());
     return {
       execute: async <T = unknown>(
         sql: string,
@@ -993,21 +1001,21 @@ export class PostgresAdapter extends DrizzleAdapter {
         return result.rows as T[];
       },
 
-      // TransactionContext CRUD methods delegate to the adapter's CRUD
-      // which uses Drizzle query API via the TableResolver.
-      // The Drizzle transaction is handled at a higher level.
+      // TransactionContext CRUD methods delegate to the adapter's Drizzle CRUD
+      // but pass the transaction-bound executor so they run inside this
+      // transaction rather than on the pool.
       select: async <T = unknown>(
         table: string,
         options?: SelectOptions
       ): Promise<T[]> => {
-        return this.select<T>(table, options);
+        return this.select<T>(table, options, txDb());
       },
 
       selectOne: async <T = unknown>(
         table: string,
         options?: SelectOptions
       ): Promise<T | null> => {
-        return this.selectOne<T>(table, options);
+        return this.selectOne<T>(table, options, txDb());
       },
 
       update: async <T = unknown>(
@@ -1016,15 +1024,15 @@ export class PostgresAdapter extends DrizzleAdapter {
         where: WhereClause,
         options?: UpdateOptions
       ): Promise<T[]> => {
-        return this.update<T>(table, data, where, options);
+        return this.update<T>(table, data, where, options, txDb());
       },
 
       delete: async (
         table: string,
         where: WhereClause,
-        _options?: DeleteOptions
+        options?: DeleteOptions
       ): Promise<number> => {
-        return this.delete(table, where);
+        return this.delete(table, where, options, txDb());
       },
 
       upsert: async <T = unknown>(
@@ -1032,7 +1040,7 @@ export class PostgresAdapter extends DrizzleAdapter {
         data: Record<string, unknown>,
         options: UpsertOptions
       ): Promise<T> => {
-        return this.upsert<T>(table, data, options);
+        return this.upsert<T>(table, data, options, txDb());
       },
 
       savepoint: async (name: string): Promise<void> => {

--- a/packages/adapter-sqlite/src/__tests__/transaction-read-your-writes.integration.test.ts
+++ b/packages/adapter-sqlite/src/__tests__/transaction-read-your-writes.integration.test.ts
@@ -1,0 +1,75 @@
+// Verifies that the TransactionContext's Drizzle-path CRUD (select/selectOne)
+// runs inside the open transaction and observes rows written earlier in the
+// same uncommitted transaction. SQLite is single-connection, so this has always
+// worked here; the test locks that in and mirrors the pooled-adapter suites
+// (Postgres/MySQL) where the same guarantee is the actual bug fix.
+
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createSqliteAdapter } from "../index";
+
+const TABLE = "int_txsqlite_ryw";
+
+// Drizzle table definition backing the resolver so the adapter's Drizzle CRUD
+// path (used by ctx.select / ctx.selectOne) can resolve this table.
+const posts = sqliteTable(TABLE, {
+  id: text("id").primaryKey(),
+  slug: text("slug").notNull(),
+});
+
+describe("SQLite transaction read-your-writes", () => {
+  let adapter: ReturnType<typeof createSqliteAdapter>;
+
+  beforeAll(async () => {
+    adapter = createSqliteAdapter({ memory: true });
+    await adapter.connect();
+    await adapter.executeQuery(
+      `CREATE TABLE ${TABLE} (id text PRIMARY KEY, slug text NOT NULL UNIQUE)`
+    );
+    adapter.setTableResolver({
+      getTable: (name: string) => (name === TABLE ? posts : null),
+    });
+  });
+
+  afterAll(async () => {
+    await adapter.disconnect();
+  });
+
+  it("selectOne sees a row inserted earlier in the same transaction", async () => {
+    const found = await adapter.transaction(async ctx => {
+      await ctx.insert(TABLE, { id: "a", slug: "hello" });
+      return ctx.selectOne<{ slug: string }>(TABLE, {
+        where: { and: [{ column: "slug", op: "=", value: "hello" }] },
+      });
+    });
+
+    expect(found).not.toBeNull();
+    expect(found?.slug).toBe("hello");
+  });
+
+  it("dedupes generated slugs within a single transaction", async () => {
+    // Mirrors the collection slug-dedupe path: each iteration must see the
+    // pending row from the previous one, so two same-base slugs resolve to
+    // `dup` and `dup-2` rather than both choosing `dup`.
+    const chosen = await adapter.transaction(async ctx => {
+      const results: string[] = [];
+      for (const base of ["dup", "dup"]) {
+        let candidate = base;
+        let suffix = 2;
+        while (
+          await ctx.selectOne(TABLE, {
+            where: { and: [{ column: "slug", op: "=", value: candidate }] },
+          })
+        ) {
+          candidate = `${base}-${suffix++}`;
+        }
+        await ctx.insert(TABLE, { id: `id-${candidate}`, slug: candidate });
+        results.push(candidate);
+      }
+      return results;
+    });
+
+    expect(chosen).toEqual(["dup", "dup-2"]);
+  });
+});

--- a/packages/adapter-sqlite/src/__tests__/transaction-read-your-writes.integration.test.ts
+++ b/packages/adapter-sqlite/src/__tests__/transaction-read-your-writes.integration.test.ts
@@ -1,8 +1,8 @@
-// Verifies that the TransactionContext's Drizzle-path CRUD (select/selectOne)
-// runs inside the open transaction and observes rows written earlier in the
-// same uncommitted transaction. SQLite is single-connection, so this has always
-// worked here; the test locks that in and mirrors the pooled-adapter suites
-// (Postgres/MySQL) where the same guarantee is the actual bug fix.
+// The TransactionContext's Drizzle-path CRUD (select/selectOne) runs inside the
+// open transaction and observes rows written earlier in the same uncommitted
+// transaction. SQLite is single-connection, so the delegated reads share the
+// transaction's connection; this locks that guarantee in and mirrors the
+// pooled-adapter suites (Postgres/MySQL).
 
 import { sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";

--- a/packages/adapter-sqlite/src/index.ts
+++ b/packages/adapter-sqlite/src/index.ts
@@ -699,6 +699,15 @@ export class SqliteAdapter extends DrizzleAdapter {
   private createTransactionContext(db: Database.Database): TransactionContext {
     // better-sqlite3 is synchronous; the methods below are async to satisfy
     // the TransactionContext contract shared with truly-async dialect adapters.
+    // Bind a Drizzle instance to the transaction's connection so the delegated
+    // CRUD methods run inside it. better-sqlite3 is single-connection, so this
+    // is the same connection getDrizzle() would use, but binding explicitly
+    // keeps the three adapters consistent and correct if that ever changes.
+    // Built lazily and memoized: transactions that use only raw execute/insert
+    // never construct it.
+    const buildTxExecutor = () => drizzle({ client: db });
+    let txExecutor: ReturnType<typeof buildTxExecutor> | undefined;
+    const txDb = () => (txExecutor ??= buildTxExecutor());
     return {
       // eslint-disable-next-line @typescript-eslint/require-await
       execute: async <T = unknown>(
@@ -794,20 +803,21 @@ export class SqliteAdapter extends DrizzleAdapter {
         return stmt.all(...allValues) as T[];
       },
 
-      // TransactionContext CRUD methods delegate to the adapter's CRUD
-      // which uses Drizzle query API via the TableResolver.
+      // TransactionContext CRUD methods delegate to the adapter's Drizzle CRUD
+      // but pass the transaction-bound executor so they run inside this
+      // transaction rather than on the pool.
       select: async <T = unknown>(
         table: string,
         options?: SelectOptions
       ): Promise<T[]> => {
-        return this.select<T>(table, options);
+        return this.select<T>(table, options, txDb());
       },
 
       selectOne: async <T = unknown>(
         table: string,
         options?: SelectOptions
       ): Promise<T | null> => {
-        return this.selectOne<T>(table, options);
+        return this.selectOne<T>(table, options, txDb());
       },
 
       update: async <T = unknown>(
@@ -816,15 +826,15 @@ export class SqliteAdapter extends DrizzleAdapter {
         where: WhereClause,
         options?: UpdateOptions
       ): Promise<T[]> => {
-        return this.update<T>(table, data, where, options);
+        return this.update<T>(table, data, where, options, txDb());
       },
 
       delete: async (
         table: string,
         where: WhereClause,
-        _options?: DeleteOptions
+        options?: DeleteOptions
       ): Promise<number> => {
-        return this.delete(table, where);
+        return this.delete(table, where, options, txDb());
       },
 
       upsert: async <T = unknown>(
@@ -832,7 +842,7 @@ export class SqliteAdapter extends DrizzleAdapter {
         data: Record<string, unknown>,
         options: UpsertOptions
       ): Promise<T> => {
-        return this.upsert<T>(table, data, options);
+        return this.upsert<T>(table, data, options, txDb());
       },
 
       // eslint-disable-next-line @typescript-eslint/require-await


### PR DESCRIPTION
## What

Closes the third Codex finding from #222's post-merge review: on the pooled adapters, a read inside `adapter.transaction()` did not see rows written earlier in the same uncommitted transaction.

### Root cause
The `TransactionContext`'s `select` / `selectOne` / `update` / `delete` / `upsert` delegated to the adapter's own CRUD methods, which always run on `getDrizzle()` — the **pool-bound** Drizzle instance. `execute` / `insert` / `insertMany` correctly used the transaction's checked-out connection, but the Drizzle-path reads leaked to the pool:
- **Postgres / MySQL** (pooled): the delegated read ran on a *different* connection and could not see the transaction's uncommitted rows.
- **SQLite** (single-connection): incidentally correct, because there is only one connection.

Concrete impact: two same-title creates in one transaction (or bulk batch) both saw the base slug as free, both chose it, and the second insert hit the unique constraint instead of receiving `-2`. This is why #222's tx-scoped slug dedupe was only effective on SQLite.

### Fix
- **`adapter-drizzle` base**: `select`/`selectOne`/`update`/`delete`/`upsert` take an optional trailing `executor`, defaulting to `getDrizzle()`. Their internal read-backs (`update`→`select`, `upsert`→`selectOne`, `selectOne`→`select`) thread the same executor so a transactional call reads its own writes. Public signatures are unchanged for existing callers (the param is optional). A single consolidated `DrizzleExecutor` type replaces the per-call-site `getDrizzle<any>()` eslint-disables (net fewer disables).
- **Each dialect**: `createTransactionContext` lazily builds a Drizzle instance bound to its checked-out connection (PG `PoolClient`, MySQL the promise `PoolConnection`'s underlying callback `.connection`, SQLite the shared `db`) and routes the five delegated methods through it. Lazy + memoized, so transactions that use only raw `execute`/`insert` never construct it.

## Tests
New `transaction-read-your-writes.integration.test.ts` per dialect (self-skip without a DB URL):
- `selectOne` sees a row inserted earlier in the same transaction.
- Generated-slug dedupe within one transaction resolves `dup`, `dup-2`.

The **Postgres and MySQL** legs are the ones that fail without this fix; SQLite is a regression guard. Locally: all adapter unit suites (PG 87, MySQL 47, SQLite 61) + SQLite integration green; nextly plugin + collections integration (84 tests) green; build / check-types / lint clean across all four adapters.

Tracked in `tasks/slug-followups-post-222.md` (item #2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional transaction/executor support to Drizzle-query CRUD methods so callers can run follow-up reads/writes inside a provided transaction context.

- **Bug Fixes**
  - Improved “read-your-writes” consistency for transaction-scoped CRUD on MySQL, PostgreSQL, and SQLite.
  - Fixed transactional slug deduplication when multiple records are created in the same transaction.
  - More consistent non-`RETURNING` update/upsert readback behavior, including delete/upsert option handling.

- **Tests**
  - Added/extended integration tests validating transaction “read-your-writes” across MySQL, PostgreSQL, and SQLite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->