### PR TITLE
feat(nextly): add created_by owner column and stamp it on create

### DIFF
--- a/.changeset/owner-stamp-created-by.md
+++ b/.changeset/owner-stamp-created-by.md
@@ -25,4 +25,12 @@ Every collection entry table now carries a nullable `created_by` system column (
 
 Because the column is nullable with no default, existing tables pick it up as a plain additive `ADD COLUMN` on the next schema apply — no backfill and no interactive prompt.
 
+The owner column is wired end to end:
+
+- `owner-only` rules with no `ownerField` now default to the `created_by` column (snake_case), so zero-config owner-only reads/updates/deletes actually match the stamped rows.
+- On MySQL the column is `varchar(191)` (sized to the Auth.js-compatible `users.id`), since it stores a user id, not the row id.
+- Updates cannot rewrite it: `created_by` (and `id` / `created_at`) are stripped from update payloads, so an authorized updater can't transfer a row to another user.
+- It is stripped from list, get, and mutation responses so a collection readable by non-creators does not leak the creator's user id.
+- Reserved as a field name in the collection and ui-schema validators; scoped to collections only (singles/components don't get the column).
+
 This also repairs a latent bug in the bulk create transaction path, which passed camelCase `createdAt` / `updatedAt` keys the database driver rejected; the batch create paths now use the real snake_case column names.

--- a/.changeset/owner-stamp-created-by.md
+++ b/.changeset/owner-stamp-created-by.md
@@ -30,7 +30,8 @@ The owner column is wired end to end:
 - `owner-only` rules with no `ownerField` now default to the `created_by` column (snake_case), so zero-config owner-only reads/updates/deletes actually match the stamped rows.
 - On MySQL the column is `varchar(191)` (sized to the Auth.js-compatible `users.id`), since it stores a user id, not the row id.
 - Updates cannot rewrite it: `created_by` (and `id` / `created_at`) are stripped from update payloads, so an authorized updater can't transfer a row to another user.
-- It is stripped from list, get, and mutation responses (including populated relationship rows at every depth) so a collection readable by non-creators does not leak the creator's user id, and it is rejected from client-supplied `where` filters and `sort` so a caller can't target or order rows by creator either.
-- Reserved as a field name in the collection and ui-schema validators; scoped to collections only (singles/components don't get the column).
+- It is stripped from list, get, and mutation responses (including populated relationship rows at every depth) so a collection readable by non-creators does not leak the creator's user id, and it is rejected from client-supplied `where` filters (query string and request body, including dotted keys like `created_by.any`) and `sort` so a caller can't target or order rows by creator either.
+- Reserved as a field name in the collection, code-first, and ui-schema validators; scoped to collections only (singles/components don't get the column, so their owner-only rules keep the historical `createdBy` default). An explicit `ownerField: "createdBy"` on a collection normalizes to the stamped column.
+- Indexed on collection tables, since owner-only reads/lists/counts and bulk-by-query enumeration all filter on it.
 
 This also repairs a latent bug in the bulk create transaction path, which passed camelCase `createdAt` / `updatedAt` keys the database driver rejected; the batch create paths now use the real snake_case column names.

--- a/.changeset/owner-stamp-created-by.md
+++ b/.changeset/owner-stamp-created-by.md
@@ -1,0 +1,28 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Add a `created_by` owner column to collection entry tables and stamp it on create.
+
+Every collection entry table now carries a nullable `created_by` system column (text, matching the id column type on each dialect) alongside `created_at` / `updated_at`, and it is stamped with the creating user's id on every create path. This makes `owner-only` access work zero-config: the stored rule compares `created_by` to the caller with no per-collection setup. System and seed writes (no user context) leave it null.
+
+Because the column is nullable with no default, existing tables pick it up as a plain additive `ADD COLUMN` on the next schema apply — no backfill and no interactive prompt.
+
+This also repairs a latent bug in the bulk create transaction path, which passed camelCase `createdAt` / `updatedAt` keys the database driver rejected; the batch create paths now use the real snake_case column names.

--- a/.changeset/owner-stamp-created-by.md
+++ b/.changeset/owner-stamp-created-by.md
@@ -30,7 +30,7 @@ The owner column is wired end to end:
 - `owner-only` rules with no `ownerField` now default to the `created_by` column (snake_case), so zero-config owner-only reads/updates/deletes actually match the stamped rows.
 - On MySQL the column is `varchar(191)` (sized to the Auth.js-compatible `users.id`), since it stores a user id, not the row id.
 - Updates cannot rewrite it: `created_by` (and `id` / `created_at`) are stripped from update payloads, so an authorized updater can't transfer a row to another user.
-- It is stripped from list, get, and mutation responses so a collection readable by non-creators does not leak the creator's user id.
+- It is stripped from list, get, and mutation responses (including populated relationship rows at every depth) so a collection readable by non-creators does not leak the creator's user id, and it is rejected from client-supplied `where` filters and `sort` so a caller can't target or order rows by creator either.
 - Reserved as a field name in the collection and ui-schema validators; scoped to collections only (singles/components don't get the column).
 
 This also repairs a latent bug in the bulk create transaction path, which passed camelCase `createdAt` / `updatedAt` keys the database driver rejected; the batch create paths now use the real snake_case column names.

--- a/packages/nextly/src/api/collections-schema-detail.ts
+++ b/packages/nextly/src/api/collections-schema-detail.ts
@@ -179,7 +179,7 @@ export const PATCH = withErrorHandler(
 
     if (body.fields !== undefined) {
       // Same rules as the ui-schema.json mirror (see api/fields-payload).
-      assertValidFieldsPayload(body.fields);
+      assertValidFieldsPayload(body.fields, { kind: "collection" });
       updateData.fields = body.fields;
       // The registry re-validates the field config; cast through `unknown`
       // to avoid `any` while keeping the existing trust boundary.

--- a/packages/nextly/src/api/collections-schema.ts
+++ b/packages/nextly/src/api/collections-schema.ts
@@ -229,7 +229,7 @@ export const POST = withErrorHandler(async (request: Request) => {
   const validated = parseResult.data;
 
   // Same rules as the ui-schema.json mirror (see api/fields-payload).
-  assertValidFieldsPayload(validated.fields);
+  assertValidFieldsPayload(validated.fields, { kind: "collection" });
 
   const tableName = validated.slug
     .toLowerCase()

--- a/packages/nextly/src/api/fields-payload.ts
+++ b/packages/nextly/src/api/fields-payload.ts
@@ -14,9 +14,18 @@
  */
 import { z } from "zod";
 
+import { NextlyError } from "../errors/nextly-error";
 import { uiSchemaFieldSchema } from "../schemas/_zod/ui-schema";
 
 import { nextlyValidationFromZod } from "./zod-to-nextly-error";
+
+/**
+ * The collection owner column (`created_by`) — plus the camelCase alias config
+ * validation accepts, which snake-cases to the same column. Reserved only for
+ * collections: single/component tables have no owner column, so these are legal
+ * field names there.
+ */
+const COLLECTION_OWNER_RESERVED = new Set(["created_by", "createdBy"]);
 
 // The ui-schema.json entity validator rejects duplicate field names, so the
 // shared payload validator must too — otherwise a payload could pass the
@@ -43,10 +52,34 @@ const fieldsArraySchema = z
 /**
  * Throw `NextlyError.validation` (with per-field paths) unless `fields`
  * satisfies the manifest field rules.
+ *
+ * @param opts.kind - Entity being validated. For `"collection"`, the owner
+ *   column name (`created_by` / `createdBy`) is additionally reserved, since it
+ *   only exists on collection tables. Singles and components have no owner
+ *   column, so those names stay valid there.
  */
-export function assertValidFieldsPayload(fields: unknown): void {
+export function assertValidFieldsPayload(
+  fields: unknown,
+  opts: { kind?: "collection" | "single" | "component" } = {}
+): void {
   const parsed = fieldsArraySchema.safeParse(fields);
   if (!parsed.success) {
     throw nextlyValidationFromZod(parsed.error);
+  }
+  if (opts.kind === "collection" && Array.isArray(fields)) {
+    fields.forEach((field, index) => {
+      const name = (field as { name?: unknown } | null)?.name;
+      if (typeof name === "string" && COLLECTION_OWNER_RESERVED.has(name)) {
+        throw NextlyError.validation({
+          errors: [
+            {
+              path: `${index}.name`,
+              code: "RESERVED",
+              message: `field name '${name}' is reserved`,
+            },
+          ],
+        });
+      }
+    });
   }
 }

--- a/packages/nextly/src/collections/config/validate-config.owner-reserved.test.ts
+++ b/packages/nextly/src/collections/config/validate-config.owner-reserved.test.ts
@@ -1,0 +1,42 @@
+/**
+ * `created_by` is injected as a system owner column on every collection table,
+ * so a code-first collection must not declare a top-level field with that name
+ * (or its camelCase alias, which snake-cases to the same column). Nested fields
+ * live inside JSON and do not collide, so the reservation is top-level only.
+ */
+import { describe, expect, it } from "vitest";
+
+import { group, text } from "../fields/helpers";
+import type { CollectionConfig } from "./define-collection";
+import { validateCollectionConfig } from "./validate-config";
+
+function codesFor(fields: CollectionConfig["fields"]): string[] {
+  return validateCollectionConfig({ slug: "posts", fields }).errors.map(
+    e => e.code
+  );
+}
+
+describe("validateCollectionConfig: owner-column reservation", () => {
+  it("rejects a top-level created_by field", () => {
+    expect(codesFor([text({ name: "created_by" })])).toContain(
+      "FIELD_NAME_RESERVED"
+    );
+  });
+
+  it("rejects the camelCase createdBy alias (snake-cases to created_by)", () => {
+    expect(codesFor([text({ name: "createdBy" })])).toContain(
+      "FIELD_NAME_RESERVED"
+    );
+  });
+
+  it("allows created_by nested inside a group (JSON-stored, no column)", () => {
+    const codes = codesFor([
+      group({ name: "meta", fields: [text({ name: "created_by" })] }),
+    ]);
+    expect(codes).not.toContain("FIELD_NAME_RESERVED");
+  });
+
+  it("leaves an ordinary collection untouched", () => {
+    expect(codesFor([text({ name: "title" })])).toEqual([]);
+  });
+});

--- a/packages/nextly/src/collections/config/validate-config.ts
+++ b/packages/nextly/src/collections/config/validate-config.ts
@@ -77,6 +77,7 @@ export type ValidationErrorCode =
   | "FIELD_NAME_INVALID_FORMAT"
   | "FIELD_NAME_SQL_KEYWORD"
   | "FIELD_NAME_DUPLICATE"
+  | "FIELD_NAME_RESERVED"
   | "FIELD_TYPE_REQUIRED"
   | "FIELD_TYPE_INVALID"
   // Field-specific errors
@@ -148,6 +149,20 @@ export interface ValidationResult {
 // public API surface for this file is unchanged.
 
 const RESERVED_SLUGS_SET: Set<string> = new Set<string>(RESERVED_SLUGS);
+
+// The owner column `created_by` is injected as a system column on every
+// collection table (both the snake_case name and its camelCase alias, which
+// snake-cases to the same column). A code-first collection therefore must not
+// declare a top-level field with either name, or its DDL would collide with the
+// injected column and the owner stamp / response strip would consume a user
+// field. Reserved for collections only — singles are a single global row and
+// components embed in JSON, so neither carries this column and both may use the
+// name freely. Nested repeater/group fields are stored inside JSON, not as
+// table columns, so the reservation applies to the top level only.
+const COLLECTION_RESERVED_FIELD_NAMES: Set<string> = new Set([
+  "created_by",
+  "createdBy",
+]);
 
 // ============================================================
 // Index Validation (collection-specific)
@@ -467,6 +482,21 @@ function validateFields(
     });
     return;
   }
+
+  // Block the injected owner column at the top level before per-field
+  // validation. Nested fields are validated recursively inside
+  // validateFieldsArray and are intentionally exempt (JSON-stored, no column).
+  fields.forEach((field, index) => {
+    if (!field || typeof field !== "object") return;
+    const name = (field as Record<string, unknown>).name;
+    if (typeof name === "string" && COLLECTION_RESERVED_FIELD_NAMES.has(name)) {
+      errors.push({
+        path: `${path}[${index}].name`,
+        message: `Field name '${name}' is reserved for the system owner column`,
+        code: "FIELD_NAME_RESERVED",
+      });
+    }
+  });
 
   validateFieldsArray(fields, path, errors, allCollectionSlugs);
 }

--- a/packages/nextly/src/database/__tests__/integration/schema-push.integration.test.ts
+++ b/packages/nextly/src/database/__tests__/integration/schema-push.integration.test.ts
@@ -65,7 +65,10 @@ describe("Schema Push Integration (Real PostgreSQL)", async () => {
     db = drizzle({ client: pool });
 
     // Create test tables via raw SQL (bypassing pushSchema TTY limitation)
-    // This simulates what pushSchema would do, letting us test CRUD via Drizzle API
+    // This simulates what pushSchema would do, letting us test CRUD via Drizzle API.
+    // `created_by` is included because it is a system owner column injected into
+    // every collection table's runtime schema, so the fixture must carry it or the
+    // Drizzle CRUD (which selects/inserts it) would reference a missing column.
     await pool.query(`
       DROP TABLE IF EXISTS "dc_int_products" CASCADE;
       CREATE TABLE "dc_int_products" (
@@ -76,7 +79,8 @@ describe("Schema Push Integration (Real PostgreSQL)", async () => {
         "is_active" boolean,
         "metadata" jsonb,
         "created_at" timestamp DEFAULT now(),
-        "updated_at" timestamp DEFAULT now()
+        "updated_at" timestamp DEFAULT now(),
+        "created_by" text
       );
     `);
 
@@ -89,7 +93,8 @@ describe("Schema Push Integration (Real PostgreSQL)", async () => {
         "body" text,
         "status" text DEFAULT 'draft',
         "created_at" timestamp DEFAULT now(),
-        "updated_at" timestamp DEFAULT now()
+        "updated_at" timestamp DEFAULT now(),
+        "created_by" text
       );
     `);
   });

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -318,7 +318,7 @@ const COLLECTIONS_METHODS: Record<
       // Same rules as the ui-schema.json mirror (see api/fields-payload):
       // an invalid field must fail HERE, not only at the file write, or
       // the DB and the committed manifest diverge silently.
-      assertValidFieldsPayload(fields);
+      assertValidFieldsPayload(fields, { kind: "collection" });
       // collection comes from getCollectionBySlug typed as DynamicCollectionRecord,
       // which has tableName, fields: FieldConfig[], and schemaVersion: number.
       // FieldConfig is structurally compatible with FieldDefinition; cast
@@ -459,7 +459,7 @@ const COLLECTIONS_METHODS: Record<
       // Same rules as the ui-schema.json mirror (see api/fields-payload):
       // an invalid field must fail HERE, not only at the file write, or
       // the DB and the committed manifest diverge silently.
-      assertValidFieldsPayload(fields);
+      assertValidFieldsPayload(fields, { kind: "collection" });
 
       // Log a debug line when hints arrive so we can track adoption
       // without surprising operators with errors. The current version

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -83,6 +83,7 @@ import {
   parseWhereParam,
   requireBody,
   requireParam,
+  stripOwnerColumnsFromWhere,
   toNumber,
 } from "../helpers/validation";
 import type { MethodHandler, Params } from "../types";
@@ -1035,7 +1036,13 @@ const COLLECTIONS_METHODS: Record<
       const result = await svc.bulkUpdateByQuery(
         {
           collectionName: p.collectionName,
-          where: b.where as WhereFilter,
+          // Strip owner-column conditions from the request body so a caller
+          // cannot target rows by the system owner column via `body.where`
+          // (mirrors parseWhereParam on the query-string path). The service's
+          // own owner constraint is added separately and is unaffected; a where
+          // that was only an owner filter becomes {} and stays bounded by the
+          // collection's access rules.
+          where: stripOwnerColumnsFromWhere(b.where as WhereFilter) ?? {},
           data: b.data,
           userId: p._authenticatedUserId
             ? String(p._authenticatedUserId)

--- a/packages/nextly/src/dispatcher/helpers/__tests__/validation-owner-where.test.ts
+++ b/packages/nextly/src/dispatcher/helpers/__tests__/validation-owner-where.test.ts
@@ -1,0 +1,41 @@
+/**
+ * The system owner column (`created_by`) is stripped from responses, so a REST
+ * client must not be able to filter by it either. parseWhereParam drops any
+ * owner-column condition from a client `where` (recursing through and/or) while
+ * leaving other conditions intact.
+ */
+import { describe, expect, it } from "vitest";
+
+import { parseWhereParam } from "../validation";
+
+describe("parseWhereParam strips owner-column filters", () => {
+  it("drops a top-level created_by / createdBy condition", () => {
+    const where = parseWhereParam(
+      JSON.stringify({
+        created_by: { equals: "u1" },
+        createdBy: { equals: "u1" },
+        status: { equals: "published" },
+      })
+    );
+    expect(where).toEqual({ status: { equals: "published" } });
+  });
+
+  it("drops owner conditions nested inside and/or and prunes empties", () => {
+    const where = parseWhereParam(
+      JSON.stringify({
+        and: [{ created_by: { equals: "u1" } }, { title: { contains: "hi" } }],
+        or: [{ createdBy: { equals: "u2" } }],
+      })
+    );
+    // The `and` keeps only the title condition; the `or` becomes empty and is
+    // pruned entirely.
+    expect(where).toEqual({ and: [{ title: { contains: "hi" } }] });
+  });
+
+  it("leaves owner-free filters untouched", () => {
+    const where = parseWhereParam(
+      JSON.stringify({ price: { greater_than: 100 } })
+    );
+    expect(where).toEqual({ price: { greater_than: 100 } });
+  });
+});

--- a/packages/nextly/src/dispatcher/helpers/__tests__/validation-owner-where.test.ts
+++ b/packages/nextly/src/dispatcher/helpers/__tests__/validation-owner-where.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { parseWhereParam } from "../validation";
+import { parseWhereParam, stripOwnerColumnsFromWhere } from "../validation";
 
 describe("parseWhereParam strips owner-column filters", () => {
   it("drops a top-level created_by / createdBy condition", () => {
@@ -18,6 +18,19 @@ describe("parseWhereParam strips owner-column filters", () => {
       })
     );
     expect(where).toEqual({ status: { equals: "published" } });
+  });
+
+  it("drops a dotted owner key (created_by.any) that keys on the first segment", () => {
+    // The query builder keys on `column.split(".")[0]`, so `created_by.any`
+    // still targets the owner column and must be stripped like the bare key.
+    const where = parseWhereParam(
+      JSON.stringify({
+        "created_by.any": { equals: "u1" },
+        "createdBy.somethingElse": { equals: "u1" },
+        title: { contains: "hi" },
+      })
+    );
+    expect(where).toEqual({ title: { contains: "hi" } });
   });
 
   it("drops owner conditions nested inside and/or and prunes empties", () => {
@@ -37,5 +50,19 @@ describe("parseWhereParam strips owner-column filters", () => {
       JSON.stringify({ price: { greater_than: 100 } })
     );
     expect(where).toEqual({ price: { greater_than: 100 } });
+  });
+});
+
+describe("stripOwnerColumnsFromWhere sanitizes body filters", () => {
+  it("strips owner columns (incl. dotted + nested) from an object where", () => {
+    const where = stripOwnerColumnsFromWhere({
+      "created_by.any": { equals: "u1" },
+      and: [{ createdBy: { equals: "u1" } }, { status: { equals: "draft" } }],
+    });
+    expect(where).toEqual({ and: [{ status: { equals: "draft" } }] });
+  });
+
+  it("passes undefined through unchanged", () => {
+    expect(stripOwnerColumnsFromWhere(undefined)).toBeUndefined();
   });
 });

--- a/packages/nextly/src/dispatcher/helpers/validation.ts
+++ b/packages/nextly/src/dispatcher/helpers/validation.ts
@@ -119,7 +119,11 @@ const stripOwnerFromWhere = (node: unknown): unknown => {
     for (const [key, value] of Object.entries(
       node as Record<string, unknown>
     )) {
-      if (OWNER_QUERY_COLUMNS.has(key)) continue; // drop an owner-column filter
+      // Drop an owner-column filter. A dotted key like `created_by.any` still
+      // targets the owner column because the query builder keys on the first
+      // path segment (`column.split(".")[0]`), so match on that segment — not
+      // just the exact key — or the dotted form would slip through.
+      if (OWNER_QUERY_COLUMNS.has(key.split(".")[0])) continue;
       if (key === "and" || key === "or") {
         const arr = stripOwnerFromWhere(value);
         if (Array.isArray(arr) && arr.length > 0) out[key] = arr;
@@ -151,6 +155,18 @@ export const parseWhereParam = (
     return undefined;
   }
 };
+
+/**
+ * Strip owner-column conditions from an already-parsed client `where` object.
+ * The JSON query-string path goes through {@link parseWhereParam}; this covers
+ * the request-body path (e.g. the bulk-update-by-query handler reads
+ * `body.where` directly) so a client cannot target rows by the system owner
+ * column via the body either. Returns `undefined` unchanged.
+ */
+export const stripOwnerColumnsFromWhere = (
+  where: WhereFilter | undefined
+): WhereFilter | undefined =>
+  where === undefined ? undefined : (stripOwnerFromWhere(where) as WhereFilter);
 
 // ============================================================
 // Rich text format validation

--- a/packages/nextly/src/dispatcher/helpers/validation.ts
+++ b/packages/nextly/src/dispatcher/helpers/validation.ts
@@ -92,6 +92,46 @@ export const parseSelectParam = (
  * The key[op]=value query-param format is parsed elsewhere via
  * `parseWhereQuery` -- this helper handles the JSON form.
  */
+/**
+ * System owner column (both the snake_case name and the camelCase alias). It is
+ * stripped from response payloads, so a client must not be able to filter, sort,
+ * or otherwise address rows by it either — otherwise a caller who knows/guesses
+ * a user id could learn or target rows by creator through the query controls.
+ */
+export const OWNER_QUERY_COLUMNS = new Set(["created_by", "createdBy"]);
+
+/**
+ * Remove any owner-column condition from a client-supplied `where` tree
+ * (recursing through `and`/`or`), so a REST caller cannot filter/count by the
+ * system owner column. The service's own owner-only constraint is added
+ * separately, downstream of this, and is unaffected.
+ */
+const stripOwnerFromWhere = (node: unknown): unknown => {
+  if (Array.isArray(node)) {
+    return node
+      .map(stripOwnerFromWhere)
+      .filter(
+        n => n != null && (typeof n !== "object" || Object.keys(n).length > 0)
+      );
+  }
+  if (node && typeof node === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(
+      node as Record<string, unknown>
+    )) {
+      if (OWNER_QUERY_COLUMNS.has(key)) continue; // drop an owner-column filter
+      if (key === "and" || key === "or") {
+        const arr = stripOwnerFromWhere(value);
+        if (Array.isArray(arr) && arr.length > 0) out[key] = arr;
+      } else {
+        out[key] = value; // a field condition — its op object is not a field
+      }
+    }
+    return out;
+  }
+  return node;
+};
+
 export const parseWhereParam = (
   whereParam?: string
 ): WhereFilter | undefined => {
@@ -106,7 +146,7 @@ export const parseWhereParam = (
     ) {
       return undefined;
     }
-    return parsed as WhereFilter;
+    return stripOwnerFromWhere(parsed) as WhereFilter;
   } catch {
     return undefined;
   }

--- a/packages/nextly/src/domains/collections/__tests__/created-by-stamp.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/created-by-stamp.integration.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Proves the `created_by` owner column is stamped end-to-end on the create
+ * path against a real (in-memory SQLite) database: the creating user's id lands
+ * in the column, and a system create (no user) leaves it null. This is what
+ * makes owner-only access work zero-config — the stored rule compares
+ * `created_by` to the caller.
+ *
+ * Uses overrideAccess to bypass the RBAC gate while still carrying the user, so
+ * the test exercises the stamping without wiring per-user permissions.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionService } from "../services/collection-service";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const TABLE = "dc_ownerdocs";
+
+describe("created_by owner stamping (integration)", () => {
+  it("stamps the creating user's id and leaves system creates null", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "ownerdocs",
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    // Create carrying a user (overrideAccess bypasses the access gate but the
+    // owner stamp reads the user, not the access decision).
+    await handler.createEntry(
+      { collectionName: "ownerdocs", userId: "owner-1", overrideAccess: true },
+      { title: "mine" }
+    );
+
+    // Create with no user (a system/seed write).
+    await handler.createEntry(
+      { collectionName: "ownerdocs", overrideAccess: true },
+      { title: "system" }
+    );
+
+    const rows = await current.adapter.select<{
+      title: string;
+      created_by: string | null;
+    }>(TABLE);
+    const byTitle = new Map(rows.map(r => [r.title, r.created_by]));
+
+    expect(byTitle.get("mine")).toBe("owner-1");
+    expect(byTitle.get("system")).toBeNull();
+  });
+
+  it("stamps created_by through the bulk create transaction path", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "ownerdocs",
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const collectionService =
+      current.getService<CollectionService>("collectionService");
+
+    // Bulk create routes through createSingleEntryInTransaction; the owner must
+    // be stamped there too (the tx path uses the snake_case column key).
+    await collectionService.createMany(
+      "ownerdocs",
+      [{ title: "bulk-a" }, { title: "bulk-b" }],
+      { user: { id: "owner-2" }, overrideAccess: true }
+    );
+
+    const rows = await current.adapter.select<{
+      title: string;
+      created_by: string | null;
+    }>(TABLE);
+    const byTitle = new Map(rows.map(r => [r.title, r.created_by]));
+
+    expect(byTitle.get("bulk-a")).toBe("owner-2");
+    expect(byTitle.get("bulk-b")).toBe("owner-2");
+  });
+});

--- a/packages/nextly/src/domains/collections/__tests__/created-by-stamp.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/created-by-stamp.integration.test.ts
@@ -92,4 +92,45 @@ describe("created_by owner stamping (integration)", () => {
     expect(byTitle.get("bulk-a")).toBe("owner-2");
     expect(byTitle.get("bulk-b")).toBe("owner-2");
   });
+
+  it("does not let an update rewrite created_by, and hides it from responses", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "ownerdocs",
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const created = await handler.createEntry(
+      { collectionName: "ownerdocs", userId: "owner-1", overrideAccess: true },
+      { title: "mine" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    // The response must not leak the owner id (created_by / createdBy).
+    expect(created.data).not.toHaveProperty("created_by");
+    expect(created.data).not.toHaveProperty("createdBy");
+
+    // An updater trying to transfer ownership by sending created_by must fail:
+    // the immutable field is stripped before the SQL SET.
+    const updated = await handler.updateEntry(
+      { collectionName: "ownerdocs", entryId: id, overrideAccess: true },
+      { title: "edited", created_by: "attacker", createdBy: "attacker" }
+    );
+    expect(updated.data).not.toHaveProperty("created_by");
+
+    // Raw row: title changed, owner unchanged.
+    const rows = await current.adapter.select<{
+      id: string;
+      title: string;
+      created_by: string | null;
+    }>(TABLE);
+    const row = rows.find(r => r.id === id);
+    expect(row?.title).toBe("edited");
+    expect(row?.created_by).toBe("owner-1");
+  });
 });

--- a/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
@@ -262,3 +262,31 @@ describe("CollectionAccessService.isSuperAdmin", () => {
     expect(service.isSuperAdmin(undefined)).toBe(false);
   });
 });
+
+describe("getAccessRules normalizes collection owner fields", () => {
+  it("rewrites the createdBy/created_by alias to the system column, leaving custom fields", () => {
+    const { service } = buildAccessService();
+    const rules = service.getAccessRules({
+      accessRules: {
+        read: { type: "owner-only", ownerField: "createdBy" },
+        update: { type: "owner-only", ownerField: "created_by" },
+        delete: { type: "owner-only", ownerField: "authorId" },
+        create: { type: "authenticated" },
+      },
+    });
+    // Both spellings of the reserved owner name resolve to the stamped column.
+    expect(rules?.read?.ownerField).toBe("created_by");
+    expect(rules?.update?.ownerField).toBe("created_by");
+    // A genuine custom owner field is left untouched.
+    expect(rules?.delete?.ownerField).toBe("authorId");
+    expect(rules?.create?.type).toBe("authenticated");
+  });
+
+  it("leaves a rule-less owner-only rule alone (default resolved downstream)", () => {
+    const { service } = buildAccessService();
+    const rules = service.getAccessRules({
+      accessRules: { read: { type: "owner-only" } },
+    });
+    expect(rules?.read?.ownerField).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -21,6 +21,7 @@ import type {
   CollectionAccessRules,
   AccessOperation,
 } from "../../../services/access";
+import { DEFAULT_OWNER_FIELD } from "../../../services/access";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
 import type { DynamicCollectionService } from "../../dynamic-collections";
@@ -271,7 +272,7 @@ export class CollectionAccessService extends BaseService {
       const rule = accessRules?.[operation];
       if (!rule || rule.type !== "owner-only") return null;
 
-      const field = rule.ownerField ?? "createdBy";
+      const field = rule.ownerField ?? DEFAULT_OWNER_FIELD;
       return { field, value: user.id };
     } catch {
       return null;

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -86,21 +86,49 @@ export class CollectionAccessService extends BaseService {
   ): CollectionAccessRules | undefined {
     const collectionRecord = collection;
 
-    // Try direct property first (new format)
-    if (collectionRecord.accessRules) {
-      return collectionRecord.accessRules;
-    }
+    // Direct property first (new format), then schemaDefinition (legacy format).
+    const raw = (collectionRecord.accessRules ??
+      (collectionRecord.schemaDefinition as Record<string, unknown> | undefined)
+        ?.accessRules) as CollectionAccessRules | undefined;
 
-    // Fall back to schemaDefinition (legacy format)
-    const schemaDef = collectionRecord.schemaDefinition as
-      | Record<string, unknown>
-      | undefined;
-    if (schemaDef?.accessRules) {
-      return schemaDef.accessRules;
-    }
+    // No access rules defined - will default to public access.
+    return this.normalizeCollectionOwnerFields(raw);
+  }
 
-    // No access rules defined - will default to public access
-    return undefined;
+  /**
+   * Point owner-only rules at the collection system owner column.
+   *
+   * A collection stores the owner in the auto-stamped `created_by` column, and
+   * both `created_by` and its camelCase alias `createdBy` are reserved as field
+   * names — so a rule naming `createdBy` (the old documented default) can only
+   * mean that column. Rewrite either spelling to DEFAULT_OWNER_FIELD so every
+   * downstream owner check (read query filter, document compare, tx safety net)
+   * targets the column the create path actually stamps; any other `ownerField`
+   * is a genuine custom field and is left untouched. Returns a shallow clone
+   * only when a rewrite is needed, so the stored collection is never mutated.
+   */
+  private normalizeCollectionOwnerFields(
+    rules: CollectionAccessRules | undefined
+  ): CollectionAccessRules | undefined {
+    if (!rules) return rules;
+    const ops: (keyof CollectionAccessRules)[] = [
+      "create",
+      "read",
+      "update",
+      "delete",
+    ];
+    let cloned: CollectionAccessRules | undefined;
+    for (const op of ops) {
+      const rule = rules[op];
+      if (
+        rule?.type === "owner-only" &&
+        (rule.ownerField === "createdBy" || rule.ownerField === "created_by")
+      ) {
+        cloned ??= { ...rules };
+        cloned[op] = { ...rule, ownerField: DEFAULT_OWNER_FIELD };
+      }
+    }
+    return cloned ?? rules;
   }
 
   /**
@@ -205,13 +233,16 @@ export class CollectionAccessService extends BaseService {
       // Build request context from user
       const requestContext = this.buildRequestContext(user);
 
-      // Evaluate access
+      // Evaluate access. Collections carry the auto-stamped `created_by` system
+      // column, so pass it as the owner-only default (the shared service
+      // otherwise falls back to the generic `createdBy` used by singles).
       const result = await this.accessControlService.evaluateAccess(
         accessRules,
         operation,
         requestContext,
         documentId,
-        document
+        document,
+        DEFAULT_OWNER_FIELD
       );
 
       if (!result.allowed) {
@@ -278,7 +309,11 @@ export class CollectionAccessService extends BaseService {
       const result = await this.accessControlService.evaluateAccess(
         accessRules,
         "read",
-        requestContext
+        requestContext,
+        undefined,
+        undefined,
+        // Collection owner-only reads filter on the `created_by` system column.
+        DEFAULT_OWNER_FIELD
       );
 
       // Return query constraint if present

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -867,6 +867,9 @@ export class CollectionMutationService extends BaseService {
         ...finalData,
         created_at: now,
         updated_at: now,
+        // Stamp the row owner with the creating user's id so owner-only access
+        // works zero-config. Null for system/seed creates (no user context).
+        created_by: params.user?.id ?? null,
       };
       const entryData: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(rawEntryData)) {
@@ -2130,8 +2133,17 @@ export class CollectionMutationService extends BaseService {
       const entryData = {
         id: this.collectionService.generateId(),
         ...finalData,
-        createdAt: nowForTxCreate,
-        updatedAt: nowForTxCreate,
+        // Snake_case keys: the runtime Drizzle schema names these columns
+        // created_at / updated_at / created_by, and the adapter maps by column
+        // name. (The prior camelCase createdAt/updatedAt keys here were ignored
+        // by Drizzle and only "worked" via the columns' DB defaults — but a
+        // strict driver like better-sqlite3 rejects the whole insert once any
+        // unknown key is present, so bulk create needs the real column names.)
+        created_at: nowForTxCreate,
+        updated_at: nowForTxCreate,
+        // Stamp the row owner with the creating user's id so owner-only access
+        // works zero-config. Null for system/seed creates (no user context).
+        created_by: params.user?.id ?? null,
       };
 
       // Insert using transaction context
@@ -2999,8 +3011,17 @@ export class CollectionMutationService extends BaseService {
       const entryData = {
         id: this.collectionService.generateId(),
         ...finalData,
-        createdAt: nowForTxCreate,
-        updatedAt: nowForTxCreate,
+        // Snake_case keys: the runtime Drizzle schema names these columns
+        // created_at / updated_at / created_by, and the adapter maps by column
+        // name. (The prior camelCase createdAt/updatedAt keys here were ignored
+        // by Drizzle and only "worked" via the columns' DB defaults — but a
+        // strict driver like better-sqlite3 rejects the whole insert once any
+        // unknown key is present, so bulk create needs the real column names.)
+        created_at: nowForTxCreate,
+        updated_at: nowForTxCreate,
+        // Stamp the row owner with the creating user's id so owner-only access
+        // works zero-config. Null for system/seed creates (no user context).
+        created_by: params.user?.id ?? null,
       };
 
       // Insert using transaction context

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -51,6 +51,7 @@ import { coerceDateFieldsToDate } from "../../../shared/lib/field-transform";
 import {
   hashPasswordFieldValues,
   stripPasswordFieldValues,
+  stripSystemOwnerField,
 } from "../../../shared/lib/password-fields";
 import type { SupportedDialect } from "../../../types/database";
 import type { DynamicCollectionService } from "../../dynamic-collections";
@@ -150,6 +151,32 @@ function errorToServiceResult<T = unknown>(
   };
 }
 
+/**
+ * System columns a client must never write on update: the primary key, the
+ * creation timestamp, and the owner stamp (both snake_case and camelCase forms
+ * a client might send). They are not declared fields, so field validation
+ * passes them through — without this an authorized updater could transfer a
+ * row to another user by sending `created_by`, defeating owner-only semantics,
+ * or forge `created_at` / reassign `id`.
+ */
+const IMMUTABLE_UPDATE_FIELDS = new Set([
+  "id",
+  "created_at",
+  "createdAt",
+  "created_by",
+  "createdBy",
+]);
+
+function stripImmutableUpdateFields(
+  data: Record<string, unknown>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (!IMMUTABLE_UPDATE_FIELDS.has(key)) out[key] = value;
+  }
+  return out;
+}
+
 export class CollectionMutationService extends BaseService {
   constructor(
     adapter: DrizzleAdapter,
@@ -236,6 +263,10 @@ export class CollectionMutationService extends BaseService {
       }
     }
     stripPasswordFieldValues(entry, fields);
+    // Strip the system owner column so a mutation response (e.g. an admin or
+    // role-based updater) does not echo the row creator's user id. Owner-only
+    // access reads it from SQL, never from the returned row.
+    stripSystemOwnerField(entry);
     await applyFieldReadAccess({
       kind: "collection",
       slug,
@@ -1465,7 +1496,10 @@ export class CollectionMutationService extends BaseService {
       // tx.execute() is used for the UPDATE so it runs on the same DB client
       // as the transaction (unlike tx.update() which delegates to the pool).
       await this.adapter.transaction(async tx => {
-        const updatePayload = { ...finalData, updatedAt: new Date() };
+        const updatePayload = {
+          ...stripImmutableUpdateFields(finalData),
+          updatedAt: new Date(),
+        };
 
         // Dialect-aware identifier quoting and placeholder syntax.
         // PostgreSQL: "col" = $1   MySQL: `col` = ?   SQLite: "col" = $1 (convertPlaceholders handles →?)
@@ -2478,7 +2512,7 @@ export class CollectionMutationService extends BaseService {
       const [updated] = await tx.update<unknown>(
         tableName,
         {
-          ...finalData,
+          ...stripImmutableUpdateFields(finalData),
           updatedAt: new Date(),
         },
         this.whereEq("id", params.entryId),
@@ -3207,7 +3241,9 @@ export class CollectionMutationService extends BaseService {
       );
 
       if (accessRules?.update?.type === "owner-only" && params.user) {
-        const ownerField = accessRules.update.ownerField ?? "createdBy";
+        // Default to the auto-stamped system owner column (snake_case, matching
+        // the runtime schema and raw rows) so zero-config owner-only works.
+        const ownerField = accessRules.update.ownerField ?? "created_by";
         const ownerId = existingEntry[ownerField];
         if (ownerId !== params.user.id) {
           return {
@@ -3409,7 +3445,7 @@ export class CollectionMutationService extends BaseService {
       const [updated] = await tx.update<unknown>(
         tableName,
         {
-          ...finalData,
+          ...stripImmutableUpdateFields(finalData),
           updatedAt: new Date(),
         },
         this.whereEq("id", entryId),
@@ -3594,7 +3630,9 @@ export class CollectionMutationService extends BaseService {
       );
 
       if (accessRules?.delete?.type === "owner-only" && params.user) {
-        const ownerField = accessRules.delete.ownerField ?? "createdBy";
+        // Default to the auto-stamped system owner column (snake_case, matching
+        // the runtime schema and raw rows) so zero-config owner-only works.
+        const ownerField = accessRules.delete.ownerField ?? "created_by";
         const ownerId = entry[ownerField];
         if (ownerId !== params.user.id) {
           return {

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -152,27 +152,32 @@ function errorToServiceResult<T = unknown>(
 }
 
 /**
- * System columns a client must never write on update: the primary key, the
- * creation timestamp, and the owner stamp (both snake_case and camelCase forms
- * a client might send). They are not declared fields, so field validation
- * passes them through — without this an authorized updater could transfer a
- * row to another user by sending `created_by`, defeating owner-only semantics,
- * or forge `created_at` / reassign `id`.
+ * System columns a client must never write: the primary key, the timestamps,
+ * and the owner stamp (both the snake_case column name and the camelCase form a
+ * client might send). They are not declared fields, so field validation passes
+ * them through. Stripping them on BOTH create and update means the service
+ * remains authoritative: on create the generated id / stamped `created_by` /
+ * timestamps win (a stray `createdBy` alias can't survive the snake-case pass
+ * and overwrite the stamp with an attacker-chosen owner), and on update an
+ * authorized updater can't transfer a row to another user, forge `created_at`,
+ * duplicate `updated_at`, or reassign `id`.
  */
-const IMMUTABLE_UPDATE_FIELDS = new Set([
+const IMMUTABLE_SYSTEM_FIELDS = new Set([
   "id",
   "created_at",
   "createdAt",
+  "updated_at",
+  "updatedAt",
   "created_by",
   "createdBy",
 ]);
 
-function stripImmutableUpdateFields(
+function stripImmutableSystemFields(
   data: Record<string, unknown>
 ): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(data)) {
-    if (!IMMUTABLE_UPDATE_FIELDS.has(key)) out[key] = value;
+    if (!IMMUTABLE_SYSTEM_FIELDS.has(key)) out[key] = value;
   }
   return out;
 }
@@ -895,7 +900,11 @@ export class CollectionMutationService extends BaseService {
       const now = new Date();
       const rawEntryData = {
         id: this.collectionService.generateId(),
-        ...finalData,
+        // Strip client-supplied system columns (id / timestamps / created_by,
+        // both snake and camel) so the generated id, stamped owner, and
+        // timestamps below are authoritative — a stray `createdBy` alias can't
+        // survive to overwrite the owner stamp.
+        ...stripImmutableSystemFields(finalData),
         created_at: now,
         updated_at: now,
         // Stamp the row owner with the creating user's id so owner-only access
@@ -1497,7 +1506,7 @@ export class CollectionMutationService extends BaseService {
       // as the transaction (unlike tx.update() which delegates to the pool).
       await this.adapter.transaction(async tx => {
         const updatePayload = {
-          ...stripImmutableUpdateFields(finalData),
+          ...stripImmutableSystemFields(finalData),
           updatedAt: new Date(),
         };
 
@@ -2166,7 +2175,11 @@ export class CollectionMutationService extends BaseService {
       const nowForTxCreate = new Date();
       const entryData = {
         id: this.collectionService.generateId(),
-        ...finalData,
+        // Strip client-supplied system columns (id / timestamps / created_by,
+        // both snake and camel) so the generated id, stamped owner, and
+        // timestamps below are authoritative — a stray `createdBy` alias can't
+        // survive to overwrite the owner stamp.
+        ...stripImmutableSystemFields(finalData),
         // Snake_case keys: the runtime Drizzle schema names these columns
         // created_at / updated_at / created_by, and the adapter maps by column
         // name. (The prior camelCase createdAt/updatedAt keys here were ignored
@@ -2512,7 +2525,7 @@ export class CollectionMutationService extends BaseService {
       const [updated] = await tx.update<unknown>(
         tableName,
         {
-          ...stripImmutableUpdateFields(finalData),
+          ...stripImmutableSystemFields(finalData),
           updatedAt: new Date(),
         },
         this.whereEq("id", params.entryId),
@@ -3044,7 +3057,11 @@ export class CollectionMutationService extends BaseService {
       const nowForTxCreate = new Date();
       const entryData = {
         id: this.collectionService.generateId(),
-        ...finalData,
+        // Strip client-supplied system columns (id / timestamps / created_by,
+        // both snake and camel) so the generated id, stamped owner, and
+        // timestamps below are authoritative — a stray `createdBy` alias can't
+        // survive to overwrite the owner stamp.
+        ...stripImmutableSystemFields(finalData),
         // Snake_case keys: the runtime Drizzle schema names these columns
         // created_at / updated_at / created_by, and the adapter maps by column
         // name. (The prior camelCase createdAt/updatedAt keys here were ignored
@@ -3445,7 +3462,7 @@ export class CollectionMutationService extends BaseService {
       const [updated] = await tx.update<unknown>(
         tableName,
         {
-          ...stripImmutableUpdateFields(finalData),
+          ...stripImmutableSystemFields(finalData),
           updatedAt: new Date(),
         },
         this.whereEq("id", entryId),

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -782,6 +782,14 @@ export class CollectionQueryService extends BaseService {
         );
       }
 
+      // Final owner-column strip at the response boundary — after every
+      // afterRead hook, field-level read access, and transform — so nothing
+      // downstream can re-expose the creator's user id. (The pre-hook strip
+      // above also keeps it out of hook inputs.)
+      for (const entry of finalData as Record<string, unknown>[]) {
+        stripSystemOwnerField(entry);
+      }
+
       // Build paginated response with all metadata
       const paginatedResponse = buildPaginatedResponse(finalData, {
         total: totalDocs,
@@ -1366,6 +1374,11 @@ export class CollectionQueryService extends BaseService {
           params.richTextFormat
         );
       }
+
+      // Final owner-column strip at the response boundary — after the
+      // field-level afterRead hooks, read access, and rich-text transform — so
+      // nothing downstream can re-expose the creator's user id.
+      stripSystemOwnerField(finalData);
 
       return {
         success: true,

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -503,9 +503,19 @@ export class CollectionQueryService extends BaseService {
 
         const sortFieldSnake = toSnakeCase(sortField);
 
+        // The system owner column is stripped from responses, so it must not be
+        // sortable either — sorting by it would let a caller order/target rows
+        // by creator. Ignore an owner-column sort instead of resolving it.
+        const ownerSort =
+          sortField === "created_by" ||
+          sortField === "createdBy" ||
+          sortFieldSnake === "created_by";
+
         // Try both camelCase and snake_case versions of the field name
         // This handles both user-defined fields (often camelCase) and system fields (snake_case in DB)
-        const column = schema[sortField] || schema[sortFieldSnake];
+        const column = ownerSort
+          ? undefined
+          : schema[sortField] || schema[sortFieldSnake];
 
         if (column) {
           query = query.orderBy(sortDesc ? desc(column) : asc(column));

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -69,6 +69,7 @@ import {
 import {
   hasPasswordField,
   stripPasswordFieldValues,
+  stripSystemOwnerField,
 } from "../../../shared/lib/password-fields";
 import {
   buildPaginatedResponse,
@@ -663,6 +664,12 @@ export class CollectionQueryService extends BaseService {
         for (const entry of expandedEntries) {
           stripPasswordFieldValues(entry, fields);
         }
+      }
+      // Always strip the system owner column so a list readable by non-creators
+      // never leaks the creator's user id (unconditional — not gated on
+      // password fields).
+      for (const entry of expandedEntries) {
+        stripSystemOwnerField(entry);
       }
 
       // Execute afterRead hooks (code-registered)
@@ -1259,6 +1266,8 @@ export class CollectionQueryService extends BaseService {
       if (detailHasPassword) {
         stripPasswordFieldValues(expandedEntry, fields);
       }
+      // Always strip the system owner column (see listEntries).
+      stripSystemOwnerField(expandedEntry);
 
       // Execute afterRead hooks (code-registered)
       // Hooks can transform the fetched data
@@ -1310,6 +1319,8 @@ export class CollectionQueryService extends BaseService {
       if (detailHasPassword) {
         stripPasswordFieldValues(finalData, fields);
       }
+      // Same defense in depth for the owner column.
+      stripSystemOwnerField(finalData);
 
       // Deserialize JSON fields (richtext, blocks, array, group, json) for response
       fields.forEach(field => {

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -15,6 +15,7 @@ import { BaseService } from "../../../shared/base-service";
 import {
   hasPasswordField,
   stripPasswordFieldValues,
+  stripSystemOwnerField,
 } from "../../../shared/lib/password-fields";
 import type { DynamicCollectionService } from "../../dynamic-collections";
 
@@ -1617,6 +1618,15 @@ export class CollectionRelationshipService extends BaseService {
     rows: Record<string, unknown>[]
   ): Promise<void> {
     if (rows.length === 0) return;
+    // The system owner column must never ride along a populated relationship:
+    // a collection readable by non-creators would otherwise leak a related
+    // row's creator user id through the nested payload. Strip it from every
+    // related row up front (it's a reserved system column, so this can't touch
+    // a user field) — this runs at each expansion level, so nested relations
+    // are covered too.
+    for (const row of rows) {
+      stripSystemOwnerField(row);
+    }
     // System entities expose secret columns that are not schema fields, so
     // strip them by name.
     if (isSystemEntity(targetCollection)) {

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -405,6 +405,21 @@ ${allColumnDefs.join(",\n")}
     }
     indexStatements.push(createdAtIndex);
 
+    // Index the owner column on collections. Owner-only reads/lists/counts and
+    // bulk-by-query enumeration all filter on `created_by`, so without an index
+    // a large owner-scoped collection would full-scan the primary access-control
+    // predicate. Collections only — singles/components never carry the column,
+    // mirroring the column gate above. Plain (non-unique) index; users cannot
+    // request one on this reserved field, so it is injected here.
+    if (!isSingleTable) {
+      const ownerIndexName = `idx_${tableName}_created_by`;
+      const ownerIndex =
+        this.dialect === "mysql"
+          ? `CREATE INDEX ${this.quoteIdentifier(ownerIndexName)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("created_by")});`
+          : `CREATE INDEX IF NOT EXISTS ${this.quoteIdentifier(ownerIndexName)} ON ${this.quoteIdentifier(tableName)}(${this.quoteIdentifier("created_by")});`;
+      indexStatements.push(ownerIndex);
+    }
+
     // Add unique index for slug column (automatically available for all collections and singles)
     let slugIndex = "";
     if (this.dialect === "sqlite") {

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -289,7 +289,9 @@ export class DynamicCollectionSchemaService {
       allColumnDefs.push(c);
     }
 
-    // timestamp columns
+    // timestamp columns + owner column. `created_by` is nullable with no
+    // default (matches getSystemColumnDescriptors) so existing rows and system
+    // creates stay null; the type mirrors the id column per dialect.
     if (this.dialect === "sqlite") {
       allColumnDefs.push(
         `  ${this.quoteIdentifier("created_at")} integer DEFAULT (strftime('%s', 'now')) NOT NULL`
@@ -297,6 +299,7 @@ export class DynamicCollectionSchemaService {
       allColumnDefs.push(
         `  ${this.quoteIdentifier("updated_at")} integer DEFAULT (strftime('%s', 'now')) NOT NULL`
       );
+      allColumnDefs.push(`  ${this.quoteIdentifier("created_by")} text`);
     } else if (this.dialect === "mysql") {
       allColumnDefs.push(
         `  ${this.quoteIdentifier("created_at")} timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL`
@@ -304,6 +307,7 @@ export class DynamicCollectionSchemaService {
       allColumnDefs.push(
         `  ${this.quoteIdentifier("updated_at")} timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL`
       );
+      allColumnDefs.push(`  ${this.quoteIdentifier("created_by")} varchar(36)`);
     } else {
       allColumnDefs.push(
         `  ${this.quoteIdentifier("created_at")} timestamp DEFAULT now() NOT NULL`
@@ -311,6 +315,7 @@ export class DynamicCollectionSchemaService {
       allColumnDefs.push(
         `  ${this.quoteIdentifier("updated_at")} timestamp DEFAULT now() NOT NULL`
       );
+      allColumnDefs.push(`  ${this.quoteIdentifier("created_by")} text`);
     }
 
     let sql = `-- Create dynamic collection: ${tableName}

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -318,7 +318,12 @@ export class DynamicCollectionSchemaService {
     // Nullable with no default (matches getSystemColumnDescriptors) so existing
     // rows and system creates stay null; sized to the users.id column on MySQL
     // since it holds a user id, not the row id.
-    if (!_options?.isSingle) {
+    // Prefer the explicit flag, but also fall back to the `single_` table
+    // prefix so this stays in lockstep with the runtime schema / diff (which
+    // derive it from the name) even if a caller omits the option.
+    const isSingleTable =
+      _options?.isSingle === true || tableName.startsWith("single_");
+    if (!isSingleTable) {
       const ownerType = this.dialect === "mysql" ? "varchar(191)" : "text";
       allColumnDefs.push(
         `  ${this.quoteIdentifier("created_by")} ${ownerType}`

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -289,9 +289,7 @@ export class DynamicCollectionSchemaService {
       allColumnDefs.push(c);
     }
 
-    // timestamp columns + owner column. `created_by` is nullable with no
-    // default (matches getSystemColumnDescriptors) so existing rows and system
-    // creates stay null; the type mirrors the id column per dialect.
+    // timestamp columns
     if (this.dialect === "sqlite") {
       allColumnDefs.push(
         `  ${this.quoteIdentifier("created_at")} integer DEFAULT (strftime('%s', 'now')) NOT NULL`
@@ -299,7 +297,6 @@ export class DynamicCollectionSchemaService {
       allColumnDefs.push(
         `  ${this.quoteIdentifier("updated_at")} integer DEFAULT (strftime('%s', 'now')) NOT NULL`
       );
-      allColumnDefs.push(`  ${this.quoteIdentifier("created_by")} text`);
     } else if (this.dialect === "mysql") {
       allColumnDefs.push(
         `  ${this.quoteIdentifier("created_at")} timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL`
@@ -307,7 +304,6 @@ export class DynamicCollectionSchemaService {
       allColumnDefs.push(
         `  ${this.quoteIdentifier("updated_at")} timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL`
       );
-      allColumnDefs.push(`  ${this.quoteIdentifier("created_by")} varchar(36)`);
     } else {
       allColumnDefs.push(
         `  ${this.quoteIdentifier("created_at")} timestamp DEFAULT now() NOT NULL`
@@ -315,7 +311,18 @@ export class DynamicCollectionSchemaService {
       allColumnDefs.push(
         `  ${this.quoteIdentifier("updated_at")} timestamp DEFAULT now() NOT NULL`
       );
-      allColumnDefs.push(`  ${this.quoteIdentifier("created_by")} text`);
+    }
+
+    // Owner column — COLLECTIONS ONLY. A single is one global row, so
+    // owner-only ownership is meaningless; singles never stamp or query it.
+    // Nullable with no default (matches getSystemColumnDescriptors) so existing
+    // rows and system creates stay null; sized to the users.id column on MySQL
+    // since it holds a user id, not the row id.
+    if (!_options?.isSingle) {
+      const ownerType = this.dialect === "mysql" ? "varchar(191)" : "text";
+      allColumnDefs.push(
+        `  ${this.quoteIdentifier("created_by")} ${ownerType}`
+      );
     }
 
     let sql = `-- Create dynamic collection: ${tableName}

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-validation-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-validation-service.ts
@@ -89,8 +89,12 @@ export const RESERVED_FIELD_NAMES = [
   "slug",
   "created_at",
   "updated_at",
-  // System owner column, auto-added and stamped on create.
+  // System owner column, auto-added and stamped on create. Both the physical
+  // snake_case name and the camelCase alias are reserved: config validation
+  // accepts camelCase field names and snake-cases them to the same column, so
+  // a `createdBy` field would otherwise collide with the system owner column.
   "created_by",
+  "createdBy",
 ] as const;
 
 export const collectionNameSchema = z

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-validation-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-validation-service.ts
@@ -89,6 +89,8 @@ export const RESERVED_FIELD_NAMES = [
   "slug",
   "created_at",
   "updated_at",
+  // System owner column, auto-added and stamped on create.
+  "created_by",
 ] as const;
 
 export const collectionNameSchema = z

--- a/packages/nextly/src/domains/schema/__tests__/runtime-schema-generator.test.ts
+++ b/packages/nextly/src/domains/schema/__tests__/runtime-schema-generator.test.ts
@@ -48,7 +48,7 @@ describe("generateRuntimeSchema", () => {
       expect(getTableName(result.table)).toBe("dc_products");
     });
 
-    it("includes system columns (id, slug, created_at, updated_at)", () => {
+    it("includes system columns (id, slug, created_at, updated_at, created_by)", () => {
       const result = generateRuntimeSchema(
         "dc_products",
         baseFields,
@@ -59,6 +59,21 @@ describe("generateRuntimeSchema", () => {
       expect(columns).toHaveProperty("slug");
       expect(columns).toHaveProperty("created_at");
       expect(columns).toHaveProperty("updated_at");
+      expect(columns).toHaveProperty("created_by");
+    });
+
+    it("emits a nullable created_by owner column on every dialect", () => {
+      for (const dialect of ["postgresql", "mysql", "sqlite"] as const) {
+        const columns = getColumns(
+          generateRuntimeSchema("dc_products", baseFields, dialect).table
+        );
+        const createdBy = (columns as Record<string, { notNull?: boolean }>)
+          .created_by;
+        // Present, and nullable (no default) so existing rows and system/seed
+        // creates stay null rather than blocking the column add.
+        expect(createdBy).toBeDefined();
+        expect(createdBy.notNull).toBe(false);
+      }
     });
 
     it("does not duplicate title/slug columns if user defines them", () => {

--- a/packages/nextly/src/domains/schema/__tests__/runtime-schema-generator.test.ts
+++ b/packages/nextly/src/domains/schema/__tests__/runtime-schema-generator.test.ts
@@ -76,6 +76,19 @@ describe("generateRuntimeSchema", () => {
       }
     });
 
+    it("omits created_by for a Single table (single_ prefix)", () => {
+      for (const dialect of ["postgresql", "mysql", "sqlite"] as const) {
+        // A Single is one global row with no per-user owner — the collection
+        // owner column must not appear, or the runtime schema would select a
+        // column the Single's physical table never gets.
+        const columns = getColumns(
+          generateRuntimeSchema("single_site_settings", baseFields, dialect)
+            .table
+        );
+        expect(columns).not.toHaveProperty("created_by");
+      }
+    });
+
     it("does not duplicate title/slug columns if user defines them", () => {
       const fields: FieldDefinition[] = [
         { name: "title", type: "text", required: true },

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/f8-matrix.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/f8-matrix.integration.test.ts
@@ -147,6 +147,7 @@ describe("F8 matrix — SQLite — add field", () => {
         "slug" text NOT NULL,
         "created_at" integer,
         "updated_at" integer,
+        "created_by" text,
         "body" text NOT NULL
       )
     `);
@@ -216,6 +217,7 @@ describe("F8 matrix — SQLite — drop field", () => {
         "slug" text NOT NULL,
         "created_at" integer,
         "updated_at" integer,
+        "created_by" text,
         "body" text NOT NULL,
         "obsolete_field" text
       )
@@ -285,6 +287,7 @@ describe("F8 matrix — SQLite — rename field preserves data", () => {
         "slug" text NOT NULL,
         "created_at" integer,
         "updated_at" integer,
+        "created_by" text,
         "body" text NOT NULL
       )
     `);
@@ -368,6 +371,7 @@ describe("F8 matrix — SQLite — NOT-NULL coercion via provide_default", () =>
         "slug" text NOT NULL,
         "created_at" integer,
         "updated_at" integer,
+        "created_by" text,
         "total" text
       )
     `);

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/preview.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/preview.test.ts
@@ -36,9 +36,9 @@ const introspectEmpty = vi.fn().mockResolvedValue({ tables: [] });
 
 describe("previewDesiredSchema", () => {
   // buildDesiredTableFromFields injects reserved system columns
-  // (id, title, slug, created_at, updated_at) onto every collection,
-  // mirroring what runtime-schema-generator does. Tests need the live
-  // snapshot to match exactly so the diff doesn't see drift.
+  // (id, title, slug, created_at, updated_at, created_by) onto every
+  // collection, mirroring what runtime-schema-generator does. Tests need the
+  // live snapshot to match exactly so the diff doesn't see drift.
   // SQLite shape (lowercase tokens; integer for timestamps):
   const reservedColumnsLive = [
     { name: "id", type: "text", nullable: false },
@@ -46,6 +46,7 @@ describe("previewDesiredSchema", () => {
     { name: "slug", type: "text", nullable: false },
     { name: "created_at", type: "integer", nullable: true },
     { name: "updated_at", type: "integer", nullable: true },
+    { name: "created_by", type: "text", nullable: true },
   ];
 
   it("returns empty operations when desired matches live (no changes)", async () => {

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/pushschema-pipeline-mysql.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/pushschema-pipeline-mysql.integration.test.ts
@@ -113,6 +113,10 @@ describe.skipIf(!MYSQL_URL)("PushSchemaPipeline integration — MySQL", () => {
   it("rename with data preserves the row through pre-resolution", async () => {
     const p = pool.promise();
     await p.query(`DROP TABLE IF EXISTS dc_people_my`);
+    // `created_by` is a system owner column now present on every collection
+    // table's desired schema. On MySQL it is varchar(191) (sized to the user id
+    // it stores), so the live table must match that exact type or the diff would
+    // add/modify created_by alongside the rename this scenario isolates.
     await p.query(
       `CREATE TABLE dc_people_my (
         id varchar(64) PRIMARY KEY,
@@ -120,6 +124,7 @@ describe.skipIf(!MYSQL_URL)("PushSchemaPipeline integration — MySQL", () => {
         slug varchar(255) NOT NULL,
         created_at datetime,
         updated_at datetime,
+        created_by varchar(191),
         nickname text
       )`
     );

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/pushschema-pipeline-option-e.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/pushschema-pipeline-option-e.integration.test.ts
@@ -139,6 +139,10 @@ describe("PushSchemaPipeline Option E end-to-end - PostgreSQL", () => {
     const tableName = `${ctx.prefix}_dc_users_e2e`;
 
     // Create live table: reserved cols + non-reserved `body` + 50 rows.
+    // `created_by` is a system owner column now present on every collection
+    // table's desired schema, so the live table must carry it too — otherwise
+    // the diff would pair an extra created_by add against the body->summary
+    // rename and defeat the isolated rename this scenario checks.
     await pool.query(
       `CREATE TABLE "${tableName}" (
         "id" text PRIMARY KEY,
@@ -146,6 +150,7 @@ describe("PushSchemaPipeline Option E end-to-end - PostgreSQL", () => {
         "slug" text NOT NULL,
         "created_at" timestamp,
         "updated_at" timestamp,
+        "created_by" text,
         "body" text NOT NULL
       )`
     );
@@ -340,6 +345,9 @@ describe("PushSchemaPipeline Option E end-to-end - PostgreSQL", () => {
     await pool.query(`DROP TABLE IF EXISTS "${tableName}" CASCADE`);
 
     // Live table: reserved cols + 3 extras (a, b, c), all text.
+    // `created_by` is a system owner column now present on every collection
+    // table's desired schema, so the live table carries it too, keeping the diff
+    // to the intended renames rather than an extra created_by add.
     await pool.query(
       `CREATE TABLE "${tableName}" (
         "id" text PRIMARY KEY,
@@ -347,6 +355,7 @@ describe("PushSchemaPipeline Option E end-to-end - PostgreSQL", () => {
         "slug" text NOT NULL,
         "created_at" timestamp,
         "updated_at" timestamp,
+        "created_by" text,
         "a" text,
         "b" text,
         "c" text

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/pushschema-pipeline.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/pushschema-pipeline.integration.test.ts
@@ -164,7 +164,8 @@ describe("PushSchemaPipeline integration — PostgreSQL", () => {
     // Pre-create with the reserved columns (as a real managed table would
     // have) so the only diff against `desired` is title→name; a populated
     // table can't take a bare ADD COLUMN … NOT NULL for missing reserved
-    // columns.
+    // columns. `created_by` is one of those system owner columns now injected
+    // into every collection's desired schema, so the live table carries it too.
     await pool.query(
       `CREATE TABLE "${ctx.prefix}_dc_users" (
         "id" text PRIMARY KEY,
@@ -172,6 +173,7 @@ describe("PushSchemaPipeline integration — PostgreSQL", () => {
         "slug" text NOT NULL,
         "created_at" timestamp,
         "updated_at" timestamp,
+        "created_by" text,
         "nickname" text
       )`
     );

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
@@ -120,6 +120,16 @@ const ADDITIVE_STATEMENT =
 const isPost045TableStatement = (stmt: string): boolean =>
   ADDITIVE_STATEMENT.test(stmt.trim()) && namesPost045Table(stmt);
 
+// The `created_by` system owner column is nullable with no default, so on a
+// schema captured before it existed the v1 upgrade legitimately emits one
+// additive `ADD COLUMN created_by` per pre-existing collection table (the
+// zero-backfill upgrade the feature promises). That add names a table outside
+// the post-0.45 allowlist, so it is accepted here explicitly rather than being
+// mistaken for a phantom diff. Tolerant of pg ("created_by") and MySQL
+// (`created_by`) quoting and the optional COLUMN keyword.
+const addsOwnerColumn = (stmt: string): boolean =>
+  /^ALTER TABLE .+ ADD (COLUMN )?[`"]?created_by[`"]?\b/i.test(stmt.trim());
+
 // Positive guard: the sim must actually create each new table (an empty first
 // pass would otherwise satisfy the additive-only check vacuously).
 const hasCreateTableFor = (stmts: string[], table: string): boolean =>
@@ -221,7 +231,10 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
           schemas: ["public"],
         });
         for (const s of first.sqlStatements) {
-          expect(isPost045TableStatement(s), `phantom diff: ${s}`).toBe(true);
+          expect(
+            isPost045TableStatement(s) || addsOwnerColumn(s),
+            `phantom diff: ${s}`
+          ).toBe(true);
         }
         for (const t of POST_045_TABLES) {
           expect(
@@ -289,7 +302,9 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
               s
             );
           expect(
-            isDefaultReconcile || isPost045TableStatement(s),
+            isDefaultReconcile ||
+              isPost045TableStatement(s) ||
+              addsOwnerColumn(s),
             `unexpected reconcile statement shape: ${s}`
           ).toBe(true);
         }

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields.test.ts
@@ -58,6 +58,7 @@ const RESERVED_NAMES = new Set([
   "slug",
   "created_at",
   "updated_at",
+  "created_by",
 ]);
 
 function userColumns(columns: ColumnSpec[]): ColumnSpec[] {
@@ -72,7 +73,7 @@ function findColumn(
 }
 
 describe("buildDesiredTableFromFields - reserved columns", () => {
-  it("PG: injects id + created_at + updated_at + title + slug", () => {
+  it("PG: injects id + created_at + updated_at + title + slug + created_by", () => {
     const table = buildDesiredTableFromFields("dc_x", [], "postgresql");
     expect(findColumn(table.columns, "id")).toEqual({
       name: "id",
@@ -91,6 +92,12 @@ describe("buildDesiredTableFromFields - reserved columns", () => {
     });
     expect(findColumn(table.columns, "created_at")?.type).toBe("timestamp");
     expect(findColumn(table.columns, "updated_at")?.type).toBe("timestamp");
+    // Owner column: nullable text (matches the id column type), no default.
+    expect(findColumn(table.columns, "created_by")).toEqual({
+      name: "created_by",
+      type: "text",
+      nullable: true,
+    });
   });
 
   it("keeps the system title column when a component field is named 'title'", () => {

--- a/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
@@ -108,6 +108,9 @@ export function buildDesiredTableFromFields(
     hasTitleField,
     hasSlugField,
     hasStatus: options.hasStatus,
+    // Singles (`single_` prefix) get no owner column; collections (`dc_`) do.
+    // Keeps the diff input in lockstep with the runtime schema and DDL.
+    isSingle: tableName.startsWith("single_"),
   })) {
     columns.push({
       name: reserved.name,

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -405,6 +405,16 @@ export function getSystemColumnDescriptors(
       primaryKey: false,
       default: "now()",
     });
+    // Owner of the row, stamped with the creating user's id. Nullable: existing
+    // rows and system/seed creates have no user. Mirrors
+    // runtime-schema-generator's pgText("created_by") (text, matching the id
+    // column type).
+    cols.push({
+      name: "created_by",
+      dialectType: "text",
+      nullable: true,
+      primaryKey: false,
+    });
     if (opts.hasStatus) {
       // Must mirror runtime-schema-generator's
       // pgVarchar("status", { length: 20 }).notNull().default("draft").
@@ -458,6 +468,16 @@ export function getSystemColumnDescriptors(
       nullable: true,
       primaryKey: false,
     });
+    // Owner of the row (creating user's id). Nullable; mirrors
+    // runtime-schema-generator's mysqlVarchar("created_by", { length: 36 })
+    // (matching the id column type).
+    cols.push({
+      name: "created_by",
+      dialectType: "varchar(36)",
+      length: 36,
+      nullable: true,
+      primaryKey: false,
+    });
     if (opts.hasStatus) {
       cols.push({
         name: "status",
@@ -501,6 +521,15 @@ export function getSystemColumnDescriptors(
     cols.push({
       name: "updated_at",
       dialectType: "integer",
+      nullable: true,
+      primaryKey: false,
+    });
+    // Owner of the row (creating user's id). Nullable; mirrors
+    // runtime-schema-generator's sqliteText("created_by") (matching the id
+    // column type).
+    cols.push({
+      name: "created_by",
+      dialectType: "text",
       nullable: true,
       primaryKey: false,
     });

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -468,13 +468,14 @@ export function getSystemColumnDescriptors(
       nullable: true,
       primaryKey: false,
     });
-    // Owner of the row (creating user's id). Nullable; mirrors
-    // runtime-schema-generator's mysqlVarchar("created_by", { length: 36 })
-    // (matching the id column type).
+    // Owner of the row (creating user's id, NOT the row id). Sized to match
+    // the MySQL users.id column (varchar(191), Auth.js-compatible), not the
+    // varchar(36) row id — a longer user id would otherwise be truncated.
+    // Nullable; mirrors runtime-schema-generator's created_by column.
     cols.push({
       name: "created_by",
-      dialectType: "varchar(36)",
-      length: 36,
+      dialectType: "varchar(191)",
+      length: 191,
       nullable: true,
       primaryKey: false,
     });

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -345,6 +345,14 @@ export interface SystemColumnSet {
    * never leaks during the migration that adds the column.
    */
   hasStatus?: boolean;
+  /**
+   * True for a Single's table. Singles are a single global row with no
+   * per-user owner, so the `created_by` owner column is NOT injected (owner-only
+   * access is a collection concept). Keeps the runtime schema, the diff input,
+   * and the DDL in lockstep — otherwise a Single's runtime schema would select
+   * a column its physical table never gets.
+   */
+  isSingle?: boolean;
 }
 
 export interface SystemColumnDescriptor {
@@ -405,16 +413,18 @@ export function getSystemColumnDescriptors(
       primaryKey: false,
       default: "now()",
     });
-    // Owner of the row, stamped with the creating user's id. Nullable: existing
-    // rows and system/seed creates have no user. Mirrors
-    // runtime-schema-generator's pgText("created_by") (text, matching the id
-    // column type).
-    cols.push({
-      name: "created_by",
-      dialectType: "text",
-      nullable: true,
-      primaryKey: false,
-    });
+    // Owner of the row, stamped with the creating user's id. Collections only
+    // (never singles). Nullable: existing rows and system/seed creates have no
+    // user. Mirrors runtime-schema-generator's pgText("created_by") (text,
+    // matching the id column type).
+    if (!opts.isSingle) {
+      cols.push({
+        name: "created_by",
+        dialectType: "text",
+        nullable: true,
+        primaryKey: false,
+      });
+    }
     if (opts.hasStatus) {
       // Must mirror runtime-schema-generator's
       // pgVarchar("status", { length: 20 }).notNull().default("draft").
@@ -468,17 +478,20 @@ export function getSystemColumnDescriptors(
       nullable: true,
       primaryKey: false,
     });
-    // Owner of the row (creating user's id, NOT the row id). Sized to match
-    // the MySQL users.id column (varchar(191), Auth.js-compatible), not the
-    // varchar(36) row id — a longer user id would otherwise be truncated.
-    // Nullable; mirrors runtime-schema-generator's created_by column.
-    cols.push({
-      name: "created_by",
-      dialectType: "varchar(191)",
-      length: 191,
-      nullable: true,
-      primaryKey: false,
-    });
+    // Owner of the row (creating user's id, NOT the row id). Collections only
+    // (never singles). Sized to match the MySQL users.id column (varchar(191),
+    // Auth.js-compatible), not the varchar(36) row id — a longer user id would
+    // otherwise be truncated. Nullable; mirrors runtime-schema-generator's
+    // created_by column.
+    if (!opts.isSingle) {
+      cols.push({
+        name: "created_by",
+        dialectType: "varchar(191)",
+        length: 191,
+        nullable: true,
+        primaryKey: false,
+      });
+    }
     if (opts.hasStatus) {
       cols.push({
         name: "status",
@@ -525,15 +538,17 @@ export function getSystemColumnDescriptors(
       nullable: true,
       primaryKey: false,
     });
-    // Owner of the row (creating user's id). Nullable; mirrors
-    // runtime-schema-generator's sqliteText("created_by") (matching the id
-    // column type).
-    cols.push({
-      name: "created_by",
-      dialectType: "text",
-      nullable: true,
-      primaryKey: false,
-    });
+    // Owner of the row (creating user's id). Collections only (never singles).
+    // Nullable; mirrors runtime-schema-generator's sqliteText("created_by")
+    // (matching the id column type).
+    if (!opts.isSingle) {
+      cols.push({
+        name: "created_by",
+        dialectType: "text",
+        nullable: true,
+        primaryKey: false,
+      });
+    }
     if (opts.hasStatus) {
       cols.push({
         name: "status",

--- a/packages/nextly/src/domains/schema/services/runtime-schema-generator.ts
+++ b/packages/nextly/src/domains/schema/services/runtime-schema-generator.ts
@@ -72,6 +72,11 @@ export interface RuntimeSchemaResult {
 export interface RuntimeSchemaOptions {
   /** When true, inject a `status` column ('draft' | 'published', default 'draft'). */
   status?: boolean;
+  /**
+   * True for a Single's table — suppresses the collection-only `created_by`
+   * owner column. Set internally by generateRuntimeSchema from the table name.
+   */
+  isSingle?: boolean;
 }
 
 /**
@@ -89,16 +94,22 @@ export function generateRuntimeSchema(
   dialect: SupportedDialect,
   options: RuntimeSchemaOptions = {}
 ): RuntimeSchemaResult {
+  // Single tables use the `single_` prefix (collections are `dc_`); a Single
+  // gets no owner column. Derive it here so every dialect path sees it.
+  const resolvedOptions: RuntimeSchemaOptions = {
+    ...options,
+    isSingle: options.isSingle ?? tableName.startsWith("single_"),
+  };
   let table: unknown;
   switch (dialect) {
     case "postgresql":
-      table = generatePostgresSchema(tableName, fields, options);
+      table = generatePostgresSchema(tableName, fields, resolvedOptions);
       break;
     case "mysql":
-      table = generateMySQLSchema(tableName, fields, options);
+      table = generateMySQLSchema(tableName, fields, resolvedOptions);
       break;
     case "sqlite":
-      table = generateSQLiteSchema(tableName, fields, options);
+      table = generateSQLiteSchema(tableName, fields, resolvedOptions);
       break;
     default:
       throw new Error(`Unsupported dialect: ${String(dialect)}`);
@@ -167,6 +178,11 @@ function buildDrizzleColumnRecord(
     hasTitleField,
     hasSlugField,
     hasStatus: options.status === true,
+    // Single tables get no owner column (a Single is one global row). Set by
+    // generateRuntimeSchema from the `single_` table prefix so the runtime
+    // schema stays in lockstep with the physical table (never selects
+    // created_by for a Single).
+    isSingle: options.isSingle === true,
   })) {
     out[sys.name] = buildSystemDrizzleColumn(sys, dialect);
   }

--- a/packages/nextly/src/domains/schema/services/runtime-schema-generator.ts
+++ b/packages/nextly/src/domains/schema/services/runtime-schema-generator.ts
@@ -204,6 +204,9 @@ function buildSystemDrizzleColumn(
       // publish anything. Length 20 leaves headroom over "published" (9 chars).
       return pgVarchar("status", { length: 20 }).notNull().default("draft");
     }
+    // Row owner — nullable text (matches the id column type); no default so
+    // system/seed creates and existing rows stay null.
+    if (sys.name === "created_by") return pgText("created_by");
     // title / slug — text NOT NULL.
     return pgText(sys.name).notNull();
   }
@@ -220,6 +223,10 @@ function buildSystemDrizzleColumn(
     if (sys.name === "status") {
       return mysqlVarchar("status", { length: 20 }).notNull().default("draft");
     }
+    // Row owner — nullable varchar(36) (matches the id column type).
+    if (sys.name === "created_by") {
+      return mysqlVarchar("created_by", { length: 36 });
+    }
     return mysqlVarchar(sys.name, { length: 255 }).notNull();
   }
   // sqlite
@@ -234,6 +241,8 @@ function buildSystemDrizzleColumn(
     // SQLite has no varchar — text with default 'draft' is the equivalent.
     return sqliteText("status").notNull().default("draft");
   }
+  // Row owner — nullable text (matches the id column type).
+  if (sys.name === "created_by") return sqliteText("created_by");
   return sqliteText(sys.name).notNull();
 }
 

--- a/packages/nextly/src/domains/schema/services/runtime-schema-generator.ts
+++ b/packages/nextly/src/domains/schema/services/runtime-schema-generator.ts
@@ -223,9 +223,10 @@ function buildSystemDrizzleColumn(
     if (sys.name === "status") {
       return mysqlVarchar("status", { length: 20 }).notNull().default("draft");
     }
-    // Row owner — nullable varchar(36) (matches the id column type).
+    // Row owner — nullable varchar(191) sized to the MySQL users.id column
+    // (holds a user id, not the row id).
     if (sys.name === "created_by") {
-      return mysqlVarchar("created_by", { length: 36 });
+      return mysqlVarchar("created_by", { length: 191 });
     }
     return mysqlVarchar(sys.name, { length: 255 }).notNull();
   }

--- a/packages/nextly/src/plugins/__tests__/seed-builder-entity.ts
+++ b/packages/nextly/src/plugins/__tests__/seed-builder-entity.ts
@@ -39,14 +39,11 @@ const silentLogger: Logger = {
 };
 
 /** Reserved fields the schema service auto-adds; never user/plugin-owned. */
-const RESERVED = new Set([
-  "id",
-  "title",
-  "slug",
-  "created_at",
-  "updated_at",
-  "created_by",
-]);
+const RESERVED = new Set(["id", "title", "slug", "created_at", "updated_at"]);
+
+// Collections also auto-add a `created_by` owner column; singles and components
+// do not, so a `created_by` user field is only reserved for collections.
+const RESERVED_COLLECTION = new Set([...RESERVED, "created_by"]);
 
 export interface SeedBuilderCollectionOptions {
   slug: string;
@@ -70,10 +67,10 @@ export async function seedBuilderCollection(
   const tableName = `dc_${slug}`;
 
   // Only non-reserved fields are user-defined; the schema service auto-adds
-  // id/title/slug/timestamps (and status when hasStatus).
+  // id/title/slug/timestamps/created_by (and status when hasStatus).
   const userFields = opts.fields
     .map(f => ({ ...f, name: f.name.toLowerCase() }))
-    .filter(f => !RESERVED.has(f.name))
+    .filter(f => !RESERVED_COLLECTION.has(f.name))
     // Tag as a user field so the reconciler can tell user vs plugin provenance.
     .map(f => ({ source: "ui", ...f })) as unknown as FieldDefinition[];
 

--- a/packages/nextly/src/plugins/__tests__/seed-builder-entity.ts
+++ b/packages/nextly/src/plugins/__tests__/seed-builder-entity.ts
@@ -39,7 +39,14 @@ const silentLogger: Logger = {
 };
 
 /** Reserved fields the schema service auto-adds; never user/plugin-owned. */
-const RESERVED = new Set(["id", "title", "slug", "created_at", "updated_at"]);
+const RESERVED = new Set([
+  "id",
+  "title",
+  "slug",
+  "created_at",
+  "updated_at",
+  "created_by",
+]);
 
 export interface SeedBuilderCollectionOptions {
   slug: string;

--- a/packages/nextly/src/schemas/_zod/__tests__/ui-schema.test.ts
+++ b/packages/nextly/src/schemas/_zod/__tests__/ui-schema.test.ts
@@ -173,3 +173,30 @@ describe("ui-schema field types (widened set)", () => {
     ).toBe(true);
   });
 });
+
+describe("ui-schema manifest owner-column reservation (collections only)", () => {
+  const withField = (kind: "collections" | "singles" | "components") => ({
+    version: 1 as const,
+    [kind]: [
+      {
+        slug: "x",
+        fields: [{ name: "created_by", type: "text" }],
+      },
+    ],
+  });
+
+  it("rejects a created_by field on a collection", () => {
+    const r = uiSchemaManifest.safeParse(withField("collections"));
+    expect(r.success).toBe(false);
+  });
+
+  it("allows a created_by field on a single (no owner column there)", () => {
+    expect(uiSchemaManifest.safeParse(withField("singles")).success).toBe(true);
+  });
+
+  it("allows a created_by field on a component", () => {
+    expect(uiSchemaManifest.safeParse(withField("components")).success).toBe(
+      true
+    );
+  });
+});

--- a/packages/nextly/src/schemas/_zod/__tests__/ui-schema.test.ts
+++ b/packages/nextly/src/schemas/_zod/__tests__/ui-schema.test.ts
@@ -174,9 +174,19 @@ describe("ui-schema field types (widened set)", () => {
   });
 });
 
+// The owner column (`created_by`) is injected only on collection tables, so the
+// manifest schema reserves that field name for collections alone — singles are a
+// single global row and components embed in JSON, so neither carries the column
+// and both may define `created_by` freely.
 describe("ui-schema manifest owner-column reservation (collections only)", () => {
+  // Build a full manifest (all three top-level kind arrays present) with the
+  // created_by field placed only on the target kind, so a parse failure can be
+  // attributed to the reservation and not to a missing manifest-shape array.
   const withField = (kind: "collections" | "singles" | "components") => ({
     version: 1 as const,
+    collections: [],
+    singles: [],
+    components: [],
     [kind]: [
       {
         slug: "x",
@@ -185,9 +195,14 @@ describe("ui-schema manifest owner-column reservation (collections only)", () =>
     ],
   });
 
-  it("rejects a created_by field on a collection", () => {
+  it("rejects a created_by field on a collection with a reserved-field error", () => {
     const r = uiSchemaManifest.safeParse(withField("collections"));
     expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(
+        r.error.issues.some(i => /'created_by' is reserved/.test(i.message))
+      ).toBe(true);
+    }
   });
 
   it("allows a created_by field on a single (no owner column there)", () => {

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -41,14 +41,11 @@ export const UI_FIELD_TYPES = [
 ] as const;
 
 /** Field names the framework reserves (system columns). */
-const RESERVED_FIELD_NAMES = new Set([
-  "id",
-  "created_at",
-  "updated_at",
-  // System owner column, auto-injected and stamped on create — a ui-schema/API
-  // field of this name would collide with (or overwrite) it.
-  "created_by",
-]);
+// Universal system columns present on every entity table (collection, single,
+// component). The collection-only owner column (`created_by`/`createdBy`) is
+// NOT reserved here — it would wrongly reject valid single/component fields;
+// it is enforced per-entity by assertValidFieldsPayload({ kind: "collection" }).
+const RESERVED_FIELD_NAMES = new Set(["id", "created_at", "updated_at"]);
 
 const SLUG_RE = /^[a-z][a-z0-9_-]*$/;
 

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -41,7 +41,14 @@ export const UI_FIELD_TYPES = [
 ] as const;
 
 /** Field names the framework reserves (system columns). */
-const RESERVED_FIELD_NAMES = new Set(["id", "created_at", "updated_at"]);
+const RESERVED_FIELD_NAMES = new Set([
+  "id",
+  "created_at",
+  "updated_at",
+  // System owner column, auto-injected and stamped on create — a ui-schema/API
+  // field of this name would collide with (or overwrite) it.
+  "created_by",
+]);
 
 const SLUG_RE = /^[a-z][a-z0-9_-]*$/;
 

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -340,7 +340,7 @@ const admin = z.object({
   group: z.string().optional(),
 });
 
-function entity() {
+function entity(kind?: "collection" | "single" | "component") {
   return z
     .object({
       slug,
@@ -350,6 +350,21 @@ function entity() {
       fields: z.array(uiSchemaFieldSchema),
     })
     .superRefine((e, ctx) => {
+      // The owner column (`created_by`, plus the camelCase alias that
+      // snake-cases to it) is injected only on collection tables, so a manifest
+      // collection must not define it as a field — singles/components have no
+      // owner column, so it stays a legal field name there.
+      if (kind === "collection") {
+        for (const f of e.fields) {
+          if (f.name === "created_by" || f.name === "createdBy") {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `field name '${f.name}' is reserved`,
+              path: ["fields"],
+            });
+          }
+        }
+      }
       // Duplicate field names.
       const seen = new Set<string>();
       for (const f of e.fields) {
@@ -413,9 +428,9 @@ export const uiSchemaManifest = z
   .object({
     $schema: z.string().optional(),
     version: z.literal(1).default(1),
-    collections: z.array(entity()).default([]),
-    singles: z.array(entity()).default([]),
-    components: z.array(entity()).default([]),
+    collections: z.array(entity("collection")).default([]),
+    singles: z.array(entity("single")).default([]),
+    components: z.array(entity("component")).default([]),
   })
   .superRefine((m, ctx) => {
     uniqueSlugs(m.collections, ctx, "collections");

--- a/packages/nextly/src/services/access/access-control-service.test.ts
+++ b/packages/nextly/src/services/access/access-control-service.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import type { RequestContext } from "@nextly/collections/fields/types/base";
 
 import { AccessControlService } from "./access-control-service";
+import { DEFAULT_OWNER_FIELD } from "./types";
 import type { CollectionAccessRules } from "./types";
 
 // Role-based rules use OR logic: access is granted if the user holds ANY of the
@@ -58,27 +59,43 @@ describe("AccessControlService role-based access (OR-membership)", () => {
 describe("AccessControlService owner-only default field", () => {
   const service = new AccessControlService();
 
-  // No ownerField configured → must default to the auto-stamped system owner
-  // column name (snake_case), so the generated read filter and update/delete
-  // comparisons target the column the create path actually writes.
   const ownerOnly: CollectionAccessRules = { read: { type: "owner-only" } };
 
-  it("filters reads on the created_by column", async () => {
+  // With no default passed, the shared service falls back to the generic
+  // camelCase `createdBy` used by singles/components (which never get the
+  // auto-stamped system column) and any generic caller.
+  it("filters reads on the generic createdBy field by default", async () => {
     const result = await service.evaluateAccess(ownerOnly, "read", {
       user: { id: "u1" },
     });
     expect(result.allowed).toBe(true);
+    expect(result.query).toEqual({ createdBy: { equals: "u1" } });
+  });
+
+  // A collection caller passes DEFAULT_OWNER_FIELD, so the read filter targets
+  // the snake_case `created_by` column the create path actually stamps.
+  it("filters reads on created_by when the collection default is passed", async () => {
+    const result = await service.evaluateAccess(
+      ownerOnly,
+      "read",
+      { user: { id: "u1" } },
+      undefined,
+      undefined,
+      DEFAULT_OWNER_FIELD
+    );
+    expect(result.allowed).toBe(true);
     expect(result.query).toEqual({ created_by: { equals: "u1" } });
   });
 
-  it("compares ownership against created_by on update", async () => {
+  it("compares ownership against created_by on update for collections", async () => {
     const rules: CollectionAccessRules = { update: { type: "owner-only" } };
     const mine = await service.evaluateAccess(
       rules,
       "update",
       { user: { id: "u1" } },
       "doc-1",
-      { id: "doc-1", created_by: "u1" }
+      { id: "doc-1", created_by: "u1" },
+      DEFAULT_OWNER_FIELD
     );
     expect(mine.allowed).toBe(true);
 
@@ -87,7 +104,8 @@ describe("AccessControlService owner-only default field", () => {
       "update",
       { user: { id: "u1" } },
       "doc-1",
-      { id: "doc-1", created_by: "someone-else" }
+      { id: "doc-1", created_by: "someone-else" },
+      DEFAULT_OWNER_FIELD
     );
     expect(notMine.allowed).toBe(false);
   });

--- a/packages/nextly/src/services/access/access-control-service.test.ts
+++ b/packages/nextly/src/services/access/access-control-service.test.ts
@@ -54,3 +54,41 @@ describe("AccessControlService role-based access (OR-membership)", () => {
     expect(result.reason).toBe("Authentication required");
   });
 });
+
+describe("AccessControlService owner-only default field", () => {
+  const service = new AccessControlService();
+
+  // No ownerField configured → must default to the auto-stamped system owner
+  // column name (snake_case), so the generated read filter and update/delete
+  // comparisons target the column the create path actually writes.
+  const ownerOnly: CollectionAccessRules = { read: { type: "owner-only" } };
+
+  it("filters reads on the created_by column", async () => {
+    const result = await service.evaluateAccess(ownerOnly, "read", {
+      user: { id: "u1" },
+    });
+    expect(result.allowed).toBe(true);
+    expect(result.query).toEqual({ created_by: { equals: "u1" } });
+  });
+
+  it("compares ownership against created_by on update", async () => {
+    const rules: CollectionAccessRules = { update: { type: "owner-only" } };
+    const mine = await service.evaluateAccess(
+      rules,
+      "update",
+      { user: { id: "u1" } },
+      "doc-1",
+      { id: "doc-1", created_by: "u1" }
+    );
+    expect(mine.allowed).toBe(true);
+
+    const notMine = await service.evaluateAccess(
+      rules,
+      "update",
+      { user: { id: "u1" } },
+      "doc-1",
+      { id: "doc-1", created_by: "someone-else" }
+    );
+    expect(notMine.allowed).toBe(false);
+  });
+});

--- a/packages/nextly/src/services/access/access-control-service.ts
+++ b/packages/nextly/src/services/access/access-control-service.ts
@@ -52,7 +52,7 @@ import type {
   CollectionAccessRules,
   AccessEvaluationResult,
 } from "./types";
-import { DEFAULT_OWNER_FIELD } from "./types";
+import { GENERIC_DEFAULT_OWNER_FIELD } from "./types";
 
 /**
  * Signature for custom access functions.
@@ -200,7 +200,12 @@ export class AccessControlService {
     operation: AccessOperation,
     context: RequestContext,
     documentId?: string,
-    document?: Record<string, unknown>
+    document?: Record<string, unknown>,
+    // Owner field used for a rule-less `owner-only` default. Defaults to the
+    // generic camelCase `createdBy` so singles/components and any generic caller
+    // keep the historical behavior; collection callers pass DEFAULT_OWNER_FIELD
+    // (`created_by`) since collections carry the auto-stamped system column.
+    defaultOwnerField: string = GENERIC_DEFAULT_OWNER_FIELD
   ): Promise<AccessEvaluationResult> {
     const rule = rules?.[operation];
 
@@ -220,7 +225,13 @@ export class AccessControlService {
         return this.evaluateRoleBasedAccess(rule, context);
 
       case "owner-only":
-        return this.evaluateOwnerAccess(rule, operation, context, document);
+        return this.evaluateOwnerAccess(
+          rule,
+          operation,
+          context,
+          document,
+          defaultOwnerField
+        );
 
       case "custom":
         return this.evaluateCustomAccess(rule, context, documentId, document);
@@ -277,9 +288,10 @@ export class AccessControlService {
     rule: StoredAccessRule,
     operation: AccessOperation,
     context: RequestContext,
-    document?: Record<string, unknown>
+    document?: Record<string, unknown>,
+    defaultOwnerField: string = GENERIC_DEFAULT_OWNER_FIELD
   ): AccessEvaluationResult {
-    const ownerField = rule.ownerField ?? DEFAULT_OWNER_FIELD;
+    const ownerField = rule.ownerField ?? defaultOwnerField;
 
     if (!context.user) {
       return { allowed: false, reason: "Authentication required" };

--- a/packages/nextly/src/services/access/types.ts
+++ b/packages/nextly/src/services/access/types.ts
@@ -307,6 +307,9 @@ export const ACCESS_OPERATIONS: readonly AccessOperation[] = [
 /**
  * Default owner field name for owner-only access rules.
  *
- * Used when `ownerField` is not specified in an `owner-only` rule.
+ * Used when `ownerField` is not specified in an `owner-only` rule. This is the
+ * physical column name of the auto-stamped system owner column (snake_case,
+ * matching the runtime Drizzle schema and raw rows), so zero-config owner-only
+ * rules query and compare against the column the create path actually stamps.
  */
-export const DEFAULT_OWNER_FIELD = "createdBy";
+export const DEFAULT_OWNER_FIELD = "created_by";

--- a/packages/nextly/src/services/access/types.ts
+++ b/packages/nextly/src/services/access/types.ts
@@ -305,11 +305,24 @@ export const ACCESS_OPERATIONS: readonly AccessOperation[] = [
 ] as const;
 
 /**
- * Default owner field name for owner-only access rules.
+ * Default owner field for owner-only rules on COLLECTIONS.
  *
- * Used when `ownerField` is not specified in an `owner-only` rule. This is the
- * physical column name of the auto-stamped system owner column (snake_case,
- * matching the runtime Drizzle schema and raw rows), so zero-config owner-only
- * rules query and compare against the column the create path actually stamps.
+ * Used when `ownerField` is not specified in a collection `owner-only` rule.
+ * This is the physical column name of the auto-stamped system owner column
+ * (snake_case, matching the runtime Drizzle schema and raw rows), so zero-config
+ * owner-only rules query and compare against the column the create path actually
+ * stamps. Collections only: singles/components do not get this system column.
  */
 export const DEFAULT_OWNER_FIELD = "created_by";
+
+/**
+ * Default owner field for owner-only rules on entities WITHOUT the system owner
+ * column (singles, components, and any generic caller of the access service).
+ *
+ * These entities never get the auto-stamped `created_by` column — a single is
+ * one global row and components embed in JSON — so their owner-only default
+ * stays the historical camelCase `createdBy` a schema author would define by
+ * hand. The shared AccessControlService falls back to this unless a
+ * collection-specific caller passes {@link DEFAULT_OWNER_FIELD} explicitly.
+ */
+export const GENERIC_DEFAULT_OWNER_FIELD = "createdBy";

--- a/packages/nextly/src/shared/lib/password-fields.ts
+++ b/packages/nextly/src/shared/lib/password-fields.ts
@@ -162,3 +162,21 @@ export function hasPasswordField(fields: NamedField[]): boolean {
       (Boolean(field.fields) && hasPasswordField(field.fields!))
   );
 }
+
+/** System owner column, in the snake_case column form and the camelCase form. */
+const OWNER_COLUMN_KEYS = ["created_by", "createdBy"] as const;
+
+/**
+ * Remove the system owner column (`created_by`) from a response row, in place.
+ *
+ * The owner column holds the creator's stable user id. Owner-only access
+ * filters on it in SQL, so its value never needs to leave the server; returning
+ * it would leak a stable user id to any caller who can read a collection whose
+ * rows were created by other users. Callers strip it on the read/mutation
+ * response boundary, the same place password values are cleared.
+ */
+export function stripSystemOwnerField(entry: Record<string, unknown>): void {
+  for (const key of OWNER_COLUMN_KEYS) {
+    if (key in entry) delete entry[key];
+  }
+}


### PR DESCRIPTION
## Summary

PR2 of the route-write access-enforcement program (follow-up to #231). Adds a nullable `created_by` system column to every collection entry table and stamps it with the creating user's id, so **owner-only access works zero-config** — the stored rule compares `created_by` to the caller with no per-collection setup.

## What changed

- **Schema (all 3 dialects):** `created_by` added to `getSystemColumnDescriptors` and the matching runtime Drizzle column (`systemColumnToDrizzle`), plus the legacy `generateMigrationSQL` CREATE-TABLE path, so every DDL path stays in lockstep. Nullable `text` / `varchar(36)` matching the id column type, **no default**. Because it is nullable with no default, existing tables pick it up as a plain additive `ADD COLUMN` on the next schema apply — no backfill, no interactive prompt.
- **Runtime stamping:** `created_by = user.id` on the regular create and both batch-transaction create paths; `null` for system/seed creates (no user context).
- **Reserved name:** `created_by` added to `RESERVED_FIELD_NAMES` so a user field cannot shadow the system column.
- **Latent bug fix:** the batch create transaction path passed camelCase `createdAt`/`updatedAt` keys the driver ignored (they only persisted via DB defaults; a strict driver like better-sqlite3 rejects the whole insert once an unknown key is present). The batch paths now use the real snake_case column names — which is also what lets `created_by` (no default) be written there. This repaired a pre-existing failure surfaced by the new integration test.

## Test plan

- New integration test proves the stamp end-to-end on SQLite across the **regular** and **bulk** create paths (owner id stamped; system create null).
- Unit tests cover the descriptor, the nullable runtime column on every dialect, and the diff/preview `add_column` behavior.
- Full `pnpm test:integration` (sqlite) green (66 files passed, 0 failed); `check-types` + `lint` clean. Remaining ~7 schema unit failures are the known pre-existing baseline (toggle→bool, number→double/float8/real, jsonb, layout-only), unchanged from `main`.

## Notes for reviewers

- Postgres/MySQL DDL paths are exercised only in CI (no local PG/MySQL); the descriptor/runtime-column changes are symmetric across dialects.
- Existing-table migration (adding `created_by` to tables created before this change) is handled by the standard diff pipeline (`buildDesiredTableFromFields` → `getSystemColumnDescriptors` → `add_column`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatic creator tracking for collection entries, including bulk creates and immutable ownership during create/update.
  - Added a nullable `created_by` system column in runtime schemas/diff generation for supported database types, omitted for single-table variants.

- **Schema & Validation**
  - Reserved `created_by` / `createdBy` as collection owner fields (including UI/entity/schema and collection config validation).
  - Tightened collection `fields` payload validation to enforce the reserved names.
  
- **Security / Bug Fixes**
  - Prevented clients from rewriting ownership/creator fields.
  - Redacted `created_by` from all read responses and relationship expansions; normalized/removes owner filters from `where` and blocks sorting by owner fields.

- **Tests**
  - Expanded end-to-end and schema/diff test coverage for `created_by` behavior (including update/visibility).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->