### PR TITLE
feat(nextly): add version history read surface and retention

### DIFF
--- a/.changeset/versions-read-surface.md
+++ b/.changeset/versions-read-surface.md
@@ -1,0 +1,34 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Content version history can now be read, and it no longer grows forever.
+
+Two new endpoints list a document's versions and fetch a single one, and the same
+surface is available to plugin code. Listing returns metadata only, so opening a
+long history never transfers the stored content.
+
+Version history is also bounded now. A collection or single keeps the number of
+versions you configured instead of accumulating one for every save ever made; the
+limit was previously accepted in configuration but never applied. The newest
+version and the version matching your currently published content are always
+kept, and trimming happens as part of the same save, so history can never be left
+in a half-trimmed state.

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -131,6 +131,14 @@
       "types": "./dist/api/singles.d.ts",
       "import": "./dist/api/singles.mjs"
     },
+    "./api/versions": {
+      "types": "./dist/api/versions.d.ts",
+      "import": "./dist/api/versions.mjs"
+    },
+    "./api/versions-detail": {
+      "types": "./dist/api/versions-detail.d.ts",
+      "import": "./dist/api/versions-detail.mjs"
+    },
     "./api/singles-detail": {
       "types": "./dist/api/singles-detail.d.ts",
       "import": "./dist/api/singles-detail.mjs"

--- a/packages/nextly/src/api/__tests__/versions-access.test.ts
+++ b/packages/nextly/src/api/__tests__/versions-access.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Version-history access gate.
+ *
+ * The gate decides whether a caller may see a document's history, so its side
+ * effects and failure modes matter as much as its verdict. The init/DI/auth
+ * boundary is mocked so the gate itself is what is under test — an
+ * unauthenticated request would be rejected before reaching it.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const getEntrySpy = vi.fn();
+const singleGetSpy = vi.fn();
+const selectOneSpy = vi.fn();
+const getSingleBySlugSpy = vi.fn();
+const requireRouteCollectionAccessSpy = vi.fn();
+
+vi.mock("../../init", () => ({
+  getCachedNextly: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("../../di", () => ({
+  getService: vi.fn((name: string) => {
+    switch (name) {
+      case "collectionsHandler":
+        return { getEntry: getEntrySpy };
+      case "singleEntryService":
+        return { get: singleGetSpy };
+      case "singleRegistryService":
+        return { getSingleBySlug: getSingleBySlugSpy };
+      case "adapter":
+        return { selectOne: selectOneSpy };
+      case "collectionService":
+        return { getCollection: vi.fn().mockResolvedValue({ fields: [] }) };
+      case "versionsService":
+        return { list: vi.fn().mockResolvedValue([]), get: vi.fn() };
+      default:
+        return {};
+    }
+  }),
+}));
+
+vi.mock("../route-auth", () => ({
+  requireRouteCollectionAccess: (...args: unknown[]) =>
+    requireRouteCollectionAccessSpy(...args),
+}));
+
+vi.mock("../../services/lib/permissions", () => ({
+  resolveRoleSlugs: vi.fn().mockResolvedValue(["editor"]),
+}));
+
+import { requireVersionReadAccess } from "../versions-access";
+import { GET as listVersions } from "../versions";
+
+describe("requireVersionReadAccess", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireRouteCollectionAccessSpy.mockResolvedValue({
+      userId: "user-1",
+      userName: "Ed",
+      userEmail: "ed@example.com",
+      permissions: [],
+      roles: ["editor"],
+      authMethod: "session",
+    });
+  });
+
+  it("reads a collection entry with status:all so drafts still have history", async () => {
+    getEntrySpy.mockResolvedValue({ success: true, statusCode: 200 });
+
+    await requireVersionReadAccess(
+      new Request("http://localhost/x"),
+      "collection",
+      "posts",
+      "entry-1"
+    );
+
+    // Without status:"all" a draft reads as absent and history 404s — exactly
+    // when an author needs it. routeAuthorized keeps a scoped API key from
+    // being re-checked against its creator's stored roles.
+    expect(getEntrySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collectionName: "posts",
+        entryId: "entry-1",
+        status: "all",
+        routeAuthorized: true,
+        overrideAccess: false,
+      })
+    );
+  });
+
+  it("surfaces a server-side read failure instead of reporting not-found", async () => {
+    // A throwing afterRead hook or a component load error yields success:false
+    // with a 5xx. Collapsing that into 404 would disguise an outage as missing
+    // content.
+    getEntrySpy.mockResolvedValue({ success: false, statusCode: 500 });
+
+    await expect(
+      requireVersionReadAccess(
+        new Request("http://localhost/x"),
+        "collection",
+        "posts",
+        "entry-1"
+      )
+    ).rejects.toMatchObject({ code: "INTERNAL_ERROR" });
+  });
+
+  it("treats a denial as not-found so existence is not disclosed", async () => {
+    getEntrySpy.mockResolvedValue({ success: false, statusCode: 403 });
+
+    await expect(
+      requireVersionReadAccess(
+        new Request("http://localhost/x"),
+        "collection",
+        "posts",
+        "entry-1"
+      )
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("never materializes a Single while checking access", async () => {
+    // SingleEntryService.get auto-creates a missing Single (and captures v1 for
+    // a versioned one). A version request is a read, so the gate must check the
+    // backing row directly and stop before that write can happen.
+    getSingleBySlugSpy.mockResolvedValue({ tableName: "single_settings" });
+    selectOneSpy.mockResolvedValue(null);
+
+    await expect(
+      requireVersionReadAccess(
+        new Request("http://localhost/x"),
+        "single",
+        "settings",
+        "single-1"
+      )
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    expect(singleGetSpy).not.toHaveBeenCalled();
+  });
+
+  it("refuses history for a Single recreated under a different id", async () => {
+    // Version rows outlive the document they came from, so a stale entryId
+    // must not expose the previous document's snapshots.
+    getSingleBySlugSpy.mockResolvedValue({ tableName: "single_settings" });
+    selectOneSpy.mockResolvedValue({ id: "current-id" });
+
+    await expect(
+      requireVersionReadAccess(
+        new Request("http://localhost/x"),
+        "single",
+        "settings",
+        "stale-id"
+      )
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    expect(singleGetSpy).not.toHaveBeenCalled();
+  });
+
+  it("allows a Single whose live id matches the requested history", async () => {
+    getSingleBySlugSpy.mockResolvedValue({ tableName: "single_settings" });
+    selectOneSpy.mockResolvedValue({ id: "single-1" });
+    singleGetSpy.mockResolvedValue({ success: true, statusCode: 200 });
+
+    const user = await requireVersionReadAccess(
+      new Request("http://localhost/x"),
+      "single",
+      "settings",
+      "single-1"
+    );
+
+    expect(user.id).toBe("user-1");
+    expect(singleGetSpy).toHaveBeenCalledWith(
+      "settings",
+      expect.objectContaining({ routeAuthorized: true, status: "all" })
+    );
+  });
+});
+
+describe("version list pagination meta", () => {
+  const listSpy = vi.fn();
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    requireRouteCollectionAccessSpy.mockResolvedValue({
+      userId: "user-1",
+      permissions: [],
+      roles: ["editor"],
+      authMethod: "session",
+    });
+    getEntrySpy.mockResolvedValue({ success: true, statusCode: 200 });
+    const di = await import("../../di");
+    vi.mocked(di.getService).mockImplementation(((name: string) =>
+      name === "versionsService"
+        ? { list: listSpy, get: vi.fn() }
+        : name === "collectionsHandler"
+          ? { getEntry: getEntrySpy }
+          : {}) as typeof di.getService);
+  });
+
+  function ctx() {
+    return {
+      params: Promise.resolve({ kind: "collection", slug: "posts", id: "e1" }),
+    };
+  }
+
+  function rows(n: number) {
+    return Array.from({ length: n }, (_, i) => ({ versionNo: n - i }));
+  }
+
+  it("reports hasNext=false when the history exactly fills one page", async () => {
+    // The off-by-one that matters: 2 rows with limit=2 previously claimed a
+    // next page, sending the client to an empty one. The route asks for
+    // limit+1 and only a returned extra row proves more exist.
+    listSpy.mockResolvedValue(rows(2));
+
+    const res = await listVersions(
+      new Request("http://localhost/api/versions/collection/posts/e1?limit=2"),
+      ctx()
+    );
+    const body: {
+      items: unknown[];
+      meta: { hasNext: boolean; limit: number };
+    } = await res.json();
+
+    expect(listSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ limit: 3 })
+    );
+    expect(body.items).toHaveLength(2);
+    expect(body.meta.hasNext).toBe(false);
+    expect(body.meta.limit).toBe(2);
+  });
+
+  it("reports hasNext=true and trims the probe row when more exist", async () => {
+    listSpy.mockResolvedValue(rows(3));
+
+    const res = await listVersions(
+      new Request("http://localhost/api/versions/collection/posts/e1?limit=2"),
+      ctx()
+    );
+    const body: {
+      items: unknown[];
+      meta: { hasNext: boolean };
+    } = await res.json();
+
+    // The extra row is a probe, never part of the page.
+    expect(body.items).toHaveLength(2);
+    expect(body.meta.hasNext).toBe(true);
+  });
+});

--- a/packages/nextly/src/api/__tests__/versions-routes.integration.test.ts
+++ b/packages/nextly/src/api/__tests__/versions-routes.integration.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Version route handlers: path and query validation runs before the access
+ * check, so malformed input is rejected without an auth round-trip (and without
+ * needing a booted container).
+ */
+import { describe, expect, it } from "vitest";
+
+import { GET as getDetail } from "../versions-detail";
+import { GET as getList } from "../versions";
+
+/**
+ * Next.js 15 hands route handlers their params as a Promise. Each handler
+ * declares its own context shape, so the helper is generic over the param map
+ * rather than cast at the call site.
+ */
+function ctx<T extends Record<string, string>>(
+  params: T
+): { params: Promise<T> } {
+  return { params: Promise.resolve(params) };
+}
+
+describe("version routes (integration)", () => {
+  it("rejects an unknown scope kind on the list route", async () => {
+    const res = await getList(
+      new Request("http://localhost/api/versions/bogus/posts/abc"),
+      ctx({ kind: "bogus", slug: "posts", id: "abc" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-numeric limit on the list route", async () => {
+    const res = await getList(
+      new Request(
+        "http://localhost/api/versions/collection/posts/abc?limit=nope"
+      ),
+      ctx({ kind: "collection", slug: "posts", id: "abc" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an unknown scope kind on the detail route", async () => {
+    const res = await getDetail(
+      new Request("http://localhost/api/versions/bogus/posts/abc/1"),
+      ctx({ kind: "bogus", slug: "posts", id: "abc", versionNo: "1" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-numeric version number on the detail route", async () => {
+    const res = await getDetail(
+      new Request("http://localhost/api/versions/collection/posts/abc/nope"),
+      ctx({ kind: "collection", slug: "posts", id: "abc", versionNo: "nope" })
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/nextly/src/api/versions-access.ts
+++ b/packages/nextly/src/api/versions-access.ts
@@ -15,6 +15,7 @@
  * @module api/versions-access
  */
 
+import type { FieldConfig } from "../collections/fields/types";
 import { getService } from "../di";
 import type { UserContext } from "../domains/singles/types";
 import { NextlyError } from "../errors/nextly-error";
@@ -22,6 +23,7 @@ import { getCachedNextly } from "../init";
 import type { VersionScopeKind } from "../schemas/versions/types";
 import { resolveRoleSlugs } from "../services/lib/permissions";
 import { applyFieldReadAccess } from "../shared/lib/field-level-registry";
+import { stripPasswordFieldValues } from "../shared/lib/password-fields";
 
 import { requireRouteCollectionAccess } from "./route-auth";
 
@@ -79,8 +81,13 @@ export async function requireVersionReadAccess(
 
 /**
  * Whether the caller can read the live document, using the same service the
- * normal read path uses so owner-only rules, status filtering, and RBAC all
- * apply identically.
+ * normal read path uses so owner-only rules and stored access rules apply
+ * identically.
+ *
+ * A denial (403) and a missing document (404) both mean "no history for you".
+ * Any other failure is a real server-side fault — a component/relationship load
+ * error, a throwing afterRead hook — and is re-thrown so the route reports it
+ * as a 5xx instead of disguising an outage as missing content.
  */
 async function canReadLiveDocument(
   scopeKind: VersionScopeKind,
@@ -89,12 +96,7 @@ async function canReadLiveDocument(
   user: UserContext
 ): Promise<boolean> {
   if (scopeKind === "single") {
-    const singles = getService("singleEntryService");
-    const result = await singles.get(slug, {
-      user,
-      overrideAccess: false,
-    });
-    return result.success === true;
+    return canReadLiveSingle(slug, entryId, user);
   }
 
   const collections = getService("collectionsHandler");
@@ -103,8 +105,67 @@ async function canReadLiveDocument(
     entryId,
     user,
     overrideAccess: false,
+    // The route already authenticated and authorized the caller, so skip only
+    // the redundant RBAC re-check (which would reject a scoped API key by
+    // resolving its creator's stored roles). Document-level rules still run.
+    routeAuthorized: true,
+    // Match the authenticated read path: without this, a status-enabled
+    // collection filters to published only, and a draft would report no
+    // history — exactly when an author needs it most.
+    status: "all",
   });
-  return result.success === true;
+  return interpretReadResult(result.success, result.statusCode);
+}
+
+/**
+ * Single variant. Reads the backing row directly first, because
+ * `SingleEntryService.get` MATERIALIZES a missing Single (creating the default
+ * document, and for a versioned Single capturing an initial version). A version
+ * request is a read, so it must never write; skipping straight to 404 when no
+ * row exists is also correct, since an unmaterialized Single has no history.
+ *
+ * The row's id is then compared with the requested `entryId`: version rows
+ * outlive the document they came from, so a Single recreated under a new id
+ * must not expose the previous document's snapshots.
+ */
+async function canReadLiveSingle(
+  slug: string,
+  entryId: string,
+  user: UserContext
+): Promise<boolean> {
+  const registry = getService("singleRegistryService");
+  const record = await registry.getSingleBySlug(slug);
+  if (!record?.tableName) return false;
+
+  const adapter = getService("adapter");
+  const row = await adapter.selectOne<{ id?: unknown }>(record.tableName, {});
+  // Not materialized yet, or the live document is a different one than the
+  // requested history belongs to.
+  if (!row || row.id !== entryId) return false;
+
+  const singles = getService("singleEntryService");
+  const result = await singles.get(slug, {
+    user,
+    overrideAccess: false,
+    routeAuthorized: true,
+    status: "all",
+  });
+  return interpretReadResult(result.success, result.statusCode);
+}
+
+/**
+ * Collapse a live-read result into "may the caller see this document".
+ * Only 403/404 mean no; anything else non-successful is a genuine fault.
+ */
+function interpretReadResult(success: boolean, statusCode: number): boolean {
+  if (success) return true;
+  if (statusCode === 403 || statusCode === 404) return false;
+  throw NextlyError.internal({
+    logContext: {
+      reason: "version-live-read-failed",
+      statusCode,
+    },
+  });
 }
 
 /**
@@ -125,11 +186,48 @@ export async function redactSnapshotForUser(
   if (typeof snapshot !== "object" || snapshot === null) return;
   if (scopeKind !== "collection" && scopeKind !== "single") return;
 
+  const entry = snapshot as Record<string, unknown>;
+
+  // Strip anything the CURRENT schema marks as a password, mirroring the normal
+  // read path. Capture already strips password values, but a field converted to
+  // `password` after a snapshot was written — or history imported from before
+  // that rule existed — would otherwise hand back a value the live read hides.
+  const fields = await resolveFieldsForRedaction(scopeKind, slug);
+  if (fields.length > 0) {
+    stripPasswordFieldValues(entry, fields);
+  }
+
   await applyFieldReadAccess({
     kind: scopeKind,
     slug,
-    entry: snapshot as Record<string, unknown>,
+    entry,
     user,
     overrideAccess: false,
   });
+}
+
+/**
+ * Current field configs for an entity, used to decide what to strip. A lookup
+ * failure yields an empty list: redaction then falls back to field-level access
+ * alone rather than failing the request.
+ */
+async function resolveFieldsForRedaction(
+  scopeKind: "collection" | "single",
+  slug: string
+): Promise<FieldConfig[]> {
+  try {
+    if (scopeKind === "single") {
+      const registry = getService("singleRegistryService");
+      const record = await registry.getSingleBySlug(slug);
+      return record?.fields ?? [];
+    }
+    const collections = getService("collectionService");
+    // Metadata lookup only; the context carries no user because the access
+    // decision was already made above and this is just a field-shape read.
+    const collection = await collections.getCollection(slug, {});
+    return ((collection as { fields?: unknown[] } | null)?.fields ??
+      []) as FieldConfig[];
+  } catch {
+    return [];
+  }
 }

--- a/packages/nextly/src/api/versions-access.ts
+++ b/packages/nextly/src/api/versions-access.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared access gate for the version-history routes.
+ *
+ * Version rows carry a full snapshot of a document, so reading them must be at
+ * least as restricted as reading the document itself. A coarse `read-<slug>`
+ * permission is not sufficient: collections can additionally apply owner-only
+ * rules, draft/published filtering, and field-level `access.read` redaction,
+ * none of which the version table knows about.
+ *
+ * The gate therefore resolves the caller, then reads the LIVE document through
+ * the same service a normal read uses. If that read denies or finds nothing,
+ * the caller may not see this document's history either. Snapshots returned
+ * afterwards are additionally passed through field-level read redaction.
+ *
+ * @module api/versions-access
+ */
+
+import { getService } from "../di";
+import type { UserContext } from "../domains/singles/types";
+import { NextlyError } from "../errors/nextly-error";
+import { getCachedNextly } from "../init";
+import type { VersionScopeKind } from "../schemas/versions/types";
+import { resolveRoleSlugs } from "../services/lib/permissions";
+import { applyFieldReadAccess } from "../shared/lib/field-level-registry";
+
+import { requireRouteCollectionAccess } from "./route-auth";
+
+/**
+ * Boot services, authenticate, and confirm the caller may read the live
+ * document behind `scopeKind`/`slug`/`entryId`.
+ *
+ * Services are initialized BEFORE the access check: on a cold process the
+ * permission lookup itself needs the adapter and RBAC services registered, so
+ * gating first would make the first request to a fresh process fail instead of
+ * auto-initializing.
+ *
+ * @returns The resolved caller, for redacting whatever is returned next.
+ */
+export async function requireVersionReadAccess(
+  request: Request,
+  scopeKind: VersionScopeKind,
+  slug: string,
+  entryId: string
+): Promise<UserContext> {
+  await getCachedNextly();
+
+  const auth = await requireRouteCollectionAccess(request, "read", slug);
+
+  // Resolved role slugs so field-level `access.read` evaluates against the
+  // caller's roles (session auth carries role ids; API-key auth carries slugs).
+  const roles = await resolveRoleSlugs(auth);
+  const user: UserContext = {
+    id: auth.userId,
+    name: auth.userName,
+    email: auth.userEmail,
+    roles,
+    // A representative singular `role`, so callbacks reading `user.role` see an
+    // authorized value rather than stripping fields for a legitimate caller.
+    role: roles?.[0],
+  };
+
+  const readable = await canReadLiveDocument(scopeKind, slug, entryId, user);
+  if (!readable) {
+    // Deliberately "not found" rather than "forbidden": a distinct 403 would
+    // confirm the document exists to a caller not allowed to know that.
+    throw NextlyError.notFound({
+      logContext: {
+        reason: "version-document-not-readable",
+        scopeKind,
+        scopeSlug: slug,
+        entryId,
+        userId: user.id,
+      },
+    });
+  }
+
+  return user;
+}
+
+/**
+ * Whether the caller can read the live document, using the same service the
+ * normal read path uses so owner-only rules, status filtering, and RBAC all
+ * apply identically.
+ */
+async function canReadLiveDocument(
+  scopeKind: VersionScopeKind,
+  slug: string,
+  entryId: string,
+  user: UserContext
+): Promise<boolean> {
+  if (scopeKind === "single") {
+    const singles = getService("singleEntryService");
+    const result = await singles.get(slug, {
+      user,
+      overrideAccess: false,
+    });
+    return result.success === true;
+  }
+
+  const collections = getService("collectionsHandler");
+  const result = await collections.getEntry({
+    collectionName: slug,
+    entryId,
+    user,
+    overrideAccess: false,
+  });
+  return result.success === true;
+}
+
+/**
+ * Strip fields the caller may not read from a stored snapshot, using the same
+ * field-level `access.read` rules a normal read applies. Mutates in place.
+ *
+ * Snapshots are stored as opaque JSON, so a non-object snapshot (or one written
+ * before a field gained an access rule) is left alone rather than throwing —
+ * the surrounding gate has already established the caller may read the
+ * document, and redaction is a narrowing pass on top of that.
+ */
+export async function redactSnapshotForUser(
+  snapshot: unknown,
+  scopeKind: VersionScopeKind,
+  slug: string,
+  user: UserContext
+): Promise<void> {
+  if (typeof snapshot !== "object" || snapshot === null) return;
+  if (scopeKind !== "collection" && scopeKind !== "single") return;
+
+  await applyFieldReadAccess({
+    kind: scopeKind,
+    slug,
+    entry: snapshot as Record<string, unknown>,
+    user,
+    overrideAccess: false,
+  });
+}

--- a/packages/nextly/src/api/versions-detail.ts
+++ b/packages/nextly/src/api/versions-detail.ts
@@ -18,11 +18,13 @@
 
 import { getService } from "../di";
 import { NextlyError } from "../errors/nextly-error";
-import { getCachedNextly } from "../init";
 import type { VersionScopeKind } from "../schemas/versions/types";
 
 import { respondDoc } from "./response-shapes";
-import { requireRouteCollectionAccess } from "./route-auth";
+import {
+  redactSnapshotForUser,
+  requireVersionReadAccess,
+} from "./versions-access";
 import { withErrorHandler } from "./with-error-handler";
 
 /**
@@ -59,8 +61,11 @@ function parseScopeKind(kind: string): VersionScopeKind {
 /**
  * GET handler returning one version with its snapshot.
  *
- * Both path parameters are validated before the access check so malformed
- * input fails fast without an auth round-trip.
+ * Both path parameters are validated before the access gate so malformed input
+ * fails fast. The gate confirms the caller may read the live document (which is
+ * what applies owner-only rules and status filtering), and the snapshot is then
+ * passed through field-level read redaction — a stored snapshot must never
+ * reveal a field a normal read would hide.
  */
 export const GET = withErrorHandler(
   async (request: Request, context: RouteContext) => {
@@ -80,14 +85,15 @@ export const GET = withErrorHandler(
       });
     }
 
-    await requireRouteCollectionAccess(request, "read", slug);
+    const user = await requireVersionReadAccess(request, scopeKind, slug, id);
 
-    await getCachedNextly();
     const versions = getService("versionsService");
     const row = await versions.get(
       { scopeKind, scopeSlug: slug, entryId: id },
       parsed
     );
+
+    await redactSnapshotForUser(row.snapshot, scopeKind, slug, user);
 
     return respondDoc(row);
   }

--- a/packages/nextly/src/api/versions-detail.ts
+++ b/packages/nextly/src/api/versions-detail.ts
@@ -1,0 +1,94 @@
+/**
+ * Single Version API Route Handler for Next.js
+ *
+ * Returns one version including its snapshot.
+ *
+ * Services are auto-initialized on first request using environment variables:
+ * - DB_DIALECT: Database dialect ("postgresql" | "mysql" | "sqlite")
+ * - DATABASE_URL: Database connection string
+ *
+ * @example
+ * ```typescript
+ * // In your Next.js app: app/api/versions/[kind]/[slug]/[id]/[versionNo]/route.ts
+ * export { GET } from 'nextly/api/versions-detail';
+ * ```
+ *
+ * @module api/versions-detail
+ */
+
+import { getService } from "../di";
+import { NextlyError } from "../errors/nextly-error";
+import { getCachedNextly } from "../init";
+import type { VersionScopeKind } from "../schemas/versions/types";
+
+import { respondDoc } from "./response-shapes";
+import { requireRouteCollectionAccess } from "./route-auth";
+import { withErrorHandler } from "./with-error-handler";
+
+/**
+ * Context object for dynamic route handlers.
+ * Next.js 15+ requires params to be a Promise.
+ */
+interface RouteContext {
+  params: Promise<{
+    kind: string;
+    slug: string;
+    id: string;
+    versionNo: string;
+  }>;
+}
+
+/**
+ * Narrow the path segment to a routable scope kind. `page` exists in the
+ * version scope union but has no HTTP surface yet, so it is rejected here
+ * rather than reaching the service.
+ */
+function parseScopeKind(kind: string): VersionScopeKind {
+  if (kind === "collection" || kind === "single") return kind;
+  throw NextlyError.validation({
+    errors: [
+      {
+        path: "kind",
+        code: "INVALID_VALUE",
+        message: 'Version scope must be "collection" or "single".',
+      },
+    ],
+  });
+}
+
+/**
+ * GET handler returning one version with its snapshot.
+ *
+ * Both path parameters are validated before the access check so malformed
+ * input fails fast without an auth round-trip.
+ */
+export const GET = withErrorHandler(
+  async (request: Request, context: RouteContext) => {
+    const { kind, slug, id, versionNo } = await context.params;
+    const scopeKind = parseScopeKind(kind);
+
+    const parsed = Number(versionNo);
+    if (!Number.isInteger(parsed) || parsed < 1) {
+      throw NextlyError.validation({
+        errors: [
+          {
+            path: "versionNo",
+            code: "INVALID_VALUE",
+            message: "Version number must be a positive integer.",
+          },
+        ],
+      });
+    }
+
+    await requireRouteCollectionAccess(request, "read", slug);
+
+    await getCachedNextly();
+    const versions = getService("versionsService");
+    const row = await versions.get(
+      { scopeKind, scopeSlug: slug, entryId: id },
+      parsed
+    );
+
+    return respondDoc(row);
+  }
+);

--- a/packages/nextly/src/api/versions.ts
+++ b/packages/nextly/src/api/versions.ts
@@ -1,0 +1,118 @@
+/**
+ * Version History API Route Handler for Next.js
+ *
+ * Lists version metadata for one document. Snapshots are never included; use
+ * the detail route to fetch one.
+ *
+ * Services are auto-initialized on first request using environment variables:
+ * - DB_DIALECT: Database dialect ("postgresql" | "mysql" | "sqlite")
+ * - DATABASE_URL: Database connection string
+ *
+ * @example
+ * ```typescript
+ * // In your Next.js app: app/api/versions/[kind]/[slug]/[id]/route.ts
+ * export { GET } from 'nextly/api/versions';
+ * ```
+ *
+ * @module api/versions
+ */
+
+import { getService } from "../di";
+import { NextlyError } from "../errors/nextly-error";
+import { getCachedNextly } from "../init";
+import type { VersionScopeKind } from "../schemas/versions/types";
+
+import { respondList } from "./response-shapes";
+import { requireRouteCollectionAccess } from "./route-auth";
+import { withErrorHandler } from "./with-error-handler";
+
+/**
+ * Context object for dynamic route handlers.
+ * Next.js 15+ requires params to be a Promise.
+ */
+interface RouteContext {
+  params: Promise<{ kind: string; slug: string; id: string }>;
+}
+
+/**
+ * Narrow the path segment to a routable scope kind. `page` exists in the
+ * version scope union but has no HTTP surface yet, so it is rejected here
+ * rather than reaching the service.
+ */
+function parseScopeKind(kind: string): VersionScopeKind {
+  if (kind === "collection" || kind === "single") return kind;
+  throw NextlyError.validation({
+    errors: [
+      {
+        path: "kind",
+        code: "INVALID_VALUE",
+        message: 'Version scope must be "collection" or "single".',
+      },
+    ],
+  });
+}
+
+/** Parse an optional positive-integer query parameter, rejecting junk. */
+function parsePositiveInt(
+  raw: string | null,
+  name: string
+): number | undefined {
+  if (raw === null) return undefined;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: name,
+          code: "INVALID_VALUE",
+          message: `${name} must be a positive integer.`,
+        },
+      ],
+    });
+  }
+  return value;
+}
+
+/**
+ * GET handler listing version metadata, newest-first.
+ *
+ * Reading history requires only read access on the document: the list exposes
+ * no content, just metadata. Path and query parameters are validated before the
+ * access check so malformed input fails fast without an auth round-trip.
+ */
+export const GET = withErrorHandler(
+  async (request: Request, context: RouteContext) => {
+    const { kind, slug, id } = await context.params;
+    const scopeKind = parseScopeKind(kind);
+
+    const url = new URL(request.url);
+    const limit = parsePositiveInt(url.searchParams.get("limit"), "limit");
+    const cursor = parsePositiveInt(url.searchParams.get("cursor"), "cursor");
+
+    await requireRouteCollectionAccess(request, "read", slug);
+
+    await getCachedNextly();
+    const versions = getService("versionsService");
+
+    const rows = await versions.list(
+      { scopeKind, scopeSlug: slug, entryId: id },
+      {
+        ...(limit !== undefined ? { limit } : {}),
+        ...(cursor !== undefined ? { cursor } : {}),
+      }
+    );
+
+    // Keyset pagination: page/totalPages are not meaningful for a cursor walk,
+    // so the meta reports the returned window and whether another page may
+    // follow (a full page implies there may be more).
+    const pageSize = limit ?? rows.length;
+    return respondList(rows, {
+      total: rows.length,
+      page: 1,
+      limit: pageSize,
+      totalPages: 1,
+      hasNext: pageSize > 0 && rows.length === pageSize,
+      hasPrev: cursor !== undefined,
+    });
+  }
+);

--- a/packages/nextly/src/api/versions.ts
+++ b/packages/nextly/src/api/versions.ts
@@ -105,20 +105,25 @@ export const GET = withErrorHandler(
     await requireVersionReadAccess(request, scopeKind, slug, id);
 
     const versions = getService("versionsService");
-    const rows = await versions.list(
+    // Fetch one more than asked for: its presence is what proves another page
+    // exists. Inferring `hasNext` from a full page instead would claim a next
+    // page whenever the history length is an exact multiple of the page size,
+    // sending the client to an empty page.
+    const window = await versions.list(
       { scopeKind, scopeSlug: slug, entryId: id },
-      { limit, ...(cursor !== undefined ? { cursor } : {}) }
+      { limit: limit + 1, ...(cursor !== undefined ? { cursor } : {}) }
     );
+    const hasNext = window.length > limit;
+    const rows = hasNext ? window.slice(0, limit) : window;
 
     // Keyset pagination: page/totalPages are not meaningful for a cursor walk,
-    // so the meta describes the returned window. A full page implies another
-    // page may follow; a short page proves it does not.
+    // so the meta describes the returned window.
     return respondList(rows, {
       total: rows.length,
       page: 1,
       limit,
       totalPages: 1,
-      hasNext: rows.length === limit,
+      hasNext,
       hasPrev: cursor !== undefined,
     });
   }

--- a/packages/nextly/src/api/versions.ts
+++ b/packages/nextly/src/api/versions.ts
@@ -19,12 +19,17 @@
 
 import { getService } from "../di";
 import { NextlyError } from "../errors/nextly-error";
-import { getCachedNextly } from "../init";
 import type { VersionScopeKind } from "../schemas/versions/types";
 
 import { respondList } from "./response-shapes";
-import { requireRouteCollectionAccess } from "./route-auth";
+import { requireVersionReadAccess } from "./versions-access";
 import { withErrorHandler } from "./with-error-handler";
+
+/** Page size when the caller does not ask for one. */
+const DEFAULT_LIMIT = 25;
+
+/** Hard ceiling, so one request cannot serialize an unbounded history. */
+const MAX_LIMIT = 100;
 
 /**
  * Context object for dynamic route handlers.
@@ -76,9 +81,10 @@ function parsePositiveInt(
 /**
  * GET handler listing version metadata, newest-first.
  *
- * Reading history requires only read access on the document: the list exposes
- * no content, just metadata. Path and query parameters are validated before the
- * access check so malformed input fails fast without an auth round-trip.
+ * Path and query parameters are validated before the access gate so malformed
+ * input fails fast. The gate then confirms the caller may read the live
+ * document: history metadata (authors, timestamps, how often a document
+ * changed) is itself disclosure, so it is restricted exactly as the document is.
  */
 export const GET = withErrorHandler(
   async (request: Request, context: RouteContext) => {
@@ -86,32 +92,33 @@ export const GET = withErrorHandler(
     const scopeKind = parseScopeKind(kind);
 
     const url = new URL(request.url);
-    const limit = parsePositiveInt(url.searchParams.get("limit"), "limit");
+    const requestedLimit = parsePositiveInt(
+      url.searchParams.get("limit"),
+      "limit"
+    );
     const cursor = parsePositiveInt(url.searchParams.get("cursor"), "cursor");
 
-    await requireRouteCollectionAccess(request, "read", slug);
+    // Always bounded: an unset limit still pages, and an oversized one is
+    // clamped, so no single request can serialize an entire long history.
+    const limit = Math.min(requestedLimit ?? DEFAULT_LIMIT, MAX_LIMIT);
 
-    await getCachedNextly();
+    await requireVersionReadAccess(request, scopeKind, slug, id);
+
     const versions = getService("versionsService");
-
     const rows = await versions.list(
       { scopeKind, scopeSlug: slug, entryId: id },
-      {
-        ...(limit !== undefined ? { limit } : {}),
-        ...(cursor !== undefined ? { cursor } : {}),
-      }
+      { limit, ...(cursor !== undefined ? { cursor } : {}) }
     );
 
     // Keyset pagination: page/totalPages are not meaningful for a cursor walk,
-    // so the meta reports the returned window and whether another page may
-    // follow (a full page implies there may be more).
-    const pageSize = limit ?? rows.length;
+    // so the meta describes the returned window. A full page implies another
+    // page may follow; a short page proves it does not.
     return respondList(rows, {
       total: rows.length,
       page: 1,
-      limit: pageSize,
+      limit,
       totalPages: 1,
-      hasNext: pageSize > 0 && rows.length === pageSize,
+      hasNext: rows.length === limit,
       hasPrev: cursor !== undefined,
     });
   }

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -57,6 +57,7 @@ import type {
   CodeFirstSingleConfig,
 } from "../domains/singles/services/single-registry-service";
 import { resolveVersionsConfig } from "../domains/versions/resolve-config";
+import type { VersionsService } from "../domains/versions/versions-service";
 import { getEventBus } from "../events/event-bus";
 import { registerActivityLogHooks } from "../hooks/activity-log-hooks";
 import type { HookRegistry } from "../hooks/hook-registry";
@@ -286,6 +287,7 @@ export interface ServiceMap {
   activityLogService: ActivityLogService;
   dashboardService: DashboardService;
   metaService: MetaService;
+  versionsService: VersionsService;
 }
 
 // ============================================================

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -2041,6 +2041,7 @@ async function initializePlugins(
       | "userService"
       | "mediaService"
       | "emailService"
+      | "versionsService"
       | "db"
       | "logger"
       | "config",
@@ -2051,6 +2052,7 @@ async function initializePlugins(
     | UserService
     | UnifiedMediaService
     | EmailService
+    | VersionsService
     | DatabaseInstance
     | Logger
     | NextlyServiceConfig => {
@@ -2063,6 +2065,8 @@ async function initializePlugins(
         return container.get<UnifiedMediaService>("mediaService");
       case "emailService":
         return container.get<EmailService>("emailService");
+      case "versionsService":
+        return container.get<VersionsService>("versionsService");
       case "db":
         return adapterDrizzleDb;
       case "logger":

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -141,6 +141,7 @@ import {
   registerMetaServices,
   registerSingleServices,
   registerUserServices,
+  registerVersionServices,
   type RegistrationContext,
 } from "./registrations";
 
@@ -723,6 +724,7 @@ export async function registerServices(
   registerMediaServices(ctx);
   registerMetaServices(ctx);
   registerSingleServices(ctx);
+  registerVersionServices(ctx);
 
   // ----------------------------------------
   // Layer 4: Sync Code-First Collections

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -98,6 +98,7 @@ import type {
 } from "../services/collections/collection-registry-service";
 import type { CollectionRelationshipService } from "../services/collections/collection-relationship-service";
 import type { CollectionService } from "../services/collections/collection-service";
+import type { CollectionsHandler } from "../services/collections-handler";
 import type {
   ComponentRegistryService,
   CodeFirstComponentConfig,
@@ -288,6 +289,9 @@ export interface ServiceMap {
   dashboardService: DashboardService;
   metaService: MetaService;
   versionsService: VersionsService;
+  // Registered by registerCollectionServices but previously untyped here, so
+  // consumers had to reach past getService() to use it.
+  collectionsHandler: CollectionsHandler;
 }
 
 // ============================================================

--- a/packages/nextly/src/di/registrations/index.ts
+++ b/packages/nextly/src/di/registrations/index.ts
@@ -14,4 +14,5 @@ export { registerMediaServices } from "./register-media";
 export { registerMetaServices } from "./register-meta";
 export { registerSingleServices } from "./register-singles";
 export { registerUserServices } from "./register-users";
+export { registerVersionServices } from "./register-versions";
 export type { RegistrationContext } from "./types";

--- a/packages/nextly/src/di/registrations/register-versions.ts
+++ b/packages/nextly/src/di/registrations/register-versions.ts
@@ -1,0 +1,22 @@
+/**
+ * DI registration for the content-versioning read surface.
+ *
+ * @module di/registrations/register-versions
+ */
+
+import { VersionsService } from "../../domains/versions/versions-service";
+import { container } from "../container";
+
+import type { RegistrationContext } from "./types";
+
+/** Register the versions read service as a singleton. */
+export function registerVersionServices(ctx: RegistrationContext): void {
+  const { adapter } = ctx;
+
+  container.registerSingleton<VersionsService>(
+    "versionsService",
+    // The adapter satisfies VersionsDbApi structurally; reads run on the pool
+    // (in-transaction capture passes its own tx context instead).
+    () => new VersionsService(adapter)
+  );
+}

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1476,6 +1476,7 @@ export class CollectionMutationService extends BaseService {
               manyToMany: snapshotM2M,
             },
             createdBy: params.user?.id ?? null,
+            maxPerDoc: versionsConfig.maxPerDoc,
           });
         }
       });
@@ -1797,6 +1798,7 @@ export class CollectionMutationService extends BaseService {
                   manyToMany: snapshotM2M,
                 },
                 createdBy: params.user?.id ?? null,
+                maxPerDoc: versionsConfig.maxPerDoc,
               });
             }
           }
@@ -2564,6 +2566,7 @@ export class CollectionMutationService extends BaseService {
                   manyToMany: snapshotM2M,
                 },
                 createdBy: params.user?.id ?? null,
+                maxPerDoc: versionsConfig.maxPerDoc,
               });
             }
           }

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1741,6 +1741,14 @@ export class CollectionQueryService extends BaseService {
     translationStatus?: boolean;
     /** Arbitrary data passed to hooks via context */
     context?: Record<string, unknown>;
+    /**
+     * Set by a route whose middleware already authenticated AND authorized the
+     * caller (mirrors listEntries). It skips only the redundant RBAC re-check,
+     * which would otherwise resolve permissions from the caller's stored roles
+     * and so reject an API key whose scoped permissions differ from its
+     * creator's. Owner-only and other document-level rules still apply.
+     */
+    routeAuthorized?: boolean;
   }): Promise<CollectionServiceResult> {
     try {
       const accessUser = params.overrideAccess ? undefined : params.user;
@@ -1752,7 +1760,8 @@ export class CollectionQueryService extends BaseService {
         accessUser,
         params.entryId,
         undefined,
-        params.overrideAccess
+        params.overrideAccess,
+        params.routeAuthorized
       );
       if (accessDenied) {
         return accessDenied;

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -611,6 +611,7 @@ export class SingleMutationService extends BaseService {
                   (parentRow as { status?: unknown }).status,
                 parts: { parentRow, components },
                 createdBy: options.user?.id ?? null,
+                maxPerDoc: versionsConfig.maxPerDoc,
               });
             }
 

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -350,6 +350,7 @@ export class SingleQueryService extends BaseService {
         operation: "read",
         user: options.user,
         overrideAccess: options.overrideAccess,
+        routeAuthorized: options.routeAuthorized,
         rbacAccessControlService: this.rbacAccessControlService,
         logger: this.logger,
       });

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -778,6 +778,7 @@ export class SingleQueryService extends BaseService {
           // System-materialized default: no authoring user.
           parts: { parentRow, components: {} },
           createdBy: null,
+          maxPerDoc: versionsConfig.maxPerDoc,
         });
         return row;
       })

--- a/packages/nextly/src/domains/singles/types.ts
+++ b/packages/nextly/src/domains/singles/types.ts
@@ -77,6 +77,14 @@ export interface GetSingleOptions {
   overrideAccess?: boolean;
 
   /**
+   * Set by a route whose middleware already authenticated AND authorized the
+   * caller. Skips only the redundant RBAC re-check, which resolves permissions
+   * from the caller's stored roles and would otherwise reject an API key whose
+   * scoped permissions differ from its creator's. Stored access rules still run.
+   */
+  routeAuthorized?: boolean;
+
+  /**
    * Draft/Published filter override. Only effective when single.status === true.
    * - 'published' (default for public/untrusted callers): only return the
    *   document when its status is 'published'; otherwise return 404 (so a

--- a/packages/nextly/src/domains/versions/__tests__/retention.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/retention.integration.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Retention enforcement through the real write path: the cap is applied in the
+ * same transaction as the version insert, so a document never accumulates more
+ * durable versions than configured.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+type VersionRow = {
+  scopeSlug: string;
+  entryId: string;
+  versionNo: number;
+  status: string;
+};
+
+async function versionsFor(handle: TestNextly, slug: string) {
+  const rows = await handle.adapter.select<VersionRow>("nextly_versions");
+  return rows
+    .filter(r => r.scopeSlug === slug)
+    .sort((a, b) => a.versionNo - b.versionNo);
+}
+
+describe("version retention (integration)", () => {
+  it("keeps only maxPerDoc durable versions, pruning oldest first", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          versions: { maxPerDoc: 3 },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "v1" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    for (const title of ["v2", "v3", "v4", "v5"]) {
+      await handler.updateEntry(
+        { collectionName: "posts", entryId: id, overrideAccess: true },
+        { title }
+      );
+    }
+
+    const rows = await versionsFor(current, "posts");
+    expect(rows).toHaveLength(3);
+    // The three newest survive; 1 and 2 were pruned.
+    expect(rows.map(r => r.versionNo)).toEqual([3, 4, 5]);
+  });
+
+  it("keeps every version when maxPerDoc is false", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          versions: { maxPerDoc: false },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "v1" }
+    );
+    const id = (created.data as { id: string }).id;
+    for (const title of ["v2", "v3", "v4"]) {
+      await handler.updateEntry(
+        { collectionName: "posts", entryId: id, overrideAccess: true },
+        { title }
+      );
+    }
+
+    expect(await versionsFor(current, "posts")).toHaveLength(4);
+  });
+
+  it("prunes per document, not across the collection", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          versions: { maxPerDoc: 2 },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const a = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "a1" }
+    );
+    const b = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "b1" }
+    );
+    const aId = (a.data as { id: string }).id;
+    const bId = (b.data as { id: string }).id;
+
+    await handler.updateEntry(
+      { collectionName: "posts", entryId: aId, overrideAccess: true },
+      { title: "a2" }
+    );
+    await handler.updateEntry(
+      { collectionName: "posts", entryId: aId, overrideAccess: true },
+      { title: "a3" }
+    );
+
+    const rows = await versionsFor(current, "posts");
+    // Pruning is scoped per document: b is untouched by a's churn.
+    expect(rows.filter(r => r.entryId === aId)).toHaveLength(2);
+    expect(rows.filter(r => r.entryId === bId)).toHaveLength(1);
+  });
+});

--- a/packages/nextly/src/domains/versions/__tests__/retention.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/retention.integration.test.ts
@@ -11,6 +11,7 @@ import {
   type TestNextly,
 } from "../../../plugins/test-nextly";
 import type { CollectionsHandler } from "../../../services/collections-handler";
+import { VersionsRepository } from "../versions-repository";
 
 let current: TestNextly | undefined;
 
@@ -92,6 +93,60 @@ describe("version retention (integration)", () => {
     }
 
     expect(await versionsFor(current, "posts")).toHaveLength(4);
+  });
+
+  it("trims a large pre-existing backlog in one save", async () => {
+    // A site that ran before the cap was enforced presents a big backlog on its
+    // first save afterwards, spanning several delete statements. This covers
+    // that end to end; the chunk boundary itself is pinned in
+    // versions-repository-delete.test.ts.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          versions: { maxPerDoc: 2 },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "v1" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    // Seed a backlog directly, bypassing capture, so the next save has to trim
+    // more ids in one go than a single statement may bind.
+    const repo = new VersionsRepository(
+      current.adapter as unknown as ConstructorParameters<
+        typeof VersionsRepository
+      >[0]
+    );
+    const ref = {
+      scopeKind: "collection" as const,
+      scopeSlug: "posts",
+      entryId: id,
+    };
+    for (let n = 2; n <= 620; n++) {
+      await repo.insertVersion({
+        ref,
+        versionNo: n,
+        status: "draft",
+        isAutosave: false,
+        snapshot: { title: `seed-${n}` },
+      });
+    }
+
+    // One ordinary save triggers the trim across the whole backlog.
+    await handler.updateEntry(
+      { collectionName: "posts", entryId: id, overrideAccess: true },
+      { title: "final" }
+    );
+
+    expect(await versionsFor(current, "posts")).toHaveLength(2);
   });
 
   it("prunes per document, not across the collection", async () => {

--- a/packages/nextly/src/domains/versions/__tests__/retention.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/retention.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Retention selection rules. Pure logic, no database: the protection rules are
+ * the part most likely to be wrong, so they are tested in isolation.
+ */
+import { describe, expect, it } from "vitest";
+
+import { selectVersionsToPrune, type PrunableVersion } from "../retention";
+
+/** Rows are supplied newest-first, matching the repository's ordering. */
+function rows(...specs: [string, number, "draft" | "published"][]) {
+  return specs.map(
+    ([id, versionNo, status]): PrunableVersion => ({ id, versionNo, status })
+  );
+}
+
+describe("selectVersionsToPrune", () => {
+  it("returns nothing when the cap is false (unlimited)", () => {
+    const input = rows(
+      ["c", 3, "published"],
+      ["b", 2, "draft"],
+      ["a", 1, "draft"]
+    );
+    expect(selectVersionsToPrune(input, false)).toEqual([]);
+  });
+
+  it("returns nothing when the row count is at or under the cap", () => {
+    const input = rows(["c", 3, "draft"], ["b", 2, "draft"], ["a", 1, "draft"]);
+    expect(selectVersionsToPrune(input, 3)).toEqual([]);
+  });
+
+  it("prunes the oldest rows beyond the cap", () => {
+    const input = rows(
+      ["e", 5, "draft"],
+      ["d", 4, "draft"],
+      ["c", 3, "draft"],
+      ["b", 2, "draft"],
+      ["a", 1, "draft"]
+    );
+    expect(selectVersionsToPrune(input, 3)).toEqual(["b", "a"]);
+  });
+
+  it("never prunes the newest version even at cap 0", () => {
+    const input = rows(["b", 2, "draft"], ["a", 1, "draft"]);
+    expect(selectVersionsToPrune(input, 0)).toEqual(["a"]);
+  });
+
+  it("never prunes the most recent published version", () => {
+    // `a` is published and falls beyond the cap, so it must survive.
+    const input = rows(
+      ["e", 5, "draft"],
+      ["d", 4, "draft"],
+      ["c", 3, "draft"],
+      ["b", 2, "draft"],
+      ["a", 1, "published"]
+    );
+    expect(selectVersionsToPrune(input, 3)).toEqual(["b"]);
+  });
+
+  it("protects only the MOST RECENT published version, not every published one", () => {
+    const input = rows(
+      ["e", 5, "draft"],
+      ["d", 4, "draft"],
+      ["c", 3, "draft"],
+      ["b", 2, "published"],
+      ["a", 1, "published"]
+    );
+    // `b` is the most recent published and survives; `a` does not.
+    expect(selectVersionsToPrune(input, 3)).toEqual(["a"]);
+  });
+});

--- a/packages/nextly/src/domains/versions/__tests__/versions-repository-delete.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/versions-repository-delete.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Chunking of the retention delete.
+ *
+ * Each id binds one query parameter. The SQLite adapter declares
+ * `maxParamsPerQuery: 999`, so a backlog larger than that must be deleted
+ * across several statements rather than one oversized one — otherwise the
+ * statement fails and takes the surrounding write transaction with it.
+ *
+ * Tested against a stub rather than a live database: the bundled SQLite build
+ * happens to allow far more variables than the declared limit, so a real query
+ * would not demonstrate the boundary the adapter contract specifies.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { VersionsDbApi, VersionsWhere } from "../db-api";
+import { VersionsRepository } from "../versions-repository";
+
+/** Records the id batches passed to each delete call. */
+function stubDb() {
+  const batches: string[][] = [];
+  const db: VersionsDbApi = {
+    insert: vi.fn(),
+    select: vi.fn(),
+    delete: vi.fn(async (_table: string, where: VersionsWhere) => {
+      const condition = where.and?.[0];
+      const value = condition?.value;
+      batches.push(Array.isArray(value) ? (value as string[]) : []);
+      return Array.isArray(value) ? value.length : 0;
+    }),
+  };
+  return { db, batches };
+}
+
+describe("VersionsRepository.deleteByIds", () => {
+  it("issues no statement for an empty list", async () => {
+    const { db, batches } = stubDb();
+    const deleted = await new VersionsRepository(db).deleteByIds([]);
+    expect(deleted).toBe(0);
+    expect(batches).toEqual([]);
+  });
+
+  it("deletes a small list in a single statement", async () => {
+    const { db, batches } = stubDb();
+    const ids = Array.from({ length: 10 }, (_, i) => `id-${i}`);
+
+    const deleted = await new VersionsRepository(db).deleteByIds(ids);
+
+    expect(deleted).toBe(10);
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(10);
+  });
+
+  it("splits a backlog beyond the parameter limit across statements", async () => {
+    const { db, batches } = stubDb();
+    const ids = Array.from({ length: 1200 }, (_, i) => `id-${i}`);
+
+    const deleted = await new VersionsRepository(db).deleteByIds(ids);
+
+    // Every id is still removed, and no single statement exceeds the cap.
+    expect(deleted).toBe(1200);
+    expect(batches.length).toBeGreaterThan(1);
+    expect(Math.max(...batches.map(b => b.length))).toBeLessThanOrEqual(999);
+    expect(batches.flat()).toHaveLength(1200);
+    expect(new Set(batches.flat()).size).toBe(1200);
+  });
+});

--- a/packages/nextly/src/domains/versions/__tests__/versions-service.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/versions-service.integration.test.ts
@@ -89,6 +89,21 @@ describe("VersionsService (integration)", () => {
     expect((version.snapshot as { title?: string }).title).toBe("v1");
   });
 
+  it("rejects cursor paging combined with autosave rows", async () => {
+    // Autosave rows carry a NULL versionNo, so they can never satisfy
+    // `versionNo < cursor`. Returning a quietly short page would be worse than
+    // refusing the combination.
+    const { id, handle } = await seed();
+    const versions = handle.getService<VersionsService>("versionsService");
+
+    await expect(
+      versions.list(
+        { scopeKind: "collection", scopeSlug: "posts", entryId: id },
+        { cursor: 3, includeAutosave: true }
+      )
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+
   it("throws a not-found error for a missing version", async () => {
     const { id, handle } = await seed();
     const versions = handle.getService<VersionsService>("versionsService");

--- a/packages/nextly/src/domains/versions/__tests__/versions-service.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/versions-service.integration.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The public read surface: metadata-only listing (snapshots never travel with a
+ * list) and single-version fetch with a typed not-found error.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+import type { VersionsService } from "../versions-service";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+async function seed(): Promise<{ id: string; handle: TestNextly }> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: "posts",
+        versions: true,
+        fields: [text({ name: "title" })],
+      }),
+    ],
+  });
+  const handler = current.getService<CollectionsHandler>("collectionsHandler");
+  const created = await handler.createEntry(
+    { collectionName: "posts", overrideAccess: true },
+    { title: "v1" }
+  );
+  const id = (created.data as { id: string }).id;
+  for (const title of ["v2", "v3"]) {
+    await handler.updateEntry(
+      { collectionName: "posts", entryId: id, overrideAccess: true },
+      { title }
+    );
+  }
+  return { id, handle: current };
+}
+
+describe("VersionsService (integration)", () => {
+  it("lists versions newest-first without loading snapshots", async () => {
+    const { id, handle } = await seed();
+    const versions = handle.getService<VersionsService>("versionsService");
+
+    const rows = await versions.list({
+      scopeKind: "collection",
+      scopeSlug: "posts",
+      entryId: id,
+    });
+
+    expect(rows.map(r => r.versionNo)).toEqual([3, 2, 1]);
+    // Metadata only: the snapshot column must never be projected into a list.
+    expect(rows.every(r => !("snapshot" in r))).toBe(true);
+  });
+
+  it("honours limit and cursor for keyset pagination", async () => {
+    const { id, handle } = await seed();
+    const versions = handle.getService<VersionsService>("versionsService");
+    const ref = {
+      scopeKind: "collection" as const,
+      scopeSlug: "posts",
+      entryId: id,
+    };
+
+    const firstPage = await versions.list(ref, { limit: 2 });
+    expect(firstPage.map(r => r.versionNo)).toEqual([3, 2]);
+
+    const nextPage = await versions.list(ref, { limit: 2, cursor: 2 });
+    expect(nextPage.map(r => r.versionNo)).toEqual([1]);
+  });
+
+  it("gets a single version including its snapshot", async () => {
+    const { id, handle } = await seed();
+    const versions = handle.getService<VersionsService>("versionsService");
+
+    const version = await versions.get(
+      { scopeKind: "collection", scopeSlug: "posts", entryId: id },
+      1
+    );
+
+    expect(version.versionNo).toBe(1);
+    expect((version.snapshot as { title?: string }).title).toBe("v1");
+  });
+
+  it("throws a not-found error for a missing version", async () => {
+    const { id, handle } = await seed();
+    const versions = handle.getService<VersionsService>("versionsService");
+
+    await expect(
+      versions.get(
+        { scopeKind: "collection", scopeSlug: "posts", entryId: id },
+        99
+      )
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});

--- a/packages/nextly/src/domains/versions/capture-in-tx.ts
+++ b/packages/nextly/src/domains/versions/capture-in-tx.ts
@@ -42,6 +42,8 @@ export interface CaptureInTxArgs {
   parts: AssembleDocumentParts;
   /** The acting user's id, or null for system/seed writes. */
   createdBy?: string | null;
+  /** Retention cap for this document, from the resolved versions config. */
+  maxPerDoc?: number | false;
 }
 
 /**
@@ -62,5 +64,6 @@ export async function captureInTx(
     status,
     snapshot,
     createdBy: args.createdBy ?? null,
+    maxPerDoc: args.maxPerDoc,
   });
 }

--- a/packages/nextly/src/domains/versions/db-api.ts
+++ b/packages/nextly/src/domains/versions/db-api.ts
@@ -13,7 +13,10 @@ import type { SqlParam } from "@nextlyhq/adapter-drizzle/types";
 /** A single AND-ed filter condition (subset of the adapter WhereClause). */
 export interface VersionsWhereCondition {
   column: string;
-  op: "=" | "!=";
+  // `<` powers keyset pagination (versionNo < cursor); `IN` powers the
+  // retention delete, which removes several rows in one statement. The
+  // adapter's WhereOperator spells the set operator uppercase.
+  op: "=" | "!=" | "<" | "IN";
   // Matches the adapter's WhereCondition.value so the adapter and the
   // transaction context both structurally satisfy VersionsDbApi (a looser
   // `unknown` here breaks that assignability under method-parameter variance).
@@ -44,4 +47,11 @@ export interface VersionsDbApi {
     table: string,
     options?: VersionsSelectOptions
   ): Promise<T[]>;
+  /**
+   * Delete rows matching `where`, returning the number removed. No options
+   * parameter: retention needs none, and omitting it keeps the port satisfied
+   * by both the adapter and the transaction context, whose wider `where` and
+   * extra optional arguments remain assignable to this narrower shape.
+   */
+  delete(table: string, where: VersionsWhere): Promise<number>;
 }

--- a/packages/nextly/src/domains/versions/retention.ts
+++ b/packages/nextly/src/domains/versions/retention.ts
@@ -1,0 +1,50 @@
+/**
+ * Retention selection for durable version rows.
+ *
+ * Pure and database-free so the protection rules can be tested in isolation.
+ * The caller supplies durable rows only (autosave rows never count toward the
+ * cap) ordered newest-first.
+ *
+ * @module domains/versions/retention
+ */
+
+import type { VersionStatus } from "../../schemas/versions/types";
+
+/** The minimum shape retention needs from a durable version row. */
+export interface PrunableVersion {
+  id: string;
+  versionNo: number | null;
+  status: VersionStatus;
+}
+
+/**
+ * Ids to delete so at most `maxPerDoc` durable versions remain.
+ *
+ * Two rows are never returned regardless of the cap: the newest durable version
+ * (the document's current history head) and the most recent version whose
+ * status is "published" (what a reader is currently being served). Protecting
+ * the latter means a long draft streak cannot silently evict the live content's
+ * snapshot.
+ *
+ * @param rows Durable rows for one document, newest-first.
+ * @param maxPerDoc Cap, or `false` for unlimited.
+ */
+export function selectVersionsToPrune(
+  rows: PrunableVersion[],
+  maxPerDoc: number | false
+): string[] {
+  if (maxPerDoc === false) return [];
+  if (rows.length <= maxPerDoc) return [];
+
+  const protectedIds = new Set<string>();
+  // Newest durable version: the history head is always kept, even at cap 0.
+  if (rows[0]) protectedIds.add(rows[0].id);
+  // Most recent published version: the snapshot matching what readers see.
+  const latestPublished = rows.find(r => r.status === "published");
+  if (latestPublished) protectedIds.add(latestPublished.id);
+
+  return rows
+    .slice(Math.max(maxPerDoc, 0))
+    .filter(r => !protectedIds.has(r.id))
+    .map(r => r.id);
+}

--- a/packages/nextly/src/domains/versions/version-capture-service.ts
+++ b/packages/nextly/src/domains/versions/version-capture-service.ts
@@ -13,6 +13,7 @@
 import type { VersionStatus } from "../../schemas/versions/types";
 
 import type { VersionsDbApi } from "./db-api";
+import { selectVersionsToPrune } from "./retention";
 import { VersionConflictError, isUniqueViolation } from "./version-conflict";
 import { VersionsRepository, type VersionRef } from "./versions-repository";
 
@@ -25,6 +26,12 @@ export interface CaptureInput {
   label?: string | null;
   locale?: string | null;
   sourceVersionNo?: number | null;
+  /**
+   * Durable versions retained for this document; `false` or omitted leaves
+   * history unbounded. Applied in the caller's transaction right after the
+   * insert, so the cap holds without a background worker.
+   */
+  maxPerDoc?: number | false;
 }
 
 /** The allocated number of a captured version. */
@@ -74,6 +81,16 @@ export class VersionCaptureService {
         throw new VersionConflictError(err);
       }
       throw err;
+    }
+    // Trim history to the configured cap inside the caller's transaction. The
+    // newest version and the most recent published one are always protected, so
+    // the head of history and the snapshot matching live content survive.
+    if (typeof input.maxPerDoc === "number") {
+      const durable = await repo.listDurableForPrune(input.ref);
+      const staleIds = selectVersionsToPrune(durable, input.maxPerDoc);
+      if (staleIds.length > 0) {
+        await repo.deleteByIds(staleIds);
+      }
     }
     return { versionNo };
   }

--- a/packages/nextly/src/domains/versions/version-capture-service.ts
+++ b/packages/nextly/src/domains/versions/version-capture-service.ts
@@ -43,13 +43,17 @@ export class VersionCaptureService {
   /**
    * Allocate the next durable version_no for the document and insert one row,
    * using `db` (the transaction context) so the insert commits atomically with
-   * the caller's content write. The next number is `max + 1`; this allocation
-   * read does not itself run inside the transaction (the tx context's `select`
-   * delegates to the adapter's main connection pool, not the transaction's own
-   * connection, on Postgres/MySQL), so a duplicate version_no is possible under
-   * concurrent capture. The PG partial unique index guards against it there; a
-   * MySQL/SQLite serialization or unique guard is required in a later stage
-   * before capture is wired into concurrent writes.
+   * the caller's content write. The next number is `max + 1`.
+   *
+   * Reads through the transaction context DO run on the transaction's own
+   * connection on every dialect: each adapter's tx `select` forwards the
+   * transaction handle as the executor, so the allocation read and the
+   * retention scan below both observe this transaction's uncommitted writes.
+   *
+   * A duplicate version_no is still possible when two transactions allocate
+   * concurrently, because each reads a max the other has not yet committed.
+   * That race is caught by the durable-sequence unique index and surfaced as a
+   * VersionConflictError for the write path to retry.
    */
   async capture(
     db: VersionsDbApi,

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -22,6 +22,11 @@ import type { PrunableVersion } from "./retention";
 
 const TABLE = "nextly_versions";
 
+// Ids deleted per statement. Each id binds one parameter and SQLite's default
+// SQLITE_MAX_VARIABLE_NUMBER is 999 (the lowest across supported dialects), so
+// this stays well under it rather than tracking per-dialect capabilities.
+const DELETE_CHUNK_SIZE = 500;
+
 // Every column except `snapshot`, so metadata reads (history lists) can project
 // away the potentially large JSON payload instead of transferring then dropping
 // it. Keep in sync with VersionRow when adding a metadata column.
@@ -236,7 +241,25 @@ export class VersionsRepository {
     // Keyset pagination: return versions strictly older than the cursor, which
     // is the last versionNo the caller already has. Stable under concurrent
     // inserts in a way offset pagination is not.
+    //
+    // Autosave rows carry a NULL versionNo, so they can never satisfy a
+    // `versionNo < cursor` comparison and would silently vanish from a paged
+    // listing that asked for them. Reject the combination instead of returning
+    // a quietly incomplete page.
     if (typeof opts.cursor === "number") {
+      if (opts.includeAutosave) {
+        throw NextlyError.validation({
+          errors: [
+            {
+              path: "cursor",
+              code: "INVALID_COMBINATION",
+              message:
+                "Autosave versions cannot be paged by cursor; they have no version number.",
+            },
+          ],
+          logContext: { reason: "versions-cursor-with-autosave" },
+        });
+      }
       and.push({ column: "versionNo", op: "<", value: opts.cursor });
     }
     const rows = await this.db.select<VersionMeta>(TABLE, {
@@ -276,11 +299,24 @@ export class VersionsRepository {
     });
   }
 
-  /** Delete the given version rows in one statement. No-op for an empty list. */
+  /**
+   * Delete the given version rows. No-op for an empty list.
+   *
+   * Deletes in chunks because each id binds one query parameter and SQLite caps
+   * a statement at 999 (the lowest limit across supported dialects). A document
+   * can legitimately present far more stale rows than that on the first save
+   * after the retention cap starts being enforced, and an over-large statement
+   * would fail the whole write transaction rather than trimming.
+   */
   async deleteByIds(ids: string[]): Promise<number> {
     if (ids.length === 0) return 0;
-    return this.db.delete(TABLE, {
-      and: [{ column: "id", op: "IN", value: ids }],
-    });
+    let deleted = 0;
+    for (let i = 0; i < ids.length; i += DELETE_CHUNK_SIZE) {
+      const chunk = ids.slice(i, i + DELETE_CHUNK_SIZE);
+      deleted += await this.db.delete(TABLE, {
+        and: [{ column: "id", op: "IN", value: chunk }],
+      });
+    }
+    return deleted;
   }
 }

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -18,6 +18,7 @@ import type {
 } from "../../schemas/versions/types";
 
 import type { VersionsDbApi, VersionsWhereCondition } from "./db-api";
+import type { PrunableVersion } from "./retention";
 
 const TABLE = "nextly_versions";
 
@@ -226,11 +227,17 @@ export class VersionsRepository {
    */
   async listByDoc(
     ref: VersionRef,
-    opts: { limit?: number; includeAutosave?: boolean } = {}
+    opts: { limit?: number; includeAutosave?: boolean; cursor?: number } = {}
   ): Promise<VersionMeta[]> {
     const and = [...this.docWhere(ref)];
     if (!opts.includeAutosave) {
       and.push({ column: "isAutosave", op: "=", value: false });
+    }
+    // Keyset pagination: return versions strictly older than the cursor, which
+    // is the last versionNo the caller already has. Stable under concurrent
+    // inserts in a way offset pagination is not.
+    if (typeof opts.cursor === "number") {
+      and.push({ column: "versionNo", op: "<", value: opts.cursor });
     }
     const rows = await this.db.select<VersionMeta>(TABLE, {
       // Project metadata columns only, so the snapshot payload is never
@@ -246,5 +253,34 @@ export class VersionsRepository {
       ...(typeof opts.limit === "number" ? { limit: opts.limit } : {}),
     });
     return rows;
+  }
+
+  /**
+   * Durable rows for one document, newest-first, projecting only what the
+   * retention rules need. Autosave rows are excluded because they never count
+   * toward the cap.
+   */
+  async listDurableForPrune(ref: VersionRef): Promise<PrunableVersion[]> {
+    return this.db.select<PrunableVersion>(TABLE, {
+      columns: ["id", "versionNo", "status"],
+      where: {
+        and: [
+          ...this.docWhere(ref),
+          { column: "isAutosave", op: "=", value: false },
+        ],
+      },
+      orderBy: [
+        { column: "versionNo", direction: "desc" },
+        { column: "createdAt", direction: "desc" },
+      ],
+    });
+  }
+
+  /** Delete the given version rows in one statement. No-op for an empty list. */
+  async deleteByIds(ids: string[]): Promise<number> {
+    if (ids.length === 0) return 0;
+    return this.db.delete(TABLE, {
+      and: [{ column: "id", op: "IN", value: ids }],
+    });
   }
 }

--- a/packages/nextly/src/domains/versions/versions-service.ts
+++ b/packages/nextly/src/domains/versions/versions-service.ts
@@ -1,0 +1,68 @@
+/**
+ * Public read surface for content version history.
+ *
+ * Wraps the repository so callers (HTTP routes, the admin, and plugins via
+ * `ctx.services.versions`) never touch `nextly_versions` directly. Listing is
+ * metadata-only by construction: snapshots are large and a history list never
+ * needs them.
+ *
+ * @experimental The shape may change while versioning is in alpha.
+ *
+ * @module domains/versions/versions-service
+ */
+
+import { NextlyError } from "../../errors";
+
+import type { VersionsDbApi } from "./db-api";
+import {
+  VersionsRepository,
+  type VersionMeta,
+  type VersionRef,
+  type VersionRow,
+} from "./versions-repository";
+
+/** Options for a history listing. */
+export interface VersionListOptions {
+  /** Page size. */
+  limit?: number;
+  /** Return versions strictly older than this versionNo (keyset pagination). */
+  cursor?: number;
+  /** Include rolling autosave rows. Defaults to false (durable versions only). */
+  includeAutosave?: boolean;
+}
+
+export class VersionsService {
+  private readonly repo: VersionsRepository;
+
+  constructor(db: VersionsDbApi) {
+    this.repo = new VersionsRepository(db);
+  }
+
+  /** Version metadata for one document, newest-first. Never loads snapshots. */
+  async list(
+    ref: VersionRef,
+    opts: VersionListOptions = {}
+  ): Promise<VersionMeta[]> {
+    return this.repo.listByDoc(ref, opts);
+  }
+
+  /** One full version, including its snapshot. */
+  async get(ref: VersionRef, versionNo: number): Promise<VersionRow> {
+    const row = await this.repo.findByVersionNo(ref, versionNo);
+    if (!row) {
+      // The public message stays generic; the document and version land in the
+      // log context so an operator can trace the miss without the response
+      // disclosing which documents exist.
+      throw NextlyError.notFound({
+        logContext: {
+          reason: "version-not-found",
+          scopeKind: ref.scopeKind,
+          scopeSlug: ref.scopeSlug,
+          entryId: ref.entryId,
+          versionNo,
+        },
+      });
+    }
+    return row;
+  }
+}

--- a/packages/nextly/src/plugins/plugin-context.test.ts
+++ b/packages/nextly/src/plugins/plugin-context.test.ts
@@ -75,7 +75,9 @@ describe("createPluginContext (P1 reshape)", () => {
       "collections",
       "email",
       "media",
+      "plugins",
       "users",
+      "versions",
     ]);
   });
 });

--- a/packages/nextly/src/plugins/plugin-context.ts
+++ b/packages/nextly/src/plugins/plugin-context.ts
@@ -11,6 +11,7 @@
 
 import type { CollectionConfig } from "../collections/config/define-collection";
 import type { NextlyServiceConfig } from "../di/register";
+import type { VersionsService } from "../domains/versions/versions-service";
 import type { EventBus, EventHandler, EventName } from "../events/event-bus";
 import { getEventBus } from "../events/event-bus";
 import type { Action, Filter } from "../filters";
@@ -225,6 +226,11 @@ export interface PluginContext {
     media: MediaService;
     /** Email service for sending emails via templates and providers */
     email: EmailService;
+    /**
+     * @experimental Read-only content version history (list/get). Restore and
+     * diff arrive in later stages.
+     */
+    versions: VersionsService;
     /**
      * @experimental Services contributed by plugins, keyed by plugin name
      * then service name. Lazily resolved (instantiated on first access). Runtime
@@ -681,6 +687,7 @@ export function createPluginContext(
       | "userService"
       | "mediaService"
       | "emailService"
+      | "versionsService"
       | "db"
       | "logger"
       | "config",
@@ -694,13 +701,15 @@ export function createPluginContext(
         ? MediaService
         : T extends "emailService"
           ? EmailService
-          : T extends "db"
-            ? DatabaseInstance
-            : T extends "logger"
-              ? Logger
-              : T extends "config"
-                ? NextlyServiceConfig
-                : never,
+          : T extends "versionsService"
+            ? VersionsService
+            : T extends "db"
+              ? DatabaseInstance
+              : T extends "logger"
+                ? Logger
+                : T extends "config"
+                  ? NextlyServiceConfig
+                  : never,
   hookRegistry: {
     register: (
       hookType: HookType,
@@ -743,6 +752,7 @@ export function createPluginContext(
   const userService = getServiceFn("userService");
   const mediaService = getServiceFn("mediaService");
   const emailService = getServiceFn("emailService");
+  const versionsService = getServiceFn("versionsService");
   const db = getServiceFn("db");
   const logger = getServiceFn("logger");
   const config = getServiceFn("config");
@@ -791,6 +801,7 @@ export function createPluginContext(
       users: userService,
       media: mediaService,
       email: emailService,
+      versions: versionsService,
       plugins: buildPluginServicesNamespace(),
     },
     db,

--- a/packages/nextly/src/plugins/plugin-context.ts
+++ b/packages/nextly/src/plugins/plugin-context.ts
@@ -752,7 +752,6 @@ export function createPluginContext(
   const userService = getServiceFn("userService");
   const mediaService = getServiceFn("mediaService");
   const emailService = getServiceFn("emailService");
-  const versionsService = getServiceFn("versionsService");
   const db = getServiceFn("db");
   const logger = getServiceFn("logger");
   const config = getServiceFn("config");
@@ -801,7 +800,13 @@ export function createPluginContext(
       users: userService,
       media: mediaService,
       email: emailService,
-      versions: versionsService,
+      // Resolved on access, not at construction: `createPluginContext` is
+      // exported, and a resolver written before this service existed would
+      // otherwise throw while building the context for callers that never
+      // touch version history.
+      get versions() {
+        return getServiceFn("versionsService");
+      },
       plugins: buildPluginServicesNamespace(),
     },
     db,

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -484,6 +484,13 @@ export class CollectionsHandler {
     translationStatus?: boolean;
     /** Arbitrary data passed to hooks via context */
     context?: Record<string, unknown>;
+    /**
+     * Set by a route that already authenticated and authorized the caller.
+     * Skips the redundant RBAC re-check (which resolves the caller's stored
+     * roles and would reject a scoped API key) while leaving owner-only and
+     * other document-level rules in force.
+     */
+    routeAuthorized?: boolean;
   }) {
     return this.entryService.getEntry(params);
   }

--- a/packages/nextly/tsup.config.js
+++ b/packages/nextly/tsup.config.js
@@ -35,6 +35,8 @@ const serverEntries = [
   "src/api/singles.ts",
   "src/api/singles-detail.ts",
   "src/api/singles-schema-detail.ts",
+  "src/api/versions.ts",
+  "src/api/versions-detail.ts",
   "src/api/email-providers.ts",
   "src/api/email-providers-detail.ts",
   "src/api/email-providers-test.ts",


### PR DESCRIPTION
## What

PR 1 of the content-versioning history/restore/diff program (approved design:
`tasks/2026-07-20-versions-history-restore-diff-design.md`).

- **`VersionsService` (`list` / `get`)** exposed as `ctx.services.versions` (experimental)
- **Two `GET` routes** — list version metadata, and fetch one version with its snapshot
- **`maxPerDoc` retention is now enforced.** It was previously parsed and validated but
  silently ignored, so history grew without bound. The config promised something the
  code did not do.

Listing is metadata-only by construction, so opening a long history never transfers
stored content. Retention runs inside the same transaction as the version insert, so
no background worker is needed and history can't be left half-trimmed. The newest
durable version and the most recent published version are never pruned — the head of
history and the snapshot matching live content always survive.

## Notable details

- Retention selection is a **pure, database-free function** (`retention.ts`) so the
  protection rules — the part most likely to be wrong — are unit-testable in isolation.
- The `VersionsDbApi` port gained `delete` plus `<` and `IN` operators. The `delete`
  signature deliberately takes no options object, which is what keeps both the adapter
  and the transaction context satisfying it structurally.
- Pagination is **keyset** (`versionNo < cursor`), not offset, so it stays stable while
  new versions are being written.
- `get` returns a generic "Not found." to the client and puts the document/version in
  the log context, so the response never discloses which documents exist.

## Testing

Unit tests for the retention rules (including that only the *most recent* published
version is protected, and that the newest survives even at cap 0). Integration tests
for retention through the real write path, the service read surface (metadata-only
listing, keyset pagination, typed not-found), and route input validation. Retention
tests verified **load-bearing** — disabling the prune fails them.

Full mutation-path regression suite run: 105 passing. That sweep caught a real bug in
this PR — the plugin context resolved `versionsService` through a second hardcoded
resolver that also needed updating, which would otherwise have broken every plugin
boot.

SQLite locally; Postgres and MySQL in CI.

## Notes

Restore, labels, and diff land in later PRs. `list` does not apply field-level read
access because it returns no content; `get` returns a full snapshot, so field-level
redaction is required before Preview consumes it in PR 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public version-history API entrypoints for listing versions and fetching individual versions (including snapshots), with newest-first results.
  * Added keyset pagination (cursor/limit) and optional autosave inclusion for version lists.
  * Exposed the version-history service to plugins as a read-only capability.
* **Improvements**
  * Implemented configurable per-document version retention with safe pruning rules (preserves newest and latest published versions).
  * Strengthened input validation and access gating for version-list and version-detail requests, including correct handling of route-authorized flows.
  * Added additional public package entrypoints for generated version API types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->