### PR TITLE
feat(admin): show version history in the entry editor

### DIFF
--- a/.changeset/admin-version-history-drawer.md
+++ b/.changeset/admin-version-history-drawer.md
@@ -1,0 +1,27 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+You can now see a document's version history from the editor.
+
+A History control in the entry header opens a panel listing every saved version of the document, newest first, with who saved it and when. Selecting one shows what the document held at that point, field by field, clearly marked as a past state rather than the live one. Long histories page on demand rather than loading at once.
+
+Available for both collection entries and singles, on any document with versioning enabled. Restoring a version is not part of this change.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -18,6 +18,7 @@
 import { resolveLocalizedFieldNames } from "nextly/config";
 import { useMemo } from "react";
 
+import { historyEnabledFrom } from "@admin/components/features/versions/history-enabled";
 import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { useAutoSlug } from "@admin/hooks/useAutoSlug";
 import { useEntryFormShortcuts } from "@admin/hooks/useKeyboardShortcuts";
@@ -386,10 +387,7 @@ export function EntryForm({
                   entry={entry}
                   collectionSlug={collection.name}
                   historyFields={getCollectionFields(collection)}
-                  historyEnabled={
-                    (collection as { versions?: { enabled?: boolean } | null })
-                      .versions?.enabled
-                  }
+                  historyEnabled={historyEnabledFrom(collection)}
                   locale={locale}
                   onLocaleChange={onLocaleChange}
                   toolbarSlot={

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -385,6 +385,7 @@ export function EntryForm({
                   isDirty={isDirty}
                   entry={entry}
                   collectionSlug={collection.name}
+                  historyFields={getCollectionFields(collection)}
                   locale={locale}
                   onLocaleChange={onLocaleChange}
                   toolbarSlot={

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -386,6 +386,10 @@ export function EntryForm({
                   entry={entry}
                   collectionSlug={collection.name}
                   historyFields={getCollectionFields(collection)}
+                  historyEnabled={
+                    (collection as { versions?: { enabled?: boolean } | null })
+                      .versions?.enabled
+                  }
                   locale={locale}
                   onLocaleChange={onLocaleChange}
                   toolbarSlot={

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -12,11 +12,13 @@ import { isFieldLocalized, type FieldConfig } from "nextly/config";
 import { useEffect, useRef, useState } from "react";
 import { useFormContext } from "react-hook-form";
 
+import { VersionHistorySheet } from "@admin/components/features/versions/VersionHistorySheet";
 import {
   Code,
   Copy,
   EyeOff,
   Globe,
+  History,
   Loader2,
   MoreHorizontal,
   PanelRight,
@@ -128,6 +130,12 @@ export interface EntrySystemHeaderProps {
    * plugin-agnostic — the caller builds it from `entryFormToolbarSlot`.
    */
   toolbarSlot?: React.ReactNode;
+
+  /**
+   * Current schema fields, used to render a stored version in the history
+   * panel. Absent means the caller cannot show history, so the control hides.
+   */
+  historyFields?: FieldConfig[];
 }
 
 export function EntrySystemHeader({
@@ -152,6 +160,7 @@ export function EntrySystemHeader({
   onViewApi,
   showJson = true,
   scope = "collection",
+  historyFields,
   lockIdentity = false,
   isRailCollapsed = false,
   onToggleRail,
@@ -161,6 +170,7 @@ export function EntrySystemHeader({
   const entryLocale = useEntryLocale();
   const inputRef = useRef<HTMLInputElement>(null);
   const [unpublishOpen, setUnpublishOpen] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
 
   // Why: autofocus the title input on create so the cursor blinks ready for
   // typing. Skip in edit mode — focusing a populated title interrupts the
@@ -263,6 +273,21 @@ export function EntrySystemHeader({
       {/* Action cluster — right-aligned */}
       <div className="flex items-center gap-1.5 shrink-0">
         {toolbarSlot}
+        {/* A document only has history once it has been saved, and rendering a
+            snapshot needs the schema, so both are required to offer this. */}
+        {showEditMenuItems && historyFields ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="px-2"
+            aria-label="Version history"
+            title="Version history"
+            onClick={() => setHistoryOpen(true)}
+          >
+            <History className="h-4 w-4" />
+          </Button>
+        ) : null}
         {/* i18n M7: content-language switcher. Renders only when a change handler is wired AND
             localization is configured (the component self-hides otherwise). */}
         {onLocaleChange && (
@@ -458,6 +483,21 @@ export function EntrySystemHeader({
         }}
         isLoading={isSubmitting}
       />
+
+      {/* Mounted at the component root for the same reason as the dialog above:
+          the panel must survive whichever button matrix branch rendered. */}
+      {historyFields && entry?.id ? (
+        <VersionHistorySheet
+          open={historyOpen}
+          onOpenChange={setHistoryOpen}
+          scope={
+            scope === "single"
+              ? { kind: "single", slug: collectionSlug }
+              : { kind: "collection", slug: collectionSlug, entryId: entry.id }
+          }
+          fields={historyFields}
+        />
+      ) : null}
     </div>
   );
 }

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -136,6 +136,14 @@ export interface EntrySystemHeaderProps {
    * panel. Absent means the caller cannot show history, so the control hides.
    */
   historyFields?: FieldConfig[];
+
+  /**
+   * Whether this entity captures versions. Only writes on a versioning-enabled
+   * entity record a snapshot, so offering history elsewhere leads to a panel
+   * that can never fill. Undefined means the caller could not determine it, in
+   * which case the control is still offered and the panel reports honestly.
+   */
+  historyEnabled?: boolean;
 }
 
 export function EntrySystemHeader({
@@ -161,6 +169,7 @@ export function EntrySystemHeader({
   showJson = true,
   scope = "collection",
   historyFields,
+  historyEnabled,
   lockIdentity = false,
   isRailCollapsed = false,
   onToggleRail,
@@ -275,7 +284,7 @@ export function EntrySystemHeader({
         {toolbarSlot}
         {/* A document only has history once it has been saved, and rendering a
             snapshot needs the schema, so both are required to offer this. */}
-        {showEditMenuItems && historyFields ? (
+        {showEditMenuItems && historyFields && historyEnabled !== false ? (
           <Button
             type="button"
             variant="outline"
@@ -492,8 +501,16 @@ export function EntrySystemHeader({
           onOpenChange={setHistoryOpen}
           scope={
             scope === "single"
-              ? { kind: "single", slug: collectionSlug }
-              : { kind: "collection", slug: collectionSlug, entryId: entry.id }
+              ? {
+                  kind: "single",
+                  slug: collectionSlug,
+                  documentId: String(entry.id),
+                }
+              : {
+                  kind: "collection",
+                  slug: collectionSlug,
+                  entryId: String(entry.id),
+                }
           }
           fields={historyFields}
         />

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.history.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.history.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * The history control is offered only when there is history to look at and a
+ * schema to render it with. Offering it otherwise leads to a panel that can
+ * only report emptiness or fail.
+ */
+import type { FieldConfig } from "nextly/config";
+import type { ReactNode } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+const { sheetMock } = vi.hoisted(() => ({ sheetMock: vi.fn() }));
+
+vi.mock("@admin/components/features/versions/VersionHistorySheet", () => ({
+  VersionHistorySheet: (props: Record<string, unknown>) => {
+    sheetMock(props);
+    return null;
+  },
+}));
+
+import { EntrySystemHeader } from "../EntrySystemHeader";
+
+/**
+ * The header reads form state through context, so it is given a real form
+ * rather than a stubbed one — a partial stub misses the ref plumbing that
+ * `register` returns and fails for reasons unrelated to what is under test.
+ */
+function WithForm({ children }: { children: ReactNode }) {
+  const form = useForm();
+  return <FormProvider {...form}>{children}</FormProvider>;
+}
+
+const fields = [{ name: "title", type: "text" }] as FieldConfig[];
+
+function renderHeader(overrides: Record<string, unknown> = {}) {
+  return render(
+    <WithForm>
+      <EntrySystemHeader
+        mode="edit"
+        hasStatus={false}
+        collectionSlug="posts"
+        entry={{ id: "e1" } as never}
+        historyFields={fields}
+        isSubmitting={false}
+        isDirty={false}
+        {...overrides}
+      />
+    </WithForm>
+  );
+}
+
+describe("EntrySystemHeader version history", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("offers history for a saved document", () => {
+    renderHeader();
+
+    expect(
+      screen.getByRole("button", { name: "Version history" })
+    ).toBeInTheDocument();
+  });
+
+  it("does not offer history for a document that was never saved", () => {
+    // A create form has no entry id, so there is nothing to have history of.
+    renderHeader({ mode: "create", entry: null });
+
+    expect(
+      screen.queryByRole("button", { name: "Version history" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not offer history without a schema to render it with", () => {
+    renderHeader({ historyFields: undefined });
+
+    expect(
+      screen.queryByRole("button", { name: "Version history" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("addresses a collection entry by its id", () => {
+    renderHeader();
+
+    expect(sheetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: { kind: "collection", slug: "posts", entryId: "e1" },
+      })
+    );
+  });
+
+  it("addresses a Single by slug alone", () => {
+    // A Single has one document and the server resolves its id, so no entry id
+    // is sent even though the header has one.
+    renderHeader({ scope: "single", collectionSlug: "settings" });
+
+    expect(sheetMock).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: { kind: "single", slug: "settings" } })
+    );
+  });
+});

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.history.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.history.test.tsx
@@ -78,6 +78,26 @@ describe("EntrySystemHeader version history", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("does not offer history for an entity that records no versions", () => {
+    // Writes only capture a snapshot when versioning is enabled, so offering
+    // history elsewhere leads to a panel that can never fill.
+    renderHeader({ historyEnabled: false });
+
+    expect(
+      screen.queryByRole("button", { name: "Version history" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("still offers history when the setting could not be determined", () => {
+    // Hiding on an absent flag would silently remove the feature wherever the
+    // schema payload omits it.
+    renderHeader({ historyEnabled: undefined });
+
+    expect(
+      screen.getByRole("button", { name: "Version history" })
+    ).toBeInTheDocument();
+  });
+
   it("addresses a collection entry by its id", () => {
     renderHeader();
 
@@ -93,8 +113,12 @@ describe("EntrySystemHeader version history", () => {
     // is sent even though the header has one.
     renderHeader({ scope: "single", collectionSlug: "settings" });
 
+    // The document id travels for cache identity only, so a recreated Single
+    // cannot be served its predecessor's cached history.
     expect(sheetMock).toHaveBeenCalledWith(
-      expect.objectContaining({ scope: { kind: "single", slug: "settings" } })
+      expect.objectContaining({
+        scope: { kind: "single", slug: "settings", documentId: "e1" },
+      })
     );
   });
 });

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -554,6 +554,10 @@ export function SingleForm({
                 mode="edit"
                 titleField={titleField}
                 historyFields={schema.fields}
+                historyEnabled={
+                  (schema as { versions?: { enabled?: boolean } | null })
+                    .versions?.enabled
+                }
                 hasStatus={hasStatus}
                 isSubmitting={isSubmitting}
                 isDirty={isDirty}

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -553,6 +553,7 @@ export function SingleForm({
               <EntrySystemHeader
                 mode="edit"
                 titleField={titleField}
+                historyFields={schema.fields}
                 hasStatus={hasStatus}
                 isSubmitting={isSubmitting}
                 isDirty={isDirty}

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -44,6 +44,7 @@ import {
   EntryLocaleProvider,
   type EntryLocaleContextValue,
 } from "@admin/components/features/entries/EntryLocaleContext";
+import { historyEnabledFrom } from "@admin/components/features/versions/history-enabled";
 import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { useAutoSlug } from "@admin/hooks/useAutoSlug";
 import { useEntryFormShortcuts } from "@admin/hooks/useKeyboardShortcuts";
@@ -554,10 +555,7 @@ export function SingleForm({
                 mode="edit"
                 titleField={titleField}
                 historyFields={schema.fields}
-                historyEnabled={
-                  (schema as { versions?: { enabled?: boolean } | null })
-                    .versions?.enabled
-                }
+                historyEnabled={historyEnabledFrom(schema)}
                 hasStatus={hasStatus}
                 isSubmitting={isSubmitting}
                 isDirty={isDirty}

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -1,0 +1,172 @@
+/**
+ * A document's version history, as a right-side panel.
+ *
+ * Preview is a mode inside this panel rather than a second sheet: the editor is
+ * looking at one thing — this document's history — and nesting dialogs would
+ * trap focus twice for what is conceptually a step, not a new context.
+ *
+ * @module components/features/versions/VersionHistorySheet
+ */
+
+import type { FieldConfig } from "nextly/config";
+import { useEffect, useState } from "react";
+
+import {
+  Alert,
+  AlertDescription,
+  Button,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  Skeleton,
+} from "@admin/components/ui";
+import { useVersion, useVersions } from "@admin/hooks/queries/useVersions";
+import type { VersionScope } from "@admin/services/versionApi";
+
+import { VersionPreview } from "./VersionPreview";
+import { VersionRow } from "./VersionRow";
+
+export interface VersionHistorySheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  scope: VersionScope;
+  /** Current schema fields, used to render a snapshot. */
+  fields: FieldConfig[];
+}
+
+function ListSkeleton() {
+  return (
+    <div className="p-4 flex flex-col gap-4" aria-busy="true">
+      <span className="sr-only" role="status" aria-live="polite">
+        Loading history
+      </span>
+      {[0, 1, 2].map(i => (
+        <div key={i} className="flex flex-col gap-1">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-3 w-24" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function VersionHistorySheet({
+  open,
+  onOpenChange,
+  scope,
+  fields,
+}: VersionHistorySheetProps) {
+  const [selected, setSelected] = useState<number | null>(null);
+
+  // Reopening the panel should start at the list. Without this the previously
+  // previewed version would still be showing, which reads as a stale panel.
+  useEffect(() => {
+    if (!open) setSelected(null);
+  }, [open]);
+
+  const list = useVersions({ scope, enabled: open });
+  const detail = useVersion({ scope, versionNo: selected, enabled: open });
+
+  const versions = list.data?.pages.flatMap(page => page.items) ?? [];
+  const isEmpty = !list.isLoading && !list.isError && versions.length === 0;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="w-[480px] sm:max-w-[480px] p-0 flex flex-col"
+      >
+        <SheetHeader className="p-4 border-b border-border">
+          <SheetTitle>
+            {selected === null ? "Version history" : `Version ${selected}`}
+          </SheetTitle>
+          <SheetDescription className="sr-only">
+            Past versions of this document, newest first.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 overflow-y-auto">
+          {selected !== null ? (
+            <VersionPreview
+              versionNo={selected}
+              fields={fields}
+              snapshot={detail.data?.snapshot}
+              isLoading={detail.isLoading}
+              error={detail.error}
+            />
+          ) : list.isLoading ? (
+            <ListSkeleton />
+          ) : list.isError ? (
+            <div className="p-4 flex flex-col gap-3">
+              <Alert variant="destructive">
+                <AlertDescription>
+                  This document&apos;s history could not be loaded.
+                </AlertDescription>
+              </Alert>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void list.refetch()}
+              >
+                Try again
+              </Button>
+            </div>
+          ) : isEmpty ? (
+            <div className="px-4 py-8 text-center">
+              <p className="text-sm text-muted-foreground">
+                No earlier versions yet. Each time this document is saved, a
+                version is recorded here.
+              </p>
+            </div>
+          ) : (
+            <>
+              {versions.map(version => (
+                <VersionRow
+                  key={version.id}
+                  version={version}
+                  onSelect={setSelected}
+                />
+              ))}
+
+              {list.hasNextPage ? (
+                <div className="p-4">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="w-full"
+                    disabled={list.isFetchingNextPage}
+                    onClick={() => void list.fetchNextPage()}
+                  >
+                    {list.isFetchingNextPage ? "Loading…" : "Load more"}
+                  </Button>
+                </div>
+              ) : null}
+            </>
+          )}
+        </div>
+
+        <div className="p-4 border-t border-border flex items-center gap-2">
+          {selected !== null ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setSelected(null)}
+            >
+              Back to history
+            </Button>
+          ) : null}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="ml-auto"
+            onClick={() => onOpenChange(false)}
+          >
+            Close
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -95,6 +95,8 @@ export function VersionHistorySheet({
               snapshot={detail.data?.snapshot}
               isLoading={detail.isLoading}
               error={detail.error}
+              onRetry={() => void detail.refetch()}
+              locale={detail.data?.locale ?? null}
             />
           ) : list.isLoading ? (
             <ListSkeleton />
@@ -116,8 +118,7 @@ export function VersionHistorySheet({
           ) : isEmpty ? (
             <div className="px-4 py-8 text-center">
               <p className="text-sm text-muted-foreground">
-                No earlier versions yet. Each time this document is saved, a
-                version is recorded here.
+                No versions recorded for this document yet.
               </p>
             </div>
           ) : (

--- a/packages/admin/src/components/features/versions/VersionPreview.tsx
+++ b/packages/admin/src/components/features/versions/VersionPreview.tsx
@@ -1,0 +1,92 @@
+/**
+ * One stored version rendered read-only.
+ *
+ * Every field in the current schema is rendered, including ones the snapshot
+ * has no value for: an editor comparing versions needs to see that a field was
+ * blank then, which omitting it would hide.
+ *
+ * @module components/features/versions/VersionPreview
+ */
+
+import type { FieldConfig } from "nextly/config";
+
+import { FieldValueDisplay } from "@admin/components/features/versions/value-display/FieldValueDisplay";
+import { Alert, AlertDescription, Skeleton } from "@admin/components/ui";
+
+export interface VersionPreviewProps {
+  versionNo: number;
+  fields: FieldConfig[];
+  snapshot: unknown;
+  isLoading?: boolean;
+  error?: Error | null;
+}
+
+function PreviewSkeleton() {
+  return (
+    <div className="p-4 flex flex-col gap-4" aria-busy="true">
+      <span className="sr-only" role="status" aria-live="polite">
+        Loading version
+      </span>
+      {[0, 1, 2, 3].map(i => (
+        <div key={i} className="flex flex-col gap-1">
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="h-5 w-full" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function VersionPreview({
+  versionNo,
+  fields,
+  snapshot,
+  isLoading = false,
+  error = null,
+}: VersionPreviewProps) {
+  if (isLoading) return <PreviewSkeleton />;
+
+  if (error) {
+    return (
+      <div className="p-4">
+        <Alert variant="destructive">
+          <AlertDescription>This version could not be loaded.</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const values =
+    typeof snapshot === "object" && snapshot !== null
+      ? (snapshot as Record<string, unknown>)
+      : {};
+
+  return (
+    <div className="flex flex-col">
+      <div className="px-4 py-2 bg-primary/5 border-b border-border">
+        <p className="text-sm text-foreground">
+          Viewing version {versionNo}. This is a past state of the document, not
+          what is live.
+        </p>
+      </div>
+
+      <div className="p-4 flex flex-col gap-4">
+        {fields.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            This document has no fields to show.
+          </p>
+        ) : (
+          fields.map(field =>
+            field.name ? (
+              <FieldValueDisplay
+                key={field.name}
+                field={field}
+                value={values[field.name]}
+              />
+            ) : null
+          )
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/versions/VersionPreview.tsx
+++ b/packages/admin/src/components/features/versions/VersionPreview.tsx
@@ -11,7 +11,12 @@
 import type { FieldConfig } from "nextly/config";
 
 import { FieldValueDisplay } from "@admin/components/features/versions/value-display/FieldValueDisplay";
-import { Alert, AlertDescription, Skeleton } from "@admin/components/ui";
+import {
+  Alert,
+  AlertDescription,
+  Button,
+  Skeleton,
+} from "@admin/components/ui";
 
 export interface VersionPreviewProps {
   versionNo: number;
@@ -19,6 +24,9 @@ export interface VersionPreviewProps {
   snapshot: unknown;
   isLoading?: boolean;
   error?: Error | null;
+  onRetry?: () => void;
+  /** The locale this version was captured in, when the document is localized. */
+  locale?: string | null;
 }
 
 function PreviewSkeleton() {
@@ -43,15 +51,24 @@ export function VersionPreview({
   snapshot,
   isLoading = false,
   error = null,
+  onRetry,
+  locale = null,
 }: VersionPreviewProps) {
   if (isLoading) return <PreviewSkeleton />;
 
   if (error) {
     return (
-      <div className="p-4">
+      <div className="p-4 flex flex-col gap-3">
         <Alert variant="destructive">
           <AlertDescription>This version could not be loaded.</AlertDescription>
         </Alert>
+        {/* Retried in place: the alternative is going back and reopening the
+            same version, which is the same request with extra steps. */}
+        {onRetry ? (
+          <Button variant="outline" size="sm" onClick={onRetry}>
+            Try again
+          </Button>
+        ) : null}
       </div>
     );
   }
@@ -65,8 +82,11 @@ export function VersionPreview({
     <div className="flex flex-col">
       <div className="px-4 py-2 bg-primary/5 border-b border-border">
         <p className="text-sm text-foreground">
-          Viewing version {versionNo}. This is a past state of the document, not
-          what is live.
+          Viewing version {versionNo}
+          {/* A localized document captures a version per locale, so the banner
+              names which translation this one holds. */}
+          {locale ? ` (${locale})` : ""}. This is a past state of the document,
+          not what is live.
         </p>
       </div>
 
@@ -76,15 +96,35 @@ export function VersionPreview({
             This document has no fields to show.
           </p>
         ) : (
-          fields.map(field =>
-            field.name ? (
-              <FieldValueDisplay
-                key={field.name}
-                field={field}
-                value={values[field.name]}
-              />
-            ) : null
-          )
+          fields.map((field, i) => {
+            if (field.name) {
+              return (
+                <FieldValueDisplay
+                  key={field.name}
+                  field={field}
+                  value={values[field.name]}
+                />
+              );
+            }
+
+            // A presentational group has no name and stores its children at
+            // this level, so it is rendered against the same object rather than
+            // dropped along with everything inside it.
+            const children = (field as { fields?: FieldConfig[] }).fields;
+            if (field.type === "group" && Array.isArray(children)) {
+              return children.map(child =>
+                child.name ? (
+                  <FieldValueDisplay
+                    key={child.name}
+                    field={child}
+                    value={values[child.name]}
+                  />
+                ) : null
+              );
+            }
+
+            return <span key={`unnamed-${i}`} />;
+          })
         )}
       </div>
     </div>

--- a/packages/admin/src/components/features/versions/VersionRow.tsx
+++ b/packages/admin/src/components/features/versions/VersionRow.tsx
@@ -1,0 +1,73 @@
+/**
+ * One entry in a document's version history.
+ *
+ * Shows only metadata: the list never carries snapshots, so a row describes a
+ * version rather than containing it.
+ *
+ * @module components/features/versions/VersionRow
+ */
+
+import { formatRelativeTime } from "@admin/components/features/notifications/relative-time";
+import { Badge } from "@admin/components/ui";
+import { formatDateTime } from "@admin/lib/dates/format";
+import { cn } from "@admin/lib/utils";
+import type { VersionMeta } from "@admin/services/versionApi";
+
+export interface VersionRowProps {
+  version: VersionMeta;
+  /** Highlighted because it is the version currently being previewed. */
+  active?: boolean;
+  onSelect: (versionNo: number) => void;
+}
+
+export function VersionRow({
+  version,
+  active = false,
+  onSelect,
+}: VersionRowProps) {
+  // A version with no number is an autosave and cannot be addressed on its own,
+  // so it is shown but not offered as something to open.
+  const selectable = typeof version.versionNo === "number";
+
+  const label = selectable ? `Version ${version.versionNo}` : "Autosave";
+
+  // Attribution is absent for a system write rather than missing, so it reads
+  // as "nobody signed this" instead of looking like a failed lookup.
+  const author = version.author?.name ?? "Unknown author";
+
+  return (
+    <button
+      type="button"
+      disabled={!selectable}
+      onClick={() => selectable && onSelect(version.versionNo as number)}
+      aria-label={`${label}, ${version.status}, by ${author}`}
+      aria-current={active ? "true" : undefined}
+      className={cn(
+        "w-full text-left px-4 py-3 border-b border-border last:border-b-0",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        selectable ? "hover:bg-muted cursor-pointer" : "cursor-default",
+        active && "bg-primary/5"
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium text-foreground truncate">
+          {label}
+        </span>
+        <Badge variant="outline" className="shrink-0">
+          {version.status}
+        </Badge>
+        <span
+          className="ml-auto text-xs text-muted-foreground shrink-0"
+          // The relative label is scannable; the exact time is what an editor
+          // needs when deciding between two nearby versions.
+          title={formatDateTime(version.createdAt)}
+        >
+          {formatRelativeTime(version.createdAt)}
+        </span>
+      </div>
+      <div className="mt-1 text-xs text-muted-foreground truncate">
+        {author}
+      </div>
+    </button>
+  );
+}

--- a/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
@@ -98,7 +98,9 @@ describe("VersionHistorySheet", () => {
   it("says a document with no history has none, rather than erroring", () => {
     renderSheet();
 
-    expect(screen.getByText(/No earlier versions yet/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/No versions recorded for this document yet/)
+    ).toBeInTheDocument();
   });
 
   it("offers a retry when history could not be loaded", () => {
@@ -112,7 +114,7 @@ describe("VersionHistorySheet", () => {
     expect(
       screen.getByRole("button", { name: /Try again/ })
     ).toBeInTheDocument();
-    expect(screen.queryByText(/No earlier versions/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/No versions recorded/)).not.toBeInTheDocument();
   });
 
   it("offers more only when another page exists", () => {

--- a/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * The history panel. What matters is that each state says something true: no
+ * history yet is not an error, a failed load is not an empty document, and
+ * previewing a version never implies it is the live one.
+ */
+import userEvent from "@testing-library/user-event";
+import type { FieldConfig } from "nextly/config";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+const { useVersionsMock, useVersionMock } = vi.hoisted(() => ({
+  useVersionsMock: vi.fn(),
+  useVersionMock: vi.fn(),
+}));
+
+vi.mock("@admin/hooks/queries/useVersions", () => ({
+  useVersions: (...a: unknown[]) => useVersionsMock(...a),
+  useVersion: (...a: unknown[]) => useVersionMock(...a),
+}));
+
+import { VersionHistorySheet } from "../VersionHistorySheet";
+
+const scope = { kind: "collection" as const, slug: "posts", entryId: "e1" };
+const fields = [
+  { name: "title", type: "text", label: "Title" },
+] as FieldConfig[];
+
+function listState(overrides: Record<string, unknown> = {}) {
+  return {
+    data: { pages: [{ items: [], meta: { hasNext: false } }] },
+    isLoading: false,
+    isError: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+    refetch: vi.fn(),
+    error: null,
+    ...overrides,
+  };
+}
+
+function detailState(overrides: Record<string, unknown> = {}) {
+  return { data: undefined, isLoading: false, error: null, ...overrides };
+}
+
+function version(versionNo: number) {
+  return {
+    id: `v${versionNo}`,
+    versionNo,
+    status: "published",
+    isAutosave: false,
+    label: null,
+    locale: null,
+    sourceVersionNo: null,
+    createdBy: "u1",
+    author: { id: "u1", name: "Ada" },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function renderSheet() {
+  return render(
+    <VersionHistorySheet
+      open
+      onOpenChange={vi.fn()}
+      scope={scope}
+      fields={fields}
+    />
+  );
+}
+
+describe("VersionHistorySheet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useVersionsMock.mockReturnValue(listState());
+    useVersionMock.mockReturnValue(detailState());
+  });
+
+  it("lists the versions it received", () => {
+    useVersionsMock.mockReturnValue(
+      listState({
+        data: {
+          pages: [
+            { items: [version(2), version(1)], meta: { hasNext: false } },
+          ],
+        },
+      })
+    );
+
+    renderSheet();
+
+    expect(screen.getByText("Version 2")).toBeInTheDocument();
+    expect(screen.getByText("Version 1")).toBeInTheDocument();
+  });
+
+  it("says a document with no history has none, rather than erroring", () => {
+    renderSheet();
+
+    expect(screen.getByText(/No earlier versions yet/)).toBeInTheDocument();
+  });
+
+  it("offers a retry when history could not be loaded", () => {
+    // A failed load must not render as an empty history, which would claim the
+    // document has never been saved.
+    useVersionsMock.mockReturnValue(listState({ isError: true }));
+
+    renderSheet();
+
+    expect(screen.getByText(/could not be loaded/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Try again/ })
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/No earlier versions/)).not.toBeInTheDocument();
+  });
+
+  it("offers more only when another page exists", () => {
+    useVersionsMock.mockReturnValue(
+      listState({
+        data: { pages: [{ items: [version(1)], meta: { hasNext: false } }] },
+        hasNextPage: false,
+      })
+    );
+    const { unmount } = renderSheet();
+    expect(
+      screen.queryByRole("button", { name: /Load more/ })
+    ).not.toBeInTheDocument();
+    unmount();
+
+    useVersionsMock.mockReturnValue(
+      listState({
+        data: { pages: [{ items: [version(1)], meta: { hasNext: true } }] },
+        hasNextPage: true,
+      })
+    );
+    renderSheet();
+    expect(
+      screen.getByRole("button", { name: /Load more/ })
+    ).toBeInTheDocument();
+  });
+
+  it("opens a version and states plainly that it is not live", async () => {
+    useVersionsMock.mockReturnValue(
+      listState({
+        data: { pages: [{ items: [version(3)], meta: { hasNext: false } }] },
+      })
+    );
+    useVersionMock.mockReturnValue(
+      detailState({ data: { snapshot: { title: "Old title" } } })
+    );
+
+    renderSheet();
+    await userEvent.click(screen.getByRole("button", { name: /Version 3/ }));
+
+    expect(screen.getByText(/Viewing version 3/)).toBeInTheDocument();
+    expect(screen.getByText("Old title")).toBeInTheDocument();
+  });
+
+  it("returns to the list from a preview", async () => {
+    useVersionsMock.mockReturnValue(
+      listState({
+        data: { pages: [{ items: [version(3)], meta: { hasNext: false } }] },
+      })
+    );
+    useVersionMock.mockReturnValue(detailState({ data: { snapshot: {} } }));
+
+    renderSheet();
+    await userEvent.click(screen.getByRole("button", { name: /Version 3/ }));
+    await userEvent.click(
+      screen.getByRole("button", { name: /Back to history/ })
+    );
+
+    expect(screen.queryByText(/Viewing version/)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Version 3/ })
+    ).toBeInTheDocument();
+  });
+
+  it("does not query while closed", () => {
+    render(
+      <VersionHistorySheet
+        open={false}
+        onOpenChange={vi.fn()}
+        scope={scope}
+        fields={fields}
+      />
+    );
+
+    // Mounted but idle: the panel exists in the header regardless of state, so
+    // it must not fetch a document's history until asked for.
+    expect(useVersionsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false })
+    );
+  });
+});

--- a/packages/admin/src/components/features/versions/__tests__/VersionPreview.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionPreview.test.tsx
@@ -3,8 +3,9 @@
  * matter are the ones that could mislead: a field that was blank then, and a
  * snapshot that failed to load.
  */
+import userEvent from "@testing-library/user-event";
 import type { FieldConfig } from "nextly/config";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { render, screen } from "@admin/__tests__/utils";
 
@@ -71,6 +72,55 @@ describe("VersionPreview", () => {
 
     expect(screen.getByRole("status")).toHaveTextContent(/Loading/);
     expect(screen.queryByText("Not set")).not.toBeInTheDocument();
+  });
+
+  it("offers an in-place retry when a version fails to load", async () => {
+    // Without it the only recovery is going back and reopening the same
+    // version, which is the same request with extra steps.
+    const onRetry = vi.fn();
+    render(
+      <VersionPreview
+        versionNo={3}
+        fields={fields}
+        snapshot={undefined}
+        error={new Error("boom")}
+        onRetry={onRetry}
+      />
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /Try again/ }));
+    expect(onRetry).toHaveBeenCalled();
+  });
+
+  it("names the locale a version was captured in", () => {
+    render(
+      <VersionPreview versionNo={3} fields={fields} snapshot={{}} locale="de" />
+    );
+
+    expect(screen.getByText(/\(de\)/)).toBeInTheDocument();
+  });
+
+  it("renders the children of a top-level presentational group", () => {
+    // A nameless group stores its children at this level; dropping it would
+    // hide every field inside from the historical document.
+    const grouped = [
+      {
+        name: "",
+        type: "group",
+        fields: [{ name: "city", type: "text", label: "City" }],
+      },
+    ] as FieldConfig[];
+
+    render(
+      <VersionPreview
+        versionNo={3}
+        fields={grouped}
+        snapshot={{ city: "Lisbon" }}
+      />
+    );
+
+    expect(screen.getByText("City")).toBeInTheDocument();
+    expect(screen.getByText("Lisbon")).toBeInTheDocument();
   });
 
   it("reports a failed load instead of rendering an empty document", () => {

--- a/packages/admin/src/components/features/versions/__tests__/VersionPreview.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionPreview.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * A preview shows what a document held at an earlier point. The states that
+ * matter are the ones that could mislead: a field that was blank then, and a
+ * snapshot that failed to load.
+ */
+import type { FieldConfig } from "nextly/config";
+import { describe, it, expect } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+import { VersionPreview } from "../VersionPreview";
+
+const fields = [
+  { name: "title", type: "text", label: "Title" },
+  { name: "subtitle", type: "text", label: "Subtitle" },
+] as FieldConfig[];
+
+describe("VersionPreview", () => {
+  it("renders each field's stored value", () => {
+    render(
+      <VersionPreview
+        versionNo={3}
+        fields={fields}
+        snapshot={{ title: "Hello", subtitle: "World" }}
+      />
+    );
+
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+    expect(screen.getByText("World")).toBeInTheDocument();
+  });
+
+  it("says plainly which version is on screen and that it is not live", () => {
+    render(<VersionPreview versionNo={7} fields={fields} snapshot={{}} />);
+
+    expect(screen.getByText(/Viewing version 7/)).toBeInTheDocument();
+    expect(screen.getByText(/not\s+what is live/)).toBeInTheDocument();
+  });
+
+  it("shows a field the snapshot has no value for rather than omitting it", () => {
+    // Omitting it would hide that the field was blank at this point, which is
+    // exactly what someone comparing versions is looking for.
+    render(
+      <VersionPreview
+        versionNo={3}
+        fields={fields}
+        snapshot={{ title: "Hello" }}
+      />
+    );
+
+    expect(screen.getByText("Subtitle")).toBeInTheDocument();
+    expect(screen.getByText("Not set")).toBeInTheDocument();
+  });
+
+  it("tolerates a snapshot that is not an object", () => {
+    render(
+      <VersionPreview versionNo={3} fields={fields} snapshot={"corrupt"} />
+    );
+
+    expect(screen.getAllByText("Not set")).toHaveLength(2);
+  });
+
+  it("announces loading without claiming the document is empty", () => {
+    render(
+      <VersionPreview
+        versionNo={3}
+        fields={fields}
+        snapshot={undefined}
+        isLoading
+      />
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(/Loading/);
+    expect(screen.queryByText("Not set")).not.toBeInTheDocument();
+  });
+
+  it("reports a failed load instead of rendering an empty document", () => {
+    // Rendering empty fields on error would look like a version that held
+    // nothing, which is a different and wrong claim.
+    render(
+      <VersionPreview
+        versionNo={3}
+        fields={fields}
+        snapshot={undefined}
+        error={new Error("boom")}
+      />
+    );
+
+    expect(screen.getByText(/could not be loaded/)).toBeInTheDocument();
+    expect(screen.queryByText("Not set")).not.toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/features/versions/__tests__/VersionRow.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionRow.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * A history row has to answer "which version, by whom, when" at a glance, and
+ * must not offer to open something that cannot be opened.
+ */
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+import type { VersionMeta } from "@admin/services/versionApi";
+
+import { VersionRow } from "../VersionRow";
+
+function version(overrides: Partial<VersionMeta> = {}): VersionMeta {
+  return {
+    id: "v1",
+    versionNo: 3,
+    status: "published",
+    isAutosave: false,
+    label: null,
+    locale: null,
+    sourceVersionNo: null,
+    createdBy: "u1",
+    author: { id: "u1", name: "Ada Lovelace" },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("VersionRow", () => {
+  it("shows the version number, status, and author", () => {
+    render(<VersionRow version={version()} onSelect={vi.fn()} />);
+
+    expect(screen.getByText("Version 3")).toBeInTheDocument();
+    expect(screen.getByText("published")).toBeInTheDocument();
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+  });
+
+  it("reports an unattributed version rather than leaving it blank", () => {
+    // A system write records no author. Blank space would read as a failed
+    // lookup rather than as nobody having signed the change.
+    render(
+      <VersionRow version={version({ author: null })} onSelect={vi.fn()} />
+    );
+
+    expect(screen.getByText("Unknown author")).toBeInTheDocument();
+  });
+
+  it("names the version in its accessible label", () => {
+    render(<VersionRow version={version()} onSelect={vi.fn()} />);
+
+    expect(
+      screen.getByRole("button", { name: /Version 3, published, by Ada/ })
+    ).toBeInTheDocument();
+  });
+
+  it("selects the version it displays", async () => {
+    const onSelect = vi.fn();
+
+    render(<VersionRow version={version()} onSelect={onSelect} />);
+    await userEvent.click(screen.getByRole("button"));
+
+    expect(onSelect).toHaveBeenCalledWith(3);
+  });
+
+  it("does not offer to open an autosave", () => {
+    // An autosave carries no version number, so there is no address to fetch.
+    render(
+      <VersionRow
+        version={version({ versionNo: null, isAutosave: true })}
+        onSelect={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button")).toBeDisabled();
+    expect(screen.getByText("Autosave")).toBeInTheDocument();
+  });
+
+  it("carries the exact time as a title for the relative label", () => {
+    // The relative label is scannable; the exact time is what distinguishes
+    // two versions saved minutes apart.
+    render(<VersionRow version={version()} onSelect={vi.fn()} />);
+
+    const relative = screen.getByTitle(/\d/);
+    expect(relative).toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/features/versions/__tests__/history-enabled.test.ts
+++ b/packages/admin/src/components/features/versions/__tests__/history-enabled.test.ts
@@ -1,0 +1,36 @@
+/**
+ * The registry always writes a `versions` property and sets it to null when the
+ * entity is unversioned. Reading `versions?.enabled` alone collapses that into
+ * the same `undefined` as a payload that says nothing, which is what made every
+ * unversioned document offer history.
+ */
+import { describe, it, expect } from "vitest";
+
+import { historyEnabledFrom } from "../history-enabled";
+
+describe("historyEnabledFrom", () => {
+  it("reports enabled when the entity records versions", () => {
+    expect(historyEnabledFrom({ versions: { enabled: true } })).toBe(true);
+  });
+
+  it("reports disabled for an unversioned entity", () => {
+    // The distinguishing case: present, but null.
+    expect(historyEnabledFrom({ versions: null })).toBe(false);
+  });
+
+  it("reports disabled when versioning is present but off", () => {
+    expect(historyEnabledFrom({ versions: { enabled: false } })).toBe(false);
+  });
+
+  it("reports unknown when the payload says nothing about versioning", () => {
+    // Distinct from `versions: null`. Answering "no" here would hide the
+    // feature wherever a payload simply omits the property.
+    expect(historyEnabledFrom({ slug: "posts" })).toBeUndefined();
+  });
+
+  it("reports unknown for a value that is not a schema", () => {
+    expect(historyEnabledFrom(null)).toBeUndefined();
+    expect(historyEnabledFrom(undefined)).toBeUndefined();
+    expect(historyEnabledFrom("posts")).toBeUndefined();
+  });
+});

--- a/packages/admin/src/components/features/versions/history-enabled.ts
+++ b/packages/admin/src/components/features/versions/history-enabled.ts
@@ -1,0 +1,29 @@
+/**
+ * Whether an entity records version history, read from its schema payload.
+ *
+ * The registry always writes a `versions` property and sets it to `null` when
+ * the entity is unversioned, so a present-but-null value is a definite "no"
+ * rather than missing information. Reading `versions?.enabled` alone cannot
+ * tell those apart — both yield `undefined` — which would offer history for
+ * every unversioned document.
+ *
+ * A payload with no `versions` property at all is genuinely unknown, and stays
+ * undefined so the caller can decide rather than being told "no" on no evidence.
+ *
+ * @module components/features/versions/history-enabled
+ */
+
+/**
+ * @returns `true`/`false` when the schema states it, `undefined` when the
+ * payload carries no versioning information.
+ */
+export function historyEnabledFrom(schema: unknown): boolean | undefined {
+  if (typeof schema !== "object" || schema === null) return undefined;
+  if (!("versions" in schema)) return undefined;
+
+  const { versions } = schema as {
+    versions?: { enabled?: boolean } | null;
+  };
+
+  return Boolean(versions?.enabled);
+}

--- a/packages/admin/src/components/icons/index.ts
+++ b/packages/admin/src/components/icons/index.ts
@@ -100,6 +100,7 @@ export {
   Heart, // Collection Settings: icon picker
   Highlighter, // Rich text editor: text highlight
   HelpCircle,
+  History, // Entry header: version history
   Home,
   Image,
   Inbox, // Collection Settings: icon picker

--- a/packages/admin/src/hooks/queries/__tests__/useVersions.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useVersions.test.tsx
@@ -90,6 +90,28 @@ describe("useVersions", () => {
     expect(result.current.hasNextPage).toBe(false);
   });
 
+  it("stays idle for an entry that has no id yet", () => {
+    // An empty entryId interpolates into a URL that addresses the collection
+    // rather than an entry, so the request must not be made at all.
+    renderHook(() => useVersions({ scope: { ...scope, entryId: "" } }), {
+      wrapper,
+    });
+
+    expect(listSpy).not.toHaveBeenCalled();
+  });
+
+  it("stays idle for a Single whose live document is unknown", () => {
+    renderHook(
+      () =>
+        useVersions({
+          scope: { kind: "single", slug: "settings", documentId: "" },
+        }),
+      { wrapper }
+    );
+
+    expect(listSpy).not.toHaveBeenCalled();
+  });
+
   it("keeps two documents' histories in separate cache entries", async () => {
     listSpy.mockResolvedValue(page([{ versionNo: 1 }], false));
     const other = { ...scope, entryId: "e2" };

--- a/packages/admin/src/hooks/queries/__tests__/useVersions.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useVersions.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * History paging is keyset, not page-numbered, and the response carries no
+ * cursor — the client derives it from the page it just received. That derivation
+ * is the part worth pinning: getting it wrong either stops paging early or
+ * queries against a null anchor.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { listSpy, getSpy } = vi.hoisted(() => ({
+  listSpy: vi.fn(),
+  getSpy: vi.fn(),
+}));
+
+vi.mock("@admin/services/versionApi", () => ({
+  versionApi: { list: listSpy, get: getSpy },
+}));
+
+import { useVersion, useVersions } from "../useVersions";
+
+const scope = { kind: "collection" as const, slug: "posts", entryId: "e1" };
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function page(items: unknown[], hasNext: boolean) {
+  return { items, meta: { hasNext } };
+}
+
+describe("useVersions", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("requests the first page without a cursor", async () => {
+    listSpy.mockResolvedValue(page([{ versionNo: 3 }], false));
+
+    const { result } = renderHook(() => useVersions({ scope }), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(listSpy).toHaveBeenCalledWith(
+      scope,
+      expect.not.objectContaining({ cursor: expect.anything() })
+    );
+  });
+
+  it("pages from the oldest version number on the page just received", async () => {
+    listSpy.mockResolvedValueOnce(
+      page([{ versionNo: 5 }, { versionNo: 4 }], true)
+    );
+    listSpy.mockResolvedValueOnce(page([{ versionNo: 3 }], false));
+
+    const { result } = renderHook(() => useVersions({ scope }), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    await result.current.fetchNextPage();
+
+    await waitFor(() =>
+      expect(listSpy).toHaveBeenLastCalledWith(
+        scope,
+        expect.objectContaining({ cursor: 4 })
+      )
+    );
+  });
+
+  it("stops paging when the server reports no further page", async () => {
+    listSpy.mockResolvedValue(page([{ versionNo: 3 }], false));
+
+    const { result } = renderHook(() => useVersions({ scope }), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it("stops paging when the last row cannot anchor a cursor", async () => {
+    // An autosave row carries a null versionNo. Paging from it would query
+    // against a null anchor and match nothing.
+    listSpy.mockResolvedValue(page([{ versionNo: null }], true));
+
+    const { result } = renderHook(() => useVersions({ scope }), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it("keeps two documents' histories in separate cache entries", async () => {
+    listSpy.mockResolvedValue(page([{ versionNo: 1 }], false));
+    const other = { ...scope, entryId: "e2" };
+
+    const a = renderHook(() => useVersions({ scope }), { wrapper });
+    const b = renderHook(() => useVersions({ scope: other }), { wrapper });
+
+    await waitFor(() => expect(a.result.current.isSuccess).toBe(true));
+    await waitFor(() => expect(b.result.current.isSuccess).toBe(true));
+
+    expect(listSpy).toHaveBeenCalledWith(scope, expect.anything());
+    expect(listSpy).toHaveBeenCalledWith(other, expect.anything());
+  });
+});
+
+describe("useVersion", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("fetches the requested version", async () => {
+    getSpy.mockResolvedValue({ versionNo: 2, snapshot: {} });
+
+    const { result } = renderHook(() => useVersion({ scope, versionNo: 2 }), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getSpy).toHaveBeenCalledWith(scope, 2);
+  });
+
+  it("does not fetch without a version number", () => {
+    renderHook(() => useVersion({ scope, versionNo: null }), { wrapper });
+
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/admin/src/hooks/queries/useVersions.ts
+++ b/packages/admin/src/hooks/queries/useVersions.ts
@@ -1,0 +1,116 @@
+"use client";
+
+/**
+ * Version History Query Hooks
+ *
+ * Query Keys:
+ * - `["versions"]` — base key for invalidation
+ * - `["versions", "list", kind, slug, entryId]` — one document's history
+ * - `["versions", "detail", kind, slug, entryId, versionNo]` — one version
+ *
+ * @see https://tanstack.com/query/v5/docs/react/reference/useInfiniteQuery
+ */
+
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+
+import {
+  versionApi,
+  type VersionDetail,
+  type VersionListResponse,
+  type VersionScope,
+} from "@admin/services/versionApi";
+
+/** Page size for the history list. */
+const PAGE_SIZE = 25;
+
+/** Stable cache identity for a scope, so two documents never share a page. */
+function scopeKey(scope: VersionScope): readonly string[] {
+  return scope.kind === "single"
+    ? ["single", scope.slug]
+    : ["collection", scope.slug, scope.entryId];
+}
+
+// ============================================================
+// Query Key Factory
+// ============================================================
+
+export const versionKeys = {
+  all: () => ["versions"] as const,
+  lists: () => [...versionKeys.all(), "list"] as const,
+  list: (scope: VersionScope) =>
+    [...versionKeys.lists(), ...scopeKey(scope)] as const,
+  details: () => [...versionKeys.all(), "detail"] as const,
+  detail: (scope: VersionScope, versionNo: number) =>
+    [...versionKeys.details(), ...scopeKey(scope), versionNo] as const,
+};
+
+// ============================================================
+// Query Hooks
+// ============================================================
+
+export interface UseVersionsOptions {
+  scope: VersionScope;
+  enabled?: boolean;
+}
+
+/**
+ * One document's history, newest first, paged by keyset.
+ *
+ * The response carries no cursor of its own, so the next one is the oldest
+ * `versionNo` on the page just received.
+ */
+export function useVersions({ scope, enabled = true }: UseVersionsOptions) {
+  return useInfiniteQuery<VersionListResponse, Error>({
+    queryKey: versionKeys.list(scope),
+    queryFn: ({ pageParam }) =>
+      versionApi.list(scope, {
+        limit: PAGE_SIZE,
+        ...(typeof pageParam === "number" ? { cursor: pageParam } : {}),
+      }),
+    initialPageParam: undefined,
+    getNextPageParam: lastPage => {
+      // `hasNext` comes from the server's probe row and is the only reliable
+      // signal: `total` describes the returned window, not the history.
+      if (!lastPage.meta?.hasNext) return undefined;
+
+      // Autosave rows carry a null `versionNo` and cannot anchor a keyset walk,
+      // so a page ending in one stops paging rather than querying `< null`.
+      const last = lastPage.items.at(-1);
+      return typeof last?.versionNo === "number" ? last.versionNo : undefined;
+    },
+    enabled: enabled && Boolean(scope.slug),
+    staleTime: 30_000,
+  });
+}
+
+export interface UseVersionOptions {
+  scope: VersionScope;
+  versionNo: number | null;
+  enabled?: boolean;
+}
+
+/**
+ * One stored version, including its snapshot.
+ *
+ * A stored version never changes, so this stays fresh longer than the list —
+ * which does change as the document is edited.
+ */
+export function useVersion({
+  scope,
+  versionNo,
+  enabled = true,
+}: UseVersionOptions) {
+  return useQuery<VersionDetail, Error>({
+    queryKey:
+      versionNo === null
+        ? versionKeys.details()
+        : versionKeys.detail(scope, versionNo),
+    queryFn: () => {
+      // Guarded by `enabled`; this is defence against a direct queryFn call.
+      if (versionNo === null) throw new Error("A version number is required");
+      return versionApi.get(scope, versionNo);
+    },
+    enabled: enabled && versionNo !== null,
+    staleTime: 60_000,
+  });
+}

--- a/packages/admin/src/hooks/queries/useVersions.ts
+++ b/packages/admin/src/hooks/queries/useVersions.ts
@@ -23,11 +23,30 @@ import {
 /** Page size for the history list. */
 const PAGE_SIZE = 25;
 
-/** Stable cache identity for a scope, so two documents never share a page. */
+/**
+ * Stable cache identity for a scope, so two documents never share a page.
+ *
+ * A Single's URL carries no entry id, but its cache key does: the server
+ * refuses to serve a recreated Single its predecessor's snapshots, and keying
+ * only on the slug would let a client that fetched before the recreation
+ * re-render those cached pages without asking again.
+ */
 function scopeKey(scope: VersionScope): readonly string[] {
   return scope.kind === "single"
-    ? ["single", scope.slug]
+    ? ["single", scope.slug, scope.documentId]
     : ["collection", scope.slug, scope.entryId];
+}
+
+/**
+ * Whether the scope names a document at all. A collection entry that has never
+ * been saved has no id, and interpolating an empty one builds a URL that
+ * addresses the collection rather than an entry.
+ */
+function isAddressable(scope: VersionScope): boolean {
+  if (!scope.slug) return false;
+  return scope.kind === "single"
+    ? Boolean(scope.documentId)
+    : Boolean(scope.entryId);
 }
 
 // ============================================================
@@ -78,8 +97,10 @@ export function useVersions({ scope, enabled = true }: UseVersionsOptions) {
       const last = lastPage.items.at(-1);
       return typeof last?.versionNo === "number" ? last.versionNo : undefined;
     },
-    enabled: enabled && Boolean(scope.slug),
-    staleTime: 30_000,
+    enabled: enabled && isAddressable(scope),
+    // Saving the document adds a version, and the panel is opened on demand, so
+    // each open re-reads rather than serving a list captured before the save.
+    staleTime: 0,
   });
 }
 
@@ -101,16 +122,18 @@ export function useVersion({
   enabled = true,
 }: UseVersionOptions) {
   return useQuery<VersionDetail, Error>({
+    // A disabled placeholder must not occupy the parent key, which a broad
+    // `invalidateQueries({ queryKey: versionKeys.details() })` would match.
     queryKey:
       versionNo === null
-        ? versionKeys.details()
+        ? ([...versionKeys.details(), "none"] as const)
         : versionKeys.detail(scope, versionNo),
     queryFn: () => {
       // Guarded by `enabled`; this is defence against a direct queryFn call.
       if (versionNo === null) throw new Error("A version number is required");
       return versionApi.get(scope, versionNo);
     },
-    enabled: enabled && versionNo !== null,
+    enabled: enabled && versionNo !== null && isAddressable(scope),
     staleTime: 60_000,
   });
 }

--- a/packages/admin/src/services/__tests__/versionApi.test.ts
+++ b/packages/admin/src/services/__tests__/versionApi.test.ts
@@ -19,7 +19,11 @@ const collection = {
   slug: "posts",
   entryId: "e1",
 };
-const single = { kind: "single" as const, slug: "settings" };
+const single = {
+  kind: "single" as const,
+  slug: "settings",
+  documentId: "s1",
+};
 
 describe("versionApi.list", () => {
   beforeEach(() => {
@@ -36,6 +40,8 @@ describe("versionApi.list", () => {
   });
 
   it("addresses a Single's history without an entry id", async () => {
+    // The document id is carried for cache identity only; sending it would let
+    // a client name which document's history to read.
     await versionApi.list(single);
 
     expect(getSpy).toHaveBeenCalledWith("/singles/settings/versions");

--- a/packages/admin/src/services/__tests__/versionApi.test.ts
+++ b/packages/admin/src/services/__tests__/versionApi.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Version history URLs nest under the document they belong to, and the two
+ * scopes address that document differently — a Single carries no entry id,
+ * because the server resolves it from the live row rather than trusting one
+ * sent by the client.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { getSpy } = vi.hoisted(() => ({ getSpy: vi.fn() }));
+
+vi.mock("@admin/lib/api/protectedApi", () => ({
+  protectedApi: { get: getSpy },
+}));
+
+import { versionApi } from "../versionApi";
+
+const collection = {
+  kind: "collection" as const,
+  slug: "posts",
+  entryId: "e1",
+};
+const single = { kind: "single" as const, slug: "settings" };
+
+describe("versionApi.list", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSpy.mockResolvedValue({ items: [], meta: {} });
+  });
+
+  it("nests a collection entry's history under the entry", async () => {
+    await versionApi.list(collection);
+
+    expect(getSpy).toHaveBeenCalledWith(
+      "/collections/posts/entries/e1/versions"
+    );
+  });
+
+  it("addresses a Single's history without an entry id", async () => {
+    await versionApi.list(single);
+
+    expect(getSpy).toHaveBeenCalledWith("/singles/settings/versions");
+  });
+
+  it("sends the limit and cursor when paging", async () => {
+    await versionApi.list(collection, { limit: 25, cursor: 12 });
+
+    expect(getSpy).toHaveBeenCalledWith(
+      "/collections/posts/entries/e1/versions?limit=25&cursor=12"
+    );
+  });
+
+  it("omits an absent cursor rather than sending it empty", async () => {
+    // The server rejects a cursor that is not a positive integer, so an unset
+    // one must not reach it as the string "undefined".
+    await versionApi.list(collection, { limit: 10 });
+
+    expect(getSpy).toHaveBeenCalledWith(
+      "/collections/posts/entries/e1/versions?limit=10"
+    );
+  });
+});
+
+describe("versionApi.get", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSpy.mockResolvedValue({ id: "v1" });
+  });
+
+  it("addresses one version of a collection entry", async () => {
+    await versionApi.get(collection, 3);
+
+    expect(getSpy).toHaveBeenCalledWith(
+      "/collections/posts/entries/e1/versions/3"
+    );
+  });
+
+  it("addresses one version of a Single", async () => {
+    await versionApi.get(single, 2);
+
+    expect(getSpy).toHaveBeenCalledWith("/singles/settings/versions/2");
+  });
+});

--- a/packages/admin/src/services/versionApi.ts
+++ b/packages/admin/src/services/versionApi.ts
@@ -20,7 +20,16 @@ import type { ListResponse } from "@admin/lib/api/response-types";
  */
 export type VersionScope =
   | { kind: "collection"; slug: string; entryId: string }
-  | { kind: "single"; slug: string };
+  | {
+      kind: "single";
+      slug: string;
+      /**
+       * The live document's id. Not sent — the server resolves it itself — but
+       * carried so a client cache can tell one incarnation of a Single from a
+       * recreated one.
+       */
+      documentId: string;
+    };
 
 /** Display identity of whoever wrote a version. */
 export interface VersionAuthor {

--- a/packages/admin/src/services/versionApi.ts
+++ b/packages/admin/src/services/versionApi.ts
@@ -1,0 +1,87 @@
+/**
+ * Version history wire types and fetchers.
+ *
+ * Mirrors the server surface in `packages/nextly/src/dispatcher/handlers/
+ * versions-methods.ts`. History nests under the document it belongs to, so the
+ * URL carries the document's identity and the permission that guards reading
+ * the document guards its history too.
+ *
+ * @module services/versionApi
+ */
+
+import { protectedApi } from "@admin/lib/api/protectedApi";
+import type { ListResponse } from "@admin/lib/api/response-types";
+
+/**
+ * Which document's history to read.
+ *
+ * A Single's URL carries no entry id: it has exactly one document, and the
+ * server resolves its id from the live row rather than trusting the client.
+ */
+export type VersionScope =
+  | { kind: "collection"; slug: string; entryId: string }
+  | { kind: "single"; slug: string };
+
+/** Display identity of whoever wrote a version. */
+export interface VersionAuthor {
+  id: string;
+  name: string | null;
+}
+
+/** One version's metadata. Snapshots are never included in a list. */
+export interface VersionMeta {
+  id: string;
+  versionNo: number | null;
+  status: string;
+  isAutosave: boolean;
+  label: string | null;
+  locale: string | null;
+  sourceVersionNo: number | null;
+  createdBy: string | null;
+  author: VersionAuthor | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** One version including the stored document. */
+export type VersionDetail = VersionMeta & { snapshot: unknown };
+
+export type VersionListResponse = ListResponse<VersionMeta>;
+
+export interface ListVersionsParams {
+  limit?: number;
+  /**
+   * Keyset cursor: the `versionNo` to read backwards from. Not an offset and
+   * not an opaque token.
+   */
+  cursor?: number;
+}
+
+/** Base path for a scope's history. */
+function basePath(scope: VersionScope): string {
+  return scope.kind === "single"
+    ? `/singles/${scope.slug}/versions`
+    : `/collections/${scope.slug}/entries/${scope.entryId}/versions`;
+}
+
+export const versionApi = {
+  list: (
+    scope: VersionScope,
+    params: ListVersionsParams = {}
+  ): Promise<VersionListResponse> => {
+    const search = new URLSearchParams();
+    if (params.limit !== undefined) search.set("limit", String(params.limit));
+    // Only sent when paging: the server rejects a non-positive-integer cursor,
+    // so an absent one must stay absent rather than become "undefined".
+    if (params.cursor !== undefined)
+      search.set("cursor", String(params.cursor));
+
+    const query = search.toString();
+    return protectedApi.get<VersionListResponse>(
+      `${basePath(scope)}${query ? `?${query}` : ""}`
+    );
+  },
+
+  get: (scope: VersionScope, versionNo: number): Promise<VersionDetail> =>
+    protectedApi.get<VersionDetail>(`${basePath(scope)}/${versionNo}`),
+};


### PR DESCRIPTION
PR 2 of the content-versioning program (roadmap item 8), and the first one an editor can actually see. #252 built the read surface, #256 made it reachable, #257 added authors, #258 added the read-only field display. This wires them into a panel.

## What it does

A History control in `EntrySystemHeader` opens a right-side panel listing a document's versions, newest first, with author and time. Selecting one shows what the document held at that point, rendered through the read-only display from #258.

Because both the collection entry editor and the Single editor already render `EntrySystemHeader`, one change covers both. The scope is derived from the existing `scope` prop rather than new plumbing, so nothing decides the URL shape twice.

## Details worth review

- **The control is offered only when there is history to look at** — an edit-mode document with an id, and a schema to render snapshots with. A create form has no id, so nothing to have history of.
- **Nothing is fetched until the panel is opened.** It is mounted at the component root (like the existing unpublish dialog, and for the same reason — surviving whichever button-matrix branch rendered), so it must stay idle while closed. Pinned by a test.
- **Preview is a mode inside the panel, not a second sheet.** The editor is looking at one thing; nesting dialogs would trap focus twice for what is a step, not a new context.
- **Each state says something true.** No history yet reads as "none yet", not as an error. A failed load offers a retry and does **not** render as an empty history, which would claim the document was never saved. A field the snapshot has no value for renders as empty rather than being omitted — that a field was blank then is exactly what someone comparing versions is looking for.
- **Paging is keyset.** The response carries no cursor, so the next one is the oldest `versionNo` on the page just received. An autosave row has a null `versionNo` and cannot anchor a walk, so a page ending in one stops rather than querying against null.
- **`meta.total`, `page`, and `totalPages` are deliberately unused** — for a cursor walk they describe the returned window, not the history, so there is no count and no numbered pager.
- Built on the `@public` Sheet exports only (#259). `SheetClose`/`SheetFooter` are `@experimental`, and `FieldEditorSheet` already uses a plain `<div>` footer, so this matches both the ledger and precedent.
- `History` added to the curated icon barrel, which exists to keep lucide tree-shakable.

## Not in this PR

**Restore** (PR 3), **diff** (PRs 6–7), and the **"restored from vN"** marker — `sourceVersionNo` has no writer until Restore exists.

Relationship and upload values in Preview render as ids for now, because snapshots return raw references until the deferred hydration work lands. `FieldValueDisplay` already renders an unresolved reference as its id, so this degrades honestly and upgrades for free.

## Testing

29 new tests across the API client, hooks, row, preview, panel, and header wiring.

Two verification notes, since both cost time here:
- **`tsc` was run separately from tests.** The header test passed while missing a required prop — admin tests do not typecheck, which is the same trap that hid four type errors in #258.
- **The 37 admin suite failures are pre-existing.** Proven, not assumed: reverting only my modified files to `origin/main` reproduces the identical 37 across the identical 8 files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added version history access for saved entries and single documents, with a “Version history” control that appears in edit mode only when history is available and enabled.
  * Users can browse versions, load more results, and preview a selected stored version (with timestamps, authors, and locale when present).
* **Bug Fixes**
  * Prevent autosaved items from being selectable for preview.
  * Clear the selected version when the panel closes to avoid stale previews.
  * Show retry (“Try again”) for recoverable errors instead of falling back to empty states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->