### PR TITLE
feat(nextly): generate and encrypt webhook signing secrets

### DIFF
--- a/.changeset/webhook-signing-secret-lifecycle.md
+++ b/.changeset/webhook-signing-secret-lifecycle.md
@@ -1,0 +1,27 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Webhook signing secrets can now be generated and stored encrypted.
+
+Delivery signs each request with the endpoint's secret, but nothing could produce one: there was no generator, and the decrypt step the delivery engine depends on had no implementation outside a test stub. This adds that boundary — a `whsec_` secret in the format Standard Webhooks receivers expect, encrypted under `NEXTLY_SECRET` with the same scheme that already protects email provider credentials.
+
+Storing a signing secret requires `NEXTLY_SECRET` to be set. Unlike provider configuration, which degrades to plaintext when no key is present, a webhook secret is the signing key itself: stored readable, anyone with database access could sign requests your receivers would trust. It fails instead, and says so.

--- a/packages/nextly/src/domains/webhooks/__tests__/secret.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/secret.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The signing-secret lifecycle.
+ *
+ * A generated secret has to satisfy two independent readers: `signing.ts`,
+ * which strips `whsec_` and base64-decodes the rest to HMAC key bytes, and the
+ * receiver's own Standard Webhooks library, which does exactly the same. A
+ * secret that decodes to nothing still produces a valid-looking signature, so
+ * the format is asserted rather than assumed.
+ *
+ * The encryption half is asserted through a round trip rather than against a
+ * fixed ciphertext: AES-GCM uses a random salt and IV, so the same plaintext
+ * encrypts differently every time, and a golden value would only prove the
+ * test was written from the output.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildSignatureHeaders } from "../signing";
+
+import {
+  WEBHOOK_SECRET_PREFIX,
+  decryptWebhookSecret,
+  encryptWebhookSecret,
+  generateWebhookSecret,
+  webhookEncryptionKey,
+  webhookSecretPrefix,
+} from "../secret";
+
+// The crypto takes its key as a parameter, so these need no environment at
+// all. Only the env-sourcing helper below does.
+const KEY = "test-application-secret";
+
+describe("generateWebhookSecret", () => {
+  it("produces a secret signing.ts can turn into key bytes", () => {
+    const secret = generateWebhookSecret();
+
+    expect(secret.startsWith(WEBHOOK_SECRET_PREFIX)).toBe(true);
+    const decoded = Buffer.from(
+      secret.slice(WEBHOOK_SECRET_PREFIX.length),
+      "base64"
+    );
+    expect(decoded.length).toBe(32);
+
+    // The real contract: it signs. A secret that decoded to zero bytes would
+    // make signing throw rather than emit a weak signature.
+    const headers = buildSignatureHeaders({
+      id: "msg_1",
+      timestamp: 1_700_000_000,
+      body: '{"a":1}',
+      secrets: [secret],
+    });
+    expect(headers["webhook-signature"]).toMatch(/^v1,/);
+  });
+
+  it("does not repeat", () => {
+    const seen = new Set(
+      Array.from({ length: 50 }, () => generateWebhookSecret())
+    );
+    expect(seen.size).toBe(50);
+  });
+});
+
+describe("webhookSecretPrefix", () => {
+  it("keeps enough to identify a secret and little enough to be public", () => {
+    const secret = `${WEBHOOK_SECRET_PREFIX}abcdefghijklmnop`;
+
+    // Includes the scheme prefix, so what is stored reads as an identifier
+    // rather than as key material.
+    expect(webhookSecretPrefix(secret)).toBe("whsec_ab");
+    expect(webhookSecretPrefix(secret).length).toBeLessThan(secret.length / 2);
+  });
+});
+
+describe("encrypt/decrypt round trip", () => {
+  it("recovers the exact secret", () => {
+    const secret = generateWebhookSecret();
+    expect(decryptWebhookSecret(encryptWebhookSecret(secret, KEY), KEY)).toBe(
+      secret
+    );
+  });
+
+  it("produces different ciphertext for the same secret", () => {
+    // Random salt and IV per call: identical stored values would leak that two
+    // endpoints share a secret.
+    const secret = generateWebhookSecret();
+    expect(encryptWebhookSecret(secret, KEY)).not.toBe(
+      encryptWebhookSecret(secret, KEY)
+    );
+  });
+
+  it("does not store the plaintext anywhere in the ciphertext", () => {
+    const secret = generateWebhookSecret();
+    const stored = encryptWebhookSecret(secret, KEY);
+
+    expect(stored).not.toContain(secret);
+    expect(stored).not.toContain(secret.slice(WEBHOOK_SECRET_PREFIX.length));
+  });
+
+  it("refuses a value encrypted under a different key", () => {
+    const stored = encryptWebhookSecret(generateWebhookSecret(), KEY);
+
+    expect(() =>
+      decryptWebhookSecret(stored, "a-different-application-secret")
+    ).toThrow();
+  });
+});
+
+describe("webhookEncryptionKey", () => {
+  // Reading env validates the whole environment, so these set the database
+  // fields the schema requires alongside the key under test. The env module
+  // caches after its first read, so each case loads a fresh copy rather than
+  // seeing whatever the previous one cached.
+  const saved: Record<string, string | undefined> = {};
+  const set = (k: string, v: string | undefined): void => {
+    if (!(k in saved)) saved[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  };
+
+  const loadKey = async (): Promise<() => string> => {
+    vi.resetModules();
+    const mod = await import("../secret");
+    return mod.webhookEncryptionKey;
+  };
+
+  beforeEach(() => {
+    set("DB_DIALECT", "sqlite");
+    set("DATABASE_URL", "file:./secret-test.db");
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(saved)) {
+      // Assigning undefined stores the literal string "undefined", which a
+      // later read in this shared process would treat as a real value.
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it("returns the configured key", async () => {
+    set("NEXTLY_SECRET", KEY);
+    expect((await loadKey())()).toBe(KEY);
+  });
+
+  // The email provider service stores its configuration in the clear when no
+  // key is set. That is survivable for one provider's credentials; a webhook
+  // secret IS the signing key, so storing it readable would let anyone with
+  // database access forge a signature every receiver accepts. Fail instead.
+  it("throws when no key is configured", async () => {
+    set("NEXTLY_SECRET", undefined);
+    const key = await loadKey();
+    expect(() => key()).toThrow();
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/secret.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/secret.test.ts
@@ -14,6 +14,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { NextlyError } from "../../../errors";
 import { buildSignatureHeaders } from "../signing";
 
 import {
@@ -60,13 +61,39 @@ describe("generateWebhookSecret", () => {
 });
 
 describe("webhookSecretPrefix", () => {
-  it("keeps enough to identify a secret and little enough to be public", () => {
+  it("keeps the scheme prefix plus eight random characters", () => {
     const secret = `${WEBHOOK_SECRET_PREFIX}abcdefghijklmnop`;
 
-    // Includes the scheme prefix, so what is stored reads as an identifier
-    // rather than as key material.
-    expect(webhookSecretPrefix(secret)).toBe("whsec_ab");
-    expect(webhookSecretPrefix(secret).length).toBeLessThan(secret.length / 2);
+    expect(webhookSecretPrefix(secret)).toBe("whsec_abcdefgh");
+  });
+
+  it("fits the column on every dialect", () => {
+    // secret_prefix is varchar(16) on PostgreSQL and MySQL.
+    expect(
+      webhookSecretPrefix(generateWebhookSecret()).length
+    ).toBeLessThanOrEqual(16);
+  });
+
+  it("distinguishes real secrets rather than colliding", () => {
+    // Counting from the whole string instead of the random part left two
+    // random characters, and two of fifty endpoints would then usually share
+    // a prefix — which is exactly the case the display value exists for.
+    const prefixes = new Set(
+      Array.from({ length: 50 }, () =>
+        webhookSecretPrefix(generateWebhookSecret())
+      )
+    );
+    expect(prefixes.size).toBe(50);
+  });
+
+  it("reveals only a small fraction of the key", () => {
+    const secret = generateWebhookSecret();
+    const shown = webhookSecretPrefix(secret).slice(
+      WEBHOOK_SECRET_PREFIX.length
+    );
+    expect(shown.length).toBeLessThan(
+      (secret.length - WEBHOOK_SECRET_PREFIX.length) / 4
+    );
   });
 });
 
@@ -100,7 +127,15 @@ describe("encrypt/decrypt round trip", () => {
 
     expect(() =>
       decryptWebhookSecret(stored, "a-different-application-secret")
-    ).toThrow();
+    ).toThrow(NextlyError);
+  });
+
+  it("reports a malformed stored value as a NextlyError", () => {
+    // utils/encryption throws a bare Error, and node's cipher does too. This
+    // is inside packages/nextly, so neither may escape untyped.
+    expect(() => decryptWebhookSecret("not-ciphertext", KEY)).toThrow(
+      NextlyError
+    );
   });
 });
 

--- a/packages/nextly/src/domains/webhooks/secret.ts
+++ b/packages/nextly/src/domains/webhooks/secret.ts
@@ -1,0 +1,118 @@
+/**
+ * Webhook domain — the signing-secret lifecycle.
+ *
+ * `signing.ts` is pure functions over a plaintext secret and says where the
+ * plaintext is meant to come from: secrets live encrypted at rest, and the CRUD
+ * and delivery slices own the encrypt/decrypt boundary. This module is that
+ * boundary. Delivery cannot sign without it — `decryptSecret` is an injected
+ * dependency the delivery engine has no production implementation for — and
+ * CRUD has nothing safe to store without it.
+ *
+ * Encryption reuses `utils/encryption` (AES-256-GCM, scrypt-derived key,
+ * `salt.iv.authTag.ciphertext`) rather than a second scheme, so webhook secrets
+ * are protected exactly as email provider credentials already are.
+ *
+ * @module domains/webhooks/secret
+ */
+
+import { randomBytes } from "node:crypto";
+
+import { NextlyError } from "../../errors";
+import { env } from "../../lib/env";
+import { decrypt, encrypt } from "../../utils/encryption";
+
+/**
+ * Standard Webhooks secrets are `whsec_`-prefixed, base64-encoded key bytes.
+ * Kept identical to the prefix `signing.ts` strips before decoding, so a secret
+ * generated here is one the reference `standardwebhooks` libraries accept.
+ */
+export const WEBHOOK_SECRET_PREFIX = "whsec_";
+
+/** 32 bytes: the HMAC-SHA256 block size, and what the reference tooling emits. */
+const SECRET_BYTES = 32;
+
+/**
+ * Characters of the secret kept for display. Enough to tell two secrets apart
+ * in a list without being enough to attack: the prefix is stored in the clear
+ * and shown after the one-time reveal, so it must never narrow the key
+ * meaningfully.
+ */
+const DISPLAY_PREFIX_LENGTH = 8;
+
+/** A new signing secret, in the form a receiver's library expects. */
+export function generateWebhookSecret(): string {
+  return `${WEBHOOK_SECRET_PREFIX}${randomBytes(SECRET_BYTES).toString("base64")}`;
+}
+
+/**
+ * The display-only fragment stored alongside the ciphertext.
+ *
+ * Taken from the front of the secret including its prefix, so the stored value
+ * reads as `whsec_ab` rather than as key material. The plaintext is shown to
+ * the user exactly once at creation; this is what every screen after that has
+ * to identify the secret by.
+ */
+export function webhookSecretPrefix(secret: string): string {
+  return secret.slice(0, DISPLAY_PREFIX_LENGTH);
+}
+
+/**
+ * The application key webhook secrets are encrypted under.
+ *
+ * Exported so a caller can resolve it once and hand it to both halves, and so
+ * the crypto below stays a pure function of its inputs — reading the
+ * environment inside it would pull full env validation into every consumer and
+ * every test that touches a secret.
+ *
+ * Absent, this throws rather than degrading. The email provider service stores
+ * its configuration in the clear when no key is set, which is a survivable
+ * trade for credentials that are already scoped to one provider — but a webhook
+ * secret IS the signing key. Storing it readable would let anyone with database
+ * read access forge a signature that every receiver accepts as genuine, and it
+ * would do so silently. `signing.ts` already refuses to emit an unsigned
+ * request for the same reason; refusing to store an unprotected secret is the
+ * same posture one step earlier.
+ */
+export function webhookEncryptionKey(): string {
+  const key = env.NEXTLY_SECRET;
+  if (!key) {
+    throw NextlyError.internal({
+      logContext: {
+        reason: "webhook-secret-no-encryption-key",
+        remedy:
+          "Set NEXTLY_SECRET. Webhook signing secrets are encrypted under it, " +
+          "and without it the secret would be stored readable — anyone with " +
+          "database access could then sign requests your receivers trust.",
+      },
+    });
+  }
+  return key;
+}
+
+/**
+ * Encrypt a plaintext signing secret for storage.
+ *
+ * The key defaults to the application secret; passing one explicitly keeps the
+ * function pure for callers that have already resolved it.
+ */
+export function encryptWebhookSecret(
+  plaintext: string,
+  key: string = webhookEncryptionKey()
+): string {
+  return encrypt(plaintext, key);
+}
+
+/**
+ * Recover a stored signing secret.
+ *
+ * Throws when the key is missing or the value does not decrypt — a secret that
+ * cannot be recovered cannot sign, and delivering unsigned or wrongly-signed is
+ * worse than not delivering. The caller records the failed attempt so the
+ * endpoint surfaces as broken rather than silently going quiet.
+ */
+export function decryptWebhookSecret(
+  ciphertext: string,
+  key: string = webhookEncryptionKey()
+): string {
+  return decrypt(ciphertext, key);
+}

--- a/packages/nextly/src/domains/webhooks/secret.ts
+++ b/packages/nextly/src/domains/webhooks/secret.ts
@@ -28,16 +28,26 @@ import { decrypt, encrypt } from "../../utils/encryption";
  */
 export const WEBHOOK_SECRET_PREFIX = "whsec_";
 
-/** 32 bytes: the HMAC-SHA256 block size, and what the reference tooling emits. */
+/**
+ * 32 bytes — SHA-256's digest size, and the key length the reference Standard
+ * Webhooks tooling emits. (Its block size is 64; a key at least as long as the
+ * digest is what HMAC guidance asks for.)
+ */
 const SECRET_BYTES = 32;
 
 /**
- * Characters of the secret kept for display. Enough to tell two secrets apart
- * in a list without being enough to attack: the prefix is stored in the clear
- * and shown after the one-time reveal, so it must never narrow the key
- * meaningfully.
+ * Characters kept from the secret's random part for display.
+ *
+ * Counted AFTER the fixed `whsec_`, which carries no information: keeping eight
+ * characters of the whole string would leave two random ones, about 12 bits,
+ * and two of fifty endpoints would then share a prefix more often than not.
+ * Eight base64 characters is roughly 48 bits, which distinguishes secrets in a
+ * list and across a rotation while revealing a small fraction of a 256-bit key.
+ *
+ * The total stored value is `whsec_` plus this, so it must stay within the
+ * column: `secret_prefix` is varchar(16) on PostgreSQL and MySQL.
  */
-const DISPLAY_PREFIX_LENGTH = 8;
+const DISPLAY_RANDOM_CHARS = 8;
 
 /** A new signing secret, in the form a receiver's library expects. */
 export function generateWebhookSecret(): string {
@@ -53,7 +63,7 @@ export function generateWebhookSecret(): string {
  * to identify the secret by.
  */
 export function webhookSecretPrefix(secret: string): string {
-  return secret.slice(0, DISPLAY_PREFIX_LENGTH);
+  return secret.slice(0, WEBHOOK_SECRET_PREFIX.length + DISPLAY_RANDOM_CHARS);
 }
 
 /**
@@ -99,7 +109,17 @@ export function encryptWebhookSecret(
   plaintext: string,
   key: string = webhookEncryptionKey()
 ): string {
-  return encrypt(plaintext, key);
+  try {
+    return encrypt(plaintext, key);
+  } catch (err) {
+    // `utils/encryption` throws bare Errors, and node's cipher does too. This
+    // is the domain boundary, so the failure is translated here rather than
+    // travelling out of packages/nextly as an untyped error.
+    throw NextlyError.internal({
+      cause: err instanceof Error ? err : undefined,
+      logContext: { reason: "webhook-secret-encrypt-failed" },
+    });
+  }
 }
 
 /**
@@ -114,5 +134,16 @@ export function decryptWebhookSecret(
   ciphertext: string,
   key: string = webhookEncryptionKey()
 ): string {
-  return decrypt(ciphertext, key);
+  try {
+    return decrypt(ciphertext, key);
+  } catch (err) {
+    // A malformed value throws `Invalid encrypted data format`; a value stored
+    // under a different NEXTLY_SECRET fails the GCM auth tag. Both arrive as
+    // bare Errors, and both mean the same thing to a caller: this secret
+    // cannot sign. The cause is preserved for the operator-facing rendering.
+    throw NextlyError.internal({
+      cause: err instanceof Error ? err : undefined,
+      logContext: { reason: "webhook-secret-decrypt-failed" },
+    });
+  }
 }


### PR DESCRIPTION
First slice of the webhooks work, chosen after a full audit of the domain.

## Why this first

Delivery signs every request with the endpoint's secret. Nothing could produce one:

- no secret generator anywhere in the repo
- `decryptSecret` is an injected dependency consumed at `deliver.ts:375`, and **no product code supplies it** — the only implementation is an identity stub in `deliver.integration.test.ts:190`

So the delivery path cannot sign a real encrypted secret today, and endpoint CRUD has nothing safe to store. `signing.ts:19` already documents this boundary as belonging to the CRUD and delivery slices:

> Secrets live encrypted at rest (utils/encryption.ts + NEXTLY_SECRET); the CRUD and delivery slices own the encrypt/decrypt boundary and pass the decrypted secret in here.

This is that boundary. It unblocks CRUD, which unblocks the drain trigger, which is what makes any additional event types worth recording.

## What it does

`generateWebhookSecret()` returns `whsec_` plus 32 base64-encoded bytes — exactly what `secretToKey` (`signing.ts:42`) strips and decodes, and what a receiver's Standard Webhooks library expects. The test asserts this by **signing a payload**, not by inspecting the string: a secret decoding to zero bytes would still look plausible but `signing.ts` rejects it.

`encryptWebhookSecret` / `decryptWebhookSecret` reuse `utils/encryption` (AES-256-GCM, scrypt-derived key), the same scheme already protecting email provider credentials, rather than introducing a second one.

`webhookSecretPrefix()` produces the display-only `secret_prefix` value, including the scheme prefix so what is stored reads as an identifier rather than key material.

## One deliberate difference from existing behaviour

`EmailProviderService` stores its configuration **in the clear** when `NEXTLY_SECRET` is unset (`email-provider-service.ts:130-135`). This does not copy that.

A provider credential stored readable is a scoped exposure. A webhook secret **is the signing key** — stored readable, anyone with database read access could sign requests every receiver accepts as genuine, silently. `signing.ts:118` already refuses to emit an unsigned request for the same reason; refusing to store an unprotected secret is the same posture one step earlier. `NEXTLY_SECRET` is `z.string().optional()` (`shared/lib/env.ts:41`), so this is a real runtime case, and the error carries the remedy.

## Design note

The key is a parameter with an env-sourced default (`webhookEncryptionKey()`). Reading env inside the crypto would drag full environment validation into every consumer and every test that touches a secret — `env` validates the entire schema on first access, so `NEXTLY_SECRET` alone pulls in `DATABASE_URL`. Injectable keeps the crypto pure; the default keeps call sites short; the fail-closed check stays in exactly one place.

## Verification

9 new tests. Round trips are asserted through encrypt/decrypt rather than against a golden ciphertext, since AES-GCM randomises salt and IV per call — a fixed value would only prove the test was written from the output. Also asserted: the ciphertext contains no fragment of the plaintext, two encryptions of the same secret differ, and a wrong key fails.

Load-bearing: neutering the fail-closed guard fails the suite. Whole domain green — 13 files, 137 tests. Typecheck and eslint clean.

## Not in this PR

The `secret_hash` column stores reversible ciphertext, not a hash (`deliver.ts:130` says so). Renaming it is nearly free while the table has no production rows, but it is a core-table column rename and the diff pipeline may see drop+add rather than a rename — that needs its own verification, so it gets its own PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure webhook signing secret generation with a consistent, recognizable prefix.
  * Added display-safe secret prefix extraction for safer webhook management.
  * Added encryption and decryption helpers to securely store webhook signing secrets.
  * Added configuration validation for required encryption key presence.

* **Tests**
  * Added coverage for secret uniqueness, prefix length/partial disclosure behavior, signature header compatibility, and encryption/decryption round-tripping.
  * Added tests for incorrect keys, malformed ciphertext handling, and missing encryption key scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->