### PR TITLE
feat(nextly): add Standard Webhooks payload signing

### DIFF
--- a/.changeset/webhook-signing.md
+++ b/.changeset/webhook-signing.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Add Standard Webhooks payload signing.
+
+Pure signing primitives for outbound webhook deliveries: `signPayload` and `buildSignatureHeaders` produce the `webhook-id`/`webhook-timestamp`/`webhook-signature` headers (`v1,<base64 HMAC-SHA256 of "<id>.<timestamp>.<body>">`), and `verifySignature` is a constant-time verify helper covering secret rotation. `whsec_`-prefixed secrets are base64-decoded to key bytes. The delivery engine wires these in later; secrets live encrypted at rest and are decrypted before signing.

--- a/packages/nextly/src/domains/webhooks/__tests__/signing.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/signing.test.ts
@@ -213,6 +213,27 @@ describe("verifySignature", () => {
     ).toBe(false);
   });
 
+  it("stays fail-closed (returns false, does not throw) on a bad secret entry", () => {
+    // A zero-length secret in the list must not crash verification; a valid
+    // secret alongside it still verifies.
+    expect(
+      verifySignature({
+        ...base,
+        signatureHeader: header,
+        secrets: [""],
+        now,
+      })
+    ).toBe(false);
+    expect(
+      verifySignature({
+        ...base,
+        signatureHeader: header,
+        secrets: ["", secret],
+        now,
+      })
+    ).toBe(true);
+  });
+
   it("rejects a header with no v1 token", () => {
     expect(
       verifySignature({

--- a/packages/nextly/src/domains/webhooks/__tests__/signing.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/signing.test.ts
@@ -58,6 +58,10 @@ describe("buildSignatureHeaders", () => {
     expect(headers[WEBHOOK_SIGNATURE_HEADER]).toBe(`v1,${hmac(KEY)}`);
   });
 
+  it("throws rather than emitting a blank signature for an empty secret list", () => {
+    expect(() => buildSignatureHeaders({ ...base, secrets: [] })).toThrow();
+  });
+
   it("emits one space-delimited signature per active secret during rotation", () => {
     const oldKey = Buffer.from("old-secret-key-material-zzzzzzzz");
     const headers = buildSignatureHeaders({

--- a/packages/nextly/src/domains/webhooks/__tests__/signing.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/signing.test.ts
@@ -11,23 +11,35 @@ import {
   WEBHOOK_TIMESTAMP_HEADER,
 } from "../signing";
 
+// Secrets are Standard Webhooks base64 key material. KEY is the raw bytes;
+// `secret` is the stored (base64) form, and the whsec_ form decodes to the same
+// KEY — all three must produce the same HMAC.
+const KEY = Buffer.from("shared-secret-key-material-abcdef");
+const secret = KEY.toString("base64");
 const base = {
   id: "evt_1",
   timestamp: "1752796800",
   body: '{"type":"entry.updated"}',
-  secret: "shared-secret",
+  secret,
 };
+// A clock inside the freshness window for the fixed fixture timestamp.
+const now = new Date(Number(base.timestamp) * 1000);
+
+function hmac(key: Buffer): string {
+  return createHmac("sha256", key)
+    .update(`${base.id}.${base.timestamp}.${base.body}`)
+    .digest("base64");
+}
 
 describe("signPayload", () => {
-  it("produces a v1 token equal to base64(HMAC-SHA256 of id.timestamp.body)", () => {
-    const expected = createHmac("sha256", Buffer.from(base.secret, "utf8"))
-      .update(`${base.id}.${base.timestamp}.${base.body}`)
-      .digest("base64");
-    expect(signPayload(base)).toBe(`v1,${expected}`);
+  it("produces a v1 token equal to base64(HMAC-SHA256 over the base64-decoded key)", () => {
+    expect(signPayload(base)).toBe(`v1,${hmac(KEY)}`);
   });
 
-  it("is deterministic for the same input", () => {
-    expect(signPayload(base)).toBe(signPayload(base));
+  it("treats a whsec_-prefixed secret as the same base64 key material", () => {
+    expect(signPayload({ ...base, secret: `whsec_${secret}` })).toBe(
+      signPayload(base)
+    );
   });
 
   it("changes when the body, id, or timestamp changes", () => {
@@ -36,35 +48,49 @@ describe("signPayload", () => {
     expect(signPayload({ ...base, id: "evt_2" })).not.toBe(sig);
     expect(signPayload({ ...base, timestamp: "1752796801" })).not.toBe(sig);
   });
-
-  it("base64-decodes a whsec_-prefixed secret to key bytes", () => {
-    const raw = Buffer.from("rotation-key-material");
-    const secret = `whsec_${raw.toString("base64")}`;
-    const expected = createHmac("sha256", raw)
-      .update(`${base.id}.${base.timestamp}.${base.body}`)
-      .digest("base64");
-    expect(signPayload({ ...base, secret })).toBe(`v1,${expected}`);
-  });
 });
 
 describe("buildSignatureHeaders", () => {
-  it("returns the three Standard Webhooks headers", () => {
-    const headers = buildSignatureHeaders(base);
+  it("returns the three headers, signed with the single active secret", () => {
+    const headers = buildSignatureHeaders({ ...base, secrets: [secret] });
     expect(headers[WEBHOOK_ID_HEADER]).toBe(base.id);
     expect(headers[WEBHOOK_TIMESTAMP_HEADER]).toBe(base.timestamp);
-    expect(headers[WEBHOOK_SIGNATURE_HEADER]).toBe(signPayload(base));
+    expect(headers[WEBHOOK_SIGNATURE_HEADER]).toBe(`v1,${hmac(KEY)}`);
+  });
+
+  it("emits one space-delimited signature per active secret during rotation", () => {
+    const oldKey = Buffer.from("old-secret-key-material-zzzzzzzz");
+    const headers = buildSignatureHeaders({
+      ...base,
+      secrets: [secret, oldKey.toString("base64")],
+    });
+    expect(headers[WEBHOOK_SIGNATURE_HEADER]).toBe(
+      `v1,${hmac(KEY)} v1,${hmac(oldKey)}`
+    );
   });
 });
 
 describe("verifySignature", () => {
   const header = signPayload(base);
 
-  it("accepts a signature made with the matching secret", () => {
+  it("accepts a fresh signature made with the matching secret", () => {
     expect(
       verifySignature({
         ...base,
         signatureHeader: header,
-        secrets: [base.secret],
+        secrets: [secret],
+        now,
+      })
+    ).toBe(true);
+  });
+
+  it("accepts a whsec_-prefixed secret round-trip", () => {
+    expect(
+      verifySignature({
+        ...base,
+        signatureHeader: header,
+        secrets: [`whsec_${secret}`],
+        now,
       })
     ).toBe(true);
   });
@@ -74,7 +100,10 @@ describe("verifySignature", () => {
       verifySignature({
         ...base,
         signatureHeader: header,
-        secrets: ["other-secret"],
+        secrets: [
+          Buffer.from("other-key-material-1234567890").toString("base64"),
+        ],
+        now,
       })
     ).toBe(false);
   });
@@ -85,30 +114,60 @@ describe("verifySignature", () => {
         ...base,
         body: '{"type":"entry.deleted"}',
         signatureHeader: header,
-        secrets: [base.secret],
+        secrets: [secret],
+        now,
       })
     ).toBe(false);
   });
 
   it("accepts when the header carries multiple space-separated tokens", () => {
-    const multi = `v1,invalidsig ${header}`;
     expect(
       verifySignature({
         ...base,
-        signatureHeader: multi,
-        secrets: [base.secret],
+        signatureHeader: `v1,AAAA ${header}`,
+        secrets: [secret],
+        now,
       })
     ).toBe(true);
   });
 
   it("verifies against any secret during rotation", () => {
-    // Signed with the old secret; the new (primary) secret is also present.
-    const oldHeader = signPayload({ ...base, secret: "old-secret" });
+    const oldSecret = Buffer.from("old-key-material-abcdefghij").toString(
+      "base64"
+    );
+    const oldHeader = signPayload({ ...base, secret: oldSecret });
     expect(
       verifySignature({
         ...base,
         signatureHeader: oldHeader,
-        secrets: ["new-secret", "old-secret"],
+        secrets: [secret, oldSecret],
+        now,
+      })
+    ).toBe(true);
+  });
+
+  it("rejects a stale timestamp outside the tolerance", () => {
+    // now is ~10 minutes after the signed timestamp; default tolerance is 5.
+    const stale = new Date((Number(base.timestamp) + 600) * 1000);
+    expect(
+      verifySignature({
+        ...base,
+        signatureHeader: header,
+        secrets: [secret],
+        now: stale,
+      })
+    ).toBe(false);
+  });
+
+  it("can skip the freshness check with an infinite tolerance", () => {
+    const stale = new Date((Number(base.timestamp) + 600) * 1000);
+    expect(
+      verifySignature({
+        ...base,
+        signatureHeader: header,
+        secrets: [secret],
+        now: stale,
+        toleranceSeconds: Infinity,
       })
     ).toBe(true);
   });
@@ -118,7 +177,8 @@ describe("verifySignature", () => {
       verifySignature({
         ...base,
         signatureHeader: "v2,whatever",
-        secrets: [base.secret],
+        secrets: [secret],
+        now,
       })
     ).toBe(false);
   });

--- a/packages/nextly/src/domains/webhooks/__tests__/signing.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/signing.test.ts
@@ -1,0 +1,125 @@
+import { createHmac } from "node:crypto";
+
+import { describe, it, expect } from "vitest";
+
+import {
+  buildSignatureHeaders,
+  signPayload,
+  verifySignature,
+  WEBHOOK_ID_HEADER,
+  WEBHOOK_SIGNATURE_HEADER,
+  WEBHOOK_TIMESTAMP_HEADER,
+} from "../signing";
+
+const base = {
+  id: "evt_1",
+  timestamp: "1752796800",
+  body: '{"type":"entry.updated"}',
+  secret: "shared-secret",
+};
+
+describe("signPayload", () => {
+  it("produces a v1 token equal to base64(HMAC-SHA256 of id.timestamp.body)", () => {
+    const expected = createHmac("sha256", Buffer.from(base.secret, "utf8"))
+      .update(`${base.id}.${base.timestamp}.${base.body}`)
+      .digest("base64");
+    expect(signPayload(base)).toBe(`v1,${expected}`);
+  });
+
+  it("is deterministic for the same input", () => {
+    expect(signPayload(base)).toBe(signPayload(base));
+  });
+
+  it("changes when the body, id, or timestamp changes", () => {
+    const sig = signPayload(base);
+    expect(signPayload({ ...base, body: base.body + " " })).not.toBe(sig);
+    expect(signPayload({ ...base, id: "evt_2" })).not.toBe(sig);
+    expect(signPayload({ ...base, timestamp: "1752796801" })).not.toBe(sig);
+  });
+
+  it("base64-decodes a whsec_-prefixed secret to key bytes", () => {
+    const raw = Buffer.from("rotation-key-material");
+    const secret = `whsec_${raw.toString("base64")}`;
+    const expected = createHmac("sha256", raw)
+      .update(`${base.id}.${base.timestamp}.${base.body}`)
+      .digest("base64");
+    expect(signPayload({ ...base, secret })).toBe(`v1,${expected}`);
+  });
+});
+
+describe("buildSignatureHeaders", () => {
+  it("returns the three Standard Webhooks headers", () => {
+    const headers = buildSignatureHeaders(base);
+    expect(headers[WEBHOOK_ID_HEADER]).toBe(base.id);
+    expect(headers[WEBHOOK_TIMESTAMP_HEADER]).toBe(base.timestamp);
+    expect(headers[WEBHOOK_SIGNATURE_HEADER]).toBe(signPayload(base));
+  });
+});
+
+describe("verifySignature", () => {
+  const header = signPayload(base);
+
+  it("accepts a signature made with the matching secret", () => {
+    expect(
+      verifySignature({
+        ...base,
+        signatureHeader: header,
+        secrets: [base.secret],
+      })
+    ).toBe(true);
+  });
+
+  it("rejects a signature when no secret matches", () => {
+    expect(
+      verifySignature({
+        ...base,
+        signatureHeader: header,
+        secrets: ["other-secret"],
+      })
+    ).toBe(false);
+  });
+
+  it("rejects a tampered body", () => {
+    expect(
+      verifySignature({
+        ...base,
+        body: '{"type":"entry.deleted"}',
+        signatureHeader: header,
+        secrets: [base.secret],
+      })
+    ).toBe(false);
+  });
+
+  it("accepts when the header carries multiple space-separated tokens", () => {
+    const multi = `v1,invalidsig ${header}`;
+    expect(
+      verifySignature({
+        ...base,
+        signatureHeader: multi,
+        secrets: [base.secret],
+      })
+    ).toBe(true);
+  });
+
+  it("verifies against any secret during rotation", () => {
+    // Signed with the old secret; the new (primary) secret is also present.
+    const oldHeader = signPayload({ ...base, secret: "old-secret" });
+    expect(
+      verifySignature({
+        ...base,
+        signatureHeader: oldHeader,
+        secrets: ["new-secret", "old-secret"],
+      })
+    ).toBe(true);
+  });
+
+  it("rejects a header with no v1 token", () => {
+    expect(
+      verifySignature({
+        ...base,
+        signatureHeader: "v2,whatever",
+        secrets: [base.secret],
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/signing.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/signing.test.ts
@@ -62,6 +62,13 @@ describe("buildSignatureHeaders", () => {
     expect(() => buildSignatureHeaders({ ...base, secrets: [] })).toThrow();
   });
 
+  it("throws on a zero-length signing key (empty or bare whsec_)", () => {
+    expect(() => buildSignatureHeaders({ ...base, secrets: [""] })).toThrow();
+    expect(() =>
+      buildSignatureHeaders({ ...base, secrets: ["whsec_"] })
+    ).toThrow();
+  });
+
   it("emits one space-delimited signature per active secret during rotation", () => {
     const oldKey = Buffer.from("old-secret-key-material-zzzzzzzz");
     const headers = buildSignatureHeaders({
@@ -174,6 +181,36 @@ describe("verifySignature", () => {
         toleranceSeconds: Infinity,
       })
     ).toBe(true);
+  });
+
+  it("fails closed on a malformed tolerance or now (does not skip the check)", () => {
+    // NaN/negative tolerance and an invalid `now` must reject, not accept.
+    expect(
+      verifySignature({
+        ...base,
+        signatureHeader: header,
+        secrets: [secret],
+        now,
+        toleranceSeconds: NaN,
+      })
+    ).toBe(false);
+    expect(
+      verifySignature({
+        ...base,
+        signatureHeader: header,
+        secrets: [secret],
+        now,
+        toleranceSeconds: -1,
+      })
+    ).toBe(false);
+    expect(
+      verifySignature({
+        ...base,
+        signatureHeader: header,
+        secrets: [secret],
+        now: new Date(NaN),
+      })
+    ).toBe(false);
   });
 
   it("rejects a header with no v1 token", () => {

--- a/packages/nextly/src/domains/webhooks/index.ts
+++ b/packages/nextly/src/domains/webhooks/index.ts
@@ -16,6 +16,7 @@ export {
   WEBHOOK_TIMESTAMP_HEADER,
   WEBHOOK_SIGNATURE_HEADER,
   type SignInput,
+  type SignHeadersInput,
   type VerifyInput,
 } from "./signing";
 export {

--- a/packages/nextly/src/domains/webhooks/index.ts
+++ b/packages/nextly/src/domains/webhooks/index.ts
@@ -9,6 +9,16 @@
 export { buildEnvelope, type BuildEnvelopeInput } from "./envelope";
 export { matchesFilter } from "./filter";
 export {
+  signPayload,
+  buildSignatureHeaders,
+  verifySignature,
+  WEBHOOK_ID_HEADER,
+  WEBHOOK_TIMESTAMP_HEADER,
+  WEBHOOK_SIGNATURE_HEADER,
+  type SignInput,
+  type VerifyInput,
+} from "./signing";
+export {
   WEBHOOK_EVENT_TYPES,
   type WebhookEventType,
   type WebhookResourceKind,

--- a/packages/nextly/src/domains/webhooks/signing.ts
+++ b/packages/nextly/src/domains/webhooks/signing.ts
@@ -24,6 +24,8 @@
 
 import { createHmac, timingSafeEqual } from "node:crypto";
 
+import { NextlyError } from "../../errors";
+
 export const WEBHOOK_ID_HEADER = "webhook-id";
 export const WEBHOOK_TIMESTAMP_HEADER = "webhook-timestamp";
 export const WEBHOOK_SIGNATURE_HEADER = "webhook-signature";
@@ -103,6 +105,14 @@ export interface SignHeadersInput {
 export function buildSignatureHeaders(
   input: SignHeadersInput
 ): Record<string, string> {
+  // A delivery must be signed. An empty secret list would otherwise produce a
+  // blank webhook-signature header that every conformant receiver rejects, with
+  // no signal to the caller — fail loudly instead.
+  if (input.secrets.length === 0) {
+    throw NextlyError.internal({
+      logContext: { reason: "no-signing-secrets", webhookEventId: input.id },
+    });
+  }
   const signatures = input.secrets.map(
     secret =>
       `v1,${computeSignature(secret, input.id, input.timestamp, input.body)}`

--- a/packages/nextly/src/domains/webhooks/signing.ts
+++ b/packages/nextly/src/domains/webhooks/signing.ts
@@ -189,12 +189,20 @@ export function verifySignature(input: VerifyInput): boolean {
   if (presented.length === 0) return false;
 
   for (const secret of input.secrets) {
-    const expected = computeSignature(
-      secret,
-      input.id,
-      input.timestamp,
-      input.body
-    );
+    // Verification must stay fail-closed: a malformed/empty secret entry (which
+    // `secretToKey` rejects by throwing) simply can't match, so skip it rather
+    // than let the exception escape. Signing still fails loud on a bad key.
+    let expected: string;
+    try {
+      expected = computeSignature(
+        secret,
+        input.id,
+        input.timestamp,
+        input.body
+      );
+    } catch {
+      continue;
+    }
     if (presented.some(sig => signaturesEqual(sig, expected))) return true;
   }
   return false;

--- a/packages/nextly/src/domains/webhooks/signing.ts
+++ b/packages/nextly/src/domains/webhooks/signing.ts
@@ -11,9 +11,9 @@
  *
  * The signature covers the EXACT bytes that are sent, so the delivery engine
  * must sign the already-serialized body and transmit that same string. Secrets
- * are handled as a list (one active now) so key rotation is additive: a
- * delivery is signed with the primary secret, and verification accepts a match
- * against any secret in the list.
+ * are handled as a list so key rotation is additive: a delivery is signed with
+ * every active secret (one `v1` token per secret), and verification accepts a
+ * match against any secret in the list.
  *
  * These are pure functions over the plaintext secret. Secrets live encrypted at
  * rest (utils/encryption.ts + NEXTLY_SECRET); the CRUD and delivery slices own
@@ -43,7 +43,14 @@ function secretToKey(secret: string): Buffer {
   const encoded = secret.startsWith(SECRET_PREFIX)
     ? secret.slice(SECRET_PREFIX.length)
     : secret;
-  return Buffer.from(encoded, "base64");
+  const key = Buffer.from(encoded, "base64");
+  // A zero-length key (empty string, or a bare `whsec_`) is a broken secret:
+  // it would still produce a valid-looking HMAC, so reject it rather than sign
+  // or verify with no real key material.
+  if (key.length === 0) {
+    throw NextlyError.internal({ logContext: { reason: "empty-signing-key" } });
+  }
+  return key;
 }
 
 /** The exact content the signature is computed over. */
@@ -161,11 +168,17 @@ export interface VerifyInput {
  * be replayed indefinitely.
  */
 export function verifySignature(input: VerifyInput): boolean {
+  // Fail closed: only an explicit `Infinity` disables freshness. A NaN,
+  // negative, or otherwise non-finite tolerance, or an invalid `now`, must
+  // reject rather than silently accept a possibly-replayed signature.
   const tolerance = input.toleranceSeconds ?? DEFAULT_TOLERANCE_SECONDS;
-  if (Number.isFinite(tolerance)) {
+  if (tolerance !== Infinity) {
+    if (!Number.isFinite(tolerance) || tolerance < 0) return false;
     const signedAt = Number(input.timestamp);
     if (!Number.isFinite(signedAt)) return false;
-    const nowSeconds = Math.floor((input.now ?? new Date()).getTime() / 1000);
+    const nowMs = (input.now ?? new Date()).getTime();
+    if (!Number.isFinite(nowMs)) return false;
+    const nowSeconds = Math.floor(nowMs / 1000);
     if (Math.abs(nowSeconds - signedAt) > tolerance) return false;
   }
 

--- a/packages/nextly/src/domains/webhooks/signing.ts
+++ b/packages/nextly/src/domains/webhooks/signing.ts
@@ -1,0 +1,140 @@
+/**
+ * Webhook domain — Standard Webhooks signing.
+ *
+ * Implements the Standard Webhooks (standardwebhooks.com) symmetric signing
+ * scheme so receivers can verify a delivery came from this site and was not
+ * tampered with:
+ *
+ *   signedContent = "<id>.<timestamp>.<rawBody>"
+ *   signature     = base64(HMAC_SHA256(secretBytes, signedContent))
+ *   webhook-signature: "v1,<signature>"
+ *
+ * The signature covers the EXACT bytes that are sent, so the delivery engine
+ * must sign the already-serialized body and transmit that same string. Secrets
+ * are handled as a list (one active now) so key rotation is additive: a
+ * delivery is signed with the primary secret, and verification accepts a match
+ * against any secret in the list.
+ *
+ * These are pure functions over the plaintext secret. Secrets live encrypted at
+ * rest (utils/encryption.ts + NEXTLY_SECRET); the CRUD and delivery slices own
+ * the encrypt/decrypt boundary and pass the decrypted secret in here.
+ *
+ * @module domains/webhooks/signing
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export const WEBHOOK_ID_HEADER = "webhook-id";
+export const WEBHOOK_TIMESTAMP_HEADER = "webhook-timestamp";
+export const WEBHOOK_SIGNATURE_HEADER = "webhook-signature";
+
+/** Standard Webhooks secrets may be `whsec_`-prefixed and base64-encoded. */
+const SECRET_PREFIX = "whsec_";
+
+/**
+ * Resolve a secret string to its raw key bytes. A `whsec_`-prefixed secret is
+ * base64-decoded (the Standard Webhooks convention); any other string is used
+ * as UTF-8 bytes, so plain shared secrets also work.
+ */
+function secretToKey(secret: string): Buffer {
+  if (secret.startsWith(SECRET_PREFIX)) {
+    return Buffer.from(secret.slice(SECRET_PREFIX.length), "base64");
+  }
+  return Buffer.from(secret, "utf8");
+}
+
+/** The exact content the signature is computed over. */
+function signedContent(id: string, timestamp: string, body: string): string {
+  return `${id}.${timestamp}.${body}`;
+}
+
+/** Base64 HMAC-SHA256 of `<id>.<timestamp>.<body>` under one secret. */
+function computeSignature(
+  secret: string,
+  id: string,
+  timestamp: string,
+  body: string
+): string {
+  return createHmac("sha256", secretToKey(secret))
+    .update(signedContent(id, timestamp, body))
+    .digest("base64");
+}
+
+export interface SignInput {
+  /** Envelope id; also the `webhook-id` header. */
+  id: string;
+  /** Unix seconds as a string; also the `webhook-timestamp` header. */
+  timestamp: string;
+  /** The exact serialized body bytes that will be sent. */
+  body: string;
+  /** Active signing secret (plaintext). */
+  secret: string;
+}
+
+/** The versioned signature token, e.g. `v1,<base64>`. */
+export function signPayload(input: SignInput): string {
+  const sig = computeSignature(
+    input.secret,
+    input.id,
+    input.timestamp,
+    input.body
+  );
+  return `v1,${sig}`;
+}
+
+/**
+ * The three Standard Webhooks headers for a delivery. Signed with the primary
+ * (first) secret; additional secrets exist only so verification survives a
+ * rotation.
+ */
+export function buildSignatureHeaders(
+  input: SignInput
+): Record<string, string> {
+  return {
+    [WEBHOOK_ID_HEADER]: input.id,
+    [WEBHOOK_TIMESTAMP_HEADER]: input.timestamp,
+    [WEBHOOK_SIGNATURE_HEADER]: signPayload(input),
+  };
+}
+
+/** Constant-time equality for two base64 signature strings. */
+function signaturesEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, "utf8");
+  const bufB = Buffer.from(b, "utf8");
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
+export interface VerifyInput {
+  id: string;
+  timestamp: string;
+  body: string;
+  /** The received `webhook-signature` header (may hold multiple space-separated tokens). */
+  signatureHeader: string;
+  /** Every currently-valid secret (plaintext); rotation keeps more than one. */
+  secrets: readonly string[];
+}
+
+/**
+ * Whether `signatureHeader` contains a valid `v1` signature for `body` under
+ * any of `secrets`. A verify helper for tests and for documenting the scheme;
+ * receivers are pointed at the `standardwebhooks` libraries.
+ */
+export function verifySignature(input: VerifyInput): boolean {
+  const presented = input.signatureHeader
+    .split(" ")
+    .filter(token => token.startsWith("v1,"))
+    .map(token => token.slice("v1,".length));
+  if (presented.length === 0) return false;
+
+  for (const secret of input.secrets) {
+    const expected = computeSignature(
+      secret,
+      input.id,
+      input.timestamp,
+      input.body
+    );
+    if (presented.some(sig => signaturesEqual(sig, expected))) return true;
+  }
+  return false;
+}

--- a/packages/nextly/src/domains/webhooks/signing.ts
+++ b/packages/nextly/src/domains/webhooks/signing.ts
@@ -28,19 +28,20 @@ export const WEBHOOK_ID_HEADER = "webhook-id";
 export const WEBHOOK_TIMESTAMP_HEADER = "webhook-timestamp";
 export const WEBHOOK_SIGNATURE_HEADER = "webhook-signature";
 
-/** Standard Webhooks secrets may be `whsec_`-prefixed and base64-encoded. */
+/** Standard Webhooks secrets are `whsec_`-prefixed, base64-encoded key bytes. */
 const SECRET_PREFIX = "whsec_";
 
 /**
- * Resolve a secret string to its raw key bytes. A `whsec_`-prefixed secret is
- * base64-decoded (the Standard Webhooks convention); any other string is used
- * as UTF-8 bytes, so plain shared secrets also work.
+ * Resolve a secret string to its raw key bytes. Matches the `standardwebhooks`
+ * reference libraries exactly: strip the optional `whsec_` prefix, then
+ * base64-decode the remainder to the HMAC key. Decoding is unconditional so a
+ * receiver using the same secret with those libraries computes the same HMAC.
  */
 function secretToKey(secret: string): Buffer {
-  if (secret.startsWith(SECRET_PREFIX)) {
-    return Buffer.from(secret.slice(SECRET_PREFIX.length), "base64");
-  }
-  return Buffer.from(secret, "utf8");
+  const encoded = secret.startsWith(SECRET_PREFIX)
+    ? secret.slice(SECRET_PREFIX.length)
+    : secret;
+  return Buffer.from(encoded, "base64");
 }
 
 /** The exact content the signature is computed over. */
@@ -82,28 +83,47 @@ export function signPayload(input: SignInput): string {
   return `v1,${sig}`;
 }
 
+export interface SignHeadersInput {
+  id: string;
+  timestamp: string;
+  body: string;
+  /**
+   * Active signing secrets, primary first. One `v1` signature is emitted per
+   * secret so that during a rotation window a consumer holding either the new
+   * or the old secret can verify.
+   */
+  secrets: readonly string[];
+}
+
 /**
- * The three Standard Webhooks headers for a delivery. Signed with the primary
- * (first) secret; additional secrets exist only so verification survives a
- * rotation.
+ * The three Standard Webhooks headers for a delivery. The `webhook-signature`
+ * value is the space-delimited set of `v1,<sig>` tokens — one per active
+ * secret — which is how the spec expects a producer to sign through a rotation.
  */
 export function buildSignatureHeaders(
-  input: SignInput
+  input: SignHeadersInput
 ): Record<string, string> {
+  const signatures = input.secrets.map(
+    secret =>
+      `v1,${computeSignature(secret, input.id, input.timestamp, input.body)}`
+  );
   return {
     [WEBHOOK_ID_HEADER]: input.id,
     [WEBHOOK_TIMESTAMP_HEADER]: input.timestamp,
-    [WEBHOOK_SIGNATURE_HEADER]: signPayload(input),
+    [WEBHOOK_SIGNATURE_HEADER]: signatures.join(" "),
   };
 }
 
-/** Constant-time equality for two base64 signature strings. */
+/** Constant-time equality over the raw HMAC bytes of two base64 signatures. */
 function signaturesEqual(a: string, b: string): boolean {
-  const bufA = Buffer.from(a, "utf8");
-  const bufB = Buffer.from(b, "utf8");
+  const bufA = Buffer.from(a, "base64");
+  const bufB = Buffer.from(b, "base64");
   if (bufA.length !== bufB.length) return false;
   return timingSafeEqual(bufA, bufB);
 }
+
+/** Default replay window: reject timestamps more than 5 minutes from now. */
+const DEFAULT_TOLERANCE_SECONDS = 300;
 
 export interface VerifyInput {
   id: string;
@@ -113,14 +133,32 @@ export interface VerifyInput {
   signatureHeader: string;
   /** Every currently-valid secret (plaintext); rotation keeps more than one. */
   secrets: readonly string[];
+  /**
+   * Max allowed difference between the signed timestamp and `now`, in seconds.
+   * Defaults to 300 (the Standard Webhooks recommendation); pass `Infinity` to
+   * skip the freshness check.
+   */
+  toleranceSeconds?: number;
+  /** Current time; defaults to the wall clock. Injectable for tests. */
+  now?: Date;
 }
 
 /**
- * Whether `signatureHeader` contains a valid `v1` signature for `body` under
- * any of `secrets`. A verify helper for tests and for documenting the scheme;
- * receivers are pointed at the `standardwebhooks` libraries.
+ * Whether `signatureHeader` contains a valid, fresh `v1` signature for `body`
+ * under any of `secrets`. A verify helper for tests and for documenting the
+ * scheme; receivers are pointed at the `standardwebhooks` libraries. The
+ * timestamp is checked against a tolerance first so a captured delivery cannot
+ * be replayed indefinitely.
  */
 export function verifySignature(input: VerifyInput): boolean {
+  const tolerance = input.toleranceSeconds ?? DEFAULT_TOLERANCE_SECONDS;
+  if (Number.isFinite(tolerance)) {
+    const signedAt = Number(input.timestamp);
+    if (!Number.isFinite(signedAt)) return false;
+    const nowSeconds = Math.floor((input.now ?? new Date()).getTime() / 1000);
+    if (Math.abs(nowSeconds - signedAt) > tolerance) return false;
+  }
+
   const presented = input.signatureHeader
     .split(" ")
     .filter(token => token.startsWith("v1,"))


### PR DESCRIPTION
## What

P1e (signing half) of the webhooks program. Pure Standard Webhooks (standardwebhooks.com) signing primitives the delivery engine will use to sign every outbound delivery. **Stacked on #223**; retarget to `main` once it merges. Independent of the capture slice (#225).

`domains/webhooks/signing.ts`:
- **`signPayload`** / **`buildSignatureHeaders`** — emit `webhook-id`, `webhook-timestamp`, and `webhook-signature: v1,<base64(HMAC-SHA256(secret, "<id>.<timestamp>.<body>"))>`. Signs the EXACT serialized body bytes (never re-serialized).
- **`verifySignature`** — constant-time (`timingSafeEqual`) verify helper for tests + docs; handles multiple space-separated header tokens and multiple secrets.
- **Secret list + rotation** — sign with the primary secret; verify against any. `whsec_`-prefixed secrets are base64-decoded to key bytes (Standard Webhooks convention); plain strings work as UTF-8 bytes.

## Secret storage decision (researched)

HMAC signing needs the raw secret to sign each delivery, so the "hashed at rest like api-keys" note doesn't work for signing — you can't sign with a one-way hash. Following the existing Nextly pattern (email-provider credentials use `utils/encryption.ts` AES-256-GCM + `NEXTLY_SECRET`), **signing secrets are stored encrypted at rest and decrypted to sign** (matches Stripe/Svix; secret stays retrievable for the user to configure their receiver). The merged `nextly_webhooks.secret_hash` jsonb-array column therefore holds ciphertext (array for rotation), not a hash. This module is pure over the plaintext secret; the encrypt-on-create wiring is P2 (CRUD) and decrypt-on-send is P1f (delivery).

## Tests

11 unit tests: signature equals a hand-computed HMAC, determinism, sensitivity to id/timestamp/body, `whsec_` base64 decode, header set, verify accept/reject, tamper detection, multi-token headers, rotation, and non-v1 rejection. `check-types`, `eslint`, tests green locally.

## Not in this PR

The SSRF DNS-rebinding fix (the other half of P1e) is a separate PR — it touches existing `validate-external-url`/`safeFetch` production code and is a distinct concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Standard Webhooks-compatible signing and verification for webhook payloads.
  - Added webhook signature header generation, including support for multiple active secrets for rotation.
  - Exported Standard Webhooks header names and TypeScript input types for signing/verification.
  - Added timestamp freshness validation with configurable tolerance, including an option to disable it.
- **Tests**
  - Added comprehensive test coverage for signature correctness, rotation behavior, tampered payloads, stale timestamps, malformed inputs, and fail-closed verification on invalid secrets or signature headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->