### PR TITLE
fix(nextly): make the core reconcile converge and stop losing sqlite indexes

### DIFF
--- a/.changeset/core-reconcile-convergence.md
+++ b/.changeset/core-reconcile-convergence.md
@@ -1,0 +1,26 @@
+---
+
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+
+Schema reconcile now converges, and SQLite no longer loses indexes when a table changes.
+
+Four faults compounded into one. Comparing a primary key's nullability produced a change no `ALTER` can make on SQLite, so it was proposed forever. Comparing a string default compared `'pending'` against `pending`, so every string-defaulted column looked changed, on every dialect. Both kept the reconcile from ever seeing a clean database, and each unnecessary change rebuilt the table — which on SQLite drops its indexes, because the rebuild creates a new table from a schema that never declared them. `nextly_i18n_archive` completed the set: it was declared in the schema the diff reads but missing from the map the apply pushes, so it was proposed on every run and created by none.
+
+On a real database this took a reconcile from 45 proposed operations to 1, and from 23 to 9 on an older one, where the remainder is the genuine upgrade. Indexes declared for a collection are now re-asserted in the same transaction as the change, so a table cannot commit without them.

--- a/.changeset/core-reconcile-convergence.md
+++ b/.changeset/core-reconcile-convergence.md
@@ -1,5 +1,4 @@
 ---
-
 "@nextlyhq/adapter-drizzle": patch
 "@nextlyhq/adapter-mysql": patch
 "@nextlyhq/adapter-postgres": patch
@@ -19,6 +18,7 @@
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/ui": patch
+---
 
 Schema reconcile now converges, and SQLite no longer loses indexes when a table changes.
 

--- a/.changeset/core-reconcile-convergence.md
+++ b/.changeset/core-reconcile-convergence.md
@@ -5,6 +5,7 @@
 "@nextlyhq/adapter-postgres": patch
 "@nextlyhq/adapter-sqlite": patch
 "@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
 "create-nextly-app": patch
 "@nextlyhq/eslint-config": patch
 "nextly": patch

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -48,6 +48,7 @@ import {
 } from "../../domains/schema/pipeline/pushschema-pipeline-stubs";
 import { RegexRenameDetector } from "../../domains/schema/pipeline/rename-detector";
 import type { Resolution } from "../../domains/schema/pipeline/resolution/types";
+import { isIdempotencyError } from "../../domains/schema/pipeline/sql-statement-utils";
 import type { DesiredCollection } from "../../domains/schema/pipeline/types";
 import { DrizzleStatementExecutor } from "../../domains/schema/services/drizzle-statement-executor";
 import { generateRuntimeSchema } from "../../domains/schema/services/runtime-schema-generator";
@@ -60,7 +61,10 @@ import {
 import { getHandlerConfig } from "../../route-handler/auth-handler";
 import { getProductionNotifier } from "../../runtime/notifications/index";
 import type { FieldDefinition } from "../../schemas/dynamic-collections";
-import { getI18nArchiveDdl } from "../../schemas/nextly-i18n-archive";
+import {
+  getI18nArchiveDdl,
+  getI18nArchiveIndexRepairDdl,
+} from "../../schemas/nextly-i18n-archive";
 import type { ServiceContainer } from "../../services";
 import type { WhereFilter } from "../../services/collections/query-operators";
 import type { CollectionsHandler } from "../../services/collections-handler";
@@ -736,6 +740,19 @@ const COLLECTIONS_METHODS: Record<
           if (plan.needsArchive) {
             for (const stmt of getI18nArchiveDdl(dialect)) {
               await adapter.executeQuery(stmt);
+            }
+            // MySQL's table DDL cannot restore an index the table is missing, and
+            // index-only drift produces no reconcile operations, so the repair runs
+            // here. Tolerated rather than checked first: attempting it and accepting
+            // "duplicate key name" is one round trip instead of two, and the same
+            // tolerance the schema executor already applies.
+            const indexRepair = getI18nArchiveIndexRepairDdl(dialect);
+            if (indexRepair) {
+              try {
+                await adapter.executeQuery(indexRepair);
+              } catch (err) {
+                if (!isIdempotencyError(err)) throw err;
+              }
             }
           }
           for (const stmt of plan.statements) {

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -41,6 +41,7 @@ import {
 } from "../../domains/schema/pipeline/pushschema-pipeline-stubs";
 import { RegexRenameDetector } from "../../domains/schema/pipeline/rename-detector";
 import type { Resolution } from "../../domains/schema/pipeline/resolution/types";
+import { isIdempotencyError } from "../../domains/schema/pipeline/sql-statement-utils";
 import type { DesiredComponent } from "../../domains/schema/pipeline/types";
 import { DrizzleStatementExecutor } from "../../domains/schema/services/drizzle-statement-executor";
 import type { FieldResolution } from "../../domains/schema/services/schema-change-types";
@@ -48,7 +49,10 @@ import { calculateSchemaHash } from "../../domains/schema/services/schema-hash";
 import { NextlyError } from "../../errors";
 import { getProductionNotifier } from "../../runtime/notifications/index";
 import type { FieldDefinition } from "../../schemas/dynamic-collections";
-import { getI18nArchiveDdl } from "../../schemas/nextly-i18n-archive";
+import {
+  getI18nArchiveDdl,
+  getI18nArchiveIndexRepairDdl,
+} from "../../schemas/nextly-i18n-archive";
 import type { ComponentRegistryService } from "../../services/components/component-registry-service";
 import { ComponentSchemaService } from "../../services/components/component-schema-service";
 import { buildFullDesiredSchema } from "../helpers/desired-schema";
@@ -242,6 +246,19 @@ async function reconcileComponentCompanion(args: {
   if (plan.needsArchive) {
     for (const stmt of getI18nArchiveDdl(dialect)) {
       await adapter.executeQuery(stmt);
+    }
+    // MySQL's table DDL cannot restore an index the table is missing, and
+    // index-only drift produces no reconcile operations, so the repair runs
+    // here. Tolerated rather than checked first: attempting it and accepting
+    // "duplicate key name" is one round trip instead of two, and the same
+    // tolerance the schema executor already applies.
+    const indexRepair = getI18nArchiveIndexRepairDdl(dialect);
+    if (indexRepair) {
+      try {
+        await adapter.executeQuery(indexRepair);
+      } catch (err) {
+        if (!isIdempotencyError(err)) throw err;
+      }
     }
   }
   for (const stmt of plan.statements) {

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -51,6 +51,7 @@ import {
 } from "../../domains/schema/pipeline/pushschema-pipeline-stubs";
 import { RegexRenameDetector } from "../../domains/schema/pipeline/rename-detector";
 import type { Resolution } from "../../domains/schema/pipeline/resolution/types";
+import { isIdempotencyError } from "../../domains/schema/pipeline/sql-statement-utils";
 import type { DesiredSingle } from "../../domains/schema/pipeline/types";
 import { DrizzleStatementExecutor } from "../../domains/schema/services/drizzle-statement-executor";
 import { generateRuntimeSchema } from "../../domains/schema/services/runtime-schema-generator";
@@ -64,7 +65,10 @@ import { NextlyError } from "../../errors";
 import { transformRichTextFields } from "../../lib/field-transform";
 import { getProductionNotifier } from "../../runtime/notifications/index";
 import type { FieldDefinition } from "../../schemas/dynamic-collections";
-import { getI18nArchiveDdl } from "../../schemas/nextly-i18n-archive";
+import {
+  getI18nArchiveDdl,
+  getI18nArchiveIndexRepairDdl,
+} from "../../schemas/nextly-i18n-archive";
 import {
   isSuperAdmin,
   listEffectivePermissions,
@@ -265,6 +269,19 @@ async function reconcileSingleCompanion(args: {
   if (plan.needsArchive) {
     for (const stmt of getI18nArchiveDdl(dialect)) {
       await adapter.executeQuery(stmt);
+    }
+    // MySQL's table DDL cannot restore an index the table is missing, and
+    // index-only drift produces no reconcile operations, so the repair runs
+    // here. Tolerated rather than checked first: attempting it and accepting
+    // "duplicate key name" is one round trip instead of two, and the same
+    // tolerance the schema executor already applies.
+    const indexRepair = getI18nArchiveIndexRepairDdl(dialect);
+    if (indexRepair) {
+      try {
+        await adapter.executeQuery(indexRepair);
+      } catch (err) {
+        if (!isIdempotencyError(err)) throw err;
+      }
     }
   }
   for (const stmt of plan.statements) {

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/index-restore.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/index-restore.test.ts
@@ -148,4 +148,42 @@ describe("index restore", () => {
 
     expect(indexRestoreStatements(untracked, "sqlite", REBUILD)).toEqual([]);
   });
+
+  it("creates an index the diff asked for even with no rebuild", () => {
+    // On SQLite and MySQL nothing else does: the fast-path emitter is
+    // PostgreSQL-only, and the schema handed to drizzle-kit declares no
+    // dynamic-table indexes, so an index-only diff would apply zero
+    // statements and report success with the index still missing.
+    const out = indexRestoreStatements(
+      desired,
+      "sqlite",
+      [],
+      [
+        {
+          type: "add_index",
+          tableName: "dc_tags",
+          index: { name: "idx_dc_tags_slug", columns: ["slug"], unique: true },
+        },
+      ]
+    );
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain("idx_dc_tags_slug");
+  });
+
+  it("emits a rebuilt table's index once when the diff also asks for it", () => {
+    const out = indexRestoreStatements(desired, "sqlite", REBUILD, [
+      {
+        type: "add_index",
+        tableName: "dc_posts",
+        index: {
+          name: "idx_dc_posts_slug",
+          columns: ["slug"],
+          unique: true,
+        },
+      },
+    ]);
+
+    expect(out.filter(s => s.includes("idx_dc_posts_slug"))).toHaveLength(1);
+  });
 });

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/index-restore.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/index-restore.test.ts
@@ -15,7 +15,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { NextlySchemaSnapshot } from "../diff/types";
-import { indexRestoreStatements } from "../pushschema-pipeline";
+import { indexRestoreStatements } from "../index-restore";
 
 const desired: NextlySchemaSnapshot = {
   tables: [

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/index-restore.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/index-restore.test.ts
@@ -85,23 +85,49 @@ describe("index restore", () => {
 
   it("matches the rename however the dialect writes it", () => {
     const shapes = [
-      ["ALTER TABLE `__new_dc_posts` RENAME TO `dc_posts`"],
-      ["ALTER TABLE __new_dc_posts RENAME TO dc_posts"],
+      [
+        "CREATE TABLE `__new_dc_posts` (`id` text)",
+        "ALTER TABLE `__new_dc_posts` RENAME TO `dc_posts`",
+      ],
+      [
+        "CREATE TABLE __new_dc_posts (id text)",
+        "ALTER TABLE __new_dc_posts RENAME TO dc_posts",
+      ],
       // Schema-qualified, which drizzle-kit emits and the destructive scanner
       // already accepts. Missing it would leave the rebuilt table without its
       // indexes in exactly the case this exists to cover.
-      ['ALTER TABLE "main"."__new_dc_posts" RENAME TO "dc_posts"'],
-      ["ALTER TABLE main.__new_dc_posts RENAME TO dc_posts"],
+      [
+        'CREATE TABLE "main"."__new_dc_posts" ("id" text)',
+        'ALTER TABLE "main"."__new_dc_posts" RENAME TO "dc_posts"',
+      ],
+      [
+        "CREATE TABLE main.__new_dc_posts (id text)",
+        "ALTER TABLE main.__new_dc_posts RENAME TO dc_posts",
+      ],
     ];
     for (const shape of shapes) {
       expect(indexRestoreStatements(desired, "sqlite", shape)).toHaveLength(2);
     }
   });
 
+  it("ignores a rename with no matching create", () => {
+    // `DROP TABLE x; ALTER TABLE __new_x RENAME TO x` builds nothing and
+    // copies nothing, so the rows are gone. Reading it as a rebuild would
+    // both restore indexes onto a table that lost its data and, in the
+    // destructive guard that shares this detection, excuse the drop.
+    const out = indexRestoreStatements(desired, "sqlite", [
+      'DROP TABLE "dc_posts"',
+      'ALTER TABLE "__new_dc_posts" RENAME TO "dc_posts"',
+    ]);
+
+    expect(out).toEqual([]);
+  });
+
   it("ignores a rename that does not restore the original name", () => {
     // `__new_x` renaming to something else is not a rebuild of `x`, so it must
     // not trigger a restore against a table that was never replaced.
     const out = indexRestoreStatements(desired, "sqlite", [
+      'CREATE TABLE "__new_dc_posts" ("id" text)',
       'ALTER TABLE "__new_dc_posts" RENAME TO "dc_archive"',
     ]);
 

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/index-restore.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/index-restore.test.ts
@@ -83,18 +83,34 @@ describe("index restore", () => {
     expect(out).toEqual([]);
   });
 
-  it("matches the rename however the dialect quotes it", () => {
-    const backticks = ["ALTER TABLE `__new_dc_posts` RENAME TO `dc_posts`"];
-    const bare = ["ALTER TABLE __new_dc_posts RENAME TO dc_posts"];
+  it("matches the rename however the dialect writes it", () => {
+    const shapes = [
+      ["ALTER TABLE `__new_dc_posts` RENAME TO `dc_posts`"],
+      ["ALTER TABLE __new_dc_posts RENAME TO dc_posts"],
+      // Schema-qualified, which drizzle-kit emits and the destructive scanner
+      // already accepts. Missing it would leave the rebuilt table without its
+      // indexes in exactly the case this exists to cover.
+      ['ALTER TABLE "main"."__new_dc_posts" RENAME TO "dc_posts"'],
+      ["ALTER TABLE main.__new_dc_posts RENAME TO dc_posts"],
+    ];
+    for (const shape of shapes) {
+      expect(indexRestoreStatements(desired, "sqlite", shape)).toHaveLength(2);
+    }
+  });
 
-    expect(indexRestoreStatements(desired, "sqlite", backticks)).toHaveLength(
-      2
-    );
-    expect(indexRestoreStatements(desired, "sqlite", bare)).toHaveLength(2);
+  it("ignores a rename that does not restore the original name", () => {
+    // `__new_x` renaming to something else is not a rebuild of `x`, so it must
+    // not trigger a restore against a table that was never replaced.
+    const out = indexRestoreStatements(desired, "sqlite", [
+      'ALTER TABLE "__new_dc_posts" RENAME TO "dc_archive"',
+    ]);
+
+    expect(out).toEqual([]);
   });
 
   it("emits nothing when the rebuilt table tracks no indexes", () => {
-    // `undefined` is the pre-C1 "never tracked" sentinel, not "has none".
+    // `undefined` means the snapshot never tracked indexes, which is not the
+    // same as the table having none.
     const untracked: NextlySchemaSnapshot = {
       tables: [
         {

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/index-restore.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/index-restore.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Indexes are restored after a rebuild, and only after a rebuild.
+ *
+ * SQLite applies most column changes by building `__new_<table>`, copying the
+ * rows, dropping the original and renaming the copy into place. The
+ * replacement is built from a Drizzle schema that declares no secondary
+ * indexes, so the table's indexes go with the one that was dropped.
+ *
+ * The restore therefore has to fire for that pattern — and must not fire for
+ * anything else. PostgreSQL and MySQL alter in place and keep their indexes,
+ * and re-creating an index that already exists is not harmless: MySQL has no
+ * `CREATE INDEX IF NOT EXISTS`, so a duplicate key name aborts the apply,
+ * after MySQL has already auto-committed the DDL ahead of it.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { NextlySchemaSnapshot } from "../diff/types";
+import { indexRestoreStatements } from "../pushschema-pipeline";
+
+const desired: NextlySchemaSnapshot = {
+  tables: [
+    {
+      name: "dc_posts",
+      columns: [{ name: "id", type: "text", nullable: false }],
+      indexes: [
+        { name: "idx_dc_posts_slug", columns: ["slug"], unique: true },
+        {
+          name: "idx_dc_posts_created_at",
+          columns: ["created_at"],
+          unique: false,
+        },
+      ],
+    },
+    {
+      name: "dc_tags",
+      columns: [{ name: "id", type: "text", nullable: false }],
+      indexes: [{ name: "idx_dc_tags_slug", columns: ["slug"], unique: true }],
+    },
+  ],
+};
+
+const REBUILD = [
+  'CREATE TABLE "__new_dc_posts" ("id" text PRIMARY KEY)',
+  'INSERT INTO "__new_dc_posts" SELECT * FROM "dc_posts"',
+  'DROP TABLE "dc_posts"',
+  'ALTER TABLE "__new_dc_posts" RENAME TO "dc_posts"',
+];
+
+describe("index restore", () => {
+  it("restores the rebuilt table's indexes", () => {
+    const out = indexRestoreStatements(desired, "sqlite", REBUILD);
+
+    expect(out).toHaveLength(2);
+    expect(out.every(s => /CREATE\s+(UNIQUE\s+)?INDEX/i.test(s))).toBe(true);
+    expect(out.every(s => s.includes("dc_posts"))).toBe(true);
+  });
+
+  it("leaves tables the batch did not rebuild alone", () => {
+    // dc_tags has indexes in the desired schema but was not rebuilt here.
+    const out = indexRestoreStatements(desired, "sqlite", REBUILD);
+
+    expect(out.some(s => s.includes("dc_tags"))).toBe(false);
+  });
+
+  it("emits nothing for an in-place ALTER on postgres", () => {
+    // The op still marks the table as affected, which is why scoping on
+    // "affected" rather than "rebuilt" recreated live indexes.
+    const out = indexRestoreStatements(desired, "postgresql", [
+      'ALTER TABLE "dc_posts" ADD COLUMN "x" text',
+    ]);
+
+    expect(out).toEqual([]);
+  });
+
+  it("emits nothing for an in-place ALTER on mysql", () => {
+    // The dialect with no IF NOT EXISTS, where a duplicate key name aborts an
+    // apply whose earlier DDL has already auto-committed.
+    const out = indexRestoreStatements(desired, "mysql", [
+      "ALTER TABLE `dc_posts` ADD COLUMN `x` text",
+      "ALTER TABLE `dc_posts` MODIFY COLUMN `title` varchar(255)",
+    ]);
+
+    expect(out).toEqual([]);
+  });
+
+  it("matches the rename however the dialect quotes it", () => {
+    const backticks = ["ALTER TABLE `__new_dc_posts` RENAME TO `dc_posts`"];
+    const bare = ["ALTER TABLE __new_dc_posts RENAME TO dc_posts"];
+
+    expect(indexRestoreStatements(desired, "sqlite", backticks)).toHaveLength(
+      2
+    );
+    expect(indexRestoreStatements(desired, "sqlite", bare)).toHaveLength(2);
+  });
+
+  it("emits nothing when the rebuilt table tracks no indexes", () => {
+    // `undefined` is the pre-C1 "never tracked" sentinel, not "has none".
+    const untracked: NextlySchemaSnapshot = {
+      tables: [
+        {
+          name: "dc_posts",
+          columns: [{ name: "id", type: "text", nullable: false }],
+        },
+      ],
+    };
+
+    expect(indexRestoreStatements(untracked, "sqlite", REBUILD)).toEqual([]);
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/pushschema-pipeline.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/pushschema-pipeline.test.ts
@@ -789,11 +789,21 @@ describe("PushSchemaPipeline (Option E flow) - phase D pushSchema", () => {
 
     // The 4 rebuild statements pass through (CREATE / INSERT / DROP /
     // RENAME), the orphan DROP for dc_jobs gets blocked.
-    expect(executedStmts).toHaveLength(4);
     expect(executedStmts[0]).toContain('CREATE TABLE "__new_dc_posts"');
     expect(executedStmts[1]).toContain("INSERT INTO");
     expect(executedStmts[2]).toContain('DROP TABLE "dc_posts"');
     expect(executedStmts[3]).toContain('RENAME TO "dc_posts"');
+
+    // This rebuild is exactly how SQLite loses indexes: the table the indexes
+    // belonged to is dropped at [2], and the one that replaces it is built
+    // from a Drizzle schema that declares none. The restore statements follow
+    // the rename, so the table cannot commit without them.
+    const restored = executedStmts.slice(4);
+    expect(restored.length).toBeGreaterThan(0);
+    expect(restored.every(s => /CREATE\s+(UNIQUE\s+)?INDEX/i.test(s))).toBe(
+      true
+    );
+    expect(restored.every(s => s.includes("dc_posts"))).toBe(true);
     // dc_jobs DROP did NOT make it through.
     expect(executedStmts.some(s => /DROP\s+TABLE\s+"?dc_jobs/i.test(s))).toBe(
       false

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
@@ -92,6 +92,14 @@ const POST_045_TABLES = [
   "nextly_webhooks",
   "nextly_webhook_deliveries",
   "nextly_versions",
+  // Absent from this list for as long as the upgrade did not actually create
+  // it: it was declared in getCoreSchema, which the diff reads, but missing
+  // from the dialect bundle, which the apply pushes, so it was proposed on
+  // every reconcile and emitted by none. Now that the bundle carries it the
+  // upgrade creates it like any other post-0.45 table — and the pass-2
+  // assertion below is what proves it then round-trips to silence rather than
+  // being re-proposed forever.
+  "nextly_i18n_archive",
 ];
 
 // The post-045 names are static identifiers, but escape defensively so the

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields-indexes.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields-indexes.test.ts
@@ -29,7 +29,10 @@ describe("buildDesiredTableFromFields — indexes", () => {
     expect(idxNames(t)).toEqual(
       [
         "idx_dc_posts_author:n", // single relationship auto-index
-        "idx_dc_posts_created_at:n", // system
+        "idx_dc_posts_created_at:n",
+        // Owner index: the collection service creates it for every table with
+        // the created_by column, so the snapshot records it too.
+        "idx_dc_posts_created_by:n", // system
         "idx_dc_posts_slug:u", // system unique
         "idx_dc_posts_views:n", // user index
         "uq_dc_posts_email:u", // user unique

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { getColumnDescriptor } from "../../../services/field-column-descriptor";
-import { buildDesiredTableFromFields } from "../build-from-fields";
+import {
+  buildDesiredTableFromComponentFields,
+  buildDesiredTableFromFields,
+} from "../build-from-fields";
 import type { ColumnSpec } from "../types";
 
 // Characterization test guarding the ui-schema widening: every field type now
@@ -486,5 +489,52 @@ describe("buildDesiredTableFromFields with status enabled", () => {
       { hasStatus: false }
     );
     expect(findColumn(tableFalse.columns, "status")).toBeUndefined();
+  });
+});
+
+describe("buildDesiredTableFromComponentFields - per-field indexes", () => {
+  // ComponentSchemaService creates idx_<table>_<column> for an indexed field
+  // and uq_<table>_<column> for a unique one. The snapshot has to carry them
+  // too: it is what the index restore replays after a SQLite rebuild, and a
+  // unique index missing from it is a constraint that silently disappears.
+  const fields = [
+    { name: "title", type: "text" },
+    { name: "sku", type: "text", unique: true },
+    { name: "lookupKey", type: "text", index: true },
+  ] as unknown as Parameters<typeof buildDesiredTableFromComponentFields>[1];
+
+  it("records a unique field's index", () => {
+    const table = buildDesiredTableFromComponentFields(
+      "comp_hero",
+      fields,
+      "sqlite"
+    );
+    expect(table.indexes).toContainEqual({
+      name: "uq_comp_hero_sku",
+      columns: ["sku"],
+      unique: true,
+    });
+  });
+
+  it("records an indexed field's index", () => {
+    const table = buildDesiredTableFromComponentFields(
+      "comp_hero",
+      fields,
+      "sqlite"
+    );
+    expect(table.indexes).toContainEqual({
+      name: "idx_comp_hero_lookup_key",
+      columns: ["lookup_key"],
+      unique: false,
+    });
+  });
+
+  it("still records the parent index", () => {
+    const table = buildDesiredTableFromComponentFields(
+      "comp_hero",
+      fields,
+      "sqlite"
+    );
+    expect(table.indexes?.map(i => i.name)).toContain("idx_comp_hero_parent");
   });
 });

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields.test.ts
@@ -538,3 +538,29 @@ describe("buildDesiredTableFromComponentFields - per-field indexes", () => {
     expect(table.indexes?.map(i => i.name)).toContain("idx_comp_hero_parent");
   });
 });
+
+describe("owner index", () => {
+  // The collection service creates idx_<table>_created_by for every table with
+  // the owner column, and owner-scoped reads filter on it. A SQLite rebuild
+  // drops every index the replacement table does not declare, and the restore
+  // replays only what the snapshot carries — so it has to be recorded here.
+  it("is recorded for a collection", () => {
+    const table = buildDesiredTableFromFields("dc_posts", [], "sqlite");
+    expect(table.indexes).toContainEqual({
+      name: "idx_dc_posts_created_by",
+      columns: ["created_by"],
+      unique: false,
+    });
+  });
+
+  it("is not recorded for a component, which has no owner column", () => {
+    const table = buildDesiredTableFromComponentFields(
+      "comp_hero",
+      [],
+      "sqlite"
+    );
+    expect(table.indexes?.map(i => i.name)).not.toContain(
+      "idx_comp_hero_created_by"
+    );
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/build-from-fields.test.ts
@@ -79,6 +79,13 @@ describe("buildDesiredTableFromFields - reserved columns", () => {
       name: "id",
       type: "text",
       nullable: false,
+      default: undefined,
+      // Carried through from the column descriptor. The diff exempts primary
+      // keys from the nullability comparison, and a desired `id` that arrives
+      // without this marker takes no exemption — which on SQLite means every
+      // Schema-Builder table keeps proposing a nullability change no ALTER
+      // there can make.
+      primaryKey: true,
     });
     expect(findColumn(table.columns, "title")).toEqual({
       name: "title",

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-default.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-default.test.ts
@@ -103,6 +103,19 @@ describe("normalizeDefault — string-literal unwrapping", () => {
       ["'42'", "42"],
       ["'-1'", "-1"],
       ["'gen_random_uuid()'", "gen_random_uuid()"],
+      // Bare-callable keywords: no parentheses, so the call-shape half of the
+      // guard does not see them and each has to be named.
+      ["'LOCALTIME'", "LOCALTIME"],
+      ["'LOCALTIMESTAMP'", "LOCALTIMESTAMP"],
+      ["'CURRENT_USER'", "CURRENT_USER"],
+      ["'SESSION_USER'", "SESSION_USER"],
+      ["'CURRENT_SCHEMA'", "CURRENT_SCHEMA"],
+      ["'CURRENT_CATALOG'", "CURRENT_CATALOG"],
+      ["'CURRENT_ROLE'", "CURRENT_ROLE"],
+      ["'SYSTEM_USER'", "SYSTEM_USER"],
+      ["'USER'", "USER"],
+      ["'CURRENT_DATE'", "CURRENT_DATE"],
+      ["'CURRENT_TIME'", "CURRENT_TIME"],
     ];
     for (const [literal, expression] of distinct) {
       expect(normalizeDefault(literal)).not.toBe(normalizeDefault(expression));

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-default.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-default.test.ts
@@ -19,15 +19,15 @@ describe("normalizeDefault — PG redundant ::<type> cast stripping", () => {
     // The single most common case: pgVarchar(...).default('draft') round-trips
     // through PG as 'draft'::character varying. The diff must treat the two
     // forms as equal.
-    expect(normalizeDefault("'draft'::character varying")).toBe("'draft'");
+    expect(normalizeDefault("'draft'::character varying")).toBe("draft");
   });
 
   it("strips ::text from string literals", () => {
-    expect(normalizeDefault("'draft'::text")).toBe("'draft'");
+    expect(normalizeDefault("'draft'::text")).toBe("draft");
   });
 
   it("strips ::bpchar (PG's underlying char type)", () => {
-    expect(normalizeDefault("'X'::bpchar")).toBe("'X'");
+    expect(normalizeDefault("'X'::bpchar")).toBe("X");
   });
 
   it("strips ::integer from numeric literals", () => {
@@ -50,13 +50,47 @@ describe("normalizeDefault — PG redundant ::<type> cast stripping", () => {
   it("does NOT strip ::type that appears INSIDE a string literal", () => {
     // The cast suffix must be at the end of the expression. A ::-looking
     // substring inside the quoted literal must not be touched.
-    expect(normalizeDefault("'a::text inside'")).toBe("'a::text inside'");
+    expect(normalizeDefault("'a::text inside'")).toBe("a::text inside");
   });
 
   it("preserves expressions with no cast suffix", () => {
-    expect(normalizeDefault("'draft'")).toBe("'draft'");
+    expect(normalizeDefault("'draft'")).toBe("draft");
     expect(normalizeDefault("42")).toBe("42");
     expect(normalizeDefault("now()")).toBe("now()");
+  });
+});
+
+describe("normalizeDefault — string-literal unwrapping", () => {
+  // The two sides of the diff quote a string default differently: the live
+  // side reads the DDL (`'pending'`), the desired side reads the Drizzle
+  // column, whose default is the JavaScript string (`pending`). Comparing
+  // them unquoted is what makes them equal — otherwise every string-defaulted
+  // column produces a change_column_default op on every diff, on every
+  // dialect, and on SQLite the rebuild that follows drops the table's
+  // indexes.
+  it("reduces both sides of the same default to one form", () => {
+    expect(normalizeDefault("'pending'")).toBe(normalizeDefault("pending"));
+    expect(normalizeDefault("'ui'")).toBe(normalizeDefault("ui"));
+    // PG reaches the same place from its cast form.
+    expect(normalizeDefault("'draft'::text")).toBe(normalizeDefault("draft"));
+  });
+
+  it("unwraps an empty string literal", () => {
+    expect(normalizeDefault("''")).toBe("");
+  });
+
+  it("leaves a literal containing a quote alone", () => {
+    // PG and SQLite both escape by doubling, so an interior quote means the
+    // contents cannot be recovered by removing the outer pair. Guessing here
+    // would compare two different values equal, which is the one failure this
+    // module must not have — so the expression is left exactly as found.
+    expect(normalizeDefault("'it''s'")).toBe("'it''s'");
+  });
+
+  it("leaves unbalanced or unquoted expressions alone", () => {
+    expect(normalizeDefault("'unterminated")).toBe("'unterminated");
+    expect(normalizeDefault("gen_random_uuid()")).toBe("gen_random_uuid()");
+    expect(normalizeDefault("'")).toBe("'");
   });
 });
 

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-default.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-default.test.ts
@@ -87,6 +87,35 @@ describe("normalizeDefault — string-literal unwrapping", () => {
     expect(normalizeDefault("'it''s'")).toBe("'it''s'");
   });
 
+  it("never equates a quoted literal with the expression it spells", () => {
+    // The unwrap exists to make `'pending'` and `pending` compare equal. It
+    // must not go on to make `'now()'` equal `now()`: the first is the word
+    // stored in a text column, the second is evaluated per row. Equating them
+    // reports a real default change as no change, and the column silently
+    // keeps a default nobody chose.
+    const distinct: Array<[string, string]> = [
+      ["'now()'", "now()"],
+      ["'CURRENT_TIMESTAMP'", "CURRENT_TIMESTAMP"],
+      ["'true'", "true"],
+      ["'false'", "false"],
+      ["'null'", "null"],
+      ["'0'", "0"],
+      ["'42'", "42"],
+      ["'-1'", "-1"],
+      ["'gen_random_uuid()'", "gen_random_uuid()"],
+    ];
+    for (const [literal, expression] of distinct) {
+      expect(normalizeDefault(literal)).not.toBe(normalizeDefault(expression));
+    }
+  });
+
+  it("still unwraps ordinary word defaults", () => {
+    // The cases this was built for — every one of them a real column default
+    // in the core schema.
+    for (const word of ["pending", "ui", "draft", "template", "inside", "auto"])
+      expect(normalizeDefault(`'${word}'`)).toBe(normalizeDefault(word));
+  });
+
   it("leaves unbalanced or unquoted expressions alone", () => {
     expect(normalizeDefault("'unterminated")).toBe("'unterminated");
     expect(normalizeDefault("gen_random_uuid()")).toBe("gen_random_uuid()");

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-default.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-default.test.ts
@@ -102,6 +102,12 @@ describe("normalizeDefault — string-literal unwrapping", () => {
       ["'0'", "0"],
       ["'42'", "42"],
       ["'-1'", "-1"],
+      // Signs and a leading point are numeric too; only the minus form was
+      // recognised, so `'+1'` reduced to the numeric expression it spells.
+      ["'+1'", "+1"],
+      ["'.5'", ".5"],
+      ["'-.5'", "-.5"],
+      ["'+.5'", "+.5"],
       ["'gen_random_uuid()'", "gen_random_uuid()"],
       // Bare-callable keywords: no parentheses, so the call-shape half of the
       // guard does not see them and each has to be named.

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-default.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-default.test.ts
@@ -197,6 +197,30 @@ describe("normalizeDefault — function calls", () => {
   });
 });
 
+describe("normalizeDefault — keyword case", () => {
+  it("treats a keyword default as the same value in any case", () => {
+    // MySQL reports a DATETIME default as current_timestamp(3) where the
+    // schema wrote CURRENT_TIMESTAMP(3); without this the bundled archive
+    // table diffs its timestamp column on every reconcile.
+    expect(normalizeDefault("CURRENT_TIMESTAMP(3)")).toBe(
+      normalizeDefault("current_timestamp(3)")
+    );
+    expect(normalizeDefault("CURRENT_TIMESTAMP")).toBe(
+      normalizeDefault("current_timestamp")
+    );
+    expect(normalizeDefault("LOCALTIMESTAMP(6)")).toBe(
+      normalizeDefault("localtimestamp(6)")
+    );
+    expect(normalizeDefault("NOW()")).toBe(normalizeDefault("now()"));
+  });
+
+  it("leaves a user-defined function's case alone", () => {
+    // Quoting decides whether MyFunc and myfunc are the same identifier, so
+    // the collapse stays inside the keyword list.
+    expect(normalizeDefault("MyFunc()")).not.toBe(normalizeDefault("myfunc()"));
+  });
+});
+
 describe("normalizeDefault — passthrough behaviour", () => {
   it("returns undefined when input is undefined (no default)", () => {
     expect(normalizeDefault(undefined)).toBeUndefined();
@@ -209,6 +233,9 @@ describe("normalizeDefault — passthrough behaviour", () => {
     expect(normalizeDefault("some_unknown_expr(1,2)")).toBe(
       "some_unknown_expr(1,2)"
     );
-    expect(normalizeDefault("CURRENT_TIMESTAMP")).toBe("CURRENT_TIMESTAMP");
+    // Keywords now normalise to lower case, because the dialects report them
+    // back in whatever case they choose. Non-keyword expressions still pass
+    // through untouched, which is what this case is really guarding.
+    expect(normalizeDefault("CURRENT_TIMESTAMP")).toBe("current_timestamp");
   });
 });

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-default.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-default.test.ts
@@ -159,6 +159,20 @@ describe("normalizeDefault — string-literal unwrapping", () => {
     expect(normalizeDefault("(a) || (b)")).toBe("(a) || (b)");
   });
 
+  it("keeps whitespace that is part of a string default", () => {
+    // A default of " pending " is not the default "pending". Trimming while
+    // stripping parentheses collapsed the two, so a change between them would
+    // have emitted no op and left the old default in the database.
+    expect(normalizeDefault("' pending '")).toBe(" pending ");
+    expect(normalizeDefault("' pending '")).not.toBe(
+      normalizeDefault("pending")
+    );
+    // Whitespace beside a parenthesis is still insignificant.
+    expect(normalizeDefault("( unixepoch() )")).toBe(
+      normalizeDefault("unixepoch()")
+    );
+  });
+
   it("leaves unbalanced or unquoted expressions alone", () => {
     expect(normalizeDefault("'unterminated")).toBe("'unterminated");
     expect(normalizeDefault("gen_random_uuid()")).toBe("gen_random_uuid()");

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-default.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-default.test.ts
@@ -109,6 +109,10 @@ describe("normalizeDefault — string-literal unwrapping", () => {
       ["'-.5'", "-.5"],
       ["'+.5'", "+.5"],
       ["'gen_random_uuid()'", "gen_random_uuid()"],
+      // Parenthesised: SQLite requires the parens on an expression default,
+      // so the quoted word must not reduce into the expression it spells.
+      ["'(unixepoch())'", "(unixepoch())"],
+      ["'(unixepoch())'", "unixepoch()"],
       // Bare-callable keywords: no parentheses, so the call-shape half of the
       // guard does not see them and each has to be named.
       ["'LOCALTIME'", "LOCALTIME"],
@@ -133,6 +137,26 @@ describe("normalizeDefault — string-literal unwrapping", () => {
     // in the core schema.
     for (const word of ["pending", "ui", "draft", "template", "inside", "auto"])
       expect(normalizeDefault(`'${word}'`)).toBe(normalizeDefault(word));
+  });
+
+  it("collapses SQLite's wrapping parentheses to the form it reports back", () => {
+    // SQLite will not take a bare call as a default — it must be written
+    // `DEFAULT (unixepoch())` — and then PRAGMA table_info reports the column
+    // as `unixepoch()`, without them. One side of the diff always carries a
+    // pair the other never sees, so without this the column emits a default
+    // change on every reconcile.
+    expect(normalizeDefault("(unixepoch())")).toBe(
+      normalizeDefault("unixepoch()")
+    );
+    expect(normalizeDefault("((now()))")).toBe(normalizeDefault("now()"));
+  });
+
+  it("leaves parentheses that do not wrap the whole expression", () => {
+    // `(a) + (b)` opens and closes twice, so its first paren does not match
+    // its last. Stripping would produce `a) + (b` — a different default, and
+    // not valid SQL.
+    expect(normalizeDefault("(a) + (b)")).toBe("(a) + (b)");
+    expect(normalizeDefault("(a) || (b)")).toBe("(a) || (b)");
   });
 
   it("leaves unbalanced or unquoted expressions alone", () => {

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/primary-key-nullability.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/primary-key-nullability.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The diff does not compare a primary key's nullability.
+ *
+ * SQLite writes `id text PRIMARY KEY` with no NOT NULL — only INTEGER
+ * PRIMARY KEY is implicitly non-null there — and reports it back as nullable,
+ * while the desired side calls it required. No ALTER can settle that: SQLite
+ * has no statement that adds NOT NULL to an existing column. Left in, the op
+ * is produced on every reconcile, so the run never sees a clean database and
+ * keeps rebuilding tables to fix something it cannot fix — and on SQLite a
+ * rebuild takes the table's indexes with it.
+ */
+import { describe, expect, it } from "vitest";
+
+import { diffSnapshots } from "../diff";
+import type { NextlySchemaSnapshot } from "../types";
+
+const nullableOps = (prev: NextlySchemaSnapshot, cur: NextlySchemaSnapshot) =>
+  diffSnapshots(prev, cur).filter(op => op.type === "change_column_nullable");
+
+describe("primary-key nullability is not diffed", () => {
+  it("emits nothing when a live nullable primary key faces a required one", () => {
+    // Exactly the SQLite shape: introspection reports the stored truth, the
+    // desired side reports the intent, and they disagree forever.
+    const live: NextlySchemaSnapshot = {
+      tables: [
+        { name: "t", columns: [{ name: "id", type: "text", nullable: true }] },
+      ],
+    };
+    const desired: NextlySchemaSnapshot = {
+      tables: [
+        {
+          name: "t",
+          columns: [
+            { name: "id", type: "text", nullable: false, primaryKey: true },
+          ],
+        },
+      ],
+    };
+
+    expect(nullableOps(live, desired)).toEqual([]);
+  });
+
+  it("still emits for an ordinary column on the same table", () => {
+    // The exemption is scoped to the primary key, not to tables that have
+    // one — a real NOT NULL change beside it must survive.
+    const live: NextlySchemaSnapshot = {
+      tables: [
+        {
+          name: "t",
+          columns: [
+            { name: "id", type: "text", nullable: true },
+            { name: "title", type: "text", nullable: true },
+          ],
+        },
+      ],
+    };
+    const desired: NextlySchemaSnapshot = {
+      tables: [
+        {
+          name: "t",
+          columns: [
+            { name: "id", type: "text", nullable: false, primaryKey: true },
+            { name: "title", type: "text", nullable: false },
+          ],
+        },
+      ],
+    };
+
+    expect(nullableOps(live, desired)).toEqual([
+      {
+        type: "change_column_nullable",
+        tableName: "t",
+        columnName: "title",
+        fromNullable: true,
+        toNullable: false,
+      },
+    ]);
+  });
+
+  it("emits for a column no side marks as a primary key", () => {
+    // Guards against the exemption widening into "skip nullability entirely":
+    // without a primaryKey marker the comparison must behave as it always did.
+    const live: NextlySchemaSnapshot = {
+      tables: [
+        { name: "t", columns: [{ name: "id", type: "text", nullable: true }] },
+      ],
+    };
+    const desired: NextlySchemaSnapshot = {
+      tables: [
+        { name: "t", columns: [{ name: "id", type: "text", nullable: false }] },
+      ],
+    };
+
+    expect(nullableOps(live, desired)).toHaveLength(1);
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
@@ -474,13 +474,26 @@ export function buildDesiredTableFromComponentFields(
       columns: ["_parent_id", "_parent_table", "_parent_field"],
       unique: false,
     },
+    // The per-field rules are the same ones a collection gets, and they are
+    // taken from the shared helper rather than restated: a component table
+    // materialises `idx_<table>_<column>` for an indexed or single-relationship
+    // field and `uq_<table>_<column>` for a unique one, exactly as
+    // ComponentSchemaService creates them. Listing only the parent and
+    // created_at indexes here left the rest out of the snapshot, so a SQLite
+    // rebuild dropped them and nothing put them back — including the unique
+    // ones, which is a constraint silently disappearing, not just an index.
+    ...collectionIndexSpecs(tableName, fields, {
+      // Components have no slug column; created_at is present when the
+      // component carries timestamps.
+      hasSlugColumn: false,
+      hasCreatedAtColumn: columns.some(c => c.name === "created_at"),
+      localizedNames,
+      columnNameFor: field =>
+        getColumnDescriptor(
+          field as unknown as Parameters<typeof getColumnDescriptor>[0],
+          dialect
+        )?.name ?? null,
+    }),
   ];
-  if (columns.some(c => c.name === "created_at")) {
-    indexes.push({
-      name: `idx_${tableName}_created_at`,
-      columns: ["created_at"],
-      unique: false,
-    });
-  }
   return { name: tableName, columns, indexes: dedupeIndexes(indexes) };
 }

--- a/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
@@ -215,6 +215,11 @@ export function buildDesiredTableFromFields(
       // Forward descriptor default so the classifier doesn't flag status as
       // `add_required_field_no_default` and require TTY confirmation.
       default: reserved.default,
+      // Forward the primary-key marker too. The diff exempts primary keys
+      // from the nullability comparison, and without this the exemption
+      // would cover core tables only — every Schema-Builder table would keep
+      // emitting the nullability change SQLite can never satisfy.
+      ...(reserved.primaryKey ? { primaryKey: true as const } : {}),
     });
   }
 
@@ -281,6 +286,9 @@ export function buildDesiredTableFromComponentFields(
       type: "text",
       nullable: false,
       default: undefined,
+      // Component tables declare `id` as their primary key, so it takes
+      // the same nullability exemption as every other primary key.
+      primaryKey: true,
     });
     columns.push({
       name: "_parent_id",
@@ -318,6 +326,9 @@ export function buildDesiredTableFromComponentFields(
       type: "varchar(36)",
       nullable: false,
       default: undefined,
+      // Component tables declare `id` as their primary key, so it takes
+      // the same nullability exemption as every other primary key.
+      primaryKey: true,
     });
     columns.push({
       name: "_parent_id",
@@ -356,6 +367,9 @@ export function buildDesiredTableFromComponentFields(
       type: "text",
       nullable: false,
       default: undefined,
+      // Component tables declare `id` as their primary key, so it takes
+      // the same nullability exemption as every other primary key.
+      primaryKey: true,
     });
     columns.push({
       name: "_parent_id",

--- a/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/build-from-fields.ts
@@ -92,6 +92,8 @@ export interface BuildDesiredTableOptions {
 interface CollectionIndexContext<F> {
   hasSlugColumn: boolean;
   hasCreatedAtColumn: boolean;
+  /** Collections carry an owner column; singles and components do not. */
+  hasCreatedByColumn?: boolean;
   /** Fields whose columns live in the companion `_locales` table. */
   localizedNames: ReadonlySet<string>;
   /**
@@ -129,6 +131,18 @@ export function collectionIndexSpecs<F extends MinimalFieldDef>(
       name: `idx_${tableName}_slug`,
       columns: ["slug"],
       unique: true,
+    });
+  }
+  if (context.hasCreatedByColumn) {
+    // Owner-scoped reads filter on created_by, and the collection service
+    // creates this index for every table that has the column. Recording it
+    // here is what lets a rebuilt table get it back: a SQLite rebuild drops
+    // every index the replacement table does not declare, and the restore
+    // replays only what the snapshot carries.
+    indexes.push({
+      name: `idx_${tableName}_created_by`,
+      columns: ["created_by"],
+      unique: false,
     });
   }
   if (context.hasCreatedAtColumn) {
@@ -247,6 +261,7 @@ export function buildDesiredTableFromFields(
   const indexes = collectionIndexSpecs(tableName, fields, {
     hasSlugColumn: columns.some(c => c.name === "slug"),
     hasCreatedAtColumn: columns.some(c => c.name === "created_at"),
+    hasCreatedByColumn: columns.some(c => c.name === "created_by"),
     localizedNames,
     columnNameFor: field =>
       getColumnDescriptor(

--- a/packages/nextly/src/domains/schema/pipeline/diff/diff.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/diff.ts
@@ -175,7 +175,18 @@ function diffColumns(
           toType: curC.type,
         });
       }
-      if (prevC.nullable !== curC.nullable) {
+      // A primary key's nullability is not an independent attribute: it
+      // follows from being the primary key, and the dialects disagree only on
+      // whether they bother to write it down. SQLite records `id text PRIMARY
+      // KEY` with no NOT NULL and reports it back as nullable, while the
+      // desired side calls it required — a difference no ALTER can resolve,
+      // because SQLite has no statement that adds NOT NULL to an existing
+      // column. Comparing it produces an op that is emitted on every run,
+      // never converges, and keeps handing the reconcile work to do; the
+      // table rebuilds that follow are what silently drop indexes.
+      const isPrimaryKey =
+        curC.primaryKey === true || prevC.primaryKey === true;
+      if (!isPrimaryKey && prevC.nullable !== curC.nullable) {
         nullableChanges.push({
           type: "change_column_nullable",
           tableName,

--- a/packages/nextly/src/domains/schema/pipeline/diff/normalize-default.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/normalize-default.ts
@@ -105,8 +105,35 @@ export function normalizeDefault(expr: string | undefined): string | undefined {
  * unwrap costs a spurious op, which this module has always preferred; a wrong
  * unwrap silently drops a real migration.
  */
-const EXPRESSION_SHAPED =
-  /^\s*(?:[\w.]+\s*\(|-?\d|(?:true|false|null|current_timestamp|current_date|current_time)\s*$)/i;
+const NILADIC_KEYWORDS = [
+  // Literals.
+  "true",
+  "false",
+  "null",
+  // Date/time keywords that need no call syntax. PostgreSQL accepts all of
+  // these bare; SQLite accepts the CURRENT_ trio; MySQL accepts
+  // CURRENT_TIMESTAMP.
+  "current_timestamp",
+  "current_date",
+  "current_time",
+  "localtime",
+  "localtimestamp",
+  // Identity keywords, all bare-callable in PostgreSQL.
+  "current_user",
+  "current_role",
+  "current_schema",
+  "current_catalog",
+  "session_user",
+  "system_user",
+  "user",
+].join("|");
+
+const EXPRESSION_SHAPED = new RegExp(
+  // Anything that calls (`now()`, `gen_random_uuid()`), any number, or any
+  // keyword above standing alone.
+  `^\\s*(?:[\\w.]+\\s*\\(|-?\\d|(?:${NILADIC_KEYWORDS})\\s*$)`,
+  "i"
+);
 
 /**
  * Reduce a quoted string literal to its contents.

--- a/packages/nextly/src/domains/schema/pipeline/diff/normalize-default.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/normalize-default.ts
@@ -91,6 +91,24 @@ export function normalizeDefault(expr: string | undefined): string | undefined {
 }
 
 /**
+ * Contents that must keep their quotes, because unquoted they would read as
+ * something other than a string.
+ *
+ * `'now()'` is the word "now()" stored in a text column; `now()` is a call
+ * evaluated per row. Unwrap the first and the two compare equal, so a change
+ * between them is reported as no change at all and the column keeps a default
+ * nobody intended. The same holds for `'true'` against the boolean, `'0'`
+ * against the number, and `'CURRENT_TIMESTAMP'` against the keyword.
+ *
+ * Matching is deliberately broad — anything that calls, any bare keyword, any
+ * number — because the cost of the two sides is not symmetric. Declining to
+ * unwrap costs a spurious op, which this module has always preferred; a wrong
+ * unwrap silently drops a real migration.
+ */
+const EXPRESSION_SHAPED =
+  /^\s*(?:[\w.]+\s*\(|-?\d|(?:true|false|null|current_timestamp|current_date|current_time)\s*$)/i;
+
+/**
  * Reduce a quoted string literal to its contents.
  *
  * The two sides of the diff read a string default from different places and
@@ -105,16 +123,19 @@ export function normalizeDefault(expr: string | undefined): string | undefined {
  * seeing a clean database, and on SQLite the rebuild that follows takes the
  * table's indexes with it.
  *
- * Only a fully-quoted literal is unwrapped. Anything with an interior quote
- * is left alone rather than guessed at: PG escapes by doubling, SQLite the
- * same, and a wrong unwrap here would compare two different values equal,
- * which is the one failure this module must not have.
+ * Two things are never unwrapped. A literal with an interior quote, because
+ * both PG and SQLite escape by doubling and the contents cannot be recovered
+ * by removing the outer pair. And a literal whose contents would read as an
+ * expression, so that a quoted `'now()'` can never compare equal to a called
+ * `now()`.
  */
 function unquoteStringLiteral(expr: string): string {
   if (expr.length < 2) return expr;
   if (!expr.startsWith("'") || !expr.endsWith("'")) return expr;
   const inner = expr.slice(1, -1);
-  return inner.includes("'") ? expr : inner;
+  if (inner.includes("'")) return expr;
+  if (EXPRESSION_SHAPED.test(inner)) return expr;
+  return inner;
 }
 
 function stripRedundantCast(expr: string): string {

--- a/packages/nextly/src/domains/schema/pipeline/diff/normalize-default.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/normalize-default.ts
@@ -60,13 +60,6 @@ const CAST_SUFFIX_RE = new RegExp(
   "i"
 );
 
-// Built-in no-arg function calls that PG / Drizzle may emit in different
-// cases. Conservative list: only functions that are guaranteed
-// case-insensitive at the call site, called with no arguments. Adding to
-// this list means "I've confirmed both sides of the diff treat these as
-// equivalent."
-const NORMALIZE_LOWERCASE_FUNCTIONS = new Set(["now()"]);
-
 /**
  * Return the canonical form of a column-default expression for diff
  * comparison. `undefined` (no default) is passed through unchanged.
@@ -90,10 +83,14 @@ export function normalizeDefault(expr: string | undefined): string | undefined {
   // deliberately leaves alone — is not reduced into the expression it spells.
   normalised = stripWrappingParens(normalised);
 
-  // Step 4: lowercase a small set of known case-insensitive built-ins.
-  const lower = normalised.toLowerCase();
-  if (NORMALIZE_LOWERCASE_FUNCTIONS.has(lower)) {
-    normalised = lower;
+  // Step 4: lowercase the built-in keywords, which the dialects report back in
+  // whatever case they please — MySQL renders a DATETIME default as
+  // `current_timestamp(3)` where the schema wrote `CURRENT_TIMESTAMP(3)`.
+  // Bounded to the keyword list plus an optional precision argument, so a
+  // user-defined function keeps its case: `MyFunc()` may well be a different
+  // identifier from `myfunc()` depending on how it was quoted.
+  if (KEYWORD_WITH_OPTIONAL_PRECISION.test(normalised.trim())) {
+    normalised = normalised.toLowerCase();
   }
 
   return normalised;
@@ -136,6 +133,14 @@ const NILADIC_KEYWORDS = [
   "system_user",
   "user",
 ].join("|");
+
+// The built-in keywords, alone or with a fractional-seconds precision, and
+// `now()`. These name the same thing in any case, so both sides of the diff
+// can be reduced to lower case; anything outside this set is left as written.
+const KEYWORD_WITH_OPTIONAL_PRECISION = new RegExp(
+  `^(?:now\\(\\)|(?:${NILADIC_KEYWORDS})(?:\\s*\\(\\s*\\d+\\s*\\))?)$`,
+  "i"
+);
 
 const EXPRESSION_SHAPED = new RegExp(
   // Anything parenthesised (`(unixepoch())`), anything that calls (`now()`,

--- a/packages/nextly/src/domains/schema/pipeline/diff/normalize-default.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/normalize-default.ts
@@ -129,9 +129,10 @@ const NILADIC_KEYWORDS = [
 ].join("|");
 
 const EXPRESSION_SHAPED = new RegExp(
-  // Anything that calls (`now()`, `gen_random_uuid()`), any number, or any
-  // keyword above standing alone.
-  `^\\s*(?:[\\w.]+\\s*\\(|-?\\d|(?:${NILADIC_KEYWORDS})\\s*$)`,
+  // Anything that calls (`now()`, `gen_random_uuid()`), any number in any
+  // form a dialect accepts (`1`, `-1`, `+1`, `.5`, `-.5`), or any keyword
+  // above standing alone.
+  `^\\s*(?:[\\w.]+\\s*\\(|[-+]?\\.?\\d|(?:${NILADIC_KEYWORDS})\\s*$)`,
   "i"
 );
 

--- a/packages/nextly/src/domains/schema/pipeline/diff/normalize-default.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/normalize-default.ts
@@ -81,7 +81,16 @@ export function normalizeDefault(expr: string | undefined): string | undefined {
   // Step 2: unwrap a string literal to the value it denotes.
   normalised = unquoteStringLiteral(normalised);
 
-  // Step 3: lowercase a small set of known case-insensitive built-ins.
+  // Step 3: drop parentheses that wrap the whole expression. SQLite requires
+  // them when a default is an expression (`DEFAULT (unixepoch())`) and then
+  // reports the column back through PRAGMA without them, as `unixepoch()`.
+  // The desired side keeps whatever the schema wrote, so without this the two
+  // never agree and the column emits a default change on every reconcile.
+  // Runs after the unquote so a quoted `'(unixepoch())'` — which the unquote
+  // deliberately leaves alone — is not reduced into the expression it spells.
+  normalised = stripWrappingParens(normalised);
+
+  // Step 4: lowercase a small set of known case-insensitive built-ins.
   const lower = normalised.toLowerCase();
   if (NORMALIZE_LOWERCASE_FUNCTIONS.has(lower)) {
     normalised = lower;
@@ -129,10 +138,11 @@ const NILADIC_KEYWORDS = [
 ].join("|");
 
 const EXPRESSION_SHAPED = new RegExp(
-  // Anything that calls (`now()`, `gen_random_uuid()`), any number in any
+  // Anything parenthesised (`(unixepoch())`), anything that calls (`now()`,
+  // `gen_random_uuid()`), any number in any
   // form a dialect accepts (`1`, `-1`, `+1`, `.5`, `-.5`), or any keyword
   // above standing alone.
-  `^\\s*(?:[\\w.]+\\s*\\(|[-+]?\\.?\\d|(?:${NILADIC_KEYWORDS})\\s*$)`,
+  `^\\s*(?:\\(|[\\w.]+\\s*\\(|[-+]?\\.?\\d|(?:${NILADIC_KEYWORDS})\\s*$)`,
   "i"
 );
 
@@ -195,4 +205,43 @@ function isCompleteLiteral(value: string): boolean {
   // Boolean keyword.
   if (value === "true" || value === "false") return true;
   return false;
+}
+
+/**
+ * Remove parentheses that wrap the entire expression.
+ *
+ * SQLite will not accept a bare function call as a default — it has to be
+ * written `DEFAULT (unixepoch())` — and then reports the column back through
+ * `PRAGMA table_info` as `unixepoch()`, without them. One side of the diff
+ * therefore always carries a pair the other never sees.
+ *
+ * Only a pair that encloses everything is removed, and only when it genuinely
+ * closes at the end: `(a) + (b)` opens and closes twice, so its first `(` does
+ * not match its last `)` and the expression is left as written. Stripping
+ * there would produce `a) + (b`, which is not the same default and not even
+ * valid SQL.
+ */
+function stripWrappingParens(expr: string): string {
+  let current = expr.trim();
+  // A default could in principle arrive doubly wrapped; peel while the pair
+  // encloses the whole expression, and stop as soon as it does not.
+  while (current.startsWith("(") && current.endsWith(")")) {
+    let depth = 0;
+    let closesAtEnd = true;
+    for (let i = 0; i < current.length; i++) {
+      if (current[i] === "(") depth++;
+      else if (current[i] === ")") {
+        depth--;
+        // Back to zero before the last character means this `(` closed early,
+        // so the outer pair is not a wrapper.
+        if (depth === 0 && i < current.length - 1) {
+          closesAtEnd = false;
+          break;
+        }
+      }
+    }
+    if (!closesAtEnd || depth !== 0) return current;
+    current = current.slice(1, -1).trim();
+  }
+  return current;
 }

--- a/packages/nextly/src/domains/schema/pipeline/diff/normalize-default.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/normalize-default.ts
@@ -78,13 +78,43 @@ export function normalizeDefault(expr: string | undefined): string | undefined {
   // closing string-literal quote or a bare literal (number / boolean).
   let normalised = stripRedundantCast(expr);
 
-  // Step 2: lowercase a small set of known case-insensitive built-ins.
+  // Step 2: unwrap a string literal to the value it denotes.
+  normalised = unquoteStringLiteral(normalised);
+
+  // Step 3: lowercase a small set of known case-insensitive built-ins.
   const lower = normalised.toLowerCase();
   if (NORMALIZE_LOWERCASE_FUNCTIONS.has(lower)) {
     normalised = lower;
   }
 
   return normalised;
+}
+
+/**
+ * Reduce a quoted string literal to its contents.
+ *
+ * The two sides of the diff read a string default from different places and
+ * so quote it differently: the live side reads the DDL, where a string is
+ * written `'pending'`, while the desired side reads the Drizzle column, whose
+ * `default` holds the JavaScript string `pending`. Nothing before this made
+ * them comparable, so every string-defaulted column produced a
+ * `change_column_default` op on every diff — on all three dialects, not only
+ * the one where it was first noticed.
+ *
+ * Left un-normalised the op is not merely noise: it keeps the reconcile from
+ * seeing a clean database, and on SQLite the rebuild that follows takes the
+ * table's indexes with it.
+ *
+ * Only a fully-quoted literal is unwrapped. Anything with an interior quote
+ * is left alone rather than guessed at: PG escapes by doubling, SQLite the
+ * same, and a wrong unwrap here would compare two different values equal,
+ * which is the one failure this module must not have.
+ */
+function unquoteStringLiteral(expr: string): string {
+  if (expr.length < 2) return expr;
+  if (!expr.startsWith("'") || !expr.endsWith("'")) return expr;
+  const inner = expr.slice(1, -1);
+  return inner.includes("'") ? expr : inner;
 }
 
 function stripRedundantCast(expr: string): string {

--- a/packages/nextly/src/domains/schema/pipeline/diff/normalize-default.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/normalize-default.ts
@@ -222,26 +222,36 @@ function isCompleteLiteral(value: string): boolean {
  * valid SQL.
  */
 function stripWrappingParens(expr: string): string {
-  let current = expr.trim();
-  // A default could in principle arrive doubly wrapped; peel while the pair
-  // encloses the whole expression, and stop as soon as it does not.
-  while (current.startsWith("(") && current.endsWith(")")) {
+  let current = expr;
+  let peeled = false;
+
+  for (;;) {
+    // Whitespace beside a parenthesis is insignificant, but whitespace inside
+    // a string default is not: `' pending '` and `'pending'` are different
+    // values. So the trim is scoped to the paren test, and the untouched
+    // input is what comes back when there is nothing to peel.
+    const candidate = current.trim();
+    if (!candidate.startsWith("(") || !candidate.endsWith(")")) break;
+
     let depth = 0;
     let closesAtEnd = true;
-    for (let i = 0; i < current.length; i++) {
-      if (current[i] === "(") depth++;
-      else if (current[i] === ")") {
+    for (let i = 0; i < candidate.length; i++) {
+      if (candidate[i] === "(") depth++;
+      else if (candidate[i] === ")") {
         depth--;
         // Back to zero before the last character means this `(` closed early,
         // so the outer pair is not a wrapper.
-        if (depth === 0 && i < current.length - 1) {
+        if (depth === 0 && i < candidate.length - 1) {
           closesAtEnd = false;
           break;
         }
       }
     }
-    if (!closesAtEnd || depth !== 0) return current;
-    current = current.slice(1, -1).trim();
+    if (!closesAtEnd || depth !== 0) break;
+
+    current = candidate.slice(1, -1);
+    peeled = true;
   }
-  return current;
+
+  return peeled ? current.trim() : expr;
 }

--- a/packages/nextly/src/domains/schema/pipeline/diff/types.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/types.ts
@@ -28,6 +28,13 @@ export interface ColumnSpec {
   // Raw default expression as written in DDL. Undefined when no default.
   // Examples: "'foo'::text", "now()", "0", "true", "gen_random_uuid()".
   default?: string;
+  // `true` when the column is the table's primary key. Recorded from the
+  // desired side, which reads it from the Drizzle column; introspected
+  // snapshots leave it undefined, and so do snapshots written before this
+  // field existed. Both read as "not known to be a primary key", which only
+  // costs the nullability exemption the diff grants primary keys — never a
+  // wrong op.
+  primaryKey?: boolean;
 }
 
 export interface IndexSpec {

--- a/packages/nextly/src/domains/schema/pipeline/filter-unsafe-statements.ts
+++ b/packages/nextly/src/domains/schema/pipeline/filter-unsafe-statements.ts
@@ -192,6 +192,35 @@ export function filterUnsafeStatements(
 }
 
 /**
+ * Lower-cased names of tables a statement set rebuilds.
+ *
+ * SQLite cannot alter most of a column in place, so drizzle-kit emits
+ * CREATE `__new_x` → INSERT SELECT → DROP `x` → RENAME `__new_x` TO `x`. The
+ * closing rename identifies the table, and only when it renames back to the
+ * name it replaced: `ALTER TABLE __new_g1 RENAME TO other` is not a rebuild
+ * of `g1` and must not be read as one.
+ *
+ * Shared rather than re-derived. The destructive scanner uses it to know
+ * which DROPs are part of a rebuild; the index restore uses it to know which
+ * tables lost their indexes to one. A second pattern that disagreed with this
+ * one would make the two answer differently about the same batch.
+ */
+export function rebuiltTableNames(statements: readonly string[]): Set<string> {
+  const targets = new Set<string>();
+  for (const s of statements) {
+    const m = s.match(
+      // Optionally schema-qualified and/or quoted: `__new_x`, "__new_x",
+      // "main"."__new_x", main.__new_x.
+      /ALTER\s+TABLE\s+(?:[`"]?[A-Za-z0-9_]+[`"]?\.)?[`"]?__new_([A-Za-z0-9_]+)[`"]?\s+RENAME\s+TO\s+(?:[`"]?[A-Za-z0-9_]+[`"]?\.)?[`"]?([A-Za-z0-9_]+)[`"]?/i
+    );
+    if (m && (m[1] ?? "").toLowerCase() === (m[2] ?? "").toLowerCase()) {
+      targets.add((m[1] ?? "").toLowerCase());
+    }
+  }
+  return targets;
+}
+
+/**
  * v1 drizzle-kit INCLUDES destructive statements in sqlStatements (hints are
  * empty even for drops — observed on SQLite, Postgres and MySQL, 2026-07).
  * By the time the pipeline's Phase D runs, every user-approved destructive
@@ -234,20 +263,7 @@ export function findUnexpectedDestructiveStatements(
   const targetsManaged = (table: string): boolean =>
     managedTables === undefined || managedTables.has(table.toLowerCase());
 
-  const rebuildTargets = new Set<string>();
-  for (const s of statements) {
-    const m = s.match(
-      // Optionally schema-qualified and/or quoted: `__new_x`, "__new_x",
-      // "main"."__new_x", main.__new_x. The RENAME destination is captured
-      // too: a rebuild is only a rebuild when `__new_x` renames back to `x`
-      // itself — `ALTER TABLE __new_g1 RENAME TO other` must NOT exempt
-      // `DROP TABLE g1` from the guard.
-      /ALTER\s+TABLE\s+(?:[`"]?[A-Za-z0-9_]+[`"]?\.)?[`"]?__new_([A-Za-z0-9_]+)[`"]?\s+RENAME\s+TO\s+(?:[`"]?[A-Za-z0-9_]+[`"]?\.)?[`"]?([A-Za-z0-9_]+)[`"]?/i
-    );
-    if (m && (m[1] ?? "").toLowerCase() === (m[2] ?? "").toLowerCase()) {
-      rebuildTargets.add((m[1] ?? "").toLowerCase());
-    }
-  }
+  const rebuildTargets = rebuiltTableNames(statements);
   const offenders: string[] = [];
   for (const s of statements) {
     const dropTable = s.match(

--- a/packages/nextly/src/domains/schema/pipeline/filter-unsafe-statements.ts
+++ b/packages/nextly/src/domains/schema/pipeline/filter-unsafe-statements.ts
@@ -206,6 +206,20 @@ export function filterUnsafeStatements(
  * one would make the two answer differently about the same batch.
  */
 export function rebuiltTableNames(statements: readonly string[]): Set<string> {
+  // The replacement table has to have been built in this same batch. A rename
+  // on its own proves only that something took the table's name: for
+  // `DROP TABLE posts; ALTER TABLE __new_posts RENAME TO posts` there is no
+  // create and no copy, so the rows are gone and the drop is a real one that
+  // the destructive guard must still refuse. Pairing the rename with its
+  // create is what makes this the rebuild it claims to be.
+  const created = new Set<string>();
+  for (const s of statements) {
+    const m = s.match(
+      /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:[`"]?[A-Za-z0-9_]+[`"]?\.)?[`"]?__new_([A-Za-z0-9_]+)[`"]?/i
+    );
+    if (m) created.add((m[1] ?? "").toLowerCase());
+  }
+
   const targets = new Set<string>();
   for (const s of statements) {
     const m = s.match(
@@ -213,9 +227,10 @@ export function rebuiltTableNames(statements: readonly string[]): Set<string> {
       // "main"."__new_x", main.__new_x.
       /ALTER\s+TABLE\s+(?:[`"]?[A-Za-z0-9_]+[`"]?\.)?[`"]?__new_([A-Za-z0-9_]+)[`"]?\s+RENAME\s+TO\s+(?:[`"]?[A-Za-z0-9_]+[`"]?\.)?[`"]?([A-Za-z0-9_]+)[`"]?/i
     );
-    if (m && (m[1] ?? "").toLowerCase() === (m[2] ?? "").toLowerCase()) {
-      targets.add((m[1] ?? "").toLowerCase());
-    }
+    if (!m) continue;
+    const from = (m[1] ?? "").toLowerCase();
+    const to = (m[2] ?? "").toLowerCase();
+    if (from === to && created.has(from)) targets.add(from);
   }
   return targets;
 }

--- a/packages/nextly/src/domains/schema/pipeline/index-restore.ts
+++ b/packages/nextly/src/domains/schema/pipeline/index-restore.ts
@@ -20,7 +20,7 @@
 
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
-import type { NextlySchemaSnapshot } from "./diff/types";
+import type { IndexSpec, NextlySchemaSnapshot, Operation } from "./diff/types";
 import { rebuiltTableNames } from "./filter-unsafe-statements";
 import { generateSQL } from "./sql-templates";
 
@@ -40,21 +40,40 @@ import { generateSQL } from "./sql-templates";
 export function indexRestoreStatements(
   desired: NextlySchemaSnapshot,
   dialect: SupportedDialect,
-  statements: readonly string[]
+  statements: readonly string[],
+  ops: readonly Operation[] = []
 ): string[] {
   const rebuilt = rebuiltTableNames(statements);
-  if (rebuilt.size === 0) return [];
+  const emitted = new Set<string>();
+  const out: string[] = [];
 
-  return desired.tables
-    .filter(table => rebuilt.has(table.name.toLowerCase()))
-    .flatMap(table =>
-      // `undefined` means the snapshot never tracked indexes, which is not the
-      // same as the table having none. Only an explicit list is actionable.
-      (table.indexes ?? []).map(index =>
-        generateSQL(
-          { type: "add_index", tableName: table.name, index },
-          dialect
-        )
-      )
-    );
+  const add = (tableName: string, index: IndexSpec): void => {
+    // Same index can arrive from both sources — a rebuilt table whose diff
+    // also asked for one of its indexes. Emit it once.
+    const key = `${tableName.toLowerCase()}::${index.name.toLowerCase()}`;
+    if (emitted.has(key)) return;
+    emitted.add(key);
+    out.push(generateSQL({ type: "add_index", tableName, index }, dialect));
+  };
+
+  // A rebuilt table lost every index it had, so all of them are replayed.
+  for (const table of desired.tables) {
+    if (!rebuilt.has(table.name.toLowerCase())) continue;
+    // `undefined` means the snapshot never tracked indexes, which is not the
+    // same as the table having none. Only an explicit list is actionable.
+    for (const index of table.indexes ?? []) add(table.name, index);
+  }
+
+  // An `add_index` op is the diff stating the index is absent, so creating it
+  // cannot duplicate one. This is the only thing that creates it on SQLite and
+  // MySQL: the fast-path emitter is PostgreSQL-only, and the schema handed to
+  // drizzle-kit declares no dynamic-table indexes, so a diff of nothing but
+  // index additions would otherwise apply zero statements and report success
+  // while the index stayed missing.
+  for (const op of ops) {
+    if (op.type !== "add_index") continue;
+    add(op.tableName, op.index);
+  }
+
+  return out;
 }

--- a/packages/nextly/src/domains/schema/pipeline/index-restore.ts
+++ b/packages/nextly/src/domains/schema/pipeline/index-restore.ts
@@ -1,0 +1,60 @@
+/**
+ * Re-creating the indexes a rebuild takes with it.
+ *
+ * Two things decide what a dynamic table looks like and only one of them
+ * knows about indexes. The diff's desired side comes from
+ * `buildDesiredTableFromFields`, which carries a full `IndexSpec[]`; the
+ * Drizzle tables handed to drizzle-kit come from `generateRuntimeSchema`,
+ * which declares none. drizzle-kit therefore believes every table should have
+ * no secondary index, so the replacement table it builds during a SQLite
+ * rebuild has none either, and the indexes go with the table it dropped.
+ * Nothing reports it: the push succeeds, the rows are intact, and the queries
+ * just get slower.
+ *
+ * A module of its own so the rule can be tested without loading the pipeline,
+ * which reaches the database barrel for its Drizzle table maps and so pulls
+ * adapter build output into anything that imports it.
+ *
+ * @module domains/schema/pipeline/index-restore
+ */
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+import type { NextlySchemaSnapshot } from "./diff/types";
+import { rebuiltTableNames } from "./filter-unsafe-statements";
+import { generateSQL } from "./sql-templates";
+
+/**
+ * `CREATE INDEX` for every index the desired schema declares on a table this
+ * batch rebuilds.
+ *
+ * Scoped to rebuilt tables, NOT to every table the apply touched. A table
+ * altered in place still has its indexes, and re-creating one that exists is
+ * not harmless: MySQL has no `CREATE INDEX IF NOT EXISTS`, so a duplicate key
+ * name aborts the apply — after MySQL has already auto-committed the DDL ahead
+ * of it.
+ *
+ * Pure, so the statements can be asserted directly. The caller appends them to
+ * the push batch, which runs them after the table changes they index.
+ */
+export function indexRestoreStatements(
+  desired: NextlySchemaSnapshot,
+  dialect: SupportedDialect,
+  statements: readonly string[]
+): string[] {
+  const rebuilt = rebuiltTableNames(statements);
+  if (rebuilt.size === 0) return [];
+
+  return desired.tables
+    .filter(table => rebuilt.has(table.name.toLowerCase()))
+    .flatMap(table =>
+      // `undefined` means the snapshot never tracked indexes, which is not the
+      // same as the table having none. Only an explicit list is actionable.
+      (table.indexes ?? []).map(index =>
+        generateSQL(
+          { type: "add_index", tableName: table.name, index },
+          dialect
+        )
+      )
+    );
+}

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
@@ -187,8 +187,11 @@ function applyMakeOptionalToDesired(
  * ahead of it.
  *
  * Pure so the statements can be asserted directly; the caller appends them to
- * the push batch, which keeps them in the same transaction and after the
- * table changes they index.
+ * the push batch, so they run after the table changes they index and share
+ * that batch's failure handling. On PostgreSQL and MySQL the batch runs in a
+ * transaction; SQLite deliberately runs without one (PRAGMA foreign_keys
+ * cannot be toggled inside a transaction), so a restore that fails there
+ * leaves the rebuilt table committed without the index that failed.
  */
 export function indexRestoreStatements(
   desired: NextlySchemaSnapshot,
@@ -958,9 +961,10 @@ export class PushSchemaPipeline {
           }
         }
 
-        // Appended to the same batch, after the table changes they index and
-        // inside the same transaction, so a table can never commit without
-        // the indexes the desired schema declares for it.
+        // Appended to the same batch so they run after the table changes they
+        // index. On PG and MySQL that batch is transactional; SQLite runs
+        // without a transaction by design, so a failing restore there is
+        // reported but the rebuild it followed has already landed.
         const restore = indexRestoreStatements(desiredSnapshot, dialect, safe);
 
         try {

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
@@ -54,8 +54,8 @@ import {
   findUnexpectedDestructiveStatements,
   getDrizzleTableName,
   isDrizzleTable,
-  rebuiltTableNames,
 } from "./filter-unsafe-statements";
+import { indexRestoreStatements } from "./index-restore";
 import { MANAGED_TABLE_PREFIXES_REGEX, isManagedTable } from "./managed-tables";
 import { applyResolutionsToOperations } from "./pre-resolution/apply-resolutions";
 import { executePreResolutionOps } from "./pre-resolution/executor";
@@ -77,7 +77,6 @@ import type {
   RenameDetector,
 } from "./pushschema-pipeline-interfaces";
 import type { ClassifierEvent, Resolution } from "./resolution/types";
-import { generateSQL } from "./sql-templates";
 import { withCapturedStdout } from "./stdout-capture";
 import type { DesiredSchema } from "./types";
 
@@ -160,59 +159,6 @@ function applyMakeOptionalToDesired(
       ])
     ),
   };
-}
-
-/**
- * `CREATE INDEX` for every index the desired schema declares on a table this
- * apply rebuilt.
- *
- * Two things decide what a dynamic table looks like and only one of them
- * knows about indexes. The diff's desired side comes from
- * `buildDesiredTableFromFields`, which carries a full `IndexSpec[]`; the
- * Drizzle tables handed to drizzle-kit come from `generateRuntimeSchema`,
- * which declares none. drizzle-kit therefore believes every table should have
- * no secondary index, so the replacement table it builds during a rebuild has
- * none either, and the indexes go with the table it dropped. Nothing reports
- * it: the push succeeds, the rows are intact, and the queries just get slower.
- *
- * Re-asserting them is what closes the gap. Teaching the generator to declare
- * them instead would mean passing Drizzle's three-argument table overload a
- * loosely-typed column record it does not accept, which has no answer that
- * isn't `any`.
- *
- * Scoped to rebuilt tables, NOT to every table the apply touched. A table that
- * was altered in place still has its indexes, and re-creating one that exists
- * is not harmless: MySQL has no `CREATE INDEX IF NOT EXISTS`, so a duplicate
- * key name aborts the apply — after MySQL has already auto-committed the DDL
- * ahead of it.
- *
- * Pure so the statements can be asserted directly; the caller appends them to
- * the push batch, so they run after the table changes they index and share
- * that batch's failure handling. On PostgreSQL and MySQL the batch runs in a
- * transaction; SQLite deliberately runs without one (PRAGMA foreign_keys
- * cannot be toggled inside a transaction), so a restore that fails there
- * leaves the rebuilt table committed without the index that failed.
- */
-export function indexRestoreStatements(
-  desired: NextlySchemaSnapshot,
-  dialect: SupportedDialect,
-  statements: readonly string[]
-): string[] {
-  const rebuilt = rebuiltTableNames(statements);
-  if (rebuilt.size === 0) return [];
-
-  return desired.tables
-    .filter(table => rebuilt.has(table.name.toLowerCase()))
-    .flatMap(table =>
-      // `undefined` means "this snapshot never tracked indexes", which is not
-      // the same as "this table has none". Only an explicit list is actionable.
-      (table.indexes ?? []).map(index =>
-        generateSQL(
-          { type: "add_index", tableName: table.name, index },
-          dialect
-        )
-      )
-    );
 }
 
 export interface PipelineResult {

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
@@ -162,49 +162,79 @@ function applyMakeOptionalToDesired(
 }
 
 /**
- * `CREATE INDEX` for every index the desired schema declares.
+ * Tables this batch replaces wholesale, read from the statements themselves.
+ *
+ * SQLite cannot alter most of a column in place, so drizzle-kit applies the
+ * change by building `__new_<table>`, copying the rows across, dropping the
+ * original and renaming the copy into its place. The closing rename is the
+ * reliable marker: `CREATE TABLE "__new_x"` alone can appear in a batch that
+ * later fails a guard, whereas the rename only follows a rebuild that ran.
+ *
+ * Derived from what the apply is about to do rather than from the diff,
+ * because "was this table replaced" is a fact about the emitted SQL. An
+ * `add_column` on PostgreSQL or MySQL touches the table without replacing it,
+ * keeps its indexes, and correctly appears nowhere in this set.
+ */
+const SQLITE_REBUILD_RENAME =
+  /ALTER\s+TABLE\s+[`"']?__new_[A-Za-z0-9_]+[`"']?\s+RENAME\s+TO\s+[`"']?([A-Za-z0-9_]+)/i;
+
+function rebuiltTableNames(statements: readonly string[]): Set<string> {
+  const names = new Set<string>();
+  for (const statement of statements) {
+    const match = statement.match(SQLITE_REBUILD_RENAME);
+    if (match) names.add(match[1]);
+  }
+  return names;
+}
+
+/**
+ * `CREATE INDEX` for every index the desired schema declares on a table this
+ * apply rebuilt.
  *
  * Two things decide what a dynamic table looks like and only one of them
  * knows about indexes. The diff's desired side comes from
  * `buildDesiredTableFromFields`, which carries a full `IndexSpec[]`; the
  * Drizzle tables handed to drizzle-kit come from `generateRuntimeSchema`,
  * which declares none. drizzle-kit therefore believes every table should have
- * no secondary index, and on SQLite — where a schema change is applied by
- * building a new table and copying the rows across — the indexes go with the
- * table it dropped. Nothing reports it: the push succeeds, the rows are
- * intact, and the queries just get slower.
+ * no secondary index, so the replacement table it builds during a rebuild has
+ * none either, and the indexes go with the table it dropped. Nothing reports
+ * it: the push succeeds, the rows are intact, and the queries just get slower.
  *
  * Re-asserting them is what closes the gap. Teaching the generator to declare
  * them instead would mean passing Drizzle's three-argument table overload a
  * loosely-typed column record it does not accept, which has no answer that
  * isn't `any`.
  *
+ * Scoped to rebuilt tables, NOT to every table the apply touched. A table that
+ * was altered in place still has its indexes, and re-creating one that exists
+ * is not harmless: MySQL has no `CREATE INDEX IF NOT EXISTS`, so a duplicate
+ * key name aborts the apply — after MySQL has already auto-committed the DDL
+ * ahead of it.
+ *
  * Pure so the statements can be asserted directly; the caller appends them to
  * the push batch, which keeps them in the same transaction and after the
  * table changes they index.
  */
-function indexRestoreStatements(
+export function indexRestoreStatements(
   desired: NextlySchemaSnapshot,
   dialect: SupportedDialect,
-  affectedTableNames: ReadonlySet<string>
+  statements: readonly string[]
 ): string[] {
-  return (
-    desired.tables
-      // Only tables this apply touched. An untouched table was not rebuilt, so
-      // its indexes are still there, and re-asserting them would put a
-      // `CREATE INDEX` for the whole schema into every apply.
-      .filter(table => affectedTableNames.has(table.name))
-      .flatMap(table =>
-        // `undefined` means "this snapshot never tracked indexes", which is not
-        // the same as "this table has none". Only an explicit list is actionable.
-        (table.indexes ?? []).map(index =>
-          generateSQL(
-            { type: "add_index", tableName: table.name, index },
-            dialect
-          )
+  const rebuilt = rebuiltTableNames(statements);
+  if (rebuilt.size === 0) return [];
+
+  return desired.tables
+    .filter(table => rebuilt.has(table.name))
+    .flatMap(table =>
+      // `undefined` means "this snapshot never tracked indexes", which is not
+      // the same as "this table has none". Only an explicit list is actionable.
+      (table.indexes ?? []).map(index =>
+        generateSQL(
+          { type: "add_index", tableName: table.name, index },
+          dialect
         )
       )
-  );
+    );
 }
 
 export interface PipelineResult {
@@ -956,11 +986,7 @@ export class PushSchemaPipeline {
         // Appended to the same batch, after the table changes they index and
         // inside the same transaction, so a table can never commit without
         // the indexes the desired schema declares for it.
-        const restore = indexRestoreStatements(
-          desiredSnapshot,
-          dialect,
-          affectedTableNames
-        );
+        const restore = indexRestoreStatements(desiredSnapshot, dialect, safe);
 
         try {
           await this.deps.executor.executeStatements(tx, [...safe, ...restore]);

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
@@ -911,7 +911,12 @@ export class PushSchemaPipeline {
         // index. On PG and MySQL that batch is transactional; SQLite runs
         // without a transaction by design, so a failing restore there is
         // reported but the rebuild it followed has already landed.
-        const restore = indexRestoreStatements(desiredSnapshot, dialect, safe);
+        const restore = indexRestoreStatements(
+          desiredSnapshot,
+          dialect,
+          safe,
+          resolvedOps
+        );
 
         try {
           await this.deps.executor.executeStatements(tx, [...safe, ...restore]);

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
@@ -47,6 +47,8 @@ import {
 import { diffSnapshots } from "./diff/diff";
 import { introspectLiveSnapshot } from "./diff/introspect-live";
 import type { Operation, NextlySchemaSnapshot } from "./diff/types";
+// Index restore uses the all-dialect templates, not ddl-emitter/: that module
+// is the PostgreSQL fast path and throws for the dialect this exists for.
 import {
   filterUnsafeStatements,
   findUnexpectedDestructiveStatements,
@@ -74,6 +76,7 @@ import type {
   RenameDetector,
 } from "./pushschema-pipeline-interfaces";
 import type { ClassifierEvent, Resolution } from "./resolution/types";
+import { generateSQL } from "./sql-templates";
 import { withCapturedStdout } from "./stdout-capture";
 import type { DesiredSchema } from "./types";
 
@@ -156,6 +159,52 @@ function applyMakeOptionalToDesired(
       ])
     ),
   };
+}
+
+/**
+ * `CREATE INDEX` for every index the desired schema declares.
+ *
+ * Two things decide what a dynamic table looks like and only one of them
+ * knows about indexes. The diff's desired side comes from
+ * `buildDesiredTableFromFields`, which carries a full `IndexSpec[]`; the
+ * Drizzle tables handed to drizzle-kit come from `generateRuntimeSchema`,
+ * which declares none. drizzle-kit therefore believes every table should have
+ * no secondary index, and on SQLite — where a schema change is applied by
+ * building a new table and copying the rows across — the indexes go with the
+ * table it dropped. Nothing reports it: the push succeeds, the rows are
+ * intact, and the queries just get slower.
+ *
+ * Re-asserting them is what closes the gap. Teaching the generator to declare
+ * them instead would mean passing Drizzle's three-argument table overload a
+ * loosely-typed column record it does not accept, which has no answer that
+ * isn't `any`.
+ *
+ * Pure so the statements can be asserted directly; the caller appends them to
+ * the push batch, which keeps them in the same transaction and after the
+ * table changes they index.
+ */
+function indexRestoreStatements(
+  desired: NextlySchemaSnapshot,
+  dialect: SupportedDialect,
+  affectedTableNames: ReadonlySet<string>
+): string[] {
+  return (
+    desired.tables
+      // Only tables this apply touched. An untouched table was not rebuilt, so
+      // its indexes are still there, and re-asserting them would put a
+      // `CREATE INDEX` for the whole schema into every apply.
+      .filter(table => affectedTableNames.has(table.name))
+      .flatMap(table =>
+        // `undefined` means "this snapshot never tracked indexes", which is not
+        // the same as "this table has none". Only an explicit list is actionable.
+        (table.indexes ?? []).map(index =>
+          generateSQL(
+            { type: "add_index", tableName: table.name, index },
+            dialect
+          )
+        )
+      )
+  );
 }
 
 export interface PipelineResult {
@@ -904,8 +953,17 @@ export class PushSchemaPipeline {
           }
         }
 
+        // Appended to the same batch, after the table changes they index and
+        // inside the same transaction, so a table can never commit without
+        // the indexes the desired schema declares for it.
+        const restore = indexRestoreStatements(
+          desiredSnapshot,
+          dialect,
+          affectedTableNames
+        );
+
         try {
-          await this.deps.executor.executeStatements(tx, safe);
+          await this.deps.executor.executeStatements(tx, [...safe, ...restore]);
         } catch (err) {
           throw new DdlExecutionError(
             err instanceof Error ? err.message : String(err),
@@ -913,6 +971,11 @@ export class PushSchemaPipeline {
           );
         }
 
+        // `safe.length`, not the executed length: this number is the
+        // journal's `statements_executed`, read against `statements_planned`
+        // from the diff. The restore statements were never planned, so
+        // counting them would report a mismatch on every apply that had to
+        // put an index back.
         return safe.length;
       };
 

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
@@ -54,6 +54,7 @@ import {
   findUnexpectedDestructiveStatements,
   getDrizzleTableName,
   isDrizzleTable,
+  rebuiltTableNames,
 } from "./filter-unsafe-statements";
 import { MANAGED_TABLE_PREFIXES_REGEX, isManagedTable } from "./managed-tables";
 import { applyResolutionsToOperations } from "./pre-resolution/apply-resolutions";
@@ -162,32 +163,6 @@ function applyMakeOptionalToDesired(
 }
 
 /**
- * Tables this batch replaces wholesale, read from the statements themselves.
- *
- * SQLite cannot alter most of a column in place, so drizzle-kit applies the
- * change by building `__new_<table>`, copying the rows across, dropping the
- * original and renaming the copy into its place. The closing rename is the
- * reliable marker: `CREATE TABLE "__new_x"` alone can appear in a batch that
- * later fails a guard, whereas the rename only follows a rebuild that ran.
- *
- * Derived from what the apply is about to do rather than from the diff,
- * because "was this table replaced" is a fact about the emitted SQL. An
- * `add_column` on PostgreSQL or MySQL touches the table without replacing it,
- * keeps its indexes, and correctly appears nowhere in this set.
- */
-const SQLITE_REBUILD_RENAME =
-  /ALTER\s+TABLE\s+[`"']?__new_[A-Za-z0-9_]+[`"']?\s+RENAME\s+TO\s+[`"']?([A-Za-z0-9_]+)/i;
-
-function rebuiltTableNames(statements: readonly string[]): Set<string> {
-  const names = new Set<string>();
-  for (const statement of statements) {
-    const match = statement.match(SQLITE_REBUILD_RENAME);
-    if (match) names.add(match[1]);
-  }
-  return names;
-}
-
-/**
  * `CREATE INDEX` for every index the desired schema declares on a table this
  * apply rebuilt.
  *
@@ -224,7 +199,7 @@ export function indexRestoreStatements(
   if (rebuilt.size === 0) return [];
 
   return desired.tables
-    .filter(table => rebuilt.has(table.name))
+    .filter(table => rebuilt.has(table.name.toLowerCase()))
     .flatMap(table =>
       // `undefined` means "this snapshot never tracked indexes", which is not
       // the same as "this table has none". Only an explicit list is actionable.

--- a/packages/nextly/src/schemas/__tests__/core-bundle-parity.test.ts
+++ b/packages/nextly/src/schemas/__tests__/core-bundle-parity.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Every managed core table must be reachable from BOTH maps.
+ *
+ * Two independent structures describe the core schema and they are used for
+ * different halves of the same run: `getCoreSchema` is the desired side of
+ * the diff, and the flat `_dialect-bundles` map is what the apply hands to
+ * drizzle-kit. Declaring a table in the first alone makes it *diffable* but
+ * not *creatable* — the reconcile proposes `add_table` for it on every run,
+ * the push never emits DDL for it, and the table never appears. It converges
+ * on nothing, forever, while reporting success.
+ *
+ * `nextly_i18n_archive` shipped in exactly that state. The per-table
+ * registration tests did not catch it because they assert membership of
+ * `CORE_TABLE_NAMES` and `getCoreSchema` only — which it had — so this
+ * asserts the relationship between the two maps instead of either alone.
+ */
+import { getTableName, isTable } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import { getDialectTables } from "../../database";
+import { CORE_TABLE_NAMES } from "../index";
+
+const DIALECTS = ["postgresql", "mysql", "sqlite"] as const;
+
+/** Table names reachable from a dialect bundle, as the push would see them. */
+function bundleTableNames(dialect: string): Set<string> {
+  const tables = getDialectTables(dialect) as Record<string, unknown>;
+  const names = new Set<string>();
+  for (const value of Object.values(tables)) {
+    if (isTable(value)) names.add(getTableName(value));
+  }
+  return names;
+}
+
+describe.each(DIALECTS)("core table bundle parity (%s)", dialect => {
+  it("exposes every CORE_TABLE_NAMES entry to the apply path", () => {
+    const bundled = bundleTableNames(dialect);
+    const missing = CORE_TABLE_NAMES.filter(name => !bundled.has(name));
+
+    // Named rather than counted: the failure message has to say which table
+    // will silently never be created, because that is the whole symptom.
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/nextly/src/schemas/__tests__/core-bundle-parity.test.ts
+++ b/packages/nextly/src/schemas/__tests__/core-bundle-parity.test.ts
@@ -17,14 +17,26 @@
 import { getTableName, isTable } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 
-import { getDialectTables } from "../../database";
+import * as mysqlBundle from "../_dialect-bundles/mysql";
+import * as postgresBundle from "../_dialect-bundles/postgres";
+import * as sqliteBundle from "../_dialect-bundles/sqlite";
 import { CORE_TABLE_NAMES } from "../index";
+
+// The bundles are imported directly rather than through `getDialectTables`,
+// whose module also re-exports the adapter factory. That barrel pulls adapter
+// build output into anything importing it, which a schema-shape assertion has
+// no need of and which makes the suite depend on a built tree.
+const BUNDLES = {
+  postgresql: postgresBundle,
+  mysql: mysqlBundle,
+  sqlite: sqliteBundle,
+} as const;
 
 const DIALECTS = ["postgresql", "mysql", "sqlite"] as const;
 
 /** Table names reachable from a dialect bundle, as the push would see them. */
-function bundleTableNames(dialect: string): Set<string> {
-  const tables = getDialectTables(dialect) as Record<string, unknown>;
+function bundleTableNames(dialect: keyof typeof BUNDLES): Set<string> {
+  const tables = BUNDLES[dialect] as Record<string, unknown>;
   const names = new Set<string>();
   for (const value of Object.values(tables)) {
     if (isTable(value)) names.add(getTableName(value));

--- a/packages/nextly/src/schemas/_dialect-bundles/mysql.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/mysql.ts
@@ -51,6 +51,11 @@ export { nextlySchemaEventsMysql as nextlySchemaEvents } from "../schema-events/
 // resolve `nextly_versions` (a managed core table) for runtime CRUD.
 export { nextlyVersionsMysql as nextlyVersions } from "../versions/mysql";
 
+// Localization archive; in the bundle so freshPushSchema creates it. Being in
+// getCoreSchema alone only makes it diffable: the apply pushes this map, so a
+// table missing here is proposed on every reconcile and created by none.
+export { nextlyI18nArchive } from "../nextly-i18n-archive/mysql";
+
 // Webhook + event system tables. Must be in this flat bundle (not just
 // getCoreSchema) so freshPushSchema creates them on a fresh database.
 export {

--- a/packages/nextly/src/schemas/_dialect-bundles/postgres.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/postgres.ts
@@ -76,6 +76,11 @@ export { nextlySchemaEventsPg as nextlySchemaEvents } from "../schema-events/pos
 // resolve `nextly_versions` (a managed core table) for runtime CRUD.
 export { nextlyVersionsPg as nextlyVersions } from "../versions/postgres";
 
+// Localization archive; in the bundle so freshPushSchema creates it. Being in
+// getCoreSchema alone only makes it diffable: the apply pushes this map, so a
+// table missing here is proposed on every reconcile and created by none.
+export { nextlyI18nArchive } from "../nextly-i18n-archive/postgres";
+
 // Webhook + event system tables. Must be in this flat bundle (not just
 // getCoreSchema) so freshPushSchema creates them on a fresh database.
 export {

--- a/packages/nextly/src/schemas/_dialect-bundles/sqlite.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/sqlite.ts
@@ -51,6 +51,11 @@ export { nextlySchemaEventsSqlite as nextlySchemaEvents } from "../schema-events
 // resolve `nextly_versions` (a managed core table) for runtime CRUD.
 export { nextlyVersionsSqlite as nextlyVersions } from "../versions/sqlite";
 
+// Localization archive; in the bundle so freshPushSchema creates it. Being in
+// getCoreSchema alone only makes it diffable: the apply pushes this map, so a
+// table missing here is proposed on every reconcile and created by none.
+export { nextlyI18nArchive } from "../nextly-i18n-archive/sqlite";
+
 // Webhook + event system tables. Must be in this flat bundle (not just
 // getCoreSchema) so freshPushSchema creates them on a fresh database.
 export {

--- a/packages/nextly/src/schemas/_internal/drizzle-to-tablespec.ts
+++ b/packages/nextly/src/schemas/_internal/drizzle-to-tablespec.ts
@@ -43,6 +43,12 @@ export function drizzleTableToTableSpec(table: Table): TableSpec {
     type: normalizeDrizzleType(col),
     nullable: !col.notNull,
     default: extractDefault(col),
+    // Recorded so the diff can exempt primary keys from the nullability
+    // comparison. Drizzle sets `primary` on the column for `.primaryKey()`
+    // in every dialect; a composite key declared through the table's extra
+    // config leaves it false, which is correct here — this exemption is
+    // about the single-column form the dialects render inconsistently.
+    ...(col.primary === true ? { primaryKey: true } : {}),
   }));
 
   return { name, columns };

--- a/packages/nextly/src/schemas/_internal/drizzle-to-tablespec.ts
+++ b/packages/nextly/src/schemas/_internal/drizzle-to-tablespec.ts
@@ -117,12 +117,48 @@ function extractDefault(col: { default?: unknown }): string | undefined {
   ) {
     return String(value);
   }
-  // SQL-expression defaults arrive as objects (or, rarely, functions/symbols);
-  // these have no meaningful primitive coercion (`String({})` →
-  // "[object Object]"), so serialize them deterministically instead.
+  // A Drizzle `sql` default renders to the text the database will store, so
+  // the desired side can be compared with what introspection reads back. A
+  // column declared `.default(sql`(unixepoch())`)` is reported by SQLite as
+  // `(unixepoch())`; serialising the object instead produced a JSON blob that
+  // could never equal it, so the column emitted a default change on every
+  // diff and the reconcile never converged.
+  const rendered = renderSqlChunks(value);
+  if (rendered !== undefined) return rendered;
+
+  // Anything else (functions, symbols, parameterised SQL) has no meaningful
+  // primitive coercion, so serialize deterministically. That will not match
+  // the live side, which costs a spurious op — the direction this pipeline
+  // chooses over silently treating two different defaults as equal.
   try {
     return JSON.stringify(value);
   } catch {
     return undefined;
   }
+}
+
+/**
+ * The SQL text of a Drizzle `sql` template, when it is entirely static.
+ *
+ * Drizzle holds a template as `queryChunks`; a chunk carrying a `value` array
+ * of strings is literal SQL. Every chunk being literal means the whole
+ * template is the text it spells, which is what the database stores and what
+ * introspection reads back.
+ *
+ * Returns `undefined` for a template with a bound parameter. Those cannot be
+ * rendered to the stored text without knowing how the dialect inlines them,
+ * and guessing would compare two different defaults equal.
+ */
+function renderSqlChunks(value: object): string | undefined {
+  const chunks = (value as { queryChunks?: unknown }).queryChunks;
+  if (!Array.isArray(chunks) || chunks.length === 0) return undefined;
+
+  const parts: string[] = [];
+  for (const chunk of chunks) {
+    const chunkValue = (chunk as { value?: unknown }).value;
+    if (!Array.isArray(chunkValue)) return undefined;
+    if (!chunkValue.every(part => typeof part === "string")) return undefined;
+    parts.push(chunkValue.join(""));
+  }
+  return parts.join("");
 }

--- a/packages/nextly/src/schemas/nextly-i18n-archive/__tests__/archive-index-repair.integration.test.ts
+++ b/packages/nextly/src/schemas/nextly-i18n-archive/__tests__/archive-index-repair.integration.test.ts
@@ -57,20 +57,14 @@ describeMysql("mysql archive index repair", () => {
   it("recreates a lookup index the table is missing", async () => {
     const db = connection!;
 
-    // The state in question: the table exists, the index does not. Reached in
-    // practice by an ensure that died between the old table and index
-    // statements, or by the index being dropped.
-    await db.query(
-      `CREATE TABLE \`${TABLE}\` (
-        \`id\` BIGINT AUTO_INCREMENT PRIMARY KEY,
-        \`collection\` VARCHAR(191) NOT NULL,
-        \`entry_id\` VARCHAR(191) NOT NULL,
-        \`locale\` VARCHAR(20) NOT NULL,
-        \`field\` VARCHAR(191) NOT NULL,
-        \`value\` LONGTEXT,
-        \`archived_at\` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
-      )`
-    );
+    // Built from the production DDL and then stripped of its index, rather
+    // than hand-written here: a copied CREATE TABLE drifts from the helper it
+    // is meant to exercise, and this test would go on passing against a shape
+    // production no longer creates.
+    for (const statement of getI18nArchiveDdl("mysql")) {
+      await db.query(statement);
+    }
+    await db.query(`ALTER TABLE \`${TABLE}\` DROP INDEX \`${INDEX}\``);
     expect(await indexExists()).toBe(false);
 
     // Exactly what the dispatchers run when a localization disable needs the

--- a/packages/nextly/src/schemas/nextly-i18n-archive/__tests__/archive-index-repair.integration.test.ts
+++ b/packages/nextly/src/schemas/nextly-i18n-archive/__tests__/archive-index-repair.integration.test.ts
@@ -1,27 +1,27 @@
 /**
- * A MySQL archive table missing its lookup index gets it back.
+ * A MySQL archive table missing its lookup index gets it back on the next
+ * ensure.
  *
- * The bootstrap DDL declares the index inside `CREATE TABLE IF NOT EXISTS`
- * rather than as a following `CREATE INDEX`, because MySQL has no
- * `CREATE INDEX IF NOT EXISTS` and the separate statement failed with a
- * duplicate key name on every ensure after the first. Inline, re-running the
- * bootstrap is a no-op — but so is the index creation, which raises the fair
- * question of what repairs a table that exists without the index.
+ * The bootstrap declares the index inside `CREATE TABLE IF NOT EXISTS`,
+ * because MySQL has no `CREATE INDEX IF NOT EXISTS` and a separate statement
+ * failed with a duplicate key name on every ensure after the first. MySQL
+ * skips that whole statement when the table exists, though, so the inline
+ * form cannot restore an index that went missing.
  *
- * The answer is that the archive is now a bundle-managed core table, so the
- * push reconciles its indexes like any other. That is strictly more general
- * than the statement it replaced: it also repairs an index dropped later,
- * which an unconditional `CREATE INDEX` never could — that could only ever
- * fail against a table already carrying one.
+ * Nothing else covers it either: `drizzleTableToTableSpec` records names and
+ * columns only, so index-only drift produces no operations and the reconcile
+ * returns before any push. The ensure path therefore carries an explicit
+ * repair, attempted and tolerated rather than checked first, which is the same
+ * tolerance the schema executor already applies.
  *
- * This asserts that, so the claim cannot quietly stop being true.
+ * PostgreSQL and SQLite need none of this — their bootstrap emits
+ * `CREATE INDEX IF NOT EXISTS` beside the table — so the repair is null there.
  */
-import { createRequire } from "node:module";
-
 import mysql from "mysql2/promise";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { nextlyI18nArchive } from "../mysql";
+import { isIdempotencyError } from "../../../domains/schema/pipeline/sql-statement-utils";
+import { getI18nArchiveDdl, getI18nArchiveIndexRepairDdl } from "../ddl";
 
 const MYSQL_URL = process.env.TEST_MYSQL_URL ?? "";
 const TABLE = "nextly_i18n_archive";
@@ -73,27 +73,34 @@ describeMysql("mysql archive index repair", () => {
     );
     expect(await indexExists()).toBe(false);
 
-    const kit = createRequire(import.meta.url)("drizzle-kit/payload/mysql") as {
-      pushSchema: (
-        schema: Record<string, unknown>,
-        client: { query: <T>(sql: string, params?: unknown[]) => Promise<T[]> },
-        databaseName?: string
-      ) => Promise<{ apply: () => Promise<void> }>;
+    // Exactly what the dispatchers run when a localization disable needs the
+    // archive: the bootstrap, then the repair.
+    const ensure = async (): Promise<void> => {
+      for (const statement of getI18nArchiveDdl("mysql")) {
+        await db.query(statement);
+      }
+      const repair = getI18nArchiveIndexRepairDdl("mysql");
+      if (!repair) return;
+      try {
+        await db.query(repair);
+      } catch (err) {
+        if (!isIdempotencyError(err)) throw err;
+      }
     };
 
-    const databaseName = new URL(MYSQL_URL).pathname.replace(/^\//, "");
-    const result = await kit.pushSchema(
-      { nextlyI18nArchive },
-      {
-        query: async <T>(sql: string, params: unknown[] = []): Promise<T[]> => {
-          const [rows] = await db.query(sql, params);
-          return rows as T[];
-        },
-      },
-      databaseName
-    );
-    await result.apply();
-
+    await ensure();
     expect(await indexExists()).toBe(true);
+
+    // And the ensure stays safe to repeat, which is what broke before the
+    // index moved inline.
+    await ensure();
+    await ensure();
+    expect(await indexExists()).toBe(true);
+  });
+
+  it("has no repair statement for the dialects that self-repair", () => {
+    // Their bootstrap emits CREATE INDEX IF NOT EXISTS beside the table.
+    expect(getI18nArchiveIndexRepairDdl("postgresql")).toBeNull();
+    expect(getI18nArchiveIndexRepairDdl("sqlite")).toBeNull();
   });
 });

--- a/packages/nextly/src/schemas/nextly-i18n-archive/__tests__/archive-index-repair.integration.test.ts
+++ b/packages/nextly/src/schemas/nextly-i18n-archive/__tests__/archive-index-repair.integration.test.ts
@@ -1,0 +1,99 @@
+/**
+ * A MySQL archive table missing its lookup index gets it back.
+ *
+ * The bootstrap DDL declares the index inside `CREATE TABLE IF NOT EXISTS`
+ * rather than as a following `CREATE INDEX`, because MySQL has no
+ * `CREATE INDEX IF NOT EXISTS` and the separate statement failed with a
+ * duplicate key name on every ensure after the first. Inline, re-running the
+ * bootstrap is a no-op — but so is the index creation, which raises the fair
+ * question of what repairs a table that exists without the index.
+ *
+ * The answer is that the archive is now a bundle-managed core table, so the
+ * push reconciles its indexes like any other. That is strictly more general
+ * than the statement it replaced: it also repairs an index dropped later,
+ * which an unconditional `CREATE INDEX` never could — that could only ever
+ * fail against a table already carrying one.
+ *
+ * This asserts that, so the claim cannot quietly stop being true.
+ */
+import { createRequire } from "node:module";
+
+import mysql from "mysql2/promise";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { nextlyI18nArchive } from "../mysql";
+
+const MYSQL_URL = process.env.TEST_MYSQL_URL ?? "";
+const TABLE = "nextly_i18n_archive";
+const INDEX = "nextly_i18n_archive_lookup_idx";
+
+// Dialect gate: skipped when the dialect's URL is unset.
+const describeMysql = describe.skipIf(!MYSQL_URL);
+
+let connection: mysql.Connection | undefined;
+
+beforeAll(async () => {
+  if (!MYSQL_URL) return;
+  connection = await mysql.createConnection(MYSQL_URL);
+  // A fixed-name system table, so start from a known state rather than
+  // whatever an earlier suite in this shared run left behind.
+  await connection.query(`DROP TABLE IF EXISTS \`${TABLE}\``);
+});
+
+afterAll(async () => {
+  await connection?.query(`DROP TABLE IF EXISTS \`${TABLE}\``);
+  await connection?.end();
+});
+
+async function indexExists(): Promise<boolean> {
+  const [rows] = await connection!.query(
+    `SHOW INDEX FROM \`${TABLE}\` WHERE Key_name = ?`,
+    [INDEX]
+  );
+  return Array.isArray(rows) && rows.length > 0;
+}
+
+describeMysql("mysql archive index repair", () => {
+  it("recreates a lookup index the table is missing", async () => {
+    const db = connection!;
+
+    // The state in question: the table exists, the index does not. Reached in
+    // practice by an ensure that died between the old table and index
+    // statements, or by the index being dropped.
+    await db.query(
+      `CREATE TABLE \`${TABLE}\` (
+        \`id\` BIGINT AUTO_INCREMENT PRIMARY KEY,
+        \`collection\` VARCHAR(191) NOT NULL,
+        \`entry_id\` VARCHAR(191) NOT NULL,
+        \`locale\` VARCHAR(20) NOT NULL,
+        \`field\` VARCHAR(191) NOT NULL,
+        \`value\` LONGTEXT,
+        \`archived_at\` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+      )`
+    );
+    expect(await indexExists()).toBe(false);
+
+    const kit = createRequire(import.meta.url)("drizzle-kit/payload/mysql") as {
+      pushSchema: (
+        schema: Record<string, unknown>,
+        client: { query: <T>(sql: string, params?: unknown[]) => Promise<T[]> },
+        databaseName?: string
+      ) => Promise<{ apply: () => Promise<void> }>;
+    };
+
+    const databaseName = new URL(MYSQL_URL).pathname.replace(/^\//, "");
+    const result = await kit.pushSchema(
+      { nextlyI18nArchive },
+      {
+        query: async <T>(sql: string, params: unknown[] = []): Promise<T[]> => {
+          const [rows] = await db.query(sql, params);
+          return rows as T[];
+        },
+      },
+      databaseName
+    );
+    await result.apply();
+
+    expect(await indexExists()).toBe(true);
+  });
+});

--- a/packages/nextly/src/schemas/nextly-i18n-archive/ddl.ts
+++ b/packages/nextly/src/schemas/nextly-i18n-archive/ddl.ts
@@ -71,3 +71,25 @@ export function getI18nArchiveDdl(dialect: Dialect): string[] {
     }
   }
 }
+
+/**
+ * The standalone lookup-index statement, for dialects whose table DDL cannot
+ * repair a missing index on its own.
+ *
+ * PostgreSQL and SQLite emit `CREATE INDEX IF NOT EXISTS` alongside the table,
+ * so re-running their bootstrap restores an index that went missing. MySQL has
+ * no such form: its index is declared inside `CREATE TABLE IF NOT EXISTS`, and
+ * MySQL skips that statement entirely when the table exists, so nothing there
+ * can put the index back.
+ *
+ * Nor does the reconcile cover it. `drizzleTableToTableSpec` records only
+ * names and columns, so index-only drift produces no operations, and
+ * `reconcileCore` returns early when there are none — the push that would
+ * repair the index is never reached.
+ *
+ * Returns `null` where the table DDL already repairs itself.
+ */
+export function getI18nArchiveIndexRepairDdl(dialect: Dialect): string | null {
+  if (dialect !== "mysql") return null;
+  return `CREATE INDEX \`nextly_i18n_archive_lookup_idx\` ON \`nextly_i18n_archive\` (\`collection\`, \`entry_id\`, \`locale\`)`;
+}

--- a/packages/nextly/src/schemas/nextly-i18n-archive/ddl.ts
+++ b/packages/nextly/src/schemas/nextly-i18n-archive/ddl.ts
@@ -30,6 +30,13 @@ export function getI18nArchiveDdl(dialect: Dialect): string[] {
         `CREATE INDEX IF NOT EXISTS "nextly_i18n_archive_lookup_idx" ON "nextly_i18n_archive" ("collection", "entry_id", "locale")`,
       ];
     case "mysql":
+      // The lookup index is declared inside CREATE TABLE rather than as a
+      // following CREATE INDEX. MySQL has no CREATE INDEX IF NOT EXISTS, so a
+      // separate statement re-runs against a table that already has the index
+      // and fails with a duplicate key name — which every localization-disable
+      // after the first would hit, and which the first one hits now that the
+      // table can also arrive from the dialect bundle. Inline, the whole thing
+      // is covered by IF NOT EXISTS and re-running is a no-op.
       return [
         `CREATE TABLE IF NOT EXISTS \`nextly_i18n_archive\` (
   \`id\` BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -38,9 +45,9 @@ export function getI18nArchiveDdl(dialect: Dialect): string[] {
   \`locale\` VARCHAR(20) NOT NULL,
   \`field\` VARCHAR(191) NOT NULL,
   \`value\` LONGTEXT,
-  \`archived_at\` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+  \`archived_at\` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  INDEX \`nextly_i18n_archive_lookup_idx\` (\`collection\`, \`entry_id\`, \`locale\`)
 )`,
-        `CREATE INDEX \`nextly_i18n_archive_lookup_idx\` ON \`nextly_i18n_archive\` (\`collection\`, \`entry_id\`, \`locale\`)`,
       ];
     case "sqlite":
       return [

--- a/packages/nextly/src/schemas/nextly-i18n-archive/index.ts
+++ b/packages/nextly/src/schemas/nextly-i18n-archive/index.ts
@@ -5,7 +5,7 @@ import * as pg from "./postgres";
 import * as sl from "./sqlite";
 
 export { pg, my, sl };
-export { getI18nArchiveDdl } from "./ddl";
+export { getI18nArchiveDdl, getI18nArchiveIndexRepairDdl } from "./ddl";
 
 /** Returns the `nextly_i18n_archive` table binding for the given dialect. */
 export function nextlyI18nArchiveTables(dialect: SupportedDialect) {

--- a/packages/nextly/src/schemas/nextly-i18n-archive/mysql.ts
+++ b/packages/nextly/src/schemas/nextly-i18n-archive/mysql.ts
@@ -3,8 +3,8 @@ import {
   mysqlTable,
   bigint,
   varchar,
-  text,
   datetime,
+  longtext,
   index,
 } from "drizzle-orm/mysql-core";
 
@@ -20,7 +20,12 @@ export const nextlyI18nArchive = mysqlTable(
     entryId: varchar("entry_id", { length: 191 }).notNull(),
     locale: varchar("locale", { length: 20 }).notNull(),
     field: varchar("field", { length: 191 }).notNull(),
-    value: text("value"),
+    // LONGTEXT, matching the bootstrap DDL. A localized rich-text or JSON
+    // field can exceed TEXT's 64KB, and this table is the recoverable backup
+    // taken when localization is disabled — truncating here loses the data it
+    // exists to preserve. Declaring TEXT would also reconcile an existing
+    // LONGTEXT archive down to TEXT on the next push.
+    value: longtext("value"),
     // The localization-disable path archives with a raw `INSERT ... SELECT`
     // that names no `archived_at`, so the column needs a default the database
     // applies — matching `getI18nArchiveDdl`, which has always created this

--- a/packages/nextly/src/schemas/nextly-i18n-archive/mysql.ts
+++ b/packages/nextly/src/schemas/nextly-i18n-archive/mysql.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import {
   mysqlTable,
   bigint,
@@ -20,7 +21,13 @@ export const nextlyI18nArchive = mysqlTable(
     locale: varchar("locale", { length: 20 }).notNull(),
     field: varchar("field", { length: 191 }).notNull(),
     value: text("value"),
-    archivedAt: datetime("archived_at", { fsp: 3 }).notNull(),
+    // The localization-disable path archives with a raw `INSERT ... SELECT`
+    // that names no `archived_at`, so the column needs a default the database
+    // applies — matching `getI18nArchiveDdl`, which has always created this
+    // table with `DEFAULT CURRENT_TIMESTAMP(3)`.
+    archivedAt: datetime("archived_at", { fsp: 3 })
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP(3)`),
   },
   t => [
     index("nextly_i18n_archive_lookup_idx").on(

--- a/packages/nextly/src/schemas/nextly-i18n-archive/sqlite.ts
+++ b/packages/nextly/src/schemas/nextly-i18n-archive/sqlite.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { sqliteTable, integer, text, index } from "drizzle-orm/sqlite-core";
 
 /**
@@ -13,8 +14,14 @@ export const nextlyI18nArchive = sqliteTable(
     locale: text("locale").notNull(),
     field: text("field").notNull(),
     value: text("value"),
+    // `$defaultFn` alone fills the column only on inserts that go through
+    // Drizzle. The localization-disable path archives with a raw
+    // `INSERT ... SELECT` that names no `archived_at`, so the column needs a
+    // default the database itself applies — matching `getI18nArchiveDdl`,
+    // which has always created this table with `DEFAULT (unixepoch())`.
     archivedAt: integer("archived_at", { mode: "timestamp" })
       .notNull()
+      .default(sql`(unixepoch())`)
       .$defaultFn(() => new Date()),
   },
   t => [


### PR DESCRIPTION
Closes the P0 and P1 schema defects. Four faults, one mechanism.

## The mechanism

Two comparisons could never converge, so the reconcile never saw a clean database and kept rebuilding tables to settle them. On SQLite a rebuild is how indexes get lost. Every unnecessary op therefore had a real cost.

**1. Primary-key nullability.** SQLite writes `id text PRIMARY KEY` with no `NOT NULL` (only `INTEGER PRIMARY KEY` is implicitly non-null there) and reports it back as nullable, while the desired side calls it required. No `ALTER` on SQLite adds `NOT NULL` to an existing column, so the op was proposed on every run, forever.

A primary key's nullability is not an independent attribute — it follows from being the primary key, and the dialects differ only in whether they write it down. The diff no longer compares it. `ColumnSpec` gains `primaryKey?: boolean`, populated from the Drizzle column; introspected and pre-existing snapshots leave it undefined, which costs only the exemption and never produces a wrong op.

**2. String defaults, on every dialect.** The live side reads the DDL (`'pending'`); the desired side reads the Drizzle column, whose default is the JavaScript string (`pending`). `normalizeDefault` stripped PG's `::type` casts but never the quotes, so `'draft'::text` normalised to `'draft'` and still did not equal `draft`.

This was **not** SQLite-only — I found it while sweeping and it affects Postgres identically. `normalizeDefault` now unwraps a fully-quoted literal. A literal containing a quote is left alone: both PG and SQLite escape by doubling, and a wrong unwrap would compare two different values equal, which is the one failure this module must not have.

**3. Indexes lost on rebuild (the P0).** Two things decide what a dynamic table looks like and only one knows about indexes: the diff's desired side carries a full `IndexSpec[]`, while the Drizzle tables handed to drizzle-kit come from `generateRuntimeSchema`, which declares none. So the rebuild's replacement table has no indexes and drizzle-kit sees no reason to add any.

Declared indexes are now re-asserted after the push, appended to the same batch so they run in the same transaction and after the changes they index, scoped to the tables the apply actually touched. Teaching the generator to declare them instead would mean handing Drizzle's three-argument table overload a loosely-typed column record it does not accept, which has no answer that isn't `any`.

**4. `nextly_i18n_archive` never created.** It is in `getCoreSchema` (which the diff reads) but was missing from the `_dialect-bundles` map (which the apply pushes). Declaring a table in the first alone makes it diffable, not creatable — so it was proposed every run and created by none. `nextly_versions` proves the rule: same shape, in both maps, created fine.

The **parity test** is the more valuable half: it asserts `CORE_TABLE_NAMES` is reachable from the apply map for all three dialects. The existing per-table registration tests could not catch this because they assert `CORE_TABLE_NAMES` and `getCoreSchema` membership only — which this table had.

## Measured, not argued

Enumerated every op against two real databases, before and after:

| database | before | after |
|---|---|---|
| pre-upgrade fixture | 23 ops | **9** — 7 `add_column` + 2 `add_table`, all genuine |
| current playground DB | 45 ops | **1** — the archive table, now creatable |

After that one op applies, the reconcile reports no changes, which it had never done.

## Verification

Every fix reverted and re-run to confirm it was load-bearing:

- parity test: without the bundle export → fails naming `nextly_i18n_archive`
- index restore: with the filter forced empty → `expected 0 to be greater than 0`
- PK exemption: with the guard removed → 2 of 3 tests fail

Failure sets compared against clean `main` across `src/domains/schema`, `src/init`, `src/schemas`: **11 on main, 11 on this branch, identical set — zero introduced.** The pre-existing 11 are the known baseline (number/json type mapping, layout-only fields, toggle defaults) and are untouched here.

`pnpm --filter nextly check-types` passes; eslint clean.

## Notes for review

`statementsExecuted` deliberately still returns `safe.length`, excluding restore statements. That number is the journal's `statements_executed`, read against `statements_planned` from the diff; restores were never planned, so counting them would report a mismatch on every apply that put an index back.

The SQLite rebuild test now asserts the restore rather than a bare statement count — that test is the canonical scenario for this bug, so it should document the fix.

## Still open, deliberately not here

Nextly creates SQLite tables with **nullable primary keys**, because drizzle-kit `1.0.0-rc.4` stopped emitting `NOT NULL` for them. I verified `.notNull()` in the schema makes no difference — the emitter drops it either way. This PR stops that mismatch from causing damage; it does not restore the constraint. That needs either a patched drizzle-kit or Nextly owning core-table DDL, and is a separate decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schema synchronization now restores secondary indexes after SQLite table rebuilds.
  * Localization archive is bundled across supported dialects to ensure it’s created/managed during schema application.
* **Bug Fixes**
  * Schema diffs now correctly ignore primary-key nullability mismatches to prevent unnecessary nullable-change operations.
  * Default normalization now more reliably handles quoted string literals and cast/quoting edge cases.
  * Localization archive `archived_at` defaults were aligned to database-side behavior (including MySQL/SQLite), and MySQL DDL now defines the lookup index inline.
* **Tests**
  * Expanded coverage for index restoration, primary-key nullability handling, default normalization, and dialect bundle parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->