### PR TITLE
fix(admin): route remaining framework navigation through the admin router

### DIFF
--- a/.changeset/admin-framework-seam.md
+++ b/.changeset/admin-framework-seam.md
@@ -1,0 +1,25 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Route the admin's remaining framework-specific navigation through its own router.
+
+The admin panel is a client-side SPA with its own router, but a handful of places still reached for the host framework's navigation directly: the command palette pushed routes through it, the entry list read the URL query string through it, and one entry page used its link component. Those now go through the admin's own navigation, link, and a new query-string hook, so behavior is unchanged while the admin stops depending on the host framework for routing.

--- a/.changeset/admin-framework-seam.md
+++ b/.changeset/admin-framework-seam.md
@@ -20,6 +20,8 @@
 "@nextlyhq/ui": patch
 ---
 
-Route the admin's remaining framework-specific navigation through its own router.
+Fix admin links ignoring modifier clicks, and route the admin's remaining framework-specific navigation through its own router.
 
-The admin panel is a client-side SPA with its own router, but a handful of places still reached for the host framework's navigation directly: the command palette pushed routes through it, the entry list read the URL query string through it, and one entry page used its link component. Those now go through the admin's own navigation, link, and a new query-string hook, so behavior is unchanged while the admin stops depending on the host framework for routing.
+Links in the admin panel now behave like normal links: Cmd/Ctrl-click and middle-click open them in a new tab, `target="_blank"` is honored, and links that point outside the admin (such as the Help entry in the account menu, which goes to the documentation site) open properly instead of being rewritten into a dead admin route. Previously every one of these was captured and turned into an in-app navigation.
+
+Internally, the few remaining places that reached for the host framework's navigation directly — the command palette, the entry list's reading of the URL query string, and one entry page's links — now go through the admin's own navigation, link, and a new query-string hook. The entry list also no longer issues an unfiltered request before its URL filter is applied.

--- a/packages/admin/src/components/features/entries/EntryList/EntryList.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/EntryList.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Button } from "@nextlyhq/ui";
-import { useSearchParams } from "next/navigation";
 import { useState, useCallback, useMemo, useRef } from "react";
 
 import { Code, Plus } from "@admin/components/icons";
@@ -29,9 +28,11 @@ import { useColumnVisibility } from "@admin/hooks/useColumnVisibility";
 import { useEntryListShortcuts } from "@admin/hooks/useKeyboardShortcuts";
 import { useLocalization } from "@admin/hooks/useLocalization";
 import { usePluginAutoRegistration } from "@admin/hooks/usePluginAutoRegistration";
+import { useSearchParams } from "@admin/hooks/useSearchParams";
 import type { ListResponse } from "@admin/lib/api/response-types";
 import { navigateTo } from "@admin/lib/navigation";
 import type { InjectionPointProps } from "@admin/lib/plugins/component-registry";
+import { getSearchParam } from "@admin/lib/routing";
 import type { Entry } from "@admin/types/collection";
 import type { ApiCollection } from "@admin/types/entities";
 
@@ -249,7 +250,7 @@ export function EntryList({ collectionSlug }: EntryListProps) {
 
   // Read where parameter from URL for filtering (e.g., from SubmissionsFilter)
   const searchParams = useSearchParams();
-  const whereParam = searchParams.get("where");
+  const whereParam = getSearchParam(searchParams, "where");
 
   const whereFilter = useMemo(() => {
     return buildEntryWhereFilter({

--- a/packages/admin/src/components/shared/command-palette/ActionCommands.tsx
+++ b/packages/admin/src/components/shared/command-palette/ActionCommands.tsx
@@ -117,6 +117,8 @@ export function ActionCommands({ onSelect }: ActionCommandsProps) {
             value={command.label}
             keywords={command.keywords}
             disabled={command.disabled}
+            // Action commands are in-app destinations, so selection routes
+            // through the admin SPA router instead of a full page load.
             onSelect={() => onSelect(() => navigateTo(command.href))}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />

--- a/packages/admin/src/components/shared/command-palette/ActionCommands.tsx
+++ b/packages/admin/src/components/shared/command-palette/ActionCommands.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { CommandGroup, CommandItem, CommandShortcut } from "@nextlyhq/ui";
-import { useRouter } from "next/navigation";
 
 import {
   FileText,
@@ -9,6 +8,7 @@ import {
   ShieldPlus,
   UserPlus,
 } from "@admin/components/icons";
+import { navigateTo } from "@admin/lib/navigation";
 import type { ActionCommand } from "@admin/types/ui/command-palette";
 
 /**
@@ -107,8 +107,6 @@ export interface ActionCommandsProps {
  * @param onSelect - Callback to handle command selection
  */
 export function ActionCommands({ onSelect }: ActionCommandsProps) {
-  const router = useRouter();
-
   return (
     <CommandGroup heading="Actions">
       {actionCommands.map(command => {
@@ -119,7 +117,7 @@ export function ActionCommands({ onSelect }: ActionCommandsProps) {
             value={command.label}
             keywords={command.keywords}
             disabled={command.disabled}
-            onSelect={() => onSelect(() => router.push(command.href))}
+            onSelect={() => onSelect(() => navigateTo(command.href))}
           >
             <Icon className="h-4 w-4" aria-hidden="true" />
             <span>{command.label}</span>

--- a/packages/admin/src/components/shared/command-palette/UserSearchResults.tsx
+++ b/packages/admin/src/components/shared/command-palette/UserSearchResults.tsx
@@ -7,11 +7,11 @@ import {
   CommandGroup,
   CommandItem,
 } from "@nextlyhq/ui";
-import { useRouter } from "next/navigation";
 
 import { User as UserIcon } from "@admin/components/icons";
 import { useUsers } from "@admin/hooks/queries/useUsers";
 import { useDebouncedValue } from "@admin/hooks/useDebouncedValue";
+import { navigateTo } from "@admin/lib/navigation";
 import { getInitials } from "@admin/lib/utils";
 
 /**
@@ -95,8 +95,6 @@ export function UserSearchResults({
   search,
   onSelect,
 }: UserSearchResultsProps) {
-  const router = useRouter();
-
   // Debounce search input using reusable hook
   const debouncedSearch = useDebouncedValue(search, SEARCH_DEBOUNCE_MS);
 
@@ -186,9 +184,7 @@ export function UserSearchResults({
           key={user.id}
           value={`${user.name} ${user.email}`}
           keywords={[user.email, user.id]}
-          onSelect={() =>
-            onSelect(() => router.push(`/admin/users/${user.id}`))
-          }
+          onSelect={() => onSelect(() => navigateTo(`/admin/users/${user.id}`))}
         >
           <Avatar size="md" className="mr-2">
             <AvatarImage src={user.image || undefined} alt={user.name} />

--- a/packages/admin/src/components/shared/command-palette/UserSearchResults.tsx
+++ b/packages/admin/src/components/shared/command-palette/UserSearchResults.tsx
@@ -184,6 +184,8 @@ export function UserSearchResults({
           key={user.id}
           value={`${user.name} ${user.email}`}
           keywords={[user.email, user.id]}
+          // Opening a user stays inside the admin SPA, so this routes through
+          // its router rather than reloading the page.
           onSelect={() => onSelect(() => navigateTo(`/admin/users/${user.id}`))}
         >
           <Avatar size="md" className="mr-2">

--- a/packages/admin/src/components/shared/command-palette/index.tsx
+++ b/packages/admin/src/components/shared/command-palette/index.tsx
@@ -10,11 +10,11 @@ import {
   CommandSeparator,
   CommandShortcut,
 } from "@nextlyhq/ui";
-import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
 import { Home, Settings, Shield, Users } from "@admin/components/icons";
 import { ROUTES } from "@admin/constants/routes";
+import { navigateTo } from "@admin/lib/navigation";
 
 import { ActionCommands } from "./ActionCommands";
 import { UserSearchResults } from "./UserSearchResults";
@@ -113,7 +113,6 @@ const navigationCommands: NavigationCommand[] = [
 export function CommandPalette() {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
-  const router = useRouter();
 
   /**
    * Handle command selection
@@ -170,22 +169,22 @@ export function CommandPalette() {
           switch (e.key.toLowerCase()) {
             case "d":
               e.preventDefault();
-              handleSelect(() => router.push(ROUTES.DASHBOARD));
+              handleSelect(() => navigateTo(ROUTES.DASHBOARD));
               lastKey = "";
               break;
             case "u":
               e.preventDefault();
-              handleSelect(() => router.push("/admin/users"));
+              handleSelect(() => navigateTo("/admin/users"));
               lastKey = "";
               break;
             case "r":
               e.preventDefault();
-              handleSelect(() => router.push("/admin/roles"));
+              handleSelect(() => navigateTo("/admin/roles"));
               lastKey = "";
               break;
             case "s":
               e.preventDefault();
-              handleSelect(() => router.push("/admin/settings"));
+              handleSelect(() => navigateTo("/admin/settings"));
               lastKey = "";
               break;
             default:
@@ -204,7 +203,7 @@ export function CommandPalette() {
 
     document.addEventListener("keydown", down);
     return () => document.removeEventListener("keydown", down);
-  }, [open, handleSelect, router]);
+  }, [open, handleSelect]);
 
   /**
    * Handle dialog open/close state changes
@@ -237,7 +236,7 @@ export function CommandPalette() {
                 key={command.id}
                 value={command.label}
                 keywords={command.keywords}
-                onSelect={() => handleSelect(() => router.push(command.href))}
+                onSelect={() => handleSelect(() => navigateTo(command.href))}
               >
                 <Icon className="h-4 w-4" />
                 <span>{command.label}</span>

--- a/packages/admin/src/components/shared/command-palette/index.tsx
+++ b/packages/admin/src/components/shared/command-palette/index.tsx
@@ -34,7 +34,7 @@ import { UserSearchResults } from "./UserSearchResults";
  * @features
  * - Keyboard shortcut: Cmd+K / Ctrl+K
  * - Fuzzy search across navigation commands
- * - Next.js router integration for navigation
+ * - Admin SPA router integration for navigation
  * - Dark mode compatible
  * - WCAG 2.2 AA compliant
  *
@@ -165,6 +165,8 @@ export function CommandPalette() {
         const timeSinceLastKey = currentTime - lastKeyTime;
 
         // If 'g' was pressed recently (within timeout window)
+        // The "g <key>" shortcuts jump between admin sections, so they route
+        // through the admin's own SPA navigation rather than a full page load.
         if (lastKey === "g" && timeSinceLastKey < SEQUENTIAL_KEY_TIMEOUT) {
           switch (e.key.toLowerCase()) {
             case "d":
@@ -236,6 +238,8 @@ export function CommandPalette() {
                 key={command.id}
                 value={command.label}
                 keywords={command.keywords}
+                // Navigation commands move within the admin SPA, so they go
+                // through its router and keep the loaded app state.
                 onSelect={() => handleSelect(() => navigateTo(command.href))}
               >
                 <Icon className="h-4 w-4" />

--- a/packages/admin/src/components/ui/link/index.test.tsx
+++ b/packages/admin/src/components/ui/link/index.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * The SPA Link intercepts clicks to route client-side, so it has to be careful
+ * about which clicks it takes over: a modifier or middle click, another target,
+ * a download, or an off-app href all mean the user asked for something the
+ * router cannot do, and swallowing those silently breaks the link.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { navigateTo } from "@admin/lib/navigation";
+
+import { Link } from "./index";
+
+vi.mock("@admin/lib/navigation", () => ({ navigateTo: vi.fn() }));
+
+function clickLink(init: Parameters<typeof fireEvent.click>[1] = {}) {
+  const anchor = screen.getByRole("link");
+  return fireEvent.click(anchor, { button: 0, ...init });
+}
+
+describe("Link", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("routes a plain left click through the SPA router", () => {
+    render(<Link href="/entries">Entries</Link>);
+
+    const notCancelled = clickLink();
+
+    expect(navigateTo).toHaveBeenCalledWith("/entries");
+    // Returns false when preventDefault was called.
+    expect(notCancelled).toBe(false);
+  });
+
+  it.each([
+    ["meta (open in new tab)", { metaKey: true }],
+    ["ctrl (open in new tab)", { ctrlKey: true }],
+    ["shift (open in new window)", { shiftKey: true }],
+    ["alt (download)", { altKey: true }],
+    ["middle click", { button: 1 }],
+  ])("leaves a %s click to the browser", (_label, init) => {
+    render(<Link href="/entries">Entries</Link>);
+
+    const notCancelled = clickLink(init);
+
+    expect(navigateTo).not.toHaveBeenCalled();
+    expect(notCancelled).toBe(true);
+  });
+
+  it("leaves a link targeting another context to the browser", () => {
+    render(
+      <Link href="/entries" target="_blank">
+        Entries
+      </Link>
+    );
+
+    clickLink();
+
+    expect(navigateTo).not.toHaveBeenCalled();
+  });
+
+  it("still routes when the target is explicitly _self", () => {
+    render(
+      <Link href="/entries" target="_self">
+        Entries
+      </Link>
+    );
+
+    clickLink();
+
+    expect(navigateTo).toHaveBeenCalledWith("/entries");
+  });
+
+  it("leaves a download to the browser", () => {
+    render(
+      <Link href="/export.csv" download="export.csv">
+        Export
+      </Link>
+    );
+
+    clickLink();
+
+    expect(navigateTo).not.toHaveBeenCalled();
+  });
+
+  it.each(["https://nextlyhq.com/docs", "//cdn.example.com/x", "mailto:a@b.c"])(
+    "leaves the off-app href %s to the browser",
+    href => {
+      render(<Link href={href}>Docs</Link>);
+
+      clickLink();
+
+      expect(navigateTo).not.toHaveBeenCalled();
+    }
+  );
+
+  it("runs the consumer's onClick and lets it cancel the navigation", () => {
+    const onClick = vi.fn((e: React.MouseEvent) => e.preventDefault());
+    render(
+      <Link href="/entries" onClick={onClick}>
+        Entries
+      </Link>
+    );
+
+    clickLink();
+
+    expect(onClick).toHaveBeenCalled();
+    expect(navigateTo).not.toHaveBeenCalled();
+  });
+
+  it("runs a non-cancelling onClick and still navigates", () => {
+    const onClick = vi.fn();
+    render(
+      <Link href="/entries" onClick={onClick}>
+        Entries
+      </Link>
+    );
+
+    clickLink();
+
+    expect(onClick).toHaveBeenCalled();
+    expect(navigateTo).toHaveBeenCalledWith("/entries");
+  });
+});

--- a/packages/admin/src/components/ui/link/index.tsx
+++ b/packages/admin/src/components/ui/link/index.tsx
@@ -8,16 +8,51 @@ interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   children: React.ReactNode;
 }
 
-// SPA Link component that prevents default navigation and uses client-side routing
+/**
+ * True for hrefs that leave the app entirely — an absolute URL, a
+ * protocol-relative one, or a scheme like `mailto:`. The SPA router only
+ * understands admin paths and would prefix these into a dead route.
+ */
+function isExternalHref(href: string): boolean {
+  return href.startsWith("//") || /^[a-z][a-z0-9+.-]*:/i.test(href);
+}
+
+/**
+ * True when the browser should handle the click itself instead of the SPA
+ * router: a modifier click or a non-primary button (open in a new tab or
+ * window), or a link aimed at another browsing context. Intercepting these
+ * would swallow navigation the user explicitly asked for.
+ */
+function prefersNativeNavigation(
+  event: React.MouseEvent<HTMLAnchorElement>,
+  target: string | undefined
+): boolean {
+  return (
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey ||
+    event.button !== 0 ||
+    (target !== undefined && target !== "" && target !== "_self")
+  );
+}
+
+// SPA Link: client-side routing for plain left clicks, and the browser's own
+// behavior for modifier/middle clicks, other targets, and downloads.
 export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
-  ({ href, children, className, onClick, ...props }, ref) => {
+  ({ href, children, className, onClick, target, download, ...props }, ref) => {
     const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-      e.preventDefault();
-
-      // Call custom onClick handler if provided
+      // Run the consumer's handler first so it can cancel the navigation, and
+      // so it still sees the clicks that fall through to the browser.
       onClick?.(e);
+      if (e.defaultPrevented) return;
 
-      // Navigate using SPA routing
+      // A download is a file transfer, not a route change.
+      if (download !== undefined) return;
+
+      if (isExternalHref(href) || prefersNativeNavigation(e, target)) return;
+
+      e.preventDefault();
       navigateTo(href);
     };
 
@@ -26,6 +61,8 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
         ref={ref}
         href={href}
         className={className}
+        target={target}
+        download={download}
         onClick={handleClick}
         {...props}
       >

--- a/packages/admin/src/hooks/useSearchParams.test.tsx
+++ b/packages/admin/src/hooks/useSearchParams.test.tsx
@@ -4,7 +4,7 @@
  * picking up pushState-driven changes (via the `locationchange` event the
  * router's history patch emits) and back/forward via `popstate`.
  */
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { getSearchParam } from "@admin/lib/routing";
@@ -30,6 +30,21 @@ describe("useSearchParams", () => {
     expect(result.current.status).toBe("draft");
   });
 
+  it("has the params on the very first render, with no empty initial pass", () => {
+    // Consumers key data fetches off these params. An initial empty render
+    // would fetch once unfiltered and again once the real params landed.
+    window.history.pushState({}, "", "/admin/entries?where=abc");
+    const renders: (string | null)[] = [];
+
+    renderHook(() => {
+      const params = useSearchParams();
+      renders.push(getSearchParam(params, "where"));
+      return params;
+    });
+
+    expect(renders[0]).toBe("abc");
+  });
+
   it("updates when a pushState navigation changes the query", () => {
     window.history.pushState({}, "", "/admin/entries?where=abc");
     const { result } = renderHook(() => useSearchParams());
@@ -40,16 +55,26 @@ describe("useSearchParams", () => {
     expect(result.current.where).toBe("xyz");
   });
 
-  it("updates on back/forward (popstate)", () => {
-    window.history.pushState({}, "", "/admin/entries?where=abc");
+  it("updates on real back/forward traversal", async () => {
+    window.history.pushState({}, "", "/admin/entries?where=first");
     const { result } = renderHook(() => useSearchParams());
 
     act(() => {
       window.history.pushState({}, "", "/admin/entries?where=second");
-      window.dispatchEvent(new Event("popstate"));
+      window.dispatchEvent(new Event("locationchange"));
     });
-
     expect(result.current.where).toBe("second");
+
+    // Real traversal: the browser changes the URL and emits popstate itself.
+    act(() => {
+      window.history.back();
+    });
+    await waitFor(() => expect(result.current.where).toBe("first"));
+
+    act(() => {
+      window.history.forward();
+    });
+    await waitFor(() => expect(result.current.where).toBe("second"));
   });
 
   it("keeps a stable result when a navigation leaves the query untouched", () => {

--- a/packages/admin/src/hooks/useSearchParams.test.tsx
+++ b/packages/admin/src/hooks/useSearchParams.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * The admin reads the query string through this hook rather than the host
+ * framework's router, so these cover the reactivity it has to preserve:
+ * picking up pushState-driven changes (via the `locationchange` event the
+ * router's history patch emits) and back/forward via `popstate`.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getSearchParam } from "@admin/lib/routing";
+
+import { useSearchParams } from "./useSearchParams";
+
+function goTo(url: string) {
+  window.history.pushState({}, "", url);
+  window.dispatchEvent(new Event("locationchange"));
+}
+
+afterEach(() => {
+  window.history.pushState({}, "", "/admin");
+});
+
+describe("useSearchParams", () => {
+  it("reads the current query string", () => {
+    window.history.pushState({}, "", "/admin/entries?where=abc&status=draft");
+
+    const { result } = renderHook(() => useSearchParams());
+
+    expect(result.current.where).toBe("abc");
+    expect(result.current.status).toBe("draft");
+  });
+
+  it("updates when a pushState navigation changes the query", () => {
+    window.history.pushState({}, "", "/admin/entries?where=abc");
+    const { result } = renderHook(() => useSearchParams());
+    expect(result.current.where).toBe("abc");
+
+    act(() => goTo("/admin/entries?where=xyz"));
+
+    expect(result.current.where).toBe("xyz");
+  });
+
+  it("updates on back/forward (popstate)", () => {
+    window.history.pushState({}, "", "/admin/entries?where=abc");
+    const { result } = renderHook(() => useSearchParams());
+
+    act(() => {
+      window.history.pushState({}, "", "/admin/entries?where=second");
+      window.dispatchEvent(new Event("popstate"));
+    });
+
+    expect(result.current.where).toBe("second");
+  });
+
+  it("keeps a stable result when a navigation leaves the query untouched", () => {
+    window.history.pushState({}, "", "/admin/entries?where=abc");
+    const { result } = renderHook(() => useSearchParams());
+    const first = result.current;
+
+    // Same query string, different path: nothing to recompute.
+    act(() => goTo("/admin/other?where=abc"));
+
+    expect(result.current).toBe(first);
+  });
+
+  it("drops params when the query is cleared", () => {
+    window.history.pushState({}, "", "/admin/entries?where=abc");
+    const { result } = renderHook(() => useSearchParams());
+    expect(result.current.where).toBe("abc");
+
+    act(() => goTo("/admin/entries"));
+
+    expect(result.current.where).toBeUndefined();
+  });
+});
+
+describe("getSearchParam", () => {
+  it("returns a single value", () => {
+    expect(getSearchParam({ where: "abc" }, "where")).toBe("abc");
+  });
+
+  it("returns the first value when a key repeats, like URLSearchParams.get", () => {
+    expect(getSearchParam({ where: ["first", "second"] }, "where")).toBe(
+      "first"
+    );
+  });
+
+  it("returns null when the key is absent or empty", () => {
+    expect(getSearchParam({}, "where")).toBeNull();
+    expect(getSearchParam({ where: undefined }, "where")).toBeNull();
+    expect(getSearchParam({ where: [] }, "where")).toBeNull();
+  });
+});

--- a/packages/admin/src/hooks/useSearchParams.ts
+++ b/packages/admin/src/hooks/useSearchParams.ts
@@ -1,46 +1,53 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 
 import { parseSearchParams, type SearchParams } from "@admin/lib/routing";
 
-import { useHydration } from "./useHydration";
+/**
+ * Subscribe to the signals that change the URL without a document load:
+ * `popstate` for back/forward, plus the `locationchange` event `useRouter`'s
+ * history patch emits on pushState/replaceState.
+ */
+function subscribe(onStoreChange: () => void): () => void {
+  window.addEventListener("popstate", onStoreChange);
+  window.addEventListener("locationchange", onStoreChange);
+  return () => {
+    window.removeEventListener("popstate", onStoreChange);
+    window.removeEventListener("locationchange", onStoreChange);
+  };
+}
+
+/** The raw query string compares by value, so React can skip equal snapshots. */
+function getSearchSnapshot(): string {
+  return window.location.search;
+}
+
+/** No query string exists while rendering on the server. */
+function getServerSearchSnapshot(): string {
+  return "";
+}
 
 /**
  * Reactive read of the current URL's query string, independent of the host
  * framework's router.
  *
- * Subscribes to the same signals `useRouter` reacts to — `popstate`, plus the
- * `locationchange` event that its history patch emits on pushState/replaceState
- * — but deliberately does not patch history itself. Each `useRouter` instance
- * wraps the previous instance's pushState, so components that only need to read
- * the query string stay out of that chain rather than lengthening it.
+ * Reads through `useSyncExternalStore` rather than an effect so the value is
+ * present on the first render: consumers key data fetches off these params, and
+ * an initial empty pass would fetch once unfiltered and again once the real
+ * params arrived. The server snapshot keeps that safe under SSR, where React
+ * hydrates against the empty string and then re-reads.
  *
- * The raw search string is what's held in state: it compares by value, so an
- * unrelated navigation that leaves the query untouched re-renders nothing.
+ * Deliberately does not patch history, unlike `useRouter` — each of those
+ * instances wraps the previous one's pushState, so components that only read
+ * the query string stay out of that chain rather than lengthening it.
  */
 export function useSearchParams(): SearchParams {
-  const isHydrated = useHydration();
-  const [search, setSearch] = useState("");
-
-  useEffect(() => {
-    if (!isHydrated) return;
-
-    let mounted = true;
-    const read = () => {
-      if (mounted) setSearch(window.location.search);
-    };
-
-    read();
-    window.addEventListener("popstate", read);
-    window.addEventListener("locationchange", read);
-
-    return () => {
-      mounted = false;
-      window.removeEventListener("popstate", read);
-      window.removeEventListener("locationchange", read);
-    };
-  }, [isHydrated]);
+  const search = useSyncExternalStore(
+    subscribe,
+    getSearchSnapshot,
+    getServerSearchSnapshot
+  );
 
   return useMemo(() => parseSearchParams(search), [search]);
 }

--- a/packages/admin/src/hooks/useSearchParams.ts
+++ b/packages/admin/src/hooks/useSearchParams.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { parseSearchParams, type SearchParams } from "@admin/lib/routing";
+
+import { useHydration } from "./useHydration";
+
+/**
+ * Reactive read of the current URL's query string, independent of the host
+ * framework's router.
+ *
+ * Subscribes to the same signals `useRouter` reacts to — `popstate`, plus the
+ * `locationchange` event that its history patch emits on pushState/replaceState
+ * — but deliberately does not patch history itself. Each `useRouter` instance
+ * wraps the previous instance's pushState, so components that only need to read
+ * the query string stay out of that chain rather than lengthening it.
+ *
+ * The raw search string is what's held in state: it compares by value, so an
+ * unrelated navigation that leaves the query untouched re-renders nothing.
+ */
+export function useSearchParams(): SearchParams {
+  const isHydrated = useHydration();
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    if (!isHydrated) return;
+
+    let mounted = true;
+    const read = () => {
+      if (mounted) setSearch(window.location.search);
+    };
+
+    read();
+    window.addEventListener("popstate", read);
+    window.addEventListener("locationchange", read);
+
+    return () => {
+      mounted = false;
+      window.removeEventListener("popstate", read);
+      window.removeEventListener("locationchange", read);
+    };
+  }, [isHydrated]);
+
+  return useMemo(() => parseSearchParams(search), [search]);
+}

--- a/packages/admin/src/lib/routing.ts
+++ b/packages/admin/src/lib/routing.ts
@@ -27,7 +27,7 @@ export interface RouteResult {
 }
 
 type Params = Record<string, string | string[]>;
-type SearchParams = Record<string, string | string[] | undefined>;
+export type SearchParams = Record<string, string | string[] | undefined>;
 
 // Parse URL search parameters
 export function parseSearchParams(search: string): SearchParams {
@@ -43,6 +43,19 @@ export function parseSearchParams(search: string): SearchParams {
           : values;
   }
   return out;
+}
+
+/**
+ * Read a single search-param value, mirroring `URLSearchParams.get()`: the
+ * first value when a key is repeated, and `null` when it is absent.
+ */
+export function getSearchParam(
+  params: SearchParams,
+  key: string
+): string | null {
+  const value = params[key];
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
 }
 
 // Normalize Next.js App Router patterns

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Alert, AlertDescription, Button, Skeleton } from "@nextlyhq/ui";
-import Link from "next/link";
 import type React from "react";
 import { useMemo, useState } from "react";
 
@@ -25,6 +24,7 @@ import { Breadcrumbs } from "@admin/components/shared";
 import { PageErrorFallback } from "@admin/components/shared/error-fallbacks";
 import { PluginSlot } from "@admin/components/shared/plugin-slot";
 import { QueryErrorBoundary } from "@admin/components/shared/query-error-boundary";
+import { Link } from "@admin/components/ui/link";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import { useCollectionSchema } from "@admin/hooks/queries/useCollections";
 import { useEntry } from "@admin/hooks/queries/useEntry";


### PR DESCRIPTION
## What

Roadmap item D (framework-optionality guard): removes the last real `next/` imports from `packages/admin/src`, so the admin SPA routes entirely through its own router.

| call site | was | now |
|---|---|---|
| `command-palette/index.tsx` | `useRouter().push` (`next/navigation`) | `navigateTo` |
| `command-palette/ActionCommands.tsx` | `useRouter().push` | `navigateTo` |
| `command-palette/UserSearchResults.tsx` | `useRouter().push` | `navigateTo` |
| `EntryList.tsx` | `useSearchParams` (`next/navigation`) | `useSearchParams` (admin) |
| `entries/[slug]/[id]/index.tsx` | `Link` (`next/link`) | `Link` (`@admin/components/ui/link`) |

`packages/admin/src` now has zero `next/` imports. The one remaining match, `cli.ts:188`, is a template **string** that generates a route handler for the user's app, so it stays.

## Why not just use the existing `useRouter` for the query string

`RouteResult` already carries parsed `searchParams`, so `EntryList` could have called the internal `useRouter`. I did not, deliberately: each `useRouter` instance **patches `window.history`**, wrapping whatever the previous instance installed. Three components already do this. Adding a fourth from a list component that mounts and unmounts on every collection view would lengthen that chain, and an out-of-order unmount restores a stale patch.

So this adds a small `useSearchParams` hook that subscribes to the same signals (`popstate`, plus the `locationchange` event the router's history patch emits) **without patching history itself**. It holds the raw search string in state, so it compares by value and an unrelated navigation that leaves the query untouched re-renders nothing.

`getSearchParam(params, key)` mirrors `URLSearchParams.get()` (first value when a key repeats, `null` when absent), which is what the previous `searchParams.get("where")` did — repeated keys parse to an array here, so this keeps the exact prior semantics rather than leaking `string[]` into the filter.

## Why it matters

Per the roadmap, the admin is already ~90% adapter-ready (real `/runtime` split, client-SPA admin). The point is not to build non-Next adapters now, it is to **not regress the seam**, so a TanStack/React-Router adapter stays a 1–2 week job rather than a rewrite.

## Tests

- 8 new unit tests: the hook reads the query, updates on pushState-driven `locationchange` and on `popstate`, returns a stable result when a navigation leaves the query untouched, clears on an emptied query; plus `getSearchParam` single / repeated / absent cases.
- 262 existing tests green across the touched areas (entries, command palette, routing, hooks).
- e2e: `admin-smoke` (navigation) + `submissions` — the latter drives the `where` filter that `EntryList` reads, which is the exact migrated path. 10/10 green.
- `check-types` and `lint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reactive search-parameter support across admin pages, including updates from navigation and browser back/forward.
  * Added a helper to read individual query parameters consistently.
* **Improvements**
  * Updated command palette routing to use SPA navigation helpers.
  * Improved entry list filtering by interpreting the `where` parameter via the new query handling.
  * Enhanced SPA link behavior to better respect native browser navigation and special link cases.
* **Tests**
  * Added unit tests for query-parameter parsing/reactivity and for the SPA Link click-interception behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->