### PR TITLE
refactor(nextly): extract the collection index rules into one function

### DIFF
--- a/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
@@ -31,7 +31,6 @@ import { resolveLocalizedFieldNames } from "../../../i18n/classify-fields";
 import {
   getColumnDescriptor,
   getSystemColumnDescriptors,
-  toSnakeCase,
 } from "../../services/field-column-descriptor";
 
 import { indexKey } from "./index-util";
@@ -96,11 +95,13 @@ interface CollectionIndexContext<F> {
   /** Fields whose columns live in the companion `_locales` table. */
   localizedNames: ReadonlySet<string>;
   /**
-   * Whether a field materialises a column on this table. Supplied by the
-   * caller because each already resolves descriptors in its own field shape;
-   * a column-less field must receive no index.
+   * The column a field materialises, or null when it materialises none (a
+   * component field stores its data in its own table and must receive no
+   * index). Supplied by the caller so the field-to-column mapping stays in
+   * the descriptor module rather than being recomputed here: a descriptor
+   * change would otherwise produce indexes naming columns that do not exist.
    */
-  producesColumn: (field: F) => boolean;
+  columnNameFor: (field: F) => string | null;
 }
 
 /**
@@ -117,7 +118,7 @@ export function collectionIndexSpecs<F extends MinimalFieldDef>(
   fields: readonly F[],
   context: CollectionIndexContext<F>
 ): IndexSpec[] {
-  const { producesColumn } = context;
+  const { columnNameFor } = context;
 
   // System slug(unique)+created_at, plus per-field unique/index and a
   // single-relationship auto-index (matches the runtime live-DDL). hasMany /
@@ -139,12 +140,13 @@ export function collectionIndexSpecs<F extends MinimalFieldDef>(
   }
   for (const field of fields) {
     if (context.localizedNames.has(field.name)) continue; // companion-owned; no main-table index
-    const col = toSnakeCase(field.name);
-    // Skip fields that materialize no column (e.g. component fields): a unique
-    // or plain index on a nonexistent column is invalid DDL. Check the field
-    // directly (not column presence) so a component named after a system column
-    // like `title` does not index the system-injected column instead.
-    if (!producesColumn(field)) continue;
+    const col = columnNameFor(field);
+    // A field materialising no column (e.g. a component, which stores its data
+    // in its own table) gets no index: one on a nonexistent column is invalid
+    // DDL. Asking the descriptor per field, rather than checking whether a
+    // column of that name exists, keeps a component named after a system
+    // column from indexing the system-injected column instead.
+    if (col === null) continue;
     const isSingleRelation =
       (field.type === "relationship" || field.type === "upload") &&
       field.hasMany !== true &&
@@ -241,7 +243,11 @@ export function buildDesiredTableFromFields(
     hasSlugColumn: columns.some(c => c.name === "slug"),
     hasCreatedAtColumn: columns.some(c => c.name === "created_at"),
     localizedNames,
-    producesColumn,
+    columnNameFor: field =>
+      getColumnDescriptor(
+        field as unknown as Parameters<typeof getColumnDescriptor>[0],
+        dialect
+      )?.name ?? null,
   });
 
   return { name: tableName, columns, indexes };

--- a/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
@@ -89,6 +89,83 @@ export interface BuildDesiredTableOptions {
  * created_at, updated_at, and conditionally status) are injected to match
  * runtime-schema-generator's behavior — the descriptor module owns that list.
  */
+/** Inputs the index rules need that only the caller can determine. */
+interface CollectionIndexContext<F> {
+  hasSlugColumn: boolean;
+  hasCreatedAtColumn: boolean;
+  /** Fields whose columns live in the companion `_locales` table. */
+  localizedNames: ReadonlySet<string>;
+  /**
+   * Whether a field materialises a column on this table. Supplied by the
+   * caller because each already resolves descriptors in its own field shape;
+   * a column-less field must receive no index.
+   */
+  producesColumn: (field: F) => boolean;
+}
+
+/**
+ * The indexes a collection table should carry, derived from its fields.
+ *
+ * Shared with the runtime schema generator rather than restated there. Two
+ * places decide what a collection table looks like — this one, which the diff
+ * compares against, and the Drizzle table the push path builds — and when only
+ * one of them knew about indexes, a push rebuilt the table without them and
+ * the indexes were silently lost.
+ */
+export function collectionIndexSpecs<F extends MinimalFieldDef>(
+  tableName: string,
+  fields: readonly F[],
+  context: CollectionIndexContext<F>
+): IndexSpec[] {
+  const { producesColumn } = context;
+
+  // System slug(unique)+created_at, plus per-field unique/index and a
+  // single-relationship auto-index (matches the runtime live-DDL). hasMany /
+  // polymorphic relationships are JSON columns and get NO index.
+  const indexes: IndexSpec[] = [];
+  if (context.hasSlugColumn) {
+    indexes.push({
+      name: `idx_${tableName}_slug`,
+      columns: ["slug"],
+      unique: true,
+    });
+  }
+  if (context.hasCreatedAtColumn) {
+    indexes.push({
+      name: `idx_${tableName}_created_at`,
+      columns: ["created_at"],
+      unique: false,
+    });
+  }
+  for (const field of fields) {
+    if (context.localizedNames.has(field.name)) continue; // companion-owned; no main-table index
+    const col = toSnakeCase(field.name);
+    // Skip fields that materialize no column (e.g. component fields): a unique
+    // or plain index on a nonexistent column is invalid DDL. Check the field
+    // directly (not column presence) so a component named after a system column
+    // like `title` does not index the system-injected column instead.
+    if (!producesColumn(field)) continue;
+    const isSingleRelation =
+      (field.type === "relationship" || field.type === "upload") &&
+      field.hasMany !== true &&
+      !Array.isArray(field.relationTo);
+    if (field.unique === true) {
+      indexes.push({
+        name: `uq_${tableName}_${col}`,
+        columns: [col],
+        unique: true,
+      });
+    } else if (field.index === true || isSingleRelation) {
+      indexes.push({
+        name: `idx_${tableName}_${col}`,
+        columns: [col],
+        unique: false,
+      });
+    }
+  }
+  return dedupeIndexes(indexes);
+}
+
 export function buildDesiredTableFromFields(
   tableName: string,
   fields: MinimalFieldDef[],
@@ -160,51 +237,14 @@ export function buildDesiredTableFromFields(
     });
   }
 
-  // Indexes: system slug(unique)+created_at, plus per-field unique/index and a
-  // single-relationship auto-index (matches the runtime live-DDL). hasMany /
-  // polymorphic relationships are JSON columns and get NO index.
-  const indexes: IndexSpec[] = [];
-  if (columns.some(c => c.name === "slug")) {
-    indexes.push({
-      name: `idx_${tableName}_slug`,
-      columns: ["slug"],
-      unique: true,
-    });
-  }
-  if (columns.some(c => c.name === "created_at")) {
-    indexes.push({
-      name: `idx_${tableName}_created_at`,
-      columns: ["created_at"],
-      unique: false,
-    });
-  }
-  for (const field of fields) {
-    if (localizedNames.has(field.name)) continue; // companion-owned; no main-table index
-    const col = toSnakeCase(field.name);
-    // Skip fields that materialize no column (e.g. component fields): a unique
-    // or plain index on a nonexistent column is invalid DDL. Check the field
-    // directly (not column presence) so a component named after a system column
-    // like `title` does not index the system-injected column instead.
-    if (!producesColumn(field)) continue;
-    const isSingleRelation =
-      (field.type === "relationship" || field.type === "upload") &&
-      field.hasMany !== true &&
-      !Array.isArray(field.relationTo);
-    if (field.unique === true) {
-      indexes.push({
-        name: `uq_${tableName}_${col}`,
-        columns: [col],
-        unique: true,
-      });
-    } else if (field.index === true || isSingleRelation) {
-      indexes.push({
-        name: `idx_${tableName}_${col}`,
-        columns: [col],
-        unique: false,
-      });
-    }
-  }
-  return { name: tableName, columns, indexes: dedupeIndexes(indexes) };
+  const indexes = collectionIndexSpecs(tableName, fields, {
+    hasSlugColumn: columns.some(c => c.name === "slug"),
+    hasCreatedAtColumn: columns.some(c => c.name === "created_at"),
+    localizedNames,
+    producesColumn,
+  });
+
+  return { name: tableName, columns, indexes };
 }
 
 /**


### PR DESCRIPTION
Groundwork for a **P0 I found but have not fixed**, opened separately so the safe half is reviewable on its own.

## The bug this is groundwork for

`nextly db:sync` silently destroys every index on a Schema-Builder collection, on SQLite, on `main` today. Reproduced:

```
BEFORE db:sync:  idx_dc_idxprobe_slug, idx_dc_idxprobe_created_at, idx_dc_idxprobe_created_by
AFTER  db:sync:  (all three gone)
```

`generateRuntimeSchema` builds the Drizzle tables the push path diffs against, and it declares **no indexes at all**. drizzle-kit therefore sees live indexes the desired schema does not mention, rebuilds the table without them, and the indexes go with it. The `Blocked DROP INDEX` warnings in the logs are misleading — they announce a block that protects nothing, because the rebuild removes the indexes regardless. I verified that by running the same scenario with the drop-blocking both enabled and disabled: identical outcome.

This is pre-existing and unrelated to my other PRs. It is the only defect in this programme that silently loses something.

## What this PR contains

Only the safe half: the index rules move out of `buildDesiredTableFromFields` into an exported `collectionIndexSpecs`, so the generator can consume the same source rather than restate it. Restating them is what allowed the two to diverge in the first place, so the fix should not begin by doing it again.

**No behaviour change.** `src/domains/schema/pipeline/diff`: 5 failed / 100 passed both with and without this commit, matching the pre-existing baseline.

The caller supplies `producesColumn` rather than the shared function resolving descriptors itself, which keeps an existing double cast where it already lives instead of duplicating it.

## What is NOT here, and why

Wiring the specs into `pgTable`/`mysqlTable`/`sqliteTable` as a third argument. I attempted it twice and stopped both times:

1. **The dialect-agnostic helper wants `any`.** Drizzle's `index`/`uniqueIndex` share no common type. A structural `IndexBuilders<TColumn>` interface solves that cleanly and typechecks — that part works.
2. **The real wall is `buildDrizzleColumnRecord`.** It returns `Record<string, any>` (lines 175 and 257, pre-existing, with eslint-disables). The two-argument table overload accepts that; the **three**-argument form does not, and resolves to a different overload entirely:

```
Argument of type 'Record<string, any>' is not assignable to parameter of type
'(columnTypes: {...}) => Record<...>'
```

So declaring indexes requires typing that column record per dialect first. That is a real refactor, not an add-on, and doing it while reaching for `as any` or an eslint-disable would violate the repo rule I have been holding reviewers to all day. Precedent in the surrounding file is not permission.

I would rather land the neutral half and scope the typing work deliberately than push a rushed version of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection table indexing for system fields, uniquely constrained fields, explicitly indexed fields, and single relationships.
  * Prevented duplicate indexes from being generated during schema derivation.
  * Avoided creating indexes for localized companion fields and for fields that do not materialize into database columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->