### PR TITLE
fix(nextly): emit complete css colors and the rendered scope for admin branding

### DIFF
--- a/.changeset/branding-colors-paint.md
+++ b/.changeset/branding-colors-paint.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Fix custom admin branding colors, which made branded surfaces transparent instead of applying the configured color.
+
+Setting `admin.branding.colors` did not tint the admin — it broke it. Buttons, the active navigation item, focus rings and the first chart series lost their background entirely and rendered transparent. Removing the setting was the only way back to a working admin, so the feature was effectively unusable.
+
+The admin's design tokens hold complete colors and are read directly, but branding was still resolving colors to the bare `H S% L%` form an older token scheme expected. That produced an invalid value, which browsers discard. The server-rendered stylesheet that exists to prevent a flash of unbranded color had drifted further still, targeting a CSS class the admin no longer renders and writing token names nothing reads, so it had no effect at all.
+
+Branding now resolves to complete colors on both paths, and the server-rendered rule targets the class the admin actually uses, so configured colors appear immediately on load without a flash.

--- a/apps/playground/nextly.config.ts
+++ b/apps/playground/nextly.config.ts
@@ -36,6 +36,13 @@ export default defineConfig({
       logoUrlLight: "/Nextly_Icon_dark.svg",
       logoUrlDark: "/Nextly_Icon_Light.svg",
       logoText: "Nextly Playground",
+      // Exercised by e2e/tests/admin-branding.spec.ts. Branded colors were
+      // silently broken for as long as the harness only configured logos, so
+      // the harness now configures colors too.
+      colors: {
+        primary: "#6366f1",
+        accent: "#f59e0b",
+      },
     },
     devAutoLogin: {
       email: "dev@nextly.local",

--- a/e2e/tests/admin-branding.spec.ts
+++ b/e2e/tests/admin-branding.spec.ts
@@ -40,7 +40,11 @@ test("a bg-primary surface paints the brand color instead of going transparent",
 }) => {
   await gotoAdmin(page, "/");
 
-  const branded = page.locator('.nextly-admin [class*="bg-primary"]').first();
+  // `~=` matches the whole class, not a substring: the admin uses far more
+  // `bg-primary/5` and `bg-primary-500` than plain `bg-primary`, and a
+  // translucent or shaded surface would not carry the brand color at full
+  // strength.
+  const branded = page.locator('.nextly-admin [class~="bg-primary"]').first();
   await expect(branded).toBeVisible({ timeout: 30_000 });
 
   const background = await branded.evaluate(
@@ -49,12 +53,18 @@ test("a bg-primary surface paints the brand color instead of going transparent",
 
   expect(background).not.toBe(TRANSPARENT);
 
+  const channels = background.match(/[\d.]+/g)?.map(Number) ?? [];
+  expect(channels.length).toBeGreaterThanOrEqual(3);
+
+  // Opaque, so this is a solid brand surface. An `rgba(...)` with alpha < 1
+  // keeps the same rgb channels, so the comparison below would pass on a
+  // 5%-opacity `bg-primary/5` element while proving nothing visible.
+  expect(channels[3] ?? 1).toBe(1);
+
   // And it is the configured brand color, not the default token.
   const [r, g, b] = [0, 2, 4].map(i =>
     parseInt(PRIMARY_HEX.slice(1 + i, 3 + i), 16)
   );
-  const channels = background.match(/[\d.]+/g)?.map(Number) ?? [];
-  expect(channels.length).toBeGreaterThanOrEqual(3);
   for (const [i, expected] of [r, g, b].entries()) {
     // Allow for color-space conversion rounding.
     expect(Math.abs(channels[i] - expected)).toBeLessThanOrEqual(3);

--- a/e2e/tests/admin-branding.spec.ts
+++ b/e2e/tests/admin-branding.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * Configured brand colors actually paint.
+ *
+ * The `--nx-*` tokens hold complete CSS colors and are consumed directly
+ * (`--color-primary: var(--nx-primary)`). When branding resolved to a bare
+ * "H S% L%" triplet instead, `background-color` got an invalid value and was
+ * dropped, so every `bg-primary` surface rendered transparent rather than
+ * branded — visibly broken, but silent. These assert the value both arrives
+ * and is usable.
+ */
+import { expect, test } from "@playwright/test";
+
+import { gotoAdmin } from "./support/admin";
+
+// Mirrors apps/playground/nextly.config.ts.
+const PRIMARY_HEX = "#6366f1";
+const EXPECTED_PRIMARY = "hsl(238.7 83.5% 66.7%)";
+
+const TRANSPARENT = "rgba(0, 0, 0, 0)";
+
+test("the configured brand color reaches --nx-primary as a complete color", async ({
+  page,
+}) => {
+  await gotoAdmin(page, "/");
+
+  const primary = await page
+    .locator(".nextly-admin")
+    .first()
+    .evaluate(el =>
+      getComputedStyle(el).getPropertyValue("--nx-primary").trim()
+    );
+
+  expect(primary).toBe(EXPECTED_PRIMARY);
+  // A bare triplet would be silently unusable downstream.
+  expect(primary).not.toMatch(/^[\d.]+\s/);
+});
+
+test("a bg-primary surface paints the brand color instead of going transparent", async ({
+  page,
+}) => {
+  await gotoAdmin(page, "/");
+
+  const branded = page.locator('.nextly-admin [class*="bg-primary"]').first();
+  await expect(branded).toBeVisible({ timeout: 30_000 });
+
+  const background = await branded.evaluate(
+    el => getComputedStyle(el).backgroundColor
+  );
+
+  expect(background).not.toBe(TRANSPARENT);
+
+  // And it is the configured brand color, not the default token.
+  const [r, g, b] = [0, 2, 4].map(i =>
+    parseInt(PRIMARY_HEX.slice(1 + i, 3 + i), 16)
+  );
+  const channels = background.match(/[\d.]+/g)?.map(Number) ?? [];
+  expect(channels.length).toBeGreaterThanOrEqual(3);
+  for (const [i, expected] of [r, g, b].entries()) {
+    // Allow for color-space conversion rounding.
+    expect(Math.abs(channels[i] - expected)).toBeLessThanOrEqual(3);
+  }
+});

--- a/packages/admin/src/context/providers/BrandingProvider.tsx
+++ b/packages/admin/src/context/providers/BrandingProvider.tsx
@@ -44,7 +44,8 @@ function useColorInjection(colors: ResolvedBrandingColors | undefined) {
 
     const rules: string[] = [];
 
-    // Note: The /admin-meta API already returns HSL triplets like "0 0% 0%"
+    // The /admin-meta API resolves these to complete CSS colors (e.g.
+    // "hsl(239 84.3% 64.7%)"), which is what the `--nx-*` tokens hold.
     const primaryHsl = colors.primary;
     const accentHsl = colors.accent;
 
@@ -70,7 +71,9 @@ function useColorInjection(colors: ResolvedBrandingColors | undefined) {
 
     // Scoped to .nextly-admin so we never leak styles to the host application.
     // Applied to both light and dark variants since the user's brand colors
-    // are injected as the same HSL values in both modes.
+    // are injected as the same values in both modes. Keep this selector and the
+    // token names in step with `getBrandingCss`, which server-renders the same
+    // declarations to avoid a flash of unbranded color before this runs.
     const css = `.nextly-admin, .nextly-admin.dark { ${rules.join(" ")} }`;
 
     const style = document.createElement("style");

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -94,7 +94,7 @@ import {
   isBuilderRoute,
 } from "./shared/builder-access";
 import {
-  hexToHslTriplet,
+  hexToCssColor,
   getForegroundForBackground,
   isValidHex,
 } from "./utils/color-utils";
@@ -957,8 +957,10 @@ async function handleServiceRequest(
  *
  * Returns the admin branding configuration to the admin UI.
  * Public — no authentication required.
- * Colors are converted from user-supplied hex to HSL triplets here on the
- * server so the client only has to inject them as CSS variables.
+ * Colors are converted from user-supplied hex to complete CSS colors here on
+ * the server so the client only has to inject them as CSS variables. They must
+ * be complete colors: the `--nx-*` tokens are consumed directly by the theme,
+ * so a bare "H S% L%" triplet would be an invalid value and get dropped.
  */
 async function handleAdminMetaRequest(): Promise<Response> {
   const config = getHandlerConfig();
@@ -991,11 +993,11 @@ async function handleAdminMetaRequest(): Promise<Response> {
     const resolved: Record<string, string> = {};
 
     if (colors.primary && isValidHex(colors.primary)) {
-      resolved.primary = hexToHslTriplet(colors.primary);
+      resolved.primary = hexToCssColor(colors.primary);
       resolved.primaryForeground = getForegroundForBackground(colors.primary);
     }
     if (colors.accent && isValidHex(colors.accent)) {
-      resolved.accent = hexToHslTriplet(colors.accent);
+      resolved.accent = hexToCssColor(colors.accent);
       resolved.accentForeground = getForegroundForBackground(colors.accent);
     }
 

--- a/packages/nextly/src/utils/__tests__/color-utils.test.ts
+++ b/packages/nextly/src/utils/__tests__/color-utils.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Branding colors reach the browser as `--nx-*` custom properties that the
+ * theme consumes directly (`--color-primary: var(--nx-primary)`), so anything
+ * these helpers emit has to be a complete CSS color and has to land on the
+ * class the admin actually renders. Both were wrong before: a bare "H S% L%"
+ * triplet computed to `rgba(0,0,0,0)`, and the server-rendered rule targeted a
+ * class that exists nowhere, so branded admins painted transparent surfaces.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  getBrandingCss,
+  getForegroundForBackground,
+  hexToCssColor,
+  isValidHex,
+} from "../color-utils";
+
+/** A bare triplet is not a color; `hsl(...)`/`oklch(...)`/`#hex` are. */
+const COMPLETE_CSS_COLOR = /^(hsl|oklch|rgb)\(|^#[0-9a-fA-F]{3,8}$/;
+
+describe("hexToCssColor", () => {
+  it("emits a complete CSS color, not a bare triplet", () => {
+    expect(hexToCssColor("#6366f1")).toMatch(COMPLETE_CSS_COLOR);
+  });
+
+  it("preserves the converted hue, saturation and lightness", () => {
+    expect(hexToCssColor("#6366f1")).toBe("hsl(238.7 83.5% 66.7%)");
+  });
+
+  it.each([
+    ["#000000", "hsl(0 0% 0%)"],
+    ["#ffffff", "hsl(0 0% 100%)"],
+  ])("handles the achromatic bound %s", (hex, expected) => {
+    expect(hexToCssColor(hex)).toBe(expected);
+  });
+});
+
+describe("getForegroundForBackground", () => {
+  it("returns white on a dark background, as a complete color", () => {
+    const fg = getForegroundForBackground("#000000");
+    expect(fg).toBe("hsl(0 0% 100%)");
+    expect(fg).toMatch(COMPLETE_CSS_COLOR);
+  });
+
+  it("returns the dark tone on a light background, as a complete color", () => {
+    const fg = getForegroundForBackground("#ffffff");
+    expect(fg).toBe("hsl(222.2 47.4% 11.2%)");
+    expect(fg).toMatch(COMPLETE_CSS_COLOR);
+  });
+});
+
+describe("isValidHex", () => {
+  it.each(["#6366f1", "#ABCDEF"])("accepts %s", v =>
+    expect(isValidHex(v)).toBe(true)
+  );
+
+  it.each(["6366f1", "#fff", "#6366f", "rgb(1,2,3)", ""])("rejects %s", v =>
+    expect(isValidHex(v)).toBe(false)
+  );
+});
+
+describe("getBrandingCss", () => {
+  it("returns null when no colors are configured", () => {
+    expect(getBrandingCss(undefined)).toBeNull();
+    expect(getBrandingCss({})).toBeNull();
+    expect(getBrandingCss({ colors: {} })).toBeNull();
+  });
+
+  it("returns null when every configured color is invalid", () => {
+    expect(getBrandingCss({ colors: { primary: "nope" } })).toBeNull();
+  });
+
+  it("targets .nextly-admin, the class the admin root renders", () => {
+    const css = getBrandingCss({ colors: { primary: "#6366f1" } });
+
+    expect(css).toContain(".nextly-admin, .nextly-admin.dark {");
+    // The rule previously targeted a class that is rendered nowhere.
+    expect(css).not.toContain("adminapp");
+  });
+
+  it("writes the --nx-* tokens the theme actually defines", () => {
+    const css = getBrandingCss({
+      colors: { primary: "#6366f1", accent: "#f59e0b" },
+    });
+
+    for (const token of [
+      "--nx-primary:",
+      "--nx-primary-foreground:",
+      "--nx-ring:",
+      "--nx-focus-ring:",
+      "--nx-sidebar-ring:",
+      "--nx-chart-1:",
+      "--nx-accent:",
+      "--nx-accent-foreground:",
+      "--nx-chart-2:",
+    ]) {
+      expect(css).toContain(token);
+    }
+  });
+
+  it("never writes an unprefixed token, which nothing consumes", () => {
+    const css = getBrandingCss({
+      colors: { primary: "#6366f1", accent: "#f59e0b" },
+    });
+
+    // e.g. "--primary:" would be dead weight; only "--nx-primary:" is read.
+    expect(css).not.toMatch(/[^-]--primary:/);
+    expect(css).not.toMatch(/[^-]--accent:/);
+  });
+
+  it("assigns only complete CSS colors", () => {
+    const css =
+      getBrandingCss({ colors: { primary: "#6366f1", accent: "#f59e0b" } }) ??
+      "";
+
+    const values = [...css.matchAll(/--nx-[\w-]+:\s*([^;]+);/g)].map(m =>
+      m[1].trim()
+    );
+
+    expect(values.length).toBeGreaterThan(0);
+    for (const value of values) {
+      expect(value).toMatch(COMPLETE_CSS_COLOR);
+    }
+  });
+
+  it("emits only the accent tokens when only accent is configured", () => {
+    const css = getBrandingCss({ colors: { accent: "#f59e0b" } }) ?? "";
+
+    expect(css).toContain("--nx-accent:");
+    expect(css).not.toContain("--nx-primary:");
+  });
+});

--- a/packages/nextly/src/utils/color-utils.ts
+++ b/packages/nextly/src/utils/color-utils.ts
@@ -1,16 +1,18 @@
 /**
  * Color utility functions for admin branding.
  *
- * Converts user-supplied hex colors to the HSL triplet format expected by
- * Tailwind v4 CSS custom properties (bare "H S% L%" without hsl() wrapper).
+ * Emits complete CSS color values. The `--nx-*` design tokens hold full colors
+ * (`--nx-primary: oklch(...)`) and are consumed directly, e.g.
+ * `--color-primary: var(--nx-primary)`, so a bare "H S% L%" triplet would land
+ * in `background-color` as an invalid value and be dropped.
  */
 
 /**
- * Convert a 6-digit hex color string to a Tailwind-style HSL triplet.
+ * Convert a 6-digit hex color string to a CSS `hsl()` color.
  *
- * @example hexToHslTriplet("#6366f1") → "239 84.3% 64.7%"
+ * @example hexToCssColor("#6366f1") → "hsl(238.7 83.5% 66.7%)"
  */
-export function hexToHslTriplet(hex: string): string {
+export function hexToCssColor(hex: string): string {
   const clean = hex.replace("#", "");
   const r = parseInt(clean.slice(0, 2), 16) / 255;
   const g = parseInt(clean.slice(2, 4), 16) / 255;
@@ -44,16 +46,16 @@ export function hexToHslTriplet(hex: string): string {
   const sPct = Math.round(s * 100 * 10) / 10;
   const lPct = Math.round(l * 100 * 10) / 10;
 
-  return `${hDeg} ${sPct}% ${lPct}%`;
+  return `hsl(${hDeg} ${sPct}% ${lPct}%)`;
 }
 
 /**
  * Determine the best foreground color (white or dark) for readable text on
  * the given background hex color, using WCAG relative luminance.
  *
- * Returns an HSL triplet string:
- * - "0 0% 100%"        → white (used on dark/saturated backgrounds)
- * - "222.2 47.4% 11.2%" → slate-900 (used on light backgrounds)
+ * Returns a CSS color:
+ * - "hsl(0 0% 100%)"          → white (used on dark/saturated backgrounds)
+ * - "hsl(222.2 47.4% 11.2%)"  → slate-900 (used on light backgrounds)
  */
 export function getForegroundForBackground(hex: string): string {
   const clean = hex.replace("#", "");
@@ -70,7 +72,9 @@ export function getForegroundForBackground(hex: string): string {
   const whiteContrast = 1.05 / (L + 0.05);
   const darkContrast = (L + 0.05) / 0.05;
 
-  return whiteContrast >= darkContrast ? "0 0% 100%" : "222.2 47.4% 11.2%";
+  return whiteContrast >= darkContrast
+    ? "hsl(0 0% 100%)"
+    : "hsl(222.2 47.4% 11.2%)";
 }
 
 /**
@@ -82,7 +86,8 @@ export function isValidHex(value: string): boolean {
 
 /**
  * Generate a CSS string that sets admin branding custom properties on
- * `.adminapp`. Intended to be injected as a `<style>` tag in the
+ * `.nextly-admin`, the class the admin root renders and that the admin
+ * stylesheet is scoped to. Intended to be injected as a `<style>` tag in the
  * server-side layout so colors are present in the initial HTML —
  * no FOUC while waiting for the client-side `/admin-meta` fetch.
  *
@@ -112,25 +117,25 @@ export function getBrandingCss(
   const rules: string[] = [];
 
   if (colors.primary && isValidHex(colors.primary)) {
-    const hsl = hexToHslTriplet(colors.primary);
+    const hsl = hexToCssColor(colors.primary);
     const fg = getForegroundForBackground(colors.primary);
-    rules.push(`--primary: ${hsl};`);
-    rules.push(`--primary-foreground: ${fg};`);
-    rules.push(`--ring: ${hsl};`);
-    rules.push(`--focus-ring: ${hsl};`);
-    rules.push(`--sidebar-ring: ${hsl};`);
-    rules.push(`--chart-1: ${hsl};`);
+    rules.push(`--nx-primary: ${hsl};`);
+    rules.push(`--nx-primary-foreground: ${fg};`);
+    rules.push(`--nx-ring: ${hsl};`);
+    rules.push(`--nx-focus-ring: ${hsl};`);
+    rules.push(`--nx-sidebar-ring: ${hsl};`);
+    rules.push(`--nx-chart-1: ${hsl};`);
   }
 
   if (colors.accent && isValidHex(colors.accent)) {
-    const hsl = hexToHslTriplet(colors.accent);
+    const hsl = hexToCssColor(colors.accent);
     const fg = getForegroundForBackground(colors.accent);
-    rules.push(`--accent: ${hsl};`);
-    rules.push(`--accent-foreground: ${fg};`);
-    rules.push(`--chart-2: ${hsl};`);
+    rules.push(`--nx-accent: ${hsl};`);
+    rules.push(`--nx-accent-foreground: ${fg};`);
+    rules.push(`--nx-chart-2: ${hsl};`);
   }
 
   if (rules.length === 0) return null;
 
-  return `.adminapp, .adminapp.dark { ${rules.join(" ")} }`;
+  return `.nextly-admin, .nextly-admin.dark { ${rules.join(" ")} }`;
 }


### PR DESCRIPTION
## What

Custom admin branding colors were broken end-to-end. Setting `admin.branding.colors` did not tint the admin — it made branded surfaces **transparent**. Buttons, the active nav item, focus rings and `chart-1` all lost their background.

Found while researching roadmap item 21; filed separately since it is unrelated to that decision.

## Proof

The `--nx-*` tokens hold complete colors and are consumed directly (`--color-primary: var(--nx-primary)`). Branding was resolving to the bare `H S% L%` triplet an older token scheme expected, which is not a valid CSS color. Verified in Chromium:

| `--nx-primary` set to | computed `background-color` |
|---|---|
| `oklch(0.55 0.2 260)` (theme default) | ✅ `oklch(0.55 0.2 260)` |
| `217 91% 60%` (what branding produced) | ❌ **`rgba(0, 0, 0, 0)`** |
| `hsl(...)` / full color | ✅ applies |

## Three defects, both paths

| | before | after |
|---|---|---|
| Value format (**client + server**) | bare `217 91% 60%` → invalid → dropped | complete `hsl(...)` color |
| `getBrandingCss` selector | `.adminapp` — rendered nowhere in admin or ui | `.nextly-admin` — what `RootLayout` renders |
| `getBrandingCss` token names | `--primary`, `--accent`, … — nothing reads them | `--nx-primary`, `--nx-accent`, … |

So the client path applied an invalid value, and the server-rendered anti-FOUC rule was inert on all three counts — meaning branded admins also flashed unbranded color on every load.

Only `getBrandingCss` is public API (`nextly/config`); the two conversion helpers are internal, so fixing the value format at the source repairs both paths at once. `hexToHslTriplet` is renamed `hexToCssColor` — the old name asserted precisely the thing that caused the bug.

## Why it went unnoticed

The playground configured logos but never colors, so nothing in dev or CI ever exercised the path. That is the systemic fix here: the harness now sets brand colors, and `e2e/tests/admin-branding.spec.ts` asserts both that `--nx-primary` arrives as a complete color and that a real `bg-primary` surface paints it instead of going transparent.

## Tests

- **20 unit tests** for `color-utils`: complete-color output, the `.nextly-admin` scope, `--nx-*` token names, no unprefixed tokens, and only-accent / invalid / empty cases.
- **e2e**: the two branding assertions above.
- Full e2e suite green at **30 passed** (28 pre-existing + 2 new), confirming the harness colour change breaks nothing.
- `check-types` and `lint` clean.

One bonus fix: a unit test caught that the function's own JSDoc example (`239 84.3% 64.7%`) was a value it never produced. Verified by hand — `#6366f1` is rgb(99,102,241) → H 238.7°, S 83.5%, L 66.7% — and corrected the example.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable primary and accent colors for admin interface branding.
  * Admin branding now renders using complete CSS color values for consistent theming.
* **Bug Fixes**
  * Improved admin color token handling so branding CSS variables resolve correctly, including foreground and dark-theme variants.
  * Updated server-side branding meta to provide CSS-ready color values (not partial triplets).
* **Tests**
  * Added e2e coverage validating rendered branding color tokens and opacity.
  * Added unit tests for color conversion/validation and generated branding CSS tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->