### PR TITLE
fix(nextly): make many-to-many relationships work across dialects

### DIFF
--- a/.changeset/fix-many-to-many-relationships.md
+++ b/.changeset/fix-many-to-many-relationships.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Fix many-to-many relationships, which did not work on any database.
+
+Creating a many-to-many field produced an invalid junction-table migration, so the junction table was never created. Even past that, the target collection was never resolved (so links silently did nothing), the parent table gained a phantom column it should not have, inserts crashed on SQLite, and reads plus inserts failed on MySQL. Many-to-many links now create, read, and delete correctly on Postgres, MySQL, and SQLite.

--- a/packages/nextly/src/domains/collections/services/__tests__/collection-relationship-service-mysql.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/collection-relationship-service-mysql.integration.test.ts
@@ -1,0 +1,198 @@
+/**
+ * MySQL dialect gate for the many-to-many junction fix bundle.
+ *
+ * `createTestNextly` (used by collection-relationship-service.m2m.integration.test.ts)
+ * always boots on in-memory SQLite by design — it never reads TEST_MYSQL_URL,
+ * so running that suite through `pnpm test:integration:mysql` still only
+ * exercises SQLite. Dialect-specific DDL and driver bugs (invalid junction DDL,
+ * placeholder/param binding, MySQL's stricter FK ordering) hide there, so this
+ * suite drives the same fixes directly against a real MySQL server. Follows the
+ * repo convention used by pushschema-pipeline-mysql.integration.test.ts:
+ * connect via `TEST_MYSQL_URL`, skip when unreachable, and self-clean the
+ * tables it creates.
+ *
+ * Exercises the same three fixes as the SQLite suite:
+ *   1. generateJunctionTable() emits valid, single-statement DDL.
+ *   2. getTargetCollection() falls back to field.options.target.
+ *   3. insertManyToManyRelations binds created_at correctly for this dialect
+ *      (a Date, not the SQLite epoch-seconds path).
+ */
+import { randomUUID } from "node:crypto";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
+
+import { createAdapter } from "../../../../database/factory";
+import type { DynamicCollectionService } from "../../../dynamic-collections";
+import { DynamicCollectionSchemaService } from "../../../dynamic-collections/services/dynamic-collection-schema-service";
+import type { Logger } from "../../../../services/shared";
+import { CollectionRelationshipService } from "../collection-relationship-service";
+
+// Minimal stub: insertManyToManyRelations only calls generateId() on the
+// collectionService dependency (the fetch path is what needs a real
+// fileManager/collectionService, covered separately by the SQLite
+// full-service-boot suite).
+const collectionServiceStub = {
+  generateId: () => randomUUID(),
+} as unknown as DynamicCollectionService;
+
+const MYSQL_URL = process.env.TEST_MYSQL_URL ?? "";
+
+const silentLogger: Logger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+// Fixed, dedicated table names for this gate — dropped before and after so
+// reruns against the shared test database are idempotent (the sequential
+// integration run, fileParallelism: false, is what makes this safe, same as
+// other suites that touch fixed-name tables).
+const POSTS_TABLE = "dc_m2m_gate_posts";
+const TAGS_TABLE = "dc_m2m_gate_tags";
+const JUNCTION_TABLE = "dc_m2m_gate_posts_dc_m2m_gate_tags_tags";
+
+const m2mField = {
+  name: "tags",
+  type: "relationship",
+  options: { relationType: "manyToMany", target: "m2m_gate_tags" },
+} as unknown as FieldDefinition;
+
+async function connectIfAvailable(): Promise<Awaited<
+  ReturnType<typeof createAdapter>
+> | null> {
+  if (!MYSQL_URL) return null;
+  process.env.DB_DIALECT = "mysql";
+  // env.ts validates DATABASE_URL against DB_DIALECT the first time ANY
+  // env.* property is read in this worker (it caches after that first read),
+  // and createAdapter's pool-defaults layering reads env.DB_POOL_MAX
+  // unconditionally. Passing `url` directly in the createAdapter config
+  // isn't enough to satisfy that validation — DATABASE_URL must also be set
+  // on process.env, or the validation throws regardless of run order.
+  process.env.DATABASE_URL = MYSQL_URL;
+  try {
+    const adapter = await createAdapter({
+      type: "mysql",
+      url: MYSQL_URL,
+    } as Parameters<typeof createAdapter>[0]);
+    await adapter.executeQuery("SELECT 1");
+    return adapter;
+  } catch {
+    return null;
+  }
+}
+
+const adapter = await connectIfAvailable();
+const describeMysql = adapter ? describe : describe.skip;
+
+async function dropFixtureTables(): Promise<void> {
+  if (!adapter) return;
+  // Junction first: MySQL blocks dropping a table still referenced by an FK,
+  // and (unlike Postgres) its DROP TABLE ... CASCADE only parses the keyword
+  // without cascading, so the drop order must be correct on its own.
+  await adapter.executeQuery(`DROP TABLE IF EXISTS ${JUNCTION_TABLE}`);
+  await adapter.executeQuery(`DROP TABLE IF EXISTS ${POSTS_TABLE}`);
+  await adapter.executeQuery(`DROP TABLE IF EXISTS ${TAGS_TABLE}`);
+}
+
+beforeAll(async () => {
+  await dropFixtureTables();
+});
+
+afterAll(async () => {
+  if (!adapter) return;
+  await dropFixtureTables();
+  await adapter.disconnect();
+});
+
+describeMysql(
+  "CollectionRelationshipService many-to-many junction writes (MySQL dialect gate)",
+  () => {
+    it("creates valid junction DDL, inserts a link, and deletes it, on real MySQL", async () => {
+      const a = adapter!;
+      const schemaService = new DynamicCollectionSchemaService(
+        undefined,
+        "mysql"
+      );
+
+      // Base tables: reuse the product DDL generator (no user fields) so the
+      // id/title/slug/timestamp columns match exactly what the junction FK
+      // expects.
+      const tagsDdl = schemaService.generateMigrationSQL(TAGS_TABLE, []);
+      const postsDdl = schemaService.generateMigrationSQL(POSTS_TABLE, []);
+      for (const stmt of [tagsDdl, postsDdl]) {
+        for (const statement of stmt
+          .split("--> statement-breakpoint")
+          .map(s => s.trim())
+          .filter(Boolean)) {
+          await a.executeQuery(statement);
+        }
+      }
+
+      // Junction table — this is bug #1's fix under direct test: on the
+      // pre-fix code this DDL contained an orphaned CONSTRAINT fragment and
+      // failed to execute at all.
+      const junctionDdl = schemaService.generateJunctionTable(
+        POSTS_TABLE,
+        m2mField
+      );
+      for (const statement of junctionDdl
+        .split("--> statement-breakpoint")
+        .map(s => s.trim())
+        .filter(Boolean)) {
+        await a.executeQuery(statement);
+      }
+
+      const tagId = "mysql-tag-1";
+      const postId = "mysql-post-1";
+      await a.executeQuery(
+        `INSERT INTO ${TAGS_TABLE} (id, title, slug) VALUES ('${tagId}', 'JavaScript', 'javascript')`
+      );
+      await a.executeQuery(
+        `INSERT INTO ${POSTS_TABLE} (id, title, slug) VALUES ('${postId}', 'Hello', 'hello')`
+      );
+
+      // fileManager/collectionService are unused by insert/delete (only the
+      // fetch path resolves the target schema through them), so stubs are
+      // fine here — see collection-relationship-service.m2m.integration.test.ts
+      // for the fetch-path assertion under the full service boot.
+      const rel = new CollectionRelationshipService(
+        a,
+        silentLogger,
+        {} as never,
+        collectionServiceStub
+      );
+
+      // Bug #2 under direct test: this field only carries options.target,
+      // never relationTo, so without the fallback this resolves no target
+      // and silently no-ops instead of inserting.
+      //
+      // Bug #3 under direct test: insertManyToManyRelations binds created_at
+      // as `new Date()` on this dialect (the epoch-seconds path is
+      // SQLite-only) — mysql2 accepts a Date directly.
+      await rel.insertManyToManyRelations("m2m_gate_posts", postId, m2mField, [
+        tagId,
+      ]);
+
+      const rows = await a.executeQuery<{
+        id: string;
+        m2m_gate_posts_id: string;
+        m2m_gate_tags_id: string;
+      }>(
+        `SELECT id, m2m_gate_posts_id, m2m_gate_tags_id FROM ${JUNCTION_TABLE} WHERE m2m_gate_posts_id = '${postId}'`
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].m2m_gate_posts_id).toBe(postId);
+      expect(rows[0].m2m_gate_tags_id).toBe(tagId);
+
+      await rel.deleteManyToManyRelations("m2m_gate_posts", postId, m2mField);
+
+      const afterDelete = await a.executeQuery<{ id: string }>(
+        `SELECT id FROM ${JUNCTION_TABLE} WHERE m2m_gate_posts_id = '${postId}'`
+      );
+      expect(afterDelete).toHaveLength(0);
+    });
+  }
+);

--- a/packages/nextly/src/domains/collections/services/__tests__/collection-relationship-service-mysql.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/collection-relationship-service-mysql.integration.test.ts
@@ -72,16 +72,14 @@ async function connectIfAvailable(): Promise<Awaited<
   // isn't enough to satisfy that validation — DATABASE_URL must also be set
   // on process.env, or the validation throws regardless of run order.
   process.env.DATABASE_URL = MYSQL_URL;
-  try {
-    const adapter = await createAdapter({
-      type: "mysql",
-      url: MYSQL_URL,
-    } as Parameters<typeof createAdapter>[0]);
-    await adapter.executeQuery("SELECT 1");
-    return adapter;
-  } catch {
-    return null;
-  }
+  // When the URL IS configured, a connection failure must surface (fail the
+  // suite), not be swallowed into a skip that would hide a broken database.
+  const adapter = await createAdapter({
+    type: "mysql",
+    url: MYSQL_URL,
+  } as Parameters<typeof createAdapter>[0]);
+  await adapter.executeQuery("SELECT 1");
+  return adapter;
 }
 
 const adapter = await connectIfAvailable();

--- a/packages/nextly/src/domains/collections/services/__tests__/collection-relationship-service-pg.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/collection-relationship-service-pg.integration.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Postgres dialect gate for the many-to-many junction fix bundle.
+ *
+ * `createTestNextly` (used by collection-relationship-service.m2m.integration.test.ts)
+ * always boots on in-memory SQLite by design — it never reads TEST_POSTGRES_URL,
+ * so running that suite through `pnpm test:integration:postgres17` still only
+ * exercises SQLite. Dialect-specific DDL and driver bugs (invalid junction DDL,
+ * placeholder/param binding) hide there, so this suite drives the same fixes
+ * directly against a real Postgres server. Follows the repo convention used by
+ * builder-extend-pg.integration.test.ts: connect via `TEST_POSTGRES_URL`, skip
+ * when unreachable, and self-clean the tables it creates.
+ *
+ * Exercises the same three fixes as the SQLite suite:
+ *   1. generateJunctionTable() emits valid, single-statement DDL.
+ *   2. getTargetCollection() falls back to field.options.target.
+ *   3. insertManyToManyRelations binds created_at correctly for this dialect
+ *      (a Date, not the SQLite epoch-seconds path).
+ */
+import { randomUUID } from "node:crypto";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
+
+import { createAdapter } from "../../../../database/factory";
+import type { DynamicCollectionService } from "../../../dynamic-collections";
+import { DynamicCollectionSchemaService } from "../../../dynamic-collections/services/dynamic-collection-schema-service";
+import type { Logger } from "../../../../services/shared";
+import { CollectionRelationshipService } from "../collection-relationship-service";
+
+// Minimal stub: insertManyToManyRelations only calls generateId() on the
+// collectionService dependency (the fetch path is what needs a real
+// fileManager/collectionService, covered separately by the SQLite
+// full-service-boot suite).
+const collectionServiceStub = {
+  generateId: () => randomUUID(),
+} as unknown as DynamicCollectionService;
+
+const PG_URL =
+  process.env.TEST_POSTGRES_URL ?? process.env.TEST_DATABASE_URL ?? "";
+
+const silentLogger: Logger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+// Fixed, dedicated table names for this gate — dropped before and after so
+// reruns against the shared test database are idempotent (the sequential
+// integration run, fileParallelism: false, is what makes this safe, same as
+// other suites that touch fixed-name tables).
+const POSTS_TABLE = "dc_m2m_gate_posts";
+const TAGS_TABLE = "dc_m2m_gate_tags";
+const JUNCTION_TABLE = "dc_m2m_gate_posts_dc_m2m_gate_tags_tags";
+
+const m2mField = {
+  name: "tags",
+  type: "relationship",
+  options: { relationType: "manyToMany", target: "m2m_gate_tags" },
+} as unknown as FieldDefinition;
+
+async function connectIfAvailable(): Promise<Awaited<
+  ReturnType<typeof createAdapter>
+> | null> {
+  if (!PG_URL) return null;
+  process.env.DB_DIALECT = "postgresql";
+  // env.ts validates DATABASE_URL against DB_DIALECT the first time ANY
+  // env.* property is read in this worker (it caches after that first read),
+  // and createAdapter's pool-defaults layering reads env.DB_POOL_MAX
+  // unconditionally. Passing `url` directly in the createAdapter config
+  // isn't enough to satisfy that validation — DATABASE_URL must also be set
+  // on process.env, or the validation throws regardless of run order.
+  process.env.DATABASE_URL = PG_URL;
+  try {
+    const adapter = await createAdapter({
+      type: "postgresql",
+      url: PG_URL,
+    } as Parameters<typeof createAdapter>[0]);
+    await adapter.executeQuery("SELECT 1");
+    return adapter;
+  } catch {
+    return null;
+  }
+}
+
+const adapter = await connectIfAvailable();
+const describePg = adapter ? describe : describe.skip;
+
+async function dropFixtureTables(): Promise<void> {
+  if (!adapter) return;
+  // Junction first: it holds the FKs to the base tables.
+  await adapter.executeQuery(`DROP TABLE IF EXISTS ${JUNCTION_TABLE} CASCADE`);
+  await adapter.executeQuery(`DROP TABLE IF EXISTS ${POSTS_TABLE} CASCADE`);
+  await adapter.executeQuery(`DROP TABLE IF EXISTS ${TAGS_TABLE} CASCADE`);
+}
+
+beforeAll(async () => {
+  await dropFixtureTables();
+});
+
+afterAll(async () => {
+  if (!adapter) return;
+  await dropFixtureTables();
+  await adapter.disconnect();
+});
+
+describePg(
+  "CollectionRelationshipService many-to-many junction writes (Postgres dialect gate)",
+  () => {
+    it("creates valid junction DDL, inserts a link, and deletes it, on real Postgres", async () => {
+      const a = adapter!;
+      const schemaService = new DynamicCollectionSchemaService(
+        undefined,
+        "postgresql"
+      );
+
+      // Base tables: reuse the product DDL generator (no user fields) so the
+      // id/title/slug/timestamp columns match exactly what the junction FK
+      // expects.
+      const tagsDdl = schemaService.generateMigrationSQL(TAGS_TABLE, []);
+      const postsDdl = schemaService.generateMigrationSQL(POSTS_TABLE, []);
+      for (const stmt of [tagsDdl, postsDdl]) {
+        for (const statement of stmt
+          .split("--> statement-breakpoint")
+          .map(s => s.trim())
+          .filter(Boolean)) {
+          await a.executeQuery(statement);
+        }
+      }
+
+      // Junction table — this is bug #1's fix under direct test: on the
+      // pre-fix code this DDL contained an orphaned CONSTRAINT fragment and
+      // failed to execute at all.
+      const junctionDdl = schemaService.generateJunctionTable(
+        POSTS_TABLE,
+        m2mField
+      );
+      for (const statement of junctionDdl
+        .split("--> statement-breakpoint")
+        .map(s => s.trim())
+        .filter(Boolean)) {
+        await a.executeQuery(statement);
+      }
+
+      const tagId = "pg-tag-1";
+      const postId = "pg-post-1";
+      await a.executeQuery(
+        `INSERT INTO ${TAGS_TABLE} (id, title, slug) VALUES ('${tagId}', 'JavaScript', 'javascript')`
+      );
+      await a.executeQuery(
+        `INSERT INTO ${POSTS_TABLE} (id, title, slug) VALUES ('${postId}', 'Hello', 'hello')`
+      );
+
+      // fileManager/collectionService are unused by insert/delete (only the
+      // fetch path resolves the target schema through them), so stubs are
+      // fine here — see collection-relationship-service.m2m.integration.test.ts
+      // for the fetch-path assertion under the full service boot.
+      const rel = new CollectionRelationshipService(
+        a,
+        silentLogger,
+        {} as never,
+        collectionServiceStub
+      );
+
+      // Bug #2 under direct test: this field only carries options.target,
+      // never relationTo, so without the fallback this resolves no target
+      // and silently no-ops instead of inserting.
+      await rel.insertManyToManyRelations("m2m_gate_posts", postId, m2mField, [
+        tagId,
+      ]);
+
+      const rows = await a.executeQuery<{
+        id: string;
+        m2m_gate_posts_id: string;
+        m2m_gate_tags_id: string;
+      }>(
+        `SELECT id, m2m_gate_posts_id, m2m_gate_tags_id FROM ${JUNCTION_TABLE} WHERE m2m_gate_posts_id = '${postId}'`
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].m2m_gate_posts_id).toBe(postId);
+      expect(rows[0].m2m_gate_tags_id).toBe(tagId);
+
+      await rel.deleteManyToManyRelations("m2m_gate_posts", postId, m2mField);
+
+      const afterDelete = await a.executeQuery<{ id: string }>(
+        `SELECT id FROM ${JUNCTION_TABLE} WHERE m2m_gate_posts_id = '${postId}'`
+      );
+      expect(afterDelete).toHaveLength(0);
+    });
+  }
+);

--- a/packages/nextly/src/domains/collections/services/__tests__/collection-relationship-service-pg.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/collection-relationship-service-pg.integration.test.ts
@@ -36,8 +36,9 @@ const collectionServiceStub = {
   generateId: () => randomUUID(),
 } as unknown as DynamicCollectionService;
 
-const PG_URL =
-  process.env.TEST_POSTGRES_URL ?? process.env.TEST_DATABASE_URL ?? "";
+// Skip ONLY when the Postgres-specific URL is unset; do not fall back to a
+// generic URL, or this gate could silently run against a non-Postgres database.
+const PG_URL = process.env.TEST_POSTGRES_URL ?? "";
 
 const silentLogger: Logger = {
   debug() {},
@@ -72,16 +73,14 @@ async function connectIfAvailable(): Promise<Awaited<
   // isn't enough to satisfy that validation — DATABASE_URL must also be set
   // on process.env, or the validation throws regardless of run order.
   process.env.DATABASE_URL = PG_URL;
-  try {
-    const adapter = await createAdapter({
-      type: "postgresql",
-      url: PG_URL,
-    } as Parameters<typeof createAdapter>[0]);
-    await adapter.executeQuery("SELECT 1");
-    return adapter;
-  } catch {
-    return null;
-  }
+  // When the URL IS configured, a connection failure must surface (fail the
+  // suite), not be swallowed into a skip that would hide a broken database.
+  const adapter = await createAdapter({
+    type: "postgresql",
+    url: PG_URL,
+  } as Parameters<typeof createAdapter>[0]);
+  await adapter.executeQuery("SELECT 1");
+  return adapter;
 }
 
 const adapter = await connectIfAvailable();

--- a/packages/nextly/src/domains/collections/services/__tests__/collection-relationship-service.m2m.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/collection-relationship-service.m2m.integration.test.ts
@@ -1,0 +1,180 @@
+/**
+ * End-to-end proof that many-to-many relationships work through the real
+ * junction-table DDL, insert, and delete path. This test only passes when
+ * all three of these fixes hold together:
+ *
+ *   1. `generateJunctionTable()` emits valid, single-statement DDL (no
+ *      orphaned CONSTRAINT fragment) — otherwise seeding the junction table
+ *      itself throws and this test never gets past setup.
+ *   2. `getTargetCollection()` falls back to `field.options.target` — a
+ *      Builder-authored (UI) manyToMany field never sets `relationTo`, so
+ *      without this fallback `insertManyToManyRelations` logs "cannot
+ *      determine target" and silently no-ops (no row, no thrown error).
+ *   3. `insertManyToManyRelations` binds the junction `created_at` as an
+ *      epoch-seconds integer on SQLite instead of a `Date` — better-sqlite3
+ *      rejects a bound `Date` outright, so without this fix the insert
+ *      throws "Failed to insert all manyToMany relations" on SQLite.
+ *
+ * Code-first collections cannot express many-to-many (the typed
+ * `relationship()` helper only supports `hasMany`), so this suite builds a
+ * REAL junction table via `seedBuilderCollection` (the Schema-Builder path).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
+
+import { clearServices } from "../../../../di/register";
+import { seedBuilderCollection } from "../../../../plugins/__tests__/seed-builder-entity";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../../plugins/test-nextly";
+import type { CollectionRelationshipService } from "../collection-relationship-service";
+
+// Raw FieldDefinition m2m shape — the typed relationship() helper cannot
+// express manyToMany, so the field is authored directly as the Builder would
+// store it (target on options.target, not on relationTo).
+const m2mField = {
+  name: "tags",
+  type: "relationship",
+  options: { relationType: "manyToMany", target: "tags" },
+} as unknown as FieldDefinition;
+
+let handle: TestNextly | undefined;
+
+afterEach(async () => {
+  await handle?.destroy();
+  handle = undefined;
+});
+
+/**
+ * Recipe: seed the target collection (`tags`) then the source collection
+ * (`posts`, carrying the m2m field) on a first boot — seeding emits the real
+ * junction table DDL (`dc_posts_dc_tags_tags`). Reset DI without disconnecting
+ * the in-memory adapter, then reboot on the SAME adapter so the seeded
+ * collections' "relationshipService" (needed below) is reachable through DI.
+ */
+async function seedTagsAndPosts(): Promise<{
+  rel: CollectionRelationshipService;
+  tagId: string;
+  postId: string;
+}> {
+  handle = await createTestNextly({});
+  const adapter = handle.adapter;
+
+  // Target seeded BEFORE source: the junction table's FK references dc_tags,
+  // so dc_tags must already exist when the posts migration creates the
+  // junction table.
+  await seedBuilderCollection(adapter, {
+    slug: "tags",
+    fields: [{ name: "name", type: "text" }],
+  });
+  await seedBuilderCollection(adapter, {
+    slug: "posts",
+    fields: [
+      { name: "title", type: "text" },
+      {
+        name: "tags",
+        type: "relationship",
+        options: { relationType: "manyToMany", target: "tags" },
+      },
+    ],
+  });
+
+  clearServices();
+  handle = await createTestNextly({ adapter });
+
+  // "relationshipService" is registered as a side effect of resolving
+  // "collectionService" (its factory wires up + registers the relationship
+  // service instance it composes) — force that resolution before fetching it.
+  handle.getService("collectionService");
+  const rel = handle.getService("relationshipService");
+
+  const tagId = "tag-1";
+  const postId = "post-1";
+  // Seed via raw SQL, not adapter.insert(): a manyToMany field is not
+  // represented on the runtime Drizzle table object for dc_posts (it has no
+  // parent column — see field-column-descriptor's "skip" classification), so
+  // there is no typed column to insert through. Raw SQL bypasses that
+  // entirely and writes straight to the physical columns the DDL created.
+  //
+  // Values are inlined as literals (no $1/? placeholders): node-postgres
+  // expects `$1`, mysql2 expects `?`, and the adapter only rewrites `$1`
+  // style for SQLite (see SqliteAdapter.convertPlaceholders) — there is no
+  // single placeholder syntax that all three dialect drivers accept via
+  // executeQuery. Table/column names are unquoted since none are reserved
+  // words, matching the identifier style existing dialect-matrix integration
+  // suites (e.g. seed-system-permissions.integration.test.ts) use.
+  const nowEpoch = Math.floor(Date.now() / 1000);
+  await adapter.executeQuery(
+    `INSERT INTO dc_tags (id, title, slug, name, created_at, updated_at) VALUES ('${tagId}', 'JavaScript', 'javascript', 'javascript', ${nowEpoch}, ${nowEpoch})`
+  );
+  await adapter.executeQuery(
+    `INSERT INTO dc_posts (id, title, slug, created_at, updated_at) VALUES ('${postId}', 'Hello', 'hello', ${nowEpoch}, ${nowEpoch})`
+  );
+
+  return { rel, tagId, postId };
+}
+
+describe("CollectionRelationshipService many-to-many junction writes (integration)", () => {
+  let rel: CollectionRelationshipService;
+  let tagId: string;
+  let postId: string;
+
+  beforeEach(async () => {
+    ({ rel, tagId, postId } = await seedTagsAndPosts());
+  });
+
+  it("insertManyToManyRelations creates a junction row linking post to tag", async () => {
+    const adapter = handle!.adapter;
+
+    await rel.insertManyToManyRelations("posts", postId, m2mField, [tagId]);
+
+    // The junction table isn't a registered dynamic collection, so
+    // `adapter.select` can't resolve it; query it directly instead.
+    const rows = await adapter.executeQuery<{
+      id: string;
+      posts_id: string;
+      tags_id: string;
+    }>(
+      `SELECT id, posts_id, tags_id FROM dc_posts_dc_tags_tags WHERE posts_id = '${postId}'`
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].posts_id).toBe(postId);
+    expect(rows[0].tags_id).toBe(tagId);
+  });
+
+  it("fetchManyToManyRelationsBatch resolves the linked tag through the target-fallback lookup", async () => {
+    await rel.insertManyToManyRelations("posts", postId, m2mField, [tagId]);
+
+    const dataMap = await rel.batchFetchManyToManyRelations(
+      "posts",
+      [postId],
+      m2mField
+    );
+
+    const related = dataMap.get(postId);
+    expect(related).toBeDefined();
+    expect(related).toHaveLength(1);
+    expect(related?.[0].id).toBe(tagId);
+  });
+
+  it("deleteManyToManyRelations removes the junction row", async () => {
+    const adapter = handle!.adapter;
+
+    await rel.insertManyToManyRelations("posts", postId, m2mField, [tagId]);
+
+    const before = await adapter.executeQuery<{ id: string }>(
+      `SELECT id FROM dc_posts_dc_tags_tags WHERE posts_id = '${postId}'`
+    );
+    expect(before).toHaveLength(1);
+
+    await rel.deleteManyToManyRelations("posts", postId, m2mField);
+
+    const after = await adapter.executeQuery<{ id: string }>(
+      `SELECT id FROM dc_posts_dc_tags_tags WHERE posts_id = '${postId}'`
+    );
+    expect(after).toHaveLength(0);
+  });
+});

--- a/packages/nextly/src/domains/collections/services/__tests__/collection-relationship-service.m2m.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/collection-relationship-service.m2m.integration.test.ts
@@ -160,6 +160,24 @@ describe("CollectionRelationshipService many-to-many junction writes (integratio
     expect(related?.[0].id).toBe(tagId);
   });
 
+  it("expandRelationships populates m2m links on a single-entry read", async () => {
+    await rel.insertManyToManyRelations("posts", postId, m2mField, [tagId]);
+
+    // The single-entry expansion path (findById / create+update responses at
+    // depth > 0) must populate m2m links even though a m2m field has no
+    // parent-row value — its links live only in the junction table, keyed by
+    // entry.id. A row-value guard here would wrongly skip the field.
+    const entry = { id: postId, title: "Hello", slug: "hello" };
+    const expanded = await rel.expandRelationships(entry, "posts", [m2mField], {
+      depth: 1,
+    });
+
+    const tags = expanded.tags as Array<{ id: string }> | undefined;
+    expect(tags).toBeDefined();
+    expect(tags).toHaveLength(1);
+    expect(tags?.[0].id).toBe(tagId);
+  });
+
   it("deleteManyToManyRelations removes the junction row", async () => {
     const adapter = handle!.adapter;
 

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -391,19 +391,21 @@ function expandMediaInData(
  * For polymorphic relationships (relationTo is array), returns the first collection.
  */
 function getTargetCollection(field: FieldDefinition): string | undefined {
+  // A many-to-many field's junction table is created from `options.target`
+  // (see generateJunctionTable), so resolve m2m targets from there FIRST. A
+  // stale or legacy `relationTo` would otherwise make reads/writes derive a
+  // different junction-table name than the one that physically exists.
+  if (field.options?.relationType === "manyToMany" && field.options.target) {
+    return field.options.target;
+  }
   if (field.relationTo) {
     return Array.isArray(field.relationTo)
       ? field.relationTo[0]
       : field.relationTo;
   }
-  // A many-to-many field carries its target on `options.target`, not
-  // `relationTo` (the typed `relationship()` helper never sets `relationTo`
-  // for m2m). Without this, every junction insert/delete/fetch resolves no
-  // target and silently no-ops.
-  if (field.options?.target) {
-    return field.options.target;
-  }
-  return undefined;
+  // Other Builder-authored relationship fields may also carry the target under
+  // `options.target`; fall back to it when `relationTo` is absent.
+  return field.options?.target;
 }
 
 /**
@@ -1296,7 +1298,14 @@ export class CollectionRelationshipService extends BaseService {
       const targetCollection = getTargetCollection(field);
       const hasMany = isHasManyRelationship(field);
 
-      if (!targetCollection || !entry[field.name]) {
+      if (!targetCollection) {
+        continue;
+      }
+      // A many-to-many field has no parent-row value (its links live in the
+      // junction table, keyed by entry.id), so the `entry[field.name]` guard
+      // would wrongly skip it on single-entry reads. Only non-m2m fields read
+      // their FK id(s) off the row, so gate on the row value for those.
+      if (relationType !== "manyToMany" && !entry[field.name]) {
         continue;
       }
 

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -396,6 +396,13 @@ function getTargetCollection(field: FieldDefinition): string | undefined {
       ? field.relationTo[0]
       : field.relationTo;
   }
+  // A many-to-many field carries its target on `options.target`, not
+  // `relationTo` (the typed `relationship()` helper never sets `relationTo`
+  // for m2m). Without this, every junction insert/delete/fetch resolves no
+  // target and silently no-ops.
+  if (field.options?.target) {
+    return field.options.target;
+  }
   return undefined;
 }
 
@@ -560,20 +567,30 @@ export class CollectionRelationshipService extends BaseService {
    * Run a SELECT-style raw SQL tag and return its rows in a normalized
    * `{ rows: [...] }` shape regardless of dialect.
    *
-   * Drizzle's API for raw SQL differs across dialects:
-   *   - PG / MySQL: `db.execute(sqlTag)` → `{ rows, ... }`
-   *   - SQLite (better-sqlite3): `db.all(sqlTag)` → `unknown[]`
+   * Drizzle's raw-execute result shape differs across drivers:
+   *   - Postgres (node-postgres): `db.execute(sqlTag)` → `{ rows: [...] }`
+   *   - MySQL (mysql2): `db.execute(sqlTag)` → a `[rows, fieldPackets]` tuple
+   *     (or a flat rows array), NOT `{ rows }`
+   *   - SQLite (better-sqlite3): `db.all(sqlTag)` → `unknown[]` (no execute())
    *
-   * Without this helper, the existing `(this.db as any).execute(...)`
-   * calls in the junction-table code paths blow up at runtime on
-   * SQLite with `this.db.execute is not a function`.
+   * Without this helper, the junction-table code paths blow up at runtime on
+   * SQLite (`this.db.execute is not a function`) and on MySQL (reading
+   * `.rows` off the tuple yields undefined). The MySQL normalization mirrors
+   * the defensive handling in schema/pipeline/classifier/count-helpers.ts.
    */
   private async selectRawSql(query: unknown): Promise<{ rows: unknown[] }> {
     if (this.dialect === "sqlite") {
       const rows = this.db.all(query) as unknown[];
       return { rows };
     }
-    return (await this.db.execute(query)) as { rows: unknown[] };
+    const result: unknown = await this.db.execute(query);
+    if (this.dialect === "mysql" && Array.isArray(result)) {
+      // Tuple form `[rows, fieldPackets]` -> take rows; a flat rows array (first
+      // element is a row object, not an array) is already the rows.
+      const first = result[0];
+      return { rows: Array.isArray(first) ? (first as unknown[]) : result };
+    }
+    return result as { rows: unknown[] };
   }
 
   /**
@@ -1904,13 +1921,34 @@ export class CollectionRelationshipService extends BaseService {
     for (const targetId of relatedIds) {
       try {
         const id = this.collectionService.generateId();
-        const now = new Date();
+        // This raw sql`` template binds straight to the driver, bypassing
+        // Drizzle's per-column serialization. better-sqlite3 only accepts
+        // numbers/strings/bigints/buffers/null, so a Date throws; the junction
+        // created_at column is `integer` epoch-seconds on SQLite (see
+        // generateJunctionTable), so bind that. PG/MySQL drivers accept a Date.
+        const createdAt =
+          this.dialect === "sqlite"
+            ? Math.floor(Date.now() / 1000)
+            : new Date();
+
+        // "Insert, ignore an existing (source,target) pair" is spelled
+        // differently per dialect: MySQL has no ON CONFLICT (it errors with
+        // ER_PARSE_ERROR). Use ON DUPLICATE KEY UPDATE with a no-op assignment
+        // rather than INSERT IGNORE, so only a duplicate-key conflict is
+        // swallowed while other errors (e.g. a foreign-key violation from a
+        // bad target id) still surface, matching the Postgres/SQLite
+        // ON CONFLICT DO NOTHING behaviour against the unique pair index.
+        const idCol = sql.identifier("id");
+        const conflictClause =
+          this.dialect === "mysql"
+            ? sql`ON DUPLICATE KEY UPDATE ${idCol} = ${idCol}`
+            : sql`ON CONFLICT DO NOTHING`;
 
         const query = sql`
           INSERT INTO ${sql.identifier(junctionTableName)}
           (id, ${sourceIdCol}, ${targetIdCol}, created_at)
-          VALUES (${id}, ${sourceEntryId}, ${targetId}, ${now})
-          ON CONFLICT DO NOTHING
+          VALUES (${id}, ${sourceEntryId}, ${targetId}, ${createdAt})
+          ${conflictClause}
         `;
 
         console.log(`[ManyToMany] Executing insert for targetId: ${targetId}`);

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/junction-ddl.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/junction-ddl.test.ts
@@ -1,0 +1,124 @@
+/**
+ * `generateJunctionTable()` previously appended a duplicated, orphaned
+ * `CONSTRAINT ... UNIQUE(...);` fragment after the closing `);` of the
+ * CREATE TABLE statement. The UNIQUE pair constraint belongs inside the
+ * CREATE TABLE body only — a bare `CONSTRAINT ... );` fragment is not valid
+ * SQL standing on its own, so every junction table migration failed on every
+ * dialect (Postgres, MySQL, and SQLite all reject a statement that opens with
+ * a bare `CONSTRAINT` keyword).
+ *
+ * These tests split the generated SQL on the same `--> statement-breakpoint`
+ * marker the runtime migration executor uses (see `executeStatements` in
+ * seed-builder-entity.ts and the migration runner), so they exercise the
+ * exact unit of "one statement" the fix must produce: exactly one CREATE
+ * TABLE, two CREATE INDEX statements, and no orphaned CONSTRAINT fragment.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
+
+import {
+  DynamicCollectionSchemaService,
+  type SupportedDialect,
+} from "../dynamic-collection-schema-service";
+
+// Raw FieldDefinition m2m shape — mirrors what the Builder stores for a
+// manyToMany relationship field (target lives under options.target).
+const m2mField = {
+  name: "tags",
+  type: "relationship",
+  options: { relationType: "manyToMany", target: "tags" },
+} as unknown as FieldDefinition;
+
+/** Split generated SQL the same way the runtime migration executor does. */
+function splitStatements(sql: string): string[] {
+  return sql
+    .split("--> statement-breakpoint")
+    .map(s => s.trim())
+    .filter(s => s.length > 0);
+}
+
+/** Strip SQL line comments so a leading `-- comment` line doesn't mask a bare CONSTRAINT statement. */
+function stripComments(statement: string): string {
+  return statement
+    .split("\n")
+    .filter(line => !line.trim().startsWith("--"))
+    .join("\n")
+    .trim();
+}
+
+const dialects: SupportedDialect[] = ["sqlite", "postgresql", "mysql"];
+
+describe("DynamicCollectionSchemaService.generateJunctionTable", () => {
+  for (const dialect of dialects) {
+    describe(`dialect=${dialect}`, () => {
+      it("emits exactly one CREATE TABLE statement, two CREATE INDEX statements, and no orphaned CONSTRAINT fragment", () => {
+        const service = new DynamicCollectionSchemaService(undefined, dialect);
+        const sql = service.generateJunctionTable("dc_posts", m2mField);
+
+        const statements = splitStatements(sql);
+        const cleaned = statements.map(stripComments);
+
+        const createTableStatements = cleaned.filter(s =>
+          /CREATE TABLE/i.test(s)
+        );
+        expect(createTableStatements).toHaveLength(1);
+
+        // A bare/orphan CONSTRAINT fragment is one that starts a whole
+        // statement with the CONSTRAINT keyword — valid CONSTRAINT clauses
+        // only ever appear inside a CREATE TABLE body, never as their own
+        // top-level statement.
+        const orphanConstraints = cleaned.filter(s => /^CONSTRAINT\b/i.test(s));
+        expect(orphanConstraints).toHaveLength(0);
+
+        const createIndexStatements = cleaned.filter(s =>
+          /CREATE INDEX/i.test(s)
+        );
+        expect(createIndexStatements).toHaveLength(2);
+
+        // Every statement must be non-empty and end with a semicolon — a
+        // truncated/duplicated fragment would fail this on at least one
+        // dialect.
+        for (const statement of cleaned) {
+          expect(statement.length).toBeGreaterThan(0);
+          expect(statement.trim().endsWith(";")).toBe(true);
+        }
+
+        // The CREATE TABLE statement itself must be well-formed: it opens
+        // with CREATE TABLE and closes with a single `);` — the bug produced
+        // a second, invalid `);`-adjacent CONSTRAINT fragment appended after
+        // the real close.
+        const tableStatement = createTableStatements[0];
+        const closingParenCount = (tableStatement.match(/\);/g) || []).length;
+        expect(closingParenCount).toBe(1);
+
+        // The UNIQUE pair constraint must still exist, but ONLY inside the
+        // CREATE TABLE body (i.e. within the single statement asserted
+        // above), not as a separate trailing statement.
+        expect(tableStatement).toMatch(/CONSTRAINT[\s\S]*UNIQUE/i);
+      });
+
+      it("generateMigrationSQL embeds the same valid junction table for a manyToMany field", () => {
+        const service = new DynamicCollectionSchemaService(undefined, dialect);
+        const sql = service.generateMigrationSQL("dc_posts", [
+          { name: "title", type: "text" } as unknown as FieldDefinition,
+          m2mField,
+        ]);
+
+        const statements = splitStatements(sql).map(stripComments);
+
+        // Two CREATE TABLE statements total: dc_posts itself, plus the
+        // junction table.
+        const createTableStatements = statements.filter(s =>
+          /CREATE TABLE/i.test(s)
+        );
+        expect(createTableStatements).toHaveLength(2);
+
+        const orphanConstraints = statements.filter(s =>
+          /^CONSTRAINT\b/i.test(s)
+        );
+        expect(orphanConstraints).toHaveLength(0);
+      });
+    });
+  }
+});

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -850,6 +850,12 @@ ${dropStatement}`;
       timestampDefault = "timestamp DEFAULT now() NOT NULL";
     }
 
+    // The result is split on `--> statement-breakpoint` and each part executed
+    // as one statement, so every part must be a complete, standalone statement:
+    // one CREATE TABLE (closed by its own `);`), then the two CREATE INDEX
+    // statements. The UNIQUE pair constraint belongs inside the CREATE TABLE
+    // body only; it must not appear again as a trailing fragment (a bare
+    // `CONSTRAINT ... );` is not valid SQL on any dialect).
     return `-- Junction table for many-to-many: ${sourceCollectionName}.${field.name} -> ${targetCollectionName}
 CREATE TABLE IF NOT EXISTS ${this.quoteIdentifier(junctionTableName)} (
   ${this.quoteIdentifier("id")} ${this.dialect === "mysql" ? "varchar(36)" : "text"} PRIMARY KEY NOT NULL,
@@ -858,9 +864,6 @@ CREATE TABLE IF NOT EXISTS ${this.quoteIdentifier(junctionTableName)} (
   ${this.quoteIdentifier("created_at")} ${timestampDefault},
   CONSTRAINT ${this.quoteIdentifier(`fk_${junctionTableName}_${sourceCollectionName}`)} FOREIGN KEY (${this.quoteIdentifier(`${sourceCollectionName}_id`)}) REFERENCES ${this.quoteIdentifier(sourceTableName)}(${this.quoteIdentifier("id")}) ON DELETE ${onDelete} ON UPDATE ${onUpdate},
   CONSTRAINT ${this.quoteIdentifier(`fk_${junctionTableName}_${targetCollectionName}`)} FOREIGN KEY (${this.quoteIdentifier(`${targetCollectionName}_id`)}) REFERENCES ${this.quoteIdentifier(targetTableName)}(${this.quoteIdentifier("id")}) ON DELETE ${onDelete} ON UPDATE ${onUpdate},
-  CONSTRAINT ${this.quoteIdentifier(`uq_${junctionTableName}_pair`)} UNIQUE (${this.quoteIdentifier(`${sourceCollectionName}_id`)}, ${this.quoteIdentifier(`${targetCollectionName}_id`)})
-);
---> statement-breakpoint
   CONSTRAINT ${this.quoteIdentifier(`uq_${junctionTableName}_pair`)} UNIQUE (${this.quoteIdentifier(`${sourceCollectionName}_id`)}, ${this.quoteIdentifier(`${targetCollectionName}_id`)})
 );
 --> statement-breakpoint

--- a/packages/nextly/src/domains/schema/services/__tests__/field-column-descriptor.m2m.test.ts
+++ b/packages/nextly/src/domains/schema/services/__tests__/field-column-descriptor.m2m.test.ts
@@ -1,0 +1,70 @@
+/**
+ * `classifyFieldKind()` must return "skip" for a many-to-many relationship
+ * field so `getColumnDescriptor()` returns null and no phantom parent column
+ * is emitted. A many-to-many relationship's links live entirely in a
+ * dedicated junction table (see dynamic-collection-schema-service's
+ * `generateJunctionTable`); a parent-row column for it would describe a
+ * column the physical schema never has, so the Drizzle runtime table object
+ * would disagree with the database on every m2m collection.
+ *
+ * Contrasted here against a single-target relationship (still gets an
+ * `fkSingle` column) and a hasMany relationship (gets a `json` column) so the
+ * "skip only for manyToMany" boundary is pinned down, not just its positive
+ * case.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { FieldDefinition } from "../../../schemas/dynamic-collections";
+import { getColumnDescriptor } from "../field-column-descriptor";
+
+describe("getColumnDescriptor — many-to-many relationship fields", () => {
+  it("returns null (no parent column) for a manyToMany relationship field", () => {
+    const field = {
+      name: "tags",
+      type: "relationship",
+      options: { relationType: "manyToMany", target: "tags" },
+    } as unknown as FieldDefinition;
+
+    expect(getColumnDescriptor(field, "postgresql")).toBeNull();
+    expect(getColumnDescriptor(field, "mysql")).toBeNull();
+    expect(getColumnDescriptor(field, "sqlite")).toBeNull();
+  });
+
+  it("still emits an fkSingle column for a single-target (manyToOne) relationship", () => {
+    const field = {
+      name: "author",
+      type: "relationship",
+      options: { relationType: "manyToOne", target: "users" },
+    } as unknown as FieldDefinition;
+
+    const desc = getColumnDescriptor(field, "postgresql");
+    expect(desc).not.toBeNull();
+    expect(desc?.kind).toBe("fkSingle");
+    expect(desc?.name).toBe("author");
+  });
+
+  it("still emits a json column for a hasMany relationship (array of FK ids, not a junction table)", () => {
+    const field = {
+      name: "collaborators",
+      type: "relationship",
+      hasMany: true,
+      options: { target: "users" },
+    } as unknown as FieldDefinition;
+
+    const desc = getColumnDescriptor(field, "postgresql");
+    expect(desc).not.toBeNull();
+    expect(desc?.kind).toBe("json");
+  });
+
+  it("emits a json column for a polymorphic array-target relationship (relationTo as array)", () => {
+    const field = {
+      name: "linkable",
+      type: "relationship",
+      relationTo: ["posts", "pages"],
+    } as unknown as FieldDefinition;
+
+    const desc = getColumnDescriptor(field, "postgresql");
+    expect(desc).not.toBeNull();
+    expect(desc?.kind).toBe("json");
+  });
+});

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -203,6 +203,14 @@ function classifyFieldKind(field: FieldDefinition): ColumnKind {
 
     case "relationship":
     case "upload": {
+      // A many-to-many relationship stores its links in a dedicated junction
+      // table, not on the parent row, so the parent needs no column (mirrors
+      // component fields, which return "skip"). Emitting an fkSingle column
+      // here produced a phantom parent column the junction-only physical
+      // schema never has, so the runtime table object disagreed with the DB.
+      const relationType = (field as { options?: { relationType?: string } })
+        .options?.relationType;
+      if (relationType === "manyToMany") return "skip";
       // hasMany or array-target relationships are stored as JSON
       // arrays of FK ids. Single-target -> plain FK column.
       const hasMany = (field as { hasMany?: boolean }).hasMany;


### PR DESCRIPTION
## What

Many-to-many relationships were broken end to end in Nextly. Building the content-versioning atomicity work surfaced this, and (per maintainer decision) it is fixed here as its own focused PR before that work continues. Six distinct defects, each independently fatal, are fixed and verified on Postgres 17, MySQL 8, and SQLite.

## The six bugs

1. **Invalid junction DDL** (`dynamic-collection-schema-service.ts`) - `generateJunctionTable()` emitted a duplicated, orphaned `CONSTRAINT ... UNIQUE(...);` fragment after the `CREATE TABLE` closed. Split on `--> statement-breakpoint`, that orphan is a bare `CONSTRAINT ...);` statement - a syntax error on every dialect - so the junction table was never created.
2. **Target never resolved** (`collection-relationship-service.ts`) - `getTargetCollection()` only read `field.relationTo`; a many-to-many field carries its target on `field.options.target`, so every insert/delete/fetch silently no-op'd.
3. **SQLite insert crash** - the junction insert bound a `Date` into a raw `sql` template; better-sqlite3 rejects Date objects. The SQLite `created_at` column is `integer` epoch-seconds, so it now binds `Math.floor(Date.now()/1000)`.
4. **Phantom parent column** (`field-column-descriptor.ts`) - a many-to-many field classified as `fkSingle`, giving the parent runtime table a column the junction-only physical schema never has (runtime/DB disagreement). It now classifies as `skip`, like component fields.
5. **MySQL result-shape crash** - `selectRawSql` assumed `db.execute()` returns `{ rows }`; `drizzle-orm/mysql2` returns a `[rows, fieldPackets]` tuple, so every junction read crashed on MySQL. Normalized (mirrors `count-helpers.ts`).
6. **`ON CONFLICT` on MySQL** - the junction insert used `ON CONFLICT DO NOTHING`, which MySQL rejects (`ER_PARSE_ERROR`). Now dialect-aware: `ON DUPLICATE KEY UPDATE id = id` on MySQL (scoped to the unique-pair conflict so FK violations still surface, matching PG/SQLite), `ON CONFLICT DO NOTHING` on PG/SQLite.

## Tests

- Unit: `junction-ddl.test.ts` (one valid CREATE TABLE + two CREATE INDEX, no orphan constraint, all dialects) and `field-column-descriptor.m2m.test.ts` (m2m -> skip vs manyToOne -> fk vs hasMany -> json). Both confirmed RED on `main`, GREEN with the fix.
- Integration (create + read + delete a real junction link): **SQLite 3/3, real Postgres 17 1/1, real MySQL 8 1/1**. PG/MySQL gate files self-skip when the dialect URL is unset and drop their fixture tables.
- No new regressions: clean `main` has 4 failing tests in the touched suites; with this change, 3 (the bug-4 test flipped to passing). The remaining 3 are pre-existing baseline (two `manyToMany` auto-rename tests using a `type: "relation"` fixture, one `toggle` test), unrelated to this diff.

## Notes

- The per-row `console.log` debug lines in `insertManyToManyRelations` are pre-existing; now that m2m actually runs, they will emit. Routing them through the injected logger (or removing them) is a reasonable follow-up, left out here to keep this diff focused on correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved many-to-many relationship insertion, fetching, and deletion across SQLite, PostgreSQL, and MySQL.
  * Corrected database-specific SQL behavior for raw queries and duplicate handling.
  * Fixed junction-table SQL generation to avoid invalid/duplicate constraints.
  * Prevented incorrect parent-column generation for many-to-many fields, aligning runtime shape with the junction schema.
* **Tests**
  * Added/expanded cross-database integration and SQL-generation coverage for many-to-many junction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->