### PR TITLE
fix(nextly): surface the real cause of CLI and collection failures

### DIFF
--- a/.changeset/cli-error-visibility.md
+++ b/.changeset/cli-error-visibility.md
@@ -1,0 +1,27 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+CLI commands now explain why they failed.
+
+Errors carry two messages: a safe one for the browser and a detailed one for whoever is running the code. The CLI was printing the safe one, so a failed `nextly db:sync` said only "An unexpected error occurred." with no table, no query and no cause. The same command now reports the failing query and the database's own explanation, for example `no such column: "localized"`, which is usually the whole answer. Full stack traces remain behind `DEBUG=1`.
+
+A crash inside Nextly is also no longer reported as a validation error. Creating or updating a collection returned HTTP 400 "Validation failed" when the real cause was a defect in Nextly itself, sending people to search their own payload for a problem that was never there. Those now return 500, so the two cases can be told apart.

--- a/packages/nextly/src/cli/commands/add.ts
+++ b/packages/nextly/src/cli/commands/add.ts
@@ -23,6 +23,7 @@ import { join } from "node:path";
 import type { Command } from "commander";
 import pc from "picocolors";
 
+import { describeError } from "../../errors/index";
 import {
   createContext,
   type CommandContext,
@@ -169,9 +170,7 @@ export function registerAddCommand(program: Command): void {
         try {
           await runAdd(pkg, resolved, context);
         } catch (error) {
-          context.logger.error(
-            error instanceof Error ? error.message : String(error)
-          );
+          context.logger.error(describeError(error));
           process.exit(1);
         }
       }

--- a/packages/nextly/src/cli/commands/build.ts
+++ b/packages/nextly/src/cli/commands/build.ts
@@ -41,6 +41,7 @@ import {
   type TypeGeneratorOptions,
 } from "../../domains/schema/services/type-generator";
 import { ZodGenerator } from "../../domains/schema/services/zod-generator";
+import { describeError } from "../../errors/index";
 import type { DynamicCollectionRecord } from "../../schemas/dynamic-collections/types";
 import { toSingularLabel, toPluralLabel } from "../../shared/lib/pluralization";
 import { createContext, type CommandContext } from "../program";
@@ -217,9 +218,7 @@ export async function runBuild(
       debug: options.verbose,
     });
   } catch (error) {
-    logger.error(
-      `Failed to load config: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logger.error(`Failed to load config: ${describeError(error)}`);
     process.exit(1);
   }
 
@@ -309,9 +308,7 @@ export async function runBuild(
       }
     } catch (error) {
       result.success = false;
-      logger.error(
-        `File generation failed: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logger.error(`File generation failed: ${describeError(error)}`);
     }
   }
 
@@ -451,7 +448,7 @@ function validateAllCollections(
     try {
       assertValidCollectionConfig(collection);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = describeError(error);
       errors.push({
         collection: collection.slug,
         message,
@@ -729,9 +726,7 @@ async function checkMigrationStatus(
     });
     logger.debug(`Connected to ${getDialectDisplayName(dialect)}`);
   } catch (error) {
-    logger.debug(
-      `Cannot check migrations: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logger.debug(`Cannot check migrations: ${describeError(error)}`);
     return result;
   }
 
@@ -871,9 +866,7 @@ export function registerBuildCommand(program: Command): void {
       try {
         await runBuild(resolvedOptions, context);
       } catch (error) {
-        context.logger.error(
-          error instanceof Error ? error.message : String(error)
-        );
+        context.logger.error(describeError(error));
         process.exit(1);
       }
     });

--- a/packages/nextly/src/cli/commands/db-sync-demote.ts
+++ b/packages/nextly/src/cli/commands/db-sync-demote.ts
@@ -11,6 +11,7 @@ import * as p from "@clack/prompts";
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import { serializeCollection } from "../../domains/schema/services/code-generator";
+import { describeError } from "../../errors/index";
 import { CollectionRegistryService } from "../../services/collections/collection-registry-service";
 import type { CommandContext } from "../program";
 import { createAdapter, validateDatabaseEnv } from "../utils/adapter";
@@ -37,9 +38,7 @@ export async function runDemote(
     const result = await loadNextlyConfig(context.cwd);
     config = result.config;
   } catch (err) {
-    logger.error(
-      `Could not load nextly config: ${err instanceof Error ? err.message : String(err)}`
-    );
+    logger.error(`Could not load nextly config: ${describeError(err)}`);
     process.exit(1);
   }
 

--- a/packages/nextly/src/cli/commands/db-sync.ts
+++ b/packages/nextly/src/cli/commands/db-sync.ts
@@ -62,6 +62,7 @@ import type { Command } from "commander";
 
 import { getDialectTables } from "../../database/index";
 import { SchemaRegistry } from "../../database/schema-registry";
+import { describeError } from "../../errors/index";
 import {
   createContext,
   type CommandContext,
@@ -210,9 +211,7 @@ export async function runDbSync(
       debug: options.verbose,
     });
   } catch (error) {
-    logger.error(
-      `Failed to load config: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logger.error(`Failed to load config: ${describeError(error)}`);
     process.exit(1);
   }
 
@@ -258,9 +257,7 @@ export async function runDbSync(
     (adapter as unknown as DrizzleAdapter).setTableResolver(earlyRegistry);
     logger.debug("Schema registry initialized with static tables");
   } catch (error) {
-    logger.error(
-      `Failed to connect to database: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logger.error(`Failed to connect to database: ${describeError(error)}`);
     process.exit(1);
   }
 
@@ -417,9 +414,7 @@ export function registerDbSyncCommand(program: Command): void {
             await runPromote(cmdOptions.promote, context);
             return;
           } catch (error) {
-            context.logger.error(
-              error instanceof Error ? error.message : String(error)
-            );
+            context.logger.error(describeError(error));
             process.exit(1);
           }
         }
@@ -430,9 +425,7 @@ export function registerDbSyncCommand(program: Command): void {
             await runDemote(cmdOptions.demote, context);
             return;
           } catch (error) {
-            context.logger.error(
-              error instanceof Error ? error.message : String(error)
-            );
+            context.logger.error(describeError(error));
             process.exit(1);
           }
         }
@@ -448,9 +441,7 @@ export function registerDbSyncCommand(program: Command): void {
         try {
           await runDbSync(resolvedOptions, context);
         } catch (error) {
-          context.logger.error(
-            error instanceof Error ? error.message : String(error)
-          );
+          context.logger.error(describeError(error));
           process.exit(1);
         }
       }

--- a/packages/nextly/src/cli/commands/dev-build.ts
+++ b/packages/nextly/src/cli/commands/dev-build.ts
@@ -14,7 +14,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import { PermissionSeedService } from "../../domains/auth/services/permission-seed-service";
 // Resolve the versioning config so `db:sync` persists it (parity with boot/HMR).
 import { resolveVersionsConfig } from "../../domains/versions/resolve-config";
-import { describeError } from "../../errors/index";
+import { describeError, immediateMessage } from "../../errors/index";
 import { CollectionSyncService } from "../../services/collections/collection-sync-service";
 import type { CollectionSyncResultWithValidation } from "../../services/collections/collection-sync-service";
 import {
@@ -474,15 +474,20 @@ export async function syncUserFields(
       logger.warn("user_ext table creation SQL executed but table not found");
     }
   } catch (error) {
-    const errorMsg = describeError(error);
-    // Table already exists is expected with CREATE TABLE IF NOT EXISTS
-    if (errorMsg.includes("already exists") || errorMsg.includes("duplicate")) {
+    // Table already exists is expected with CREATE TABLE IF NOT EXISTS.
+    // Match the immediate message only, so a wrapped failure carrying those
+    // words deeper in its cause chain is still reported rather than skipped.
+    const immediate = immediateMessage(error);
+    if (
+      immediate.includes("already exists") ||
+      immediate.includes("duplicate")
+    ) {
       const tableExists = await drizzleAdapter.tableExists("user_ext");
       if (tableExists) {
         logger.success("user_ext table already exists");
       }
     } else {
-      logger.warn(`user_ext sync error: ${errorMsg}`);
+      logger.warn(`user_ext sync error: ${describeError(error)}`);
     }
   }
 }
@@ -597,17 +602,19 @@ export async function performPermissionSeeding(
       }
     }
   } catch (error) {
-    const errorMsg = describeError(error);
-    // Handle fresh DB scenarios gracefully (tables may not exist yet)
+    // Handle fresh DB scenarios gracefully (tables may not exist yet). The
+    // immediate message decides: a real seeding failure that merely wraps a
+    // "does not exist" cause must still be reported, not skipped silently.
+    const immediate = immediateMessage(error);
     if (
-      errorMsg.includes("no such table") ||
-      errorMsg.includes("does not exist") ||
-      errorMsg.includes("relation") ||
-      errorMsg.includes("doesn't exist")
+      immediate.includes("no such table") ||
+      immediate.includes("does not exist") ||
+      immediate.includes("relation") ||
+      immediate.includes("doesn't exist")
     ) {
       logger.debug("Skipping permission seeding (tables may not exist yet)");
     } else {
-      logger.warn(`Permission seeding failed: ${errorMsg}`);
+      logger.warn(`Permission seeding failed: ${describeError(error)}`);
     }
   }
 }

--- a/packages/nextly/src/cli/commands/dev-build.ts
+++ b/packages/nextly/src/cli/commands/dev-build.ts
@@ -14,6 +14,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import { PermissionSeedService } from "../../domains/auth/services/permission-seed-service";
 // Resolve the versioning config so `db:sync` persists it (parity with boot/HMR).
 import { resolveVersionsConfig } from "../../domains/versions/resolve-config";
+import { describeError } from "../../errors/index";
 import { CollectionSyncService } from "../../services/collections/collection-sync-service";
 import type { CollectionSyncResultWithValidation } from "../../services/collections/collection-sync-service";
 import {
@@ -106,9 +107,10 @@ export async function syncCollections(
       onRemoved: options.removeOrphaned ? "delete" : "warn",
     });
   } catch (error) {
-    logger.error(
-      `Sync failed: ${error instanceof Error ? error.message : String(error)}`
-    );
+    // Name the phase that failed, then rethrow. The detail is deliberately
+    // left to the top-level handler: printing it here too would render the
+    // same description twice for a single failure.
+    logger.error("Sync failed while registering collections.");
     throw error;
   }
 
@@ -190,9 +192,7 @@ export async function syncSingles(
   try {
     result = await singleRegistry.syncCodeFirstSingles(codeFirstConfigs);
   } catch (error) {
-    logger.error(
-      `Singles sync failed: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logger.error("Singles sync failed while registering singles.");
     throw error;
   }
 
@@ -304,9 +304,7 @@ export async function syncComponents(
   try {
     result = await componentRegistry.syncCodeFirstComponents(codeFirstConfigs);
   } catch (error) {
-    logger.error(
-      `Components sync failed: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logger.error("Components sync failed while registering components.");
     throw error;
   }
 
@@ -476,7 +474,7 @@ export async function syncUserFields(
       logger.warn("user_ext table creation SQL executed but table not found");
     }
   } catch (error) {
-    const errorMsg = error instanceof Error ? error.message : String(error);
+    const errorMsg = describeError(error);
     // Table already exists is expected with CREATE TABLE IF NOT EXISTS
     if (errorMsg.includes("already exists") || errorMsg.includes("duplicate")) {
       const tableExists = await drizzleAdapter.tableExists("user_ext");
@@ -599,7 +597,7 @@ export async function performPermissionSeeding(
       }
     }
   } catch (error) {
-    const errorMsg = error instanceof Error ? error.message : String(error);
+    const errorMsg = describeError(error);
     // Handle fresh DB scenarios gracefully (tables may not exist yet)
     if (
       errorMsg.includes("no such table") ||
@@ -680,7 +678,7 @@ async function handleRemovedSingles(
       logger.success(`Deleted orphaned single: ${slug} (table: ${tableName})`);
     } catch (error) {
       logger.error(
-        `Failed to delete single "${slug}": ${error instanceof Error ? error.message : String(error)}`
+        `Failed to delete single "${slug}": ${describeError(error)}`
       );
     }
   }
@@ -732,7 +730,7 @@ async function handleRemovedComponents(
       );
     } catch (error) {
       logger.error(
-        `Failed to delete component "${slug}": ${error instanceof Error ? error.message : String(error)}`
+        `Failed to delete component "${slug}": ${describeError(error)}`
       );
     }
   }

--- a/packages/nextly/src/cli/commands/dev-server.ts
+++ b/packages/nextly/src/cli/commands/dev-server.ts
@@ -45,6 +45,7 @@ import { generateRuntimeSchema } from "../../domains/schema/services/runtime-sch
 import { addMissingColumnsForFields } from "../../domains/schema/utils/missing-columns";
 import { reconcileSingleTables } from "../../domains/singles/services/reconcile-single-tables";
 import { resolveSingleTableName } from "../../domains/singles/services/resolve-single-table-name";
+import { describeError } from "../../errors/index";
 import { getProductionNotifier } from "../../runtime/notifications/index";
 import type { FieldDefinition } from "../../schemas/dynamic-collections";
 import type { CollectionSyncResultWithValidation } from "../../services/collections/collection-sync-service";
@@ -122,8 +123,7 @@ export async function ensureCoreTables(
   } catch (pushError) {
     // pushSchema failed (e.g., TTY prompt needed, or drizzle-kit error).
     // Fall back to raw SQL for SQLite, or error for PG/MySQL.
-    const pushMsg =
-      pushError instanceof Error ? pushError.message : String(pushError);
+    const pushMsg = describeError(pushError);
     logger.debug(`pushSchema failed: ${pushMsg}`);
 
     if (dialect === "sqlite") {
@@ -133,7 +133,7 @@ export async function ensureCoreTables(
         try {
           await drizzleAdapter.executeQuery(statement);
         } catch (error) {
-          const msg = error instanceof Error ? error.message : String(error);
+          const msg = describeError(error);
           if (!msg.includes("already exists")) {
             logger.debug(`Table creation statement failed: ${msg}`);
           }
@@ -157,8 +157,7 @@ export async function ensureCoreTables(
         );
         await systemTableService.ensureSystemTables();
       } catch (sysError) {
-        const msg =
-          sysError instanceof Error ? sysError.message : String(sysError);
+        const msg = describeError(sysError);
         logger.debug(`System table creation: ${msg}`);
       }
 
@@ -391,7 +390,7 @@ export async function performAutoSync(
     // Catastrophic failures (DB connection lost, etc.) reach here. The
     // pipeline's typed errors come back as { success: false } — those are
     // handled below.
-    const msg = error instanceof Error ? error.message : String(error);
+    const msg = describeError(error);
     logger.error(`Auto-sync failed: ${msg}`);
     throw error;
   }
@@ -496,7 +495,7 @@ function registerSingleTableInResolver(
     // Deliberately swallow: subsequent queries in this boot may fail but
     // the next restart rebuilds the resolver from the registry rows.
     logger.debug(
-      `Could not register runtime schema for ${tableName}: ${err instanceof Error ? err.message : String(err)}`
+      `Could not register runtime schema for ${tableName}: ${describeError(err)}`
     );
   }
 }
@@ -650,7 +649,7 @@ export async function performSinglesAutoSync(
         }
       }
     } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
+      const errorMsg = describeError(error);
       try {
         await singleRegistry.updateMigrationStatus(slug, "failed");
       } catch {
@@ -919,7 +918,7 @@ export async function performComponentsAutoSync(
         }
       }
     } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
+      const errorMsg = describeError(error);
       try {
         await componentRegistry.updateMigrationStatus(slug, "failed");
       } catch {

--- a/packages/nextly/src/cli/commands/dev-server.ts
+++ b/packages/nextly/src/cli/commands/dev-server.ts
@@ -45,7 +45,7 @@ import { generateRuntimeSchema } from "../../domains/schema/services/runtime-sch
 import { addMissingColumnsForFields } from "../../domains/schema/utils/missing-columns";
 import { reconcileSingleTables } from "../../domains/singles/services/reconcile-single-tables";
 import { resolveSingleTableName } from "../../domains/singles/services/resolve-single-table-name";
-import { describeError } from "../../errors/index";
+import { describeError, immediateMessage } from "../../errors/index";
 import { getProductionNotifier } from "../../runtime/notifications/index";
 import type { FieldDefinition } from "../../schemas/dynamic-collections";
 import type { CollectionSyncResultWithValidation } from "../../services/collections/collection-sync-service";
@@ -133,9 +133,13 @@ export async function ensureCoreTables(
         try {
           await drizzleAdapter.executeQuery(statement);
         } catch (error) {
-          const msg = describeError(error);
-          if (!msg.includes("already exists")) {
-            logger.debug(`Table creation statement failed: ${msg}`);
+          // Branch on the immediate message only: a wrapped failure whose
+          // cause chain happens to mention "already exists" is not the benign
+          // duplicate-table case and must not be silenced.
+          if (!immediateMessage(error).includes("already exists")) {
+            logger.debug(
+              `Table creation statement failed: ${describeError(error)}`
+            );
           }
         }
       }

--- a/packages/nextly/src/cli/commands/dev-watcher.ts
+++ b/packages/nextly/src/cli/commands/dev-watcher.ts
@@ -8,6 +8,7 @@
  * @module cli/commands/dev-watcher
  */
 
+import { describeError } from "../../errors/index";
 import type { CommandContext } from "../program";
 import type { CLIDatabaseAdapter } from "../utils/adapter";
 import type { LoadConfigResult } from "../utils/config-loader";
@@ -81,9 +82,7 @@ export function createDebouncedSync(
       // Seed permissions for new/updated collections and singles
       await performPermissionSeeding(adapter, options, context);
     } catch (error) {
-      logger.error(
-        `Re-sync failed: ${error instanceof Error ? error.message : String(error)}`
-      );
+      logger.error(`Re-sync failed: ${describeError(error)}`);
     } finally {
       isSyncing = false;
 

--- a/packages/nextly/src/cli/commands/generate-types.ts
+++ b/packages/nextly/src/cli/commands/generate-types.ts
@@ -38,6 +38,7 @@ import {
 } from "../../domains/schema/services/type-generator";
 import { ZodGenerator } from "../../domains/schema/services/zod-generator";
 import { resolveSingleTableName } from "../../domains/singles/services/resolve-single-table-name";
+import { describeError } from "../../errors/index";
 import { collectCodegenNames } from "../../plugins/codegen/collect-codegen-names";
 import { buildImportMapArtifact } from "../../plugins/codegen/component-import-map";
 import type { DynamicCollectionRecord } from "../../schemas/dynamic-collections/types";
@@ -144,9 +145,7 @@ export async function runGenerateTypes(
       debug: options.verbose,
     });
   } catch (error) {
-    logger.error(
-      `Failed to load config: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logger.error(`Failed to load config: ${describeError(error)}`);
     process.exit(1);
   }
 
@@ -191,9 +190,7 @@ export async function runGenerateTypes(
     logger.divider();
     logger.success(`Type generation completed in ${formatDuration(duration)}`);
   } catch (error) {
-    logger.error(
-      `Generation failed: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logger.error(`Generation failed: ${describeError(error)}`);
     process.exit(1);
   }
 }
@@ -598,9 +595,7 @@ export function registerGenerateTypesCommand(program: Command): void {
       try {
         await runGenerateTypes(resolvedOptions, context);
       } catch (error) {
-        context.logger.error(
-          error instanceof Error ? error.message : String(error)
-        );
+        context.logger.error(describeError(error));
         process.exit(1);
       }
     });

--- a/packages/nextly/src/cli/commands/i18n-restore.ts
+++ b/packages/nextly/src/cli/commands/i18n-restore.ts
@@ -23,6 +23,7 @@ import type { Command } from "commander";
 import { resolveEntityTable } from "../../domains/i18n/migration/resolve-entity-table";
 import { restoreI18nArchive } from "../../domains/i18n/migration/restore-archive";
 import { loadUiSchema } from "../../domains/schema/ui-schema/loader";
+import { describeError } from "../../errors/index";
 import { createContext, type CommandContext } from "../program";
 import { validateDatabaseEnv, withAdapter } from "../utils/adapter";
 import { loadConfig } from "../utils/config-loader";
@@ -162,9 +163,7 @@ export function registerI18nRestoreCommand(program: Command): void {
           context
         );
       } catch (error) {
-        context.logger.error(
-          error instanceof Error ? error.message : String(error)
-        );
+        context.logger.error(describeError(error));
         process.exit(1);
       }
     });

--- a/packages/nextly/src/cli/commands/init.ts
+++ b/packages/nextly/src/cli/commands/init.ts
@@ -30,6 +30,7 @@ import { confirm, input } from "@inquirer/prompts";
 import type { Command } from "commander";
 import pc from "picocolors";
 
+import { describeError } from "../../errors/index";
 import {
   createContext,
   type CommandContext,
@@ -654,9 +655,7 @@ export function registerInitCommand(program: Command): void {
       try {
         await runInit(resolvedOptions, context);
       } catch (error) {
-        context.logger.error(
-          error instanceof Error ? error.message : String(error)
-        );
+        context.logger.error(describeError(error));
         process.exit(1);
       }
     });

--- a/packages/nextly/src/cli/commands/migrate-check.ts
+++ b/packages/nextly/src/cli/commands/migrate-check.ts
@@ -69,6 +69,7 @@ import {
   applyDeferredExtendsToManifest,
   mergeUiEntities,
 } from "../../domains/schema/ui-schema/merge";
+import { describeError } from "../../errors/index";
 import { createContext, type CommandContext } from "../program";
 import { validateDatabaseEnv, type SupportedDialect } from "../utils/adapter";
 import { loadConfig, type LoadConfigResult } from "../utils/config-loader";
@@ -129,9 +130,7 @@ export async function runMigrateCheck(
       debug: options.verbose,
     });
   } catch (error) {
-    logger.error(
-      `Failed to load config: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logger.error(`Failed to load config: ${describeError(error)}`);
     process.exit(1);
   }
 
@@ -146,9 +145,7 @@ export async function runMigrateCheck(
       uiSchemaFile: configResult.config.db.uiSchemaFile,
     });
   } catch (error) {
-    logger.error(
-      `UI_SCHEMA_INVALID: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logger.error(`UI_SCHEMA_INVALID: ${describeError(error)}`);
     process.exit(1);
   }
 
@@ -462,9 +459,7 @@ export function registerMigrateCheckCommand(program: Command): void {
       try {
         await runMigrateCheck(resolvedOptions, context);
       } catch (error) {
-        context.logger.error(
-          error instanceof Error ? error.message : String(error)
-        );
+        context.logger.error(describeError(error));
         process.exit(1);
       }
     });

--- a/packages/nextly/src/cli/commands/migrate-create.ts
+++ b/packages/nextly/src/cli/commands/migrate-create.ts
@@ -69,6 +69,7 @@ import {
   buildComponentMetadataUpsert,
   buildSingleMetadataUpsert,
 } from "../../domains/schema/ui-schema/metadata-sql";
+import { describeError } from "../../errors/index";
 import { createContext, type CommandContext } from "../program";
 import {
   getDialectDisplayName,
@@ -171,9 +172,7 @@ export async function runMigrateCreate(
       debug: options.verbose,
     });
   } catch (error) {
-    logger.error(
-      `Failed to load config: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logger.error(`Failed to load config: ${describeError(error)}`);
     process.exit(1);
   }
 
@@ -241,7 +240,7 @@ export async function runMigrateCreate(
       uiSchemaFile: configResult.config.db.uiSchemaFile,
     });
   } catch (error) {
-    logger.error(error instanceof Error ? error.message : String(error));
+    logger.error(describeError(error));
     process.exit(1);
   }
 
@@ -330,9 +329,7 @@ export async function runMigrateCreate(
       // message before throwing. Just exit.
       process.exit(1);
     }
-    logger.error(
-      `Failed to generate migration: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logger.error(`Failed to generate migration: ${describeError(error)}`);
     process.exit(1);
   }
 
@@ -520,9 +517,7 @@ export function registerMigrateCreateCommand(program: Command): void {
         try {
           await runMigrateCreate(positionalName, resolvedOptions, context);
         } catch (error) {
-          context.logger.error(
-            error instanceof Error ? error.message : String(error)
-          );
+          context.logger.error(describeError(error));
           process.exit(1);
         }
       }

--- a/packages/nextly/src/cli/commands/migrate-create.ts
+++ b/packages/nextly/src/cli/commands/migrate-create.ts
@@ -240,7 +240,7 @@ export async function runMigrateCreate(
       uiSchemaFile: configResult.config.db.uiSchemaFile,
     });
   } catch (error) {
-    logger.error(describeError(error));
+    logger.error(`Failed to load UI schema: ${describeError(error)}`);
     process.exit(1);
   }
 

--- a/packages/nextly/src/cli/commands/migrate-down.ts
+++ b/packages/nextly/src/cli/commands/migrate-down.ts
@@ -177,7 +177,7 @@ export async function migrateDownCore(
         } catch (err) {
           await deps.recordFailed(
             p.filename,
-            truncateErrorMessage(describeError(err))
+            truncateErrorMessage(describeError(err, { context: false }))
           );
           throw err;
         }

--- a/packages/nextly/src/cli/commands/migrate-down.ts
+++ b/packages/nextly/src/cli/commands/migrate-down.ts
@@ -23,6 +23,7 @@ import {
 } from "../../domains/schema/events/schema-events-repository";
 import { resolveMigration } from "../../domains/schema/migrate/resolve";
 import { withMigrateLock } from "../../domains/schema/pipeline/locks";
+import { describeError } from "../../errors/index";
 import { createContext, type CommandContext } from "../program";
 import {
   createAdapter,
@@ -173,10 +174,7 @@ export async function migrateDownCore(
         try {
           await deps.execDown(p.downSql);
         } catch (err) {
-          await deps.recordFailed(
-            p.filename,
-            err instanceof Error ? err.message : String(err)
-          );
+          await deps.recordFailed(p.filename, describeError(err));
           throw err;
         }
         await deps.recordRolledBack(p.filename);
@@ -371,9 +369,7 @@ export function registerMigrateDownCommand(program: Command): void {
       try {
         await runMigrateDown(resolvedOptions, context);
       } catch (error) {
-        context.logger.error(
-          error instanceof Error ? error.message : String(error)
-        );
+        context.logger.error(describeError(error));
         process.exit(1);
       }
     });

--- a/packages/nextly/src/cli/commands/migrate-down.ts
+++ b/packages/nextly/src/cli/commands/migrate-down.ts
@@ -21,6 +21,7 @@ import {
   SchemaEventsRepository,
   type SchemaEventRow,
 } from "../../domains/schema/events/schema-events-repository";
+import { truncateErrorMessage } from "../../domains/schema/events/schema-events-repository";
 import { resolveMigration } from "../../domains/schema/migrate/resolve";
 import { withMigrateLock } from "../../domains/schema/pipeline/locks";
 import { describeError } from "../../errors/index";
@@ -174,7 +175,10 @@ export async function migrateDownCore(
         try {
           await deps.execDown(p.downSql);
         } catch (err) {
-          await deps.recordFailed(p.filename, describeError(err));
+          await deps.recordFailed(
+            p.filename,
+            truncateErrorMessage(describeError(err))
+          );
           throw err;
         }
         await deps.recordRolledBack(p.filename);

--- a/packages/nextly/src/cli/commands/migrate-fresh.ts
+++ b/packages/nextly/src/cli/commands/migrate-fresh.ts
@@ -41,7 +41,7 @@ import { seedAll, type SeederResult } from "../../database/seeders/index";
 // helper which has the same dialect-aware behavior but is self-contained
 // (no class state, no preview/apply duality).
 import { freshPushSchema } from "../../domains/schema/pipeline/fresh-push";
-import { describeError } from "../../errors/index";
+import { describeError, immediateMessage } from "../../errors/index";
 import { createContext, type CommandContext } from "../program";
 import {
   createAdapter,
@@ -585,8 +585,10 @@ async function reconcileMysqlSchema(
     // Reconciliation is a safety net for historical MySQL drift. Do not
     // block migrate:fresh --seed if drizzle-kit emits duplicate/constraint
     // alteration errors after migrations have already created the schema.
+    // Classify on the immediate message; a wrapped failure whose cause chain
+    // mentions a known drift phrase is not itself known drift.
     const message = describeError(error);
-    if (isKnownMysqlReconcileDriftError(message)) {
+    if (isKnownMysqlReconcileDriftError(immediateMessage(error))) {
       logger.debug(
         "[schema] Skipping known MySQL reconciliation drift (media FK already reconciled)"
       );

--- a/packages/nextly/src/cli/commands/migrate-fresh.ts
+++ b/packages/nextly/src/cli/commands/migrate-fresh.ts
@@ -41,6 +41,7 @@ import { seedAll, type SeederResult } from "../../database/seeders/index";
 // helper which has the same dialect-aware behavior but is self-contained
 // (no class state, no preview/apply duality).
 import { freshPushSchema } from "../../domains/schema/pipeline/fresh-push";
+import { describeError } from "../../errors/index";
 import { createContext, type CommandContext } from "../program";
 import {
   createAdapter,
@@ -147,9 +148,7 @@ export async function runMigrateFresh(
       debug: options.verbose,
     });
   } catch (error) {
-    logger.error(
-      `Failed to load config: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logger.error(`Failed to load config: ${describeError(error)}`);
     process.exit(1);
   }
 
@@ -193,9 +192,7 @@ export async function runMigrateFresh(
     });
     logger.success("Database connected");
   } catch (error) {
-    logger.error(
-      `Failed to connect to database: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logger.error(`Failed to connect to database: ${describeError(error)}`);
     process.exit(1);
   }
 
@@ -382,7 +379,7 @@ async function discoverTables(
  * Supabase) forbids that superuser-only GUC.
  */
 function isReplicationRolePermissionError(err: unknown): boolean {
-  const msg = err instanceof Error ? err.message : String(err);
+  const msg = describeError(err);
   return /permission denied to set parameter/i.test(msg);
 }
 
@@ -546,9 +543,7 @@ export function registerMigrateFreshCommand(program: Command): void {
       try {
         await runMigrateFresh(resolvedOptions, context);
       } catch (error) {
-        context.logger.error(
-          error instanceof Error ? error.message : String(error)
-        );
+        context.logger.error(describeError(error));
         process.exit(1);
       }
     });
@@ -590,7 +585,7 @@ async function reconcileMysqlSchema(
     // Reconciliation is a safety net for historical MySQL drift. Do not
     // block migrate:fresh --seed if drizzle-kit emits duplicate/constraint
     // alteration errors after migrations have already created the schema.
-    const message = error instanceof Error ? error.message : String(error);
+    const message = describeError(error);
     if (isKnownMysqlReconcileDriftError(message)) {
       logger.debug(
         "[schema] Skipping known MySQL reconciliation drift (media FK already reconciled)"
@@ -637,9 +632,7 @@ async function performSeeding(
       skipSuperAdmin: true,
     });
   } catch (error) {
-    logger.error(
-      `Seeding failed: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logger.error(`Seeding failed: ${describeError(error)}`);
     throw error;
   }
 

--- a/packages/nextly/src/cli/commands/migrate-resolve.ts
+++ b/packages/nextly/src/cli/commands/migrate-resolve.ts
@@ -25,6 +25,7 @@ import { parseSnapshotFile } from "../../domains/schema/migrate-create/snapshot-
 import { introspectLiveSnapshot } from "../../domains/schema/pipeline/diff/introspect-live";
 import type { NextlySchemaSnapshot } from "../../domains/schema/pipeline/diff/types";
 import { withMigrateLock } from "../../domains/schema/pipeline/locks";
+import { describeError } from "../../errors/index";
 import { CORE_TABLE_PREFIXES } from "../../schemas";
 import { createContext, type CommandContext } from "../program";
 import {
@@ -219,9 +220,7 @@ export function registerMigrateResolveCommand(program: Command): void {
       try {
         await runMigrateResolve(resolvedOptions, context);
       } catch (error) {
-        context.logger.error(
-          error instanceof Error ? error.message : String(error)
-        );
+        context.logger.error(describeError(error));
         process.exit(1);
       }
     });

--- a/packages/nextly/src/cli/commands/migrate-status.ts
+++ b/packages/nextly/src/cli/commands/migrate-status.ts
@@ -32,6 +32,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { Command } from "commander";
 
 import { SchemaEventsRepository } from "../../domains/schema/events/schema-events-repository";
+import { describeError } from "../../errors/index";
 import type {
   MigrationErrorJson,
   MigrationRecordStatus,
@@ -192,7 +193,7 @@ export async function runMigrateStatus(
       debug: options.verbose,
     });
   } catch (error) {
-    const errorMsg = `Failed to load config: ${error instanceof Error ? error.message : String(error)}`;
+    const errorMsg = `Failed to load config: ${describeError(error)}`;
     if (options.json) {
       console.log(JSON.stringify({ error: errorMsg }, null, 2));
       process.exit(1);
@@ -221,7 +222,7 @@ export async function runMigrateStatus(
     });
     logger.debug("Database connected");
   } catch (error) {
-    const errorMsg = `Failed to connect to database: ${error instanceof Error ? error.message : String(error)}`;
+    const errorMsg = `Failed to connect to database: ${describeError(error)}`;
     if (options.json) {
       console.log(JSON.stringify({ error: errorMsg }, null, 2));
       process.exit(1);
@@ -654,17 +655,9 @@ export function registerMigrateStatusCommand(program: Command): void {
         await runMigrateStatus(resolvedOptions, context);
       } catch (error) {
         if (resolvedOptions.json) {
-          console.log(
-            JSON.stringify(
-              { error: error instanceof Error ? error.message : String(error) },
-              null,
-              2
-            )
-          );
+          console.log(JSON.stringify({ error: describeError(error) }, null, 2));
         } else {
-          context.logger.error(
-            error instanceof Error ? error.message : String(error)
-          );
+          context.logger.error(describeError(error));
         }
         process.exit(1);
       }

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -52,6 +52,7 @@ import {
   withMigrateLock,
 } from "../../domains/schema/pipeline/locks";
 import { isCompanionTable } from "../../domains/schema/pipeline/managed-tables";
+import { describeError } from "../../errors/index";
 import { CORE_TABLE_PREFIXES } from "../../schemas";
 import { createContext, type CommandContext } from "../program";
 import {
@@ -171,9 +172,7 @@ export async function runMigrate(
       debug: options.verbose,
     });
   } catch (error) {
-    logger.error(
-      `Failed to load config: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logger.error(`Failed to load config: ${describeError(error)}`);
     process.exit(1);
   }
 
@@ -201,9 +200,7 @@ export async function runMigrate(
     });
     logger.success("Database connected");
   } catch (error) {
-    logger.error(
-      `Failed to connect to database: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logger.error(`Failed to connect to database: ${describeError(error)}`);
     process.exit(1);
   }
 
@@ -277,7 +274,7 @@ export async function runMigrate(
           : `${formatCount(applied, "migration")} applied.`
       );
     } catch (err) {
-      logger.error(err instanceof Error ? err.message : String(err));
+      logger.error(describeError(err));
       process.exit(1);
     }
 
@@ -500,7 +497,7 @@ export async function runFileMigrations(args: {
         });
       } catch (err) {
         await repo.markFailed(id, {
-          errorMessage: err instanceof Error ? err.message : String(err),
+          errorMessage: describeError(err),
         });
         throw err;
       }
@@ -578,7 +575,7 @@ async function discoverMigrations(
       migrations.push(parsed);
     } catch (error) {
       logger.warn(
-        `Failed to parse migration file ${file}: ${error instanceof Error ? error.message : String(error)}`
+        `Failed to parse migration file ${file}: ${describeError(error)}`
       );
     }
   }
@@ -822,9 +819,7 @@ export function registerMigrateCommand(program: Command): void {
       try {
         await runMigrate(resolvedOptions, context);
       } catch (error) {
-        context.logger.error(
-          error instanceof Error ? error.message : String(error)
-        );
+        context.logger.error(describeError(error));
         process.exit(1);
       }
     });

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -38,7 +38,10 @@ import type { Command } from "commander";
 
 import { assertNoLegacyBookkeeping } from "../../domains/schema/events/legacy-detection";
 import { getSchemaEventsDdl } from "../../domains/schema/events/schema-events-ddl";
-import { SchemaEventsRepository } from "../../domains/schema/events/schema-events-repository";
+import {
+  SchemaEventsRepository,
+  truncateErrorMessage,
+} from "../../domains/schema/events/schema-events-repository";
 import { reconcileCore } from "../../domains/schema/migrate/core-reconcile";
 import { reconcileFile } from "../../domains/schema/migrate/drift-reconcile";
 import {
@@ -497,7 +500,9 @@ export async function runFileMigrations(args: {
         });
       } catch (err) {
         await repo.markFailed(id, {
-          errorMessage: describeError(err),
+          // Bounded: an unbounded description could fail this very write and
+          // leave the migration with no recorded failure at all.
+          errorMessage: truncateErrorMessage(describeError(err)),
         });
         throw err;
       }

--- a/packages/nextly/src/cli/commands/migrate.ts
+++ b/packages/nextly/src/cli/commands/migrate.ts
@@ -500,9 +500,14 @@ export async function runFileMigrations(args: {
         });
       } catch (err) {
         await repo.markFailed(id, {
-          // Bounded: an unbounded description could fail this very write and
+          // Bounded, and without logContext: this row is persisted and is
+          // served back by the schema-journal endpoint, so it keeps the code,
+          // message and cause chain but not the arbitrary identifiers a log
+          // context can carry. An unbounded write could also fail here and
           // leave the migration with no recorded failure at all.
-          errorMessage: truncateErrorMessage(describeError(err)),
+          errorMessage: truncateErrorMessage(
+            describeError(err, { context: false })
+          ),
         });
         throw err;
       }

--- a/packages/nextly/src/cli/commands/plugins.ts
+++ b/packages/nextly/src/cli/commands/plugins.ts
@@ -21,6 +21,7 @@
 import type { Command } from "commander";
 
 import type { NextlyServiceConfig } from "../../di/register";
+import { describeError } from "../../errors/index";
 import { pluginAdminSlug } from "../../plugins/admin-meta";
 import { getCoreVersion } from "../../plugins/core-version";
 import {
@@ -165,9 +166,7 @@ export function registerPluginsCommand(program: Command): void {
           context
         );
       } catch (error) {
-        context.logger.error(
-          error instanceof Error ? error.message : String(error)
-        );
+        context.logger.error(describeError(error));
         process.exit(1);
       }
     });
@@ -187,9 +186,7 @@ export function registerPluginsCommand(program: Command): void {
           context
         );
       } catch (error) {
-        context.logger.error(
-          error instanceof Error ? error.message : String(error)
-        );
+        context.logger.error(describeError(error));
         process.exit(1);
       }
     });

--- a/packages/nextly/src/cli/commands/prune.ts
+++ b/packages/nextly/src/cli/commands/prune.ts
@@ -19,6 +19,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { Command } from "commander";
 
 import { CollectionRegistryService } from "../../domains/collections/services/collection-registry-service";
+import { describeError } from "../../errors/index";
 import { createContext, type CommandContext } from "../program";
 import {
   createAdapter,
@@ -115,9 +116,7 @@ export async function runPruneCommand(
       databaseUrl: dbValidation.databaseUrl,
     });
   } catch (error) {
-    logger.error(
-      `Failed to connect to database: ${error instanceof Error ? error.message : String(error)}`
-    );
+    logger.error(`Failed to connect to database: ${describeError(error)}`);
     process.exit(1);
   }
 
@@ -173,9 +172,7 @@ export function registerPruneCommand(program: Command): void {
           context
         );
       } catch (error) {
-        context.logger.error(
-          error instanceof Error ? error.message : String(error)
-        );
+        context.logger.error(describeError(error));
         process.exit(1);
       }
     });

--- a/packages/nextly/src/cli/commands/upgrade.ts
+++ b/packages/nextly/src/cli/commands/upgrade.ts
@@ -29,7 +29,7 @@ import { getSchemaEventsDdl } from "../../domains/schema/events/schema-events-dd
 import { SchemaEventsRepository } from "../../domains/schema/events/schema-events-repository";
 import { reconcileCore } from "../../domains/schema/migrate/core-reconcile";
 import { withMigrateLock } from "../../domains/schema/pipeline/locks";
-import { NextlyError } from "../../errors";
+import { NextlyError, describeError } from "../../errors";
 import { createContext } from "../program";
 import { createAdapter, validateDatabaseEnv } from "../utils/adapter";
 
@@ -387,7 +387,7 @@ export function registerUpgradeCommand(program: Command): void {
         })) as unknown as { disconnect?: () => Promise<void> } & UpgradeAdapter;
       } catch (error) {
         context.logger.error(
-          `Failed to connect to database: ${error instanceof Error ? error.message : String(error)}`
+          `Failed to connect to database: ${describeError(error)}`
         );
         process.exit(1);
       }
@@ -425,9 +425,7 @@ export function registerUpgradeCommand(program: Command): void {
           );
         }
       } catch (error) {
-        context.logger.error(
-          error instanceof Error ? error.message : String(error)
-        );
+        context.logger.error(describeError(error));
         process.exitCode = 1;
       } finally {
         await adapter.disconnect?.();

--- a/packages/nextly/src/cli/nextly.ts
+++ b/packages/nextly/src/cli/nextly.ts
@@ -64,7 +64,7 @@ if (existsSync(envPath)) {
 async function main(): Promise<void> {
   const { createProgram } = await import("./program");
   const { createLogger } = await import("./utils/logger");
-  const { NextlyError } = await import("../errors/index");
+  const { NextlyError, describeError } = await import("../errors/index");
   const telemetry = await import("@nextlyhq/telemetry");
 
   const program = createProgram();
@@ -88,26 +88,16 @@ async function main(): Promise<void> {
       // Swallow.
     }
 
-    const debugMode =
-      process.env.DEBUG === "true" || process.env.DEBUG === "1";
+    const debugMode = process.env.DEBUG === "true" || process.env.DEBUG === "1";
 
     if (NextlyError.is(error)) {
-      // CLI is operator-facing — print publicMessage as the headline,
-      // then a one-line `[code] key=value …` summary from logContext for
-      // triage. cause.stack only under DEBUG=true per existing convention.
-      logger.error(error.publicMessage);
-      const ctxParts: string[] = [`[${String(error.code)}]`];
-      if (error.logContext) {
-        for (const [k, v] of Object.entries(error.logContext)) {
-          if (v === undefined) continue;
-          ctxParts.push(
-            `${k}=${typeof v === "string" ? v : JSON.stringify(v)}`
-          );
-        }
-      }
-      if (ctxParts.length > 1) {
-        console.error(ctxParts.join(" "));
-      }
+      // CLI is operator-facing — print publicMessage as the headline, then the
+      // full description (code, cause chain, logContext) so the terminal
+      // carries what the wire deliberately withholds. cause.stack only under
+      // DEBUG=true per existing convention.
+      // describeError already leads with the public message, so printing it
+      // separately would say the same thing twice.
+      logger.error(describeError(error));
       if (debugMode && error.cause?.stack) {
         logger.newline();
         console.error(error.cause.stack);
@@ -120,8 +110,9 @@ async function main(): Promise<void> {
         process.exit(1);
       }
 
-      // Application error
-      logger.error(error.message);
+      // Application error. describeError adds any `cause` chain, which a bare
+      // `error.message` drops.
+      logger.error(describeError(error));
 
       // Show stack trace in debug mode
       if (debugMode) {
@@ -129,8 +120,9 @@ async function main(): Promise<void> {
         console.error(error.stack);
       }
     } else {
-      logger.error("An unexpected error occurred");
-      console.error(error);
+      // Non-Error throwables still get rendered rather than reported as an
+      // opaque "unexpected error".
+      logger.error(describeError(error));
     }
 
     process.exit(1);

--- a/packages/nextly/src/cli/utils/config-loader.ts
+++ b/packages/nextly/src/cli/utils/config-loader.ts
@@ -36,7 +36,7 @@ import {
 } from "../../domains/schema/field-types/field-type-registry";
 import { loadUiSchema } from "../../domains/schema/ui-schema/loader";
 import { manifestToBuilderEntities } from "../../domains/schema/ui-schema/merge";
-import { NextlyError } from "../../errors/index";
+import { NextlyError, describeError } from "../../errors/index";
 import { getCoreVersion } from "../../plugins/core-version";
 import { collectCustomPermissions } from "../../plugins/permissions/collect-permissions";
 import type { PluginDefinition } from "../../plugins/plugin-context";
@@ -353,7 +353,7 @@ async function loadConfigInternal(
                 configPath,
                 reason: "plugin-setup-transformer-failed",
                 pluginName: plugin.name,
-                cause: error instanceof Error ? error.message : String(error),
+                cause: describeError(error),
               },
               cause: error instanceof Error ? error : undefined,
             });
@@ -444,7 +444,7 @@ async function loadConfigInternal(
       logContext: {
         configPath,
         reason: "load-error",
-        cause: error instanceof Error ? error.message : String(error),
+        cause: describeError(error),
       },
       cause: error instanceof Error ? error : undefined,
     });

--- a/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
@@ -9,7 +9,7 @@ import { toDbError } from "../../../database/errors";
 // out-of-scope callers (CollectionService orchestrator, dynamic-collections)
 // still consume the result tuple; only the internal error mapping changed.
 import type { PermissionSeedService } from "../../../domains/auth/services/permission-seed-service";
-import { NextlyError } from "../../../errors";
+import { NextlyError, isProgrammerError } from "../../../errors";
 import type { CollectionFileManager } from "../../../services/collection-file-manager";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
@@ -54,6 +54,18 @@ function errorToMetadataResult(
   // dialect explicitly (no `this`); without normalising via toDbError(dialect)
   // first, real unique/fk violations would collapse to INTERNAL_ERROR and the
   // caller's fallback statusCode would always win.
+  // A defect in our own code (a bad property access, a missing binding) is not
+  // a caller mistake, so it must not inherit the caller's 4xx fallback. Left
+  // unchecked, a TypeError reaches the wire as "Validation failed" and sends
+  // the caller hunting through their payload for a bug that is ours.
+  if (isProgrammerError(error)) {
+    return {
+      success: false,
+      statusCode: 500,
+      message: fallback.defaultMessage,
+      data: null,
+    };
+  }
   const mapped = NextlyError.fromDatabaseError(toDbError(dialect, error));
   // If the input was a true DbError, fromDatabaseError returns a non-internal
   // code. For anything else we honour the caller's fallback so e.g.

--- a/packages/nextly/src/domains/collections/services/collection-registry-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-registry-service.ts
@@ -19,7 +19,7 @@ import { toDbError } from "../../../database/errors";
 // NextlyError API. Public messages follow §13.8 — generic, no identifiers,
 // no constraint hints — and identifying detail moves to logContext.
 import type { PermissionSeedService } from "../../../domains/auth/services/permission-seed-service";
-import { NextlyError, describeError } from "../../../errors";
+import { NextlyError, describeError, immediateMessage } from "../../../errors";
 import type {
   DynamicCollectionInsert,
   DynamicCollectionRecord,
@@ -561,14 +561,19 @@ export class CollectionRegistryService extends BaseRegistryService<
         // with a debugger. Fall back to plain `error.message` for
         // non-NextlyError throws.
         const message = describeError(error);
+        // Classify on the thrown error's own message: a description
+        // concatenates the cause chain, so a genuine failure that merely
+        // wraps something saying "already exists" would enter duplicate
+        // recovery and mask the real error.
+        const immediate = immediateMessage(error).toLowerCase();
         // Prefer the structured NextlyError code over message string matching.
         // Falls back to legacy substring sniffing for any non-NextlyError that
         // bubbles up from deeper layers during the migration window.
         const isDuplicate =
           (NextlyError.is(error) && error.code === "DUPLICATE") ||
-          message.toLowerCase().includes("already exists") ||
-          message.toLowerCase().includes("duplicate") ||
-          message.toLowerCase().includes("unique constraint");
+          immediate.includes("already exists") ||
+          immediate.includes("duplicate") ||
+          immediate.includes("unique constraint");
         if (isDuplicate) {
           const refetched = await this.getCollectionBySlug(config.slug).catch(
             () => null

--- a/packages/nextly/src/domains/collections/services/collection-registry-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-registry-service.ts
@@ -19,7 +19,7 @@ import { toDbError } from "../../../database/errors";
 // NextlyError API. Public messages follow §13.8 — generic, no identifiers,
 // no constraint hints — and identifying detail moves to logContext.
 import type { PermissionSeedService } from "../../../domains/auth/services/permission-seed-service";
-import { NextlyError } from "../../../errors";
+import { NextlyError, describeError } from "../../../errors";
 import type {
   DynamicCollectionInsert,
   DynamicCollectionRecord,
@@ -37,41 +37,6 @@ import {
   calculateSchemaHash,
   schemaHashesMatch,
 } from "../../schema/services/schema-hash";
-
-/**
- * Build a developer-readable error string from any thrown value.
- *
- * For `NextlyError`, the public `message` is a generic fallback like
- * "An unexpected error occurred." that hides the actual cause from
- * server logs. This pulls the structured `code`, `cause.message`, and
- * key `logContext` fields so the recorded error string carries enough
- * signal to debug without re-running with a debugger attached.
- */
-function describeError(error: unknown): string {
-  if (NextlyError.is(error)) {
-    const parts: string[] = [];
-    parts.push(`[${error.code}] ${error.message}`);
-    if (error.cause instanceof Error && error.cause.message) {
-      parts.push(`cause: ${error.cause.message}`);
-    } else if (typeof error.cause === "string") {
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      parts.push(`cause: ${error.cause}`);
-    }
-    const ctx = error.logContext;
-    if (ctx && typeof ctx === "object" && Object.keys(ctx).length > 0) {
-      try {
-        parts.push(`context: ${JSON.stringify(ctx)}`);
-      } catch {
-        // Drop unprintable context rather than mask the rest.
-      }
-    }
-    return parts.join(" | ");
-  }
-  if (error instanceof Error) {
-    return error.message;
-  }
-  return String(error);
-}
 
 /** Options for updating a collection. */
 export interface UpdateCollectionOptions {

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-validation.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-validation.test.ts
@@ -56,6 +56,32 @@ describe("generateCollection request validation", () => {
     expect((err as NextlyError).statusCode).toBe(400);
   });
 
+  it("rejects a field element with no name, which is normalised before validation", async () => {
+    // `fields: [{}]` reaches `f.name.toLowerCase()` during normalisation,
+    // which runs before field validation — the same shape as the missing
+    // top-level name, one level down.
+    const err = await service()
+      .generateCollection({ name: "posts", fields: [{}] } as unknown as Input)
+      .catch((e: unknown) => e);
+
+    expect(NextlyError.is(err)).toBe(true);
+    expect((err as NextlyError).statusCode).toBe(400);
+    expect(err).not.toBeInstanceOf(TypeError);
+  });
+
+  it("reports which field element was malformed", async () => {
+    const err = await service()
+      .generateCollection({
+        name: "posts",
+        fields: [{ name: "ok" }, {}],
+      } as unknown as Input)
+      .catch((e: unknown) => e);
+
+    expect(JSON.stringify((err as NextlyError).publicData)).toContain(
+      "fields[1].name"
+    );
+  });
+
   it("rejects a body whose fields are not an array", async () => {
     const err = await service()
       .generateCollection({ name: "posts" } as unknown as Input)

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-validation.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-validation.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Request-shape validation before any dereference.
+ *
+ * The REST dispatcher forwards the raw request body, so `generateCollection`
+ * receives caller-controlled input. It used to read `data.name.toLowerCase()`
+ * immediately, so a body missing `name` threw a TypeError — a shape that is
+ * indistinguishable from a genuine defect in our own code, and so could not be
+ * reported as the 400 it actually is.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../../../errors";
+import { DynamicCollectionService } from "../dynamic-collection-service";
+
+type Input = Parameters<DynamicCollectionService["generateCollection"]>[0];
+
+beforeAll(() => {
+  // The schema service reads the dialect at construction; these cases never
+  // reach a database, but the constructor must still resolve it.
+  process.env.DB_DIALECT ??= "sqlite";
+  process.env.DATABASE_URL ??= "file::memory:";
+});
+
+function service(): DynamicCollectionService {
+  const logger = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+  // Minimal adapter slice: the constructor resolves the dialect eagerly, but
+  // these cases reject before any query is attempted.
+  const adapter = {
+    getCapabilities: () => ({ dialect: "sqlite" as const }),
+  } as unknown as ConstructorParameters<typeof DynamicCollectionService>[0];
+  return new DynamicCollectionService(adapter, logger);
+}
+
+describe("generateCollection request validation", () => {
+  it("rejects a body with no name as a validation error, not a crash", async () => {
+    const err = await service()
+      .generateCollection({ fields: [] } as unknown as Input)
+      .catch((e: unknown) => e);
+
+    expect(NextlyError.is(err)).toBe(true);
+    expect((err as NextlyError).statusCode).toBe(400);
+    expect(err).not.toBeInstanceOf(TypeError);
+  });
+
+  it("rejects a blank name", async () => {
+    const err = await service()
+      .generateCollection({ name: "   ", fields: [] } as unknown as Input)
+      .catch((e: unknown) => e);
+
+    expect(NextlyError.is(err)).toBe(true);
+    expect((err as NextlyError).statusCode).toBe(400);
+  });
+
+  it("rejects a body whose fields are not an array", async () => {
+    const err = await service()
+      .generateCollection({ name: "posts" } as unknown as Input)
+      .catch((e: unknown) => e);
+
+    expect(NextlyError.is(err)).toBe(true);
+    expect((err as NextlyError).statusCode).toBe(400);
+  });
+});

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-validation.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-validation.test.ts
@@ -121,3 +121,40 @@ describe("generateCollectionUpdate field validation", () => {
     expect((err as NextlyError).statusCode).toBe(400);
   });
 });
+
+describe("non-string scalar fields", () => {
+  it("rejects a numeric group on create rather than crashing on toLowerCase", async () => {
+    // `group?.toLowerCase()` guards null and undefined but not a number.
+    const err = await service()
+      .generateCollection({
+        name: "posts",
+        fields: [],
+        group: 123,
+      } as unknown as Input)
+      .catch((e: unknown) => e);
+
+    expect(NextlyError.is(err)).toBe(true);
+    expect((err as NextlyError).statusCode).toBe(400);
+    expect(err).not.toBeInstanceOf(TypeError);
+  });
+
+  it("rejects a numeric group on update", async () => {
+    const err = await service()
+      .generateCollectionUpdate("posts", { group: 123 } as never)
+      .catch((e: unknown) => e);
+
+    expect(NextlyError.is(err)).toBe(true);
+    expect((err as NextlyError).statusCode).toBe(400);
+  });
+
+  it("still accepts an absent group", async () => {
+    // Guarding on presence must not turn an omitted optional into an error.
+    const err = await service()
+      .generateCollectionUpdate("posts", { labels: undefined } as never)
+      .catch((e: unknown) => e);
+
+    expect(NextlyError.is(err) && (err as NextlyError).statusCode === 400).toBe(
+      false
+    );
+  });
+});

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-validation.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/generate-collection-validation.test.ts
@@ -91,3 +91,33 @@ describe("generateCollection request validation", () => {
     expect((err as NextlyError).statusCode).toBe(400);
   });
 });
+
+describe("generateCollectionUpdate field validation", () => {
+  async function update(updates: unknown): Promise<unknown> {
+    return service()
+      .generateCollectionUpdate("posts", updates as never)
+      .catch((e: unknown) => e);
+  }
+
+  it("rejects an explicitly null fields value rather than treating it as absent", async () => {
+    // `if (updates.fields)` skipped these, so the update reported success
+    // while silently applying no field change at all.
+    const err = await update({ fields: null });
+    expect(NextlyError.is(err)).toBe(true);
+    expect((err as NextlyError).statusCode).toBe(400);
+  });
+
+  it("rejects other supplied falsy non-arrays", async () => {
+    for (const value of ["", false, 0]) {
+      const err = await update({ fields: value });
+      expect(NextlyError.is(err)).toBe(true);
+      expect((err as NextlyError).statusCode).toBe(400);
+    }
+  });
+
+  it("rejects a field element with no name on the update path", async () => {
+    const err = await update({ fields: [{ type: "text" }] });
+    expect(NextlyError.is(err)).toBe(true);
+    expect((err as NextlyError).statusCode).toBe(400);
+  });
+});

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -374,6 +374,44 @@ export class DynamicCollectionService extends BaseService {
     migrationFileName: string | null;
     metadataUpdates: Record<string, unknown>;
   }> {
+    // Validate caller input before any I/O: the shape checks below cannot
+    // depend on the registry, and rejecting a malformed body after a fetch
+    // does pointless work for a request that was never going to apply.
+    //
+    // Presence, not truthiness: `fields: null` or `fields: ""` is a supplied
+    // value that cannot be applied, and treating it as absent would report
+    // success for an update that silently did nothing to the fields.
+    if (updates.fields !== undefined) {
+      if (!Array.isArray(updates.fields)) {
+        throw NextlyError.validation({
+          errors: [
+            {
+              path: "fields",
+              code: "REQUIRED",
+              message: "Fields must be an array.",
+            },
+          ],
+        });
+      }
+      // The array is normalised through `f.name.toLowerCase()` before field
+      // validation runs, so an element without a string name throws an
+      // untyped TypeError rather than reporting the client error it is.
+      const malformedUpdate = updates.fields.findIndex(
+        f => typeof (f as { name?: unknown })?.name !== "string"
+      );
+      if (malformedUpdate !== -1) {
+        throw NextlyError.validation({
+          errors: [
+            {
+              path: `fields[${malformedUpdate}].name`,
+              code: "REQUIRED",
+              message: "Each field requires a name.",
+            },
+          ],
+        });
+      }
+    }
+
     const collection = (await this.registryService.getCollection(
       collectionName
     )) as CollectionMetadata;
@@ -464,38 +502,7 @@ export class DynamicCollectionService extends BaseService {
       (f: FieldDefinition) => !reservedForFields.includes(f.name)
     );
 
-    if (updates.fields) {
-      // Same caller-controlled dereference as the create path: the update
-      // body arrives unvalidated and is normalised through `f.name
-      // .toLowerCase()` before field validation runs, so a field without a
-      // string name throws an untyped TypeError instead of reporting the
-      // client error it is.
-      if (!Array.isArray(updates.fields)) {
-        throw NextlyError.validation({
-          errors: [
-            {
-              path: "fields",
-              code: "REQUIRED",
-              message: "Fields must be an array.",
-            },
-          ],
-        });
-      }
-      const malformedUpdate = updates.fields.findIndex(
-        f => typeof (f as { name?: unknown })?.name !== "string"
-      );
-      if (malformedUpdate !== -1) {
-        throw NextlyError.validation({
-          errors: [
-            {
-              path: `fields[${malformedUpdate}].name`,
-              code: "REQUIRED",
-              message: "Each field requires a name.",
-            },
-          ],
-        });
-      }
-
+    if (updates.fields !== undefined) {
       const normalizedFields = updates.fields.map(f => ({
         ...f,
         name: f.name.toLowerCase(),

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -173,6 +173,21 @@ export class DynamicCollectionService extends BaseService {
       });
     }
 
+    // `group` is lower-cased later without a type check; `?.` guards null and
+    // undefined but not a number or object, which would throw an untyped
+    // TypeError from a caller-supplied value.
+    if (data.group !== undefined && typeof data.group !== "string") {
+      throw NextlyError.validation({
+        errors: [
+          {
+            path: "group",
+            code: "INVALID",
+            message: "Group must be a string.",
+          },
+        ],
+      });
+    }
+
     const normalizedName = data.name.toLowerCase();
     const tableName = `dc_${normalizedName}`;
 
@@ -374,6 +389,18 @@ export class DynamicCollectionService extends BaseService {
     migrationFileName: string | null;
     metadataUpdates: Record<string, unknown>;
   }> {
+    if (updates.group !== undefined && typeof updates.group !== "string") {
+      throw NextlyError.validation({
+        errors: [
+          {
+            path: "group",
+            code: "INVALID",
+            message: "Group must be a string.",
+          },
+        ],
+      });
+    }
+
     // Validate caller input before any I/O: the shape checks below cannot
     // depend on the registry, and rejecting a malformed body after a fetch
     // does pointless work for a request that was never going to apply.

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -7,6 +7,7 @@ import { createHash, randomBytes } from "crypto";
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
+import { NextlyError } from "../../../errors";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import type { MigrationStatus } from "../../../schemas/dynamic-collections/types";
 import { getI18nArchiveDdl } from "../../../schemas/nextly-i18n-archive";
@@ -130,6 +131,30 @@ export class DynamicCollectionService extends BaseService {
   async generateCollection(
     data: CreateCollectionInput
   ): Promise<CollectionArtifacts> {
+    // The REST dispatcher forwards the request body unvalidated, so `data` is
+    // caller-controlled and the fields below may be absent. Check them before
+    // dereferencing: without this a body missing `name` throws a TypeError
+    // from `.toLowerCase()`, which is indistinguishable from a defect in our
+    // own code and cannot be reported as the client error it is.
+    if (typeof data?.name !== "string" || data.name.trim() === "") {
+      throw NextlyError.validation({
+        errors: [
+          { path: "name", code: "REQUIRED", message: "Name is required." },
+        ],
+      });
+    }
+    if (!Array.isArray(data.fields)) {
+      throw NextlyError.validation({
+        errors: [
+          {
+            path: "fields",
+            code: "REQUIRED",
+            message: "Fields must be an array.",
+          },
+        ],
+      });
+    }
+
     const normalizedName = data.name.toLowerCase();
     const tableName = `dc_${normalizedName}`;
 

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -154,6 +154,24 @@ export class DynamicCollectionService extends BaseService {
         ],
       });
     }
+    // Element shape matters too: the array is normalised with `f.name
+    // .toLowerCase()` below, before field validation runs, so an element
+    // without a string name throws the same untyped TypeError the checks
+    // above exist to prevent.
+    const malformed = data.fields.findIndex(
+      f => typeof (f as { name?: unknown })?.name !== "string"
+    );
+    if (malformed !== -1) {
+      throw NextlyError.validation({
+        errors: [
+          {
+            path: `fields[${malformed}].name`,
+            code: "REQUIRED",
+            message: "Each field requires a name.",
+          },
+        ],
+      });
+    }
 
     const normalizedName = data.name.toLowerCase();
     const tableName = `dc_${normalizedName}`;
@@ -447,6 +465,37 @@ export class DynamicCollectionService extends BaseService {
     );
 
     if (updates.fields) {
+      // Same caller-controlled dereference as the create path: the update
+      // body arrives unvalidated and is normalised through `f.name
+      // .toLowerCase()` before field validation runs, so a field without a
+      // string name throws an untyped TypeError instead of reporting the
+      // client error it is.
+      if (!Array.isArray(updates.fields)) {
+        throw NextlyError.validation({
+          errors: [
+            {
+              path: "fields",
+              code: "REQUIRED",
+              message: "Fields must be an array.",
+            },
+          ],
+        });
+      }
+      const malformedUpdate = updates.fields.findIndex(
+        f => typeof (f as { name?: unknown })?.name !== "string"
+      );
+      if (malformedUpdate !== -1) {
+        throw NextlyError.validation({
+          errors: [
+            {
+              path: `fields[${malformedUpdate}].name`,
+              code: "REQUIRED",
+              message: "Each field requires a name.",
+            },
+          ],
+        });
+      }
+
       const normalizedFields = updates.fields.map(f => ({
         ...f,
         name: f.name.toLowerCase(),

--- a/packages/nextly/src/domains/schema/events/__tests__/truncate-error-message.test.ts
+++ b/packages/nextly/src/domains/schema/events/__tests__/truncate-error-message.test.ts
@@ -1,0 +1,45 @@
+/**
+ * The `error_message` column bound.
+ *
+ * This guard exists so that recording a failure cannot itself fail. A helper
+ * that returns more than the bound defeats that entirely, and does so at the
+ * one moment it is needed.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  ERROR_MESSAGE_MAX_LEN,
+  truncateErrorMessage,
+} from "../schema-events-repository";
+
+describe("truncateErrorMessage", () => {
+  it("never returns more than the column bound", () => {
+    // The regression: slicing to the full bound and then appending "..."
+    // returned bound + 3 characters.
+    for (const length of [
+      ERROR_MESSAGE_MAX_LEN - 1,
+      ERROR_MESSAGE_MAX_LEN,
+      ERROR_MESSAGE_MAX_LEN + 1,
+      ERROR_MESSAGE_MAX_LEN * 4,
+    ]) {
+      const out = truncateErrorMessage("x".repeat(length));
+      expect(out.length).toBeLessThanOrEqual(ERROR_MESSAGE_MAX_LEN);
+    }
+  });
+
+  it("leaves a message at exactly the bound untouched", () => {
+    const exact = "x".repeat(ERROR_MESSAGE_MAX_LEN);
+    expect(truncateErrorMessage(exact)).toBe(exact);
+  });
+
+  it("marks a message that was cut", () => {
+    expect(truncateErrorMessage("x".repeat(ERROR_MESSAGE_MAX_LEN + 1))).toMatch(
+      /\.\.\.$/
+    );
+  });
+
+  it("handles an absent message, which optional error fields produce", () => {
+    expect(truncateErrorMessage(undefined)).toBe("");
+    expect(truncateErrorMessage("")).toBe("");
+  });
+});

--- a/packages/nextly/src/domains/schema/events/schema-events-repository.ts
+++ b/packages/nextly/src/domains/schema/events/schema-events-repository.ts
@@ -106,11 +106,26 @@ export interface MarkFailedInput {
  */
 export const ERROR_MESSAGE_MAX_LEN = 1000;
 
-/** Clamp a message to the `error_message` column bound, marking any cut. */
-export function truncateErrorMessage(message: string): string {
-  return message.length > ERROR_MESSAGE_MAX_LEN
-    ? `${message.slice(0, ERROR_MESSAGE_MAX_LEN)}...`
-    : message;
+/** Marks a truncated message; its length is reserved from the budget. */
+const TRUNCATION_SUFFIX = "...";
+
+/**
+ * Clamp a message to the `error_message` column bound, marking any cut.
+ *
+ * The suffix counts against the budget. Appending it to a full-length slice
+ * would return more characters than the bound allows, which defeats the point:
+ * the write this guards could still overflow, and it would do so exactly when
+ * a failure is being recorded.
+ */
+export function truncateErrorMessage(message: string | undefined): string {
+  // Callers reach this from optional error fields, so an absent message is a
+  // real input rather than a type violation.
+  if (!message) return "";
+  if (message.length <= ERROR_MESSAGE_MAX_LEN) return message;
+  return (
+    message.slice(0, ERROR_MESSAGE_MAX_LEN - TRUNCATION_SUFFIX.length) +
+    TRUNCATION_SUFFIX
+  );
 }
 
 export class SchemaEventsRepository {

--- a/packages/nextly/src/domains/schema/events/schema-events-repository.ts
+++ b/packages/nextly/src/domains/schema/events/schema-events-repository.ts
@@ -98,13 +98,18 @@ export interface MarkFailedInput {
 /**
  * Storage bound for the `error_message` column.
  *
- * Recorded descriptions can be long — a generated migration statement plus its
- * cause chain and context runs to thousands of characters. Writing that
- * unbounded risks the failure record itself failing, which would leave the
- * migration with no failed status at all: the worst outcome, since the
- * operator then sees neither the error nor the fact that one occurred.
+ * The column is `text` on every dialect, so this is not a schema limit. It is
+ * a guard against the one real ceiling: MySQL `TEXT` holds 65,535 bytes, and a
+ * write that exceeds it fails — which would leave the migration with no failed
+ * status at all, the worst outcome, since the operator then sees neither the
+ * error nor that one occurred.
+ *
+ * Sized well above any genuine message so the cause chain, which is the part
+ * worth reading and sits at the END of a description, is not cut off. A
+ * tighter cap would routinely discard the driver error while keeping the
+ * generic wrapper text in front of it.
  */
-export const ERROR_MESSAGE_MAX_LEN = 1000;
+export const ERROR_MESSAGE_MAX_LEN = 8000;
 
 /** Marks a truncated message; its length is reserved from the budget. */
 const TRUNCATION_SUFFIX = "...";

--- a/packages/nextly/src/domains/schema/events/schema-events-repository.ts
+++ b/packages/nextly/src/domains/schema/events/schema-events-repository.ts
@@ -95,6 +95,24 @@ export interface MarkFailedInput {
   errorJson?: unknown;
 }
 
+/**
+ * Storage bound for the `error_message` column.
+ *
+ * Recorded descriptions can be long — a generated migration statement plus its
+ * cause chain and context runs to thousands of characters. Writing that
+ * unbounded risks the failure record itself failing, which would leave the
+ * migration with no failed status at all: the worst outcome, since the
+ * operator then sees neither the error nor the fact that one occurred.
+ */
+export const ERROR_MESSAGE_MAX_LEN = 1000;
+
+/** Clamp a message to the `error_message` column bound, marking any cut. */
+export function truncateErrorMessage(message: string): string {
+  return message.length > ERROR_MESSAGE_MAX_LEN
+    ? `${message.slice(0, ERROR_MESSAGE_MAX_LEN)}...`
+    : message;
+}
+
 export class SchemaEventsRepository {
   private readonly db: AnyDb;
   private readonly table: ReturnType<

--- a/packages/nextly/src/domains/schema/journal/migration-journal.ts
+++ b/packages/nextly/src/domains/schema/journal/migration-journal.ts
@@ -56,7 +56,10 @@ function stringifyError(err: unknown): string {
   if (typeof err === "number" || typeof err === "boolean") return String(err);
   if (err === null) return "null";
   try {
-    return JSON.stringify(err);
+    // JSON.stringify returns undefined for undefined, functions and symbols,
+    // so it cannot be returned directly from a function declared to yield a
+    // string — `args.error` is optional and reaches here as undefined.
+    return JSON.stringify(err) ?? "unknown error";
   } catch {
     return "[unstringifiable error]";
   }

--- a/packages/nextly/src/domains/schema/journal/migration-journal.ts
+++ b/packages/nextly/src/domains/schema/journal/migration-journal.ts
@@ -16,7 +16,10 @@ import type {
   SchemaEventSource,
   SchemaEventType,
 } from "../../../schemas/schema-events/types";
-import { SchemaEventsRepository } from "../events/schema-events-repository";
+import {
+  SchemaEventsRepository,
+  truncateErrorMessage,
+} from "../events/schema-events-repository";
 import type {
   MigrationJournal,
   MigrationJournalScope,
@@ -45,8 +48,6 @@ export interface DrizzleMigrationJournalDeps {
 // recordEnd skips the update when it sees this prefix.
 const FAILED_INSERT_PREFIX = "journal-failed-";
 
-const ERROR_MESSAGE_MAX_LEN = 1000;
-
 // Safe stringification for the recorded error column. Avoids
 // "[object Object]" output (lint rule no-base-to-string flags raw String()).
 function stringifyError(err: unknown): string {
@@ -73,7 +74,9 @@ function mapSourceToEvent(source: "ui" | "code"): {
 }
 
 // The events table has no "fresh-push" scope; fold it into "global".
-function mapScopeKind(kind: MigrationJournalScope["kind"]): SchemaEventScopeKind {
+function mapScopeKind(
+  kind: MigrationJournalScope["kind"]
+): SchemaEventScopeKind {
   return kind === "fresh-push" ? "global" : kind;
 }
 
@@ -144,11 +147,7 @@ export class DrizzleMigrationJournal implements MigrationJournal {
           durationMs,
         });
       } else {
-        const raw = stringifyError(args.error);
-        const errorMessage =
-          raw.length > ERROR_MESSAGE_MAX_LEN
-            ? `${raw.slice(0, ERROR_MESSAGE_MAX_LEN)}...`
-            : raw;
+        const errorMessage = truncateErrorMessage(stringifyError(args.error));
         await this.repo.markFailed(journalId, {
           errorMessage,
           errorJson:

--- a/packages/nextly/src/errors/__tests__/describe-error.test.ts
+++ b/packages/nextly/src/errors/__tests__/describe-error.test.ts
@@ -93,6 +93,24 @@ describe("describeError", () => {
     expect(immediateMessage(wrapped)).not.toContain("already exists");
   });
 
+  it("omits logContext when the description will be persisted", () => {
+    // A terminal line is read once; a stored row outlives the incident and is
+    // served back by the schema-journal endpoint, so the arbitrary identifiers
+    // a log context carries do not belong in it. Code, message and cause do.
+    const err = NextlyError.internal({
+      cause: new Error("no such column: localized"),
+      logContext: { table: "dc_secret_project", dialect: "sqlite" },
+    });
+
+    const stored = describeError(err, { context: false });
+
+    expect(stored).toContain("INTERNAL_ERROR");
+    expect(stored).toContain("no such column: localized");
+    expect(stored).not.toContain("dc_secret_project");
+    // Default stays unchanged for terminal output.
+    expect(describeError(err)).toContain("dc_secret_project");
+  });
+
   it("does not stringify an object cause as [object Object]", () => {
     const err = NextlyError.internal({});
     Object.defineProperty(err, "cause", { value: { detail: "x" } });

--- a/packages/nextly/src/errors/__tests__/describe-error.test.ts
+++ b/packages/nextly/src/errors/__tests__/describe-error.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Operator-facing error rendering.
+ *
+ * The point of `describeError` is that `NextlyError.message` is the PUBLIC
+ * message by construction, so anything rendering a caught error with
+ * `.message` shows the generic wire text. These pin that the structured
+ * fields the wire withholds do reach an operator channel.
+ */
+import { describe, expect, it } from "vitest";
+
+import { describeError } from "../describe-error";
+import { NextlyError } from "../nextly-error";
+
+describe("describeError", () => {
+  it("surfaces the code and cause a NextlyError hides behind its public message", () => {
+    // The exact shape that made `nextly db:sync` print only "An unexpected
+    // error occurred." while the real failure was a missing column.
+    const err = NextlyError.internal({
+      cause: new Error('Failed query: select "localized" from "x"'),
+      logContext: { dbKind: "internal", dialect: "sqlite" },
+    });
+
+    const out = describeError(err);
+
+    expect(out).toContain("INTERNAL_ERROR");
+    expect(out).toContain("Failed query");
+    expect(out).toContain("sqlite");
+    // The public message alone is what the bug looked like.
+    expect(out).not.toBe(err.publicMessage);
+  });
+
+  it("reaches the driver message at the bottom of a real database chain", () => {
+    // The production shape is four deep: NextlyError -> DbError ->
+    // DrizzleQueryError -> driver error. Only the deepest link names the
+    // fault; every wrapper above it says "Failed query". A shallower walk
+    // silently drops the one segment worth reading.
+    const driver = new Error('no such column: "localized"');
+    const drizzle = new Error("Failed query: select ...", { cause: driver });
+    const dbError = new Error("Failed query: select ...", { cause: drizzle });
+    const err = NextlyError.internal({ cause: dbError });
+
+    expect(describeError(err)).toContain('no such column: "localized"');
+  });
+
+  it("collapses wrappers that echo the same message", () => {
+    // DbError and DrizzleQueryError carry identical text; printing both
+    // doubles an already-long line for no gain.
+    const inner = new Error("Failed query: select ...");
+    const outer = new Error("Failed query: select ...", { cause: inner });
+    const err = NextlyError.internal({ cause: outer });
+
+    const occurrences = describeError(err).split("Failed query").length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it("returns the plain message for an ordinary Error", () => {
+    expect(describeError(new Error("boom"))).toBe("boom");
+  });
+
+  it("includes an ordinary Error's cause chain", () => {
+    const out = describeError(
+      new Error("outer", { cause: new Error("inner") })
+    );
+    expect(out).toContain("outer");
+    expect(out).toContain("inner");
+  });
+
+  it("renders non-Error throwables instead of reporting them as unexpected", () => {
+    expect(describeError("just a string")).toBe("just a string");
+    expect(describeError(null)).toBe("null");
+    expect(describeError(undefined)).toBe("undefined");
+    expect(describeError(42)).toBe("42");
+    expect(describeError({ code: "E1" })).toBe('{"code":"E1"}');
+  });
+
+  it("never throws on a circular value", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() => describeError(circular)).not.toThrow();
+    // Falls back to the type tag rather than an unhelpful empty string.
+    expect(describeError(circular)).toContain("Object");
+  });
+
+  it("does not stringify an object cause as [object Object]", () => {
+    const err = NextlyError.internal({});
+    Object.defineProperty(err, "cause", { value: { detail: "x" } });
+    expect(describeError(err)).not.toContain("[object Object]");
+  });
+});

--- a/packages/nextly/src/errors/__tests__/describe-error.test.ts
+++ b/packages/nextly/src/errors/__tests__/describe-error.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { describeError } from "../describe-error";
+import { describeError, immediateMessage } from "../describe-error";
 import { NextlyError } from "../nextly-error";
 
 describe("describeError", () => {
@@ -79,6 +79,18 @@ describe("describeError", () => {
     expect(() => describeError(circular)).not.toThrow();
     // Falls back to the type tag rather than an unhelpful empty string.
     expect(describeError(circular)).toContain("Object");
+  });
+
+  it("is not safe as a branching predicate, which is why immediateMessage exists", () => {
+    // Callers ask "is this the benign 'already exists' case?" by substring
+    // match. A description concatenates the whole chain, so an unrelated
+    // failure that merely WRAPS such a message would match and be swallowed.
+    const wrapped = new Error("permission denied opening database", {
+      cause: new Error('table "x" already exists'),
+    });
+
+    expect(describeError(wrapped)).toContain("already exists");
+    expect(immediateMessage(wrapped)).not.toContain("already exists");
   });
 
   it("does not stringify an object cause as [object Object]", () => {

--- a/packages/nextly/src/errors/__tests__/programmer-error.test.ts
+++ b/packages/nextly/src/errors/__tests__/programmer-error.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Our defects versus the caller's mistakes.
+ *
+ * A service that maps every throwable onto one fallback status reports its own
+ * crashes as the caller's fault. These pin which natives count as ours, and
+ * more importantly which do not.
+ */
+import { describe, expect, it } from "vitest";
+
+import { isProgrammerError } from "../programmer-error";
+
+describe("isProgrammerError", () => {
+  it("treats a bad property access as our defect", () => {
+    // The exact failure that surfaced to the API as "Validation failed": a
+    // service read `.toLowerCase()` off an undefined field.
+    let caught: unknown;
+    try {
+      const value = undefined as unknown as { name: string };
+      value.name.toLowerCase();
+    } catch (error) {
+      caught = error;
+    }
+    expect(isProgrammerError(caught)).toBe(true);
+  });
+
+  it("treats an unbound identifier as our defect", () => {
+    const err = new ReferenceError("x is not defined");
+    expect(isProgrammerError(err)).toBe(true);
+  });
+
+  it("does NOT claim a malformed JSON body", () => {
+    // JSON.parse on a caller-supplied payload throws SyntaxError. Calling that
+    // our bug would turn a genuine 400 into a 500.
+    let caught: unknown;
+    try {
+      JSON.parse("{ not json");
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(SyntaxError);
+    expect(isProgrammerError(caught)).toBe(false);
+  });
+
+  it("does NOT claim a caller-supplied out-of-range value", () => {
+    expect(isProgrammerError(new RangeError("Invalid array length"))).toBe(
+      false
+    );
+  });
+
+  it("does not claim ordinary errors or non-Error throwables", () => {
+    expect(isProgrammerError(new Error("expected failure"))).toBe(false);
+    expect(isProgrammerError("string")).toBe(false);
+    expect(isProgrammerError(null)).toBe(false);
+    expect(isProgrammerError(undefined)).toBe(false);
+  });
+});

--- a/packages/nextly/src/errors/describe-error.ts
+++ b/packages/nextly/src/errors/describe-error.ts
@@ -79,6 +79,24 @@ function collectCauses(
 }
 
 /**
+ * The thrown value's own message, with no cause chain appended.
+ *
+ * Use this, never `describeError`, when the result feeds a decision. Code that
+ * asks "is this the benign 'already exists' case?" by substring match must see
+ * only the immediate failure: `describeError` concatenates the whole chain, so
+ * an unrelated error that merely *wraps* something containing the phrase would
+ * match and be swallowed. Descriptions are for reading; this is for branching.
+ *
+ * Substring-matching a driver message is itself a weak test. It is preserved
+ * here because replacing it is a separate change, but new code should prefer a
+ * structured signal such as `DbError.kind`.
+ */
+export function immediateMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return stringifyUnknown(error);
+}
+
+/**
  * Build a developer-readable description of any thrown value.
  *
  * For a `NextlyError` this is `[CODE] public message | cause: … | context: {…}`.

--- a/packages/nextly/src/errors/describe-error.ts
+++ b/packages/nextly/src/errors/describe-error.ts
@@ -1,0 +1,117 @@
+/**
+ * Developer-facing rendering of a thrown value.
+ *
+ * `NextlyError.message` is deliberately the public message, so anything that
+ * renders a caught error with `error.message` shows the generic wire text
+ * ("An unexpected error occurred.") and drops the code, the cause and the log
+ * context. That is the correct behaviour on the wire and the wrong behaviour
+ * on an operator channel: a server log or a terminal.
+ *
+ * This builds the operator view instead, pulling the structured fields that
+ * identify the failure. Stack traces are deliberately excluded — they are the
+ * noisy part, and callers that want them render `cause.stack` behind a flag.
+ *
+ * @module errors/describe-error
+ */
+
+import { NextlyError } from "./nextly-error";
+
+/**
+ * How far to walk a `cause` chain.
+ *
+ * The database path alone nests four deep (NextlyError -> DbError ->
+ * DrizzleQueryError -> driver error), and it is the DEEPEST link that names the
+ * actual fault: the driver says "no such column: localized" while every wrapper
+ * above it says only "Failed query". Stopping short drops the one segment worth
+ * reading. Repeated messages are collapsed, so the extra depth costs nothing
+ * when wrappers merely echo each other.
+ */
+const MAX_CAUSE_DEPTH = 4;
+
+/**
+ * Render an unknown value as a single line, without throwing.
+ *
+ * Falls back through JSON so a plain object cause (some drivers reject with
+ * one) still contributes signal rather than "[object Object]".
+ */
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  try {
+    // JSON.stringify returns undefined for functions and symbols; fall through
+    // to the type tag rather than stringifying an object into "[object Object]".
+    const json = JSON.stringify(value);
+    if (json !== undefined) return json;
+  } catch {
+    // Circular or otherwise unserialisable: the type tag still beats nothing.
+  }
+  return Object.prototype.toString.call(value);
+}
+
+/**
+ * Append `cause: …` segments, walking nested causes up to the depth cap.
+ *
+ * Repeated messages are skipped. A wrapper that re-uses its inner error's text
+ * is the norm rather than the exception (a DbError wrapping a driver error
+ * carries the same string), and echoing it twice doubles the length of an
+ * already-long line without adding signal.
+ */
+function collectCauses(
+  cause: unknown,
+  parts: string[],
+  depth: number,
+  seen: Set<string>
+): void {
+  if (cause === undefined || cause === null || depth >= MAX_CAUSE_DEPTH) return;
+  const message =
+    cause instanceof Error ? cause.message : stringifyUnknown(cause);
+  if (message && !seen.has(message)) {
+    seen.add(message);
+    parts.push(`cause: ${message}`);
+  }
+  if (cause instanceof Error) {
+    collectCauses(cause.cause, parts, depth + 1, seen);
+  }
+}
+
+/**
+ * Build a developer-readable description of any thrown value.
+ *
+ * For a `NextlyError` this is `[CODE] public message | cause: … | context: {…}`.
+ * For a plain `Error` it is the message plus any cause chain. For anything else
+ * it is a best-effort stringification.
+ */
+export function describeError(error: unknown): string {
+  if (NextlyError.is(error)) {
+    const parts: string[] = [`[${String(error.code)}] ${error.publicMessage}`];
+    // logMessage is the operator-facing headline the factories set (e.g.
+    // "Database error"); it is dropped from the wire, so surface it here when
+    // it says something the public message does not.
+    if (error.logMessage && error.logMessage !== error.publicMessage) {
+      parts.push(error.logMessage);
+    }
+    const seen = new Set<string>([error.publicMessage]);
+    collectCauses(error.cause, parts, 0, seen);
+    const ctx = error.logContext;
+    if (ctx && Object.keys(ctx).length > 0) {
+      try {
+        parts.push(`context: ${JSON.stringify(ctx)}`);
+      } catch {
+        // Drop unprintable context rather than mask the rest of the line.
+      }
+    }
+    return parts.join(" | ");
+  }
+
+  if (error instanceof Error) {
+    const parts: string[] = [error.message];
+    collectCauses(error.cause, parts, 0, new Set([error.message]));
+    return parts.join(" | ");
+  }
+
+  return stringifyUnknown(error);
+}

--- a/packages/nextly/src/errors/describe-error.ts
+++ b/packages/nextly/src/errors/describe-error.ts
@@ -96,6 +96,20 @@ export function immediateMessage(error: unknown): string {
   return stringifyUnknown(error);
 }
 
+/** Options for {@link describeError}. */
+export interface DescribeErrorOptions {
+  /**
+   * Append `logContext`. Default true.
+   *
+   * Set false when the result is PERSISTED rather than printed. A terminal
+   * line is read once and discarded; a stored row outlives the incident and
+   * may be served back over an API, so the arbitrary identifiers and values a
+   * log context can carry are worth leaving out of it. The code, message and
+   * cause chain carry the diagnostic value and are kept either way.
+   */
+  context?: boolean;
+}
+
 /**
  * Build a developer-readable description of any thrown value.
  *
@@ -103,7 +117,10 @@ export function immediateMessage(error: unknown): string {
  * For a plain `Error` it is the message plus any cause chain. For anything else
  * it is a best-effort stringification.
  */
-export function describeError(error: unknown): string {
+export function describeError(
+  error: unknown,
+  options: DescribeErrorOptions = {}
+): string {
   if (NextlyError.is(error)) {
     const parts: string[] = [`[${String(error.code)}] ${error.publicMessage}`];
     // logMessage is the operator-facing headline the factories set (e.g.
@@ -114,7 +131,7 @@ export function describeError(error: unknown): string {
     }
     const seen = new Set<string>([error.publicMessage]);
     collectCauses(error.cause, parts, 0, seen);
-    const ctx = error.logContext;
+    const ctx = options.context === false ? undefined : error.logContext;
     if (ctx && Object.keys(ctx).length > 0) {
       try {
         parts.push(`context: ${JSON.stringify(ctx)}`);

--- a/packages/nextly/src/errors/index.ts
+++ b/packages/nextly/src/errors/index.ts
@@ -1,7 +1,7 @@
 // Public exports for nextly/errors entry point.
 
 export { NextlyError, type NextlyErrorResponseJSON } from "./nextly-error";
-export { describeError } from "./describe-error";
+export { describeError, immediateMessage } from "./describe-error";
 export { isProgrammerError } from "./programmer-error";
 export { NEXTLY_ERROR_STATUS, type NextlyErrorCode } from "./error-codes";
 export type {

--- a/packages/nextly/src/errors/index.ts
+++ b/packages/nextly/src/errors/index.ts
@@ -1,6 +1,8 @@
 // Public exports for nextly/errors entry point.
 
 export { NextlyError, type NextlyErrorResponseJSON } from "./nextly-error";
+export { describeError } from "./describe-error";
+export { isProgrammerError } from "./programmer-error";
 export { NEXTLY_ERROR_STATUS, type NextlyErrorCode } from "./error-codes";
 export type {
   PublicData,

--- a/packages/nextly/src/errors/programmer-error.ts
+++ b/packages/nextly/src/errors/programmer-error.ts
@@ -1,0 +1,30 @@
+/**
+ * Telling our bugs apart from the caller's mistakes.
+ *
+ * Service layers commonly wrap their body in one try/catch and map anything
+ * thrown onto a single fallback status. That is right for expected failures
+ * (invalid input, a missing row) and wrong for a defect in our own code: a
+ * `TypeError` from a bad property access surfaces to the caller as
+ * "Validation failed", so they inspect a payload that was never the problem
+ * while the real defect leaves no trace at the status code.
+ *
+ * @module errors/programmer-error
+ */
+
+/**
+ * Whether a thrown value indicates a defect in Nextly rather than bad input.
+ *
+ * Only `TypeError` and `ReferenceError` qualify. Both are raised by the
+ * runtime for operations that are wrong regardless of input: reading a
+ * property of `undefined`, calling a non-function, touching an unbound
+ * identifier.
+ *
+ * `SyntaxError` and `RangeError` are deliberately excluded even though they
+ * are also natives. `JSON.parse` of a caller-supplied body throws
+ * `SyntaxError`, and a caller-supplied count throws `RangeError`; treating
+ * either as our defect would turn genuine 4xx cases into 500s, which is the
+ * same misreporting in the other direction.
+ */
+export function isProgrammerError(error: unknown): boolean {
+  return error instanceof TypeError || error instanceof ReferenceError;
+}

--- a/packages/nextly/src/runtime/notifications/dispatcher.ts
+++ b/packages/nextly/src/runtime/notifications/dispatcher.ts
@@ -8,6 +8,8 @@
 // The pipeline depends on the `Notifier` interface, not on this
 // concrete factory; tests can swap in a fake notifier via DI.
 
+import { describeError } from "../../errors";
+
 import type {
   MigrationNotificationEvent,
   NotificationChannel,
@@ -21,21 +23,6 @@ interface LoggerLike {
 export interface CreateNotifierOptions {
   channels: NotificationChannel[];
   logger?: LoggerLike;
-}
-
-function describeError(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  if (typeof err === "string") return err;
-  if (err === undefined) return "undefined";
-  if (err === null) return "null";
-  if (typeof err === "number" || typeof err === "boolean") {
-    return String(err);
-  }
-  try {
-    return JSON.stringify(err);
-  } catch {
-    return "[unstringifiable error]";
-  }
 }
 
 export function createNotifier(opts: CreateNotifierOptions): Notifier {


### PR DESCRIPTION
## Why

`nextly db:sync` failed with exactly this and nothing else:

```
✗ Sync failed: An unexpected error occurred.
```

The real cause was a query against `dynamic_collections` selecting a column the database did not have. Finding that required editing Nextly's source, rebuilding, and dumping the error object by hand.

The cause is structural, not a one-off. `NextlyError` sets `Error.message` to the **public** message by construction:

```ts
// nextly-error.ts:139
super(opts.publicMessage);
```

so every `catch` that renders `error.message` prints the generic wire text and silently drops `code`, `cause` and `logContext`. That is correct on the wire and wrong on an operator channel. There were 58 such sites across the CLI.

`src/cli/nextly.ts` already had a good handler for this, but ~20 per-command catches log-and-exit before it can run, so it was effectively unreachable.

## What changed

**A shared `describeError` in `src/errors`**, exported from `nextly/errors`. It renders `[CODE] public message | cause: … | context: {…}`.

Two design points worth reviewing:

- **Cause depth 4.** The database path nests `NextlyError → DbError → DrizzleQueryError → driver error`, and only the deepest link names the fault. Every wrapper above it says "Failed query".
- **Repeated messages collapse.** Wrappers commonly echo each other, and printing both doubled an already-long line.

Both are pinned by tests, and both were verified load-bearing by reverting them and confirming the matching test fails.

This also replaces two private copies of the same idea: one in `collection-registry-service` (which carried an `eslint-disable` that AGENTS.md forbids, now removed via a real type guard) and one in `runtime/notifications/dispatcher` that was NextlyError-blind, so it masked exactly like the CLI did.

**Programmer errors no longer inherit the caller's 4xx.** `errorToMetadataResult` mapped any non-DbError throwable onto the caller's fallback status, so a `TypeError` inside Nextly reached the API as `400 "Validation failed"`. It now returns 500. `SyntaxError` and `RangeError` are deliberately **excluded** from that check, because `JSON.parse` on a caller-supplied body throws `SyntaxError` and treating it as our defect would turn a genuine 400 into a 500.

## Result

Same command, same database:

```
✗ Sync failed while registering collections.
✗ [INTERNAL_ERROR] An unexpected error occurred. | Database error | cause: Failed query: select "id", ..., "localized", "versions", ... from "dynamic_collections"
  | cause: no such column: "localized" | context: {"dbKind":"internal","dialect":"sqlite"}
```

Stack traces stay behind `DEBUG=1`, unchanged.

## Testing

- `tsc --noEmit`: clean. `eslint --max-warnings 0` on all touched areas: clean.
- 13 new unit tests; `src/errors` 62 passed.
- Regression check on `src/domains/collections`, `src/runtime/notifications`, `src/cli`: **9 failed / 247 passed both with and without this change** — identical to the pre-existing baseline, no new failures.
- Verified end to end against a real database exhibiting the original failure.

## Note for review

This is the first of several PRs from a schema/CLI defect investigation. The `no such column: "localized"` above is a **separate** and more serious bug (core system tables never gain columns on upgrade) which this PR only makes visible. That fix is coming separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized operator-facing error rendering across CLI commands and runtime notifications using shared helpers (including improved nested-cause handling, safer non-`Error` throwables, and optional context inclusion).
  * Added “immediate” vs full error message helpers, plus programmer-error classification.
  * Added upfront request validation for dynamic collection creation and updates.
  * Improved truncation of persisted schema/migration error messages to a fixed maximum length.
* **Bug Fixes**
  * Programmer/internal defects are now mapped to server-error responses (avoiding incorrect caller-facing fallbacks).
* **Tests**
  * Added/extended Vitest coverage for shared error rendering, programmer-error detection, truncation behavior, and dynamic collection validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->