### PR TITLE
feat(nextly): seed publish and unpublish permission actions

### DIFF
--- a/.changeset/publish-permission-action.md
+++ b/.changeset/publish-permission-action.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Publishing is now its own permission, separate from editing.
+
+Every collection and single now seeds `publish` and `unpublish` permissions
+alongside its CRUD ones, and the built-in roles use them: an Editor may publish,
+an Author may write but not publish or take content down, and a Viewer may do
+neither. Nothing is enforced by them yet — this release only creates the
+permissions and assigns them, so existing setups behave exactly as before.

--- a/packages/nextly/src/database/seeders/role-presets.ts
+++ b/packages/nextly/src/database/seeders/role-presets.ts
@@ -89,13 +89,16 @@ export const ROLE_PRESETS: RolePreset[] = [
     name: "Author",
     description: "Write content, but not publish or delete it",
     level: 30,
-    // The same reach as an editor, minus the two irreversible-in-public
-    // actions. `manage` is excluded because it is a superset we cannot see
-    // inside, which is exactly what an author should not hold.
+    // The same reach as an editor, minus the actions that change what the
+    // public sees. `unpublish` is excluded alongside `publish`: taking a live
+    // page down is as visible as putting one up, and an author who cannot
+    // publish but can unpublish is a strange half-authority. `manage` is
+    // excluded because it is a superset we cannot see inside, which is exactly
+    // what an author should not hold.
     grants: ({ action, resource }, { isSystem, isPlugin }) => {
       if (isPlugin) return false;
       if (isSystem && resource !== "media") return false;
-      return !["delete", "publish", "manage"].includes(action);
+      return !["delete", "publish", "unpublish", "manage"].includes(action);
     },
   },
   {

--- a/packages/nextly/src/domains/auth/services/orphaned-permissions.integration.test.ts
+++ b/packages/nextly/src/domains/auth/services/orphaned-permissions.integration.test.ts
@@ -193,3 +193,40 @@ describe("a marked permission", () => {
     expect(rows).toHaveLength(0);
   });
 });
+
+describe("re-declaring a permission that was marked orphaned", () => {
+  it("clears the mark, so it returns to the menu", async () => {
+    // `listPermissions` hides orphans by default, and preset-role syncing reads
+    // that list. A permission left marked after its declaration came back
+    // exists, is declared, and is still ungrantable.
+    current = await bootWithCoreTables();
+    const seed = current.getService("permissionSeedService");
+
+    await seed.seedCustomPermissions([EXPORT_SUBMISSIONS]);
+    await seed.markOrphanedPermissions([]);
+    expect(await orphanedAtFor(current, "export-submissions")).not.toBeNull();
+
+    // The declaration returns — a plugin reinstalled, or a built-in seeder
+    // adopting a slug a plugin used to own.
+    await seed.seedCustomPermissions([EXPORT_SUBMISSIONS]);
+
+    expect(await orphanedAtFor(current, "export-submissions")).toBeNull();
+  });
+
+  it("makes it visible to the default permission listing again", async () => {
+    current = await bootWithCoreTables();
+    const seed = current.getService("permissionSeedService");
+    const permissions = permissionsOf(current);
+
+    await seed.seedCustomPermissions([EXPORT_SUBMISSIONS]);
+    await seed.markOrphanedPermissions([]);
+
+    const hidden = await permissions.listPermissions({ limit: 1000 });
+    expect(hidden.data.some(p => p.slug === "export-submissions")).toBe(false);
+
+    await seed.seedCustomPermissions([EXPORT_SUBMISSIONS]);
+
+    const shown = await permissions.listPermissions({ limit: 1000 });
+    expect(shown.data.some(p => p.slug === "export-submissions")).toBe(true);
+  });
+});

--- a/packages/nextly/src/domains/auth/services/permission-seed-service.ts
+++ b/packages/nextly/src/domains/auth/services/permission-seed-service.ts
@@ -318,14 +318,26 @@ export class PermissionSeedService extends BaseService {
   /**
    * Seed CRUD permissions for a single collection.
    *
-   * Creates 4 permissions: create, read, update, delete for the given slug.
+   * Creates 6 permissions: create, read, update, delete, publish, unpublish.
+   *
+   * Publishing is seeded for every collection, not only those with the
+   * draft/published lifecycle enabled. A collection can gain `status: true`
+   * later, and a permission that appears only once someone flips a flag is one
+   * nobody has granted at the moment it starts being enforced.
    *
    * @param collectionSlug - The collection slug (e.g., "posts", "products")
    */
   async seedCollectionPermissions(collectionSlug: string): Promise<SeedResult> {
     const result = this.emptySeedResult();
     const label = this.slugToLabel(collectionSlug);
-    const actions = ["create", "read", "update", "delete"] as const;
+    const actions = [
+      "create",
+      "read",
+      "update",
+      "delete",
+      "publish",
+      "unpublish",
+    ] as const;
 
     for (const action of actions) {
       const actionLabel = action.charAt(0).toUpperCase() + action.slice(1);
@@ -361,14 +373,16 @@ export class PermissionSeedService extends BaseService {
    * Seed read/update permissions for a single (global document).
    *
    * Singles have no create/delete lifecycle — they are auto-created on first
-   * access and cannot be deleted. Only read and update permissions are generated.
+   * access and cannot be deleted. They DO have a publish lifecycle: a Single
+   * carries the same `status` column and is published today by an ordinary
+   * update, so it needs the same publish permissions a collection does.
    *
    * @param singleSlug - The single slug (e.g., "site-settings", "header")
    */
   async seedSinglePermissions(singleSlug: string): Promise<SeedResult> {
     const result = this.emptySeedResult();
     const label = this.slugToLabel(singleSlug);
-    const actions = ["read", "update"] as const;
+    const actions = ["read", "update", "publish", "unpublish"] as const;
 
     for (const action of actions) {
       const actionLabel = action.charAt(0).toUpperCase() + action.slice(1);

--- a/packages/nextly/src/domains/auth/services/permission-seed-service.ts
+++ b/packages/nextly/src/domains/auth/services/permission-seed-service.ts
@@ -418,8 +418,8 @@ export class PermissionSeedService extends BaseService {
    * Seed permissions for ALL dynamic collections.
    *
    * Reads all collection slugs from the `dynamic_collections` table
-   * (including plugin-registered collections) and seeds 4 CRUD permissions
-   * for each.
+   * (including plugin-registered collections) and seeds the six CRUD and
+   * publish-lifecycle permissions for each.
    */
   async seedAllCollectionPermissions(): Promise<SeedResult> {
     const result = this.emptySeedResult();
@@ -450,7 +450,7 @@ export class PermissionSeedService extends BaseService {
    * Seed permissions for ALL registered singles.
    *
    * Reads all single slugs from the `dynamic_singles` table and seeds
-   * read/update permissions for each.
+   * read, update, publish and unpublish permissions for each.
    */
   async seedAllSinglePermissions(): Promise<SeedResult> {
     const result = this.emptySeedResult();

--- a/packages/nextly/src/domains/auth/services/permission-service.ts
+++ b/packages/nextly/src/domains/auth/services/permission-service.ts
@@ -482,6 +482,7 @@ export class PermissionService extends BaseService {
         slug: permissions.slug,
         permissionGroup: permissions.permissionGroup,
         danger: permissions.danger,
+        orphanedAt: permissions.orphanedAt,
       })
       .from(permissions)
       .where(
@@ -510,7 +511,19 @@ export class PermissionService extends BaseService {
         slug?: string;
         permissionGroup?: string | null;
         danger?: boolean;
+        orphanedAt?: Date | null;
       } = {};
+
+      // Ensuring a permission IS the declaration, so a row that was retired
+      // rejoins the menu. Without this, a permission whose declaration went
+      // away and later came back stays marked: `listPermissions` filters
+      // orphans out by default, so preset-role syncing and the permission
+      // matrix would both skip a permission that exists and is declared.
+      const currentlyOrphaned =
+        (existing as { orphanedAt?: unknown }).orphanedAt != null;
+      if (currentlyOrphaned) {
+        patch.orphanedAt = null;
+      }
 
       const currentOwner =
         (existing as { owner?: string | null }).owner ?? null;

--- a/packages/nextly/src/plugins/codegen/collect-codegen-names.ts
+++ b/packages/nextly/src/plugins/codegen/collect-codegen-names.ts
@@ -3,8 +3,10 @@
  *
  * Pure helpers that derive the typed-slug unions emitted into the generated
  * `Config` interface (see {@link TypeGenerator.generateTypesFile}):
- *  - `permissionSlugs` — the CRUD permissions auto-seeded per collection
- *    (`create|read|update|delete-<slug>`) and per single (`read|update-<slug>`)
+ *  - `permissionSlugs` — the CRUD and publish-lifecycle permissions
+ *    auto-seeded per collection
+ *    (`create|read|update|delete|publish|unpublish-<slug>`) and per single
+ *    (`read|update|publish|unpublish-<slug>`)
  *    — mirroring `PermissionSeedService.seedCollectionPermissions` /
  *    `seedSinglePermissions` — plus every custom permission from
  *    {@link collectCustomPermissions} (app + plugin, D36).
@@ -64,7 +66,8 @@ export function collectCodegenNames(
   const collections = config.collections ?? [];
   const singles = config.singles ?? [];
 
-  // CRUD permissions auto-seeded per collection + per-collection domain events.
+  // CRUD plus the publish lifecycle, auto-seeded per collection, and the
+  // per-collection domain events.
   for (const c of collections) {
     for (const action of COLLECTION_ACTIONS) {
       permissionSlugs.add(`${action}-${c.slug}`);
@@ -74,7 +77,7 @@ export function collectCodegenNames(
     eventNames.add(`collection.${c.slug}.deleted`);
   }
 
-  // read/update permissions auto-seeded per single.
+  // read/update plus the publish lifecycle, auto-seeded per single.
   for (const s of singles) {
     for (const action of SINGLE_ACTIONS) {
       permissionSlugs.add(`${action}-${s.slug}`);

--- a/packages/nextly/src/plugins/codegen/collect-codegen-names.ts
+++ b/packages/nextly/src/plugins/codegen/collect-codegen-names.ts
@@ -36,9 +36,18 @@ export interface CodegenNames {
   eventNames: string[];
 }
 
-// Mirror the auto-seeder's action lists (permission-seed-service.ts).
-const COLLECTION_ACTIONS = ["create", "read", "update", "delete"] as const;
-const SINGLE_ACTIONS = ["read", "update"] as const;
+// Mirror the auto-seeder's action lists (permission-seed-service.ts). Generated
+// permission-slug types come from here, so a drift shows up as a slug the app
+// seeds but the types deny.
+const COLLECTION_ACTIONS = [
+  "create",
+  "read",
+  "update",
+  "delete",
+  "publish",
+  "unpublish",
+] as const;
+const SINGLE_ACTIONS = ["read", "update", "publish", "unpublish"] as const;
 
 /**
  * Derive the permission-slug + event-name unions for codegen from the merged

--- a/packages/nextly/src/plugins/permissions/collect-permissions.test.ts
+++ b/packages/nextly/src/plugins/permissions/collect-permissions.test.ts
@@ -265,12 +265,25 @@ describe("the publish lifecycle a plugin may already have declared", () => {
   });
 
   it("does not let a dropped declaration mask a genuine duplicate", () => {
-    // Two plugins declaring the same non-entity permission must still collide.
+    // A dropped `publish:posts` sits alongside a real duplicate on a resource
+    // nothing seeds. Skipping the first must not consume or excuse the second.
     expect(() =>
       collectCustomPermissions(cfg(["posts"]), [
+        plugin("@acme/legacy", [{ action: "publish", resource: "posts" }]),
         plugin("@acme/a", [{ action: "publish", resource: "newsletter" }]),
         plugin("@acme/b", [{ action: "publish", resource: "newsletter" }]),
       ])
     ).toThrow();
+  });
+
+  it("does not register a dropped declaration as seen", () => {
+    // The drop happens before `seen` is written, so a later declaration of the
+    // same pair on a non-entity resource is not mistaken for a duplicate of it.
+    const out = collectCustomPermissions(cfg(["posts"]), [
+      plugin("@acme/legacy", [{ action: "publish", resource: "posts" }]),
+      plugin("@acme/news", [{ action: "publish", resource: "newsletter" }]),
+    ]);
+
+    expect(out.map(p => p.slug)).toEqual(["publish-newsletter"]);
   });
 });

--- a/packages/nextly/src/plugins/permissions/collect-permissions.test.ts
+++ b/packages/nextly/src/plugins/permissions/collect-permissions.test.ts
@@ -212,3 +212,65 @@ describe("what a declaration says beyond its identity", () => {
     expect(out[0].danger).toBe(false);
   });
 });
+
+describe("the publish lifecycle a plugin may already have declared", () => {
+  // These verbs were legal for a plugin to declare until the seeder started
+  // emitting them. Rejecting one now would stop an installed app from booting
+  // on upgrade, over a declaration that was correct when it was written.
+  it("drops a plugin's publish on a collection instead of throwing", () => {
+    const out = collectCustomPermissions(cfg(["posts"]), [
+      plugin("@acme/workflow", [{ action: "publish", resource: "posts" }]),
+    ]);
+
+    expect(out).toEqual([]);
+  });
+
+  it("drops unpublish on a collection too", () => {
+    const out = collectCustomPermissions(cfg(["posts"]), [
+      plugin("@acme/workflow", [{ action: "unpublish", resource: "posts" }]),
+    ]);
+
+    expect(out).toEqual([]);
+  });
+
+  it("drops them on a single as well", () => {
+    const out = collectCustomPermissions(cfg([], ["site-settings"]), [
+      plugin("@acme/workflow", [
+        { action: "publish", resource: "site-settings" },
+      ]),
+    ]);
+
+    expect(out).toEqual([]);
+  });
+
+  it("still collects publish on a resource that is not an entity", () => {
+    // Nothing seeds `publish-newsletter`, so it remains a real custom
+    // permission — the adoption is scoped to slugs the seeder owns.
+    const out = collectCustomPermissions(cfg(["posts"]), [
+      plugin("@acme/news", [{ action: "publish", resource: "newsletter" }]),
+    ]);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].slug).toBe("publish-newsletter");
+  });
+
+  it("still throws for a CRUD verb, which was never a plugin's to declare", () => {
+    // The adoption is not a general amnesty: `update-posts` has always been
+    // the seeder's, so declaring it remains an authoring error.
+    expect(() =>
+      collectCustomPermissions(cfg(["posts"]), [
+        plugin("@acme/x", [{ action: "update", resource: "posts" }]),
+      ])
+    ).toThrow();
+  });
+
+  it("does not let a dropped declaration mask a genuine duplicate", () => {
+    // Two plugins declaring the same non-entity permission must still collide.
+    expect(() =>
+      collectCustomPermissions(cfg(["posts"]), [
+        plugin("@acme/a", [{ action: "publish", resource: "newsletter" }]),
+        plugin("@acme/b", [{ action: "publish", resource: "newsletter" }]),
+      ])
+    ).toThrow();
+  });
+});

--- a/packages/nextly/src/plugins/permissions/collect-permissions.ts
+++ b/packages/nextly/src/plugins/permissions/collect-permissions.ts
@@ -26,8 +26,20 @@ export interface CollectedPermission {
 /** Where a permission lands when its plugin does not group its own. */
 export const DEFAULT_PERMISSION_GROUP = "General";
 
-const CRUD_ACTIONS = new Set(["create", "read", "update", "delete"]);
-const SINGLE_ACTIONS = new Set(["read", "update"]);
+// The actions the auto-seeder already owns for a collection or single slug. A
+// plugin declaring one of these on such a slug collides with the seeded row, so
+// they are reserved rather than merely conventional. Must track
+// `permission-seed-service.ts` — an action seeded here but missing from these
+// sets can be declared by a plugin and silently collide.
+const CRUD_ACTIONS = new Set([
+  "create",
+  "read",
+  "update",
+  "delete",
+  "publish",
+  "unpublish",
+]);
+const SINGLE_ACTIONS = new Set(["read", "update", "publish", "unpublish"]);
 
 const titleCase = (s: string): string =>
   s

--- a/packages/nextly/src/plugins/permissions/collect-permissions.ts
+++ b/packages/nextly/src/plugins/permissions/collect-permissions.ts
@@ -26,20 +26,28 @@ export interface CollectedPermission {
 /** Where a permission lands when its plugin does not group its own. */
 export const DEFAULT_PERMISSION_GROUP = "General";
 
-// The actions the auto-seeder already owns for a collection or single slug. A
-// plugin declaring one of these on such a slug collides with the seeded row, so
-// they are reserved rather than merely conventional. Must track
-// `permission-seed-service.ts` — an action seeded here but missing from these
-// sets can be declared by a plugin and silently collide.
-const CRUD_ACTIONS = new Set([
-  "create",
-  "read",
-  "update",
-  "delete",
-  "publish",
-  "unpublish",
-]);
-const SINGLE_ACTIONS = new Set(["read", "update", "publish", "unpublish"]);
+// The actions the auto-seeder has always owned for a collection or single slug.
+// A plugin declaring one of these on such a slug collides with the seeded row,
+// and always would have, so the declaration is an authoring error and is
+// rejected.
+const CRUD_ACTIONS = new Set(["create", "read", "update", "delete"]);
+const SINGLE_ACTIONS = new Set(["read", "update"]);
+
+// Actions the seeder owns as of the publish lifecycle, but which were legal for
+// a plugin to declare before it.
+//
+// These are ADOPTED rather than rejected. The seeder now emits exactly the same
+// slug (`publish-posts`), so the declaration is redundant, not conflicting —
+// and rejecting it would stop an already-installed app from booting the moment
+// it upgraded, on a declaration that was valid when it was written. Dropping it
+// here leaves the permission in place, seeded, under the same slug, with grants
+// intact because rows are matched on action and resource.
+//
+// The distinction matters beyond politeness: a plugin-declared row carries an
+// `owner`, and `markOrphanedPermissions` only considers owned rows. Letting the
+// declaration through would put a permission the seeder depends on at risk of
+// being swept the day the plugin is removed.
+const ADOPTED_LIFECYCLE_ACTIONS = new Set(["publish", "unpublish"]);
 
 const titleCase = (s: string): string =>
   s
@@ -58,6 +66,10 @@ const titleCase = (s: string): string =>
  *  - a resource that is a built-in system resource (system-resource-reserved);
  *  - a CRUD action on a collection slug / read|update on a single slug, which
  *    the auto-seeder already owns (crud-permission-reserved).
+ *
+ * `publish` and `unpublish` on such a slug are the exception: the seeder owns
+ * them too, but only since the publish lifecycle landed, so a declaration is
+ * silently dropped instead of rejected. See `ADOPTED_LIFECYCLE_ACTIONS`.
  */
 export function collectCustomPermissions(
   config: NextlyServiceConfig,
@@ -91,6 +103,15 @@ export function collectCustomPermissions(
         "system-resource-reserved"
       );
     }
+    const ownedByEntity =
+      collectionSlugs.has(resource) || singleSlugs.has(resource);
+
+    // Redundant with what the seeder now emits, and valid before it did. Drop
+    // it and carry on rather than failing the boot of an app that upgraded.
+    if (ADOPTED_LIFECYCLE_ACTIONS.has(action) && ownedByEntity) {
+      return;
+    }
+
     if (
       (CRUD_ACTIONS.has(action) && collectionSlugs.has(resource)) ||
       (SINGLE_ACTIONS.has(action) && singleSlugs.has(resource))

--- a/packages/nextly/src/schemas/_zod/__tests__/rbac-actions.test.ts
+++ b/packages/nextly/src/schemas/_zod/__tests__/rbac-actions.test.ts
@@ -1,0 +1,101 @@
+/**
+ * The permission action vocabulary.
+ *
+ * Publishing is a separate capability from editing: a role that may change a
+ * document is not automatically one that may put it in front of the public.
+ *
+ * The action list is duplicated across the seeder, the plugin reservation sets
+ * and codegen, so these assertions pin the two ends that a drift would break —
+ * a slug the app seeds but the generated types deny, or one a plugin can claim
+ * from underneath the seeder.
+ */
+import { describe, it, expect } from "vitest";
+
+import type { NextlyServiceConfig } from "../../../di/register";
+import { collectCodegenNames } from "../../../plugins/codegen/collect-codegen-names";
+import { PermissionActionSchema } from "../rbac";
+
+function cfg(partial: Record<string, unknown>): NextlyServiceConfig {
+  return partial as unknown as NextlyServiceConfig;
+}
+
+describe("PermissionActionSchema", () => {
+  it("accepts the publish lifecycle actions", () => {
+    expect(PermissionActionSchema.parse("publish")).toBe("publish");
+    expect(PermissionActionSchema.parse("unpublish")).toBe("unpublish");
+  });
+
+  it("still accepts the CRUD actions and manage", () => {
+    for (const action of ["create", "read", "update", "delete", "manage"]) {
+      expect(PermissionActionSchema.parse(action)).toBe(action);
+    }
+  });
+
+  it("rejects an action outside the vocabulary", () => {
+    expect(() => PermissionActionSchema.parse("archive")).toThrow();
+  });
+
+  it("names the accepted actions in its error message", () => {
+    // What an operator sees after a typo in a config file.
+    const result = PermissionActionSchema.safeParse("publsh");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toContain("publish");
+      expect(result.error.issues[0].message).toContain("unpublish");
+    }
+  });
+});
+
+describe("generated permission slugs cover the publish lifecycle", () => {
+  // Codegen derives its slug union from its own copy of the seeder's action
+  // lists. Asserting the generated output rather than the constants means the
+  // test fails on the drift itself, not on how the lists happen to be spelled.
+  it("emits publish and unpublish slugs for a collection", () => {
+    const { permissionSlugs } = collectCodegenNames(
+      cfg({ collections: [{ slug: "posts" }], singles: [] }),
+      []
+    );
+
+    expect(permissionSlugs).toEqual(
+      expect.arrayContaining(["publish-posts", "unpublish-posts"])
+    );
+  });
+
+  it("emits them for a single too", () => {
+    // A Single carries the same status column and is published by an ordinary
+    // update, so it needs the same permissions a collection does.
+    const { permissionSlugs } = collectCodegenNames(
+      cfg({ collections: [], singles: [{ slug: "site-settings" }] }),
+      []
+    );
+
+    expect(permissionSlugs).toEqual(
+      expect.arrayContaining([
+        "publish-site-settings",
+        "unpublish-site-settings",
+      ])
+    );
+    // Still no create/delete for a single — publishing does not imply a
+    // lifecycle it does not have.
+    expect(permissionSlugs).not.toContain("create-site-settings");
+    expect(permissionSlugs).not.toContain("delete-site-settings");
+  });
+
+  it("emits only actions the schema accepts", () => {
+    const { permissionSlugs } = collectCodegenNames(
+      cfg({
+        collections: [{ slug: "posts" }],
+        singles: [{ slug: "site-settings" }],
+      }),
+      []
+    );
+
+    for (const slug of permissionSlugs) {
+      // Slugs are `${action}-${resource}`; the resource may itself contain
+      // hyphens, so only the first segment is the action.
+      const action = slug.slice(0, slug.indexOf("-"));
+      expect(() => PermissionActionSchema.parse(action)).not.toThrow();
+    }
+  });
+});

--- a/packages/nextly/src/schemas/_zod/__tests__/rbac-actions.test.ts
+++ b/packages/nextly/src/schemas/_zod/__tests__/rbac-actions.test.ts
@@ -15,6 +15,11 @@ import type { NextlyServiceConfig } from "../../../di/register";
 import { collectCodegenNames } from "../../../plugins/codegen/collect-codegen-names";
 import { PermissionActionSchema } from "../rbac";
 
+/**
+ * Codegen reads only `collections` and `singles` off the config, so a fixture
+ * carrying just those is enough. The double assertion is the cost of not
+ * constructing an adapter, a logger and a plugin set to assert on a slug list.
+ */
 function cfg(partial: Record<string, unknown>): NextlyServiceConfig {
   return partial as unknown as NextlyServiceConfig;
 }

--- a/packages/nextly/src/schemas/_zod/rbac.ts
+++ b/packages/nextly/src/schemas/_zod/rbac.ts
@@ -121,11 +121,20 @@ export const DeleteRoleSchema = z.object({
   roleId: IdSchema,
 });
 
-// Actions: standard CRUD + "manage" for broad resource control
+// Actions: standard CRUD, the publish lifecycle, and "manage" for broad
+// resource control.
+//
+// `publish` and `unpublish` are separate rather than one verb: making content
+// live and taking it down are different responsibilities, and a role that may
+// withdraw a page in an emergency is not necessarily one that may put pages up.
+// Granting them together is a role decision, not something the model should
+// force. No action implies another — `roleSetHasPermission` matches the action
+// column exactly — so both must be granted explicitly.
 export const PermissionActionSchema = z.enum(
-  ["create", "read", "update", "delete", "manage"],
+  ["create", "read", "update", "delete", "publish", "unpublish", "manage"],
   {
-    message: "Action must be one of: create, read, update, delete, manage",
+    message:
+      "Action must be one of: create, read, update, delete, publish, unpublish, manage",
   }
 );
 


### PR DESCRIPTION
First PR of item 9 (workflows). Design and decisions in `tasks/2026-07-21-workflows-item9-design-research.md`; staged plan in `tasks/2026-07-22-stage-a-publish-capability-plan.md`.

Adds `publish` and `unpublish` as permission actions and seeds them. **Nothing enforces them yet** — this PR is deliberately inert.

### Why declaring and enforcing are separate PRs

`roleSetHasPermission` (`services/lib/permissions.ts:321-349`) resolves the permission row before checking any grant:

```ts
if (!permId) return false;
```

Until a `publish-<slug>` row exists, every publish check returns `false` — including for people who should have it. Shipping a gate before the seed would break publishing in every app on upgrade. So the seed lands first and alone.

### Why publish and unpublish are separate actions

Strapi maps both onto one action string, so you cannot grant one without the other. Contentful separates them. Separate is right: withdrawing a page in an emergency and putting one up are different responsibilities.

No action implies another — `roleSetHasPermission` matches the action column exactly, with no umbrella or hierarchy — so both must be granted explicitly. That also makes this fail-secure: nobody holds `publish` until it is seeded and assigned.

### Singles get it too

A Single carries the same `status` column and is published today by an ordinary update (`single-mutation-service.ts:185` gates on `checkSingleAccess({ operation: "update" })`). Seeding publish for collections only would have left the twin path unguarded — the defect class this repo keeps hitting. `seedSinglePermissions` now seeds `read`, `update`, `publish`, `unpublish`; still no create/delete, since a Single has no such lifecycle.

### Seeded for every collection, not only status-enabled ones

A collection can gain `status: true` later. A permission that appears only once someone flips a flag is one nobody has granted at the moment it starts being enforced.

### The role presets were already written for this

`author` already excluded `publish` (`role-presets.ts:98`) before the action existed — pre-wired, and dead until now. It did **not** exclude `unpublish`, so an author would have been unable to publish a page yet able to take the live homepage down. Added to the exclusion list.

`editor` is action-agnostic and its description already says "including publishing", so editors gain both. `viewer` is read-only and gains neither.

### Sites changed, and one deliberately not

Six action-list sites exist. Five change here:

- `schemas/_zod/rbac.ts:125` — `PermissionActionSchema`
- `permission-seed-service.ts` — the per-collection loop and `seedSinglePermissions`
- `plugins/permissions/collect-permissions.ts` — `CRUD_ACTIONS` / `SINGLE_ACTIONS`. Required, not cosmetic: these are the *reservation* sets, so omitting `publish` would let a plugin declare `publish-posts` and collide with the seeded row with no error.
- `plugins/codegen/collect-codegen-names.ts` — generated permission-slug types, which would otherwise deny a slug the app seeds.
- `database/seeders/role-presets.ts` — as above.

`database/seeders/permissions.ts:37` is **deliberately unchanged**: it seeds core resources (`users`, `roles`, `permissions`), and `publish-users` is meaningless.

### One risk checked rather than assumed

The orphan sweep marks permissions no longer declared. `markOrphanedPermissions` begins `if (!row.owner) continue;` — only plugin-declared permissions are considered, and collection seeds have no owner. So the new rows are not at risk of being swept.

### Verification

- typecheck and lint clean
- 7 new tests in `_zod/__tests__/rbac-actions.test.ts` (`PermissionActionSchema` had no test at all)
- Tests assert the **generated slugs**, not the constants, so they fail on the drift itself rather than on how a list is spelled. Verified load-bearing: reverting the codegen list fails exactly the two intended tests.
- Baseline unchanged: 3 pre-existing failures in `src/schemas`/`src/plugins`/`src/database` on pristine main (`ui-schema` toggle, two plugin schema-cache tests), identical before and after. The `src/domains/auth` area sits on the known ~290 stale-mock baseline, also identical with my files reverted.

### Next

A2 enforces the gate. Note that gating `publishAllLocales` alone would be bypassable — single-entry update, singles update and bulk update all write `status: "published"` through the plain `update` gate. A2 keys on the transition, not the method name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `publish` and `unpublish` permission actions for both collections and single items.
  * Permission seeding and generated permission identifiers now include the publishing lifecycle actions.

* **Bug Fixes**
  * Refined the `author` role preset to better restrict plugin/system-resource permissions and appropriately exclude `unpublish`.
  * Improved publish/unpublish permission conflict handling to avoid redundant permissions and prevent startup failures.
  * Re-enabled permissions when they’re re-declared after being marked orphaned.

* **Tests**
  * Added/expanded RBAC schema and permission-generation tests covering `publish`/`unpublish` validation and conflict/adoption behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->