### PR TITLE
feat(nextly): bound the webhook event ledger with configurable retention

### DIFF
--- a/.changeset/webhook-retention.md
+++ b/.changeset/webhook-retention.md
@@ -1,0 +1,27 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Recorded webhook events are now cleaned up automatically.
+
+Every content change records an event, including in projects that have not set up any webhooks, so that table would otherwise grow for as long as the project is edited. Events are now removed once they are old enough and nothing is still waiting to deliver them, and delivery attempts are removed sooner than the events they belong to. Cleanup runs when webhooks are processed and, for projects that never process any, alongside ordinary content saves, so it does not depend on a scheduled job. It is bounded, so no single save waits on a large cleanup, and a cleanup that fails can never fail the save it followed.
+
+How long to keep everything is configurable under `webhooks.retention`, in milliseconds, with `false` anywhere meaning keep forever. Events are kept 30 days by default and delivery attempts 7 days. Events also carry a retention class, so the ones a future audit log depends on can be kept for a year while the rest are cleaned up in days.

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -89,6 +89,33 @@ import { createDatabaseError, isDatabaseError } from "./types";
  *
  * @public
  */
+/**
+ * Rows affected by a write, normalised across the driver shapes Drizzle returns.
+ *
+ * mysql2 resolves to `[ResultSetHeader, FieldPacket[]]`, so treating any array
+ * as a row list reports the tuple length — a constant 2 whether the statement
+ * matched nothing, one row, or many. Callers that branch on the count (a
+ * conditional claim, a retention loop) silently get the wrong answer on MySQL,
+ * so the header is read first. node-postgres reports `rowCount` and
+ * better-sqlite3 reports `changes`; a plain array is a RETURNING row list, whose
+ * length is the count.
+ */
+function affectedRowCount(result: unknown): number {
+  if (Array.isArray(result)) {
+    const header = result[0] as { affectedRows?: unknown } | undefined;
+    if (header && typeof header.affectedRows === "number") {
+      return header.affectedRows;
+    }
+    return result.length;
+  }
+  const record = result as Record<string, unknown> | null | undefined;
+  const rowCount = record?.rowCount;
+  if (typeof rowCount === "number") return rowCount;
+  const changes = record?.changes;
+  if (typeof changes === "number") return changes;
+  return 0;
+}
+
 export abstract class DrizzleAdapter {
   // ============================================================
   // Abstract Methods (MUST be implemented by subclasses)
@@ -957,12 +984,7 @@ export abstract class DrizzleAdapter {
         }
 
         const result = await query;
-        // Drizzle returns different shapes per dialect
-        return Array.isArray(result)
-          ? result.length
-          : (((result as Record<string, unknown>)?.rowCount as number) ??
-              ((result as Record<string, unknown>)?.changes as number) ??
-              0);
+        return affectedRowCount(result);
       } catch (error) {
         throw this.handleQueryError(error, "delete", table);
       }

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -58,6 +58,7 @@ import type {
 } from "../domains/singles/services/single-registry-service";
 import { resolveVersionsConfig } from "../domains/versions/resolve-config";
 import type { VersionsService } from "../domains/versions/versions-service";
+import type { ResolvedWebhookRetentionConfig } from "../domains/webhooks/retention-config";
 import { getEventBus } from "../events/event-bus";
 import { registerActivityLogHooks } from "../hooks/activity-log-hooks";
 import type { HookRegistry } from "../hooks/hook-registry";
@@ -251,6 +252,13 @@ export interface NextlyServiceConfig {
    * populating localized fields from the companion `_locales` table.
    */
   localization?: SanitizedLocalizationConfig;
+
+  /**
+   * Resolved webhook retention policy, carried through so services can offer a
+   * retention pass without re-deriving it. Null when the user switched
+   * retention off; absent when this container was built without app config.
+   */
+  webhookRetention?: ResolvedWebhookRetentionConfig | null;
 }
 
 // ============================================================

--- a/packages/nextly/src/di/registrations/register-collections.ts
+++ b/packages/nextly/src/di/registrations/register-collections.ts
@@ -21,7 +21,7 @@
 import type { PermissionSeedService } from "../../domains/auth/services/permission-seed-service";
 import type { RBACAccessControlService } from "../../domains/auth/services/rbac-access-control-service";
 import { DynamicCollectionService } from "../../domains/dynamic-collections";
-import { MetaService } from "../../domains/meta/services/meta-service";
+import { MetaRetentionGate } from "../../domains/webhooks/retention-gate";
 import { WebhookRetentionRunner } from "../../domains/webhooks/retention-runner";
 import { AccessControlService } from "../../services/access";
 import { CollectionFileManager } from "../../services/collection-file-manager";
@@ -168,7 +168,7 @@ export function registerCollectionServices(ctx: RegistrationContext): void {
         ? new WebhookRetentionRunner({
             policy: ctx.config.webhookRetention,
             prune: { adapter, logger },
-            gate: new MetaService(adapter, logger),
+            gate: new MetaRetentionGate(adapter),
             logger,
           })
         : undefined

--- a/packages/nextly/src/di/registrations/register-collections.ts
+++ b/packages/nextly/src/di/registrations/register-collections.ts
@@ -21,6 +21,8 @@
 import type { PermissionSeedService } from "../../domains/auth/services/permission-seed-service";
 import type { RBACAccessControlService } from "../../domains/auth/services/rbac-access-control-service";
 import { DynamicCollectionService } from "../../domains/dynamic-collections";
+import { MetaService } from "../../domains/meta/services/meta-service";
+import { WebhookRetentionRunner } from "../../domains/webhooks/retention-runner";
 import { AccessControlService } from "../../services/access";
 import { CollectionFileManager } from "../../services/collection-file-manager";
 import { CollectionEntryService } from "../../services/collections/collection-entry-service";
@@ -159,7 +161,17 @@ export function registerCollectionServices(ctx: RegistrationContext): void {
       rbacAccessControlService,
       // i18n M4: forward normalized localization config so localized reads resolve
       // translatable fields from the companion table.
-      ctx.config.localization
+      ctx.config.localization,
+      // CollectionService writes append events through this same service, so it
+      // needs its own runner — the handler's is not on this path.
+      ctx.config.webhookRetention
+        ? new WebhookRetentionRunner({
+            policy: ctx.config.webhookRetention,
+            prune: { adapter, logger },
+            gate: new MetaService(adapter, logger),
+            logger,
+          })
+        : undefined
     );
 
     return new CollectionService(

--- a/packages/nextly/src/di/registrations/register-collections.ts
+++ b/packages/nextly/src/di/registrations/register-collections.ts
@@ -181,7 +181,10 @@ export function registerCollectionServices(ctx: RegistrationContext): void {
       logger,
       basePath,
       // i18n M4: enable companion-aware reads on the dispatcher-facing handler.
-      ctx.config.localization
+      ctx.config.localization,
+      // Content writes offer a retention pass, so the event ledger stays
+      // bounded in installs that never run the drain.
+      ctx.config.webhookRetention
     );
 
     if (container.has("permissionSeedService")) {

--- a/packages/nextly/src/domains/webhooks/__tests__/delete-count.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/delete-count.integration.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Affected-row count from `adapter.delete`, per dialect.
+ *
+ * The retention gate decides who runs a pass by whether its conditional delete
+ * removed the marker, so a count that does not reflect reality removes the
+ * gating entirely. mysql2 resolves a delete to `[ResultSetHeader, FieldPacket[]]`,
+ * and reading that as a row list reports a constant 2 — every caller would then
+ * see a successful claim. Version retention counts its pruned rows the same way,
+ * so this is not specific to webhooks.
+ *
+ * SQLite is covered by the ordinary suite; this gate exists for the drivers whose
+ * result shape differs and which the shared harness never exercises.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createAdapter } from "../../../database/factory";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+type Dialect = "postgresql" | "mysql";
+
+interface Leg {
+  name: string;
+  dialect: Dialect;
+  url: string;
+}
+
+const LEGS: Leg[] = [
+  {
+    name: "postgres",
+    dialect: "postgresql",
+    url: process.env.TEST_POSTGRES_URL ?? "",
+  },
+  { name: "mysql", dialect: "mysql", url: process.env.TEST_MYSQL_URL ?? "" },
+];
+
+const KEYS = ["delcount.a", "delcount.b", "delcount.c"];
+
+for (const leg of LEGS) {
+  // eslint-disable-next-line vitest/no-conditional-tests -- dialect gate: skipped
+  // wholesale when the dialect's URL is unset, matching the other gates here.
+  const describeLeg = leg.url ? describe : describe.skip;
+
+  describeLeg(`adapter.delete affected rows (${leg.name})`, () => {
+    let handle: TestNextly | undefined;
+
+    beforeAll(async () => {
+      if (!leg.url) return;
+      // env.ts validates DATABASE_URL against DB_DIALECT on first read and
+      // caches it, so both must be set before the adapter is built.
+      process.env.DB_DIALECT = leg.dialect;
+      process.env.DATABASE_URL = leg.url;
+      const adapter = await createAdapter({
+        type: leg.dialect,
+        url: leg.url,
+      } as Parameters<typeof createAdapter>[0]);
+      handle = await createTestNextly({ adapter });
+    });
+
+    afterAll(async () => {
+      await handle?.destroy();
+    });
+
+    it("reports 0, 1 and 2 rather than a constant", async () => {
+      const adapter = handle!.adapter;
+      for (const key of KEYS) {
+        await adapter.delete("nextly_meta", {
+          and: [{ column: "key", op: "=", value: key }],
+        });
+      }
+
+      const none = await adapter.delete("nextly_meta", {
+        and: [{ column: "key", op: "=", value: "delcount.absent" }],
+      });
+      expect(none).toBe(0);
+
+      await adapter.insert("nextly_meta", {
+        key: KEYS[0],
+        value: JSON.stringify("v"),
+        updated_at: new Date(),
+      });
+      const one = await adapter.delete("nextly_meta", {
+        and: [{ column: "key", op: "=", value: KEYS[0] }],
+      });
+      expect(one).toBe(1);
+
+      for (const key of [KEYS[1], KEYS[2]]) {
+        await adapter.insert("nextly_meta", {
+          key,
+          value: JSON.stringify("v"),
+          updated_at: new Date(),
+        });
+      }
+      const two = await adapter.delete("nextly_meta", {
+        and: [{ column: "key", op: "IN", value: [KEYS[1], KEYS[2]] }],
+      });
+      expect(two).toBe(2);
+    });
+  });
+}

--- a/packages/nextly/src/domains/webhooks/__tests__/delete-count.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/delete-count.integration.test.ts
@@ -39,9 +39,9 @@ const LEGS: Leg[] = [
 const KEYS = ["delcount.a", "delcount.b", "delcount.c"];
 
 for (const leg of LEGS) {
-  // eslint-disable-next-line vitest/no-conditional-tests -- dialect gate: skipped
-  // wholesale when the dialect's URL is unset, matching the other gates here.
-  const describeLeg = leg.url ? describe : describe.skip;
+  // Dialect gate: the whole suite is skipped when this dialect's URL is
+  // unset, matching how the other dialect gates in this package self-skip.
+  const describeLeg = describe.skipIf(!leg.url);
 
   describeLeg(`adapter.delete affected rows (${leg.name})`, () => {
     let handle: TestNextly | undefined;

--- a/packages/nextly/src/domains/webhooks/__tests__/outbox-preimage-lock.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/outbox-preimage-lock.integration.test.ts
@@ -65,10 +65,9 @@ function envelopeOf(row: { payload: unknown }): WebhookEvent {
 }
 
 for (const leg of LEGS) {
-  // eslint-disable-next-line vitest/no-conditional-tests -- dialect gate: the
-  // suite is skipped wholesale when the dialect's URL is unset, matching the
-  // other dialect gates in this package.
-  const describeLeg = leg.url ? describe : describe.skip;
+  // Dialect gate: the whole suite is skipped when this dialect's URL is
+  // unset, matching how the other dialect gates in this package self-skip.
+  const describeLeg = describe.skipIf(!leg.url);
 
   describeLeg(`outbox pre-image row lock (${leg.name} dialect gate)`, () => {
     let cleanup: TestAdapter | undefined;

--- a/packages/nextly/src/domains/webhooks/__tests__/prune.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/prune.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Retention pruning — the safety rules and the bounds.
+ *
+ * Driven through a fake adapter so the batching, the live-delivery guard, and
+ * the pass budget can be pinned without a database. Dialect behaviour is
+ * covered by the integration suite.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { pruneWebhookData, pruneWebhookDataSafely } from "../prune";
+import { resolveWebhookRetentionConfig } from "../retention-config";
+
+interface SelectCall {
+  table: string;
+  where?: { and: { column: string; op: string; value?: unknown }[] };
+  limit?: number;
+}
+
+/**
+ * A fake adapter driven by scripted select results. Records every call so tests
+ * can assert on the predicates the engine builds, not just its return value.
+ */
+function fakeAdapter(script: {
+  events?: string[][];
+  deliveries?: string[][];
+  liveEventIds?: string[];
+}) {
+  const selects: SelectCall[] = [];
+  const deletes: { table: string; ids: unknown }[] = [];
+  const events = [...(script.events ?? [])];
+  const deliveries = [...(script.deliveries ?? [])];
+
+  return {
+    selects,
+    deletes,
+    adapter: {
+      select: async <T>(table: string, options?: SelectCall): Promise<T[]> => {
+        selects.push({ table, where: options?.where, limit: options?.limit });
+        const isLiveLookup =
+          table === "nextly_webhook_deliveries" &&
+          options?.where?.and.some(c => c.column === "eventId");
+        if (isLiveLookup) {
+          return (script.liveEventIds ?? []).map(id => ({
+            eventId: id,
+          })) as T[];
+        }
+        const queue = table === "nextly_events" ? events : deliveries;
+        return ((queue.shift() ?? []).map(id => ({ id })) as T[]) ?? [];
+      },
+      delete: async (
+        table: string,
+        where: { and: { column: string; value?: unknown }[] }
+      ): Promise<number> => {
+        const ids = where.and[0]?.value;
+        deletes.push({ table, ids });
+        return Array.isArray(ids) ? ids.length : 0;
+      },
+    },
+  };
+}
+
+const policy = () =>
+  resolveWebhookRetentionConfig({ batchSize: 2, maxBatchesPerRun: 10 })!;
+
+describe("pruneWebhookData", () => {
+  it("never deletes an event whose fan-out has not run", async () => {
+    // fanned_out_at IS NULL means the event still needs fan-out; deleting one
+    // would discard an event nobody ever delivered.
+    const f = fakeAdapter({ events: [["e1"]] });
+    await pruneWebhookData({ adapter: f.adapter }, policy());
+
+    const eventSelect = f.selects.find(s => s.table === "nextly_events");
+    expect(eventSelect?.where?.and).toContainEqual({
+      column: "fannedOutAt",
+      op: "IS NOT NULL",
+    });
+  });
+
+  it("never deletes an event that still has a live delivery", async () => {
+    // The delivery FK cascades, so deleting the event would silently take a
+    // pending or retrying delivery with it.
+    const f = fakeAdapter({ events: [["e1", "e2"]], liveEventIds: ["e1"] });
+    const result = await pruneWebhookData({ adapter: f.adapter }, policy());
+
+    const eventDeletes = f.deletes.filter(d => d.table === "nextly_events");
+    expect(eventDeletes).toHaveLength(1);
+    expect(eventDeletes[0].ids).toEqual(["e2"]);
+    expect(result.events.webhook).toBe(1);
+  });
+
+  it("prunes only terminal deliveries, so it cannot race the drain", async () => {
+    const f = fakeAdapter({ deliveries: [["d1"]] });
+    await pruneWebhookData({ adapter: f.adapter }, policy());
+
+    const statusCondition = f.selects
+      .find(
+        s =>
+          s.table === "nextly_webhook_deliveries" &&
+          s.where?.and.some(c => c.column === "status")
+      )
+      ?.where?.and.find(c => c.column === "status");
+    expect(statusCondition?.value).toEqual(["delivered", "failed"]);
+  });
+
+  it("stops at the batch budget and reports the pass as truncated", async () => {
+    // Full batches every time: there is always more to do, so the bound is what
+    // ends the pass. This is what keeps one pass short on a serverless request.
+    const f = fakeAdapter({
+      deliveries: Array.from({ length: 20 }, (_, i) => [`d${i}a`, `d${i}b`]),
+    });
+    const bounded = resolveWebhookRetentionConfig({
+      batchSize: 2,
+      maxBatchesPerRun: 3,
+    })!;
+    const result = await pruneWebhookData({ adapter: f.adapter }, bounded);
+
+    expect(result.batches).toBe(3);
+    expect(result.truncated).toBe(true);
+    expect(result.deliveries).toBe(6);
+  });
+
+  it("stops instead of spinning when every candidate is blocked", async () => {
+    // Re-reading would return the same blocked rows forever.
+    const f = fakeAdapter({
+      events: Array.from({ length: 20 }, () => ["e1", "e2"]),
+      liveEventIds: ["e1", "e2"],
+    });
+    const result = await pruneWebhookData({ adapter: f.adapter }, policy());
+
+    expect(result.events.webhook).toBe(0);
+    expect(f.deletes).toHaveLength(0);
+    expect(result.batches).toBeLessThanOrEqual(2);
+  });
+
+  it("skips a class configured to be kept forever", async () => {
+    const f = fakeAdapter({ events: [["e1"]] });
+    const keepEvents = resolveWebhookRetentionConfig({
+      eventsMaxAgeMs: false,
+      auditEventsMaxAgeMs: false,
+      deliveriesMaxAgeMs: false,
+    })!;
+    const result = await pruneWebhookData({ adapter: f.adapter }, keepEvents);
+
+    expect(f.selects).toHaveLength(0);
+    expect(result.batches).toBe(0);
+  });
+
+  it("counts without deleting in dry-run", async () => {
+    const f = fakeAdapter({ events: [["e1", "e2"]] });
+    const result = await pruneWebhookData({ adapter: f.adapter }, policy(), {
+      dryRun: true,
+    });
+
+    expect(result.events.webhook).toBe(2);
+    expect(f.deletes).toHaveLength(0);
+  });
+
+  it("applies the cutoff from the injected clock", async () => {
+    const f = fakeAdapter({ events: [["e1"]] });
+    const now = new Date("2026-07-21T00:00:00.000Z");
+    await pruneWebhookData(
+      { adapter: f.adapter, now: () => now },
+      resolveWebhookRetentionConfig({ eventsMaxAgeMs: 1000, batchSize: 2 })!
+    );
+
+    const cutoff = f.selects
+      .find(s => s.table === "nextly_events")
+      ?.where?.and.find(c => c.column === "createdAt")?.value;
+    expect(cutoff).toEqual(new Date(now.getTime() - 1000));
+  });
+});
+
+describe("pruneWebhookDataSafely", () => {
+  it("swallows a failure so a content write is never turned into an error", async () => {
+    // Retention is housekeeping. Versions deliberately fail the write when their
+    // prune fails, because a violated cap is a correctness bug; an untidy event
+    // ledger is not.
+    const warn = vi.fn();
+    const exploding = {
+      select: async () => {
+        throw new Error("connection reset");
+      },
+      delete: async () => 0,
+    };
+
+    const result = await pruneWebhookDataSafely(
+      { adapter: exploding, logger: { warn } as never },
+      policy()
+    );
+
+    expect(result.deliveries).toBe(0);
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/prune.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/prune.test.ts
@@ -25,6 +25,8 @@ function fakeAdapter(script: {
   events?: string[][];
   deliveries?: string[][];
   liveEventIds?: string[];
+  /** Events holding a terminal delivery that has not aged past its window. */
+  youngDeliveryEventIds?: string[];
   /** Whether an enabled endpoint exists; drives the fan-out requirement. */
   hasEndpoint?: boolean;
 }) {
@@ -47,13 +49,16 @@ function fakeAdapter(script: {
         if (table === "nextly_webhooks") {
           return (script.hasEndpoint ? [{ id: "wh1" }] : []) as T[];
         }
-        const isLiveLookup =
+        const isDeliveryLookup =
           table === "nextly_webhook_deliveries" &&
           options?.where?.and.some(c => c.column === "eventId");
-        if (isLiveLookup) {
-          return (script.liveEventIds ?? []).map(id => ({
-            eventId: id,
-          })) as T[];
+        if (isDeliveryLookup) {
+          // Two lookups now: live deliveries, then deliveries too young to drop.
+          const byStatus = options?.where?.and.some(c => c.column === "status");
+          const ids = byStatus
+            ? (script.liveEventIds ?? [])
+            : (script.youngDeliveryEventIds ?? []);
+          return ids.map(id => ({ eventId: id })) as T[];
         }
         const queue = table === "nextly_events" ? events : deliveries;
         return ((queue.shift() ?? []).map(id => ({ id })) as T[]) ?? [];
@@ -129,6 +134,38 @@ describe("pruneWebhookData", () => {
         ?.where?.and.some(c => c.column === "fannedOutAt")
     ).toBe(false);
     expect(result.events.webhook).toBe(1);
+  });
+
+  it("keeps an event whose delivery log is younger than the delivery window", async () => {
+    // A delayed drain routinely finishes an event that is already past its own
+    // window. Deleting it would cascade an attempt log seconds old and defeat
+    // the delivery retention the user configured.
+    const f = fakeAdapter({
+      events: [["e1", "e2"]],
+      youngDeliveryEventIds: ["e1"],
+      hasEndpoint: true,
+    });
+    const result = await pruneWebhookData({ adapter: f.adapter }, policy());
+
+    const eventDeletes = f.deletes.filter(d => d.table === "nextly_events");
+    expect(eventDeletes[0].ids).toEqual(["e2"]);
+    expect(result.events.webhook).toBe(1);
+  });
+
+  it("ages terminal deliveries from when they finished, not when they began", async () => {
+    // A delivery that retried for days before succeeding must still be kept for
+    // its window; created_at would delete it the moment it finished.
+    const f = fakeAdapter({ deliveries: [["d1"]] });
+    await pruneWebhookData({ adapter: f.adapter }, policy());
+
+    const scan = f.selects.find(
+      s =>
+        s.table === "nextly_webhook_deliveries" &&
+        s.where?.and.some(c => c.column === "status") &&
+        !s.where?.and.some(c => c.column === "eventId")
+    );
+    expect(scan?.where?.and.some(c => c.column === "updatedAt")).toBe(true);
+    expect(scan?.where?.and.some(c => c.column === "createdAt")).toBe(false);
   });
 
   it("prunes only terminal deliveries, so it cannot race the drain", async () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/prune.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/prune.test.ts
@@ -168,6 +168,39 @@ describe("pruneWebhookData", () => {
     expect(scan?.where?.and.some(c => c.column === "createdAt")).toBe(false);
   });
 
+  it("does not let a delivery hold an event past the event's own window", async () => {
+    // Events kept an hour, deliveries a week. Without clamping per class, any
+    // event that was ever delivered would live the full week and the configured
+    // event window would mean nothing.
+    const f = fakeAdapter({
+      events: [["e1"]],
+      youngDeliveryEventIds: ["e1"],
+      hasEndpoint: true,
+    });
+    const shortEvents = resolveWebhookRetentionConfig({
+      eventsMaxAgeMs: 60 * 60 * 1000,
+      auditEventsMaxAgeMs: 365 * 24 * 60 * 60 * 1000,
+      deliveriesMaxAgeMs: 7 * 24 * 60 * 60 * 1000,
+      batchSize: 2,
+    })!;
+    const now = new Date("2026-07-21T12:00:00.000Z");
+
+    await pruneWebhookData({ adapter: f.adapter, now: () => now }, shortEvents);
+
+    // The pin is taken at the event's cutoff, not the older delivery cutoff.
+    // The pin lookup is the one keyed by event id; the delivery prune scan also
+    // filters on updatedAt and runs first.
+    const pinLookup = f.selects.find(
+      s =>
+        s.table === "nextly_webhook_deliveries" &&
+        s.where?.and.some(c => c.column === "eventId") &&
+        s.where?.and.some(c => c.column === "updatedAt")
+    );
+    const pinAt = pinLookup?.where?.and.find(c => c.column === "updatedAt")
+      ?.value as Date;
+    expect(pinAt).toEqual(new Date(now.getTime() - 60 * 60 * 1000));
+  });
+
   it("prunes only terminal deliveries, so it cannot race the drain", async () => {
     const f = fakeAdapter({ deliveries: [["d1"]] });
     await pruneWebhookData({ adapter: f.adapter }, policy());

--- a/packages/nextly/src/domains/webhooks/__tests__/prune.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/prune.test.ts
@@ -14,6 +14,7 @@ interface SelectCall {
   table: string;
   where?: { and: { column: string; op: string; value?: unknown }[] };
   limit?: number;
+  offset?: number;
 }
 
 /**
@@ -24,6 +25,8 @@ function fakeAdapter(script: {
   events?: string[][];
   deliveries?: string[][];
   liveEventIds?: string[];
+  /** Whether an enabled endpoint exists; drives the fan-out requirement. */
+  hasEndpoint?: boolean;
 }) {
   const selects: SelectCall[] = [];
   const deletes: { table: string; ids: unknown }[] = [];
@@ -35,7 +38,15 @@ function fakeAdapter(script: {
     deletes,
     adapter: {
       select: async <T>(table: string, options?: SelectCall): Promise<T[]> => {
-        selects.push({ table, where: options?.where, limit: options?.limit });
+        selects.push({
+          table,
+          where: options?.where,
+          limit: options?.limit,
+          offset: options?.offset,
+        });
+        if (table === "nextly_webhooks") {
+          return (script.hasEndpoint ? [{ id: "wh1" }] : []) as T[];
+        }
         const isLiveLookup =
           table === "nextly_webhook_deliveries" &&
           options?.where?.and.some(c => c.column === "eventId");
@@ -66,7 +77,7 @@ describe("pruneWebhookData", () => {
   it("never deletes an event whose fan-out has not run", async () => {
     // fanned_out_at IS NULL means the event still needs fan-out; deleting one
     // would discard an event nobody ever delivered.
-    const f = fakeAdapter({ events: [["e1"]] });
+    const f = fakeAdapter({ events: [["e1"]], hasEndpoint: true });
     await pruneWebhookData({ adapter: f.adapter }, policy());
 
     const eventSelect = f.selects.find(s => s.table === "nextly_events");
@@ -79,12 +90,44 @@ describe("pruneWebhookData", () => {
   it("never deletes an event that still has a live delivery", async () => {
     // The delivery FK cascades, so deleting the event would silently take a
     // pending or retrying delivery with it.
-    const f = fakeAdapter({ events: [["e1", "e2"]], liveEventIds: ["e1"] });
+    const f = fakeAdapter({
+      events: [["e1", "e2"]],
+      liveEventIds: ["e1"],
+      hasEndpoint: true,
+    });
     const result = await pruneWebhookData({ adapter: f.adapter }, policy());
 
     const eventDeletes = f.deletes.filter(d => d.table === "nextly_events");
     expect(eventDeletes).toHaveLength(1);
     expect(eventDeletes[0].ids).toEqual(["e2"]);
+    expect(result.events.webhook).toBe(1);
+  });
+
+  it("requires a completed fan-out only when an endpoint could receive it", async () => {
+    const withEndpoint = fakeAdapter({ events: [["e1"]], hasEndpoint: true });
+    await pruneWebhookData({ adapter: withEndpoint.adapter }, policy());
+    expect(
+      withEndpoint.selects
+        .find(s => s.table === "nextly_events")
+        ?.where?.and.some(c => c.column === "fannedOutAt")
+    ).toBe(true);
+  });
+
+  it("prunes un-fanned-out events when no endpoint exists at all", async () => {
+    // The case retention exists for. With no endpoint the drain never runs, so
+    // fanned_out_at stays NULL forever — demanding it would delete nothing in
+    // exactly the installs that grow unbounded.
+    const noEndpoint = fakeAdapter({ events: [["e1"]], hasEndpoint: false });
+    const result = await pruneWebhookData(
+      { adapter: noEndpoint.adapter },
+      policy()
+    );
+
+    expect(
+      noEndpoint.selects
+        .find(s => s.table === "nextly_events")
+        ?.where?.and.some(c => c.column === "fannedOutAt")
+    ).toBe(false);
     expect(result.events.webhook).toBe(1);
   });
 
@@ -119,17 +162,54 @@ describe("pruneWebhookData", () => {
     expect(result.deliveries).toBe(6);
   });
 
-  it("stops instead of spinning when every candidate is blocked", async () => {
-    // Re-reading would return the same blocked rows forever.
-    const f = fakeAdapter({
-      events: Array.from({ length: 20 }, () => ["e1", "e2"]),
-      liveEventIds: ["e1", "e2"],
-    });
-    const result = await pruneWebhookData({ adapter: f.adapter }, policy());
+  it("scans past blocked rows instead of stopping at them", async () => {
+    // A batch-sized wall of stuck deliveries must not hide the younger eligible
+    // rows behind it. The cursor steps over what it cannot delete, while deleted
+    // rows leave the table — so the blocked pair stays at the front and the
+    // offset lands past exactly them.
+    let table = ["blocked1", "blocked2", "free1", "free2"];
+    const offsets: (number | undefined)[] = [];
+    const deletes: unknown[] = [];
 
-    expect(result.events.webhook).toBe(0);
-    expect(f.deletes).toHaveLength(0);
-    expect(result.batches).toBeLessThanOrEqual(2);
+    const adapter = {
+      select: async <T>(t: string, options?: SelectCall): Promise<T[]> => {
+        if (t === "nextly_webhooks") return [{ id: "wh1" }] as T[];
+        if (
+          t === "nextly_webhook_deliveries" &&
+          options?.where?.and.some(c => c.column === "eventId")
+        ) {
+          const ids = options.where.and[0].value as string[];
+          return ids
+            .filter(id => id.startsWith("blocked"))
+            .map(id => ({ eventId: id })) as T[];
+        }
+        if (t === "nextly_events") {
+          offsets.push(options?.offset);
+          const from = options?.offset ?? 0;
+          return table
+            .slice(from, from + (options?.limit ?? table.length))
+            .map(id => ({ id })) as T[];
+        }
+        return [] as T[];
+      },
+      delete: async (
+        _t: string,
+        where: { and: { value?: unknown }[] }
+      ): Promise<number> => {
+        const ids = where.and[0]?.value as string[];
+        deletes.push(ids);
+        table = table.filter(id => !ids.includes(id));
+        return ids.length;
+      },
+    };
+
+    const result = await pruneWebhookData({ adapter }, policy());
+
+    expect(deletes).toEqual([["free1", "free2"]]);
+    expect(result.events.webhook).toBe(2);
+    // Second read starts past the blocked pair; the third finds nothing left.
+    expect(offsets.slice(0, 3)).toEqual([0, 2, 2]);
+    expect(table).toEqual(["blocked1", "blocked2"]);
   });
 
   it("skips a class configured to be kept forever", async () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/retention-config.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/retention-config.test.ts
@@ -51,6 +51,17 @@ describe("resolveWebhookRetentionConfig", () => {
     expect(policy?.deliveriesMaxAgeMs).toBe(5_000);
   });
 
+  it("honours an explicit keep-forever for deliveries", () => {
+    // `false` is a request, not a bound to be normalised away. Rewriting it to
+    // the event window would prune attempt logs the user asked to keep.
+    const policy = resolveWebhookRetentionConfig({
+      eventsMaxAgeMs: 1_000,
+      auditEventsMaxAgeMs: 5_000,
+      deliveriesMaxAgeMs: false,
+    });
+    expect(policy?.deliveriesMaxAgeMs).toBe(false);
+  });
+
   it("leaves the delivery window alone when events are kept forever", () => {
     const policy = resolveWebhookRetentionConfig({
       eventsMaxAgeMs: false,

--- a/packages/nextly/src/domains/webhooks/__tests__/retention-config.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/retention-config.test.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_BATCH_SIZE,
   DEFAULT_DELIVERIES_MAX_AGE_MS,
   DEFAULT_EVENTS_MAX_AGE_MS,
+  MAX_BATCH_SIZE,
   resolveWebhookRetentionConfig,
   windowForClass,
 } from "../retention-config";
@@ -70,6 +71,14 @@ describe("resolveWebhookRetentionConfig", () => {
     expect(policy?.batchSize).toBe(DEFAULT_BATCH_SIZE);
     expect(policy?.maxBatchesPerRun).toBeGreaterThan(0);
     expect(policy?.intervalMs).toBeGreaterThan(0);
+  });
+
+  it("clamps an oversized batch to the portable bind-parameter limit", () => {
+    // Above this a pass exceeds SQLite's parameter cap and fails every time,
+    // and the safe runner swallows it, so retention would stop making progress
+    // with nothing visible to explain why.
+    const policy = resolveWebhookRetentionConfig({ batchSize: 100_000 });
+    expect(policy?.batchSize).toBe(MAX_BATCH_SIZE);
   });
 
   it("routes each class to its own window", () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/retention-config.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/retention-config.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Retention policy resolution.
+ *
+ * The resolver is pure and total: it never throws, and it clamps rather than
+ * rejecting, so a malformed value degrades to something safe instead of failing
+ * a boot.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_AUDIT_EVENTS_MAX_AGE_MS,
+  DEFAULT_BATCH_SIZE,
+  DEFAULT_DELIVERIES_MAX_AGE_MS,
+  DEFAULT_EVENTS_MAX_AGE_MS,
+  resolveWebhookRetentionConfig,
+  windowForClass,
+} from "../retention-config";
+
+describe("resolveWebhookRetentionConfig", () => {
+  it("enables retention at defaults when nothing is configured", () => {
+    // The row is written on every content write whether or not the user asked
+    // for webhooks, so an unconfigured install must not grow without bound.
+    const policy = resolveWebhookRetentionConfig(undefined);
+    expect(policy).not.toBeNull();
+    expect(policy?.eventsMaxAgeMs).toBe(DEFAULT_EVENTS_MAX_AGE_MS);
+    expect(policy?.auditEventsMaxAgeMs).toBe(DEFAULT_AUDIT_EVENTS_MAX_AGE_MS);
+    expect(policy?.deliveriesMaxAgeMs).toBe(DEFAULT_DELIVERIES_MAX_AGE_MS);
+    expect(policy?.batchSize).toBe(DEFAULT_BATCH_SIZE);
+  });
+
+  it("disables retention wholesale on `false`", () => {
+    expect(resolveWebhookRetentionConfig(false)).toBeNull();
+  });
+
+  it("keeps a class forever when its window is `false`", () => {
+    const policy = resolveWebhookRetentionConfig({ eventsMaxAgeMs: false });
+    expect(policy?.eventsMaxAgeMs).toBe(false);
+    // The other class keeps its own window.
+    expect(policy?.auditEventsMaxAgeMs).toBe(DEFAULT_AUDIT_EVENTS_MAX_AGE_MS);
+  });
+
+  it("clamps the delivery window to the longest event window", () => {
+    // Deliveries cascade from their event, so a longer delivery window is not
+    // merely unhelpful — it cannot be honoured, and storing it would be a lie.
+    const policy = resolveWebhookRetentionConfig({
+      eventsMaxAgeMs: 1_000,
+      auditEventsMaxAgeMs: 5_000,
+      deliveriesMaxAgeMs: 60_000,
+    });
+    expect(policy?.deliveriesMaxAgeMs).toBe(5_000);
+  });
+
+  it("leaves the delivery window alone when events are kept forever", () => {
+    const policy = resolveWebhookRetentionConfig({
+      eventsMaxAgeMs: false,
+      auditEventsMaxAgeMs: false,
+      deliveriesMaxAgeMs: 60_000,
+    });
+    expect(policy?.deliveriesMaxAgeMs).toBe(60_000);
+  });
+
+  it("falls back to defaults for malformed values instead of throwing", () => {
+    const policy = resolveWebhookRetentionConfig({
+      eventsMaxAgeMs: Number.NaN,
+      batchSize: -5,
+      maxBatchesPerRun: 0,
+      intervalMs: Number.POSITIVE_INFINITY,
+    });
+    expect(policy?.eventsMaxAgeMs).toBe(DEFAULT_EVENTS_MAX_AGE_MS);
+    expect(policy?.batchSize).toBe(DEFAULT_BATCH_SIZE);
+    expect(policy?.maxBatchesPerRun).toBeGreaterThan(0);
+    expect(policy?.intervalMs).toBeGreaterThan(0);
+  });
+
+  it("routes each class to its own window", () => {
+    const policy = resolveWebhookRetentionConfig({
+      eventsMaxAgeMs: 10,
+      auditEventsMaxAgeMs: 20,
+    });
+    expect(windowForClass(policy!, "webhook")).toBe(10);
+    expect(windowForClass(policy!, "audit")).toBe(20);
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/retention-gate.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/retention-gate.test.ts
@@ -2,76 +2,137 @@
  * Retention pass gating.
  *
  * There is no scheduler to hang retention off, so passes are gated on a stored
- * timestamp instead. Any caller may offer to run one; at most one gets through
- * per interval per install.
+ * marker instead. Any caller may offer to run one; the claim decides.
  */
 import { describe, expect, it, vi } from "vitest";
 
-import { claimRetentionPass, RETENTION_GATE_KEY } from "../retention-gate";
-
-function memoryStore(initial?: unknown) {
-  const values = new Map<string, unknown>();
-  if (initial !== undefined) values.set(RETENTION_GATE_KEY, initial);
-  return {
-    values,
-    get: async <T>(key: string): Promise<T | null> =>
-      (values.get(key) as T) ?? null,
-    set: async (key: string, value: unknown): Promise<void> => {
-      values.set(key, value);
-    },
-  };
-}
+import {
+  claimRetentionPass,
+  MetaRetentionGate,
+  RETENTION_GATE_KEY,
+} from "../retention-gate";
 
 const T0 = new Date("2026-07-21T12:00:00.000Z");
 const HOUR = 60 * 60 * 1000;
 
+/** A store that records how it was asked, so the claim contract is visible. */
+function recordingStore(result: boolean) {
+  const calls: { key: string; dueBefore: Date; now: Date }[] = [];
+  return {
+    calls,
+    claim: async (
+      key: string,
+      dueBefore: Date,
+      now: Date
+    ): Promise<boolean> => {
+      calls.push({ key, dueBefore, now });
+      return result;
+    },
+  };
+}
+
 describe("claimRetentionPass", () => {
-  it("lets the first caller through when nothing is recorded", async () => {
-    const store = memoryStore();
+  it("asks the store to claim the marker as of one interval ago", async () => {
+    const store = recordingStore(true);
     await expect(claimRetentionPass(store, HOUR, T0)).resolves.toBe(true);
+    expect(store.calls[0].key).toBe(RETENTION_GATE_KEY);
+    expect(store.calls[0].dueBefore).toEqual(new Date(T0.getTime() - HOUR));
   });
 
-  it("holds off a second caller inside the interval", async () => {
-    const store = memoryStore();
-    await claimRetentionPass(store, HOUR, T0);
-    const soon = new Date(T0.getTime() + 60_000);
-    await expect(claimRetentionPass(store, HOUR, soon)).resolves.toBe(false);
-  });
-
-  it("lets a caller through once the interval has elapsed", async () => {
-    const store = memoryStore();
-    await claimRetentionPass(store, HOUR, T0);
-    const later = new Date(T0.getTime() + HOUR + 1);
-    await expect(claimRetentionPass(store, HOUR, later)).resolves.toBe(true);
-  });
-
-  it("records the attempt BEFORE the pass runs", async () => {
-    // A pass that throws must still hold off the next one for a full interval,
-    // or every subsequent write would retry a failing prune.
-    const store = memoryStore();
-    await claimRetentionPass(store, HOUR, T0);
-    expect(store.values.get(RETENTION_GATE_KEY)).toBe(T0.toISOString());
-  });
-
-  it("reads a stored ISO string back", async () => {
-    const store = memoryStore(T0.toISOString());
-    const soon = new Date(T0.getTime() + 1000);
-    await expect(claimRetentionPass(store, HOUR, soon)).resolves.toBe(false);
-  });
-
-  it("treats an unreadable marker as never having run", async () => {
-    const store = memoryStore({ unexpected: "shape" });
-    await expect(claimRetentionPass(store, HOUR, T0)).resolves.toBe(true);
+  it("does not run when the claim is refused", async () => {
+    const store = recordingStore(false);
+    await expect(claimRetentionPass(store, HOUR, T0)).resolves.toBe(false);
   });
 
   it("declines rather than pruning ungated when the store fails", async () => {
-    // If the gate cannot be read, an ungated pass could run on every write.
+    // If the gate cannot be claimed, an ungated pass could run on every write.
     const broken = {
-      get: vi.fn(async () => {
+      claim: vi.fn(async () => {
         throw new Error("meta table unavailable");
       }),
-      set: vi.fn(async () => {}),
     };
     await expect(claimRetentionPass(broken, HOUR, T0)).resolves.toBe(false);
+  });
+});
+
+describe("MetaRetentionGate", () => {
+  /** A `nextly_meta` stand-in whose key is unique, as the real primary key is. */
+  function fakeAdapter(existing?: { updatedAt: Date }) {
+    let row = existing ? { ...existing } : undefined;
+    const ops: string[] = [];
+    return {
+      ops,
+      get row() {
+        return row;
+      },
+      adapter: {
+        delete: async (
+          _t: string,
+          where: { and: { column: string; value?: unknown }[] }
+        ): Promise<number> => {
+          ops.push("delete");
+          const before = where.and.find(c => c.column === "updatedAt")
+            ?.value as Date;
+          if (row && row.updatedAt < before) {
+            row = undefined;
+            return 1;
+          }
+          return 0;
+        },
+        insert: async (
+          _t: string,
+          data: Record<string, unknown>
+        ): Promise<unknown> => {
+          ops.push("insert");
+          // The primary key rejects a second row for the same marker.
+          if (row) throw new Error("duplicate key");
+          row = { updatedAt: data.updated_at as Date };
+          return data;
+        },
+      },
+    };
+  }
+
+  it("claims when no marker exists yet", async () => {
+    const f = fakeAdapter();
+    const gate = new MetaRetentionGate(f.adapter);
+    await expect(
+      gate.claim(RETENTION_GATE_KEY, new Date(T0.getTime() - HOUR), T0)
+    ).resolves.toBe(true);
+    expect(f.row?.updatedAt).toEqual(T0);
+  });
+
+  it("claims by removing a stale marker, then restamping it", async () => {
+    const f = fakeAdapter({ updatedAt: new Date(T0.getTime() - 2 * HOUR) });
+    const gate = new MetaRetentionGate(f.adapter);
+    await expect(
+      gate.claim(RETENTION_GATE_KEY, new Date(T0.getTime() - HOUR), T0)
+    ).resolves.toBe(true);
+    // The conditional delete IS the claim; the insert only restamps it.
+    expect(f.ops).toEqual(["delete", "insert"]);
+    expect(f.row?.updatedAt).toEqual(T0);
+  });
+
+  it("refuses while the marker is still current", async () => {
+    const f = fakeAdapter({ updatedAt: new Date(T0.getTime() - 60_000) });
+    const gate = new MetaRetentionGate(f.adapter);
+    await expect(
+      gate.claim(RETENTION_GATE_KEY, new Date(T0.getTime() - HOUR), T0)
+    ).resolves.toBe(false);
+    // Nothing stale to delete, and the primary key rejects a duplicate.
+    expect(f.ops).toEqual(["delete", "insert"]);
+  });
+
+  it("lets exactly one of two racing callers through", async () => {
+    // The point of the atomic claim: without it every instance of a
+    // multi-instance deployment would run its own pass each interval.
+    const f = fakeAdapter({ updatedAt: new Date(T0.getTime() - 2 * HOUR) });
+    const gate = new MetaRetentionGate(f.adapter);
+    const dueBefore = new Date(T0.getTime() - HOUR);
+
+    const first = await gate.claim(RETENTION_GATE_KEY, dueBefore, T0);
+    const second = await gate.claim(RETENTION_GATE_KEY, dueBefore, T0);
+
+    expect([first, second]).toEqual([true, false]);
   });
 });

--- a/packages/nextly/src/domains/webhooks/__tests__/retention-gate.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/retention-gate.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Retention pass gating.
+ *
+ * There is no scheduler to hang retention off, so passes are gated on a stored
+ * timestamp instead. Any caller may offer to run one; at most one gets through
+ * per interval per install.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { claimRetentionPass, RETENTION_GATE_KEY } from "../retention-gate";
+
+function memoryStore(initial?: unknown) {
+  const values = new Map<string, unknown>();
+  if (initial !== undefined) values.set(RETENTION_GATE_KEY, initial);
+  return {
+    values,
+    get: async <T>(key: string): Promise<T | null> =>
+      (values.get(key) as T) ?? null,
+    set: async (key: string, value: unknown): Promise<void> => {
+      values.set(key, value);
+    },
+  };
+}
+
+const T0 = new Date("2026-07-21T12:00:00.000Z");
+const HOUR = 60 * 60 * 1000;
+
+describe("claimRetentionPass", () => {
+  it("lets the first caller through when nothing is recorded", async () => {
+    const store = memoryStore();
+    await expect(claimRetentionPass(store, HOUR, T0)).resolves.toBe(true);
+  });
+
+  it("holds off a second caller inside the interval", async () => {
+    const store = memoryStore();
+    await claimRetentionPass(store, HOUR, T0);
+    const soon = new Date(T0.getTime() + 60_000);
+    await expect(claimRetentionPass(store, HOUR, soon)).resolves.toBe(false);
+  });
+
+  it("lets a caller through once the interval has elapsed", async () => {
+    const store = memoryStore();
+    await claimRetentionPass(store, HOUR, T0);
+    const later = new Date(T0.getTime() + HOUR + 1);
+    await expect(claimRetentionPass(store, HOUR, later)).resolves.toBe(true);
+  });
+
+  it("records the attempt BEFORE the pass runs", async () => {
+    // A pass that throws must still hold off the next one for a full interval,
+    // or every subsequent write would retry a failing prune.
+    const store = memoryStore();
+    await claimRetentionPass(store, HOUR, T0);
+    expect(store.values.get(RETENTION_GATE_KEY)).toBe(T0.toISOString());
+  });
+
+  it("reads a stored ISO string back", async () => {
+    const store = memoryStore(T0.toISOString());
+    const soon = new Date(T0.getTime() + 1000);
+    await expect(claimRetentionPass(store, HOUR, soon)).resolves.toBe(false);
+  });
+
+  it("treats an unreadable marker as never having run", async () => {
+    const store = memoryStore({ unexpected: "shape" });
+    await expect(claimRetentionPass(store, HOUR, T0)).resolves.toBe(true);
+  });
+
+  it("declines rather than pruning ungated when the store fails", async () => {
+    // If the gate cannot be read, an ungated pass could run on every write.
+    const broken = {
+      get: vi.fn(async () => {
+        throw new Error("meta table unavailable");
+      }),
+      set: vi.fn(async () => {}),
+    };
+    await expect(claimRetentionPass(broken, HOUR, T0)).resolves.toBe(false);
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/retention-gate.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/retention-gate.test.ts
@@ -130,8 +130,13 @@ describe("MetaRetentionGate", () => {
     const gate = new MetaRetentionGate(f.adapter);
     const dueBefore = new Date(T0.getTime() - HOUR);
 
-    const first = await gate.claim(RETENTION_GATE_KEY, dueBefore, T0);
-    const second = await gate.claim(RETENTION_GATE_KEY, dueBefore, T0);
+    // Started together rather than in sequence: sequencing them would only
+    // retest that a freshly stamped marker blocks the next claim, not the
+    // delete-to-restamp contention the atomic claim exists for.
+    const [first, second] = await Promise.all([
+      gate.claim(RETENTION_GATE_KEY, dueBefore, T0),
+      gate.claim(RETENTION_GATE_KEY, dueBefore, T0),
+    ]);
 
     expect([first, second]).toEqual([true, false]);
   });

--- a/packages/nextly/src/domains/webhooks/__tests__/retention-runner.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/retention-runner.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Opportunistic retention passes.
+ *
+ * The runner is what content writes call. It decides whether a pass is due, and
+ * how large a pass the caller is willing to wait for — the write path awaits its
+ * pass, so the budget it passes is what bounds a user's save.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveWebhookRetentionConfig } from "../retention-config";
+import { WebhookRetentionRunner } from "../retention-runner";
+
+const T0 = new Date("2026-07-21T12:00:00.000Z");
+
+/** Records the policy each pass ran with, so the budget is observable. */
+function spyAdapter() {
+  const limits: (number | undefined)[] = [];
+  return {
+    limits,
+    adapter: {
+      select: async <T>(
+        _t: string,
+        options?: { limit?: number }
+      ): Promise<T[]> => {
+        limits.push(options?.limit);
+        return [] as T[];
+      },
+      delete: async (): Promise<number> => 0,
+    },
+  };
+}
+
+function alwaysClaims() {
+  return { claim: async (): Promise<boolean> => true };
+}
+
+describe("WebhookRetentionRunner", () => {
+  it("runs a pass when the gate lets it through", async () => {
+    const f = spyAdapter();
+    const runner = new WebhookRetentionRunner({
+      policy: resolveWebhookRetentionConfig({})!,
+      prune: { adapter: f.adapter },
+      gate: alwaysClaims(),
+      now: () => T0,
+    });
+
+    await runner.maybeRun();
+    expect(f.limits.length).toBeGreaterThan(0);
+  });
+
+  it("does not consult the gate again inside the same interval", async () => {
+    // The in-process guard is what keeps the common case free: a busy site must
+    // not pay a database round trip on every write just to be told "not yet".
+    const gate = { claim: vi.fn(async () => true) };
+    const runner = new WebhookRetentionRunner({
+      policy: resolveWebhookRetentionConfig({ intervalMs: 60_000 })!,
+      prune: { adapter: spyAdapter().adapter },
+      gate,
+      now: () => T0,
+    });
+
+    await runner.maybeRun();
+    await runner.maybeRun();
+    await runner.maybeRun();
+
+    expect(gate.claim).toHaveBeenCalledTimes(1);
+  });
+
+  it("consults the gate again once the interval has elapsed", async () => {
+    const gate = { claim: vi.fn(async () => true) };
+    let now = T0;
+    const runner = new WebhookRetentionRunner({
+      policy: resolveWebhookRetentionConfig({ intervalMs: 60_000 })!,
+      prune: { adapter: spyAdapter().adapter },
+      gate,
+      now: () => now,
+    });
+
+    await runner.maybeRun();
+    now = new Date(T0.getTime() + 60_001);
+    await runner.maybeRun();
+
+    expect(gate.claim).toHaveBeenCalledTimes(2);
+  });
+
+  it("caps the pass to the batch budget the caller asks for", async () => {
+    // The write path awaits its pass, so this is what bounds a user's save. A
+    // caller that passes nothing gets the policy's full budget.
+    const f = spyAdapter();
+    const runner = new WebhookRetentionRunner({
+      policy: resolveWebhookRetentionConfig({ batchSize: 7 })!,
+      prune: { adapter: f.adapter },
+      gate: alwaysClaims(),
+      now: () => T0,
+    });
+
+    await runner.maybeRun(1);
+    // One batch attempt per table/class, none of them repeated.
+    expect(f.limits.every(l => l === 7 || l === 1)).toBe(true);
+  });
+
+  it("never rejects, so a write cannot fail because housekeeping did", async () => {
+    const runner = new WebhookRetentionRunner({
+      policy: resolveWebhookRetentionConfig({})!,
+      prune: {
+        adapter: {
+          select: async () => {
+            throw new Error("connection reset");
+          },
+          delete: async () => 0,
+        },
+      },
+      gate: alwaysClaims(),
+      now: () => T0,
+    });
+
+    await expect(runner.maybeRun()).resolves.toBeUndefined();
+  });
+
+  it("does not run when the gate refuses", async () => {
+    const f = spyAdapter();
+    const runner = new WebhookRetentionRunner({
+      policy: resolveWebhookRetentionConfig({})!,
+      prune: { adapter: f.adapter },
+      gate: { claim: async (): Promise<boolean> => false },
+      now: () => T0,
+    });
+
+    await runner.maybeRun();
+    expect(f.limits).toHaveLength(0);
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/retention.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/retention.integration.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Retention through the real write path.
+ *
+ * The unit suite pins the engine against a fake adapter. This proves the whole
+ * chain: config resolution, the wiring that hangs a pass off a content write,
+ * and the delete itself against a real database — including that an install
+ * with no webhooks configured, which therefore never runs the drain, still gets
+ * its event ledger bounded.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+import { pruneWebhookData } from "../prune";
+import { resolveWebhookRetentionConfig } from "../retention-config";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+interface EventRow {
+  id: string;
+  retentionClass: string;
+  fannedOutAt: Date | number | null;
+}
+
+async function events(handle: TestNextly): Promise<EventRow[]> {
+  return handle.adapter.select<EventRow>("nextly_events");
+}
+
+async function boot(): Promise<TestNextly> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({ slug: "posts", fields: [text({ name: "title" })] }),
+    ],
+  });
+  return current;
+}
+
+/** Mark an event fanned out and backdate it, as an aged, delivered row would be. */
+async function ageEvent(
+  handle: TestNextly,
+  id: string,
+  createdAt: Date,
+  fannedOut: boolean
+): Promise<void> {
+  await handle.adapter.update(
+    "nextly_events",
+    {
+      created_at: createdAt,
+      fanned_out_at: fannedOut ? createdAt : null,
+    },
+    { and: [{ column: "id", op: "=", value: id }] }
+  );
+}
+
+const OLD = new Date("2020-01-01T00:00:00.000Z");
+
+describe("webhook retention (integration)", () => {
+  it("writes events with the webhook retention class by default", async () => {
+    // Audit-class rows only appear once the audit log exists; until then every
+    // row takes the short window.
+    const t = await boot();
+    const handler = t.getService<CollectionsHandler>("collectionsHandler");
+    await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "hello" }
+    );
+
+    const rows = await events(t);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].retentionClass).toBe("webhook");
+  });
+
+  it("prunes an aged, fanned-out event", async () => {
+    const t = await boot();
+    const handler = t.getService<CollectionsHandler>("collectionsHandler");
+    await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "old" }
+    );
+    const [row] = await events(t);
+    await ageEvent(t, row.id, OLD, true);
+
+    const result = await pruneWebhookData(
+      { adapter: t.adapter },
+      resolveWebhookRetentionConfig({})!
+    );
+
+    expect(result.events.webhook).toBe(1);
+    expect(await events(t)).toHaveLength(0);
+  });
+
+  it("leaves an aged event alone while its fan-out has not run", async () => {
+    // The row is old enough, but nothing has delivered it. Pruning here would
+    // discard an event no subscriber ever saw.
+    const t = await boot();
+    const handler = t.getService<CollectionsHandler>("collectionsHandler");
+    await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "never fanned out" }
+    );
+    const [row] = await events(t);
+    await ageEvent(t, row.id, OLD, false);
+
+    const result = await pruneWebhookData(
+      { adapter: t.adapter },
+      resolveWebhookRetentionConfig({})!
+    );
+
+    expect(result.events.webhook).toBe(0);
+    expect(await events(t)).toHaveLength(1);
+  });
+
+  it("keeps a recent event", async () => {
+    const t = await boot();
+    const handler = t.getService<CollectionsHandler>("collectionsHandler");
+    await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "fresh" }
+    );
+    const [row] = await events(t);
+    // Fanned out, but written just now: inside the window.
+    await ageEvent(t, row.id, new Date(), true);
+
+    await pruneWebhookData(
+      { adapter: t.adapter },
+      resolveWebhookRetentionConfig({})!
+    );
+
+    expect(await events(t)).toHaveLength(1);
+  });
+
+  it("keeps everything when retention is switched off", async () => {
+    const t = await boot();
+    const handler = t.getService<CollectionsHandler>("collectionsHandler");
+    await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "kept" }
+    );
+    const [row] = await events(t);
+    await ageEvent(t, row.id, OLD, true);
+
+    // `false` disables retention wholesale, so there is no policy to run.
+    expect(resolveWebhookRetentionConfig(false)).toBeNull();
+    expect(await events(t)).toHaveLength(1);
+  });
+
+  it("respects the audit class's own, longer window", async () => {
+    // A row the audit log depends on outlives one that only drove a webhook,
+    // which is the whole reason the class exists.
+    const t = await boot();
+    const handler = t.getService<CollectionsHandler>("collectionsHandler");
+    await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "audit" }
+    );
+    const [row] = await events(t);
+    await ageEvent(t, row.id, OLD, true);
+    await t.adapter.update(
+      "nextly_events",
+      { retention_class: "audit" },
+      { and: [{ column: "id", op: "=", value: row.id }] }
+    );
+
+    // Short webhook window, unlimited audit window.
+    const result = await pruneWebhookData(
+      { adapter: t.adapter },
+      resolveWebhookRetentionConfig({
+        eventsMaxAgeMs: 1,
+        auditEventsMaxAgeMs: false,
+      })!
+    );
+
+    expect(result.events.audit).toBe(0);
+    expect(await events(t)).toHaveLength(1);
+  });
+
+  it("bounds a pass to the configured batch budget", async () => {
+    const t = await boot();
+    const handler = t.getService<CollectionsHandler>("collectionsHandler");
+    for (let i = 0; i < 5; i += 1) {
+      await handler.createEntry(
+        { collectionName: "posts", overrideAccess: true },
+        { title: `post ${i}` }
+      );
+    }
+    for (const row of await events(t)) {
+      await ageEvent(t, row.id, OLD, true);
+    }
+
+    // One batch of two, then stop — a pass must stay short on a serverless
+    // request rather than deleting an unbounded backlog in one go.
+    const result = await pruneWebhookData(
+      { adapter: t.adapter },
+      resolveWebhookRetentionConfig({ batchSize: 2, maxBatchesPerRun: 1 })!
+    );
+
+    expect(result.events.webhook).toBe(2);
+    expect(result.truncated).toBe(true);
+    expect(await events(t)).toHaveLength(3);
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/retention.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/retention.integration.test.ts
@@ -98,14 +98,46 @@ describe("webhook retention (integration)", () => {
     expect(await events(t)).toHaveLength(0);
   });
 
-  it("leaves an aged event alone while its fan-out has not run", async () => {
-    // The row is old enough, but nothing has delivered it. Pruning here would
-    // discard an event no subscriber ever saw.
+  it("leaves an aged, un-fanned-out event alone while an endpoint exists", async () => {
+    // The row is old enough, but an endpoint could still receive it and the
+    // drain has not run. Pruning here would discard an event a subscriber is
+    // owed.
     const t = await boot();
     const handler = t.getService<CollectionsHandler>("collectionsHandler");
     await handler.createEntry(
       { collectionName: "posts", overrideAccess: true },
       { title: "never fanned out" }
+    );
+    const [row] = await events(t);
+    await ageEvent(t, row.id, OLD, false);
+    await t.adapter.insert("nextly_webhooks", {
+      id: "wh-waiting",
+      name: "endpoint",
+      url: "https://example.test/hook",
+      enabled: true,
+      event_types: ["entry.created"],
+      secret_hash: [],
+      secret_prefix: "whsec_y",
+    });
+
+    const result = await pruneWebhookData(
+      { adapter: t.adapter },
+      resolveWebhookRetentionConfig({})!
+    );
+
+    expect(result.events.webhook).toBe(0);
+    expect(await events(t)).toHaveLength(1);
+  });
+
+  it("prunes an aged, un-fanned-out event when no endpoint exists", async () => {
+    // The majority install: no webhooks, so no drain ever runs and
+    // fanned_out_at stays NULL forever. Requiring it would leave the ledger
+    // unbounded for exactly the case retention was built for.
+    const t = await boot();
+    const handler = t.getService<CollectionsHandler>("collectionsHandler");
+    await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "nobody is listening" }
     );
     const [row] = await events(t);
     await ageEvent(t, row.id, OLD, false);
@@ -115,8 +147,8 @@ describe("webhook retention (integration)", () => {
       resolveWebhookRetentionConfig({})!
     );
 
-    expect(result.events.webhook).toBe(0);
-    expect(await events(t)).toHaveLength(1);
+    expect(result.events.webhook).toBe(1);
+    expect(await events(t)).toHaveLength(0);
   });
 
   it("keeps a recent event", async () => {
@@ -181,6 +213,48 @@ describe("webhook retention (integration)", () => {
 
     expect(result.events.audit).toBe(0);
     expect(await events(t)).toHaveLength(1);
+  });
+
+  it("spares an event whose delivery is still live, against a real adapter", async () => {
+    // The unit suite drives this through a fake, which cannot catch a column
+    // projection that silently returns undefined. Only a real row proves the
+    // guard holds — and the delivery FK cascades, so a guard that failed would
+    // take a pending delivery with the event and the drain would never retry it.
+    const t = await boot();
+    const handler = t.getService<CollectionsHandler>("collectionsHandler");
+    await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "has a live delivery" }
+    );
+    const [row] = await events(t);
+    await ageEvent(t, row.id, OLD, true);
+
+    await t.adapter.insert("nextly_webhooks", {
+      id: "wh-live",
+      name: "endpoint",
+      url: "https://example.test/hook",
+      enabled: true,
+      event_types: ["entry.created"],
+      secret_hash: [],
+      secret_prefix: "whsec_x",
+    });
+    await t.adapter.insert("nextly_webhook_deliveries", {
+      id: "dl-live",
+      webhook_id: "wh-live",
+      event_id: row.id,
+      status: "retrying",
+      attempt_count: 1,
+    });
+
+    const result = await pruneWebhookData(
+      { adapter: t.adapter },
+      resolveWebhookRetentionConfig({})!
+    );
+
+    expect(result.events.webhook).toBe(0);
+    expect(await events(t)).toHaveLength(1);
+    const deliveries = await t.adapter.select("nextly_webhook_deliveries");
+    expect(deliveries).toHaveLength(1);
   });
 
   it("bounds a pass to the configured batch budget", async () => {

--- a/packages/nextly/src/domains/webhooks/prune.ts
+++ b/packages/nextly/src/domains/webhooks/prune.ts
@@ -358,6 +358,17 @@ export async function pruneWebhookData(
   for (const eventClass of EVENT_RETENTION_CLASSES) {
     const cutoff = cutoffFor(now, windowForClass(policy, eventClass));
     if (!cutoff) continue;
+    // A delivery can only hold its event back within the event's own window.
+    // Otherwise a long delivery window would silently override a short event
+    // one — with events kept an hour and deliveries a week, any event that was
+    // ever delivered would live the full week. The later of the two cutoffs is
+    // the shorter effective window, and a null delivery cutoff means keep
+    // forever, which the config already documents as winning over the cascade.
+    const pinCutoff =
+      deliveryCutoff === null
+        ? null
+        : new Date(Math.max(deliveryCutoff.getTime(), cutoff.getTime()));
+
     const outcome = await pruneEventClass(
       deps,
       policy,
@@ -366,7 +377,7 @@ export async function pruneWebhookData(
       budget,
       options,
       requireFanOut,
-      deliveryCutoff
+      pinCutoff
     );
     result.events[eventClass] = outcome.deleted;
     if (!outcome.exhausted) result.truncated = true;

--- a/packages/nextly/src/domains/webhooks/prune.ts
+++ b/packages/nextly/src/domains/webhooks/prune.ts
@@ -1,0 +1,330 @@
+/**
+ * Webhook domain — retention pruning.
+ *
+ * Deletes aged rows from `nextly_events` and `nextly_webhook_deliveries` in
+ * bounded batches. Never runs inside a content write's transaction: pruning is
+ * housekeeping, and failing a user's save because it hiccuped is the wrong
+ * trade. (Version retention deliberately takes the opposite position, because a
+ * violated version cap is a correctness bug rather than untidiness.)
+ *
+ * Two safety rules govern which events may go, both forced by the schema:
+ *
+ * 1. `fanned_out_at IS NULL` means the event still needs fan-out. Deleting one
+ *    would discard an event nobody ever delivered.
+ * 2. `nextly_webhook_deliveries.event_id` cascades, so deleting an event takes
+ *    its delivery rows with it — including any still pending or retrying. An
+ *    event is therefore only prunable once every child delivery is terminal.
+ *
+ * Deletion is two round trips per batch (select ids, then delete by id) because
+ * no single statement batches a delete across all three dialects: PostgreSQL has
+ * no `DELETE ... LIMIT`, MySQL rejects a subquery against the delete target, and
+ * SQLite only supports it when compiled with a non-default flag. Selecting ids
+ * first also confines MySQL's locks to specific records rather than gap-locking
+ * a range of the index that concurrent inserts need.
+ *
+ * @module domains/webhooks/prune
+ */
+
+import type { WhereCondition } from "@nextlyhq/adapter-drizzle/types";
+
+import { NextlyError } from "../../errors";
+import type { Logger } from "../../shared/types";
+
+import {
+  EVENT_RETENTION_CLASSES,
+  windowForClass,
+  type EventRetentionClass,
+  type ResolvedWebhookRetentionConfig,
+} from "./retention-config";
+
+const EVENTS_TABLE = "nextly_events";
+const DELIVERIES_TABLE = "nextly_webhook_deliveries";
+
+/** Delivery states that still represent work the drain may pick up. */
+const LIVE_DELIVERY_STATUSES = ["pending", "processing", "retrying"] as const;
+
+/** Delivery states that are finished and therefore prunable. */
+const TERMINAL_DELIVERY_STATUSES = ["delivered", "failed"] as const;
+
+/** The subset of the adapter this module needs, so tests can supply a double. */
+export interface PruneAdapter {
+  select<T = unknown>(
+    table: string,
+    options?: {
+      where?: { and: WhereCondition[] };
+      orderBy?: { column: string; direction: "asc" | "desc" }[];
+      limit?: number;
+      columns?: string[];
+    }
+  ): Promise<T[]>;
+  delete(table: string, where: { and: WhereCondition[] }): Promise<number>;
+}
+
+export interface PruneDeps {
+  adapter: PruneAdapter;
+  /** Injectable so tests can pin the cutoff instead of sleeping. */
+  now?: () => Date;
+  logger?: Logger;
+}
+
+export interface PruneOptions {
+  /** Count what would be deleted without deleting it. */
+  dryRun?: boolean;
+}
+
+export interface PruneResult {
+  /** Events removed, per retention class. */
+  events: Record<EventRetentionClass, number>;
+  /** Terminal delivery rows removed ahead of their event. */
+  deliveries: number;
+  /** Batches issued, across both tables. */
+  batches: number;
+  /** True when a bound stopped the pass before it ran out of rows. */
+  truncated: boolean;
+}
+
+function emptyResult(): PruneResult {
+  return {
+    events: { webhook: 0, audit: 0 },
+    deliveries: 0,
+    batches: 0,
+    truncated: false,
+  };
+}
+
+/** A cutoff instant, or null when this class is kept forever. */
+function cutoffFor(now: Date, maxAgeMs: number | false): Date | null {
+  return maxAgeMs === false ? null : new Date(now.getTime() - maxAgeMs);
+}
+
+/**
+ * Of the given event ids, those that still have a live delivery.
+ *
+ * Expressed as a second query rather than a `NOT EXISTS` subquery because the
+ * adapter's where vocabulary has no correlated-subquery form, and reaching for
+ * raw SQL here would put dialect-specific strings in product code. The
+ * `(event_id)` index serves this lookup.
+ */
+async function eventIdsWithLiveDeliveries(
+  adapter: PruneAdapter,
+  eventIds: string[]
+): Promise<Set<string>> {
+  if (eventIds.length === 0) return new Set();
+  const rows = await adapter.select<{ eventId: string }>(DELIVERIES_TABLE, {
+    where: {
+      and: [
+        { column: "eventId", op: "IN", value: eventIds },
+        {
+          column: "status",
+          op: "IN",
+          value: [...LIVE_DELIVERY_STATUSES],
+        },
+      ],
+    },
+    columns: ["event_id"],
+  });
+  return new Set(rows.map(r => r.eventId));
+}
+
+/**
+ * Prune one class of event. Returns the number deleted.
+ *
+ * Each batch selects candidate ids oldest-first, drops the ones still holding
+ * live deliveries, and deletes the remainder by id. A batch that yields fewer
+ * candidates than the batch size means the table is exhausted for this class.
+ */
+async function pruneEventClass(
+  deps: PruneDeps,
+  policy: ResolvedWebhookRetentionConfig,
+  eventClass: EventRetentionClass,
+  cutoff: Date,
+  budget: { batchesLeft: number },
+  options: PruneOptions
+): Promise<{ deleted: number; exhausted: boolean }> {
+  let deleted = 0;
+
+  while (budget.batchesLeft > 0) {
+    const candidates = await deps.adapter.select<{ id: string }>(EVENTS_TABLE, {
+      where: {
+        and: [
+          { column: "retentionClass", op: "=", value: eventClass },
+          { column: "fannedOutAt", op: "IS NOT NULL" },
+          { column: "createdAt", op: "<", value: cutoff },
+        ],
+      },
+      orderBy: [{ column: "createdAt", direction: "asc" }],
+      limit: policy.batchSize,
+      columns: ["id"],
+    });
+
+    // The steady state is "nothing to prune"; that costs one index probe and
+    // takes no write lock.
+    if (candidates.length === 0) return { deleted, exhausted: true };
+
+    const ids = candidates.map(c => c.id);
+    const blocked = await eventIdsWithLiveDeliveries(deps.adapter, ids);
+    const deletable = ids.filter(id => !blocked.has(id));
+
+    budget.batchesLeft -= 1;
+
+    if (deletable.length > 0 && !options.dryRun) {
+      deleted += await deps.adapter.delete(EVENTS_TABLE, {
+        and: [{ column: "id", op: "IN", value: deletable }],
+      });
+    } else {
+      deleted += deletable.length;
+    }
+
+    // A short read means no more rows match; a full one may have more behind it.
+    if (candidates.length < policy.batchSize) {
+      return { deleted, exhausted: true };
+    }
+    // Every candidate was blocked by a live delivery, so re-reading would return
+    // the same rows forever. Stop rather than spin.
+    if (deletable.length === 0) return { deleted, exhausted: true };
+  }
+
+  return { deleted, exhausted: false };
+}
+
+/** Prune terminal delivery rows that have aged out ahead of their event. */
+async function pruneDeliveries(
+  deps: PruneDeps,
+  policy: ResolvedWebhookRetentionConfig,
+  cutoff: Date,
+  budget: { batchesLeft: number },
+  options: PruneOptions
+): Promise<{ deleted: number; exhausted: boolean }> {
+  let deleted = 0;
+
+  while (budget.batchesLeft > 0) {
+    const candidates = await deps.adapter.select<{ id: string }>(
+      DELIVERIES_TABLE,
+      {
+        where: {
+          and: [
+            {
+              column: "status",
+              op: "IN",
+              value: [...TERMINAL_DELIVERY_STATUSES],
+            },
+            { column: "createdAt", op: "<", value: cutoff },
+          ],
+        },
+        orderBy: [{ column: "createdAt", direction: "asc" }],
+        limit: policy.batchSize,
+        columns: ["id"],
+      }
+    );
+
+    if (candidates.length === 0) return { deleted, exhausted: true };
+
+    budget.batchesLeft -= 1;
+    const ids = candidates.map(c => c.id);
+
+    if (!options.dryRun) {
+      deleted += await deps.adapter.delete(DELIVERIES_TABLE, {
+        and: [{ column: "id", op: "IN", value: ids }],
+      });
+    } else {
+      deleted += ids.length;
+    }
+
+    if (candidates.length < policy.batchSize) {
+      return { deleted, exhausted: true };
+    }
+  }
+
+  return { deleted, exhausted: false };
+}
+
+/**
+ * Run one retention pass.
+ *
+ * Deliveries are pruned first and on their own, shorter window: they grow as
+ * events x matching endpoints and carry the per-attempt log, so they are the
+ * larger share of the volume. Only terminal rows are eligible, which makes the
+ * prune set disjoint from the set the drain claims — the two cannot contend for
+ * the same rows by construction rather than by locking.
+ */
+export async function pruneWebhookData(
+  deps: PruneDeps,
+  policy: ResolvedWebhookRetentionConfig,
+  options: PruneOptions = {}
+): Promise<PruneResult> {
+  const now = (deps.now ?? (() => new Date()))();
+  const result = emptyResult();
+  const budget = { batchesLeft: policy.maxBatchesPerRun };
+
+  const deliveryCutoff = cutoffFor(now, policy.deliveriesMaxAgeMs);
+  if (deliveryCutoff) {
+    const outcome = await pruneDeliveries(
+      deps,
+      policy,
+      deliveryCutoff,
+      budget,
+      options
+    );
+    result.deliveries = outcome.deleted;
+    if (!outcome.exhausted) result.truncated = true;
+  }
+
+  for (const eventClass of EVENT_RETENTION_CLASSES) {
+    const cutoff = cutoffFor(now, windowForClass(policy, eventClass));
+    if (!cutoff) continue;
+    const outcome = await pruneEventClass(
+      deps,
+      policy,
+      eventClass,
+      cutoff,
+      budget,
+      options
+    );
+    result.events[eventClass] = outcome.deleted;
+    if (!outcome.exhausted) result.truncated = true;
+  }
+
+  result.batches = policy.maxBatchesPerRun - budget.batchesLeft;
+
+  if (result.batches > 0) {
+    deps.logger?.debug?.("webhook retention pass complete", {
+      events: result.events,
+      deliveries: result.deliveries,
+      batches: result.batches,
+      truncated: result.truncated,
+      dryRun: options.dryRun === true,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Run a pass without letting a failure reach the caller.
+ *
+ * Used by the seams that hang off a user write. Retention must never turn a
+ * successful content save into a failed request, so a prune error is logged and
+ * swallowed; the next pass will retry the same rows.
+ */
+export async function pruneWebhookDataSafely(
+  deps: PruneDeps,
+  policy: ResolvedWebhookRetentionConfig,
+  options: PruneOptions = {}
+): Promise<PruneResult> {
+  try {
+    return await pruneWebhookData(deps, policy, options);
+  } catch (error) {
+    deps.logger?.warn?.(
+      "webhook retention pass failed; rows stay until the next pass",
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : NextlyError.is(error)
+              ? error.message
+              : String(error),
+      }
+    );
+    return emptyResult();
+  }
+}

--- a/packages/nextly/src/domains/webhooks/prune.ts
+++ b/packages/nextly/src/domains/webhooks/prune.ts
@@ -121,32 +121,57 @@ async function deliveryIsPossible(adapter: PruneAdapter): Promise<boolean> {
 }
 
 /**
- * Of the given event ids, those that still have a live delivery.
+ * Of the given event ids, those whose deliveries must outlive them.
  *
- * Expressed as a second query rather than a `NOT EXISTS` subquery because the
- * adapter's where vocabulary has no correlated-subquery form, and reaching for
- * raw SQL here would put dialect-specific strings in product code. The
- * `(event_id)` index serves this lookup.
+ * Two reasons a delivery holds its event back. It may still be live, in which
+ * case removing the event would cascade away work the drain has not finished.
+ * Or it may be terminal but younger than the delivery window: the attempt log is
+ * the only record of how a webhook was behaving, and a delayed drain routinely
+ * produces a fresh terminal delivery on an event that is already past its own
+ * window — deleting the event then would cascade an attempt log that is seconds
+ * old and silently defeat the configured delivery retention.
+ *
+ * Expressed as two queries rather than one disjunction because the narrow
+ * adapter surface this module declares takes conjunctions only, and widening it
+ * to carry an `or` for a single call site buys nothing. The `(event_id)` index
+ * serves both.
  */
-async function eventIdsWithLiveDeliveries(
+async function eventIdsWithRetainedDeliveries(
   adapter: PruneAdapter,
-  eventIds: string[]
+  eventIds: string[],
+  deliveryCutoff: Date | null
 ): Promise<Set<string>> {
   if (eventIds.length === 0) return new Set();
-  const rows = await adapter.select<{ eventId: string }>(DELIVERIES_TABLE, {
+
+  const live = await adapter.select<{ eventId: string }>(DELIVERIES_TABLE, {
     where: {
       and: [
         { column: "eventId", op: "IN", value: eventIds },
-        {
-          column: "status",
-          op: "IN",
-          value: [...LIVE_DELIVERY_STATUSES],
-        },
+        { column: "status", op: "IN", value: [...LIVE_DELIVERY_STATUSES] },
       ],
     },
     columns: ["event_id"],
   });
-  return new Set(rows.map(r => r.eventId));
+  const retained = new Set(live.map(r => r.eventId));
+
+  // With deliveries kept forever there is no cutoff to compare against, so any
+  // delivery at all pins its event.
+  const young = await adapter.select<{ eventId: string }>(DELIVERIES_TABLE, {
+    where: {
+      and: [
+        { column: "eventId", op: "IN", value: eventIds },
+        ...(deliveryCutoff
+          ? ([
+              { column: "updatedAt", op: ">=", value: deliveryCutoff },
+            ] as const)
+          : []),
+      ],
+    },
+    columns: ["event_id"],
+  });
+  for (const row of young) retained.add(row.eventId);
+
+  return retained;
 }
 
 /**
@@ -163,7 +188,8 @@ async function pruneEventClass(
   cutoff: Date,
   budget: { batchesLeft: number },
   options: PruneOptions,
-  requireFanOut: boolean
+  requireFanOut: boolean,
+  deliveryCutoff: Date | null
 ): Promise<{ deleted: number; exhausted: boolean }> {
   let deleted = 0;
   // Rows this pass has looked at and will not delete: those held by a live
@@ -196,7 +222,11 @@ async function pruneEventClass(
     if (candidates.length === 0) return { deleted, exhausted: true };
 
     const ids = candidates.map(c => c.id);
-    const blocked = await eventIdsWithLiveDeliveries(deps.adapter, ids);
+    const blocked = await eventIdsWithRetainedDeliveries(
+      deps.adapter,
+      ids,
+      deliveryCutoff
+    );
     const deletable = ids.filter(id => !blocked.has(id));
 
     budget.batchesLeft -= 1;
@@ -246,10 +276,15 @@ async function pruneDeliveries(
               op: "IN",
               value: [...TERMINAL_DELIVERY_STATUSES],
             },
-            { column: "createdAt", op: "<", value: cutoff },
+            // Aged from the terminal transition, which `finalizeDelivery`
+            // stamps on `updated_at`, not from creation. A delivery that
+            // retried for days before succeeding would otherwise be deleted the
+            // moment it finished, losing the attempt log exactly when it became
+            // worth reading.
+            { column: "updatedAt", op: "<", value: cutoff },
           ],
         },
-        orderBy: [{ column: "createdAt", direction: "asc" }],
+        orderBy: [{ column: "updatedAt", direction: "asc" }],
         limit: policy.batchSize,
         offset: skipped,
         columns: ["id"],
@@ -330,7 +365,8 @@ export async function pruneWebhookData(
       cutoff,
       budget,
       options,
-      requireFanOut
+      requireFanOut,
+      deliveryCutoff
     );
     result.events[eventClass] = outcome.deleted;
     if (!outcome.exhausted) result.truncated = true;

--- a/packages/nextly/src/domains/webhooks/prune.ts
+++ b/packages/nextly/src/domains/webhooks/prune.ts
@@ -27,7 +27,6 @@
 
 import type { WhereCondition } from "@nextlyhq/adapter-drizzle/types";
 
-import { NextlyError } from "../../errors";
 import type { Logger } from "../../shared/types";
 
 import {
@@ -39,6 +38,7 @@ import {
 
 const EVENTS_TABLE = "nextly_events";
 const DELIVERIES_TABLE = "nextly_webhook_deliveries";
+const WEBHOOKS_TABLE = "nextly_webhooks";
 
 /** Delivery states that still represent work the drain may pick up. */
 const LIVE_DELIVERY_STATUSES = ["pending", "processing", "retrying"] as const;
@@ -54,6 +54,7 @@ export interface PruneAdapter {
       where?: { and: WhereCondition[] };
       orderBy?: { column: string; direction: "asc" | "desc" }[];
       limit?: number;
+      offset?: number;
       columns?: string[];
     }
   ): Promise<T[]>;
@@ -98,6 +99,28 @@ function cutoffFor(now: Date, maxAgeMs: number | false): Date | null {
 }
 
 /**
+ * Whether any endpoint could ever receive an event.
+ *
+ * With no enabled endpoint there is nothing to fan out to, so `fanned_out_at`
+ * stays NULL forever — the drain only runs where webhooks are configured. That
+ * is the majority install, and requiring a completed fan-out there would make
+ * retention delete nothing at all, leaving the ledger unbounded for exactly the
+ * population the policy exists for.
+ *
+ * An endpoint added later does not get a backlog of historical events, which is
+ * the intended contract: webhooks deliver what happens after you subscribe, not
+ * what happened before.
+ */
+async function deliveryIsPossible(adapter: PruneAdapter): Promise<boolean> {
+  const rows = await adapter.select<{ id: string }>(WEBHOOKS_TABLE, {
+    where: { and: [{ column: "enabled", op: "=", value: true }] },
+    limit: 1,
+    columns: ["id"],
+  });
+  return rows.length > 0;
+}
+
+/**
  * Of the given event ids, those that still have a live delivery.
  *
  * Expressed as a second query rather than a `NOT EXISTS` subquery because the
@@ -139,21 +162,32 @@ async function pruneEventClass(
   eventClass: EventRetentionClass,
   cutoff: Date,
   budget: { batchesLeft: number },
-  options: PruneOptions
+  options: PruneOptions,
+  requireFanOut: boolean
 ): Promise<{ deleted: number; exhausted: boolean }> {
   let deleted = 0;
+  // Rows this pass has looked at and will not delete: those held by a live
+  // delivery, and in a dry run every row it merely counted. Deleted rows leave
+  // the table, so the skipped ones collect at the front of the next read and
+  // the cursor steps over them. Without it a batch-sized wall of stuck
+  // deliveries would hide every younger eligible row behind it forever, and a
+  // dry run would keep recounting its first batch.
+  let skipped = 0;
 
   while (budget.batchesLeft > 0) {
     const candidates = await deps.adapter.select<{ id: string }>(EVENTS_TABLE, {
       where: {
         and: [
           { column: "retentionClass", op: "=", value: eventClass },
-          { column: "fannedOutAt", op: "IS NOT NULL" },
+          ...(requireFanOut
+            ? ([{ column: "fannedOutAt", op: "IS NOT NULL" }] as const)
+            : []),
           { column: "createdAt", op: "<", value: cutoff },
         ],
       },
       orderBy: [{ column: "createdAt", direction: "asc" }],
       limit: policy.batchSize,
+      offset: skipped,
       columns: ["id"],
     });
 
@@ -167,21 +201,22 @@ async function pruneEventClass(
 
     budget.batchesLeft -= 1;
 
-    if (deletable.length > 0 && !options.dryRun) {
-      deleted += await deps.adapter.delete(EVENTS_TABLE, {
-        and: [{ column: "id", op: "IN", value: deletable }],
-      });
-    } else {
+    if (options.dryRun) {
       deleted += deletable.length;
+      skipped += candidates.length;
+    } else {
+      if (deletable.length > 0) {
+        deleted += await deps.adapter.delete(EVENTS_TABLE, {
+          and: [{ column: "id", op: "IN", value: deletable }],
+        });
+      }
+      skipped += blocked.size;
     }
 
     // A short read means no more rows match; a full one may have more behind it.
     if (candidates.length < policy.batchSize) {
       return { deleted, exhausted: true };
     }
-    // Every candidate was blocked by a live delivery, so re-reading would return
-    // the same rows forever. Stop rather than spin.
-    if (deletable.length === 0) return { deleted, exhausted: true };
   }
 
   return { deleted, exhausted: false };
@@ -196,6 +231,9 @@ async function pruneDeliveries(
   options: PruneOptions
 ): Promise<{ deleted: number; exhausted: boolean }> {
   let deleted = 0;
+  // Only meaningful in a dry run, where nothing leaves the table; a real pass
+  // deletes every row it reads here, so the next read starts fresh.
+  let skipped = 0;
 
   while (budget.batchesLeft > 0) {
     const candidates = await deps.adapter.select<{ id: string }>(
@@ -213,6 +251,7 @@ async function pruneDeliveries(
         },
         orderBy: [{ column: "createdAt", direction: "asc" }],
         limit: policy.batchSize,
+        offset: skipped,
         columns: ["id"],
       }
     );
@@ -222,12 +261,13 @@ async function pruneDeliveries(
     budget.batchesLeft -= 1;
     const ids = candidates.map(c => c.id);
 
-    if (!options.dryRun) {
+    if (options.dryRun) {
+      deleted += ids.length;
+      skipped += ids.length;
+    } else {
       deleted += await deps.adapter.delete(DELIVERIES_TABLE, {
         and: [{ column: "id", op: "IN", value: ids }],
       });
-    } else {
-      deleted += ids.length;
     }
 
     if (candidates.length < policy.batchSize) {
@@ -269,6 +309,17 @@ export async function pruneWebhookData(
     if (!outcome.exhausted) result.truncated = true;
   }
 
+  // Resolved once per pass rather than per class: an install either has an
+  // endpoint or it does not, and this decides whether an un-fanned-out event is
+  // safe to remove. Skipped entirely when every class is kept forever, so a
+  // policy that prunes nothing costs no queries at all.
+  const anyClassPrunable = EVENT_RETENTION_CLASSES.some(
+    c => windowForClass(policy, c) !== false
+  );
+  const requireFanOut = anyClassPrunable
+    ? await deliveryIsPossible(deps.adapter)
+    : false;
+
   for (const eventClass of EVENT_RETENTION_CLASSES) {
     const cutoff = cutoffFor(now, windowForClass(policy, eventClass));
     if (!cutoff) continue;
@@ -278,7 +329,8 @@ export async function pruneWebhookData(
       eventClass,
       cutoff,
       budget,
-      options
+      options,
+      requireFanOut
     );
     result.events[eventClass] = outcome.deleted;
     if (!outcome.exhausted) result.truncated = true;
@@ -317,12 +369,7 @@ export async function pruneWebhookDataSafely(
     deps.logger?.warn?.(
       "webhook retention pass failed; rows stay until the next pass",
       {
-        error:
-          error instanceof Error
-            ? error.message
-            : NextlyError.is(error)
-              ? error.message
-              : String(error),
+        error: error instanceof Error ? error.message : String(error),
       }
     );
     return emptyResult();

--- a/packages/nextly/src/domains/webhooks/retention-config.ts
+++ b/packages/nextly/src/domains/webhooks/retention-config.ts
@@ -1,0 +1,184 @@
+/**
+ * Webhook domain — retention policy resolution.
+ *
+ * Recording is unconditional: every content write appends a row to
+ * `nextly_events`, including in the majority of installs that never configure a
+ * webhook. Without a retention policy that table grows forever, so this is a
+ * release gate for the webhook series rather than a tuning knob.
+ *
+ * Resolution is pure and total — it never throws, and it clamps rather than
+ * rejects, so a malformed value degrades to something safe instead of failing a
+ * boot. Mirrors `domains/versions/resolve-config.ts`.
+ *
+ * @module domains/webhooks/retention-config
+ */
+
+/**
+ * Which retention window governs an event row.
+ *
+ * A single event can drive a webhook AND be audit-relevant, so the class
+ * records the LONGEST retention the row needs rather than what produced it.
+ * Everything written today is `webhook`; the audit-log feature will mark the
+ * rows it depends on as `audit` so outbox hygiene cannot evict its history.
+ */
+export type EventRetentionClass = "webhook" | "audit";
+
+export const EVENT_RETENTION_CLASSES: readonly EventRetentionClass[] = [
+  "webhook",
+  "audit",
+];
+
+/** The class every event is written with until the audit log exists. */
+export const DEFAULT_EVENT_RETENTION_CLASS: EventRetentionClass = "webhook";
+
+/** User-facing retention options. `false` anywhere means "keep forever". */
+export interface WebhookRetentionConfig {
+  /** Age after which a webhook-class event is prunable. `false` = keep forever. */
+  eventsMaxAgeMs?: number | false;
+  /**
+   * Age after which an audit-class event is prunable. `false` = keep forever.
+   * Separate from `eventsMaxAgeMs` because audit history is measured in months
+   * while outbox hygiene is measured in days.
+   */
+  auditEventsMaxAgeMs?: number | false;
+  /**
+   * Age after which a TERMINAL delivery row is prunable. `false` = keep forever.
+   * Clamped to at most the event windows: deliveries cascade from their event,
+   * so a delivery can never outlive it and a larger value would be a lie.
+   */
+  deliveriesMaxAgeMs?: number | false;
+  /** Rows deleted per statement. */
+  batchSize?: number;
+  /** Batches per pass, so one pass stays bounded on a serverless request. */
+  maxBatchesPerRun?: number;
+  /** Minimum spacing between passes. */
+  intervalMs?: number;
+}
+
+/** Retention fully resolved; every field is present and safe to use. */
+export interface ResolvedWebhookRetentionConfig {
+  eventsMaxAgeMs: number | false;
+  auditEventsMaxAgeMs: number | false;
+  deliveriesMaxAgeMs: number | false;
+  batchSize: number;
+  maxBatchesPerRun: number;
+  intervalMs: number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * 30 days. The correctness floor is far lower — the retry envelope tops out
+ * around half an hour — so this is chosen for debugging and replay, matching
+ * Stripe's replay window.
+ */
+export const DEFAULT_EVENTS_MAX_AGE_MS = 30 * DAY_MS;
+
+/** 365 days. Audit history is kept in years; SOC 2 practice is a one-year floor. */
+export const DEFAULT_AUDIT_EVENTS_MAX_AGE_MS = 365 * DAY_MS;
+
+/**
+ * 7 days. Deliveries are the faster-growing table (events x matching endpoints)
+ * and carry the per-attempt log, so they are pruned sooner than their events.
+ */
+export const DEFAULT_DELIVERIES_MAX_AGE_MS = 7 * DAY_MS;
+
+/**
+ * 500 ids per statement. Matches the version-retention chunk size and stays
+ * under SQLite's `SQLITE_MAX_VARIABLE_NUMBER` of 999 on older builds — event ids
+ * are text, so the id list IS the bind-parameter count.
+ */
+export const DEFAULT_BATCH_SIZE = 500;
+
+/** 20 batches, so a single pass deletes at most 10k rows and then stops. */
+export const DEFAULT_MAX_BATCHES_PER_RUN = 20;
+
+/** One hour between passes. */
+export const DEFAULT_INTERVAL_MS = 60 * 60 * 1000;
+
+/** A positive, finite integer, or the fallback. Never throws. */
+function positiveInt(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : fallback;
+}
+
+/** A non-negative duration, `false` for "keep forever", or the fallback. */
+function maxAge(value: unknown, fallback: number | false): number | false {
+  if (value === false) return false;
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return Math.floor(value);
+  }
+  return fallback;
+}
+
+/** The longest window any event class may be kept for. */
+function longestEventWindow(
+  events: number | false,
+  audit: number | false
+): number | false {
+  if (events === false || audit === false) return false;
+  return Math.max(events, audit);
+}
+
+/**
+ * Resolve user retention options into a complete, safe policy.
+ *
+ * `false` disables retention wholesale, mirroring `versions: false`. Passing
+ * nothing enables it at defaults: the row is written on every content write
+ * whether or not the user asked for webhooks, so leaving that unbounded by
+ * default would tax installs that never opted in.
+ */
+export function resolveWebhookRetentionConfig(
+  config: WebhookRetentionConfig | boolean | undefined | null
+): ResolvedWebhookRetentionConfig | null {
+  if (config === false) return null;
+  const input: WebhookRetentionConfig =
+    config === true || config == null ? {} : config;
+
+  const eventsMaxAgeMs = maxAge(
+    input.eventsMaxAgeMs,
+    DEFAULT_EVENTS_MAX_AGE_MS
+  );
+  const auditEventsMaxAgeMs = maxAge(
+    input.auditEventsMaxAgeMs,
+    DEFAULT_AUDIT_EVENTS_MAX_AGE_MS
+  );
+
+  // A delivery row is removed by cascade when its event goes, so a window
+  // longer than the event's cannot be honoured. Clamp instead of erroring: the
+  // configured intent (prune deliveries no later than this) still holds.
+  const requested = maxAge(
+    input.deliveriesMaxAgeMs,
+    DEFAULT_DELIVERIES_MAX_AGE_MS
+  );
+  const ceiling = longestEventWindow(eventsMaxAgeMs, auditEventsMaxAgeMs);
+  const deliveriesMaxAgeMs =
+    ceiling === false
+      ? requested
+      : requested === false
+        ? ceiling
+        : Math.min(requested, ceiling);
+
+  return {
+    eventsMaxAgeMs,
+    auditEventsMaxAgeMs,
+    deliveriesMaxAgeMs,
+    batchSize: positiveInt(input.batchSize, DEFAULT_BATCH_SIZE),
+    maxBatchesPerRun: positiveInt(
+      input.maxBatchesPerRun,
+      DEFAULT_MAX_BATCHES_PER_RUN
+    ),
+    intervalMs: positiveInt(input.intervalMs, DEFAULT_INTERVAL_MS),
+  };
+}
+
+/** The window governing a class, or `false` when that class is kept forever. */
+export function windowForClass(
+  policy: ResolvedWebhookRetentionConfig,
+  eventClass: EventRetentionClass
+): number | false {
+  return eventClass === "audit"
+    ? policy.auditEventsMaxAgeMs
+    : policy.eventsMaxAgeMs;
+}

--- a/packages/nextly/src/domains/webhooks/retention-config.ts
+++ b/packages/nextly/src/domains/webhooks/retention-config.ts
@@ -47,7 +47,10 @@ export interface WebhookRetentionConfig {
    * so a delivery can never outlive it and a larger value would be a lie.
    */
   deliveriesMaxAgeMs?: number | false;
-  /** Rows deleted per statement. */
+  /**
+   * Rows deleted per statement. Clamped to {@link MAX_BATCH_SIZE}, above which a
+   * pass would exceed SQLite's bind-parameter limit and fail every time.
+   */
   batchSize?: number;
   /** Batches per pass, so one pass stays bounded on a serverless request. */
   maxBatchesPerRun?: number;
@@ -90,17 +93,32 @@ export const DEFAULT_DELIVERIES_MAX_AGE_MS = 7 * DAY_MS;
  */
 export const DEFAULT_BATCH_SIZE = 500;
 
+/**
+ * The largest batch that stays portable.
+ *
+ * A batch becomes an `IN` list of ids, and ids are text, so the batch size IS
+ * the bind-parameter count. SQLite builds before 3.32 cap a statement at 999
+ * parameters, and the live-delivery lookup adds a few more on top. Above this a
+ * pass would fail on every run, and because the runner swallows the failure
+ * after the gate has recorded the attempt, retention would simply stop making
+ * progress with no visible error. Clamped rather than rejected so a large value
+ * still prunes, just in portable-sized pieces.
+ */
+export const MAX_BATCH_SIZE = 900;
+
 /** 20 batches, so a single pass deletes at most 10k rows and then stops. */
 export const DEFAULT_MAX_BATCHES_PER_RUN = 20;
 
 /** One hour between passes. */
 export const DEFAULT_INTERVAL_MS = 60 * 60 * 1000;
 
-/** A positive, finite integer, or the fallback. Never throws. */
-function positiveInt(value: unknown, fallback: number): number {
-  return typeof value === "number" && Number.isFinite(value) && value > 0
-    ? Math.floor(value)
-    : fallback;
+/** A positive, finite integer, optionally capped, or the fallback. Never throws. */
+function positiveInt(value: unknown, fallback: number, max?: number): number {
+  const resolved =
+    typeof value === "number" && Number.isFinite(value) && value > 0
+      ? Math.floor(value)
+      : fallback;
+  return max === undefined ? resolved : Math.min(resolved, max);
 }
 
 /** A non-negative duration, `false` for "keep forever", or the fallback. */
@@ -164,7 +182,7 @@ export function resolveWebhookRetentionConfig(
     eventsMaxAgeMs,
     auditEventsMaxAgeMs,
     deliveriesMaxAgeMs,
-    batchSize: positiveInt(input.batchSize, DEFAULT_BATCH_SIZE),
+    batchSize: positiveInt(input.batchSize, DEFAULT_BATCH_SIZE, MAX_BATCH_SIZE),
     maxBatchesPerRun: positiveInt(
       input.maxBatchesPerRun,
       DEFAULT_MAX_BATCHES_PER_RUN

--- a/packages/nextly/src/domains/webhooks/retention-config.ts
+++ b/packages/nextly/src/domains/webhooks/retention-config.ts
@@ -170,13 +170,16 @@ export function resolveWebhookRetentionConfig(
     input.deliveriesMaxAgeMs,
     DEFAULT_DELIVERIES_MAX_AGE_MS
   );
+  // `false` is an explicit "keep forever" and is honoured as given. The cascade
+  // still bounds it in practice — a delivery cannot outlive its event — but the
+  // prune treats a null cutoff as "any delivery pins its event", so nothing is
+  // deleted ahead of its window. Rewriting it to the event window here would
+  // silently prune attempt logs the user asked to keep.
   const ceiling = longestEventWindow(eventsMaxAgeMs, auditEventsMaxAgeMs);
   const deliveriesMaxAgeMs =
-    ceiling === false
+    requested === false || ceiling === false
       ? requested
-      : requested === false
-        ? ceiling
-        : Math.min(requested, ceiling);
+      : Math.min(requested, ceiling);
 
   return {
     eventsMaxAgeMs,

--- a/packages/nextly/src/domains/webhooks/retention-gate.ts
+++ b/packages/nextly/src/domains/webhooks/retention-gate.ts
@@ -11,45 +11,101 @@
  * offer to run one; the gate lets at most one through per interval per install,
  * whatever the process or request count.
  *
- * The gate is deliberately a read-then-write rather than a compare-and-swap.
- * Two callers racing can both pass it, and the cost of that is two bounded,
- * idempotent prune passes deleting overlapping id sets — the second simply
- * removes fewer rows. Buying strictness would mean relying on an update's
- * affected-row count, which MySQL cannot report without RETURNING, so the
- * portable version of that guarantee does not exist.
+ * Claiming is atomic where the database allows it. A read-then-write gate would
+ * let every instance of a multi-instance deployment win the same interval, so
+ * each would run its own pass and the coordination the stored marker exists for
+ * would buy nothing. `UPDATE ... WHERE` with an affected-row count would be the
+ * natural primitive, but the adapter cannot report one portably — `update`
+ * returns an empty array on dialects without RETURNING. `delete` does return a
+ * reliable count on all three, so the claim is expressed as a conditional
+ * delete of the marker followed by re-inserting it.
+ *
+ * That leaves a window of two statements rather than one, which is not perfect
+ * mutual exclusion. It is a large improvement over a whole interval, and the
+ * cost of a loss is only a second bounded, idempotent pass — the overlapping
+ * deletes simply remove fewer rows.
  *
  * @module domains/webhooks/retention-gate
  */
 
+import type { WhereClause } from "@nextlyhq/adapter-drizzle/types";
+
 /** Where the last-pass timestamp lives, in the `nextly_meta` KV table. */
 export const RETENTION_GATE_KEY = "webhooks.retention.lastPassAt";
 
-/** The slice of `MetaService` this needs, so tests can supply a double. */
+/**
+ * The atomic claim primitive. Implemented against `nextly_meta` in
+ * {@link MetaRetentionGate}; tests supply their own.
+ */
 export interface RetentionGateStore {
-  get<T = unknown>(key: string): Promise<T | null>;
-  set(key: string, value: unknown): Promise<void>;
+  /**
+   * Take the marker if it is absent or older than `dueBefore`, stamping it with
+   * `now`. Returns true only for the caller that took it.
+   */
+  claim(key: string, dueBefore: Date, now: Date): Promise<boolean>;
 }
 
-/** Milliseconds since the epoch, or null when nothing readable is stored. */
-function storedAt(value: unknown): number | null {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string") {
-    const parsed = Date.parse(value);
-    return Number.isNaN(parsed) ? null : parsed;
+/** The subset of the adapter the gate needs. */
+export interface RetentionGateAdapter {
+  delete(table: string, where: WhereClause): Promise<number>;
+  insert(table: string, data: Record<string, unknown>): Promise<unknown>;
+}
+
+const META_TABLE = "nextly_meta";
+
+/**
+ * The gate backed by the `nextly_meta` key/value table, whose `key` is the
+ * primary key — which is what makes the bootstrap insert a claim rather than a
+ * race.
+ */
+export class MetaRetentionGate implements RetentionGateStore {
+  constructor(private readonly adapter: RetentionGateAdapter) {}
+
+  async claim(key: string, dueBefore: Date, now: Date): Promise<boolean> {
+    // Removing the stale marker IS the claim: only one caller can delete a
+    // given row, and the count says whether it was this one.
+    const removed = await this.adapter.delete(META_TABLE, {
+      and: [
+        { column: "key", op: "=", value: key },
+        { column: "updatedAt", op: "<", value: dueBefore },
+      ],
+    });
+
+    if (removed > 0) {
+      await this.adapter.insert(META_TABLE, {
+        key,
+        value: JSON.stringify(now.toISOString()),
+        updated_at: now,
+      });
+      return true;
+    }
+
+    // Nothing stale to remove: either the marker is current, or none exists
+    // yet. Inserting distinguishes the two — the primary key rejects the first
+    // case, so only a genuinely first run gets through.
+    try {
+      await this.adapter.insert(META_TABLE, {
+        key,
+        value: JSON.stringify(now.toISOString()),
+        updated_at: now,
+      });
+      return true;
+    } catch {
+      return false;
+    }
   }
-  return null;
 }
 
 /**
  * Try to claim the next retention pass.
  *
  * Returns true when the caller should run one, having already recorded the
- * attempt — the marker is written BEFORE the pass, not after, so a pass that
- * throws still holds off the next one for a full interval instead of letting
- * every subsequent write retry a failing prune.
+ * attempt — the marker is written as part of the claim, not after the pass, so
+ * a pass that throws still holds off the next one for a full interval instead
+ * of letting every subsequent write retry a failing prune.
  *
- * A store failure returns false: if the gate cannot be read or written, the safe
- * answer is not to prune, since an ungated pass could run on every write.
+ * A store failure returns false: if the gate cannot be claimed, the safe answer
+ * is not to prune, since an ungated pass could run on every write.
  */
 export async function claimRetentionPass(
   store: RetentionGateStore,
@@ -57,10 +113,11 @@ export async function claimRetentionPass(
   now: Date = new Date()
 ): Promise<boolean> {
   try {
-    const last = storedAt(await store.get(RETENTION_GATE_KEY));
-    if (last !== null && now.getTime() - last < intervalMs) return false;
-    await store.set(RETENTION_GATE_KEY, now.toISOString());
-    return true;
+    return await store.claim(
+      RETENTION_GATE_KEY,
+      new Date(now.getTime() - intervalMs),
+      now
+    );
   } catch {
     return false;
   }

--- a/packages/nextly/src/domains/webhooks/retention-gate.ts
+++ b/packages/nextly/src/domains/webhooks/retention-gate.ts
@@ -1,0 +1,67 @@
+/**
+ * Webhook domain — retention pass scheduling.
+ *
+ * Retention has no scheduler to hang off. Nextly is a library inside someone
+ * else's Next.js app: there is no daemon, and an in-process timer would run on a
+ * self-hosted server and silently never fire on serverless, where the instance
+ * is frozen between requests. That failure mode is environment-dependent and
+ * invisible, which is worse than not having a timer at all.
+ *
+ * So passes are gated on a stored timestamp instead of scheduled. Any caller may
+ * offer to run one; the gate lets at most one through per interval per install,
+ * whatever the process or request count.
+ *
+ * The gate is deliberately a read-then-write rather than a compare-and-swap.
+ * Two callers racing can both pass it, and the cost of that is two bounded,
+ * idempotent prune passes deleting overlapping id sets — the second simply
+ * removes fewer rows. Buying strictness would mean relying on an update's
+ * affected-row count, which MySQL cannot report without RETURNING, so the
+ * portable version of that guarantee does not exist.
+ *
+ * @module domains/webhooks/retention-gate
+ */
+
+/** Where the last-pass timestamp lives, in the `nextly_meta` KV table. */
+export const RETENTION_GATE_KEY = "webhooks.retention.lastPassAt";
+
+/** The slice of `MetaService` this needs, so tests can supply a double. */
+export interface RetentionGateStore {
+  get<T = unknown>(key: string): Promise<T | null>;
+  set(key: string, value: unknown): Promise<void>;
+}
+
+/** Milliseconds since the epoch, or null when nothing readable is stored. */
+function storedAt(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  return null;
+}
+
+/**
+ * Try to claim the next retention pass.
+ *
+ * Returns true when the caller should run one, having already recorded the
+ * attempt — the marker is written BEFORE the pass, not after, so a pass that
+ * throws still holds off the next one for a full interval instead of letting
+ * every subsequent write retry a failing prune.
+ *
+ * A store failure returns false: if the gate cannot be read or written, the safe
+ * answer is not to prune, since an ungated pass could run on every write.
+ */
+export async function claimRetentionPass(
+  store: RetentionGateStore,
+  intervalMs: number,
+  now: Date = new Date()
+): Promise<boolean> {
+  try {
+    const last = storedAt(await store.get(RETENTION_GATE_KEY));
+    if (last !== null && now.getTime() - last < intervalMs) return false;
+    await store.set(RETENTION_GATE_KEY, now.toISOString());
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/nextly/src/domains/webhooks/retention-runner.ts
+++ b/packages/nextly/src/domains/webhooks/retention-runner.ts
@@ -1,0 +1,74 @@
+/**
+ * Webhook domain — opportunistic retention passes.
+ *
+ * The drain is the natural home for retention, but it only runs where webhooks
+ * are actually configured. The event ledger fills on every content write
+ * regardless, so installs with no webhooks — the majority — would never prune at
+ * all if the drain were the only trigger. This is the seam that covers them:
+ * content writes offer to run a pass, and the gate decides.
+ *
+ * Two layers of gating, for different reasons. The in-process guard makes the
+ * common case free: once a pass is claimed, this process stops consulting the
+ * database for a full interval, so a busy site pays nothing per write. The
+ * stored gate behind it is what coordinates across processes and survives a
+ * restart, which an in-memory value alone cannot.
+ *
+ * @module domains/webhooks/retention-runner
+ */
+
+import type { Logger } from "../../shared/types";
+
+import { pruneWebhookDataSafely, type PruneDeps } from "./prune";
+import type { ResolvedWebhookRetentionConfig } from "./retention-config";
+import { claimRetentionPass, type RetentionGateStore } from "./retention-gate";
+
+export interface RetentionRunnerDeps {
+  policy: ResolvedWebhookRetentionConfig;
+  prune: PruneDeps;
+  gate: RetentionGateStore;
+  /** Injectable so tests can move time without sleeping. */
+  now?: () => Date;
+  logger?: Logger;
+}
+
+/**
+ * Runs retention passes on demand, at most one per interval.
+ *
+ * `maybeRun` never throws and never rejects: callers hang it off a successful
+ * content write, and housekeeping must not be able to turn that into an error.
+ */
+export class WebhookRetentionRunner {
+  /** Epoch ms before which this process will not consult the stored gate. */
+  private nextEligibleAt = 0;
+
+  constructor(private readonly deps: RetentionRunnerDeps) {}
+
+  async maybeRun(): Promise<void> {
+    try {
+      const now = (this.deps.now ?? (() => new Date()))().getTime();
+      if (now < this.nextEligibleAt) return;
+
+      // Held off BEFORE the stored gate is consulted, so a burst of concurrent
+      // writes in one process produces one database read rather than one per
+      // write. A pass that then loses the stored gate still waits its turn,
+      // which is the intended outcome.
+      this.nextEligibleAt = now + this.deps.policy.intervalMs;
+
+      const claimed = await claimRetentionPass(
+        this.deps.gate,
+        this.deps.policy.intervalMs,
+        new Date(now)
+      );
+      if (!claimed) return;
+
+      await pruneWebhookDataSafely(this.deps.prune, this.deps.policy);
+    } catch (error) {
+      // pruneWebhookDataSafely and claimRetentionPass both absorb their own
+      // failures, so reaching here means something unforeseen. Swallow it for
+      // the same reason they do.
+      this.deps.logger?.warn?.("webhook retention pass could not start", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}

--- a/packages/nextly/src/domains/webhooks/retention-runner.ts
+++ b/packages/nextly/src/domains/webhooks/retention-runner.ts
@@ -43,7 +43,12 @@ export class WebhookRetentionRunner {
 
   constructor(private readonly deps: RetentionRunnerDeps) {}
 
-  async maybeRun(): Promise<void> {
+  /**
+   * @param maxBatches Caps this pass, overriding the policy. The write path
+   *   passes a small number so a save that happens to win the gate is not held
+   *   up by a full backlog sweep; the drain leaves it unset and takes the lot.
+   */
+  async maybeRun(maxBatches?: number): Promise<void> {
     try {
       const now = (this.deps.now ?? (() => new Date()))().getTime();
       if (now < this.nextEligibleAt) return;
@@ -61,7 +66,11 @@ export class WebhookRetentionRunner {
       );
       if (!claimed) return;
 
-      await pruneWebhookDataSafely(this.deps.prune, this.deps.policy);
+      const policy =
+        maxBatches === undefined
+          ? this.deps.policy
+          : { ...this.deps.policy, maxBatchesPerRun: maxBatches };
+      await pruneWebhookDataSafely(this.deps.prune, policy);
     } catch (error) {
       // pruneWebhookDataSafely and claimRetentionPass both absorb their own
       // failures, so reaching here means something unforeseen. Swallow it for

--- a/packages/nextly/src/domains/webhooks/run-drain.ts
+++ b/packages/nextly/src/domains/webhooks/run-drain.ts
@@ -12,6 +12,9 @@
 
 import { deliverDueDeliveries, type DeliverDeps } from "./deliver";
 import { fanOutDueEvents, type FanOutDeps } from "./fan-out";
+import { pruneWebhookDataSafely, type PruneDeps } from "./prune";
+import type { ResolvedWebhookRetentionConfig } from "./retention-config";
+import { claimRetentionPass, type RetentionGateStore } from "./retention-gate";
 
 /** Hard cap on rounds so a persistently-retrying backlog can't loop unbounded. */
 const DEFAULT_MAX_ROUNDS = 100;
@@ -21,6 +24,16 @@ export interface RunDrainDeps {
   deliver: DeliverDeps;
   /** Max fan-out/deliver rounds before returning. Defaults to 100. */
   maxRounds?: number;
+  /**
+   * Retention, when configured. The pass runs after delivery so it only ever
+   * sees rows this drain has finished with, and it is gated so a frequently
+   * invoked drain does not prune on every call.
+   */
+  retention?: {
+    policy: ResolvedWebhookRetentionConfig;
+    prune: PruneDeps;
+    gate: RetentionGateStore;
+  };
 }
 
 export interface RunDrainResult {
@@ -31,6 +44,8 @@ export interface RunDrainResult {
   delivered: number;
   retried: number;
   failed: number;
+  /** Rows retention removed on this call; zero when the gate held it off. */
+  pruned: { events: number; deliveries: number };
 }
 
 /**
@@ -50,6 +65,7 @@ export async function runDrain(deps: RunDrainDeps): Promise<RunDrainResult> {
     delivered: 0,
     retried: 0,
     failed: 0,
+    pruned: { events: 0, deliveries: 0 },
   };
 
   for (let round = 0; round < maxRounds; round += 1) {
@@ -67,6 +83,26 @@ export async function runDrain(deps: RunDrainDeps): Promise<RunDrainResult> {
     // Nothing was fanned out and nothing was attempted this round → the queue is
     // drained of everything currently due; stop.
     if (fan.eventsProcessed === 0 && del.attempted === 0) break;
+  }
+
+  // After the queue is quiet, not between rounds: pruning mid-drain would race
+  // the deliveries this very call is still working through. Failure is
+  // swallowed — a drain that delivered successfully must not report failure
+  // because housekeeping could not run.
+  const retention = deps.retention;
+  if (retention) {
+    const due = await claimRetentionPass(
+      retention.gate,
+      retention.policy.intervalMs
+    );
+    if (due) {
+      const pruned = await pruneWebhookDataSafely(
+        retention.prune,
+        retention.policy
+      );
+      result.pruned.events = pruned.events.webhook + pruned.events.audit;
+      result.pruned.deliveries = pruned.deliveries;
+    }
   }
 
   return result;

--- a/packages/nextly/src/init/build-service-config.ts
+++ b/packages/nextly/src/init/build-service-config.ts
@@ -167,6 +167,17 @@ export function buildServiceConfig(
     if (!serviceConfig.localization && nextlyConfig?.localization) {
       serviceConfig.localization = nextlyConfig.localization;
     }
+
+    // Webhook retention — carry the resolved policy through so writes can offer
+    // a retention pass. `undefined` here means "not carried"; the sanitizer
+    // always produces either a policy or an explicit null, so a null must be
+    // preserved rather than treated as absent.
+    if (
+      serviceConfig.webhookRetention === undefined &&
+      nextlyConfig?.webhookRetention !== undefined
+    ) {
+      serviceConfig.webhookRetention = nextlyConfig.webhookRetention;
+    }
   }
 
   // Ensure imageProcessor is always provided

--- a/packages/nextly/src/route-handler/auth-handler.ts
+++ b/packages/nextly/src/route-handler/auth-handler.ts
@@ -88,6 +88,12 @@ async function ensureServicesInitialized(): Promise<void> {
       if (nextlyConfig.localization)
         serviceConfig.localization = nextlyConfig.localization;
       if (nextlyConfig.apiKeys) serviceConfig.apiKeys = nextlyConfig.apiKeys;
+      // Webhook retention: carry the resolved policy so a request-path boot
+      // wires the cleanup runner too. Compared against undefined rather than
+      // truthiness because null is the meaningful "retention off" value and
+      // must not be mistaken for absent.
+      if (nextlyConfig.webhookRetention !== undefined)
+        serviceConfig.webhookRetention = nextlyConfig.webhookRetention;
       if (nextlyConfig.db) {
         const dbConfig = nextlyConfig.db as Record<string, unknown>;
         if (dbConfig.schemasDir) serviceConfig.schemasDir = dbConfig.schemasDir;

--- a/packages/nextly/src/schemas/webhooks/mysql.ts
+++ b/packages/nextly/src/schemas/webhooks/mysql.ts
@@ -125,6 +125,6 @@ export const nextlyWebhookDeliveries = mysqlTable(
     // schema is identical across dialects and the diff pipeline round-trips.
     index("nextly_webhook_deliveries_event_idx").on(t.eventId),
     // Retention scans terminal rows oldest-first; see the PostgreSQL definition.
-    index("nextly_webhook_deliveries_retention_idx").on(t.status, t.createdAt),
+    index("nextly_webhook_deliveries_retention_idx").on(t.status, t.updatedAt),
   ]
 );

--- a/packages/nextly/src/schemas/webhooks/mysql.ts
+++ b/packages/nextly/src/schemas/webhooks/mysql.ts
@@ -41,11 +41,17 @@ export const nextlyEvents = mysqlTable(
     // Set by the drain's fan-out pass once delivery rows exist for this event;
     // NULL means the event still needs fan-out.
     fannedOutAt: datetime("fanned_out_at"),
+    // Which retention window governs this row; see the PostgreSQL definition.
+    retentionClass: varchar("retention_class", { length: 20 })
+      .notNull()
+      .default("webhook"),
   },
   t => [
     index("nextly_events_type_created_at_idx").on(t.type, t.createdAt),
     // The fan-out pass scans for events still needing fan-out, oldest first.
     index("nextly_events_fanned_out_at_idx").on(t.fannedOutAt, t.createdAt),
+    // Retention prunes one class at a time, oldest first.
+    index("nextly_events_retention_idx").on(t.retentionClass, t.createdAt),
   ]
 );
 
@@ -118,5 +124,7 @@ export const nextlyWebhookDeliveries = mysqlTable(
     // MySQL auto-indexes FK columns, but declare event_id explicitly so the
     // schema is identical across dialects and the diff pipeline round-trips.
     index("nextly_webhook_deliveries_event_idx").on(t.eventId),
+    // Retention scans terminal rows oldest-first; see the PostgreSQL definition.
+    index("nextly_webhook_deliveries_retention_idx").on(t.status, t.createdAt),
   ]
 );

--- a/packages/nextly/src/schemas/webhooks/postgres.ts
+++ b/packages/nextly/src/schemas/webhooks/postgres.ts
@@ -167,6 +167,6 @@ export const nextlyWebhookDeliveries = pgTable(
     index("nextly_webhook_deliveries_event_idx").on(t.eventId),
     // Retention scans terminal rows oldest-first; without this the prune would
     // sequentially scan the fastest-growing table in the system.
-    index("nextly_webhook_deliveries_retention_idx").on(t.status, t.createdAt),
+    index("nextly_webhook_deliveries_retention_idx").on(t.status, t.updatedAt),
   ]
 );

--- a/packages/nextly/src/schemas/webhooks/postgres.ts
+++ b/packages/nextly/src/schemas/webhooks/postgres.ts
@@ -59,12 +59,20 @@ export const nextlyEvents = pgTable(
     // NULL means the event still needs fan-out. Lets the drain find un-fanned
     // events cheaply without rescanning the delivery table.
     fannedOutAt: timestamp("fanned_out_at", { withTimezone: false }),
+    // Which retention window governs this row. A single event can serve both
+    // roles at once, so this records the LONGEST retention it needs: rows the
+    // audit log depends on outlive rows that only ever drove a webhook.
+    retentionClass: varchar("retention_class", { length: 20 })
+      .notNull()
+      .default("webhook"),
   },
   t => [
     // Drain/reporting scans by type and recency.
     index("nextly_events_type_created_at_idx").on(t.type, t.createdAt),
     // The fan-out pass scans for events still needing fan-out, oldest first.
     index("nextly_events_fanned_out_at_idx").on(t.fannedOutAt, t.createdAt),
+    // Retention prunes one class at a time, oldest first.
+    index("nextly_events_retention_idx").on(t.retentionClass, t.createdAt),
   ]
 );
 
@@ -157,5 +165,8 @@ export const nextlyWebhookDeliveries = pgTable(
     // Postgres does not auto-index FK columns, so index event_id explicitly for
     // the event -> deliveries cascade delete and event-scoped admin queries.
     index("nextly_webhook_deliveries_event_idx").on(t.eventId),
+    // Retention scans terminal rows oldest-first; without this the prune would
+    // sequentially scan the fastest-growing table in the system.
+    index("nextly_webhook_deliveries_retention_idx").on(t.status, t.createdAt),
   ]
 );

--- a/packages/nextly/src/schemas/webhooks/sqlite.ts
+++ b/packages/nextly/src/schemas/webhooks/sqlite.ts
@@ -39,11 +39,15 @@ export const nextlyEvents = sqliteTable(
     // Set by the drain's fan-out pass once delivery rows exist for this event;
     // NULL means the event still needs fan-out.
     fannedOutAt: integer("fanned_out_at", { mode: "timestamp" }),
+    // Which retention window governs this row; see the PostgreSQL definition.
+    retentionClass: text("retention_class").notNull().default("webhook"),
   },
   t => [
     index("nextly_events_type_created_at_idx").on(t.type, t.createdAt),
     // The fan-out pass scans for events still needing fan-out, oldest first.
     index("nextly_events_fanned_out_at_idx").on(t.fannedOutAt, t.createdAt),
+    // Retention prunes one class at a time, oldest first.
+    index("nextly_events_retention_idx").on(t.retentionClass, t.createdAt),
   ]
 );
 
@@ -118,5 +122,7 @@ export const nextlyWebhookDeliveries = sqliteTable(
     // Index event_id for the event -> deliveries cascade delete and
     // event-scoped admin queries.
     index("nextly_webhook_deliveries_event_idx").on(t.eventId),
+    // Retention scans terminal rows oldest-first; see the PostgreSQL definition.
+    index("nextly_webhook_deliveries_retention_idx").on(t.status, t.createdAt),
   ]
 );

--- a/packages/nextly/src/schemas/webhooks/sqlite.ts
+++ b/packages/nextly/src/schemas/webhooks/sqlite.ts
@@ -123,6 +123,6 @@ export const nextlyWebhookDeliveries = sqliteTable(
     // event-scoped admin queries.
     index("nextly_webhook_deliveries_event_idx").on(t.eventId),
     // Retention scans terminal rows oldest-first; see the PostgreSQL definition.
-    index("nextly_webhook_deliveries_retention_idx").on(t.status, t.createdAt),
+    index("nextly_webhook_deliveries_retention_idx").on(t.status, t.updatedAt),
   ]
 );

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -60,9 +60,6 @@ export class CollectionsHandler {
   private readonly fileManager: CollectionFileManager;
   private readonly logger: Logger;
 
-  /** Present only when retention is configured; see the constructor. */
-  private readonly retentionRunner?: WebhookRetentionRunner;
-
   constructor(
     adapter: DrizzleAdapter,
     db: DatabaseInstance,
@@ -80,15 +77,16 @@ export class CollectionsHandler {
     this.logger = logger;
     this.collectionService = new DynamicCollectionService(adapter, logger);
 
-    if (webhookRetention) {
-      const meta = new MetaService(adapter, logger);
-      this.retentionRunner = new WebhookRetentionRunner({
-        policy: webhookRetention,
-        prune: { adapter, logger },
-        gate: meta,
-        logger,
-      });
-    }
+    // Built here because this is where the resolved policy arrives, but handed
+    // to the entry service, which is the seam every write path runs through.
+    const retentionRunner = webhookRetention
+      ? new WebhookRetentionRunner({
+          policy: webhookRetention,
+          prune: { adapter, logger },
+          gate: new MetaService(adapter, logger),
+          logger,
+        })
+      : undefined;
 
     const hookRegistry = getHookRegistry();
 
@@ -172,7 +170,8 @@ export class CollectionsHandler {
       accessControlService,
       componentDataService,
       undefined,
-      this.localization
+      this.localization,
+      retentionRunner
     );
   }
 
@@ -465,7 +464,7 @@ export class CollectionsHandler {
     },
     body: Record<string, unknown>
   ) {
-    const result = await this.entryService.createEntry(
+    return this.entryService.createEntry(
       {
         ...this.resolveUserParam(params),
         locale: params.locale,
@@ -474,22 +473,6 @@ export class CollectionsHandler {
       body,
       params.depth
     );
-    this.offerRetentionPass();
-    return result;
-  }
-
-  /**
-   * Offer a retention pass after a successful write.
-   *
-   * Deliberately not awaited: a pass can delete thousands of rows, and no
-   * user's save should wait on housekeeping. `maybeRun` absorbs its own
-   * failures, so nothing can reject here. On a serverless runtime the process
-   * may be frozen before a pass finishes — that is acceptable, because the
-   * deletes are batched and already committed, and the gate has recorded the
-   * attempt either way.
-   */
-  private offerRetentionPass(): void {
-    void this.retentionRunner?.maybeRun();
   }
 
   /**
@@ -604,7 +587,7 @@ export class CollectionsHandler {
     },
     body: Record<string, unknown>
   ) {
-    const result = await this.entryService.updateEntry(
+    return this.entryService.updateEntry(
       {
         ...this.resolveUserParam(params),
         locale: params.locale,
@@ -613,8 +596,6 @@ export class CollectionsHandler {
       body,
       params.depth
     );
-    this.offerRetentionPass();
-    return result;
   }
 
   /**
@@ -733,11 +714,7 @@ export class CollectionsHandler {
     /** Acting identity from the transport, forwarded to the recorded event. */
     actor?: RequestActor;
   }) {
-    const result = await this.entryService.bulkUpdateEntries(
-      this.resolveUserParam(params)
-    );
-    this.offerRetentionPass();
-    return result;
+    return this.entryService.bulkUpdateEntries(this.resolveUserParam(params));
   }
 
   /**
@@ -773,12 +750,10 @@ export class CollectionsHandler {
     // Resolve userId -> user and mark route-authorized, mirroring
     // bulkUpdateEntries so the query-based bulk update honors access control
     // and redaction instead of running as an anonymous caller.
-    const result = await this.entryService.bulkUpdateByQuery(
+    return this.entryService.bulkUpdateByQuery(
       this.resolveUserParam(params),
       options
     );
-    this.offerRetentionPass();
-    return result;
   }
 
   /**
@@ -844,11 +819,7 @@ export class CollectionsHandler {
     /** Acting identity from the transport, forwarded to the recorded event. */
     actor?: RequestActor;
   }) {
-    const result = await this.entryService.duplicateEntry(
-      this.resolveUserParam(params)
-    );
-    this.offerRetentionPass();
-    return result;
+    return this.entryService.duplicateEntry(this.resolveUserParam(params));
   }
 
   /**

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -9,8 +9,8 @@ import { container } from "../di/container";
 import type { PermissionSeedService } from "../domains/auth/services/permission-seed-service";
 import { DynamicCollectionService } from "../domains/dynamic-collections";
 import type { SanitizedLocalizationConfig } from "../domains/i18n/config/types";
-import { MetaService } from "../domains/meta/services/meta-service";
 import type { ResolvedWebhookRetentionConfig } from "../domains/webhooks/retention-config";
+import { MetaRetentionGate } from "../domains/webhooks/retention-gate";
 import { WebhookRetentionRunner } from "../domains/webhooks/retention-runner";
 import type { RichTextOutputFormat } from "../lib/rich-text-html";
 import type { FieldDefinition } from "../schemas/dynamic-collections";
@@ -83,7 +83,7 @@ export class CollectionsHandler {
       ? new WebhookRetentionRunner({
           policy: webhookRetention,
           prune: { adapter, logger },
-          gate: new MetaService(adapter, logger),
+          gate: new MetaRetentionGate(adapter),
           logger,
         })
       : undefined;

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -9,6 +9,9 @@ import { container } from "../di/container";
 import type { PermissionSeedService } from "../domains/auth/services/permission-seed-service";
 import { DynamicCollectionService } from "../domains/dynamic-collections";
 import type { SanitizedLocalizationConfig } from "../domains/i18n/config/types";
+import { MetaService } from "../domains/meta/services/meta-service";
+import type { ResolvedWebhookRetentionConfig } from "../domains/webhooks/retention-config";
+import { WebhookRetentionRunner } from "../domains/webhooks/retention-runner";
 import type { RichTextOutputFormat } from "../lib/rich-text-html";
 import type { FieldDefinition } from "../schemas/dynamic-collections";
 import type { DatabaseInstance } from "../types/database-operations";
@@ -57,16 +60,35 @@ export class CollectionsHandler {
   private readonly fileManager: CollectionFileManager;
   private readonly logger: Logger;
 
+  /** Present only when retention is configured; see the constructor. */
+  private readonly retentionRunner?: WebhookRetentionRunner;
+
   constructor(
     adapter: DrizzleAdapter,
     db: DatabaseInstance,
     logger: Logger = consoleLogger,
     consumerAppRoot?: string,
     /** Normalized localization config (i18n M4) — enables companion-aware reads. */
-    private readonly localization?: SanitizedLocalizationConfig
+    private readonly localization?: SanitizedLocalizationConfig,
+    /**
+     * Resolved webhook retention policy. Content writes offer to run a pass so
+     * the event ledger stays bounded in installs that never configure a webhook
+     * and therefore never run the drain. Null or absent disables it.
+     */
+    webhookRetention?: ResolvedWebhookRetentionConfig | null
   ) {
     this.logger = logger;
     this.collectionService = new DynamicCollectionService(adapter, logger);
+
+    if (webhookRetention) {
+      const meta = new MetaService(adapter, logger);
+      this.retentionRunner = new WebhookRetentionRunner({
+        policy: webhookRetention,
+        prune: { adapter, logger },
+        gate: meta,
+        logger,
+      });
+    }
 
     const hookRegistry = getHookRegistry();
 
@@ -443,7 +465,7 @@ export class CollectionsHandler {
     },
     body: Record<string, unknown>
   ) {
-    return this.entryService.createEntry(
+    const result = await this.entryService.createEntry(
       {
         ...this.resolveUserParam(params),
         locale: params.locale,
@@ -452,6 +474,22 @@ export class CollectionsHandler {
       body,
       params.depth
     );
+    this.offerRetentionPass();
+    return result;
+  }
+
+  /**
+   * Offer a retention pass after a successful write.
+   *
+   * Deliberately not awaited: a pass can delete thousands of rows, and no
+   * user's save should wait on housekeeping. `maybeRun` absorbs its own
+   * failures, so nothing can reject here. On a serverless runtime the process
+   * may be frozen before a pass finishes — that is acceptable, because the
+   * deletes are batched and already committed, and the gate has recorded the
+   * attempt either way.
+   */
+  private offerRetentionPass(): void {
+    void this.retentionRunner?.maybeRun();
   }
 
   /**
@@ -566,7 +604,7 @@ export class CollectionsHandler {
     },
     body: Record<string, unknown>
   ) {
-    return this.entryService.updateEntry(
+    const result = await this.entryService.updateEntry(
       {
         ...this.resolveUserParam(params),
         locale: params.locale,
@@ -575,6 +613,8 @@ export class CollectionsHandler {
       body,
       params.depth
     );
+    this.offerRetentionPass();
+    return result;
   }
 
   /**

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -733,7 +733,11 @@ export class CollectionsHandler {
     /** Acting identity from the transport, forwarded to the recorded event. */
     actor?: RequestActor;
   }) {
-    return this.entryService.bulkUpdateEntries(this.resolveUserParam(params));
+    const result = await this.entryService.bulkUpdateEntries(
+      this.resolveUserParam(params)
+    );
+    this.offerRetentionPass();
+    return result;
   }
 
   /**
@@ -769,10 +773,12 @@ export class CollectionsHandler {
     // Resolve userId -> user and mark route-authorized, mirroring
     // bulkUpdateEntries so the query-based bulk update honors access control
     // and redaction instead of running as an anonymous caller.
-    return this.entryService.bulkUpdateByQuery(
+    const result = await this.entryService.bulkUpdateByQuery(
       this.resolveUserParam(params),
       options
     );
+    this.offerRetentionPass();
+    return result;
   }
 
   /**
@@ -838,7 +844,11 @@ export class CollectionsHandler {
     /** Acting identity from the transport, forwarded to the recorded event. */
     actor?: RequestActor;
   }) {
-    return this.entryService.duplicateEntry(this.resolveUserParam(params));
+    const result = await this.entryService.duplicateEntry(
+      this.resolveUserParam(params)
+    );
+    this.offerRetentionPass();
+    return result;
   }
 
   /**

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -39,6 +39,7 @@ import type {
 } from "../../domains/collections/services/collection-types";
 import type { DynamicCollectionService } from "../../domains/dynamic-collections";
 import type { SanitizedLocalizationConfig } from "../../domains/i18n/config/types";
+import type { WebhookRetentionRunner } from "../../domains/webhooks/retention-runner";
 import type { PaginatedResponse } from "../../types/pagination";
 import type { AccessControlService } from "../access";
 import { BaseService } from "../base-service";
@@ -85,7 +86,14 @@ export class CollectionEntryService extends BaseService {
     componentDataService?: ComponentDataService,
     rbacAccessControlService?: RBACAccessControlService,
     /** Normalized localization config (i18n M4) — forwarded to the query service. */
-    localization?: SanitizedLocalizationConfig
+    localization?: SanitizedLocalizationConfig,
+    /**
+     * Offers a webhook-retention pass after a write. Wired here rather than at
+     * a caller because every write path that appends an event runs through this
+     * service — the dispatcher-facing handler, `CollectionService`, and direct
+     * callers alike — so this is the one place that covers them all.
+     */
+    private readonly retentionRunner?: WebhookRetentionRunner
   ) {
     super(adapter, logger);
 
@@ -189,6 +197,17 @@ export class CollectionEntryService extends BaseService {
     return this.queryService.getEntry(params);
   }
 
+  /**
+   * Offer a retention pass after a successful write.
+   *
+   * Deliberately not awaited: a pass can delete thousands of rows and no user's
+   * save should wait on housekeeping. `maybeRun` absorbs its own failures, so
+   * nothing can reject here.
+   */
+  private offerRetentionPass(): void {
+    void this.retentionRunner?.maybeRun();
+  }
+
   async createEntry(
     params: {
       collectionName: string;
@@ -203,7 +222,9 @@ export class CollectionEntryService extends BaseService {
     body: Record<string, unknown>,
     depth?: number
   ) {
-    return this.mutationService.createEntry(params, body, depth);
+    const result = await this.mutationService.createEntry(params, body, depth);
+    this.offerRetentionPass();
+    return result;
   }
 
   async updateEntry(
@@ -221,7 +242,9 @@ export class CollectionEntryService extends BaseService {
     body: Record<string, unknown>,
     depth?: number
   ) {
-    return this.mutationService.updateEntry(params, body, depth);
+    const result = await this.mutationService.updateEntry(params, body, depth);
+    this.offerRetentionPass();
+    return result;
   }
 
   /** i18n M7: publish every language of an entry at once (spec §10). */
@@ -281,7 +304,9 @@ export class CollectionEntryService extends BaseService {
     /** Acting identity from the transport, forwarded to the recorded event. */
     actor?: RequestActor;
   }) {
-    return this.bulkService.duplicateEntry(params);
+    const result = await this.bulkService.duplicateEntry(params);
+    this.offerRetentionPass();
+    return result;
   }
 
   // Phase 4.5: bulk methods carry full records on update (caller needs
@@ -306,7 +331,9 @@ export class CollectionEntryService extends BaseService {
     /** Acting identity from the transport, forwarded to the recorded event. */
     actor?: RequestActor;
   }): Promise<BulkOperationResult<Record<string, unknown>>> {
-    return this.bulkService.bulkUpdateEntries(params);
+    const result = await this.bulkService.bulkUpdateEntries(params);
+    this.offerRetentionPass();
+    return result;
   }
 
   async bulkUpdateByQuery(
@@ -324,7 +351,9 @@ export class CollectionEntryService extends BaseService {
     },
     options?: BulkOperationOptions & { limit?: number }
   ): Promise<BulkOperationResult<Record<string, unknown>>> {
-    return this.bulkService.bulkUpdateByQuery(params, options);
+    const result = await this.bulkService.bulkUpdateByQuery(params, options);
+    this.offerRetentionPass();
+    return result;
   }
 
   async bulkDeleteByQuery(
@@ -349,7 +378,13 @@ export class CollectionEntryService extends BaseService {
     entries: Record<string, unknown>[],
     options?: BulkOperationOptions
   ): Promise<BatchOperationResult> {
-    return this.bulkService.createEntries(params, entries, options);
+    const result = await this.bulkService.createEntries(
+      params,
+      entries,
+      options
+    );
+    this.offerRetentionPass();
+    return result;
   }
 
   async createEntriesInTransaction(

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -254,7 +254,9 @@ export class CollectionEntryService extends BaseService {
     user?: UserContext;
     overrideAccess?: boolean;
   }) {
-    return this.mutationService.publishAllLocales(params);
+    const result = await this.mutationService.publishAllLocales(params);
+    this.offerRetentionPass();
+    return result;
   }
 
   async deleteEntry(params: {
@@ -264,7 +266,9 @@ export class CollectionEntryService extends BaseService {
     overrideAccess?: boolean;
     context?: Record<string, unknown>;
   }) {
-    return this.mutationService.deleteEntry(params);
+    const result = await this.mutationService.deleteEntry(params);
+    this.offerRetentionPass();
+    return result;
   }
 
   async createEntryInTransaction(
@@ -318,7 +322,9 @@ export class CollectionEntryService extends BaseService {
     overrideAccess?: boolean;
     context?: Record<string, unknown>;
   }): Promise<BulkOperationResult<{ id: string }>> {
-    return this.bulkService.bulkDeleteEntries(params);
+    const result = await this.bulkService.bulkDeleteEntries(params);
+    this.offerRetentionPass();
+    return result;
   }
 
   async bulkUpdateEntries(params: {
@@ -366,7 +372,9 @@ export class CollectionEntryService extends BaseService {
     },
     options?: { limit?: number }
   ): Promise<BulkOperationResult<{ id: string }>> {
-    return this.bulkService.bulkDeleteByQuery(params, options);
+    const result = await this.bulkService.bulkDeleteByQuery(params, options);
+    this.offerRetentionPass();
+    return result;
   }
 
   async createEntries(
@@ -406,7 +414,13 @@ export class CollectionEntryService extends BaseService {
     entries: BulkUpdateEntry[],
     options?: BulkOperationOptions
   ): Promise<BatchOperationResult> {
-    return this.bulkService.updateEntries(params, entries, options);
+    const result = await this.bulkService.updateEntries(
+      params,
+      entries,
+      options
+    );
+    this.offerRetentionPass();
+    return result;
   }
 
   async updateEntriesInTransaction(
@@ -428,7 +442,9 @@ export class CollectionEntryService extends BaseService {
     ids: string[],
     options?: BulkOperationOptions
   ): Promise<BatchOperationResult> {
-    return this.bulkService.deleteEntries(params, ids, options);
+    const result = await this.bulkService.deleteEntries(params, ids, options);
+    this.offerRetentionPass();
+    return result;
   }
 
   async deleteEntriesInTransaction(

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -198,14 +198,29 @@ export class CollectionEntryService extends BaseService {
   }
 
   /**
-   * Offer a retention pass after a successful write.
-   *
-   * Deliberately not awaited: a pass can delete thousands of rows and no user's
-   * save should wait on housekeeping. `maybeRun` absorbs its own failures, so
-   * nothing can reject here.
+   * Batches a write-triggered pass may run. Small on purpose: the write path is
+   * the only retention trigger an install without a drain has, so the pass must
+   * be awaited to survive a serverless invocation being frozen after the
+   * response — which means one save per interval pays for it, and that save
+   * should not be waiting on a full backlog sweep. Ten thousand rows an hour
+   * from this path alone keeps ahead of most sites; anything with a drain gets
+   * the full budget there.
    */
-  private offerRetentionPass(): void {
-    void this.retentionRunner?.maybeRun();
+  private static readonly WRITE_PATH_PRUNE_BATCHES = 2;
+
+  /**
+   * Run a retention pass after a successful write, if one is due.
+   *
+   * Awaited rather than fired and forgotten: on a serverless runtime the
+   * invocation can be frozen or torn down as soon as the response is returned,
+   * so a detached promise may never get past the gate — and for an install with
+   * no drain this is the only trigger there is. `maybeRun` absorbs its own
+   * failures, so this cannot turn a successful save into an error.
+   */
+  private async offerRetentionPass(): Promise<void> {
+    await this.retentionRunner?.maybeRun(
+      CollectionEntryService.WRITE_PATH_PRUNE_BATCHES
+    );
   }
 
   async createEntry(
@@ -223,7 +238,7 @@ export class CollectionEntryService extends BaseService {
     depth?: number
   ) {
     const result = await this.mutationService.createEntry(params, body, depth);
-    this.offerRetentionPass();
+    await this.offerRetentionPass();
     return result;
   }
 
@@ -243,7 +258,7 @@ export class CollectionEntryService extends BaseService {
     depth?: number
   ) {
     const result = await this.mutationService.updateEntry(params, body, depth);
-    this.offerRetentionPass();
+    await this.offerRetentionPass();
     return result;
   }
 
@@ -255,7 +270,7 @@ export class CollectionEntryService extends BaseService {
     overrideAccess?: boolean;
   }) {
     const result = await this.mutationService.publishAllLocales(params);
-    this.offerRetentionPass();
+    await this.offerRetentionPass();
     return result;
   }
 
@@ -267,7 +282,7 @@ export class CollectionEntryService extends BaseService {
     context?: Record<string, unknown>;
   }) {
     const result = await this.mutationService.deleteEntry(params);
-    this.offerRetentionPass();
+    await this.offerRetentionPass();
     return result;
   }
 
@@ -309,7 +324,7 @@ export class CollectionEntryService extends BaseService {
     actor?: RequestActor;
   }) {
     const result = await this.bulkService.duplicateEntry(params);
-    this.offerRetentionPass();
+    await this.offerRetentionPass();
     return result;
   }
 
@@ -323,7 +338,7 @@ export class CollectionEntryService extends BaseService {
     context?: Record<string, unknown>;
   }): Promise<BulkOperationResult<{ id: string }>> {
     const result = await this.bulkService.bulkDeleteEntries(params);
-    this.offerRetentionPass();
+    await this.offerRetentionPass();
     return result;
   }
 
@@ -338,7 +353,7 @@ export class CollectionEntryService extends BaseService {
     actor?: RequestActor;
   }): Promise<BulkOperationResult<Record<string, unknown>>> {
     const result = await this.bulkService.bulkUpdateEntries(params);
-    this.offerRetentionPass();
+    await this.offerRetentionPass();
     return result;
   }
 
@@ -358,7 +373,7 @@ export class CollectionEntryService extends BaseService {
     options?: BulkOperationOptions & { limit?: number }
   ): Promise<BulkOperationResult<Record<string, unknown>>> {
     const result = await this.bulkService.bulkUpdateByQuery(params, options);
-    this.offerRetentionPass();
+    await this.offerRetentionPass();
     return result;
   }
 
@@ -373,7 +388,7 @@ export class CollectionEntryService extends BaseService {
     options?: { limit?: number }
   ): Promise<BulkOperationResult<{ id: string }>> {
     const result = await this.bulkService.bulkDeleteByQuery(params, options);
-    this.offerRetentionPass();
+    await this.offerRetentionPass();
     return result;
   }
 
@@ -391,7 +406,7 @@ export class CollectionEntryService extends BaseService {
       entries,
       options
     );
-    this.offerRetentionPass();
+    await this.offerRetentionPass();
     return result;
   }
 
@@ -419,7 +434,7 @@ export class CollectionEntryService extends BaseService {
       entries,
       options
     );
-    this.offerRetentionPass();
+    await this.offerRetentionPass();
     return result;
   }
 
@@ -443,7 +458,7 @@ export class CollectionEntryService extends BaseService {
     options?: BulkOperationOptions
   ): Promise<BatchOperationResult> {
     const result = await this.bulkService.deleteEntries(params, ids, options);
-    this.offerRetentionPass();
+    await this.offerRetentionPass();
     return result;
   }
 

--- a/packages/nextly/src/shared/types/config.ts
+++ b/packages/nextly/src/shared/types/config.ts
@@ -736,7 +736,7 @@ export interface SanitizedNextlyConfig {
    * Resolved webhook retention policy, or null when retention is switched off.
    * Always present after sanitization so consumers never re-resolve it.
    */
-  webhookRetention?: ResolvedWebhookRetentionConfig | null;
+  webhookRetention: ResolvedWebhookRetentionConfig | null;
 }
 
 // ============================================================

--- a/packages/nextly/src/shared/types/config.ts
+++ b/packages/nextly/src/shared/types/config.ts
@@ -18,6 +18,11 @@ import type {
   LocalizationConfig,
   SanitizedLocalizationConfig,
 } from "../../domains/i18n/config/types";
+import { resolveWebhookRetentionConfig } from "../../domains/webhooks/retention-config";
+import type {
+  ResolvedWebhookRetentionConfig,
+  WebhookRetentionConfig,
+} from "../../domains/webhooks/retention-config";
 import type { CorsConfig } from "../../middleware/cors";
 import type { RateLimitStore } from "../../middleware/rate-limit";
 import type { SecurityHeadersConfig } from "../../middleware/security-headers";
@@ -635,6 +640,28 @@ export interface NextlyConfig {
    * See docs/superpowers/specs/2026-07-08-multilingual-i18n-design.md.
    */
   localization?: LocalizationConfig;
+
+  /** Outbound webhook configuration. */
+  webhooks?: WebhookConfig;
+}
+
+/**
+ * Outbound webhook configuration.
+ *
+ * Only retention is configurable today; endpoints are registered as rows rather
+ * than declared here, so this is where operational policy lives rather than the
+ * subscription list.
+ */
+export interface WebhookConfig {
+  /**
+   * How long recorded events and delivery attempts are kept.
+   *
+   * Enabled by default. A row is appended to the event ledger on every content
+   * write, whether or not this install uses webhooks at all, so leaving it
+   * unbounded would tax people who never opted in. `false` keeps everything
+   * forever and accepts that growth.
+   */
+  retention?: WebhookRetentionConfig | false;
 }
 
 /**
@@ -704,6 +731,12 @@ export interface SanitizedNextlyConfig {
 
   /** Normalized multilingual content configuration (undefined when i18n is off). */
   localization?: SanitizedLocalizationConfig;
+
+  /**
+   * Resolved webhook retention policy, or null when retention is switched off.
+   * Always present after sanitization so consumers never re-resolve it.
+   */
+  webhookRetention?: ResolvedWebhookRetentionConfig | null;
 }
 
 // ============================================================
@@ -871,5 +904,9 @@ export function sanitizeConfig(config: NextlyConfig): SanitizedNextlyConfig {
     localization: config.localization
       ? normalizeLocalization(config.localization)
       : undefined,
+    // Resolved once at boot so nothing downstream re-derives it. Null means the
+    // user switched retention off; an absent `webhooks` key resolves to the
+    // defaults, since the event ledger fills whether or not webhooks are used.
+    webhookRetention: resolveWebhookRetentionConfig(config.webhooks?.retention),
   };
 }


### PR DESCRIPTION
Closes the release gate for the webhook series.

## Why now

Recording is unconditional, so every entry create and update appends a full-document JSON row to `nextly_events` — including in the majority of installs that never configure a webhook. The build plan flagged this as a release gate rather than a tuning knob, and Version PR #248 already carries the #251 changeset, so a release would publish unbounded growth with no way to clear it.

## What it does

Events are removed once they are past their window, their fan-out has run, and no delivery is still live. Terminal delivery rows are removed sooner, on their own shorter window.

Two rules decide what may go, both forced by the schema:

- `fanned_out_at IS NULL` means the event still needs fan-out. Deleting one would discard an event nobody ever delivered.
- `nextly_webhook_deliveries.event_id` cascades, so deleting an event takes its deliveries with it — including pending and retrying ones. An event is only prunable once every child delivery is terminal.

Both are pinned by tests that fail when the guard is removed.

## Where it runs

The drain prunes after its queue goes quiet, so a pass never races the deliveries that same call is still working through. But the drain only runs where webhooks are configured, while the ledger fills on every write — so content writes also offer a pass. Without that second seam, the installs the gate exists for would never prune at all.

Passes are gated twice: an in-process guard makes the steady state free, and a stored marker behind it coordinates across processes and survives a restart. The marker is written before the pass, so a pass that throws still waits a full interval rather than being retried by every subsequent write.

The offer is not awaited, and pruning absorbs its own failures — a content write can never fail because housekeeping did.

## Two decisions worth review

**Retention is on by default.** The row is appended whether or not the install uses webhooks, so leaving it unbounded taxes people who never opted in. Shipping retention alongside the feature that fills the table is the one moment when this costs nobody existing data.

**Events carry a retention class.** `nextly_events` is documented as the substrate the audit log will reuse, and audit history is measured in years while outbox hygiene is measured in days. One window cannot serve both, and adding the discriminator later — after installs carry real rows — is much more expensive than adding it now. Defaults: 30 days for webhook-class, 365 for audit-class, 7 for deliveries.

## Deliberately different from version retention

Version retention prunes inside the write transaction with no `try/catch`, so a failed prune rolls back the user's save. That is right there — a violated version cap is a correctness bug. Events go the other way: pruning runs outside the transaction and a failure is logged. Failing a content save because an auxiliary ledger could not be tidied is the wrong trade. The divergence is documented at the module level so it reads as intentional.

## Portability

No `DELETE ... LIMIT`: PostgreSQL lacks it, MySQL rejects a subquery against the delete target, and SQLite only has it behind a non-default compile flag. Batches select ids then delete by id, which also keeps MySQL from gap-locking a range of the index that concurrent inserts need. Batch size 500 matches the existing version-retention chunk and stays under SQLite's 999 bind-parameter limit on older builds.

Partitioning was ruled out rather than deferred: MySQL forbids partitioning a table referenced by a foreign key, and SQLite has none.

## Verification

- SQLite: 147 integration passed / 6 skipped
- Postgres: 150 passed / 3 skipped (on a fresh database — see below)
- Unit: 251 passed
- Types and lint clean

Every new guard verified load-bearing by reverting it, at both unit and integration level.

One note for reviewers: the shared `nextly_test` Postgres database holds an `events` table predating this column, so a run against it fails with `42703`. A fresh database passes. That mirrors how `fanned_out_at` was added in #233 — also with no migration — but it does mean the upgrade path for column additions to core tables is worth a separate look, for that column as much as this one.

Design note: `tasks/2026-07-21-webhooks-retention-design.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable webhook/audit retention policies (including “keep forever” and fully disabled) and wired the resolved settings into service startup.
  * Introduced opportunistic, interval-gated retention pruning that runs after writes and when the delivery queue is quiet.
  * Extended storage with retention-class support for faster pruning.
* **Bug Fixes**
  * Improved pruning correctness by avoiding in-flight work (and respecting endpoint + fan-out completion rules).
  * Retention failures are now swallowed with warning logging to prevent impacting normal processing.
* **Tests**
  * Added unit and integration coverage for config resolution, gating/claims, pruning safety, dry-run behavior, and batch limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->