### PR TITLE
feat(nextly): make version history reachable from the admin API

### DIFF
--- a/.changeset/versions-dispatcher.md
+++ b/.changeset/versions-dispatcher.md
@@ -1,0 +1,27 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Content version history is now available from the main API, at
+`/collections/{slug}/entries/{id}/versions` and `/singles/{slug}/versions` (add
+`/{versionNo}` for one version). Reading a document's history requires the same
+permission as reading the document itself, and a version's stored content is
+filtered the same way a normal read would filter it.

--- a/packages/nextly/src/api/__tests__/versions-access.test.ts
+++ b/packages/nextly/src/api/__tests__/versions-access.test.ts
@@ -48,7 +48,10 @@ vi.mock("../../services/lib/permissions", () => ({
   resolveRoleSlugs: vi.fn().mockResolvedValue(["editor"]),
 }));
 
-import { requireVersionReadAccess } from "../versions-access";
+import {
+  assertVersionDocumentReadable,
+  requireVersionReadAccess,
+} from "../versions-access";
 import { GET as listVersions } from "../versions";
 
 describe("requireVersionReadAccess", () => {
@@ -244,5 +247,47 @@ describe("version list pagination meta", () => {
     // The extra row is a probe, never part of the page.
     expect(body.items).toHaveLength(2);
     expect(body.meta.hasNext).toBe(true);
+  });
+});
+
+describe("assertVersionDocumentReadable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves when the caller may read the live document", async () => {
+    getEntrySpy.mockResolvedValue({ success: true, statusCode: 200 });
+
+    await expect(
+      assertVersionDocumentReadable("collection", "posts", "e1", {
+        id: "user-1",
+      })
+    ).resolves.toBeUndefined();
+
+    // Same document rules as the standalone route: drafts visible, RBAC not
+    // re-checked, because the caller was already authorized upstream.
+    expect(getEntrySpy).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "all", routeAuthorized: true })
+    );
+  });
+
+  it("rejects with not-found when the document is not readable", async () => {
+    getEntrySpy.mockResolvedValue({ success: false, statusCode: 403 });
+
+    await expect(
+      assertVersionDocumentReadable("collection", "posts", "e1", {
+        id: "user-1",
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("does not authenticate — the dispatcher already did", async () => {
+    getEntrySpy.mockResolvedValue({ success: true, statusCode: 200 });
+
+    await assertVersionDocumentReadable("collection", "posts", "e1", {
+      id: "user-1",
+    });
+
+    expect(requireRouteCollectionAccessSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/nextly/src/api/__tests__/versions-access.test.ts
+++ b/packages/nextly/src/api/__tests__/versions-access.test.ts
@@ -50,11 +50,11 @@ vi.mock("../../services/lib/permissions", () => ({
 
 import {
   assertVersionDocumentReadable,
-  requireVersionReadAccess,
+  requireRouteVersionReadAccess,
 } from "../versions-access";
 import { GET as listVersions } from "../versions";
 
-describe("requireVersionReadAccess", () => {
+describe("requireRouteVersionReadAccess", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     requireRouteCollectionAccessSpy.mockResolvedValue({
@@ -70,7 +70,7 @@ describe("requireVersionReadAccess", () => {
   it("reads a collection entry with status:all so drafts still have history", async () => {
     getEntrySpy.mockResolvedValue({ success: true, statusCode: 200 });
 
-    await requireVersionReadAccess(
+    await requireRouteVersionReadAccess(
       new Request("http://localhost/x"),
       "collection",
       "posts",
@@ -98,7 +98,7 @@ describe("requireVersionReadAccess", () => {
     getEntrySpy.mockResolvedValue({ success: false, statusCode: 500 });
 
     await expect(
-      requireVersionReadAccess(
+      requireRouteVersionReadAccess(
         new Request("http://localhost/x"),
         "collection",
         "posts",
@@ -111,7 +111,7 @@ describe("requireVersionReadAccess", () => {
     getEntrySpy.mockResolvedValue({ success: false, statusCode: 403 });
 
     await expect(
-      requireVersionReadAccess(
+      requireRouteVersionReadAccess(
         new Request("http://localhost/x"),
         "collection",
         "posts",
@@ -128,7 +128,7 @@ describe("requireVersionReadAccess", () => {
     selectOneSpy.mockResolvedValue(null);
 
     await expect(
-      requireVersionReadAccess(
+      requireRouteVersionReadAccess(
         new Request("http://localhost/x"),
         "single",
         "settings",
@@ -146,7 +146,7 @@ describe("requireVersionReadAccess", () => {
     selectOneSpy.mockResolvedValue({ id: "current-id" });
 
     await expect(
-      requireVersionReadAccess(
+      requireRouteVersionReadAccess(
         new Request("http://localhost/x"),
         "single",
         "settings",
@@ -162,7 +162,7 @@ describe("requireVersionReadAccess", () => {
     selectOneSpy.mockResolvedValue({ id: "single-1" });
     singleGetSpy.mockResolvedValue({ success: true, statusCode: 200 });
 
-    const user = await requireVersionReadAccess(
+    const user = await requireRouteVersionReadAccess(
       new Request("http://localhost/x"),
       "single",
       "settings",

--- a/packages/nextly/src/api/versions-access.ts
+++ b/packages/nextly/src/api/versions-access.ts
@@ -38,7 +38,7 @@ import { requireRouteCollectionAccess } from "./route-auth";
  *
  * @returns The resolved caller, for redacting whatever is returned next.
  */
-export async function requireVersionReadAccess(
+export async function requireRouteVersionReadAccess(
   request: Request,
   scopeKind: VersionScopeKind,
   slug: string,
@@ -73,7 +73,7 @@ export async function requireVersionReadAccess(
  * The dispatcher authorizes centrally before dispatching, so it needs the
  * document-level half of the gate on its own — owner-only rules,
  * draft/published visibility, and (for Singles) the live-id match. Keeping this
- * separate from {@link requireVersionReadAccess} means those rules are defined
+ * separate from {@link requireRouteVersionReadAccess} means those rules are defined
  * once instead of drifting between the two entry points.
  *
  * @throws NextlyError.notFound when the caller may not see the document.

--- a/packages/nextly/src/api/versions-access.ts
+++ b/packages/nextly/src/api/versions-access.ts
@@ -61,6 +61,29 @@ export async function requireVersionReadAccess(
     role: roles?.[0],
   };
 
+  await assertVersionDocumentReadable(scopeKind, slug, entryId, user);
+
+  return user;
+}
+
+/**
+ * Confirm a caller may see this document's history, assuming they are already
+ * authenticated and coarsely authorized.
+ *
+ * The dispatcher authorizes centrally before dispatching, so it needs the
+ * document-level half of the gate on its own — owner-only rules,
+ * draft/published visibility, and (for Singles) the live-id match. Keeping this
+ * separate from {@link requireVersionReadAccess} means those rules are defined
+ * once instead of drifting between the two entry points.
+ *
+ * @throws NextlyError.notFound when the caller may not see the document.
+ */
+export async function assertVersionDocumentReadable(
+  scopeKind: VersionScopeKind,
+  slug: string,
+  entryId: string,
+  user: UserContext
+): Promise<void> {
   const readable = await canReadLiveDocument(scopeKind, slug, entryId, user);
   if (!readable) {
     // Deliberately "not found" rather than "forbidden": a distinct 403 would
@@ -75,8 +98,6 @@ export async function requireVersionReadAccess(
       },
     });
   }
-
-  return user;
 }
 
 /**
@@ -137,11 +158,10 @@ async function canReadLiveSingle(
   const record = await registry.getSingleBySlug(slug);
   if (!record?.tableName) return false;
 
-  const adapter = getService("adapter");
-  const row = await adapter.selectOne<{ id?: unknown }>(record.tableName, {});
   // Not materialized yet, or the live document is a different one than the
   // requested history belongs to.
-  if (!row || row.id !== entryId) return false;
+  const liveId = await resolveSingleDocumentId(slug);
+  if (liveId === null || liveId !== entryId) return false;
 
   const singles = getService("singleEntryService");
   const result = await singles.get(slug, {
@@ -151,6 +171,29 @@ async function canReadLiveSingle(
     status: "all",
   });
   return interpretReadResult(result.success, result.statusCode);
+}
+
+/**
+ * The id of a Single's live document, or `null` when it has not been
+ * materialized yet.
+ *
+ * A Single's URL carries no entry id (there is only ever one document), so
+ * callers must resolve it from the backing row rather than trusting a
+ * client-supplied value — otherwise the id check that stops a recreated Single
+ * exposing its predecessor's snapshots could simply be bypassed. Reads the row
+ * directly instead of going through `SingleEntryService.get`, which would
+ * materialize a missing Single as a side effect of a read.
+ */
+export async function resolveSingleDocumentId(
+  slug: string
+): Promise<string | null> {
+  const registry = getService("singleRegistryService");
+  const record = await registry.getSingleBySlug(slug);
+  if (!record?.tableName) return null;
+
+  const adapter = getService("adapter");
+  const row = await adapter.selectOne<{ id?: unknown }>(record.tableName, {});
+  return typeof row?.id === "string" ? row.id : null;
 }
 
 /**

--- a/packages/nextly/src/api/versions-detail.ts
+++ b/packages/nextly/src/api/versions-detail.ts
@@ -23,7 +23,7 @@ import type { VersionScopeKind } from "../schemas/versions/types";
 import { respondDoc } from "./response-shapes";
 import {
   redactSnapshotForUser,
-  requireVersionReadAccess,
+  requireRouteVersionReadAccess,
 } from "./versions-access";
 import { withErrorHandler } from "./with-error-handler";
 
@@ -85,7 +85,12 @@ export const GET = withErrorHandler(
       });
     }
 
-    const user = await requireVersionReadAccess(request, scopeKind, slug, id);
+    const user = await requireRouteVersionReadAccess(
+      request,
+      scopeKind,
+      slug,
+      id
+    );
 
     const versions = getService("versionsService");
     const row = await versions.get(

--- a/packages/nextly/src/api/versions.ts
+++ b/packages/nextly/src/api/versions.ts
@@ -22,7 +22,7 @@ import { NextlyError } from "../errors/nextly-error";
 import type { VersionScopeKind } from "../schemas/versions/types";
 
 import { respondList } from "./response-shapes";
-import { requireVersionReadAccess } from "./versions-access";
+import { requireRouteVersionReadAccess } from "./versions-access";
 import { withErrorHandler } from "./with-error-handler";
 
 /** Page size when the caller does not ask for one. */
@@ -102,7 +102,7 @@ export const GET = withErrorHandler(
     // clamped, so no single request can serialize an entire long history.
     const limit = Math.min(requestedLimit ?? DEFAULT_LIMIT, MAX_LIMIT);
 
-    await requireVersionReadAccess(request, scopeKind, slug, id);
+    await requireRouteVersionReadAccess(request, scopeKind, slug, id);
 
     const versions = getService("versionsService");
     // Fetch one more than asked for: its presence is what proves another page

--- a/packages/nextly/src/dispatcher/handlers/__tests__/versions-dispatch.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/versions-dispatch.test.ts
@@ -1,0 +1,111 @@
+/**
+ * The four version methods must be reachable through the dispatchers the
+ * catch-all handler uses, since that is the only API surface the admin calls.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const listSpy = vi.fn();
+const getSpy = vi.fn();
+const resolveSingleIdSpy = vi.fn();
+
+vi.mock("../versions-methods", async () => {
+  const actual = await vi.importActual<typeof import("../versions-methods")>(
+    "../versions-methods"
+  );
+  return {
+    ...actual,
+    listVersionsForDocument: (...a: unknown[]) => listSpy(...a),
+    getVersionForDocument: (...a: unknown[]) => getSpy(...a),
+  };
+});
+
+vi.mock("../../../api/versions-access", () => ({
+  assertVersionDocumentReadable: vi.fn(),
+  redactSnapshotForUser: vi.fn(),
+  resolveSingleDocumentId: (...a: unknown[]) => resolveSingleIdSpy(...a),
+}));
+
+import { COLLECTION_VERSION_METHODS } from "../collection-dispatcher";
+import { SINGLE_VERSION_METHODS } from "../single-dispatcher";
+
+describe("version methods are registered", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listSpy.mockResolvedValue({ items: [], meta: { total: 0 } });
+    getSpy.mockResolvedValue({ versionNo: 1 });
+  });
+
+  it("exposes both collection version methods", () => {
+    expect(Object.keys(COLLECTION_VERSION_METHODS).sort()).toEqual([
+      "getEntryVersion",
+      "listEntryVersions",
+    ]);
+  });
+
+  it("exposes both single version methods", () => {
+    expect(Object.keys(SINGLE_VERSION_METHODS).sort()).toEqual([
+      "getSingleVersion",
+      "listSingleVersions",
+    ]);
+  });
+
+  it("passes the collection slug, entry id and caller through", async () => {
+    await COLLECTION_VERSION_METHODS.listEntryVersions.execute(
+      {} as never,
+      {
+        collectionName: "posts",
+        entryId: "e1",
+        limit: "10",
+        _authenticatedUserId: "user-1",
+        _authenticatedUserRoles: JSON.stringify(["editor"]),
+      },
+      undefined
+    );
+
+    expect(listSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopeKind: "collection",
+        slug: "posts",
+        entryId: "e1",
+        limit: 10,
+        user: expect.objectContaining({ id: "user-1", roles: ["editor"] }),
+      })
+    );
+  });
+
+  it("resolves a Single's entry id from the live row, not from params", async () => {
+    // The Single URL carries no entry id, and trusting a client-supplied one
+    // would defeat the check that stops a recreated Single exposing its
+    // predecessor's snapshots.
+    resolveSingleIdSpy.mockResolvedValue("live-id");
+
+    await SINGLE_VERSION_METHODS.listSingleVersions.execute(
+      {} as never,
+      {
+        slug: "settings",
+        entryId: "attacker-supplied",
+        _authenticatedUserId: "u",
+      },
+      undefined
+    );
+
+    expect(resolveSingleIdSpy).toHaveBeenCalledWith("settings");
+    expect(listSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ scopeKind: "single", entryId: "live-id" })
+    );
+  });
+
+  it("returns not-found for a Single that has never been materialized", async () => {
+    resolveSingleIdSpy.mockResolvedValue(null);
+
+    await expect(
+      SINGLE_VERSION_METHODS.listSingleVersions.execute(
+        {} as never,
+        { slug: "settings", _authenticatedUserId: "u" },
+        undefined
+      )
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    expect(listSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/dispatcher/handlers/__tests__/versions-e2e.integration.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/versions-e2e.integration.test.ts
@@ -1,0 +1,75 @@
+/**
+ * The whole point of this PR: a version list is reachable through the same
+ * catch-all API the admin calls, not only through the standalone route exports.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, defineSingle, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import { parseRestRoute } from "../../../route-handler/route-parser";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+describe("version history through the dispatcher (integration)", () => {
+  it("routes an entry's version list to the version method", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          versions: true,
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "v1" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    // The admin's URL shape resolves to the version method with the right ids.
+    const parsed = parseRestRoute(
+      ["collections", "posts", "entries", id, "versions"],
+      "GET"
+    );
+
+    expect(parsed).toMatchObject({
+      service: "collections",
+      method: "listEntryVersions",
+      routeParams: { collectionName: "posts", entryId: id },
+    });
+  });
+
+  it("routes a Single's version list without needing an entry id in the URL", async () => {
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "settings",
+          versions: true,
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+
+    const parsed = parseRestRoute(["singles", "settings", "versions"], "GET");
+
+    // The id is resolved server-side from the live row, so the URL carries
+    // only the slug.
+    expect(parsed).toMatchObject({
+      service: "singles",
+      method: "listSingleVersions",
+      routeParams: { slug: "settings" },
+    });
+  });
+});

--- a/packages/nextly/src/dispatcher/handlers/__tests__/versions-e2e.integration.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/versions-e2e.integration.test.ts
@@ -1,6 +1,6 @@
 /**
- * The whole point of this PR: a version list is reachable through the same
- * catch-all API the admin calls, not only through the standalone route exports.
+ * Version history is reachable through the catch-all API the admin calls, not
+ * only through the standalone route exports.
  */
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/packages/nextly/src/dispatcher/handlers/__tests__/versions-methods.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/versions-methods.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Dispatcher-side version reads. The document gate and the pagination contract
+ * must behave exactly as they do on the standalone routes, since both are
+ * public surfaces onto the same data.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const assertReadableSpy = vi.fn();
+const redactSpy = vi.fn();
+const resolveSingleIdSpy = vi.fn();
+const listSpy = vi.fn();
+const getSpy = vi.fn();
+
+vi.mock("../../../api/versions-access", () => ({
+  assertVersionDocumentReadable: (...a: unknown[]) => assertReadableSpy(...a),
+  redactSnapshotForUser: (...a: unknown[]) => redactSpy(...a),
+  resolveSingleDocumentId: (...a: unknown[]) => resolveSingleIdSpy(...a),
+}));
+
+vi.mock("../../../di", () => ({
+  getService: vi.fn(() => ({ list: listSpy, get: getSpy })),
+}));
+
+import {
+  getVersionForDocument,
+  listVersionsForDocument,
+  userFromParams,
+} from "../versions-methods";
+
+const user = { id: "user-1" };
+
+describe("listVersionsForDocument", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("gates on the live document before reading history", async () => {
+    listSpy.mockResolvedValue([]);
+
+    await listVersionsForDocument({
+      scopeKind: "collection",
+      slug: "posts",
+      entryId: "e1",
+      user,
+    });
+
+    expect(assertReadableSpy).toHaveBeenCalledWith(
+      "collection",
+      "posts",
+      "e1",
+      user
+    );
+  });
+
+  it("reports hasNext from a probe row and never returns it", async () => {
+    // Asking for limit+1 is what distinguishes "a full page" from "more exist".
+    listSpy.mockResolvedValue([
+      { versionNo: 3 },
+      { versionNo: 2 },
+      { versionNo: 1 },
+    ]);
+
+    const result = await listVersionsForDocument({
+      scopeKind: "collection",
+      slug: "posts",
+      entryId: "e1",
+      user,
+      limit: 2,
+    });
+
+    expect(listSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ limit: 3 })
+    );
+    expect(result.items).toHaveLength(2);
+    expect(result.meta.hasNext).toBe(true);
+  });
+
+  it("clamps an oversized limit", async () => {
+    listSpy.mockResolvedValue([]);
+
+    await listVersionsForDocument({
+      scopeKind: "collection",
+      slug: "posts",
+      entryId: "e1",
+      user,
+      limit: 5000,
+    });
+
+    expect(listSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ limit: 101 })
+    );
+  });
+});
+
+describe("getVersionForDocument", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("redacts the snapshot before returning it", async () => {
+    getSpy.mockResolvedValue({ versionNo: 1, snapshot: { title: "x" } });
+
+    await getVersionForDocument({
+      scopeKind: "collection",
+      slug: "posts",
+      entryId: "e1",
+      user,
+      versionNo: 1,
+    });
+
+    // A stored snapshot must never reveal a field the live read would hide.
+    expect(redactSpy).toHaveBeenCalledWith(
+      { title: "x" },
+      "collection",
+      "posts",
+      user
+    );
+  });
+
+  it("rejects a non-positive version number before querying", async () => {
+    await expect(
+      getVersionForDocument({
+        scopeKind: "collection",
+        slug: "posts",
+        entryId: "e1",
+        user,
+        versionNo: 0,
+      })
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("userFromParams", () => {
+  it("rebuilds the caller the route handler stamped onto params", () => {
+    const result = userFromParams({
+      _authenticatedUserId: "user-9",
+      _authenticatedUserName: "Ada",
+      _authenticatedUserEmail: "ada@example.com",
+      _authenticatedUserRoles: JSON.stringify(["editor", "author"]),
+    });
+
+    expect(result).toMatchObject({
+      id: "user-9",
+      name: "Ada",
+      email: "ada@example.com",
+      roles: ["editor", "author"],
+      // A representative singular role, so a callback reading `user.role`
+      // sees an authorized value rather than stripping fields.
+      role: "editor",
+    });
+  });
+
+  it("tolerates a caller with no roles stamped on", () => {
+    const result = userFromParams({ _authenticatedUserId: "user-9" });
+
+    expect(result.id).toBe("user-9");
+    expect(result.roles).toBeUndefined();
+  });
+
+  it("does not throw on a malformed roles value", () => {
+    // Defensive: a corrupt value must not turn a read into a 500.
+    const result = userFromParams({
+      _authenticatedUserId: "user-9",
+      _authenticatedUserRoles: "not-json",
+    });
+
+    expect(result.roles).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/dispatcher/handlers/__tests__/versions-methods.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/versions-methods.test.ts
@@ -74,6 +74,48 @@ describe("listVersionsForDocument", () => {
     expect(result.meta.hasNext).toBe(true);
   });
 
+  it("rejects a negative limit rather than clamping it", async () => {
+    // Math.min(-2, MAX_LIMIT) is still -2, and the repository would receive
+    // limit + 1 === -1, which SQLite treats as unbounded — defeating MAX_LIMIT.
+    await expect(
+      listVersionsForDocument({
+        scopeKind: "collection",
+        slug: "posts",
+        entryId: "e1",
+        user,
+        limit: -2,
+      })
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    expect(listSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-numeric limit", async () => {
+    await expect(
+      listVersionsForDocument({
+        scopeKind: "collection",
+        slug: "posts",
+        entryId: "e1",
+        user,
+        limit: Number("abc"),
+      })
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+
+  it("rejects a malformed cursor instead of querying versionNo < NaN", async () => {
+    await expect(
+      listVersionsForDocument({
+        scopeKind: "collection",
+        slug: "posts",
+        entryId: "e1",
+        user,
+        cursor: Number("abc"),
+      })
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+
+    expect(listSpy).not.toHaveBeenCalled();
+  });
+
   it("clamps an oversized limit", async () => {
     listSpy.mockResolvedValue([]);
 

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -98,6 +98,11 @@ import type { MethodHandler, Params } from "../types";
 // Shared guard that centralizes required + stale schema-version validation for
 // all three entity kinds, so a stale UI save is rejected before any DDL runs.
 import { assertSchemaVersionMatch } from "./schema-version-guard";
+import {
+  getVersionForDocument,
+  listVersionsForDocument,
+  userFromParams,
+} from "./versions-methods";
 
 type CollectionsHandlerType = CollectionsHandler;
 
@@ -136,10 +141,49 @@ function formatToastSummary(summary: {
   return parts.length > 0 ? parts.join(", ") : "no changes";
 }
 
+/**
+ * Version-history reads for a collection entry.
+ *
+ * Split out so the dispatcher registration and the auth method set in
+ * `routeHandler.ts` stay in step, and so the Single equivalent can mirror it.
+ * The shared methods return data; the canonical envelope is applied here.
+ */
+export const COLLECTION_VERSION_METHODS: Record<
+  string,
+  MethodHandler<CollectionsHandlerType>
+> = {
+  listEntryVersions: {
+    execute: async (_svc, p) => {
+      const result = await listVersionsForDocument({
+        scopeKind: "collection",
+        slug: String(p.collectionName ?? ""),
+        entryId: String(p.entryId ?? ""),
+        user: userFromParams(p),
+        limit: p.limit !== undefined ? Number(p.limit) : undefined,
+        cursor: p.cursor !== undefined ? Number(p.cursor) : undefined,
+      });
+      return respondList(result.items, result.meta);
+    },
+  },
+  getEntryVersion: {
+    execute: async (_svc, p) => {
+      const row = await getVersionForDocument({
+        scopeKind: "collection",
+        slug: String(p.collectionName ?? ""),
+        entryId: String(p.entryId ?? ""),
+        user: userFromParams(p),
+        versionNo: Number(p.versionNo),
+      });
+      return respondDoc(row);
+    },
+  },
+};
+
 const COLLECTIONS_METHODS: Record<
   string,
   MethodHandler<CollectionsHandlerType>
 > = {
+  ...COLLECTION_VERSION_METHODS,
   createCollection: {
     // The metadata service returns the legacy CollectionServiceResult
     // envelope; we unwrap it and pass the legacy success message through

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -27,6 +27,7 @@ import {
   respondList,
   respondMutation,
 } from "../../api/response-shapes";
+import { resolveSingleDocumentId } from "../../api/versions-access";
 import type { FieldConfig } from "../../collections/fields/types";
 import { container } from "../../di/container";
 import { DynamicCollectionSchemaService } from "../../domains/dynamic-collections/services/dynamic-collection-schema-service";
@@ -90,6 +91,11 @@ import {
 import type { MethodHandler, Params } from "../types";
 
 import { assertSchemaVersionMatch } from "./schema-version-guard";
+import {
+  getVersionForDocument,
+  listVersionsForDocument,
+  userFromParams,
+} from "./versions-methods";
 
 // ============================================================
 // Default field helpers
@@ -293,7 +299,65 @@ async function reconcileSingleCompanion(args: {
 // Method definitions
 // ============================================================
 
+/**
+ * Version-history reads for a Single document.
+ *
+ * A Single's URL carries no entry id — there is only ever one document — so the
+ * id is resolved from the live row rather than taken from params. Trusting a
+ * client-supplied value would defeat the check that stops a Single recreated
+ * under a new id from exposing its predecessor's snapshots.
+ */
+export const SINGLE_VERSION_METHODS: Record<
+  string,
+  MethodHandler<SinglesServices>
+> = {
+  listSingleVersions: {
+    execute: async (_svc, p) => {
+      const slug = String(p.slug ?? "");
+      const entryId = await requireLiveSingleId(slug);
+      const result = await listVersionsForDocument({
+        scopeKind: "single",
+        slug,
+        entryId,
+        user: userFromParams(p),
+        limit: p.limit !== undefined ? Number(p.limit) : undefined,
+        cursor: p.cursor !== undefined ? Number(p.cursor) : undefined,
+      });
+      return respondList(result.items, result.meta);
+    },
+  },
+  getSingleVersion: {
+    execute: async (_svc, p) => {
+      const slug = String(p.slug ?? "");
+      const entryId = await requireLiveSingleId(slug);
+      const row = await getVersionForDocument({
+        scopeKind: "single",
+        slug,
+        entryId,
+        user: userFromParams(p),
+        versionNo: Number(p.versionNo),
+      });
+      return respondDoc(row);
+    },
+  },
+};
+
+/**
+ * The live document's id, or a not-found error when the Single has never been
+ * materialized — in which case it has no history to show either.
+ */
+async function requireLiveSingleId(slug: string): Promise<string> {
+  const id = await resolveSingleDocumentId(slug);
+  if (id === null) {
+    throw NextlyError.notFound({
+      logContext: { reason: "single-not-materialized", slug },
+    });
+  }
+  return id;
+}
+
 const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
+  ...SINGLE_VERSION_METHODS,
   listSingles: {
     // Permission filtering is pushed into the registry as a slug allowlist
     // so the SQL count and the row results share the same scope. This keeps

--- a/packages/nextly/src/dispatcher/handlers/versions-methods.ts
+++ b/packages/nextly/src/dispatcher/handlers/versions-methods.ts
@@ -1,0 +1,167 @@
+/**
+ * Version-history reads for the dispatcher.
+ *
+ * The admin talks to the catch-all handler rather than the standalone route
+ * exports, so version history needs a dispatcher surface too. Both surfaces
+ * share the document gate and the redaction step from `api/versions-access`, so
+ * the access rules have exactly one definition.
+ *
+ * @module dispatcher/handlers/versions-methods
+ */
+
+import type { PaginationMeta } from "../../api/response-shapes";
+import {
+  assertVersionDocumentReadable,
+  redactSnapshotForUser,
+} from "../../api/versions-access";
+import { getService } from "../../di";
+import type { UserContext } from "../../domains/singles/types";
+import type {
+  VersionMeta,
+  VersionRow,
+} from "../../domains/versions/versions-repository";
+import { NextlyError } from "../../errors/nextly-error";
+import type { VersionScopeKind } from "../../schemas/versions/types";
+import type { Params } from "../types";
+
+/** Page size when the caller does not ask for one. */
+const DEFAULT_LIMIT = 25;
+
+/** Hard ceiling, so one request cannot serialize an unbounded history. */
+const MAX_LIMIT = 100;
+
+/** What every version method needs to identify and authorize a document. */
+export interface VersionMethodArgs {
+  scopeKind: VersionScopeKind;
+  slug: string;
+  entryId: string;
+  user: UserContext;
+  limit?: number;
+  cursor?: number;
+}
+
+/**
+ * Rebuild the caller from the params the route handler stamped on.
+ *
+ * `setAuthenticatedRouteParams` writes the authenticated identity onto
+ * `routeParams` as `_authenticatedUser*` values, so dispatcher methods recover
+ * it from there rather than receiving a user object directly.
+ */
+export function userFromParams(p: Params): UserContext {
+  let roles: string[] | undefined;
+  if (p._authenticatedUserRoles) {
+    try {
+      const parsed: unknown = JSON.parse(String(p._authenticatedUserRoles));
+      if (Array.isArray(parsed)) roles = parsed as string[];
+    } catch {
+      // A corrupt value must not turn a read into a server error; treat it as
+      // no roles and let the access rules decide.
+      roles = undefined;
+    }
+  }
+
+  return {
+    id: String(p._authenticatedUserId ?? ""),
+    name: p._authenticatedUserName
+      ? String(p._authenticatedUserName)
+      : undefined,
+    email: p._authenticatedUserEmail
+      ? String(p._authenticatedUserEmail)
+      : undefined,
+    roles,
+    // A representative singular role, matching what the standalone routes
+    // pass, so a callback reading `user.role` sees an authorized value.
+    role: roles?.[0],
+  };
+}
+
+/**
+ * Version metadata for one document, newest-first. Snapshots are never included
+ * here — a history list does not need them and they are large.
+ */
+export async function listVersionsForDocument(
+  args: VersionMethodArgs
+): Promise<{ items: VersionMeta[]; meta: PaginationMeta }> {
+  await assertVersionDocumentReadable(
+    args.scopeKind,
+    args.slug,
+    args.entryId,
+    args.user
+  );
+
+  const limit = Math.min(args.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+  const versions = getService("versionsService");
+  // Ask for one extra row: its presence is what proves another page exists.
+  // Inferring from a full page would claim a next page whenever the history
+  // length is an exact multiple of the page size.
+  const window = await versions.list(
+    {
+      scopeKind: args.scopeKind,
+      scopeSlug: args.slug,
+      entryId: args.entryId,
+    },
+    {
+      limit: limit + 1,
+      ...(args.cursor !== undefined ? { cursor: args.cursor } : {}),
+    }
+  );
+  const hasNext = window.length > limit;
+  const items = hasNext ? window.slice(0, limit) : window;
+
+  // Keyset pagination: page/totalPages are not meaningful for a cursor walk,
+  // so the meta describes the returned window.
+  return {
+    items,
+    meta: {
+      total: items.length,
+      page: 1,
+      limit,
+      totalPages: 1,
+      hasNext,
+      hasPrev: args.cursor !== undefined,
+    },
+  };
+}
+
+/** One version, including its snapshot, redacted for the caller. */
+export async function getVersionForDocument(
+  args: VersionMethodArgs & { versionNo: number }
+): Promise<VersionRow> {
+  if (!Number.isInteger(args.versionNo) || args.versionNo < 1) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "versionNo",
+          code: "INVALID_VALUE",
+          message: "Version number must be a positive integer.",
+        },
+      ],
+    });
+  }
+
+  await assertVersionDocumentReadable(
+    args.scopeKind,
+    args.slug,
+    args.entryId,
+    args.user
+  );
+
+  const versions = getService("versionsService");
+  const row = await versions.get(
+    {
+      scopeKind: args.scopeKind,
+      scopeSlug: args.slug,
+      entryId: args.entryId,
+    },
+    args.versionNo
+  );
+
+  await redactSnapshotForUser(
+    row.snapshot,
+    args.scopeKind,
+    args.slug,
+    args.user
+  );
+
+  return row;
+}

--- a/packages/nextly/src/dispatcher/handlers/versions-methods.ts
+++ b/packages/nextly/src/dispatcher/handlers/versions-methods.ts
@@ -30,6 +30,30 @@ const DEFAULT_LIMIT = 25;
 /** Hard ceiling, so one request cannot serialize an unbounded history. */
 const MAX_LIMIT = 100;
 
+/**
+ * Reject a pagination value that is not a positive integer.
+ *
+ * The dispatchers convert raw query strings with `Number(...)`, so `?limit=abc`
+ * arrives as `NaN` and `?limit=-2` arrives negative. Neither is caught by the
+ * clamp below: `Math.min(-2, MAX_LIMIT)` is still `-2`, and the repository then
+ * receives `limit + 1 === -1`, which SQLite treats as *unbounded* — silently
+ * defeating MAX_LIMIT. A `NaN` cursor would likewise produce a
+ * `versionNo < NaN` predicate that matches nothing.
+ */
+function assertPositiveInteger(value: number, path: string): void {
+  if (!Number.isInteger(value) || value < 1) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path,
+          code: "INVALID_VALUE",
+          message: `${path} must be a positive integer.`,
+        },
+      ],
+    });
+  }
+}
+
 /** What every version method needs to identify and authorize a document. */
 export interface VersionMethodArgs {
   scopeKind: VersionScopeKind;
@@ -82,6 +106,11 @@ export function userFromParams(p: Params): UserContext {
 export async function listVersionsForDocument(
   args: VersionMethodArgs
 ): Promise<{ items: VersionMeta[]; meta: PaginationMeta }> {
+  // Validate before the gate so malformed pagination fails fast, and validate
+  // here rather than per dispatcher so every caller of this core is covered.
+  if (args.limit !== undefined) assertPositiveInteger(args.limit, "limit");
+  if (args.cursor !== undefined) assertPositiveInteger(args.cursor, "cursor");
+
   await assertVersionDocumentReadable(
     args.scopeKind,
     args.slug,

--- a/packages/nextly/src/route-handler/__tests__/route-parser.versions.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.versions.test.ts
@@ -56,8 +56,27 @@ describe("version routes", () => {
     });
   });
 
+  it("rejects a path with segments beyond the version number", () => {
+    // A deeper path is not a route this owns; truncating it to a version read
+    // would answer a request that was never made.
+    const parsed = parseRestRoute(
+      ["collections", "posts", "entries", "e1", "versions", "3", "extra"],
+      "GET"
+    );
+
+    expect(parsed.method).not.toBe("getEntryVersion");
+  });
+
+  it("rejects a single version path with trailing segments", () => {
+    const parsed = parseRestRoute(
+      ["singles", "settings", "versions", "2", "extra"],
+      "GET"
+    );
+
+    expect(parsed.method).not.toBe("getSingleVersion");
+  });
+
   it("does not claim version routes for non-GET methods", () => {
-    // Restore arrives in a later stage; until then only reads exist.
     const parsed = parseRestRoute(
       ["collections", "posts", "entries", "e1", "versions"],
       "POST"

--- a/packages/nextly/src/route-handler/__tests__/route-parser.versions.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.versions.test.ts
@@ -56,32 +56,74 @@ describe("version routes", () => {
     });
   });
 
-  it("rejects a path with segments beyond the version number", () => {
-    // A deeper path is not a route this owns; truncating it to a version read
-    // would answer a request that was never made.
+  it("matches no route at all for segments beyond the version number", () => {
+    // Asserting the absence of a route, not merely of the version route: the
+    // entry branches sit below this one, so a path that is merely "not a
+    // version read" could still be answered as a read of the entry itself.
     const parsed = parseRestRoute(
       ["collections", "posts", "entries", "e1", "versions", "3", "extra"],
       "GET"
     );
 
-    expect(parsed.method).not.toBe("getEntryVersion");
+    expect(parsed.method).toBeUndefined();
   });
 
-  it("rejects a single version path with trailing segments", () => {
+  it("matches no route for a single version path with trailing segments", () => {
     const parsed = parseRestRoute(
       ["singles", "settings", "versions", "2", "extra"],
       "GET"
     );
 
-    expect(parsed.method).not.toBe("getSingleVersion");
+    expect(parsed.method).toBeUndefined();
   });
 
-  it("does not claim version routes for non-GET methods", () => {
-    const parsed = parseRestRoute(
-      ["collections", "posts", "entries", "e1", "versions"],
-      "POST"
-    );
+  it.each([
+    ["POST", "listEntryVersions"],
+    ["PATCH", "updateEntry"],
+    ["DELETE", "deleteEntry"],
+  ])(
+    "does not answer %s on a version path as an entry write",
+    (httpMethod, forbiddenMethod) => {
+      // A version path with a mutating verb owns no route. It must not fall
+      // through to the entry branches, where DELETE would destroy the very
+      // document whose history was addressed.
+      const parsed = parseRestRoute(
+        ["collections", "posts", "entries", "e1", "versions"],
+        httpMethod
+      );
 
-    expect(parsed.method).not.toBe("listEntryVersions");
+      expect(parsed.method).not.toBe(forbiddenMethod);
+      expect(parsed.method).toBeUndefined();
+    }
+  );
+
+  it("still matches the entry itself when no segments trail", () => {
+    // The guard must not cost the entry routes their own paths.
+    expect(
+      parseRestRoute(["collections", "posts", "entries", "e1"], "DELETE").method
+    ).toBe("deleteEntry");
+    expect(
+      parseRestRoute(["collections", "posts", "entries", "e1"], "GET").method
+    ).toBe("getEntry");
+    expect(
+      parseRestRoute(["collections", "posts", "entries", "e1"], "PATCH").method
+    ).toBe("updateEntry");
+  });
+
+  it("leaves the real entry sub-routes matching", () => {
+    // These are claimed by earlier, POST-only parsers; the guard sits below
+    // them and must not shadow them.
+    expect(
+      parseRestRoute(
+        ["collections", "posts", "entries", "e1", "duplicate"],
+        "POST"
+      ).method
+    ).toBe("duplicateEntry");
+    expect(
+      parseRestRoute(
+        ["collections", "posts", "entries", "e1", "publish-all"],
+        "POST"
+      ).method
+    ).toBe("publishAllLocales");
   });
 });

--- a/packages/nextly/src/route-handler/__tests__/route-parser.versions.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.versions.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Version history nests under the document it belongs to, so the existing
+ * per-slug permission that guards reading the document also guards its history.
+ */
+import { describe, it, expect } from "vitest";
+
+import { parseRestRoute } from "../route-parser";
+
+describe("version routes", () => {
+  it("parses a collection entry's version list", () => {
+    const parsed = parseRestRoute(
+      ["collections", "posts", "entries", "e1", "versions"],
+      "GET"
+    );
+
+    expect(parsed).toMatchObject({
+      service: "collections",
+      method: "listEntryVersions",
+      routeParams: { collectionName: "posts", entryId: "e1" },
+    });
+  });
+
+  it("parses a single collection entry version", () => {
+    const parsed = parseRestRoute(
+      ["collections", "posts", "entries", "e1", "versions", "3"],
+      "GET"
+    );
+
+    expect(parsed).toMatchObject({
+      service: "collections",
+      method: "getEntryVersion",
+      routeParams: { collectionName: "posts", entryId: "e1", versionNo: "3" },
+    });
+  });
+
+  it("parses a single document's version list", () => {
+    const parsed = parseRestRoute(["singles", "settings", "versions"], "GET");
+
+    expect(parsed).toMatchObject({
+      service: "singles",
+      method: "listSingleVersions",
+      routeParams: { slug: "settings" },
+    });
+  });
+
+  it("parses one version of a single document", () => {
+    const parsed = parseRestRoute(
+      ["singles", "settings", "versions", "2"],
+      "GET"
+    );
+
+    expect(parsed).toMatchObject({
+      service: "singles",
+      method: "getSingleVersion",
+      routeParams: { slug: "settings", versionNo: "2" },
+    });
+  });
+
+  it("does not claim version routes for non-GET methods", () => {
+    // Restore arrives in a later stage; until then only reads exist.
+    const parsed = parseRestRoute(
+      ["collections", "posts", "entries", "e1", "versions"],
+      "POST"
+    );
+
+    expect(parsed.method).not.toBe("listEntryVersions");
+  });
+});

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -745,6 +745,88 @@ function parseCollectionEntryPublishAllRoute(
  * Parse bulk delete route for collection entries
  * POST /api/collections/{slug}/entries/bulk-delete
  */
+/**
+ * `/collections/{slug}/entries/{entryId}/versions[/{versionNo}]`
+ *
+ * Version history nests under its entry so the existing `read-{slug}`
+ * permission that guards the document guards its history too, with no separate
+ * authorization branch.
+ */
+function parseCollectionEntryVersionRoutes(
+  id: string | undefined,
+  subresource: string | undefined,
+  subId: string | undefined,
+  additionalParams: string[],
+  httpMethod: string,
+  routeParams: Record<string, string>
+): ParsedRoute | null {
+  if (
+    !id ||
+    subresource !== "entries" ||
+    !subId ||
+    additionalParams[0] !== "versions" ||
+    httpMethod !== "GET"
+  ) {
+    return null;
+  }
+
+  routeParams.collectionName = id;
+  routeParams.entryId = subId;
+
+  const versionNo = additionalParams[1];
+  if (versionNo) {
+    routeParams.versionNo = versionNo;
+    return {
+      service: "collections",
+      operation: "single",
+      method: "getEntryVersion",
+      routeParams,
+    };
+  }
+
+  return {
+    service: "collections",
+    operation: "list",
+    method: "listEntryVersions",
+    routeParams,
+  };
+}
+
+/**
+ * `/singles/{slug}/versions[/{versionNo}]` — the Single equivalent, nesting
+ * under the document for the same reason.
+ */
+function parseSingleVersionRoutes(
+  id: string | undefined,
+  subresource: string | undefined,
+  subId: string | undefined,
+  httpMethod: string,
+  routeParams: Record<string, string>
+): ParsedRoute | null {
+  if (!id || subresource !== "versions" || httpMethod !== "GET") {
+    return null;
+  }
+
+  routeParams.slug = id;
+
+  if (subId) {
+    routeParams.versionNo = subId;
+    return {
+      service: "singles",
+      operation: "single",
+      method: "getSingleVersion",
+      routeParams,
+    };
+  }
+
+  return {
+    service: "singles",
+    operation: "list",
+    method: "listSingleVersions",
+    routeParams,
+  };
+}
+
 function parseCollectionEntryBulkDeleteRoute(
   id: string | undefined,
   subresource: string | undefined,
@@ -1747,6 +1829,18 @@ export function parseRestRoute(
 
   // Handle Collections endpoints
   if (resource === "collections") {
+    // Nested version history is matched first: it sits deeper than the entry
+    // routes below, which would otherwise claim the path.
+    const versionResult = parseCollectionEntryVersionRoutes(
+      id,
+      subresource,
+      subId,
+      additionalParams,
+      httpMethod,
+      routeParams
+    );
+    if (versionResult) return versionResult;
+
     const result = parseCollectionRoutes(
       id,
       subresource,
@@ -1766,6 +1860,17 @@ export function parseRestRoute(
 
   // Handle Singles endpoints (globals)
   if (resource === "singles") {
+    // Version history is matched before the schema/document routes so
+    // `/singles/{slug}/versions` is not read as a sub-resource of the document.
+    const versionResult = parseSingleVersionRoutes(
+      id,
+      subresource,
+      subId,
+      httpMethod,
+      routeParams
+    );
+    if (versionResult) return versionResult;
+
     const result = parseSingleRoutes(
       id,
       subresource,

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -641,7 +641,20 @@ function parseCollectionRoutes(
     };
   }
 
-  if (id && subresource === "entries" && subId && httpMethod === "GET") {
+  // The three branches below match the entry itself, so they must not claim a
+  // path that carries further segments. Every real sub-route (duplicate,
+  // publish-all, count, bulk, versions) is matched earlier, so anything still
+  // trailing here belongs to no route: without this guard
+  // `DELETE /entries/{id}/versions` would silently delete the entry.
+  const targetsEntryItself = additionalParams.length === 0;
+
+  if (
+    id &&
+    subresource === "entries" &&
+    subId &&
+    targetsEntryItself &&
+    httpMethod === "GET"
+  ) {
     // GET /api/collections/products/entries/123 → get entry by id
     routeParams.collectionName = id;
     routeParams.entryId = subId;
@@ -653,7 +666,13 @@ function parseCollectionRoutes(
     };
   }
 
-  if (id && subresource === "entries" && subId && httpMethod === "PATCH") {
+  if (
+    id &&
+    subresource === "entries" &&
+    subId &&
+    targetsEntryItself &&
+    httpMethod === "PATCH"
+  ) {
     // PATCH /api/collections/products/entries/123 → update entry
     routeParams.collectionName = id;
     routeParams.entryId = subId;
@@ -665,7 +684,13 @@ function parseCollectionRoutes(
     };
   }
 
-  if (id && subresource === "entries" && subId && httpMethod === "DELETE") {
+  if (
+    id &&
+    subresource === "entries" &&
+    subId &&
+    targetsEntryItself &&
+    httpMethod === "DELETE"
+  ) {
     // DELETE /api/collections/products/entries/123 → delete entry
     routeParams.collectionName = id;
     routeParams.entryId = subId;

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -765,6 +765,9 @@ function parseCollectionEntryVersionRoutes(
     subresource !== "entries" ||
     !subId ||
     additionalParams[0] !== "versions" ||
+    // Only `versions` or `versions/{versionNo}`; anything deeper is not a
+    // route this owns and must not be silently truncated to one that is.
+    additionalParams.length > 2 ||
     httpMethod !== "GET"
   ) {
     return null;
@@ -800,10 +803,17 @@ function parseSingleVersionRoutes(
   id: string | undefined,
   subresource: string | undefined,
   subId: string | undefined,
+  additionalParams: string[],
   httpMethod: string,
   routeParams: Record<string, string>
 ): ParsedRoute | null {
-  if (!id || subresource !== "versions" || httpMethod !== "GET") {
+  if (
+    !id ||
+    subresource !== "versions" ||
+    // Only `versions` or `versions/{versionNo}`; a deeper path is not ours.
+    additionalParams.length > 0 ||
+    httpMethod !== "GET"
+  ) {
     return null;
   }
 
@@ -1866,6 +1876,7 @@ export function parseRestRoute(
       id,
       subresource,
       subId,
+      additionalParams,
       httpMethod,
       routeParams
     );

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -430,12 +430,34 @@ const COLLECTION_ENTRY_METHODS = new Set([
   "countEntries",
   "duplicateEntry",
   "publishAllLocales",
+  // Version history is guarded by the same per-collection read permission as
+  // the entry itself; the document-level rules run inside the methods.
+  "listEntryVersions",
+  "getEntryVersion",
 ]);
 
 /** Single document methods (read/update content, not schema definitions). */
 const SINGLE_DOCUMENT_METHODS = new Set([
   "getSingleDocument",
   "updateSingleDocument",
+  // Read-only history for the document, guarded by the same read permission.
+  "listSingleVersions",
+  "getSingleVersion",
+]);
+
+/**
+ * Read methods that still need resolved role slugs.
+ *
+ * Their responses run field-level `access.read`, which evaluates role-based
+ * rules against the caller's roles. Reads normally skip the roles lookup, but
+ * skipping it here would treat a permitted caller as having no roles and
+ * silently strip fields they are allowed to see.
+ */
+const ROLE_AWARE_READ_METHODS = new Set([
+  "listEntryVersions",
+  "getEntryVersion",
+  "listSingleVersions",
+  "getSingleVersion",
 ]);
 
 /**
@@ -473,8 +495,14 @@ async function resolveAuthorization(
   // --- Singles endpoints ---
   if (service === "singles") {
     if (SINGLE_DOCUMENT_METHODS.has(method)) {
-      // Document operations → {action}-{singleSlug}
-      const action = method === "getSingleDocument" ? "read" : "update";
+      // Document operations → {action}-{singleSlug}. The read-only methods
+      // must not demand update permission just by sharing this set.
+      const action =
+        method === "getSingleDocument" ||
+        method === "listSingleVersions" ||
+        method === "getSingleVersion"
+          ? "read"
+          : "update";
       const slug = routeParams?.slug || "";
       return requireCollectionAccess(req, action, slug);
     }
@@ -813,10 +841,13 @@ async function handleServiceRequest(
   // the lookup for reads and every other service so they don't incur a
   // permissions query.
   const needsRoles =
-    (service === "collections" || service === "singles") &&
-    httpMethod !== "GET" &&
-    httpMethod !== "HEAD" &&
-    httpMethod !== "OPTIONS";
+    ((service === "collections" || service === "singles") &&
+      httpMethod !== "GET" &&
+      httpMethod !== "HEAD" &&
+      httpMethod !== "OPTIONS") ||
+    // Version reads are GETs but still redact per field-level `access.read`,
+    // which needs the caller's roles to evaluate role-based rules.
+    ROLE_AWARE_READ_METHODS.has(method);
   await setAuthenticatedRouteParams(routeParams, authorizedUser, needsRoles);
 
   const dispatchRequest: DispatchRequest = {

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -446,12 +446,19 @@ const SINGLE_DOCUMENT_METHODS = new Set([
 ]);
 
 /**
- * Read methods that still need resolved role slugs.
+ * Read methods that still need resolved role slugs, even though reads normally
+ * skip the lookup.
  *
- * Their responses run field-level `access.read`, which evaluates role-based
- * rules against the caller's roles. Reads normally skip the roles lookup, but
- * skipping it here would treat a permitted caller as having no roles and
- * silently strip fields they are allowed to see.
+ * All four run the version access gate, which reads the live document through
+ * `checkCollectionAccess`. That evaluates roles twice over: the super-admin
+ * bypass is keyed on the role set (`isSuperAdminContext`), and stored
+ * role-based access rules match against the roles forwarded in the request
+ * context. A caller arriving without roles would therefore be treated as a
+ * non-super-admin with no roles and wrongly denied — surfaced as a 404, since
+ * the gate does not disclose existence.
+ *
+ * The two `get*` methods additionally return a snapshot that is redacted by
+ * field-level `access.read`, which reads the same role set.
  */
 const ROLE_AWARE_READ_METHODS = new Set([
   "listEntryVersions",


### PR DESCRIPTION
## What

PR 2a of the content-versioning program. PR 1 shipped `VersionsService` plus
standalone route exports, but **the admin only ever calls the catch-all
`createDynamicHandlers` at `/admin/api/*`**, which knew nothing about versions —
so version history was unreachable from the admin. This adds that surface.

Version reads nest under the document they belong to:

- `GET /collections/{slug}/entries/{entryId}/versions[/{versionNo}]`
- `GET /singles/{slug}/versions[/{versionNo}]`

Nesting is what keeps this small. `resolveAuthorization` already maps collection-entry
and single-document methods to the right per-slug permission, so adding four method
names to the existing sets is the whole authorization change — no new service, no
allowlist entry, no dispatcher switch case, no new auth branch. Version history is
guarded by exactly the permission that guards reading the document, by construction.

The document-level gate from PR 1 (owner-only rules, draft visibility, Single id
match, snapshot redaction, password stripping) is **reused, not duplicated**: it was
split so its auth half and its access half can be used independently, since the
dispatcher authenticates centrally before dispatching while the standalone routes
authenticate themselves.

## Two bugs found while building this

**Version reads would have silently over-redacted.** `needsRoles` deliberately skips
the role lookup for GETs, but `redactSnapshotForUser` runs field-level `access.read`,
which evaluates role-based rules against the caller's roles. Version reads are GETs,
so a role-scoped caller would have been treated as having none and fields they are
allowed to see would have been stripped — data silently missing rather than an error.
Fixed by a `ROLE_AWARE_READ_METHODS` set that widens the condition.

**A contract test was failing on `main`.** `route-auth-contract` asserts every exported
HTTP handler has a verifiable auth gate, detected by a `requireRoute*(` call. When PR 1
refactored the routes onto `requireVersionReadAccess`, that regex stopped matching and
I did not run that suite. Renamed to `requireRouteVersionReadAccess`, matching the
existing `requireRouteCollectionAccess` / `requireRoutePermission` convention, so the
contract passes without weakening it.

## Testing

Unit tests for the split gate (including that it does *not* authenticate), the shared
version methods (pagination probe row, limit clamping, redaction, validation), caller
reconstruction from route params, route parsing for all four URLs, and dispatcher
registration. Integration tests prove the admin's URL shapes resolve to the version
methods. The gate is verified load-bearing.

A Single's URL carries no entry id, so it is resolved from the live row rather than
params — trusting a client value there would defeat the id check added in PR 1. Two
tests pin that.

## Notes

The drawer and preview UI that consume this are PR 2b. Restore, labels, and diff
follow per the approved design
(`tasks/2026-07-20-versions-history-restore-diff-design.md`).

Pre-existing baseline: `collection-dispatcher-shapes`, `single-dispatcher-shapes` and
`component-dispatcher-shapes` have 8 stale-mock failures unrelated to this change —
verified identical with and without the changes here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added version history endpoints for collection entries and Single documents, including paginated listing and fetching specific historical versions.
  * Implemented role-aware access checks and redaction for returned version snapshots.

* **Bug Fixes**
  * Version-history routes are now recognized only for the supported GET patterns (and no longer match deeper/trailing segments).
  * Single version history now returns `not found` when the live Single document was never materialized.

* **Tests**
  * Added and expanded coverage for route parsing, dispatcher wiring, pagination/cursor behavior, input validation, and snapshot redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->