### PR TITLE
feat(nextly): commit content writes atomically (m2m + components in one tx)

### DIFF
--- a/.changeset/atomic-content-writes.md
+++ b/.changeset/atomic-content-writes.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Content writes now commit their relationships and component data in the same transaction as the entry.
+
+Creating or updating an entry now writes the entry, its component data, and its many-to-many relationships in a single database transaction. Previously the relationship writes ran after the transaction had already committed, so if they failed the entry was left behind without them; now such a failure rolls the whole write back. Single-document updates likewise write the document and its component data in one transaction, so a component failure no longer leaves a half-updated document.

--- a/packages/adapter-drizzle/src/__tests__/adapter.test.ts
+++ b/packages/adapter-drizzle/src/__tests__/adapter.test.ts
@@ -110,6 +110,9 @@ class MockAdapter extends DrizzleAdapter {
       ): Promise<U> => {
         return this.upsert<U>(table, data, options);
       },
+      // Required by the TransactionContext contract; this mock does not run
+      // Drizzle queries, so return an empty stub.
+      getDrizzle: <U = unknown>(): U => ({}) as U,
     };
 
     return callback(ctx);

--- a/packages/adapter-drizzle/src/types/transaction.ts
+++ b/packages/adapter-drizzle/src/types/transaction.ts
@@ -212,10 +212,11 @@ export interface TransactionContext {
    * Runs Drizzle `sql` templates / fluent queries inside the caller's
    * transaction (same client the delegated CRUD methods use), so services
    * that drop to Drizzle raw SQL (e.g. junction-table writes) can participate
-   * in the transaction instead of running on the pooled connection. Optional
-   * so a minimal adapter still satisfies the contract; all first-party
-   * adapters implement it. Generic return so callers narrow to the dialect
-   * Drizzle type they need without an `any` cast.
+   * in the transaction instead of running on the pooled connection. Required
+   * so callers never silently fall back to the pooled connection (which would
+   * run a write outside the transaction); every adapter must implement it.
+   * Generic return so callers narrow to the dialect Drizzle type they need
+   * without an `any` cast.
    */
-  getDrizzle?<T = unknown>(): T;
+  getDrizzle<T = unknown>(): T;
 }

--- a/packages/adapter-drizzle/src/types/transaction.ts
+++ b/packages/adapter-drizzle/src/types/transaction.ts
@@ -204,4 +204,18 @@ export interface TransactionContext {
    * @param name - Savepoint name
    */
   releaseSavepoint?(name: string): Promise<void>;
+
+  /**
+   * Return the Drizzle ORM instance bound to THIS transaction's connection.
+   *
+   * @remarks
+   * Runs Drizzle `sql` templates / fluent queries inside the caller's
+   * transaction (same client the delegated CRUD methods use), so services
+   * that drop to Drizzle raw SQL (e.g. junction-table writes) can participate
+   * in the transaction instead of running on the pooled connection. Optional
+   * so a minimal adapter still satisfies the contract; all first-party
+   * adapters implement it. Generic return so callers narrow to the dialect
+   * Drizzle type they need without an `any` cast.
+   */
+  getDrizzle?<T = unknown>(): T;
 }

--- a/packages/adapter-mysql/src/index.ts
+++ b/packages/adapter-mysql/src/index.ts
@@ -933,6 +933,12 @@ export class MySqlAdapter extends DrizzleAdapter {
       savepoint: undefined,
       rollbackToSavepoint: undefined,
       releaseSavepoint: undefined,
+
+      // Expose the transaction-bound Drizzle instance so callers can run
+      // Drizzle sql templates inside this transaction (junction-table writes
+      // need this to be atomic with the entry write). Reuses the memoized
+      // txDb() built for the delegated CRUD methods.
+      getDrizzle: <T = unknown>(): T => txDb() as T,
     };
   }
 

--- a/packages/adapter-postgres/src/__tests__/transaction-read-your-writes.integration.test.ts
+++ b/packages/adapter-postgres/src/__tests__/transaction-read-your-writes.integration.test.ts
@@ -5,6 +5,7 @@
 //
 // Self-skips when TEST_POSTGRES_URL is unset.
 
+import { sql } from "drizzle-orm";
 import { pgTable, text } from "drizzle-orm/pg-core";
 import pg from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -97,5 +98,31 @@ describe("PostgreSQL transaction read-your-writes", async () => {
     });
 
     expect(chosen).toEqual(["dup", "dup-2"]);
+  });
+
+  it("getDrizzle() returns a handle bound to the transaction", async () => {
+    // A raw sql insert via the tx-scoped Drizzle handle must be visible to a
+    // read on the SAME handle inside the tx, and must vanish after rollback.
+    const id = "tx-drizzle-1";
+    await expect(
+      adapter.transaction(async tx => {
+        const db = tx.getDrizzle!<{
+          execute: (q: unknown) => Promise<{ rows: unknown[] }>;
+        }>();
+        await db.execute(
+          sql`INSERT INTO ${sql.identifier(TABLE)} (id, slug) VALUES (${id}, ${"tx-drizzle-slug"})`
+        );
+        const seen = await db.execute(
+          sql`SELECT id FROM ${sql.identifier(TABLE)} WHERE id = ${id}`
+        );
+        expect(seen.rows.length).toBe(1); // read-your-writes inside the tx
+        throw new Error("rollback"); // force rollback
+      })
+    ).rejects.toThrow("rollback");
+
+    const after = await adapter.select(TABLE, {
+      where: { and: [{ column: "id", op: "=", value: id }] },
+    });
+    expect(after.length).toBe(0); // rolled back, no row
   });
 });

--- a/packages/adapter-postgres/src/__tests__/transaction-read-your-writes.integration.test.ts
+++ b/packages/adapter-postgres/src/__tests__/transaction-read-your-writes.integration.test.ts
@@ -5,6 +5,9 @@
 //
 // Self-skips when TEST_POSTGRES_URL is unset.
 
+// `sql` builds the tagged-template query run through the transaction-bound
+// Drizzle handle (tx.getDrizzle()); the getDrizzle test below uses it to prove
+// a write on that handle is visible in-transaction and rolls back.
 import { sql } from "drizzle-orm";
 import { pgTable, text } from "drizzle-orm/pg-core";
 import pg from "pg";
@@ -106,7 +109,7 @@ describe("PostgreSQL transaction read-your-writes", async () => {
     const id = "tx-drizzle-1";
     await expect(
       adapter.transaction(async tx => {
-        const db = tx.getDrizzle!<{
+        const db = tx.getDrizzle<{
           execute: (q: unknown) => Promise<{ rows: unknown[] }>;
         }>();
         await db.execute(

--- a/packages/adapter-postgres/src/index.ts
+++ b/packages/adapter-postgres/src/index.ts
@@ -1068,6 +1068,12 @@ export class PostgresAdapter extends DrizzleAdapter {
       releaseSavepoint: async (name: string): Promise<void> => {
         await client.query(`RELEASE SAVEPOINT ${this.escapeIdentifier(name)}`);
       },
+
+      // Expose the transaction-bound Drizzle instance so callers can run
+      // Drizzle sql templates inside this transaction (junction-table writes
+      // need this to be atomic with the entry write). Reuses the memoized
+      // txDb() built for the delegated CRUD methods.
+      getDrizzle: <T = unknown>(): T => txDb() as T,
     };
   }
 

--- a/packages/adapter-sqlite/src/__tests__/adapter.test.ts
+++ b/packages/adapter-sqlite/src/__tests__/adapter.test.ts
@@ -618,9 +618,12 @@ describe("SqliteAdapter", () => {
       const adapter = createSqliteAdapter({ memory: true });
       await adapter.connect();
 
+      // getDrizzle must be exposed from the ACTIVE transaction context so
+      // callers can run Drizzle queries on the transaction's connection rather
+      // than the pool; assert it is present and returns a handle.
       await adapter.transaction(async tx => {
         expect(typeof tx.getDrizzle).toBe("function");
-        const db = tx.getDrizzle!();
+        const db = tx.getDrizzle();
         expect(db).toBeDefined();
       });
     });

--- a/packages/adapter-sqlite/src/__tests__/adapter.test.ts
+++ b/packages/adapter-sqlite/src/__tests__/adapter.test.ts
@@ -614,6 +614,17 @@ describe("SqliteAdapter", () => {
       });
     });
 
+    it("transaction context exposes a bound Drizzle handle", async () => {
+      const adapter = createSqliteAdapter({ memory: true });
+      await adapter.connect();
+
+      await adapter.transaction(async tx => {
+        expect(typeof tx.getDrizzle).toBe("function");
+        const db = tx.getDrizzle!();
+        expect(db).toBeDefined();
+      });
+    });
+
     it("should provide savepoint methods", async () => {
       const adapter = createSqliteAdapter({ memory: true });
       await adapter.connect();

--- a/packages/adapter-sqlite/src/index.ts
+++ b/packages/adapter-sqlite/src/index.ts
@@ -880,6 +880,12 @@ export class SqliteAdapter extends DrizzleAdapter {
       releaseSavepoint: async (name: string): Promise<void> => {
         db.exec(`RELEASE SAVEPOINT ${this.escapeIdentifier(name)}`);
       },
+
+      // Expose the transaction-bound Drizzle instance so callers can run
+      // Drizzle sql templates inside this transaction (junction-table writes
+      // need this to be atomic with the entry write). Reuses the memoized
+      // txDb() built for the delegated CRUD methods.
+      getDrizzle: <T = unknown>(): T => txDb() as T,
     };
   }
 

--- a/packages/nextly/src/domains/collections/services/__tests__/collection-mutation-service.m2m-atomicity-mysql.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/collection-mutation-service.m2m-atomicity-mysql.integration.test.ts
@@ -1,0 +1,178 @@
+/**
+ * MySQL dialect gate for the m2m write-atomicity fix.
+ *
+ * `createTestNextly` (used by collection-mutation-service.m2m-atomicity.
+ * integration.test.ts) always boots on in-memory SQLite by design — it never
+ * reads TEST_MYSQL_URL, so running that suite through
+ * `pnpm test:integration:mysql` still only exercises SQLite. The fix under
+ * test (junction writes moved inside `adapter.transaction(...)`) is
+ * dialect-agnostic application logic, but the only way to be sure the real
+ * MySQL driver honours the same rollback semantics is to drive the full
+ * mutation path against a real server. Follows the repo convention used by
+ * collection-relationship-service-mysql.integration.test.ts: connect via
+ * `TEST_MYSQL_URL`, skip when unreachable, and self-clean the tables/rows it
+ * creates.
+ *
+ * Unlike the relationship-service dialect gates (which call
+ * `CollectionRelationshipService` directly with stub dependencies), this
+ * suite boots the FULL service container (`createTestNextly({ adapter })`)
+ * against the real MySQL connection so `collectionService.createEntry`
+ * exercises the exact same code path as production: hooks, validation,
+ * `CollectionMutationService.createEntry`, and the widened transaction.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createAdapter } from "../../../../database/factory";
+import { clearServices } from "../../../../di/register";
+import { seedBuilderCollection } from "../../../../plugins/__tests__/seed-builder-entity";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../../plugins/test-nextly";
+import type { CollectionService } from "../collection-service";
+
+const MYSQL_URL = process.env.TEST_MYSQL_URL ?? "";
+
+// Fixed, dedicated slugs/tables for this gate — dropped before and after so
+// reruns against the shared test database are idempotent (the sequential
+// integration run, fileParallelism: false, is what makes this safe).
+const TAGS_SLUG = "atomtags";
+const POSTS_SLUG = "atomposts";
+const TAGS_TABLE = `dc_${TAGS_SLUG}`;
+const POSTS_TABLE = `dc_${POSTS_SLUG}`;
+const JUNCTION_TABLE = `${POSTS_TABLE}_${TAGS_TABLE}_tags`;
+
+type TestAdapter = Awaited<ReturnType<typeof createAdapter>>;
+
+async function connectIfAvailable(): Promise<TestAdapter | null> {
+  if (!MYSQL_URL) return null;
+  process.env.DB_DIALECT = "mysql";
+  // env.ts validates DATABASE_URL against DB_DIALECT the first time ANY
+  // env.* property is read in this worker (it caches after that first read),
+  // and createAdapter's pool-defaults layering reads env.DB_POOL_MAX
+  // unconditionally. Passing `url` directly in the createAdapter config
+  // isn't enough to satisfy that validation — DATABASE_URL must also be set
+  // on process.env, or the validation throws regardless of run order.
+  process.env.DATABASE_URL = MYSQL_URL;
+  const adapter = await createAdapter({
+    type: "mysql",
+    url: MYSQL_URL,
+  } as Parameters<typeof createAdapter>[0]);
+  await adapter.executeQuery("SELECT 1");
+  return adapter;
+}
+
+// Dedicated connection used only for raw cleanup queries — kept open across
+// the whole file (unlike the `createTestNextly`-managed connection below,
+// whose `handle.destroy()` disconnects it).
+const cleanupAdapter = await connectIfAvailable();
+const describeMysql = cleanupAdapter ? describe : describe.skip;
+
+/**
+ * Best-effort cleanup so reruns against the shared MySQL test database are
+ * idempotent. Wrapped in try/catch per statement: on a database where this
+ * suite has never run, `dynamic_collections` may not exist yet, which must
+ * not fail the whole cleanup (mirrors the `IF EXISTS` DROP pattern other
+ * dialect gates use for the same reason). Junction dropped first: MySQL
+ * blocks dropping a table still referenced by an FK.
+ */
+async function dropFixtures(): Promise<void> {
+  if (!cleanupAdapter) return;
+  for (const stmt of [
+    `DROP TABLE IF EXISTS ${JUNCTION_TABLE}`,
+    `DROP TABLE IF EXISTS ${POSTS_TABLE}`,
+    `DROP TABLE IF EXISTS ${TAGS_TABLE}`,
+    `DELETE FROM dynamic_collections WHERE slug IN ('${POSTS_SLUG}', '${TAGS_SLUG}')`,
+  ]) {
+    try {
+      await cleanupAdapter.executeQuery(stmt);
+    } catch {
+      // best-effort cleanup — table may not exist yet on a fresh database.
+    }
+  }
+}
+
+beforeAll(async () => {
+  await dropFixtures();
+});
+
+afterAll(async () => {
+  await dropFixtures();
+  if (cleanupAdapter) await cleanupAdapter.disconnect();
+});
+
+describeMysql(
+  "CollectionMutationService m2m write atomicity (MySQL dialect gate)",
+  () => {
+    it("createEntry rolls back the entry when the junction insert fails, on real MySQL", async () => {
+      // Second, independent connection to the same database, dedicated to
+      // the full-service boot — `handle.destroy()` disconnects it, leaving
+      // `cleanupAdapter` (used by beforeAll/afterAll) untouched.
+      const bootAdapter = await createAdapter({
+        type: "mysql",
+        url: MYSQL_URL,
+      } as Parameters<typeof createAdapter>[0]);
+
+      let handle: TestNextly | undefined;
+      try {
+        // First boot creates the system tables (dynamic_collections, etc.).
+        handle = await createTestNextly({ adapter: bootAdapter });
+
+        await seedBuilderCollection(bootAdapter, {
+          slug: TAGS_SLUG,
+          fields: [{ name: "name", type: "text" }],
+        });
+        await seedBuilderCollection(bootAdapter, {
+          slug: POSTS_SLUG,
+          fields: [
+            { name: "title", type: "text" },
+            {
+              name: "tags",
+              type: "relationship",
+              options: { relationType: "manyToMany", target: TAGS_SLUG },
+            },
+          ],
+        });
+
+        // Reset DI without disconnecting, then reboot on the SAME adapter so
+        // `collectionService` resolves the just-seeded collections.
+        clearServices();
+        handle = await createTestNextly({ adapter: bootAdapter });
+
+        const collections = handle.getService(
+          "collectionService"
+        ) as CollectionService;
+
+        const tagId = "mysql-atom-tag-1";
+        // NOW() (not an epoch literal) — this row is read by real MySQL,
+        // whose timestamp columns need a proper timestamp value, unlike the
+        // SQLite suite's epoch-seconds integer literal.
+        await bootAdapter.executeQuery(
+          `INSERT INTO ${TAGS_TABLE} (id, title, slug, name, created_at, updated_at) VALUES ('${tagId}', 'JavaScript', 'javascript', 'javascript', NOW(), NOW())`
+        );
+
+        // Drop the junction table so insertManyToManyRelations throws from
+        // inside the entry's transaction.
+        await bootAdapter.executeQuery(`DROP TABLE ${JUNCTION_TABLE}`);
+
+        await expect(
+          collections.createEntry(
+            POSTS_SLUG,
+            { title: "Hello", tags: [tagId] },
+            { overrideAccess: true }
+          )
+        ).rejects.toThrow();
+
+        // Pre-fix, the junction write ran AFTER the entry's transaction
+        // committed, so the entry would survive here. Post-fix, the junction
+        // write is inside the transaction, so the entry never lands.
+        const rows = await bootAdapter.executeQuery<{ id: string }>(
+          `SELECT id FROM ${POSTS_TABLE}`
+        );
+        expect(rows).toHaveLength(0);
+      } finally {
+        await handle?.destroy();
+      }
+    });
+  }
+);

--- a/packages/nextly/src/domains/collections/services/__tests__/collection-mutation-service.m2m-atomicity-pg.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/collection-mutation-service.m2m-atomicity-pg.integration.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Postgres dialect gate for the m2m write-atomicity fix.
+ *
+ * `createTestNextly` (used by collection-mutation-service.m2m-atomicity.
+ * integration.test.ts) always boots on in-memory SQLite by design — it never
+ * reads TEST_POSTGRES_URL, so running that suite through
+ * `pnpm test:integration:postgres17` still only exercises SQLite. The fix
+ * under test (junction writes moved inside `adapter.transaction(...)`) is
+ * dialect-agnostic application logic, but the only way to be sure the real
+ * Postgres driver honours the same rollback semantics is to drive the full
+ * mutation path against a real server. Follows the repo convention used by
+ * collection-relationship-service-pg.integration.test.ts: connect via
+ * `TEST_POSTGRES_URL`, skip when unreachable, and self-clean the tables/rows
+ * it creates.
+ *
+ * Unlike the relationship-service dialect gates (which call
+ * `CollectionRelationshipService` directly with stub dependencies), this
+ * suite boots the FULL service container (`createTestNextly({ adapter })`)
+ * against the real Postgres connection so `collectionService.createEntry`
+ * exercises the exact same code path as production: hooks, validation,
+ * `CollectionMutationService.createEntry`, and the widened transaction.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createAdapter } from "../../../../database/factory";
+import { clearServices } from "../../../../di/register";
+import { seedBuilderCollection } from "../../../../plugins/__tests__/seed-builder-entity";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../../plugins/test-nextly";
+import type { CollectionService } from "../collection-service";
+
+// Skip ONLY when the Postgres-specific URL is unset; do not fall back to a
+// generic URL, or this gate could silently run against a non-Postgres database.
+const PG_URL = process.env.TEST_POSTGRES_URL ?? "";
+
+// Fixed, dedicated slugs/tables for this gate — dropped before and after so
+// reruns against the shared test database are idempotent (the sequential
+// integration run, fileParallelism: false, is what makes this safe).
+const TAGS_SLUG = "atomtags";
+const POSTS_SLUG = "atomposts";
+const TAGS_TABLE = `dc_${TAGS_SLUG}`;
+const POSTS_TABLE = `dc_${POSTS_SLUG}`;
+const JUNCTION_TABLE = `${POSTS_TABLE}_${TAGS_TABLE}_tags`;
+
+type TestAdapter = Awaited<ReturnType<typeof createAdapter>>;
+
+async function connectIfAvailable(): Promise<TestAdapter | null> {
+  if (!PG_URL) return null;
+  process.env.DB_DIALECT = "postgresql";
+  // env.ts validates DATABASE_URL against DB_DIALECT the first time ANY
+  // env.* property is read in this worker (it caches after that first read),
+  // and createAdapter's pool-defaults layering reads env.DB_POOL_MAX
+  // unconditionally. Passing `url` directly in the createAdapter config
+  // isn't enough to satisfy that validation — DATABASE_URL must also be set
+  // on process.env, or the validation throws regardless of run order.
+  process.env.DATABASE_URL = PG_URL;
+  const adapter = await createAdapter({
+    type: "postgresql",
+    url: PG_URL,
+  } as Parameters<typeof createAdapter>[0]);
+  await adapter.executeQuery("SELECT 1");
+  return adapter;
+}
+
+// Dedicated connection used only for raw cleanup queries — kept open across
+// the whole file (unlike the `createTestNextly`-managed connection below,
+// whose `handle.destroy()` disconnects it).
+const cleanupAdapter = await connectIfAvailable();
+const describePg = cleanupAdapter ? describe : describe.skip;
+
+/**
+ * Best-effort cleanup so reruns against the shared Postgres test database
+ * are idempotent. Wrapped in try/catch per statement: on a database where
+ * this suite has never run, `dynamic_collections` may not exist yet, which
+ * must not fail the whole cleanup (mirrors the `IF EXISTS` DROP pattern
+ * other dialect gates use for the same reason).
+ */
+async function dropFixtures(): Promise<void> {
+  if (!cleanupAdapter) return;
+  for (const stmt of [
+    `DROP TABLE IF EXISTS ${JUNCTION_TABLE} CASCADE`,
+    `DROP TABLE IF EXISTS ${POSTS_TABLE} CASCADE`,
+    `DROP TABLE IF EXISTS ${TAGS_TABLE} CASCADE`,
+    `DELETE FROM dynamic_collections WHERE slug IN ('${POSTS_SLUG}', '${TAGS_SLUG}')`,
+  ]) {
+    try {
+      await cleanupAdapter.executeQuery(stmt);
+    } catch {
+      // best-effort cleanup — table may not exist yet on a fresh database.
+    }
+  }
+}
+
+beforeAll(async () => {
+  await dropFixtures();
+});
+
+afterAll(async () => {
+  await dropFixtures();
+  if (cleanupAdapter) await cleanupAdapter.disconnect();
+});
+
+describePg(
+  "CollectionMutationService m2m write atomicity (Postgres dialect gate)",
+  () => {
+    it("createEntry rolls back the entry when the junction insert fails, on real Postgres", async () => {
+      // Second, independent connection to the same database, dedicated to
+      // the full-service boot — `handle.destroy()` disconnects it, leaving
+      // `cleanupAdapter` (used by beforeAll/afterAll) untouched.
+      const bootAdapter = await createAdapter({
+        type: "postgresql",
+        url: PG_URL,
+      } as Parameters<typeof createAdapter>[0]);
+
+      let handle: TestNextly | undefined;
+      try {
+        // First boot creates the system tables (dynamic_collections, etc.).
+        handle = await createTestNextly({ adapter: bootAdapter });
+
+        await seedBuilderCollection(bootAdapter, {
+          slug: TAGS_SLUG,
+          fields: [{ name: "name", type: "text" }],
+        });
+        await seedBuilderCollection(bootAdapter, {
+          slug: POSTS_SLUG,
+          fields: [
+            { name: "title", type: "text" },
+            {
+              name: "tags",
+              type: "relationship",
+              options: { relationType: "manyToMany", target: TAGS_SLUG },
+            },
+          ],
+        });
+
+        // Reset DI without disconnecting, then reboot on the SAME adapter so
+        // `collectionService` resolves the just-seeded collections.
+        clearServices();
+        handle = await createTestNextly({ adapter: bootAdapter });
+
+        const collections = handle.getService(
+          "collectionService"
+        ) as CollectionService;
+
+        const tagId = "pg-atom-tag-1";
+        // NOW() (not an epoch literal) — this row is read by real Postgres,
+        // whose timestamp columns need a proper timestamp value, unlike the
+        // SQLite suite's epoch-seconds integer literal.
+        await bootAdapter.executeQuery(
+          `INSERT INTO ${TAGS_TABLE} (id, title, slug, name, created_at, updated_at) VALUES ('${tagId}', 'JavaScript', 'javascript', 'javascript', NOW(), NOW())`
+        );
+
+        // Drop the junction table so insertManyToManyRelations throws from
+        // inside the entry's transaction.
+        await bootAdapter.executeQuery(`DROP TABLE ${JUNCTION_TABLE}`);
+
+        await expect(
+          collections.createEntry(
+            POSTS_SLUG,
+            { title: "Hello", tags: [tagId] },
+            { overrideAccess: true }
+          )
+        ).rejects.toThrow();
+
+        // Pre-fix, the junction write ran AFTER the entry's transaction
+        // committed, so the entry would survive here. Post-fix, the junction
+        // write is inside the transaction, so the entry never lands.
+        const rows = await bootAdapter.executeQuery<{ id: string }>(
+          `SELECT id FROM ${POSTS_TABLE}`
+        );
+        expect(rows).toHaveLength(0);
+      } finally {
+        await handle?.destroy();
+      }
+    });
+  }
+);

--- a/packages/nextly/src/domains/collections/services/__tests__/collection-mutation-service.m2m-atomicity.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/collection-mutation-service.m2m-atomicity.integration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Proof that a many-to-many junction write failure rolls back the entry.
+ *
+ * `CollectionMutationService.createEntry`/`updateEntry` used to write the
+ * junction rows AFTER `adapter.transaction(...)` committed the entry (on the
+ * pool, not the transaction's connection) — a junction failure left an
+ * orphaned entry (create) or a committed scalar change with no way to undo it
+ * (update). The fix moves the junction write inside the same transaction,
+ * passing `tx.getDrizzle?.<RelationshipDbExecutor>()` down to
+ * `insertManyToManyRelations`/`deleteManyToManyRelations` so a junction
+ * failure aborts the whole transaction.
+ *
+ * Code-first collections cannot express many-to-many (the typed
+ * `relationship()` helper only supports `hasMany`), so this suite builds a
+ * REAL junction table via `seedBuilderCollection` (the Schema-Builder path),
+ * mirroring the setup in collection-relationship-service.m2m.integration.test.ts:
+ * seed `tags` then `posts` (with a raw m2m FieldDefinition) on a first boot,
+ * reset DI without disconnecting the adapter, then reboot on the SAME adapter
+ * so `collectionService` resolves against the seeded collections.
+ *
+ * Failure injection: after seeding, `DROP TABLE dc_posts_dc_tags_tags` so any
+ * subsequent `insertManyToManyRelations`/`deleteManyToManyRelations` call
+ * throws "junction does not exist" from inside the widened transaction.
+ *
+ * This drives the mutation path through `getService("collectionService")`
+ * (not `relationshipService` directly) because `CollectionService.createEntry`/
+ * `updateEntry` throw a `NextlyError` on failure (unlike the lower-level
+ * `CollectionMutationService`, which returns `{ success: false }`), giving a
+ * clean `rejects.toThrow()` assertion while still exercising the exact
+ * product code under test (`CollectionService` → `CollectionEntryService` →
+ * `CollectionMutationService`).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { clearServices } from "../../../../di/register";
+import { seedBuilderCollection } from "../../../../plugins/__tests__/seed-builder-entity";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../../plugins/test-nextly";
+import type { CollectionService } from "../collection-service";
+
+let handle: TestNextly | undefined;
+
+afterEach(async () => {
+  await handle?.destroy();
+  handle = undefined;
+});
+
+/**
+ * Recipe: seed the target collection (`tags`) then the source collection
+ * (`posts`, carrying the m2m field) on a first boot — seeding emits the real
+ * junction table DDL (`dc_posts_dc_tags_tags`). Reset DI without disconnecting
+ * the in-memory adapter, then reboot on the SAME adapter so `collectionService`
+ * resolves against the seeded collections (mirrors the relationship-service
+ * m2m suite's setup).
+ */
+async function seedTagsAndPosts(): Promise<{
+  collections: CollectionService;
+  tagId: string;
+}> {
+  handle = await createTestNextly({});
+  const adapter = handle.adapter;
+
+  await seedBuilderCollection(adapter, {
+    slug: "tags",
+    fields: [{ name: "name", type: "text" }],
+  });
+  await seedBuilderCollection(adapter, {
+    slug: "posts",
+    fields: [
+      { name: "title", type: "text" },
+      {
+        name: "tags",
+        type: "relationship",
+        options: { relationType: "manyToMany", target: "tags" },
+      },
+    ],
+  });
+
+  clearServices();
+  handle = await createTestNextly({ adapter });
+
+  const collections = handle.getService(
+    "collectionService"
+  ) as CollectionService;
+
+  const tagId = "tag-1";
+  // Raw SQL, not adapter.insert(): matches the seeding convention in the
+  // sibling relationship-service m2m suite (no typed column path exists for
+  // a manyToMany field's junction target row).
+  const nowEpoch = Math.floor(Date.now() / 1000);
+  await adapter.executeQuery(
+    `INSERT INTO dc_tags (id, title, slug, name, created_at, updated_at) VALUES ('${tagId}', 'JavaScript', 'javascript', 'javascript', ${nowEpoch}, ${nowEpoch})`
+  );
+
+  return { collections, tagId };
+}
+
+describe("CollectionMutationService m2m write atomicity (integration)", () => {
+  it("createEntry rolls back the entry when the junction insert fails", async () => {
+    const { collections, tagId } = await seedTagsAndPosts();
+    const adapter = handle!.adapter;
+
+    // Drop the junction table so insertManyToManyRelations throws from
+    // inside the entry's transaction.
+    await adapter.executeQuery(`DROP TABLE "dc_posts_dc_tags_tags"`);
+
+    await expect(
+      collections.createEntry(
+        "posts",
+        { title: "Hello", tags: [tagId] },
+        { overrideAccess: true }
+      )
+    ).rejects.toThrow();
+
+    // Pre-fix, the junction write ran AFTER the entry's transaction
+    // committed, so the entry would survive here. Post-fix, the junction
+    // write is inside the transaction, so the entry never lands.
+    const rows = await adapter.executeQuery<{ id: string }>(
+      `SELECT id FROM dc_posts`
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it("updateEntry rolls back the scalar change when the junction write fails", async () => {
+    const { collections, tagId } = await seedTagsAndPosts();
+    const adapter = handle!.adapter;
+
+    // Create successfully first (junction intact) so there is a real,
+    // persisted entry to attempt the update against.
+    const created = (await collections.createEntry(
+      "posts",
+      { title: "Original", tags: [tagId] },
+      { overrideAccess: true }
+    )) as { id: string };
+    const postId = created.id;
+
+    // Now break the junction for the update attempt.
+    await adapter.executeQuery(`DROP TABLE "dc_posts_dc_tags_tags"`);
+
+    await expect(
+      collections.updateEntry(
+        "posts",
+        postId,
+        { title: "Changed", tags: [] },
+        { overrideAccess: true }
+      )
+    ).rejects.toThrow();
+
+    // Pre-fix, the scalar UPDATE committed on its own transaction before the
+    // (pool-level) junction delete ran, so the title would have changed here.
+    // Post-fix, the scalar UPDATE and the junction delete share one
+    // transaction, so a junction failure rolls the title back too.
+    const rows = await adapter.executeQuery<{ title: string }>(
+      `SELECT title FROM dc_posts WHERE id = '${postId}'`
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].title).toBe("Original");
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -36,7 +36,10 @@ import { emitDocumentEvent } from "../../../events/domain-events";
 import { getEventBus } from "../../../events/event-bus";
 import { toSnakeCase } from "../../../lib/case-conversion";
 import type { CollectionFileManager } from "../../../services/collection-file-manager";
-import type { CollectionRelationshipService } from "../../../services/collections/collection-relationship-service";
+import type {
+  CollectionRelationshipService,
+  RelationshipDbExecutor,
+} from "../../../services/collections/collection-relationship-service";
 import type { ComponentDataService } from "../../../services/components/component-data-service";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
@@ -901,20 +904,24 @@ export class CollectionMutationService extends BaseService {
             data: componentFieldData,
           });
         }
-      });
 
-      // Handle many-to-many relationships (uses its own DB reference, outside transaction)
-      for (const field of manyToManyFields) {
-        const relatedIds = manyToManyData[field.name];
-        if (relatedIds && relatedIds.length > 0) {
-          await this.relationshipService.insertManyToManyRelations(
-            params.collectionName,
-            entry.id as string,
-            field,
-            relatedIds
-          );
+        // Write many-to-many junction rows inside the transaction so a junction
+        // failure rolls back the entry (atomic write). The tx-scoped Drizzle
+        // handle binds the junction writes to this transaction's connection.
+        const txExecutor = tx.getDrizzle?.<RelationshipDbExecutor>();
+        for (const field of manyToManyFields) {
+          const relatedIds = manyToManyData[field.name];
+          if (relatedIds && relatedIds.length > 0) {
+            await this.relationshipService.insertManyToManyRelations(
+              params.collectionName,
+              entry.id as string,
+              field,
+              relatedIds,
+              txExecutor
+            );
+          }
         }
-      }
+      });
 
       // Execute afterCreate hooks (code-registered)
       // Hooks run after database insert completes (for side effects)
@@ -1498,6 +1505,32 @@ export class CollectionMutationService extends BaseService {
             data: componentFieldData,
           });
         }
+
+        // Replace many-to-many junction rows inside the transaction so a
+        // junction failure rolls back the update (atomic write). The entry is
+        // already known to exist (validated before the transaction). The
+        // tx-scoped Drizzle handle binds the junction writes to this tx.
+        const txExecutor = tx.getDrizzle?.<RelationshipDbExecutor>();
+        for (const field of manyToManyFields) {
+          if (manyToManyData[field.name] !== undefined) {
+            await this.relationshipService.deleteManyToManyRelations(
+              params.collectionName,
+              params.entryId,
+              field,
+              txExecutor
+            );
+            const relatedIds = manyToManyData[field.name];
+            if (relatedIds.length > 0) {
+              await this.relationshipService.insertManyToManyRelations(
+                params.collectionName,
+                params.entryId,
+                field,
+                relatedIds,
+                txExecutor
+              );
+            }
+          }
+        }
       });
 
       // Fetch the updated entry to return it and use in hooks
@@ -1514,29 +1547,6 @@ export class CollectionMutationService extends BaseService {
           message: "Entry not found",
           data: null,
         };
-      }
-
-      // Handle many-to-many relationships (replace existing relations; outside transaction)
-      for (const field of manyToManyFields) {
-        if (manyToManyData[field.name] !== undefined) {
-          // Delete existing relations
-          await this.relationshipService.deleteManyToManyRelations(
-            params.collectionName,
-            params.entryId,
-            field
-          );
-
-          // Insert new relations
-          const relatedIds = manyToManyData[field.name];
-          if (relatedIds.length > 0) {
-            await this.relationshipService.insertManyToManyRelations(
-              params.collectionName,
-              params.entryId,
-              field,
-              relatedIds
-            );
-          }
-        }
       }
 
       // Execute afterUpdate hooks (code-registered)
@@ -2139,7 +2149,9 @@ export class CollectionMutationService extends BaseService {
         returning: "*",
       });
 
-      // Handle many-to-many relationships
+      // Handle many-to-many relationships on the caller's transaction so the
+      // junction writes commit atomically with the entry.
+      const txExecutor = tx.getDrizzle?.<RelationshipDbExecutor>();
       for (const field of manyToManyFields) {
         const relatedIds = manyToManyData[field.name];
         if (relatedIds && relatedIds.length > 0) {
@@ -2147,7 +2159,8 @@ export class CollectionMutationService extends BaseService {
             params.collectionName,
             (entry as Record<string, unknown>).id as string,
             field,
-            relatedIds
+            relatedIds,
+            txExecutor
           );
         }
       }
@@ -2482,13 +2495,16 @@ export class CollectionMutationService extends BaseService {
         };
       }
 
-      // Handle many-to-many relationships
+      // Handle many-to-many relationships on the caller's transaction so the
+      // junction writes commit atomically with the update.
+      const txExecutor = tx.getDrizzle?.<RelationshipDbExecutor>();
       for (const field of manyToManyFields) {
         if (manyToManyData[field.name] !== undefined) {
           await this.relationshipService.deleteManyToManyRelations(
             params.collectionName,
             params.entryId,
-            field
+            field,
+            txExecutor
           );
 
           const relatedIds = manyToManyData[field.name];
@@ -2497,7 +2513,8 @@ export class CollectionMutationService extends BaseService {
               params.collectionName,
               params.entryId,
               field,
-              relatedIds
+              relatedIds,
+              txExecutor
             );
           }
         }
@@ -3008,7 +3025,9 @@ export class CollectionMutationService extends BaseService {
         returning: "*",
       });
 
-      // Handle many-to-many relationships
+      // Handle many-to-many relationships on the caller's transaction so the
+      // junction writes commit atomically with the entry.
+      const txExecutor = tx.getDrizzle?.<RelationshipDbExecutor>();
       for (const field of manyToManyFields) {
         const relatedIds = manyToManyData[field.name];
         if (relatedIds && relatedIds.length > 0) {
@@ -3016,7 +3035,8 @@ export class CollectionMutationService extends BaseService {
             params.collectionName,
             (entry as Record<string, unknown>).id as string,
             field,
-            relatedIds
+            relatedIds,
+            txExecutor
           );
         }
       }
@@ -3404,14 +3424,17 @@ export class CollectionMutationService extends BaseService {
         };
       }
 
-      // Handle many-to-many relationships (replace existing relations)
+      // Handle many-to-many relationships on the caller's transaction so the
+      // junction writes commit atomically with the update.
+      const txExecutor = tx.getDrizzle?.<RelationshipDbExecutor>();
       for (const field of manyToManyFields) {
         if (manyToManyData[field.name] !== undefined) {
           // Delete existing relations
           await this.relationshipService.deleteManyToManyRelations(
             params.collectionName,
             entryId,
-            field
+            field,
+            txExecutor
           );
 
           // Insert new relations
@@ -3421,7 +3444,8 @@ export class CollectionMutationService extends BaseService {
               params.collectionName,
               entryId,
               field,
-              relatedIds
+              relatedIds,
+              txExecutor
             );
           }
         }

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -908,7 +908,7 @@ export class CollectionMutationService extends BaseService {
         // Write many-to-many junction rows inside the transaction so a junction
         // failure rolls back the entry (atomic write). The tx-scoped Drizzle
         // handle binds the junction writes to this transaction's connection.
-        const txExecutor = tx.getDrizzle?.<RelationshipDbExecutor>();
+        const txExecutor = tx.getDrizzle<RelationshipDbExecutor>();
         for (const field of manyToManyFields) {
           const relatedIds = manyToManyData[field.name];
           if (relatedIds && relatedIds.length > 0) {
@@ -1510,7 +1510,7 @@ export class CollectionMutationService extends BaseService {
         // junction failure rolls back the update (atomic write). The entry is
         // already known to exist (validated before the transaction). The
         // tx-scoped Drizzle handle binds the junction writes to this tx.
-        const txExecutor = tx.getDrizzle?.<RelationshipDbExecutor>();
+        const txExecutor = tx.getDrizzle<RelationshipDbExecutor>();
         for (const field of manyToManyFields) {
           if (manyToManyData[field.name] !== undefined) {
             await this.relationshipService.deleteManyToManyRelations(
@@ -2151,7 +2151,7 @@ export class CollectionMutationService extends BaseService {
 
       // Handle many-to-many relationships on the caller's transaction so the
       // junction writes commit atomically with the entry.
-      const txExecutor = tx.getDrizzle?.<RelationshipDbExecutor>();
+      const txExecutor = tx.getDrizzle<RelationshipDbExecutor>();
       for (const field of manyToManyFields) {
         const relatedIds = manyToManyData[field.name];
         if (relatedIds && relatedIds.length > 0) {
@@ -2497,7 +2497,7 @@ export class CollectionMutationService extends BaseService {
 
       // Handle many-to-many relationships on the caller's transaction so the
       // junction writes commit atomically with the update.
-      const txExecutor = tx.getDrizzle?.<RelationshipDbExecutor>();
+      const txExecutor = tx.getDrizzle<RelationshipDbExecutor>();
       for (const field of manyToManyFields) {
         if (manyToManyData[field.name] !== undefined) {
           await this.relationshipService.deleteManyToManyRelations(
@@ -3027,7 +3027,7 @@ export class CollectionMutationService extends BaseService {
 
       // Handle many-to-many relationships on the caller's transaction so the
       // junction writes commit atomically with the entry.
-      const txExecutor = tx.getDrizzle?.<RelationshipDbExecutor>();
+      const txExecutor = tx.getDrizzle<RelationshipDbExecutor>();
       for (const field of manyToManyFields) {
         const relatedIds = manyToManyData[field.name];
         if (relatedIds && relatedIds.length > 0) {
@@ -3426,7 +3426,7 @@ export class CollectionMutationService extends BaseService {
 
       // Handle many-to-many relationships on the caller's transaction so the
       // junction writes commit atomically with the update.
-      const txExecutor = tx.getDrizzle?.<RelationshipDbExecutor>();
+      const txExecutor = tx.getDrizzle<RelationshipDbExecutor>();
       for (const field of manyToManyFields) {
         if (manyToManyData[field.name] !== undefined) {
           // Delete existing relations

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -555,6 +555,17 @@ function normalizeToIdArray(value: unknown): string[] {
  * const expanded = await relationshipService.expandRelationships(entry, 'posts', fields);
  * ```
  */
+// The minimal raw-SQL surface the junction-table code needs from a database
+// handle. Both the pooled `this.db` and a transaction-scoped Drizzle instance
+// (from `tx.getDrizzle()`) satisfy it, so junction writes can run either on the
+// pool (default) or inside a caller's transaction (when an executor is passed),
+// keeping the junction write atomic with the entry write.
+export type RelationshipDbExecutor = {
+  all(query: unknown): unknown[];
+  run(query: unknown): unknown;
+  execute(query: unknown): Promise<unknown>;
+};
+
 export class CollectionRelationshipService extends BaseService {
   constructor(
     adapter: DrizzleAdapter,
@@ -580,12 +591,16 @@ export class CollectionRelationshipService extends BaseService {
    * `.rows` off the tuple yields undefined). The MySQL normalization mirrors
    * the defensive handling in schema/pipeline/classifier/count-helpers.ts.
    */
-  private async selectRawSql(query: unknown): Promise<{ rows: unknown[] }> {
+  private async selectRawSql(
+    query: unknown,
+    // Run on the caller's transaction handle when provided, else the pool.
+    db: RelationshipDbExecutor = this.db
+  ): Promise<{ rows: unknown[] }> {
     if (this.dialect === "sqlite") {
-      const rows = this.db.all(query) as unknown[];
+      const rows = db.all(query);
       return { rows };
     }
-    const result: unknown = await this.db.execute(query);
+    const result: unknown = await db.execute(query);
     if (this.dialect === "mysql" && Array.isArray(result)) {
       // Tuple form `[rows, fieldPackets]` -> take rows; a flat rows array (first
       // element is a row object, not an array) is already the rows.
@@ -598,14 +613,18 @@ export class CollectionRelationshipService extends BaseService {
   /**
    * Run an INSERT / UPDATE / DELETE / DDL raw SQL tag, dialect-aware.
    * Same rationale as `selectRawSql`. Returns void since callers don't
-   * inspect the mutation result here.
+   * inspect the mutation result here. Accepts an optional handle for the same
+   * reason as `selectRawSql` (defaults to the pool).
    */
-  private async mutateRawSql(query: unknown): Promise<void> {
+  private async mutateRawSql(
+    query: unknown,
+    db: RelationshipDbExecutor = this.db
+  ): Promise<void> {
     if (this.dialect === "sqlite") {
-      this.db.run(query);
+      db.run(query);
       return;
     }
-    await this.db.execute(query);
+    await db.execute(query);
   }
 
   /**
@@ -1837,12 +1856,17 @@ export class CollectionRelationshipService extends BaseService {
    * @param sourceEntryId - ID of the source entry
    * @param field - Field definition
    * @param relatedIds - Array of related entry IDs to link
+   * @param executor - Optional transaction-scoped Drizzle handle (from
+   *   `tx.getDrizzle()`); when provided, the junction existence check and
+   *   inserts run inside the caller's transaction so they commit atomically
+   *   with the entry write instead of always hitting the pool.
    */
   async insertManyToManyRelations(
     sourceCollectionName: string,
     sourceEntryId: string,
     field: FieldDefinition,
-    relatedIds: string[]
+    relatedIds: string[],
+    executor?: RelationshipDbExecutor
   ): Promise<void> {
     if (relatedIds.length === 0) return;
 
@@ -1901,7 +1925,7 @@ export class CollectionRelationshipService extends BaseService {
           ) as table_exists
         `;
       }
-      const result = (await this.selectRawSql(checkQuery)) as {
+      const result = (await this.selectRawSql(checkQuery, executor)) as {
         rows: Array<{ table_exists: boolean | number }>;
       };
       const exists = Boolean(result.rows[0]?.table_exists);
@@ -1961,7 +1985,7 @@ export class CollectionRelationshipService extends BaseService {
         `;
 
         console.log(`[ManyToMany] Executing insert for targetId: ${targetId}`);
-        await this.mutateRawSql(query);
+        await this.mutateRawSql(query, executor);
         console.log(
           `[ManyToMany] ✓ Insert successful for targetId: ${targetId}`
         );
@@ -1995,11 +2019,15 @@ export class CollectionRelationshipService extends BaseService {
    * @param sourceCollectionName - Name of the source collection
    * @param sourceEntryId - ID of the source entry
    * @param field - Field definition
+   * @param executor - Optional transaction-scoped Drizzle handle; when
+   *   provided, the delete runs inside the caller's transaction instead of the
+   *   pool (see `insertManyToManyRelations` for the rationale).
    */
   async deleteManyToManyRelations(
     sourceCollectionName: string,
     sourceEntryId: string,
-    field: FieldDefinition
+    field: FieldDefinition,
+    executor?: RelationshipDbExecutor
   ): Promise<void> {
     // Same dual-aware target lookup as fetchManyToManyRelationsBatch above.
     // See that comment for the code-first vs UI-built shape rationale.
@@ -2022,7 +2050,7 @@ export class CollectionRelationshipService extends BaseService {
       WHERE ${sourceIdCol} = ${sourceEntryId}
     `;
 
-    await this.mutateRawSql(query);
+    await this.mutateRawSql(query, executor);
   }
 
   /**

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -560,10 +560,15 @@ function normalizeToIdArray(value: unknown): string[] {
 // (from `tx.getDrizzle()`) satisfy it, so junction writes can run either on the
 // pool (default) or inside a caller's transaction (when an executor is passed),
 // keeping the junction write atomic with the entry write.
+// Each method is optional because a given dialect's Drizzle handle exposes only
+// a subset: SQLite's better-sqlite3 handle has `all`/`run` (no `execute`),
+// while the Postgres/MySQL handles have `execute` (no `all`/`run`). The
+// junction raw-SQL helpers below are dialect-gated, so the method they call is
+// always present for the current dialect.
 export type RelationshipDbExecutor = {
-  all(query: unknown): unknown[];
-  run(query: unknown): unknown;
-  execute(query: unknown): Promise<unknown>;
+  all?(query: unknown): unknown[];
+  run?(query: unknown): unknown;
+  execute?(query: unknown): Promise<unknown>;
 };
 
 export class CollectionRelationshipService extends BaseService {
@@ -597,10 +602,12 @@ export class CollectionRelationshipService extends BaseService {
     db: RelationshipDbExecutor = this.db
   ): Promise<{ rows: unknown[] }> {
     if (this.dialect === "sqlite") {
-      const rows = db.all(query);
+      // SQLite's handle exposes all(); the dialect gate guarantees it here.
+      const rows = db.all!(query);
       return { rows };
     }
-    const result: unknown = await db.execute(query);
+    // Postgres/MySQL handles expose execute().
+    const result: unknown = await db.execute!(query);
     if (this.dialect === "mysql" && Array.isArray(result)) {
       // Tuple form `[rows, fieldPackets]` -> take rows; a flat rows array (first
       // element is a row object, not an array) is already the rows.
@@ -621,10 +628,12 @@ export class CollectionRelationshipService extends BaseService {
     db: RelationshipDbExecutor = this.db
   ): Promise<void> {
     if (this.dialect === "sqlite") {
-      db.run(query);
+      // SQLite's handle exposes run(); the dialect gate guarantees it here.
+      db.run!(query);
       return;
     }
-    await db.execute(query);
+    // Postgres/MySQL handles expose execute().
+    await db.execute!(query);
   }
 
   /**
@@ -1946,69 +1955,43 @@ export class CollectionRelationshipService extends BaseService {
     const sourceIdCol = sql.identifier(sourceCollectionName + "_id");
     const targetIdCol = sql.identifier(targetCollectionName + "_id");
 
-    // Track errors
-    const errors: string[] = [];
-
-    // Insert each relationship individually for reliability
-    // Modern databases handle this efficiently with proper indexes
+    // Insert each relationship. A genuine failure (for example a foreign-key
+    // violation from a bad target id) is allowed to propagate: junction writes
+    // run inside the caller's transaction via `executor`, so throwing rolls the
+    // whole write back instead of committing a partial set of junction rows.
+    // Duplicate (source,target) pairs never throw here (the dialect conflict
+    // clause below ignores them).
     for (const targetId of relatedIds) {
-      try {
-        const id = this.collectionService.generateId();
-        // This raw sql`` template binds straight to the driver, bypassing
-        // Drizzle's per-column serialization. better-sqlite3 only accepts
-        // numbers/strings/bigints/buffers/null, so a Date throws; the junction
-        // created_at column is `integer` epoch-seconds on SQLite (see
-        // generateJunctionTable), so bind that. PG/MySQL drivers accept a Date.
-        const createdAt =
-          this.dialect === "sqlite"
-            ? Math.floor(Date.now() / 1000)
-            : new Date();
+      const id = this.collectionService.generateId();
+      // This raw sql`` template binds straight to the driver, bypassing
+      // Drizzle's per-column serialization. better-sqlite3 only accepts
+      // numbers/strings/bigints/buffers/null, so a Date throws; the junction
+      // created_at column is `integer` epoch-seconds on SQLite (see
+      // generateJunctionTable), so bind that. PG/MySQL drivers accept a Date.
+      const createdAt =
+        this.dialect === "sqlite" ? Math.floor(Date.now() / 1000) : new Date();
 
-        // "Insert, ignore an existing (source,target) pair" is spelled
-        // differently per dialect: MySQL has no ON CONFLICT (it errors with
-        // ER_PARSE_ERROR). Use ON DUPLICATE KEY UPDATE with a no-op assignment
-        // rather than INSERT IGNORE, so only a duplicate-key conflict is
-        // swallowed while other errors (e.g. a foreign-key violation from a
-        // bad target id) still surface, matching the Postgres/SQLite
-        // ON CONFLICT DO NOTHING behaviour against the unique pair index.
-        const idCol = sql.identifier("id");
-        const conflictClause =
-          this.dialect === "mysql"
-            ? sql`ON DUPLICATE KEY UPDATE ${idCol} = ${idCol}`
-            : sql`ON CONFLICT DO NOTHING`;
+      // "Insert, ignore an existing (source,target) pair" is spelled
+      // differently per dialect: MySQL has no ON CONFLICT (it errors with
+      // ER_PARSE_ERROR). Use ON DUPLICATE KEY UPDATE with a no-op assignment
+      // rather than INSERT IGNORE, so only a duplicate-key conflict is
+      // swallowed while other errors (e.g. a foreign-key violation from a
+      // bad target id) still surface, matching the Postgres/SQLite
+      // ON CONFLICT DO NOTHING behaviour against the unique pair index.
+      const idCol = sql.identifier("id");
+      const conflictClause =
+        this.dialect === "mysql"
+          ? sql`ON DUPLICATE KEY UPDATE ${idCol} = ${idCol}`
+          : sql`ON CONFLICT DO NOTHING`;
 
-        const query = sql`
-          INSERT INTO ${sql.identifier(junctionTableName)}
-          (id, ${sourceIdCol}, ${targetIdCol}, created_at)
-          VALUES (${id}, ${sourceEntryId}, ${targetId}, ${createdAt})
-          ${conflictClause}
-        `;
+      const query = sql`
+        INSERT INTO ${sql.identifier(junctionTableName)}
+        (id, ${sourceIdCol}, ${targetIdCol}, created_at)
+        VALUES (${id}, ${sourceEntryId}, ${targetId}, ${createdAt})
+        ${conflictClause}
+      `;
 
-        console.log(`[ManyToMany] Executing insert for targetId: ${targetId}`);
-        await this.mutateRawSql(query, executor);
-        console.log(
-          `[ManyToMany] ✓ Insert successful for targetId: ${targetId}`
-        );
-      } catch (error: unknown) {
-        const errorMsg = `Failed to insert junction record for ${targetId}: ${error instanceof Error ? error.message : String(error)}`;
-        console.error(`[ManyToMany] ✗ ${errorMsg}`);
-        console.error(`[ManyToMany] Full error:`, error);
-        errors.push(errorMsg);
-      }
-    }
-
-    // If all inserts failed, throw error
-    if (errors.length === relatedIds.length && relatedIds.length > 0) {
-      throw new Error(
-        `Failed to insert all manyToMany relations for field "${field.name}". Errors: ${errors.join("; ")}`
-      );
-    }
-
-    // If some failed, log warning
-    if (errors.length > 0) {
-      console.warn(
-        `[ManyToMany] Partial failure: ${errors.length}/${relatedIds.length} inserts failed`
-      );
+      await this.mutateRawSql(query, executor);
     }
   }
 

--- a/packages/nextly/src/domains/singles/__tests__/single-entry-service.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-entry-service.test.ts
@@ -468,6 +468,33 @@ describe("SingleEntryService", () => {
       expect(result.data?.siteName).toBe("Set");
     });
 
+    it("preserves a component validation error (400) the adapter wraps in the transaction", async () => {
+      ctx.adapter.selectOne.mockResolvedValue({
+        id: "doc-1",
+        siteName: "Old",
+        updated_at: "2026-01-01T00:00:00.000Z",
+      });
+      // The real adapter classifies a callback error (a component NextlyError)
+      // as a database error, preserving the original on `.cause`. Simulate that
+      // wrapping so the service must recover the 400 instead of reporting 500.
+      const validationError = new NextlyError({
+        code: "VALIDATION_ERROR",
+        publicMessage: "bad component field",
+        statusCode: 400,
+      });
+      ctx.adapter.transaction.mockRejectedValueOnce(
+        Object.assign(new Error("database error"), { cause: validationError })
+      );
+
+      const result = await ctx.service.update("site-settings", {
+        siteName: "New",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.statusCode).toBe(400);
+      expect(result.message).toBe("bad component field");
+    });
+
     it("removes id and createdAt from the update payload", async () => {
       ctx.adapter.selectOne.mockResolvedValue({
         id: "doc-1",

--- a/packages/nextly/src/domains/singles/__tests__/single-entry-service.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-entry-service.test.ts
@@ -653,12 +653,15 @@ describe("SingleEntryService", () => {
       >;
       expect(payload.seo).toBeUndefined();
 
-      // The component service should be called with the component data
-      expect(ctx.componentDataService.saveComponentData).toHaveBeenCalledTimes(
-        1
-      );
+      // The component service should be called with the component data. The
+      // single update now writes components inside a transaction, so the call
+      // is saveComponentDataInTransaction(tx, params) — params is the 2nd arg.
+      expect(
+        ctx.componentDataService.saveComponentDataInTransaction
+      ).toHaveBeenCalledTimes(1);
       const saveCall =
-        ctx.componentDataService.saveComponentData.mock.calls[0][0];
+        ctx.componentDataService.saveComponentDataInTransaction.mock
+          .calls[0][1];
       expect(saveCall.parentTable).toBe("single_site_settings");
       expect(saveCall.data).toEqual({ seo: { metaTitle: "Hello" } });
     });
@@ -679,7 +682,9 @@ describe("SingleEntryService", () => {
 
       await ctx.service.update("site-settings", { siteName: "New" });
 
-      expect(ctx.componentDataService.saveComponentData).not.toHaveBeenCalled();
+      expect(
+        ctx.componentDataService.saveComponentDataInTransaction
+      ).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/nextly/src/domains/singles/__tests__/single-test-helpers.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-test-helpers.ts
@@ -41,7 +41,7 @@ export function createSilentLogger(): Logger {
  * Override any method via the `overrides` parameter.
  */
 export function createMockAdapter(overrides: MockRecord = {}): MockRecord {
-  return {
+  const adapter: MockRecord = {
     dialect: "postgresql",
     getCapabilities: vi.fn().mockReturnValue({
       dialect: "postgresql",
@@ -64,6 +64,18 @@ export function createMockAdapter(overrides: MockRecord = {}): MockRecord {
     getDialect: vi.fn().mockReturnValue("postgresql"),
     ...overrides,
   };
+  // Run a transaction callback with the adapter itself as the tx context, so
+  // `tx.update`/`tx.insert` resolve to the same mocks the tests assert on and
+  // callers that write inside `adapter.transaction(...)` behave like the real
+  // adapter. Only default it when an override did not provide one.
+  if (!adapter.transaction) {
+    adapter.transaction = vi
+      .fn()
+      .mockImplementation(async (cb: (tx: MockRecord) => Promise<unknown>) =>
+        cb(adapter)
+      );
+  }
+  return adapter;
 }
 
 // ── Mock SingleRegistryService ──────────────────────────────────────────
@@ -134,6 +146,7 @@ export function createMockComponentDataService(): MockRecord {
         async ({ entry }: { entry: Record<string, unknown> }) => entry
       ),
     saveComponentData: vi.fn().mockResolvedValue(undefined),
+    saveComponentDataInTransaction: vi.fn().mockResolvedValue(undefined),
     deleteComponentData: vi.fn().mockResolvedValue(undefined),
   };
 }

--- a/packages/nextly/src/domains/singles/services/__tests__/single-mutation-service.atomicity.integration.test.ts
+++ b/packages/nextly/src/domains/singles/services/__tests__/single-mutation-service.atomicity.integration.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Proof that a component-save failure rolls back a Single's scalar update.
+ *
+ * `SingleMutationService.update()` used to run the scalar `adapter.update`
+ * and `ComponentDataService.saveComponentDataInTransaction` as separate
+ * operations — a component-save failure left the scalar change committed
+ * with no way to undo it. The fix wraps both in one `adapter.transaction(...)`
+ * so a component failure aborts the scalar update too.
+ *
+ * A single with a component field can't be expressed by the typed
+ * `single()`/`component()` config helpers alone in a way that lets this
+ * suite drop the component's physical table afterward and still resolve it
+ * through the registry, so this builds a REAL Builder single + component via
+ * `seedBuilderSingle`/`seedBuilderComponent` (the same two-phase recipe used
+ * by builder-extend.integration.test.ts's single/component parity suite):
+ * seed the component, then the single (its `type: "component"` field is
+ * `"skip"`-classified — no physical column, see field-column-descriptor.ts —
+ * so seeding order relative to the single doesn't matter for DDL, but the
+ * component must exist before any write attempts to resolve it), reset DI
+ * without disconnecting the adapter, then reboot on the SAME adapter so
+ * `singleEntryService` resolves the seeded single/component through the
+ * registry.
+ *
+ * Failure injection: after establishing an initial value via one successful
+ * update, `DROP TABLE comp_hero` so the next update's
+ * `saveComponentDataInTransaction` call throws from inside the same
+ * transaction as the scalar update.
+ *
+ * Unlike `CollectionService.createEntry`/`updateEntry` (which throw a
+ * `NextlyError` on failure), `SingleEntryService.update()` catches every
+ * error internally and returns `{ success: false, ... }` — see
+ * `single-mutation-service.ts`'s outer try/catch. So the assertion here
+ * checks `result.success`, not `rejects.toThrow()`.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { clearServices } from "../../../../di/register";
+import {
+  seedBuilderComponent,
+  seedBuilderSingle,
+} from "../../../../plugins/__tests__/seed-builder-entity";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../../plugins/test-nextly";
+import type { SingleEntryService } from "../single-entry-service";
+
+let handle: TestNextly | undefined;
+
+afterEach(async () => {
+  await handle?.destroy();
+  handle = undefined;
+});
+
+/**
+ * Recipe: seed the `hero` component then the `settings` single (carrying a
+ * component field that embeds `hero`) on a first boot, reset DI without
+ * disconnecting the in-memory adapter, then reboot on the SAME adapter so
+ * `singleEntryService` resolves the seeded single/component through the
+ * registry (mirrors builder-extend.integration.test.ts's single/component
+ * parity setup).
+ */
+async function seedSettingsWithHero(): Promise<{
+  singles: SingleEntryService;
+}> {
+  handle = await createTestNextly({});
+  const adapter = handle.adapter;
+
+  await seedBuilderComponent(adapter, {
+    slug: "hero",
+    fields: [{ name: "heading", type: "text" }],
+  });
+  await seedBuilderSingle(adapter, {
+    slug: "settings",
+    fields: [
+      { name: "headline", type: "text" },
+      { name: "seo", type: "component", component: "hero" },
+    ],
+  });
+
+  clearServices();
+  handle = await createTestNextly({ adapter });
+
+  const singles = handle.getService("singleEntryService") as SingleEntryService;
+
+  return { singles };
+}
+
+describe("SingleMutationService component-save atomicity (integration)", () => {
+  it("update() rolls back the scalar change when the component save fails", async () => {
+    const { singles } = await seedSettingsWithHero();
+    const adapter = handle!.adapter;
+
+    // Establish an initial value (scalar + component) via a successful
+    // update — the component table exists at this point, so this must
+    // succeed before the failure is injected.
+    const first = await singles.update(
+      "settings",
+      { headline: "Original headline", seo: { heading: "Original SEO" } },
+      { overrideAccess: true }
+    );
+    expect(first.success).toBe(true);
+
+    // Drop the component's table so the next update's component save fails
+    // from inside the same transaction as the scalar update.
+    await adapter.executeQuery(`DROP TABLE "comp_hero"`);
+
+    const second = await singles.update(
+      "settings",
+      { headline: "Changed headline", seo: { heading: "Changed SEO" } },
+      { overrideAccess: true }
+    );
+
+    // update() never throws — every error is caught and mapped to a
+    // { success: false } result (see single-mutation-service.ts's catch).
+    expect(second.success).toBe(false);
+
+    // Pre-fix, the scalar UPDATE ran on its own operation before the
+    // component save, so the headline would have changed here. Post-fix,
+    // both share one transaction, so the component failure rolls the
+    // headline back too.
+    const rows = await adapter.executeQuery<{ headline: string }>(
+      `SELECT headline FROM single_settings LIMIT 1`
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].headline).toBe("Original headline");
+  });
+});

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -288,35 +288,51 @@ export class SingleMutationService extends BaseService {
 
       // Commit the scalar update and the component subtree writes atomically so
       // a component-save failure rolls back the scalar update (no partial single
-      // state). The scalar row and comp_ tables both write on the same tx.
-      let updatedRows: SingleDocument[] = [];
-      await this.adapter.transaction(async tx => {
-        updatedRows = await tx.update<SingleDocument>(
-          singleMeta.tableName,
-          updatePayload,
-          this.whereEq("id", existingDoc.id),
-          { returning: "*" }
-        );
+      // state). The scalar row and comp_ tables both write on the same tx. The
+      // rows are RETURNED from the callback (not assigned to an outer variable),
+      // so the value read below is only ever the committed result.
+      let updatedRows: SingleDocument[];
+      try {
+        updatedRows = await this.adapter.transaction(async tx => {
+          const rows = await tx.update<SingleDocument>(
+            singleMeta.tableName,
+            updatePayload,
+            this.whereEq("id", existingDoc.id),
+            { returning: "*" }
+          );
 
-        // Nothing updated: leave the (empty) transaction to commit and surface
-        // the 500 after it; do not attempt the component write.
-        if (updatedRows.length === 0) {
-          return;
-        }
+          // Nothing updated: return the empty result; the 500 is surfaced after
+          // the (empty) transaction, and the component write is skipped.
+          if (rows.length === 0) {
+            return rows;
+          }
 
-        // 9.5. Save component field data to separate comp_{slug} tables
-        if (
-          this.componentDataService &&
-          Object.keys(componentFieldData).length > 0
-        ) {
-          await this.componentDataService.saveComponentDataInTransaction(tx, {
-            parentId: existingDoc.id,
-            parentTable: singleMeta.tableName,
-            fields: fieldConfigs,
-            data: componentFieldData,
-          });
+          // 9.5. Save component field data to separate comp_{slug} tables
+          if (
+            this.componentDataService &&
+            Object.keys(componentFieldData).length > 0
+          ) {
+            await this.componentDataService.saveComponentDataInTransaction(tx, {
+              parentId: existingDoc.id,
+              parentTable: singleMeta.tableName,
+              fields: fieldConfigs,
+              data: componentFieldData,
+            });
+          }
+
+          return rows;
+        });
+      } catch (error) {
+        // A component validation failure (NextlyError) thrown inside the
+        // transaction callback is re-wrapped as a database error by the adapter;
+        // recover it from the cause so an invalid component update still yields
+        // the original validation response (400) instead of a generic 500.
+        const cause = (error as { cause?: unknown } | null)?.cause;
+        if (cause instanceof NextlyError) {
+          throw cause;
         }
-      });
+        throw error;
+      }
 
       if (updatedRows.length === 0) {
         return {

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -286,12 +286,37 @@ export class SingleMutationService extends BaseService {
         updated_at: new Date(),
       };
 
-      const updatedRows = await this.adapter.update<SingleDocument>(
-        singleMeta.tableName,
-        updatePayload,
-        this.whereEq("id", existingDoc.id),
-        { returning: "*" }
-      );
+      // Commit the scalar update and the component subtree writes atomically so
+      // a component-save failure rolls back the scalar update (no partial single
+      // state). The scalar row and comp_ tables both write on the same tx.
+      let updatedRows: SingleDocument[] = [];
+      await this.adapter.transaction(async tx => {
+        updatedRows = await tx.update<SingleDocument>(
+          singleMeta.tableName,
+          updatePayload,
+          this.whereEq("id", existingDoc.id),
+          { returning: "*" }
+        );
+
+        // Nothing updated: leave the (empty) transaction to commit and surface
+        // the 500 after it; do not attempt the component write.
+        if (updatedRows.length === 0) {
+          return;
+        }
+
+        // 9.5. Save component field data to separate comp_{slug} tables
+        if (
+          this.componentDataService &&
+          Object.keys(componentFieldData).length > 0
+        ) {
+          await this.componentDataService.saveComponentDataInTransaction(tx, {
+            parentId: existingDoc.id,
+            parentTable: singleMeta.tableName,
+            fields: fieldConfigs,
+            data: componentFieldData,
+          });
+        }
+      });
 
       if (updatedRows.length === 0) {
         return {
@@ -299,19 +324,6 @@ export class SingleMutationService extends BaseService {
           statusCode: 500,
           message: "Failed to update Single document",
         };
-      }
-
-      // 9.5. Save component field data to separate comp_{slug} tables
-      if (
-        this.componentDataService &&
-        Object.keys(componentFieldData).length > 0
-      ) {
-        await this.componentDataService.saveComponentData({
-          parentId: existingDoc.id,
-          parentTable: singleMeta.tableName,
-          fields: fieldConfigs,
-          data: componentFieldData,
-        });
       }
 
       let updatedDoc = updatedRows[0];


### PR DESCRIPTION
## What

Makes content writes fully atomic: an entry, its component data, and its many-to-many junction rows now commit in a single database transaction. Previously the m2m links were written on the pool AFTER the entry transaction committed, so a junction failure left an orphaned entry. Single-document updates now write the scalar row and component data in one transaction too.

This is the first of the two content-versioning Stage 2a PRs (the atomicity prerequisite); it does not add versioning behavior. It builds on the merged many-to-many fix (#236).

## Changes

- **`getDrizzle()` on the adapter `TransactionContext`** (`adapter-drizzle` + all three adapters): exposes the transaction-scoped Drizzle handle each adapter already builds (`txDb()`), so a service that drops to Drizzle raw SQL can run inside the caller's transaction instead of on the pool.
- **m2m junction writes inside the entry transaction**: `insertManyToManyRelations` / `deleteManyToManyRelations` gained an optional `executor` (a `RelationshipDbExecutor`) threaded through `selectRawSql` / `mutateRawSql` (defaults to the pool, so read paths are unchanged). `createEntry`, `updateEntry`, and the four `*InTransaction` batch/coordination helpers now run the m2m loop inside their `adapter.transaction(...)`, passing `tx.getDrizzle?.<RelationshipDbExecutor>()`.
- **Singles update in one transaction**: `single-mutation-service.update()` wraps the scalar `tx.update` and the component `saveComponentDataInTransaction` in one `adapter.transaction(...)`.

## Tests

- Atomicity integration tests: a dropped junction makes the m2m write fail, and the entry (`createEntry`) / scalar change (`updateEntry`) rolls back; a dropped `comp_` table rolls back a single update. **Confirmed RED on the pre-fix code** (entry/scalar not rolled back) and GREEN with the fix.
- Verified on **SQLite (198 passed / 42 skipped), real Postgres 17 (246 / 22), real MySQL 8 (212 / 30)** — all exit 0. `tsc` + lint clean. m2m createEntry/updateEntry rollback additionally gated against real PG + MySQL.
- Singles mock helpers + two assertions updated for the new transaction path (singles suite 97/97).

## Notes / follow-ups (from review)

- `insertManyToManyRelations` swallows individual per-target insert errors and only rethrows when every target fails (pre-existing behavior, unchanged here). So a whole-junction failure rolls back the entry (what this PR delivers and tests); a partial per-target failure inside the batch does not. Making a genuine partial failure abort the tx is a reasonable follow-up.
- `tx.getDrizzle?` is optional on the contract; a hypothetical third-party adapter that omits it would fall back to the pool (non-atomic) silently rather than erroring. All three first-party adapters implement it. A loud guard is a possible follow-up.
- Singles atomicity is covered on SQLite; a real-PG/MySQL gate parallel to the m2m ones is a nice-to-have.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `getDrizzle()` on transaction contexts for MySQL, PostgreSQL, and SQLite, exposing a transaction-bound Drizzle handle for raw SQL/template execution within the active transaction.

* **Bug Fixes**
  * Many-to-many collection mutations now commit or roll back parent and relationship changes together, avoiding partial saves on relationship failures.
  * Single-entry updates now run scalar and component persistence atomically; if component saving fails, scalar changes are rolled back and wrapped validation errors preserve the original 400 status.

* **Tests**
  * Added integration coverage for transaction “read-your-writes” and atomicity/rollback behavior across collection and single-entry mutation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->