### PR TITLE
feat(ui): add a scoped stylesheet for embedding the kit in an existing app

### DIFF
--- a/.changeset/ui-scoped-stylesheet.md
+++ b/.changeset/ui-scoped-stylesheet.md
@@ -24,7 +24,9 @@ Add a stylesheet for using the UI components inside an existing application.
 
 `@nextlyhq/ui` previously shipped one compiled stylesheet, and it styles the whole page: it includes Tailwind's preflight, which resets headings, lists, form controls and spacing document-wide. That is what a new app wants, and it is why the kit could not be dropped into an app that already has its own design — importing it restyled everything around the components.
 
-`@nextlyhq/ui/styles.scoped.css` confines every rule to a `.nextly-ui` wrapper, so the components still get the normalised baseline they are built against while the rest of the page keeps its own styling. Put the class on any element and everything inside it is styled; dark mode goes on the same element. Its animation names are namespaced as well, so the sheet cannot displace a `spin`, `pulse` or `fade-in` the host application already defines.
+`@nextlyhq/ui/styles.scoped.css` confines every rule to a `.nextly-ui` wrapper, so the components still get the normalised baseline they are built against while the rest of the page keeps its own styling. Put the class on any element and everything inside it is styled; dark mode goes on the same element.
+
+Selectors are not the only way a stylesheet reaches outside itself, so the scoped sheet also namespaces the three things CSS resolves globally: animation names, so it cannot displace a `spin`, `pulse` or `fade-in` the host defines; Tailwind's internal `--tw-*` property registrations, which would otherwise change the meaning of those names across the whole host document; and the ancestor classes that `dark:` and `group-*:` variants look for, so a `dark` class higher up the host page no longer flips the components into dark utilities while their tokens stay light.
 
 Overlay components (Dialog, Select, DropdownMenu, Popover, Tooltip, Command) portal to `document.body`, which sits outside that wrapper, so the scoped sheet needs a `PortalProvider` pointing back inside it. The README shows the setup, and `PortalProvider` and `usePortalContainer` are now part of the stable surface because the scoped stylesheet cannot be used correctly without them.
 

--- a/.changeset/ui-scoped-stylesheet.md
+++ b/.changeset/ui-scoped-stylesheet.md
@@ -24,6 +24,8 @@ Add a stylesheet for using the UI components inside an existing application.
 
 `@nextlyhq/ui` previously shipped one compiled stylesheet, and it styles the whole page: it includes Tailwind's preflight, which resets headings, lists, form controls and spacing document-wide. That is what a new app wants, and it is why the kit could not be dropped into an app that already has its own design — importing it restyled everything around the components.
 
-`@nextlyhq/ui/styles.scoped.css` confines every rule to a `.nextly-ui` wrapper, so the components still get the normalised baseline they are built against while the rest of the page keeps its own styling. Put the class on any element and everything inside it is styled; dark mode goes on the same element.
+`@nextlyhq/ui/styles.scoped.css` confines every rule to a `.nextly-ui` wrapper, so the components still get the normalised baseline they are built against while the rest of the page keeps its own styling. Put the class on any element and everything inside it is styled; dark mode goes on the same element. Its animation names are namespaced as well, so the sheet cannot displace a `spin`, `pulse` or `fade-in` the host application already defines.
+
+Overlay components (Dialog, Select, DropdownMenu, Popover, Tooltip, Command) portal to `document.body`, which sits outside that wrapper, so the scoped sheet needs a `PortalProvider` pointing back inside it. The README shows the setup, and `PortalProvider` and `usePortalContainer` are now part of the stable surface because the scoped stylesheet cannot be used correctly without them.
 
 The plugin styling guide now also explains why a plugin compiles its own CSS ahead of time rather than relying on the host to scan it, and the README documents which of the three stylesheets to reach for.

--- a/.changeset/ui-scoped-stylesheet.md
+++ b/.changeset/ui-scoped-stylesheet.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Add a stylesheet for using the UI components inside an existing application.
+
+`@nextlyhq/ui` previously shipped one compiled stylesheet, and it styles the whole page: it includes Tailwind's preflight, which resets headings, lists, form controls and spacing document-wide. That is what a new app wants, and it is why the kit could not be dropped into an app that already has its own design — importing it restyled everything around the components.
+
+`@nextlyhq/ui/styles.scoped.css` confines every rule to a `.nextly-ui` wrapper, so the components still get the normalised baseline they are built against while the rest of the page keeps its own styling. Put the class on any element and everything inside it is styled; dark mode goes on the same element.
+
+The plugin styling guide now also explains why a plugin compiles its own CSS ahead of time rather than relying on the host to scan it, and the README documents which of the three stylesheets to reach for.

--- a/apps/playground/.gitignore
+++ b/apps/playground/.gitignore
@@ -53,3 +53,6 @@ yarn-debug.log*
 
 # coverage
 /coverage
+
+# schema-builder output (this harness defines its schema code-first)
+ui-schema.json

--- a/apps/playground/next.config.ts
+++ b/apps/playground/next.config.ts
@@ -196,7 +196,7 @@ const nextConfig: NextConfig = {
       "mysql2/promise": "./src/stubs/mysql2-stub.js",
       mysql2: "./src/stubs/mysql2-stub.js",
       // CSS files come from dist (the build-css.mjs pipeline applies
-      // the .adminapp scoping post-process and runs a watch loop so
+      // the .nextly-admin scoping post-process and runs a watch loop so
       // the dist file stays fresh during dev). With @nextlyhq/admin
       // aliased to src above, Turbopack stops consulting admin's
       // package.json exports for subpaths — so the CSS alias is

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@nextlyhq/admin-css": "workspace:^",
     "@tailwindcss/postcss": "^4.3.2",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.19.17",

--- a/apps/playground/scripts/__tests__/style-fixture-manifest.test.ts
+++ b/apps/playground/scripts/__tests__/style-fixture-manifest.test.ts
@@ -16,6 +16,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { checkAdminStyles } from "@nextlyhq/admin-css";
 import { describe, expect, it } from "vitest";
 
 import { styleFixturePlugin } from "../../src/plugins/style-fixture/plugin";
@@ -60,9 +61,17 @@ describe("style-fixture admin.styles", () => {
     const file = declaredStylesheet().split("/").pop() as string;
     const css = readFileSync(resolve(FIXTURE, file), "utf8");
 
-    // Built by nextly-build-admin-css: every rule confined to the admin root,
-    // and no hardcoded colors that would ignore the theme.
-    expect(css).toContain(".nextly-admin");
+    // The same validator nextly-build-admin-css gates on, rather than a
+    // substring check: one `.nextly-admin` rule alongside an unscoped rule or a
+    // hardcoded color would satisfy the latter while breaking both invariants
+    // this fixture exists to demonstrate.
+    const issues = checkAdminStyles({ css });
+    expect(
+      issues.map(i => i.message),
+      "the fixture stylesheet must pass the admin.styles validator"
+    ).toEqual([]);
+
+    // And that it is compiled output, not the Tailwind source it was built from.
     expect(css).not.toMatch(/@import\s+["']tailwindcss["']/);
   });
 });

--- a/apps/playground/scripts/__tests__/style-fixture-manifest.test.ts
+++ b/apps/playground/scripts/__tests__/style-fixture-manifest.test.ts
@@ -1,0 +1,68 @@
+/**
+ * `contributes.admin.styles` declares a stylesheet; the admin entry's
+ * side-effect import is what actually loads it. Nothing at runtime reconciles
+ * the two, so a plugin can declare one file and import another (or forget the
+ * import entirely) and simply render unstyled — no error, in the host app or
+ * here.
+ *
+ * This fixture is the first-party example plugin authors copy, so the two
+ * statements are asserted to agree, and the declared file is asserted to exist
+ * and to be the scoped, precompiled artifact the contract calls for.
+ *
+ * It sits with the other harness checks rather than beside the fixture because
+ * the playground app itself is not unit-tested at that layer.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { styleFixturePlugin } from "../../src/plugins/style-fixture/plugin";
+
+const FIXTURE = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../src/plugins/style-fixture"
+);
+
+/** The single stylesheet this fixture declares. */
+function declaredStylesheet(): string {
+  const declared = styleFixturePlugin.contributes?.admin?.styles;
+  expect(declared, "the fixture must declare admin.styles").toBeTruthy();
+  return Array.isArray(declared) ? declared[0] : (declared as string);
+}
+
+describe("style-fixture admin.styles", () => {
+  it("declares the file the admin entry actually imports", () => {
+    const entry = readFileSync(resolve(FIXTURE, "admin.tsx"), "utf8");
+    const sideEffectImports = [
+      ...entry.matchAll(/^import\s+"([^"]+\.css)";/gm),
+    ].map(m => m[1]);
+
+    // The declaration is package-relative; the import is module-relative. Both
+    // must name the same file, which is the part nothing else checks.
+    const declaredFile = declaredStylesheet().split("/").pop();
+    const importedFiles = sideEffectImports.map(p => p.split("/").pop());
+
+    expect(
+      importedFiles,
+      `admin.tsx imports ${importedFiles.join(", ") || "no stylesheet"} but ` +
+        `the manifest declares ${declaredStylesheet()}`
+    ).toContain(declaredFile);
+  });
+
+  it("declares a file that exists", () => {
+    const file = declaredStylesheet().split("/").pop() as string;
+    expect(existsSync(resolve(FIXTURE, file))).toBe(true);
+  });
+
+  it("declares a scoped, token-driven artifact rather than raw source", () => {
+    const file = declaredStylesheet().split("/").pop() as string;
+    const css = readFileSync(resolve(FIXTURE, file), "utf8");
+
+    // Built by nextly-build-admin-css: every rule confined to the admin root,
+    // and no hardcoded colors that would ignore the theme.
+    expect(css).toContain(".nextly-admin");
+    expect(css).not.toMatch(/@import\s+["']tailwindcss["']/);
+  });
+});

--- a/docs/plugins/admin-ui.mdx
+++ b/docs/plugins/admin-ui.mdx
@@ -108,7 +108,14 @@ light and dark automatically.
 
 **3. Ship your own CSS (`admin.styles`).** For anything beyond the safelist, compile a
 scoped, token-driven stylesheet with the `nextly-build-admin-css` CLI (from
-`@nextlyhq/admin-css`, add it as a devDependency) and declare it in your manifest:
+`@nextlyhq/admin-css`, add it as a devDependency) and declare it in your manifest.
+
+Your CSS is compiled in **your** package, not by the host. That is deliberate: the admin
+sheet is built when Nextly is released, so it can never scan a plugin that is installed
+later, and pointing Tailwind at an installed package with `@source` is not a reliable
+substitute — it does not accept package references, and it resolves inconsistently under
+pnpm, which is what this repository and many plugin projects use. Compiling ahead of time
+means your styles do not depend on the host's build at all.
 
 ```css
 /* src/admin.css — author against the shared token preset */

--- a/e2e/tests/ui-standalone.spec.ts
+++ b/e2e/tests/ui-standalone.spec.ts
@@ -106,6 +106,85 @@ test("the scoped sheet does not hijack the host's animation names", async ({
   expect(opacity).toBe("0.5");
 });
 
+test("a host dark mode does not flip the kit's dark utilities", async ({
+  page,
+}) => {
+  // `dark:` compiles to `:where(.dark, .dark *)`, which a host `<html class="dark">`
+  // satisfies for everything on the page. The dark tokens, though, are declared
+  // on `.nextly-ui.dark`. So an unconfined variant flips the utilities while the
+  // tokens stay light, painting dark-mode rules with light-mode values.
+  const markup = (hostClass: string, wrapperClass: string) => `
+    <div class="${hostClass}">
+      <div class="${wrapperClass}">
+        <div id="swatch" class="dark:bg-primary/20">swatch</div>
+      </div>
+    </div>
+  `;
+
+  const read = async (hostClass: string, wrapperClass: string) => {
+    await page.setContent(markup(hostClass, wrapperClass));
+    await page.addStyleTag({ content: sheet("styles.scoped.css") });
+    return page.$eval("#swatch", el => getComputedStyle(el).backgroundColor);
+  };
+
+  const neutral = await read("", "nextly-ui");
+  const hostDark = await read("dark", "nextly-ui");
+  const wrapperDark = await read("", "nextly-ui dark");
+
+  // The host's dark class must not reach inside the wrapper.
+  expect(hostDark).toBe(neutral);
+  // And the wrapper's own dark class still must, or the variant is simply dead.
+  expect(wrapperDark).not.toBe(neutral);
+});
+
+test("the scoped sheet keeps @property-backed utilities working", async ({
+  page,
+}) => {
+  // Tailwind's `--tw-*` registrations are document-global, so the scoped sheet
+  // namespaces them rather than redefining names the host may use itself.
+  // Renaming a registration without renaming every reference would leave the
+  // utility composing against an unregistered property, so assert one that
+  // actually composes through them still resolves.
+  await page.setContent(`
+    <div class="nextly-ui">
+      <div id="shifted" class="-translate-y-1/2">shifted</div>
+    </div>
+  `);
+  await page.addStyleTag({ content: sheet("styles.scoped.css") });
+
+  // The utility sets `translate: var(--nx-tw-translate-x) var(--nx-tw-translate-y)`.
+  // Both halves have to resolve for the shorthand to be valid, and the x half
+  // comes only from its @property initial value — so this is dead unless the
+  // registration and the reference were renamed together.
+  const translate = await page.$eval(
+    "#shifted",
+    el => getComputedStyle(el).translate
+  );
+
+  expect(translate).not.toBe("none");
+  expect(translate).toContain("-50%");
+});
+
+test("the scoped sheet leaves the host's --tw-* properties alone", async ({
+  page,
+}) => {
+  // A Tailwind v3 host uses `--tw-*` as ordinary inherited custom properties.
+  // Registering them via @property would make them non-inheriting with an
+  // initial value, changing the host's rendering without any selector leaking.
+  await page.setContent(`
+    <div id="outer" style="--tw-translate-x: 42px">
+      <div id="inner">inner</div>
+    </div>
+  `);
+  await page.addStyleTag({ content: sheet("styles.scoped.css") });
+
+  const inherited = await page.$eval("#inner", el =>
+    getComputedStyle(el).getPropertyValue("--tw-translate-x").trim()
+  );
+
+  expect(inherited).toBe("42px");
+});
+
 test("the scoped sheet leaves the host document alone", async ({ page }) => {
   // Baseline: what the browser gives an <h1> with no stylesheet at all.
   await page.setContent(HOST_MARKUP);

--- a/e2e/tests/ui-standalone.spec.ts
+++ b/e2e/tests/ui-standalone.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * `@nextlyhq/ui` outside the admin.
+ *
+ * The package ships two compiled stylesheets and, until now, nothing exercised
+ * either of them away from `.nextly-admin`:
+ *
+ *   - `styles.css` styles the whole document, which is what a greenfield app
+ *     wants and what makes it unsafe to drop into an existing one — Tailwind's
+ *     preflight resets `html`/`body`/`*`.
+ *   - `styles.scoped.css` confines every rule to `.nextly-ui`, so components
+ *     still get the preflight they are designed against while the rest of the
+ *     host page keeps its own styles.
+ *
+ * These assert both halves of that contract in a real browser: the components
+ * paint, and the scoped sheet leaves the surrounding document alone.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+const DIST = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../packages/ui/dist"
+);
+
+const UNSCOPED = readFileSync(resolve(DIST, "styles.css"), "utf8");
+const SCOPED = readFileSync(resolve(DIST, "styles.scoped.css"), "utf8");
+
+const TRANSPARENT = "rgba(0, 0, 0, 0)";
+
+/** A host page that already has its own content and styling expectations. */
+const HOST_MARKUP = `
+  <h1 id="host-heading">Host heading</h1>
+  <div class="nextly-ui">
+    <div id="kit-surface" class="bg-primary">Kit surface</div>
+  </div>
+`;
+
+test("the precompiled sheet styles components on a bare page", async ({
+  page,
+}) => {
+  await page.setContent(`<div id="kit-surface" class="bg-primary">x</div>`);
+  await page.addStyleTag({ content: UNSCOPED });
+
+  const background = await page.$eval(
+    "#kit-surface",
+    el => getComputedStyle(el).backgroundColor
+  );
+
+  expect(background).not.toBe(TRANSPARENT);
+});
+
+test("the scoped sheet styles components inside the wrapper", async ({
+  page,
+}) => {
+  await page.setContent(HOST_MARKUP);
+  await page.addStyleTag({ content: SCOPED });
+
+  const background = await page.$eval(
+    "#kit-surface",
+    el => getComputedStyle(el).backgroundColor
+  );
+
+  // The token has to resolve too: `bg-primary` reads `--nx-primary`, which the
+  // scoped sheet declares on `.nextly-ui` rather than `:root`.
+  expect(background).not.toBe(TRANSPARENT);
+});
+
+test("the scoped sheet leaves the host document alone", async ({ page }) => {
+  // Baseline: what the browser gives an <h1> with no stylesheet at all.
+  await page.setContent(HOST_MARKUP);
+  const untouched = await page.$eval(
+    "#host-heading",
+    el => getComputedStyle(el).marginTop
+  );
+
+  await page.setContent(HOST_MARKUP);
+  await page.addStyleTag({ content: SCOPED });
+  const withScoped = await page.$eval(
+    "#host-heading",
+    el => getComputedStyle(el).marginTop
+  );
+
+  expect(withScoped).toBe(untouched);
+
+  // And prove the assertion is meaningful: the unscoped sheet does reset it,
+  // which is exactly why the scoped variant exists.
+  await page.setContent(HOST_MARKUP);
+  await page.addStyleTag({ content: UNSCOPED });
+  const withUnscoped = await page.$eval(
+    "#host-heading",
+    el => getComputedStyle(el).marginTop
+  );
+
+  expect(withUnscoped).not.toBe(untouched);
+});

--- a/e2e/tests/ui-standalone.spec.ts
+++ b/e2e/tests/ui-standalone.spec.ts
@@ -25,8 +25,20 @@ const DIST = resolve(
   "../../packages/ui/dist"
 );
 
-const UNSCOPED = readFileSync(resolve(DIST, "styles.css"), "utf8");
-const SCOPED = readFileSync(resolve(DIST, "styles.scoped.css"), "utf8");
+/**
+ * Read on demand rather than at module load: an unbuilt `packages/ui/dist`
+ * would otherwise throw during collection, and the runner reports a module
+ * load failure with a bare ENOENT instead of naming the test and the fix.
+ */
+function sheet(name: string): string {
+  try {
+    return readFileSync(resolve(DIST, name), "utf8");
+  } catch {
+    throw new Error(
+      `${name} is missing from ${DIST}. Build the UI package first: pnpm build`
+    );
+  }
+}
 
 const TRANSPARENT = "rgba(0, 0, 0, 0)";
 
@@ -42,7 +54,7 @@ test("the precompiled sheet styles components on a bare page", async ({
   page,
 }) => {
   await page.setContent(`<div id="kit-surface" class="bg-primary">x</div>`);
-  await page.addStyleTag({ content: UNSCOPED });
+  await page.addStyleTag({ content: sheet("styles.css") });
 
   const background = await page.$eval(
     "#kit-surface",
@@ -56,7 +68,7 @@ test("the scoped sheet styles components inside the wrapper", async ({
   page,
 }) => {
   await page.setContent(HOST_MARKUP);
-  await page.addStyleTag({ content: SCOPED });
+  await page.addStyleTag({ content: sheet("styles.scoped.css") });
 
   const background = await page.$eval(
     "#kit-surface",
@@ -68,6 +80,32 @@ test("the scoped sheet styles components inside the wrapper", async ({
   expect(background).not.toBe(TRANSPARENT);
 });
 
+test("the scoped sheet does not hijack the host's animation names", async ({
+  page,
+}) => {
+  // Animation names resolve globally, so selector scoping alone does not
+  // isolate them. The host defines `spin` — a name the kit also uses — and its
+  // definition must survive the scoped sheet being added afterwards, which is
+  // the source order that would let a colliding definition win.
+  await page.setContent(`
+    <style>
+      @keyframes spin { from, to { opacity: 0.5 } }
+      #host-spinner { animation: spin 10s infinite }
+    </style>
+    <div id="host-spinner">Host spinner</div>
+  `);
+  await page.addStyleTag({ content: sheet("styles.scoped.css") });
+
+  // The kit's own `spin` animates transform and never touches opacity, so if it
+  // had displaced the host's definition this would read back as "1".
+  const opacity = await page.$eval(
+    "#host-spinner",
+    el => getComputedStyle(el).opacity
+  );
+
+  expect(opacity).toBe("0.5");
+});
+
 test("the scoped sheet leaves the host document alone", async ({ page }) => {
   // Baseline: what the browser gives an <h1> with no stylesheet at all.
   await page.setContent(HOST_MARKUP);
@@ -77,7 +115,7 @@ test("the scoped sheet leaves the host document alone", async ({ page }) => {
   );
 
   await page.setContent(HOST_MARKUP);
-  await page.addStyleTag({ content: SCOPED });
+  await page.addStyleTag({ content: sheet("styles.scoped.css") });
   const withScoped = await page.$eval(
     "#host-heading",
     el => getComputedStyle(el).marginTop
@@ -88,7 +126,7 @@ test("the scoped sheet leaves the host document alone", async ({ page }) => {
   // And prove the assertion is meaningful: the unscoped sheet does reset it,
   // which is exactly why the scoped variant exists.
   await page.setContent(HOST_MARKUP);
-  await page.addStyleTag({ content: UNSCOPED });
+  await page.addStyleTag({ content: sheet("styles.css") });
   const withUnscoped = await page.$eval(
     "#host-heading",
     el => getComputedStyle(el).marginTop

--- a/packages/admin-css/__fixtures__/poc-plugin/admin.css
+++ b/packages/admin-css/__fixtures__/poc-plugin/admin.css
@@ -8,5 +8,12 @@
  * `admin.styles`.
  */
 @import "tailwindcss";
-@import "@nextlyhq/ui/theme.css";
+/*
+ * A published plugin writes `@import "@nextlyhq/ui/theme.css"`. This fixture
+ * reaches the same file by path because `@nextlyhq/ui` cannot be a dependency
+ * of this package: `ui` already depends on `admin-css` for the scoper, and
+ * declaring the reverse edge makes the two builds a cycle. The tokens the
+ * compile needs are identical either way.
+ */
+@import "../../../ui/src/styles/theme.css";
 @source inline("grid-cols-12 bg-accent text-accent-foreground");

--- a/packages/admin-css/package.json
+++ b/packages/admin-css/package.json
@@ -22,7 +22,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.34.0",
-    "@nextlyhq/ui": "workspace:*",
     "eslint": "^9.39.1",
     "vitest": "^4.1.0"
   }

--- a/packages/admin-css/package.json
+++ b/packages/admin-css/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@eslint/js": "^9.34.0",
     "eslint": "^9.39.1",
+    "tailwindcss": "^4.3.2",
     "vitest": "^4.1.0"
   }
 }

--- a/packages/admin-css/src/css-scope.mjs
+++ b/packages/admin-css/src/css-scope.mjs
@@ -1,5 +1,13 @@
+/** The admin's root class — the historical and default scope. */
+const DEFAULT_SCOPE = ".nextly-admin";
+
 /**
- * Scoping the admin's CSS to `.nextly-admin`.
+ * Scoping a compiled stylesheet under a single root class.
+ *
+ * Defaults to the admin's `.nextly-admin`. The scope is a parameter because the
+ * same problem exists wherever this design system is embedded in a page it does
+ * not own: Tailwind's preflight resets `html`/`body`/`*`, so an unscoped sheet
+ * restyles the host document.
  *
  * The admin is a whole Tailwind app — tokens, utilities, preflight reset —
  * mounted inside the host's document. Any rule that escapes the wrapper
@@ -36,9 +44,10 @@ export function splitTopLevel(selector) {
 }
 
 /**
- * Scope a single selector within `.nextly-admin`.
+ * Scope a single selector within `scope` (a class selector such as
+ * `.nextly-admin`).
  */
-export function scopeSelector(selector) {
+export function scopeSelector(selector, scope = DEFAULT_SCOPE) {
   selector = selector.trim();
   if (!selector) return selector;
 
@@ -56,11 +65,11 @@ export function scopeSelector(selector) {
   // inside parens yields one part and must not re-recurse.
   const parts = splitTopLevel(selector);
   if (parts.length > 1) {
-    return parts.map(s => scopeSelector(s.trim())).join(", ");
+    return parts.map(s => scopeSelector(s.trim(), scope)).join(", ");
   }
 
   // Already scoped.
-  if (selector.includes(".nextly-admin")) return selector;
+  if (selector.includes(scope)) return selector;
 
   // Document-root selectors collapse onto the admin root, so the theme and the
   // preflight reset apply inside the admin and never reach the host.
@@ -70,13 +79,13 @@ export function scopeSelector(selector) {
     selector === ":host" ||
     selector === "body"
   ) {
-    return ".nextly-admin";
+    return scope;
   }
 
-  // The dark class sits on the admin root itself, not on a descendant.
-  if (selector === ".dark") return ".nextly-admin.dark";
+  // The dark class sits on the scope root itself, not on a descendant.
+  if (selector === ".dark") return `${scope}.dark`;
 
-  return `.nextly-admin ${selector}`;
+  return `${scope} ${selector}`;
 }
 
 /** How far a line opens or closes the brace depth. */
@@ -91,7 +100,7 @@ function countBraces(line) {
  * holds for Tailwind's output but not for arbitrary hand-authored CSS.
  * {@link findUnscopedRules} is what catches the difference.
  */
-export function scopeCss(css) {
+export function scopeCss(css, scope = DEFAULT_SCOPE) {
   const lines = css.split("\n");
   const result = [];
   let inKeyframes = false;
@@ -144,12 +153,12 @@ export function scopeCss(css) {
         result.push(line);
         continue;
       }
-      if (selector.includes(".nextly-admin")) {
+      if (selector.includes(scope)) {
         result.push(line);
         continue;
       }
 
-      result.push(`${scopeSelector(selector)}{${rest}`);
+      result.push(`${scopeSelector(selector, scope)}{${rest}`);
     } else {
       result.push(line);
     }
@@ -164,7 +173,7 @@ export function scopeCss(css) {
  * Walks brace depth so nested at-rules (@layer/@media/@supports) are checked,
  * while at-rules whose bodies are not selectors are skipped.
  */
-export function findUnscopedRules(css) {
+export function findUnscopedRules(css, scope = DEFAULT_SCOPE) {
   const offenders = [];
   const skipAtRule = /^@(keyframes|font-face|property|counter-style|page)/i;
   // Comments would otherwise be swallowed into the following rule's prelude
@@ -201,7 +210,7 @@ export function findUnscopedRules(css) {
         // scopes it, letting `.leak` restyle the host page.
         for (const part of splitTopLevel(prelude)) {
           const trimmed = part.trim();
-          if (trimmed && !trimmed.includes(".nextly-admin")) {
+          if (trimmed && !trimmed.includes(scope)) {
             offenders.push(trimmed.slice(0, 100));
           }
         }

--- a/packages/admin-css/src/css-scope.mjs
+++ b/packages/admin-css/src/css-scope.mjs
@@ -281,8 +281,14 @@ export function confineVariantClasses(css, scope = DEFAULT_SCOPE) {
       )
       // A lone `.dark` ancestor reference, same reasoning.
       .replace(/:where\(\s*\.dark\s*\)/g, `:where(${scope}.dark)`)
-      // `group` / `peer` markers must be ones inside the wrapper.
-      .replace(/:where\(\s*\.(group|peer)\s*\)/g, `:where(${scope} .$1)`)
+      // `group` / `peer` markers must be ones inside the wrapper. Named
+      // variants (`group-hover/item:`) emit `:where(.group\/item)`, and the
+      // leak check cannot catch those: the rule's own compound is scoped, so
+      // only this ancestor reference reaches outside.
+      .replace(
+        /:where\(\s*\.(group|peer)((?:\\\/[\w-]+)?)\s*\)/g,
+        `:where(${scope} .$1$2)`
+      )
   );
 }
 

--- a/packages/admin-css/src/css-scope.mjs
+++ b/packages/admin-css/src/css-scope.mjs
@@ -44,6 +44,24 @@ export function splitTopLevel(selector) {
 }
 
 /**
+ * Whether a selector is genuinely constrained to `scope`.
+ *
+ * A substring test is not enough. `.nextly-admin-card` contains the scope text
+ * but is an unrelated class, and `[class*=".nextly-admin"]` matches host
+ * elements the wrapper does not contain — both would be left unprefixed and
+ * then pass the leak check, so the sheet escapes while the build reports
+ * success. Attribute selectors are dropped before matching, and the class must
+ * end at a boundary: the next character cannot continue a CSS identifier.
+ */
+export function isScoped(selector, scope = DEFAULT_SCOPE) {
+  const withoutAttributes = selector.replace(/\[[^\]]*\]/g, "");
+  const className = scope.replace(/^\./, "");
+  return new RegExp(`\\.${escapeRegExp(className)}(?![\\w-])`).test(
+    withoutAttributes
+  );
+}
+
+/**
  * Scope a single selector within `scope` (a class selector such as
  * `.nextly-admin`).
  */
@@ -69,7 +87,7 @@ export function scopeSelector(selector, scope = DEFAULT_SCOPE) {
   }
 
   // Already scoped.
-  if (selector.includes(scope)) return selector;
+  if (isScoped(selector, scope)) return selector;
 
   // Document-root selectors collapse onto the admin root, so the theme and the
   // preflight reset apply inside the admin and never reach the host.
@@ -153,11 +171,10 @@ export function scopeCss(css, scope = DEFAULT_SCOPE) {
         result.push(line);
         continue;
       }
-      if (selector.includes(scope)) {
-        result.push(line);
-        continue;
-      }
 
+      // No whole-prelude "already scoped" shortcut: in a list like
+      // `.nextly-admin .a, .b` it would leave `.b` unscoped. scopeSelector
+      // splits the list and decides per part.
       result.push(`${scopeSelector(selector, scope)}{${rest}`);
     } else {
       result.push(line);
@@ -165,6 +182,55 @@ export function scopeCss(css, scope = DEFAULT_SCOPE) {
   }
 
   return result.join("\n");
+}
+
+/** Escape a string for literal use inside a RegExp. */
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Matches a keyframes definition, capturing the vendor prefix and the name. */
+const KEYFRAMES_RE = /@(-webkit-)?keyframes\s+("[^"]*"|'[^']*'|[\w-]+)/gi;
+
+/**
+ * Namespace every `@keyframes` name in a stylesheet.
+ *
+ * Animation names are global no matter where the rule that uses them lives, so
+ * scoping selectors is not enough: this sheet defines `spin`, `pulse` and
+ * `fade-in`, and a host page that defines its own wins or loses by source
+ * order. Prefixing the definitions and every reference to them keeps the
+ * promise that importing the scoped sheet cannot change the host's rendering.
+ *
+ * References are rewritten only inside `animation`, `animation-name` and
+ * `--animate-*` values, so an unrelated identifier that happens to share a
+ * keyframe's name is left alone.
+ */
+export function prefixKeyframes(css, prefix) {
+  const names = new Set();
+  for (const match of css.matchAll(KEYFRAMES_RE)) {
+    names.add(match[2].replace(/^["']|["']$/g, ""));
+  }
+  if (names.size === 0) return css;
+
+  const renamed = css.replace(
+    KEYFRAMES_RE,
+    (_full, webkit, name) =>
+      `@${webkit ?? ""}keyframes ${prefix}${name.replace(/^["']|["']$/g, "")}`
+  );
+
+  return renamed.replace(
+    /(^|[;{\s])(animation(?:-name)?|--animate-[\w-]+)(\s*:\s*)([^;}]*)/gi,
+    (_full, lead, property, colon, value) => {
+      let rewritten = value;
+      for (const name of names) {
+        rewritten = rewritten.replace(
+          new RegExp(`(^|[\\s,])${escapeRegExp(name)}(?=$|[\\s,])`, "g"),
+          `$1${prefix}${name}`
+        );
+      }
+      return `${lead}${property}${colon}${rewritten}`;
+    }
+  );
 }
 
 /**
@@ -210,7 +276,7 @@ export function findUnscopedRules(css, scope = DEFAULT_SCOPE) {
         // scopes it, letting `.leak` restyle the host page.
         for (const part of splitTopLevel(prelude)) {
           const trimmed = part.trim();
-          if (trimmed && !trimmed.includes(scope)) {
+          if (trimmed && !isScoped(trimmed, scope)) {
             offenders.push(trimmed.slice(0, 100));
           }
         }

--- a/packages/admin-css/src/css-scope.mjs
+++ b/packages/admin-css/src/css-scope.mjs
@@ -44,21 +44,93 @@ export function splitTopLevel(selector) {
 }
 
 /**
+ * Split a selector into its compounds and the combinators between them, at the
+ * top level only, so combinators inside `:is(...)` / `:where(...)` stay put.
+ */
+function splitCombinators(selector) {
+  const compounds = [];
+  const combinators = [];
+  let depth = 0;
+  let current = "";
+  let i = 0;
+
+  while (i < selector.length) {
+    const ch = selector[i];
+    if (ch === "(" || ch === "[") depth++;
+    else if (ch === ")" || ch === "]") depth--;
+
+    if (depth === 0 && (ch === ">" || ch === "+" || ch === "~")) {
+      compounds.push(current.trim());
+      combinators.push(ch);
+      current = "";
+      i++;
+      continue;
+    }
+    if (depth === 0 && /\s/.test(ch)) {
+      // Collapse whitespace, and let an explicit combinator that follows win.
+      let j = i;
+      while (j < selector.length && /\s/.test(selector[j])) j++;
+      const next = selector[j];
+      if (next === ">" || next === "+" || next === "~") {
+        i = j;
+        continue;
+      }
+      if (current.trim()) {
+        compounds.push(current.trim());
+        combinators.push(" ");
+        current = "";
+      }
+      i = j;
+      continue;
+    }
+    current += ch;
+    i++;
+  }
+  if (current.trim()) compounds.push(current.trim());
+  return { compounds, combinators };
+}
+
+/**
  * Whether a selector is genuinely constrained to `scope`.
  *
- * A substring test is not enough. `.nextly-admin-card` contains the scope text
- * but is an unrelated class, and `[class*=".nextly-admin"]` matches host
- * elements the wrapper does not contain — both would be left unprefixed and
- * then pass the leak check, so the sheet escapes while the build reports
- * success. Attribute selectors are dropped before matching, and the class must
- * end at a boundary: the next character cannot continue a CSS identifier.
+ * Presence of the scope's text is not enough, and neither is presence of the
+ * class token. The scope has to be an ancestor of (or the same element as) the
+ * element the rule actually styles:
+ *
+ *   - `.nextly-admin-card` is a different class that merely shares a prefix.
+ *   - `[class*=".nextly-admin"]` matches host elements by substring.
+ *   - `:not(.nextly-admin)` matches everything the scope does not.
+ *   - `.nextly-admin + .host` styles a sibling of the wrapper, outside it.
+ *
+ * So negations are stripped, attribute selectors are dropped, the class must
+ * end at an identifier boundary, and everything after the scope's compound must
+ * be a descendant or child step — a sibling combinator leaves the wrapper.
  */
 export function isScoped(selector, scope = DEFAULT_SCOPE) {
-  const withoutAttributes = selector.replace(/\[[^\]]*\]/g, "");
+  // Tailwind escapes arbitrary variants into the class name itself, so a
+  // selector can contain `\~`, `\[` or `\:not\(` as literal characters. Collapse
+  // every escape sequence to one inert placeholder first, or the structural
+  // parsing below reads those as real combinators and brackets.
+  // The placeholder is an identifier character, so `.nextly-ui\~x` — a
+  // different class that merely starts with the scope — still fails the
+  // boundary check below.
+  const literal = selector.replace(/\\./g, "_");
+  // A scope inside a negation is the opposite of being scoped by it.
+  const withoutNegation = literal.replace(/:not\(([^()]*)\)/g, "");
+  const withoutAttributes = withoutNegation.replace(/\[[^\]]*\]/g, "");
   const className = scope.replace(/^\./, "");
-  return new RegExp(`\\.${escapeRegExp(className)}(?![\\w-])`).test(
-    withoutAttributes
-  );
+  const token = new RegExp(`\\.${escapeRegExp(className)}(?![\\w-])`);
+
+  const { compounds, combinators } = splitCombinators(withoutAttributes);
+  const index = compounds.findIndex(part => token.test(part));
+  if (index === -1) return false;
+
+  // Only the step taken directly from the scope matters. `.scope + .x` is a
+  // sibling of the wrapper and therefore outside it, but `.scope .a + .b` is
+  // not: `.b` shares a parent with `.a`, which is already inside, so every
+  // later combinator stays within the subtree.
+  const next = combinators[index];
+  return next === undefined || next === " " || next === ">";
 }
 
 /**
@@ -182,6 +254,51 @@ export function scopeCss(css, scope = DEFAULT_SCOPE) {
   }
 
   return result.join("\n");
+}
+
+/**
+ * Confine the bare state classes Tailwind's variants reference to `scope`.
+ *
+ * Scoping a rule's own compound is not enough when the variant reaches for an
+ * ancestor. `dark:` compiles to `:where(.dark, .dark *)` and `group-*:` to
+ * `:is(:where(.group)… *)`, and both name a class the rule does not own — so a
+ * host `<html class="dark">` or a host `.group` ancestor activates them inside
+ * the wrapper. Dark is the damaging one: the dark tokens are declared on
+ * `<scope>.dark`, so the utilities would flip while the tokens did not, painting
+ * dark-mode rules with light-mode values.
+ *
+ * Rewriting the reference to sit under the scope ties both to the wrapper the
+ * consumer actually controls.
+ */
+export function confineVariantClasses(css, scope = DEFAULT_SCOPE) {
+  return (
+    css
+      // `:where(.dark, .dark *)` — the wrapper itself carries `.dark`, so the
+      // first branch is the scope element and the second its descendants.
+      .replace(
+        /:where\(\s*\.dark\s*,\s*\.dark\s+\*\s*\)/g,
+        `:where(${scope}.dark,${scope}.dark *)`
+      )
+      // A lone `.dark` ancestor reference, same reasoning.
+      .replace(/:where\(\s*\.dark\s*\)/g, `:where(${scope}.dark)`)
+      // `group` / `peer` markers must be ones inside the wrapper.
+      .replace(/:where\(\s*\.(group|peer)\s*\)/g, `:where(${scope} .$1)`)
+  );
+}
+
+/**
+ * Namespace Tailwind's internal `--tw-*` custom properties.
+ *
+ * `@property` registrations are document-global no matter which selector they
+ * accompany, so a scoped sheet still publishes ~50 of them. Registering a name
+ * changes its semantics everywhere — an inherited property becomes
+ * non-inheriting, and it gains an initial value — which is a real behaviour
+ * change for a host that uses those names itself, as a Tailwind v3 application
+ * does. Renaming the registrations and every reference together keeps the
+ * utilities working while leaving the host's `--tw-*` untouched.
+ */
+export function namespaceInternalProperties(css, prefix) {
+  return css.replace(/--tw-/g, `--${prefix}tw-`);
 }
 
 /** Escape a string for literal use inside a RegExp. */

--- a/packages/admin-css/src/css-scope.test.mjs
+++ b/packages/admin-css/src/css-scope.test.mjs
@@ -11,6 +11,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   findUnscopedRules,
+  isScoped,
+  prefixKeyframes,
   scopeCss,
   scopeSelector,
   splitTopLevel,
@@ -199,5 +201,72 @@ describe("a custom scope", () => {
   it("still reports a leak when a rule escapes the given scope", () => {
     expect(findUnscopedRules(".nextly-ui .a, .leak{color:red}", ".nextly-ui"))
       .toHaveLength(1);
+  });
+
+  // A class that merely starts with the scope text is a different class, and an
+  // attribute selector matching the scope as a substring is not constrained by
+  // the wrapper at all. Both must be treated as unscoped, or they pass straight
+  // through scoping and the leak check into the shipped sheet.
+  it("does not mistake a longer class name for the scope", () => {
+    expect(scopeSelector(".nextly-ui-card", ".nextly-ui")).toBe(
+      ".nextly-ui .nextly-ui-card"
+    );
+    expect(
+      findUnscopedRules(".nextly-ui-card{color:red}", ".nextly-ui")
+    ).toEqual([".nextly-ui-card"]);
+  });
+
+  it("does not accept the scope appearing inside an attribute selector", () => {
+    expect(
+      findUnscopedRules('[class*=".nextly-ui"]{color:red}', ".nextly-ui")
+    ).toEqual(['[class*=".nextly-ui"]']);
+  });
+
+  it("accepts the scope when the class ends at a boundary", () => {
+    expect(isScoped(".nextly-ui.dark .card", ".nextly-ui")).toBe(true);
+    expect(isScoped(".nextly-ui > .card", ".nextly-ui")).toBe(true);
+    expect(isScoped(".nextly-uix", ".nextly-ui")).toBe(false);
+  });
+
+  it("namespaces keyframe names and the references to them", () => {
+    const css = [
+      "@keyframes spin{to{transform:rotate(360deg)}}",
+      ".nextly-ui .a{animation:spin 1s linear infinite}",
+      ".nextly-ui{--animate-spin:spin 1s linear infinite}",
+      ".nextly-ui .b{animation-name:spin}",
+    ].join("\n");
+    const out = prefixKeyframes(css, "nx-");
+
+    expect(out).toContain("@keyframes nx-spin");
+    expect(out).toContain("animation:nx-spin 1s linear infinite");
+    expect(out).toContain("--animate-spin:nx-spin 1s linear infinite");
+    expect(out).toContain("animation-name:nx-spin");
+    // No bare reference survives to collide with a host animation.
+    expect(out).not.toMatch(/(^|[\s,:]) spin(?=$|[\s,;}])/);
+  });
+
+  it("leaves identifiers that merely share a keyframe name alone", () => {
+    const css = [
+      "@keyframes spin{to{opacity:1}}",
+      ".nextly-ui .a{content:'spin';transition:spin 1s}",
+    ].join("\n");
+    const out = prefixKeyframes(css, "nx-");
+
+    expect(out).toContain("content:'spin'");
+    expect(out).toContain("transition:spin 1s");
+  });
+
+  it("keeps a var() reference intact while namespacing the token value", () => {
+    const out = prefixKeyframes(
+      "@keyframes pulse{to{opacity:1}}\n.nextly-ui .a{animation:var(--animate-pulse)}",
+      "nx-"
+    );
+    expect(out).toContain("animation:var(--animate-pulse)");
+  });
+
+  it("scopes the unscoped half of a partially scoped selector list", () => {
+    expect(scopeCss(".nextly-ui .a, .b{color:red}", ".nextly-ui")).toContain(
+      ".nextly-ui .a, .nextly-ui .b{"
+    );
   });
 });

--- a/packages/admin-css/src/css-scope.test.mjs
+++ b/packages/admin-css/src/css-scope.test.mjs
@@ -163,3 +163,41 @@ describe("findUnscopedRules", () => {
     ).toEqual([]);
   });
 });
+
+describe("a custom scope", () => {
+  // The same sheet is emitted for embedding outside the admin, where the root
+  // class differs; preflight and the token block must follow the scope given.
+  it("collapses document-root selectors onto the given scope", () => {
+    expect(scopeSelector(":root", ".nextly-ui")).toBe(".nextly-ui");
+    expect(scopeSelector("html", ".nextly-ui")).toBe(".nextly-ui");
+    expect(scopeSelector("body", ".nextly-ui")).toBe(".nextly-ui");
+  });
+
+  it("puts the dark class on the scope root, not a descendant", () => {
+    expect(scopeSelector(".dark", ".nextly-ui")).toBe(".nextly-ui.dark");
+  });
+
+  it("scopes each part of a grouped preflight selector", () => {
+    expect(scopeSelector("*, ::after, ::before", ".nextly-ui")).toBe(
+      ".nextly-ui *, .nextly-ui ::after, .nextly-ui ::before"
+    );
+  });
+
+  it("leaves selectors already carrying the scope alone", () => {
+    expect(scopeSelector(".nextly-ui .card", ".nextly-ui")).toBe(
+      ".nextly-ui .card"
+    );
+  });
+
+  it("scopes a whole sheet and reports nothing unscoped", () => {
+    const out = scopeCss(":root{--nx-a:1}\n.card{color:red}", ".nextly-ui");
+    expect(out).toContain(".nextly-ui{--nx-a:1}");
+    expect(out).toContain(".nextly-ui .card{color:red}");
+    expect(findUnscopedRules(out, ".nextly-ui")).toEqual([]);
+  });
+
+  it("still reports a leak when a rule escapes the given scope", () => {
+    expect(findUnscopedRules(".nextly-ui .a, .leak{color:red}", ".nextly-ui"))
+      .toHaveLength(1);
+  });
+});

--- a/packages/admin-css/src/css-scope.test.mjs
+++ b/packages/admin-css/src/css-scope.test.mjs
@@ -10,6 +10,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  confineVariantClasses,
   findUnscopedRules,
   isScoped,
   prefixKeyframes,
@@ -226,6 +227,72 @@ describe("a custom scope", () => {
     expect(isScoped(".nextly-ui.dark .card", ".nextly-ui")).toBe(true);
     expect(isScoped(".nextly-ui > .card", ".nextly-ui")).toBe(true);
     expect(isScoped(".nextly-uix", ".nextly-ui")).toBe(false);
+  });
+
+  // The scope class can appear in a selector without constraining the rule to
+  // the wrapper: negated, or on a sibling the wrapper does not contain.
+  it("rejects a negated scope", () => {
+    expect(isScoped(":not(.nextly-ui)", ".nextly-ui")).toBe(false);
+    expect(isScoped(".card:not(.nextly-ui)", ".nextly-ui")).toBe(false);
+    expect(
+      findUnscopedRules(":not(.nextly-ui){color:red}", ".nextly-ui")
+    ).toEqual([":not(.nextly-ui)"]);
+  });
+
+  it("rejects a sibling of the wrapper", () => {
+    expect(isScoped(".nextly-ui + .host", ".nextly-ui")).toBe(false);
+    expect(isScoped(".nextly-ui ~ .host", ".nextly-ui")).toBe(false);
+    expect(
+      findUnscopedRules(".nextly-ui + .host{color:red}", ".nextly-ui")
+    ).toEqual([".nextly-ui + .host"]);
+  });
+
+  it("accepts a sibling of an element already inside the wrapper", () => {
+    // `.b` shares a parent with `.a`, and `.a` is inside, so `.b` is too. Only
+    // a sibling of the wrapper itself escapes.
+    expect(isScoped(".nextly-ui .a + .b", ".nextly-ui")).toBe(true);
+    expect(isScoped(".nextly-ui .a ~ .b", ".nextly-ui")).toBe(true);
+    expect(isScoped(".nextly-ui > .a + .b", ".nextly-ui")).toBe(true);
+    expect(
+      findUnscopedRules(".nextly-ui .a + .b{color:red}", ".nextly-ui")
+    ).toEqual([]);
+  });
+
+  it("accepts descendant and child steps below the wrapper", () => {
+    expect(isScoped(".nextly-ui > .card", ".nextly-ui")).toBe(true);
+    expect(isScoped(".nextly-ui .a > .b", ".nextly-ui")).toBe(true);
+    // A sibling BEFORE the scope is fine: the subject is still inside it.
+    expect(isScoped(".host + .nextly-ui .card", ".nextly-ui")).toBe(true);
+  });
+
+  it("keeps combinators inside :is()/:where() out of the structural check", () => {
+    expect(isScoped(".nextly-ui .a:is(.x + .y)", ".nextly-ui")).toBe(true);
+  });
+
+  // Tailwind escapes arbitrary variants into the class name, so `~`, `[` and
+  // `:not(` can appear as literal characters that are not structure.
+  it("reads escaped characters in a class name as literals", () => {
+    const cmdk =
+      ".nextly-ui .\\[\\&_\\[cmdk-group\\]\\:not\\(\\[hidden\\]\\)_\\~\\[cmdk-group\\]\\]\\:pt-0";
+    expect(isScoped(cmdk, ".nextly-ui")).toBe(true);
+    expect(findUnscopedRules(`${cmdk}{color:red}`, ".nextly-ui")).toEqual([]);
+  });
+
+  it("does not read an escaped class as the scope itself", () => {
+    expect(isScoped(".nextly-ui\\~x", ".nextly-ui")).toBe(false);
+  });
+
+  it("confines dark and group variants to the scope", () => {
+    const css =
+      ".nextly-ui .dark\\:bg-x:where(.dark, .dark *){color:red}" +
+      ".nextly-ui .group-hover\\:x:is(:where(.group):hover *){color:blue}";
+    const out = confineVariantClasses(css, ".nextly-ui");
+
+    expect(out).toContain(":where(.nextly-ui.dark,.nextly-ui.dark *)");
+    expect(out).toContain(":where(.nextly-ui .group)");
+    // No bare ancestor reference is left for the host to satisfy.
+    expect(out).not.toContain(":where(.dark, .dark *)");
+    expect(out).not.toContain(":where(.group)");
   });
 
   it("namespaces keyframe names and the references to them", () => {

--- a/packages/admin-css/src/css-scope.test.mjs
+++ b/packages/admin-css/src/css-scope.test.mjs
@@ -295,6 +295,21 @@ describe("a custom scope", () => {
     expect(out).not.toContain(":where(.group)");
   });
 
+  // Named variants (`group-hover/item:`) reference `.group\/item`. The leak
+  // check cannot see these — the rule's own compound is scoped, so the ancestor
+  // reference is the only part that reaches outside the wrapper.
+  it("confines named group and peer markers", () => {
+    const css =
+      ".nextly-ui .group-hover\\/item\\:underline:is(:where(.group\\/item):hover *){color:red}" +
+      ".nextly-ui .peer-checked\\/field\\:font-bold:is(:where(.peer\\/field):checked ~ *){color:blue}";
+    const out = confineVariantClasses(css, ".nextly-ui");
+
+    expect(out).toContain(":where(.nextly-ui .group\\/item)");
+    expect(out).toContain(":where(.nextly-ui .peer\\/field)");
+    expect(out).not.toContain(":where(.group\\/item)");
+    expect(out).not.toContain(":where(.peer\\/field)");
+  });
+
   it("namespaces keyframe names and the references to them", () => {
     const css = [
       "@keyframes spin{to{transform:rotate(360deg)}}",

--- a/packages/admin-css/src/index.mjs
+++ b/packages/admin-css/src/index.mjs
@@ -9,8 +9,10 @@
  */
 export {
   scopeCss,
+  confineVariantClasses,
   findUnscopedRules,
   isScoped,
+  namespaceInternalProperties,
   prefixKeyframes,
   scopeSelector,
   splitTopLevel,

--- a/packages/admin-css/src/index.mjs
+++ b/packages/admin-css/src/index.mjs
@@ -10,6 +10,8 @@
 export {
   scopeCss,
   findUnscopedRules,
+  isScoped,
+  prefixKeyframes,
   scopeSelector,
   splitTopLevel,
 } from "./css-scope.mjs";

--- a/packages/nextly/src/plugins/admin-contributions.ts
+++ b/packages/nextly/src/plugins/admin-contributions.ts
@@ -130,10 +130,16 @@ export interface PluginAdminContributions {
    * Precompiled, `.nextly-admin`-scoped, token-driven CSS this plugin ships for
    * admin components whose utilities are not in the built-in safelist. A
    * package-relative reference (or several), e.g. "@acme/plugin/dist/admin.css".
-   * The plugin's admin entry side-effect-imports the file so the consumer's
-   * bundler loads/dedups it; this declaration is the contract the plugin doctor
-   * and tooling key off. Omit when the plugin styles itself from SDK components
-   * plus safelisted utilities.
+   *
+   * Declaring this does NOT load anything. The plugin's admin entry must
+   * side-effect-import the file (`import "./dist/admin.css"`), which is what
+   * makes the consumer's bundler load and dedupe it; this field is the
+   * machine-readable statement of that fact, for tooling and for anyone reading
+   * the manifest. The two can therefore disagree — declaring a file the entry
+   * never imports renders unstyled with no error — so keep them in step.
+   *
+   * Omit when the plugin styles itself from SDK components plus safelisted
+   * utilities.
    */
   styles?: string | string[];
   /**

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -31,7 +31,7 @@ pnpm add react react-dom lucide-react
 
 ## Setup
 
-The package ships two CSS entry points. Pick one:
+The package ships three CSS entry points. Pick one:
 
 **Zero config — pre-compiled bundle**
 
@@ -109,7 +109,37 @@ import "@nextlyhq/ui/styles.scoped.css";
 
 It keeps preflight rather than dropping it — these components are designed against a
 normalised baseline — but confines it to the wrapper, so your headings, lists and form
-controls outside it are untouched.
+controls outside it are untouched. Animation names are namespaced too, so the sheet
+cannot displace a `spin` or `fade-in` your own app already defines.
+
+### Overlays need a portal container
+
+Dialog, Select, DropdownMenu, Popover, Tooltip and Command render their overlay through
+a portal, which defaults to `document.body` — outside the wrapper, where the scoped rules
+and tokens do not reach. Triggers would look right and the menus they open would not.
+Point them back inside with `PortalProvider`:
+
+```tsx
+import { useState } from "react";
+import { PortalProvider } from "@nextlyhq/ui";
+import "@nextlyhq/ui/styles.scoped.css";
+
+function Kit({ children }: { children: React.ReactNode }) {
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+
+  return (
+    <div className="nextly-ui" ref={setContainer}>
+      <PortalProvider container={container}>{children}</PortalProvider>
+    </div>
+  );
+}
+```
+
+A callback ref rather than `useRef` because the container has to be a state value: on the
+first render it is still `null`, and the overlays need a re-render once the element exists.
+
+This does not apply to `styles.css`, where the rules are document-wide and
+`document.body` is already covered.
 
 ## Compatibility
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -89,6 +89,28 @@ as a Tailwind v3 preset from `@nextlyhq/ui/tailwind-preset`.
 > published with `"use client"`, and neither of these contains a React runtime,
 > so a server component or a Tailwind config can import them safely.
 
+## Stylesheets
+
+| Import                           | Use when                                                                                                                              |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `@nextlyhq/ui/styles.css`        | The app is yours end to end. Styles the whole document, Tailwind preflight included.                                                  |
+| `@nextlyhq/ui/styles.scoped.css` | Dropping a few components into an existing app. Every rule is confined to `.nextly-ui`, so the rest of the page keeps its own styles. |
+| `@nextlyhq/ui/theme.css`         | You compile Tailwind yourself and want the token contract only.                                                                       |
+
+The scoped sheet needs a wrapper element, and dark mode goes on the same element:
+
+```tsx
+import "@nextlyhq/ui/styles.scoped.css";
+
+<div className="nextly-ui">
+  <Button>Save</Button>
+</div>;
+```
+
+It keeps preflight rather than dropping it — these components are designed against a
+normalised baseline — but confines it to the wrapper, so your headings, lists and form
+controls outside it are untouched.
+
 ## Compatibility
 
 | Tool           | Version                                                                |

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -109,15 +109,19 @@ import "@nextlyhq/ui/styles.scoped.css";
 
 It keeps preflight rather than dropping it — these components are designed against a
 normalised baseline — but confines it to the wrapper, so your headings, lists and form
-controls outside it are untouched. Animation names are namespaced too, so the sheet
-cannot displace a `spin` or `fade-in` your own app already defines.
+controls outside it are untouched. Three things CSS resolves globally are namespaced
+along with the selectors, so the sheet cannot reach outside the wrapper through them
+either: animation names (it will not displace a `spin` or `fade-in` you define),
+Tailwind's internal `--tw-*` registrations, and the ancestor classes `dark:` and
+`group-*:` variants look for. Dark mode is therefore driven by the wrapper, not by a
+`dark` class higher up your page.
 
 ### Overlays need a portal container
 
-Dialog, Select, DropdownMenu, Popover, Tooltip and Command render their overlay through
-a portal, which defaults to `document.body` — outside the wrapper, where the scoped rules
-and tokens do not reach. Triggers would look right and the menus they open would not.
-Point them back inside with `PortalProvider`:
+AlertDialog, Command, Dialog, DropdownMenu, Popover, Select, Sheet and Tooltip render
+their overlay through a portal, which defaults to `document.body` — outside the wrapper,
+where the scoped rules and tokens do not reach. Triggers would look right and the menus
+they open would not. Point them back inside with `PortalProvider`:
 
 ```tsx
 import { useState } from "react";

--- a/packages/ui/STABILITY.md
+++ b/packages/ui/STABILITY.md
@@ -61,7 +61,7 @@ that swap fails the snapshot too.
 | Dropdown menu | `DropdownMenu`, `DropdownMenuTrigger`, `DropdownMenuContent`, `DropdownMenuItem`, `DropdownMenuCheckboxItem`, `DropdownMenuSeparator` | page-builder               |
 | Tooltip       | `Tooltip`, `TooltipTrigger`, `TooltipContent`                                                                                         | form-builder, page-builder |
 | Notifications | `toast`                                                                                                                               | admin, page-builder        |
-| Design tokens | `theme.css`, `styles.css`, and the `--nx-*` custom properties they define                                                             | admin, all plugins         |
+| Design tokens | `theme.css`, `styles.css`, `styles.scoped.css`, and the `--nx-*` custom properties they define                                        | admin, all plugins         |
 
 | Prop types | `ButtonProps`, `InputProps`, `FormLabelWithTooltipProps` | form-builder, page-builder |
 

--- a/packages/ui/STABILITY.md
+++ b/packages/ui/STABILITY.md
@@ -33,6 +33,12 @@ looks finished.
 The public surface is kept **deliberately small** (D40). Everything not listed as
 `@public` is `@experimental` and may change in any release.
 
+One export graduates on a second route: **what a `@public` artifact requires in order to
+work.** `styles.scoped.css` is public, and overlays portal to `document.body` — outside
+the wrapper the scoped rules are confined to — so `PortalProvider` is mandatory for the
+documented setup. Promising the stylesheet is stable while the only correct way to use it
+may change in any release would not be a real guarantee, so the two move together.
+
 ## The semver guarantee
 
 The `@public` surface is the semver-protected contract. After `1.0`, breaking a
@@ -62,6 +68,7 @@ that swap fails the snapshot too.
 | Tooltip       | `Tooltip`, `TooltipTrigger`, `TooltipContent`                                                                                         | form-builder, page-builder |
 | Notifications | `toast`                                                                                                                               | admin, page-builder        |
 | Design tokens | `theme.css`, `styles.css`, `styles.scoped.css`, and the `--nx-*` custom properties they define                                        | admin, all plugins         |
+| Portals       | `PortalProvider`, `usePortalContainer`                                                                                                | admin, `styles.scoped.css` |
 
 | Prop types | `ButtonProps`, `InputProps`, `FormLabelWithTooltipProps` | form-builder, page-builder |
 
@@ -72,8 +79,7 @@ Prop types carry the same guarantee as the component they belong to.
 Everything else the barrel exports, including: `Accordion`, `Alert`, `AlertDialog`,
 `Avatar`, `Card`, `Collapsible`, `Command`, `Popover`, `Progress`, `Separator`,
 `Skeleton`, `Spinner`, `Table` and its family, `TableSearch`, `TableSkeleton`, the table
-state components, the layout primitives (`Stack`, `Grid`, `Stat`), `Toaster`,
-`PortalProvider` and `usePortalContainer`.
+state components, the layout primitives (`Stack`, `Grid`, `Stat`) and `Toaster`.
 
 These are shipped and used by the admin, but no first-party plugin depends on them yet,
 so they have not met the graduation bar. Use them — that is what promotes them — but

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,7 +47,8 @@
       }
     },
     "./theme.css": "./dist/theme.css",
-    "./styles.css": "./dist/styles.css"
+    "./styles.css": "./dist/styles.css",
+    "./styles.scoped.css": "./dist/styles.scoped.css"
   },
   "sideEffects": [
     "**/*.css"
@@ -79,6 +80,7 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
+    "@nextlyhq/admin-css": "workspace:*",
     "@nextlyhq/eslint-config": "workspace:*",
     "@nextlyhq/tsconfig": "workspace:*",
     "@tailwindcss/cli": "^4.3.2",

--- a/packages/ui/scripts/build-css.mjs
+++ b/packages/ui/scripts/build-css.mjs
@@ -9,12 +9,19 @@
  *     themselves against the token contract.
  *   - dist/styles.css — Tailwind + theme + this package's component utilities,
  *     pre-compiled and minified, so a consumer can drop it in with no setup.
- *
- * Unlike the admin build, output is NOT scoped: tokens land on `:root` / `.dark`
- * so a bare `import "@nextlyhq/ui/styles.css"` styles the whole document.
+ *     NOT scoped: tokens land on `:root` / `.dark` and Tailwind's preflight
+ *     applies document-wide, which is what a greenfield app wants.
+ *   - dist/styles.scoped.css — the same sheet with every rule confined to
+ *     `.nextly-ui`. Preflight resets `html`/`body`/`*`, so the unscoped sheet
+ *     restyles a host application that only wanted a few components; this
+ *     variant normalises inside the wrapper and leaves the rest of the page
+ *     untouched. Components still get the preflight they are designed against,
+ *     which dropping preflight altogether would not give them.
  */
 
 import { execSync } from "child_process";
+
+import { scopeCss, findUnscopedRules } from "@nextlyhq/admin-css";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -27,6 +34,10 @@ const stylesInput = path.join(rootDir, "src/styles/index.css");
 const outputDir = path.join(rootDir, "dist");
 const themeOutput = path.join(outputDir, "theme.css");
 const stylesOutput = path.join(outputDir, "styles.css");
+const scopedOutput = path.join(outputDir, "styles.scoped.css");
+
+/** Wrapper class a consumer puts on the subtree that should be styled. */
+const UI_SCOPE = ".nextly-ui";
 
 if (!fs.existsSync(outputDir)) {
   fs.mkdirSync(outputDir, { recursive: true });
@@ -44,10 +55,39 @@ try {
     { cwd: rootDir, stdio: "inherit" },
   );
 
+  // Scope for embedded use. The scoper is line-based, so it has to run on
+  // unminified CSS — minified output puts the whole sheet on one line — which
+  // is why this compiles again rather than reusing the minified bundle.
+  console.log("🔒 Scoping styles for embedded use...");
+  const unminified = path.join(outputDir, "styles.unscoped.tmp.css");
+  const scopedTemp = path.join(outputDir, "styles.scoped.tmp.css");
+  execSync(`npx @tailwindcss/cli -i "${stylesInput}" -o "${unminified}"`, {
+    cwd: rootDir,
+    stdio: "inherit",
+  });
+
+  const scoped = scopeCss(fs.readFileSync(unminified, "utf8"), UI_SCOPE);
+  const leaks = findUnscopedRules(scoped, UI_SCOPE);
+  if (leaks.length > 0) {
+    console.error(
+      `❌ ${leaks.length} rule(s) escaped ${UI_SCOPE}:\n  ` +
+        leaks.slice(0, 5).join("\n  ")
+    );
+    process.exit(1);
+  }
+  fs.writeFileSync(scopedTemp, scoped);
+  execSync(`npx @tailwindcss/cli -i "${scopedTemp}" -o "${scopedOutput}" --minify`, {
+    cwd: rootDir,
+    stdio: "inherit",
+  });
+  fs.unlinkSync(unminified);
+  fs.unlinkSync(scopedTemp);
+
   const sizeKB = (fs.statSync(stylesOutput).size / 1024).toFixed(2);
   console.log(`✅ CSS built (styles.css ${sizeKB} KB)`);
   console.log(`   Output: ${themeOutput}`);
   console.log(`   Output: ${stylesOutput}`);
+  console.log(`   Output: ${scopedOutput}`);
 } catch (error) {
   console.error("❌ Failed to build CSS:", error.message);
   process.exit(1);

--- a/packages/ui/scripts/build-css.mjs
+++ b/packages/ui/scripts/build-css.mjs
@@ -22,8 +22,10 @@
 import { execSync } from "child_process";
 
 import {
+  confineVariantClasses,
   scopeCss,
   findUnscopedRules,
+  namespaceInternalProperties,
   prefixKeyframes,
 } from "@nextlyhq/admin-css";
 import fs from "fs";
@@ -77,11 +79,22 @@ try {
   // which throws rather than calling process.exit, because process.exit does
   // not unwind the stack and would skip the cleanup entirely.
   try {
-    // Selector scoping alone does not isolate animations: `@keyframes` names
-    // are global, and this sheet defines `spin`, `pulse` and `fade-in`, which a
-    // host page may well define too.
-    const scoped = prefixKeyframes(
-      scopeCss(fs.readFileSync(unminified, "utf8"), UI_SCOPE),
+    // Selector scoping alone leaves three things global. `@keyframes` names
+    // resolve document-wide, and this sheet defines `spin`, `pulse` and
+    // `fade-in`, which a host page may well define too. Variants like `dark:`
+    // and `group-*:` reach for an ancestor class the rule does not own, so a
+    // host `<html class="dark">` would flip the utilities while the tokens,
+    // declared on the wrapper, stayed light. And `@property` registrations
+    // apply to the whole document, redefining the semantics of any `--tw-*` the
+    // host uses itself.
+    const scoped = namespaceInternalProperties(
+      prefixKeyframes(
+        confineVariantClasses(
+          scopeCss(fs.readFileSync(unminified, "utf8"), UI_SCOPE),
+          UI_SCOPE
+        ),
+        KEYFRAME_PREFIX
+      ),
       KEYFRAME_PREFIX
     );
     const leaks = findUnscopedRules(scoped, UI_SCOPE);

--- a/packages/ui/scripts/build-css.mjs
+++ b/packages/ui/scripts/build-css.mjs
@@ -3,7 +3,7 @@
 /**
  * Build CSS Script
  *
- * Emits the package's two CSS entry points:
+ * Emits the package's three CSS entry points:
  *   - dist/theme.css  — the raw design-system source (tokens, @theme inline,
  *     @custom-variant, base reset) for consumers that compile Tailwind
  *     themselves against the token contract.
@@ -21,7 +21,11 @@
 
 import { execSync } from "child_process";
 
-import { scopeCss, findUnscopedRules } from "@nextlyhq/admin-css";
+import {
+  scopeCss,
+  findUnscopedRules,
+  prefixKeyframes,
+} from "@nextlyhq/admin-css";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -38,6 +42,8 @@ const scopedOutput = path.join(outputDir, "styles.scoped.css");
 
 /** Wrapper class a consumer puts on the subtree that should be styled. */
 const UI_SCOPE = ".nextly-ui";
+/** Namespace for animation names, which CSS resolves globally. */
+const KEYFRAME_PREFIX = "nx-";
 
 if (!fs.existsSync(outputDir)) {
   fs.mkdirSync(outputDir, { recursive: true });
@@ -66,22 +72,34 @@ try {
     stdio: "inherit",
   });
 
-  const scoped = scopeCss(fs.readFileSync(unminified, "utf8"), UI_SCOPE);
-  const leaks = findUnscopedRules(scoped, UI_SCOPE);
-  if (leaks.length > 0) {
-    console.error(
-      `❌ ${leaks.length} rule(s) escaped ${UI_SCOPE}:\n  ` +
-        leaks.slice(0, 5).join("\n  ")
+  // dist/ is published, so an intermediate left behind by a failed build would
+  // ship. Every exit path from here clears them, including the leak bail-out —
+  // which throws rather than calling process.exit, because process.exit does
+  // not unwind the stack and would skip the cleanup entirely.
+  try {
+    // Selector scoping alone does not isolate animations: `@keyframes` names
+    // are global, and this sheet defines `spin`, `pulse` and `fade-in`, which a
+    // host page may well define too.
+    const scoped = prefixKeyframes(
+      scopeCss(fs.readFileSync(unminified, "utf8"), UI_SCOPE),
+      KEYFRAME_PREFIX
     );
-    process.exit(1);
+    const leaks = findUnscopedRules(scoped, UI_SCOPE);
+    if (leaks.length > 0) {
+      throw new Error(
+        `${leaks.length} rule(s) escaped ${UI_SCOPE}:\n  ` +
+          leaks.slice(0, 5).join("\n  ")
+      );
+    }
+    fs.writeFileSync(scopedTemp, scoped);
+    execSync(
+      `npx @tailwindcss/cli -i "${scopedTemp}" -o "${scopedOutput}" --minify`,
+      { cwd: rootDir, stdio: "inherit" }
+    );
+  } finally {
+    fs.rmSync(unminified, { force: true });
+    fs.rmSync(scopedTemp, { force: true });
   }
-  fs.writeFileSync(scopedTemp, scoped);
-  execSync(`npx @tailwindcss/cli -i "${scopedTemp}" -o "${scopedOutput}" --minify`, {
-    cwd: rootDir,
-    stdio: "inherit",
-  });
-  fs.unlinkSync(unminified);
-  fs.unlinkSync(scopedTemp);
 
   const sizeKB = (fs.statSync(stylesOutput).size / 1024).toFixed(2);
   console.log(`✅ CSS built (styles.css ${sizeKB} KB)`);

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -412,7 +412,7 @@ export type {
   DataFetcher,
 } from "./types/table";
 
-/** @experimental Portal provider; the admin mounts it, no plugin does. */
+/** @public Required to use styles.scoped.css correctly; see STABILITY.md. */
 // Providers
 export {
   PortalProvider,

--- a/packages/ui/src/portal-docs.test.ts
+++ b/packages/ui/src/portal-docs.test.ts
@@ -3,9 +3,8 @@
  * `PortalProvider`, because a portalled overlay defaults to `document.body` —
  * outside the wrapper, where the scoped rules and tokens do not reach.
  *
- * That list was hand-written and already drifted from the components that
- * actually portal, which is silent: the omitted ones simply render unstyled for
- * anyone following the docs. Derive it from the source instead.
+ * The list is derived from the source rather than trusted as prose: an omission
+ * is invisible, since the overlay still renders, just unstyled.
  */
 import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";

--- a/packages/ui/src/portal-docs.test.ts
+++ b/packages/ui/src/portal-docs.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The README tells consumers of `styles.scoped.css` which components need a
+ * `PortalProvider`, because a portalled overlay defaults to `document.body` —
+ * outside the wrapper, where the scoped rules and tokens do not reach.
+ *
+ * That list was hand-written and already drifted from the components that
+ * actually portal, which is silent: the omitted ones simply render unstyled for
+ * anyone following the docs. Derive it from the source instead.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const COMPONENTS = resolve(HERE, "components");
+const README = resolve(HERE, "../README.md");
+
+/** `select.tsx` -> `Select`, `alert-dialog.tsx` -> `AlertDialog`. */
+function componentName(file: string): string {
+  return file
+    .replace(/\.tsx$/, "")
+    .split("-")
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join("");
+}
+
+function portalledComponents(): string[] {
+  return readdirSync(COMPONENTS)
+    .filter(file => file.endsWith(".tsx"))
+    .filter(file =>
+      readFileSync(join(COMPONENTS, file), "utf8").includes(
+        "usePortalContainer"
+      )
+    )
+    .map(componentName)
+    .sort();
+}
+
+describe("scoped stylesheet portal docs", () => {
+  it("names every component that portals its overlay", () => {
+    const readme = readFileSync(README, "utf8");
+    const section = readme.slice(readme.indexOf("### Overlays need a portal"));
+    const listed = section.slice(0, section.indexOf("```"));
+
+    const missing = portalledComponents().filter(
+      name => !new RegExp(`\\b${name}\\b`).test(listed)
+    );
+
+    expect(
+      missing,
+      "these components call usePortalContainer but the README does not list them"
+    ).toEqual([]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -719,9 +719,6 @@ importers:
       '@eslint/js':
         specifier: ^9.34.0
         version: 9.39.1
-      '@nextlyhq/ui':
-        specifier: workspace:*
-        version: link:../ui
       eslint:
         specifier: ^9.39.1
         version: 9.39.1(jiti@2.7.0)
@@ -1418,6 +1415,9 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0
     devDependencies:
+      '@nextlyhq/admin-css':
+        specifier: workspace:*
+        version: link:../admin-css
       '@nextlyhq/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -725,6 +725,9 @@ importers:
       eslint:
         specifier: ^9.39.1
         version: 9.39.1(jiti@2.7.0)
+      tailwindcss:
+        specifier: ^4.3.2
+        version: 4.3.2
       vitest:
         specifier: ^4.1.0
         version: 4.1.10(@types/node@24.10.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.3.1
+      '@nextlyhq/admin-css':
+        specifier: workspace:^
+        version: link:../../packages/admin-css
       '@tailwindcss/postcss':
         specifier: ^4.3.2
         version: 4.3.2


### PR DESCRIPTION
## What

Item 21 **Stage 3** (distribution DX) plus the accumulated loose ends. Stages 1 (#255) and 2 (#259) covered packaging correctness and the stability contract; this is the part about actually consuming the kit.

## The problem

`@nextlyhq/ui` shipped one compiled stylesheet, and it styles the whole document — Tailwind's preflight resets `html`, `body` and `*`. Verified rather than assumed: `dist/styles.css` does contain bare `:root`/`html`/`body` rules. Fine for a greenfield app, unusable for dropping a few components into an app that already has its own design.

## `@nextlyhq/ui/styles.scoped.css`

The same sheet with every rule confined to `.nextly-ui`.

I deliberately did **not** solve this by dropping preflight: these components are built against a normalised baseline, so a preflight-free sheet would render them subtly wrong. Scoping keeps the reset and confines it, which is the same approach the admin already uses for its own sheet.

That meant reusing the admin's scoper rather than writing a second one, so `scopeSelector`/`scopeCss`/`findUnscopedRules` now take a `scope` argument defaulting to `.nextly-admin` — the admin build is untouched, and its 29 existing tests still pass and guard that default. Six tests cover the new parameter.

Two things the implementation had to get right, both caught by the build:

- **The scoper is line-based**, so it cannot run on minified CSS. The build now compiles unminified → scopes → minifies, mirroring the admin's proven sequence. My first attempt skipped that and the verifier reported **597 escaped rules**.
- **The build fails if any rule escapes the scope.** A single unscoped rule silently restyles the host page, so it is checked before the file is written.

## Proving the standalone path

The research flagged this path as built but unproven — nothing exercised either stylesheet away from `.nextly-admin`. `e2e/tests/ui-standalone.spec.ts` now asserts, in a real browser, that the precompiled sheet styles components on a bare page, the scoped sheet styles them inside the wrapper, and the scoped sheet leaves the host document alone. The third test also asserts the **unscoped** sheet *does* reset the host, so it cannot pass vacuously.

## Docs

- The plugin guide now explains *why* a plugin compiles its own CSS instead of relying on the host to scan it: the admin sheet is built at Nextly release time and can never see a later-installed plugin, and `@source` is not a reliable substitute — it takes no package references and resolves inconsistently under pnpm, which this repo and many plugin projects use.
- The README documents which of the three stylesheets to reach for.
- `STABILITY.md` lists the new entry point; the surface guard from #259 verified it is genuinely in the `exports` map.

## Loose ends

- **`contributes.admin.styles` was inert.** Declaring it loads nothing — the admin entry's side-effect import does. The two could disagree and the plugin would simply render unstyled with no error. The type now says so explicitly, and a harness test asserts the fixture's declaration and its import name the same existing, scoped file. Verified it fails when they diverge.
- Stale `.adminapp` comment in `apps/playground/next.config.ts` (the scope is `.nextly-admin`).
- `apps/playground/ui-schema.json` is schema-builder output and this harness is code-first, so it is now ignored rather than sitting untracked.

## A cycle, found by the build

Adding `@nextlyhq/admin-css` as a ui devDependency produced `@nextlyhq/ui#build → @nextlyhq/admin-css#build → @nextlyhq/ui#build`. The cause was a stale `@nextlyhq/ui` devDependency in `admin-css` that nothing references — not its source, tests or bin. Removing it breaks the cycle at the correct end and is a genuine cleanup; admin-css's 35 tests still pass without it.

## Tests

- ui **179**, admin-css **35**, playground **19** — all green
- full e2e **33 passed** (30 existing + 3 new)
- build, `check-types`, turbo lint, `lint:workspace`, **attw** — clean
- `nextly`'s failing suites are the known baseline: **394 failed / 3660 passed** identically with and without this branch (measured by stashing), so nothing new was introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a public `styles.scoped.css` entry point that confines UI styles under a required `.nextly-ui` wrapper (including correct dark-mode scoping).
  - Stylesheet builds now detect and fail on CSS “leaks” outside the wrapper, and namespace keyframes to avoid animation collisions.
  - Publicly exposed both `styles.css` (unscoped) and `styles.scoped.css` (scoped).

- **Documentation**
  - Updated UI and admin CSS docs to clarify scoped stylesheet requirements and overlay portal container usage.
  - Updated stability guidance and marked `PortalProvider` as public.

- **Tests**
  - Added end-to-end checks for scoped vs unscoped behavior, and manifest/portal-document consistency tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->