### PR TITLE
fix(nextly): keep array columns comparable between desired and live schema

### DIFF
--- a/.changeset/array-type-roundtrip.md
+++ b/.changeset/array-type-roundtrip.md
@@ -1,0 +1,27 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+`nextly migrate` now works on PostgreSQL.
+
+Nextly compares the database it finds against the schema it expects, and refuses to continue if the difference looks like it could destroy data. One comparison was wrong: a column holding a list of values, such as the tags on a media item, was described as a plain value on one side and as a list on the other. Nextly read that as someone having changed the column's type, treated it as destructive, and stopped.
+
+Because the check runs before anything else, this blocked the whole command on every PostgreSQL project, including a database Nextly itself had just created. The only documented way past it was a flag that permits destructive changes, which in this case would have rewritten the column and lost the values in it.

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/fresh-schema-roundtrip.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/fresh-schema-roundtrip.integration.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Push-then-diff round trip on the core schema.
+ *
+ * A database Nextly has just created must not report type changes against the
+ * definition it was created from. When it does, `nextly migrate` classifies
+ * them as destructive and refuses the whole reconcile, which is how a single
+ * mis-rendered column type made core reconcile unusable on every PostgreSQL
+ * install — including a database created seconds earlier.
+ *
+ * Scoped to type changes on purpose. Default rendering does not round-trip
+ * yet (SQL-expression defaults serialise as objects, and PostgreSQL echoes
+ * casts back), so a blanket zero-ops assertion would encode today's noise as
+ * expected rather than pinning the invariant that matters.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createAdapter } from "../../../../../database/factory";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../../../plugins/test-nextly";
+import { CORE_TABLE_NAMES, getCoreSchema } from "../../../../../schemas/index";
+import { diffSnapshots } from "../diff";
+import { introspectLiveSnapshot } from "../introspect-live";
+
+const URL = process.env.TEST_POSTGRES_URL ?? "";
+
+// Dialect gate: skipped when the dialect's URL is unset, matching the other
+// dialect gates in this package.
+const describePg = describe.skipIf(!URL);
+
+describePg("core schema round trip (postgres)", () => {
+  let handle: TestNextly | undefined;
+
+  beforeAll(async () => {
+    if (!URL) return;
+    // env.ts validates DATABASE_URL against DB_DIALECT on first read and
+    // caches it, so both must be set before the adapter is built.
+    process.env.DB_DIALECT = "postgresql";
+    process.env.DATABASE_URL = URL;
+    const adapter = await createAdapter({
+      type: "postgresql",
+      url: URL,
+    } as Parameters<typeof createAdapter>[0]);
+    handle = await createTestNextly({ adapter });
+  });
+
+  afterAll(async () => {
+    await handle?.destroy();
+  });
+
+  it("reports no type change against the schema it was created from", async () => {
+    const live = await introspectLiveSnapshot(
+      handle!.adapter.getDrizzle(),
+      "postgresql",
+      [...CORE_TABLE_NAMES]
+    );
+    const ops = diffSnapshots(live, getCoreSchema("postgresql"));
+
+    const typeChanges = ops.filter(o => o.type === "change_column_type");
+    expect(typeChanges).toEqual([]);
+  });
+
+  it("keeps an array column comparable in both directions", async () => {
+    // media.tags is `text("tags").array()`; PostgreSQL reports `_text`. This
+    // is the column whose mismatch refused every core reconcile.
+    const live = await introspectLiveSnapshot(
+      handle!.adapter.getDrizzle(),
+      "postgresql",
+      ["media"]
+    );
+    const liveTags = live.tables
+      .find(t => t.name === "media")
+      ?.columns.find(c => c.name === "tags");
+    const desiredTags = getCoreSchema("postgresql")
+      .tables.find(t => t.name === "media")
+      ?.columns.find(c => c.name === "tags");
+
+    expect(liveTags?.type).toBe("_text");
+    expect(desiredTags?.type).toBe("text[]");
+    expect(
+      diffSnapshots(live, getCoreSchema("postgresql")).filter(
+        o => o.type === "change_column_type"
+      )
+    ).toEqual([]);
+  });
+});

--- a/packages/nextly/src/schemas/_internal/__tests__/drizzle-to-tablespec-array.test.ts
+++ b/packages/nextly/src/schemas/_internal/__tests__/drizzle-to-tablespec-array.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Array columns in the desired snapshot.
+ *
+ * The desired and live snapshots must agree on a column nobody has touched.
+ * Drizzle marks `text("tags").array()` as a PgText column carrying
+ * `dimensions: 1`, so `getSQLType()` returns "text" for both a text column and
+ * a text[] column. Live introspection reads PostgreSQL's `_text`, which
+ * normalises to "text[]". Losing the dimension therefore reports a type change
+ * on an untouched column — and a type change is destructive, which refuses the
+ * entire core reconcile.
+ */
+import { pgTable, text, integer } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+
+import { normalizeType } from "../../../domains/schema/pipeline/diff/normalize-type";
+import { drizzleTableToTableSpec } from "../drizzle-to-tablespec";
+
+describe("drizzleTableToTableSpec array columns", () => {
+  const table = pgTable("probe", {
+    tags: text("tags").array(),
+    plain: text("plain"),
+    counts: integer("counts").array(),
+  });
+
+  function typeOf(column: string): string | undefined {
+    return drizzleTableToTableSpec(table).columns.find(c => c.name === column)
+      ?.type;
+  }
+
+  it("marks an array column as an array", () => {
+    expect(typeOf("tags")).toBe("text[]");
+  });
+
+  it("leaves a non-array column alone", () => {
+    expect(typeOf("plain")).toBe("text");
+  });
+
+  it("applies to any base type, not just text", () => {
+    expect(typeOf("counts")).toBe("integer[]");
+  });
+
+  it("agrees with what introspection reports for the same column", () => {
+    // PostgreSQL's udt_name for text[] is `_text`. Both sides must reduce to
+    // one token or the diff sees a change that is not there.
+    expect(normalizeType(typeOf("tags"))).toBe(normalizeType("_text"));
+    expect(normalizeType(typeOf("plain"))).not.toBe(normalizeType("_text"));
+  });
+});

--- a/packages/nextly/src/schemas/_internal/drizzle-to-tablespec.ts
+++ b/packages/nextly/src/schemas/_internal/drizzle-to-tablespec.ts
@@ -63,17 +63,32 @@ export function drizzleTableToTableSpec(table: Table): TableSpec {
 function normalizeDrizzleType(col: {
   columnType: string;
   dataType: string;
+  dimensions?: number;
   getSQLType?: () => string;
 }): string {
+  let base: string | undefined;
   if (typeof col.getSQLType === "function") {
     try {
-      return col.getSQLType().toLowerCase();
+      base = col.getSQLType().toLowerCase();
     } catch {
       // Some column subclasses throw if called without a configured table;
       // fall through to the dataType fallback below.
     }
   }
-  return col.dataType.toLowerCase();
+  base ??= col.dataType.toLowerCase();
+
+  // Array-ness lives in `dimensions`, not in the rendered type: Drizzle marks
+  // `text("tags").array()` as PgText with dimensions 1, so getSQLType() returns
+  // "text" for both a text column and a text[] column. Live introspection
+  // reads PostgreSQL's `_text` for the array, which normalises to "text[]", so
+  // omitting this reports a type change on a column nobody touched — and a
+  // type change is destructive, which refuses the entire core reconcile.
+  //
+  // One suffix regardless of depth: PostgreSQL's udt_name is `_text` for any
+  // dimensionality, so the live side cannot distinguish text[] from text[][]
+  // and matching that keeps both sides comparable.
+  const dimensions = col.dimensions ?? 0;
+  return dimensions > 0 ? `${base}[]` : base;
 }
 
 /**


### PR DESCRIPTION
## Why

`nextly migrate` refused to run on PostgreSQL:

```
Core schema reconciliation requires destructive operations:
changes column 'media.tags' type from '_text' to 'text'.
Set NEXTLY_ALLOW_CORE_DESTRUCTIVE=1 to proceed.
```

I checked whether this was real drift by running it against **a database Nextly had created seconds earlier**. Same refusal. Nextly's own fresh output failed its own inspection, so core reconcile was unusable on every PostgreSQL install.

The suggested escape hatch would have been worse: `media.tags` genuinely is `text[]`, so applying the "change" rewrites it to `text` and loses the values.

## Root cause

Not where I first assumed. `normalizeType` already collapses `_text` and `text[]` to one token, so introspection was fine. The fault is on the **desired** side.

Drizzle represents `text("tags").array()` as a `PgText` column carrying `dimensions: 1` rather than a distinct array type. Probed directly:

```
tags  | columnType: PgText | getSQLType(): text | dimensions: 1
plain | columnType: PgText | getSQLType(): text | dimensions: 0
```

`drizzleTableToTableSpec` used `getSQLType()` alone, so both rendered as `text`. Live said `_text` → `text[]`, desired said `text`, and a type change is destructive, which refuses the entire reconcile.

## The fix

Reflect `dimensions` in the emitted type. One `[]` regardless of depth, because PostgreSQL's `udt_name` is `_text` for any dimensionality and matching that keeps both sides comparable.

## Testing

- 4 unit tests on the converter, including that both sides reduce to the same token via `normalizeType`.
- A **push-then-diff round-trip integration test** on Postgres: create a database, immediately diff it against the schema it was created from, assert no type changes. This is the invariant that was missing — if push and diff disagree about Nextly's own output, every downstream schema decision is unreliable.
- Verified load-bearing: reverting the fix fails both integration tests.
- Regression check on `src/schemas` + `src/domains/schema`: 8 failures with and without this change, all pre-existing.
- Verified end to end: `reconcileCore` against a pristine database now succeeds where it previously threw.

## What this does NOT fix

The round-trip test is deliberately scoped to **type** changes, because a blanket zero-ops assertion would fail today. On a freshly created database the diff still reports 66 spurious operations:

- `add_table nextly_i18n_archive` — declared in `getCoreSchema` but bootstrapped out-of-band, so it is proposed on every reconcile.
- 65 × `change_column_default`, in two classes:
  - `now()` versus `{"decoder":{},"shouldInlineParams":false,...}` — `extractDefault` JSON-serialises SQL-expression defaults instead of rendering them.
  - `'pending'::character varying` versus `pending` — PostgreSQL echoes casts and quotes that the desired side does not carry.

These are currently harmless because `pushSchema` computes its own statements and executes none of them, but they feed the destructive classifier — which is exactly how the bug in this PR blocked everything. Asserting zero ops now would encode that noise as expected. Worth its own PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema comparison accuracy for PostgreSQL array columns.
  * Array types now retain their correct notation, such as `text[]` and `integer[]`, preventing false column-type differences.

* **Tests**
  * Added coverage for array type conversion and PostgreSQL schema round trips.
  * Added validation for bidirectional compatibility between database introspection and expected schema definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->