### PR TITLE
feat(nextly): make publish and unpublish expressible in the access layer

### DIFF
--- a/.changeset/publish-access-operation.md
+++ b/.changeset/publish-access-operation.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+The access layer now understands publish and unpublish as operations.
+
+A collection or single may carry an access rule for `publish` and `unpublish`
+the same way it does for `create` or `update`, and the RBAC check accepts them.
+Nothing enforces them on a write yet; this makes the checks expressible so the
+next release can gate publishing on them.

--- a/packages/nextly/src/auth/guards/require-collection-access.ts
+++ b/packages/nextly/src/auth/guards/require-collection-access.ts
@@ -2,7 +2,13 @@ import type { AuthContext } from "../session/session-types";
 
 import { checkPermission } from "./require-permission";
 
-export type CollectionOperation = "create" | "read" | "update" | "delete";
+export type CollectionOperation =
+  | "create"
+  | "read"
+  | "update"
+  | "delete"
+  | "publish"
+  | "unpublish";
 
 export interface CollectionAccessDeps {
   /** Check a user's permission via RBAC service */

--- a/packages/nextly/src/direct-api/types/rbac.ts
+++ b/packages/nextly/src/direct-api/types/rbac.ts
@@ -11,6 +11,7 @@ import type {
   ApiKeyTokenType,
   ExpiresIn,
 } from "../../domains/auth/services/api-key-service";
+import type { AccessOperation } from "../../services/access/types";
 
 import type { DirectAPIConfig } from "./shared";
 
@@ -349,7 +350,7 @@ export interface CheckAccessArgs {
    */
   resource: string;
   /** The operation to check */
-  operation: "create" | "read" | "update" | "delete";
+  operation: AccessOperation;
 }
 
 /**
@@ -360,14 +361,14 @@ export interface CheckAccessArgs {
  * surface it to the user immediately.
  */
 export type ApiKeyResult = ApiKeyMeta & {
-    /**
-     * The full raw key value (e.g., `"nx_live_..."`).
-     *
-     * Only present on `apiKeys.create()` responses.
-     * This is the only time the raw key is returned — store it safely.
-     */
-    key?: string;
-  };
+  /**
+   * The full raw key value (e.g., `"nx_live_..."`).
+   *
+   * Only present on `apiKeys.create()` responses.
+   * This is the only time the raw key is returned — store it safely.
+   */
+  key?: string;
+};
 
 /**
  * Arguments for listing API keys.

--- a/packages/nextly/src/domains/auth/services/rbac-access-control-service.ts
+++ b/packages/nextly/src/domains/auth/services/rbac-access-control-service.ts
@@ -39,6 +39,7 @@
  * ```
  */
 
+import type { AccessOperation } from "../../../services/access/types";
 import {
   hasPermission,
   isSuperAdmin,
@@ -152,9 +153,10 @@ export class RBACAccessControlService {
 
     const codeAccess = params.codeAccess ?? this.getRegisteredAccess(resource);
 
-    const operationAccess = codeAccess?.[
-      operation as keyof (CollectionAccessControl | SingleAccessControl)
-    ];
+    const operationAccess =
+      codeAccess?.[
+        operation as keyof (CollectionAccessControl | SingleAccessControl)
+      ];
 
     if (operationAccess !== undefined) {
       if (typeof operationAccess === "boolean") {
@@ -194,7 +196,7 @@ export class RBACAccessControlService {
    */
   async buildContext(
     userId: string,
-    operation: "create" | "read" | "update" | "delete",
+    operation: AccessOperation,
     resource: string
   ): Promise<AccessControlContext> {
     const [roleSlugs, permissions] = await Promise.all([

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -111,12 +111,18 @@ export class CollectionAccessService extends BaseService {
     rules: CollectionAccessRules | undefined
   ): CollectionAccessRules | undefined {
     if (!rules) return rules;
-    const ops: (keyof CollectionAccessRules)[] = [
-      "create",
-      "read",
-      "update",
-      "delete",
-    ];
+    // Keyed off the interface so a new rule kind (publish, unpublish) cannot be
+    // added there and silently skipped here — leaving an owner-only rule of that
+    // kind with an unnormalized owner field, which then checks the wrong column.
+    const opFlags: Record<keyof CollectionAccessRules, true> = {
+      create: true,
+      read: true,
+      update: true,
+      delete: true,
+      publish: true,
+      unpublish: true,
+    };
+    const ops = Object.keys(opFlags) as (keyof CollectionAccessRules)[];
     let cloned: CollectionAccessRules | undefined;
     for (const op of ops) {
       const rule = rules[op];

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts
@@ -56,6 +56,8 @@ export interface CollectionMetadata {
     read?: { type: string; allowedRoles?: string[] };
     update?: { type: string; allowedRoles?: string[] };
     delete?: { type: string; allowedRoles?: string[] };
+    publish?: { type: string; allowedRoles?: string[] };
+    unpublish?: { type: string; allowedRoles?: string[] };
   };
   hooks?: Record<string, unknown>[];
   createdBy?: string;

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -148,7 +148,7 @@ export function buildSingleHookContext<T>(
  */
 export async function checkSingleAccess(params: {
   slug: string;
-  operation: "read" | "update";
+  operation: "read" | "update" | "publish" | "unpublish";
   user?: UserContext;
   overrideAccess?: boolean;
   routeAuthorized?: boolean;

--- a/packages/nextly/src/schemas/dynamic-collections/mysql.ts
+++ b/packages/nextly/src/schemas/dynamic-collections/mysql.ts
@@ -247,6 +247,8 @@ export const dynamicCollectionsMysql = mysqlTable(
       read?: { type: string; allowedRoles?: string[] };
       update?: { type: string; allowedRoles?: string[] };
       delete?: { type: string; allowedRoles?: string[] };
+      publish?: { type: string; allowedRoles?: string[] };
+      unpublish?: { type: string; allowedRoles?: string[] };
     }>(),
 
     // --------------------------------------------------------

--- a/packages/nextly/src/schemas/dynamic-collections/postgres.ts
+++ b/packages/nextly/src/schemas/dynamic-collections/postgres.ts
@@ -250,6 +250,8 @@ export const dynamicCollectionsPg = pgTable(
       read?: { type: string; allowedRoles?: string[] };
       update?: { type: string; allowedRoles?: string[] };
       delete?: { type: string; allowedRoles?: string[] };
+      publish?: { type: string; allowedRoles?: string[] };
+      unpublish?: { type: string; allowedRoles?: string[] };
     }>(),
 
     // --------------------------------------------------------

--- a/packages/nextly/src/schemas/dynamic-collections/sqlite.ts
+++ b/packages/nextly/src/schemas/dynamic-collections/sqlite.ts
@@ -238,6 +238,8 @@ export const dynamicCollectionsSqlite = sqliteTable(
       read?: { type: string; allowedRoles?: string[] };
       update?: { type: string; allowedRoles?: string[] };
       delete?: { type: string; allowedRoles?: string[] };
+      publish?: { type: string; allowedRoles?: string[] };
+      unpublish?: { type: string; allowedRoles?: string[] };
     }>(),
 
     // --------------------------------------------------------

--- a/packages/nextly/src/schemas/dynamic-singles/types.ts
+++ b/packages/nextly/src/schemas/dynamic-singles/types.ts
@@ -111,6 +111,18 @@ export interface SingleAccessRules {
    * If not specified, defaults to public access.
    */
   update?: StoredAccessRule;
+
+  /**
+   * Access rule for making the Single public (status → published).
+   * If not specified, defaults to public access.
+   */
+  publish?: StoredAccessRule;
+
+  /**
+   * Access rule for taking the Single down (status → out of published).
+   * If not specified, defaults to public access.
+   */
+  unpublish?: StoredAccessRule;
 }
 
 // ============================================================

--- a/packages/nextly/src/schemas/dynamic-singles/types.ts
+++ b/packages/nextly/src/schemas/dynamic-singles/types.ts
@@ -407,7 +407,20 @@ export const SINGLE_MIGRATION_STATUSES: readonly SingleMigrationStatus[] = [
  * }
  * ```
  */
-export const SINGLE_ACCESS_OPERATIONS: readonly (keyof SingleAccessRules)[] = [
+export const SINGLE_ACCESS_OPERATIONS = [
   "read",
   "update",
-] as const;
+  "publish",
+  "unpublish",
+] as const satisfies readonly (keyof SingleAccessRules)[];
+
+// Fails to compile if a rule key is added to `SingleAccessRules` without being
+// listed here, so the enumerable list can never fall behind the rule shape.
+type _UnlistedSingleOperation = Exclude<
+  keyof SingleAccessRules,
+  (typeof SINGLE_ACCESS_OPERATIONS)[number]
+>;
+const _singleOperationsAreComplete: [_UnlistedSingleOperation] extends [never]
+  ? true
+  : never = true;
+void _singleOperationsAreComplete;

--- a/packages/nextly/src/services/access/access-control-service.test.ts
+++ b/packages/nextly/src/services/access/access-control-service.test.ts
@@ -110,3 +110,66 @@ describe("AccessControlService owner-only default field", () => {
     expect(notMine.allowed).toBe(false);
   });
 });
+
+// The publish lifecycle is a distinct access operation, evaluated against its
+// own stored rule. A caller allowed to update must not be assumed able to
+// publish, and vice versa — the two are keyed separately.
+describe("AccessControlService publish lifecycle operations", () => {
+  const service = new AccessControlService();
+  const rules: CollectionAccessRules = {
+    update: { type: "role-based", allowedRoles: ["author", "editor"] },
+    publish: { type: "role-based", allowedRoles: ["editor"] },
+    unpublish: { type: "role-based", allowedRoles: ["editor"] },
+  };
+
+  it("evaluates publish against the publish rule, not update", async () => {
+    // An author may update but not publish; the two rules diverge and the
+    // operation selects which one applies.
+    const author = { id: "u1", roles: ["author"] };
+
+    const canUpdate = await service.evaluateAccess(rules, "update", {
+      user: author,
+    });
+    const canPublish = await service.evaluateAccess(rules, "publish", {
+      user: author,
+    });
+
+    expect(canUpdate.allowed).toBe(true);
+    expect(canPublish.allowed).toBe(false);
+  });
+
+  it("allows publish for a role the publish rule names", async () => {
+    const editor = { id: "u2", roles: ["editor"] };
+
+    const result = await service.evaluateAccess(rules, "publish", {
+      user: editor,
+    });
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it("evaluates unpublish against its own rule", async () => {
+    const author = { id: "u3", roles: ["author"] };
+
+    const result = await service.evaluateAccess(rules, "unpublish", {
+      user: author,
+    });
+
+    expect(result.allowed).toBe(false);
+  });
+
+  it("defaults an unspecified publish rule to public access", async () => {
+    // No publish rule means the stored layer does not gate it — RBAC's
+    // `publish-<slug>` permission remains the only gate, exactly as a missing
+    // update rule leaves update to RBAC.
+    const updateOnly: CollectionAccessRules = {
+      update: { type: "role-based", allowedRoles: ["editor"] },
+    };
+
+    const result = await service.evaluateAccess(updateOnly, "publish", {
+      user: { id: "u4", roles: ["nobody"] },
+    });
+
+    expect(result.allowed).toBe(true);
+  });
+});

--- a/packages/nextly/src/services/access/types.ts
+++ b/packages/nextly/src/services/access/types.ts
@@ -316,12 +316,27 @@ export const ACCESS_RULE_TYPES: readonly AccessRuleType[] = [
  * }
  * ```
  */
-export const ACCESS_OPERATIONS: readonly AccessOperation[] = [
+export const ACCESS_OPERATIONS = [
   "create",
   "read",
   "update",
   "delete",
-] as const;
+  "publish",
+  "unpublish",
+] as const satisfies readonly AccessOperation[];
+
+// The runtime list must name every member of the type; a consumer that
+// enumerates it to build a matrix or validate an input would otherwise silently
+// omit an operation the type accepts. This fails to compile the moment
+// `AccessOperation` gains a value this array does not.
+type _UnlistedAccessOperation = Exclude<
+  AccessOperation,
+  (typeof ACCESS_OPERATIONS)[number]
+>;
+const _accessOperationsAreComplete: [_UnlistedAccessOperation] extends [never]
+  ? true
+  : never = true;
+void _accessOperationsAreComplete;
 
 /**
  * Default owner field for owner-only rules on COLLECTIONS.

--- a/packages/nextly/src/services/access/types.ts
+++ b/packages/nextly/src/services/access/types.ts
@@ -62,7 +62,13 @@ export type AccessRuleType =
  * const operation: AccessOperation = 'read';
  * ```
  */
-export type AccessOperation = "create" | "read" | "update" | "delete";
+export type AccessOperation =
+  | "create"
+  | "read"
+  | "update"
+  | "delete"
+  | "publish"
+  | "unpublish";
 
 /**
  * A storable access rule configuration.
@@ -211,6 +217,19 @@ export interface CollectionAccessRules {
    * If not specified, defaults to public access.
    */
   delete?: StoredAccessRule;
+
+  /**
+   * Access rule for making a document public (status → published).
+   * If not specified, defaults to public access, so the RBAC
+   * `publish-<slug>` permission is the only gate.
+   */
+  publish?: StoredAccessRule;
+
+  /**
+   * Access rule for taking a document down (status → out of published).
+   * If not specified, defaults to public access.
+   */
+  unpublish?: StoredAccessRule;
 }
 
 /**

--- a/packages/nextly/src/shared/types/access.ts
+++ b/packages/nextly/src/shared/types/access.ts
@@ -59,8 +59,8 @@ export interface AccessControlContext {
   roles: string[];
   /** The user's effective permission slugs in 'resource:action' format */
   permissions: string[];
-  /** The CRUD operation being performed */
-  operation: "create" | "read" | "update" | "delete";
+  /** The operation being performed */
+  operation: "create" | "read" | "update" | "delete" | "publish" | "unpublish";
   /** The collection or single slug */
   collection: string;
 }
@@ -175,8 +175,8 @@ export interface SingleAccessControl {
 export interface CheckAccessParams {
   /** The authenticated user's ID (null for unauthenticated requests) */
   userId: string | null;
-  /** The CRUD operation being performed */
-  operation: "create" | "read" | "update" | "delete";
+  /** The operation being performed */
+  operation: "create" | "read" | "update" | "delete" | "publish" | "unpublish";
   /** The collection or single slug (used as the permission resource) */
   resource: string;
   /** Optional code-defined access control from defineCollection/defineSingle */


### PR DESCRIPTION
Second PR of Stage A (item 9 workflows). #285 seeded `publish`/`unpublish` as permission actions; this makes them **expressible in the access layer**, so the next PR can gate on them.

Plan: `tasks/2026-07-22-stage-a2-publish-enforcement-plan.md`.

### Still inert

No mutation path passes `"publish"` yet, so no write behaves differently. This PR only removes the type-level barrier that #285 left in place: #285 added the seed/data layer, but every *typed enforcement* hop was still CRUD-only and would reject or silently downgrade `"publish"`.

### What widened

- `AccessOperation` (the canonical union) — `services/access/types.ts`
- `CollectionOperation` — `auth/guards/require-collection-access.ts`
- `CheckAccessParams.operation` and `CheckPermissionContext.operation` — `shared/types/access.ts`
- `RBACAccessControlService.buildContext` operation — `rbac-access-control-service.ts`
- `checkSingleAccess`'s inline `operation` union — `single-query-service.ts`
- `CollectionAccessRules` and `SingleAccessRules` gained `publish`/`unpublish` rule keys

Below all of this, `hasPermission(userId, action: string, resource)` already took a plain string, so once `"publish"` reaches it, `publish-<slug>` is checked correctly. This PR is about letting it reach there intact.

### One drift-proofing change

`normalizeCollectionOwnerFields` had a hardcoded `["create","read","update","delete"]` array. An owner-only `publish` rule would have had its owner field left unnormalized — silently checking the wrong column. Replaced the literal with a `Record<keyof CollectionAccessRules, true>`, so the compiler now forces every rule key to be listed. A future rule kind cannot be added to the interface and skipped here.

### Not in this PR

- **The enforcement itself** — A2b gates the transition on all six write paths (single-entry update, publishAllLocales, both bulk methods, singles, and create-as-published). Research confirmed two of those, `updateEntries` and create-as-published, bypass any gate keyed only on `updateEntry`.
- **Code-defined publish access** (`defineCollection({ access: { publish: fn } })`). The route-level middleware casts and `evaluateCodeAccess` stay CRUD-only here; that is a separate feature and route-level auth maps publish→update anyway. Stored-rule and RBAC publish access — the service-layer path A2b needs — is what this PR enables.

### A decision A2b needs from the founder

Does creating a document directly with `status: "published"` require `publish-<slug>`, or is `create-<slug>` enough? My recommendation is to require it — it matches the WordPress model this program emulates, where a Contributor can create but not publish. Noted in the plan; A2a does not depend on it.

### Verification

- typecheck and lint clean
- 5 new tests in `access-control-service.test.ts`: publish evaluates against its own rule not update; an author who may update may not publish; an unspecified publish rule defaults to public (RBAC-only), matching how a missing update rule behaves
- Verified load-bearing at the type level: reverting `AccessOperation` to CRUD-only produces 2 errors in real enforcement code (`single-query-service`, `rbac-service`) — the plumbing only compiles because the type is widened
- Baseline unchanged: 298 pre-existing failures across the touched areas (stale-mock baseline), identical with my files reverted to main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate access controls for publishing and unpublishing collections and Singles, including dedicated rules for each transition.
  * Administrators can define distinct permissions (role- and owner-based) for entering and leaving the published state.
  * Expanded dynamic collection metadata and schemas to support publish/unpublish access rules.
  * When no publishing rule is configured, publishing remains allowed by default.
* **Bug Fixes**
  * Publishing no longer incorrectly falls back to update permissions.
  * Unpublish access is evaluated against its own dedicated rule.
* **Tests**
  * Added coverage for publish/unpublish lifecycle access behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->