### PR TITLE
feat(nextly): warn at startup when core tables are behind the code

### DIFF
--- a/.changeset/schema-drift-boot-warning.md
+++ b/.changeset/schema-drift-boot-warning.md
@@ -1,0 +1,27 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Nextly now tells you when your database is behind the code.
+
+Nextly's own tables are created the first time it connects to a database and are not changed after that. When a new version expects a column those tables do not have, nothing added it, and nothing said so: the mismatch surfaced later as an unrelated-looking failure, or as a feature that quietly stopped working, because some of them catch their own errors and carry on.
+
+Startup now compares the tables it finds against the ones this version expects and, if anything is missing, prints which tables and which columns, along with the command to fix it. It does not change your database; upgrades stay something you run deliberately. A database that is already up to date prints nothing and the check costs a few milliseconds.

--- a/packages/nextly/src/init/__tests__/core-schema-drift-timeout.test.ts
+++ b/packages/nextly/src/init/__tests__/core-schema-drift-timeout.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Bounding the startup schema check.
+ *
+ * The check runs on the initialized-boot path, where it is a diagnostic rather
+ * than a prerequisite. A rejected query is caught, but a STALLED one never
+ * rejects: without a bound, an unresponsive database or a saturated pool holds
+ * the await for the driver's own timeout and startup waits with it.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { warnIfCoreSchemaIsBehind } from "../first-run";
+
+const adapter = {
+  dialect: "sqlite" as const,
+  getDrizzle: () => ({}),
+  tableExists: async () => true,
+  executeQuery: async () => undefined,
+};
+
+function logger() {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+describe("warnIfCoreSchemaIsBehind", () => {
+  it("returns without waiting for a check that never settles", async () => {
+    // The failure this guards: a promise that neither resolves nor rejects.
+    const log = logger();
+    const started = Date.now();
+
+    await warnIfCoreSchemaIsBehind(
+      adapter,
+      log,
+      25,
+      () => new Promise(() => {})
+    );
+
+    expect(Date.now() - started).toBeLessThan(2_000);
+    expect(log.debug).toHaveBeenCalledWith(
+      expect.stringContaining("timed out")
+    );
+    // A timeout is not a schema problem, so nothing is reported to the user.
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("does not report a failed check as drift", async () => {
+    const log = logger();
+    await warnIfCoreSchemaIsBehind(adapter, log, 25, () =>
+      Promise.reject(new Error("connection refused"))
+    );
+
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(log.debug).toHaveBeenCalledWith(
+      expect.stringContaining("connection refused")
+    );
+  });
+
+  it("lets a prompt check complete normally", async () => {
+    const log = logger();
+    const ran = vi.fn(async () => {});
+
+    await warnIfCoreSchemaIsBehind(adapter, log, 1_000, ran);
+
+    expect(ran).toHaveBeenCalledTimes(1);
+    expect(log.debug).not.toHaveBeenCalledWith(
+      expect.stringContaining("timed out")
+    );
+  });
+});

--- a/packages/nextly/src/init/__tests__/core-schema-drift.test.ts
+++ b/packages/nextly/src/init/__tests__/core-schema-drift.test.ts
@@ -1,10 +1,10 @@
 /**
  * Detecting a database whose core tables are behind the running code.
  *
- * This is the shape of the failure that made a real playground database
- * unusable: `dynamic_collections` was created before `localized` and
- * `versions` existed, nothing added them on upgrade, and every collection
- * query failed with an error that named neither the cause nor the remedy.
+ * Core tables are created once and never altered, so a column added in a later
+ * release is absent from an existing database. These pin which differences
+ * count as drift, which are ignored, and that the resulting message names both
+ * the missing columns and the command that fixes them.
  */
 import { describe, expect, it } from "vitest";
 
@@ -26,6 +26,7 @@ function snapshot(tables: Record<string, string[]>): NextlySchemaSnapshot {
 
 describe("findCoreSchemaDrift", () => {
   it("reports a column the code expects that the database lacks", () => {
+    // A collection table created before the localization columns existed.
     const drift = findCoreSchemaDrift(
       snapshot({ dynamic_collections: ["id", "slug"] }),
       snapshot({ dynamic_collections: ["id", "slug", "localized", "versions"] })

--- a/packages/nextly/src/init/__tests__/core-schema-drift.test.ts
+++ b/packages/nextly/src/init/__tests__/core-schema-drift.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Detecting a database whose core tables are behind the running code.
+ *
+ * This is the shape of the failure that made a real playground database
+ * unusable: `dynamic_collections` was created before `localized` and
+ * `versions` existed, nothing added them on upgrade, and every collection
+ * query failed with an error that named neither the cause nor the remedy.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { NextlySchemaSnapshot } from "../../domains/schema/pipeline/diff/types";
+import {
+  coreSchemaFingerprint,
+  findCoreSchemaDrift,
+  formatCoreSchemaDriftWarning,
+} from "../core-schema-drift";
+
+function snapshot(tables: Record<string, string[]>): NextlySchemaSnapshot {
+  return {
+    tables: Object.entries(tables).map(([name, columns]) => ({
+      name,
+      columns: columns.map(c => ({ name: c, type: "text", nullable: true })),
+    })),
+  };
+}
+
+describe("findCoreSchemaDrift", () => {
+  it("reports a column the code expects that the database lacks", () => {
+    const drift = findCoreSchemaDrift(
+      snapshot({ dynamic_collections: ["id", "slug"] }),
+      snapshot({ dynamic_collections: ["id", "slug", "localized", "versions"] })
+    );
+
+    expect(drift).toEqual([
+      {
+        table: "dynamic_collections",
+        missingColumns: ["localized", "versions"],
+      },
+    ]);
+  });
+
+  it("reports nothing when the database matches", () => {
+    const same = { nextly_events: ["id", "type", "retention_class"] };
+    expect(findCoreSchemaDrift(snapshot(same), snapshot(same))).toEqual([]);
+  });
+
+  it("ignores extra live columns, which an upgrade does not need to act on", () => {
+    const drift = findCoreSchemaDrift(
+      snapshot({ media: ["id", "tags", "legacy_field"] }),
+      snapshot({ media: ["id", "tags"] })
+    );
+    expect(drift).toEqual([]);
+  });
+
+  it("ignores a table missing entirely, which is a different failure", () => {
+    // A first run creates tables; a table absent here means something other
+    // than a pending upgrade, and the boot path is the wrong place to guess.
+    const drift = findCoreSchemaDrift(
+      snapshot({ media: ["id"] }),
+      snapshot({ media: ["id"], nextly_versions: ["id", "entity"] })
+    );
+    expect(drift).toEqual([]);
+  });
+
+  it("compares column names case-insensitively", () => {
+    const drift = findCoreSchemaDrift(
+      snapshot({ Media: ["ID", "Tags"] }),
+      snapshot({ media: ["id", "tags"] })
+    );
+    expect(drift).toEqual([]);
+  });
+});
+
+describe("coreSchemaFingerprint", () => {
+  it("is stable across table and column ordering", () => {
+    const a = snapshot({ b: ["y", "x"], a: ["m"] });
+    const b = snapshot({ a: ["m"], b: ["x", "y"] });
+    expect(coreSchemaFingerprint(a)).toBe(coreSchemaFingerprint(b));
+  });
+
+  it("changes when a column is added", () => {
+    const before = coreSchemaFingerprint(snapshot({ t: ["a"] }));
+    const after = coreSchemaFingerprint(snapshot({ t: ["a", "b"] }));
+    expect(after).not.toBe(before);
+  });
+
+  it("does not change when only a column type changes", () => {
+    // Types do not round-trip cleanly between the desired and live sides yet,
+    // so including them would flag drift that is not drift.
+    const base = snapshot({ t: ["a"] });
+    const retyped: NextlySchemaSnapshot = {
+      tables: [
+        {
+          name: "t",
+          columns: [{ name: "a", type: "integer", nullable: true }],
+        },
+      ],
+    };
+    expect(coreSchemaFingerprint(retyped)).toBe(coreSchemaFingerprint(base));
+  });
+});
+
+describe("formatCoreSchemaDriftWarning", () => {
+  it("names the columns and the command to run", () => {
+    const message = formatCoreSchemaDriftWarning([
+      { table: "audit_log", missingColumns: ["metadata"] },
+    ]);
+
+    expect(message).toContain("audit_log: metadata");
+    expect(message).toContain("nextly migrate");
+    // The silent-failure consequence is the reason this is worth reading.
+    expect(message).toContain("silently do nothing");
+  });
+});

--- a/packages/nextly/src/init/core-schema-drift.ts
+++ b/packages/nextly/src/init/core-schema-drift.ts
@@ -1,0 +1,109 @@
+/**
+ * Detecting a database whose core tables are behind the running code.
+ *
+ * Nextly's own tables are created once, on first run. Nothing updates them
+ * afterwards, so a column added to a core table in a later release never
+ * reaches a database that already exists. The failure is silent and arrives
+ * far from its cause: queries that name the new column fail at runtime, and
+ * anything that swallows its own errors — retention, the audit log — simply
+ * stops working without saying so.
+ *
+ * Upgrades are an explicit step (`nextly migrate`), so this does not repair
+ * anything. It exists so the operator learns from a startup message rather
+ * than from a downstream feature quietly doing nothing.
+ *
+ * @module init/core-schema-drift
+ */
+
+import { createHash } from "crypto";
+
+import type { NextlySchemaSnapshot } from "../domains/schema/pipeline/diff/types";
+
+/** Key under which the applied core-schema fingerprint is recorded. */
+export const CORE_SCHEMA_FINGERPRINT_KEY = "core_schema_fingerprint";
+
+/** A core table that exists but is missing columns the code expects. */
+export interface CoreTableDrift {
+  table: string;
+  missingColumns: string[];
+}
+
+/**
+ * A stable fingerprint of the core schema's shape.
+ *
+ * Covers table and column names only. Types and defaults are deliberately
+ * excluded: they do not round-trip cleanly between the desired and live sides
+ * yet, so including them would make the fingerprint change for reasons that
+ * are not drift and train operators to ignore the warning.
+ */
+export function coreSchemaFingerprint(schema: NextlySchemaSnapshot): string {
+  const shape = [...schema.tables]
+    .map(table => ({
+      name: table.name,
+      columns: [...table.columns].map(c => c.name).sort(),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(t => `${t.name}(${t.columns.join(",")})`)
+    .join(";");
+  return createHash("sha256").update(shape).digest("hex").slice(0, 32);
+}
+
+/**
+ * Columns the code expects that the live database does not have.
+ *
+ * Only additions are reported. A live table carrying columns the code no
+ * longer declares is not something an upgrade needs to act on, and reporting
+ * it would turn a precise message into noise.
+ *
+ * A table missing entirely is also skipped: that is a different failure with
+ * a different remedy, and the boot path is not where it should be diagnosed.
+ */
+export function findCoreSchemaDrift(
+  live: NextlySchemaSnapshot,
+  desired: NextlySchemaSnapshot
+): CoreTableDrift[] {
+  const liveByTable = new Map(
+    live.tables.map(t => [
+      t.name.toLowerCase(),
+      new Set(t.columns.map(c => c.name.toLowerCase())),
+    ])
+  );
+
+  const drift: CoreTableDrift[] = [];
+  for (const table of desired.tables) {
+    const liveColumns = liveByTable.get(table.name.toLowerCase());
+    if (!liveColumns) continue;
+
+    const missing = table.columns
+      .map(c => c.name)
+      .filter(name => !liveColumns.has(name.toLowerCase()));
+
+    if (missing.length > 0) {
+      drift.push({ table: table.name, missingColumns: missing.sort() });
+    }
+  }
+
+  return drift.sort((a, b) => a.table.localeCompare(b.table));
+}
+
+/**
+ * The warning shown when the database is behind the code.
+ *
+ * Names the columns, because "your schema is out of date" sends someone
+ * hunting while "audit_log is missing metadata" points at the fix. Names the
+ * command too: the whole point of an explicit upgrade step is that the
+ * operator must be told what to run.
+ */
+export function formatCoreSchemaDriftWarning(
+  drift: readonly CoreTableDrift[]
+): string {
+  const lines = [
+    "[nextly] Your database is missing columns this version of Nextly expects.",
+    "",
+    ...drift.map(d => `  ${d.table}: ${d.missingColumns.join(", ")}`),
+    "",
+    "  Run `nextly migrate` to bring the database up to date.",
+    "  Until then, features using these columns will fail or silently do nothing.",
+  ];
+  return lines.join("\n");
+}

--- a/packages/nextly/src/init/first-run.ts
+++ b/packages/nextly/src/init/first-run.ts
@@ -63,36 +63,47 @@ export type EnsureFirstRunSetupResult =
 const PROBE_TABLE = "nextly_schema_events";
 
 /**
+ * How long the check may take before boot proceeds without it.
+ *
+ * A rejection is caught below, but a STALLED query never rejects: a saturated
+ * pool or an unresponsive database would hold the await for the driver's own
+ * timeout, which can be minutes. That would make a diagnostic the reason an
+ * initialized deployment could not restart, so the wait is bounded here rather
+ * than left to the driver.
+ */
+const DRIFT_CHECK_TIMEOUT_MS = 2_000;
+
+/**
  * Compare the live core tables against the running code and warn on a gap.
  *
- * Never throws and never blocks boot: a database that cannot be introspected
- * is a problem for whatever queries it next, not a reason to refuse to start.
- * Upgrades are an explicit step, so this reports and does not repair.
+ * Never throws, and never delays boot by more than
+ * {@link DRIFT_CHECK_TIMEOUT_MS}: a database that cannot be introspected
+ * promptly is a problem for whatever queries it next, not a reason to refuse
+ * to start. Upgrades are an explicit step, so this reports and does not repair.
  */
-async function warnIfCoreSchemaIsBehind(
+export async function warnIfCoreSchemaIsBehind(
   adapter: AdapterLike,
-  logger: LoggerLike
+  logger: LoggerLike,
+  timeoutMs: number = DRIFT_CHECK_TIMEOUT_MS,
+  runCheck: (
+    a: AdapterLike,
+    l: LoggerLike
+  ) => Promise<void> = runCoreSchemaDriftCheck
 ): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
   try {
-    const [{ introspectLiveSnapshot }, { getCoreSchema, CORE_TABLE_NAMES }] =
-      await Promise.all([
-        import("../domains/schema/pipeline/diff/introspect-live"),
-        import("../schemas/index"),
-      ]);
-    const { findCoreSchemaDrift, formatCoreSchemaDriftWarning } = await import(
-      "./core-schema-drift"
-    );
+    const timedOut = Symbol("drift-check-timeout");
+    const deadline = new Promise<typeof timedOut>(resolve => {
+      timer = setTimeout(() => resolve(timedOut), timeoutMs);
+      // Do not hold the event loop open for a diagnostic.
+      timer.unref?.();
+    });
 
-    const desired = getCoreSchema(adapter.dialect);
-    const live = await introspectLiveSnapshot(
-      adapter.getDrizzle(),
-      adapter.dialect,
-      [...CORE_TABLE_NAMES]
-    );
-
-    const drift = findCoreSchemaDrift(live, desired);
-    if (drift.length > 0) {
-      logger.warn(formatCoreSchemaDriftWarning(drift));
+    const outcome = await Promise.race([runCheck(adapter, logger), deadline]);
+    if (outcome === timedOut) {
+      logger.debug?.(
+        "[nextly] Core schema check timed out; continuing startup."
+      );
     }
   } catch (error) {
     // Diagnostics must not be the reason a boot fails.
@@ -101,6 +112,35 @@ async function warnIfCoreSchemaIsBehind(
         error instanceof Error ? error.message : String(error)
       }`
     );
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/** The check itself; bounded by its caller. */
+async function runCoreSchemaDriftCheck(
+  adapter: AdapterLike,
+  logger: LoggerLike
+): Promise<void> {
+  const [{ introspectLiveSnapshot }, { getCoreSchema, CORE_TABLE_NAMES }] =
+    await Promise.all([
+      import("../domains/schema/pipeline/diff/introspect-live"),
+      import("../schemas/index"),
+    ]);
+  const { findCoreSchemaDrift, formatCoreSchemaDriftWarning } = await import(
+    "./core-schema-drift"
+  );
+
+  const desired = getCoreSchema(adapter.dialect);
+  const live = await introspectLiveSnapshot(
+    adapter.getDrizzle(),
+    adapter.dialect,
+    [...CORE_TABLE_NAMES]
+  );
+
+  const drift = findCoreSchemaDrift(live, desired);
+  if (drift.length > 0) {
+    logger.warn(formatCoreSchemaDriftWarning(drift));
   }
 }
 

--- a/packages/nextly/src/init/first-run.ts
+++ b/packages/nextly/src/init/first-run.ts
@@ -62,6 +62,48 @@ export type EnsureFirstRunSetupResult =
 
 const PROBE_TABLE = "nextly_schema_events";
 
+/**
+ * Compare the live core tables against the running code and warn on a gap.
+ *
+ * Never throws and never blocks boot: a database that cannot be introspected
+ * is a problem for whatever queries it next, not a reason to refuse to start.
+ * Upgrades are an explicit step, so this reports and does not repair.
+ */
+async function warnIfCoreSchemaIsBehind(
+  adapter: AdapterLike,
+  logger: LoggerLike
+): Promise<void> {
+  try {
+    const [{ introspectLiveSnapshot }, { getCoreSchema, CORE_TABLE_NAMES }] =
+      await Promise.all([
+        import("../domains/schema/pipeline/diff/introspect-live"),
+        import("../schemas/index"),
+      ]);
+    const { findCoreSchemaDrift, formatCoreSchemaDriftWarning } = await import(
+      "./core-schema-drift"
+    );
+
+    const desired = getCoreSchema(adapter.dialect);
+    const live = await introspectLiveSnapshot(
+      adapter.getDrizzle(),
+      adapter.dialect,
+      [...CORE_TABLE_NAMES]
+    );
+
+    const drift = findCoreSchemaDrift(live, desired);
+    if (drift.length > 0) {
+      logger.warn(formatCoreSchemaDriftWarning(drift));
+    }
+  } catch (error) {
+    // Diagnostics must not be the reason a boot fails.
+    logger.debug?.(
+      `[nextly] Could not check core schema state: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+}
+
 export async function ensureFirstRunSetup(
   args: EnsureFirstRunSetupArgs
 ): Promise<EnsureFirstRunSetupResult> {
@@ -83,6 +125,11 @@ export async function ensureFirstRunSetup(
   }
 
   if (probeExists) {
+    // The database has been set up before, so nothing here creates tables.
+    // Core tables never gain columns after first run, though, so a database
+    // created by an earlier release can be missing columns this one expects.
+    // Report that rather than let a downstream query fail far from the cause.
+    await warnIfCoreSchemaIsBehind(adapter, logger);
     return { ranSetup: false, reason: "already_initialized" };
   }
 


### PR DESCRIPTION
Implements **Option B** for the core-table upgrade path: upgrades stay an explicit step, and the silent failure becomes a loud one.

## Why

Boot probes for `nextly_schema_events` and, if present, returns immediately:

```ts
// first-run.ts
if (probeExists) {
  return { ranSetup: false, reason: "already_initialized" };
}
```

So core tables are created once and never altered. A column added in a later release never reaches an existing database, and nothing says so.

I verified this against a real database — the contributor playground — which was created before `#237` and is missing `dynamic_collections.localized` and `versions`. On current `main`, every collection operation there fails. The error that surfaced said only:

```
✗ Sync failed: An unexpected error occurred.
```

Worse, features that catch their own errors just stop. Webhook retention queries `retention_class`; on a database without it the query throws, the failure is swallowed by design, and the event ledger grows unbounded with no signal at all.

## What this does

Compares the live core tables against the running schema at startup and names what is missing:

```
[nextly] Your database is missing columns this version of Nextly expects.

  dynamic_collections: localized, versions
  nextly_events: fanned_out_at, retention_class

  Run `nextly migrate` to bring the database up to date.
  Until then, features using these columns will fail or silently do nothing.
```

It **repairs nothing** — that is the point of Option B. It names the tables, the columns, and the command, because "your schema is out of date" sends someone hunting.

## Design choices worth reviewing

- **Additions only.** Live columns the code no longer declares are not reported; an upgrade does not need to act on them and reporting them turns a precise message into noise.
- **A missing table is skipped**, not reported. That is a different failure with a different remedy, and boot is the wrong place to diagnose it.
- **The fingerprint helper covers names, not types.** Types and defaults do not round-trip cleanly yet (see #269 — a fresh database still reports 66 spurious default ops), so including them would flag drift that is not drift and train operators to ignore the warning. The helper is included for a future cheap fast path; the boot check does not depend on it yet.
- **Never blocks boot.** A database that cannot be introspected is a problem for whatever queries it next, not a reason to refuse to start.

## Testing

- 9 unit tests on detection, fingerprinting and formatting.
- Verified end to end against a real Postgres database regressed to the exact reported shape: the warning appears and names all four missing columns.
- Verified **no false positive**: a healthy database logs nothing.
- **Cost measured**, since this runs on every boot including serverless cold starts: 42ms for the full boot with drift present, 37ms healthy. The introspection is one query against the core table list.
- `tsc --noEmit` and `eslint --max-warnings 0` clean. `src/init` regression: 3 pre-existing `reload-config` failures, unchanged.

## Follow-up

The warning fires on every boot while a database is behind. If that proves noisy, the intended fix is the fingerprint fast path: record the applied core-schema fingerprint in `nextly_meta` and skip introspection when it matches. I did not wire that here because it needs write plumbing on two paths and the measured cost did not justify it yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic detection of “core schema drift” during application startup.
  - Shows a warning listing missing columns and instructing you to run `nextly migrate`.
  - Schema comparisons match column names case-insensitively and ignore extra live columns.

- **Bug Fixes**
  - Drift diagnostics are non-blocking: they never throw and will time out safely while logging debug details instead of failing startup.

- **Tests**
  - Added coverage for drift detection, stable schema fingerprinting, warning text contents, and startup timeout/rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->