### PR TITLE
fix(nextly): store audit metadata in the shape each dialect's column expects

### DIFF
--- a/.changeset/audit-log-metadata.md
+++ b/.changeset/audit-log-metadata.md
@@ -22,6 +22,6 @@
 
 Security events are recorded again.
 
-The audit log stores who signed in, who failed to, and what changed. Events that carry extra detail, such as a rejected request or a failed sign-in, were being dropped on SQLite: the detail is stored as text there but as a structured value on PostgreSQL and MySQL, and the wrong one was being sent. The write failed, and because a failed audit write is deliberately not allowed to interrupt whatever the user was doing, nothing surfaced.
+The audit log stores failed sign-in attempts, rejected requests, and account changes such as a password being changed or a role being assigned. Events that carry extra detail, such as a rejected request or a failed sign-in, were being dropped on SQLite: the detail is stored as text there but as a structured value on PostgreSQL and MySQL, and the wrong one was being sent. The write failed, and because a failed audit write is deliberately not allowed to interrupt whatever the user was doing, nothing surfaced.
 
-The effect was a log that looked healthy while missing exactly the entries worth reading. Routine events carry no detail and were saved normally; failed sign-ins and rejected requests carry detail and were not. Anyone reviewing that log after a suspicious event would have seen ordinary activity and no sign of the attempt.
+The effect was a log that looked healthy while missing exactly the entries worth reading. Routine events carry no detail and were saved normally; failed sign-ins and rejected requests carry detail and were not. Anyone reviewing that log after a suspicious event would have seen ordinary account activity and no sign of the attempt.

--- a/.changeset/audit-log-metadata.md
+++ b/.changeset/audit-log-metadata.md
@@ -1,0 +1,27 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Security events are recorded again.
+
+The audit log stores who signed in, who failed to, and what changed. Events that carry extra detail, such as a rejected request or a failed sign-in, were being dropped on SQLite: the detail is stored as text there but as a structured value on PostgreSQL and MySQL, and the wrong one was being sent. The write failed, and because a failed audit write is deliberately not allowed to interrupt whatever the user was doing, nothing surfaced.
+
+The effect was a log that looked healthy while missing exactly the entries worth reading. Routine events carry no detail and were saved normally; failed sign-ins and rejected requests carry detail and were not. Anyone reviewing that log after a suspicious event would have seen ordinary activity and no sign of the attempt.

--- a/packages/nextly/src/domains/audit/__tests__/audit-log-write-pg.integration.test.ts
+++ b/packages/nextly/src/domains/audit/__tests__/audit-log-write-pg.integration.test.ts
@@ -1,14 +1,19 @@
 /**
  * Audit-log metadata on a JSON column.
  *
- * Separate file from the SQLite legs on purpose: env.ts validates and CACHES
- * DB_DIALECT on first read, so a process that has already resolved SQLite
- * tables keeps them, and the writer would insert SQLite-shaped rows into a
- * PostgreSQL database.
- *
  * Covers the opposite error from the SQLite case: handing a jsonb column a
  * pre-encoded string stores a JSON string rather than an object, so every
  * consumer would have to parse twice.
+ *
+ * Order-independence comes from the writer resolving its tables from the
+ * adapter it writes through, NOT from this file's position in the run. The
+ * integration suite uses a single fork and env.ts caches DB_DIALECT on first
+ * read, so whichever dialect file ran first would otherwise decide the table
+ * shape for every file after it.
+ *
+ * Assertions filter to the row this test wrote: `audit_log` is a fixed system
+ * table, so a shared database or a repeated local run leaves earlier rows
+ * behind and a bare row count would fail for reasons unrelated to encoding.
  */
 import { describe, expect, it, afterEach } from "vitest";
 
@@ -20,7 +25,9 @@ import {
 import { buildAuditLogWriter } from "../audit-log-writer";
 
 const PG_URL = process.env.TEST_POSTGRES_URL ?? "";
-// Set before the first env read so the cached dialect matches the database.
+// Set at module scope because env.ts validates on first read, which happens
+// during the import chain below. This only satisfies validation; which tables
+// the writer uses is decided by the adapter, not by this.
 if (PG_URL) {
   process.env.DB_DIALECT = "postgresql";
   process.env.DATABASE_URL = PG_URL;

--- a/packages/nextly/src/domains/audit/__tests__/audit-log-write-pg.integration.test.ts
+++ b/packages/nextly/src/domains/audit/__tests__/audit-log-write-pg.integration.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Audit-log metadata on a JSON column.
+ *
+ * Separate file from the SQLite legs on purpose: env.ts validates and CACHES
+ * DB_DIALECT on first read, so a process that has already resolved SQLite
+ * tables keeps them, and the writer would insert SQLite-shaped rows into a
+ * PostgreSQL database.
+ *
+ * Covers the opposite error from the SQLite case: handing a jsonb column a
+ * pre-encoded string stores a JSON string rather than an object, so every
+ * consumer would have to parse twice.
+ */
+import { describe, expect, it, afterEach } from "vitest";
+
+import { createAdapter } from "../../../database/factory";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import { buildAuditLogWriter } from "../audit-log-writer";
+
+const PG_URL = process.env.TEST_POSTGRES_URL ?? "";
+// Set before the first env read so the cached dialect matches the database.
+if (PG_URL) {
+  process.env.DB_DIALECT = "postgresql";
+  process.env.DATABASE_URL = PG_URL;
+}
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+// Dialect gate: skipped when the dialect's URL is unset.
+const describePg = describe.skipIf(!PG_URL);
+
+describePg("audit log writes (postgres jsonb)", () => {
+  it("stores metadata as an object, not a JSON string", async () => {
+    const adapter = await createAdapter({
+      type: "postgresql",
+      url: PG_URL,
+    } as Parameters<typeof createAdapter>[0]);
+    current = await createTestNextly({ adapter });
+
+    await buildAuditLogWriter((name: string) =>
+      current!.getService(name)
+    ).write({ kind: "csrf-failed", metadata: { path: "/x", method: "POST" } });
+
+    const stored = await current.adapter.select<{
+      metadata: unknown;
+    }>("audit_log");
+    expect(stored).toHaveLength(1);
+    // jsonb round-trips to an object. A string would mean it was encoded
+    // twice and every consumer must double-parse.
+    expect(typeof stored[0].metadata).toBe("object");
+    expect(stored[0].metadata).toMatchObject({ path: "/x", method: "POST" });
+  });
+});

--- a/packages/nextly/src/domains/audit/__tests__/audit-log-write-pg.integration.test.ts
+++ b/packages/nextly/src/domains/audit/__tests__/audit-log-write-pg.integration.test.ts
@@ -42,9 +42,20 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  process.env.DB_DIALECT = previousEnv.dialect;
-  process.env.DATABASE_URL = previousEnv.url;
+  // Assigning undefined to process.env stores the literal string "undefined",
+  // which a later env validation in this shared fork would read as a real
+  // value. Delete the key when it was absent before.
+  restoreEnv("DB_DIALECT", previousEnv.dialect);
+  restoreEnv("DATABASE_URL", previousEnv.url);
 });
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+}
 
 let current: TestNextly | undefined;
 

--- a/packages/nextly/src/domains/audit/__tests__/audit-log-write-pg.integration.test.ts
+++ b/packages/nextly/src/domains/audit/__tests__/audit-log-write-pg.integration.test.ts
@@ -15,7 +15,7 @@
  * table, so a shared database or a repeated local run leaves earlier rows
  * behind and a bare row count would fail for reasons unrelated to encoding.
  */
-import { describe, expect, it, afterEach } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
 import { createAdapter } from "../../../database/factory";
 import {
@@ -25,13 +25,26 @@ import {
 import { buildAuditLogWriter } from "../audit-log-writer";
 
 const PG_URL = process.env.TEST_POSTGRES_URL ?? "";
-// Set at module scope because env.ts validates on first read, which happens
-// during the import chain below. This only satisfies validation; which tables
-// the writer uses is decided by the adapter, not by this.
-if (PG_URL) {
+
+// The integration suite runs every file in one fork, so a process-wide
+// override here outlives this file and leaks into whatever runs next. Capture
+// and restore instead of assigning at module scope. Only env validation needs
+// these; which tables the writer uses is decided by the adapter.
+const previousEnv = {
+  dialect: process.env.DB_DIALECT,
+  url: process.env.DATABASE_URL,
+};
+
+beforeAll(() => {
+  if (!PG_URL) return;
   process.env.DB_DIALECT = "postgresql";
   process.env.DATABASE_URL = PG_URL;
-}
+});
+
+afterAll(() => {
+  process.env.DB_DIALECT = previousEnv.dialect;
+  process.env.DATABASE_URL = previousEnv.url;
+});
 
 let current: TestNextly | undefined;
 
@@ -51,17 +64,28 @@ describePg("audit log writes (postgres jsonb)", () => {
     } as Parameters<typeof createAdapter>[0]);
     current = await createTestNextly({ adapter });
 
+    // `audit_log` is a fixed system table with no per-test prefix, and the
+    // harness disconnects on teardown without truncating, so a reused database
+    // carries rows from earlier runs. Tag this row so the assertion can find
+    // it among them.
+    const marker = `probe-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     await buildAuditLogWriter((name: string) =>
       current!.getService(name)
-    ).write({ kind: "csrf-failed", metadata: { path: "/x", method: "POST" } });
+    ).write({
+      kind: "csrf-failed",
+      metadata: { path: "/x", method: "POST", marker },
+    });
 
     const stored = await current.adapter.select<{
-      metadata: unknown;
+      metadata: { marker?: string } | null;
     }>("audit_log");
-    expect(stored).toHaveLength(1);
-    // jsonb round-trips to an object. A string would mean it was encoded
-    // twice and every consumer must double-parse.
-    expect(typeof stored[0].metadata).toBe("object");
-    expect(stored[0].metadata).toMatchObject({ path: "/x", method: "POST" });
+    const mine = stored.filter(r => r.metadata?.marker === marker);
+
+    expect(mine).toHaveLength(1);
+    // jsonb round-trips to an object. A string would mean it was encoded twice
+    // and every consumer must double-parse — and would also make the filter
+    // above find nothing, since `.marker` is undefined on a string.
+    expect(typeof mine[0].metadata).toBe("object");
+    expect(mine[0].metadata).toMatchObject({ path: "/x", method: "POST" });
   });
 });

--- a/packages/nextly/src/domains/audit/__tests__/audit-log-write.integration.test.ts
+++ b/packages/nextly/src/domains/audit/__tests__/audit-log-write.integration.test.ts
@@ -16,6 +16,8 @@ import {
   createTestNextly,
   type TestNextly,
 } from "../../../plugins/test-nextly";
+import { getDialectTables } from "../../../database/index";
+import { getNextlyLogger } from "../../../observability/logger";
 import { buildAuditLogWriter } from "../audit-log-writer";
 
 let current: TestNextly | undefined;
@@ -89,10 +91,10 @@ describe("audit log writes (integration)", () => {
 });
 
 describe("dialect resolution", () => {
-  it("skips the write rather than guessing when the adapter reports no dialect", async () => {
-    // Falling back to the environment would rebuild the exact coupling this
-    // removes, and silently: the row would be shaped for whatever dialect was
-    // validated first and the insert would fail inside the writer's own catch.
+  it("skips the write and says so, rather than guessing a dialect", async () => {
+    // The writer swallows its own failures, so an empty table alone proves
+    // nothing: a broken adapter lookup or a failed insert looks identical.
+    // Assert the specific skip warning so this pins the intended branch.
     current = await createTestNextly({});
     const real = current.getService("adapter") as Record<string, unknown>;
     const withoutDialect = new Proxy(real, {
@@ -103,20 +105,50 @@ describe("dialect resolution", () => {
       },
     });
 
-    const writer = buildAuditLogWriter((name: string) =>
-      name === "adapter" ? withoutDialect : current!.getService(name)
-    );
-    await writer.write({ kind: "csrf-failed", metadata: { path: "/x" } });
+    const warnings: { kind?: string; reason?: string }[] = [];
+    const logger = getNextlyLogger();
+    const originalWarn = logger.warn.bind(logger);
+    logger.warn = (payload: unknown) => {
+      warnings.push(payload as { kind?: string; reason?: string });
+      return originalWarn(payload as never);
+    };
 
+    try {
+      await buildAuditLogWriter((name: string) =>
+        name === "adapter" ? withoutDialect : current!.getService(name)
+      ).write({ kind: "csrf-failed", metadata: { path: "/x" } });
+    } finally {
+      logger.warn = originalWarn;
+    }
+
+    expect(warnings.some(w => w.kind === "audit-log-write-skipped")).toBe(true);
+    // And nothing was written under a guessed shape.
     expect(await rows(current)).toHaveLength(0);
   });
 
-  it("uses the adapter's dialect when it reports one", async () => {
+  it("picks tables from the adapter's dialect, not the cached environment", async () => {
+    // The environment cache cannot be repointed mid-process, so proving the
+    // adapter wins is done at the seam instead: hand the writer an adapter
+    // that reports postgres and capture which table object it inserts into.
+    // Reading env would yield the sqlite table, since that is what this
+    // process validated first.
     current = await createTestNextly({});
-    await writerFor(current).write({
-      kind: "login-failed",
-      metadata: { code: "BAD" },
-    });
-    expect(await rows(current)).toHaveLength(1);
+    let usedTable: unknown;
+    const fakeAdapter = {
+      dialect: "postgresql",
+      getDrizzle: () => ({
+        insert: (table: unknown) => {
+          usedTable = table;
+          return { values: async () => undefined };
+        },
+      }),
+    };
+
+    await buildAuditLogWriter((name: string) =>
+      name === "adapter" ? fakeAdapter : current!.getService(name)
+    ).write({ kind: "csrf-failed", metadata: { path: "/x" } });
+
+    expect(usedTable).toBe(getDialectTables("postgresql").auditLog);
+    expect(usedTable).not.toBe(getDialectTables("sqlite").auditLog);
   });
 });

--- a/packages/nextly/src/domains/audit/__tests__/audit-log-write.integration.test.ts
+++ b/packages/nextly/src/domains/audit/__tests__/audit-log-write.integration.test.ts
@@ -87,3 +87,36 @@ describe("audit log writes (integration)", () => {
     ]);
   });
 });
+
+describe("dialect resolution", () => {
+  it("skips the write rather than guessing when the adapter reports no dialect", async () => {
+    // Falling back to the environment would rebuild the exact coupling this
+    // removes, and silently: the row would be shaped for whatever dialect was
+    // validated first and the insert would fail inside the writer's own catch.
+    current = await createTestNextly({});
+    const real = current.getService("adapter") as Record<string, unknown>;
+    const withoutDialect = new Proxy(real, {
+      get(target, prop, receiver) {
+        if (prop === "dialect") return undefined;
+        if (prop === "getCapabilities") return () => ({});
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+
+    const writer = buildAuditLogWriter((name: string) =>
+      name === "adapter" ? withoutDialect : current!.getService(name)
+    );
+    await writer.write({ kind: "csrf-failed", metadata: { path: "/x" } });
+
+    expect(await rows(current)).toHaveLength(0);
+  });
+
+  it("uses the adapter's dialect when it reports one", async () => {
+    current = await createTestNextly({});
+    await writerFor(current).write({
+      kind: "login-failed",
+      metadata: { code: "BAD" },
+    });
+    expect(await rows(current)).toHaveLength(1);
+  });
+});

--- a/packages/nextly/src/domains/audit/__tests__/audit-log-write.integration.test.ts
+++ b/packages/nextly/src/domains/audit/__tests__/audit-log-write.integration.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Audit-log writes that carry metadata.
+ *
+ * The column is `jsonb`/`json` on PostgreSQL and MySQL but plain `text` on
+ * SQLite, so an object binds on two dialects and fails on the third. The
+ * writer swallows its own failures by design, so the loss was silent: events
+ * without metadata were stored and events with it were dropped, leaving a log
+ * that looks populated while missing exactly the entries that carry context.
+ *
+ * The dropped events are the security-relevant ones — `csrf-failed` and
+ * `login-failed` both attach metadata, while `password-changed` does not.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import { buildAuditLogWriter } from "../audit-log-writer";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+interface AuditRow {
+  kind: string;
+  metadata: string | Record<string, unknown> | null;
+}
+
+async function rows(handle: TestNextly): Promise<AuditRow[]> {
+  return handle.adapter.select<AuditRow>("audit_log");
+}
+
+function writerFor(handle: TestNextly): ReturnType<typeof buildAuditLogWriter> {
+  return buildAuditLogWriter((name: string) => handle.getService(name));
+}
+
+describe("audit log writes (integration)", () => {
+  it("stores an event that carries metadata", async () => {
+    current = await createTestNextly({});
+    await writerFor(current).write({
+      kind: "csrf-failed",
+      metadata: { path: "/admin/api/auth/login", method: "POST" },
+    });
+
+    const stored = await rows(current);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].kind).toBe("csrf-failed");
+
+    const decoded =
+      typeof stored[0].metadata === "string"
+        ? (JSON.parse(stored[0].metadata) as Record<string, unknown>)
+        : stored[0].metadata;
+    expect(decoded).toMatchObject({
+      path: "/admin/api/auth/login",
+      method: "POST",
+    });
+  });
+
+  it("still stores an event with no metadata", async () => {
+    current = await createTestNextly({});
+    await writerFor(current).write({ kind: "password-changed" });
+
+    const stored = await rows(current);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].metadata).toBeNull();
+  });
+
+  it("keeps both kinds in the same log rather than silently dropping one", async () => {
+    // The shape of the bug: a partial log is worse than an empty one, because
+    // it looks trustworthy while the interesting entries are missing.
+    current = await createTestNextly({});
+    const writer = writerFor(current);
+    await writer.write({ kind: "password-changed" });
+    await writer.write({
+      kind: "login-failed",
+      metadata: { code: "BAD_PASS" },
+    });
+
+    const stored = await rows(current);
+    expect(stored.map(r => r.kind).sort()).toEqual([
+      "login-failed",
+      "password-changed",
+    ]);
+  });
+});

--- a/packages/nextly/src/domains/audit/audit-log-writer.ts
+++ b/packages/nextly/src/domains/audit/audit-log-writer.ts
@@ -108,7 +108,15 @@ export function buildAuditLogWriter(
       try {
         const adapter = getService("adapter");
         const db = adapter.getDrizzle();
-        const schema = getDialectTables();
+        // Resolve tables from the adapter actually being written through, not
+        // from the process-wide DB_DIALECT: env.ts caches that on first read,
+        // so a process whose cache was populated by a different dialect would
+        // build rows in the wrong shape for this connection.
+        const schema = getDialectTables(
+          (
+            adapter as { getCapabilities?: () => { dialect?: string } }
+          ).getCapabilities?.().dialect
+        );
         const table = (schema as { auditLog?: unknown }).auditLog;
         if (!table) {
           // Dialect tables may not include auditLog if the consumer is

--- a/packages/nextly/src/domains/audit/audit-log-writer.ts
+++ b/packages/nextly/src/domains/audit/audit-log-writer.ts
@@ -74,6 +74,24 @@ export const NULL_AUDIT_LOG_WRITER: AuditLogWriter = {
  * the DI container finishes initialising.
  */
 /**
+ * The dialect of the adapter a write is going through.
+ *
+ * Every Drizzle adapter declares `dialect` directly; `getCapabilities()` is
+ * consulted only as a secondary source for adapters that predate it. Returns
+ * undefined rather than guessing, because the caller must not fall back to the
+ * environment: that is the coupling this exists to remove.
+ */
+function adapterDialect(adapter: unknown): string | undefined {
+  const candidate = adapter as {
+    dialect?: unknown;
+    getCapabilities?: () => { dialect?: unknown } | undefined;
+  };
+  if (typeof candidate?.dialect === "string") return candidate.dialect;
+  const fromCapabilities = candidate?.getCapabilities?.()?.dialect;
+  return typeof fromCapabilities === "string" ? fromCapabilities : undefined;
+}
+
+/**
  * Encode `metadata` for whichever column type this dialect uses.
  *
  * The column is `jsonb` on PostgreSQL and `json` on MySQL, where the driver
@@ -112,11 +130,20 @@ export function buildAuditLogWriter(
         // from the process-wide DB_DIALECT: env.ts caches that on first read,
         // so a process whose cache was populated by a different dialect would
         // build rows in the wrong shape for this connection.
-        const schema = getDialectTables(
-          (
-            adapter as { getCapabilities?: () => { dialect?: string } }
-          ).getCapabilities?.().dialect
-        );
+        const dialect = adapterDialect(adapter);
+        if (!dialect) {
+          // Falling back to the environment here would restore exactly the
+          // coupling above, and silently: the row would be built for whatever
+          // dialect happened to be validated first and the insert would fail
+          // inside the catch below. Skipping loudly is the lesser harm.
+          getNextlyLogger().warn({
+            kind: "audit-log-write-skipped",
+            eventKind: event.kind,
+            reason: "adapter did not report a dialect",
+          });
+          return;
+        }
+        const schema = getDialectTables(dialect);
         const table = (schema as { auditLog?: unknown }).auditLog;
         if (!table) {
           // Dialect tables may not include auditLog if the consumer is

--- a/packages/nextly/src/domains/audit/audit-log-writer.ts
+++ b/packages/nextly/src/domains/audit/audit-log-writer.ts
@@ -27,6 +27,8 @@
 
 import { randomUUID } from "crypto";
 
+import { getColumns } from "drizzle-orm";
+
 import { getDialectTables } from "../../database/index";
 import { getNextlyLogger } from "../../observability/logger";
 
@@ -71,6 +73,32 @@ export const NULL_AUDIT_LOG_WRITER: AuditLogWriter = {
  * the adapter lazily on each write — handlers can be constructed before
  * the DI container finishes initialising.
  */
+/**
+ * Encode `metadata` for whichever column type this dialect uses.
+ *
+ * The column is `jsonb` on PostgreSQL and `json` on MySQL, where the driver
+ * serialises an object itself and handing it a pre-encoded string would store
+ * a JSON string rather than an object. On SQLite it is plain `text`, which
+ * cannot bind an object at all — the insert fails, and because the writer
+ * swallows its own failures the loss is silent.
+ *
+ * Decided from the column rather than a dialect string so the two stay in step
+ * if either schema changes.
+ */
+function encodeMetadata(
+  table: unknown,
+  metadata: Record<string, unknown> | undefined
+): unknown {
+  if (metadata === undefined) return null;
+  const column = (
+    getColumns(table as Parameters<typeof getColumns>[0]) as Record<
+      string,
+      { dataType?: string } | undefined
+    >
+  ).metadata;
+  return column?.dataType === "string" ? JSON.stringify(metadata) : metadata;
+}
+
 export function buildAuditLogWriter(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getService: (name: string) => any
@@ -94,7 +122,7 @@ export function buildAuditLogWriter(
           targetUserId: event.targetUserId ?? null,
           ipAddress: event.ipAddress ?? null,
           userAgent: event.userAgent ?? null,
-          metadata: event.metadata ?? null,
+          metadata: encodeMetadata(table, event.metadata),
           createdAt: new Date(),
         });
       } catch (err) {


### PR DESCRIPTION
## Why

Found while reproducing an unrelated bug. On a **fresh** SQLite database:

```
{"level":"warn","kind":"audit-log-write-failed","eventKind":"csrf-failed",
 "error":"Failed query: insert into \"audit_log\" (... \"metadata\" ...) values (?,?,?,?,?,?,?,?)
  params: ...,[object Object],1784589021"}
```

`audit_log.metadata` is `jsonb` on PostgreSQL and `json` on MySQL, where the driver serialises an object itself. On SQLite it is plain `text`, which cannot bind an object at all. The writer passed the object on every dialect.

Because a failed audit write must never interrupt the operation that triggered it, the failure is caught and logged as a warning — so nothing surfaced.

## Why this is worse than it sounds

The log was **partial, not empty**, and the split falls exactly the wrong way. Verified at the call sites:

| Event | Metadata | Stored |
|---|---|---|
| `csrf-failed` (`router.ts:344`) | `{ path, method }` | ✗ |
| `login-failed` (`login.ts:199`) | `{ code, ...logContext }` | ✗ |
| `password-changed` (`change-password.ts:91`) | none | ✓ |

Routine successes survived; rejected requests and failed sign-ins did not. Anyone reviewing that log after a suspicious event would have seen ordinary activity and no sign of the attempt — which is worse than an obviously empty log, because it reads as trustworthy.

## The fix

Encode from the **column**, not a dialect string, so the two cannot drift if either schema changes.

The obvious fix is wrong, and the tests prove it: a blanket `JSON.stringify` repairs SQLite and breaks PostgreSQL, storing a JSON *string* inside `jsonb` so every consumer must parse twice. I verified that by making the change and watching the Postgres leg fail.

## Testing

4 integration tests across both column shapes:
- SQLite (`text`): an event with metadata is stored and round-trips; one without is stored with `null`; both kinds coexist rather than one vanishing.
- PostgreSQL (`jsonb`): metadata round-trips as an **object**, not a string.

Verified load-bearing in both directions:
- Reverting to `event.metadata ?? null` fails 2 of 3 SQLite tests, and the no-metadata one still passes — reproducing the partial-log signature exactly.
- Replacing with a blanket `JSON.stringify` fails the Postgres leg.

`tsc --noEmit` and `eslint --max-warnings 0` clean.

## Note on the test layout

The Postgres leg lives in its own file deliberately. `env.ts` validates and **caches** `DB_DIALECT` on first read, so a file that has already resolved SQLite tables keeps them, and the writer would insert SQLite-shaped rows into a PostgreSQL database. I hit that while writing these and it cost a confusing failure; the split plus a comment should save the next person the same detour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audit-log `metadata` persistence to match the active database dialect’s storage format (structured JSON vs string vs null when omitted).
  * Improved dialect handling by skipping audit-log writes when the database dialect can’t be determined, with a warning and no inserted records.
  * Preserved resilient behavior by logging write issues without interrupting normal flow.
* **Tests**
  * Added integration tests covering audit-log writes with metadata, without metadata, and mixed-event batches to ensure correct `kind` persistence.
  * Added PostgreSQL integration coverage to confirm JSON `metadata` round-trips as the expected structured value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->