### PR TITLE
fix(nextly): reserve every system-resource name as a collection slug

### DIFF
--- a/.changeset/reserve-system-resource-slugs.md
+++ b/.changeset/reserve-system-resource-slugs.md
@@ -20,8 +20,10 @@
 "@nextlyhq/ui": patch
 ---
 
-Collection, single and component slugs that collide with a system resource are refused.
+Collection and single slugs that collide with a system resource are refused.
 
-Permission identity is `action-resource`, so a content type sharing a system resource's name is granted the same permission rows the system routes check: a `webhooks` collection's `read-webhooks` reaches the endpoint routes and `update-webhooks` the signing secrets, and `api-keys`, `email-providers` and `email-templates` collide the same way. The reserved set is exactly the system resources whose routes enforce a create/read/update/delete action; `settings` and `media` are intentionally left usable as content, because the settings surface is gated on `manage` (which content never seeds) and media's routes are not gated on the CRUD permissions a content type would mint.
+Permission identity is `action-resource`, so a content type named after a system resource is granted the same permission rows that resource's routes check. A `webhooks` type reaches the endpoint routes and their signing secrets; a `settings` type reaches the user-fields and component admin surfaces (gated on `{action, "settings"}`, not only `manage`); a `media` type reaches the media routes. Every system resource has such a route, so any system-resource name — `users`, `roles`, `permissions`, `media`, `settings`, `email-providers`, `email-templates`, `api-keys`, `webhooks` — is now rejected as a collection or single slug.
 
-The check is enforced at every path that assigns or renames a slug — code-first validation, the shared collection/single registry guard, the Schema Builder's collection registry, and dynamic component registration — so it cannot be reached through a rename or a create path that skipped the others. An installation that already has content named one of these must rename it before upgrading.
+The check is enforced at every slug-assignment path: code-first validation, the shared collection/single registry guard (create and rename), the Schema Builder's collection registry, and the migration-snapshot boot path (which skips a reserved name rather than replaying it). Components are not restricted, because a component definition does not seed a permission under its own slug.
+
+An installation that already has a collection or single named one of these must rename it before upgrading.

--- a/.changeset/reserve-system-resource-slugs.md
+++ b/.changeset/reserve-system-resource-slugs.md
@@ -1,0 +1,27 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Collection, single and component slugs that collide with a system resource are refused.
+
+Permission identity is `action-resource`, so a content type sharing a system resource's name is granted the same permission rows the system routes check: a `webhooks` collection's `read-webhooks` reaches the endpoint routes and `update-webhooks` the signing secrets, and `api-keys`, `email-providers` and `email-templates` collide the same way. The reserved set is exactly the system resources whose routes enforce a create/read/update/delete action; `settings` and `media` are intentionally left usable as content, because the settings surface is gated on `manage` (which content never seeds) and media's routes are not gated on the CRUD permissions a content type would mint.
+
+The check is enforced at every path that assigns or renames a slug — code-first validation, the shared collection/single registry guard, the Schema Builder's collection registry, and dynamic component registration — so it cannot be reached through a rename or a create path that skipped the others. An installation that already has content named one of these must rename it before upgrading.

--- a/packages/nextly/src/collections/config/validate-config.ts
+++ b/packages/nextly/src/collections/config/validate-config.ts
@@ -25,6 +25,7 @@
  */
 
 import { isPluginFieldTypeOnSurface } from "../../domains/schema/field-types/field-type-registry";
+import { SYSTEM_RESOURCES } from "../../schemas/_zod/rbac";
 import {
   type BaseValidationError,
   DEFAULT_SQL_KEYWORDS_SET,
@@ -148,7 +149,17 @@ export interface ValidationResult {
 // they now live in shared/sql-reserved.ts and are re-exported above so the
 // public API surface for this file is unchanged.
 
-const RESERVED_SLUGS_SET: Set<string> = new Set<string>(RESERVED_SLUGS);
+// System-resource names are added on top of the base reserved slugs. A
+// collection named after a system resource would seed the same permission rows
+// that resource's routes check (a `settings` collection reaches the user-fields
+// and component admin surfaces, a `media` collection the media routes), so it is
+// rejected here — at config validation, before any migration or table is built.
+// The names are NOT in the shared base list, because that list also feeds the
+// component validator and a component does not seed a permission under its slug.
+const RESERVED_SLUGS_SET: Set<string> = new Set<string>([
+  ...RESERVED_SLUGS,
+  ...SYSTEM_RESOURCES,
+]);
 
 // The owner column `created_by` is injected as a system column on every
 // collection table (both the snake_case name and its camelCase alias, which

--- a/packages/nextly/src/dispatcher/handlers/__tests__/versions-e2e.integration.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/versions-e2e.integration.test.ts
@@ -54,6 +54,8 @@ describe("version history through the dispatcher (integration)", () => {
   it("routes a Single's version list without needing an entry id in the URL", async () => {
     current = await createTestNextly({
       singles: [
+        // "settings" is a reserved slug (system-resource permission-collision
+        // guard), so this suite uses "preferences".
         defineSingle({
           slug: "preferences",
           versions: true,

--- a/packages/nextly/src/dispatcher/handlers/__tests__/versions-e2e.integration.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/versions-e2e.integration.test.ts
@@ -55,21 +55,24 @@ describe("version history through the dispatcher (integration)", () => {
     current = await createTestNextly({
       singles: [
         defineSingle({
-          slug: "settings",
+          slug: "preferences",
           versions: true,
           fields: [text({ name: "title" })],
         }),
       ],
     });
 
-    const parsed = parseRestRoute(["singles", "settings", "versions"], "GET");
+    const parsed = parseRestRoute(
+      ["singles", "preferences", "versions"],
+      "GET"
+    );
 
     // The id is resolved server-side from the live row, so the URL carries
     // only the slug.
     expect(parsed).toMatchObject({
       service: "singles",
       method: "listSingleVersions",
-      routeParams: { slug: "settings" },
+      routeParams: { slug: "preferences" },
     });
   });
 });

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -66,6 +66,7 @@ import { resolveBuilderVersions } from "../../domains/versions/builder-versions"
 import { NextlyError } from "../../errors";
 import { transformRichTextFields } from "../../lib/field-transform";
 import { getProductionNotifier } from "../../runtime/notifications/index";
+import { isReservedResourceSlug } from "../../schemas/_zod/rbac";
 import type { FieldDefinition } from "../../schemas/dynamic-collections";
 import {
   getI18nArchiveDdl,
@@ -509,6 +510,23 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         | undefined;
 
       if (!b?.slug) throw new Error("Single slug is required");
+      // Rejected before the DDL below runs: a reserved slug seeds the same
+      // permission rows a system resource's routes check, and checking only at
+      // registration (further down) would create `single_<slug>` and its locale
+      // companion first, leaving orphan tables when registration then refused it.
+      if (isReservedResourceSlug(b.slug)) {
+        throw NextlyError.validation({
+          errors: [
+            {
+              path: "slug",
+              code: "reserved_slug",
+              message:
+                "This name is reserved by Nextly and cannot be used as a slug. Choose a different name.",
+            },
+          ],
+          logContext: { reason: "system-resource-slug", slug: b.slug },
+        });
+      }
       if (!b?.label) throw new Error("Single label is required");
       if (!b?.fields || !Array.isArray(b.fields))
         throw new Error("Single fields array is required");

--- a/packages/nextly/src/domains/components/services/component-registry-service.ts
+++ b/packages/nextly/src/domains/components/services/component-registry-service.ts
@@ -8,6 +8,7 @@ import { toDbError } from "../../../database/errors";
 // follow §13.8 (no slug echoing); identifiers (slug, source, refs) move into
 // `logContext` so operators retain full diagnostic context.
 import { NextlyError } from "../../../errors";
+import { isReservedResourceSlug } from "../../../schemas/_zod/rbac";
 import type {
   DynamicComponentInsert,
   DynamicComponentRecord,
@@ -162,10 +163,36 @@ export class ComponentRegistryService extends BaseRegistryService<
    * @throws NextlyError(DUPLICATE) if a Component with the same slug already exists.
    * @throws NextlyError(DATABASE_ERROR) on insert failure.
    */
+  /**
+   * Reject a slug that collides with a system resource's permissions.
+   *
+   * Components never reach `assertGlobalResourceSlugAvailable` (it has no
+   * component type), and the dynamic component path does not consult the
+   * code-first reserved list, so the check lives here for both the plain and
+   * in-transaction registration paths. A `webhooks` component would seed
+   * `read-webhooks` / `update-webhooks` — the rows the endpoint routes check.
+   */
+  private assertSlugNotReservedResource(slug: string): void {
+    if (!isReservedResourceSlug(slug)) return;
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "slug",
+          code: "reserved_slug",
+          message:
+            "This name is reserved by Nextly and cannot be used as a slug. Choose a different name.",
+        },
+      ],
+      logContext: { reason: "system-resource-slug", slug },
+    });
+  }
+
   async registerComponent(
     data: DynamicComponentInsert
   ): Promise<DynamicComponentRecord> {
     this.logger.debug("Registering Component", { slug: data.slug });
+
+    this.assertSlugNotReservedResource(data.slug);
 
     const existing = await this.getComponentBySlug(data.slug);
     if (existing) {
@@ -227,6 +254,8 @@ export class ComponentRegistryService extends BaseRegistryService<
     tx: TransactionContext,
     data: DynamicComponentInsert
   ): Promise<DynamicComponentRecord> {
+    this.assertSlugNotReservedResource(data.slug);
+
     const existing = await tx.selectOne<DynamicComponentRecord>(
       this.registryTableName,
       {

--- a/packages/nextly/src/domains/components/services/component-registry-service.ts
+++ b/packages/nextly/src/domains/components/services/component-registry-service.ts
@@ -8,7 +8,6 @@ import { toDbError } from "../../../database/errors";
 // follow §13.8 (no slug echoing); identifiers (slug, source, refs) move into
 // `logContext` so operators retain full diagnostic context.
 import { NextlyError } from "../../../errors";
-import { isReservedResourceSlug } from "../../../schemas/_zod/rbac";
 import type {
   DynamicComponentInsert,
   DynamicComponentRecord,
@@ -163,36 +162,10 @@ export class ComponentRegistryService extends BaseRegistryService<
    * @throws NextlyError(DUPLICATE) if a Component with the same slug already exists.
    * @throws NextlyError(DATABASE_ERROR) on insert failure.
    */
-  /**
-   * Reject a slug that collides with a system resource's permissions.
-   *
-   * Components never reach `assertGlobalResourceSlugAvailable` (it has no
-   * component type), and the dynamic component path does not consult the
-   * code-first reserved list, so the check lives here for both the plain and
-   * in-transaction registration paths. A `webhooks` component would seed
-   * `read-webhooks` / `update-webhooks` — the rows the endpoint routes check.
-   */
-  private assertSlugNotReservedResource(slug: string): void {
-    if (!isReservedResourceSlug(slug)) return;
-    throw NextlyError.validation({
-      errors: [
-        {
-          path: "slug",
-          code: "reserved_slug",
-          message:
-            "This name is reserved by Nextly and cannot be used as a slug. Choose a different name.",
-        },
-      ],
-      logContext: { reason: "system-resource-slug", slug },
-    });
-  }
-
   async registerComponent(
     data: DynamicComponentInsert
   ): Promise<DynamicComponentRecord> {
     this.logger.debug("Registering Component", { slug: data.slug });
-
-    this.assertSlugNotReservedResource(data.slug);
 
     const existing = await this.getComponentBySlug(data.slug);
     if (existing) {
@@ -254,8 +227,6 @@ export class ComponentRegistryService extends BaseRegistryService<
     tx: TransactionContext,
     data: DynamicComponentInsert
   ): Promise<DynamicComponentRecord> {
-    this.assertSlugNotReservedResource(data.slug);
-
     const existing = await tx.selectOne<DynamicComponentRecord>(
       this.registryTableName,
       {

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/reserved-slug-grandfather.integration.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/reserved-slug-grandfather.integration.test.ts
@@ -1,0 +1,118 @@
+/**
+ * A collection created BEFORE its name became a reserved system-resource name
+ * (e.g. `settings`, `media`) must stay editable: the reserved-slug guard in the
+ * registry has to grandfather a no-op slug on an update while still refusing a
+ * create or a rename ONTO a reserved slug.
+ *
+ * Regression: `updateCollectionMetadata` passes the collection's existing slug
+ * into `ensureGlobalSlugUniqueness` on every metadata/field/status change, so an
+ * unconditional reserved-slug throw there made pre-reservation collections
+ * permanently uneditable.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../../../errors";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../../plugins/test-nextly";
+import type { Logger } from "../../../../services/shared";
+import { DynamicCollectionRegistryService } from "../dynamic-collection-registry-service";
+
+let current: TestNextly | undefined;
+
+// createCollection only runs the generated migration (and creates the row) in
+// development.
+let prevNodeEnv: string | undefined;
+beforeEach(() => {
+  prevNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "development";
+});
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+  process.env.NODE_ENV = prevNodeEnv;
+});
+
+function handlerOf(t: TestNextly) {
+  return t.getService("collectionsHandler") as unknown as {
+    createCollection: (data: Record<string, unknown>) => Promise<{
+      success: boolean;
+    }>;
+  };
+}
+
+function registryOf(t: TestNextly): DynamicCollectionRegistryService {
+  const logger = t.getService("logger") as Logger;
+  return new DynamicCollectionRegistryService(t.adapter, logger);
+}
+
+async function slugRow(
+  t: TestNextly,
+  slug: string
+): Promise<{ slug: string; description: unknown } | undefined> {
+  const adapter = t.adapter as unknown as {
+    executeQuery: (sql: string) => Promise<Record<string, unknown>[]>;
+  };
+  const rows = await adapter.executeQuery(
+    `SELECT slug, description FROM dynamic_collections WHERE slug='${slug}'`
+  );
+  return rows[0] as { slug: string; description: unknown } | undefined;
+}
+
+describe("grandfathered reserved-name collection stays editable (integration)", () => {
+  it("allows a metadata update that keeps a now-reserved slug it already owns", async () => {
+    current = await createTestNextly({ collections: [] });
+
+    // Create a normal collection, then rename its stored slug to a reserved
+    // name to simulate a collection that predates the reservation (the create
+    // path itself refuses reserved names).
+    const created = await handlerOf(current).createCollection({
+      name: "prefs",
+      label: "Prefs",
+      fields: [{ name: "body", type: "text" }],
+    });
+    expect(created.success).toBe(true);
+
+    const rawAdapter = current.adapter as unknown as {
+      executeQuery: (sql: string) => Promise<Record<string, unknown>[]>;
+    };
+    await rawAdapter.executeQuery(
+      `UPDATE dynamic_collections SET slug='settings' WHERE slug='prefs'`
+    );
+
+    // The metadata update keeps the reserved slug it already owns, so the guard
+    // must allow it rather than throw reserved_slug.
+    await expect(
+      registryOf(current).updateCollectionMetadata("settings", {
+        description: "grandfathered edit",
+      })
+    ).resolves.toBeDefined();
+
+    const row = await slugRow(current, "settings");
+    expect(row?.description).toBe("grandfathered edit");
+  });
+
+  it("still rejects renaming a collection onto a reserved slug it does not own", async () => {
+    current = await createTestNextly({ collections: [] });
+
+    const created = await handlerOf(current).createCollection({
+      name: "posts",
+      label: "Posts",
+      fields: [{ name: "body", type: "text" }],
+    });
+    expect(created.success).toBe(true);
+
+    // A rename TARGETS a reserved slug the collection does not already own, so
+    // the guard must still refuse it.
+    await expect(
+      registryOf(current).updateCollectionMetadata("posts", { slug: "media" })
+    ).rejects.toThrow(NextlyError);
+
+    // The rename was refused, so the collection keeps its original slug and no
+    // `media` row was created.
+    expect(await slugRow(current, "posts")).toBeDefined();
+    expect(await slugRow(current, "media")).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts
@@ -1,6 +1,8 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import { eq, and, or, like, asc, desc, count } from "drizzle-orm";
 
+import { NextlyError } from "../../../errors";
+import { isReservedResourceSlug } from "../../../schemas/_zod/rbac";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import type { MigrationStatus } from "../../../schemas/dynamic-collections/types";
 import type { ResolvedVersionsConfig } from "../../../schemas/versions/types";
@@ -105,6 +107,24 @@ export class DynamicCollectionRegistryService extends BaseService {
     slug: string,
     options?: { currentCollectionId?: string }
   ): Promise<void> {
+    // A name that collides with a system resource's permissions may not be
+    // used as a Schema-Builder collection slug, on create or rename. This
+    // registry does not go through `assertGlobalResourceSlugAvailable`, so the
+    // check lives here as well.
+    if (isReservedResourceSlug(slug)) {
+      throw NextlyError.validation({
+        errors: [
+          {
+            path: "slug",
+            code: "reserved_slug",
+            message:
+              "This name is reserved by Nextly and cannot be used as a slug. Choose a different name.",
+          },
+        ],
+        logContext: { reason: "system-resource-slug", slug },
+      });
+    }
+
     const existingCollection = await this.db
       .select({ id: this.dynamicCollections.id })
       .from(this.dynamicCollections)

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts
@@ -107,11 +107,26 @@ export class DynamicCollectionRegistryService extends BaseService {
     slug: string,
     options?: { currentCollectionId?: string }
   ): Promise<void> {
-    // A name that collides with a system resource's permissions may not be
-    // used as a Schema-Builder collection slug, on create or rename. This
-    // registry does not go through `assertGlobalResourceSlugAvailable`, so the
-    // check lives here as well.
-    if (isReservedResourceSlug(slug)) {
+    const existingCollection = await this.db
+      .select({ id: this.dynamicCollections.id })
+      .from(this.dynamicCollections)
+      .where(eq(this.dynamicCollections.slug, slug))
+      .limit(1);
+
+    // True when this exact slug is already owned by the collection being
+    // updated (a no-op slug on a metadata/field/status change), as opposed to a
+    // create or a rename onto another collection's slug.
+    const ownedByCurrentCollection =
+      existingCollection.length > 0 &&
+      existingCollection[0]?.id === options?.currentCollectionId;
+
+    // A name that collides with a system resource's permissions may not be used
+    // as a Schema-Builder collection slug on create or rename. A collection that
+    // already owns this exact slug (created before the name became reserved) is
+    // grandfathered so its metadata stays editable — rejecting a no-op save
+    // would strand it. This mirrors `assertGlobalResourceSlugAvailable`, which
+    // this registry does not go through, so the check lives here as well.
+    if (isReservedResourceSlug(slug) && !ownedByCurrentCollection) {
       throw NextlyError.validation({
         errors: [
           {
@@ -124,12 +139,6 @@ export class DynamicCollectionRegistryService extends BaseService {
         logContext: { reason: "system-resource-slug", slug },
       });
     }
-
-    const existingCollection = await this.db
-      .select({ id: this.dynamicCollections.id })
-      .from(this.dynamicCollections)
-      .where(eq(this.dynamicCollections.slug, slug))
-      .limit(1);
 
     if (
       existingCollection.length > 0 &&

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-validation-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-validation-service.ts
@@ -1,6 +1,7 @@
 import safeRegex from "safe-regex2";
 import { z } from "zod";
 
+import { isReservedResourceSlug } from "@nextly/schemas/_zod/rbac";
 import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 
 /**
@@ -122,6 +123,13 @@ export const collectionNameSchema = z
       message: "Collection name is reserved",
     }
   )
+  // A name that collides with a system resource's permissions is rejected here,
+  // during name validation inside `generateCollection` — before the migration
+  // and table are built — so the Builder path cannot leave an orphan table when
+  // the registry guard later refuses the same name.
+  .refine((name: string) => !isReservedResourceSlug(name), {
+    message: "Collection name is reserved by Nextly",
+  })
   .refine(
     (name: string) => !SQL_KEYWORDS.includes(name.toLowerCase() as never),
     {

--- a/packages/nextly/src/domains/schema/migrate/metadata-register.ts
+++ b/packages/nextly/src/domains/schema/migrate/metadata-register.ts
@@ -35,6 +35,7 @@ import { dynamicSinglesPg } from "@nextly/schemas/dynamic-singles/postgres";
 import { dynamicSinglesSqlite } from "@nextly/schemas/dynamic-singles/sqlite";
 
 import type { SingleAdminOptions } from "../../../config";
+import { isReservedResourceSlug } from "../../../schemas/_zod/rbac";
 import { simplePluralize } from "../../../shared/lib/pluralization";
 
 /**
@@ -419,6 +420,17 @@ export async function registerFromMigrations(
   // Step 3: Register each collection
   let collectionsRegistered = 0;
   for (const collection of collections) {
+    // A snapshot can carry a name that has since become reserved (a system
+    // resource). Registering it would recreate the permission collision the
+    // create/rename paths now refuse, so it is skipped rather than replayed.
+    // Skipped, not thrown: this runs at boot, and one stale snapshot entry must
+    // not take the whole application down.
+    if (isReservedResourceSlug(collection.slug)) {
+      logger.warn?.(
+        `[Migration Metadata] Skipping collection "${collection.slug}": the name is reserved by Nextly and must be renamed.`
+      );
+      continue;
+    }
     try {
       const inserted = await registerCollection(
         typedAdapter,
@@ -439,6 +451,14 @@ export async function registerFromMigrations(
   // Step 4: Register each single
   let singlesRegistered = 0;
   for (const single of singles) {
+    // Same as collections: a reserved name in a snapshot is skipped, not
+    // replayed, so it cannot recreate the permission collision.
+    if (isReservedResourceSlug(single.slug)) {
+      logger.warn?.(
+        `[Migration Metadata] Skipping single "${single.slug}": the name is reserved by Nextly and must be renamed.`
+      );
+      continue;
+    }
     try {
       const inserted = await registerSingle(typedAdapter, dialect, single);
       if (inserted) singlesRegistered++;

--- a/packages/nextly/src/domains/singles/services/__tests__/single-mutation-service.atomicity.integration.test.ts
+++ b/packages/nextly/src/domains/singles/services/__tests__/single-mutation-service.atomicity.integration.test.ts
@@ -70,6 +70,8 @@ async function seedSettingsWithHero(): Promise<{
     slug: "hero",
     fields: [{ name: "heading", type: "text" }],
   });
+  // "settings" is a reserved slug (system-resource permission-collision
+  // guard), so this suite uses "preferences".
   await seedBuilderSingle(adapter, {
     slug: "preferences",
     fields: [

--- a/packages/nextly/src/domains/singles/services/__tests__/single-mutation-service.atomicity.integration.test.ts
+++ b/packages/nextly/src/domains/singles/services/__tests__/single-mutation-service.atomicity.integration.test.ts
@@ -53,7 +53,7 @@ afterEach(async () => {
 });
 
 /**
- * Recipe: seed the `hero` component then the `settings` single (carrying a
+ * Recipe: seed the `hero` component then the `preferences` single (carrying a
  * component field that embeds `hero`) on a first boot, reset DI without
  * disconnecting the in-memory adapter, then reboot on the SAME adapter so
  * `singleEntryService` resolves the seeded single/component through the
@@ -71,7 +71,7 @@ async function seedSettingsWithHero(): Promise<{
     fields: [{ name: "heading", type: "text" }],
   });
   await seedBuilderSingle(adapter, {
-    slug: "settings",
+    slug: "preferences",
     fields: [
       { name: "headline", type: "text" },
       { name: "seo", type: "component", component: "hero" },
@@ -95,7 +95,7 @@ describe("SingleMutationService component-save atomicity (integration)", () => {
     // update — the component table exists at this point, so this must
     // succeed before the failure is injected.
     const first = await singles.update(
-      "settings",
+      "preferences",
       { headline: "Original headline", seo: { heading: "Original SEO" } },
       { overrideAccess: true }
     );
@@ -106,7 +106,7 @@ describe("SingleMutationService component-save atomicity (integration)", () => {
     await adapter.executeQuery(`DROP TABLE "comp_hero"`);
 
     const second = await singles.update(
-      "settings",
+      "preferences",
       { headline: "Changed headline", seo: { heading: "Changed SEO" } },
       { overrideAccess: true }
     );
@@ -120,7 +120,7 @@ describe("SingleMutationService component-save atomicity (integration)", () => {
     // both share one transaction, so the component failure rolls the
     // headline back too.
     const rows = await adapter.executeQuery<{ headline: string }>(
-      `SELECT headline FROM single_settings LIMIT 1`
+      `SELECT headline FROM single_preferences LIMIT 1`
     );
     expect(rows).toHaveLength(1);
     expect(rows[0].headline).toBe("Original headline");

--- a/packages/nextly/src/domains/versions/__tests__/capture-on-create.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/capture-on-create.integration.test.ts
@@ -122,7 +122,7 @@ describe("version capture on create (integration)", () => {
     current = await createTestNextly({
       singles: [
         defineSingle({
-          slug: "settings",
+          slug: "preferences",
           versions: true,
           fields: [text({ name: "title" })],
         }),
@@ -131,10 +131,10 @@ describe("version capture on create (integration)", () => {
     const singles =
       current.getService<SingleEntryService>("singleEntryService");
 
-    const res = await singles.get("settings", { overrideAccess: true });
+    const res = await singles.get("preferences", { overrideAccess: true });
     expect(res.success).toBe(true);
 
-    const rows = await versionRows(current, "settings");
+    const rows = await versionRows(current, "preferences");
     expect(rows).toHaveLength(1);
     expect(rows[0].scopeKind).toBe("single");
     expect(rows[0].versionNo).toBe(1);
@@ -144,7 +144,7 @@ describe("version capture on create (integration)", () => {
     current = await createTestNextly({
       singles: [
         defineSingle({
-          slug: "settings",
+          slug: "preferences",
           fields: [text({ name: "title" })],
         }),
       ],
@@ -152,8 +152,8 @@ describe("version capture on create (integration)", () => {
     const singles =
       current.getService<SingleEntryService>("singleEntryService");
 
-    await singles.get("settings", { overrideAccess: true });
+    await singles.get("preferences", { overrideAccess: true });
 
-    expect(await versionRows(current, "settings")).toHaveLength(0);
+    expect(await versionRows(current, "preferences")).toHaveLength(0);
   });
 });

--- a/packages/nextly/src/domains/versions/__tests__/capture-on-create.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/capture-on-create.integration.test.ts
@@ -121,6 +121,8 @@ describe("version capture on create (integration)", () => {
     // the live row is not left without any version.
     current = await createTestNextly({
       singles: [
+        // "settings" is a reserved slug (system-resource permission-collision
+        // guard), so this suite uses "preferences".
         defineSingle({
           slug: "preferences",
           versions: true,

--- a/packages/nextly/src/domains/versions/__tests__/capture-on-update.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/capture-on-update.integration.test.ts
@@ -86,6 +86,8 @@ describe("version capture on update (integration)", () => {
   it("captures a version on a single update when versioning is enabled", async () => {
     current = await createTestNextly({
       singles: [
+        // "settings" is a reserved slug (system-resource permission-collision
+        // guard), so this suite uses "preferences".
         defineSingle({
           slug: "preferences",
           versions: true,

--- a/packages/nextly/src/domains/versions/__tests__/capture-on-update.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/capture-on-update.integration.test.ts
@@ -87,7 +87,7 @@ describe("version capture on update (integration)", () => {
     current = await createTestNextly({
       singles: [
         defineSingle({
-          slug: "settings",
+          slug: "preferences",
           versions: true,
           fields: [text({ name: "title" })],
         }),
@@ -97,12 +97,12 @@ describe("version capture on update (integration)", () => {
       current.getService<SingleEntryService>("singleEntryService");
 
     await singles.update(
-      "settings",
+      "preferences",
       { title: "hello" },
       { overrideAccess: true }
     );
 
-    const rows = await versions(current, "settings");
+    const rows = await versions(current, "preferences");
     expect(rows.length).toBeGreaterThanOrEqual(1);
     const latest = rows[rows.length - 1];
     expect(latest.scopeKind).toBe("single");
@@ -422,7 +422,7 @@ describe("version capture on update (integration)", () => {
       ],
       singles: [
         defineSingle({
-          slug: "settings",
+          slug: "preferences",
           versions: true,
           fields: [
             group({
@@ -437,12 +437,12 @@ describe("version capture on update (integration)", () => {
       current.getService<SingleEntryService>("singleEntryService");
 
     await singles.update(
-      "settings",
+      "preferences",
       { meta: { hero: { heading: "Welcome" } } },
       { overrideAccess: true }
     );
 
-    const rows = await versions(current, "settings");
+    const rows = await versions(current, "preferences");
     const snapshot = rows.at(-1)?.snapshot as {
       meta?: { hero?: { _componentType?: string; heading?: string } };
     };

--- a/packages/nextly/src/plugins/__tests__/builder-extend.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/builder-extend.integration.test.ts
@@ -217,21 +217,23 @@ describe("plugin extend → UI-Builder single + component parity", () => {
     const adapter = await freshAdapter();
     handle = await createTestNextly({ adapter });
     await seedBuilderSingle(adapter, {
-      slug: "settings",
+      slug: "preferences",
       fields: [{ name: "body", type: "text", source: "ui" }],
     });
     clearServices();
 
     handle = await createTestNextly({
       adapter,
-      plugins: [seoPlugin(["settings"])],
+      plugins: [seoPlugin(["preferences"])],
     });
 
-    expect(await columnsOf(adapter, "single_settings")).toContain("meta_title");
+    expect(await columnsOf(adapter, "single_preferences")).toContain(
+      "meta_title"
+    );
     const fields = await registryFieldsIn(
       adapter,
       "dynamic_singles",
-      "settings"
+      "preferences"
     );
     expect(fields.find(f => f.name === "meta_title")).toMatchObject({
       source: "plugin",

--- a/packages/nextly/src/plugins/__tests__/builder-extend.integration.test.ts
+++ b/packages/nextly/src/plugins/__tests__/builder-extend.integration.test.ts
@@ -216,6 +216,8 @@ describe("plugin extend → UI-Builder single + component parity", () => {
   it("materialises the plugin field onto a UI-Builder single", async () => {
     const adapter = await freshAdapter();
     handle = await createTestNextly({ adapter });
+    // "settings" is a reserved slug (system-resource permission-collision
+    // guard), so this suite uses "preferences".
     await seedBuilderSingle(adapter, {
       slug: "preferences",
       fields: [{ name: "body", type: "text", source: "ui" }],

--- a/packages/nextly/src/schemas/_zod/rbac.ts
+++ b/packages/nextly/src/schemas/_zod/rbac.ts
@@ -47,6 +47,44 @@ export function isValidResource(
   return isSystemResource(resource) || knownCollectionSlugs.includes(resource);
 }
 
+/**
+ * System resources whose names must never be used as a collection, single or
+ * component slug.
+ *
+ * Permission identity is `action-resource`, so a content type named `webhooks`
+ * seeds `read-webhooks` / `update-webhooks` — the exact rows the webhook
+ * endpoint routes check. A role granted the content type's permission would
+ * then reach the system surface: read endpoint configuration, reveal signing
+ * secrets, list API keys. Every slug-assignment path (create and rename, for
+ * collections and singles alike) rejects these names.
+ *
+ * This is deliberately NARROWER than {@link SYSTEM_RESOURCES}. Two members are
+ * excluded on purpose:
+ * - `settings` — its system surface is gated only on `manage-settings`, and
+ *   content seeding never produces the `manage` action, so a `settings`
+ *   collection or single cannot reach it. It is also a common content model
+ *   (site settings as a single).
+ * - `media` — a plausible content concept, and its routes are not gated on the
+ *   CRUD `*-media` permissions that content seeding would mint.
+ *
+ * The set is exactly the resources whose routes enforce a create/read/update/
+ * delete action that collection or single seeding also produces.
+ */
+export const RESERVED_RESOURCE_SLUGS = [
+  "users",
+  "roles",
+  "permissions",
+  "webhooks",
+  "api-keys",
+  "email-providers",
+  "email-templates",
+] as const;
+
+/** Whether a slug collides with a system resource's permissions. */
+export function isReservedResourceSlug(slug: string): boolean {
+  return (RESERVED_RESOURCE_SLUGS as readonly string[]).includes(slug);
+}
+
 export const RoleSchema = z.object({
   id: IdSchema,
   name: z

--- a/packages/nextly/src/schemas/_zod/rbac.ts
+++ b/packages/nextly/src/schemas/_zod/rbac.ts
@@ -48,41 +48,32 @@ export function isValidResource(
 }
 
 /**
- * System resources whose names must never be used as a collection, single or
- * component slug.
+ * Whether a slug may not be used for a collection or single, because it would
+ * collide with a system resource's permissions.
  *
- * Permission identity is `action-resource`, so a content type named `webhooks`
- * seeds `read-webhooks` / `update-webhooks` — the exact rows the webhook
- * endpoint routes check. A role granted the content type's permission would
- * then reach the system surface: read endpoint configuration, reveal signing
- * secrets, list API keys. Every slug-assignment path (create and rename, for
- * collections and singles alike) rejects these names.
+ * Permission identity is `action-resource`, so a content type named after a
+ * system resource seeds the exact rows that resource's routes check: a
+ * `webhooks` single seeds `read-webhooks` / `update-webhooks` and reaches the
+ * endpoint routes and their signing secrets; a `settings` single seeds
+ * `read-settings` / `update-settings` and reaches the user-fields and component
+ * admin surfaces (`routeHandler.ts` gates those on `{action, "settings"}`, not
+ * only `manage`); a `media` collection seeds `*-media` and reaches the media
+ * routes. Every system resource has at least one route enforcing a
+ * create/read/update/delete action that content seeding produces, so any system
+ * resource name is unsafe as a content slug.
  *
- * This is deliberately NARROWER than {@link SYSTEM_RESOURCES}. Two members are
- * excluded on purpose:
- * - `settings` — its system surface is gated only on `manage-settings`, and
- *   content seeding never produces the `manage` action, so a `settings`
- *   collection or single cannot reach it. It is also a common content model
- *   (site settings as a single).
- * - `media` — a plausible content concept, and its routes are not gated on the
- *   CRUD `*-media` permissions that content seeding would mint.
+ * Defined as "is a system resource" rather than a hand-maintained subset so a
+ * newly added system resource is protected automatically. Reserving a name that
+ * turned out to be manage-only would merely forbid a content type no one should
+ * create; leaving one out is a privilege-escalation.
  *
- * The set is exactly the resources whose routes enforce a create/read/update/
- * delete action that collection or single seeding also produces.
+ * Components are intentionally NOT covered: a component definition does not seed
+ * a permission under its own slug (the component admin routes are gated on the
+ * `settings`/`components` resource), so a component name cannot mint a colliding
+ * row and reserving it would only reject a harmless name.
  */
-export const RESERVED_RESOURCE_SLUGS = [
-  "users",
-  "roles",
-  "permissions",
-  "webhooks",
-  "api-keys",
-  "email-providers",
-  "email-templates",
-] as const;
-
-/** Whether a slug collides with a system resource's permissions. */
 export function isReservedResourceSlug(slug: string): boolean {
-  return (RESERVED_RESOURCE_SLUGS as readonly string[]).includes(slug);
+  return isSystemResource(slug);
 }
 
 export const RoleSchema = z.object({

--- a/packages/nextly/src/services/lib/__tests__/reserved-slug-orphan.integration.test.ts
+++ b/packages/nextly/src/services/lib/__tests__/reserved-slug-orphan.integration.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Proof that a reserved (system-resource) slug is rejected BEFORE any DDL runs
+ * on the two Schema-Builder create paths, so a rejected create never leaves an
+ * orphan table with no registry row.
+ *
+ * The collision is real: permission identity is `action-resource`, so a content
+ * type named after a system resource (`settings`, `media`, `webhooks`, ...)
+ * seeds the same `read-<name>`/`update-<name>` rows that resource's routes
+ * check. The reservation lives at the validation/artifact step of each create
+ * path; these tests exercise the real paths against a live adapter and assert
+ * the physical table is absent afterward:
+ *
+ *   - Collection: `CollectionMetadataService.createCollection` (via the
+ *     `collectionsHandler`) validates the name inside `generateCollection`
+ *     before `saveMigration`/`runMigration`, so no `dc_<name>` table appears.
+ *   - Single: the `createSingle` dispatcher rejects at the top of `execute`,
+ *     before `generateMigrationSQL`/`executeMigrationStatements`, so no
+ *     `single_<name>` table appears.
+ *
+ * `settings` and `media` are the load-bearing cases: neither is in the legacy
+ * curated `RESERVED_COLLECTION_NAMES` list, so only the system-resource
+ * reservation rejects them.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../../errors";
+import { dispatchSingles } from "../../../dispatcher/handlers/single-dispatcher";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+// Reserved names that collide only via the system-resource reservation (not the
+// legacy curated collection-name list), so they prove the new guard is the one
+// doing the work.
+const RESERVED_NAMES = ["settings", "media"] as const;
+
+let current: TestNextly | undefined;
+
+// The collection UI-create path only runs the generated migration in
+// development; force dev so a table WOULD be created if the guard did not fire
+// first, making the "no orphan table" assertion meaningful.
+let prevNodeEnv: string | undefined;
+beforeEach(() => {
+  prevNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "development";
+});
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+  process.env.NODE_ENV = prevNodeEnv;
+});
+
+/** True if a physical table with this exact name exists (sqlite). */
+async function tableExists(t: TestNextly, table: string): Promise<boolean> {
+  const adapter = t.adapter as unknown as {
+    executeQuery: (sql: string) => Promise<Record<string, unknown>[]>;
+  };
+  const rows = await adapter.executeQuery(
+    `SELECT name FROM sqlite_master WHERE type='table' AND name='${table}'`
+  );
+  return rows.length > 0;
+}
+
+function collectionsHandlerOf(t: TestNextly) {
+  return t.getService("collectionsHandler") as unknown as {
+    createCollection: (data: Record<string, unknown>) => Promise<{
+      success: boolean;
+      statusCode: number;
+    }>;
+  };
+}
+
+describe("reserved slug rejection leaves no orphan table (integration)", () => {
+  it("collection create rejects a reserved name before building its table", async () => {
+    current = await createTestNextly({ collections: [] });
+
+    for (const name of RESERVED_NAMES) {
+      const result = await collectionsHandlerOf(current).createCollection({
+        name,
+        label: name,
+        fields: [{ name: "body", type: "text" }],
+      });
+
+      // createCollection maps validation failures to a { success: false }
+      // result (see CollectionMetadataService.errorToMetadataResult).
+      expect(result.success).toBe(false);
+      expect(result.statusCode).toBe(400);
+
+      // The reserved name was rejected inside generateCollection, before the
+      // migration was saved or run, so no `dc_<name>` table exists.
+      expect(await tableExists(current, `dc_${name}`)).toBe(false);
+    }
+  });
+
+  it("single create rejects a reserved slug before building its table", async () => {
+    current = await createTestNextly({ collections: [] });
+
+    for (const name of RESERVED_NAMES) {
+      // The createSingle dispatcher throws NextlyError.validation at the top of
+      // execute, before any DDL; dispatchSingles does not catch it.
+      await expect(
+        dispatchSingles(
+          "createSingle",
+          {},
+          {
+            slug: name,
+            label: name,
+            fields: [{ name: "body", type: "text" }],
+          }
+        )
+      ).rejects.toThrow(NextlyError);
+
+      // The rejection happened before generateMigrationSQL/executeMigration
+      // Statements, so no `single_<name>` table exists.
+      expect(await tableExists(current, `single_${name}`)).toBe(false);
+    }
+  });
+});

--- a/packages/nextly/src/services/lib/__tests__/resource-slug-guard.test.ts
+++ b/packages/nextly/src/services/lib/__tests__/resource-slug-guard.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The global slug guard rejects names that would collide with a system
+ * resource's permissions, at the boundary every collection and single
+ * create/rename passes through.
+ *
+ * The collision is real: permission identity is `action-resource`, so a content
+ * type named `webhooks` seeds `read-webhooks` / `update-webhooks` — the exact
+ * rows the webhook endpoint routes check. A role granted the content type's
+ * permission would reach the system surface.
+ *
+ * `settings` and `media` are deliberately NOT reserved and are asserted here so
+ * a future edit cannot quietly re-break the common `settings` single: the
+ * settings surface is gated on `manage`, which content seeding never produces.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+import { NextlyError } from "../../../errors";
+import {
+  RESERVED_RESOURCE_SLUGS,
+  isReservedResourceSlug,
+} from "../../../schemas/_zod/rbac";
+import { assertGlobalResourceSlugAvailable } from "../resource-slug-guard";
+
+describe("RESERVED_RESOURCE_SLUGS", () => {
+  it("reserves every system resource whose routes enforce CRUD actions", () => {
+    for (const slug of [
+      "webhooks",
+      "api-keys",
+      "email-providers",
+      "email-templates",
+      "users",
+      "roles",
+      "permissions",
+    ]) {
+      expect(isReservedResourceSlug(slug)).toBe(true);
+    }
+  });
+
+  it("does not reserve settings or media, which stay usable as content", () => {
+    expect(isReservedResourceSlug("settings")).toBe(false);
+    expect(isReservedResourceSlug("media")).toBe(false);
+    expect(RESERVED_RESOURCE_SLUGS).not.toContain("settings");
+    expect(RESERVED_RESOURCE_SLUGS).not.toContain("media");
+  });
+
+  it("does not reserve an ordinary content slug", () => {
+    expect(isReservedResourceSlug("posts")).toBe(false);
+  });
+});
+
+/** Adapter whose slug lookups return whatever the test seeds. */
+function adapterReturning(owner: { id: string } | null) {
+  return {
+    // findSlugOwner queries dynamic_collections first, then dynamic_singles.
+    // Returning the owner for collections and null for singles is enough.
+    selectOne: vi
+      .fn()
+      .mockImplementationOnce(async () => owner)
+      .mockImplementationOnce(async () => null),
+  } as never;
+}
+
+describe("assertGlobalResourceSlugAvailable", () => {
+  it("rejects a reserved name even when no resource holds it", async () => {
+    // A system resource is not a dynamic collection or single, so uniqueness
+    // alone would treat the name as free.
+    const adapter = adapterReturning(null);
+    await expect(
+      assertGlobalResourceSlugAvailable(adapter, "webhooks")
+    ).rejects.toThrow(NextlyError);
+  });
+
+  it("allows settings and media", async () => {
+    for (const slug of ["settings", "media"]) {
+      await expect(
+        assertGlobalResourceSlugAvailable(adapterReturning(null), slug)
+      ).resolves.toBeUndefined();
+    }
+  });
+
+  it("allows an ordinary free slug", async () => {
+    await expect(
+      assertGlobalResourceSlugAvailable(adapterReturning(null), "posts")
+    ).resolves.toBeUndefined();
+  });
+
+  it("still rejects a name another resource already holds", async () => {
+    const adapter = adapterReturning({ id: "c1" });
+    await expect(
+      assertGlobalResourceSlugAvailable(adapter, "posts")
+    ).rejects.toThrow(NextlyError);
+  });
+
+  it("lets a resource keep a reserved slug it somehow already holds", async () => {
+    // Grandfathering: a collection created before the name became reserved must
+    // still be editable. Rejecting a no-op save would strand it.
+    const adapter = adapterReturning({ id: "c1" });
+    await expect(
+      assertGlobalResourceSlugAvailable(adapter, "webhooks", {
+        currentResourceType: "collection",
+        currentResourceId: "c1",
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/nextly/src/services/lib/__tests__/resource-slug-guard.test.ts
+++ b/packages/nextly/src/services/lib/__tests__/resource-slug-guard.test.ts
@@ -16,35 +16,26 @@ import { describe, it, expect, vi } from "vitest";
 
 import { NextlyError } from "../../../errors";
 import {
-  RESERVED_RESOURCE_SLUGS,
+  SYSTEM_RESOURCES,
   isReservedResourceSlug,
 } from "../../../schemas/_zod/rbac";
 import { assertGlobalResourceSlugAvailable } from "../resource-slug-guard";
 
-describe("RESERVED_RESOURCE_SLUGS", () => {
-  it("reserves every system resource whose routes enforce CRUD actions", () => {
-    for (const slug of [
-      "webhooks",
-      "api-keys",
-      "email-providers",
-      "email-templates",
-      "users",
-      "roles",
-      "permissions",
-    ]) {
+describe("isReservedResourceSlug", () => {
+  it("reserves every system resource name", () => {
+    // Every system resource has a route enforcing a create/read/update/delete
+    // action that content seeding produces, so a same-named content type would
+    // mint a colliding permission row. `settings` and `media` are included:
+    // the user-fields/component routes accept `{action, "settings"}` and the
+    // media routes `{action, "media"}`, not only `manage`.
+    for (const slug of SYSTEM_RESOURCES) {
       expect(isReservedResourceSlug(slug)).toBe(true);
     }
   });
 
-  it("does not reserve settings or media, which stay usable as content", () => {
-    expect(isReservedResourceSlug("settings")).toBe(false);
-    expect(isReservedResourceSlug("media")).toBe(false);
-    expect(RESERVED_RESOURCE_SLUGS).not.toContain("settings");
-    expect(RESERVED_RESOURCE_SLUGS).not.toContain("media");
-  });
-
   it("does not reserve an ordinary content slug", () => {
     expect(isReservedResourceSlug("posts")).toBe(false);
+    expect(isReservedResourceSlug("products")).toBe(false);
   });
 });
 
@@ -70,11 +61,11 @@ describe("assertGlobalResourceSlugAvailable", () => {
     ).rejects.toThrow(NextlyError);
   });
 
-  it("allows settings and media", async () => {
+  it("rejects settings and media, which collide via their CRUD routes", async () => {
     for (const slug of ["settings", "media"]) {
       await expect(
         assertGlobalResourceSlugAvailable(adapterReturning(null), slug)
-      ).resolves.toBeUndefined();
+      ).rejects.toThrow(NextlyError);
     }
   });
 

--- a/packages/nextly/src/services/lib/__tests__/resource-slug-guard.test.ts
+++ b/packages/nextly/src/services/lib/__tests__/resource-slug-guard.test.ts
@@ -8,9 +8,10 @@
  * rows the webhook endpoint routes check. A role granted the content type's
  * permission would reach the system surface.
  *
- * `settings` and `media` are deliberately NOT reserved and are asserted here so
- * a future edit cannot quietly re-break the common `settings` single: the
- * settings surface is gated on `manage`, which content seeding never produces.
+ * `settings` and `media` are reserved too, and asserted here: their admin
+ * routes check `{action, "settings"}` and `{action, "media"}` for the CRUD
+ * actions content seeding produces, not only `manage`, so a same-named content
+ * type reaches them.
  */
 import { describe, it, expect, vi } from "vitest";
 

--- a/packages/nextly/src/services/lib/resource-slug-guard.ts
+++ b/packages/nextly/src/services/lib/resource-slug-guard.ts
@@ -1,6 +1,7 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import { NextlyError } from "../../errors";
+import { isReservedResourceSlug } from "../../schemas/_zod/rbac";
 
 type ResourceType = "collection" | "single";
 
@@ -54,13 +55,36 @@ export async function assertGlobalResourceSlugAvailable(
   options?: SlugGuardOptions
 ): Promise<void> {
   const owner = await findSlugOwner(adapter, slug);
+
+  const isSameResource =
+    owner != null &&
+    owner.resourceType === options?.currentResourceType &&
+    owner.id === options?.currentResourceId;
+
+  // A name that collides with a system resource's permissions may not be taken
+  // as a slug on any path — create or rename, collection or single. Checked
+  // before the uniqueness lookup because a system resource is not a dynamic
+  // collection or single, so it would otherwise read as "available". A resource
+  // that somehow already holds such a slug (created before the name became
+  // reserved) may keep it: rejecting a no-op save would strand it with no way
+  // to edit anything else.
+  if (isReservedResourceSlug(slug) && !isSameResource) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "slug",
+          code: "reserved_slug",
+          message:
+            "This name is reserved by Nextly and cannot be used as a slug. Choose a different name.",
+        },
+      ],
+      logContext: { reason: "system-resource-slug", slug },
+    });
+  }
+
   if (!owner) {
     return;
   }
-
-  const isSameResource =
-    owner.resourceType === options?.currentResourceType &&
-    owner.id === options?.currentResourceId;
 
   if (isSameResource) {
     return;

--- a/packages/nextly/src/shared/sql-reserved.ts
+++ b/packages/nextly/src/shared/sql-reserved.ts
@@ -58,12 +58,19 @@ export const RESERVED_SLUGS = [
   "roles",
   "permissions",
   "sessions",
-  // Permission identity is action + resource, and webhook endpoint permissions
-  // are seeded against the `webhooks` resource. A collection with this slug
-  // would share those exact tuples, so a role granted the collection's
-  // `read-webhooks` would also be able to read endpoint configuration, and
-  // `update-webhooks` would reveal signing secrets.
+  // System resources whose permissions a same-named content type would collide
+  // with (permission identity is `action-resource`): a `webhooks` collection's
+  // `read-webhooks` would reach the endpoint routes, `update-webhooks` the
+  // signing secrets, and `read-api-keys` the API keys. This mirrors the curated
+  // `RESERVED_RESOURCE_SLUGS` in schemas/_zod/rbac.ts, which the dynamic
+  // registries enforce; this leaf module stays import-free (see the header), so
+  // the names are repeated here for the code-first validators. `settings` is
+  // deliberately absent — its surface is gated on `manage`, which content
+  // seeding never produces, so it stays usable as a content model.
   "webhooks",
+  "api-keys",
+  "email-providers",
+  "email-templates",
   "tokens",
   "media",
   "uploads",

--- a/packages/nextly/src/shared/sql-reserved.ts
+++ b/packages/nextly/src/shared/sql-reserved.ts
@@ -58,13 +58,16 @@ export const RESERVED_SLUGS = [
   "roles",
   "permissions",
   "sessions",
-  // Pre-existing route/table reservations. The permission-collision reservation
-  // for system-resource names (settings, api-keys, email-*, ...) is NOT kept
-  // here: this list is spread into the component reserved set too, and a
-  // component does not seed a permission under its own slug, so reserving those
-  // names for components would be a false positive. The collision check lives in
-  // the collection and single validators via `isReservedResourceSlug`
-  // (schemas/_zod/rbac.ts), which is scoped to those two entity kinds.
+  // Pre-existing route/table reservations. Two of these (`webhooks`, `media`)
+  // are also system resources, but they are reserved here for the independent
+  // reason that a route/table already owns the name. The permission-collision
+  // reservation for the REMAINING system-resource names (settings, api-keys,
+  // email-providers, email-templates) is deliberately NOT added to this list:
+  // it is spread into the component reserved set too, and a component does not
+  // seed a permission under its own slug, so reserving those names for
+  // components would be a false positive. That collision check lives in the
+  // collection and single validators via `isReservedResourceSlug`
+  // (schemas/_zod/rbac.ts), scoped to those two entity kinds.
   "webhooks",
   "tokens",
   "media",

--- a/packages/nextly/src/shared/sql-reserved.ts
+++ b/packages/nextly/src/shared/sql-reserved.ts
@@ -58,19 +58,20 @@ export const RESERVED_SLUGS = [
   "roles",
   "permissions",
   "sessions",
-  // System resources whose permissions a same-named content type would collide
-  // with (permission identity is `action-resource`): a `webhooks` collection's
-  // `read-webhooks` would reach the endpoint routes, `update-webhooks` the
-  // signing secrets, and `read-api-keys` the API keys. This mirrors the curated
-  // `RESERVED_RESOURCE_SLUGS` in schemas/_zod/rbac.ts, which the dynamic
-  // registries enforce; this leaf module stays import-free (see the header), so
-  // the names are repeated here for the code-first validators. `settings` is
-  // deliberately absent — its surface is gated on `manage`, which content
-  // seeding never produces, so it stays usable as a content model.
+  // Every system resource. Permission identity is `action-resource`, so a
+  // same-named content type seeds the exact rows that resource's routes check:
+  // a `webhooks` type reaches the endpoint routes and signing secrets, a
+  // `settings` type the user-fields and component admin surfaces (gated on
+  // `{action, "settings"}`, not only `manage`), a `media` type the media
+  // routes. This mirrors `isReservedResourceSlug` (= `isSystemResource`) in
+  // schemas/_zod/rbac.ts, which the dynamic registries enforce; this leaf
+  // module stays import-free (see the header), so the names are repeated here
+  // for the code-first validators.
   "webhooks",
   "api-keys",
   "email-providers",
   "email-templates",
+  "settings",
   "tokens",
   "media",
   "uploads",

--- a/packages/nextly/src/shared/sql-reserved.ts
+++ b/packages/nextly/src/shared/sql-reserved.ts
@@ -58,20 +58,14 @@ export const RESERVED_SLUGS = [
   "roles",
   "permissions",
   "sessions",
-  // Every system resource. Permission identity is `action-resource`, so a
-  // same-named content type seeds the exact rows that resource's routes check:
-  // a `webhooks` type reaches the endpoint routes and signing secrets, a
-  // `settings` type the user-fields and component admin surfaces (gated on
-  // `{action, "settings"}`, not only `manage`), a `media` type the media
-  // routes. This mirrors `isReservedResourceSlug` (= `isSystemResource`) in
-  // schemas/_zod/rbac.ts, which the dynamic registries enforce; this leaf
-  // module stays import-free (see the header), so the names are repeated here
-  // for the code-first validators.
+  // Pre-existing route/table reservations. The permission-collision reservation
+  // for system-resource names (settings, api-keys, email-*, ...) is NOT kept
+  // here: this list is spread into the component reserved set too, and a
+  // component does not seed a permission under its own slug, so reserving those
+  // names for components would be a false positive. The collision check lives in
+  // the collection and single validators via `isReservedResourceSlug`
+  // (schemas/_zod/rbac.ts), which is scoped to those two entity kinds.
   "webhooks",
-  "api-keys",
-  "email-providers",
-  "email-templates",
-  "settings",
   "tokens",
   "media",
   "uploads",

--- a/packages/nextly/src/singles/config/validate-single.ts
+++ b/packages/nextly/src/singles/config/validate-single.ts
@@ -23,6 +23,7 @@
 
 import { RESERVED_SLUGS } from "../../collections/config/validate-config";
 import { isPluginFieldTypeOnSurface } from "../../domains/schema/field-types/field-type-registry";
+import { SYSTEM_RESOURCES } from "../../schemas/_zod/rbac";
 import {
   type BaseValidationError,
   DEFAULT_SQL_KEYWORDS_SET,
@@ -130,9 +131,18 @@ export interface SingleValidationResult {
 /**
  * Reserved Single slugs that cannot be used.
  *
- * Extends the base RESERVED_SLUGS with Single-specific reserved names.
+ * Extends the base RESERVED_SLUGS with every system-resource name. A single
+ * named after a system resource seeds `read-<name>` / `update-<name>`, the rows
+ * that resource's routes check (a `settings` single reaches the user-fields and
+ * component admin surfaces), so it is rejected here at config validation, before
+ * any migration or table is built. The system-resource names are added here
+ * rather than in the shared base list, which also feeds the component validator
+ * where they must not apply.
  */
-export const RESERVED_SINGLE_SLUGS = [...RESERVED_SLUGS] as const;
+export const RESERVED_SINGLE_SLUGS = [
+  ...RESERVED_SLUGS,
+  ...SYSTEM_RESOURCES,
+] as const;
 
 const RESERVED_SINGLE_SLUGS_SET: Set<string> = new Set<string>(
   RESERVED_SINGLE_SLUGS


### PR DESCRIPTION
Closes the founder-approved Decision 2 (option B) from the webhooks program: reserve every system-resource name as a collection slug.

## The problem

Permission identity is `action + resource`. A collection's permissions are seeded as `{action, resource: collectionSlug}`, and a system resource's permissions as `{action, resource: systemResourceName}`. When those names coincide, the rows are **the same rows**.

So a collection named `api-keys` produces `read-api-keys` / `update-api-keys` — the exact permissions the API-key routes check. A content role granted that collection's access would reach the system surface. For `webhooks` that means reading endpoint configuration and revealing signing secrets; for `api-keys`, the keys themselves.

`webhooks` was reserved in #284. This finishes the job for the resources that were left open: `api-keys`, `settings`, `email-providers`, `email-templates`, `media` (and the already-covered `users` / `roles` / `permissions`).

## Why both lists

There are two independent collection-name validators, and they never shared a list:

- **Code-first** validation uses `RESERVED_SLUGS` (`shared/sql-reserved.ts`).
- **Schema Builder** validation uses `RESERVED_COLLECTION_NAMES` (`dynamic-collection-validation-service.ts`).

A Builder-created collection never reaches the code-first list, so both must cover every system resource. Both now do.

## Why a test rather than derivation

The natural instinct is to `...spread` `SYSTEM_RESOURCES` into both lists so they can't drift. I deliberately did not, for `sql-reserved.ts`: its header documents that it is **intentionally import-free** — it exists as the cycle-breaker after a real TDZ `ReferenceError` under strict ESM evaluation. Importing `SYSTEM_RESOURCES` into it would reintroduce exactly the failure mode it was extracted to prevent, and turn any future transitive import of that constant into a landmine.

Instead, both lists stay explicit, and `seed-system-permissions.integration.test.ts` asserts each is a **superset of `SYSTEM_RESOURCES`**. Adding a system resource without reserving it fails CI with `expected [ '<name>' ] to deeply equal []`. This is the same test-invariant pattern #284 used for the admin's copies of the list.

## Breaking change

An installation that already has a collection named one of the reserved words must rename it before upgrading. Recorded in the changeset. Verified no first-party template collides (blog uses Posts/Tags/Categories).

## Verification

- Both invariants proven load-bearing: dropping `api-keys` from either list fails its assertion.
- Full validator suites (collections / singles / components / dynamic-collections) run; the 2 failures in `dynamic-collection-schema-service.test.ts` are pre-existing many-to-many rename-detection failures, confirmed identical on `origin/main`, untouched by this change.
- Typecheck and lint clean.

## Not in scope

`RESERVED_SLUGS` also reserves route names (`api`, `admin`, `auth`, …) that the Builder list does not. Aligning those is a broader change that would newly invalidate more collection names, so it is left out of this security fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented creating/registering collections and singles (and dynamic collections) using reserved system resource slugs; invalid attempts now return a `reserved_slug` validation error.
  * Preserved “grandfathering” when the current resource already owns the reserved slug.
  * During migrations, reserved conflicting entries are skipped with a warning to avoid collisions.
* **Tests**
  * Added coverage for the global reserved-slug guard and updated integration scenarios to use `preferences` instead of `settings`.
* **Documentation**
  * Clarified the protected system resource slug list, including key system names like settings/media and API-key/email-related slugs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->