### PR TITLE
feat(nextly): add webhook fan-out from events to delivery rows

### DIFF
--- a/.changeset/webhook-fan-out.md
+++ b/.changeset/webhook-fan-out.md
@@ -1,0 +1,25 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/ui": patch
+---
+
+Add webhook fan-out: turn durable events into per-endpoint delivery rows.
+
+`fanOutDueEvents` is the drain's first phase. `recordEvent` writes only the durable event inside the content transaction; fan-out runs separately and matches each un-fanned event to the enabled endpoints (subscribed type plus the endpoint filter) and inserts one `nextly_webhook_deliveries` row per match. This keeps content writes fully decoupled from the webhook registry (the transactional-outbox split), so creating, disabling, or deleting a webhook can never fail an unrelated content write.
+
+A new `fanned_out_at` marker column on `nextly_events` lets the drain find events still needing fan-out. Fan-out is idempotent under concurrent drains: each event is processed in its own transaction that inserts only the deliveries not already present, with the unique `(webhook_id, event_id)` index as the hard backstop, and a losing race simply retries on the next pass. Also adds the race-safe `WebhookEndpointRegistry` (cached enabled-endpoint load) and the pure `selectDeliveryTargets`. Delivery (signing, sending, retries) lands in a following change.

--- a/packages/nextly/src/domains/webhooks/__tests__/endpoint-registry.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/endpoint-registry.test.ts
@@ -76,6 +76,42 @@ describe("WebhookEndpointRegistry", () => {
     expect((await after).map(e => e.id)).toEqual(["fresh"]);
   });
 
+  it("normalizes a malformed array column to an array (no throw during matching)", async () => {
+    const reader = new FakeReader();
+    const registry = new WebhookEndpointRegistry(reader);
+    const p = registry.getEnabledEndpoints();
+    // A legacy/manual write stored event_types as a bare string.
+    reader.resolveNext([{ ...row("wh_bad"), eventTypes: "entry.updated" }]);
+    const [endpoint] = await p;
+    expect(Array.isArray(endpoint.eventTypes)).toBe(true);
+    expect(endpoint.eventTypes).toEqual([]);
+  });
+
+  it("reloads after the TTL elapses (bounds cross-process staleness)", async () => {
+    let clock = 1000;
+    const reader = new FakeReader();
+    const registry = new WebhookEndpointRegistry(reader, {
+      ttlMs: 500,
+      now: () => clock,
+    });
+
+    const first = registry.getEnabledEndpoints();
+    reader.resolveNext([row("v1")]);
+    expect((await first).map(e => e.id)).toEqual(["v1"]);
+
+    // Within the TTL: cache hit, no reload.
+    clock = 1400;
+    await registry.getEnabledEndpoints();
+    expect(reader.calls).toBe(1);
+
+    // Past the TTL: reload.
+    clock = 1600;
+    const stale = registry.getEnabledEndpoints();
+    expect(reader.calls).toBe(2);
+    reader.resolveNext([row("v2")]);
+    expect((await stale).map(e => e.id)).toEqual(["v2"]);
+  });
+
   it("does not let a load that finishes after invalidate() repopulate the cache", async () => {
     const reader = new FakeReader();
     const registry = new WebhookEndpointRegistry(reader);

--- a/packages/nextly/src/domains/webhooks/__tests__/endpoint-registry.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/endpoint-registry.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  WebhookEndpointRegistry,
+  type WebhookEndpointReader,
+} from "../endpoint-registry";
+
+// A reader that counts loads and resolves each on demand, so concurrency and
+// invalidation ordering can be driven deterministically.
+class FakeReader implements WebhookEndpointReader {
+  calls = 0;
+  private resolvers: Array<(rows: Record<string, unknown>[]) => void> = [];
+
+  select<T = unknown>(): Promise<T[]> {
+    this.calls += 1;
+    return new Promise<T[]>(resolve => {
+      this.resolvers.push(resolve as (rows: Record<string, unknown>[]) => void);
+    }) as Promise<T[]>;
+  }
+
+  resolveNext(rows: Record<string, unknown>[]): void {
+    const resolve = this.resolvers.shift();
+    resolve?.(rows);
+  }
+}
+
+function row(id: string): Record<string, unknown> {
+  return {
+    id,
+    name: id,
+    url: "https://example.com",
+    enabled: true,
+    eventTypes: ["entry.updated"],
+    filter: null,
+    headers: null,
+    secretHash: [],
+    secretPrefix: "",
+    fieldAllowlist: null,
+    createdBy: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+describe("WebhookEndpointRegistry", () => {
+  it("coalesces concurrent first-loads into a single query", async () => {
+    const reader = new FakeReader();
+    const registry = new WebhookEndpointRegistry(reader);
+
+    const a = registry.getEnabledEndpoints();
+    const b = registry.getEnabledEndpoints();
+    expect(reader.calls).toBe(1);
+
+    reader.resolveNext([row("wh_1")]);
+    const [ra, rb] = await Promise.all([a, b]);
+    expect(ra.map(e => e.id)).toEqual(["wh_1"]);
+    expect(rb).toBe(ra);
+
+    // Cache hit: no further query.
+    await registry.getEnabledEndpoints();
+    expect(reader.calls).toBe(1);
+  });
+
+  it("starts a fresh load for callers arriving after invalidate(), not the stale in-flight one", async () => {
+    const reader = new FakeReader();
+    const registry = new WebhookEndpointRegistry(reader);
+
+    const before = registry.getEnabledEndpoints(); // load 1, in flight
+    registry.invalidate();
+    const after = registry.getEnabledEndpoints(); // must NOT reuse load 1
+    expect(reader.calls).toBe(2);
+
+    reader.resolveNext([row("stale")]); // resolves load 1 (pre-invalidation caller)
+    reader.resolveNext([row("fresh")]); // resolves load 2
+    expect((await before).map(e => e.id)).toEqual(["stale"]);
+    expect((await after).map(e => e.id)).toEqual(["fresh"]);
+  });
+
+  it("does not let a load that finishes after invalidate() repopulate the cache", async () => {
+    const reader = new FakeReader();
+    const registry = new WebhookEndpointRegistry(reader);
+
+    const first = registry.getEnabledEndpoints();
+    // CRUD changes an endpoint mid-load and invalidates.
+    registry.invalidate();
+    reader.resolveNext([row("stale")]);
+    await first;
+
+    // The stale result must not have been cached; the next read reloads.
+    const second = registry.getEnabledEndpoints();
+    expect(reader.calls).toBe(2);
+    reader.resolveNext([row("fresh")]);
+    expect((await second).map(e => e.id)).toEqual(["fresh"]);
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/endpoint-registry.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/endpoint-registry.test.ts
@@ -87,6 +87,19 @@ describe("WebhookEndpointRegistry", () => {
     expect(endpoint.eventTypes).toEqual([]);
   });
 
+  it("normalizes a malformed v1 filter so matching cannot throw", async () => {
+    const reader = new FakeReader();
+    const registry = new WebhookEndpointRegistry(reader);
+    const p = registry.getEnabledEndpoints();
+    // A legacy/manual write stored changedFields as a bare string; matchesFilter
+    // would call .some(...) on it and throw.
+    reader.resolveNext([
+      { ...row("wh"), filter: { version: 1, changedFields: "title" } },
+    ]);
+    const [endpoint] = await p;
+    expect(endpoint.filter).toMatchObject({ version: 1, changedFields: null });
+  });
+
   it("reloads after the TTL elapses (bounds cross-process staleness)", async () => {
     let clock = 1000;
     const reader = new FakeReader();

--- a/packages/nextly/src/domains/webhooks/__tests__/fan-out.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/fan-out.integration.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Integration test for webhook fan-out (`fanOutDueEvents`) against a real
+ * SQLite database. Exercises the full events -> delivery-rows path: matching,
+ * per-endpoint delivery inserts, the fanned_out_at marker, and idempotency
+ * (marker-based and read-filter dedup).
+ *
+ * Uses an in-memory SQLite database built from the production table definitions
+ * via drizzle-kit (never hand-copied CREATE TABLE; see
+ * .claude/rules/integration-tests.md).
+ */
+
+import { createSqliteAdapter } from "@nextlyhq/adapter-sqlite";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { getSQLiteDrizzleKit } from "../../../database/drizzle-kit-lazy";
+import { SchemaRegistry } from "../../../database/schema-registry";
+import { splitStatements } from "../../schema/pipeline/sql-statement-utils";
+import {
+  nextlyEvents,
+  nextlyWebhooks,
+  nextlyWebhookDeliveries,
+} from "../../../schemas/webhooks/sqlite";
+import { users } from "../../../schemas/users/sqlite";
+import { buildEnvelope } from "../envelope";
+import { recordEvent } from "../record-event";
+import { WebhookEndpointRegistry } from "../endpoint-registry";
+import { fanOutDueEvents } from "../fan-out";
+import type { WebhookEventType } from "../types";
+
+process.env.DB_DIALECT = "sqlite";
+
+const tables = { nextlyEvents, nextlyWebhooks, nextlyWebhookDeliveries };
+// nextly_webhooks.created_by references users, so the FK target table must
+// exist for SQLite's foreign-key enforcement on webhook writes.
+const ddlTables = { ...tables, users };
+
+async function schemaDdl(): Promise<string[]> {
+  const kit = await getSQLiteDrizzleKit();
+  const statements = await kit.generateMigration(
+    await kit.generateDrizzleJson({}),
+    await kit.generateDrizzleJson(ddlTables)
+  );
+  return splitStatements(statements);
+}
+
+describe("webhook fan-out (real SQLite)", () => {
+  let adapter: ReturnType<typeof createSqliteAdapter>;
+
+  beforeAll(async () => {
+    adapter = createSqliteAdapter({ memory: true });
+    await adapter.connect();
+    for (const stmt of await schemaDdl()) await adapter.executeQuery(stmt);
+
+    const schemaRegistry = new SchemaRegistry();
+    schemaRegistry.registerStaticSchemas(tables);
+    adapter.setTableResolver(schemaRegistry);
+  });
+
+  afterAll(async () => {
+    try {
+      await adapter?.disconnect?.();
+    } catch {
+      // ignore teardown errors
+    }
+  });
+
+  beforeEach(async () => {
+    await adapter.executeQuery("DELETE FROM nextly_webhook_deliveries");
+    await adapter.executeQuery("DELETE FROM nextly_webhooks");
+    await adapter.executeQuery("DELETE FROM nextly_events");
+  });
+
+  async function seedWebhook(
+    id: string,
+    eventTypes: WebhookEventType[] = ["entry.updated"]
+  ): Promise<void> {
+    const now = new Date();
+    await adapter.insert("nextly_webhooks", {
+      id,
+      name: id,
+      url: `https://example.com/${id}`,
+      enabled: true,
+      event_types: eventTypes,
+      filter: null,
+      headers: null,
+      secret_hash: [],
+      secret_prefix: "",
+      field_allowlist: null,
+      created_by: null,
+      created_at: now,
+      updated_at: now,
+    });
+  }
+
+  async function seedEvent(
+    id: string,
+    type: WebhookEventType = "entry.updated"
+  ): Promise<void> {
+    const envelope = buildEnvelope({
+      id,
+      type,
+      timestamp: new Date("2026-07-18T00:00:00.000Z"),
+      resource: { kind: "entry", collection: "posts", id: "p1" },
+      data: { id: "p1", title: "Hello" },
+    });
+    await adapter.transaction(async tx => recordEvent(tx, { envelope }));
+  }
+
+  function runFanOut() {
+    const registry = new WebhookEndpointRegistry(adapter);
+    return fanOutDueEvents({
+      db: adapter,
+      loadEndpoints: () => registry.getEnabledEndpoints(),
+    });
+  }
+
+  async function deliveries(): Promise<
+    Array<{ webhookId: string; eventId: string; status: string }>
+  > {
+    return adapter.select("nextly_webhook_deliveries");
+  }
+
+  async function fannedOutAt(eventId: string): Promise<unknown> {
+    const rows = await adapter.select<{ fannedOutAt: unknown }>(
+      "nextly_events",
+      { where: { and: [{ column: "id", op: "=", value: eventId }] } }
+    );
+    return rows[0]?.fannedOutAt ?? null;
+  }
+
+  it("creates a delivery per matching endpoint and marks the event fanned out", async () => {
+    await seedWebhook("wh_a");
+    await seedWebhook("wh_b");
+    await seedEvent("evt_1");
+
+    const result = await runFanOut();
+
+    expect(result).toEqual({ eventsProcessed: 1, deliveriesCreated: 2 });
+    const rows = await deliveries();
+    expect(rows.map(r => r.webhookId).sort()).toEqual(["wh_a", "wh_b"]);
+    expect(rows.every(r => r.eventId === "evt_1")).toBe(true);
+    expect(rows.every(r => r.status === "pending")).toBe(true);
+    expect(await fannedOutAt("evt_1")).not.toBeNull();
+  });
+
+  it("is idempotent: a second pass finds no un-fanned events and creates nothing", async () => {
+    await seedWebhook("wh_a");
+    await seedEvent("evt_1");
+
+    await runFanOut();
+    const second = await runFanOut();
+
+    expect(second).toEqual({ eventsProcessed: 0, deliveriesCreated: 0 });
+    expect(await deliveries()).toHaveLength(1);
+  });
+
+  it("skips endpoints already delivered-to (read-filter dedup)", async () => {
+    await seedWebhook("wh_a");
+    await seedWebhook("wh_b");
+    await seedEvent("evt_1");
+    // A delivery for wh_a already exists (e.g. a prior partial pass); fan-out
+    // must insert only wh_b and never conflict on the unique index.
+    const now = new Date();
+    await adapter.insert("nextly_webhook_deliveries", {
+      id: "dlv_pre",
+      webhook_id: "wh_a",
+      event_id: "evt_1",
+      status: "delivered",
+      attempt_count: 1,
+      next_attempt_at: null,
+      created_at: now,
+      updated_at: now,
+    });
+
+    const result = await runFanOut();
+
+    expect(result.deliveriesCreated).toBe(1);
+    const rows = await deliveries();
+    expect(rows.map(r => r.webhookId).sort()).toEqual(["wh_a", "wh_b"]);
+    expect(rows).toHaveLength(2);
+  });
+
+  it("marks an event with no matching endpoint fanned out, creating no deliveries", async () => {
+    await seedWebhook("wh_a", ["entry.created"]);
+    await seedEvent("evt_1", "entry.updated");
+
+    const result = await runFanOut();
+
+    expect(result).toEqual({ eventsProcessed: 1, deliveriesCreated: 0 });
+    expect(await deliveries()).toHaveLength(0);
+    expect(await fannedOutAt("evt_1")).not.toBeNull();
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/fan-out.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/fan-out.integration.test.ts
@@ -87,7 +87,8 @@ describe("webhook fan-out (real SQLite)", () => {
       secret_prefix: "",
       field_allowlist: null,
       created_by: null,
-      created_at: now,
+      // Well before the seeded event time so the pre-subscription guard admits it.
+      created_at: new Date("2020-01-01T00:00:00.000Z"),
       updated_at: now,
     });
   }

--- a/packages/nextly/src/domains/webhooks/__tests__/fan-out.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/fan-out.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+
+import { selectDeliveryTargets } from "../fan-out";
+import type { WebhookEndpoint, WebhookEvent } from "../types";
+
+function endpoint(over: Partial<WebhookEndpoint>): WebhookEndpoint {
+  return {
+    id: "wh",
+    name: "wh",
+    url: "https://example.com",
+    enabled: true,
+    eventTypes: ["entry.updated"],
+    filter: null,
+    headers: null,
+    secretHash: [],
+    secretPrefix: "",
+    fieldAllowlist: null,
+    createdBy: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...over,
+  };
+}
+
+function event(over: Partial<WebhookEvent> = {}): WebhookEvent {
+  return {
+    id: "evt",
+    type: "entry.updated",
+    specversion: "1",
+    timestamp: "2026-07-18T00:00:00.000Z",
+    resource: { kind: "entry", collection: "posts", id: "p1" },
+    data: { id: "p1", title: "new" },
+    previous: { id: "p1", title: "old" },
+    changedFields: ["title"],
+    ...over,
+  };
+}
+
+describe("selectDeliveryTargets", () => {
+  it("selects enabled endpoints subscribed to the type with no filter", () => {
+    const targets = selectDeliveryTargets(
+      [endpoint({ id: "a" }), endpoint({ id: "b" })],
+      event()
+    );
+    expect(targets.map(t => t.id)).toEqual(["a", "b"]);
+  });
+
+  it("excludes disabled endpoints", () => {
+    const targets = selectDeliveryTargets(
+      [endpoint({ id: "on" }), endpoint({ id: "off", enabled: false })],
+      event()
+    );
+    expect(targets.map(t => t.id)).toEqual(["on"]);
+  });
+
+  it("excludes endpoints not subscribed to the event type", () => {
+    const targets = selectDeliveryTargets(
+      [
+        endpoint({ id: "sub", eventTypes: ["entry.updated"] }),
+        endpoint({ id: "other", eventTypes: ["entry.created"] }),
+      ],
+      event({ type: "entry.updated" })
+    );
+    expect(targets.map(t => t.id)).toEqual(["sub"]);
+  });
+
+  it("applies the endpoint filter (collection scope)", () => {
+    const targets = selectDeliveryTargets(
+      [
+        endpoint({
+          id: "posts-only",
+          filter: { version: 1, collections: ["posts"] },
+        }),
+        endpoint({
+          id: "pages-only",
+          filter: { version: 1, collections: ["pages"] },
+        }),
+      ],
+      event({ resource: { kind: "entry", collection: "posts", id: "p1" } })
+    );
+    expect(targets.map(t => t.id)).toEqual(["posts-only"]);
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/fan-out.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/fan-out.test.ts
@@ -111,9 +111,10 @@ describe("fanOutDueEvents (invalid payload)", () => {
       logger: { warn: m => warnings.push(m) },
     });
 
-    // Not counted, never marked, and surfaced via the logger.
-    expect(result).toEqual({ eventsProcessed: 0, deliveriesCreated: 0 });
-    expect(marked).toHaveLength(0);
+    // Marked fanned out (forward progress) and surfaced via the logger; no
+    // deliveries created for an undeliverable event.
+    expect(result).toEqual({ eventsProcessed: 1, deliveriesCreated: 0 });
+    expect(marked).toHaveLength(1);
     expect(warnings.some(w => w.includes("evt_bad"))).toBe(true);
   });
 
@@ -144,8 +145,8 @@ describe("fanOutDueEvents (invalid payload)", () => {
       logger: { warn: m => warnings.push(m) },
     });
 
-    expect(result).toEqual({ eventsProcessed: 0, deliveriesCreated: 0 });
-    expect(marked).toHaveLength(0);
+    expect(result).toEqual({ eventsProcessed: 1, deliveriesCreated: 0 });
+    expect(marked).toHaveLength(1);
     expect(warnings.some(w => w.includes("evt_noresource"))).toBe(true);
   });
 });

--- a/packages/nextly/src/domains/webhooks/__tests__/fan-out.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/fan-out.test.ts
@@ -21,8 +21,9 @@ function endpoint(over: Partial<WebhookEndpoint>): WebhookEndpoint {
     secretPrefix: "",
     fieldAllowlist: null,
     createdBy: null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
+    // Well before the sample event time so the pre-subscription guard admits it.
+    createdAt: new Date("2020-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2020-01-01T00:00:00.000Z"),
     ...over,
   };
 }
@@ -67,6 +68,23 @@ describe("selectDeliveryTargets", () => {
       event({ type: "entry.updated" })
     );
     expect(targets.map(t => t.id)).toEqual(["sub"]);
+  });
+
+  it("excludes endpoints created after the event (no pre-subscription backlog)", () => {
+    const targets = selectDeliveryTargets(
+      [
+        endpoint({
+          id: "before",
+          createdAt: new Date("2026-07-17T00:00:00.000Z"),
+        }),
+        endpoint({
+          id: "after",
+          createdAt: new Date("2026-07-19T00:00:00.000Z"),
+        }),
+      ],
+      event({ timestamp: "2026-07-18T00:00:00.000Z" })
+    );
+    expect(targets.map(t => t.id)).toEqual(["before"]);
   });
 
   it("applies the endpoint filter (collection scope)", () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/fan-out.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/fan-out.test.ts
@@ -87,6 +87,14 @@ describe("selectDeliveryTargets", () => {
     expect(targets.map(t => t.id)).toEqual(["before"]);
   });
 
+  it("fails closed when the event timestamp is unparseable", () => {
+    const targets = selectDeliveryTargets(
+      [endpoint({ id: "a" })],
+      event({ timestamp: "not-a-date" })
+    );
+    expect(targets).toEqual([]);
+  });
+
   it("applies the endpoint filter (collection scope)", () => {
     const targets = selectDeliveryTargets(
       [
@@ -207,5 +215,43 @@ describe("fanOutDueEvents (invalid payload)", () => {
     expect(result).toEqual({ eventsProcessed: 1, deliveriesCreated: 0 });
     expect(marked).toHaveLength(1);
     expect(warnings.some(w => w.includes("evt_badchanged"))).toBe(true);
+  });
+
+  it("treats a missing/unparseable timestamp as invalid (drives the createdAt cutoff)", async () => {
+    const marked: string[] = [];
+    const warnings: string[] = [];
+    const tx: FanOutTx = {
+      select: async <T>() => [] as T[],
+      insertMany: async <T>() => [] as T[],
+      update: async <T>() => {
+        marked.push("update");
+        return [] as T[];
+      },
+    };
+    const db: FanOutDatabase = {
+      select: async <T>() =>
+        [
+          {
+            id: "evt_badts",
+            payload: {
+              type: "entry.updated",
+              resource: { kind: "entry", collection: "posts", id: "p1" },
+              changedFields: [],
+              timestamp: "nonsense",
+            },
+          },
+        ] as T[],
+      transaction: async fn => fn(tx),
+    };
+
+    const result = await fanOutDueEvents({
+      db,
+      loadEndpoints: async () => [endpoint({ id: "f" })],
+      logger: { warn: m => warnings.push(m) },
+    });
+
+    expect(result).toEqual({ eventsProcessed: 1, deliveriesCreated: 0 });
+    expect(marked).toHaveLength(1);
+    expect(warnings.some(w => w.includes("evt_badts"))).toBe(true);
   });
 });

--- a/packages/nextly/src/domains/webhooks/__tests__/fan-out.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/fan-out.test.ts
@@ -116,4 +116,36 @@ describe("fanOutDueEvents (invalid payload)", () => {
     expect(marked).toHaveLength(0);
     expect(warnings.some(w => w.includes("evt_bad"))).toBe(true);
   });
+
+  it("skips a structurally-invalid envelope (missing resource) without throwing", async () => {
+    const marked: string[] = [];
+    const warnings: string[] = [];
+    const tx: FanOutTx = {
+      select: async <T>() => [] as T[],
+      insertMany: async <T>() => [] as T[],
+      update: async <T>() => {
+        marked.push("update");
+        return [] as T[];
+      },
+    };
+    const db: FanOutDatabase = {
+      // Parseable object but missing `resource`; matchesFilter would throw on
+      // a collections filter if it reached it.
+      select: async <T>() =>
+        [{ id: "evt_noresource", payload: { type: "entry.updated" } }] as T[],
+      transaction: async fn => fn(tx),
+    };
+
+    const result = await fanOutDueEvents({
+      db,
+      loadEndpoints: async () => [
+        endpoint({ id: "f", filter: { version: 1, collections: ["posts"] } }),
+      ],
+      logger: { warn: m => warnings.push(m) },
+    });
+
+    expect(result).toEqual({ eventsProcessed: 0, deliveriesCreated: 0 });
+    expect(marked).toHaveLength(0);
+    expect(warnings.some(w => w.includes("evt_noresource"))).toBe(true);
+  });
 });

--- a/packages/nextly/src/domains/webhooks/__tests__/fan-out.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/fan-out.test.ts
@@ -149,4 +149,45 @@ describe("fanOutDueEvents (invalid payload)", () => {
     expect(marked).toHaveLength(1);
     expect(warnings.some(w => w.includes("evt_noresource"))).toBe(true);
   });
+
+  it("treats a non-array changedFields as invalid (would throw in matchesFilter)", async () => {
+    const marked: string[] = [];
+    const warnings: string[] = [];
+    const tx: FanOutTx = {
+      select: async <T>() => [] as T[],
+      insertMany: async <T>() => [] as T[],
+      update: async <T>() => {
+        marked.push("update");
+        return [] as T[];
+      },
+    };
+    const db: FanOutDatabase = {
+      // Valid type + resource, but changedFields is not an array; a
+      // changedFields-filter endpoint would make matchesFilter throw.
+      select: async <T>() =>
+        [
+          {
+            id: "evt_badchanged",
+            payload: {
+              type: "entry.updated",
+              resource: { kind: "entry", collection: "posts", id: "p1" },
+              changedFields: "title",
+            },
+          },
+        ] as T[],
+      transaction: async fn => fn(tx),
+    };
+
+    const result = await fanOutDueEvents({
+      db,
+      loadEndpoints: async () => [
+        endpoint({ id: "f", filter: { version: 1, changedFields: ["title"] } }),
+      ],
+      logger: { warn: m => warnings.push(m) },
+    });
+
+    expect(result).toEqual({ eventsProcessed: 1, deliveriesCreated: 0 });
+    expect(marked).toHaveLength(1);
+    expect(warnings.some(w => w.includes("evt_badchanged"))).toBe(true);
+  });
 });

--- a/packages/nextly/src/domains/webhooks/__tests__/fan-out.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/fan-out.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 
-import { selectDeliveryTargets } from "../fan-out";
+import {
+  fanOutDueEvents,
+  selectDeliveryTargets,
+  type FanOutDatabase,
+  type FanOutTx,
+} from "../fan-out";
 import type { WebhookEndpoint, WebhookEvent } from "../types";
 
 function endpoint(over: Partial<WebhookEndpoint>): WebhookEndpoint {
@@ -79,5 +84,36 @@ describe("selectDeliveryTargets", () => {
       event({ resource: { kind: "entry", collection: "posts", id: "p1" } })
     );
     expect(targets.map(t => t.id)).toEqual(["posts-only"]);
+  });
+});
+
+describe("fanOutDueEvents (invalid payload)", () => {
+  it("skips an unparseable event without marking it fanned out", async () => {
+    const marked: string[] = [];
+    const warnings: string[] = [];
+    const tx: FanOutTx = {
+      select: async <T>() => [] as T[],
+      insertMany: async <T>() => [] as T[],
+      update: async <T>() => {
+        marked.push("update");
+        return [] as T[];
+      },
+    };
+    const db: FanOutDatabase = {
+      select: async <T>() =>
+        [{ id: "evt_bad", payload: "{not valid json" }] as T[],
+      transaction: async fn => fn(tx),
+    };
+
+    const result = await fanOutDueEvents({
+      db,
+      loadEndpoints: async () => [],
+      logger: { warn: m => warnings.push(m) },
+    });
+
+    // Not counted, never marked, and surfaced via the logger.
+    expect(result).toEqual({ eventsProcessed: 0, deliveriesCreated: 0 });
+    expect(marked).toHaveLength(0);
+    expect(warnings.some(w => w.includes("evt_bad"))).toBe(true);
   });
 });

--- a/packages/nextly/src/domains/webhooks/endpoint-registry.ts
+++ b/packages/nextly/src/domains/webhooks/endpoint-registry.ts
@@ -30,17 +30,26 @@ export interface WebhookEndpointReader {
  * `unknown`, so each is narrowed to its stored shape here.
  */
 function toEndpoint(row: Record<string, unknown>): WebhookEndpoint {
+  // Normalize the JSON array columns to arrays: a malformed row (e.g. a legacy
+  // or manual write that stored a non-array) must not later throw inside
+  // `.includes(...)`/`new Set(...)` during matching and stall the drain.
   return {
     id: row.id as string,
     name: row.name as string,
     url: row.url as string,
     enabled: Boolean(row.enabled),
-    eventTypes: (row.eventTypes as WebhookEventType[] | null) ?? [],
+    eventTypes: Array.isArray(row.eventTypes)
+      ? (row.eventTypes as WebhookEventType[])
+      : [],
     filter: (row.filter as FilterSpec | null) ?? null,
     headers: (row.headers as Record<string, string> | null) ?? null,
-    secretHash: (row.secretHash as string[] | null) ?? [],
+    secretHash: Array.isArray(row.secretHash)
+      ? (row.secretHash as string[])
+      : [],
     secretPrefix: (row.secretPrefix as string) ?? "",
-    fieldAllowlist: (row.fieldAllowlist as string[] | null) ?? null,
+    fieldAllowlist: Array.isArray(row.fieldAllowlist)
+      ? (row.fieldAllowlist as string[])
+      : null,
     createdBy: (row.createdBy as string | null) ?? null,
     createdAt: row.createdAt as Date,
     updatedAt: row.updatedAt as Date,
@@ -49,18 +58,40 @@ function toEndpoint(row: Record<string, unknown>): WebhookEndpoint {
 
 export class WebhookEndpointRegistry {
   private cache: readonly WebhookEndpoint[] | null = null;
+  private cachedAtMs = 0;
   // A single in-flight load shared by concurrent callers (no stampede), tagged
   // with the generation it was started at. `invalidate()` bumps the generation
   // so a load started before it is neither cached nor reused by later callers.
   private inFlight: Promise<readonly WebhookEndpoint[]> | null = null;
   private inFlightGeneration = -1;
   private generation = 0;
+  private readonly ttlMs?: number;
+  private readonly now: () => number;
 
-  constructor(private readonly reader: WebhookEndpointReader) {}
+  /**
+   * `invalidate()` handles same-process CRUD changes. `ttlMs` additionally
+   * bounds staleness from OTHER processes (a webhook created/enabled elsewhere
+   * that can't call this instance's `invalidate()`): after `ttlMs` the next read
+   * reloads. Omit it (the default) to cache until `invalidate()` — appropriate
+   * for a short-lived registry built fresh per drain run.
+   */
+  constructor(
+    private readonly reader: WebhookEndpointReader,
+    options?: { ttlMs?: number; now?: () => number }
+  ) {
+    this.ttlMs = options?.ttlMs;
+    this.now = options?.now ?? (() => Date.now());
+  }
 
-  /** Enabled endpoints, loaded once and cached until `invalidate()`. */
+  private isExpired(): boolean {
+    return (
+      this.ttlMs !== undefined && this.now() - this.cachedAtMs > this.ttlMs
+    );
+  }
+
+  /** Enabled endpoints, loaded once and cached until `invalidate()` (or TTL). */
   async getEnabledEndpoints(): Promise<readonly WebhookEndpoint[]> {
-    if (this.cache !== null) return this.cache;
+    if (this.cache !== null && !this.isExpired()) return this.cache;
     // Join an in-flight load only if it was started under the current
     // generation; a load from before an invalidation must not be reused.
     if (this.inFlight !== null && this.inFlightGeneration === this.generation) {
@@ -71,7 +102,10 @@ export class WebhookEndpointRegistry {
     const load = this.load().then(
       rows => {
         // Commit to the cache only if no invalidation happened while loading.
-        if (gen === this.generation) this.cache = rows;
+        if (gen === this.generation) {
+          this.cache = rows;
+          this.cachedAtMs = this.now();
+        }
         if (this.inFlight === load) this.inFlight = null;
         return rows;
       },

--- a/packages/nextly/src/domains/webhooks/endpoint-registry.ts
+++ b/packages/nextly/src/domains/webhooks/endpoint-registry.ts
@@ -1,0 +1,101 @@
+/**
+ * Webhook domain — enabled-endpoint registry.
+ *
+ * Provides the set of enabled endpoints the drain fans events out to, cached in
+ * memory so a drain pass loads them once rather than per event. The cache is
+ * loaded lazily on first use and dropped by `invalidate()` — the webhook CRUD
+ * surface (a later slice) calls that on create/update/delete so changes take
+ * effect without a restart.
+ *
+ * @module domains/webhooks/endpoint-registry
+ */
+
+import type { FilterSpec, WebhookEndpoint, WebhookEventType } from "./types";
+
+/** The narrow read surface the registry needs (satisfied by the DB adapter). */
+export interface WebhookEndpointReader {
+  select<T = unknown>(
+    table: string,
+    options?: {
+      where?: {
+        and: Array<{ column: string; op: string; value: unknown }>;
+      };
+    }
+  ): Promise<T[]>;
+}
+
+/**
+ * Map a raw `nextly_webhooks` row (Drizzle returns camelCased columns with the
+ * JSON columns already parsed) to the typed endpoint. JSON columns are declared
+ * `unknown`, so each is narrowed to its stored shape here.
+ */
+function toEndpoint(row: Record<string, unknown>): WebhookEndpoint {
+  return {
+    id: row.id as string,
+    name: row.name as string,
+    url: row.url as string,
+    enabled: Boolean(row.enabled),
+    eventTypes: (row.eventTypes as WebhookEventType[] | null) ?? [],
+    filter: (row.filter as FilterSpec | null) ?? null,
+    headers: (row.headers as Record<string, string> | null) ?? null,
+    secretHash: (row.secretHash as string[] | null) ?? [],
+    secretPrefix: (row.secretPrefix as string) ?? "",
+    fieldAllowlist: (row.fieldAllowlist as string[] | null) ?? null,
+    createdBy: (row.createdBy as string | null) ?? null,
+    createdAt: row.createdAt as Date,
+    updatedAt: row.updatedAt as Date,
+  };
+}
+
+export class WebhookEndpointRegistry {
+  private cache: readonly WebhookEndpoint[] | null = null;
+  // A single in-flight load shared by concurrent callers (no stampede), tagged
+  // with the generation it was started at. `invalidate()` bumps the generation
+  // so a load started before it is neither cached nor reused by later callers.
+  private inFlight: Promise<readonly WebhookEndpoint[]> | null = null;
+  private inFlightGeneration = -1;
+  private generation = 0;
+
+  constructor(private readonly reader: WebhookEndpointReader) {}
+
+  /** Enabled endpoints, loaded once and cached until `invalidate()`. */
+  async getEnabledEndpoints(): Promise<readonly WebhookEndpoint[]> {
+    if (this.cache !== null) return this.cache;
+    // Join an in-flight load only if it was started under the current
+    // generation; a load from before an invalidation must not be reused.
+    if (this.inFlight !== null && this.inFlightGeneration === this.generation) {
+      return this.inFlight;
+    }
+
+    const gen = this.generation;
+    const load = this.load().then(
+      rows => {
+        // Commit to the cache only if no invalidation happened while loading.
+        if (gen === this.generation) this.cache = rows;
+        if (this.inFlight === load) this.inFlight = null;
+        return rows;
+      },
+      err => {
+        if (this.inFlight === load) this.inFlight = null;
+        throw err;
+      }
+    );
+    this.inFlight = load;
+    this.inFlightGeneration = gen;
+    return load;
+  }
+
+  /** Drop the cache so the next read reloads from the database. */
+  invalidate(): void {
+    this.cache = null;
+    this.generation++;
+  }
+
+  private async load(): Promise<WebhookEndpoint[]> {
+    const rows = await this.reader.select<Record<string, unknown>>(
+      "nextly_webhooks",
+      { where: { and: [{ column: "enabled", op: "=", value: true }] } }
+    );
+    return rows.map(toEndpoint);
+  }
+}

--- a/packages/nextly/src/domains/webhooks/endpoint-registry.ts
+++ b/packages/nextly/src/domains/webhooks/endpoint-registry.ts
@@ -12,6 +12,28 @@
 
 import type { FilterSpec, WebhookEndpoint, WebhookEventType } from "./types";
 
+/**
+ * Normalize a stored filter so a malformed value can't throw during matching.
+ * For the v1 shape, coerce each array field to an array (or drop it): a legacy
+ * or manual write of `{ version: 1, changedFields: "title" }` would otherwise
+ * make `matchesFilter` call `.some(...)` on a string and throw, stalling the
+ * batch. A non-object is treated as no filter; a non-v1 shape is passed through
+ * unchanged (matchesFilter rejects unknown versions on its own).
+ */
+function normalizeFilter(raw: unknown): FilterSpec | null {
+  if (raw == null || typeof raw !== "object") return null;
+  const f = raw as Record<string, unknown>;
+  if (f.version !== 1) return f as unknown as FilterSpec;
+  const asArray = (v: unknown): string[] | undefined =>
+    Array.isArray(v) ? (v as string[]) : undefined;
+  return {
+    version: 1,
+    eventTypes: asArray(f.eventTypes) as WebhookEventType[] | undefined,
+    collections: asArray(f.collections) ?? null,
+    changedFields: asArray(f.changedFields) ?? null,
+  };
+}
+
 /** The narrow read surface the registry needs (satisfied by the DB adapter). */
 export interface WebhookEndpointReader {
   select<T = unknown>(
@@ -41,7 +63,7 @@ function toEndpoint(row: Record<string, unknown>): WebhookEndpoint {
     eventTypes: Array.isArray(row.eventTypes)
       ? (row.eventTypes as WebhookEventType[])
       : [],
-    filter: (row.filter as FilterSpec | null) ?? null,
+    filter: normalizeFilter(row.filter),
     headers: (row.headers as Record<string, string> | null) ?? null,
     secretHash: Array.isArray(row.secretHash)
       ? (row.secretHash as string[])

--- a/packages/nextly/src/domains/webhooks/fan-out.ts
+++ b/packages/nextly/src/domains/webhooks/fan-out.ts
@@ -170,14 +170,31 @@ export async function fanOutDueEvents(deps: FanOutDeps): Promise<FanOutResult> {
   for (const event of events) {
     const envelope = parseEnvelope(event.payload);
     if (!envelope) {
-      // An unparseable payload is a data-integrity anomaly (recordEvent always
-      // writes a valid envelope). Surface it and skip rather than fabricate a
-      // successful fan-out via the zero-target marker path; the event stays
-      // un-fanned for investigation. A durable poison-event/dead-letter policy
-      // is a follow-up.
+      // An unparseable/invalid payload is a data-integrity anomaly (recordEvent
+      // always writes a valid envelope). It can never be delivered, so mark it
+      // fanned out to guarantee forward progress: leaving it un-fanned would let
+      // one corrupt row at the head of the queue stall every event behind it
+      // forever. Log loudly so it is not silently dropped; a durable
+      // dead-letter table is a follow-up.
       deps.logger?.warn(
-        `webhook fan-out skipped event ${event.id} with an unparseable payload`
+        `webhook fan-out marking event ${event.id} fanned out (undeliverable: unparseable/invalid payload)`
       );
+      try {
+        await deps.db.transaction(async tx => {
+          await tx.update(
+            "nextly_events",
+            { fanned_out_at: now() },
+            { and: [{ column: "id", op: "=", value: event.id }] }
+          );
+        });
+        eventsProcessed += 1;
+      } catch (err) {
+        // Could not mark it; it will be retried next pass. Do not abort.
+        deps.logger?.warn(
+          `webhook fan-out could not mark poison event ${event.id}`,
+          err
+        );
+      }
       continue;
     }
 

--- a/packages/nextly/src/domains/webhooks/fan-out.ts
+++ b/packages/nextly/src/domains/webhooks/fan-out.ts
@@ -1,0 +1,210 @@
+/**
+ * Webhook domain — fan-out (events to delivery rows).
+ *
+ * The drain's first phase. `recordEvent` writes only the durable event; this
+ * turns each un-fanned event into per-endpoint `nextly_webhook_deliveries`
+ * rows. Splitting fan-out out of the content transaction is the transactional
+ * outbox pattern: content writes never touch the webhook registry, so a webhook
+ * being created, disabled, or deleted can never fail an unrelated content write.
+ *
+ * Fan-out is idempotent under concurrent drains: each event is fanned out in
+ * its own transaction that reads the deliveries already present and inserts only
+ * the missing ones, and the unique `(webhook_id, event_id)` index is the hard
+ * backstop. If two drains race the same event, the loser's transaction rolls
+ * back and the event is simply retried on the next pass. An event with no
+ * matching endpoint is still marked fanned out (it needs no delivery).
+ *
+ * @module domains/webhooks/fan-out
+ */
+
+import type { SelectOptions } from "@nextlyhq/adapter-drizzle/types";
+
+import { matchesFilter } from "./filter";
+import type { WebhookEndpoint, WebhookEvent } from "./types";
+
+/** Default number of un-fanned events a single `fanOutDueEvents` call claims. */
+const DEFAULT_FANOUT_BATCH = 100;
+/**
+ * Rows per delivery INSERT. A delivery row binds ~8 parameters and SQLite caps
+ * a statement at 999 bind parameters, so chunk well under every dialect's limit.
+ */
+const DELIVERY_INSERT_CHUNK = 100;
+
+/**
+ * The endpoints that should receive an event: enabled, subscribed to the
+ * event's type, and passing the endpoint's filter. Pure.
+ */
+export function selectDeliveryTargets(
+  endpoints: readonly WebhookEndpoint[],
+  envelope: WebhookEvent
+): WebhookEndpoint[] {
+  return endpoints.filter(
+    e =>
+      e.enabled &&
+      e.eventTypes.includes(envelope.type) &&
+      matchesFilter(e.filter, envelope)
+  );
+}
+
+/** The transaction surface `fanOutDueEvents` needs (subset of the adapter tx). */
+export interface FanOutTx {
+  select<T = unknown>(table: string, options?: SelectOptions): Promise<T[]>;
+  insertMany<T = unknown>(
+    table: string,
+    data: Record<string, unknown>[]
+  ): Promise<T[]>;
+  update<T = unknown>(
+    table: string,
+    data: Record<string, unknown>,
+    where: { and: Array<{ column: string; op: string; value: unknown }> }
+  ): Promise<T[]>;
+}
+
+/** The database surface `fanOutDueEvents` needs (satisfied by the adapter). */
+export interface FanOutDatabase {
+  select<T = unknown>(table: string, options?: SelectOptions): Promise<T[]>;
+  transaction<T>(fn: (tx: FanOutTx) => Promise<T>): Promise<T>;
+}
+
+/** Minimal logger surface; fan-out only warns on a deferred event. */
+export interface FanOutLogger {
+  warn(message: string, context?: unknown): void;
+}
+
+export interface FanOutDeps {
+  db: FanOutDatabase;
+  /** Loads the enabled endpoints once per pass (e.g. a `WebhookEndpointRegistry`). */
+  loadEndpoints: () => Promise<readonly WebhookEndpoint[]>;
+  /** Max events to claim this pass. Defaults to 100. */
+  batchSize?: number;
+  /** Clock; injectable for deterministic tests. */
+  now?: () => Date;
+  /** Delivery id generator; injectable for deterministic tests. */
+  newId?: () => string;
+  logger?: FanOutLogger;
+}
+
+export interface FanOutResult {
+  /** Events marked fanned out this pass. */
+  eventsProcessed: number;
+  /** Delivery rows inserted this pass. */
+  deliveriesCreated: number;
+}
+
+/** Raw `nextly_events` row shape this module reads (camelCased by Drizzle). */
+interface EventRow {
+  id: string;
+  payload: unknown;
+}
+
+/** Parse the stored envelope, tolerating both a JSON string and a parsed object. */
+function parseEnvelope(payload: unknown): WebhookEvent | null {
+  if (payload == null) return null;
+  if (typeof payload === "string") {
+    try {
+      return JSON.parse(payload) as WebhookEvent;
+    } catch {
+      return null;
+    }
+  }
+  if (typeof payload === "object") return payload as WebhookEvent;
+  return null;
+}
+
+/** Build a fresh, due-immediately delivery row (snake_case columns). */
+function deliveryRow(
+  id: string,
+  webhookId: string,
+  eventId: string,
+  now: Date
+): Record<string, unknown> {
+  return {
+    id,
+    webhook_id: webhookId,
+    event_id: eventId,
+    status: "pending",
+    attempt_count: 0,
+    // Due immediately; the delivery phase claims rows whose next_attempt_at <= now.
+    next_attempt_at: now,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+/**
+ * Claim a batch of un-fanned events and turn each into delivery rows. Returns
+ * how many events were processed and delivery rows created. Bounded work per
+ * call (one batch); the caller loops until a pass processes nothing.
+ */
+export async function fanOutDueEvents(deps: FanOutDeps): Promise<FanOutResult> {
+  const batchSize = deps.batchSize ?? DEFAULT_FANOUT_BATCH;
+  const now = deps.now ?? (() => new Date());
+  const newId = deps.newId ?? (() => crypto.randomUUID());
+
+  // WHERE/orderBy columns are the Drizzle JS property names (camelCase); the
+  // adapter resolves them via getColumns, not the SQL column names.
+  const events = await deps.db.select<EventRow>("nextly_events", {
+    where: { and: [{ column: "fannedOutAt", op: "IS NULL", value: null }] },
+    orderBy: [{ column: "createdAt", direction: "asc" }],
+    limit: batchSize,
+  });
+  if (events.length === 0) {
+    return { eventsProcessed: 0, deliveriesCreated: 0 };
+  }
+
+  const endpoints = await deps.loadEndpoints();
+
+  let eventsProcessed = 0;
+  let deliveriesCreated = 0;
+
+  for (const event of events) {
+    const envelope = parseEnvelope(event.payload);
+    const targets = envelope ? selectDeliveryTargets(endpoints, envelope) : [];
+
+    try {
+      const created = await deps.db.transaction(async tx => {
+        let inserted = 0;
+        if (targets.length > 0) {
+          // Skip endpoints already delivered-to for this event so a retry (or a
+          // racing drain that got here first) does not hit the unique index.
+          const existing = await tx.select<{ webhookId: string }>(
+            "nextly_webhook_deliveries",
+            {
+              where: { and: [{ column: "eventId", op: "=", value: event.id }] },
+            }
+          );
+          const existingIds = new Set(existing.map(r => r.webhookId));
+          const fresh = targets.filter(t => !existingIds.has(t.id));
+          const rows = fresh.map(t =>
+            deliveryRow(newId(), t.id, event.id, now())
+          );
+          for (let i = 0; i < rows.length; i += DELIVERY_INSERT_CHUNK) {
+            await tx.insertMany(
+              "nextly_webhook_deliveries",
+              rows.slice(i, i + DELIVERY_INSERT_CHUNK)
+            );
+          }
+          inserted = rows.length;
+        }
+        // Mark fanned out even with zero targets: the event needs no delivery
+        // and must not be reconsidered on the next pass.
+        await tx.update(
+          "nextly_events",
+          { fanned_out_at: now() },
+          { and: [{ column: "id", op: "=", value: event.id }] }
+        );
+        return inserted;
+      });
+      eventsProcessed += 1;
+      deliveriesCreated += created;
+    } catch (err) {
+      // A concurrent drain likely fanned this event out first (unique-index
+      // conflict) or a transient DB error occurred; the transaction rolled back,
+      // so fanned_out_at stays NULL and the next pass retries. Do not abort the
+      // rest of the batch.
+      deps.logger?.warn(`webhook fan-out deferred for event ${event.id}`, err);
+    }
+  }
+
+  return { eventsProcessed, deliveriesCreated };
+}

--- a/packages/nextly/src/domains/webhooks/fan-out.ts
+++ b/packages/nextly/src/domains/webhooks/fan-out.ts
@@ -49,8 +49,11 @@ export function selectDeliveryTargets(
     e =>
       e.enabled &&
       e.eventTypes.includes(envelope.type) &&
-      // Permissive if the timestamp is unparseable (don't silently drop).
-      (!Number.isFinite(eventTime) || e.createdAt.getTime() <= eventTime) &&
+      // Fail closed on an unparseable timestamp: never deliver an event we
+      // can't place relative to the subscription cutoff. (The fan-out path
+      // rejects such events upstream as poison; this guards direct callers.)
+      Number.isFinite(eventTime) &&
+      e.createdAt.getTime() <= eventTime &&
       matchesFilter(e.filter, envelope)
   );
 }
@@ -130,6 +133,14 @@ function parseEnvelope(payload: unknown): WebhookEvent | null {
     return null;
   }
   if (!Array.isArray(record.changedFields)) return null;
+  // timestamp drives the pre-subscription cutoff in selectDeliveryTargets, so a
+  // missing/unparseable one is poison rather than something to silently bypass.
+  if (
+    typeof record.timestamp !== "string" ||
+    !Number.isFinite(Date.parse(record.timestamp))
+  ) {
+    return null;
+  }
   return value as WebhookEvent;
 }
 

--- a/packages/nextly/src/domains/webhooks/fan-out.ts
+++ b/packages/nextly/src/domains/webhooks/fan-out.ts
@@ -159,7 +159,18 @@ export async function fanOutDueEvents(deps: FanOutDeps): Promise<FanOutResult> {
 
   for (const event of events) {
     const envelope = parseEnvelope(event.payload);
-    const targets = envelope ? selectDeliveryTargets(endpoints, envelope) : [];
+    if (!envelope) {
+      // An unparseable payload is a data-integrity anomaly (recordEvent always
+      // writes a valid envelope). Surface it and skip rather than fabricate a
+      // successful fan-out via the zero-target marker path; the event stays
+      // un-fanned for investigation. A durable poison-event/dead-letter policy
+      // is a follow-up.
+      deps.logger?.warn(
+        `webhook fan-out skipped event ${event.id} with an unparseable payload`
+      );
+      continue;
+    }
+    const targets = selectDeliveryTargets(endpoints, envelope);
 
     try {
       const created = await deps.db.transaction(async tx => {

--- a/packages/nextly/src/domains/webhooks/fan-out.ts
+++ b/packages/nextly/src/domains/webhooks/fan-out.ts
@@ -32,16 +32,25 @@ const DELIVERY_INSERT_CHUNK = 100;
 
 /**
  * The endpoints that should receive an event: enabled, subscribed to the
- * event's type, and passing the endpoint's filter. Pure.
+ * event's type, created no later than the event, and passing the endpoint's
+ * filter. Pure.
+ *
+ * The `createdAt <= event time` guard gives standard webhook semantics — an
+ * endpoint receives only events that occurred after it was created — and makes
+ * fan-out deterministic regardless of drain lag: a webhook created after an
+ * event but before the drain runs must not receive that backlog event.
  */
 export function selectDeliveryTargets(
   endpoints: readonly WebhookEndpoint[],
   envelope: WebhookEvent
 ): WebhookEndpoint[] {
+  const eventTime = Date.parse(envelope.timestamp);
   return endpoints.filter(
     e =>
       e.enabled &&
       e.eventTypes.includes(envelope.type) &&
+      // Permissive if the timestamp is unparseable (don't silently drop).
+      (!Number.isFinite(eventTime) || e.createdAt.getTime() <= eventTime) &&
       matchesFilter(e.filter, envelope)
   );
 }

--- a/packages/nextly/src/domains/webhooks/fan-out.ts
+++ b/packages/nextly/src/domains/webhooks/fan-out.ts
@@ -99,9 +99,11 @@ interface EventRow {
 
 /**
  * Parse the stored envelope, tolerating both a JSON string and a parsed object,
- * and structurally validate the fields matching relies on. An object missing
- * `type` or `resource` would otherwise throw inside `matchesFilter`; returning
- * null routes it through the same skip-and-log path as an unparseable payload.
+ * and structurally validate every field matching relies on. An object missing
+ * `type`/`resource`, or whose `changedFields` is not an array, would otherwise
+ * throw inside `matchesFilter` (which does `new Set(envelope.changedFields)`);
+ * returning null routes it through the same skip-and-log path so a corrupt row
+ * can never throw and stall the batch.
  */
 function parseEnvelope(payload: unknown): WebhookEvent | null {
   let value: unknown = payload;
@@ -118,6 +120,7 @@ function parseEnvelope(payload: unknown): WebhookEvent | null {
   if (typeof record.resource !== "object" || record.resource === null) {
     return null;
   }
+  if (!Array.isArray(record.changedFields)) return null;
   return value as WebhookEvent;
 }
 

--- a/packages/nextly/src/domains/webhooks/fan-out.ts
+++ b/packages/nextly/src/domains/webhooks/fan-out.ts
@@ -97,18 +97,28 @@ interface EventRow {
   payload: unknown;
 }
 
-/** Parse the stored envelope, tolerating both a JSON string and a parsed object. */
+/**
+ * Parse the stored envelope, tolerating both a JSON string and a parsed object,
+ * and structurally validate the fields matching relies on. An object missing
+ * `type` or `resource` would otherwise throw inside `matchesFilter`; returning
+ * null routes it through the same skip-and-log path as an unparseable payload.
+ */
 function parseEnvelope(payload: unknown): WebhookEvent | null {
-  if (payload == null) return null;
+  let value: unknown = payload;
   if (typeof payload === "string") {
     try {
-      return JSON.parse(payload) as WebhookEvent;
+      value = JSON.parse(payload);
     } catch {
       return null;
     }
   }
-  if (typeof payload === "object") return payload as WebhookEvent;
-  return null;
+  if (value == null || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.type !== "string") return null;
+  if (typeof record.resource !== "object" || record.resource === null) {
+    return null;
+  }
+  return value as WebhookEvent;
 }
 
 /** Build a fresh, due-immediately delivery row (snake_case columns). */
@@ -170,9 +180,11 @@ export async function fanOutDueEvents(deps: FanOutDeps): Promise<FanOutResult> {
       );
       continue;
     }
-    const targets = selectDeliveryTargets(endpoints, envelope);
 
     try {
+      // Inside the try so a matching throw (e.g. a structurally-odd envelope)
+      // is caught per-event and never aborts the whole batch.
+      const targets = selectDeliveryTargets(endpoints, envelope);
       const created = await deps.db.transaction(async tx => {
         let inserted = 0;
         if (targets.length > 0) {

--- a/packages/nextly/src/domains/webhooks/index.ts
+++ b/packages/nextly/src/domains/webhooks/index.ts
@@ -10,6 +10,19 @@ export { buildEnvelope, type BuildEnvelopeInput } from "./envelope";
 export { matchesFilter } from "./filter";
 export { recordEvent } from "./record-event";
 export {
+  WebhookEndpointRegistry,
+  type WebhookEndpointReader,
+} from "./endpoint-registry";
+export {
+  selectDeliveryTargets,
+  fanOutDueEvents,
+  type FanOutDeps,
+  type FanOutDatabase,
+  type FanOutTx,
+  type FanOutLogger,
+  type FanOutResult,
+} from "./fan-out";
+export {
   sensitiveFieldNames,
   type SensitiveFieldSource,
 } from "./sensitive-fields";

--- a/packages/nextly/src/schemas/webhooks/__tests__/tables.test.ts
+++ b/packages/nextly/src/schemas/webhooks/__tests__/tables.test.ts
@@ -88,4 +88,16 @@ describe("webhook system tables", () => {
       expect(cols).toContain(col);
     }
   });
+
+  for (const dialect of DIALECTS) {
+    it(`gives the event ledger a fanned_out_at drain marker (${dialect})`, () => {
+      // The drain's fan-out pass claims events by fanned_out_at IS NULL, so the
+      // column must exist on every dialect.
+      const events = getCoreSchema(dialect).tables.find(
+        t => t.name === "nextly_events"
+      );
+      const cols = events?.columns.map(c => c.name) ?? [];
+      expect(cols).toContain("fanned_out_at");
+    });
+  }
 });

--- a/packages/nextly/src/schemas/webhooks/mysql.ts
+++ b/packages/nextly/src/schemas/webhooks/mysql.ts
@@ -38,8 +38,15 @@ export const nextlyEvents = mysqlTable(
     createdAt: datetime("created_at")
       .notNull()
       .default(sql`CURRENT_TIMESTAMP`),
+    // Set by the drain's fan-out pass once delivery rows exist for this event;
+    // NULL means the event still needs fan-out.
+    fannedOutAt: datetime("fanned_out_at"),
   },
-  t => [index("nextly_events_type_created_at_idx").on(t.type, t.createdAt)]
+  t => [
+    index("nextly_events_type_created_at_idx").on(t.type, t.createdAt),
+    // The fan-out pass scans for events still needing fan-out, oldest first.
+    index("nextly_events_fanned_out_at_idx").on(t.fannedOutAt, t.createdAt),
+  ]
 );
 
 export const nextlyWebhooks = mysqlTable(

--- a/packages/nextly/src/schemas/webhooks/postgres.ts
+++ b/packages/nextly/src/schemas/webhooks/postgres.ts
@@ -55,10 +55,16 @@ export const nextlyEvents = pgTable(
     createdAt: timestamp("created_at", { withTimezone: false })
       .defaultNow()
       .notNull(),
+    // Set by the drain's fan-out pass once delivery rows exist for this event;
+    // NULL means the event still needs fan-out. Lets the drain find un-fanned
+    // events cheaply without rescanning the delivery table.
+    fannedOutAt: timestamp("fanned_out_at", { withTimezone: false }),
   },
   t => [
     // Drain/reporting scans by type and recency.
     index("nextly_events_type_created_at_idx").on(t.type, t.createdAt),
+    // The fan-out pass scans for events still needing fan-out, oldest first.
+    index("nextly_events_fanned_out_at_idx").on(t.fannedOutAt, t.createdAt),
   ]
 );
 

--- a/packages/nextly/src/schemas/webhooks/sqlite.ts
+++ b/packages/nextly/src/schemas/webhooks/sqlite.ts
@@ -36,8 +36,15 @@ export const nextlyEvents = sqliteTable(
     createdAt: integer("created_at", { mode: "timestamp" })
       .notNull()
       .$defaultFn(() => new Date()),
+    // Set by the drain's fan-out pass once delivery rows exist for this event;
+    // NULL means the event still needs fan-out.
+    fannedOutAt: integer("fanned_out_at", { mode: "timestamp" }),
   },
-  t => [index("nextly_events_type_created_at_idx").on(t.type, t.createdAt)]
+  t => [
+    index("nextly_events_type_created_at_idx").on(t.type, t.createdAt),
+    // The fan-out pass scans for events still needing fan-out, oldest first.
+    index("nextly_events_fanned_out_at_idx").on(t.fannedOutAt, t.createdAt),
+  ]
 );
 
 export const nextlyWebhooks = sqliteTable(


### PR DESCRIPTION
## What

Adds webhook **fan-out** — the drain's first phase that turns durable events into per-endpoint delivery rows. This is the delivery side of the webhooks/events program (roadmap item 6), following the merged P1 foundation (#221/#223/#225/#227).

`recordEvent` (merged) writes only the durable `nextly_events` row inside the content transaction. `fanOutDueEvents` runs separately: it claims un-fanned events, matches each to the enabled endpoints (subscribed type **and** the endpoint filter), and inserts one `nextly_webhook_deliveries` row per match. Content writes stay fully decoupled from the webhook registry — the canonical transactional-outbox split — so creating, disabling, or deleting a webhook can never fail an unrelated content write.

## Changes

- **`fanned_out_at` marker column** on `nextly_events` (all 3 dialects + index) so the drain finds events still needing fan-out. It is a POST-045 table, so the upgrade-sim needs no change (its `CREATE TABLE`/`CREATE INDEX` stay additive).
- **`fanOutDueEvents(deps)`** — claims a batch (`fannedOutAt IS NULL`, oldest first), and for each event, in its own transaction: reads the deliveries already present, inserts only the missing targets, and marks the event fanned out. Bounded work per call; the caller loops.
- **`selectDeliveryTargets`** (pure): enabled ∩ subscribed-type ∩ `matchesFilter`.
- **`WebhookEndpointRegistry`** — race-safe cached enabled-endpoint load (single in-flight promise + generation guard), re-introduced from the P1c history with real coverage.

## Idempotency / concurrency

Fan-out is at-least-once and safe under concurrent drains. Each event is fanned out in its own transaction that inserts only deliveries not already present, and the unique `(webhook_id, event_id)` index is the hard backstop; a losing race rolls back and the event is retried on the next pass. An event with no matching endpoint is still marked fanned out (it needs no delivery). Fan-out is deliberately kept out of the content transaction, so no webhook-table contention touches content writes.

## Tests

- Unit: `selectDeliveryTargets` (enabled / subscribed / filter), `WebhookEndpointRegistry` (coalescing + invalidation ordering), `tables.test` asserts the marker column on all dialects.
- Integration (real SQLite): a delivery per matching endpoint + the marker set; second pass is a no-op (marker idempotency); already-delivered endpoints skipped (read-filter dedup); a zero-target event is marked with no deliveries.
- `pnpm --filter nextly lint` + `check-types` clean; sqlite upgrade-sim green (PG/MySQL legs run in CI).

## Note

The `onConflict: "ignore"` option declared on `InsertOptions` is not implemented in the adapter, so idempotency here uses read-filter-in-transaction with the unique index as the backstop rather than `ON CONFLICT DO NOTHING`. Implementing the declared option is a reasonable adapter follow-up.

## Next

The delivery phase (decrypt secret → sign → SSRF-safe send → record outcome + backoff) and the `/drain` route follow in a stacked PR (depends on the `safeFetch` hardening in #232).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added webhook fan-out processing that creates delivery records for each matching enabled endpoint using event-type targeting and endpoint filter rules.
  * Introduced `fanned_out_at` progress tracking and updated event indexing to efficiently scan pending events across PostgreSQL, MySQL, and SQLite.
  * Added an enabled-endpoint registry with concurrency-safe lazy loading, TTL-based refresh, and cache invalidation.
* **Tests**
  * Expanded unit and integration coverage for target selection, idempotency and retry behavior, invalid payload handling, and cache/load correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->