### PR TITLE
fix(release): add @nextlyhq/admin-css to the changesets fixed group

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,7 @@
       "nextly",
       "create-nextly-app",
       "@nextlyhq/admin",
+      "@nextlyhq/admin-css",
       "@nextlyhq/ui",
       "@nextlyhq/adapter-drizzle",
       "@nextlyhq/adapter-postgres",


### PR DESCRIPTION
## What

Adds `@nextlyhq/admin-css` to the `fixed` (lockstep) group in `.changeset/config.json`. One line.

## Why

`@nextlyhq/admin-css` was introduced in #240 as a published package, but was never added to the `fixed` group. Everything else publishes in lockstep, so it has already drifted:

| package | version |
|---|---|
| `@nextlyhq/admin-css` | `0.0.2-alpha.36` |
| `@nextlyhq/admin`, `@nextlyhq/ui`, `nextly`, … | `0.0.2-alpha.37` |

It still gets bumped when a changeset happens to list it, but nothing *forces* it into step, so any changeset that omits it desyncs it further. That matters because `@nextlyhq/admin` depends on `@nextlyhq/admin-css`: consumers can end up resolving mismatched admin / admin-css versions, which is exactly what lockstep exists to prevent. (Older changesets predate the package and omit it, which is how the current gap opened.)

## Verification

Ran `changeset version` locally against the 67 pending changesets, both ways, then reverted:

| | `admin-css` | `admin` / `ui` / `nextly` |
|---|---|---|
| **without this fix** | `0.0.2-alpha.37` | `0.0.2-alpha.38` — drift persists |
| **with this fix** | `0.0.2-alpha.38` | `0.0.2-alpha.38` — back in lockstep |

So the fix both stops future drift and heals the existing one on the next release.

## No changeset

Release-config only: no published package's code changes here, so there is nothing to describe in a changelog. The corrected `fixed` group applies on the next release triggered by any other PR's changeset.
