### PR TITLE
feat(nextly): manage webhook endpoints

### DIFF
--- a/.changeset/webhook-endpoint-management.md
+++ b/.changeset/webhook-endpoint-management.md
@@ -20,7 +20,9 @@
 "@nextlyhq/ui": patch
 ---
 
-Webhook endpoints can now be registered, changed, disabled and removed.
+Internal: the management layer for webhook endpoints.
+
+Not yet reachable from an installed package. There is no REST route, Direct API method or exported subpath that reaches it, so webhooks remain unusable until that wiring lands. This entry is here to describe the change, not to announce a feature.
 
 The delivery engine, fan-out and signing were all built before anything could create an endpoint for them to act on — the only rows that ever reached the table were test fixtures. This adds the management layer they were waiting for: an endpoint carries a name, a target URL, the event types it subscribes to, and optional static headers, and it receives its own signing secret at creation.
 

--- a/.changeset/webhook-endpoint-management.md
+++ b/.changeset/webhook-endpoint-management.md
@@ -27,3 +27,7 @@ The delivery engine, fan-out and signing were all built before anything could cr
 A URL is resolved and checked before it is stored, not only before it is called. Delivery already refuses private, loopback and cloud-metadata addresses, but that happens long after whoever typed the URL has moved on, so a mistake shows up as a silent, repeating delivery failure. Checking at registration turns it into an error that can still be corrected.
 
 Disabling an endpoint is kept separate from deleting it. Only one of those is reversible, and an endpoint id tends to end up in someone else's configuration.
+
+Disabling now also stops deliveries that were already queued. Previously it only removed the endpoint from future fan-out, so a retry scheduled by an earlier failure, or an event that fanned out moments before, would keep being POSTed until it succeeded or ran out of attempts. Those deliveries are now ended rather than held, so re-enabling an endpoint does not release a burst of events its receiver has long since stopped expecting.
+
+Static headers are checked when they are saved. A header name that is not a valid HTTP token, or a value containing a line break, can never be sent: the delivery path could not tell that apart from a network fault, so it treated it as temporary and retried an endpoint that could never succeed.

--- a/.changeset/webhook-endpoint-management.md
+++ b/.changeset/webhook-endpoint-management.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Webhook endpoints can now be registered, changed, disabled and removed.
+
+The delivery engine, fan-out and signing were all built before anything could create an endpoint for them to act on — the only rows that ever reached the table were test fixtures. This adds the management layer they were waiting for: an endpoint carries a name, a target URL, the event types it subscribes to, and optional static headers, and it receives its own signing secret at creation.
+
+A URL is resolved and checked before it is stored, not only before it is called. Delivery already refuses private, loopback and cloud-metadata addresses, but that happens long after whoever typed the URL has moved on, so a mistake shows up as a silent, repeating delivery failure. Checking at registration turns it into an error that can still be corrected.
+
+Disabling an endpoint is kept separate from deleting it. Only one of those is reversible, and an endpoint id tends to end up in someone else's configuration.

--- a/packages/nextly/src/domains/webhooks/__tests__/deliver.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/deliver.integration.test.ts
@@ -80,7 +80,7 @@ describe("webhook delivery engine (real SQLite)", () => {
     await adapter.connect();
     for (const stmt of await schemaDdl()) await adapter.executeQuery(stmt);
 
-    const schemaRegistry = new SchemaRegistry();
+    const schemaRegistry = new SchemaRegistry("sqlite");
     schemaRegistry.registerStaticSchemas(tables);
     adapter.setTableResolver(schemaRegistry);
   });
@@ -105,13 +105,14 @@ describe("webhook delivery engine (real SQLite)", () => {
       secrets?: string[];
       headers?: Record<string, string> | null;
       eventTypes?: WebhookEventType[];
+      enabled?: boolean;
     } = {}
   ): Promise<void> {
     await adapter.insert("nextly_webhooks", {
       id,
       name: id,
       url: `https://example.com/${id}`,
-      enabled: true,
+      enabled: opts.enabled ?? true,
       event_types: opts.eventTypes ?? ["entry.updated"],
       filter: null,
       headers: opts.headers ?? null,
@@ -324,6 +325,31 @@ describe("webhook delivery engine (real SQLite)", () => {
     const row = await getDelivery("dlv_1");
     expect(row.status).toBe("failed");
     expect(row.lastError).toContain("no signing secret");
+  });
+
+  it("stops delivering to an endpoint that was disabled after the row was queued", async () => {
+    // Disabling only removes an endpoint from fan-out, so a row queued before
+    // it happened — or a retry scheduled by an earlier failure — would still be
+    // due. Without a check at send time, disabling would keep POSTing until the
+    // row succeeded or exhausted its attempts.
+    await seedWebhook("wh_a", { enabled: false });
+    await seedEvent("evt_1");
+    await seedDelivery("dlv_1", "wh_a", "evt_1", {
+      status: "retrying",
+      attemptCount: 1,
+    });
+    const { transport, calls } = makeTransport(200);
+
+    const result = await deliverDueDeliveries(deps(transport));
+
+    expect(result).toMatchObject({ attempted: 1, failed: 1 });
+    expect(calls).toHaveLength(0);
+    const row = await getDelivery("dlv_1");
+    expect(row.status).toBe("failed");
+    expect(row.lastError).toContain("webhook disabled");
+    // Terminal, not held: re-enabling must not later release a burst of events
+    // the receiver has stopped expecting.
+    expect(row.nextAttemptAt).toBeNull();
   });
 
   it("records an unexpected mid-attempt throw as a transient failure without escaping the batch", async () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/deliver.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/deliver.integration.test.ts
@@ -105,14 +105,13 @@ describe("webhook delivery engine (real SQLite)", () => {
       secrets?: string[];
       headers?: Record<string, string> | null;
       eventTypes?: WebhookEventType[];
-      enabled?: boolean;
     } = {}
   ): Promise<void> {
     await adapter.insert("nextly_webhooks", {
       id,
       name: id,
       url: `https://example.com/${id}`,
-      enabled: opts.enabled ?? true,
+      enabled: true,
       event_types: opts.eventTypes ?? ["entry.updated"],
       filter: null,
       headers: opts.headers ?? null,
@@ -332,12 +331,21 @@ describe("webhook delivery engine (real SQLite)", () => {
     // it happened — or a retry scheduled by an earlier failure — would still be
     // due. Without a check at send time, disabling would keep POSTing until the
     // row succeeded or exhausted its attempts.
-    await seedWebhook("wh_a", { enabled: false });
+    // Ordered deliberately: the endpoint is enabled while the delivery is
+    // queued and only disabled afterwards, which is the sequence that actually
+    // happens. Seeding it disabled would only prove a delivery is never created
+    // for an endpoint that was already off.
+    await seedWebhook("wh_a");
     await seedEvent("evt_1");
     await seedDelivery("dlv_1", "wh_a", "evt_1", {
       status: "retrying",
       attemptCount: 1,
     });
+    await adapter.update(
+      "nextly_webhooks",
+      { enabled: false },
+      { and: [{ column: "id", op: "=", value: "wh_a" }] }
+    );
     const { transport, calls } = makeTransport(200);
 
     const result = await deliverDueDeliveries(deps(transport));

--- a/packages/nextly/src/domains/webhooks/__tests__/fan-out.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/fan-out.integration.test.ts
@@ -51,7 +51,7 @@ describe("webhook fan-out (real SQLite)", () => {
     await adapter.connect();
     for (const stmt of await schemaDdl()) await adapter.executeQuery(stmt);
 
-    const schemaRegistry = new SchemaRegistry();
+    const schemaRegistry = new SchemaRegistry("sqlite");
     schemaRegistry.registerStaticSchemas(tables);
     adapter.setTableResolver(schemaRegistry);
   });

--- a/packages/nextly/src/domains/webhooks/__tests__/record-event.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/record-event.integration.test.ts
@@ -56,7 +56,7 @@ describe("webhook outbox capture (real SQLite)", () => {
     await adapter.connect();
     for (const stmt of await schemaDdl()) await adapter.executeQuery(stmt);
 
-    const schemaRegistry = new SchemaRegistry();
+    const schemaRegistry = new SchemaRegistry("sqlite");
     schemaRegistry.registerStaticSchemas({ nextlyEvents });
     adapter.setTableResolver(schemaRegistry);
   });

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-endpoint-service.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-endpoint-service.integration.test.ts
@@ -72,7 +72,7 @@ describe("webhook endpoint management (real SQLite)", () => {
       "INSERT INTO users (id, email, created_at, updated_at) VALUES ('user_1', 'dev@example.com', 0, 0)"
     );
 
-    const schemaRegistry = new SchemaRegistry();
+    const schemaRegistry = new SchemaRegistry("sqlite");
     schemaRegistry.registerStaticSchemas({ users, nextlyWebhooks });
     adapter.setTableResolver(schemaRegistry);
   });

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-endpoint-service.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-endpoint-service.integration.test.ts
@@ -20,7 +20,11 @@ import { getSQLiteDrizzleKit } from "../../../database/drizzle-kit-lazy";
 import { SchemaRegistry } from "../../../database/schema-registry";
 import { NextlyError } from "../../../errors";
 import { users } from "../../../schemas/users/sqlite";
-import { nextlyWebhooks } from "../../../schemas/webhooks/sqlite";
+import {
+  nextlyEvents,
+  nextlyWebhooks,
+  nextlyWebhookDeliveries,
+} from "../../../schemas/webhooks/sqlite";
 import { splitStatements } from "../../schema/pipeline/sql-statement-utils";
 import { WEBHOOK_SECRET_PREFIX } from "../secret";
 import { WebhookEndpointService } from "../services/webhook-endpoint-service";
@@ -37,7 +41,12 @@ async function schemaDdl(): Promise<string[]> {
     await kit.generateDrizzleJson({}),
     // `created_by` references users.id, so the referenced table has to exist
     // for the foreign key to be creatable.
-    await kit.generateDrizzleJson({ users, nextlyWebhooks })
+    await kit.generateDrizzleJson({
+      users,
+      nextlyEvents,
+      nextlyWebhooks,
+      nextlyWebhookDeliveries,
+    })
   );
   return splitStatements(statements);
 }
@@ -73,7 +82,12 @@ describe("webhook endpoint management (real SQLite)", () => {
     );
 
     const schemaRegistry = new SchemaRegistry("sqlite");
-    schemaRegistry.registerStaticSchemas({ users, nextlyWebhooks });
+    schemaRegistry.registerStaticSchemas({
+      users,
+      nextlyEvents,
+      nextlyWebhooks,
+      nextlyWebhookDeliveries,
+    });
     adapter.setTableResolver(schemaRegistry);
   });
 
@@ -86,6 +100,8 @@ describe("webhook endpoint management (real SQLite)", () => {
   });
 
   beforeEach(async () => {
+    await adapter.executeQuery("DELETE FROM nextly_webhook_deliveries");
+    await adapter.executeQuery("DELETE FROM nextly_events");
     await adapter.executeQuery("DELETE FROM nextly_webhooks");
     registry = new RecordingRegistry();
     service = new WebhookEndpointService(
@@ -95,11 +111,18 @@ describe("webhook endpoint management (real SQLite)", () => {
     );
   });
 
+  // An address literal, not a hostname: `createEndpoint` runs the same URL
+  // validator delivery uses, and that resolves a hostname through real DNS. A
+  // literal short-circuits before the lookup, so the suite does not fail with
+  // EAI_AGAIN wherever DNS is unavailable. Nothing is ever connected to; only
+  // the address is examined.
+  const PUBLIC_URL = "https://93.184.216.34/hooks";
+
   const create = (overrides: Record<string, unknown> = {}) =>
     service.createEndpoint(
       {
         name: "Orders",
-        url: "https://example.com/hooks",
+        url: PUBLIC_URL,
         eventTypes: EVENTS,
         ...overrides,
       } as never,
@@ -164,7 +187,7 @@ describe("webhook endpoint management (real SQLite)", () => {
         service.createEndpoint(
           {
             name: "Orphaned",
-            url: "https://example.com/hooks",
+            url: PUBLIC_URL,
             eventTypes: EVENTS,
           },
           "user_that_does_not_exist"
@@ -181,7 +204,7 @@ describe("webhook endpoint management (real SQLite)", () => {
       ["loopback", "https://127.0.0.1/hooks"],
       ["private range", "https://10.0.0.5/hooks"],
       ["link-local metadata", "https://169.254.169.254/latest/meta-data"],
-      ["plain http", "http://example.com/hooks"],
+      ["plain http", "http://93.184.216.34/hooks"],
     ])("refuses %s", async (_label, url) => {
       await expect(create({ url })).rejects.toThrow(NextlyError);
     });
@@ -199,7 +222,7 @@ describe("webhook endpoint management (real SQLite)", () => {
       ).rejects.toThrow(NextlyError);
 
       const unchanged = await service.getEndpoint(endpoint.id);
-      expect(unchanged?.url).toBe("https://example.com/hooks");
+      expect(unchanged?.url).toBe(PUBLIC_URL);
     });
   });
 
@@ -223,7 +246,7 @@ describe("webhook endpoint management (real SQLite)", () => {
 
       await service.updateEndpoint(endpoint.id, { name: "A" });
       await service.updateEndpoint(endpoint.id, {
-        url: "https://example.org/h",
+        url: "https://93.184.216.35/h",
       });
 
       // Not only on an enabled toggle: url, event types and headers are cached
@@ -235,6 +258,94 @@ describe("webhook endpoint management (real SQLite)", () => {
       await expect(
         service.updateEndpoint("missing", { name: "x" })
       ).rejects.toThrow(NextlyError);
+    });
+  });
+
+  describe("disabling ends outstanding deliveries", () => {
+    /** A queued delivery for an endpoint, in the state a drain would pick up. */
+    async function queueDelivery(
+      id: string,
+      webhookId: string,
+      status: string
+    ): Promise<void> {
+      await adapter.insert("nextly_events", {
+        id: `evt_${id}`,
+        type: "entry.updated",
+        resource_kind: "entry",
+        resource_id: "p1",
+        collection: "posts",
+        payload: { id: "p1" },
+        created_at: new Date(0),
+      });
+      await adapter.insert("nextly_webhook_deliveries", {
+        id,
+        webhook_id: webhookId,
+        event_id: `evt_${id}`,
+        status,
+        attempt_count: 1,
+        next_attempt_at: new Date(0),
+        locked_by: null,
+        locked_until: null,
+        created_at: new Date(0),
+        updated_at: new Date(0),
+      });
+    }
+
+    async function deliveryStatus(id: string): Promise<string> {
+      const rows = await adapter.select<{ status: string }>(
+        "nextly_webhook_deliveries",
+        { where: { and: [{ column: "id", op: "=", value: id }] } }
+      );
+      return rows[0]?.status ?? "gone";
+    }
+
+    it("ends queued and retrying deliveries when the endpoint is disabled", async () => {
+      // Delivery refuses a disabled endpoint when it attempts one, but only if
+      // a drain runs during the disabled window. Without this, disabling and
+      // re-enabling with no drain in between would release the queue in a
+      // burst afterwards.
+      const { endpoint } = await create();
+      await queueDelivery("dlv_pending", endpoint.id, "pending");
+      await queueDelivery("dlv_retrying", endpoint.id, "retrying");
+
+      await service.setEnabled(endpoint.id, false);
+
+      expect(await deliveryStatus("dlv_pending")).toBe("failed");
+      expect(await deliveryStatus("dlv_retrying")).toBe("failed");
+    });
+
+    it("leaves already-delivered rows alone", async () => {
+      // Only outstanding work is ended. Rewriting a terminal row would corrupt
+      // the record of what was actually sent.
+      const { endpoint } = await create();
+      await queueDelivery("dlv_done", endpoint.id, "delivered");
+
+      await service.setEnabled(endpoint.id, false);
+
+      expect(await deliveryStatus("dlv_done")).toBe("delivered");
+    });
+
+    it("ends them when disabling through a plain field update too", async () => {
+      // setEnabled is a convenience over updateEndpoint; disabling through
+      // either must behave the same.
+      const { endpoint } = await create();
+      await queueDelivery("dlv_x", endpoint.id, "pending");
+
+      await service.updateEndpoint(endpoint.id, { enabled: false });
+
+      expect(await deliveryStatus("dlv_x")).toBe("failed");
+    });
+
+    it("does not touch another endpoint's queue", async () => {
+      const a = await create({ name: "A" });
+      const b = await create({ name: "B" });
+      await queueDelivery("dlv_a", a.endpoint.id, "pending");
+      await queueDelivery("dlv_b", b.endpoint.id, "pending");
+
+      await service.setEnabled(a.endpoint.id, false);
+
+      expect(await deliveryStatus("dlv_a")).toBe("failed");
+      expect(await deliveryStatus("dlv_b")).toBe("pending");
     });
   });
 

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-endpoint-service.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-endpoint-service.integration.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Endpoint management against a real SQLite database.
+ *
+ * The interesting assertions are not that CRUD stores fields — they are that a
+ * secret never leaks through an ordinary read, that a URL delivery could not
+ * call is refused before it is stored, and that the cached endpoint list is
+ * dropped on every change. Each of those fails silently if it regresses: a
+ * leaked secret looks like a successful response, an unreachable URL looks like
+ * a saved endpoint, and a stale cache looks like a working install still
+ * delivering to an endpoint the operator disabled.
+ *
+ * Schema comes from the production table definition via drizzle-kit, never a
+ * hand-copied CREATE TABLE (see .claude/rules/integration-tests.md).
+ */
+
+import { createSqliteAdapter } from "@nextlyhq/adapter-sqlite";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { getSQLiteDrizzleKit } from "../../../database/drizzle-kit-lazy";
+import { SchemaRegistry } from "../../../database/schema-registry";
+import { NextlyError } from "../../../errors";
+import { users } from "../../../schemas/users/sqlite";
+import { nextlyWebhooks } from "../../../schemas/webhooks/sqlite";
+import { splitStatements } from "../../schema/pipeline/sql-statement-utils";
+import { WEBHOOK_SECRET_PREFIX } from "../secret";
+import { WebhookEndpointService } from "../services/webhook-endpoint-service";
+import type { WebhookEventType } from "../types";
+
+process.env.DB_DIALECT = "sqlite";
+process.env.NEXTLY_SECRET = "integration-test-application-secret";
+
+const EVENTS: WebhookEventType[] = ["entry.created", "entry.updated"];
+
+async function schemaDdl(): Promise<string[]> {
+  const kit = await getSQLiteDrizzleKit();
+  const statements = await kit.generateMigration(
+    await kit.generateDrizzleJson({}),
+    // `created_by` references users.id, so the referenced table has to exist
+    // for the foreign key to be creatable.
+    await kit.generateDrizzleJson({ users, nextlyWebhooks })
+  );
+  return splitStatements(statements);
+}
+
+/** Records invalidations so the cache-drop can be asserted rather than assumed. */
+class RecordingRegistry {
+  invalidations = 0;
+  invalidate(): void {
+    this.invalidations += 1;
+  }
+}
+
+describe("webhook endpoint management (real SQLite)", () => {
+  let adapter: ReturnType<typeof createSqliteAdapter>;
+  let registry: RecordingRegistry;
+  let service: WebhookEndpointService;
+
+  const logger = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+
+  beforeAll(async () => {
+    adapter = createSqliteAdapter({ memory: true });
+    await adapter.connect();
+    for (const stmt of await schemaDdl()) await adapter.executeQuery(stmt);
+
+    // created_by is a real foreign key, so attribution needs a real user.
+    await adapter.executeQuery(
+      "INSERT INTO users (id, email, created_at, updated_at) VALUES ('user_1', 'dev@example.com', 0, 0)"
+    );
+
+    const schemaRegistry = new SchemaRegistry();
+    schemaRegistry.registerStaticSchemas({ users, nextlyWebhooks });
+    adapter.setTableResolver(schemaRegistry);
+  });
+
+  afterAll(async () => {
+    try {
+      await adapter?.disconnect?.();
+    } catch {
+      // ignore teardown errors
+    }
+  });
+
+  beforeEach(async () => {
+    await adapter.executeQuery("DELETE FROM nextly_webhooks");
+    registry = new RecordingRegistry();
+    service = new WebhookEndpointService(
+      adapter as never,
+      logger as never,
+      registry
+    );
+  });
+
+  const create = (overrides: Record<string, unknown> = {}) =>
+    service.createEndpoint(
+      {
+        name: "Orders",
+        url: "https://example.com/hooks",
+        eventTypes: EVENTS,
+        ...overrides,
+      } as never,
+      "user_1"
+    );
+
+  describe("creating", () => {
+    it("returns the secret once and never again", async () => {
+      const { endpoint, secret } = await create();
+
+      expect(secret.startsWith(WEBHOOK_SECRET_PREFIX)).toBe(true);
+      expect(endpoint.secretPrefix).toBe(secret.slice(0, 14));
+
+      // The summary type has no secret field; this asserts the object really
+      // does not carry one, which is what a JSON response would serialise.
+      expect(JSON.stringify(endpoint)).not.toContain(secret);
+
+      const fetched = await service.getEndpoint(endpoint.id);
+      expect(JSON.stringify(fetched)).not.toContain(secret);
+
+      const listed = await service.listEndpoints();
+      expect(JSON.stringify(listed)).not.toContain(secret);
+    });
+
+    it("stores the secret encrypted, not in the clear", async () => {
+      const { secret } = await create();
+
+      const raw = await adapter.executeQuery<{ secret_hash: string }>(
+        "SELECT secret_hash FROM nextly_webhooks"
+      );
+      const stored = String(raw[0]?.secret_hash ?? "");
+
+      expect(stored).not.toContain(secret);
+      expect(stored).not.toContain(secret.slice(WEBHOOK_SECRET_PREFIX.length));
+    });
+
+    it("gives each endpoint its own secret", async () => {
+      // The spec is explicit that a signing key is never shared across
+      // endpoints: one compromised receiver would otherwise be able to forge
+      // traffic for every other.
+      const a = await create();
+      const b = await create({ name: "Second" });
+      expect(a.secret).not.toBe(b.secret);
+    });
+
+    it("defaults to enabled", async () => {
+      const { endpoint } = await create();
+      expect(endpoint.enabled).toBe(true);
+    });
+
+    it("drops the cached endpoint list", async () => {
+      await create();
+      expect(registry.invalidations).toBe(1);
+    });
+  });
+
+  describe("URL validation at registration", () => {
+    // Delivery refuses these too, but that happens long after whoever typed the
+    // URL has gone. Refusing here turns a silent, repeating delivery failure
+    // into an error the person responsible can still act on.
+    it.each([
+      ["loopback", "https://127.0.0.1/hooks"],
+      ["private range", "https://10.0.0.5/hooks"],
+      ["link-local metadata", "https://169.254.169.254/latest/meta-data"],
+      ["plain http", "http://example.com/hooks"],
+    ])("refuses %s", async (_label, url) => {
+      await expect(create({ url })).rejects.toThrow(NextlyError);
+    });
+
+    it("stores nothing when the URL is refused", async () => {
+      await expect(create({ url: "https://10.0.0.5/hooks" })).rejects.toThrow();
+      expect(await service.listEndpoints()).toHaveLength(0);
+    });
+
+    it("re-checks on update, which is how an endpoint gets re-pointed", async () => {
+      const { endpoint } = await create();
+
+      await expect(
+        service.updateEndpoint(endpoint.id, { url: "https://10.0.0.5/x" })
+      ).rejects.toThrow(NextlyError);
+
+      const unchanged = await service.getEndpoint(endpoint.id);
+      expect(unchanged?.url).toBe("https://example.com/hooks");
+    });
+  });
+
+  describe("updating", () => {
+    it("moves only the named fields", async () => {
+      const { endpoint } = await create();
+
+      const updated = await service.updateEndpoint(endpoint.id, {
+        name: "Renamed",
+      });
+
+      expect(updated.name).toBe("Renamed");
+      expect(updated.url).toBe(endpoint.url);
+      expect(updated.eventTypes).toEqual(EVENTS);
+      expect(updated.enabled).toBe(true);
+    });
+
+    it("drops the cached list on every change", async () => {
+      const { endpoint } = await create();
+      registry.invalidations = 0;
+
+      await service.updateEndpoint(endpoint.id, { name: "A" });
+      await service.updateEndpoint(endpoint.id, {
+        url: "https://example.org/h",
+      });
+
+      // Not only on an enabled toggle: url, event types and headers are cached
+      // too, so a stale copy would keep delivering to the previous target.
+      expect(registry.invalidations).toBe(2);
+    });
+
+    it("reports an unknown endpoint as not found", async () => {
+      await expect(
+        service.updateEndpoint("missing", { name: "x" })
+      ).rejects.toThrow(NextlyError);
+    });
+  });
+
+  describe("disable versus delete", () => {
+    it("disabling keeps the endpoint and its id", async () => {
+      const { endpoint } = await create();
+
+      const disabled = await service.setEnabled(endpoint.id, false);
+      expect(disabled.enabled).toBe(false);
+      expect(await service.getEndpoint(endpoint.id)).not.toBeNull();
+
+      const reenabled = await service.setEnabled(endpoint.id, true);
+      expect(reenabled.enabled).toBe(true);
+    });
+
+    it("deleting removes it and drops the cache", async () => {
+      const { endpoint } = await create();
+      registry.invalidations = 0;
+
+      await service.deleteEndpoint(endpoint.id);
+
+      expect(await service.getEndpoint(endpoint.id)).toBeNull();
+      expect(registry.invalidations).toBe(1);
+    });
+
+    it("reports deleting an unknown endpoint as not found", async () => {
+      await expect(service.deleteEndpoint("missing")).rejects.toThrow(
+        NextlyError
+      );
+    });
+  });
+
+  describe("revealing the secret", () => {
+    it("recovers exactly what creation returned", async () => {
+      const { endpoint, secret } = await create();
+      expect(await service.revealSecrets(endpoint.id)).toEqual([secret]);
+    });
+
+    it("reports an unknown endpoint as not found", async () => {
+      await expect(service.revealSecrets("missing")).rejects.toThrow(
+        NextlyError
+      );
+    });
+  });
+
+  describe("listing", () => {
+    it("returns every endpoint, newest first", async () => {
+      const first = await create({ name: "First" });
+      const second = await create({ name: "Second" });
+
+      const listed = await service.listEndpoints();
+      expect(listed).toHaveLength(2);
+      expect(listed.map(e => e.id)).toContain(first.endpoint.id);
+      expect(listed.map(e => e.id)).toContain(second.endpoint.id);
+    });
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-endpoint-service.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-endpoint-service.integration.test.ts
@@ -154,6 +154,23 @@ describe("webhook endpoint management (real SQLite)", () => {
       await create();
       expect(registry.invalidations).toBe(1);
     });
+
+    it("reports a database failure as a NextlyError, not a driver error", async () => {
+      // created_by is a real foreign key, so attributing an endpoint to a user
+      // that no longer exists fails in the driver. Nothing above this layer
+      // knows how to render a raw driver exception, and it is not something a
+      // caller should ever see.
+      await expect(
+        service.createEndpoint(
+          {
+            name: "Orphaned",
+            url: "https://example.com/hooks",
+            eventTypes: EVENTS,
+          },
+          "user_that_does_not_exist"
+        )
+      ).rejects.toThrow(NextlyError);
+    });
   });
 
   describe("URL validation at registration", () => {

--- a/packages/nextly/src/domains/webhooks/deliver.ts
+++ b/packages/nextly/src/domains/webhooks/deliver.ts
@@ -65,6 +65,8 @@ interface WebhookRow {
   headers: Record<string, string> | null;
   /** Encrypted (not hashed) active signing secrets, primary first. */
   secretHash: string[];
+  /** Stored as an integer on SQLite, so it is coerced before it is trusted. */
+  enabled: unknown;
 }
 
 /** The subset of a `nextly_events` row delivery needs (camelCase). */
@@ -293,8 +295,9 @@ async function attemptDelivery(
   const transport = deps.transport ?? safeFetch;
   const timeoutMs = deps.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
 
-  // Load the endpoint and the event. A delivery for a deleted webhook or a
-  // missing event can never be sent, so mark it failed and move on.
+  // Load the endpoint and the event. A delivery for a deleted webhook, a
+  // disabled one, or a missing event can never be sent, so mark it failed and
+  // move on.
   const webhookRows = await deps.db.select<WebhookRow>("nextly_webhooks", {
     where: { and: [{ column: "id", op: "=", value: row.webhookId }] },
     limit: 1,
@@ -306,8 +309,24 @@ async function attemptDelivery(
   });
   const event = eventRows[0];
 
-  if (!webhook || !event) {
-    const reason = !webhook ? "webhook deleted" : "event missing";
+  // Disabling is checked here and not only at fan-out because rows can already
+  // be queued when it happens: a retry scheduled by an earlier failure, or an
+  // event that fanned out moments before. Without this, disabling stops new
+  // deliveries but the existing ones keep POSTing until they succeed or
+  // exhaust their attempts, which is the opposite of what disabling means.
+  //
+  // The row is failed rather than held, so re-enabling does not later release a
+  // burst of events the receiver has long since stopped expecting. Replaying
+  // them is a separate, deliberate act.
+  // Truthiness rather than a strict comparison: SQLite stores the flag as 0/1
+  // and the other dialects as a boolean.
+  const disabled = webhook !== undefined && !webhook.enabled;
+  if (!webhook || !event || disabled) {
+    const reason = !webhook
+      ? "webhook deleted"
+      : disabled
+        ? "webhook disabled"
+        : "event missing";
     deps.logger?.warn(
       `webhook delivery ${row.id} undeliverable (${reason}); marking failed`
     );

--- a/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
+++ b/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
@@ -1,0 +1,335 @@
+/**
+ * Webhook domain — endpoint management.
+ *
+ * The delivery engine, fan-out, signing and retention were all built before
+ * anything could create an endpoint for them to act on: the only rows that ever
+ * reached `nextly_webhooks` were test fixtures. This is the surface that makes
+ * the rest of the domain reachable.
+ *
+ * Two behaviours here are security-relevant rather than cosmetic.
+ *
+ * A URL is resolved and checked before it is stored, not only before it is
+ * called. Delivery already refuses private, loopback and cloud-metadata
+ * addresses through `safeFetch`, and that check is the one that cannot be
+ * fooled by a hostname re-pointed after registration — but it fires long after
+ * the person who typed the URL has gone. Checking at registration turns a
+ * silent, repeated delivery failure into an immediate, correctable error.
+ *
+ * Secrets are stored encrypted and can be read back by a caller the route
+ * authorises. That follows the webhook-first providers rather than the
+ * write-only model: a secret that can never be re-read forces a full rotation
+ * every time an operator loses their copy, and rotation is the more dangerous
+ * operation. The column is list-shaped for the same reason — Standard Webhooks
+ * rotation signs with every active secret at once.
+ *
+ * @module domains/webhooks/services/webhook-endpoint-service
+ */
+
+import { and, eq, desc } from "drizzle-orm";
+
+import { NextlyError } from "../../../errors";
+import { nextlyWebhooks as webhooksMysql } from "../../../schemas/webhooks/mysql";
+import { nextlyWebhooks as webhooksPg } from "../../../schemas/webhooks/postgres";
+import { nextlyWebhooks as webhooksSqlite } from "../../../schemas/webhooks/sqlite";
+import { BaseService } from "../../../shared/base-service";
+import {
+  ExternalUrlError,
+  validateExternalUrl,
+} from "../../../utils/validate-external-url";
+import type { WebhookEndpointRegistry } from "../endpoint-registry";
+import {
+  decryptWebhookSecret,
+  encryptWebhookSecret,
+  generateWebhookSecret,
+  webhookSecretPrefix,
+} from "../secret";
+import type { WebhookEventType } from "../types";
+
+/**
+ * An endpoint as any caller after creation sees it.
+ *
+ * Carries `secretPrefix` but never the secret or its ciphertext: reading the
+ * secret is a separate, separately-authorisable act, so it must not ride along
+ * on an ordinary list or fetch.
+ */
+export interface WebhookEndpointSummary {
+  id: string;
+  name: string;
+  url: string;
+  enabled: boolean;
+  eventTypes: WebhookEventType[];
+  headers: Record<string, string> | null;
+  secretPrefix: string;
+  createdBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** What creating an endpoint returns: the endpoint, plus its secret once. */
+export interface CreatedWebhookEndpoint {
+  endpoint: WebhookEndpointSummary;
+  secret: string;
+}
+
+export interface CreateWebhookEndpointInput {
+  name: string;
+  url: string;
+  eventTypes: WebhookEventType[];
+  enabled?: boolean;
+  headers?: Record<string, string> | null;
+}
+
+export interface UpdateWebhookEndpointInput {
+  name?: string;
+  url?: string;
+  eventTypes?: WebhookEventType[];
+  enabled?: boolean;
+  headers?: Record<string, string> | null;
+}
+
+type WebhooksTable =
+  | typeof webhooksPg
+  | typeof webhooksMysql
+  | typeof webhooksSqlite;
+
+/** A stored row, before it is narrowed to what a caller may see. */
+interface WebhookRow {
+  id: string;
+  name: string;
+  url: string;
+  enabled: boolean;
+  eventTypes: unknown;
+  headers: unknown;
+  secretHash: unknown;
+  secretPrefix: string;
+  createdBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export class WebhookEndpointService extends BaseService {
+  private readonly table: WebhooksTable;
+
+  constructor(
+    adapter: ConstructorParameters<typeof BaseService>[0],
+    logger: ConstructorParameters<typeof BaseService>[1],
+    /**
+     * Dropped on every mutation so a change takes effect without a restart.
+     * Optional because the registry is constructed per drain today; once it
+     * becomes a shared instance this is what keeps it honest. Without it a
+     * disabled endpoint would keep receiving deliveries from a cached list,
+     * silently and for as long as the process lives.
+     */
+    private readonly registry?: Pick<WebhookEndpointRegistry, "invalidate">
+  ) {
+    super(adapter, logger);
+    switch (this.adapter.getCapabilities().dialect) {
+      case "postgresql":
+        this.table = webhooksPg;
+        break;
+      case "mysql":
+        this.table = webhooksMysql;
+        break;
+      default:
+        this.table = webhooksSqlite;
+        break;
+    }
+  }
+
+  /**
+   * Reject a URL delivery could never safely call.
+   *
+   * Reuses the same validator the transport uses, so registration and delivery
+   * cannot disagree about what is acceptable. The failure is translated to a
+   * field-level validation error: this is a correctable mistake in submitted
+   * input, not an internal fault, and it should read that way to whoever typed
+   * it.
+   */
+  private async assertDeliverableUrl(url: string): Promise<void> {
+    try {
+      await validateExternalUrl(url);
+    } catch (err) {
+      if (err instanceof ExternalUrlError) {
+        throw NextlyError.validation({
+          errors: [
+            {
+              path: "url",
+              code: "unreachable_url",
+              message:
+                "This URL cannot be delivered to. It must be https, publicly resolvable, " +
+                "and must not point at a private, loopback or cloud-metadata address.",
+            },
+          ],
+          logContext: { reason: "webhook-url-rejected", url },
+        });
+      }
+      throw err;
+    }
+  }
+
+  /** Narrow a stored row to what a caller may see. */
+  private toSummary(row: WebhookRow): WebhookEndpointSummary {
+    return {
+      id: row.id,
+      name: row.name,
+      url: row.url,
+      enabled: row.enabled,
+      eventTypes: (Array.isArray(row.eventTypes)
+        ? row.eventTypes
+        : []) as WebhookEventType[],
+      headers:
+        row.headers && typeof row.headers === "object"
+          ? (row.headers as Record<string, string>)
+          : null,
+      secretPrefix: row.secretPrefix,
+      createdBy: row.createdBy,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    };
+  }
+
+  /**
+   * Register an endpoint and return its signing secret once.
+   *
+   * The secret is generated here rather than accepted from the caller so it is
+   * always the length and shape the signing path and a receiver's Standard
+   * Webhooks library expect, and so it is never shared between endpoints.
+   */
+  async createEndpoint(
+    input: CreateWebhookEndpointInput,
+    createdBy: string | null
+  ): Promise<CreatedWebhookEndpoint> {
+    await this.assertDeliverableUrl(input.url);
+
+    const secret = generateWebhookSecret();
+    const now = new Date();
+    const row = {
+      id: crypto.randomUUID(),
+      name: input.name,
+      url: input.url,
+      enabled: input.enabled ?? true,
+      eventTypes: input.eventTypes,
+      filter: null,
+      headers: input.headers ?? null,
+      // List-shaped from the first write, so adding a second active secret
+      // during a rotation is an append rather than a migration.
+      secretHash: [encryptWebhookSecret(secret)],
+      secretPrefix: webhookSecretPrefix(secret),
+      fieldAllowlist: null,
+      createdBy,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await this.db.insert(this.table).values(row);
+    this.registry?.invalidate();
+
+    return { endpoint: this.toSummary(row), secret };
+  }
+
+  /** Every registered endpoint, newest first. */
+  async listEndpoints(): Promise<WebhookEndpointSummary[]> {
+    const rows = (await this.db
+      .select()
+      .from(this.table)
+      .orderBy(desc(this.table.createdAt))) as WebhookRow[];
+    return rows.map(row => this.toSummary(row));
+  }
+
+  /** One endpoint, or null when it does not exist. */
+  async getEndpoint(id: string): Promise<WebhookEndpointSummary | null> {
+    const rows = (await this.db
+      .select()
+      .from(this.table)
+      .where(eq(this.table.id, id))
+      .limit(1)) as WebhookRow[];
+    return rows[0] ? this.toSummary(rows[0]) : null;
+  }
+
+  /**
+   * Change an endpoint. Only the named fields move.
+   *
+   * A URL is re-validated on the way in, because an update is exactly how an
+   * endpoint that passed at registration would be re-pointed somewhere it
+   * should not reach.
+   */
+  async updateEndpoint(
+    id: string,
+    patch: UpdateWebhookEndpointInput
+  ): Promise<WebhookEndpointSummary> {
+    const existing = await this.getEndpoint(id);
+    if (!existing) throw this.notFound(id);
+
+    if (patch.url !== undefined) await this.assertDeliverableUrl(patch.url);
+
+    const changes: Record<string, unknown> = { updatedAt: new Date() };
+    if (patch.name !== undefined) changes.name = patch.name;
+    if (patch.url !== undefined) changes.url = patch.url;
+    if (patch.eventTypes !== undefined) changes.eventTypes = patch.eventTypes;
+    if (patch.enabled !== undefined) changes.enabled = patch.enabled;
+    if (patch.headers !== undefined) changes.headers = patch.headers;
+
+    await this.db.update(this.table).set(changes).where(eq(this.table.id, id));
+    // Invalidated for every field, not only `enabled`: the cached list carries
+    // url, event types and headers too, and a stale copy would keep delivering
+    // to the old target.
+    this.registry?.invalidate();
+
+    const updated = await this.getEndpoint(id);
+    if (!updated) throw this.notFound(id);
+    return updated;
+  }
+
+  /**
+   * Stop delivering without discarding the endpoint.
+   *
+   * Kept distinct from deletion because they are different intentions and only
+   * one is reversible. An endpoint id tends to end up in someone's
+   * infrastructure, so removing the row is the operation that cannot be undone.
+   */
+  async setEnabled(
+    id: string,
+    enabled: boolean
+  ): Promise<WebhookEndpointSummary> {
+    return this.updateEndpoint(id, { enabled });
+  }
+
+  /** Remove an endpoint. Delivery rows are retained for their own retention. */
+  async deleteEndpoint(id: string): Promise<void> {
+    const existing = await this.getEndpoint(id);
+    if (!existing) throw this.notFound(id);
+
+    await this.db.delete(this.table).where(eq(this.table.id, id));
+    this.registry?.invalidate();
+  }
+
+  /**
+   * Recover the active signing secrets.
+   *
+   * Separate from every other read so the route can require a stronger
+   * permission for it: the secret is what proves a request came from this
+   * install, and it should not arrive incidentally in a list response.
+   *
+   * Returns every active secret because rotation keeps more than one alive at
+   * a time, and a caller reconciling their configuration needs to see them all.
+   */
+  async revealSecrets(id: string): Promise<string[]> {
+    const rows = (await this.db
+      .select()
+      .from(this.table)
+      .where(and(eq(this.table.id, id)))
+      .limit(1)) as WebhookRow[];
+
+    const row = rows[0];
+    if (!row) throw this.notFound(id);
+
+    const stored = Array.isArray(row.secretHash) ? row.secretHash : [];
+    return stored.map(value => decryptWebhookSecret(String(value)));
+  }
+
+  private notFound(id: string): NextlyError {
+    return NextlyError.notFound({
+      logContext: { entity: "webhook-endpoint", id },
+    });
+  }
+}

--- a/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
+++ b/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
@@ -25,13 +25,22 @@
  * @module domains/webhooks/services/webhook-endpoint-service
  */
 
-import { eq, desc } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 
 import { toDbError } from "../../../database/errors";
 import { NextlyError } from "../../../errors";
-import { nextlyWebhooks as webhooksMysql } from "../../../schemas/webhooks/mysql";
-import { nextlyWebhooks as webhooksPg } from "../../../schemas/webhooks/postgres";
-import { nextlyWebhooks as webhooksSqlite } from "../../../schemas/webhooks/sqlite";
+import {
+  nextlyWebhooks as webhooksMysql,
+  nextlyWebhookDeliveries as deliveriesMysql,
+} from "../../../schemas/webhooks/mysql";
+import {
+  nextlyWebhooks as webhooksPg,
+  nextlyWebhookDeliveries as deliveriesPg,
+} from "../../../schemas/webhooks/postgres";
+import {
+  nextlyWebhooks as webhooksSqlite,
+  nextlyWebhookDeliveries as deliveriesSqlite,
+} from "../../../schemas/webhooks/sqlite";
 import { BaseService } from "../../../shared/base-service";
 import {
   ExternalUrlError,
@@ -93,6 +102,11 @@ type WebhooksTable =
   | typeof webhooksMysql
   | typeof webhooksSqlite;
 
+type DeliveriesTable =
+  | typeof deliveriesPg
+  | typeof deliveriesMysql
+  | typeof deliveriesSqlite;
+
 /** A stored row, before it is narrowed to what a caller may see. */
 interface WebhookRow {
   id: string;
@@ -110,6 +124,8 @@ interface WebhookRow {
 
 export class WebhookEndpointService extends BaseService {
   private readonly table: WebhooksTable;
+  /** Needed so disabling an endpoint can end the deliveries still queued for it. */
+  private readonly deliveries: DeliveriesTable;
 
   constructor(
     adapter: ConstructorParameters<typeof BaseService>[0],
@@ -127,12 +143,15 @@ export class WebhookEndpointService extends BaseService {
     switch (this.adapter.getCapabilities().dialect) {
       case "postgresql":
         this.table = webhooksPg;
+        this.deliveries = deliveriesPg;
         break;
       case "mysql":
         this.table = webhooksMysql;
+        this.deliveries = deliveriesMysql;
         break;
       default:
         this.table = webhooksSqlite;
+        this.deliveries = deliveriesSqlite;
         break;
     }
   }
@@ -302,9 +321,48 @@ export class WebhookEndpointService extends BaseService {
     // to the old target.
     this.registry?.invalidate();
 
+    // Done here rather than in `setEnabled` so that disabling through a plain
+    // field update cannot skip it.
+    if (patch.enabled === false) await this.cancelQueuedDeliveries(id);
+
     const updated = await this.getEndpoint(id);
     if (!updated) throw this.notFound(id);
     return updated;
+  }
+
+  /**
+   * End the deliveries still outstanding for an endpoint that was just
+   * disabled.
+   *
+   * Delivery refuses a disabled endpoint when it attempts one, which covers a
+   * drain running during the disabled window. It does not cover the window
+   * itself: with no drain between disabling and re-enabling, those rows are
+   * still due and would go out in a burst afterwards, which is the opposite of
+   * what disabling promised.
+   *
+   * They are ended rather than held for the same reason delivery ends them.
+   * Sending events an operator switched off, hours late, is worse than not
+   * sending them, and replaying is a separate deliberate act.
+   */
+  private async cancelQueuedDeliveries(webhookId: string): Promise<void> {
+    await this.query(() =>
+      this.db
+        .update(this.deliveries)
+        .set({
+          status: "failed",
+          nextAttemptAt: null,
+          lockedBy: null,
+          lockedUntil: null,
+          lastError: "webhook disabled",
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(this.deliveries.webhookId, webhookId),
+            inArray(this.deliveries.status, ["pending", "retrying"])
+          )
+        )
+    );
   }
 
   /**

--- a/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
+++ b/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
@@ -25,8 +25,9 @@
  * @module domains/webhooks/services/webhook-endpoint-service
  */
 
-import { and, eq, desc } from "drizzle-orm";
+import { eq, desc } from "drizzle-orm";
 
+import { toDbError } from "../../../database/errors";
 import { NextlyError } from "../../../errors";
 import { nextlyWebhooks as webhooksMysql } from "../../../schemas/webhooks/mysql";
 import { nextlyWebhooks as webhooksPg } from "../../../schemas/webhooks/postgres";
@@ -137,6 +138,24 @@ export class WebhookEndpointService extends BaseService {
   }
 
   /**
+   * Run a database call, turning a driver error into the canonical envelope.
+   *
+   * Every statement here can fail for reasons the caller should see as a typed
+   * error rather than a driver exception: `created_by` referencing a user that
+   * has since been removed, a constraint violation, a lost connection. Without
+   * this the raw driver `Error` escapes `packages/nextly`, where nothing above
+   * knows how to render it.
+   */
+  private async query<T>(run: () => Promise<T>): Promise<T> {
+    try {
+      return await run();
+    } catch (err) {
+      if (err instanceof NextlyError) throw err;
+      throw NextlyError.fromDatabaseError(toDbError(this.dialect, err));
+    }
+  }
+
+  /**
    * Reject a URL delivery could never safely call.
    *
    * Reuses the same validator the transport uses, so registration and delivery
@@ -221,7 +240,7 @@ export class WebhookEndpointService extends BaseService {
       updatedAt: now,
     };
 
-    await this.db.insert(this.table).values(row);
+    await this.query(() => this.db.insert(this.table).values(row));
     this.registry?.invalidate();
 
     return { endpoint: this.toSummary(row), secret };
@@ -229,20 +248,26 @@ export class WebhookEndpointService extends BaseService {
 
   /** Every registered endpoint, newest first. */
   async listEndpoints(): Promise<WebhookEndpointSummary[]> {
-    const rows = (await this.db
-      .select()
-      .from(this.table)
-      .orderBy(desc(this.table.createdAt))) as WebhookRow[];
+    const rows = await this.query(
+      async () =>
+        (await this.db
+          .select()
+          .from(this.table)
+          .orderBy(desc(this.table.createdAt))) as WebhookRow[]
+    );
     return rows.map(row => this.toSummary(row));
   }
 
   /** One endpoint, or null when it does not exist. */
   async getEndpoint(id: string): Promise<WebhookEndpointSummary | null> {
-    const rows = (await this.db
-      .select()
-      .from(this.table)
-      .where(eq(this.table.id, id))
-      .limit(1)) as WebhookRow[];
+    const rows = await this.query(
+      async () =>
+        (await this.db
+          .select()
+          .from(this.table)
+          .where(eq(this.table.id, id))
+          .limit(1)) as WebhookRow[]
+    );
     return rows[0] ? this.toSummary(rows[0]) : null;
   }
 
@@ -269,7 +294,9 @@ export class WebhookEndpointService extends BaseService {
     if (patch.enabled !== undefined) changes.enabled = patch.enabled;
     if (patch.headers !== undefined) changes.headers = patch.headers;
 
-    await this.db.update(this.table).set(changes).where(eq(this.table.id, id));
+    await this.query(() =>
+      this.db.update(this.table).set(changes).where(eq(this.table.id, id))
+    );
     // Invalidated for every field, not only `enabled`: the cached list carries
     // url, event types and headers too, and a stale copy would keep delivering
     // to the old target.
@@ -294,12 +321,21 @@ export class WebhookEndpointService extends BaseService {
     return this.updateEndpoint(id, { enabled });
   }
 
-  /** Remove an endpoint. Delivery rows are retained for their own retention. */
+  /**
+   * Remove an endpoint and, with it, its delivery history.
+   *
+   * `nextly_webhook_deliveries.webhook_id` cascades, so deleting an endpoint
+   * discards the record of what was sent to it rather than leaving that to
+   * retention. This is why disabling exists and is the reversible option:
+   * deletion is for an endpoint whose history is no longer wanted either.
+   */
   async deleteEndpoint(id: string): Promise<void> {
     const existing = await this.getEndpoint(id);
     if (!existing) throw this.notFound(id);
 
-    await this.db.delete(this.table).where(eq(this.table.id, id));
+    await this.query(() =>
+      this.db.delete(this.table).where(eq(this.table.id, id))
+    );
     this.registry?.invalidate();
   }
 
@@ -314,11 +350,14 @@ export class WebhookEndpointService extends BaseService {
    * a time, and a caller reconciling their configuration needs to see them all.
    */
   async revealSecrets(id: string): Promise<string[]> {
-    const rows = (await this.db
-      .select()
-      .from(this.table)
-      .where(and(eq(this.table.id, id)))
-      .limit(1)) as WebhookRow[];
+    const rows = await this.query(
+      async () =>
+        (await this.db
+          .select()
+          .from(this.table)
+          .where(eq(this.table.id, id))
+          .limit(1)) as WebhookRow[]
+    );
 
     const row = rows[0];
     if (!row) throw this.notFound(id);

--- a/packages/nextly/src/schemas/_zod/__tests__/barrel-coverage.test.ts
+++ b/packages/nextly/src/schemas/_zod/__tests__/barrel-coverage.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Barrel coverage guard for the Zod schema modules.
+ *
+ * `nextly/schemas` is the only entry point that exposes these validators, and
+ * it reaches them solely through `_zod/index.ts`. A module that is not
+ * re-exported there is unreachable from outside the package while still
+ * compiling, passing its own unit tests and looking finished in review — the
+ * failure only surfaces when route code tries to import it.
+ *
+ * The check is structural rather than a hand-written list, so adding a module
+ * cannot pass by forgetting to update the list too.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, it, expect } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ZOD_DIR = join(__dirname, "..");
+
+/** Every schema module in the directory, by import specifier. */
+function schemaModules(): string[] {
+  return readdirSync(ZOD_DIR, { withFileTypes: true })
+    .filter(entry => entry.isFile())
+    .map(entry => entry.name)
+    .filter(
+      name =>
+        name.endsWith(".ts") &&
+        name !== "index.ts" &&
+        // Colocated runtime and type tests are not part of the public surface.
+        !name.endsWith(".test.ts") &&
+        !name.endsWith(".test-d.ts")
+    )
+    .map(name => name.slice(0, -".ts".length));
+}
+
+describe("_zod barrel coverage", () => {
+  it("re-exports every schema module", () => {
+    const barrel = readFileSync(join(ZOD_DIR, "index.ts"), "utf-8");
+    const modules = schemaModules();
+
+    // A directory that reads as empty would make every assertion below vacuous.
+    expect(modules.length).toBeGreaterThan(0);
+
+    const missing = modules.filter(
+      name => !new RegExp(`export \\* from "\\./${name}"`).test(barrel)
+    );
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/nextly/src/schemas/_zod/__tests__/webhooks.test.ts
+++ b/packages/nextly/src/schemas/_zod/__tests__/webhooks.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Request validation for the webhook endpoint surface.
+ *
+ * The assertions worth having here are the ones that protect delivery rather
+ * than the ones that restate the schema. A caller-supplied `webhook-signature`
+ * header would let a request overwrite the header a receiver verifies against,
+ * and an unknown event type would be accepted into a subscription the fan-out
+ * never matches — a subscription that silently never fires.
+ */
+import { describe, it, expect } from "vitest";
+
+import { WEBHOOK_EVENT_TYPES } from "../../../domains/webhooks/types";
+import { CreateWebhookSchema, UpdateWebhookSchema } from "../webhooks";
+
+const valid = {
+  name: "Orders",
+  url: "https://example.com/hooks",
+  eventTypes: ["entry.created"],
+};
+
+describe("CreateWebhookSchema", () => {
+  it("accepts a minimal endpoint", () => {
+    expect(CreateWebhookSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("accepts every type the fan-out can deliver", () => {
+    // Bound to the same constant delivery matches on, so a type that can be
+    // subscribed to is always a type that can fire.
+    const parsed = CreateWebhookSchema.safeParse({
+      ...valid,
+      eventTypes: [...WEBHOOK_EVENT_TYPES],
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects an event type nothing emits", () => {
+    const parsed = CreateWebhookSchema.safeParse({
+      ...valid,
+      eventTypes: ["entry.exploded"],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("requires at least one subscription", () => {
+    expect(
+      CreateWebhookSchema.safeParse({ ...valid, eventTypes: [] }).success
+    ).toBe(false);
+  });
+
+  it("rejects a duplicated event type", () => {
+    const parsed = CreateWebhookSchema.safeParse({
+      ...valid,
+      eventTypes: ["entry.created", "entry.created"],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  describe("headers delivery owns", () => {
+    it.each([
+      ["webhook-signature"],
+      ["webhook-id"],
+      ["Webhook-Timestamp"],
+      ["Content-Type"],
+      ["user-agent"],
+    ])("rejects %s", header => {
+      const parsed = CreateWebhookSchema.safeParse({
+        ...valid,
+        headers: { [header]: "forged" },
+      });
+      expect(parsed.success).toBe(false);
+    });
+
+    it("allows an ordinary header", () => {
+      const parsed = CreateWebhookSchema.safeParse({
+        ...valid,
+        headers: { Authorization: "Bearer token" },
+      });
+      expect(parsed.success).toBe(true);
+    });
+  });
+
+  describe("headers the transport could never send", () => {
+    // Node rejects these when it builds the request, and delivery cannot
+    // distinguish that from a network fault — it records a transient failure
+    // and retries an endpoint that can never succeed.
+    it.each([
+      ["a space in the name", { "bad header": "x" }],
+      ["a colon in the name", { "bad:header": "x" }],
+      ["a CR/LF injection in the value", { "X-Trace": "a\r\nX-Forged: 1" }],
+      ["a bare newline in the value", { "X-Trace": "a\nb" }],
+      ["a NUL in the value", { "X-Trace": "a\u0000b" }],
+      ["an empty name", { "": "x" }],
+    ])("rejects %s", (_label, headers) => {
+      expect(CreateWebhookSchema.safeParse({ ...valid, headers }).success).toBe(
+        false
+      );
+    });
+
+    it("still allows the punctuation a token permits", () => {
+      const parsed = CreateWebhookSchema.safeParse({
+        ...valid,
+        headers: { "X-Trace_Id.v1": "abc-123" },
+      });
+      expect(parsed.success).toBe(true);
+    });
+  });
+
+  it("rejects a URL longer than the column holds", () => {
+    const parsed = CreateWebhookSchema.safeParse({
+      ...valid,
+      url: `https://example.com/${"a".repeat(2048)}`,
+    });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe("UpdateWebhookSchema", () => {
+  it("accepts a single field", () => {
+    expect(UpdateWebhookSchema.safeParse({ name: "Renamed" }).success).toBe(
+      true
+    );
+  });
+
+  it("rejects an empty patch", () => {
+    // An empty patch would otherwise bump updated_at and invalidate the
+    // endpoint cache while changing nothing.
+    expect(UpdateWebhookSchema.safeParse({}).success).toBe(false);
+  });
+
+  it("applies the same header rule as creation", () => {
+    const parsed = UpdateWebhookSchema.safeParse({
+      headers: { "webhook-signature": "forged" },
+    });
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/packages/nextly/src/schemas/_zod/index.ts
+++ b/packages/nextly/src/schemas/_zod/index.ts
@@ -13,3 +13,4 @@ export * from "./rbac";
 export * from "./validation";
 export * from "./api-keys";
 export * from "./ui-schema";
+export * from "./webhooks";

--- a/packages/nextly/src/schemas/_zod/webhooks.test-d.ts
+++ b/packages/nextly/src/schemas/_zod/webhooks.test-d.ts
@@ -1,0 +1,27 @@
+/**
+ * The webhook request schemas must preserve event-type literals.
+ *
+ * Runtime validation is identical whether the enum is built from the literal
+ * tuple or a widened `string[]`, so nothing at runtime can catch the widening.
+ * It only shows up at the request-to-service boundary: a parsed body whose
+ * `eventTypes` is `string[]` cannot be handed to the endpoint service without
+ * a cast, which is exactly the check that should be doing the work there.
+ */
+import { expectTypeOf } from "vitest";
+
+import type { WebhookEventType } from "../../domains/webhooks/types";
+
+import type { CreateWebhookInput, UpdateWebhookInput } from "./webhooks";
+
+expectTypeOf<CreateWebhookInput["eventTypes"]>().toEqualTypeOf<
+  WebhookEventType[]
+>();
+
+expectTypeOf<UpdateWebhookInput["eventTypes"]>().toEqualTypeOf<
+  WebhookEventType[] | undefined
+>();
+
+// Stated explicitly: this is the shape the widening cast produced, and it is
+// assignable from the correct type in one direction, so equality alone could
+// pass for the wrong reason if the literals ever collapsed to `string`.
+expectTypeOf<CreateWebhookInput["eventTypes"]>().not.toEqualTypeOf<string[]>();

--- a/packages/nextly/src/schemas/_zod/webhooks.ts
+++ b/packages/nextly/src/schemas/_zod/webhooks.ts
@@ -26,16 +26,50 @@ import { WEBHOOK_EVENT_TYPES } from "../../domains/webhooks/types";
  * Bound to the same constant the fan-out matches against, so a type that
  * cannot be delivered cannot be subscribed to either — a silently-never-firing
  * subscription is worse than a rejected one.
+ *
+ * Passed directly rather than widened to `[string, ...string[]]`: the literal
+ * members survive inference, so a parsed request body carries
+ * `WebhookEventType[]` and reaches the service without a cast at the boundary.
  */
-export const WebhookEventTypeSchema = z.enum(
-  WEBHOOK_EVENT_TYPES as unknown as [string, ...string[]]
-);
+export const WebhookEventTypeSchema = z.enum(WEBHOOK_EVENT_TYPES);
 
 /** Header names a caller may not set, because delivery owns them. */
 const RESERVED_HEADER_PREFIXES = ["webhook-", "content-type", "user-agent"];
 
+/**
+ * A field name must be an RFC 9110 token, and a value must be printable ASCII
+ * with no CR, LF or NUL.
+ *
+ * These are rejected at registration rather than left to the transport because
+ * of where the transport rejects them: Node refuses an invalid name or a value
+ * containing CR/LF when the request is built, and the delivery path cannot tell
+ * that apart from a network fault, so it records a transient failure and
+ * retries. A header that can never be sent would then be retried on every event
+ * until the endpoint exhausted its attempts. A value carrying CR/LF is also the
+ * classic header-injection shape, and storing one is not something to allow on
+ * the assumption that a downstream library will catch it.
+ */
+const HEADER_NAME = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+const HEADER_VALUE = /^[\t\x20-\x7e\x80-\xff]*$/;
+
 const HeadersSchema = z
-  .record(z.string(), z.string())
+  .record(
+    z
+      .string()
+      .min(1)
+      .max(256)
+      .regex(
+        HEADER_NAME,
+        "Header names may only contain letters, digits and !#$%&'*+-.^_`|~"
+      ),
+    z
+      .string()
+      .max(4096)
+      .regex(
+        HEADER_VALUE,
+        "Header values cannot contain line breaks or control characters."
+      )
+  )
   .refine(
     headers =>
       Object.keys(headers).every(

--- a/packages/nextly/src/schemas/_zod/webhooks.ts
+++ b/packages/nextly/src/schemas/_zod/webhooks.ts
@@ -1,0 +1,107 @@
+/**
+ * Request shapes for the webhook endpoint surface.
+ *
+ * Field names follow what the webhook ecosystem has converged on — `url`,
+ * `enabled`, an explicit event-type list, a human `description` — so an
+ * integration written against Stripe or Svix reads the same here.
+ *
+ * Subscription is an explicit list rather than a wildcard. Both models exist in
+ * the market, but they fail in opposite directions: adding a new event type to
+ * Nextly would immediately change what a wildcard endpoint receives, which
+ * breaks a consumer doing exhaustive matching on the type. Explicit costs the
+ * consumer an update when they want the new type, and that is the safe
+ * direction. Wildcards can be added later without breaking anyone; removing
+ * them could not.
+ *
+ * @module schemas/_zod/webhooks
+ */
+
+import { z } from "zod";
+
+import { WEBHOOK_EVENT_TYPES } from "../../domains/webhooks/types";
+
+/**
+ * The event types an endpoint may subscribe to.
+ *
+ * Bound to the same constant the fan-out matches against, so a type that
+ * cannot be delivered cannot be subscribed to either — a silently-never-firing
+ * subscription is worse than a rejected one.
+ */
+export const WebhookEventTypeSchema = z.enum(
+  WEBHOOK_EVENT_TYPES as unknown as [string, ...string[]]
+);
+
+/** Header names a caller may not set, because delivery owns them. */
+const RESERVED_HEADER_PREFIXES = ["webhook-", "content-type", "user-agent"];
+
+const HeadersSchema = z
+  .record(z.string(), z.string())
+  .refine(
+    headers =>
+      Object.keys(headers).every(
+        name =>
+          !RESERVED_HEADER_PREFIXES.some(reserved =>
+            name.toLowerCase().startsWith(reserved)
+          )
+      ),
+    {
+      // Silently dropping them would look like the header was accepted; letting
+      // them through would let a caller overwrite the signature headers a
+      // receiver verifies against.
+      message:
+        "Headers named webhook-*, content-type or user-agent are set by delivery and cannot be overridden.",
+    }
+  );
+
+/**
+ * `url` is checked for shape here and for reachability in the service, which
+ * resolves the host and rejects private or metadata addresses. Both are needed:
+ * this gives an immediate, field-level error, and the service check is the one
+ * that cannot be fooled by a hostname that resolves somewhere unexpected.
+ */
+const UrlSchema = z
+  .string()
+  .url("Must be a valid URL.")
+  .max(2048, "URL must be 2048 characters or fewer.");
+
+export const CreateWebhookSchema = z.object({
+  name: z.string().min(1, "Name is required.").max(255),
+  url: UrlSchema,
+  eventTypes: z
+    .array(WebhookEventTypeSchema)
+    .min(1, "Subscribe to at least one event type.")
+    // A duplicate would not change delivery, but it would make the stored
+    // subscription disagree with what the user typed.
+    .refine(types => new Set(types).size === types.length, {
+      message: "Event types must be unique.",
+    }),
+  enabled: z.boolean().optional(),
+  headers: HeadersSchema.nullable().optional(),
+});
+
+/**
+ * Every field optional: a PATCH updates what it names. `null` on a nullable
+ * field means "clear this", `undefined` means "leave it alone" — the
+ * distinction the update path relies on to tell an omitted field from a
+ * deliberate reset.
+ */
+export const UpdateWebhookSchema = z
+  .object({
+    name: z.string().min(1).max(255).optional(),
+    url: UrlSchema.optional(),
+    eventTypes: z
+      .array(WebhookEventTypeSchema)
+      .min(1, "Subscribe to at least one event type.")
+      .refine(types => new Set(types).size === types.length, {
+        message: "Event types must be unique.",
+      })
+      .optional(),
+    enabled: z.boolean().optional(),
+    headers: HeadersSchema.nullable().optional(),
+  })
+  .refine(patch => Object.keys(patch).length > 0, {
+    message: "Provide at least one field to update.",
+  });
+
+export type CreateWebhookInput = z.infer<typeof CreateWebhookSchema>;
+export type UpdateWebhookInput = z.infer<typeof UpdateWebhookSchema>;


### PR DESCRIPTION
Second slice of the webhooks work. Depends on #281 (secret crypto), which is on main.

## Why this exists

The audit found the engine complete and the product absent: delivery, fan-out, signing, SSRF-safe transport and retention were all built, but **the only rows that ever reached `nextly_webhooks` were test fixtures**. There was no create, update, delete or list anywhere in the repo. This is the layer that makes everything already built reachable.

## Design decisions, and why

**Registration-time URL validation.** Delivery already refuses private, loopback and cloud-metadata addresses via `safeFetch`, and that check is the one that survives a hostname re-pointed after registration — but it fires long after whoever typed the URL has gone, so a mistake surfaces as a silent, repeating delivery failure. Both checks are needed and they use the same validator, so registration and delivery cannot disagree about what is acceptable. It runs on update too, since an update is exactly how a passing endpoint gets re-pointed somewhere it should not reach.

**Secrets are retrievable, not write-only.** Research across Stripe, Svix and GitHub: only GitHub is write-only; the webhook-first providers keep the secret readable behind permission (Stripe's *Click to reveal*, Svix's `GET /endpoint/{id}/secret`). For a self-hosted framework that is the better trade — write-only forces a full rotation every time an operator loses their copy, and rotation is the more dangerous operation. `revealSecrets` is a separate call precisely so the route can require a stronger permission; it never rides along on a list or fetch.

This is also what the schema was built for: `secret_hash` stores **reversible ciphertext**, not a hash.

**Explicit event types, no wildcard.** Both models exist in the market. They fail in opposite directions: adding a new event type to Nextly would immediately change what a wildcard endpoint receives, breaking a consumer that matches exhaustively. Explicit costs a consumer an update when they want a new type — the safe direction. Wildcards can be added later without breaking anyone; removing them could not.

**Disable distinct from delete.** Universal across every provider studied, trivial now, impossible to retrofit once endpoint ids are in people's infrastructure.

**Invalidation on every mutation, not just `enabled`.** The cached list carries url, event types and headers too. The registry defaults to caching *forever* (`ttlMs` is optional), so a missed invalidation is silent and unbounded — a disabled endpoint would keep receiving deliveries for the life of the process.

## Deviations from the api-keys blueprint, deliberate

- **No per-user ownership.** api-keys does ownership-in-`where` with super-admin widening. Webhooks are a global system resource; `created_by` is `onDelete: "set null"`, which is attribution, not ownership. Copying that machinery would invent a concept the schema does not have.
- **Encrypted, not hashed.** api-keys SHA-256s its key because it only ever needs to compare. Delivery must recover the plaintext to HMAC-sign, so reversible is required.
- **No audit_log writes**, matching api-keys. The domain already has a richer ledger in `nextly_events` and `nextly_webhook_deliveries`.

## Verification

20 integration tests against real SQLite, schema generated from the production table definitions via drizzle-kit — no hand-copied DDL. The assertions that matter are the ones that fail silently in production:

- the secret does not appear in create's endpoint object, a fetch, or a list — asserted by serialising and searching, since that is what a JSON response would do
- what lands in the column contains no fragment of the plaintext
- each endpoint gets its own secret (the spec forbids sharing)
- loopback, private-range, link-local metadata and plain http are all refused, and **nothing is stored** when they are
- the cache is dropped on create, on every update field, and on delete

Load-bearing on both security behaviours: removing registration-time validation fails 6 tests; removing invalidation fails 3.

Typecheck and eslint clean. Whole webhook domain green — 61 integration tests, 141 unit.

## Not in this PR

REST handlers, route parsing, dispatcher branch and permission seeds are the next slice; the admin UI after that. Splitting because #277 took 25 review findings as one bundle, and the seam between a service and its transport is a natural place to cut.

Also still open from the audit: no test-send affordance (the highest DX-per-line item in the research), no delivery-history surface, and no rotation overlap window — the storage shape anticipates it but there is no `expiresAt` per secret yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added webhook endpoint lifecycle management (create, list, retrieve, update, enable/disable, delete) with one-time secret issuance and controlled secret reveal.
  * Added webhook request Zod schemas for event types, delivery URL validation, and strict header validation (including PATCH semantics).
* **Bug Fixes**
  * Webhook deliveries are now blocked when an endpoint is disabled at delivery time, marking impacted deliveries as permanently failed.
* **Tests**
  * Expanded SQLite real-database integration coverage for endpoint behavior, cache invalidation, secret safety, and URL/update validation.
  * Added Zod schema tests, type-level checks, and barrel re-export coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->