### PR TITLE
fix(nextly): apply document update rules when renaming a version

### DIFF
--- a/.changeset/versions-label-update-access.md
+++ b/.changeset/versions-label-update-access.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Renaming a version now respects the document own access rules.
+
+A collection or Single can restrict who may edit a particular document, for
+example by allowing only its owner. Someone who could not edit the document
+itself was still able to rename entries in its history, because that check was
+never run on this path. It now is, for both collections and Singles.

--- a/packages/nextly/src/api/versions-access.ts
+++ b/packages/nextly/src/api/versions-access.ts
@@ -17,10 +17,12 @@
 
 import type { FieldConfig } from "../collections/fields/types";
 import { getService } from "../di";
+import { checkSingleAccess } from "../domains/singles";
 import type { UserContext } from "../domains/singles/types";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
 import type { VersionScopeKind } from "../schemas/versions/types";
+import { AccessControlService } from "../services/access/access-control-service";
 import { resolveRoleSlugs } from "../services/lib/permissions";
 import { applyFieldReadAccess } from "../shared/lib/field-level-registry";
 import { stripPasswordFieldValues } from "../shared/lib/password-fields";
@@ -98,6 +100,104 @@ export async function assertVersionDocumentReadable(
       },
     });
   }
+}
+
+/**
+ * Confirm the caller may UPDATE the live document, for writes to its history.
+ *
+ * Renaming or otherwise editing a version changes a record of the document, so
+ * it owes the document's own update rules. The route-level `update-<slug>`
+ * permission is coarse: it says the caller may update documents of this kind,
+ * not that they may update THIS one. A collection or Single carrying an
+ * owner-only or role-based per-document rule refuses the document itself while
+ * that coarse permission still stands, and without this gate the history would
+ * stay editable.
+ *
+ * Read access is assumed to have been established already. That is why a
+ * refusal here is 403 rather than the read gate's 404: the caller has proven
+ * they can see this document, so concealing its existence protects nothing and
+ * only makes the refusal harder to act on.
+ *
+ * Both entity kinds are covered deliberately. A gate that reached only one
+ * would read as complete and would not be.
+ */
+export async function assertVersionDocumentUpdatable(
+  scopeKind: VersionScopeKind,
+  slug: string,
+  entryId: string,
+  user: UserContext
+): Promise<void> {
+  const allowed =
+    scopeKind === "single"
+      ? await canUpdateLiveSingle(slug, entryId, user)
+      : await getService("collectionsHandler").canUpdateEntry({
+          collectionName: slug,
+          entryId,
+          user,
+          // As the read gate does: route authorization already ran, so skip
+          // only the redundant coarse re-check. The stored per-document rules
+          // this gate exists for still run.
+          routeAuthorized: true,
+        });
+
+  if (!allowed) {
+    throw NextlyError.forbidden({
+      logContext: {
+        reason: "version-document-not-updatable",
+        scopeKind,
+        scopeSlug: slug,
+        entryId,
+        userId: user.id,
+      },
+    });
+  }
+}
+
+/**
+ * Single variant of the update gate.
+ *
+ * Reads the row directly rather than through `SingleEntryService`, which
+ * materializes a missing Single. The live id is compared with the requested
+ * one for the same reason the read gate compares it: version rows outlive the
+ * document they came from, so a Single recreated under a new id must not have
+ * the previous document's history edited through it.
+ */
+async function canUpdateLiveSingle(
+  slug: string,
+  entryId: string,
+  user: UserContext
+): Promise<boolean> {
+  const registry = getService("singleRegistryService");
+  const record = await registry.getSingleBySlug(slug);
+  if (!record?.tableName) return false;
+
+  const liveId = await resolveSingleDocumentId(slug);
+  if (liveId === null || liveId !== entryId) return false;
+
+  const adapter = getService("adapter");
+  // Loaded because an owner-only rule compares against the stored row, and
+  // `checkSingleAccess` refuses outright when such a rule has no document.
+  const document = await adapter.selectOne<Record<string, unknown>>(
+    record.tableName,
+    {}
+  );
+  if (!document) return false;
+
+  const denied = await checkSingleAccess({
+    slug,
+    operation: "update",
+    user,
+    overrideAccess: false,
+    routeAuthorized: true,
+    rbacAccessControlService: getService("rbacAccessControlService"),
+    // Stateless evaluator for the Single's stored rules; it holds no
+    // per-request state, so constructing one here matches the write path.
+    accessControlService: new AccessControlService(),
+    accessRules: record.accessRules,
+    document,
+    logger: getService("logger"),
+  });
+  return denied === null;
 }
 
 /**

--- a/packages/nextly/src/dispatcher/handlers/__tests__/versions-label.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/versions-label.test.ts
@@ -6,12 +6,14 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { setLabelSpy, getSpy, readableSpy, canReadSpy } = vi.hoisted(() => ({
-  setLabelSpy: vi.fn(),
-  getSpy: vi.fn(),
-  readableSpy: vi.fn(),
-  canReadSpy: vi.fn(),
-}));
+const { setLabelSpy, getSpy, readableSpy, canReadSpy, updatableSpy } =
+  vi.hoisted(() => ({
+    setLabelSpy: vi.fn(),
+    getSpy: vi.fn(),
+    readableSpy: vi.fn(),
+    canReadSpy: vi.fn(),
+    updatableSpy: vi.fn(),
+  }));
 
 vi.mock("../../../di", () => ({
   getService: vi.fn(() => ({ setLabel: setLabelSpy, get: getSpy })),
@@ -19,6 +21,7 @@ vi.mock("../../../di", () => ({
 
 vi.mock("../../../api/versions-access", () => ({
   assertVersionDocumentReadable: readableSpy,
+  assertVersionDocumentUpdatable: updatableSpy,
   redactSnapshotForUser: vi.fn(),
   resolveSingleDocumentId: vi.fn(),
 }));
@@ -219,5 +222,75 @@ describe("setVersionLabelForDocument — an omitted label", () => {
     const row = await setVersionLabelForDocument(argsWithoutLabel());
 
     expect(row).not.toHaveProperty("snapshot");
+  });
+});
+
+describe("setVersionLabelForDocument — document-level update rules", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canReadSpy.mockResolvedValue(true);
+    readableSpy.mockResolvedValue(undefined);
+    updatableSpy.mockResolvedValue(undefined);
+    setLabelSpy.mockResolvedValue({ versionNo: 3, snapshot: {} });
+    getSpy.mockResolvedValue({ versionNo: 3, snapshot: {} });
+  });
+
+  it("refuses a caller who may read the document but not update it", async () => {
+    // The coarse `update-<slug>` the route earns says the caller may update
+    // documents of this kind, not this one. An owner-only rule refuses the
+    // document itself, and its history has to follow.
+    updatableSpy.mockRejectedValue(new Error("forbidden"));
+
+    await expect(setVersionLabelForDocument(args("Approved"))).rejects.toThrow(
+      "forbidden"
+    );
+    expect(setLabelSpy).not.toHaveBeenCalled();
+  });
+
+  it("checks the same document the read gate checked", async () => {
+    await setVersionLabelForDocument(args("Approved"));
+
+    expect(updatableSpy).toHaveBeenCalledWith(
+      "collection",
+      "posts",
+      "e1",
+      expect.objectContaining({ id: "u1" })
+    );
+  });
+
+  it("gates a Single by the same rule", async () => {
+    // Both entity kinds or neither: a gate covering one reads as complete and
+    // is not.
+    updatableSpy.mockRejectedValue(new Error("forbidden"));
+
+    await expect(
+      setVersionLabelForDocument({
+        ...args("Approved"),
+        scopeKind: "single" as const,
+        slug: "settings",
+      })
+    ).rejects.toThrow("forbidden");
+    expect(setLabelSpy).not.toHaveBeenCalled();
+  });
+
+  it("runs after the read gates, so it cannot be used to probe", async () => {
+    // A caller who cannot see the document must be refused by the read gate
+    // first; reaching the update check would confirm the document exists.
+    readableSpy.mockRejectedValue(new Error("not found"));
+
+    await expect(setVersionLabelForDocument(args("Approved"))).rejects.toThrow(
+      "not found"
+    );
+    expect(updatableSpy).not.toHaveBeenCalled();
+  });
+
+  it("gates a request that writes nothing", async () => {
+    // Otherwise the no-op becomes a way to discover what the caller may change.
+    updatableSpy.mockRejectedValue(new Error("forbidden"));
+
+    await expect(
+      setVersionLabelForDocument(argsWithoutLabel())
+    ).rejects.toThrow("forbidden");
+    expect(getSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/nextly/src/dispatcher/handlers/versions-methods.ts
+++ b/packages/nextly/src/dispatcher/handlers/versions-methods.ts
@@ -12,6 +12,7 @@
 import type { PaginationMeta } from "../../api/response-shapes";
 import {
   assertVersionDocumentReadable,
+  assertVersionDocumentUpdatable,
   redactSnapshotForUser,
 } from "../../api/versions-access";
 import {
@@ -364,6 +365,18 @@ export async function setVersionLabelForDocument(
   }
 
   await assertVersionDocumentReadable(
+    args.scopeKind,
+    args.slug,
+    args.entryId,
+    args.user
+  );
+
+  // Renaming a version edits a record of the document, so it owes the
+  // document's own update rules and not just the coarse `update-<slug>` the
+  // route earned. Applied even when the request turns out to write nothing:
+  // this is a write endpoint, and gating only the writing case would let the
+  // no-op be used to discover what the caller is allowed to change.
+  await assertVersionDocumentUpdatable(
     args.scopeKind,
     args.slug,
     args.entryId,

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -2133,6 +2133,53 @@ export class CollectionMutationService extends BaseService {
     }
   }
 
+  /**
+   * Whether this user may update the entry, decided without writing anything.
+   *
+   * The same load-then-check `updateEntry` performs, so it sees the
+   * collection's stored per-document rules — owner-only and role-based — which
+   * coarse RBAC does not express. For callers that write something OTHER than
+   * the document and must still be held to the document's update rules;
+   * version history is one. Sharing this path rather than restating the
+   * decision elsewhere is what stops the gate drifting from the writer.
+   */
+  async canUpdateEntry(params: {
+    collectionName: string;
+    entryId: string;
+    user?: UserContext;
+    routeAuthorized?: boolean;
+  }): Promise<boolean> {
+    const schema = await this.fileManager.loadDynamicSchema(
+      params.collectionName
+    );
+
+    // Loaded because owner-only rules compare against the stored row; without
+    // it those rules cannot be evaluated at all.
+    const [existingEntry] = await this.db
+      .select()
+      .from(schema)
+      .where(eq(schema.id, params.entryId))
+      .limit(1);
+
+    // A document that is not there cannot be updated. Answered as a refusal so
+    // the caller treats missing and forbidden identically, rather than letting
+    // the difference between them be probed.
+    if (!existingEntry) return false;
+
+    const denied = await this.accessService.checkCollectionAccess(
+      params.collectionName,
+      "update",
+      params.user,
+      params.entryId,
+      existingEntry,
+      // Never overridden: this exists to APPLY the document's rules, so a
+      // caller that could opt out of them would defeat the point.
+      false,
+      params.routeAuthorized
+    );
+    return denied === null;
+  }
+
   async updateEntry(
     params: {
       collectionName: string;

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -192,6 +192,22 @@ export class CollectionsHandler {
    * field. Trusted-server bypass is a separate, explicit `overrideAccess: true`
    * (seeds, plugin `as:'system'`), never inferred from route auth.
    */
+  /**
+   * Whether this user may update the entry, without performing the update.
+   *
+   * Routed through the handler for the same reason the version read gate is:
+   * this is the instance that actually serves collection writes, so a decision
+   * taken here is the decision the write would take.
+   */
+  async canUpdateEntry(params: {
+    collectionName: string;
+    entryId: string;
+    user?: UserContext;
+    routeAuthorized?: boolean;
+  }): Promise<boolean> {
+    return this.entryService.canUpdateEntry(params);
+  }
+
   private resolveUserParam<
     T extends {
       userId?: string;

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -242,6 +242,22 @@ export class CollectionEntryService extends BaseService {
     return result;
   }
 
+  /**
+   * Whether this user may update the entry, without performing the update.
+   *
+   * For callers that write something other than the document and still owe it
+   * the document's own update rules. See the mutation service for why this
+   * shares `updateEntry`'s evaluation rather than restating it.
+   */
+  async canUpdateEntry(params: {
+    collectionName: string;
+    entryId: string;
+    user?: UserContext;
+    routeAuthorized?: boolean;
+  }): Promise<boolean> {
+    return this.mutationService.canUpdateEntry(params);
+  }
+
   async updateEntry(
     params: {
       collectionName: string;


### PR DESCRIPTION
Closes the security gap raised on #278 and tracked in `2026-07-21-label-document-update-rules-followup.md`.

### The gap

`setVersionLabelForDocument` ran two READ gates and then wrote straight to `nextly_versions`. The only update authorization was the coarse `update-{slug}` permission the route earns, which says the caller may update documents of this kind, not that they may update *this* one.

So a caller holding `update-{slug}` could rename the history of a document that an owner-only or role-based per-document rule refuses them. Restore never had this problem, because it writes through `updateEntry` / `singles.update`, which run the document check on the way past. Labelling writes to the version table directly, so nothing on that path ever saw the document.

Exposure is narrow but real: it needs an entity carrying **stored per-document rules**. With collection-level rules only, the coarse gate was already the whole answer.

### Approach, and why not the one in the follow-up doc

The write-up proposed registering `CollectionAccessService` in the DI ServiceMap. Tracing it first showed that would be worse than it looks: `DynamicCollectionService` and `AccessControlService` are **not** registered either, and both live inside the `collectionService` factory closure. Registering the access service would have meant constructing a second instance of each, so the gate could evaluate against different state than the writer.

For a security check that is the wrong property to have. The gate must not be able to drift from the enforcer.

Instead the check is exposed along the path that already performs collection writes:

`CollectionsHandler.canUpdateEntry` → `CollectionEntryService.canUpdateEntry` → `CollectionMutationService.canUpdateEntry`

which does the same load-then-check `updateEntry` itself performs, against the same `accessService` instance, and returns the decision without writing. `collectionsHandler` is already the door the version READ gate uses, so both halves of the gate now resolve through the same service instance. No DI changes, no second instances.

Two doors were considered and rejected:

- `auth/guards/require-collection-access.ts` exports a `checkCollectionAccess` free function, but it is coarse only (super-admin → code-defined access → RBAC). It does not evaluate stored per-document rules, which are exactly what was missing.
- `rbacAccessControlService` is registered, but has the same limitation.

### Both entity kinds

`assertVersionDocumentUpdatable` covers collections and Singles together. A gate reaching only one reads as complete and is not.

The Single path mirrors the read gate: it reads the row directly rather than through `SingleEntryService` (which materializes a missing Single), and compares the live id against the requested one, since version rows outlive the document they came from. It loads the document before calling `checkSingleAccess`, because an owner-only rule with no document is refused outright.

### 403, not 404

The read gate answers 404 to avoid revealing that a document exists. This gate answers **403**, deliberately: by the time it runs the caller has already proven they can read the document, so concealing its existence protects nothing and only makes the refusal harder to act on.

### Applied even to a no-op

The endpoint accepts a request that names no label and writes nothing. The gate still runs, so the no-op cannot be used to discover what the caller is allowed to change.

### Verification

- typecheck and lint clean
- 22 tests in the label suite, 5 of them new: read-but-not-update denial, the Single equivalent, gate ordering (read gates first, so this cannot be used to probe), the no-op case, and that it checks the same document the read gate checked
- Verified load-bearing: removing the gate call fails 4 of the 5 new tests
- Known baseline unchanged — 8 failures in the three `*-dispatcher-shapes` files, identical before and after

Changeset generated from `.changeset/config.json`'s fixed group (19 packages) rather than hand-listed, after `admin-css` was missed twice recently.

pg/mysql legs verify in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Version labels can now be changed only when the caller has permission to update the associated document.
  - Added consistent update-permission checks for both collection entries and single documents.
  - Unauthorized requests, including no-op label changes, are rejected without exposing document information.
  - Missing collection entries are correctly denied update access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->