### PR TITLE
feat(nextly): keep delivery history when a webhook endpoint is deleted

### DIFF
--- a/.changeset/webhook-delete-keeps-history.md
+++ b/.changeset/webhook-delete-keeps-history.md
@@ -1,0 +1,27 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Deleting a webhook endpoint keeps its delivery history.
+
+Deleting an endpoint used to remove its delivery log with it, because the delivery table's foreign key cascaded. The record of what was sent to an integration is often wanted right after it is torn down, which is exactly when it used to disappear.
+
+Deleting now retires the endpoint instead of removing it: the row is kept and stamped as deleted, so it vanishes from every read and stops receiving deliveries, but the delivery ledger keeps a real endpoint on the other end of its link. Disabling is still the way to pause an endpoint you mean to bring back; deleting is for one you are finished with but whose record still matters. A retired endpoint is never resurrected, and its outstanding deliveries are ended the same way disabling ends them.

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-endpoint-service.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-endpoint-service.integration.test.ts
@@ -507,10 +507,42 @@ describe("webhook endpoint management (real SQLite)", () => {
 
       await service.deleteEndpoint(endpoint.id);
 
-      const rows = await adapter.executeQuery<{ status: string }>(
-        "SELECT status FROM nextly_webhook_deliveries WHERE id = 'dlv_q'"
+      const rows = await adapter.executeQuery<{
+        status: string;
+        last_error: string;
+      }>(
+        "SELECT status, last_error FROM nextly_webhook_deliveries WHERE id = 'dlv_q'"
       );
       expect(rows[0]?.status).toBe("failed");
+      // The retained history must say the endpoint was deleted, not merely
+      // disabled, so the audit trail is accurate in exactly the case this
+      // feature preserves.
+      expect(rows[0]?.last_error).toBe("webhook deleted");
+    });
+
+    it("clears the signing secret and static headers on delete", async () => {
+      // A retired endpoint never delivers again, so its receiver credentials
+      // are of no further use and should not linger. Attribution stays.
+      const { endpoint } = await create({
+        headers: { Authorization: "Bearer receiver-token" },
+      });
+
+      await service.deleteEndpoint(endpoint.id);
+
+      const rows = await adapter.executeQuery<{
+        secret_hash: string;
+        headers: string | null;
+        name: string;
+        url: string;
+      }>(
+        `SELECT secret_hash, headers, name, url FROM nextly_webhooks WHERE id = '${endpoint.id}'`
+      );
+      expect(String(rows[0]?.secret_hash)).not.toContain("receiver-token");
+      expect(rows[0]?.secret_hash).toBe("[]");
+      expect(rows[0]?.headers).toBeNull();
+      // Attribution the delivery history relies on is kept.
+      expect(rows[0]?.name).toBe("Orders");
+      expect(rows[0]?.url).toBe(PUBLIC_URL);
     });
 
     it("lets the same URL be registered again as a distinct live endpoint", async () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-endpoint-service.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-endpoint-service.integration.test.ts
@@ -426,18 +426,115 @@ describe("webhook endpoint management (real SQLite)", () => {
       expect(reenabled.enabled).toBe(true);
     });
 
-    it("deleting removes it and drops the cache", async () => {
+    it("deleting hides the endpoint from every read and drops the cache", async () => {
       const { endpoint } = await create();
       registry.invalidations = 0;
 
       await service.deleteEndpoint(endpoint.id);
 
       expect(await service.getEndpoint(endpoint.id)).toBeNull();
+      expect(await service.listEndpoints()).toHaveLength(0);
+      await expect(service.revealSecrets(endpoint.id)).rejects.toThrow(
+        NextlyError
+      );
       expect(registry.invalidations).toBe(1);
+    });
+
+    it("keeps the row and its delivery history rather than removing them", async () => {
+      // The point of the soft delete: the ledger of what was sent survives with
+      // a real endpoint still on the other end of its foreign key.
+      const { endpoint } = await create();
+      await adapter.insert("nextly_events", {
+        id: "evt_hist",
+        type: "entry.updated",
+        resource_kind: "entry",
+        resource_id: "p1",
+        collection: "posts",
+        payload: { id: "p1" },
+        created_at: new Date(0),
+      });
+      await adapter.insert("nextly_webhook_deliveries", {
+        id: "dlv_hist",
+        webhook_id: endpoint.id,
+        event_id: "evt_hist",
+        status: "delivered",
+        attempt_count: 1,
+        next_attempt_at: null,
+        locked_by: null,
+        locked_until: null,
+        created_at: new Date(0),
+        updated_at: new Date(0),
+      });
+
+      await service.deleteEndpoint(endpoint.id);
+
+      const webhookRows = await adapter.executeQuery<{ deleted_at: number }>(
+        `SELECT deleted_at FROM nextly_webhooks WHERE id = '${endpoint.id}'`
+      );
+      expect(webhookRows).toHaveLength(1);
+      expect(webhookRows[0]?.deleted_at).not.toBeNull();
+
+      const deliveryRows = await adapter.executeQuery(
+        "SELECT id FROM nextly_webhook_deliveries WHERE id = 'dlv_hist'"
+      );
+      expect(deliveryRows).toHaveLength(1);
+    });
+
+    it("ends deliveries still queued for the endpoint on delete", async () => {
+      // Retiring an endpoint must stop it POSTing, the same way disabling does.
+      const { endpoint } = await create();
+      await adapter.insert("nextly_events", {
+        id: "evt_q",
+        type: "entry.updated",
+        resource_kind: "entry",
+        resource_id: "p1",
+        collection: "posts",
+        payload: { id: "p1" },
+        created_at: new Date(0),
+      });
+      await adapter.insert("nextly_webhook_deliveries", {
+        id: "dlv_q",
+        webhook_id: endpoint.id,
+        event_id: "evt_q",
+        status: "pending",
+        attempt_count: 0,
+        next_attempt_at: new Date(0),
+        locked_by: null,
+        locked_until: null,
+        created_at: new Date(0),
+        updated_at: new Date(0),
+      });
+
+      await service.deleteEndpoint(endpoint.id);
+
+      const rows = await adapter.executeQuery<{ status: string }>(
+        "SELECT status FROM nextly_webhook_deliveries WHERE id = 'dlv_q'"
+      );
+      expect(rows[0]?.status).toBe("failed");
+    });
+
+    it("lets the same URL be registered again as a distinct live endpoint", async () => {
+      // A retired endpoint is not resurrected; re-registering makes a new one.
+      const first = await create();
+      await service.deleteEndpoint(first.endpoint.id);
+
+      const second = await create();
+
+      expect(second.endpoint.id).not.toBe(first.endpoint.id);
+      expect(await service.getEndpoint(second.endpoint.id)).not.toBeNull();
+      expect(await service.listEndpoints()).toHaveLength(1);
     });
 
     it("reports deleting an unknown endpoint as not found", async () => {
       await expect(service.deleteEndpoint("missing")).rejects.toThrow(
+        NextlyError
+      );
+    });
+
+    it("reports deleting an already-retired endpoint as not found", async () => {
+      const { endpoint } = await create();
+      await service.deleteEndpoint(endpoint.id);
+      await expect(service.deleteEndpoint(endpoint.id)).rejects.toThrow(
         NextlyError
       );
     });

--- a/packages/nextly/src/domains/webhooks/endpoint-registry.ts
+++ b/packages/nextly/src/domains/webhooks/endpoint-registry.ts
@@ -150,7 +150,17 @@ export class WebhookEndpointRegistry {
   private async load(): Promise<WebhookEndpoint[]> {
     const rows = await this.reader.select<Record<string, unknown>>(
       "nextly_webhooks",
-      { where: { and: [{ column: "enabled", op: "=", value: true }] } }
+      {
+        where: {
+          and: [
+            { column: "enabled", op: "=", value: true },
+            // A retired endpoint is cleared to disabled on delete, so the
+            // enabled filter already excludes it; this makes the intent
+            // explicit and holds even if a row were re-enabled out of band.
+            { column: "deletedAt", op: "IS NULL", value: null },
+          ],
+        },
+      }
     );
     return rows.map(toEndpoint);
   }

--- a/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
+++ b/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
@@ -123,6 +123,18 @@ interface WebhookRow {
   updatedAt: Date;
 }
 
+/**
+ * The subset of the Drizzle fluent API a write needs, so a `BaseService`
+ * transaction handle (typed `unknown`) can be narrowed without pulling in a
+ * dialect-specific driver type. Matches the `DrizzleTransactionLike` shape used
+ * elsewhere for the same reason.
+ */
+interface DrizzleWriteExecutor {
+  update(table: unknown): {
+    set(data: unknown): { where(condition: unknown): Promise<unknown> };
+  };
+}
+
 /** Replace every stored header value with the redaction placeholder. */
 function redactHeaderValues(stored: unknown): Record<string, string> | null {
   if (!stored || typeof stored !== "object") return null;
@@ -319,7 +331,15 @@ export class WebhookEndpointService extends BaseService {
     return rows.map(row => this.toSummary(row));
   }
 
-  /** One endpoint, or null when it does not exist. */
+  /**
+   * One endpoint, or null when there is no live endpoint with this id.
+   *
+   * A retired (soft-deleted) endpoint reads as null, the same as one that never
+   * existed: it is kept only for its delivery history and is not part of the
+   * manageable set. Callers cannot, and should not, tell the two apart. Every
+   * read here filters `deleted_at IS NULL` for that reason, and `updateEndpoint`
+   * relies on it to refuse edits to a retired row.
+   */
   async getEndpoint(id: string): Promise<WebhookEndpointSummary | null> {
     const rows = await this.query(
       async () =>
@@ -364,8 +384,14 @@ export class WebhookEndpointService extends BaseService {
     this.registry?.invalidate();
 
     // Done here rather than in `setEnabled` so that disabling through a plain
-    // field update cannot skip it.
-    if (patch.enabled === false) await this.cancelQueuedDeliveries(id);
+    // field update cannot skip it. Not wrapped in a transaction with the update
+    // above: disabling leaves the endpoint visible, so a failed cancellation is
+    // simply retried by disabling again — unlike delete, which hides the row.
+    if (patch.enabled === false) {
+      await this.query(() =>
+        this.cancelQueuedDeliveries(this.db, id, "webhook disabled")
+      );
+    }
 
     const updated = await this.getEndpoint(id);
     if (!updated) throw this.notFound(id);
@@ -373,38 +399,45 @@ export class WebhookEndpointService extends BaseService {
   }
 
   /**
-   * End the deliveries still outstanding for an endpoint that was just
-   * disabled.
+   * End the deliveries still outstanding for an endpoint that was just disabled
+   * or retired.
    *
    * Delivery refuses a disabled endpoint when it attempts one, which covers a
-   * drain running during the disabled window. It does not cover the window
-   * itself: with no drain between disabling and re-enabling, those rows are
-   * still due and would go out in a burst afterwards, which is the opposite of
-   * what disabling promised.
+   * drain running during the window. It does not cover the window itself: with
+   * no drain between disabling and re-enabling, those rows are still due and
+   * would go out in a burst afterwards, which is the opposite of what disabling
+   * promised.
    *
    * They are ended rather than held for the same reason delivery ends them.
    * Sending events an operator switched off, hours late, is worse than not
    * sending them, and replaying is a separate deliberate act.
+   *
+   * The `executor` is either the shared connection or a transaction, so a delete
+   * can end the deliveries in the same transaction that retires the endpoint.
+   * The `reason` is recorded on each row so the retained history says why they
+   * stopped — "disabled" or "deleted" — rather than always "disabled".
    */
-  private async cancelQueuedDeliveries(webhookId: string): Promise<void> {
-    await this.query(() =>
-      this.db
-        .update(this.deliveries)
-        .set({
-          status: "failed",
-          nextAttemptAt: null,
-          lockedBy: null,
-          lockedUntil: null,
-          lastError: "webhook disabled",
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(this.deliveries.webhookId, webhookId),
-            inArray(this.deliveries.status, ["pending", "retrying"])
-          )
+  private cancelQueuedDeliveries(
+    executor: DrizzleWriteExecutor,
+    webhookId: string,
+    reason: string
+  ): Promise<unknown> {
+    return executor
+      .update(this.deliveries)
+      .set({
+        status: "failed",
+        nextAttemptAt: null,
+        lockedBy: null,
+        lockedUntil: null,
+        lastError: reason,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(this.deliveries.webhookId, webhookId),
+          inArray(this.deliveries.status, ["pending", "retrying"])
         )
-    );
+      );
   }
 
   /**
@@ -439,17 +472,33 @@ export class WebhookEndpointService extends BaseService {
     if (!existing) throw this.notFound(id);
 
     const now = new Date();
-    // Soft delete: the row is retired, not removed, so its delivery history
-    // survives with a real endpoint still on the other end of the foreign key.
-    // `enabled` is cleared as well so fan-out drops it immediately, and the
-    // outstanding deliveries are ended for the same reason disabling ends them.
+    // Retiring the endpoint and ending its deliveries happen in one transaction.
+    // The tombstone hides the row from every read, so a delete that stamped the
+    // tombstone but then failed to cancel would leave deliveries queued with no
+    // way to retry — a second delete returns not-found. One transaction makes it
+    // all-or-nothing: a failure rolls the tombstone back and the endpoint stays
+    // visible and retryable.
+    //
+    // The signing secrets and static headers are cleared. A retired endpoint
+    // never delivers again, so the receiver credentials they hold serve no
+    // purpose and should not linger; attribution (name, url, event types) is
+    // what the delivery history needs and is what is kept.
     await this.query(() =>
-      this.db
-        .update(this.table)
-        .set({ deletedAt: now, enabled: false, updatedAt: now })
-        .where(eq(this.table.id, id))
+      this.withTransaction(async tx => {
+        const txDb = tx as DrizzleWriteExecutor;
+        await txDb
+          .update(this.table)
+          .set({
+            deletedAt: now,
+            enabled: false,
+            updatedAt: now,
+            secretHash: [],
+            headers: null,
+          })
+          .where(eq(this.table.id, id));
+        await this.cancelQueuedDeliveries(txDb, id, "webhook deleted");
+      })
     );
-    await this.cancelQueuedDeliveries(id);
     this.registry?.invalidate();
   }
 
@@ -462,6 +511,9 @@ export class WebhookEndpointService extends BaseService {
    *
    * Returns every active secret because rotation keeps more than one alive at
    * a time, and a caller reconciling their configuration needs to see them all.
+   *
+   * A retired endpoint is not found here, like every other read: its secrets are
+   * also cleared on delete, so there would be nothing to return in any case.
    */
   async revealSecrets(id: string): Promise<string[]> {
     const rows = await this.query(

--- a/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
+++ b/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
@@ -25,7 +25,7 @@
  * @module domains/webhooks/services/webhook-endpoint-service
  */
 
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 
 import { toDbError } from "../../../database/errors";
 import { NextlyError } from "../../../errors";
@@ -311,6 +311,9 @@ export class WebhookEndpointService extends BaseService {
         (await this.db
           .select()
           .from(this.table)
+          // Retired endpoints are kept for their delivery history but are not
+          // part of the live set, so they never appear in a list.
+          .where(isNull(this.table.deletedAt))
           .orderBy(desc(this.table.createdAt))) as WebhookRow[]
     );
     return rows.map(row => this.toSummary(row));
@@ -323,7 +326,7 @@ export class WebhookEndpointService extends BaseService {
         (await this.db
           .select()
           .from(this.table)
-          .where(eq(this.table.id, id))
+          .where(and(eq(this.table.id, id), isNull(this.table.deletedAt)))
           .limit(1)) as WebhookRow[]
     );
     return rows[0] ? this.toSummary(rows[0]) : null;
@@ -419,20 +422,34 @@ export class WebhookEndpointService extends BaseService {
   }
 
   /**
-   * Remove an endpoint and, with it, its delivery history.
+   * Retire an endpoint while keeping its delivery history.
    *
-   * `nextly_webhook_deliveries.webhook_id` cascades, so deleting an endpoint
-   * discards the record of what was sent to it rather than leaving that to
-   * retention. This is why disabling exists and is the reversible option:
-   * deletion is for an endpoint whose history is no longer wanted either.
+   * The row is soft-deleted rather than removed: it disappears from every read
+   * and stops receiving deliveries, but stays in the table so the delivery
+   * ledger keeps a real endpoint on the other end of its foreign key. "What did
+   * we send to that integration, and did it arrive?" is answerable after the
+   * endpoint is gone, which is exactly when it tends to be asked.
+   *
+   * Disabling remains the way to pause an endpoint you intend to bring back;
+   * this is for one you are finished with but whose record still matters. A row
+   * once retired is not resurrected — a later registration is a new endpoint.
    */
   async deleteEndpoint(id: string): Promise<void> {
     const existing = await this.getEndpoint(id);
     if (!existing) throw this.notFound(id);
 
+    const now = new Date();
+    // Soft delete: the row is retired, not removed, so its delivery history
+    // survives with a real endpoint still on the other end of the foreign key.
+    // `enabled` is cleared as well so fan-out drops it immediately, and the
+    // outstanding deliveries are ended for the same reason disabling ends them.
     await this.query(() =>
-      this.db.delete(this.table).where(eq(this.table.id, id))
+      this.db
+        .update(this.table)
+        .set({ deletedAt: now, enabled: false, updatedAt: now })
+        .where(eq(this.table.id, id))
     );
+    await this.cancelQueuedDeliveries(id);
     this.registry?.invalidate();
   }
 
@@ -452,7 +469,7 @@ export class WebhookEndpointService extends BaseService {
         (await this.db
           .select()
           .from(this.table)
-          .where(eq(this.table.id, id))
+          .where(and(eq(this.table.id, id), isNull(this.table.deletedAt)))
           .limit(1)) as WebhookRow[]
     );
 

--- a/packages/nextly/src/schemas/webhooks/mysql.ts
+++ b/packages/nextly/src/schemas/webhooks/mysql.ts
@@ -78,6 +78,10 @@ export const nextlyWebhooks = mysqlTable(
     updatedAt: datetime("updated_at")
       .notNull()
       .default(sql`CURRENT_TIMESTAMP`),
+    // Soft-delete marker; see the PostgreSQL definition. Deleting an endpoint
+    // stamps this instead of removing the row, so its delivery history and
+    // attribution survive. NULL means live.
+    deletedAt: datetime("deleted_at"),
   },
   t => [index("nextly_webhooks_enabled_idx").on(t.enabled)]
 );

--- a/packages/nextly/src/schemas/webhooks/postgres.ts
+++ b/packages/nextly/src/schemas/webhooks/postgres.ts
@@ -110,6 +110,11 @@ export const nextlyWebhooks = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: false })
       .defaultNow()
       .notNull(),
+    // Soft-delete marker. Deleting an endpoint stamps this instead of removing
+    // the row, so its delivery history survives with its attribution intact
+    // (the delivery foreign key still resolves to a real endpoint). NULL means
+    // live; a timestamp means retired and hidden from every read.
+    deletedAt: timestamp("deleted_at", { withTimezone: false }),
   },
   t => [index("nextly_webhooks_enabled_idx").on(t.enabled)]
 );

--- a/packages/nextly/src/schemas/webhooks/sqlite.ts
+++ b/packages/nextly/src/schemas/webhooks/sqlite.ts
@@ -75,6 +75,10 @@ export const nextlyWebhooks = sqliteTable(
     updatedAt: integer("updated_at", { mode: "timestamp" })
       .notNull()
       .$defaultFn(() => new Date()),
+    // Soft-delete marker; see the PostgreSQL definition. Deleting an endpoint
+    // stamps this instead of removing the row, so its delivery history and
+    // attribution survive. NULL means live.
+    deletedAt: integer("deleted_at", { mode: "timestamp" }),
   },
   t => [index("nextly_webhooks_enabled_idx").on(t.enabled)]
 );


### PR DESCRIPTION
Implements the founder-approved **Decision 1 (option B)**: deleting a webhook endpoint keeps its delivery history.

## Why

Every delivery attempt is recorded in `nextly_webhook_deliveries` — the audit trail of what was sent, where, and whether it arrived. The delivery table's `webhook_id` foreign key was `ON DELETE CASCADE`, so deleting an endpoint erased that trail instantly. The trail is most often wanted right after an integration is torn down, which was exactly when it vanished.

## Approach: soft delete (tombstone), not null-FK

I chose tombstone over the alternatives deliberately. Dropping the cascade and nulling `webhook_id` would keep the rows but lose *which* endpoint they belonged to — a log of deliveries "to some deleted endpoint" answers nothing. Tombstone keeps the endpoint row (name, URL, id) alongside its deliveries, so the ledger stays fully meaningful.

`deleteEndpoint` now stamps `deleted_at` and clears `enabled` instead of removing the row. The endpoint disappears from every read (`getEndpoint`, `listEndpoints`, `revealSecrets` all filter `deleted_at IS NULL`), stops receiving deliveries (fan-out already excludes disabled; the registry query now also excludes tombstoned explicitly), and its outstanding deliveries are ended the same way disabling ends them. A retired endpoint is never resurrected — re-registering the same URL makes a new one.

The FK cascade is left in place, now dormant: nothing hard-deletes an endpoint through the service, but if a genuine purge path is ever added it should still take the deliveries with it.

## Schema

Adds a nullable `deleted_at` to `nextly_webhooks` on all three dialects. I verified with drizzle-kit that the upgrade diff is a single in-place `ALTER TABLE nextly_webhooks ADD deleted_at` on SQLite — **no table rebuild, no index loss** (the #277 hazard). Postgres and MySQL add the column in place as well.

## Tests

`webhook-endpoint-service.integration.test.ts` (35 passing) now covers: delete hides the endpoint from every read; the row and its deliveries survive in the database; queued deliveries are ended on delete; the same URL can be re-registered as a distinct live endpoint; and deleting an already-retired endpoint is not-found.

## Verification

- Full webhook integration suite green (81 tests).
- Upgrade diff confirmed in-place ADD COLUMN on SQLite.
- Typecheck and lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook endpoints are now retired via soft-delete, preserving historical delivery records.
  * Retired endpoints are excluded from active listings and lookups, and any queued deliveries are ended.
  * Re-registering a previously used URL creates a new active endpoint.
* **Bug Fixes**
  * Prevented retired endpoints from being revealed or exposing stored signing secrets/headers.
  * Improved delete behavior and error handling for unknown or already-retired endpoints.
* **Chores**
  * Updated database schemas to support endpoint soft-deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->