### PR TITLE
fix(nextly): handle empty encoded bodies and over-limit url attachments in safeFetch

### DIFF
--- a/.changeset/safefetch-followups.md
+++ b/.changeset/safefetch-followups.md
@@ -1,0 +1,25 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/ui": patch
+---
+
+Fix two safeFetch edge cases from the IP-pinning change.
+
+An empty 2xx/204/304 response that still carries a `Content-Encoding` header no longer fails: inflating zero bytes threw and turned a valid empty delivery into a `SafeFetchError`, so `decodeBody` now passes an empty body straight through.
+
+A URL-backed email attachment that exceeds the size limit now surfaces the same `EMAIL_ATTACHMENT_SIZE_EXCEEDED` validation error the local/S3 path produces, rather than an opaque storage-read failure: the fetch translates a `response-too-large` result into the size-exceeded error, and the attachment resolver passes a typed `NextlyError` from `readBytes` through instead of re-wrapping it.

--- a/packages/nextly/src/di/registrations/register-email.ts
+++ b/packages/nextly/src/di/registrations/register-email.ts
@@ -5,14 +5,16 @@
  * so that both direct API callers and the dispatcher can resolve them.
  */
 
+import { EmailErrorCode } from "../../domains/email/errors";
 import { getAttachmentLimits } from "../../domains/email/services/attachment-limits";
 import type { EmailAttachmentSource } from "../../domains/email/services/email-service";
+import { NextlyError } from "../../errors";
 import { EmailProviderService } from "../../services/email/email-provider-service";
 import { EmailService } from "../../services/email/email-service";
 import { EmailTemplateService } from "../../services/email/email-template-service";
 import type { MediaService as UnifiedMediaService } from "../../services/media/media-service";
 import { SYSTEM_CONTEXT } from "../../shared/types";
-import { safeFetch } from "../../utils/validate-external-url";
+import { SafeFetchError, safeFetch } from "../../utils/validate-external-url";
 import { container } from "../container";
 
 import type { RegistrationContext } from "./types";
@@ -83,16 +85,46 @@ export function registerEmailServices(ctx: RegistrationContext): void {
           const url = storagePath.startsWith("http")
             ? storagePath
             : storage.getPublicUrl(storagePath);
+          const limits = getAttachmentLimits();
           // Cap the fetch at the attachment size limit so a valid large
-          // attachment is not rejected by the default safeFetch cap, which is
-          // smaller than the configured attachment total.
-          const response = await safeFetch(url, {
-            maxResponseBytes: getAttachmentLimits().maxTotalBytes,
-          });
+          // attachment is not rejected by the smaller default safeFetch cap. A
+          // body over the limit surfaces as the same size-exceeded validation
+          // error the local/S3 path produces, not an opaque storage failure.
+          let response: Response;
+          try {
+            response = await safeFetch(url, {
+              maxResponseBytes: limits.maxTotalBytes,
+            });
+          } catch (err) {
+            if (
+              err instanceof SafeFetchError &&
+              err.reason === "response-too-large"
+            ) {
+              throw NextlyError.validation({
+                errors: [
+                  {
+                    path: "attachments",
+                    code: EmailErrorCode.ATTACHMENT_SIZE_EXCEEDED,
+                    message: "Attachment size exceeds the limit.",
+                  },
+                ],
+                logContext: {
+                  emailAttachmentCode: EmailErrorCode.ATTACHMENT_SIZE_EXCEEDED,
+                  max: limits.maxTotalBytes,
+                },
+              });
+            }
+            throw err;
+          }
           if (!response.ok) {
-            throw new Error(
-              `Failed to fetch attachment from ${url}: HTTP ${response.status}`
-            );
+            throw NextlyError.internal({
+              logContext: {
+                emailAttachmentCode:
+                  EmailErrorCode.ATTACHMENT_STORAGE_READ_FAILED,
+                url,
+                status: response.status,
+              },
+            });
           }
           return Buffer.from(await response.arrayBuffer());
         },

--- a/packages/nextly/src/domains/email/__tests__/attachment-resolver.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/attachment-resolver.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { NextlyError } from "../../../errors";
 import { EmailErrorCode } from "../errors";
 import { resolveAttachments } from "../services/attachment-resolver";
 import type {
@@ -89,6 +90,33 @@ describe("resolveAttachments", () => {
       code: "INTERNAL_ERROR",
       logContext: {
         emailAttachmentCode: EmailErrorCode.ATTACHMENT_STORAGE_READ_FAILED,
+      },
+    });
+  });
+
+  it("passes a typed NextlyError from readBytes through unwrapped", async () => {
+    // A URL-backed fetch that exceeds the size cap raises a size-exceeded
+    // validation error; it must surface as-is, not be re-wrapped as an opaque
+    // storage-read failure (which is what local/S3 raw throws become).
+    const deps = makeDeps({
+      readBytes: vi.fn().mockRejectedValue(
+        NextlyError.validation({
+          errors: [
+            {
+              path: "attachments",
+              code: EmailErrorCode.ATTACHMENT_SIZE_EXCEEDED,
+              message: "too big",
+            },
+          ],
+        })
+      ),
+    });
+    await expect(
+      resolveAttachments([{ mediaId: "m1" }], deps)
+    ).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: [{ code: EmailErrorCode.ATTACHMENT_SIZE_EXCEEDED }],
       },
     });
   });

--- a/packages/nextly/src/domains/email/__tests__/attachment-resolver.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/attachment-resolver.test.ts
@@ -121,6 +121,27 @@ describe("resolveAttachments", () => {
     });
   });
 
+  it("wraps a non-validation NextlyError from readBytes as STORAGE_READ_FAILED", async () => {
+    // A URL fetch that fails for a non-size reason (SSRF reject, timeout, a
+    // relative-URL/missing-file error) must not leak its code/message to the
+    // caller; only the size-exceeded validation error passes through.
+    const deps = makeDeps({
+      readBytes: vi
+        .fn()
+        .mockRejectedValue(
+          NextlyError.internal({ logContext: { reason: "ssrf-reject" } })
+        ),
+    });
+    await expect(
+      resolveAttachments([{ mediaId: "m1" }], deps)
+    ).rejects.toMatchObject({
+      code: "INTERNAL_ERROR",
+      logContext: {
+        emailAttachmentCode: EmailErrorCode.ATTACHMENT_STORAGE_READ_FAILED,
+      },
+    });
+  });
+
   it("throws SIZE_EXCEEDED when total bytes cross the cap", async () => {
     const big = Buffer.alloc(6 * 1024 * 1024); // 6 MiB each
     const deps = makeDeps({

--- a/packages/nextly/src/domains/email/services/attachment-resolver.ts
+++ b/packages/nextly/src/domains/email/services/attachment-resolver.ts
@@ -100,10 +100,12 @@ export async function resolveAttachments(
     try {
       content = await deps.readBytes(media.filename);
     } catch (err) {
-      // A typed NextlyError from readBytes (e.g. the size-exceeded validation a
-      // URL-backed fetch raises when the object is over the limit) is already
-      // precise; pass it through and wrap only opaque storage failures.
-      if (NextlyError.is(err)) throw err;
+      // Pass through only the precise validation error a URL-backed fetch raises
+      // when the object is over the limit (size-exceeded). Everything else —
+      // including SSRF/timeout errors, whose messages (e.g. "Resolved to
+      // non-public IP") must not reach the caller, and a missing-file relative
+      // URL — is wrapped as an opaque storage-read failure.
+      if (NextlyError.is(err) && err.code === "VALIDATION_ERROR") throw err;
       throw NextlyError.internal({
         cause: err instanceof Error ? err : undefined,
         logContext: {

--- a/packages/nextly/src/domains/email/services/attachment-resolver.ts
+++ b/packages/nextly/src/domains/email/services/attachment-resolver.ts
@@ -100,6 +100,10 @@ export async function resolveAttachments(
     try {
       content = await deps.readBytes(media.filename);
     } catch (err) {
+      // A typed NextlyError from readBytes (e.g. the size-exceeded validation a
+      // URL-backed fetch raises when the object is over the limit) is already
+      // precise; pass it through and wrap only opaque storage failures.
+      if (NextlyError.is(err)) throw err;
       throw NextlyError.internal({
         cause: err instanceof Error ? err : undefined,
         logContext: {

--- a/packages/nextly/src/utils/validate-external-url.test.ts
+++ b/packages/nextly/src/utils/validate-external-url.test.ts
@@ -226,6 +226,23 @@ describe("safeFetch", () => {
     expect(response.headers.get("content-length")).toBeNull();
   });
 
+  it("reports an over-cap decompressed body as response-too-large", async () => {
+    const { gzipSync } = await import("node:zlib");
+    // Small on the wire, but inflates to 4000 bytes; the 1000-byte cap trips
+    // the zlib maxOutputLength guard, which must classify as response-too-large.
+    const wire = gzipSync(Buffer.alloc(4000, 0x61));
+    const h = await startServer((_req, res) => {
+      res.writeHead(200, { "content-encoding": "gzip" });
+      res.end(wire);
+    });
+    await expect(
+      safeFetch(`${h.base}/`, { ...local, maxResponseBytes: 1000 })
+    ).rejects.toMatchObject({
+      name: "SafeFetchError",
+      reason: "response-too-large",
+    });
+  });
+
   it("does not fail an empty body that carries a content-encoding", async () => {
     // Inflating zero bytes throws; an empty encoded 2xx must stay a success.
     const h = await startServer((_req, res) => {

--- a/packages/nextly/src/utils/validate-external-url.test.ts
+++ b/packages/nextly/src/utils/validate-external-url.test.ts
@@ -226,6 +226,17 @@ describe("safeFetch", () => {
     expect(response.headers.get("content-length")).toBeNull();
   });
 
+  it("does not fail an empty body that carries a content-encoding", async () => {
+    // Inflating zero bytes throws; an empty encoded 2xx must stay a success.
+    const h = await startServer((_req, res) => {
+      res.writeHead(200, { "content-encoding": "gzip" });
+      res.end();
+    });
+    const response = await safeFetch(`${h.base}/`, local);
+    expect(response.ok).toBe(true);
+    expect(await response.text()).toBe("");
+  });
+
   it("strips a caller-supplied Host header (no vhost override)", async () => {
     // A forwarded Host could route to an internal vhost behind the validated
     // public IP; it must be derived from the URL, not the caller's headers.

--- a/packages/nextly/src/utils/validate-external-url.test.ts
+++ b/packages/nextly/src/utils/validate-external-url.test.ts
@@ -252,6 +252,8 @@ describe("safeFetch", () => {
     const response = await safeFetch(`${h.base}/`, local);
     expect(response.ok).toBe(true);
     expect(await response.text()).toBe("");
+    // The now-meaningless content-encoding header is stripped, like a decoded body.
+    expect(response.headers.get("content-encoding")).toBeNull();
   });
 
   it("strips a caller-supplied Host header (no vhost override)", async () => {

--- a/packages/nextly/src/utils/validate-external-url.test.ts
+++ b/packages/nextly/src/utils/validate-external-url.test.ts
@@ -243,6 +243,23 @@ describe("safeFetch", () => {
     });
   });
 
+  it("reports an over-cap deflate body as response-too-large (not decode-failed)", async () => {
+    const { deflateSync } = await import("node:zlib");
+    // zlib-wrapped deflate that inflates past the cap: the size signal must
+    // survive the raw-deflate fallback.
+    const wire = deflateSync(Buffer.alloc(4000, 0x61));
+    const h = await startServer((_req, res) => {
+      res.writeHead(200, { "content-encoding": "deflate" });
+      res.end(wire);
+    });
+    await expect(
+      safeFetch(`${h.base}/`, { ...local, maxResponseBytes: 1000 })
+    ).rejects.toMatchObject({
+      name: "SafeFetchError",
+      reason: "response-too-large",
+    });
+  });
+
   it("does not fail an empty body that carries a content-encoding", async () => {
     // Inflating zero bytes throws; an empty encoded 2xx must stay a success.
     const h = await startServer((_req, res) => {

--- a/packages/nextly/src/utils/validate-external-url.ts
+++ b/packages/nextly/src/utils/validate-external-url.ts
@@ -647,7 +647,12 @@ function decodeBody(
         // `deflate` is zlib-wrapped per spec, but some servers send raw deflate.
         try {
           current = zlib.inflateSync(current, opts);
-        } catch {
+        } catch (inflateErr) {
+          // Only a zlib-wrapped/raw mismatch warrants the raw retry; a size-cap
+          // overflow must keep its ERR_BUFFER_TOO_LARGE signal so it classifies
+          // as response-too-large rather than decode-failed.
+          if (errorCode(inflateErr) === "ERR_BUFFER_TOO_LARGE")
+            throw inflateErr;
           current = zlib.inflateRawSync(current, opts);
         }
       } else {

--- a/packages/nextly/src/utils/validate-external-url.ts
+++ b/packages/nextly/src/utils/validate-external-url.ts
@@ -622,8 +622,10 @@ function decodeBody(
 ): { body: Buffer; decoded: boolean } | SafeFetchError {
   if (!encoding) return { body: buf, decoded: false };
   // An empty body has nothing to decode; inflating zero bytes would throw and
-  // turn a valid empty 2xx/204/304 response into a failure. Pass it through.
-  if (buf.length === 0) return { body: buf, decoded: false };
+  // turn a valid empty 2xx/204/304 response into a failure. Report it as decoded
+  // so the now-meaningless content-encoding/-length headers are stripped, the
+  // same as a normally-decoded body.
+  if (buf.length === 0) return { body: buf, decoded: true };
   // Content-Encoding may stack (e.g. "br, gzip"): the layers are listed in the
   // order applied, so decode from the last (outermost) inward.
   const layers = encoding

--- a/packages/nextly/src/utils/validate-external-url.ts
+++ b/packages/nextly/src/utils/validate-external-url.ts
@@ -664,14 +664,29 @@ function decodeBody(
       decoded = true;
     }
     return { body: current, decoded };
-  } catch {
-    // Corrupt stream, or the inflated size exceeded the cap (bomb guard).
+  } catch (err) {
+    // node:zlib throws ERR_BUFFER_TOO_LARGE when the inflated output exceeds
+    // maxOutputLength (a decompression bomb). That is a size problem, so report
+    // it as response-too-large (callers that cap by an attachment/size limit can
+    // then treat it uniformly); anything else is a genuinely corrupt stream.
+    const tooLarge = errorCode(err) === "ERR_BUFFER_TOO_LARGE";
     return new SafeFetchError(
-      `Failed to decode ${encoding} response body`,
+      tooLarge
+        ? `Decoded ${encoding} response body exceeded the size cap`
+        : `Failed to decode ${encoding} response body`,
       url,
-      "decode-failed"
+      tooLarge ? "response-too-large" : "decode-failed"
     );
   }
+}
+
+/** The `.code` of a Node system error, if present. */
+function errorCode(err: unknown): string | undefined {
+  if (err != null && typeof err === "object" && "code" in err) {
+    const code: unknown = err.code;
+    return typeof code === "string" ? code : undefined;
+  }
+  return undefined;
 }
 
 // ---------- IP classification (regex-based, browser-safe) ----------

--- a/packages/nextly/src/utils/validate-external-url.ts
+++ b/packages/nextly/src/utils/validate-external-url.ts
@@ -621,6 +621,9 @@ function decodeBody(
   url: string
 ): { body: Buffer; decoded: boolean } | SafeFetchError {
   if (!encoding) return { body: buf, decoded: false };
+  // An empty body has nothing to decode; inflating zero bytes would throw and
+  // turn a valid empty 2xx/204/304 response into a failure. Pass it through.
+  if (buf.length === 0) return { body: buf, decoded: false };
   // Content-Encoding may stack (e.g. "br, gzip"): the layers are listed in the
   // order applied, so decode from the last (outermost) inward.
   const layers = encoding


### PR DESCRIPTION
## What

Two follow-up fixes for edge cases in the IP-pinning `safeFetch` change (#232, merged), both flagged by Codex in post-merge review.

### 1. Empty encoded bodies no longer fail
A `2xx`/`204`/`304` response that carries a `Content-Encoding: gzip|br|deflate` header but an **empty body** was turned into a `SafeFetchError` — inflating zero bytes throws. The old `fetch()` path returned an OK empty body, and the form-builder webhook handler only checks `response.ok`, so valid deliveries were being reported as failed. `decodeBody` now passes an empty body straight through.

### 2. Over-limit URL attachments produce the size-validation error
Capping the email attachment fetch at the attachment limit (from an earlier #232 fix) meant an over-limit URL-backed attachment threw `response-too-large` inside `readBytes`, which the resolver wrapped as `EMAIL_ATTACHMENT_STORAGE_READ_FAILED` (a 500-style storage failure) instead of the `EMAIL_ATTACHMENT_SIZE_EXCEEDED` validation error that local/S3 reads produce. Now:
- the attachment fetch translates a `response-too-large` `SafeFetchError` into the size-exceeded validation error, and
- the attachment resolver passes a typed `NextlyError` from `readBytes` through unchanged, wrapping only opaque (non-`NextlyError`) storage failures.

So URL, local, and S3 attachments all fail over-limit the same way.

## Tests

- `safeFetch`: an empty gzip-headed 2xx returns `ok` with an empty body.
- `attachment-resolver`: a typed `NextlyError` from `readBytes` surfaces as-is (not re-wrapped); the existing plain-`Error` case still becomes `STORAGE_READ_FAILED`.
- `pnpm --filter nextly lint` + `check-types` + the email attachment suites pass (36 tests green).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email attachment error handling by consistently enforcing attachment size limits and returning clearer validation vs internal failure details.
  * Updated attachment resolution to preserve validation errors (oversized attachments) while wrapping unexpected failures as internal errors with improved diagnostics.
  * Fixed external URL content decoding for empty gzip responses and improved “response-too-large” detection for oversized decompressed payloads.

* **Tests**
  * Added regression tests covering attachment size/error propagation and gzip/deflate decompression edge cases, including empty bodies and oversize decompressed content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->