### PR TITLE
fix(nextly): capture content version snapshots via transaction-scoped reads

### DIFF
--- a/.changeset/content-versioning-correctness.md
+++ b/.changeset/content-versioning-correctness.md
@@ -22,6 +22,10 @@
 
 Content version snapshots are now captured more faithfully: component subtrees and
 relations are read within the write transaction so just-written data is included
-correctly on every database (no leaked password hashes, no lost ids), and
+correctly on every database (no leaked password hashes, no lost ids), a partial
+translation edit keeps the language's other translated fields in the snapshot, and
 publishing all languages records a version and fires the status-change events like
-an ordinary publish.
+an ordinary publish. Publishing or changing the status of a single translation now
+also fires the document status-change events, tagged with the language. A versioned
+Single that is auto-created on its first read now starts its version history at that
+moment instead of leaving the live document without any version.

--- a/.changeset/content-versioning-correctness.md
+++ b/.changeset/content-versioning-correctness.md
@@ -1,0 +1,27 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/client": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Content version snapshots are now captured more faithfully: component subtrees and
+relations are read within the write transaction so just-written data is included
+correctly on every database (no leaked password hashes, no lost ids), and
+publishing all languages records a version and fires the status-change events like
+an ordinary publish.

--- a/packages/nextly/src/domains/collections/__tests__/status-transition-events.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/status-transition-events.integration.test.ts
@@ -9,6 +9,8 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import { defineCollection, text } from "../../../config";
+import { deriveCompanionSpec } from "../../i18n/migration/derive-companion-spec";
+import { buildCompanionCreateOnlySql } from "../../i18n/migration/generate-up";
 import {
   createTestNextly,
   type TestNextly,
@@ -110,5 +112,118 @@ describe("document status-transition events (integration)", () => {
     expect(seen).toContain("document.statusChanged");
     expect(seen).toContain("document.published");
     expect(seen).toContain("document.statusTransition");
+  });
+
+  it("per-locale draft->published emits locale-tagged status events", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "pages",
+          status: true,
+          localized: true,
+          fields: [text({ name: "title", localized: true })],
+        }),
+      ],
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+    });
+    const adapter = current.adapter as unknown as {
+      executeQuery: (sql: string) => Promise<unknown>;
+    };
+    // Create the companion (with per-locale `_status`) through the production
+    // DDL path so the fixture matches the migrated schema.
+    const spec = deriveCompanionSpec({
+      slug: "pages",
+      fields: [{ name: "title", type: "text", localized: true }],
+      dialect: current.adapter.dialect,
+      defaultLocale: "en",
+      collectionLocalized: true,
+      status: true,
+    });
+    if (!spec) throw new Error("expected a companion spec");
+    await adapter.executeQuery(buildCompanionCreateOnlySql(spec));
+
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const created = await handler.createEntry(
+      { collectionName: "pages", locale: "de", overrideAccess: true },
+      { title: "t", status: "draft" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    // Capture the payloads so we can assert the locale + prev/next status.
+    const payloads: Record<string, Record<string, unknown>> = {};
+    for (const name of DOC_EVENTS) {
+      current.events.on(name, (e: unknown) => {
+        payloads[name] = (e as { payload: Record<string, unknown> }).payload;
+      });
+    }
+
+    // Publish only the German translation — main-row status is untouched.
+    await handler.updateEntry(
+      {
+        collectionName: "pages",
+        entryId: id,
+        locale: "de",
+        overrideAccess: true,
+      },
+      { status: "published" }
+    );
+
+    expect(payloads["document.statusTransition"]).toMatchObject({
+      locale: "de",
+      previousStatus: "draft",
+      status: "published",
+    });
+    expect(payloads["document.statusChanged"]).toMatchObject({ locale: "de" });
+    expect(payloads["document.published"]).toMatchObject({ locale: "de" });
+  });
+
+  it("re-publishing an already-published locale fires no status events", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "pages",
+          status: true,
+          localized: true,
+          fields: [text({ name: "title", localized: true })],
+        }),
+      ],
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+    });
+    const adapter = current.adapter as unknown as {
+      executeQuery: (sql: string) => Promise<unknown>;
+    };
+    const spec = deriveCompanionSpec({
+      slug: "pages",
+      fields: [{ name: "title", type: "text", localized: true }],
+      dialect: current.adapter.dialect,
+      defaultLocale: "en",
+      collectionLocalized: true,
+      status: true,
+    });
+    if (!spec) throw new Error("expected a companion spec");
+    await adapter.executeQuery(buildCompanionCreateOnlySql(spec));
+
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const created = await handler.createEntry(
+      { collectionName: "pages", locale: "de", overrideAccess: true },
+      { title: "t", status: "published" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    const seen = recordEvents(current);
+    // Re-publish the same locale — no status movement.
+    await handler.updateEntry(
+      {
+        collectionName: "pages",
+        entryId: id,
+        locale: "de",
+        overrideAccess: true,
+      },
+      { status: "published" }
+    );
+
+    expect(seen).toEqual([]);
   });
 });

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -229,6 +229,11 @@ export class CollectionMutationService extends BaseService {
    * `published` has no prior status to change from, so it passes
    * `emitStatusChanged: false` to keep emitting only `published` (and now the
    * general transition), never `statusChanged`.
+   *
+   * `locale` is set only for a per-locale (companion `_status`) transition on a
+   * localized collection; when present it rides on every emitted payload so a
+   * subscriber can tell a single-language transition apart from a document-wide
+   * one (a document-wide publish carries no `locale`).
    */
   private transitionStatus(args: {
     collection: string;
@@ -238,8 +243,14 @@ export class CollectionMutationService extends BaseService {
     previousStatus: string | null;
     status: string;
     emitStatusChanged: boolean;
+    locale?: string;
   }): void {
-    const docBase = { id: args.id, data: args.data, user: args.user };
+    const docBase = {
+      id: args.id,
+      data: args.data,
+      user: args.user,
+      ...(args.locale !== undefined ? { locale: args.locale } : {}),
+    };
     emitDocumentEvent("statusTransition", args.collection, {
       ...docBase,
       previousStatus: args.previousStatus,
@@ -2234,6 +2245,10 @@ export class CollectionMutationService extends BaseService {
       // concurrent winner may have changed the status, so the D69 status event
       // below must report that as `previousStatus`, not the stale pre-tx value.
       let committedPreviousStatus: string | null | undefined;
+      // The write locale's committed companion `_status` before this write, used
+      // by the per-locale status event below. Re-read inside each attempt (like
+      // committedPreviousStatus) so a retry reports the true prior state.
+      let localizedPreviousStatus: string | null = null;
       await withVersionConflictRetry(() =>
         this.adapter.transaction(async tx => {
           const updatePayload = {
@@ -2276,6 +2291,32 @@ export class CollectionMutationService extends BaseService {
             `UPDATE ${quoteId(tableName)} SET ${setClauses} WHERE ${quoteId("id")} = ${makePlaceholder()}`,
             sqlParams as (string | number | boolean | Date | null | undefined)[]
           );
+
+          // Capture the committed per-locale `_status` BEFORE the upsert so the
+          // post-commit event can report the real prior value. Only when the
+          // write actually changes this locale's status (companion `_status` is
+          // present only when `status` was explicitly in the patch). Read with
+          // raw `tx.execute` (matching upsertCompanionRow / publishAllLocales):
+          // the companion `_locales` table is not in the Drizzle schema, and the
+          // CRUD helpers camelCase result keys, which would rename `_status`.
+          if (
+            localizedUpdate &&
+            typeof localizedUpdate.companionData._status === "string"
+          ) {
+            const isMysqlDialect = this.dialect === "mysql";
+            const quote = (id: string) =>
+              isMysqlDialect ? `\`${id}\`` : `"${id}"`;
+            const placeholder = (i: number) =>
+              this.dialect === "postgresql" ? `$${i}` : "?";
+            const priorRows = await tx.execute<{ _status?: unknown }>(
+              `SELECT ${quote("_status")} FROM ${quote(localizedUpdate.companionTableName)} ` +
+                `WHERE ${quote("_parent")} = ${placeholder(1)} AND ${quote("_locale")} = ${placeholder(2)} LIMIT 1`,
+              [params.entryId, localizedUpdate.writeLocale]
+            );
+            const priorStatus = priorRows[0]?._status;
+            localizedPreviousStatus =
+              typeof priorStatus === "string" ? priorStatus : null;
+          }
 
           // i18n M5: upsert the translatable values into the companion row for the write's locale
           // (same transaction). Only the provided localized columns are touched.
@@ -2544,6 +2585,32 @@ export class CollectionMutationService extends BaseService {
           previousStatus,
           status: nextStatus,
           emitStatusChanged: true,
+        });
+      }
+
+      // Per-locale status transition (i18n M6). On a localized collection the
+      // status moves to the companion `_status` for the write locale, leaving
+      // the main row's status unchanged — so the document-level check above
+      // never fires. Emit the same lifecycle events tagged with `locale` when a
+      // write actually changes this locale's status (companion `_status` is set
+      // only when `status` was explicitly in the patch), so workflows see the
+      // German publish they would otherwise miss. Skipped when the value did not
+      // move (re-publishing already-published content fires nothing).
+      const localizedNextStatus = localizedUpdate?.companionData._status;
+      if (
+        localizedUpdate &&
+        typeof localizedNextStatus === "string" &&
+        localizedNextStatus !== localizedPreviousStatus
+      ) {
+        this.transitionStatus({
+          collection: params.collectionName,
+          id: (updated as { id?: unknown }).id,
+          data: { ...(updated as Record<string, unknown>) },
+          user: params.user,
+          previousStatus: localizedPreviousStatus,
+          status: localizedNextStatus,
+          emitStatusChanged: true,
+          locale: localizedUpdate.writeLocale,
         });
       }
 

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -459,23 +459,23 @@ export class CollectionMutationService extends BaseService {
   }
 
   /**
-   * Build the COMPLETE component-subtree and many-to-many id maps for an entry's
-   * version snapshot. A partial update only carries the fields present in the
-   * request, so the written maps cover just those; unchanged component/relation
-   * fields are read from the current committed state and overlaid, so a
-   * scalar-only edit does not drop existing components or relations from the
-   * snapshot (which a later restore would otherwise lose). Reads run on the
-   * pooled connection — unchanged fields are untouched by the in-flight write,
-   * so their committed value is correct — and written values always win.
+   * Read the entry's component subtrees + many-to-many id arrays for a version
+   * snapshot, using the WRITE TRANSACTION's connection (read-your-writes, #226)
+   * so the components and junction rows just written in the same transaction are
+   * visible on every dialect. The read path returns the full read shape — ids
+   * populated, JSON parsed, password fields stripped — and an empty relationship
+   * reads as `[]`, so the snapshot matches a normal read with no in-memory
+   * overlay and cannot leak component password hashes. A read failure fails the
+   * capture (the whole transaction rolls back) rather than persisting a
+   * knowingly-incomplete snapshot the caller cannot tell is incomplete.
    */
   private async buildFullSnapshotRelations(
+    tx: { getDrizzle<T = unknown>(): T },
     entryId: string,
     collectionName: string,
     parentTable: string,
     fields: FieldDefinition[],
-    manyToManyFields: FieldDefinition[],
-    writtenComponents: Record<string, unknown>,
-    writtenM2M: Record<string, string[]>
+    manyToManyFields: FieldDefinition[]
   ): Promise<{
     components: Record<string, unknown>;
     manyToMany: Record<string, string[]>;
@@ -483,21 +483,18 @@ export class CollectionMutationService extends BaseService {
     const components: Record<string, unknown> = {};
     if (this.componentDataService) {
       const componentFields = fields.filter(isComponentField);
-      // Only read when a component field was omitted from the write (else the
-      // written map is already complete).
-      const hasOmitted = componentFields.some(
-        f => writtenComponents[f.name] === undefined
-      );
-      if (hasOmitted) {
+      if (componentFields.length > 0) {
         try {
           const populated =
             await this.componentDataService.populateComponentData({
               entry: { id: entryId },
-              // Use the resolved parent table (custom `dbName` collections do not
-              // match getTableName(slug)); it must equal the table the component
-              // rows were written under, or the read finds nothing.
+              // Resolved parent table (custom `dbName` collections do not match
+              // getTableName(slug)) so the read targets the right comp_ tables.
               parentTable,
               fields: fields as unknown as FieldConfig[],
+              // Read on the transaction so components written earlier in it are
+              // visible (read-your-writes); the read path strips password fields.
+              executor: tx.getDrizzle(),
             });
           for (const f of componentFields) {
             if (populated[f.name] !== undefined) {
@@ -505,13 +502,10 @@ export class CollectionMutationService extends BaseService {
             }
           }
         } catch (err) {
-          // Fail the capture rather than persist a knowingly-incomplete snapshot:
-          // silently dropping the omitted components would reintroduce the exact
-          // partial-update data loss this read exists to prevent, and a version
-          // that looks complete but isn't is worse than a failed, retriable write
-          // (the whole tx rolls back atomically).
+          // A version that looks complete but silently dropped a component is
+          // worse than a failed, retriable write — fail the capture (rolls back).
           this.logger.error(
-            "Version snapshot: failed to read existing components; failing the write instead of capturing an incomplete snapshot",
+            "Version snapshot: failed to read components; failing the write instead of capturing an incomplete snapshot",
             {
               collection: collectionName,
               entryId,
@@ -529,51 +523,41 @@ export class CollectionMutationService extends BaseService {
         }
       }
     }
-    // Written component values win over the read-back.
-    Object.assign(components, writtenComponents);
 
     const manyToMany: Record<string, string[]> = {};
-    const hasOmittedM2M = manyToManyFields.some(
-      f => writtenM2M[f.name] === undefined
-    );
-    if (hasOmittedM2M) {
-      for (const field of manyToManyFields) {
-        if (writtenM2M[field.name] !== undefined) continue;
-        try {
-          const relatedRows =
-            await this.relationshipService.fetchManyToManyRelations(
-              collectionName,
-              entryId,
-              field
-            );
-          manyToMany[field.name] = relatedRows.map(
-            r => (r as { id: string }).id
+    const txExecutor = tx.getDrizzle<RelationshipDbExecutor>();
+    for (const field of manyToManyFields) {
+      try {
+        const relatedRows =
+          await this.relationshipService.fetchManyToManyRelations(
+            collectionName,
+            entryId,
+            field,
+            txExecutor
           );
-        } catch (err) {
-          // Same reasoning as the component read above: fail the capture rather
-          // than record a snapshot that silently omits an existing relationship.
-          this.logger.error(
-            "Version snapshot: failed to read existing many-to-many relations; failing the write instead of capturing an incomplete snapshot",
-            {
-              collection: collectionName,
-              entryId,
-              field: field.name,
-              error: err instanceof Error ? err.message : String(err),
-            }
-          );
-          throw NextlyError.internal({
-            cause: err instanceof Error ? err : undefined,
-            logContext: {
-              reason: "version-snapshot-m2m-read",
-              collection: collectionName,
-              entryId,
-              field: field.name,
-            },
-          });
-        }
+        manyToMany[field.name] = relatedRows.map(r => (r as { id: string }).id);
+      } catch (err) {
+        // Same reasoning as the component read above.
+        this.logger.error(
+          "Version snapshot: failed to read many-to-many relations; failing the write instead of capturing an incomplete snapshot",
+          {
+            collection: collectionName,
+            entryId,
+            field: field.name,
+            error: err instanceof Error ? err.message : String(err),
+          }
+        );
+        throw NextlyError.internal({
+          cause: err instanceof Error ? err : undefined,
+          logContext: {
+            reason: "version-snapshot-m2m-read",
+            collection: collectionName,
+            entryId,
+            field: field.name,
+          },
+        });
       }
     }
-    Object.assign(manyToMany, writtenM2M);
 
     return { components, manyToMany };
   }
@@ -1398,30 +1382,38 @@ export class CollectionMutationService extends BaseService {
 
         // Record a durable version snapshot atomically with the write when the
         // collection opts into versioning. Runs after components + m2m so the
-        // snapshot is the full assembled document (the read-shape). History-only
-        // here: the entry's status maps to a VersionStatus inside captureInTx.
-        // A create provides all field values, so componentFieldData/
-        // manyToManyData are already complete; only the parent needs read-shape
-        // normalization (parse JSON-backed fields; strip password hashes so they
-        // never enter durable history). `entry` is reused after the tx for hooks
-        // and the response, so snapshot a copy.
+        // read from the transaction below sees them (read-your-writes).
         if (versionsConfig?.enabled) {
-          const snapshotParent = this.deserializeJsonFieldsForSnapshot(
-            entry,
-            fields
+          // Snapshot the parent from the RAW insert row (field-name keys) — not
+          // the camelCased `entry` used for the response — so user fields whose
+          // names contain underscores keep their configured keys; convert only
+          // the timestamp columns to match a normal read. Merge this locale's
+          // translatable values (split out of the main insert), parse JSON-backed
+          // fields, and strip password hashes + the owner column (created_by) so
+          // neither ever enters durable history.
+          const snapshotParent = convertTimestampsToCamelCase(
+            this.deserializeJsonFieldsForSnapshot(
+              {
+                ...(rawEntry as Record<string, unknown>),
+                ...(localizedWrite?.localizedFieldValues ?? {}),
+              },
+              fields
+            )
           );
           stripPasswordFieldValues(snapshotParent, fields);
-          // Strip the system owner column (created_by) too: normal reads/
-          // responses redact it, so history must not durably retain a stable
-          // owner id or let a restore overwrite ownership from old history.
           stripSystemOwnerField(snapshotParent);
-          // A junction relationship with no rows reads as an empty array, so
-          // seed every m2m field to [] before overlaying the written ids —
-          // otherwise a create that omits a m2m field records a snapshot missing
-          // it, and a later restore/audit can't tell "empty" from "absent".
-          const snapshotM2M: Record<string, string[]> = {};
-          for (const f of manyToManyFields) snapshotM2M[f.name] = [];
-          Object.assign(snapshotM2M, manyToManyData);
+          // Components + m2m are read from the transaction: the write above just
+          // persisted them, and an empty relationship reads as [] — so the
+          // snapshot is complete and read-shaped with no in-memory overlay.
+          const { components: snapshotComponents, manyToMany: snapshotM2M } =
+            await this.buildFullSnapshotRelations(
+              tx,
+              entry.id as string,
+              params.collectionName,
+              tableName,
+              fields,
+              manyToManyFields
+            );
           await captureInTx(tx, this.versionCapture, {
             ref: {
               scopeKind: "collection",
@@ -1431,7 +1423,7 @@ export class CollectionMutationService extends BaseService {
             contentStatus: (entry as { status?: unknown }).status,
             parts: {
               parentRow: snapshotParent,
-              components: componentFieldData,
+              components: snapshotComponents,
               manyToMany: snapshotM2M,
             },
             createdBy: params.user?.id ?? null,
@@ -2285,13 +2277,12 @@ export class CollectionMutationService extends BaseService {
                 components: snapshotComponents,
                 manyToMany: snapshotM2M,
               } = await this.buildFullSnapshotRelations(
+                tx,
                 params.entryId,
                 params.collectionName,
                 tableName,
                 fields,
-                manyToManyFields,
-                attemptComponentData,
-                manyToManyData
+                manyToManyFields
               );
               await captureInTx(tx, this.versionCapture, {
                 ref: {

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1655,6 +1655,18 @@ export class CollectionMutationService extends BaseService {
       const previousStatus =
         typeof previousStatusRaw === "string" ? previousStatusRaw : null;
 
+      // The parent row for both the snapshot and the status-change event is
+      // re-read fresh inside the transaction (not the pre-transaction
+      // `existingEntry`), mirroring updateEntry: a conflict retry re-runs this
+      // closure, and any concurrent write committed before the tx began is then
+      // reflected, so neither the recorded snapshot nor the emitted event
+      // payload exposes a stale pre-image of the non-status columns. The closure
+      // sets it; it is read once after commit for the event.
+      let publishedParentRow: Record<string, unknown> | undefined;
+      const needsFreshParent =
+        !!versionsConfig?.enabled ||
+        (hasMainStatus && previousStatus !== "published");
+
       // Retry the whole publish+capture transaction on a version_no allocation
       // race, mirroring updateEntry.
       await withVersionConflictRetry(() =>
@@ -1672,25 +1684,42 @@ export class CollectionMutationService extends BaseService {
             );
           }
 
-          // Record a version snapshot for the publish: publishing changes the
-          // document's status, so history/audit should capture that state. The
-          // parent is the current row set to published; components + m2m are read
-          // from the transaction (read-your-writes). Status/owner/password
-          // handling matches the other capture paths.
-          if (versionsConfig?.enabled) {
-            const parentRow = convertTimestampsToCamelCase(
-              this.deserializeJsonFieldsForSnapshot(
-                {
-                  ...(existingEntry as Record<string, unknown>),
-                  status: "published",
-                },
-                fields
-              )
-            );
-            stripPasswordFieldValues(parentRow, fields);
-            stripSystemOwnerField(parentRow);
-            const { components: snapshotComponents, manyToMany: snapshotM2M } =
-              await this.buildFullSnapshotRelations(
+          if (needsFreshParent) {
+            // Pool read, so it excludes this tx's own uncommitted status write —
+            // publish only mutates status, so overlaying "published" onto the
+            // fresh non-status columns reconstructs the committed post-publish
+            // state. On retry this re-reads a concurrent winner's columns.
+            const freshRows = await this.db
+              .select()
+              .from(schema)
+              .where(eq(schema.id, params.entryId))
+              .limit(1);
+            const currentRow = freshRows[0] as
+              | Record<string, unknown>
+              | undefined;
+            publishedParentRow = currentRow
+              ? { ...currentRow, status: "published" }
+              : undefined;
+
+            // Record a version snapshot for the publish: publishing changes the
+            // document's status, so history/audit should capture that state.
+            // Components + m2m are read from the transaction (read-your-writes).
+            // Status/owner/password handling matches the other capture paths. If
+            // the row was deleted concurrently, skip — nothing committed to
+            // snapshot.
+            if (versionsConfig?.enabled && publishedParentRow) {
+              const parentRow = convertTimestampsToCamelCase(
+                this.deserializeJsonFieldsForSnapshot(
+                  { ...publishedParentRow },
+                  fields
+                )
+              );
+              stripPasswordFieldValues(parentRow, fields);
+              stripSystemOwnerField(parentRow);
+              const {
+                components: snapshotComponents,
+                manyToMany: snapshotM2M,
+              } = await this.buildFullSnapshotRelations(
                 tx,
                 params.entryId,
                 params.collectionName,
@@ -1698,20 +1727,21 @@ export class CollectionMutationService extends BaseService {
                 fields,
                 manyToManyFields
               );
-            await captureInTx(tx, this.versionCapture, {
-              ref: {
-                scopeKind: "collection",
-                scopeSlug: params.collectionName,
-                entryId: params.entryId,
-              },
-              contentStatus: "published",
-              parts: {
-                parentRow,
-                components: snapshotComponents,
-                manyToMany: snapshotM2M,
-              },
-              createdBy: params.user?.id ?? null,
-            });
+              await captureInTx(tx, this.versionCapture, {
+                ref: {
+                  scopeKind: "collection",
+                  scopeSlug: params.collectionName,
+                  entryId: params.entryId,
+                },
+                contentStatus: "published",
+                parts: {
+                  parentRow,
+                  components: snapshotComponents,
+                  manyToMany: snapshotM2M,
+                },
+                createdBy: params.user?.id ?? null,
+              });
+            }
           }
         })
       );
@@ -1720,11 +1750,13 @@ export class CollectionMutationService extends BaseService {
       // workflow subscribers on statusTransition/published must see it (this
       // path previously changed status without emitting anything). Skip when the
       // main row was already published (no transition), matching updateEntry.
+      // Prefer the fresh in-tx row; fall back to the pre-read only if the row
+      // vanished mid-publish.
       if (hasMainStatus && previousStatus !== "published") {
         this.transitionStatus({
           collection: params.collectionName,
           id: params.entryId,
-          data: {
+          data: publishedParentRow ?? {
             ...(existingEntry as Record<string, unknown>),
             status: "published",
           },

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1642,20 +1642,98 @@ export class CollectionMutationService extends BaseService {
         params.collectionName
       );
 
-      await this.adapter.transaction(async tx => {
-        if (hasMainStatus) {
-          await tx.execute(
-            `UPDATE ${q(tableName)} SET ${q("status")} = ${ph(1)} WHERE ${q("id")} = ${ph(2)}`,
-            ["published", params.entryId]
-          );
-        }
-        if (companion && companionPublishable) {
-          await tx.execute(
-            `UPDATE ${q(companion.companionTableName)} SET ${q("_status")} = ${ph(1)} WHERE ${q("_parent")} = ${ph(2)}`,
-            ["published", params.entryId]
-          );
-        }
-      });
+      // Resolved versioning config + field set for the in-transaction capture.
+      const versionsConfig = (publishCollection as Record<string, unknown>)
+        .versions as ResolvedVersionsConfig | null | undefined;
+      const fields = ((publishCollection as { fields?: unknown }).fields ??
+        []) as FieldDefinition[];
+      const manyToManyFields = fields.filter(
+        f =>
+          f.type === "relationship" && f.options?.relationType === "manyToMany"
+      );
+      const previousStatusRaw = (existingEntry as { status?: unknown }).status;
+      const previousStatus =
+        typeof previousStatusRaw === "string" ? previousStatusRaw : null;
+
+      // Retry the whole publish+capture transaction on a version_no allocation
+      // race, mirroring updateEntry.
+      await withVersionConflictRetry(() =>
+        this.adapter.transaction(async tx => {
+          if (hasMainStatus) {
+            await tx.execute(
+              `UPDATE ${q(tableName)} SET ${q("status")} = ${ph(1)} WHERE ${q("id")} = ${ph(2)}`,
+              ["published", params.entryId]
+            );
+          }
+          if (companion && companionPublishable) {
+            await tx.execute(
+              `UPDATE ${q(companion.companionTableName)} SET ${q("_status")} = ${ph(1)} WHERE ${q("_parent")} = ${ph(2)}`,
+              ["published", params.entryId]
+            );
+          }
+
+          // Record a version snapshot for the publish: publishing changes the
+          // document's status, so history/audit should capture that state. The
+          // parent is the current row set to published; components + m2m are read
+          // from the transaction (read-your-writes). Status/owner/password
+          // handling matches the other capture paths.
+          if (versionsConfig?.enabled) {
+            const parentRow = convertTimestampsToCamelCase(
+              this.deserializeJsonFieldsForSnapshot(
+                {
+                  ...(existingEntry as Record<string, unknown>),
+                  status: "published",
+                },
+                fields
+              )
+            );
+            stripPasswordFieldValues(parentRow, fields);
+            stripSystemOwnerField(parentRow);
+            const { components: snapshotComponents, manyToMany: snapshotM2M } =
+              await this.buildFullSnapshotRelations(
+                tx,
+                params.entryId,
+                params.collectionName,
+                tableName,
+                fields,
+                manyToManyFields
+              );
+            await captureInTx(tx, this.versionCapture, {
+              ref: {
+                scopeKind: "collection",
+                scopeSlug: params.collectionName,
+                entryId: params.entryId,
+              },
+              contentStatus: "published",
+              parts: {
+                parentRow,
+                components: snapshotComponents,
+                manyToMany: snapshotM2M,
+              },
+              createdBy: params.user?.id ?? null,
+            });
+          }
+        })
+      );
+
+      // Post-commit status events: publishing is a real status transition, so
+      // workflow subscribers on statusTransition/published must see it (this
+      // path previously changed status without emitting anything). Skip when the
+      // main row was already published (no transition), matching updateEntry.
+      if (hasMainStatus && previousStatus !== "published") {
+        this.transitionStatus({
+          collection: params.collectionName,
+          id: params.entryId,
+          data: {
+            ...(existingEntry as Record<string, unknown>),
+            status: "published",
+          },
+          user: params.user,
+          previousStatus,
+          status: "published",
+          emitStatusChanged: true,
+        });
+      }
 
       return {
         success: true,

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -60,6 +60,7 @@ import {
 } from "../../../shared/lib/password-fields";
 import type { SupportedDialect } from "../../../types/database";
 import type { DynamicCollectionService } from "../../dynamic-collections";
+import { populateCompanionFields } from "../../i18n/companion-join";
 import type { SanitizedLocalizationConfig } from "../../i18n/config/types";
 import { resolveRequestedLocale } from "../../i18n/resolve-locale";
 import { captureInTx } from "../../versions/capture-in-tx";
@@ -2372,10 +2373,46 @@ export class CollectionMutationService extends BaseService {
               // timestamp and cannot persist forged system values — `preImage`
               // keeps the real committed system columns.
               const companionStatus = localizedUpdate?.companionData?._status;
+              // A partial translatable update only carries the *changed*
+              // localized values in `localizedFieldValues`; the write locale's
+              // other companion fields (set by a prior write, untouched here)
+              // would otherwise be dropped from the snapshot, since the main
+              // `preImage` never holds translatable values. Read the full
+              // localized field set for the write locale from the companion,
+              // tx-visibly (read-your-writes, #226) so the just-upserted row is
+              // included, with no locale fallback so the snapshot records
+              // exactly this locale. The just-written values still overlay on
+              // top. Undefined companion values are skipped so an untranslated
+              // field is not written as `undefined` over the main value.
+              const priorLocalizedValues: Record<string, unknown> = {};
+              if (localizedUpdate) {
+                const companion = await this.fileManager.loadCompanionSchema(
+                  params.collectionName
+                );
+                if (companion) {
+                  const localizedRow: Record<string, unknown> = {
+                    id: params.entryId,
+                  };
+                  await populateCompanionFields({
+                    db: tx.getDrizzle<
+                      Parameters<typeof populateCompanionFields>[0]["db"]
+                    >(),
+                    companionTable: companion.table,
+                    localizedFields: companion.localizedFields,
+                    rows: [localizedRow],
+                    localeChain: [localizedUpdate.writeLocale],
+                  });
+                  for (const f of companion.localizedFields) {
+                    const v = localizedRow[f.name];
+                    if (v !== undefined) priorLocalizedValues[f.name] = v;
+                  }
+                }
+              }
               const parentRow = this.deserializeJsonFieldsForSnapshot(
                 {
                   ...preImage,
                   ...updatePayload,
+                  ...priorLocalizedValues,
                   ...(localizedUpdate?.localizedFieldValues ?? {}),
                 },
                 fields

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -1803,7 +1803,13 @@ export class CollectionRelationshipService extends BaseService {
   async fetchManyToManyRelations(
     sourceCollectionName: string,
     sourceEntryId: string,
-    field: FieldDefinition
+    field: FieldDefinition,
+    // Optional transaction-bound executor. When supplied, the junction lookup
+    // runs on the transaction's connection (read-your-writes, #226) so a version
+    // snapshot captured inside the write transaction sees the junction rows just
+    // written in it. The target-entry fetch stays on the pool: related rows live
+    // in another (already-committed) collection, so they need no tx visibility.
+    executor?: RelationshipDbExecutor
   ): Promise<Record<string, unknown>[]> {
     // Same dual-aware target lookup as fetchManyToManyRelationsBatch above.
     // See that comment for the code-first vs UI-built shape rationale.
@@ -1831,7 +1837,10 @@ export class CollectionRelationshipService extends BaseService {
         WHERE ${sourceIdCol} = ${sourceEntryId}
       `;
 
-      const junctionResults = (await this.selectRawSql(junctionQuery)) as {
+      const junctionResults = (await this.selectRawSql(
+        junctionQuery,
+        executor
+      )) as {
         rows: Array<{ target_id: string }>;
       };
       const relatedIds = junctionResults.rows.map(row => row.target_id);

--- a/packages/nextly/src/domains/components/services/component-query-service.ts
+++ b/packages/nextly/src/domains/components/services/component-query-service.ts
@@ -47,6 +47,14 @@ export interface PopulateComponentDataParams {
    * When provided, only component fields with `select[fieldName] === true` are populated.
    */
   select?: Record<string, boolean>;
+
+  /**
+   * Optional transaction-bound executor. When supplied, component-table reads
+   * run on the transaction's connection (read-your-writes, #226) so a version
+   * snapshot assembled inside the write transaction sees the components just
+   * written in it. Omitted for ordinary reads (pooled connection).
+   */
+  executor?: unknown;
 }
 
 /**
@@ -101,6 +109,7 @@ export class ComponentQueryService extends BaseService {
       depth = DEFAULT_COMPONENT_DEPTH,
       currentDepth = 0,
       select,
+      executor,
     } = params;
     const entryId = entry.id as string;
     if (!entryId) return entry;
@@ -123,7 +132,8 @@ export class ComponentQueryService extends BaseService {
             fieldName,
             field,
             depth,
-            currentDepth
+            currentDepth,
+            executor
           );
         } else if (field.component) {
           if (field.repeatable) {
@@ -133,7 +143,8 @@ export class ComponentQueryService extends BaseService {
               fieldName,
               field.component,
               depth,
-              currentDepth
+              currentDepth,
+              executor
             );
           } else {
             result[fieldName] = await this.populateSingleField(
@@ -142,7 +153,8 @@ export class ComponentQueryService extends BaseService {
               fieldName,
               field.component,
               depth,
-              currentDepth
+              currentDepth,
+              executor
             );
           }
         }
@@ -260,7 +272,8 @@ export class ComponentQueryService extends BaseService {
     fieldName: string,
     componentSlug: string,
     depth: number,
-    currentDepth: number
+    currentDepth: number,
+    executor?: unknown
   ): Promise<Record<string, unknown> | null> {
     const meta = await this.registryService.getComponent(componentSlug);
     const componentFields = meta.fields;
@@ -268,7 +281,8 @@ export class ComponentQueryService extends BaseService {
       meta.tableName,
       parentId,
       parentTable,
-      fieldName
+      fieldName,
+      executor
     );
 
     if (rows.length === 0) return null;
@@ -291,7 +305,8 @@ export class ComponentQueryService extends BaseService {
     fieldName: string,
     componentSlug: string,
     depth: number,
-    currentDepth: number
+    currentDepth: number,
+    executor?: unknown
   ): Promise<Record<string, unknown>[]> {
     const meta = await this.registryService.getComponent(componentSlug);
     const componentFields = meta.fields;
@@ -299,7 +314,8 @@ export class ComponentQueryService extends BaseService {
       meta.tableName,
       parentId,
       parentTable,
-      fieldName
+      fieldName,
+      executor
     );
 
     let dataArray = rows.map(row =>
@@ -323,7 +339,8 @@ export class ComponentQueryService extends BaseService {
     fieldName: string,
     field: ComponentFieldConfig,
     depth: number,
-    currentDepth: number
+    currentDepth: number,
+    executor?: unknown
   ): Promise<Record<string, unknown>[]> {
     const allowedSlugs = field.components ?? [];
     const allRows: {
@@ -339,7 +356,8 @@ export class ComponentQueryService extends BaseService {
           meta.tableName,
           parentId,
           parentTable,
-          fieldName
+          fieldName,
+          executor
         );
         for (const row of rows) {
           allRows.push({ row, fields: meta.fields, slug });
@@ -515,17 +533,26 @@ export class ComponentQueryService extends BaseService {
     tableName: string,
     parentId: string,
     parentTable: string,
-    fieldName: string
+    fieldName: string,
+    // Optional transaction-bound executor. When supplied the read runs on the
+    // transaction's connection (read-your-writes, #226), so a version snapshot
+    // captured inside the write transaction sees the components just written in
+    // it. Omitted for ordinary reads, which use the pooled connection.
+    executor?: unknown
   ): Promise<ComponentRow[]> {
     try {
-      return await this.adapter.select<ComponentRow>(tableName, {
-        where: this.whereAnd({
-          _parent_id: parentId,
-          _parent_table: parentTable,
-          _parent_field: fieldName,
-        }),
-        orderBy: [{ column: "_order", direction: "asc" }],
-      });
+      return await this.adapter.select<ComponentRow>(
+        tableName,
+        {
+          where: this.whereAnd({
+            _parent_id: parentId,
+            _parent_table: parentTable,
+            _parent_field: fieldName,
+          }),
+          orderBy: [{ column: "_order", direction: "asc" }],
+        },
+        executor
+      );
     } catch (error) {
       this.logger.debug("Could not query component table", {
         tableName,

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -398,26 +398,25 @@ export class SingleMutationService extends BaseService {
                   }
                 }
               }
-              // Complete the component subtrees: a partial update only carries
-              // changed components, so read current state for omitted component
-              // fields and overlay the written ones, so a scalar-only edit does
-              // not drop existing components from the snapshot.
+              // Read the component subtrees from the TRANSACTION (read-your-
+              // writes, #226): the component save above just persisted them, so
+              // the read returns the complete, read-shaped, password-stripped
+              // subtrees with no in-memory overlay. A read failure fails the
+              // capture (rolls back) rather than persisting an incomplete snapshot.
               const components: Record<string, unknown> = {};
               if (this.componentDataService) {
                 const componentFields = fieldConfigs.filter(
                   (f): f is typeof f & { name: string } =>
                     isComponentField(f) && !!f.name
                 );
-                const hasOmitted = componentFields.some(
-                  f => attemptComponentData[f.name] === undefined
-                );
-                if (hasOmitted) {
+                if (componentFields.length > 0) {
                   try {
                     const populated =
                       await this.componentDataService.populateComponentData({
                         entry: { id: existingDoc.id },
                         parentTable: singleMeta.tableName,
                         fields: fieldConfigs,
+                        executor: tx.getDrizzle(),
                       });
                     for (const f of componentFields) {
                       if (populated[f.name] !== undefined) {
@@ -425,12 +424,8 @@ export class SingleMutationService extends BaseService {
                       }
                     }
                   } catch (err) {
-                    // Fail the capture rather than persist a knowingly-incomplete
-                    // snapshot: silently dropping omitted components would
-                    // reintroduce the partial-update data loss this read prevents,
-                    // and the whole tx rolls back so the write is retriable.
                     this.logger.error(
-                      "Version snapshot: failed to read existing single components; failing the write instead of capturing an incomplete snapshot",
+                      "Version snapshot: failed to read single components; failing the write instead of capturing an incomplete snapshot",
                       {
                         slug,
                         error: err instanceof Error ? err.message : String(err),
@@ -446,7 +441,6 @@ export class SingleMutationService extends BaseService {
                   }
                 }
               }
-              Object.assign(components, attemptComponentData);
               await captureInTx(tx, this.versionCapture, {
                 ref: {
                   scopeKind: "single",

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -43,6 +43,7 @@ import type { CollectionRelationshipService } from "../../../services/collection
 import type { CollectionsHandler } from "../../../services/collections-handler";
 import type { ComponentDataService } from "../../../services/components/component-data-service";
 import { BaseService } from "../../../shared/base-service";
+import { convertTimestampsToCamelCase } from "../../../shared/lib/case-conversion";
 import {
   applyFieldReadAccess,
   runFieldHooks,
@@ -50,8 +51,12 @@ import {
 import {
   hasPasswordField,
   stripPasswordFieldValues,
+  stripSystemOwnerField,
 } from "../../../shared/lib/password-fields";
 import type { Logger } from "../../../shared/types";
+import { captureInTx } from "../../versions/capture-in-tx";
+import { VersionCaptureService } from "../../versions/version-capture-service";
+import { withVersionConflictRetry } from "../../versions/version-conflict";
 import type {
   GetSingleOptions,
   SingleDocument,
@@ -278,6 +283,9 @@ export async function checkSingleAccess(params: {
  * service can reuse them without duplication.
  */
 export class SingleQueryService extends BaseService {
+  /** Persists version snapshots; used when a versioned Single is auto-created. */
+  private readonly versionCapture = new VersionCaptureService();
+
   constructor(
     adapter: DrizzleAdapter,
     logger: Logger,
@@ -370,10 +378,14 @@ export class SingleQueryService extends BaseService {
         {}
       );
 
-      // 6. Auto-create if document doesn't exist
+      // 6. Auto-create if document doesn't exist. Capture the initial version
+      // when the Single is versioned so a first-read materialization still
+      // starts a history (the mutation path records its own first version).
       if (!doc) {
         this.logger.info("Auto-creating Single document", { slug });
-        doc = await this.createDefaultDocument(singleMeta);
+        doc = await this.createDefaultDocument(singleMeta, {
+          captureInitialVersion: true,
+        });
       }
 
       // 6.5. Apply Draft/Published auto-filter. For Singles the rule is
@@ -494,9 +506,16 @@ export class SingleQueryService extends BaseService {
    * Applies default values from field configurations. Always includes
    * the system columns (id, title, slug, created_at, updated_at) that
    * the schema generator adds to every Single table.
+   *
+   * `captureInitialVersion` records the materialized default as the Single's
+   * first version snapshot (v1), atomically with the insert. The read path opts
+   * in so a versioned Single that is auto-created on first read still starts a
+   * history; the mutation path does NOT, because its subsequent update records
+   * the first version itself (opting in there would double-version a first edit).
    */
   async createDefaultDocument(
-    singleMeta: DynamicSingleRecord
+    singleMeta: DynamicSingleRecord,
+    options?: { captureInitialVersion?: boolean }
   ): Promise<SingleDocument> {
     const now = new Date();
     const id = crypto.randomUUID();
@@ -531,17 +550,76 @@ export class SingleQueryService extends BaseService {
       string,
       unknown
     >;
-    const inserted = await this.adapter.insert<SingleDocument>(
-      singleMeta.tableName,
-      snakeCaseDefaults,
-      { returning: "*" }
+
+    const versionsConfig = singleMeta.versions;
+    const shouldCapture =
+      options?.captureInitialVersion === true &&
+      versionsConfig?.enabled === true;
+
+    if (!shouldCapture) {
+      const inserted = await this.adapter.insert<SingleDocument>(
+        singleMeta.tableName,
+        snakeCaseDefaults,
+        { returning: "*" }
+      );
+      this.logger.debug("Created default Single document", {
+        slug: singleMeta.slug,
+        id,
+      });
+      return inserted;
+    }
+
+    // Versioned Single: insert the default row and record its v1 snapshot in one
+    // transaction, so the Single never ends up with a live row but no history.
+    // Retry on a version_no allocation race, mirroring the write paths.
+    const inserted = await withVersionConflictRetry(() =>
+      this.adapter.transaction(async tx => {
+        const row = await tx.insert<SingleDocument>(
+          singleMeta.tableName,
+          snakeCaseDefaults,
+          { returning: "*" }
+        );
+        // Match the read shape: keep user field keys (which may contain
+        // underscores like `site_title`) exactly, converting only the timestamp
+        // columns; strip password hashes and the system owner column so history
+        // never retains them; parse JSON-backed fields (stored as strings on
+        // SQLite) so a restore equals a normal read. A freshly materialized
+        // default has no component subtrees yet, so components is empty.
+        const parentRow = convertTimestampsToCamelCase({
+          ...(row as Record<string, unknown>),
+        });
+        stripPasswordFieldValues(parentRow, singleMeta.fields);
+        stripSystemOwnerField(parentRow);
+        for (const field of singleMeta.fields) {
+          if (!("name" in field) || !field.name) continue;
+          const value = parentRow[field.name];
+          if (shouldTreatAsJson(field) && typeof value === "string") {
+            try {
+              parentRow[field.name] = JSON.parse(value);
+            } catch {
+              // Not valid JSON — keep the raw string.
+            }
+          }
+        }
+        await captureInTx(tx, this.versionCapture, {
+          ref: {
+            scopeKind: "single",
+            scopeSlug: singleMeta.slug,
+            entryId: (row as { id: string }).id,
+          },
+          contentStatus: (parentRow as { status?: unknown }).status,
+          // System-materialized default: no authoring user.
+          parts: { parentRow, components: {} },
+          createdBy: null,
+        });
+        return row;
+      })
     );
 
     this.logger.debug("Created default Single document", {
       slug: singleMeta.slug,
       id,
     });
-
     return inserted;
   }
 

--- a/packages/nextly/src/domains/versions/__tests__/capture-on-create.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/capture-on-create.integration.test.ts
@@ -9,12 +9,13 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 
-import { defineCollection, text } from "../../../config";
+import { defineCollection, defineSingle, text } from "../../../config";
 import {
   createTestNextly,
   type TestNextly,
 } from "../../../plugins/test-nextly";
 import type { CollectionsHandler } from "../../../services/collections-handler";
+import type { SingleEntryService } from "../services/single-entry-service";
 
 let current: TestNextly | undefined;
 
@@ -112,5 +113,47 @@ describe("version capture on create (integration)", () => {
     // Two distinct documents, each with its own versionNo 1.
     expect(new Set(rows.map(r => r.entryId)).size).toBe(2);
     expect(rows.every(r => r.versionNo === 1)).toBe(true);
+  });
+
+  it("captures v1 when a versioned single is auto-created on first read", async () => {
+    // A versioned Single that has never been written materializes its default
+    // document on first read; that materialization must start the history so
+    // the live row is not left without any version.
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "settings",
+          versions: true,
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const singles =
+      current.getService<SingleEntryService>("singleEntryService");
+
+    const res = await singles.get("settings", { overrideAccess: true });
+    expect(res.success).toBe(true);
+
+    const rows = await versionRows(current, "settings");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].scopeKind).toBe("single");
+    expect(rows[0].versionNo).toBe(1);
+  });
+
+  it("does not version an unversioned single auto-created on read", async () => {
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "settings",
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const singles =
+      current.getService<SingleEntryService>("singleEntryService");
+
+    await singles.get("settings", { overrideAccess: true });
+
+    expect(await versionRows(current, "settings")).toHaveLength(0);
   });
 });

--- a/packages/nextly/src/domains/versions/__tests__/capture-on-update.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/capture-on-update.integration.test.ts
@@ -186,6 +186,66 @@ describe("version capture on update (integration)", () => {
     expect(latest.meta).toEqual({ views: 4, tags: ["c"] });
   });
 
+  it("preserves an untouched localized field for the write locale in a partial translatable update snapshot", async () => {
+    // A partial translatable update carries only the changed localized value in
+    // the patch. The write locale's other companion fields (set on an earlier
+    // write, untouched here) must still appear in the snapshot — otherwise a
+    // later restore silently drops this locale's other translations. The main
+    // row never holds the translatable values, so they are read back from the
+    // companion inside the write transaction.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "pages",
+          versions: true,
+          localized: true,
+          fields: [
+            text({ name: "title", localized: true }),
+            text({ name: "body", localized: true }),
+          ],
+        }),
+      ],
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+    });
+    const adapter = current.adapter as unknown as {
+      executeQuery: (sql: string) => Promise<unknown>;
+    };
+    // Companion tables are migration-owned; seed it. The main table keeps its
+    // localized columns (a fully-migrated collection hits an unrelated,
+    // pre-existing updateEntry limitation that is out of scope here).
+    await adapter.executeQuery(
+      'CREATE TABLE "dc_pages_locales" ("_parent" text, "_locale" text, "_status" text NOT NULL DEFAULT \'draft\', "title" text, "body" text, PRIMARY KEY ("_parent","_locale"))'
+    );
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const created = await handler.createEntry(
+      { collectionName: "pages", locale: "de", overrideAccess: true },
+      { title: "t1", body: "b1" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    // Partial translatable update for the same locale — `body` is NOT in the patch.
+    await handler.updateEntry(
+      {
+        collectionName: "pages",
+        entryId: id,
+        locale: "de",
+        overrideAccess: true,
+      },
+      { title: "t2" }
+    );
+
+    const rows = await versions(current, "pages");
+    const latest = rows[rows.length - 1].snapshot as {
+      title?: string;
+      body?: string;
+    };
+    expect(latest.title).toBe("t2");
+    // The untouched localized field survives into the new version.
+    expect(latest.body).toBe("b1");
+  });
+
   it("records no version when the schema does not opt in", async () => {
     current = await createTestNextly({
       collections: [

--- a/packages/nextly/src/domains/versions/__tests__/capture-on-update.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/capture-on-update.integration.test.ts
@@ -21,6 +21,8 @@ import {
   type TestNextly,
 } from "../../../plugins/test-nextly";
 import type { CollectionsHandler } from "../../../services/collections-handler";
+import { deriveCompanionSpec } from "../../i18n/migration/derive-companion-spec";
+import { buildCompanionCreateOnlySql } from "../../i18n/migration/generate-up";
 import type { SingleEntryService } from "../services/single-entry-service";
 
 let current: TestNextly | undefined;
@@ -210,12 +212,23 @@ describe("version capture on update (integration)", () => {
     const adapter = current.adapter as unknown as {
       executeQuery: (sql: string) => Promise<unknown>;
     };
-    // Companion tables are migration-owned; seed it. The main table keeps its
-    // localized columns (a fully-migrated collection hits an unrelated,
-    // pre-existing updateEntry limitation that is out of scope here).
-    await adapter.executeQuery(
-      'CREATE TABLE "dc_pages_locales" ("_parent" text, "_locale" text, "_status" text NOT NULL DEFAULT \'draft\', "title" text, "body" text, PRIMARY KEY ("_parent","_locale"))'
-    );
+    // Companion tables are migration-owned; create it through the SAME
+    // production DDL path a migration uses (derive the spec from the collection,
+    // then the create-only companion statement) so the fixture can never drift
+    // from the real localized schema.
+    const spec = deriveCompanionSpec({
+      slug: "pages",
+      fields: [
+        { name: "title", type: "text", localized: true },
+        { name: "body", type: "text", localized: true },
+      ],
+      dialect: current.adapter.dialect,
+      defaultLocale: "en",
+      collectionLocalized: true,
+    });
+    if (!spec)
+      throw new Error("expected a companion spec for a localized collection");
+    await adapter.executeQuery(buildCompanionCreateOnlySql(spec));
     const handler =
       current.getService<CollectionsHandler>("collectionsHandler");
 


### PR DESCRIPTION
## Content-versioning correctness follow-ups (single PR)

Follow-ups from the Stage 2b review (#239), tracked in
`tasks/2026-07-19-content-versioning-followups.md`. None change the opt-in
contract; they make the captured snapshots faithful across dialects and close
history/event gaps in secondary write paths.

### Landed here (tested on SQLite; pg/mysql read-your-writes on CI)

- **Transaction-scoped snapshot reads (the flagship).** Component subtrees and
  many-to-many relations for a version snapshot are now read on the write
  transaction's connection (read-your-writes, #226) instead of the pool. So the
  just-written rows are visible on Postgres/MySQL too, the read path strips
  component password hashes and populates ids, and an empty relation reads as
  `[]`. This deletes the fragile written/omitted in-memory overlay, and a read
  failure still fails the capture (rolls back) rather than persisting an
  incomplete snapshot. An optional executor is threaded through
  `populateComponentData` / `fetchManyToManyRelations`; ordinary reads stay on
  the pool (unchanged).
- **Create-snapshot key fidelity.** The create snapshot is built from the raw
  insert row (field-name keys), so user fields with underscores (`meta_title`)
  keep their configured keys and match a normal read.
- **`publishAllLocales` capture + events.** Publishing all languages now records
  a version of the published state (in the same transaction) and emits
  `document.statusTransition` / `document.published`, like the ordinary publish
  path — it previously changed status silently.

### Remaining (follow-on commits to THIS PR)

- Omitted localized companion field values in the update snapshot (read the
  companion for the write's locale, tx-visibly).
- `document.statusTransition` for localized per-locale status writes in
  `updateEntry`.
- Version capture on a versioned Single's first-read auto-create
  (`createDefaultDocument`) — narrow; assessing the least-awkward seam.

Stacked on #239 (now merged); rebased onto `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Status transition and published events now optionally include locale context, enabling per-locale status changes to be distinguished by subscribers.

- **Bug Fixes**
  - Version snapshot capture now consistently uses transaction-scoped reads for components and many-to-many relation IDs, preventing incomplete snapshots within the same write flow.
  - Durable snapshot construction during create/update/publish now correctly derives parent snapshot data and rehydrates localized companion fields.
  - Many-to-many relation fetching supports transaction-scoped reads; component subtree snapshotting no longer relies on in-memory overlays.

- **Tests**
  - Added integration coverage for partial localized updates preserving updated and untouched localized values.
  - Added event assertions for locale-tagged statusTransition/statusChanged/published payloads, including no-op re-publish behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->