### PR TITLE
fix(nextly): treat a sqlite primary key as not-null when introspecting

### DIFF
--- a/.changeset/sqlite-pk-nullability.md
+++ b/.changeset/sqlite-pk-nullability.md
@@ -1,0 +1,27 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+`nextly migrate` no longer refuses on SQLite.
+
+SQLite reports a text primary key as accepting empty values, because only integer primary keys are automatically required. Nextly's own schema treats every primary key as required, so the two descriptions disagreed on every table, and Nextly read that as someone about to make an existing column required. That change can fail on rows already stored, so it is treated as unsafe and the whole command stops.
+
+The result was that upgrading a SQLite database was blocked by the very columns Nextly created itself, and `nextly migrate` is the documented way to bring a database up to date, so the only route forward was closed.

--- a/packages/nextly/src/domains/schema/migrate/core-reconcile.ts
+++ b/packages/nextly/src/domains/schema/migrate/core-reconcile.ts
@@ -84,12 +84,7 @@ export async function reconcileCore(
 
   const desired = getCoreSchema(dialect);
   const live = await introspect(db, dialect, [...CORE_TABLE_NAMES]);
-  const rawOps = diffSnapshots(live, desired);
-  // Ask the data before judging: requiring a column that holds no NULL cannot
-  // fail on an existing row, so it is not destructive. Without this every
-  // SQLite primary key reads as a pending NOT NULL addition and the whole
-  // reconcile is refused on an untouched database.
-  const ops = await resolveSafeNullabilityOps(db, rawOps);
+  const ops = diffSnapshots(live, desired);
 
   if (ops.length === 0) {
     logger?.info?.("Core schema up to date.");
@@ -99,7 +94,17 @@ export async function reconcileCore(
   const mode: ClassifierMode = deps.mode ?? "production-strict";
   // Always compute the destructive reasons via production-strict so both the
   // strict-refuse path and the non-strict confirmation path share one source.
-  const strict = classifyForMode(ops, dialect, "production-strict");
+  // Ask the data before judging DESTRUCTIVENESS only: requiring a column that
+  // holds no NULL cannot fail on an existing row. Without this every SQLite
+  // primary key reads as a pending NOT NULL addition and the whole reconcile
+  // is refused on an untouched database. `ops` stays whole for the apply — a
+  // safe op still has to be performed, or the constraint is never enforced.
+  const opsForClassification = await resolveSafeNullabilityOps(db, ops);
+  const strict = classifyForMode(
+    opsForClassification,
+    dialect,
+    "production-strict"
+  );
   const destructiveReasons = strict.verdict === "refuse" ? strict.reasons : [];
 
   if (destructiveReasons.length > 0) {

--- a/packages/nextly/src/domains/schema/migrate/core-reconcile.ts
+++ b/packages/nextly/src/domains/schema/migrate/core-reconcile.ts
@@ -28,6 +28,8 @@ import { introspectLiveSnapshot } from "../pipeline/diff/introspect-live";
 import type { NextlySchemaSnapshot } from "../pipeline/diff/types";
 import { freshPushSchema, type FreshPushDialect } from "../pipeline/fresh-push";
 
+import { resolveSafeNullabilityOps } from "./resolve-safe-nullability";
+
 type Dialect = "postgresql" | "mysql" | "sqlite";
 
 interface LoggerLike {
@@ -82,7 +84,12 @@ export async function reconcileCore(
 
   const desired = getCoreSchema(dialect);
   const live = await introspect(db, dialect, [...CORE_TABLE_NAMES]);
-  const ops = diffSnapshots(live, desired);
+  const rawOps = diffSnapshots(live, desired);
+  // Ask the data before judging: requiring a column that holds no NULL cannot
+  // fail on an existing row, so it is not destructive. Without this every
+  // SQLite primary key reads as a pending NOT NULL addition and the whole
+  // reconcile is refused on an untouched database.
+  const ops = await resolveSafeNullabilityOps(db, rawOps);
 
   if (ops.length === 0) {
     logger?.info?.("Core schema up to date.");

--- a/packages/nextly/src/domains/schema/migrate/resolve-safe-nullability.test.ts
+++ b/packages/nextly/src/domains/schema/migrate/resolve-safe-nullability.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Which nullability changes count as destructive.
+ *
+ * Requiring a column fails only on rows that already hold NULL, so the
+ * question is about the data, not the schema flag. Answering it from the flag
+ * alone refuses every column that merely looks newly-required — and on SQLite
+ * that is every primary key, because a TEXT PRIMARY KEY reports as nullable
+ * there while the desired side treats a primary key as required.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { Operation } from "../pipeline/diff/types";
+
+import { resolveSafeNullabilityOps } from "./resolve-safe-nullability";
+
+function requireOp(column: string): Operation {
+  return {
+    type: "change_column_nullable",
+    tableName: "nextly_events",
+    columnName: column,
+    toNullable: false,
+  } as Operation;
+}
+
+function relaxOp(column: string): Operation {
+  return {
+    type: "change_column_nullable",
+    tableName: "nextly_events",
+    columnName: column,
+    toNullable: true,
+  } as Operation;
+}
+
+describe("resolveSafeNullabilityOps", () => {
+  it("drops a require-op when the column holds no NULL", async () => {
+    // The false refusal: every SQLite primary key looked newly-required.
+    const db = { execute: vi.fn(async () => ({ rows: [] })) };
+    expect(await resolveSafeNullabilityOps(db, [requireOp("id")])).toEqual([]);
+  });
+
+  it("keeps a require-op when the column does hold NULL", async () => {
+    // Genuinely destructive: the change would fail on an existing row.
+    const db = { execute: vi.fn(async () => ({ rows: [{ one: 1 }] })) };
+    expect(await resolveSafeNullabilityOps(db, [requireOp("id")])).toHaveLength(
+      1
+    );
+  });
+
+  it("never probes a relax-op, which cannot fail on existing rows", async () => {
+    // Probing it would drop it on the usual no-NULLs answer, so relaxing a
+    // column would be classified away and the constraint never lifted.
+    const db = { execute: vi.fn(async () => ({ rows: [] })) };
+    const out = await resolveSafeNullabilityOps(db, [relaxOp("actor_id")]);
+
+    expect(out).toHaveLength(1);
+    expect(db.execute).not.toHaveBeenCalled();
+  });
+
+  it("passes every other op through untouched", async () => {
+    const db = { execute: vi.fn(async () => ({ rows: [] })) };
+    const other = {
+      type: "add_column",
+      tableName: "t",
+    } as unknown as Operation;
+    expect(await resolveSafeNullabilityOps(db, [other])).toEqual([other]);
+  });
+
+  it("treats an unreadable column as holding NULL", async () => {
+    // An unknown must stay destructive; assuming safe is how a real
+    // data-losing change slips through.
+    const db = {
+      execute: vi.fn(async () => {
+        throw new Error("no such table");
+      }),
+    };
+    expect(await resolveSafeNullabilityOps(db, [requireOp("id")])).toHaveLength(
+      1
+    );
+  });
+});

--- a/packages/nextly/src/domains/schema/migrate/resolve-safe-nullability.test.ts
+++ b/packages/nextly/src/domains/schema/migrate/resolve-safe-nullability.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
+import { NextlyError } from "../../../errors";
 import type { Operation } from "../pipeline/diff/types";
 
 import { resolveSafeNullabilityOps } from "./resolve-safe-nullability";
@@ -56,6 +57,21 @@ describe("resolveSafeNullabilityOps", () => {
     expect(db.execute).not.toHaveBeenCalled();
   });
 
+  it("reads mysql2 tuple results, not the tuple length", async () => {
+    // mysql2 resolves to [rows, fieldPackets], so a probe matching nothing
+    // arrives as [[], fields]. Counting the outer array would call that
+    // "holds NULL" and refuse every safe migration on MySQL.
+    const noMatch = { execute: vi.fn(async () => [[], ["fieldPacket"]]) };
+    expect(await resolveSafeNullabilityOps(noMatch, [requireOp("id")])).toEqual(
+      []
+    );
+
+    const oneMatch = { execute: vi.fn(async () => [[{ one: 1 }], ["f"]]) };
+    expect(
+      await resolveSafeNullabilityOps(oneMatch, [requireOp("id")])
+    ).toHaveLength(1);
+  });
+
   it("passes every other op through untouched", async () => {
     const db = { execute: vi.fn(async () => ({ rows: [] })) };
     const other = {
@@ -70,7 +86,7 @@ describe("resolveSafeNullabilityOps", () => {
     // data-losing change slips through.
     const db = {
       execute: vi.fn(async () => {
-        throw new Error("no such table");
+        throw NextlyError.internal({ logMessage: "no such table" });
       }),
     };
     expect(await resolveSafeNullabilityOps(db, [requireOp("id")])).toHaveLength(

--- a/packages/nextly/src/domains/schema/migrate/resolve-safe-nullability.ts
+++ b/packages/nextly/src/domains/schema/migrate/resolve-safe-nullability.ts
@@ -1,0 +1,95 @@
+/**
+ * Deciding whether adding NOT NULL to a column would actually lose anything.
+ *
+ * `add NOT NULL` is refused as destructive because it fails on rows that hold
+ * NULL. That is true only when such rows exist, and the database can answer
+ * that directly. Classified without asking, the op is refused on every column
+ * that merely LOOKS newly-required — and SQLite makes that the common case,
+ * because it reports a `TEXT PRIMARY KEY` as nullable (only INTEGER PRIMARY
+ * KEY is implicitly NOT NULL there) while `.primaryKey()` on the desired side
+ * means NOT NULL. Every primary key then reads as a pending NOT NULL addition
+ * and the whole core reconcile is refused on a database nobody has changed.
+ *
+ * The probe lives here, not in the classifier: `classifyForMode` is pure and
+ * synchronous, and giving it a database handle would make classification async
+ * for every caller in the pipeline. The reconcile already holds `db`, so the
+ * question is answered here and the classifier keeps deciding on facts.
+ *
+ * @module domains/schema/migrate/resolve-safe-nullability
+ */
+
+import { sql } from "drizzle-orm";
+
+import type { Operation } from "../pipeline/diff/types";
+
+/** Minimal database surface: the probe needs one read. */
+interface Queryable {
+  execute?: (query: unknown) => Promise<unknown>;
+  all?: (query: unknown) => Promise<unknown>;
+}
+
+/** Rows returned by the probe, across the shapes the drivers use. */
+function hasAnyRow(result: unknown): boolean {
+  if (Array.isArray(result)) return result.length > 0;
+  if (result && typeof result === "object") {
+    const rows = (result as { rows?: unknown }).rows;
+    if (Array.isArray(rows)) return rows.length > 0;
+  }
+  return false;
+}
+
+/**
+ * Whether a column currently holds any NULL.
+ *
+ * A probe that cannot run answers `true`: an unreadable column must stay
+ * classified destructive, because treating an unknown as safe is how a real
+ * data-losing change slips through.
+ */
+async function columnHoldsNull(
+  db: Queryable,
+  tableName: string,
+  columnName: string
+): Promise<boolean> {
+  const query = sql`SELECT 1 FROM ${sql.identifier(tableName)} WHERE ${sql.identifier(columnName)} IS NULL LIMIT 1`;
+  try {
+    if (typeof db.execute === "function") {
+      return hasAnyRow(await db.execute(query));
+    }
+    if (typeof db.all === "function") {
+      return hasAnyRow(await db.all(query));
+    }
+    return true;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Drop the `change_column_nullable` ops that cannot lose data.
+ *
+ * The returned ops are what the classifier sees. An op removed here is one the
+ * database has confirmed is safe: the column holds no NULL, so requiring it
+ * cannot fail on an existing row. Every other op passes through untouched, so
+ * a column that does hold NULLs is still refused, with its real reason.
+ */
+export async function resolveSafeNullabilityOps(
+  db: unknown,
+  ops: readonly Operation[]
+): Promise<Operation[]> {
+  const queryable = db as Queryable;
+  const resolved: Operation[] = [];
+
+  for (const op of ops) {
+    if (op.type !== "change_column_nullable") {
+      resolved.push(op);
+      continue;
+    }
+    // Only the NOT NULL direction can fail on existing rows; relaxing a column
+    // to nullable never does, and is not classified destructive anyway.
+    if (await columnHoldsNull(queryable, op.tableName, op.columnName)) {
+      resolved.push(op);
+    }
+  }
+
+  return resolved;
+}

--- a/packages/nextly/src/domains/schema/migrate/resolve-safe-nullability.ts
+++ b/packages/nextly/src/domains/schema/migrate/resolve-safe-nullability.ts
@@ -65,12 +65,17 @@ async function columnHoldsNull(
 }
 
 /**
- * Drop the `change_column_nullable` ops that cannot lose data.
+ * The ops a destructive classification should consider.
  *
- * The returned ops are what the classifier sees. An op removed here is one the
- * database has confirmed is safe: the column holds no NULL, so requiring it
- * cannot fail on an existing row. Every other op passes through untouched, so
- * a column that does hold NULLs is still refused, with its real reason.
+ * Used ONLY for classification. The caller keeps the full op list for the
+ * zero-diff check and the apply, because an op removed here is safe to
+ * perform, not unnecessary: dropping it from the apply would leave the
+ * constraint unenforced while reporting success.
+ *
+ * An op is removed only when the database confirms it cannot lose data: the
+ * column holds no NULL, so requiring it cannot fail on an existing row. Every
+ * other op passes through, so a column that does hold NULLs is still refused
+ * with its real reason.
  */
 export async function resolveSafeNullabilityOps(
   db: unknown,
@@ -80,12 +85,13 @@ export async function resolveSafeNullabilityOps(
   const resolved: Operation[] = [];
 
   for (const op of ops) {
-    if (op.type !== "change_column_nullable") {
+    // Only the NOT NULL direction can fail on existing rows. Relaxing a
+    // column to nullable never can, and probing it would remove the op on the
+    // usual no-NULLs answer, so the relaxation would be classified away.
+    if (op.type !== "change_column_nullable" || op.toNullable) {
       resolved.push(op);
       continue;
     }
-    // Only the NOT NULL direction can fail on existing rows; relaxing a column
-    // to nullable never does, and is not classified destructive anyway.
     if (await columnHoldsNull(queryable, op.tableName, op.columnName)) {
       resolved.push(op);
     }

--- a/packages/nextly/src/domains/schema/migrate/resolve-safe-nullability.ts
+++ b/packages/nextly/src/domains/schema/migrate/resolve-safe-nullability.ts
@@ -28,9 +28,20 @@ interface Queryable {
   all?: (query: unknown) => Promise<unknown>;
 }
 
-/** Rows returned by the probe, across the shapes the drivers use. */
+/**
+ * Rows returned by the probe, across the shapes the drivers use.
+ *
+ * mysql2 resolves a query to `[rows, fieldPackets]`, so a probe that matched
+ * nothing arrives as `[[], fields]` — an array of length 2. Reading the outer
+ * length would call that "holds NULL" and refuse every safe migration on
+ * MySQL, which is the opposite of what the probe exists to do. Unwrap the
+ * tuple before treating an array as the row list.
+ */
 function hasAnyRow(result: unknown): boolean {
-  if (Array.isArray(result)) return result.length > 0;
+  if (Array.isArray(result)) {
+    const rows = Array.isArray(result[0]) ? result[0] : result;
+    return rows.length > 0;
+  }
   if (result && typeof result === "object") {
     const rows = (result as { rows?: unknown }).rows;
     if (Array.isArray(rows)) return rows.length > 0;

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/sqlite-pk-nullability.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/sqlite-pk-nullability.integration.test.ts
@@ -27,6 +27,14 @@ afterEach(async () => {
   current = undefined;
 });
 
+/**
+ * Introspect one table, booting a shared instance on first use.
+ *
+ * Both cases read the same table, so they reuse one in-memory database rather
+ * than paying a boot each. Isolation comes from the `afterEach` above, which
+ * destroys and clears the handle, so a later test never inherits this one's
+ * connection.
+ */
 async function columnsOf(table: string) {
   current = current ?? (await createTestNextly({}));
   const live = await introspectLiveSnapshot(

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/sqlite-pk-nullability.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/sqlite-pk-nullability.integration.test.ts
@@ -1,14 +1,16 @@
 /**
- * Primary keys must not read as a pending NOT NULL change.
+ * What SQLite reports for a primary key, and why it matters.
  *
- * SQLite reports a `TEXT PRIMARY KEY` column as nullable, because only
- * INTEGER PRIMARY KEY (the rowid alias) is implicitly NOT NULL. Drizzle's
- * `.primaryKey()` carries no such quirk and means NOT NULL, so taking SQLite's
- * storage answer literally makes every primary key look like a NOT NULL
- * addition. The classifier treats that as destructive, which refuses the whole
- * core reconcile on a database nobody has changed — and `nextly migrate` is
- * the documented way out of a schema that is behind the code, so refusing here
- * removes the only recovery path.
+ * Only INTEGER PRIMARY KEY (the rowid alias) is implicitly NOT NULL in SQLite;
+ * a TEXT PRIMARY KEY is nullable at storage level. The snapshot reports that
+ * faithfully, because it must describe the database rather than what the
+ * schema intended — every other consumer of the snapshot depends on it being
+ * true.
+ *
+ * The consequence is that the desired side, where `.primaryKey()` means NOT
+ * NULL, disagrees on every such column. Resolving that disagreement is a
+ * question about the data, not the flag, and is handled by the reconcile's
+ * probe (see resolve-safe-nullability.ts) rather than by bending this report.
  */
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -25,35 +27,30 @@ afterEach(async () => {
   current = undefined;
 });
 
-describe("sqlite primary key nullability", () => {
-  it("reports a primary key as NOT NULL", async () => {
-    current = await createTestNextly({});
-    const live = await introspectLiveSnapshot(
-      current.adapter.getDrizzle(),
-      "sqlite",
-      ["nextly_events"]
-    );
+async function columnsOf(table: string) {
+  current = current ?? (await createTestNextly({}));
+  const live = await introspectLiveSnapshot(
+    current.adapter.getDrizzle(),
+    "sqlite",
+    [table]
+  );
+  return live.tables.find(t => t.name === table)?.columns ?? [];
+}
 
-    const id = live.tables
-      .find(t => t.name === "nextly_events")
-      ?.columns.find(c => c.name === "id");
-
-    expect(id?.nullable).toBe(false);
+describe("sqlite nullability reporting", () => {
+  it("reports a text primary key as stored, which SQLite says is nullable", async () => {
+    // Reporting NOT NULL here instead would make the snapshot describe intent
+    // rather than reality, and would hide a primary key that genuinely holds
+    // NULLs along with its destructive-data check.
+    const id = (await columnsOf("nextly_events")).find(c => c.name === "id");
+    expect(id?.nullable).toBe(true);
   });
 
-  it("still reports an ordinary nullable column as nullable", async () => {
-    // The fix must not blanket-mark columns NOT NULL; only primary keys.
-    current = await createTestNextly({});
-    const live = await introspectLiveSnapshot(
-      current.adapter.getDrizzle(),
-      "sqlite",
-      ["nextly_events"]
+  it("reports a NOT NULL column as not nullable", async () => {
+    // The report is faithful in both directions, not blanket-permissive.
+    const type = (await columnsOf("nextly_events")).find(
+      c => c.name === "type"
     );
-
-    const optional = live.tables
-      .find(t => t.name === "nextly_events")
-      ?.columns.find(c => c.name === "actor_id");
-
-    expect(optional?.nullable).toBe(true);
+    expect(type?.nullable).toBe(false);
   });
 });

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/sqlite-pk-nullability.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/sqlite-pk-nullability.integration.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Primary keys must not read as a pending NOT NULL change.
+ *
+ * SQLite reports a `TEXT PRIMARY KEY` column as nullable, because only
+ * INTEGER PRIMARY KEY (the rowid alias) is implicitly NOT NULL. Drizzle's
+ * `.primaryKey()` carries no such quirk and means NOT NULL, so taking SQLite's
+ * storage answer literally makes every primary key look like a NOT NULL
+ * addition. The classifier treats that as destructive, which refuses the whole
+ * core reconcile on a database nobody has changed — and `nextly migrate` is
+ * the documented way out of a schema that is behind the code, so refusing here
+ * removes the only recovery path.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../../../plugins/test-nextly";
+import { introspectLiveSnapshot } from "../introspect-live";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+describe("sqlite primary key nullability", () => {
+  it("reports a primary key as NOT NULL", async () => {
+    current = await createTestNextly({});
+    const live = await introspectLiveSnapshot(
+      current.adapter.getDrizzle(),
+      "sqlite",
+      ["nextly_events"]
+    );
+
+    const id = live.tables
+      .find(t => t.name === "nextly_events")
+      ?.columns.find(c => c.name === "id");
+
+    expect(id?.nullable).toBe(false);
+  });
+
+  it("still reports an ordinary nullable column as nullable", async () => {
+    // The fix must not blanket-mark columns NOT NULL; only primary keys.
+    current = await createTestNextly({});
+    const live = await introspectLiveSnapshot(
+      current.adapter.getDrizzle(),
+      "sqlite",
+      ["nextly_events"]
+    );
+
+    const optional = live.tables
+      .find(t => t.name === "nextly_events")
+      ?.columns.find(c => c.name === "actor_id");
+
+    expect(optional?.nullable).toBe(true);
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
@@ -38,10 +38,7 @@ interface IndexRow {
  * DEFINED array (possibly empty) — introspection never leaves it undefined, so
  * the diff sentinel only ever comes from pre-C1 on-disk snapshots.
  */
-function attachIndexes(
-  snapshot: NextlySchemaSnapshot,
-  rows: IndexRow[]
-): void {
+function attachIndexes(snapshot: NextlySchemaSnapshot, rows: IndexRow[]): void {
   const byTable = new Map<
     string,
     Map<string, { unique: boolean; columns: string[] }>
@@ -241,9 +238,9 @@ export async function introspectLiveSnapshot(
     if (rows.length === 0) continue;
     // Indexes: PRAGMA index_list + index_info. Filter pk-origin indexes and
     // SQLite's auto-created sqlite_autoindex_* (unique-constraint backed).
-    const idxList = (await dbAny.all(
+    const idxList = await dbAny.all(
       sql`PRAGMA index_list(${sql.identifier(table)})`
-    ));
+    );
     const indexes: IndexSpec[] = [];
     for (const ix of idxList) {
       if (ix.origin === "pk") continue;
@@ -276,8 +273,15 @@ export async function introspectLiveSnapshot(
           // ever running. Lowercasing here is safe because SQLite
           // type names are case-insensitive at the engine level.
           type: r.type.toLowerCase(),
-          // SQLite stores notnull as 0/1 integer.
-          nullable: r.notnull === 0,
+          // SQLite stores notnull as 0/1 integer. A PRIMARY KEY column is
+          // reported nullable unless it was declared NOT NULL, because only
+          // INTEGER PRIMARY KEY (the rowid alias) is implicitly NOT NULL in
+          // SQLite. The desired side has no such quirk: Drizzle's
+          // `.primaryKey()` means NOT NULL. Reporting the storage answer here
+          // makes every primary key look like a pending NOT NULL addition,
+          // which the classifier calls destructive and which therefore refuses
+          // the entire core reconcile — on a database nobody has changed.
+          nullable: r.notnull === 0 && r.pk === 0,
           // dflt_value can be string, number, null, or undefined.
           // Coerce primitives to string; treat anything non-primitive as
           // missing (defensive - SQLite never returns object defaults).

--- a/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
@@ -273,15 +273,12 @@ export async function introspectLiveSnapshot(
           // ever running. Lowercasing here is safe because SQLite
           // type names are case-insensitive at the engine level.
           type: r.type.toLowerCase(),
-          // SQLite stores notnull as 0/1 integer. A PRIMARY KEY column is
-          // reported nullable unless it was declared NOT NULL, because only
-          // INTEGER PRIMARY KEY (the rowid alias) is implicitly NOT NULL in
-          // SQLite. The desired side has no such quirk: Drizzle's
-          // `.primaryKey()` means NOT NULL. Reporting the storage answer here
-          // makes every primary key look like a pending NOT NULL addition,
-          // which the classifier calls destructive and which therefore refuses
-          // the entire core reconcile — on a database nobody has changed.
-          nullable: r.notnull === 0 && r.pk === 0,
+          // SQLite stores notnull as 0/1 integer. Reported as stored: a
+          // TEXT PRIMARY KEY really is nullable here (only INTEGER PRIMARY KEY
+          // is implicitly NOT NULL), and the snapshot must describe the
+          // database. Whether requiring such a column is safe is decided from
+          // the data, in resolve-safe-nullability.ts.
+          nullable: r.notnull === 0,
           // dflt_value can be string, number, null, or undefined.
           // Coerce primitives to string; treat anything non-primitive as
           // missing (defensive - SQLite never returns object defaults).


### PR DESCRIPTION
Found while trying to repair a real database that was behind the code.

## Why

`nextly migrate` refused outright on SQLite:

```
✗ [NEXTLY_CORE_DESTRUCTIVE_REFUSED] Core schema reconciliation requires
destructive operations: adds NOT NULL to column 'nextly_events.id'
(would fail on existing rows); adds NOT NULL to column
'nextly_webhook_deliveries.id'; adds NOT NULL to column 'nextly_webhooks.id'.
```

Verified the mechanism directly:

- **Live** (`PRAGMA table_info`): `id|TEXT|0||1` — `notnull=0`, `pk=1`
- **Desired**: `text("id").primaryKey()` — Drizzle implies NOT NULL

Only `INTEGER PRIMARY KEY` (the rowid alias) is implicitly NOT NULL in SQLite; a `TEXT PRIMARY KEY` stays nullable at storage level. Taking that answer literally makes **every** primary key look like a pending NOT NULL addition. The classifier treats adding NOT NULL as destructive, so the entire reconcile is refused.

This is the same class as #269 (`_text` vs `text[]`): a desired/live round-trip failure on a column nobody touched, escalated to a hard refusal.

**It matters more than a false warning**, because `nextly migrate` is the documented way to bring a database that is behind the code forward — Option B, shipped in #271. Refusing here removes the only sanctioned recovery path.

## The fix

Report `nullable: false` when `pk === 1`, matching what `.primaryKey()` means on the desired side.

## Testing

Two integration tests, both verified load-bearing (reverting the change fails the first):

1. A primary key reads as NOT NULL.
2. An ordinary nullable column (`actor_id`) still reads as nullable — the fix must not blanket-mark columns.

Verified end to end against a copy of a real database exhibiting the failure: the destructive refusal is **gone**.

**I removed a third test before opening this.** It asserted that a freshly created database proposes no nullability changes — and it passed with the fix reverted, so it was asserting nothing. A test that cannot fail is worse than no test.

## What this does NOT fix

On that same real database, the reconcile now gets further and hits the *next* wall:

```
✗ [NEXTLY_MIGRATION_APPLY_FAILED] Core schema apply failed:
Failed query: CREATE INDEX `nextly_events_fanned_out_at_idx`
ON `nextly_events` (`fanned_out_at`,`created_at`);
```

The index is created before the column it indexes is added — that database predates `fanned_out_at`. So core reconcile still cannot complete on an older SQLite database; this PR removes the first of at least two blockers. The ordering defect is separate and needs its own investigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SQLite schema inspection so column nullability reporting matches actual PRAGMA behavior for primary-key-backed columns.
  * Improved migration safety for `NOT NULL` changes by conservatively checking whether existing data contains `NULL` before enforcing constraints.
  * Adjusted destructive-reason reporting to reflect the safer nullability evaluation.
* **Tests**
  * Added integration coverage for SQLite nullability introspection (primary-key-backed vs non-primary-key columns).
  * Added unit tests for safe nullability resolution, including pass-through, probe success/failure, and MySQL-specific probe handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->