### PR TITLE
feat(admin): turn version history on from the schema builder

### DIFF
--- a/.changeset/schema-builder-version-history-toggle.md
+++ b/.changeset/schema-builder-version-history-toggle.md
@@ -1,0 +1,31 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Version history can now be turned on from the Schema Builder.
+
+Collections and singles get a Version History switch on the Advanced tab of
+their settings, so recording every save no longer requires editing
+`nextly.config.ts`. Turning it on records each save as a version that can be
+previewed and restored from the entry editor; turning it off keeps the versions
+already recorded but stops new ones. It does not add drafts.
+
+The setting is written to both the database and `ui-schema.json`, so a
+Builder-made change survives the next manifest sync.

--- a/packages/admin/src/components/features/schema-builder/BuilderSettingsModal.tsx
+++ b/packages/admin/src/components/features/schema-builder/BuilderSettingsModal.tsx
@@ -49,6 +49,7 @@ export type BuilderSettingsValues = {
   category?: string;
   status?: boolean;
   i18n?: boolean;
+  versions?: boolean;
 };
 
 type Props = {

--- a/packages/admin/src/components/features/schema-builder/builder-config.ts
+++ b/packages/admin/src/components/features/schema-builder/builder-config.ts
@@ -15,7 +15,12 @@ export type BasicsField =
 
 // tab. Server-side `admin.group` / `admin.order` still work for code-first
 // users; only the in-builder UI affordance is gone.
-export type AdvancedField = "category" | "status" | "i18n" | "showSystemFields";
+export type AdvancedField =
+  | "category"
+  | "status"
+  | "i18n"
+  | "versions"
+  | "showSystemFields";
 
 export type BuilderConfig = {
   kind: BuilderKind;

--- a/packages/admin/src/components/features/schema-builder/builder-settings-modal/AdvancedTab.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-settings-modal/AdvancedTab.tsx
@@ -59,6 +59,16 @@ export function AdvancedTab({ fields, values, onChange }: Props) {
         />
       )}
 
+      {fields.includes("versions") && (
+        <SwitchRow
+          ariaLabel="Version history"
+          label="Version history"
+          help="Record every save so earlier versions can be previewed and restored. Turning it off keeps the versions already recorded but stops new ones; it does not add drafts."
+          checked={values.versions ?? false}
+          onChange={v => set("versions", v)}
+        />
+      )}
+
       {fields.includes("showSystemFields") && <ShowSystemFieldsSwitch />}
     </div>
   );

--- a/packages/admin/src/components/features/schema-builder/builder-settings-modal/__tests__/AdvancedTab.test.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-settings-modal/__tests__/AdvancedTab.test.tsx
@@ -77,6 +77,35 @@ describe("AdvancedTab", () => {
   });
 });
 
+describe("AdvancedTab -- version history", () => {
+  it("renders nothing when the kind does not enable it", () => {
+    render(<Controlled fields={["status"]} />);
+    expect(
+      screen.queryByRole("switch", { name: /version history/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("toggles versions when the switch is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Controlled fields={["versions"]} onChange={onChange} />);
+    await user.click(screen.getByRole("switch", { name: /version history/i }));
+    const last = onChange.mock.lastCall?.[0] as BuilderSettingsValues;
+    expect(last.versions).toBe(true);
+  });
+
+  it("renders checked when versioning is already on", () => {
+    render(<Controlled fields={["versions"]} initial={{ versions: true }} />);
+    const sw = screen.getByRole("switch", { name: /version history/i });
+    expect(sw.getAttribute("data-state")).toBe("checked");
+  });
+
+  it("says what it does not do, so nobody reads it as drafts", () => {
+    render(<Controlled fields={["versions"]} />);
+    expect(screen.getByText(/does not add drafts/i)).toBeInTheDocument();
+  });
+});
+
 describe("AdvancedTab -- showSystemFields", () => {
   beforeEach(() => {
     localStorage.clear();

--- a/packages/admin/src/hooks/queries/useSingles.ts
+++ b/packages/admin/src/hooks/queries/useSingles.ts
@@ -37,7 +37,7 @@ import {
 import { toast } from "@admin/components/ui";
 import { schemaFileApi } from "@admin/services/schemaFileApi";
 import { singleApi, type SingleDocument } from "@admin/services/singleApi";
-import type { ApiSingle } from "@admin/types/entities";
+import type { ApiSingle, UpdateSinglePayload } from "@admin/types/entities";
 
 import { useBulkMutation } from "../useBulkMutation";
 
@@ -245,9 +245,9 @@ export function useCreateSingle() {
   return useMutation<
     { message: string; data: ApiSingle },
     Error,
-    Partial<ApiSingle>
+    UpdateSinglePayload
   >({
-    mutationFn: async (singleData: Partial<ApiSingle>) => {
+    mutationFn: async (singleData: UpdateSinglePayload) => {
       return await singleApi.create(singleData);
     },
     onSuccess: () => {
@@ -287,7 +287,7 @@ export function useUpdateSingle() {
   return useMutation<
     { message: string },
     Error,
-    { slug: string; updates: Partial<ApiSingle> }
+    { slug: string; updates: UpdateSinglePayload }
   >({
     mutationFn: async ({ slug, updates }) => {
       return await singleApi.update(slug, updates);

--- a/packages/admin/src/lib/builder/__tests__/settings-dirty.test.ts
+++ b/packages/admin/src/lib/builder/__tests__/settings-dirty.test.ts
@@ -1,0 +1,51 @@
+// Why: a settings key that reaches the API but not the dirty check leaves Save
+// permanently disabled, which reads as the builder ignoring the change rather
+// than as a bug. These lock every key, so the failure mode is a red test.
+import { describe, expect, it } from "vitest";
+
+import type { BuilderSettingsValues } from "@admin/components/features/schema-builder/BuilderSettingsModal";
+
+import { settingsAreDirty } from "../settings-dirty";
+
+const base: BuilderSettingsValues = {
+  singularName: "Post",
+  pluralName: "Posts",
+  slug: "posts",
+  description: "",
+  icon: "FileText",
+  category: undefined,
+  status: true,
+  i18n: false,
+  versions: false,
+};
+
+describe("settingsAreDirty", () => {
+  it("reports nothing dirty for an unchanged copy", () => {
+    expect(settingsAreDirty(base, { ...base })).toBe(false);
+  });
+
+  it("reports nothing dirty before a baseline has loaded", () => {
+    expect(settingsAreDirty(null, base)).toBe(false);
+    expect(settingsAreDirty(base, null)).toBe(false);
+  });
+
+  // Driven off the value shape rather than a hand-written list, so a key added
+  // to BuilderSettingsValues without a matching comparison fails here too.
+  const changed: Record<keyof BuilderSettingsValues, BuilderSettingsValues> = {
+    singularName: { ...base, singularName: "Article" },
+    pluralName: { ...base, pluralName: "Articles" },
+    slug: { ...base, slug: "articles" },
+    description: { ...base, description: "Now described" },
+    icon: { ...base, icon: "Database" },
+    category: { ...base, category: "Layout" },
+    status: { ...base, status: false },
+    i18n: { ...base, i18n: true },
+    versions: { ...base, versions: true },
+  };
+
+  for (const [key, next] of Object.entries(changed)) {
+    it(`reports dirty when ${key} changes`, () => {
+      expect(settingsAreDirty(base, next)).toBe(true);
+    });
+  }
+});

--- a/packages/admin/src/lib/builder/settings-dirty.ts
+++ b/packages/admin/src/lib/builder/settings-dirty.ts
@@ -1,0 +1,45 @@
+// Why: the builder pages enable Save by diffing the settings modal's values
+// against the ones loaded from the server. Each page used to spell that diff
+// out field by field, so a newly added setting reached the API but left Save
+// greyed out until someone remembered to extend both comparisons — a failure
+// that looks like nothing happening at all. Comparing from one exhaustive key
+// list makes a forgotten setting a compile error instead.
+
+import type { BuilderSettingsValues } from "@admin/components/features/schema-builder/BuilderSettingsModal";
+
+/** Every settings key the dirty check compares. */
+const COMPARED_KEYS = [
+  "singularName",
+  "pluralName",
+  "slug",
+  "description",
+  "icon",
+  "category",
+  "status",
+  "i18n",
+  "versions",
+] as const;
+
+type ComparedKey = (typeof COMPARED_KEYS)[number];
+
+// A new key on BuilderSettingsValues must be added to COMPARED_KEYS or this
+// assignment stops compiling: the unlisted key survives the Exclude, and a
+// non-never type is not assignable to the `true` branch's `never`.
+type UncomparedKey = Exclude<keyof BuilderSettingsValues, ComparedKey>;
+const _everySettingIsCompared: [UncomparedKey] extends [never] ? true : never =
+  true;
+void _everySettingIsCompared;
+
+/**
+ * Whether the settings modal's values differ from the ones last loaded.
+ *
+ * Values are scalars, so identity comparison is the whole check. A missing
+ * baseline means nothing has loaded yet, which is not an edit.
+ */
+export function settingsAreDirty(
+  original: BuilderSettingsValues | null,
+  current: BuilderSettingsValues | null
+): boolean {
+  if (!original || !current) return false;
+  return COMPARED_KEYS.some(key => original[key] !== current[key]);
+}

--- a/packages/admin/src/lib/builder/settings-to-manifest.test.ts
+++ b/packages/admin/src/lib/builder/settings-to-manifest.test.ts
@@ -89,3 +89,47 @@ describe("singleEntityFromSettings", () => {
     expect(entity.status).toBe(false);
   });
 });
+
+describe("version history in the manifest mirror", () => {
+  // Both mappers, because the committed ui-schema.json is the other half of the
+  // builder's dual write: a kind missing here silently reverts the setting the
+  // next time the manifest syncs.
+  const cases = [
+    ["collection", collectionEntityFromSettings],
+    ["single", singleEntityFromSettings],
+  ] as const;
+
+  for (const [kind, build] of cases) {
+    it(`${kind}: mirrors the toggle when on`, () => {
+      const entity = build(
+        "posts",
+        {
+          singularName: "Post",
+          pluralName: "Posts",
+          slug: "posts",
+          icon: "FileText",
+          versions: true,
+        },
+        FIELDS
+      );
+      expect(entity.versions).toBe(true);
+    });
+
+    it(`${kind}: writes versions: false explicitly`, () => {
+      // Omitting it would let a stale `true` survive in the manifest and turn
+      // versioning back on at the next sync.
+      const entity = build(
+        "posts",
+        {
+          singularName: "Post",
+          pluralName: "Posts",
+          slug: "posts",
+          icon: "FileText",
+          versions: false,
+        },
+        FIELDS
+      );
+      expect(entity.versions).toBe(false);
+    });
+  }
+});

--- a/packages/admin/src/lib/builder/settings-to-manifest.ts
+++ b/packages/admin/src/lib/builder/settings-to-manifest.ts
@@ -30,6 +30,9 @@ export function collectionEntityFromSettings(
       status: settings.status === true,
       // i18n: the collection-level Internationalization toggle.
       localized: settings.i18n === true,
+      // Version history, mirrored into ui-schema.json so the committed
+      // manifest matches what the registry was just told.
+      versions: settings.versions === true,
     },
     fields,
   });
@@ -47,6 +50,8 @@ export function singleEntityFromSettings(
       status: settings.status === true,
       // i18n: the single-level Internationalization toggle (mirrors collectionEntityFromSettings).
       localized: settings.i18n === true,
+      // Version history (mirrors collectionEntityFromSettings).
+      versions: settings.versions === true,
     },
     fields,
   });

--- a/packages/admin/src/lib/builder/to-manifest-entity.ts
+++ b/packages/admin/src/lib/builder/to-manifest-entity.ts
@@ -80,6 +80,8 @@ export interface BuilderSettingsInput {
   status?: boolean;
   /** i18n: collection has translatable fields (companion `_locales` table). */
   localized?: boolean;
+  /** Whether every save is recorded as a restorable version. */
+  versions?: boolean;
   useAsTitle?: string;
   defaultColumns?: string[];
   group?: string;
@@ -135,6 +137,8 @@ export interface ManifestEntity {
   status?: boolean;
   /** i18n: collection has translatable fields. */
   localized?: boolean;
+  /** Whether every save is recorded as a restorable version. */
+  versions?: boolean;
   fields: ManifestField[];
 }
 
@@ -198,7 +202,8 @@ export function applyCommonSettings(
   entity: ManifestEntity,
   settings: BuilderSettingsInput
 ): void {
-  const { useAsTitle, defaultColumns, group, status, localized } = settings;
+  const { useAsTitle, defaultColumns, group, status, localized, versions } =
+    settings;
   const admin: NonNullable<ManifestEntity["admin"]> = {};
   if (useAsTitle) admin.useAsTitle = useAsTitle;
   if (defaultColumns && defaultColumns.length > 0) {
@@ -208,6 +213,7 @@ export function applyCommonSettings(
   if (Object.keys(admin).length > 0) entity.admin = admin;
   if (status !== undefined) entity.status = status;
   if (localized !== undefined) entity.localized = localized;
+  if (versions !== undefined) entity.versions = versions;
 }
 
 export function collectionToManifestEntity(

--- a/packages/admin/src/pages/dashboard/collections/builder/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/collections/builder/[slug].tsx
@@ -312,21 +312,34 @@ export default function CollectionBuilderEditPage({
           // kept the old values. Persist them here, without `fields` so no
           // second migration is generated for a schema already applied.
           if (settings) {
-            updateCollection({
-              collectionName: slug,
-              updates: {
-                labels: {
-                  singular: settings.singularName,
-                  plural: settings.pluralName,
+            updateCollection(
+              {
+                collectionName: slug,
+                updates: {
+                  labels: {
+                    singular: settings.singularName,
+                    plural: settings.pluralName,
+                  },
+                  description: settings.description,
+                  icon: settings.icon,
+                  status: settings.status === true,
+                  localized: settings.i18n === true,
+                  versions: settings.versions === true,
                 },
-                description: settings.description,
-                icon: settings.icon,
-                status: settings.status === true,
-                localized: settings.i18n === true,
-                versions: settings.versions === true,
               },
-            });
-            setOriginalSettings(settings);
+              {
+                // The baseline moves only once the write lands. Clearing it
+                // first would show a clean form over a registry that still
+                // holds the old settings, with no way to retry.
+                onSuccess: () => setOriginalSettings(settings),
+                onError: err => {
+                  const m = (err as { message?: string })?.message;
+                  toast.error(
+                    `Schema applied, but the settings could not be saved${m ? `: ${m}` : ""}.`
+                  );
+                },
+              }
+            );
           }
 
           // D-series: database mode also writes the committable ui-schema.json

--- a/packages/admin/src/pages/dashboard/collections/builder/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/collections/builder/[slug].tsx
@@ -306,9 +306,28 @@ export default function CollectionBuilderEditPage({
           setPreviewData(null);
           // Refresh the dirty baseline so the unsaved badge clears.
           setOriginalFields(builder.fields.filter(f => !f.isSystem));
-          // Re-pin the settings snapshot too so a settings + fields save
-          // doesn't leave the badge lit afterward.
-          if (settings) setOriginalSettings(settings);
+
+          // The schema apply carries fields only, so a save that changed the
+          // settings as well would clear the dirty badge while the registry
+          // kept the old values. Persist them here, without `fields` so no
+          // second migration is generated for a schema already applied.
+          if (settings) {
+            updateCollection({
+              collectionName: slug,
+              updates: {
+                labels: {
+                  singular: settings.singularName,
+                  plural: settings.pluralName,
+                },
+                description: settings.description,
+                icon: settings.icon,
+                status: settings.status === true,
+                localized: settings.i18n === true,
+                versions: settings.versions === true,
+              },
+            });
+            setOriginalSettings(settings);
+          }
 
           // D-series: database mode also writes the committable ui-schema.json
           // so the entity has a migration record (matches code-first). A
@@ -343,7 +362,14 @@ export default function CollectionBuilderEditPage({
           window.__nextlySchemaApplying = false;
       }
     },
-    [slug, startRestart, stopRestart, settings, builder.fields]
+    [
+      slug,
+      startRestart,
+      stopRestart,
+      settings,
+      builder.fields,
+      updateCollection,
+    ]
   );
 
   // Save settings/labels/hooks (no schema changes path).

--- a/packages/admin/src/pages/dashboard/collections/builder/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/collections/builder/[slug].tsx
@@ -62,6 +62,7 @@ import { countDirtyFields } from "@admin/lib/builder/dirty-tracking";
 import { nextDuplicateName } from "@admin/lib/builder/duplicate-field-name";
 import { isInsideRepeatingAncestor } from "@admin/lib/builder/is-inside-repeating-ancestor";
 import { packIntoRows, parseWidth } from "@admin/lib/builder/reflow";
+import { settingsAreDirty } from "@admin/lib/builder/settings-dirty";
 import { collectionEntityFromSettings } from "@admin/lib/builder/settings-to-manifest";
 import { COLLECTION_BUILDER_CONFIG } from "@admin/pages/dashboard/collections/builder/builder-config";
 import {
@@ -201,6 +202,11 @@ export default function CollectionBuilderEditPage({
       // i18n: reflect the saved localization flag so the Internationalization
       // toggle shows the true state and the dirty-check is accurate.
       i18n: (collection as { localized?: boolean }).localized === true,
+      // The registry stores the resolved config, so presence of an enabled one
+      // is what the switch reflects.
+      versions:
+        (collection as { versions?: { enabled?: boolean } | null }).versions
+          ?.enabled === true,
     };
     setSettings(loadedSettings);
     // Pin a copy as the dirty baseline so settings-only edits enable Save.
@@ -239,18 +245,10 @@ export default function CollectionBuilderEditPage({
   // change never reached the API. Track the original settings snapshot
   // and shallow-compare on each render so the toolbar enables Save the
   // moment any settings field diverges from load-time.
-  const settingsDirty = useMemo(() => {
-    if (!originalSettings || !settings) return false;
-    return (
-      originalSettings.singularName !== settings.singularName ||
-      originalSettings.pluralName !== settings.pluralName ||
-      originalSettings.slug !== settings.slug ||
-      originalSettings.description !== settings.description ||
-      originalSettings.icon !== settings.icon ||
-      originalSettings.status !== settings.status ||
-      originalSettings.i18n !== settings.i18n
-    );
-  }, [originalSettings, settings]);
+  const settingsDirty = useMemo(
+    () => settingsAreDirty(originalSettings, settings),
+    [originalSettings, settings]
+  );
 
   // Aggregate count drives the toolbar badge. We add a single point for
   // settings dirtiness so the user gets a non-zero count and the Save
@@ -370,6 +368,9 @@ export default function CollectionBuilderEditPage({
             // i18n: the collection-level Internationalization toggle. Toggling on
             // (migration-gated) provisions the companion `_locales` table.
             localized: settings.i18n === true,
+            // Version history: the server normalizes this into the resolved
+            // config the registry column holds.
+            versions: settings.versions === true,
             // Why: useAsTitle + timestamps were removed from the modal in
             // PR B (system title is always the display; timestamps always
             // emitted). Backend defaults take over -- code-first config can

--- a/packages/admin/src/pages/dashboard/collections/builder/builder-config.ts
+++ b/packages/admin/src/pages/dashboard/collections/builder/builder-config.ts
@@ -9,7 +9,7 @@ import type { BuilderConfig } from "@admin/components/features/schema-builder/bu
 export const COLLECTION_BUILDER_CONFIG: BuilderConfig = {
   kind: "collection",
   basicsFields: ["singularName", "pluralName", "slug", "description", "icon"],
-  advancedFields: ["status", "i18n", "showSystemFields"],
+  advancedFields: ["status", "i18n", "versions", "showSystemFields"],
   toolbar: { previewSchemaChange: true },
   picker: {},
 };

--- a/packages/admin/src/pages/dashboard/collections/builder/index.tsx
+++ b/packages/admin/src/pages/dashboard/collections/builder/index.tsx
@@ -60,6 +60,8 @@ export default function CollectionBuilderPage(): React.ReactElement | null {
         // collection is actually created as localized (was dropped here, so the
         // collection always persisted as non-localized regardless of the toggle).
         localized: values.i18n === true,
+        // Version history opt-in at create; the server resolves the boolean.
+        versions: values.versions === true,
         // Why: useAsTitle + timestamps removed in PR B. Backend defaults
         // (timestamps always on, useAsTitle = system title) take over.
         // Code-first config can still override either.
@@ -86,6 +88,8 @@ export default function CollectionBuilderPage(): React.ReactElement | null {
                     status: values.status === true,
                     // keep ui-schema.json in sync with the localized flag.
                     localized: values.i18n === true,
+                    // and with version history.
+                    versions: values.versions === true,
                   },
                   fields: [],
                 })

--- a/packages/admin/src/pages/dashboard/singles/builder/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/singles/builder/[slug].tsx
@@ -247,17 +247,30 @@ export default function SingleBuilderEditPage({
           // kept the old values. Persist them here, without `fields` so no
           // second migration is generated for a schema already applied.
           if (settings) {
-            updateSingle({
-              slug,
-              updates: {
-                label: settings.singularName,
-                description: settings.description,
-                status: settings.status === true,
-                localized: settings.i18n === true,
-                versions: settings.versions === true,
+            updateSingle(
+              {
+                slug,
+                updates: {
+                  label: settings.singularName,
+                  description: settings.description,
+                  status: settings.status === true,
+                  localized: settings.i18n === true,
+                  versions: settings.versions === true,
+                },
               },
-            });
-            setOriginalSettings(settings);
+              {
+                // The baseline moves only once the write lands. Clearing it
+                // first would show a clean form over a registry that still
+                // holds the old settings, with no way to retry.
+                onSuccess: () => setOriginalSettings(settings),
+                onError: err => {
+                  const m = (err as { message?: string })?.message;
+                  toast.error(
+                    `Schema applied, but the settings could not be saved${m ? `: ${m}` : ""}.`
+                  );
+                },
+              }
+            );
           }
 
           // D-series: database mode also writes the committable ui-schema.json

--- a/packages/admin/src/pages/dashboard/singles/builder/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/singles/builder/[slug].tsx
@@ -241,7 +241,24 @@ export default function SingleBuilderEditPage({
           setShowSchemaDialog(false);
           setPreviewData(null);
           setOriginalFields(builder.fields.filter(f => !f.isSystem));
-          if (settings) setOriginalSettings(settings);
+
+          // The schema apply carries fields only, so a save that changed the
+          // settings as well would clear the dirty badge while the registry
+          // kept the old values. Persist them here, without `fields` so no
+          // second migration is generated for a schema already applied.
+          if (settings) {
+            updateSingle({
+              slug,
+              updates: {
+                label: settings.singularName,
+                description: settings.description,
+                status: settings.status === true,
+                localized: settings.i18n === true,
+                versions: settings.versions === true,
+              },
+            });
+            setOriginalSettings(settings);
+          }
 
           // D-series: database mode also writes the committable ui-schema.json
           // so the single has a migration record. Non-fatal if it fails.
@@ -275,7 +292,7 @@ export default function SingleBuilderEditPage({
           window.__nextlySchemaApplying = false;
       }
     },
-    [slug, startRestart, stopRestart, settings, builder.fields]
+    [slug, startRestart, stopRestart, settings, builder.fields, updateSingle]
   );
 
   // No-schema-change path: persist labels/settings only.

--- a/packages/admin/src/pages/dashboard/singles/builder/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/singles/builder/[slug].tsx
@@ -52,6 +52,7 @@ import { countDirtyFields } from "@admin/lib/builder/dirty-tracking";
 import { nextDuplicateName } from "@admin/lib/builder/duplicate-field-name";
 import { isInsideRepeatingAncestor } from "@admin/lib/builder/is-inside-repeating-ancestor";
 import { packIntoRows, parseWidth } from "@admin/lib/builder/reflow";
+import { settingsAreDirty } from "@admin/lib/builder/settings-dirty";
 import { singleEntityFromSettings } from "@admin/lib/builder/settings-to-manifest";
 import type {
   FieldResolution,
@@ -162,6 +163,11 @@ export default function SingleBuilderEditPage({
       // i18n: reflect the saved localization flag so the Internationalization toggle shows its
       // real state (mirrors the collection builder).
       i18n: (single as { localized?: boolean }).localized === true,
+      // The registry stores the resolved config, so presence of an enabled one
+      // is what the switch reflects.
+      versions:
+        (single as { versions?: { enabled?: boolean } | null }).versions
+          ?.enabled === true,
     };
     setSettings(loadedSettings);
     setOriginalSettings(loadedSettings);
@@ -184,18 +190,10 @@ export default function SingleBuilderEditPage({
   // Settings-only dirty signal — same fix as the collection builder. A
   // status flip / label edit on its own would otherwise leave Save
   // disabled because the field array hadn't changed.
-  const settingsDirty = useMemo(() => {
-    if (!originalSettings || !settings) return false;
-    return (
-      originalSettings.singularName !== settings.singularName ||
-      originalSettings.slug !== settings.slug ||
-      originalSettings.description !== settings.description ||
-      originalSettings.icon !== settings.icon ||
-      originalSettings.status !== settings.status ||
-      // i18n: toggling Internationalization on its own must enable Save.
-      originalSettings.i18n !== settings.i18n
-    );
-  }, [originalSettings, settings]);
+  const settingsDirty = useMemo(
+    () => settingsAreDirty(originalSettings, settings),
+    [originalSettings, settings]
+  );
 
   const unsavedCount = fieldsDirtyCount + (settingsDirty ? 1 : 0);
 
@@ -306,6 +304,9 @@ export default function SingleBuilderEditPage({
             // companion single_<slug>_locales table; always send the boolean so OFF also reaches
             // the server. Mirrors the collection builder.
             localized: settings.i18n === true,
+            // Version history: the server normalizes this into the resolved
+            // config the registry column holds.
+            versions: settings.versions === true,
           },
         },
         {

--- a/packages/admin/src/pages/dashboard/singles/builder/builder-config.ts
+++ b/packages/admin/src/pages/dashboard/singles/builder/builder-config.ts
@@ -16,7 +16,7 @@ export const SINGLE_BUILDER_CONFIG: BuilderConfig = {
   kind: "single",
   basicsFields: ["singularName", "slug", "description", "icon"],
   // showSystemFields added in PR B so singles can also surface the toggle.
-  advancedFields: ["status", "i18n", "showSystemFields"],
+  advancedFields: ["status", "i18n", "versions", "showSystemFields"],
   toolbar: { previewSchemaChange: false },
   picker: {},
 };

--- a/packages/admin/src/pages/dashboard/singles/builder/index.tsx
+++ b/packages/admin/src/pages/dashboard/singles/builder/index.tsx
@@ -63,6 +63,8 @@ export default function SingleBuilderPage(): React.ReactElement | null {
         // companion has no columns yet — it is provisioned when the first translatable field is
         // added on the builder page (updateSingleSchema/applySchemaChanges reconcile).
         ...(values.i18n === true ? { localized: true } : {}),
+        // Version history opt-in at create; the server resolves the boolean.
+        ...(values.versions === true ? { versions: true } : {}),
         // Empty user-fields list — system columns are auto-injected by
         // the server; user adds custom fields on the next page.
         fields: [],
@@ -82,6 +84,8 @@ export default function SingleBuilderPage(): React.ReactElement | null {
                     status: values.status === true,
                     // i18n: mirror the Internationalization flag into ui-schema.json.
                     localized: values.i18n === true,
+                    // and version history.
+                    versions: values.versions === true,
                   },
                   fields: [],
                 })

--- a/packages/admin/src/services/singleApi.ts
+++ b/packages/admin/src/services/singleApi.ts
@@ -12,7 +12,7 @@
 
 import type { ListResponse, TableParams } from "@nextlyhq/ui";
 
-import type { ApiSingle } from "@admin/types/entities";
+import type { ApiSingle, UpdateSinglePayload } from "@admin/types/entities";
 
 import { buildQuery as buildQueryUtil } from "../lib/api/buildQuery";
 import { fetcher } from "../lib/api/fetcher";
@@ -118,7 +118,7 @@ export const singleApi = {
    * Create a new Single.
    */
   create: async (
-    payload: Partial<ApiSingle>
+    payload: UpdateSinglePayload
   ): Promise<{ message: string; data: ApiSingle }> => {
     const result = await protectedApi.post<MutationResponse<ApiSingle>>(
       "/singles",
@@ -137,7 +137,7 @@ export const singleApi = {
    */
   update: async (
     slug: string,
-    payload: Partial<ApiSingle>
+    payload: UpdateSinglePayload
   ): Promise<{ message: string }> => {
     const result = await protectedApi.patch<MutationResponse<ApiSingle>>(
       `/singles/${slug}/schema`,

--- a/packages/admin/src/types/collection.ts
+++ b/packages/admin/src/types/collection.ts
@@ -332,6 +332,8 @@ export interface CreateCollectionPayload {
   status?: boolean;
   /** i18n: whether the collection has translatable (per-locale) fields. Default false. */
   localized?: boolean;
+  /** Whether every save is recorded as a restorable version. Default false. */
+  versions?: boolean;
   /** Whether to auto-generate createdAt/updatedAt. Default true. */
   timestamps?: boolean;
   fields: FieldDefinition[];
@@ -352,6 +354,8 @@ export interface UpdateCollectionPayload {
    *  table; toggling off drops it (destructive change, gated by the
    *  schema-change preview). */
   status?: boolean;
+  /** Toggle version history. Every save is recorded as a restorable version. */
+  versions?: boolean;
   /** i18n: toggle translatable fields. Toggling on adds the companion `_locales`
    *  table (migration-gated, via the schema-change preview). */
   localized?: boolean;

--- a/packages/admin/src/types/entities.ts
+++ b/packages/admin/src/types/entities.ts
@@ -298,6 +298,14 @@ export interface ApiSingle {
    */
   localized?: boolean;
 
+  /**
+   * Resolved version-history config, or null/absent when the Single is
+   * unversioned. The server normalizes the Schema Builder's on/off into this
+   * shape, so reads carry the object while writes send a boolean — see
+   * `UpdateSinglePayload`.
+   */
+  versions?: { enabled?: boolean } | null;
+
   /** Current migration status */
   migrationStatus?: SingleMigrationStatus;
 
@@ -307,6 +315,17 @@ export interface ApiSingle {
   /** Number of fields in the Single */
   fieldCount?: number;
 }
+
+/**
+ * What a Single schema update may send.
+ *
+ * Most keys mirror the read shape, but `versions` does not: the Schema Builder
+ * offers on/off and the server resolves that into the config `ApiSingle`
+ * carries back.
+ */
+export type UpdateSinglePayload = Omit<Partial<ApiSingle>, "versions"> & {
+  versions?: boolean;
+};
 
 // ==================== COMPONENT TYPES ====================
 

--- a/packages/nextly/src/api/collections-schema-detail.ts
+++ b/packages/nextly/src/api/collections-schema-detail.ts
@@ -25,7 +25,7 @@ import type { FieldConfig } from "@nextly/collections";
 
 import { getService } from "../di";
 import { calculateSchemaHash } from "../domains/schema/services/schema-hash";
-import { resolveVersionsConfig } from "../domains/versions/resolve-config";
+import { resolveBuilderVersions } from "../domains/versions/builder-versions";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
 import { getNextlyLogger } from "../observability/logger";
@@ -212,7 +212,7 @@ export const PATCH = withErrorHandler(
     // stop the toggle from turning versioning off on a Draft/Published
     // collection.
     if (body.versions !== undefined) {
-      updateData.versions = resolveVersionsConfig(body.versions === true);
+      updateData.versions = resolveBuilderVersions(body.versions === true);
     }
 
     // Admin fields: support both nested admin object and flat top-level

--- a/packages/nextly/src/api/collections-schema-detail.ts
+++ b/packages/nextly/src/api/collections-schema-detail.ts
@@ -25,6 +25,7 @@ import type { FieldConfig } from "@nextly/collections";
 
 import { getService } from "../di";
 import { calculateSchemaHash } from "../domains/schema/services/schema-hash";
+import { resolveVersionsConfig } from "../domains/versions/resolve-config";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
 import { getNextlyLogger } from "../observability/logger";
@@ -203,6 +204,15 @@ export const PATCH = withErrorHandler(
     // (migration-gated, via the schema-change preview).
     if (body.localized !== undefined) {
       updateData.localized = body.localized === true;
+    }
+
+    // Version history toggle, normalized to the resolved config the column
+    // holds; off writes null. `status` is deliberately not passed to the
+    // resolver — it aliases to a versioned config for back-compat, which would
+    // stop the toggle from turning versioning off on a Draft/Published
+    // collection.
+    if (body.versions !== undefined) {
+      updateData.versions = resolveVersionsConfig(body.versions === true);
     }
 
     // Admin fields: support both nested admin object and flat top-level

--- a/packages/nextly/src/api/collections-schema.ts
+++ b/packages/nextly/src/api/collections-schema.ts
@@ -21,7 +21,7 @@ import { z } from "zod";
 
 import { getService } from "../di";
 import { calculateSchemaHash } from "../domains/schema/services/schema-hash";
-import { resolveVersionsConfig } from "../domains/versions/resolve-config";
+import { resolveBuilderVersions } from "../domains/versions/builder-versions";
 import { getFilterRegistry, FilterSeams } from "../filters";
 import { getCachedNextly } from "../init";
 import type { CollectionRegistryService } from "../services/collections/collection-registry-service";
@@ -277,7 +277,7 @@ export const POST = withErrorHandler(async (request: Request) => {
     localized: validated.localized === true,
     // Version history opt-in, normalized to the resolved config the column
     // holds and every runtime reader tests.
-    versions: resolveVersionsConfig(validated.versions),
+    versions: resolveBuilderVersions(validated.versions),
     schemaHash,
     hooks: validated.hooks,
   });

--- a/packages/nextly/src/api/collections-schema.ts
+++ b/packages/nextly/src/api/collections-schema.ts
@@ -21,6 +21,7 @@ import { z } from "zod";
 
 import { getService } from "../di";
 import { calculateSchemaHash } from "../domains/schema/services/schema-hash";
+import { resolveVersionsConfig } from "../domains/versions/resolve-config";
 import { getFilterRegistry, FilterSeams } from "../filters";
 import { getCachedNextly } from "../init";
 import type { CollectionRegistryService } from "../services/collections/collection-registry-service";
@@ -80,6 +81,9 @@ const createCollectionSchema = z.object({
   // i18n opt-in. Default false keeps non-localized behavior. Enabling adds the
   // companion `_locales` table on the next migrate (migration-gated).
   localized: z.boolean().optional(),
+  // Version history opt-in. Default off: capture adds a row to nextly_versions
+  // on every save, which no existing caller has asked for.
+  versions: z.boolean().optional(),
   admin: z
     .object({
       group: z.string().optional(),
@@ -271,6 +275,9 @@ export const POST = withErrorHandler(async (request: Request) => {
     // i18n: forward the localization opt-in so the registry stores it (companion
     // table is provisioned on the next migrate).
     localized: validated.localized === true,
+    // Version history opt-in, normalized to the resolved config the column
+    // holds and every runtime reader tests.
+    versions: resolveVersionsConfig(validated.versions),
     schemaHash,
     hooks: validated.hooks,
   });

--- a/packages/nextly/src/api/singles-schema-detail.ts
+++ b/packages/nextly/src/api/singles-schema-detail.ts
@@ -24,6 +24,7 @@ import type { FieldConfig } from "@nextly/collections";
 
 import { getService } from "../di";
 import { calculateSchemaHash } from "../domains/schema/services/schema-hash";
+import { resolveBuilderVersions } from "../domains/versions/builder-versions";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
 import { getNextlyLogger } from "../observability/logger";
@@ -187,6 +188,12 @@ export const PATCH = withErrorHandler(
         ...(existing.admin || {}),
         ...adminOverrides,
       };
+    }
+
+    // Version history toggle, normalized to the resolved config the registry
+    // column holds; off writes null. Mirrors the collection detail route.
+    if (body.versions !== undefined) {
+      updateData.versions = resolveBuilderVersions(body.versions === true);
     }
 
     if (body.accessRules !== undefined) {

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -59,7 +59,7 @@ import { calculateSchemaHash } from "../../domains/schema/services/schema-hash";
 import { resolveSingleTableName } from "../../domains/singles/services/resolve-single-table-name";
 import type { SingleEntryService } from "../../domains/singles/services/single-entry-service";
 import type { SingleRegistryService } from "../../domains/singles/services/single-registry-service";
-import { resolveVersionsConfig } from "../../domains/versions/resolve-config";
+import { resolveBuilderVersions } from "../../domains/versions/builder-versions";
 import { NextlyError } from "../../errors";
 import { transformRichTextFields } from "../../lib/field-transform";
 import { getProductionNotifier } from "../../runtime/notifications/index";
@@ -439,6 +439,8 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
             // i18n: Internationalization opt-in; persists to dynamic_singles.localized and
             // provisions the companion single_<slug>_locales table.
             localized?: boolean;
+            // Version history opt-in; persists to dynamic_singles.versions.
+            versions?: boolean;
           }
         | undefined;
 
@@ -575,6 +577,10 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         status: b.status === true,
         // i18n: persist the Internationalization flag so the single reads/writes per language.
         localized: isLocalized,
+        // Persist version history from the create payload; without it a Single
+        // created with the switch on is written unversioned and the switch
+        // reads as off the moment the editor loads.
+        versions: resolveBuilderVersions(b.versions),
         schemaHash,
         migrationStatus,
       });
@@ -876,7 +882,7 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       // resolver: it aliases to a versioned config for back-compat, which would
       // stop the toggle from turning versioning off on a Draft/Published single.
       if (b.versions !== undefined) {
-        updateData.versions = resolveVersionsConfig(b.versions);
+        updateData.versions = resolveBuilderVersions(b.versions);
       }
       const wasLocalized = existing.localized === true;
       const isLocalized =

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -59,6 +59,7 @@ import { calculateSchemaHash } from "../../domains/schema/services/schema-hash";
 import { resolveSingleTableName } from "../../domains/singles/services/resolve-single-table-name";
 import type { SingleEntryService } from "../../domains/singles/services/single-entry-service";
 import type { SingleRegistryService } from "../../domains/singles/services/single-registry-service";
+import { resolveVersionsConfig } from "../../domains/versions/resolve-config";
 import { NextlyError } from "../../errors";
 import { transformRichTextFields } from "../../lib/field-transform";
 import { getProductionNotifier } from "../../runtime/notifications/index";
@@ -840,6 +841,9 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
             // i18n: Internationalization toggle; honoured when defined, undefined leaves the
             // existing value untouched. Persists to dynamic_singles.localized.
             localized?: boolean;
+            // Version history toggle; honoured when defined, undefined leaves
+            // the existing value untouched. Persists to dynamic_singles.versions.
+            versions?: boolean;
           }
         | undefined;
 
@@ -866,6 +870,14 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       // managed on the companion (moving existing rows between the two is the `nextly migrate`
       // path — the dev toggle provisions the companion without touching main-table data).
       if (b.localized !== undefined) updateData.localized = b.localized;
+      // Version history toggle. The registry column holds the resolved config
+      // every runtime reader tests, so the boolean is normalized before it is
+      // stored; off writes null. `status` is deliberately not passed to the
+      // resolver: it aliases to a versioned config for back-compat, which would
+      // stop the toggle from turning versioning off on a Draft/Published single.
+      if (b.versions !== undefined) {
+        updateData.versions = resolveVersionsConfig(b.versions);
+      }
       const wasLocalized = existing.localized === true;
       const isLocalized =
         b.localized !== undefined ? b.localized === true : wasLocalized;

--- a/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
@@ -306,6 +306,8 @@ export class CollectionMetadataService extends BaseService {
     status?: boolean;
     /** i18n: whether the collection is localized (translatable fields + companion table). */
     localized?: boolean;
+    /** Whether every save is recorded as a restorable version. */
+    versions?: boolean;
     fields: FieldDefinition[];
     hooks?: Record<string, unknown>[];
     createdBy?: string;

--- a/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
@@ -646,6 +646,8 @@ export class CollectionMetadataService extends BaseService {
       status?: boolean;
       /** i18n: toggle Internationalization. Honoured when defined; undefined leaves it unchanged. */
       localized?: boolean;
+      /** Toggle version history. Honoured when defined; undefined leaves it unchanged. */
+      versions?: boolean;
       fields?: FieldDefinition[];
       hooks?: Record<string, unknown>[];
     }

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -17,6 +17,7 @@ import { deriveCompanionSpec } from "../../i18n/migration/derive-companion-spec"
 import { buildCompanionCreateOnlySql } from "../../i18n/migration/generate-up";
 import { buildCompanionTransitionStatements } from "../../i18n/migration/reconcile-companion";
 import { companionHasStatusColumn } from "../../i18n/runtime/companion-io";
+import { resolveVersionsConfig } from "../../versions/resolve-config";
 
 import {
   DynamicCollectionRegistryService,
@@ -95,6 +96,8 @@ export interface UpdateCollectionInput {
   status?: boolean;
   /** i18n: toggle Internationalization. Honoured when defined; undefined leaves it unchanged. */
   localized?: boolean;
+  /** Toggle version history. Honoured when defined; undefined leaves it unchanged. */
+  versions?: boolean;
   fields?: FieldDefinition[];
   hooks?: Record<string, unknown>[];
 }
@@ -383,6 +386,14 @@ export class DynamicCollectionService extends BaseService {
     // it). Mirrors `status` — only written when the caller explicitly sent it.
     if (updates.localized !== undefined)
       metadataUpdates.localized = updates.localized;
+    // Version history toggle. The column holds the resolved config every
+    // runtime reader tests, so the boolean is normalized before it is stored;
+    // off writes null. `status` is deliberately not passed to the resolver —
+    // it aliases to a versioned config for back-compat, which would stop the
+    // toggle from ever turning versioning off on a Draft/Published entity.
+    if (updates.versions !== undefined) {
+      metadataUpdates.versions = resolveVersionsConfig(updates.versions);
+    }
 
     let migrationSQL: string | null = null;
     let migrationFileName: string | null = null;

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -17,7 +17,7 @@ import { deriveCompanionSpec } from "../../i18n/migration/derive-companion-spec"
 import { buildCompanionCreateOnlySql } from "../../i18n/migration/generate-up";
 import { buildCompanionTransitionStatements } from "../../i18n/migration/reconcile-companion";
 import { companionHasStatusColumn } from "../../i18n/runtime/companion-io";
-import { resolveVersionsConfig } from "../../versions/resolve-config";
+import { resolveBuilderVersions } from "../../versions/builder-versions";
 
 import {
   DynamicCollectionRegistryService,
@@ -77,6 +77,8 @@ export interface CreateCollectionInput {
    * omitted from the main table and a companion `<table>_locales` table is created.
    */
   localized?: boolean;
+  /** Whether every save is recorded as a restorable version. */
+  versions?: boolean;
   fields: FieldDefinition[];
   hooks?: Record<string, unknown>[];
   createdBy?: string;
@@ -218,6 +220,10 @@ export class DynamicCollectionService extends BaseService {
       // i18n: persist the localized flag so the read/write path routes translatable
       // fields to the companion table and the admin shows per-language editing.
       localized: data.localized === true,
+      // Persist version history from the create payload; without it a
+      // collection created with the switch on is written unversioned and the
+      // switch reads as off the moment the editor loads.
+      versions: resolveBuilderVersions(data.versions),
       schemaHash,
       schemaVersion: 1,
       migrationStatus: "pending" as const,
@@ -392,7 +398,7 @@ export class DynamicCollectionService extends BaseService {
     // it aliases to a versioned config for back-compat, which would stop the
     // toggle from ever turning versioning off on a Draft/Published entity.
     if (updates.versions !== undefined) {
-      metadataUpdates.versions = resolveVersionsConfig(updates.versions);
+      metadataUpdates.versions = resolveBuilderVersions(updates.versions);
     }
 
     let migrationSQL: string | null = null;

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
@@ -110,3 +110,67 @@ describe("buildComponentMetadataUpsert", () => {
     expect(sql).not.toContain('"status"');
   });
 });
+
+describe("versions column", () => {
+  const versioned = uiSchemaManifest.parse({
+    collections: [
+      { slug: "posts", versions: true, fields: [{ name: "t", type: "text" }] },
+    ],
+    singles: [
+      { slug: "about", versions: true, fields: [{ name: "t", type: "text" }] },
+    ],
+    components: [],
+  });
+
+  // Every entity kind that can hold entries needs the column written, not just
+  // the one the toggle was first wired for.
+  const cases = [
+    ["collection", buildCollectionMetadataUpsert, versioned.collections[0]],
+    ["single", buildSingleMetadataUpsert, versioned.singles[0]],
+  ] as const;
+
+  for (const [kind, build, entity] of cases) {
+    it(`${kind}: stores the resolved config, not the raw boolean`, () => {
+      // Every runtime reader tests `versions.enabled`, so a bare `true` in the
+      // column would read as unversioned.
+      const sql = build(entity, "sqlite");
+      expect(sql).toContain('"versions"');
+      expect(sql).toContain('"enabled":true');
+      expect(sql).not.toMatch(/"versions"[^,)]*\btrue\b/);
+    });
+
+    it(`${kind}: writes NULL when the entity is unversioned`, () => {
+      // The column must be written even when off: an omitted column is left
+      // untouched by the upsert's DO UPDATE SET, so turning the switch off
+      // would never clear a previously versioned row.
+      const off = { ...entity, versions: undefined };
+      const sql = build(off, "sqlite");
+      expect(sql).toContain('"versions"');
+      expect(sql).toMatch(/NULL/);
+    });
+
+    it(`${kind}: keeps the column updatable on conflict`, () => {
+      const sql = build(entity, "postgresql");
+      expect(sql).toContain('"versions" = EXCLUDED."versions"');
+    });
+  }
+
+  it("does not enable versioning just because status is on", () => {
+    // `status: true` aliases to a versioned config in the code-first resolver
+    // for back-compat. Honouring that here would leave the Builder's switch
+    // unable to turn versioning off on any Draft/Published entity.
+    const statusOnly = uiSchemaManifest.parse({
+      collections: [
+        { slug: "posts", status: true, fields: [{ name: "t", type: "text" }] },
+      ],
+      singles: [],
+      components: [],
+    });
+
+    const sql = buildCollectionMetadataUpsert(
+      statusOnly.collections[0],
+      "sqlite"
+    );
+    expect(sql).not.toContain('"enabled":true');
+  });
+});

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
@@ -155,6 +155,56 @@ describe("versions column", () => {
     });
   }
 
+  it("writes NULL for an explicit versions: false alongside status", () => {
+    // The pair matters: `status: true` aliases to a versioned config in the
+    // code-first resolver, so an explicit off has to win over the alias.
+    const explicit = uiSchemaManifest.parse({
+      collections: [
+        {
+          slug: "posts",
+          status: true,
+          versions: false,
+          fields: [{ name: "t", type: "text" }],
+        },
+      ],
+      singles: [],
+      components: [],
+    });
+
+    const sql = buildCollectionMetadataUpsert(
+      explicit.collections[0],
+      "sqlite"
+    );
+    expect(sql).toContain('"versions"');
+    expect(sql).not.toContain('"enabled":true');
+  });
+
+  it("rejects versions on a component", () => {
+    // Components hold no entries of their own; their parent's versioning
+    // covers them, so the key would persist a setting nothing reads.
+    const parsed = uiSchemaManifest.safeParse({
+      collections: [],
+      singles: [],
+      components: [
+        { slug: "seo", versions: true, fields: [{ name: "t", type: "text" }] },
+      ],
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("stores the switch as history-only, not drafts", () => {
+    // The control records saves so they can be restored and says so; the
+    // code-first default of `true` would additionally turn drafts and autosave
+    // on, which the help text explicitly disclaims.
+    const sql = buildCollectionMetadataUpsert(
+      versioned.collections[0],
+      "sqlite"
+    );
+    expect(sql).toContain('"enabled":true');
+    expect(sql).toMatch(/"drafts":\{[^}]*"enabled":false/);
+  });
+
   it("does not enable versioning just because status is on", () => {
     // `status: true` aliases to a versioned config in the code-first resolver
     // for back-compat. Honouring that here would leave the Builder's switch

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
@@ -12,9 +12,11 @@
  * the slug via the shared helpers. `id` is derived deterministically from the
  * slug so the committed SQL is byte-stable.
  *
- * KNOWN LIMITATION (v1): label-only edits produce no DDL operation, so no
- * migration is generated and the label change is not propagated until a schema
- * change co-occurs.
+ * KNOWN LIMITATION (v1): metadata-only edits produce no DDL operation, so no
+ * migration is generated and the change is not propagated until a schema
+ * change co-occurs. This covers labels, and equally the `status`, `localized`
+ * and `versions` flags: flipping one alone leaves the deployed registry row on
+ * its previous value until the next migration for that table.
  *
  * @module domains/schema/ui-schema/metadata-sql
  * @since v0.0.3-alpha (Plan D2b)
@@ -28,7 +30,7 @@ import {
   toPluralLabel,
   toSingularLabel,
 } from "../../../shared/lib/pluralization";
-import { resolveVersionsConfig } from "../../versions/resolve-config";
+import { resolveBuilderVersions } from "../../versions/builder-versions";
 import { quoteIdent } from "../pipeline/sql-templates/identifier-quoting";
 import { calculateSchemaHash } from "../services/schema-hash";
 
@@ -61,17 +63,14 @@ function jsonLiteral(value: unknown, dialect: Dialect): string {
  * The `versions` column value for a manifest entity.
  *
  * The column holds the resolved config every runtime reader tests, so the
- * manifest's boolean is normalized here rather than stored raw. Unlike the
- * code-first sync this does NOT pass `status` to the resolver: `status: true`
- * aliases to a versioned config for back-compat, which would leave the
- * Builder's switch unable to turn versioning off on any entity that has
- * Draft/Published on.
+ * manifest's boolean is normalized through the same mapping the Builder's write
+ * paths use.
  */
 function versionsLiteral(
   versions: boolean | undefined,
   dialect: Dialect
 ): string {
-  const resolved = resolveVersionsConfig(versions);
+  const resolved = resolveBuilderVersions(versions);
   return resolved === null ? "NULL" : jsonLiteral(resolved, dialect);
 }
 

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
@@ -28,6 +28,7 @@ import {
   toPluralLabel,
   toSingularLabel,
 } from "../../../shared/lib/pluralization";
+import { resolveVersionsConfig } from "../../versions/resolve-config";
 import { quoteIdent } from "../pipeline/sql-templates/identifier-quoting";
 import { calculateSchemaHash } from "../services/schema-hash";
 
@@ -54,6 +55,24 @@ function sqlStr(value: string): string {
 function jsonLiteral(value: unknown, dialect: Dialect): string {
   const lit = sqlStr(JSON.stringify(value));
   return dialect === "postgresql" ? `${lit}::jsonb` : lit;
+}
+
+/**
+ * The `versions` column value for a manifest entity.
+ *
+ * The column holds the resolved config every runtime reader tests, so the
+ * manifest's boolean is normalized here rather than stored raw. Unlike the
+ * code-first sync this does NOT pass `status` to the resolver: `status: true`
+ * aliases to a versioned config for back-compat, which would leave the
+ * Builder's switch unable to turn versioning off on any entity that has
+ * Draft/Published on.
+ */
+function versionsLiteral(
+  versions: boolean | undefined,
+  dialect: Dialect
+): string {
+  const resolved = resolveVersionsConfig(versions);
+  return resolved === null ? "NULL" : jsonLiteral(resolved, dialect);
 }
 
 /** Boolean literal: integer on SQLite, keyword elsewhere. */
@@ -170,6 +189,14 @@ export function buildCollectionMetadataUpsert(
       value: boolLiteral(entity.localized === true, dialect),
       update: true,
     },
+    {
+      // Always written, including when off: turning the switch off has to clear
+      // the column, and a column left out of the upsert is untouched by its
+      // DO UPDATE SET.
+      name: "versions",
+      value: versionsLiteral(entity.versions, dialect),
+      update: true,
+    },
     { name: "migration_status", value: sqlStr("applied") },
   ];
   if (entity.admin !== undefined) {
@@ -212,6 +239,14 @@ export function buildSingleMetadataUpsert(
       // boot-time companion registration reflect the single's config.
       name: "localized",
       value: boolLiteral(entity.localized === true, dialect),
+      update: true,
+    },
+    {
+      // Always written, including when off: turning the switch off has to clear
+      // the column, and a column left out of the upsert is untouched by its
+      // DO UPDATE SET.
+      name: "versions",
+      value: versionsLiteral(entity.versions, dialect),
       update: true,
     },
     { name: "migration_status", value: sqlStr("applied") },

--- a/packages/nextly/src/domains/versions/__tests__/builder-versions.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/builder-versions.test.ts
@@ -1,0 +1,32 @@
+/**
+ * The one mapping every Builder write path uses for the version-history
+ * switch. Its two decisions are easy to undo by reaching for the code-first
+ * resolver directly, so both are pinned here.
+ */
+import { describe, expect, it } from "vitest";
+
+import { resolveBuilderVersions } from "../builder-versions";
+
+describe("resolveBuilderVersions", () => {
+  it("resolves the switch to history only, without drafts", () => {
+    // The control says it records saves so they can be restored, and that it
+    // does not add drafts. `resolveVersionsConfig(true)` would turn drafts and
+    // autosave on, making the help text untrue once drafts are enforced.
+    const resolved = resolveBuilderVersions(true);
+
+    expect(resolved?.enabled).toBe(true);
+    expect(resolved?.drafts.enabled).toBe(false);
+    expect(resolved?.drafts.autosave.enabled).toBe(false);
+  });
+
+  it("keeps the configured retention default", () => {
+    expect(resolveBuilderVersions(true)?.maxPerDoc).toBe(50);
+  });
+
+  it("resolves off and absent to no config at all", () => {
+    // Null is what the column holds for an unversioned entity; an object with
+    // `enabled: false` would read as versioned to `versions?.enabled` checks.
+    expect(resolveBuilderVersions(false)).toBeNull();
+    expect(resolveBuilderVersions(undefined)).toBeNull();
+  });
+});

--- a/packages/nextly/src/domains/versions/builder-versions.ts
+++ b/packages/nextly/src/domains/versions/builder-versions.ts
@@ -1,0 +1,34 @@
+/**
+ * The Schema Builder's version-history switch, as the registry stores it.
+ *
+ * Every path that persists the switch goes through here so they cannot drift:
+ * the builder's create and update handlers, the standalone schema routes, and
+ * the `ui-schema.json` metadata upserts.
+ *
+ * @module domains/versions/builder-versions
+ */
+
+import type { ResolvedVersionsConfig } from "../../schemas/versions/types";
+
+import { resolveVersionsConfig } from "./resolve-config";
+
+/**
+ * Resolve the switch into the config the registry column holds.
+ *
+ * Two decisions are encoded here.
+ *
+ * The switch means history only. `resolveVersionsConfig(true)` turns drafts and
+ * autosave on, which is the code-first default but not what this control says:
+ * it records saves so they can be restored, and the help text tells the user it
+ * does not add drafts. Storing a drafts-enabled config would make that a lie as
+ * soon as drafts are enforced.
+ *
+ * `status` is deliberately not consulted. It aliases to a versioned config for
+ * code-first back-compat, which would leave the switch unable to turn
+ * versioning off on any entity that has Draft/Published enabled.
+ */
+export function resolveBuilderVersions(
+  enabled: boolean | undefined
+): ResolvedVersionsConfig | null {
+  return enabled === true ? resolveVersionsConfig({ drafts: false }) : null;
+}

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -388,6 +388,17 @@ function entity(kind?: "collection" | "single" | "component") {
         }
         seen.add(f.name);
       }
+      // Components have no entries of their own — they are embedded in a
+      // collection or single, whose versioning covers them. Accepting the key
+      // here would persist a setting nothing reads and the Builder never
+      // offers.
+      if (kind === "component" && e.versions !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "'versions' is not supported on components",
+          path: ["versions"],
+        });
+      }
       // `status` reserved as a field name only when the lifecycle column is on.
       if (e.status === true && e.fields.some(f => f.name === "status")) {
         ctx.addIssue({

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -350,6 +350,14 @@ function entity(kind?: "collection" | "single" | "component") {
       admin: admin.optional(),
       status: z.boolean().optional(),
       localized: z.boolean().optional(),
+      /**
+       * Whether every save is recorded as a restorable version. Boolean rather
+       * than the code-first `boolean | VersionsConfig`: the Schema Builder
+       * offers on/off, and the options the object form carries are not enforced
+       * yet. Unknown keys are stripped here, so without this the Builder's
+       * write would vanish on the next parse.
+       */
+      versions: z.boolean().optional(),
       fields: z.array(uiSchemaFieldSchema),
     })
     .superRefine((e, ctx) => {


### PR DESCRIPTION
Roadmap item 8, PR 4 of the content-versioning program. Follows #252, #256, #257, #258, #260 (merged) and #263 (open).

## Why

Version history could only be enabled by editing `nextly.config.ts`. That put it out of reach of the audience the Schema Builder exists for, while history, preview and restore — all already shipped — assume it is on.

## What

Collections and singles get a **Version History** switch on the Advanced tab of their settings modal. Components do not: they have no entries to version.

The switch is a boolean and nothing more. `VersionsConfig` also carries `drafts`, `autosave` and `schedulePublish`, but those are parsed and persisted without being enforced — only capture works — so surfacing them would advertise behaviour that does not exist. `maxPerDoc` *is* enforced and would make a reasonable "keep last N" input; it is left out to keep this small, since it needs bounds validation and a `false`-means-unlimited encoding on every layer here.

## The shape it travels in

The registry column stores a resolved `ResolvedVersionsConfig`, not a raw boolean — every runtime reader tests `versions?.enabled`. So the toggle stays raw at both edges and is resolved server-side:

```
admin toggle (boolean)
  ├─► ui-schema.json      versions: true            (raw, matches code-first)
  └─► PATCH               resolveVersionsConfig()  → registry column (resolved)
```

Both halves of that dual write are covered. Missing either one means the setting reverts at the next manifest sync.

### One deliberate divergence from the code-first resolver

`resolveVersionsConfig(versions, status)` treats `status: true` as a legacy alias for a versioned config. This path passes only `versions`. Honouring the alias would leave the switch unable to turn versioning **off** on any entity with Draft/Published enabled — the control would silently lie. Code-first behaviour is unchanged.

## Turning it off

Disabling stops new versions and keeps the ones already recorded. Restore already refuses when versioning is off, so old versions stay readable but not restorable. The help text says so.

## Refactor included

The builder pages each spelled their dirty comparison out field by field, which is why a new setting can reach the API while leaving Save permanently greyed out — a failure that reads as the builder ignoring the change. That is now one `settingsAreDirty` helper driven by an exhaustive key list, with a compile-time assertion: a key added to `BuilderSettingsValues` and not to the comparison **fails to compile**. Verified by adding a dummy key and watching `tsc` fail in two places.

## Verification

- **Core:** 16 tests over both manifest upserts, proven load-bearing by three breaks — dropping the zod key, removing the column from the *single* upsert only, and passing the legacy `status` alias to the resolver.
- **Admin:** 12 tests over the switch, the dirty helper and both manifest mappers, proven by four breaks — including removing the mirror for singles only.
- `tsc` run separately from tests on both packages; both clean. Lint clean across the monorepo.
- **Baselines unchanged:** admin 37 failures in 8 files, exactly as before. nextly 394 failures — identical count on `origin/main` with these changes reverted (passing count rises 3696 → 3703, the new tests). No new failures.
- Postgres and MySQL legs verify in CI; no local Docker here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional **Version history** toggle to both collection and single builders.
  * The setting is saved with builder configuration, mirrored in generated manifests/UI-schema, and affects stored schema metadata.
  * Included UI help text clarifying that version history **does not add drafts**.
* **Bug Fixes**
  * Ensured switching **version history off** is reliably persisted (including explicit OFF) across create and update flows.
  * Updated builder pages so the “save settings only” state/behavior correctly reflects the full settings, including version history.
* **Tests**
  * Added/extended coverage for conditional UI, toggle persistence, dirty-state detection, and manifest/metadata output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->