### PR TITLE
fix(playground): keep the admin monochrome outside the e2e suite

### DIFF
--- a/apps/playground/nextly.config.ts
+++ b/apps/playground/nextly.config.ts
@@ -30,19 +30,30 @@ import { styleFixturePlugin } from "./src/plugins/style-fixture/plugin";
 import { Homepage } from "./src/singles/homepage";
 import { LandingPage } from "./src/singles/landing-page";
 
+// Set by e2e/playwright.config.ts for the suite's own server. Compared to
+// "1" rather than checked for presence so an empty value reads as off.
+const brandingColorsEnabled = process.env.NEXTLY_E2E_BRANDING === "1";
+
 export default defineConfig({
   admin: {
     branding: {
       logoUrlLight: "/Nextly_Icon_dark.svg",
       logoUrlDark: "/Nextly_Icon_Light.svg",
       logoText: "Nextly Playground",
-      // Exercised by e2e/tests/admin-branding.spec.ts. Branded colors were
-      // silently broken for as long as the harness only configured logos, so
-      // the harness now configures colors too.
-      colors: {
-        primary: "#6366f1",
-        accent: "#f59e0b",
-      },
+      // Branded colors only under the e2e suite, which sets this flag.
+      //
+      // The admin's identity is monochrome: --nx-primary is pure black in
+      // light and pure white in dark. Configuring a brand color overwrites
+      // that token and every token derived from it, so a contributor running
+      // the playground would see an admin no end user gets by default.
+      //
+      // The colors cannot simply be dropped either: they are the only thing
+      // that exercises the branding path, and it stayed silently broken for
+      // as long as the harness configured logos alone. Gating on the flag
+      // keeps the regression cover without repainting the daily dev surface.
+      ...(brandingColorsEnabled
+        ? { colors: { primary: "#6366f1", accent: "#f59e0b" } }
+        : {}),
     },
     devAutoLogin: {
       email: "dev@nextly.local",

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -105,6 +105,10 @@ export default defineConfig({
       // second dies before it serves anything. With this, the suite runs
       // while a contributor's dev server keeps going on 3000.
       NEXT_DIST_DIR: ".next-e2e",
+      // Turns on the playground's brand colors, which admin-branding.spec.ts
+      // asserts against. They are off by default so a contributor's admin
+      // keeps the monochrome identity a default install has.
+      NEXTLY_E2E_BRANDING: "1",
     },
   },
 

--- a/e2e/tests/admin-branding.spec.ts
+++ b/e2e/tests/admin-branding.spec.ts
@@ -12,7 +12,10 @@ import { expect, test } from "@playwright/test";
 
 import { gotoAdmin } from "./support/admin";
 
-// Mirrors apps/playground/nextly.config.ts.
+// Mirrors apps/playground/nextly.config.ts, which only configures these
+// colors when NEXTLY_E2E_BRANDING=1. playwright.config.ts sets it for the
+// suite's own server; against a server started without it the admin is
+// monochrome by design and these assertions fail on the default token.
 const PRIMARY_HEX = "#6366f1";
 const EXPECTED_PRIMARY = "hsl(238.7 83.5% 66.7%)";
 


### PR DESCRIPTION
## The problem

Running the playground showed an indigo admin. `apps/playground/nextly.config.ts` configured `admin.branding.colors` unconditionally, and a configured primary does not tint one thing: `BrandingProvider` writes it to `--nx-primary` and to every token derived from it (`--nx-ring`, `--nx-focus-ring`, `--nx-sidebar-ring`, `--nx-chart-1`), so buttons, links, focus rings and tooltips all moved at once.

That is not the admin's identity. The default is monochrome:

```css
/* packages/ui/src/styles/theme.css */
--nx-primary: oklch(0 0 0);  /* light: pure black */
--nx-primary: oklch(1 0 0);  /* dark:  pure white */
```

A contributor was therefore developing against an admin no default install produces.

## Why the colors could not simply be deleted

They were added in #240's follow-up #254 for a reason recorded in the config: branded colors had been *silently broken* for as long as the harness configured logos alone, because nothing rendered them. `e2e/tests/admin-branding.spec.ts` is the guard, and it needs a non-default color to assert against — it cannot detect the bug against a monochrome default.

So the fix keeps the coverage and moves when it applies.

## What changed

`admin.branding.colors` is now gated on `NEXTLY_E2E_BRANDING`, which `e2e/playwright.config.ts` sets on the suite's own server alongside the other overrides it already passes (`DATABASE_URL`, `NEXT_DIST_DIR`).

- `pnpm dev:app` → no colors → stock monochrome admin
- e2e run → colors configured → `admin-branding.spec.ts` unchanged and still guarding

The spec's `PRIMARY_HEX` constant is untouched; a comment there now records that the flag is what turns the colors on, so running it against a manually-started server fails for an understandable reason rather than a mysterious one.

## Verification

Loaded the config in isolated processes across every state of the flag:

| `NEXTLY_E2E_BRANDING` | resolved `colors` |
|---|---|
| unset (contributor dev) | `null` |
| `1` | `{primary: "#6366f1", accent: "#f59e0b"}` |
| empty string | `null` |
| `true` | `null` |

Compared against `"1"` rather than checked for presence, so an exported-but-empty value reads as off.

`pnpm --filter playground check-types` passes; eslint reports no errors on the changed files.

## Out of scope, but worth recording

`BrandingProvider` overwrites `--nx-primary` directly. The theme decision of 2026-07-17 (D-T2) is that the white-label override should use a **separate `--nx-brand` token with `--nx-primary` staying monochrome**, shipped post-alpha as roadmap item 19. This PR does not touch that architecture — it only stops the playground from exercising it by default. The token-level change belongs with item 19.

## No changeset

Playground and e2e harness only; no published package changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admin branding colors now appear only when explicitly enabled, preserving default monochrome styling otherwise.
  * End-to-end checks now enable branded colors so admin branding validations run against the intended appearance.

* **Documentation**
  * Clarified when branded color expectations apply in the admin branding test documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->