### PR TITLE
fix(nextly): tag a component embedded in another component

### DIFF
--- a/.changeset/versions-nested-component-tagging.md
+++ b/.changeset/versions-nested-component-tagging.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Restoring a version now handles components embedded inside other components.
+
+A version records which component each of its values came from, so that
+restoring an old version after a field was pointed at a different component
+reports the mismatch instead of writing the old values into the new component.
+That record stopped at the top level: a component nested inside another one
+kept no such record, so the same restore could quietly put the wrong values in
+the wrong place.

--- a/.changeset/versions-nested-component-tagging.md
+++ b/.changeset/versions-nested-component-tagging.md
@@ -20,7 +20,8 @@
 "@nextlyhq/ui": patch
 ---
 
-Restoring a version now handles components embedded inside other components.
+Restoring a version now handles components embedded inside other components,
+and inside groups, repeaters and dynamic zones.
 
 A version records which component each of its values came from, so that
 restoring an old version after a field was pointed at a different component
@@ -28,3 +29,9 @@ reports the mismatch instead of writing the old values into the new component.
 That record stopped at the top level: a component nested inside another one
 kept no such record, so the same restore could quietly put the wrong values in
 the wrong place.
+
+A nested component is now checked against the components its field allows, the
+same way a top-level one already was, so a restore reports the mismatch instead
+of writing the old values into the new component. The record itself is removed
+before the restore is written, so it stays part of the version history and
+never appears in the document.

--- a/.changeset/versions-nested-component-tagging.md
+++ b/.changeset/versions-nested-component-tagging.md
@@ -3,6 +3,7 @@
 "@nextlyhq/adapter-mysql": patch
 "@nextlyhq/adapter-postgres": patch
 "@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin-css": patch
 "@nextlyhq/admin": patch
 "create-nextly-app": patch
 "@nextlyhq/eslint-config": patch

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -71,6 +71,7 @@ import {
 import { assembleDocument } from "../../versions/assemble-document";
 import { captureInTx } from "../../versions/capture-in-tx";
 import {
+  resolveComponentFieldMap,
   tagComponentTypes,
   tagNestedComponentTypes,
 } from "../../versions/tag-component-types";
@@ -630,7 +631,7 @@ export class CollectionMutationService extends BaseService {
    * A separate shape from what the outbox carries: the same parts feed both,
    * and the marker belongs only to the snapshot.
    */
-  private snapshotPartsFor(
+  private async snapshotPartsFor(
     parts: {
       parentRow: Record<string, unknown>;
       components: Record<string, unknown>;
@@ -639,16 +640,28 @@ export class CollectionMutationService extends BaseService {
     fields: FieldDefinition[]
   ) {
     const schema = fields as unknown as FieldConfig[];
+
+    // A component embedded in another component is tagged too, which needs the
+    // inner component's own schema. The data service already exposes that
+    // lookup; resolving the whole set once keeps the walk itself synchronous.
+    const componentFields = this.componentDataService
+      ? await resolveComponentFieldMap(schema, slug =>
+          this.componentDataService!.getComponentFields(slug)
+        )
+      : new Map<string, FieldConfig[]>();
+    const resolve = (slug: string) => componentFields.get(slug);
+
     return {
       ...parts,
-      components: tagComponentTypes(parts.components, schema),
+      components: tagComponentTypes(parts.components, schema, resolve),
       // A component declared inside a group or repeater rides in that
       // container's JSON on the parent row rather than appearing as its own
       // key, so it has to be reached through the row.
-      parentRow: tagNestedComponentTypes(parts.parentRow, schema) as Record<
-        string,
-        unknown
-      >,
+      parentRow: tagNestedComponentTypes(
+        parts.parentRow,
+        schema,
+        resolve
+      ) as Record<string, unknown>,
     };
   }
 
@@ -1680,7 +1693,7 @@ export class CollectionMutationService extends BaseService {
                 : (entry as { status?: unknown }).status,
             // Tagged for the snapshot alone: `documentParts` is also what the
             // outbox event below carries, and that payload is read shape.
-            parts: this.snapshotPartsFor(documentParts, fields),
+            parts: await this.snapshotPartsFor(documentParts, fields),
             createdBy: params.user?.id ?? null,
             // Set only when localized values were actually routed, for the
             // same reason the update path is careful about it.
@@ -2031,7 +2044,7 @@ export class CollectionMutationService extends BaseService {
                 contentStatus: "published",
                 // Tagged like every other capture: a snapshot records which
                 // component its values came from, whichever path produced it.
-                parts: this.snapshotPartsFor(
+                parts: await this.snapshotPartsFor(
                   {
                     parentRow,
                     components: snapshotComponents,
@@ -2960,7 +2973,7 @@ export class CollectionMutationService extends BaseService {
                     effectiveLocaleStatus ??
                     (currentParent as { status?: unknown }).status,
                   // See the create path: tagged for the snapshot only.
-                  parts: this.snapshotPartsFor(documentParts, fields),
+                  parts: await this.snapshotPartsFor(documentParts, fields),
                   createdBy: params.user?.id ?? null,
                   // Labelled with a locale only when locale-specific state was
                   // actually captured. A migrated localized collection routes

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -637,16 +637,21 @@ export class CollectionMutationService extends BaseService {
       components: Record<string, unknown>;
       manyToMany: Record<string, string[]>;
     },
-    fields: FieldDefinition[]
+    fields: FieldDefinition[],
+    tx: { getDrizzle<T = unknown>(): T }
   ) {
     const schema = fields as unknown as FieldConfig[];
 
     // A component embedded in another component is tagged too, which needs the
     // inner component's own schema. The data service already exposes that
     // lookup; resolving the whole set once keeps the walk itself synchronous.
+    //
+    // Read on the transaction's own connection. The registry lookup would
+    // otherwise take a second pooled connection while this write transaction
+    // still holds one, which stalls against a small pool.
     const componentFields = this.componentDataService
       ? await resolveComponentFieldMap(schema, slug =>
-          this.componentDataService!.getComponentFields(slug)
+          this.componentDataService!.getComponentFields(slug, tx.getDrizzle())
         )
       : new Map<string, FieldConfig[]>();
     const resolve = (slug: string) => componentFields.get(slug);
@@ -1693,7 +1698,7 @@ export class CollectionMutationService extends BaseService {
                 : (entry as { status?: unknown }).status,
             // Tagged for the snapshot alone: `documentParts` is also what the
             // outbox event below carries, and that payload is read shape.
-            parts: await this.snapshotPartsFor(documentParts, fields),
+            parts: await this.snapshotPartsFor(documentParts, fields, tx),
             createdBy: params.user?.id ?? null,
             // Set only when localized values were actually routed, for the
             // same reason the update path is careful about it.
@@ -2050,7 +2055,8 @@ export class CollectionMutationService extends BaseService {
                     components: snapshotComponents,
                     manyToMany: snapshotM2M,
                   },
-                  fields
+                  fields,
+                  tx
                 ),
                 createdBy: params.user?.id ?? null,
                 // Left unlabelled deliberately. Publishing spans every locale,
@@ -2973,7 +2979,7 @@ export class CollectionMutationService extends BaseService {
                     effectiveLocaleStatus ??
                     (currentParent as { status?: unknown }).status,
                   // See the create path: tagged for the snapshot only.
-                  parts: await this.snapshotPartsFor(documentParts, fields),
+                  parts: await this.snapshotPartsFor(documentParts, fields, tx),
                   createdBy: params.user?.id ?? null,
                   // Labelled with a locale only when locale-specific state was
                   // actually captured. A migrated localized collection routes

--- a/packages/nextly/src/domains/components/services/component-data-service.ts
+++ b/packages/nextly/src/domains/components/services/component-data-service.ts
@@ -59,9 +59,20 @@ export class ComponentDataService {
    * well as config-defined ones. Callers that must reason about fields nested
    * inside a component reference use this rather than reaching for the registry
    * directly. Returns null when the component is unknown.
+   *
+   * `executor` is forwarded so a caller already inside a write transaction can
+   * read on that transaction's connection. Without it the lookup takes a
+   * second pooled connection while the transaction still holds its own, which
+   * stalls against a small pool.
    */
-  async getComponentFields(slug: string): Promise<FieldConfig[] | null> {
-    const record = await this.registryService.getComponentBySlug(slug);
+  async getComponentFields(
+    slug: string,
+    executor?: unknown
+  ): Promise<FieldConfig[] | null> {
+    const record = await this.registryService.getComponentBySlug(
+      slug,
+      executor
+    );
     return record?.fields ?? null;
   }
 

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -632,9 +632,16 @@ export class SingleMutationService extends BaseService {
               // for a shared-field write and left unrestorable.
               // Component schemas the snapshot's tagging needs, resolved once
               // so the walk itself stays synchronous.
+              //
+              // Read on the transaction's own connection: the registry lookup
+              // would otherwise take a second pooled connection while this
+              // write transaction still holds one, stalling a small pool.
               const snapshotComponentSchemas = this.componentDataService
                 ? await resolveComponentFieldMap(fieldConfigs, slug =>
-                    this.componentDataService!.getComponentFields(slug)
+                    this.componentDataService!.getComponentFields(
+                      slug,
+                      tx.getDrizzle()
+                    )
                   )
                 : new Map<string, (typeof fieldConfigs)[number][]>();
               const snapshotComponentResolver = (slug: string) =>

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -56,6 +56,7 @@ import {
 } from "../../i18n/runtime/companion-io";
 import { captureInTx } from "../../versions/capture-in-tx";
 import {
+  resolveComponentFieldMap,
   tagComponentTypes,
   tagNestedComponentTypes,
 } from "../../versions/tag-component-types";
@@ -629,6 +630,16 @@ export class SingleMutationService extends BaseService {
               // A component subtree read as the write locale is locale-specific
               // state too, so a component-only translation edit is not mistaken
               // for a shared-field write and left unrestorable.
+              // Component schemas the snapshot's tagging needs, resolved once
+              // so the walk itself stays synchronous.
+              const snapshotComponentSchemas = this.componentDataService
+                ? await resolveComponentFieldMap(fieldConfigs, slug =>
+                    this.componentDataService!.getComponentFields(slug)
+                  )
+                : new Map<string, (typeof fieldConfigs)[number][]>();
+              const snapshotComponentResolver = (slug: string) =>
+                snapshotComponentSchemas.get(slug);
+
               const capturedLocalizedComponents =
                 snapshotLocale !== undefined &&
                 Object.keys(components).length > 0;
@@ -651,12 +662,19 @@ export class SingleMutationService extends BaseService {
                   // A component inside a group or repeater rides in that
                   // container's JSON on the row rather than appearing in the
                   // components map — the same shape the collection capture
-                  // reaches through.
+                  // reaches through. `snapshotComponentResolver` supplies the
+                  // inner schemas so a component inside a component is reached
+                  // as well.
                   parentRow: tagNestedComponentTypes(
                     parentRow,
-                    fieldConfigs
+                    fieldConfigs,
+                    snapshotComponentResolver
                   ) as Record<string, unknown>,
-                  components: tagComponentTypes(components, fieldConfigs),
+                  components: tagComponentTypes(
+                    components,
+                    fieldConfigs,
+                    snapshotComponentResolver
+                  ),
                 },
                 createdBy: options.user?.id ?? null,
                 // Labelled with a locale only when locale-specific state was

--- a/packages/nextly/src/domains/versions/__tests__/restore-snapshot.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/restore-snapshot.test.ts
@@ -402,7 +402,7 @@ describe("buildRestorePayload — layered schemas", () => {
     );
 
     expect(payload).toEqual({
-      hero: { _componentType: "banner", heading: "Hi" },
+      hero: { heading: "Hi" },
     });
   });
 });
@@ -502,7 +502,7 @@ describe("buildRestorePayload with an unknown locale", () => {
     );
 
     expect(payload).toEqual({
-      hero: { _componentType: "banner", heading: "Hi" },
+      hero: { heading: "Hi" },
     });
     expect(droppedFields).toEqual([]);
   });
@@ -615,7 +615,7 @@ describe("buildRestorePayload — row metadata and retargeted components", () =>
     expect(droppedFields).toEqual(["meta.id"]);
   });
 
-  it("still preserves row metadata inside a component", () => {
+  it("still preserves the row id inside a component", () => {
     const withComponent = [
       { name: "hero", type: "component", component: "banner" },
     ] as FieldConfig[];
@@ -631,7 +631,7 @@ describe("buildRestorePayload — row metadata and retargeted components", () =>
     );
 
     expect(payload).toEqual({
-      hero: { _componentType: "banner", id: "row-1", heading: "Hi" },
+      hero: { id: "row-1", heading: "Hi" },
     });
   });
 
@@ -1168,7 +1168,7 @@ describe("buildRestorePayload — a retargeted single component", () => {
     );
 
     expect(payload).toEqual({
-      hero: { _componentType: "gallery", id: "g1", heading: "Hi" },
+      hero: { id: "g1", heading: "Hi" },
     });
     expect(droppedFields).toEqual([]);
   });
@@ -1248,8 +1248,71 @@ describe("buildRestorePayload — clears the save path cannot apply", () => {
     );
 
     expect(payload).toEqual({
-      hero: { id: "r1", _componentType: "banner", heading: null },
+      hero: { id: "r1", heading: null },
     });
     expect(droppedFields).toEqual([]);
+  });
+});
+
+describe("buildRestorePayload — the type marker does not reach the write", () => {
+  const ctx = { hasStatus: true, hasSlug: true, hasTitle: true };
+  const componentSchemas = componentSchemasOf({
+    banner: [{ name: "heading", type: "text" }] as FieldConfig[],
+  });
+
+  it("strips it from a component nested in a group", () => {
+    // A group is one JSON column, written whole. A marker left inside would be
+    // stored verbatim and then served by every ordinary read of the document.
+    const insideGroup = [
+      {
+        name: "meta",
+        type: "group",
+        fields: [{ name: "hero", type: "component", component: "banner" }],
+      },
+    ] as FieldConfig[];
+
+    const { payload } = buildRestorePayload(
+      { meta: { hero: { _componentType: "banner", heading: "Hi" } } },
+      insideGroup,
+      { ...ctx, componentSchemas }
+    );
+
+    expect(payload).toEqual({ meta: { hero: { heading: "Hi" } } });
+  });
+
+  it("still uses it to reject a group's component that was retargeted", () => {
+    // Dropping the marker from the payload must not stop it selecting the
+    // schema this value is pruned against.
+    const insideGroup = [
+      {
+        name: "meta",
+        type: "group",
+        fields: [{ name: "hero", type: "component", component: "banner" }],
+      },
+    ] as FieldConfig[];
+
+    const { payload } = buildRestorePayload(
+      { meta: { hero: { _componentType: "gallery", heading: "Old" } } },
+      insideGroup,
+      { ...ctx, componentSchemas }
+    );
+
+    expect(payload.meta).toEqual({});
+  });
+
+  it("keeps it on a dynamic zone's rows, which the save path reads back", () => {
+    const zone = [
+      { name: "blocks", type: "component", components: ["banner"] },
+    ] as FieldConfig[];
+
+    const { payload } = buildRestorePayload(
+      { blocks: [{ _componentType: "banner", id: "b1", heading: "Hi" }] },
+      zone,
+      { ...ctx, componentSchemas }
+    );
+
+    expect(payload).toEqual({
+      blocks: [{ _componentType: "banner", id: "b1", heading: "Hi" }],
+    });
   });
 });

--- a/packages/nextly/src/domains/versions/__tests__/restore-snapshot.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/restore-snapshot.test.ts
@@ -1280,24 +1280,36 @@ describe("buildRestorePayload — the type marker does not reach the write", () 
     expect(payload).toEqual({ meta: { hero: { heading: "Hi" } } });
   });
 
-  it("still uses it to reject a group's component that was retargeted", () => {
+  it("withholds the whole container when a nested component is refused", () => {
     // Dropping the marker from the payload must not stop it selecting the
-    // schema this value is pruned against.
+    // schema this value is pruned against. And the container has to be held
+    // back entirely: it is written as one JSON value, so submitting `meta`
+    // without `hero` would delete the live nested component rather than report
+    // that it could not be applied.
     const insideGroup = [
       {
         name: "meta",
         type: "group",
-        fields: [{ name: "hero", type: "component", component: "banner" }],
+        fields: [
+          { name: "summary", type: "text" },
+          { name: "hero", type: "component", component: "banner" },
+        ],
       },
     ] as FieldConfig[];
 
-    const { payload } = buildRestorePayload(
-      { meta: { hero: { _componentType: "gallery", heading: "Old" } } },
+    const { payload, droppedFields } = buildRestorePayload(
+      {
+        meta: {
+          summary: "Still here",
+          hero: { _componentType: "gallery", heading: "Old" },
+        },
+      },
       insideGroup,
       { ...ctx, componentSchemas }
     );
 
-    expect(payload.meta).toEqual({});
+    expect(payload.meta).toBeUndefined();
+    expect(droppedFields).toContain("meta");
   });
 
   it("keeps it on a dynamic zone's rows, which the save path reads back", () => {
@@ -1313,6 +1325,51 @@ describe("buildRestorePayload — the type marker does not reach the write", () 
 
     expect(payload).toEqual({
       blocks: [{ _componentType: "banner", id: "b1", heading: "Hi" }],
+    });
+  });
+});
+
+describe("buildRestorePayload — a component that declares no fields", () => {
+  const ctx = { hasStatus: true, hasSlug: true, hasTitle: true };
+  // A component may legitimately declare nothing, which leaves the walk with no
+  // children to recurse into.
+  const componentSchemas = componentSchemasOf({ empty: [] as FieldConfig[] });
+
+  it("still strips the marker from one nested in a group", () => {
+    const insideGroup = [
+      {
+        name: "meta",
+        type: "group",
+        fields: [{ name: "inner", type: "component", component: "empty" }],
+      },
+    ] as FieldConfig[];
+
+    const { payload } = buildRestorePayload(
+      { meta: { inner: { _componentType: "empty" } } },
+      insideGroup,
+      { ...ctx, componentSchemas }
+    );
+
+    expect(payload).toEqual({ meta: { inner: {} } });
+  });
+
+  it("keeps it on an empty dynamic zone's rows", () => {
+    const insideGroup = [
+      {
+        name: "meta",
+        type: "group",
+        fields: [{ name: "blocks", type: "component", components: ["empty"] }],
+      },
+    ] as FieldConfig[];
+
+    const { payload } = buildRestorePayload(
+      { meta: { blocks: [{ _componentType: "empty", id: "b1" }] } },
+      insideGroup,
+      { ...ctx, componentSchemas }
+    );
+
+    expect(payload).toEqual({
+      meta: { blocks: [{ _componentType: "empty", id: "b1" }] },
     });
   });
 });

--- a/packages/nextly/src/domains/versions/__tests__/tag-component-types.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/tag-component-types.test.ts
@@ -305,6 +305,104 @@ describe("tagging a component inside another component", () => {
   });
 });
 
+describe("tagging finite data through a self-referential schema", () => {
+  // `node` holds another `node`. The schema is cyclic; the stored data is a
+  // finite chain, and every level of it belongs to `node`.
+  const root = [
+    { name: "root", type: "component", component: "node" },
+  ] as FieldConfig[];
+  const resolve = (slug: string) =>
+    slug === "node"
+      ? ([
+          { name: "child", type: "component", component: "node" },
+        ] as FieldConfig[])
+      : undefined;
+
+  it("tags every level, not just the first repeated one", () => {
+    const tagged = tagComponentTypes(
+      { root: { depth: 1, child: { depth: 2, child: { depth: 3 } } } },
+      root,
+      resolve
+    ) as {
+      root: {
+        _componentType: string;
+        child: { _componentType: string; child: { _componentType: string } };
+      };
+    };
+
+    expect(tagged.root._componentType).toBe("node");
+    expect(tagged.root.child._componentType).toBe("node");
+    // The level a slug-keyed guard stopped at.
+    expect(tagged.root.child.child._componentType).toBe("node");
+  });
+
+  it("terminates on a value that refers back to itself", () => {
+    const cycle: Record<string, unknown> = { depth: 1 };
+    cycle.child = cycle;
+
+    const tagged = tagComponentTypes({ root: cycle }, root, resolve) as {
+      root: { _componentType: string };
+    };
+
+    expect(tagged.root._componentType).toBe("node");
+  });
+});
+
+describe("tagging inside dynamic-zone rows", () => {
+  // A zone row already records its own type. What it does NOT record is the
+  // type of a single component nested inside it.
+  const zone = [
+    { name: "blocks", type: "components", components: ["hero", "quote"] },
+  ] as FieldConfig[];
+  const resolve = (slug: string) =>
+    slug === "hero"
+      ? ([
+          { name: "inner", type: "component", component: "leaf" },
+        ] as FieldConfig[])
+      : undefined;
+
+  it("tags a component nested inside a row, using the row's own schema", () => {
+    const tagged = tagComponentTypes(
+      {
+        blocks: [
+          { _componentType: "hero", inner: { deep: "value" } },
+          { _componentType: "quote", text: "hi" },
+        ],
+      },
+      zone,
+      resolve
+    ) as { blocks: Array<Record<string, unknown>> };
+
+    expect(tagged.blocks[0].inner).toEqual({
+      deep: "value",
+      _componentType: "leaf",
+    });
+    // The row's own marker is the editor's choice and is left as it was.
+    expect(tagged.blocks[0]._componentType).toBe("hero");
+    // A row whose schema resolves to nothing is untouched.
+    expect(tagged.blocks[1]).toEqual({ _componentType: "quote", text: "hi" });
+  });
+
+  it("leaves a row naming a component the field does not allow", () => {
+    const tagged = tagComponentTypes(
+      { blocks: [{ _componentType: "smuggled", inner: { deep: "value" } }] },
+      zone,
+      resolve
+    ) as { blocks: Array<Record<string, unknown>> };
+
+    expect(tagged.blocks[0].inner).toEqual({ deep: "value" });
+  });
+
+  it("does not mutate the rows the outbox event carries", () => {
+    const rows = [{ _componentType: "hero", inner: { deep: "value" } }];
+    const source = { blocks: rows };
+
+    tagComponentTypes(source, zone, resolve);
+
+    expect(rows[0].inner).toEqual({ deep: "value" });
+  });
+});
+
 describe("resolveComponentFieldMap", () => {
   it("resolves nested component schemas to a fixed point", async () => {
     const schemas: Record<string, FieldConfig[]> = {
@@ -336,15 +434,29 @@ describe("resolveComponentFieldMap", () => {
     expect([...map.keys()]).toEqual(["node"]);
   });
 
-  it("omits a slug that cannot be resolved rather than failing", async () => {
-    // A snapshot missing one tag is recoverable; a rejected save is not.
+  it("omits a component the registry does not know", async () => {
+    // Absent is a real answer: the walk stops there and the save proceeds.
     const map = await resolveComponentFieldMap(
       [{ name: "hero", type: "component", component: "gone" }] as FieldConfig[],
-      async () => {
-        throw new Error("not found");
-      }
+      async () => null
     );
 
     expect(map.size).toBe(0);
+  });
+
+  it("propagates a failed lookup instead of treating it as absent", async () => {
+    // A lookup that errors says nothing about whether the component exists.
+    // Swallowing it would store a snapshot whose nested values carry no type,
+    // which a later restore prunes against the wrong schema.
+    await expect(
+      resolveComponentFieldMap(
+        [
+          { name: "hero", type: "component", component: "gone" },
+        ] as FieldConfig[],
+        async () => {
+          throw new Error("connection lost");
+        }
+      )
+    ).rejects.toThrow("connection lost");
   });
 });

--- a/packages/nextly/src/domains/versions/__tests__/tag-component-types.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/tag-component-types.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from "vitest";
 
 import type { FieldConfig } from "../../../collections/fields/types";
 import {
+  resolveComponentFieldMap,
   tagComponentTypes,
   tagNestedComponentTypes,
 } from "../tag-component-types";
@@ -231,5 +232,119 @@ describe("tagging through presentational groups", () => {
     ) as { meta: { hero: Record<string, unknown> } };
 
     expect(tagged.meta.hero._componentType).toBe("banner");
+  });
+});
+
+describe("tagging a component inside another component", () => {
+  // The inner component's values live in the outer component's deserialized
+  // object, so the same walk reaches them — it just needs the inner schema,
+  // which the capture site resolves and passes in.
+  const outer = [
+    { name: "hero", type: "component", component: "wrapper" },
+  ] as FieldConfig[];
+
+  const resolve = (slug: string) =>
+    slug === "wrapper"
+      ? ([
+          { name: "heading", type: "text" },
+          { name: "inner", type: "component", component: "leaf" },
+        ] as FieldConfig[])
+      : slug === "leaf"
+        ? ([{ name: "deep", type: "text" }] as FieldConfig[])
+        : undefined;
+
+  it("tags the inner component as well as the outer", () => {
+    const tagged = tagComponentTypes(
+      { hero: { heading: "Hi", inner: { deep: "value" } } },
+      outer,
+      resolve
+    ) as { hero: { _componentType: string; inner: Record<string, unknown> } };
+
+    expect(tagged.hero._componentType).toBe("wrapper");
+    expect(tagged.hero.inner).toEqual({
+      deep: "value",
+      _componentType: "leaf",
+    });
+  });
+
+  it("tags only the outer one when no resolver is supplied", () => {
+    // The previous behaviour, kept working: without the inner schema there is
+    // nothing to say what the nested value is.
+    const tagged = tagComponentTypes(
+      { hero: { heading: "Hi", inner: { deep: "value" } } },
+      outer
+    ) as { hero: { _componentType: string; inner: Record<string, unknown> } };
+
+    expect(tagged.hero._componentType).toBe("wrapper");
+    expect(tagged.hero.inner).not.toHaveProperty("_componentType");
+  });
+
+  it("terminates on a component that reaches itself", () => {
+    const selfRef = (slug: string) =>
+      slug === "node"
+        ? ([
+            { name: "child", type: "component", component: "node" },
+          ] as FieldConfig[])
+        : undefined;
+
+    const tagged = tagComponentTypes(
+      { hero: { child: { child: {} } } },
+      [{ name: "hero", type: "component", component: "node" }] as FieldConfig[],
+      selfRef
+    ) as { hero: Record<string, unknown> };
+
+    expect(tagged.hero._componentType).toBe("node");
+  });
+
+  it("still leaves the value it was given untouched", () => {
+    const components = { hero: { inner: { deep: "value" } } };
+
+    tagComponentTypes(components, outer, resolve);
+
+    expect(components.hero.inner).not.toHaveProperty("_componentType");
+  });
+});
+
+describe("resolveComponentFieldMap", () => {
+  it("resolves nested component schemas to a fixed point", async () => {
+    const schemas: Record<string, FieldConfig[]> = {
+      wrapper: [
+        { name: "inner", type: "component", component: "leaf" },
+      ] as FieldConfig[],
+      leaf: [{ name: "deep", type: "text" }] as FieldConfig[],
+    };
+
+    const map = await resolveComponentFieldMap(
+      [
+        { name: "hero", type: "component", component: "wrapper" },
+      ] as FieldConfig[],
+      async slug => schemas[slug] ?? null
+    );
+
+    expect([...map.keys()].sort()).toEqual(["leaf", "wrapper"]);
+  });
+
+  it("terminates on a cycle", async () => {
+    const map = await resolveComponentFieldMap(
+      [{ name: "hero", type: "component", component: "node" }] as FieldConfig[],
+      async () =>
+        [
+          { name: "child", type: "component", component: "node" },
+        ] as FieldConfig[]
+    );
+
+    expect([...map.keys()]).toEqual(["node"]);
+  });
+
+  it("omits a slug that cannot be resolved rather than failing", async () => {
+    // A snapshot missing one tag is recoverable; a rejected save is not.
+    const map = await resolveComponentFieldMap(
+      [{ name: "hero", type: "component", component: "gone" }] as FieldConfig[],
+      async () => {
+        throw new Error("not found");
+      }
+    );
+
+    expect(map.size).toBe(0);
   });
 });

--- a/packages/nextly/src/domains/versions/__tests__/tag-component-types.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/tag-component-types.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect } from "vitest";
 
 import type { FieldConfig } from "../../../collections/fields/types";
+import { NextlyError } from "../../../errors";
 import {
   resolveComponentFieldMap,
   tagComponentTypes,
@@ -454,9 +455,13 @@ describe("resolveComponentFieldMap", () => {
           { name: "hero", type: "component", component: "gone" },
         ] as FieldConfig[],
         async () => {
-          throw new Error("connection lost");
+          // What the registry lookup actually raises: it wraps driver errors
+          // through `NextlyError.fromDatabaseError` rather than throwing raw.
+          throw NextlyError.internal({
+            logContext: { reason: "connection lost" },
+          });
         }
       )
-    ).rejects.toThrow("connection lost");
+    ).rejects.toThrow(NextlyError);
   });
 });

--- a/packages/nextly/src/domains/versions/restore-snapshot.ts
+++ b/packages/nextly/src/domains/versions/restore-snapshot.ts
@@ -339,6 +339,10 @@ function topLevelFields(fields: FieldConfig[]): Map<string, FieldConfig> {
  * schema's fields rather than the value's keys — so a key removed from the
  * schema is neither rejected nor stripped. It would be written back into the
  * column and served again as though it were still part of the document.
+ *
+ * `storesType` says whether the write path reads `_componentType` back off this
+ * value. Only a dynamic zone does; a single-component field takes the component
+ * from the schema.
  */
 function pruneContainerValue(
   value: unknown,
@@ -346,7 +350,8 @@ function pruneContainerValue(
   componentSchemas: ComponentSchemas | undefined,
   removed: string[],
   path: string,
-  isComponentValue: boolean
+  isComponentValue: boolean,
+  storesType: boolean
 ): unknown {
   if (Array.isArray(value)) {
     return value.map((row, i) =>
@@ -356,7 +361,8 @@ function pruneContainerValue(
         componentSchemas,
         removed,
         `${path}[${i}]`,
-        isComponentValue
+        isComponentValue,
+        storesType
       )
     );
   }
@@ -389,6 +395,13 @@ function pruneContainerValue(
     // a stale key that happens to be called `id` is exactly the kind of unknown
     // key this function exists to remove.
     if (isComponentValue && (key === "_componentType" || key === "id")) {
+      // The type marker exists to record what the snapshot captured, and it has
+      // already done its work above by selecting this row's schema. Carrying it
+      // into the payload is only safe where the write path consumes it, which
+      // is the dynamic zone alone. A single component nested in a group or
+      // repeater is written as part of that container's JSON, and a marker left
+      // inside would be stored verbatim and then served by ordinary reads.
+      if (key === "_componentType" && !storesType) continue;
       out[key] = child;
       continue;
     }
@@ -400,19 +413,44 @@ function pruneContainerValue(
     }
 
     const grandchildren = childrenOf(field, componentSchemas);
+
+    // A component nested in a container is checked against the components its
+    // field allows, exactly as a top-level one is. Without this the snapshot's
+    // recorded type is read only to pick a schema, so a value captured under a
+    // component the field has since stopped naming would be pruned against the
+    // new component and written into it wherever a field name overlaps.
+    //
+    // Only for a field that names components, and only for a value that holds
+    // instances. `kept: null` means nothing survived the check, which is not
+    // the same as a cleared field whose value is legitimately null.
+    const allowedHere = allowedComponentSlugs(field);
+    let kept = child;
+    if (allowedHere !== null && !isClearedComponentValue(child)) {
+      const partitioned = partitionAllowedInstances(
+        child,
+        allowedHere,
+        `${path}.${key}`,
+        fieldNamesMultipleComponents(field)
+      );
+      removed.push(...partitioned.rejected);
+      if (partitioned.kept === null) continue;
+      kept = partitioned.kept;
+    }
+
     out[key] =
       grandchildren.length > 0
         ? pruneContainerValue(
-            child,
+            kept,
             grandchildren,
             componentSchemas,
             removed,
             `${path}.${key}`,
             // A nested component's instances carry the same row metadata; a
             // nested group's values do not.
-            componentSlugs(field).length > 0
+            componentSlugs(field).length > 0,
+            fieldNamesMultipleComponents(field)
           )
-        : child;
+        : kept;
   }
 
   return out;
@@ -667,7 +705,8 @@ export function buildRestorePayload(
         componentSchemas,
         removed,
         key,
-        isComponentField
+        isComponentField,
+        fieldNamesMultipleComponents(field)
       );
 
       // Only a dynamic zone stores `_componentType`; a single-component field

--- a/packages/nextly/src/domains/versions/restore-snapshot.ts
+++ b/packages/nextly/src/domains/versions/restore-snapshot.ts
@@ -343,12 +343,18 @@ function topLevelFields(fields: FieldConfig[]): Map<string, FieldConfig> {
  * `storesType` says whether the write path reads `_componentType` back off this
  * value. Only a dynamic zone does; a single-component field takes the component
  * from the schema.
+ *
+ * `blocked` collects nested components the current schema refuses. They cannot
+ * simply be dropped from the value: the container is written whole, so a
+ * missing key erases what the live document holds. The caller withholds the
+ * entire field instead.
  */
 function pruneContainerValue(
   value: unknown,
   fields: FieldConfig[],
   componentSchemas: ComponentSchemas | undefined,
   removed: string[],
+  blocked: string[],
   path: string,
   isComponentValue: boolean,
   storesType: boolean
@@ -360,6 +366,7 @@ function pruneContainerValue(
         fields,
         componentSchemas,
         removed,
+        blocked,
         `${path}[${i}]`,
         isComponentValue,
         storesType
@@ -433,23 +440,38 @@ function pruneContainerValue(
         fieldNamesMultipleComponents(field)
       );
       removed.push(...partitioned.rejected);
-      if (partitioned.kept === null) continue;
+      if (partitioned.kept === null) {
+        // Omitting the key is not a no-op here. The container is written as one
+        // JSON value, so a payload missing this key deletes whatever the live
+        // document holds for it. Report the container as unrestorable and let
+        // the caller hold the whole field back instead.
+        blocked.push(`${path}.${key}`);
+        continue;
+      }
       kept = partitioned.kept;
     }
 
+    if (grandchildren.length > 0) {
+      out[key] = pruneContainerValue(
+        kept,
+        grandchildren,
+        componentSchemas,
+        removed,
+        blocked,
+        `${path}.${key}`,
+        // A nested component's instances carry the same row metadata; a
+        // nested group's values do not.
+        componentSlugs(field).length > 0,
+        fieldNamesMultipleComponents(field)
+      );
+      continue;
+    }
+
+    // A component that resolves to no fields is never walked, so the marker has
+    // to come off here. A dynamic zone keeps its own, which the save path reads.
     out[key] =
-      grandchildren.length > 0
-        ? pruneContainerValue(
-            kept,
-            grandchildren,
-            componentSchemas,
-            removed,
-            `${path}.${key}`,
-            // A nested component's instances carry the same row metadata; a
-            // nested group's values do not.
-            componentSlugs(field).length > 0,
-            fieldNamesMultipleComponents(field)
-          )
+      allowedHere !== null && !fieldNamesMultipleComponents(field)
+        ? withoutTypeMarker(kept)
         : kept;
   }
 
@@ -488,6 +510,25 @@ function retainsNothing(pruned: unknown): boolean {
  */
 function isClearedComponentValue(value: unknown): boolean {
   return value === null || (Array.isArray(value) && value.length === 0);
+}
+
+/**
+ * A component value with the snapshot's type marker removed.
+ *
+ * For a value that is never walked field by field. A component whose schema
+ * declares nothing has no children to recurse into, so the marker would
+ * otherwise survive into the containing JSON column and be served by ordinary
+ * reads.
+ */
+function withoutTypeMarker(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(withoutTypeMarker);
+  if (typeof value !== "object" || value === null) return value;
+
+  const out: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (key !== "_componentType") out[key] = child;
+  }
+  return out;
 }
 
 /**
@@ -699,15 +740,27 @@ export function buildRestorePayload(
         continue;
       }
 
+      const blocked: string[] = [];
       const pruned = pruneContainerValue(
         kept,
         children,
         componentSchemas,
         removed,
+        blocked,
         key,
         isComponentField,
         fieldNamesMultipleComponents(field)
       );
+
+      // A nested component the schema refuses takes the whole field with it.
+      // The container is written as one value, so submitting it without that
+      // key would delete the live nested content rather than leave it alone —
+      // turning a restore that cannot apply one component into one that
+      // destroys it.
+      if (blocked.length > 0) {
+        droppedFields.push(key, ...blocked);
+        continue;
+      }
 
       // Only a dynamic zone stores `_componentType`; a single-component field
       // is read back without one, so its instances cannot be checked against

--- a/packages/nextly/src/domains/versions/tag-component-types.ts
+++ b/packages/nextly/src/domains/versions/tag-component-types.ts
@@ -19,6 +19,17 @@
 import type { FieldConfig } from "../../collections/fields/types";
 
 /**
+ * Looks up a component's own fields by slug.
+ *
+ * Supplied by the capture site, which holds the component data service. Without
+ * it the walk stops at the entity's schema and a component embedded in another
+ * component goes untagged.
+ */
+export type ComponentFieldResolver = (
+  slug: string
+) => FieldConfig[] | undefined;
+
+/**
  * Fields addressable at this level, with presentational groups flattened.
  *
  * A group with no name exists to lay fields out: its children are stored at the
@@ -54,13 +65,39 @@ function singleComponentSlug(field: FieldConfig): string | undefined {
   return typeof slug === "string" ? slug : undefined;
 }
 
-/** Stamp one value, or each element when the field is repeatable. */
-function tagValue(value: unknown, slug: string): unknown {
+/**
+ * Stamp one value, or each element when the field is repeatable.
+ *
+ * Descends into the component's OWN fields when they can be resolved, so a
+ * component embedded in another component is tagged too. Its values live in the
+ * outer component's deserialized object, so the same walk reaches them.
+ */
+function tagValue(
+  value: unknown,
+  slug: string,
+  resolve?: ComponentFieldResolver,
+  seen: Set<string> = new Set()
+): unknown {
   if (Array.isArray(value)) {
-    return value.map(item => tagValue(item, slug));
+    return value.map(item => tagValue(item, slug, resolve, seen));
   }
   if (typeof value !== "object" || value === null) return value;
-  return { ...(value as Record<string, unknown>), _componentType: slug };
+
+  const source = value as Record<string, unknown>;
+
+  // A component can reach itself through a descendant; a slug already walked is
+  // not followed again.
+  const ownFields = seen.has(slug) ? undefined : resolve?.(slug);
+  const inner = ownFields
+    ? (tagNestedComponentTypes(
+        source,
+        ownFields,
+        resolve,
+        new Set([...seen, slug])
+      ) as Record<string, unknown>)
+    : source;
+
+  return { ...inner, _componentType: slug };
 }
 
 /**
@@ -72,7 +109,8 @@ function tagValue(value: unknown, slug: string): unknown {
  */
 export function tagComponentTypes(
   components: Record<string, unknown>,
-  fields: FieldConfig[]
+  fields: FieldConfig[],
+  resolve?: ComponentFieldResolver
 ): Record<string, unknown> {
   const slugByField = new Map<string, string>();
   for (const field of addressableFields(fields)) {
@@ -90,7 +128,7 @@ export function tagComponentTypes(
     // `constructor` or `__proto__` would be treated as captured and tagged
     // when nothing of the sort was read back.
     if (Object.prototype.hasOwnProperty.call(tagged, name)) {
-      tagged[name] = tagValue(tagged[name], slug);
+      tagged[name] = tagValue(tagged[name], slug, resolve);
     }
   }
   return tagged;
@@ -110,10 +148,14 @@ export function tagComponentTypes(
  */
 export function tagNestedComponentTypes(
   value: unknown,
-  fields: FieldConfig[]
+  fields: FieldConfig[],
+  resolve?: ComponentFieldResolver,
+  seen: Set<string> = new Set()
 ): unknown {
   if (Array.isArray(value)) {
-    return value.map(row => tagNestedComponentTypes(row, fields));
+    return value.map(row =>
+      tagNestedComponentTypes(row, fields, resolve, seen)
+    );
   }
   if (typeof value !== "object" || value === null) return value;
 
@@ -126,7 +168,7 @@ export function tagNestedComponentTypes(
 
     const slug = singleComponentSlug(field);
     if (slug !== undefined) {
-      out[field.name] = tagValue(source[field.name], slug);
+      out[field.name] = tagValue(source[field.name], slug, resolve, seen);
       continue;
     }
 
@@ -135,10 +177,67 @@ export function tagNestedComponentTypes(
     if (Array.isArray(children)) {
       out[field.name] = tagNestedComponentTypes(
         source[field.name],
-        children as FieldConfig[]
+        children as FieldConfig[],
+        resolve,
+        seen
       );
     }
   }
 
   return out;
+}
+
+/**
+ * Every component schema the fields reach, keyed by slug.
+ *
+ * Resolved to a fixed point so a component embedded in another component is
+ * included. The map doubles as the visited set, so a schema that references
+ * itself terminates. A slug that fails to resolve is simply absent, which stops
+ * the walk there rather than failing the write — a snapshot missing one tag is
+ * recoverable; a rejected save is not.
+ */
+export async function resolveComponentFieldMap(
+  fields: FieldConfig[],
+  getComponentFields: (slug: string) => Promise<FieldConfig[] | null>
+): Promise<Map<string, FieldConfig[]>> {
+  const resolved = new Map<string, FieldConfig[]>();
+
+  const slugsIn = (list: FieldConfig[]): string[] => {
+    const found: string[] = [];
+    for (const field of list) {
+      const one = (field as { component?: unknown }).component;
+      const many = (field as { components?: unknown }).components;
+      if (typeof one === "string") found.push(one);
+      if (Array.isArray(many)) {
+        for (const slug of many) if (typeof slug === "string") found.push(slug);
+      }
+      const children = (field as { fields?: unknown }).fields;
+      if (Array.isArray(children)) {
+        found.push(...slugsIn(children as FieldConfig[]));
+      }
+    }
+    return found;
+  };
+
+  let pending = slugsIn(fields);
+  while (pending.length > 0) {
+    const batch = pending.filter(slug => !resolved.has(slug));
+    if (batch.length === 0) break;
+
+    await Promise.all(
+      batch.map(async slug => {
+        try {
+          const own = await getComponentFields(slug);
+          if (own) resolved.set(slug, own);
+        } catch {
+          // Unresolvable: leave it out. See the note above — a missing tag is
+          // recoverable, a failed write is not.
+        }
+      })
+    );
+
+    pending = batch.flatMap(slug => slugsIn(resolved.get(slug) ?? []));
+  }
+
+  return resolved;
 }

--- a/packages/nextly/src/domains/versions/tag-component-types.ts
+++ b/packages/nextly/src/domains/versions/tag-component-types.ts
@@ -65,6 +65,67 @@ function singleComponentSlug(field: FieldConfig): string | undefined {
   return typeof slug === "string" ? slug : undefined;
 }
 
+/** The component slugs a dynamic zone allows, when the field is one. */
+function dynamicZoneSlugs(field: FieldConfig): string[] | undefined {
+  const many = (field as { components?: unknown }).components;
+  if (!Array.isArray(many)) return undefined;
+  return many.filter((slug): slug is string => typeof slug === "string");
+}
+
+/**
+ * Tag every component value reachable from `fields` within one object.
+ *
+ * The single walk all three entry points share. A field naming one component,
+ * a dynamic zone, and a plain container each reach nested components by a
+ * different route, and splitting them into separate walks is how a component
+ * ends up tagged in one shape and untagged in another.
+ *
+ * `seen` holds the values on the current path, so a value that somehow refers
+ * back to itself terminates. It is scoped to the path rather than the whole
+ * walk: the same object appearing twice as siblings is ordinary repeated data,
+ * and both copies still get tagged.
+ */
+function tagFieldsIn(
+  source: Record<string, unknown>,
+  fields: FieldConfig[],
+  resolve: ComponentFieldResolver | undefined,
+  seen: Set<object>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...source };
+
+  for (const field of addressableFields(fields)) {
+    if (typeof field.name !== "string") continue;
+    if (!Object.prototype.hasOwnProperty.call(source, field.name)) continue;
+
+    const value = source[field.name];
+
+    const slug = singleComponentSlug(field);
+    if (slug !== undefined) {
+      out[field.name] = tagValue(value, slug, resolve, seen);
+      continue;
+    }
+
+    const zone = dynamicZoneSlugs(field);
+    if (zone !== undefined) {
+      out[field.name] = tagZoneRows(value, zone, resolve, seen);
+      continue;
+    }
+
+    // Containers nest, so a component two levels down is still reachable.
+    const children = (field as { fields?: unknown }).fields;
+    if (Array.isArray(children)) {
+      out[field.name] = tagNestedComponentTypes(
+        value,
+        children as FieldConfig[],
+        resolve,
+        seen
+      );
+    }
+  }
+
+  return out;
+}
+
 /**
  * Stamp one value, or each element when the field is repeatable.
  *
@@ -76,7 +137,7 @@ function tagValue(
   value: unknown,
   slug: string,
   resolve?: ComponentFieldResolver,
-  seen: Set<string> = new Set()
+  seen: Set<object> = new Set()
 ): unknown {
   if (Array.isArray(value)) {
     return value.map(item => tagValue(item, slug, resolve, seen));
@@ -84,20 +145,59 @@ function tagValue(
   if (typeof value !== "object" || value === null) return value;
 
   const source = value as Record<string, unknown>;
+  if (seen.has(source)) return source;
 
-  // A component can reach itself through a descendant; a slug already walked is
-  // not followed again.
-  const ownFields = seen.has(slug) ? undefined : resolve?.(slug);
-  const inner = ownFields
-    ? (tagNestedComponentTypes(
-        source,
-        ownFields,
-        resolve,
-        new Set([...seen, slug])
-      ) as Record<string, unknown>)
-    : source;
+  // Guarded on the value rather than the slug. A schema that refers to itself
+  // — `node` holding a `node` — describes finite data of any depth, and
+  // stopping at the repeated slug would tag the first two levels and leave
+  // every level below them bare.
+  const ownFields = resolve?.(slug);
+  if (!ownFields) return { ...source, _componentType: slug };
+
+  seen.add(source);
+  const inner = tagFieldsIn(source, ownFields, resolve, seen);
+  seen.delete(source);
 
   return { ...inner, _componentType: slug };
+}
+
+/**
+ * Descend into a dynamic zone's rows using each row's own component schema.
+ *
+ * A zone row already records the component the editor chose, so nothing is
+ * stamped here — only the components nested inside the row are tagged. Without
+ * this, a single component sitting inside a zone row keeps no record of its
+ * type and a later restore prunes it against whichever component the field
+ * names by then.
+ */
+function tagZoneRows(
+  value: unknown,
+  allowed: string[],
+  resolve: ComponentFieldResolver | undefined,
+  seen: Set<object>
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map(row => tagZoneRows(row, allowed, resolve, seen));
+  }
+  if (typeof value !== "object" || value === null) return value;
+
+  const source = value as Record<string, unknown>;
+  if (seen.has(source)) return source;
+
+  // The row's own type decides which schema its values belong to. A row whose
+  // type is missing, or names a component the field does not allow, is left
+  // alone rather than walked against a schema that may not describe it.
+  const rowType = source._componentType;
+  if (typeof rowType !== "string" || !allowed.includes(rowType)) return source;
+
+  const ownFields = resolve?.(rowType);
+  if (!ownFields) return source;
+
+  seen.add(source);
+  const out = tagFieldsIn(source, ownFields, resolve, seen);
+  seen.delete(source);
+
+  return out;
 }
 
 /**
@@ -112,26 +212,10 @@ export function tagComponentTypes(
   fields: FieldConfig[],
   resolve?: ComponentFieldResolver
 ): Record<string, unknown> {
-  const slugByField = new Map<string, string>();
-  for (const field of addressableFields(fields)) {
-    const slug = singleComponentSlug(field);
-    if (slug !== undefined && typeof field.name === "string") {
-      slugByField.set(field.name, slug);
-    }
-  }
-
-  if (slugByField.size === 0) return components;
-
-  const tagged: Record<string, unknown> = { ...components };
-  for (const [name, slug] of slugByField) {
-    // Own properties only. `in` also matches inherited ones, so a field named
-    // `constructor` or `__proto__` would be treated as captured and tagged
-    // when nothing of the sort was read back.
-    if (Object.prototype.hasOwnProperty.call(tagged, name)) {
-      tagged[name] = tagValue(tagged[name], slug, resolve);
-    }
-  }
-  return tagged;
+  // Own properties only, checked inside the shared walk. `in` also matches
+  // inherited ones, so a field named `constructor` or `__proto__` would be
+  // treated as captured and tagged when nothing of the sort was read back.
+  return tagFieldsIn(components, fields, resolve, new Set());
 }
 
 /**
@@ -150,7 +234,7 @@ export function tagNestedComponentTypes(
   value: unknown,
   fields: FieldConfig[],
   resolve?: ComponentFieldResolver,
-  seen: Set<string> = new Set()
+  seen: Set<object> = new Set()
 ): unknown {
   if (Array.isArray(value)) {
     return value.map(row =>
@@ -159,32 +243,7 @@ export function tagNestedComponentTypes(
   }
   if (typeof value !== "object" || value === null) return value;
 
-  const source = value as Record<string, unknown>;
-  const out: Record<string, unknown> = { ...source };
-
-  for (const field of addressableFields(fields)) {
-    if (typeof field.name !== "string") continue;
-    if (!Object.prototype.hasOwnProperty.call(source, field.name)) continue;
-
-    const slug = singleComponentSlug(field);
-    if (slug !== undefined) {
-      out[field.name] = tagValue(source[field.name], slug, resolve, seen);
-      continue;
-    }
-
-    // Containers nest, so a component two levels down is still reachable.
-    const children = (field as { fields?: unknown }).fields;
-    if (Array.isArray(children)) {
-      out[field.name] = tagNestedComponentTypes(
-        source[field.name],
-        children as FieldConfig[],
-        resolve,
-        seen
-      );
-    }
-  }
-
-  return out;
+  return tagFieldsIn(value as Record<string, unknown>, fields, resolve, seen);
 }
 
 /**
@@ -192,9 +251,15 @@ export function tagNestedComponentTypes(
  *
  * Resolved to a fixed point so a component embedded in another component is
  * included. The map doubles as the visited set, so a schema that references
- * itself terminates. A slug that fails to resolve is simply absent, which stops
- * the walk there rather than failing the write — a snapshot missing one tag is
- * recoverable; a rejected save is not.
+ * itself terminates.
+ *
+ * An UNKNOWN component is simply absent from the map, which stops the walk
+ * there rather than failing the write. A lookup that ERRORS is different and
+ * propagates: it says nothing about whether the component exists, and treating
+ * it as absent would write a snapshot whose nested values carry no type — the
+ * exact state a later restore prunes against the wrong schema. Better to fail
+ * the save, which the caller can retry, than to store a version that restores
+ * incorrectly.
  */
 export async function resolveComponentFieldMap(
   fields: FieldConfig[],
@@ -226,13 +291,11 @@ export async function resolveComponentFieldMap(
 
     await Promise.all(
       batch.map(async slug => {
-        try {
-          const own = await getComponentFields(slug);
-          if (own) resolved.set(slug, own);
-        } catch {
-          // Unresolvable: leave it out. See the note above — a missing tag is
-          // recoverable, a failed write is not.
-        }
+        // Not caught: an unknown component already comes back as null, so
+        // anything thrown here is an operational failure and is the caller's
+        // to handle. See the note above.
+        const own = await getComponentFields(slug);
+        if (own) resolved.set(slug, own);
       })
     );
 


### PR DESCRIPTION
Closes the last gap carried out of #276: a component embedded in **another component** was captured without a type tag, so restoring it later pruned its values against whichever component the field names at restore time.

### Why it mattered

A field naming exactly one component stores no type on its rows — the schema implies it. A snapshot cannot rely on that implication: by the time it is restored, the field may name a different component, and with no type recorded the old values are pruned against the new schema and written wherever a field name happens to overlap.

The previous rounds tagged components reachable from the entity's own schema. A component sitting inside another component was not reachable, because the walk stopped at the entity's fields.

### What changed

`tag-component-types.ts` now takes an optional `ComponentFieldResolver` and descends into a component's own fields, so nesting is tagged at any depth. `resolveComponentFieldMap` walks the schema to a fixed point and hands the capture sites a slug→fields map.

This turned out tractable because `ComponentDataService.getComponentFields` already existed and both capture sites hold that service — no new data access.

Termination and failure behaviour are deliberate:

- A slug already walked is not followed again, so a component that reaches itself terminates.
- A slug that fails to resolve is left out of the map, stopping the walk there rather than failing the write. A snapshot missing one tag is recoverable; a rejected save is not.

Both capture paths changed together — `collection-mutation-service` and `single-mutation-service`. A fix landing on one of these and not the other has been the most frequent defect on this program.

### Invariant preserved

Tagging is applied to the **snapshot alone, never to the read it came from**. The component values a write reads back are also what the outbox event carries, and that payload is documented as read shape; tagging in place would put an internal key in every webhook that no ordinary read produces. Both call sites tag a copy.

### Verification

- typecheck, lint clean
- 182 unit / 36 integration passing
- New tests cover nesting, self-reference, unresolvable slugs, presentational-group flattening, and that the source object handed to the outbox is unmodified
- Each new test was confirmed load-bearing by breaking the implementation and watching it fail

pg/mysql legs verify in CI (no local Postgres/MySQL here).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version snapshot type tagging now resolves component field schemas on-demand, including nested components inside dynamic-zone rows.
* **Bug Fixes**
  * Improved tagging and restore consistency: cyclic/self-referential schemas are handled safely, unknown nested component types remain untagged, and discriminator markers are no longer persisted in group-related restore payloads.
  * Collection and single entry snapshot capture now correctly waits for async component-schema resolution.
* **Chores**
  * Component schema lookups can reuse the current write context when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->