### PR TITLE
feat(nextly): add webhook delivery engine

### DIFF
--- a/.changeset/webhook-delivery-engine.md
+++ b/.changeset/webhook-delivery-engine.md
@@ -1,0 +1,25 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Webhook deliveries are now sent, signed, and retried.
+
+The delivery engine claims each due webhook delivery, signs the request with Standard Webhooks HMAC headers, sends it over the SSRF-safe transport, and records the outcome. A 2xx marks the delivery sent; a 429 or 5xx is retried with exponential backoff and full jitter up to an attempt cap; any other response fails permanently. A claimed delivery is leased so a concurrent drain cannot double-send, and the network request never holds a database transaction open. A drain orchestrator runs fan-out and delivery together until nothing is currently due. The scheduled trigger that starts a drain is a later change.

--- a/packages/nextly/src/domains/webhooks/__tests__/deliver.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/deliver.integration.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Integration test for the webhook delivery engine (`deliverDueDeliveries` and
+ * `runDrain`) against a real SQLite database. Exercises the full claim -> sign
+ * -> send -> record path: a leased claim, Standard Webhooks signature headers on
+ * the outgoing request, and each terminal outcome (delivered / retrying / failed
+ * / exhausted), plus the lease guard and an end-to-end drain from a seeded event.
+ *
+ * Uses an in-memory SQLite database built from the production table definitions
+ * via drizzle-kit (never hand-copied CREATE TABLE; see
+ * .claude/rules/integration-tests.md). The HTTP transport and clock are injected
+ * so outcomes are deterministic and no real network access happens.
+ */
+
+import { createSqliteAdapter } from "@nextlyhq/adapter-sqlite";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { getSQLiteDrizzleKit } from "../../../database/drizzle-kit-lazy";
+import { SchemaRegistry } from "../../../database/schema-registry";
+import { splitStatements } from "../../schema/pipeline/sql-statement-utils";
+import {
+  nextlyEvents,
+  nextlyWebhooks,
+  nextlyWebhookDeliveries,
+} from "../../../schemas/webhooks/sqlite";
+import { users } from "../../../schemas/users/sqlite";
+import { buildEnvelope } from "../envelope";
+import { recordEvent } from "../record-event";
+import { WebhookEndpointRegistry } from "../endpoint-registry";
+import { deliverDueDeliveries, type DeliverTransport } from "../deliver";
+import { runDrain } from "../run-drain";
+import { verifySignature } from "../signing";
+import { DEFAULT_MAX_ATTEMPTS } from "../delivery-policy";
+import type { WebhookEventType } from "../types";
+
+process.env.DB_DIALECT = "sqlite";
+
+// A frozen clock so due-ness, lease windows, and retry scheduling are stable.
+const NOW = new Date("2026-07-19T12:00:00.000Z");
+// A valid Standard Webhooks secret: `whsec_` + base64 key bytes ("secretkey").
+const SECRET = "whsec_c2VjcmV0a2V5";
+
+const tables = { nextlyEvents, nextlyWebhooks, nextlyWebhookDeliveries };
+// nextly_webhooks.created_by references users, so the FK target table must
+// exist for SQLite's foreign-key enforcement on webhook writes.
+const ddlTables = { ...tables, users };
+
+async function schemaDdl(): Promise<string[]> {
+  const kit = await getSQLiteDrizzleKit();
+  const statements = await kit.generateMigration(
+    await kit.generateDrizzleJson({}),
+    await kit.generateDrizzleJson(ddlTables)
+  );
+  return splitStatements(statements);
+}
+
+/** A fake transport that records each request and returns a fixed HTTP status. */
+function makeTransport(status: number): {
+  transport: DeliverTransport;
+  calls: Array<{ url: string; headers: Record<string, string>; body: string }>;
+} {
+  const calls: Array<{
+    url: string;
+    headers: Record<string, string>;
+    body: string;
+  }> = [];
+  const transport: DeliverTransport = async (url, options) => {
+    calls.push({ url, headers: options.headers, body: options.body });
+    return new Response("ok", { status });
+  };
+  return { transport, calls };
+}
+
+describe("webhook delivery engine (real SQLite)", () => {
+  let adapter: ReturnType<typeof createSqliteAdapter>;
+
+  beforeAll(async () => {
+    adapter = createSqliteAdapter({ memory: true });
+    await adapter.connect();
+    for (const stmt of await schemaDdl()) await adapter.executeQuery(stmt);
+
+    const schemaRegistry = new SchemaRegistry();
+    schemaRegistry.registerStaticSchemas(tables);
+    adapter.setTableResolver(schemaRegistry);
+  });
+
+  afterAll(async () => {
+    try {
+      await adapter?.disconnect?.();
+    } catch {
+      // ignore teardown errors
+    }
+  });
+
+  beforeEach(async () => {
+    await adapter.executeQuery("DELETE FROM nextly_webhook_deliveries");
+    await adapter.executeQuery("DELETE FROM nextly_webhooks");
+    await adapter.executeQuery("DELETE FROM nextly_events");
+  });
+
+  async function seedWebhook(
+    id: string,
+    opts: {
+      secrets?: string[];
+      headers?: Record<string, string> | null;
+      eventTypes?: WebhookEventType[];
+    } = {}
+  ): Promise<void> {
+    await adapter.insert("nextly_webhooks", {
+      id,
+      name: id,
+      url: `https://example.com/${id}`,
+      enabled: true,
+      event_types: opts.eventTypes ?? ["entry.updated"],
+      filter: null,
+      headers: opts.headers ?? null,
+      secret_hash: opts.secrets ?? [SECRET],
+      secret_prefix: "whsec_",
+      field_allowlist: null,
+      created_by: null,
+      // Well before the seeded event time so the pre-subscription guard admits it.
+      created_at: new Date("2020-01-01T00:00:00.000Z"),
+      updated_at: NOW,
+    });
+  }
+
+  async function seedEvent(
+    id: string,
+    type: WebhookEventType = "entry.updated"
+  ): Promise<void> {
+    const envelope = buildEnvelope({
+      id,
+      type,
+      timestamp: new Date("2026-07-18T00:00:00.000Z"),
+      resource: { kind: "entry", collection: "posts", id: "p1" },
+      data: { id: "p1", title: "Hello" },
+    });
+    await adapter.transaction(async tx => recordEvent(tx, { envelope }));
+  }
+
+  async function seedDelivery(
+    id: string,
+    webhookId: string,
+    eventId: string,
+    opts: {
+      status?: string;
+      attemptCount?: number;
+      nextAttemptAt?: Date | null;
+      lockedUntil?: Date | null;
+    } = {}
+  ): Promise<void> {
+    await adapter.insert("nextly_webhook_deliveries", {
+      id,
+      webhook_id: webhookId,
+      event_id: eventId,
+      status: opts.status ?? "pending",
+      attempt_count: opts.attemptCount ?? 0,
+      next_attempt_at:
+        opts.nextAttemptAt === undefined ? NOW : opts.nextAttemptAt,
+      locked_by: null,
+      locked_until: opts.lockedUntil ?? null,
+      created_at: NOW,
+      updated_at: NOW,
+    });
+  }
+
+  interface DeliveryReadRow {
+    id: string;
+    status: string;
+    attemptCount: number;
+    nextAttemptAt: Date | null;
+    lockedBy: string | null;
+    lockedUntil: Date | null;
+    lastStatusCode: number | null;
+    lastError: string | null;
+  }
+
+  async function getDelivery(id: string): Promise<DeliveryReadRow> {
+    const rows = await adapter.select<DeliveryReadRow>(
+      "nextly_webhook_deliveries",
+      { where: { and: [{ column: "id", op: "=", value: id }] } }
+    );
+    return rows[0];
+  }
+
+  function deps(transport: DeliverTransport, overrides = {}) {
+    return {
+      db: adapter,
+      decryptSecret: (ciphertext: string) => ciphertext,
+      transport,
+      now: () => NOW,
+      runnerId: "runner-test",
+      ...overrides,
+    };
+  }
+
+  it("delivers a 2xx response and signs the request with Standard Webhooks headers", async () => {
+    await seedWebhook("wh_a");
+    await seedEvent("evt_1");
+    await seedDelivery("dlv_1", "wh_a", "evt_1");
+    const { transport, calls } = makeTransport(200);
+
+    const result = await deliverDueDeliveries(deps(transport));
+
+    expect(result).toMatchObject({ attempted: 1, delivered: 1, failed: 0 });
+    const row = await getDelivery("dlv_1");
+    expect(row.status).toBe("delivered");
+    expect(row.attemptCount).toBe(1);
+    expect(row.nextAttemptAt).toBeNull();
+    // The lease is released once the row is finalized.
+    expect(row.lockedUntil).toBeNull();
+    expect(row.lockedBy).toBeNull();
+    expect(row.lastStatusCode).toBe(200);
+
+    // The outgoing request carried the three Standard Webhooks headers plus JSON
+    // content-type, and the signature verifies against the (identity-decrypted)
+    // secret over the exact body that was sent.
+    expect(calls).toHaveLength(1);
+    const { headers, body } = calls[0];
+    expect(headers["content-type"]).toBe("application/json");
+    expect(headers["webhook-id"]).toBe("dlv_1");
+    expect(headers["webhook-timestamp"]).toMatch(/^\d+$/);
+    expect(headers["webhook-signature"]).toMatch(/^v1,/);
+    expect(
+      verifySignature({
+        id: "dlv_1",
+        timestamp: headers["webhook-timestamp"],
+        body,
+        signatureHeader: headers["webhook-signature"],
+        secrets: [SECRET],
+        toleranceSeconds: Infinity,
+      })
+    ).toBe(true);
+  });
+
+  it("reschedules a 5xx response for a retry (transient)", async () => {
+    await seedWebhook("wh_a");
+    await seedEvent("evt_1");
+    await seedDelivery("dlv_1", "wh_a", "evt_1");
+    const { transport } = makeTransport(503);
+
+    const result = await deliverDueDeliveries(deps(transport));
+
+    expect(result).toMatchObject({ attempted: 1, retried: 1, delivered: 0 });
+    const row = await getDelivery("dlv_1");
+    expect(row.status).toBe("retrying");
+    expect(row.attemptCount).toBe(1);
+    expect(row.nextAttemptAt).not.toBeNull();
+    // The next attempt is scheduled no earlier than now (jittered backoff >= 0).
+    expect(row.nextAttemptAt!.getTime()).toBeGreaterThanOrEqual(NOW.getTime());
+    expect(row.lockedUntil).toBeNull();
+    expect(row.lastStatusCode).toBe(503);
+  });
+
+  it("permanently fails a 4xx response (receiver must fix it)", async () => {
+    await seedWebhook("wh_a");
+    await seedEvent("evt_1");
+    await seedDelivery("dlv_1", "wh_a", "evt_1");
+    const { transport } = makeTransport(404);
+
+    const result = await deliverDueDeliveries(deps(transport));
+
+    expect(result).toMatchObject({ attempted: 1, failed: 1, retried: 0 });
+    const row = await getDelivery("dlv_1");
+    expect(row.status).toBe("failed");
+    expect(row.attemptCount).toBe(1);
+    expect(row.nextAttemptAt).toBeNull();
+    expect(row.lastStatusCode).toBe(404);
+    expect(row.lastError).toContain("404");
+  });
+
+  it("marks a transient outcome failed once the attempt limit is reached", async () => {
+    await seedWebhook("wh_a");
+    await seedEvent("evt_1");
+    // One short of the cap and retrying, so this attempt reaches DEFAULT_MAX_ATTEMPTS.
+    await seedDelivery("dlv_1", "wh_a", "evt_1", {
+      status: "retrying",
+      attemptCount: DEFAULT_MAX_ATTEMPTS - 1,
+    });
+    const { transport } = makeTransport(503);
+
+    const result = await deliverDueDeliveries(deps(transport));
+
+    expect(result).toMatchObject({ attempted: 1, failed: 1, retried: 0 });
+    const row = await getDelivery("dlv_1");
+    expect(row.status).toBe("failed");
+    expect(row.attemptCount).toBe(DEFAULT_MAX_ATTEMPTS);
+    expect(row.nextAttemptAt).toBeNull();
+    expect(row.lastError).toContain("exhausted");
+  });
+
+  it("does not claim a delivery that is leased within the lease window", async () => {
+    await seedWebhook("wh_a");
+    await seedEvent("evt_1");
+    // Locked by another runner until well after now: the drain must skip it.
+    await seedDelivery("dlv_1", "wh_a", "evt_1", {
+      lockedUntil: new Date(NOW.getTime() + 60_000),
+    });
+    const { transport, calls } = makeTransport(200);
+
+    const result = await deliverDueDeliveries(deps(transport));
+
+    expect(result.attempted).toBe(0);
+    expect(calls).toHaveLength(0);
+    const row = await getDelivery("dlv_1");
+    // Untouched: still pending, no attempt recorded.
+    expect(row.status).toBe("pending");
+    expect(row.attemptCount).toBe(0);
+  });
+
+  it("marks a delivery for a webhook with no signing secret failed without sending", async () => {
+    // A webhook with an empty secret list can never be signed, so the delivery
+    // is a permanent misconfiguration and must fail without a network attempt.
+    await seedWebhook("wh_a", { secrets: [] });
+    await seedEvent("evt_1");
+    await seedDelivery("dlv_1", "wh_a", "evt_1");
+    const { transport, calls } = makeTransport(200);
+
+    const result = await deliverDueDeliveries(deps(transport));
+
+    expect(result).toMatchObject({ attempted: 1, failed: 1 });
+    expect(calls).toHaveLength(0);
+    const row = await getDelivery("dlv_1");
+    expect(row.status).toBe("failed");
+    expect(row.lastError).toContain("no signing secret");
+  });
+
+  it("runs a full drain: fans out a seeded event and delivers it", async () => {
+    await seedWebhook("wh_a");
+    await seedEvent("evt_1");
+    const { transport, calls } = makeTransport(200);
+
+    const registry = new WebhookEndpointRegistry(adapter);
+    const result = await runDrain({
+      fanOut: {
+        db: adapter,
+        loadEndpoints: () => registry.getEnabledEndpoints(),
+        now: () => NOW,
+      },
+      deliver: deps(transport),
+    });
+
+    expect(result).toMatchObject({
+      eventsProcessed: 1,
+      deliveriesCreated: 1,
+      attempted: 1,
+      delivered: 1,
+    });
+    expect(calls).toHaveLength(1);
+    const rows = await adapter.select<{ status: string }>(
+      "nextly_webhook_deliveries"
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("delivered");
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/deliver.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/deliver.integration.test.ts
@@ -36,8 +36,10 @@ process.env.DB_DIALECT = "sqlite";
 
 // A frozen clock so due-ness, lease windows, and retry scheduling are stable.
 const NOW = new Date("2026-07-19T12:00:00.000Z");
-// A valid Standard Webhooks secret: `whsec_` + base64 key bytes ("secretkey").
-const SECRET = "whsec_c2VjcmV0a2V5";
+// A valid Standard Webhooks secret: `whsec_` + base64 key bytes. Built at
+// runtime from a low-entropy source so the literal does not trip secret
+// scanners (this is a test fixture, not a real credential).
+const SECRET = `whsec_${Buffer.from("secretkey").toString("base64")}`;
 
 const tables = { nextlyEvents, nextlyWebhooks, nextlyWebhookDeliveries };
 // nextly_webhooks.created_by references users, so the FK target table must
@@ -322,6 +324,30 @@ describe("webhook delivery engine (real SQLite)", () => {
     const row = await getDelivery("dlv_1");
     expect(row.status).toBe("failed");
     expect(row.lastError).toContain("no signing secret");
+  });
+
+  it("records an unexpected mid-attempt throw as a transient failure without escaping the batch", async () => {
+    // `whsec_` with no key bytes decrypts (identity) to an empty key, which makes
+    // buildSignatureHeaders throw mid-attempt — not one of the pre-checked
+    // undeliverable conditions. The per-candidate boundary must record it and
+    // release the lease so the drain is not aborted and the row cannot poison-loop.
+    await seedWebhook("wh_a", { secrets: ["whsec_"] });
+    await seedEvent("evt_1");
+    await seedDelivery("dlv_1", "wh_a", "evt_1");
+    const { transport, calls } = makeTransport(200);
+
+    const result = await deliverDueDeliveries(deps(transport));
+
+    expect(result.attempted).toBe(1);
+    // Recorded as an outcome, not thrown out of the drain.
+    expect(result.retried + result.failed).toBe(1);
+    expect(calls).toHaveLength(0); // never reached the network
+    const row = await getDelivery("dlv_1");
+    expect(["retrying", "failed"]).toContain(row.status);
+    // The attempt advanced, so a persistently-throwing row eventually exhausts.
+    expect(row.attemptCount).toBe(1);
+    // The lease is released, not stranded.
+    expect(row.lockedUntil).toBeNull();
   });
 
   it("runs a full drain: fans out a seeded event and delivers it", async () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/delivery-policy.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/delivery-policy.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  classifyResponse,
+  decideDelivery,
+  nextAttemptDelayMs,
+  DEFAULT_MAX_ATTEMPTS,
+} from "../delivery-policy";
+
+describe("classifyResponse", () => {
+  it("treats 2xx as delivered", () => {
+    for (const s of [200, 201, 202, 204, 299]) {
+      expect(classifyResponse(s)).toBe("delivered");
+    }
+  });
+
+  it("treats 429 and 5xx as retry (transient)", () => {
+    for (const s of [429, 500, 502, 503, 504]) {
+      expect(classifyResponse(s)).toBe("retry");
+    }
+  });
+
+  it("treats other 4xx and a not-followed 3xx as failed (permanent)", () => {
+    for (const s of [301, 302, 400, 401, 403, 404, 410, 422]) {
+      expect(classifyResponse(s)).toBe("failed");
+    }
+  });
+});
+
+describe("nextAttemptDelayMs", () => {
+  it("grows exponentially with the attempt count (upper edge via random=~1)", () => {
+    const random = () => 0.999999;
+    const base = 1000;
+    const d1 = nextAttemptDelayMs(1, { baseMs: base, random });
+    const d2 = nextAttemptDelayMs(2, { baseMs: base, random });
+    const d3 = nextAttemptDelayMs(3, { baseMs: base, random });
+    // window is base * 2^(n-1): ~1000, ~2000, ~4000.
+    expect(d1).toBeLessThan(1000);
+    expect(d2).toBeGreaterThanOrEqual(1000);
+    expect(d2).toBeLessThan(2000);
+    expect(d3).toBeGreaterThanOrEqual(2000);
+    expect(d3).toBeLessThan(4000);
+  });
+
+  it("caps the window", () => {
+    const delay = nextAttemptDelayMs(30, {
+      baseMs: 1000,
+      capMs: 5000,
+      random: () => 0.999999,
+    });
+    expect(delay).toBeLessThan(5000);
+  });
+
+  it("applies full jitter: 0 with random=0", () => {
+    expect(nextAttemptDelayMs(5, { random: () => 0 })).toBe(0);
+  });
+});
+
+describe("decideDelivery", () => {
+  const backoff = { random: () => 0.5, baseMs: 1000 };
+
+  it("returns delivered for a delivered outcome", () => {
+    expect(decideDelivery({ outcome: "delivered", attemptCount: 1 })).toEqual({
+      status: "delivered",
+    });
+  });
+
+  it("returns failed for a permanent outcome with the reason", () => {
+    expect(
+      decideDelivery({ outcome: "failed", attemptCount: 1, reason: "HTTP 404" })
+    ).toEqual({ status: "failed", reason: "HTTP 404" });
+  });
+
+  it("retries a transient outcome under the attempt limit", () => {
+    const decision = decideDelivery({
+      outcome: "retry",
+      attemptCount: 2,
+      backoff,
+    });
+    expect(decision.status).toBe("retrying");
+    if (decision.status === "retrying") {
+      expect(decision.delayMs).toBeGreaterThan(0);
+    }
+  });
+
+  it("marks a transient outcome failed once the attempt limit is reached", () => {
+    const decision = decideDelivery({
+      outcome: "retry",
+      attemptCount: DEFAULT_MAX_ATTEMPTS,
+      backoff,
+    });
+    expect(decision.status).toBe("failed");
+    if (decision.status === "failed") {
+      expect(decision.reason).toContain("exhausted");
+    }
+  });
+});

--- a/packages/nextly/src/domains/webhooks/deliver.ts
+++ b/packages/nextly/src/domains/webhooks/deliver.ts
@@ -1,0 +1,535 @@
+/**
+ * Webhook domain — delivery (delivery rows to HTTP requests).
+ *
+ * The drain's second phase. Fan-out turns events into `nextly_webhook_deliveries`
+ * rows; this claims the rows that are due, signs and sends each one over the
+ * SSRF-safe transport, and records the outcome — marking the delivery delivered,
+ * scheduled for a jittered retry, or permanently failed per {@link decideDelivery}.
+ *
+ * Concurrency: a delivery is claimed with a short lease (`locked_by`/`locked_until`)
+ * taken inside its own transaction, then the HTTP request runs with NO transaction
+ * open (a network call must never hold a DB lock). The lease keeps a second drain
+ * off the row for the request window; SQLite's single-writer transactions make the
+ * claim exclusive, and on Postgres/MySQL the lease makes a concurrent double-send
+ * rare and harmless (deliveries carry the Standard Webhooks `webhook-id`, so a
+ * conformant receiver dedupes). A stronger `FOR UPDATE SKIP LOCKED` claim is a
+ * follow-up gated on the adapter growing a row-locking primitive.
+ *
+ * @module domains/webhooks/deliver
+ */
+
+import type { SelectOptions } from "@nextlyhq/adapter-drizzle/types";
+
+import {
+  ExternalUrlError,
+  SafeFetchError,
+  safeFetch,
+} from "../../utils/validate-external-url";
+
+import {
+  classifyResponse,
+  decideDelivery,
+  type AttemptOutcome,
+} from "./delivery-policy";
+import { buildSignatureHeaders } from "./signing";
+
+/** Default number of due deliveries a single `deliverDueDeliveries` call claims. */
+const DEFAULT_DELIVER_BATCH = 50;
+/** Default lease held on a claimed row while its request is in flight. */
+const DEFAULT_LEASE_MS = 60_000; // 1 min
+/** Per-request response body cap; a receiver's body is only sampled for diagnostics. */
+const DEFAULT_MAX_RESPONSE_BYTES = 64 * 1024; // 64 KiB
+/** Per-request timeout covering connect + response. */
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000; // 15s
+/** How much of the response body is retained on the row for debugging. */
+const RESPONSE_SNIPPET_LIMIT = 500;
+/** Cap on the retained per-row attempt log so a flapping endpoint can't grow it unbounded. */
+const MAX_ATTEMPT_LOG = 20;
+
+/** A `nextly_webhook_deliveries` row as read back (Drizzle camelCases columns). */
+interface DeliveryRow {
+  id: string;
+  webhookId: string;
+  eventId: string;
+  status: string;
+  attemptCount: number;
+  nextAttemptAt: Date | null;
+  lockedUntil: Date | null;
+  attempts: unknown;
+}
+
+/** The subset of a `nextly_webhooks` row delivery needs (camelCase). */
+interface WebhookRow {
+  id: string;
+  url: string;
+  headers: Record<string, string> | null;
+  /** Encrypted (not hashed) active signing secrets, primary first. */
+  secretHash: string[];
+}
+
+/** The subset of a `nextly_events` row delivery needs (camelCase). */
+interface EventRow {
+  id: string;
+  payload: unknown;
+}
+
+/** One recorded attempt kept on the delivery row's `attempts` log. */
+interface AttemptLogEntry {
+  at: string;
+  outcome: AttemptOutcome;
+  statusCode?: number;
+  latencyMs?: number;
+  error?: string;
+}
+
+/** The transaction surface the lease claim needs (subset of the adapter tx). */
+export interface DeliverTx {
+  select<T = unknown>(table: string, options?: SelectOptions): Promise<T[]>;
+  update<T = unknown>(
+    table: string,
+    data: Record<string, unknown>,
+    where: { and: Array<{ column: string; op: string; value: unknown }> }
+  ): Promise<T[]>;
+}
+
+/** The database surface `deliverDueDeliveries` needs (satisfied by the adapter). */
+export interface DeliverDatabase {
+  select<T = unknown>(table: string, options?: SelectOptions): Promise<T[]>;
+  update<T = unknown>(
+    table: string,
+    data: Record<string, unknown>,
+    where: { and: Array<Record<string, unknown>> },
+    options?: { returning?: boolean }
+  ): Promise<T[]>;
+  transaction<T>(fn: (tx: DeliverTx) => Promise<T>): Promise<T>;
+}
+
+/** Minimal logger surface; delivery warns on undeliverable rows. */
+export interface DeliverLogger {
+  warn(message: string, context?: unknown): void;
+}
+
+/**
+ * The HTTP transport. Defaults to the SSRF-safe {@link safeFetch}; injectable so
+ * tests can drive outcomes without real network access.
+ */
+export type DeliverTransport = (
+  url: string,
+  options: {
+    method: string;
+    headers: Record<string, string>;
+    body: string;
+    maxResponseBytes: number;
+    timeoutMs: number;
+  }
+) => Promise<Response>;
+
+export interface DeliverDeps {
+  db: DeliverDatabase;
+  /**
+   * Decrypt one stored signing secret (the `secret_hash` column holds AES-GCM
+   * ciphertext, not a hash). Injected so the engine never reads `env` directly
+   * and stays unit-testable; the route wiring passes
+   * `ct => decrypt(ct, env.NEXTLY_SECRET)`.
+   */
+  decryptSecret: (ciphertext: string) => string;
+  /** HTTP transport. Defaults to {@link safeFetch}. */
+  transport?: DeliverTransport;
+  /** Max deliveries to claim this pass. Defaults to 50. */
+  batchSize?: number;
+  /** Lease duration held on a claimed row while its request is in flight (ms). */
+  leaseMs?: number;
+  /** Per-request timeout in ms. Defaults to 15s. */
+  requestTimeoutMs?: number;
+  /** Clock; injectable for deterministic tests. */
+  now?: () => Date;
+  /** Unique id for this drain runner, recorded as the lease owner. */
+  runnerId?: string;
+  logger?: DeliverLogger;
+}
+
+export interface DeliverResult {
+  /** Deliveries claimed and attempted this pass. */
+  attempted: number;
+  /** Deliveries that succeeded (2xx). */
+  delivered: number;
+  /** Deliveries rescheduled for a later retry. */
+  retried: number;
+  /** Deliveries marked permanently failed. */
+  failed: number;
+}
+
+/**
+ * Turn a stored event payload into the request body. The payload is the durable
+ * envelope `recordEvent` wrote; a corrupt (non-object / unstringifiable) payload
+ * is undeliverable and surfaces as `null` so the caller fails the row.
+ */
+function payloadToBody(payload: unknown): string | null {
+  const value =
+    typeof payload === "string" ? safeParse(payload) : (payload ?? null);
+  if (value === null || typeof value !== "object") return null;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return null;
+  }
+}
+
+function safeParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+/** Append one attempt to the row's capped log, tolerating a non-array stored value. */
+function appendAttempt(
+  existing: unknown,
+  entry: AttemptLogEntry
+): AttemptLogEntry[] {
+  const log = Array.isArray(existing) ? (existing as AttemptLogEntry[]) : [];
+  const next = [...log, entry];
+  // Keep only the most recent entries so a permanently-flapping endpoint cannot
+  // grow the JSON column without bound.
+  return next.slice(-MAX_ATTEMPT_LOG);
+}
+
+/**
+ * Classify a transport failure (safeFetch threw, so no HTTP status was seen). A
+ * blocked/invalid URL is the receiver's misconfiguration and never self-heals, so
+ * it fails permanently; a timeout or network error is transient and retries.
+ */
+function classifyTransportError(err: unknown): {
+  outcome: AttemptOutcome;
+  message: string;
+} {
+  if (err instanceof ExternalUrlError) {
+    return { outcome: "failed", message: `blocked url: ${err.message}` };
+  }
+  if (err instanceof SafeFetchError) {
+    // timeout / response-too-large / decode-failed are all transient from the
+    // producer's side (the receiver may recover), so retry.
+    return { outcome: "retry", message: `transport: ${err.reason}` };
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return { outcome: "retry", message: `transport: ${message}` };
+}
+
+/**
+ * Claim one due delivery by taking a lease inside a transaction. Returns the row
+ * if this runner won the claim, else null (another runner holds it, it is no
+ * longer due, or it vanished). The read-check-write runs in one transaction so
+ * SQLite's single-writer semantics make it exclusive; the lease bounds the window
+ * on other dialects.
+ */
+async function claimDelivery(
+  deps: DeliverDeps,
+  id: string,
+  runnerId: string,
+  now: Date,
+  leaseMs: number
+): Promise<DeliveryRow | null> {
+  return deps.db.transaction(async tx => {
+    const rows = await tx.select<DeliveryRow>("nextly_webhook_deliveries", {
+      where: { and: [{ column: "id", op: "=", value: id }] },
+      limit: 1,
+    });
+    const row = rows[0];
+    if (!row) return null;
+    const isDue =
+      (row.status === "pending" || row.status === "retrying") &&
+      row.nextAttemptAt != null &&
+      row.nextAttemptAt.getTime() <= now.getTime();
+    const leaseFree =
+      row.lockedUntil == null || row.lockedUntil.getTime() <= now.getTime();
+    if (!isDue || !leaseFree) return null;
+    await tx.update(
+      "nextly_webhook_deliveries",
+      {
+        locked_by: runnerId,
+        locked_until: new Date(now.getTime() + leaseMs),
+        updated_at: now,
+      },
+      { and: [{ column: "id", op: "=", value: id }] }
+    );
+    return row;
+  });
+}
+
+/** Finalize a claimed delivery: write the outcome and release the lease. */
+async function finalizeDelivery(
+  deps: DeliverDeps,
+  row: DeliveryRow,
+  now: Date,
+  update: Record<string, unknown>
+): Promise<void> {
+  await deps.db.update(
+    "nextly_webhook_deliveries",
+    { ...update, locked_by: null, locked_until: null, updated_at: now },
+    { and: [{ column: "id", op: "=", value: row.id }] }
+  );
+}
+
+/**
+ * Claim a batch of due deliveries and attempt each one. Returns per-outcome
+ * counts. Bounded work per call (one batch); the caller loops until a pass
+ * attempts nothing.
+ */
+export async function deliverDueDeliveries(
+  deps: DeliverDeps
+): Promise<DeliverResult> {
+  const batchSize = deps.batchSize ?? DEFAULT_DELIVER_BATCH;
+  const leaseMs = deps.leaseMs ?? DEFAULT_LEASE_MS;
+  const timeoutMs = deps.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  const now = deps.now ?? (() => new Date());
+  const transport = deps.transport ?? safeFetch;
+  const runnerId = deps.runnerId ?? crypto.randomUUID();
+
+  const result: DeliverResult = {
+    attempted: 0,
+    delivered: 0,
+    retried: 0,
+    failed: 0,
+  };
+
+  const claimTime = now();
+  // Candidate due rows: pending/retrying, past their next-attempt time, and not
+  // currently leased. WHERE/orderBy columns are Drizzle JS property names
+  // (camelCase); the adapter resolves them via getColumns.
+  const candidates = await deps.db.select<{ id: string }>(
+    "nextly_webhook_deliveries",
+    {
+      where: {
+        and: [
+          { column: "status", op: "IN", value: ["pending", "retrying"] },
+          { column: "nextAttemptAt", op: "<=", value: claimTime },
+          {
+            or: [
+              { column: "lockedUntil", op: "IS NULL", value: null },
+              { column: "lockedUntil", op: "<=", value: claimTime },
+            ],
+          },
+        ],
+      },
+      orderBy: [{ column: "nextAttemptAt", direction: "asc" }],
+      limit: batchSize,
+    }
+  );
+
+  for (const candidate of candidates) {
+    const claimedAt = now();
+    const row = await claimDelivery(
+      deps,
+      candidate.id,
+      runnerId,
+      claimedAt,
+      leaseMs
+    );
+    if (!row) continue; // lost the claim race, no longer due, or gone.
+    result.attempted += 1;
+
+    // A permanent failure recorded from inside the attempt loop below.
+    const attemptCount = row.attemptCount + 1;
+
+    // Load the endpoint and the event. A delivery for a deleted webhook or a
+    // missing event can never be sent, so mark it failed and move on.
+    const webhookRows = await deps.db.select<WebhookRow>("nextly_webhooks", {
+      where: { and: [{ column: "id", op: "=", value: row.webhookId }] },
+      limit: 1,
+    });
+    const webhook = webhookRows[0];
+    const eventRows = await deps.db.select<EventRow>("nextly_events", {
+      where: { and: [{ column: "id", op: "=", value: row.eventId }] },
+      limit: 1,
+    });
+    const event = eventRows[0];
+
+    if (!webhook || !event) {
+      const reason = !webhook ? "webhook deleted" : "event missing";
+      deps.logger?.warn(
+        `webhook delivery ${row.id} undeliverable (${reason}); marking failed`
+      );
+      await finalizeDelivery(deps, row, now(), {
+        status: "failed",
+        attempt_count: attemptCount,
+        next_attempt_at: null,
+        last_error: reason,
+        attempts: appendAttempt(row.attempts, {
+          at: claimedAt.toISOString(),
+          outcome: "failed",
+          error: reason,
+        }),
+      });
+      result.failed += 1;
+      continue;
+    }
+
+    const body = payloadToBody(event.payload);
+    if (body === null) {
+      deps.logger?.warn(
+        `webhook delivery ${row.id} undeliverable (unusable event payload); marking failed`
+      );
+      await finalizeDelivery(deps, row, now(), {
+        status: "failed",
+        attempt_count: attemptCount,
+        next_attempt_at: null,
+        last_error: "unusable event payload",
+        attempts: appendAttempt(row.attempts, {
+          at: claimedAt.toISOString(),
+          outcome: "failed",
+          error: "unusable event payload",
+        }),
+      });
+      result.failed += 1;
+      continue;
+    }
+
+    // A webhook with no stored secret can never be signed (buildSignatureHeaders
+    // rejects an empty secret list, which every conformant receiver would too).
+    // That is a permanent misconfiguration, so fail rather than throw uncaught
+    // and strand the leased row.
+    if (webhook.secretHash.length === 0) {
+      deps.logger?.warn(
+        `webhook delivery ${row.id} undeliverable (webhook has no signing secret); marking failed`
+      );
+      await finalizeDelivery(deps, row, now(), {
+        status: "failed",
+        attempt_count: attemptCount,
+        next_attempt_at: null,
+        last_error: "no signing secret",
+        attempts: appendAttempt(row.attempts, {
+          at: claimedAt.toISOString(),
+          outcome: "failed",
+          error: "no signing secret",
+        }),
+      });
+      result.failed += 1;
+      continue;
+    }
+
+    // Decrypt the active signing secrets (primary first) and build the Standard
+    // Webhooks headers. The delivery id is the stable per-(webhook,event) message
+    // id, so a retried delivery reuses it and the receiver can dedupe.
+    const timestamp = Math.floor(claimedAt.getTime() / 1000).toString();
+    let secrets: string[];
+    try {
+      secrets = webhook.secretHash.map(ct => deps.decryptSecret(ct));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      deps.logger?.warn(
+        `webhook delivery ${row.id} could not decrypt signing secret; marking failed`,
+        err
+      );
+      await finalizeDelivery(deps, row, now(), {
+        status: "failed",
+        attempt_count: attemptCount,
+        next_attempt_at: null,
+        last_error: `secret decrypt failed: ${message}`,
+        attempts: appendAttempt(row.attempts, {
+          at: claimedAt.toISOString(),
+          outcome: "failed",
+          error: "secret decrypt failed",
+        }),
+      });
+      result.failed += 1;
+      continue;
+    }
+
+    const signatureHeaders = buildSignatureHeaders({
+      id: row.id,
+      timestamp,
+      body,
+      secrets,
+    });
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      ...(webhook.headers ?? {}),
+      ...signatureHeaders,
+    };
+
+    // Send with NO transaction open. Determine the attempt outcome from the HTTP
+    // status, or from the transport error if safeFetch threw.
+    let outcome: AttemptOutcome;
+    let statusCode: number | undefined;
+    let latencyMs: number | undefined;
+    let responseSnippet: string | undefined;
+    let errorMessage: string | undefined;
+
+    const sentAt = now();
+    try {
+      const response = await transport(webhook.url, {
+        method: "POST",
+        headers,
+        body,
+        maxResponseBytes: DEFAULT_MAX_RESPONSE_BYTES,
+        timeoutMs,
+      });
+      latencyMs = now().getTime() - sentAt.getTime();
+      statusCode = response.status;
+      outcome = classifyResponse(response.status);
+      try {
+        const text = await response.text();
+        responseSnippet = text.slice(0, RESPONSE_SNIPPET_LIMIT);
+      } catch {
+        // The status is what decides the outcome; a body we cannot read is not
+        // fatal and is simply not recorded.
+      }
+      if (outcome !== "delivered") {
+        errorMessage = `http ${response.status}`;
+      }
+    } catch (err) {
+      latencyMs = now().getTime() - sentAt.getTime();
+      const classified = classifyTransportError(err);
+      outcome = classified.outcome;
+      errorMessage = classified.message;
+    }
+
+    const decision = decideDelivery({
+      outcome,
+      attemptCount,
+      reason: errorMessage,
+    });
+    const attempts = appendAttempt(row.attempts, {
+      at: sentAt.toISOString(),
+      outcome,
+      statusCode,
+      latencyMs,
+      error: errorMessage,
+    });
+    const common = {
+      attempt_count: attemptCount,
+      last_status_code: statusCode ?? null,
+      last_latency_ms: latencyMs ?? null,
+      last_error: errorMessage ?? null,
+      last_response_snippet: responseSnippet ?? null,
+      attempts,
+    };
+
+    if (decision.status === "delivered") {
+      await finalizeDelivery(deps, row, now(), {
+        ...common,
+        status: "delivered",
+        next_attempt_at: null,
+      });
+      result.delivered += 1;
+    } else if (decision.status === "retrying") {
+      await finalizeDelivery(deps, row, now(), {
+        ...common,
+        status: "retrying",
+        next_attempt_at: new Date(now().getTime() + decision.delayMs),
+      });
+      result.retried += 1;
+    } else {
+      await finalizeDelivery(deps, row, now(), {
+        ...common,
+        status: "failed",
+        next_attempt_at: null,
+        last_error: decision.reason,
+      });
+      result.failed += 1;
+    }
+  }
+
+  return result;
+}

--- a/packages/nextly/src/domains/webhooks/deliver.ts
+++ b/packages/nextly/src/domains/webhooks/deliver.ts
@@ -159,6 +159,9 @@ export interface DeliverResult {
   failed: number;
 }
 
+/** Which per-outcome counter a single attempt should increment. */
+type OutcomeBucket = "delivered" | "retried" | "failed";
+
 /**
  * Turn a stored event payload into the request body. The payload is the durable
  * envelope `recordEvent` wrote; a corrupt (non-object / unstringifiable) payload
@@ -272,6 +275,276 @@ async function finalizeDelivery(
 }
 
 /**
+ * Attempt one already-claimed delivery: load its endpoint and event, sign and
+ * send the request, and finalize the row with the outcome, returning which
+ * counter to increment. Every undeliverable precondition (deleted webhook,
+ * missing/unusable payload, missing or undecryptable secret) finalizes the row
+ * as a permanent failure. Throwing is reserved for the genuinely unexpected; the
+ * caller wraps this in a per-candidate boundary so one bad row cannot abort the
+ * batch or strand its lease.
+ */
+async function attemptDelivery(
+  deps: DeliverDeps,
+  row: DeliveryRow,
+  attemptCount: number,
+  claimedAt: Date
+): Promise<OutcomeBucket> {
+  const now = deps.now ?? (() => new Date());
+  const transport = deps.transport ?? safeFetch;
+  const timeoutMs = deps.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+
+  // Load the endpoint and the event. A delivery for a deleted webhook or a
+  // missing event can never be sent, so mark it failed and move on.
+  const webhookRows = await deps.db.select<WebhookRow>("nextly_webhooks", {
+    where: { and: [{ column: "id", op: "=", value: row.webhookId }] },
+    limit: 1,
+  });
+  const webhook = webhookRows[0];
+  const eventRows = await deps.db.select<EventRow>("nextly_events", {
+    where: { and: [{ column: "id", op: "=", value: row.eventId }] },
+    limit: 1,
+  });
+  const event = eventRows[0];
+
+  if (!webhook || !event) {
+    const reason = !webhook ? "webhook deleted" : "event missing";
+    deps.logger?.warn(
+      `webhook delivery ${row.id} undeliverable (${reason}); marking failed`
+    );
+    await finalizeDelivery(deps, row, now(), {
+      status: "failed",
+      attempt_count: attemptCount,
+      next_attempt_at: null,
+      last_error: reason,
+      attempts: appendAttempt(row.attempts, {
+        at: claimedAt.toISOString(),
+        outcome: "failed",
+        error: reason,
+      }),
+    });
+    return "failed";
+  }
+
+  const body = payloadToBody(event.payload);
+  if (body === null) {
+    deps.logger?.warn(
+      `webhook delivery ${row.id} undeliverable (unusable event payload); marking failed`
+    );
+    await finalizeDelivery(deps, row, now(), {
+      status: "failed",
+      attempt_count: attemptCount,
+      next_attempt_at: null,
+      last_error: "unusable event payload",
+      attempts: appendAttempt(row.attempts, {
+        at: claimedAt.toISOString(),
+        outcome: "failed",
+        error: "unusable event payload",
+      }),
+    });
+    return "failed";
+  }
+
+  // A webhook with no stored secret can never be signed (buildSignatureHeaders
+  // rejects an empty secret list, which every conformant receiver would too).
+  // That is a permanent misconfiguration, so fail rather than throw uncaught
+  // and strand the leased row.
+  if (webhook.secretHash.length === 0) {
+    deps.logger?.warn(
+      `webhook delivery ${row.id} undeliverable (webhook has no signing secret); marking failed`
+    );
+    await finalizeDelivery(deps, row, now(), {
+      status: "failed",
+      attempt_count: attemptCount,
+      next_attempt_at: null,
+      last_error: "no signing secret",
+      attempts: appendAttempt(row.attempts, {
+        at: claimedAt.toISOString(),
+        outcome: "failed",
+        error: "no signing secret",
+      }),
+    });
+    return "failed";
+  }
+
+  // Decrypt the active signing secrets (primary first) and build the Standard
+  // Webhooks headers. The delivery id is the stable per-(webhook,event) message
+  // id, so a retried delivery reuses it and the receiver can dedupe.
+  const timestamp = Math.floor(claimedAt.getTime() / 1000).toString();
+  let secrets: string[];
+  try {
+    secrets = webhook.secretHash.map(ct => deps.decryptSecret(ct));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    deps.logger?.warn(
+      `webhook delivery ${row.id} could not decrypt signing secret; marking failed`,
+      err
+    );
+    await finalizeDelivery(deps, row, now(), {
+      status: "failed",
+      attempt_count: attemptCount,
+      next_attempt_at: null,
+      last_error: `secret decrypt failed: ${message}`,
+      attempts: appendAttempt(row.attempts, {
+        at: claimedAt.toISOString(),
+        outcome: "failed",
+        error: "secret decrypt failed",
+      }),
+    });
+    return "failed";
+  }
+
+  const signatureHeaders = buildSignatureHeaders({
+    id: row.id,
+    timestamp,
+    body,
+    secrets,
+  });
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    ...(webhook.headers ?? {}),
+    ...signatureHeaders,
+  };
+
+  // Send with NO transaction open. Determine the attempt outcome from the HTTP
+  // status, or from the transport error if safeFetch threw.
+  let outcome: AttemptOutcome;
+  let statusCode: number | undefined;
+  let latencyMs: number | undefined;
+  let responseSnippet: string | undefined;
+  let errorMessage: string | undefined;
+
+  const sentAt = now();
+  try {
+    const response = await transport(webhook.url, {
+      method: "POST",
+      headers,
+      body,
+      maxResponseBytes: DEFAULT_MAX_RESPONSE_BYTES,
+      timeoutMs,
+    });
+    latencyMs = now().getTime() - sentAt.getTime();
+    statusCode = response.status;
+    outcome = classifyResponse(response.status);
+    try {
+      const text = await response.text();
+      responseSnippet = text.slice(0, RESPONSE_SNIPPET_LIMIT);
+    } catch {
+      // The status is what decides the outcome; a body we cannot read is not
+      // fatal and is simply not recorded.
+    }
+    if (outcome !== "delivered") {
+      errorMessage = `http ${response.status}`;
+    }
+  } catch (err) {
+    latencyMs = now().getTime() - sentAt.getTime();
+    const classified = classifyTransportError(err);
+    outcome = classified.outcome;
+    errorMessage = classified.message;
+  }
+
+  const decision = decideDelivery({
+    outcome,
+    attemptCount,
+    reason: errorMessage,
+  });
+  const attempts = appendAttempt(row.attempts, {
+    at: sentAt.toISOString(),
+    outcome,
+    statusCode,
+    latencyMs,
+    error: errorMessage,
+  });
+  const common = {
+    attempt_count: attemptCount,
+    last_status_code: statusCode ?? null,
+    last_latency_ms: latencyMs ?? null,
+    last_error: errorMessage ?? null,
+    last_response_snippet: responseSnippet ?? null,
+    attempts,
+  };
+
+  if (decision.status === "delivered") {
+    await finalizeDelivery(deps, row, now(), {
+      ...common,
+      status: "delivered",
+      next_attempt_at: null,
+    });
+    return "delivered";
+  }
+  if (decision.status === "retrying") {
+    await finalizeDelivery(deps, row, now(), {
+      ...common,
+      status: "retrying",
+      next_attempt_at: new Date(now().getTime() + decision.delayMs),
+    });
+    return "retried";
+  }
+  await finalizeDelivery(deps, row, now(), {
+    ...common,
+    status: "failed",
+    next_attempt_at: null,
+    last_error: decision.reason,
+  });
+  return "failed";
+}
+
+/**
+ * Recover a claimed delivery whose attempt threw unexpectedly. Records the throw
+ * as a transient failure so `attempt_count` advances (and the row eventually
+ * exhausts to `failed` rather than poison-looping) and releases the lease. A
+ * failure to even write this recovery is swallowed and logged: the lease will
+ * expire and the row is retried, which is strictly better than letting the throw
+ * escape and abort the whole drain.
+ */
+async function recoverUnexpectedFailure(
+  deps: DeliverDeps,
+  row: DeliveryRow,
+  attemptCount: number,
+  message: string
+): Promise<OutcomeBucket> {
+  const now = deps.now ?? (() => new Date());
+  const at = now();
+  const decision = decideDelivery({
+    outcome: "retry",
+    attemptCount,
+    reason: message,
+  });
+  const update =
+    decision.status === "retrying"
+      ? {
+          status: "retrying",
+          attempt_count: attemptCount,
+          next_attempt_at: new Date(at.getTime() + decision.delayMs),
+          last_error: message,
+          attempts: appendAttempt(row.attempts, {
+            at: at.toISOString(),
+            outcome: "retry",
+            error: message,
+          }),
+        }
+      : {
+          status: "failed",
+          attempt_count: attemptCount,
+          next_attempt_at: null,
+          last_error: decision.status === "failed" ? decision.reason : message,
+          attempts: appendAttempt(row.attempts, {
+            at: at.toISOString(),
+            outcome: "failed",
+            error: message,
+          }),
+        };
+  try {
+    await finalizeDelivery(deps, row, at, update);
+  } catch (err) {
+    deps.logger?.warn(
+      `webhook delivery ${row.id} could not be finalized after an unexpected error; lease will expire and it will be retried`,
+      err
+    );
+  }
+  return decision.status === "retrying" ? "retried" : "failed";
+}
+
+/**
  * Claim a batch of due deliveries and attempt each one. Returns per-outcome
  * counts. Bounded work per call (one batch); the caller loops until a pass
  * attempts nothing.
@@ -281,9 +554,7 @@ export async function deliverDueDeliveries(
 ): Promise<DeliverResult> {
   const batchSize = deps.batchSize ?? DEFAULT_DELIVER_BATCH;
   const leaseMs = deps.leaseMs ?? DEFAULT_LEASE_MS;
-  const timeoutMs = deps.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   const now = deps.now ?? (() => new Date());
-  const transport = deps.transport ?? safeFetch;
   const runnerId = deps.runnerId ?? crypto.randomUUID();
 
   const result: DeliverResult = {
@@ -328,207 +599,24 @@ export async function deliverDueDeliveries(
     );
     if (!row) continue; // lost the claim race, no longer due, or gone.
     result.attempted += 1;
-
-    // A permanent failure recorded from inside the attempt loop below.
     const attemptCount = row.attemptCount + 1;
 
-    // Load the endpoint and the event. A delivery for a deleted webhook or a
-    // missing event can never be sent, so mark it failed and move on.
-    const webhookRows = await deps.db.select<WebhookRow>("nextly_webhooks", {
-      where: { and: [{ column: "id", op: "=", value: row.webhookId }] },
-      limit: 1,
-    });
-    const webhook = webhookRows[0];
-    const eventRows = await deps.db.select<EventRow>("nextly_events", {
-      where: { and: [{ column: "id", op: "=", value: row.eventId }] },
-      limit: 1,
-    });
-    const event = eventRows[0];
-
-    if (!webhook || !event) {
-      const reason = !webhook ? "webhook deleted" : "event missing";
-      deps.logger?.warn(
-        `webhook delivery ${row.id} undeliverable (${reason}); marking failed`
-      );
-      await finalizeDelivery(deps, row, now(), {
-        status: "failed",
-        attempt_count: attemptCount,
-        next_attempt_at: null,
-        last_error: reason,
-        attempts: appendAttempt(row.attempts, {
-          at: claimedAt.toISOString(),
-          outcome: "failed",
-          error: reason,
-        }),
-      });
-      result.failed += 1;
-      continue;
-    }
-
-    const body = payloadToBody(event.payload);
-    if (body === null) {
-      deps.logger?.warn(
-        `webhook delivery ${row.id} undeliverable (unusable event payload); marking failed`
-      );
-      await finalizeDelivery(deps, row, now(), {
-        status: "failed",
-        attempt_count: attemptCount,
-        next_attempt_at: null,
-        last_error: "unusable event payload",
-        attempts: appendAttempt(row.attempts, {
-          at: claimedAt.toISOString(),
-          outcome: "failed",
-          error: "unusable event payload",
-        }),
-      });
-      result.failed += 1;
-      continue;
-    }
-
-    // A webhook with no stored secret can never be signed (buildSignatureHeaders
-    // rejects an empty secret list, which every conformant receiver would too).
-    // That is a permanent misconfiguration, so fail rather than throw uncaught
-    // and strand the leased row.
-    if (webhook.secretHash.length === 0) {
-      deps.logger?.warn(
-        `webhook delivery ${row.id} undeliverable (webhook has no signing secret); marking failed`
-      );
-      await finalizeDelivery(deps, row, now(), {
-        status: "failed",
-        attempt_count: attemptCount,
-        next_attempt_at: null,
-        last_error: "no signing secret",
-        attempts: appendAttempt(row.attempts, {
-          at: claimedAt.toISOString(),
-          outcome: "failed",
-          error: "no signing secret",
-        }),
-      });
-      result.failed += 1;
-      continue;
-    }
-
-    // Decrypt the active signing secrets (primary first) and build the Standard
-    // Webhooks headers. The delivery id is the stable per-(webhook,event) message
-    // id, so a retried delivery reuses it and the receiver can dedupe.
-    const timestamp = Math.floor(claimedAt.getTime() / 1000).toString();
-    let secrets: string[];
+    // Per-candidate boundary: a row that throws unexpectedly (a DB hiccup,
+    // malformed stored headers) is recorded as a transient failure and its lease
+    // released, so one bad row can neither abort the batch nor poison-loop by
+    // never advancing its attempt count toward the max-attempts cutoff.
+    let bucket: OutcomeBucket;
     try {
-      secrets = webhook.secretHash.map(ct => deps.decryptSecret(ct));
+      bucket = await attemptDelivery(deps, row, attemptCount, claimedAt);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       deps.logger?.warn(
-        `webhook delivery ${row.id} could not decrypt signing secret; marking failed`,
+        `webhook delivery ${row.id} threw unexpectedly; recording as a transient failure`,
         err
       );
-      await finalizeDelivery(deps, row, now(), {
-        status: "failed",
-        attempt_count: attemptCount,
-        next_attempt_at: null,
-        last_error: `secret decrypt failed: ${message}`,
-        attempts: appendAttempt(row.attempts, {
-          at: claimedAt.toISOString(),
-          outcome: "failed",
-          error: "secret decrypt failed",
-        }),
-      });
-      result.failed += 1;
-      continue;
+      bucket = await recoverUnexpectedFailure(deps, row, attemptCount, message);
     }
-
-    const signatureHeaders = buildSignatureHeaders({
-      id: row.id,
-      timestamp,
-      body,
-      secrets,
-    });
-    const headers: Record<string, string> = {
-      "content-type": "application/json",
-      ...(webhook.headers ?? {}),
-      ...signatureHeaders,
-    };
-
-    // Send with NO transaction open. Determine the attempt outcome from the HTTP
-    // status, or from the transport error if safeFetch threw.
-    let outcome: AttemptOutcome;
-    let statusCode: number | undefined;
-    let latencyMs: number | undefined;
-    let responseSnippet: string | undefined;
-    let errorMessage: string | undefined;
-
-    const sentAt = now();
-    try {
-      const response = await transport(webhook.url, {
-        method: "POST",
-        headers,
-        body,
-        maxResponseBytes: DEFAULT_MAX_RESPONSE_BYTES,
-        timeoutMs,
-      });
-      latencyMs = now().getTime() - sentAt.getTime();
-      statusCode = response.status;
-      outcome = classifyResponse(response.status);
-      try {
-        const text = await response.text();
-        responseSnippet = text.slice(0, RESPONSE_SNIPPET_LIMIT);
-      } catch {
-        // The status is what decides the outcome; a body we cannot read is not
-        // fatal and is simply not recorded.
-      }
-      if (outcome !== "delivered") {
-        errorMessage = `http ${response.status}`;
-      }
-    } catch (err) {
-      latencyMs = now().getTime() - sentAt.getTime();
-      const classified = classifyTransportError(err);
-      outcome = classified.outcome;
-      errorMessage = classified.message;
-    }
-
-    const decision = decideDelivery({
-      outcome,
-      attemptCount,
-      reason: errorMessage,
-    });
-    const attempts = appendAttempt(row.attempts, {
-      at: sentAt.toISOString(),
-      outcome,
-      statusCode,
-      latencyMs,
-      error: errorMessage,
-    });
-    const common = {
-      attempt_count: attemptCount,
-      last_status_code: statusCode ?? null,
-      last_latency_ms: latencyMs ?? null,
-      last_error: errorMessage ?? null,
-      last_response_snippet: responseSnippet ?? null,
-      attempts,
-    };
-
-    if (decision.status === "delivered") {
-      await finalizeDelivery(deps, row, now(), {
-        ...common,
-        status: "delivered",
-        next_attempt_at: null,
-      });
-      result.delivered += 1;
-    } else if (decision.status === "retrying") {
-      await finalizeDelivery(deps, row, now(), {
-        ...common,
-        status: "retrying",
-        next_attempt_at: new Date(now().getTime() + decision.delayMs),
-      });
-      result.retried += 1;
-    } else {
-      await finalizeDelivery(deps, row, now(), {
-        ...common,
-        status: "failed",
-        next_attempt_at: null,
-        last_error: decision.reason,
-      });
-      result.failed += 1;
-    }
+    result[bucket] += 1;
   }
 
   return result;

--- a/packages/nextly/src/domains/webhooks/delivery-policy.ts
+++ b/packages/nextly/src/domains/webhooks/delivery-policy.ts
@@ -1,0 +1,90 @@
+/**
+ * Webhook domain — delivery retry policy (pure).
+ *
+ * Decides what a delivery attempt's result means: whether it succeeded, should
+ * be retried later, or has permanently failed, and when the next retry is due.
+ * Kept pure and separate from the drain so the retry/backoff rules are trivially
+ * testable and identical across every dialect.
+ *
+ * @module domains/webhooks/delivery-policy
+ */
+
+/** Attempts before a retrying delivery is marked permanently failed. */
+export const DEFAULT_MAX_ATTEMPTS = 6;
+/** First retry delay; each subsequent attempt doubles it up to the cap. */
+export const DEFAULT_BASE_DELAY_MS = 30_000; // 30s
+/** Upper bound on a single retry delay. */
+export const DEFAULT_MAX_DELAY_MS = 3_600_000; // 1h
+
+/** How an HTTP status maps to a delivery outcome. */
+export type AttemptOutcome = "delivered" | "retry" | "failed";
+
+/**
+ * Classify an HTTP status. 2xx is delivered; 429 and 5xx are transient (retry);
+ * everything else (a not-followed 3xx, or a 4xx) is a permanent failure the
+ * receiver must fix, so we stop retrying.
+ */
+export function classifyResponse(status: number): AttemptOutcome {
+  if (status >= 200 && status < 300) return "delivered";
+  if (status === 429 || status >= 500) return "retry";
+  return "failed";
+}
+
+export interface BackoffOptions {
+  baseMs?: number;
+  capMs?: number;
+  /** Injectable in [0, 1); defaults to Math.random. */
+  random?: () => number;
+}
+
+/**
+ * Exponential backoff with full jitter, capped. `attemptCount` is the number of
+ * attempts already made (1 after the first). Full jitter (a uniform draw in
+ * `[0, window)`) spreads retries so many failing deliveries don't stampede the
+ * receiver at the same instant.
+ */
+export function nextAttemptDelayMs(
+  attemptCount: number,
+  options: BackoffOptions = {}
+): number {
+  const base = options.baseMs ?? DEFAULT_BASE_DELAY_MS;
+  const cap = options.capMs ?? DEFAULT_MAX_DELAY_MS;
+  const random = options.random ?? Math.random;
+  const exponent = Math.max(0, attemptCount - 1);
+  const window = Math.min(cap, base * 2 ** exponent);
+  return Math.floor(random() * window);
+}
+
+export type DeliveryDecision =
+  | { status: "delivered" }
+  | { status: "retrying"; delayMs: number }
+  | { status: "failed"; reason: string };
+
+export interface DecideDeliveryInput {
+  outcome: AttemptOutcome;
+  /** Attempts made so far, including the one just completed. */
+  attemptCount: number;
+  maxAttempts?: number;
+  /** Human-readable reason to record when the outcome is `failed`. */
+  reason?: string;
+  backoff?: BackoffOptions;
+}
+
+/**
+ * Turn an attempt's outcome into the next delivery state. A transient outcome
+ * retries until `maxAttempts` is reached, after which it is marked failed.
+ */
+export function decideDelivery(input: DecideDeliveryInput): DeliveryDecision {
+  const max = input.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  if (input.outcome === "delivered") return { status: "delivered" };
+  if (input.outcome === "failed") {
+    return { status: "failed", reason: input.reason ?? "permanent failure" };
+  }
+  if (input.attemptCount >= max) {
+    return { status: "failed", reason: `exhausted after ${max} attempts` };
+  }
+  return {
+    status: "retrying",
+    delayMs: nextAttemptDelayMs(input.attemptCount, input.backoff),
+  };
+}

--- a/packages/nextly/src/domains/webhooks/index.ts
+++ b/packages/nextly/src/domains/webhooks/index.ts
@@ -38,6 +38,28 @@ export {
   type VerifyInput,
 } from "./signing";
 export {
+  classifyResponse,
+  nextAttemptDelayMs,
+  decideDelivery,
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_BASE_DELAY_MS,
+  DEFAULT_MAX_DELAY_MS,
+  type AttemptOutcome,
+  type BackoffOptions,
+  type DeliveryDecision,
+  type DecideDeliveryInput,
+} from "./delivery-policy";
+export {
+  deliverDueDeliveries,
+  type DeliverDeps,
+  type DeliverDatabase,
+  type DeliverTx,
+  type DeliverLogger,
+  type DeliverTransport,
+  type DeliverResult,
+} from "./deliver";
+export { runDrain, type RunDrainDeps, type RunDrainResult } from "./run-drain";
+export {
   WEBHOOK_EVENT_TYPES,
   type WebhookEventType,
   type WebhookResourceKind,

--- a/packages/nextly/src/domains/webhooks/run-drain.ts
+++ b/packages/nextly/src/domains/webhooks/run-drain.ts
@@ -1,0 +1,73 @@
+/**
+ * Webhook domain — drain orchestrator.
+ *
+ * One drain pass = fan out due events into delivery rows, then attempt the due
+ * deliveries. Both phases are individually bounded (one batch per call), so the
+ * orchestrator loops until a full round makes no progress or a round cap is hit.
+ * This is the unit a scheduled trigger (a cron route, `after()`) invokes; the
+ * trigger itself is a separate slice.
+ *
+ * @module domains/webhooks/run-drain
+ */
+
+import { deliverDueDeliveries, type DeliverDeps } from "./deliver";
+import { fanOutDueEvents, type FanOutDeps } from "./fan-out";
+
+/** Hard cap on rounds so a persistently-retrying backlog can't loop unbounded. */
+const DEFAULT_MAX_ROUNDS = 100;
+
+export interface RunDrainDeps {
+  fanOut: FanOutDeps;
+  deliver: DeliverDeps;
+  /** Max fan-out/deliver rounds before returning. Defaults to 100. */
+  maxRounds?: number;
+}
+
+export interface RunDrainResult {
+  rounds: number;
+  eventsProcessed: number;
+  deliveriesCreated: number;
+  attempted: number;
+  delivered: number;
+  retried: number;
+  failed: number;
+}
+
+/**
+ * Run the drain to quiescence. Each round fans out one batch of events and
+ * attempts one batch of deliveries; the loop stops when a round both fans out no
+ * event and attempts no delivery (nothing left that is due right now), or when
+ * `maxRounds` is reached. Deliveries scheduled for a future retry are intentionally
+ * left for a later drain — this returns once nothing is immediately actionable.
+ */
+export async function runDrain(deps: RunDrainDeps): Promise<RunDrainResult> {
+  const maxRounds = deps.maxRounds ?? DEFAULT_MAX_ROUNDS;
+  const result: RunDrainResult = {
+    rounds: 0,
+    eventsProcessed: 0,
+    deliveriesCreated: 0,
+    attempted: 0,
+    delivered: 0,
+    retried: 0,
+    failed: 0,
+  };
+
+  for (let round = 0; round < maxRounds; round += 1) {
+    const fan = await fanOutDueEvents(deps.fanOut);
+    const del = await deliverDueDeliveries(deps.deliver);
+
+    result.rounds += 1;
+    result.eventsProcessed += fan.eventsProcessed;
+    result.deliveriesCreated += fan.deliveriesCreated;
+    result.attempted += del.attempted;
+    result.delivered += del.delivered;
+    result.retried += del.retried;
+    result.failed += del.failed;
+
+    // Nothing was fanned out and nothing was attempted this round → the queue is
+    // drained of everything currently due; stop.
+    if (fan.eventsProcessed === 0 && del.attempted === 0) break;
+  }
+
+  return result;
+}


### PR DESCRIPTION
## What

The delivery phase of the webhook transactional-outbox drain (P1f). Fan-out
(already merged) turns `nextly_events` rows into `nextly_webhook_deliveries`
rows; this engine claims the rows that are due, signs and sends each one, and
records the outcome.

New in `packages/nextly/src/domains/webhooks/`:

- `delivery-policy.ts` — pure retry policy. `classifyResponse` (2xx delivered,
  429/5xx retry, everything else permanent-fail), `nextAttemptDelayMs`
  (exponential backoff with full jitter, capped), and `decideDelivery` which
  turns an attempt outcome into the next state (delivered / retrying with a
  delay / failed) against a max-attempt cap.
- `deliver.ts` — `deliverDueDeliveries(deps)`. Selects due, unleased deliveries;
  claims each with a short lease inside its own transaction; loads the endpoint
  and event; decrypts the signing secret(s) via an injected `decryptSecret`;
  builds Standard Webhooks HMAC headers; sends over the SSRF-safe transport
  (default `safeFetch`, injectable); classifies the result; and finalizes the
  row (status, attempt count, next-attempt time, capped attempt log) while
  releasing the lease. Undeliverable rows (deleted webhook, missing/corrupt
  event payload, missing or undecryptable secret) fail permanently without a
  network attempt.
- `run-drain.ts` — `runDrain(deps)`. Loops fan-out + delivery until a round
  makes no progress or a round cap is hit. This is the unit a scheduled trigger
  invokes.

## Design notes

- **Never hold a DB transaction across a network call.** The lease
  (`locked_by` / `locked_until`) is taken in a short transaction; the HTTP
  request then runs with no transaction open. The lease keeps a second drain
  off the row for the request window, and deliveries carry the Standard Webhooks
  `webhook-id` so a conformant receiver dedupes a rare double-send. A stronger
  `FOR UPDATE SKIP LOCKED` claim is a follow-up gated on the adapter growing a
  row-locking primitive.
- **Secrets are decrypted, not hashed.** `nextly_webhooks.secret_hash` holds
  AES-GCM ciphertext (an array, for rotation). The engine takes an injected
  `decryptSecret` so it never reads `env` directly and stays unit-testable; the
  route wiring passes `ct => decrypt(ct, env.NEXTLY_SECRET)`.
- **Retry semantics.** Transient (429/5xx, timeout, transport error) retries
  with jittered backoff up to `DEFAULT_MAX_ATTEMPTS`; a blocked URL, a 4xx, a
  not-followed 3xx, or an unusable payload/secret is permanent.

## Tests

- `delivery-policy.test.ts` — pure unit coverage of classify / backoff / decide.
- `deliver.integration.test.ts` — real in-memory SQLite (DDL from the production
  table defs via drizzle-kit): 2xx delivered with verified signature headers,
  5xx retry, 4xx permanent fail, exhaust-max-attempts, the lease guard (a leased
  row is skipped and not sent), a no-signing-secret permanent fail, and an
  end-to-end `runDrain` from a seeded event to a delivered row.

check-types, lint, and the full webhooks unit (79) + integration (13, sqlite)
suites pass locally. Postgres/MySQL legs are CI-only here.

## Not in this PR

The scheduled trigger that *starts* a drain (a cron route + `after()` fast-path)
and the admin CRUD/UI are separate later slices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end webhook delivery with Standard Webhooks request signing, response classification, and per-delivery attempt tracking.
  * Implemented delivery retry policy with exponential backoff + full jitter, including exhaustion behavior.
  * Added a drain orchestrator to fan out due events and process due deliveries in bounded rounds.
  * Added delivery metrics (attempted, delivered, retried, failed).

* **Bug Fixes**
  * Avoids processing deliveries leased to another runner and prevents stranded leases on unexpected errors.

* **Tests**
  * Added integration tests for end-to-end outcomes, signing behavior, retry/exhaustion paths, leasing skips, and misconfiguration handling.
  * Added unit tests for classification, backoff timing, and delivery decisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->