### PR TITLE
fix(admin): import css scoping from its package, not the moved path

### DIFF
--- a/packages/admin/scripts/build-css-fast.mjs
+++ b/packages/admin/scripts/build-css-fast.mjs
@@ -31,7 +31,10 @@ import { fileURLToPath } from "url";
 import postcss from "postcss";
 import tailwindcss from "@tailwindcss/postcss";
 
-import { findUnscopedRules, scopeCss } from "./lib/css-scope.mjs";
+// Scoping lives in @nextlyhq/admin-css so this build and the plugin-facing
+// CLI share one implementation and cannot drift. The release build
+// (build-css.mjs) resolves it the same way.
+import { findUnscopedRules, scopeCss } from "@nextlyhq/admin-css";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, "..");


### PR DESCRIPTION
## What

`packages/admin/scripts/build-css-fast.mjs` imported the CSS scoping helpers from `./lib/css-scope.mjs`. That file no longer exists: #240 moved it to `packages/admin-css/src/css-scope.mjs`, and this importer was not updated with it.

The result is that `pnpm dev` fails on main:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../packages/admin/scripts/lib/css-scope.mjs'
  imported from .../packages/admin/scripts/build-css-fast.mjs
[admin:dev] css-watch exited with code 1; shutting down siblings
```

The sibling release build (`build-css.mjs:20`) already imports from `@nextlyhq/admin-css`. This makes the fast dev build resolve it the same way. `@nextlyhq/admin-css` is already a `workspace:*` dependency of `@nextlyhq/admin`, and its `.` export re-exports both `findUnscopedRules` and `scopeCss`, so no dependency or export change is needed.

## Scope

I swept for the same class rather than fixing only the reported line: `build-css-fast.mjs:34` was the only remaining reference to the old path, and the only `./lib/` import left in `packages/admin/scripts/`.

## Verification

Reverted the change and re-ran to confirm the fix is load-bearing:

- with the old path: `ERR_MODULE_NOT_FOUND`
- with the fix: `[admin:css] 212.7 KB in 150ms → dist/styles/globals.css`, exit 0

## No changeset

`packages/admin` publishes `files: ["dist"]`, so `scripts/` is never shipped. This changes repo tooling only, with no effect on published package contents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the CSS build process to use shared styling utilities, with no changes to its behavior or output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->