### PR TITLE
feat: name a version so history reads by meaning, not by number

### DIFF
--- a/.changeset/version-labels.md
+++ b/.changeset/version-labels.md
@@ -1,0 +1,30 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Versions can be given a name.
+
+Version history identified everything by number, so finding the state you meant
+to go back to involved opening several and reading them. A version can now be
+named — "before the redesign" — from the history panel, and the name shows in
+the list alongside the number. Clearing the name puts it back to the number.
+
+Renaming needs the same permissions as viewing history plus editing the
+document, so it is not a way to annotate content you cannot otherwise change.

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -93,6 +93,10 @@ export function VersionHistorySheet({
     if (!open) {
       setSelected(null);
       setConfirmingRestore(false);
+      // The rename dialog is mounted outside the panel, so closing the panel
+      // does not close it. Left set, it would stay on screen over a dismissed
+      // panel, or reappear the moment the panel was reopened.
+      setRenaming(null);
     }
   }, [open]);
 
@@ -209,7 +213,10 @@ export function VersionHistorySheet({
                   version={version}
                   active={selected === version.versionNo}
                   onSelect={setSelected}
-                  onRename={setRenaming}
+                  // Renaming writes to the document's history, which needs the
+                  // same permission restoring does. Offering it to a read-only
+                  // caller would open a dialog whose save the route rejects.
+                  onRename={canRestore ? setRenaming : undefined}
                 />
               ))}
 

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -289,6 +289,10 @@ export function VersionHistorySheet({
           body so its lifecycle is independent of the panel's. */}
       {renaming !== null ? (
         <VersionLabelDialog
+          // A fresh dialog per version: the input seeds from its initial props
+          // and never resyncs, so a new version needs a new instance rather
+          // than an effect that would also clobber an in-progress edit.
+          key={renaming}
           open
           onOpenChange={open => {
             if (!open) setRenaming(null);

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -25,6 +25,7 @@ import {
 } from "@admin/components/ui";
 import {
   useRestoreVersion,
+  useSetVersionLabel,
   useVersion,
   useVersions,
 } from "@admin/hooks/queries/useVersions";
@@ -32,6 +33,7 @@ import { apiErrorMessage } from "@admin/lib/api/parseApiError";
 import type { VersionScope } from "@admin/services/versionApi";
 
 import { RestoreConfirmDialog } from "./RestoreConfirmDialog";
+import { VersionLabelDialog } from "./VersionLabelDialog";
 import { VersionPreview } from "./VersionPreview";
 import { VersionRow } from "./VersionRow";
 
@@ -81,6 +83,9 @@ export function VersionHistorySheet({
 }: VersionHistorySheetProps) {
   const [selected, setSelected] = useState<number | null>(null);
   const [confirmingRestore, setConfirmingRestore] = useState(false);
+  // The version being renamed, which is not necessarily the one being previewed
+  // — an editor can name a row without opening it.
+  const [renaming, setRenaming] = useState<number | null>(null);
 
   // Reopening the panel should start at the list. Without this the previously
   // previewed version would still be showing, which reads as a stale panel.
@@ -122,6 +127,29 @@ export function VersionHistorySheet({
   });
 
   const versions = list.data?.pages.flatMap(page => page.items) ?? [];
+
+  // The row being renamed, so the dialog opens seeded with its current name
+  // rather than blank.
+  const renamingVersion =
+    renaming === null
+      ? null
+      : (versions.find(v => v.versionNo === renaming) ?? null);
+
+  const setLabel = useSetVersionLabel({
+    scope,
+    onSuccess: result => {
+      setRenaming(null);
+      toast.success(
+        result.item.label === null
+          ? "Name removed."
+          : `Version named "${result.item.label}".`
+      );
+    },
+    onError: error => {
+      // The dialog stays open so the typed name is not lost to a failed save.
+      toast.error(apiErrorMessage(error) || "Could not rename this version.");
+    },
+  });
   const isEmpty = !list.isLoading && !list.isError && versions.length === 0;
 
   return (
@@ -179,7 +207,9 @@ export function VersionHistorySheet({
                 <VersionRow
                   key={version.id}
                   version={version}
+                  active={selected === version.versionNo}
                   onSelect={setSelected}
+                  onRename={setRenaming}
                 />
               ))}
 
@@ -252,6 +282,21 @@ export function VersionHistorySheet({
           isPublished={liveStatus === "published"}
           isRestoring={restore.isPending}
           onConfirm={() => restore.mutate(selected)}
+        />
+      ) : null}
+
+      {/* Mounted on the same terms as the restore dialog: outside the panel
+          body so its lifecycle is independent of the panel's. */}
+      {renaming !== null ? (
+        <VersionLabelDialog
+          open
+          onOpenChange={open => {
+            if (!open) setRenaming(null);
+          }}
+          versionNo={renaming}
+          currentLabel={renamingVersion?.label ?? null}
+          saving={setLabel.isPending}
+          onSubmit={label => setLabel.mutate({ versionNo: renaming, label })}
         />
       ) : null}
     </Sheet>

--- a/packages/admin/src/components/features/versions/VersionLabelDialog.tsx
+++ b/packages/admin/src/components/features/versions/VersionLabelDialog.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+/**
+ * Name a version, or clear its name.
+ *
+ * A dialog rather than an inline field: every rename in this admin is a dialog,
+ * and a history row is a single click target whose job is opening a version —
+ * putting an editable field inside it would compete with that.
+ *
+ * @module components/features/versions/VersionLabelDialog
+ */
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+} from "@nextlyhq/ui";
+import * as React from "react";
+
+/**
+ * Matches the server's bound. Enforced there too — this only spares the user a
+ * round trip to find out.
+ */
+const MAX_LABEL_LENGTH = 100;
+
+export interface VersionLabelDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The version being named, for the title and the confirm copy. */
+  versionNo: number | null;
+  /** Its current name, or null when it has none. */
+  currentLabel: string | null;
+  saving?: boolean;
+  /** `null` clears the name. */
+  onSubmit: (label: string | null) => void;
+}
+
+export function VersionLabelDialog({
+  open,
+  onOpenChange,
+  versionNo,
+  currentLabel,
+  saving = false,
+  onSubmit,
+}: VersionLabelDialogProps) {
+  const [value, setValue] = React.useState("");
+
+  // Reseed whenever the dialog opens on a different version, so reopening never
+  // shows the name of the one edited before it.
+  React.useEffect(() => {
+    if (open) setValue(currentLabel ?? "");
+  }, [open, versionNo, currentLabel]);
+
+  const trimmed = value.trim();
+  const hadLabel = currentLabel !== null && currentLabel !== "";
+  // Submitting an empty field clears the name. That is only a change when there
+  // was one to clear, which is also what stops an empty form saving nothing.
+  const isClearing = trimmed.length === 0;
+  const unchanged = trimmed === (currentLabel ?? "");
+  const tooLong = trimmed.length > MAX_LABEL_LENGTH;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (saving || unchanged || tooLong) return;
+    onSubmit(isClearing ? null : trimmed);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>
+              {hadLabel ? "Rename" : "Name"} version {versionNo}
+            </DialogTitle>
+            <DialogDescription>
+              A name makes a version easier to find later than its number. Leave
+              this empty to remove the name.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2 py-4">
+            <Label htmlFor="version-label">Name</Label>
+            <Input
+              id="version-label"
+              value={value}
+              autoFocus
+              maxLength={MAX_LABEL_LENGTH}
+              onChange={e => setValue(e.target.value)}
+              placeholder="e.g. before the redesign"
+              aria-describedby="version-label-hint"
+            />
+            <p
+              id="version-label-hint"
+              className="text-xs text-muted-foreground"
+            >
+              {isClearing && hadLabel
+                ? "This will remove the current name."
+                : `${trimmed.length} of ${MAX_LABEL_LENGTH} characters.`}
+            </p>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={saving}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={saving || unchanged || tooLong}>
+              {saving ? "Saving..." : isClearing ? "Remove name" : "Save"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/admin/src/components/features/versions/VersionLabelDialog.tsx
+++ b/packages/admin/src/components/features/versions/VersionLabelDialog.tsx
@@ -49,13 +49,16 @@ export function VersionLabelDialog({
   saving = false,
   onSubmit,
 }: VersionLabelDialogProps) {
-  const [value, setValue] = React.useState("");
-
-  // Reseed whenever the dialog opens on a different version, so reopening never
-  // shows the name of the one edited before it.
-  React.useEffect(() => {
-    if (open) setValue(currentLabel ?? "");
-  }, [open, versionNo, currentLabel]);
+  // Seeded once, from the name the version had when this dialog was opened.
+  //
+  // Deliberately NOT resynced afterwards. The history list refetches — a rename
+  // invalidates it — and reseeding on every change would wipe what the user was
+  // part-way through typing, or worse, silently swap it for someone else's
+  // edit and let them submit that instead.
+  //
+  // Reopening on a different version is handled by mounting a fresh dialog per
+  // version rather than by an effect, so there is no stale draft to carry over.
+  const [value, setValue] = React.useState(() => currentLabel ?? "");
 
   const trimmed = value.trim();
   const hadLabel = currentLabel !== null && currentLabel !== "";

--- a/packages/admin/src/components/features/versions/VersionLabelDialog.tsx
+++ b/packages/admin/src/components/features/versions/VersionLabelDialog.tsx
@@ -60,12 +60,18 @@ export function VersionLabelDialog({
   // version rather than by an effect, so there is no stale draft to carry over.
   const [value, setValue] = React.useState(() => currentLabel ?? "");
 
+  // The baseline is frozen alongside the draft. Comparing against the LIVE
+  // prop would let a refetch reporting someone else's rename turn an untouched
+  // field into a submittable change — enabling Save on a value this user never
+  // typed, and overwriting the newer name with the one they opened.
+  const [baseline] = React.useState(() => currentLabel);
+
   const trimmed = value.trim();
-  const hadLabel = currentLabel !== null && currentLabel !== "";
+  const hadLabel = baseline !== null && baseline !== "";
   // Submitting an empty field clears the name. That is only a change when there
   // was one to clear, which is also what stops an empty form saving nothing.
   const isClearing = trimmed.length === 0;
-  const unchanged = trimmed === (currentLabel ?? "");
+  const unchanged = trimmed === (baseline ?? "");
   const tooLong = trimmed.length > MAX_LABEL_LENGTH;
 
   const handleSubmit = (e: React.FormEvent) => {

--- a/packages/admin/src/components/features/versions/VersionRow.tsx
+++ b/packages/admin/src/components/features/versions/VersionRow.tsx
@@ -7,6 +7,8 @@
  * @module components/features/versions/VersionRow
  */
 
+import { Pencil } from "lucide-react";
+
 import { formatRelativeTime } from "@admin/components/features/notifications/relative-time";
 import { Badge } from "@admin/components/ui";
 import { formatDateTime } from "@admin/lib/dates/format";
@@ -18,56 +20,99 @@ export interface VersionRowProps {
   /** Highlighted because it is the version currently being previewed. */
   active?: boolean;
   onSelect: (versionNo: number) => void;
+  /** Omitted when the caller cannot rename, which hides the affordance. */
+  onRename?: (versionNo: number) => void;
 }
 
 export function VersionRow({
   version,
   active = false,
   onSelect,
+  onRename,
 }: VersionRowProps) {
   // A version with no number is an autosave and cannot be addressed on its own,
-  // so it is shown but not offered as something to open.
+  // so it is shown but not offered as something to open — or to name.
   const selectable = typeof version.versionNo === "number";
 
-  const label = selectable ? `Version ${version.versionNo}` : "Autosave";
+  // What the row is called. `version.label` is the editor's own name for it;
+  // the number is the fallback, and stays visible either way so two versions
+  // sharing a name are still tellable apart.
+  const ordinal = selectable ? `Version ${version.versionNo}` : "Autosave";
+  const named = version.label !== null && version.label !== "";
+  const title = named ? (version.label as string) : ordinal;
 
   // Attribution is absent for a system write rather than missing, so it reads
   // as "nobody signed this" instead of looking like a failed lookup.
   const author = version.author?.name ?? "Unknown author";
 
+  const canRename = selectable && onRename !== undefined;
+
   return (
-    <button
-      type="button"
-      disabled={!selectable}
-      onClick={() => selectable && onSelect(version.versionNo as number)}
-      aria-label={`${label}, ${version.status}, by ${author}`}
-      aria-current={active ? "true" : undefined}
+    // A row is not a single button: the rename control has to sit beside the
+    // open control rather than inside it, or it would be a nested interactive
+    // element — invalid, and unreachable in the tab order.
+    <div
       className={cn(
-        "w-full text-left px-4 py-3 border-b border-border last:border-b-0",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-        selectable ? "hover:bg-muted cursor-pointer" : "cursor-default",
+        "relative flex items-stretch border-b border-border last:border-b-0",
         active && "bg-primary/5"
       )}
     >
-      <div className="flex items-center gap-2">
-        <span className="text-sm font-medium text-foreground truncate">
-          {label}
-        </span>
-        <Badge variant="outline" className="shrink-0">
-          {version.status}
-        </Badge>
-        <span
-          className="ml-auto text-xs text-muted-foreground shrink-0"
-          // The relative label is scannable; the exact time is what an editor
-          // needs when deciding between two nearby versions.
-          title={formatDateTime(version.createdAt)}
+      <button
+        type="button"
+        disabled={!selectable}
+        onClick={() => selectable && onSelect(version.versionNo as number)}
+        aria-label={`${title}, ${version.status}, by ${author}`}
+        aria-current={active ? "true" : undefined}
+        className={cn(
+          "flex-1 min-w-0 text-left px-4 py-3",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+          selectable ? "hover:bg-muted cursor-pointer" : "cursor-default"
+        )}
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-foreground truncate">
+            {title}
+          </span>
+          {/* Once a version is named, its number still identifies it — for
+              telling apart two versions an editor gave the same name. */}
+          {named && selectable && (
+            <span className="text-xs text-muted-foreground shrink-0">
+              {ordinal}
+            </span>
+          )}
+          <Badge variant="outline" className="shrink-0">
+            {version.status}
+          </Badge>
+          <span
+            className="ml-auto text-xs text-muted-foreground shrink-0"
+            // The relative label is scannable; the exact time is what an editor
+            // needs when deciding between two nearby versions.
+            title={formatDateTime(version.createdAt)}
+          >
+            {formatRelativeTime(version.createdAt)}
+          </span>
+        </div>
+        <div className="mt-1 text-xs text-muted-foreground truncate">
+          {author}
+        </div>
+      </button>
+
+      {canRename && (
+        <button
+          type="button"
+          onClick={() => onRename(version.versionNo as number)}
+          aria-label={
+            named ? `Rename ${title}` : `Name version ${version.versionNo}`
+          }
+          className={cn(
+            "shrink-0 px-3 text-muted-foreground",
+            "hover:bg-muted hover:text-foreground",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+          )}
         >
-          {formatRelativeTime(version.createdAt)}
-        </span>
-      </div>
-      <div className="mt-1 text-xs text-muted-foreground truncate">
-        {author}
-      </div>
-    </button>
+          <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
+      )}
+    </div>
   );
 }

--- a/packages/admin/src/components/features/versions/VersionRow.tsx
+++ b/packages/admin/src/components/features/versions/VersionRow.tsx
@@ -61,7 +61,15 @@ export function VersionRow({
         type="button"
         disabled={!selectable}
         onClick={() => selectable && onSelect(version.versionNo as number)}
-        aria-label={`${title}, ${version.status}, by ${author}`}
+        // The ordinal is in the accessible name even when a name replaces it
+        // visually: two versions may share a name, and a screen-reader user
+        // would otherwise have no way to tell them apart that a sighted user
+        // does.
+        aria-label={
+          named
+            ? `${title}, ${ordinal}, ${version.status}, by ${author}`
+            : `${title}, ${version.status}, by ${author}`
+        }
         aria-current={active ? "true" : undefined}
         className={cn(
           "flex-1 min-w-0 text-left px-4 py-3",

--- a/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
@@ -13,12 +13,14 @@ const {
   useVersionsMock,
   useVersionMock,
   restoreMock,
+  setLabelMock,
   mutateMock,
   toastErrorMock,
 } = vi.hoisted(() => ({
   useVersionsMock: vi.fn(),
   useVersionMock: vi.fn(),
   restoreMock: vi.fn(),
+  setLabelMock: vi.fn(),
   mutateMock: vi.fn(),
   toastErrorMock: vi.fn(),
 }));
@@ -37,6 +39,7 @@ vi.mock("@admin/hooks/queries/useVersions", () => ({
   useVersions: (...a: unknown[]) => useVersionsMock(...a),
   useVersion: (...a: unknown[]) => useVersionMock(...a),
   useRestoreVersion: (...a: unknown[]) => restoreMock(...a),
+  useSetVersionLabel: (...a: unknown[]) => setLabelMock(...a),
 }));
 
 import { VersionHistorySheet } from "../VersionHistorySheet";
@@ -97,6 +100,7 @@ describe("VersionHistorySheet", () => {
     useVersionsMock.mockReturnValue(listState());
     useVersionMock.mockReturnValue(detailState());
     restoreMock.mockReturnValue({ mutate: mutateMock, isPending: false });
+    setLabelMock.mockReturnValue({ mutate: vi.fn(), isPending: false });
   });
 
   it("lists the versions it received", () => {

--- a/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
@@ -390,3 +390,51 @@ describe("VersionHistorySheet", () => {
     );
   });
 });
+
+describe("VersionHistorySheet — renaming", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useVersionsMock.mockReturnValue(
+      listState({
+        data: { pages: [{ items: [version(3)], meta: { hasNext: false } }] },
+      })
+    );
+    useVersionMock.mockReturnValue(detailState());
+    restoreMock.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    setLabelMock.mockReturnValue({ mutate: vi.fn(), isPending: false });
+  });
+
+  it("does not offer renaming to a caller who may not write the document", () => {
+    // Renaming writes to history and needs the same permission restoring does.
+    // Offering it otherwise opens a dialog whose save the route rejects.
+    render(
+      <VersionHistorySheet
+        open
+        onOpenChange={vi.fn()}
+        scope={scope}
+        fields={fields}
+        canRestore={false}
+      />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /name version/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers renaming to a caller who may", () => {
+    render(
+      <VersionHistorySheet
+        open
+        onOpenChange={vi.fn()}
+        scope={scope}
+        fields={fields}
+        canRestore
+      />
+    );
+
+    expect(
+      screen.getAllByRole("button", { name: /name version/i }).length
+    ).toBeGreaterThan(0);
+  });
+});

--- a/packages/admin/src/components/features/versions/__tests__/VersionLabelDialog.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionLabelDialog.test.tsx
@@ -150,3 +150,39 @@ describe("VersionLabelDialog", () => {
     expect(screen.getByRole("textbox")).toHaveValue("second");
   });
 });
+
+describe("VersionLabelDialog — a rename landing underneath", () => {
+  it("does not turn an untouched field into a submittable change", async () => {
+    // A refetch can report someone else's rename while this dialog is open.
+    // Comparing against the live prop would enable Save on a value this user
+    // never typed, and submitting it would overwrite the newer name.
+    const { rerender } = render(
+      <VersionLabelDialog {...base} currentLabel="mine" onSubmit={vi.fn()} />
+    );
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
+
+    rerender(
+      <VersionLabelDialog
+        {...base}
+        currentLabel="someone else's"
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
+  });
+
+  it("still judges an edit against the name it was opened with", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <VersionLabelDialog {...base} currentLabel="mine" onSubmit={onSubmit} />
+    );
+
+    await user.clear(screen.getByRole("textbox"));
+    await user.type(screen.getByRole("textbox"), "my new name");
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith("my new name");
+  });
+});

--- a/packages/admin/src/components/features/versions/__tests__/VersionLabelDialog.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionLabelDialog.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Naming a version. The cases worth pinning are the ones where the dialog has
+ * to tell "clear the name" apart from "changed nothing" — they look identical
+ * in an empty field and mean opposite things.
+ */
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+import { VersionLabelDialog } from "../VersionLabelDialog";
+
+const base = {
+  open: true,
+  onOpenChange: vi.fn(),
+  versionNo: 3,
+  currentLabel: null as string | null,
+  onSubmit: vi.fn(),
+};
+
+describe("VersionLabelDialog", () => {
+  it("offers to name a version that has no name", () => {
+    render(<VersionLabelDialog {...base} onSubmit={vi.fn()} />);
+
+    expect(
+      screen.getByRole("heading", { name: /name version 3/i })
+    ).toBeInTheDocument();
+  });
+
+  it("offers to rename one that already has a name", () => {
+    render(
+      <VersionLabelDialog
+        {...base}
+        currentLabel="before redesign"
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /rename version 3/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue("before redesign");
+  });
+
+  it("submits a trimmed name", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<VersionLabelDialog {...base} onSubmit={onSubmit} />);
+
+    await user.type(screen.getByRole("textbox"), "  launch copy  ");
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith("launch copy");
+  });
+
+  it("submits null to clear an existing name", async () => {
+    // The same empty field means "remove it" here and "nothing to do" below;
+    // what separates them is whether there was a name to begin with.
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <VersionLabelDialog {...base} currentLabel="old" onSubmit={onSubmit} />
+    );
+
+    await user.clear(screen.getByRole("textbox"));
+    await user.click(screen.getByRole("button", { name: /remove name/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith(null);
+  });
+
+  it("cannot submit when nothing changed", () => {
+    render(
+      <VersionLabelDialog {...base} currentLabel="same" onSubmit={vi.fn()} />
+    );
+
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
+  });
+
+  it("cannot submit an empty field on a version that has no name", () => {
+    render(<VersionLabelDialog {...base} onSubmit={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: /remove name/i })).toBeDisabled();
+  });
+
+  it("says what an empty field will do, before it is submitted", async () => {
+    const user = userEvent.setup();
+    render(
+      <VersionLabelDialog {...base} currentLabel="old" onSubmit={vi.fn()} />
+    );
+
+    await user.clear(screen.getByRole("textbox"));
+
+    expect(screen.getByText(/will remove the current name/i)).toBeVisible();
+  });
+
+  it("blocks a second submit while one is in flight", () => {
+    render(
+      <VersionLabelDialog
+        {...base}
+        currentLabel="old"
+        saving
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /saving/i })).toBeDisabled();
+  });
+
+  it("reseeds when reopened on a different version", () => {
+    // Otherwise the previous version's name is offered as this one's.
+    const { rerender } = render(
+      <VersionLabelDialog {...base} currentLabel="first" onSubmit={vi.fn()} />
+    );
+    expect(screen.getByRole("textbox")).toHaveValue("first");
+
+    rerender(
+      <VersionLabelDialog
+        {...base}
+        versionNo={4}
+        currentLabel="second"
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("textbox")).toHaveValue("second");
+  });
+});

--- a/packages/admin/src/components/features/versions/__tests__/VersionLabelDialog.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionLabelDialog.test.tsx
@@ -106,14 +106,39 @@ describe("VersionLabelDialog", () => {
     expect(screen.getByRole("button", { name: /saving/i })).toBeDisabled();
   });
 
-  it("reseeds when reopened on a different version", () => {
-    // Otherwise the previous version's name is offered as this one's.
+  it("keeps what the user typed when the list refetches underneath", async () => {
+    // Renaming invalidates the history list, so `currentLabel` can change while
+    // the dialog is open. Resyncing from it would wipe a draft mid-edit, or
+    // swap in someone else's rename and let this user submit that instead.
+    const user = userEvent.setup();
     const { rerender } = render(
       <VersionLabelDialog {...base} currentLabel="first" onSubmit={vi.fn()} />
     );
-    expect(screen.getByRole("textbox")).toHaveValue("first");
+
+    await user.clear(screen.getByRole("textbox"));
+    await user.type(screen.getByRole("textbox"), "my draft");
 
     rerender(
+      <VersionLabelDialog
+        {...base}
+        currentLabel="changed elsewhere"
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("textbox")).toHaveValue("my draft");
+  });
+
+  it("seeds from the version it was mounted for", () => {
+    // Opening a different version mounts a fresh dialog rather than resyncing
+    // this one, so there is no stale draft to carry across.
+    const { unmount } = render(
+      <VersionLabelDialog {...base} currentLabel="first" onSubmit={vi.fn()} />
+    );
+    expect(screen.getByRole("textbox")).toHaveValue("first");
+    unmount();
+
+    render(
       <VersionLabelDialog
         {...base}
         versionNo={4}

--- a/packages/admin/src/components/features/versions/__tests__/VersionRow.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionRow.test.tsx
@@ -120,6 +120,21 @@ describe("VersionRow — names", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps the version number in the accessible name too", () => {
+    // Two versions may share a name. The number is what tells them apart, and
+    // it is visible on the row — a screen-reader user needs it as well.
+    render(
+      <VersionRow
+        version={version({ label: "before redesign" })}
+        onSelect={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /before redesign, Version 3,/ })
+    ).toBeInTheDocument();
+  });
+
   it("offers renaming only when the caller can rename", () => {
     const { rerender } = render(
       <VersionRow version={version()} onSelect={vi.fn()} />

--- a/packages/admin/src/components/features/versions/__tests__/VersionRow.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionRow.test.tsx
@@ -85,3 +85,85 @@ describe("VersionRow", () => {
     expect(relative).toBeInTheDocument();
   });
 });
+
+describe("VersionRow — names", () => {
+  it("shows the editor's name for a version, keeping the number visible", () => {
+    // Two versions can share a name, so the number stays as the thing that
+    // actually identifies one.
+    render(
+      <VersionRow
+        version={version({ label: "before redesign" })}
+        onSelect={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("before redesign")).toBeInTheDocument();
+    expect(screen.getByText("Version 3")).toBeInTheDocument();
+  });
+
+  it("falls back to the number when a version has no name", () => {
+    render(<VersionRow version={version()} onSelect={vi.fn()} />);
+
+    expect(screen.getByText("Version 3")).toBeInTheDocument();
+  });
+
+  it("leads the accessible label with the name an editor chose", () => {
+    render(
+      <VersionRow
+        version={version({ label: "before redesign" })}
+        onSelect={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /^before redesign,/ })
+    ).toBeInTheDocument();
+  });
+
+  it("offers renaming only when the caller can rename", () => {
+    const { rerender } = render(
+      <VersionRow version={version()} onSelect={vi.fn()} />
+    );
+    expect(
+      screen.queryByRole("button", { name: /name version/i })
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <VersionRow version={version()} onSelect={vi.fn()} onRename={vi.fn()} />
+    );
+    expect(
+      screen.getByRole("button", { name: /name version 3/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renames without opening the version", async () => {
+    // The two controls sit side by side; clicking one must not trigger the
+    // other, which is what nesting them would have caused.
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const onRename = vi.fn();
+    render(
+      <VersionRow version={version()} onSelect={onSelect} onRename={onRename} />
+    );
+
+    await user.click(screen.getByRole("button", { name: /name version 3/i }));
+
+    expect(onRename).toHaveBeenCalledWith(3);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("does not offer to name an autosave", () => {
+    // An autosave has no version number, so there is nothing to address.
+    render(
+      <VersionRow
+        version={version({ versionNo: null, isAutosave: true })}
+        onSelect={vi.fn()}
+        onRename={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /name version/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/hooks/queries/useVersions.ts
+++ b/packages/admin/src/hooks/queries/useVersions.ts
@@ -22,6 +22,7 @@ import { entryKeys } from "@admin/services/entryApi";
 import {
   versionApi,
   type RestoreVersionResponse,
+  type SetVersionLabelResponse,
   type VersionDetail,
   type VersionListResponse,
   type VersionScope,
@@ -122,8 +123,10 @@ export interface UseVersionOptions {
 /**
  * One stored version, including its snapshot.
  *
- * A stored version never changes, so this stays fresh longer than the list —
- * which does change as the document is edited.
+ * A version's CONTENT never changes — history is append-only — so this stays
+ * fresh longer than the list, which grows as the document is edited. Its label
+ * can change, and a rename invalidates this key rather than waiting the window
+ * out.
  */
 export function useVersion({
   scope,
@@ -155,6 +158,50 @@ export interface UseRestoreVersionOptions {
   scope: VersionScope;
   onSuccess?: (result: RestoreVersionResponse) => void;
   onError?: (error: Error) => void;
+}
+
+/** Options for renaming a version. */
+export interface UseSetVersionLabelOptions {
+  scope: VersionScope;
+  onSuccess?: (result: SetVersionLabelResponse) => void;
+  onError?: (error: Error) => void;
+}
+
+/** What a rename is asked to do: `null` clears the name. */
+export interface SetVersionLabelInput {
+  versionNo: number;
+  label: string | null;
+}
+
+/**
+ * Name a version, or clear its name.
+ *
+ * Only the version caches are invalidated: a label is metadata about history
+ * and touches no document content, so the entry and single-document caches a
+ * restore has to clear are left alone. The detail key is included because a
+ * renamed version is stale there too, despite its snapshot being unchanged.
+ *
+ * Unlike a restore this is idempotent — the same name applied twice leaves the
+ * same state — so the default retry behaviour is correct and is left in place.
+ */
+export function useSetVersionLabel({
+  scope,
+  onSuccess,
+  onError,
+}: UseSetVersionLabelOptions) {
+  const queryClient = useQueryClient();
+
+  return useMutation<SetVersionLabelResponse, Error, SetVersionLabelInput>({
+    mutationFn: ({ versionNo, label }) =>
+      versionApi.setLabel(scope, versionNo, label),
+    onError: error => {
+      onError?.(error);
+    },
+    onSuccess: result => {
+      void queryClient.invalidateQueries({ queryKey: versionKeys.all() });
+      onSuccess?.(result);
+    },
+  });
 }
 
 /**

--- a/packages/admin/src/services/versionApi.ts
+++ b/packages/admin/src/services/versionApi.ts
@@ -84,6 +84,12 @@ export interface RestoreVersionResponse {
   droppedFields: string[];
 }
 
+/** What a rename reports back: the version's metadata, without its snapshot. */
+export interface SetVersionLabelResponse {
+  message: string;
+  item: VersionMeta;
+}
+
 export const versionApi = {
   list: (
     scope: VersionScope,
@@ -117,5 +123,22 @@ export const versionApi = {
     protectedApi.post<RestoreVersionResponse>(
       `${basePath(scope)}/${versionNo}/restore`,
       {}
+    ),
+
+  /**
+   * Name a version, or clear its name with `null`.
+   *
+   * A PATCH on the version itself rather than a nested action, because it is
+   * idempotent: sending the same name twice leaves the same state. The server
+   * trims and bounds the value, so the client's own trim is a courtesy.
+   */
+  setLabel: (
+    scope: VersionScope,
+    versionNo: number,
+    label: string | null
+  ): Promise<SetVersionLabelResponse> =>
+    protectedApi.patch<SetVersionLabelResponse>(
+      `${basePath(scope)}/${versionNo}`,
+      { label }
     ),
 };

--- a/packages/nextly/src/dispatcher/handlers/__tests__/versions-dispatch.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/versions-dispatch.test.ts
@@ -27,6 +27,7 @@ vi.mock("../../../api/versions-access", () => ({
 
 import { COLLECTION_VERSION_METHODS } from "../collection-dispatcher";
 import { SINGLE_VERSION_METHODS } from "../single-dispatcher";
+import { parseRestRoute } from "../../../route-handler/route-parser";
 
 describe("version methods are registered", () => {
   beforeEach(() => {
@@ -43,6 +44,7 @@ describe("version methods are registered", () => {
       "getEntryVersion",
       "listEntryVersions",
       "restoreEntryVersion",
+      "setEntryVersionLabel",
     ]);
   });
 
@@ -51,6 +53,7 @@ describe("version methods are registered", () => {
       "getSingleVersion",
       "listSingleVersions",
       "restoreSingleVersion",
+      "setSingleVersionLabel",
     ]);
   });
 
@@ -112,5 +115,85 @@ describe("version methods are registered", () => {
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(listSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("version methods reach the router", () => {
+  // The sets above pin what the dispatcher exposes. This pins the other half:
+  // a method the router cannot resolve is unreachable however well registered,
+  // and one resolved with the wrong operation is authorized as the wrong thing.
+  it.each([
+    {
+      method: "listEntryVersions",
+      path: ["collections", "posts", "entries", "e1", "versions"],
+      verb: "GET",
+    },
+    {
+      method: "getEntryVersion",
+      path: ["collections", "posts", "entries", "e1", "versions", "2"],
+      verb: "GET",
+    },
+    {
+      method: "restoreEntryVersion",
+      path: [
+        "collections",
+        "posts",
+        "entries",
+        "e1",
+        "versions",
+        "2",
+        "restore",
+      ],
+      verb: "POST",
+    },
+    {
+      method: "setEntryVersionLabel",
+      path: ["collections", "posts", "entries", "e1", "versions", "2"],
+      verb: "PATCH",
+    },
+    {
+      method: "listSingleVersions",
+      path: ["singles", "settings", "versions"],
+      verb: "GET",
+    },
+    {
+      method: "getSingleVersion",
+      path: ["singles", "settings", "versions", "2"],
+      verb: "GET",
+    },
+    {
+      method: "restoreSingleVersion",
+      path: ["singles", "settings", "versions", "2", "restore"],
+      verb: "POST",
+    },
+    {
+      method: "setSingleVersionLabel",
+      path: ["singles", "settings", "versions", "2"],
+      verb: "PATCH",
+    },
+  ])("$method is reachable at $verb $path", ({ method, path, verb }) => {
+    expect(parseRestRoute(path, verb).method).toBe(method);
+  });
+
+  it("routes the writes as writes and the reads as reads", () => {
+    const operationFor = (path: string[], verb: string) =>
+      parseRestRoute(path, verb).operation;
+
+    expect(
+      operationFor(
+        ["collections", "posts", "entries", "e1", "versions", "2"],
+        "PATCH"
+      )
+    ).toBe("update");
+    expect(
+      operationFor(["singles", "settings", "versions", "2"], "PATCH")
+    ).toBe("update");
+    // A read of the same version must not be promoted to a write.
+    expect(
+      operationFor(
+        ["collections", "posts", "entries", "e1", "versions", "2"],
+        "GET"
+      )
+    ).not.toBe("update");
   });
 });

--- a/packages/nextly/src/dispatcher/handlers/__tests__/versions-label.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/versions-label.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Naming a version writes to history, so it carries the same read gates a
+ * restore does — a caller who may not see a version must not be able to rename
+ * it either. The normalization is here rather than in the client because a REST
+ * API has callers that are not the client.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { setLabelSpy, getSpy, readableSpy, canReadSpy } = vi.hoisted(() => ({
+  setLabelSpy: vi.fn(),
+  getSpy: vi.fn(),
+  readableSpy: vi.fn(),
+  canReadSpy: vi.fn(),
+}));
+
+vi.mock("../../../di", () => ({
+  getService: vi.fn(() => ({ setLabel: setLabelSpy, get: getSpy })),
+}));
+
+vi.mock("../../../api/versions-access", () => ({
+  assertVersionDocumentReadable: readableSpy,
+  redactSnapshotForUser: vi.fn(),
+  resolveSingleDocumentId: vi.fn(),
+}));
+
+vi.mock("../../../auth/entity-read-access", () => ({
+  canReadEntity: canReadSpy,
+}));
+
+import { setVersionLabelForDocument } from "../versions-methods";
+
+const args = (label: unknown, versionNo = 3) => ({
+  scopeKind: "collection" as const,
+  slug: "posts",
+  entryId: "e1",
+  versionNo,
+  label,
+  user: { id: "u1", roles: ["editor"] },
+  params: { _authenticatedUserId: "u1" },
+});
+
+describe("setVersionLabelForDocument — normalization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canReadSpy.mockResolvedValue(true);
+    readableSpy.mockResolvedValue(undefined);
+    setLabelSpy.mockResolvedValue({ versionNo: 3, label: "x", snapshot: {} });
+  });
+
+  it("stores a trimmed label", async () => {
+    await setVersionLabelForDocument(args("  before redesign  "));
+
+    expect(setLabelSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      3,
+      "before redesign"
+    );
+  });
+
+  it("treats an all-whitespace label as clearing it", async () => {
+    // Otherwise a version ends up with an invisible name that cannot be
+    // distinguished from an unnamed one in the UI.
+    await setVersionLabelForDocument(args("   "));
+
+    expect(setLabelSpy).toHaveBeenCalledWith(expect.anything(), 3, null);
+  });
+
+  it("clears on an explicit null", async () => {
+    await setVersionLabelForDocument(args(null));
+
+    expect(setLabelSpy).toHaveBeenCalledWith(expect.anything(), 3, null);
+  });
+
+  it("accepts a label at the length limit", async () => {
+    const atLimit = "a".repeat(100);
+
+    await setVersionLabelForDocument(args(atLimit));
+
+    expect(setLabelSpy).toHaveBeenCalledWith(expect.anything(), 3, atLimit);
+  });
+
+  it("rejects a label past the limit", async () => {
+    // No dialect caps the column, so this is the only bound there is.
+    await expect(
+      setVersionLabelForDocument(args("a".repeat(101)))
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+    expect(setLabelSpy).not.toHaveBeenCalled();
+  });
+
+  it("measures the limit after trimming", async () => {
+    await setVersionLabelForDocument(args(`  ${"a".repeat(100)}  `));
+
+    expect(setLabelSpy).toHaveBeenCalled();
+  });
+
+  it("rejects a non-string label rather than reading it as a clear", async () => {
+    // A malformed request must not silently wipe a name.
+    await expect(setVersionLabelForDocument(args(42))).rejects.toMatchObject({
+      code: "VALIDATION_ERROR",
+    });
+    expect(setLabelSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects a version number that is not positive", async () => {
+    await expect(
+      setVersionLabelForDocument(args("name", 0))
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+    expect(setLabelSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("setVersionLabelForDocument — access", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canReadSpy.mockResolvedValue(true);
+    readableSpy.mockResolvedValue(undefined);
+    setLabelSpy.mockResolvedValue({ versionNo: 3, label: "x", snapshot: {} });
+  });
+
+  it("refuses a caller who may not read the entity's history", async () => {
+    canReadSpy.mockResolvedValue(false);
+
+    await expect(
+      setVersionLabelForDocument(args("name"))
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(setLabelSpy).not.toHaveBeenCalled();
+  });
+
+  it("refuses a caller who may not see this document", async () => {
+    readableSpy.mockRejectedValue(
+      Object.assign(new Error("nope"), { code: "NOT_FOUND" })
+    );
+
+    await expect(
+      setVersionLabelForDocument(args("name"))
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(setLabelSpy).not.toHaveBeenCalled();
+  });
+
+  it("validates before touching access, so a bad request is not a probe", async () => {
+    // A malformed label answering differently for a readable and an unreadable
+    // document would disclose which documents exist.
+    await expect(
+      setVersionLabelForDocument(args("a".repeat(101)))
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+    expect(canReadSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not return the snapshot with the renamed version", async () => {
+    // Renaming is not a read of content; returning it here would bypass the
+    // redaction the version-detail endpoint applies.
+    setLabelSpy.mockResolvedValue({
+      versionNo: 3,
+      label: "named",
+      snapshot: { secret: "value" },
+    });
+
+    const row = await setVersionLabelForDocument(args("named"));
+
+    expect(row).not.toHaveProperty("snapshot");
+    expect(row).toMatchObject({ versionNo: 3, label: "named" });
+  });
+});

--- a/packages/nextly/src/dispatcher/handlers/__tests__/versions-label.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/versions-label.test.ts
@@ -34,7 +34,18 @@ const args = (label: unknown, versionNo = 3) => ({
   slug: "posts",
   entryId: "e1",
   versionNo,
-  label,
+  body: { label },
+  user: { id: "u1", roles: ["editor"] },
+  params: { _authenticatedUserId: "u1" },
+});
+
+/** A request that names no label at all, as distinct from one naming null. */
+const argsWithoutLabel = (body: unknown = {}) => ({
+  scopeKind: "collection" as const,
+  slug: "posts",
+  entryId: "e1",
+  versionNo: 3,
+  body,
   user: { id: "u1", roles: ["editor"] },
   params: { _authenticatedUserId: "u1" },
 });
@@ -159,5 +170,54 @@ describe("setVersionLabelForDocument — access", () => {
 
     expect(row).not.toHaveProperty("snapshot");
     expect(row).toMatchObject({ versionNo: 3, label: "named" });
+  });
+});
+
+describe("setVersionLabelForDocument — an omitted label", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canReadSpy.mockResolvedValue(true);
+    readableSpy.mockResolvedValue(undefined);
+    getSpy.mockResolvedValue({ versionNo: 3, label: "kept", snapshot: {} });
+    setLabelSpy.mockResolvedValue({ versionNo: 3, label: "x", snapshot: {} });
+  });
+
+  it("leaves an existing name alone rather than clearing it", async () => {
+    // PATCH is a partial update. Treating an absent key as null erased names
+    // nobody asked to remove.
+    const row = await setVersionLabelForDocument(argsWithoutLabel());
+
+    expect(setLabelSpy).not.toHaveBeenCalled();
+    expect(row).toMatchObject({ label: "kept" });
+  });
+
+  it("treats an absent body the same way", async () => {
+    await setVersionLabelForDocument(argsWithoutLabel(undefined));
+
+    expect(setLabelSpy).not.toHaveBeenCalled();
+  });
+
+  it("still clears on an explicit null", async () => {
+    // The distinction this whole branch exists for.
+    await setVersionLabelForDocument(argsWithoutLabel({ label: null }));
+
+    expect(setLabelSpy).toHaveBeenCalledWith(expect.anything(), 3, null);
+  });
+
+  it("still gates a request that changes nothing", async () => {
+    // Otherwise a no-op PATCH answers differently for a readable and an
+    // unreadable document, which discloses which documents exist.
+    canReadSpy.mockResolvedValue(false);
+
+    await expect(
+      setVersionLabelForDocument(argsWithoutLabel())
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not return the snapshot from a no-op either", async () => {
+    const row = await setVersionLabelForDocument(argsWithoutLabel());
+
+    expect(row).not.toHaveProperty("snapshot");
   });
 });

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -103,6 +103,7 @@ import {
   getVersionForDocument,
   restoreVersionForDocument,
   listVersionsForDocument,
+  setVersionLabelForDocument,
   userFromParams,
 } from "./versions-methods";
 
@@ -165,6 +166,22 @@ export const COLLECTION_VERSION_METHODS: Record<
         cursor: p.cursor !== undefined ? Number(p.cursor) : undefined,
       });
       return respondList(result.items, result.meta);
+    },
+  },
+  setEntryVersionLabel: {
+    execute: async (_svc, p, body) => {
+      const row = await setVersionLabelForDocument({
+        scopeKind: "collection",
+        slug: String(p.collectionName ?? ""),
+        entryId: String(p.entryId ?? ""),
+        user: userFromParams(p),
+        versionNo: Number(p.versionNo),
+        // Absent means "leave it alone"; explicit null means "clear it". The
+        // dispatcher core tells the two apart.
+        label: (body as { label?: unknown } | undefined)?.label ?? null,
+        params: p,
+      });
+      return respondMutation("Version renamed.", row);
     },
   },
   restoreEntryVersion: {

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -176,9 +176,9 @@ export const COLLECTION_VERSION_METHODS: Record<
         entryId: String(p.entryId ?? ""),
         user: userFromParams(p),
         versionNo: Number(p.versionNo),
-        // Absent means "leave it alone"; explicit null means "clear it". The
-        // dispatcher core tells the two apart.
-        label: (body as { label?: unknown } | undefined)?.label ?? null,
+        // Forwarded whole: whether `label` is present is part of what the
+        // request means, and the core is what reads it.
+        body,
         params: p,
       });
       return respondMutation("Version renamed.", row);

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -96,6 +96,7 @@ import { assertSchemaVersionMatch } from "./schema-version-guard";
 import {
   getVersionForDocument,
   restoreVersionForDocument,
+  setVersionLabelForDocument,
   listVersionsForDocument,
   userFromParams,
 } from "./versions-methods";
@@ -359,6 +360,25 @@ export const SINGLE_VERSION_METHODS: Record<
         versionNo: Number(p.versionNo),
       });
       return respondDoc(row);
+    },
+  },
+  setSingleVersionLabel: {
+    execute: async (_svc, p, body) => {
+      const slug = String(p.slug ?? "");
+      // The live id comes from the server, never the request: a Single has one
+      // document and a client-supplied id would be a way to reach another.
+      const entryId = await requireLiveSingleId(slug);
+      const row = await setVersionLabelForDocument({
+        scopeKind: "single",
+        slug,
+        entryId,
+        user: userFromParams(p),
+        versionNo: Number(p.versionNo),
+        // See the collection handler: absent leaves it, null clears it.
+        label: (body as { label?: unknown } | undefined)?.label ?? null,
+        params: p,
+      });
+      return respondMutation("Version renamed.", row);
     },
   },
 };

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -374,8 +374,8 @@ export const SINGLE_VERSION_METHODS: Record<
         entryId,
         user: userFromParams(p),
         versionNo: Number(p.versionNo),
-        // See the collection handler: absent leaves it, null clears it.
-        label: (body as { label?: unknown } | undefined)?.label ?? null,
+        // See the collection handler: the body goes through whole.
+        body,
         params: p,
       });
       return respondMutation("Version renamed.", row);

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -94,6 +94,7 @@ import type { MethodHandler, Params } from "../types";
 
 import { assertSchemaVersionMatch } from "./schema-version-guard";
 import {
+  assertLabelRequestValid,
   getVersionForDocument,
   restoreVersionForDocument,
   setVersionLabelForDocument,
@@ -365,6 +366,10 @@ export const SINGLE_VERSION_METHODS: Record<
   setSingleVersionLabel: {
     execute: async (_svc, p, body) => {
       const slug = String(p.slug ?? "");
+      // Validate before resolving anything. Otherwise the same malformed
+      // request answers 404 for an unmaterialized Single and 400 for a
+      // materialized one, and performs a lookup it was never going to use.
+      assertLabelRequestValid(Number(p.versionNo), body);
       // The live id comes from the server, never the request: a Single has one
       // document and a client-supplied id would be a way to reach another.
       const entryId = await requireLiveSingleId(slug);

--- a/packages/nextly/src/dispatcher/handlers/versions-methods.ts
+++ b/packages/nextly/src/dispatcher/handlers/versions-methods.ts
@@ -237,6 +237,116 @@ function readAccessCallerFromParams(
 }
 
 /**
+ * Longest label a version may carry.
+ *
+ * No dialect caps the column — all three store `text` — so the bound has to be
+ * enforced here or not at all. A label renders inside a narrow history row, and
+ * 100 characters is generous for the naming people actually do ("before the
+ * redesign", "Q1 launch copy") while stopping a row becoming a paragraph.
+ */
+const MAX_LABEL_LENGTH = 100;
+
+/**
+ * Normalize a submitted label into what gets stored.
+ *
+ * Trims first, so "clear it" and "type three spaces" mean the same thing rather
+ * than leaving an invisible name behind. The client trims too, by this
+ * codebase's convention, but a REST API has callers that are not the client.
+ *
+ * `null` clears. Anything that is neither a string nor null is a malformed
+ * request rather than a clear, and is rejected instead of quietly wiping a name.
+ */
+function normalizeLabel(value: unknown, path: string): string | null {
+  if (value === null) return null;
+
+  if (typeof value !== "string") {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path,
+          code: "INVALID_VALUE",
+          message: `${path} must be a string, or null to clear it.`,
+        },
+      ],
+    });
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+
+  if (trimmed.length > MAX_LABEL_LENGTH) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path,
+          code: "TOO_LONG",
+          message: `${path} must be ${MAX_LABEL_LENGTH} characters or fewer.`,
+        },
+      ],
+    });
+  }
+
+  return trimmed;
+}
+
+/**
+ * Name a version, or clear its name.
+ *
+ * Gated exactly like a restore, and for the same reason: a label is written
+ * onto history, so the caller must be allowed to see that history as well as to
+ * change the document. The route marks this an update, which is what earns the
+ * write permission; these two gates are the read half.
+ */
+export async function setVersionLabelForDocument(
+  args: VersionMethodArgs & {
+    versionNo: number;
+    label: unknown;
+    params: Params;
+  }
+): Promise<VersionRow> {
+  assertPositiveInteger(args.versionNo, "versionNo");
+  const label = normalizeLabel(args.label, "label");
+
+  const caller = readAccessCallerFromParams(args.params, args.user);
+
+  if (!(await canReadEntity(args.slug, caller))) {
+    throw NextlyError.notFound({
+      logContext: {
+        reason: "version-label-read-denied",
+        scopeKind: args.scopeKind,
+        scopeSlug: args.slug,
+        entryId: args.entryId,
+        userId: args.user.id,
+      },
+    });
+  }
+
+  await assertVersionDocumentReadable(
+    args.scopeKind,
+    args.slug,
+    args.entryId,
+    args.user
+  );
+
+  const versions = getService("versionsService");
+  const row = await versions.setLabel(
+    {
+      scopeKind: args.scopeKind,
+      scopeSlug: args.slug,
+      entryId: args.entryId,
+    },
+    args.versionNo,
+    label
+  );
+
+  // The snapshot is not part of a label response: the caller asked to rename a
+  // version, not to read its content, and returning it here would bypass the
+  // redaction the version-detail endpoint applies.
+  const { snapshot: _snapshot, ...meta } = row;
+  return meta as VersionRow;
+}
+
+/**
  * Put a document back to an earlier version.
  *
  * Two gates, because a restore both reads history and writes the document.

--- a/packages/nextly/src/dispatcher/handlers/versions-methods.ts
+++ b/packages/nextly/src/dispatcher/handlers/versions-methods.ts
@@ -300,12 +300,27 @@ function normalizeLabel(value: unknown, path: string): string | null {
 export async function setVersionLabelForDocument(
   args: VersionMethodArgs & {
     versionNo: number;
-    label: unknown;
+    /**
+     * The request body, not an extracted label. Whether the key is PRESENT is
+     * part of the request's meaning, and reading it here rather than at each
+     * dispatcher keeps that from being flattened on the way in — which is
+     * exactly how an omitted label became an instruction to clear one.
+     */
+    body: unknown;
     params: Params;
   }
 ): Promise<VersionRow> {
   assertPositiveInteger(args.versionNo, "versionNo");
-  const label = normalizeLabel(args.label, "label");
+
+  // PATCH is a partial update: an omitted key means "leave this alone", and
+  // only an explicit null clears. Collapsing the two would make `PATCH {}`
+  // erase a name nobody asked to remove.
+  const provided =
+    typeof args.body === "object" && args.body !== null && "label" in args.body;
+
+  const label = provided
+    ? normalizeLabel((args.body as { label: unknown }).label, "label")
+    : null;
 
   const caller = readAccessCallerFromParams(args.params, args.user);
 
@@ -329,15 +344,18 @@ export async function setVersionLabelForDocument(
   );
 
   const versions = getService("versionsService");
-  const row = await versions.setLabel(
-    {
-      scopeKind: args.scopeKind,
-      scopeSlug: args.slug,
-      entryId: args.entryId,
-    },
-    args.versionNo,
-    label
-  );
+  const ref = {
+    scopeKind: args.scopeKind,
+    scopeSlug: args.slug,
+    entryId: args.entryId,
+  };
+
+  // Nothing was asked for, so nothing is written. The version is still read
+  // back, so the response shape is the same either way and a caller cannot
+  // tell a no-op from a rename by its status.
+  const row = provided
+    ? await versions.setLabel(ref, args.versionNo, label)
+    : await versions.get(ref, args.versionNo);
 
   // The snapshot is not part of a label response: the caller asked to rename a
   // version, not to read its content, and returning it here would bypass the

--- a/packages/nextly/src/dispatcher/handlers/versions-methods.ts
+++ b/packages/nextly/src/dispatcher/handlers/versions-methods.ts
@@ -256,6 +256,42 @@ const MAX_LABEL_LENGTH = 100;
  * `null` clears. Anything that is neither a string nor null is a malformed
  * request rather than a clear, and is rejected instead of quietly wiping a name.
  */
+/**
+ * What the request asks for: whether a label was named at all, and what it
+ * normalizes to.
+ *
+ * PATCH is a partial update, so an omitted key means "leave this alone" and
+ * only an explicit null clears. Collapsing the two would make `PATCH {}` erase
+ * a name nobody asked to remove.
+ */
+function readLabelFromBody(body: unknown): {
+  provided: boolean;
+  label: string | null;
+} {
+  const provided = typeof body === "object" && body !== null && "label" in body;
+
+  return {
+    provided,
+    label: provided ? normalizeLabel(body.label, "label") : null,
+  };
+}
+
+/**
+ * Reject a malformed label request before anything is looked up.
+ *
+ * Exported for the Singles handler, which resolves the live document id before
+ * it can call the core — a lookup that would otherwise make the same bad
+ * request answer 404 for an unmaterialized Single and 400 for a materialized
+ * one. The core validates again; this only moves the rejection earlier.
+ */
+export function assertLabelRequestValid(
+  versionNo: number,
+  body: unknown
+): void {
+  assertPositiveInteger(versionNo, "versionNo");
+  readLabelFromBody(body);
+}
+
 function normalizeLabel(value: unknown, path: string): string | null {
   if (value === null) return null;
 
@@ -311,16 +347,7 @@ export async function setVersionLabelForDocument(
   }
 ): Promise<VersionRow> {
   assertPositiveInteger(args.versionNo, "versionNo");
-
-  // PATCH is a partial update: an omitted key means "leave this alone", and
-  // only an explicit null clears. Collapsing the two would make `PATCH {}`
-  // erase a name nobody asked to remove.
-  const provided =
-    typeof args.body === "object" && args.body !== null && "label" in args.body;
-
-  const label = provided
-    ? normalizeLabel((args.body as { label: unknown }).label, "label")
-    : null;
+  const { provided, label } = readLabelFromBody(args.body);
 
   const caller = readAccessCallerFromParams(args.params, args.user);
 

--- a/packages/nextly/src/domains/versions/db-api.ts
+++ b/packages/nextly/src/domains/versions/db-api.ts
@@ -54,4 +54,18 @@ export interface VersionsDbApi {
    * extra optional arguments remain assignable to this narrower shape.
    */
   delete(table: string, where: VersionsWhere): Promise<number>;
+  /**
+   * Update rows matching `where`.
+   *
+   * Narrow for the same reason as `delete`: the only thing that edits a stored
+   * version is its label, and a snapshot is never rewritten. Keeping the port
+   * to what is actually used means both the adapter and the transaction
+   * context satisfy it without adapting, and makes any future widening a
+   * deliberate act rather than an inherited capability.
+   */
+  update(
+    table: string,
+    data: Record<string, unknown>,
+    where: VersionsWhere
+  ): Promise<unknown>;
 }

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -308,6 +308,32 @@ export class VersionsRepository {
    * after the retention cap starts being enforced, and an over-large statement
    * would fail the whole write transaction rather than trimming.
    */
+  /**
+   * Set or clear a durable version's label.
+   *
+   * Scoped by the document as well as the version number, so a caller
+   * authorized for one document cannot rename a version of another by number
+   * alone. Autosave rows are excluded on the same terms as every other durable
+   * read: they are not addressable in history, so they are not nameable either.
+   */
+  async updateLabel(
+    ref: VersionRef,
+    versionNo: number,
+    label: string | null
+  ): Promise<void> {
+    await this.db.update(
+      TABLE,
+      { label },
+      {
+        and: [
+          ...this.docWhere(ref),
+          { column: "isAutosave", op: "=", value: false },
+          { column: "versionNo", op: "=", value: versionNo },
+        ],
+      }
+    );
+  }
+
   async deleteByIds(ids: string[]): Promise<number> {
     if (ids.length === 0) return 0;
     let deleted = 0;

--- a/packages/nextly/src/domains/versions/versions-service.ts
+++ b/packages/nextly/src/domains/versions/versions-service.ts
@@ -1,10 +1,14 @@
 /**
- * Public read surface for content version history.
+ * Public surface for content version history.
  *
  * Wraps the repository so callers (HTTP routes, the admin, and plugins via
  * `ctx.services.versions`) never touch `nextly_versions` directly. Listing is
  * metadata-only by construction: snapshots are large and a history list never
  * needs them.
+ *
+ * Reads, plus the one thing about a stored version that is editable: its label.
+ * A snapshot itself is never rewritten — history is append-only, which is what
+ * makes a restore recoverable.
  *
  * @experimental The shape may change while versioning is in alpha.
  *
@@ -44,6 +48,24 @@ export class VersionsService {
     opts: VersionListOptions = {}
   ): Promise<VersionMeta[]> {
     return this.repo.listByDoc(ref, opts);
+  }
+
+  /**
+   * Name a version, or clear its name with `null`.
+   *
+   * The only mutation on a stored version. `get` runs first so an unknown
+   * version answers not-found rather than silently updating nothing — the
+   * repository's `UPDATE ... WHERE` matches no rows in that case and would
+   * otherwise report success.
+   */
+  async setLabel(
+    ref: VersionRef,
+    versionNo: number,
+    label: string | null
+  ): Promise<VersionRow> {
+    await this.get(ref, versionNo);
+    await this.repo.updateLabel(ref, versionNo, label);
+    return this.get(ref, versionNo);
   }
 
   /** One full version, including its snapshot. */

--- a/packages/nextly/src/route-handler/__tests__/route-parser.versions.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.versions.test.ts
@@ -167,3 +167,79 @@ describe("version routes", () => {
     ).toBe("publishAllLocales");
   });
 });
+
+describe("version label routes", () => {
+  it("parses a PATCH on a collection entry's version", () => {
+    const parsed = parseRestRoute(
+      ["collections", "posts", "entries", "e1", "versions", "3"],
+      "PATCH"
+    );
+
+    expect(parsed).toMatchObject({
+      service: "collections",
+      method: "setEntryVersionLabel",
+      routeParams: { collectionName: "posts", entryId: "e1", versionNo: "3" },
+    });
+  });
+
+  it("parses a PATCH on a single's version", () => {
+    const parsed = parseRestRoute(
+      ["singles", "settings", "versions", "3"],
+      "PATCH"
+    );
+
+    expect(parsed).toMatchObject({
+      service: "singles",
+      method: "setSingleVersionLabel",
+      routeParams: { slug: "settings", versionNo: "3" },
+    });
+  });
+
+  it("authorizes a label as an update, not a read of history", () => {
+    // The operation drives the permission. Read would let anyone who can see a
+    // document rename its history.
+    for (const parsed of [
+      parseRestRoute(
+        ["collections", "posts", "entries", "e1", "versions", "3"],
+        "PATCH"
+      ),
+      parseRestRoute(["singles", "settings", "versions", "3"], "PATCH"),
+    ]) {
+      expect(parsed?.operation).toBe("update");
+    }
+  });
+
+  // These assert the method is UNDEFINED rather than merely "not the label
+  // method". An unmatched route resolves to `{}`, but a path that silently
+  // matched some OTHER handler would satisfy a weaker assertion while
+  // dispatching somewhere unintended.
+  it("does not claim a PATCH on the version list itself", () => {
+    expect(
+      parseRestRoute(
+        ["collections", "posts", "entries", "e1", "versions"],
+        "PATCH"
+      ).method
+    ).toBeUndefined();
+    expect(
+      parseRestRoute(["singles", "settings", "versions"], "PATCH").method
+    ).toBeUndefined();
+  });
+
+  it("does not claim a PATCH deeper than a version number", () => {
+    expect(
+      parseRestRoute(
+        ["collections", "posts", "entries", "e1", "versions", "3", "label"],
+        "PATCH"
+      ).method
+    ).toBeUndefined();
+  });
+
+  it("leaves other methods on a version alone", () => {
+    expect(
+      parseRestRoute(
+        ["collections", "posts", "entries", "e1", "versions", "3"],
+        "DELETE"
+      ).method
+    ).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -814,6 +814,21 @@ function parseCollectionEntryVersionRoutes(
     };
   }
 
+  // Naming a version edits history rather than the document, but it is still a
+  // write, so it is authorized as one. PATCH because it is idempotent: sending
+  // the same label twice leaves the same state.
+  if (additionalParams.length === 2 && httpMethod === "PATCH") {
+    routeParams.collectionName = id;
+    routeParams.entryId = subId;
+    routeParams.versionNo = additionalParams[1] ?? "";
+    return {
+      service: "collections",
+      operation: "update",
+      method: "setEntryVersionLabel",
+      routeParams,
+    };
+  }
+
   if (
     // Only `versions` or `versions/{versionNo}`; anything deeper is not a
     // route this owns and must not be silently truncated to one that is.
@@ -876,6 +891,19 @@ function parseSingleVersionRoutes(
       // Restoring writes the document, so it is authorized as an update.
       operation: "update",
       method: "restoreSingleVersion",
+      routeParams,
+    };
+  }
+
+  // See the collection parser: naming a version is an idempotent write on
+  // history, authorized as an update.
+  if (subId && additionalParams.length === 0 && httpMethod === "PATCH") {
+    routeParams.slug = id;
+    routeParams.versionNo = subId;
+    return {
+      service: "singles",
+      operation: "update",
+      method: "setSingleVersionLabel",
       routeParams,
     };
   }

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -438,6 +438,9 @@ const COLLECTION_ENTRY_METHODS = new Set([
   // Restoring writes the document, so the route parser marks it an `update`
   // operation and this resolves to the `update-{slug}` permission.
   "restoreEntryVersion",
+  // Naming a version writes history rather than the document, but it is still
+  // a write and resolves to the same permission.
+  "setEntryVersionLabel",
 ]);
 
 /** Single document methods (read/update content, not schema definitions). */
@@ -449,6 +452,9 @@ const SINGLE_DOCUMENT_METHODS = new Set([
   "getSingleVersion",
   // A write, authorized as an update of the document.
   "restoreSingleVersion",
+  // Also a write. Deliberately absent from the read allowlist below, so the
+  // action resolves to `update` by default.
+  "setSingleVersionLabel",
 ]);
 
 /**


### PR DESCRIPTION
PR 5 of the content-versioning program. Plan: `tasks/2026-07-21-versions-labels-plan.md`.

> **Stacked on #276.** Base is `feat/versions-hardening`, not `main`. Labelling needs the same two-gate access shape restore uses, and #276 is what makes that shape correct — branching off `main` would have copied the version that resolves an API key's *owner's* permissions instead of the key's own scope. Merge #276 first; GitHub will retarget this to `main` automatically.

## Why

History identified every version by number, so finding the state you meant to go back to meant opening several and reading them.

## What already existed

The `label` column has been there since the capture engine — all three dialects, `VersionRow`, `VERSION_META_COLUMNS`, and the admin's `VersionMeta` type. Label values have been reaching the browser on every history request and being dropped on the floor. Nothing wrote them; nothing rendered them.

## Decisions worth reviewing

**`PATCH .../versions/{n}`, body `{ label: string | null }`.** Idempotent, so unlike restore it needs no retry guard — the default retry behaviour is correct and left in place. `null` clears.

**Bounded at 100 characters, enforced server-side.** No dialect caps the column (all three are `text`), so this is the only bound there is. The codebase convention for short strings is 255, but a label renders in a narrow history row; 100 is generous for the naming people actually do and stops a row becoming a paragraph.

**Normalized server-side, in the dispatcher.** Trim-and-nullify is client-side convention in this codebase today, and there's no server helper — but a REST API has callers that aren't the client, so it goes where `assertPositiveInteger` lives. An all-whitespace name clears rather than leaving an invisible one behind.

**Gated exactly like a restore.** A label is written onto history, so the caller must be allowed to see that history as well as change the document. Validation runs *before* the access checks, so a malformed request cannot be used to probe which documents exist.

**The response omits the snapshot.** Renaming is not a read of content, and returning it would bypass the redaction the version-detail endpoint applies.

## Obstacles worth knowing about

**`VersionsDbApi` had no `update`.** The port is deliberately narrow ("retention needs none"); widening it carries its own justification.

**Both route parsers hard-reject anything but GET or the exact restore shape**, so the new branch had to go before those guards or fall through to 404.

**`VersionRow` was a single `<button>`.** An edit control nested inside would have been a nested interactive element — invalid, and unreachable in the tab order. The row is now a wrapper with the open control and the rename control as siblings, with a test that clicking one doesn't trigger the other.

**`useVersion` claimed "a stored version never changes"** to justify a 60s `staleTime`. Still true of content — history is append-only — but not of the label; the comment now says which, and a rename invalidates the key rather than waiting the window out.

## Verification

- 12 dispatcher tests (normalization, both gates, snapshot omission), 20 route-parser tests, 14 dispatch/reachability, 21 admin UI tests
- The existing "exposes every version method" tripwire fired exactly as designed when I added methods without updating it; I extended it to also pin router reachability and the read-vs-write operation
- Every fix broken first to confirm the specific test fails
- typecheck, lint clean; admin baseline unchanged at 37 in 8 files; 37 versions integration tests on SQLite
- postgres and mysql verify in CI

## Out of scope

Labels on autosaves (not addressable), filtering history by label, and uniqueness — two versions may share a name, which is why the number stays visible next to it.