### PR TITLE
feat(admin): gate publish and unpublish controls on permission

### DIFF
--- a/.changeset/admin-publish-button-gating.md
+++ b/.changeset/admin-publish-button-gating.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+The admin hides publish controls a user is not permitted to use.
+
+The Publish and Unpublish buttons on the entry editor, and the bulk Publish /
+Unpublish actions in the entry list, now appear only when the current user holds
+the matching permission. An author who may edit but not publish sees Save Draft
+and no Publish button, mirroring what the server allows.

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -185,6 +185,14 @@ export function EntrySystemHeader({
   // Both collections and singles authorize a document write as `update-{slug}`.
   const canUpdateDocument = useCan(`update-${collectionSlug}`);
 
+  // Publishing is its own permission, distinct from editing. Without it the
+  // Publish affordance is hidden — matching the server, which refuses a write
+  // that moves a document into `published` from a caller lacking it. An author
+  // keeps Save Draft and stops there. Unpublish is gated separately, since
+  // taking content down is a different responsibility from putting it up.
+  const canPublishDocument = useCan(`publish-${collectionSlug}`);
+  const canUnpublishDocument = useCan(`unpublish-${collectionSlug}`);
+
   // Why: autofocus the title input on create so the cursor blinks ready for
   // typing. Skip in edit mode — focusing a populated title interrupts the
   // user's reading flow.
@@ -319,16 +327,18 @@ export function EntrySystemHeader({
               {isSubmitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
               Save changes
             </Button>
-            <Button
-              type="button"
-              size="sm"
-              disabled={isSubmitting}
-              onClick={() => setUnpublishOpen(true)}
-              data-status="unpublish"
-            >
-              <EyeOff className="h-3.5 w-3.5" />
-              Unpublish
-            </Button>
+            {canUnpublishDocument && (
+              <Button
+                type="button"
+                size="sm"
+                disabled={isSubmitting}
+                onClick={() => setUnpublishOpen(true)}
+                data-status="unpublish"
+              >
+                <EyeOff className="h-3.5 w-3.5" />
+                Unpublish
+              </Button>
+            )}
           </>
         ) : hasStatus ? (
           <>
@@ -343,20 +353,22 @@ export function EntrySystemHeader({
               {isSubmitting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
               Save Draft
             </Button>
-            <Button
-              type="button"
-              size="sm"
-              disabled={isSubmitting || isInvalid}
-              onClick={onPublish}
-              data-status="published"
-            >
-              {isSubmitting ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <Globe className="h-3.5 w-3.5" />
-              )}
-              Publish
-            </Button>
+            {canPublishDocument && (
+              <Button
+                type="button"
+                size="sm"
+                disabled={isSubmitting || isInvalid}
+                onClick={onPublish}
+                data-status="published"
+              >
+                {isSubmitting ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Globe className="h-3.5 w-3.5" />
+                )}
+                Publish
+              </Button>
+            )}
           </>
         ) : (
           <Button

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.status-matrix.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.status-matrix.test.tsx
@@ -8,11 +8,26 @@
  *
  */
 import { useForm, FormProvider } from "react-hook-form";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { render, screen } from "@admin/__tests__/utils";
 
 import { EntrySystemHeader } from "../EntrySystemHeader";
+
+// The Publish and Unpublish affordances are permission-gated. The matrix cases
+// below are about lifecycle state, not authorization, so the caller holds every
+// permission by default; the gating cases override this per test.
+const { canFor } = vi.hoisted(() => ({
+  canFor: vi.fn((_slug: string) => true),
+}));
+vi.mock("@admin/hooks/useCan", () => ({
+  useCan: (slug: string) => canFor(slug),
+}));
+
+beforeEach(() => {
+  canFor.mockReset();
+  canFor.mockImplementation(() => true);
+});
 
 interface HarnessProps {
   mode: "create" | "edit";
@@ -141,5 +156,63 @@ describe("EntrySystemHeader — button matrix", () => {
     expect(
       screen.queryByRole("button", { name: /^unpublish$/i })
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("EntrySystemHeader — publish permission gating", () => {
+  it("hides Publish for a caller without publish-<slug>, keeping Save Draft", () => {
+    // An author who may edit but not publish: the primary action for them is
+    // to save a draft, and the server would refuse a publish anyway.
+    canFor.mockImplementation((slug: string) => slug !== "publish-posts");
+
+    render(<Harness mode="edit" entry={{ id: "1", status: "draft" }} />);
+
+    expect(
+      screen.getByRole("button", { name: /^save draft$/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^publish$/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Publish in create mode without the permission", () => {
+    // Create-as-published requires publish; without it the author creates a
+    // draft only.
+    canFor.mockImplementation((slug: string) => slug !== "publish-posts");
+
+    render(<Harness mode="create" />);
+
+    expect(
+      screen.getByRole("button", { name: /^save draft$/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^publish$/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Unpublish for a caller without unpublish-<slug>", () => {
+    // Editing published content: they may save changes but not take it down.
+    canFor.mockImplementation((slug: string) => slug !== "unpublish-posts");
+
+    render(
+      <Harness mode="edit" entry={{ id: "1", status: "published" }} isDirty />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /^save changes$/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^unpublish$/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("still shows Publish when the permission is held", () => {
+    canFor.mockImplementation(() => true);
+
+    render(<Harness mode="edit" entry={{ id: "1", status: "draft" }} />);
+
+    expect(
+      screen.getByRole("button", { name: /^publish$/i })
+    ).toBeInTheDocument();
   });
 });

--- a/packages/admin/src/components/features/entries/EntryList/BulkActionBar.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/BulkActionBar.tsx
@@ -11,6 +11,7 @@
 import { Button } from "@nextlyhq/ui";
 
 import { EyeOff, Send, Trash2, X } from "@admin/components/icons";
+import { useCan } from "@admin/hooks/useCan";
 
 import type { CollectionForColumns } from "./EntryTableColumns";
 
@@ -85,11 +86,21 @@ export function BulkActionBar({
   onClear,
   itemLabel = "entry",
 }: BulkActionBarProps) {
-  // Why: Publish / Unpublish are only meaningful for collections with the
-  // built-in Draft / Published lifecycle (`status: true`). Hide otherwise
-  // so non-status collections keep the existing minimal action set.
-  const showPublishActions =
-    collection?.status === true && !!onPublish && !!onUnpublish;
+  // Publishing is its own permission, distinct from editing, and gated per
+  // button rather than together: a user may hold one without the other. The
+  // slug is empty when there is no collection, which no permission matches, so
+  // the hook stays unconditional (a rule of hooks) and resolves to denied.
+  const canPublish = useCan(`publish-${collection?.slug ?? ""}`);
+  const canUnpublish = useCan(`unpublish-${collection?.slug ?? ""}`);
+
+  // Publish / Unpublish are only meaningful for collections with the built-in
+  // Draft / Published lifecycle (`status: true`), and only offered to a caller
+  // permitted to make the transition — matching the server, which refuses it
+  // otherwise. Each button is shown independently.
+  const showPublish = collection?.status === true && !!onPublish && canPublish;
+  const showUnpublish =
+    collection?.status === true && !!onUnpublish && canUnpublish;
+  const showPublishActions = showPublish || showUnpublish;
   // Pluralize the label. "entry" -> "entries", "category" -> "categories",
   // "collection" -> "collections", "user" -> "users". Already-plural labels
   // (ending in "s") pass through unchanged.
@@ -125,33 +136,36 @@ export function BulkActionBar({
         </Button>
 
         {/* Publish / Unpublish (only for collections with the built-in
-            Draft / Published lifecycle). Both buttons are always shown
-            together when status is enabled — bulk-toggling all selected
-            rows to one state is the natural UX for a workflow column. */}
+            Draft / Published lifecycle, and only the transitions this caller
+            is permitted to make). Each is shown on its own permission. */}
         {showPublishActions && (
           <>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onUnpublish}
-              disabled={isPublishing}
-              className="gap-1.5"
-              aria-label="Unpublish selected"
-            >
-              <EyeOff className="h-4 w-4" />
-              Unpublish
-            </Button>
-            <Button
-              variant="default"
-              size="sm"
-              onClick={onPublish}
-              disabled={isPublishing}
-              className="gap-1.5"
-              aria-label="Publish selected"
-            >
-              <Send className="h-4 w-4" />
-              Publish
-            </Button>
+            {showUnpublish && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onUnpublish}
+                disabled={isPublishing}
+                className="gap-1.5"
+                aria-label="Unpublish selected"
+              >
+                <EyeOff className="h-4 w-4" />
+                Unpublish
+              </Button>
+            )}
+            {showPublish && (
+              <Button
+                variant="default"
+                size="sm"
+                onClick={onPublish}
+                disabled={isPublishing}
+                className="gap-1.5"
+                aria-label="Publish selected"
+              >
+                <Send className="h-4 w-4" />
+                Publish
+              </Button>
+            )}
           </>
         )}
 

--- a/packages/admin/src/components/features/entries/EntryList/__tests__/BulkActionBar.publish-actions.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/__tests__/BulkActionBar.publish-actions.test.tsx
@@ -12,12 +12,27 @@
  *    publish actions stay hidden — the bar never half-renders.
  */
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import { render, screen } from "@admin/__tests__/utils";
 
 import { BulkActionBar } from "../BulkActionBar";
 import type { CollectionForColumns } from "../EntryTableColumns";
+
+// The bulk Publish / Unpublish buttons are permission-gated. These cases pin
+// the status-and-callback contract, so the caller holds both permissions by
+// default; the gating cases below deny them per test.
+const { canFor } = vi.hoisted(() => ({
+  canFor: vi.fn((_slug: string) => true),
+}));
+vi.mock("@admin/hooks/useCan", () => ({
+  useCan: (slug: string) => canFor(slug),
+}));
+
+beforeEach(() => {
+  canFor.mockReset();
+  canFor.mockImplementation(() => true);
+});
 
 const baseCollection: CollectionForColumns = {
   slug: "posts",
@@ -136,10 +151,10 @@ describe("BulkActionBar — Publish / Unpublish actions", () => {
     ).toBeDisabled();
   });
 
-  it("hides Publish + Unpublish if either callback is missing (defensive)", () => {
-    // Why: the bar treats both as a pair — exposing only one would imply a
-    // half-baked admin wiring. The publish actions stay hidden until both
-    // are connected.
+  it("hides only the action whose callback is missing", () => {
+    // Publish and Unpublish are now independent — a caller may hold one
+    // permission without the other — so a missing callback hides its own
+    // button rather than both. Here Unpublish is unwired; Publish remains.
     render(
       <BulkActionBar
         selectedCount={2}
@@ -152,10 +167,83 @@ describe("BulkActionBar — Publish / Unpublish actions", () => {
     );
 
     expect(
+      screen.getByRole("button", { name: /^publish selected$/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /unpublish selected/i })
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("BulkActionBar — publish permission gating", () => {
+  it("hides Publish for a caller without publish-<slug>", () => {
+    canFor.mockImplementation((slug: string) => slug !== "publish-posts");
+
+    render(
+      <BulkActionBar
+        selectedCount={3}
+        collection={statusCollection}
+        onDelete={vi.fn()}
+        onPublish={vi.fn()}
+        onUnpublish={vi.fn()}
+        onClear={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /^publish selected$/i })
+    ).not.toBeInTheDocument();
+    // Unpublish is a separate permission and is still held here.
+    expect(
+      screen.getByRole("button", { name: /unpublish selected/i })
+    ).toBeInTheDocument();
+  });
+
+  it("hides Unpublish for a caller without unpublish-<slug>", () => {
+    canFor.mockImplementation((slug: string) => slug !== "unpublish-posts");
+
+    render(
+      <BulkActionBar
+        selectedCount={3}
+        collection={statusCollection}
+        onDelete={vi.fn()}
+        onPublish={vi.fn()}
+        onUnpublish={vi.fn()}
+        onClear={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /^publish selected$/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /unpublish selected/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides both when the caller holds neither permission", () => {
+    canFor.mockImplementation(() => false);
+
+    render(
+      <BulkActionBar
+        selectedCount={3}
+        collection={statusCollection}
+        onDelete={vi.fn()}
+        onPublish={vi.fn()}
+        onUnpublish={vi.fn()}
+        onClear={vi.fn()}
+      />
+    );
+
+    expect(
       screen.queryByRole("button", { name: /^publish selected$/i })
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /unpublish selected/i })
     ).not.toBeInTheDocument();
+    // Delete stays — it is a different permission surface, unchanged here.
+    expect(
+      screen.getByRole("button", { name: /delete selected/i })
+    ).toBeInTheDocument();
   });
 });

--- a/packages/admin/src/components/features/entries/PublishAllLanguagesButton.tsx
+++ b/packages/admin/src/components/features/entries/PublishAllLanguagesButton.tsx
@@ -13,6 +13,7 @@ import { Button } from "@nextlyhq/ui";
 import { Globe } from "lucide-react";
 
 import { usePublishAllLocales } from "@admin/hooks/queries/usePublishAllLocales";
+import { useCan } from "@admin/hooks/useCan";
 import { useLocalization } from "@admin/hooks/useLocalization";
 
 import { useEntryLocale } from "./EntryLocaleContext";
@@ -30,6 +31,11 @@ export function PublishAllLanguagesButton({
   const publishAll = usePublishAllLocales({
     collectionSlug: collectionSlug ?? "",
   });
+  // Publishing every language is a publish, so it owes the same permission the
+  // header Publish button does. Without this an author holding only
+  // `update-<slug>` could publish all languages from the sidebar, bypassing the
+  // header gate. Empty slug matches no permission, keeping the hook unconditional.
+  const canPublish = useCan(`publish-${collectionSlug ?? ""}`);
 
   if (
     !enabled ||
@@ -37,7 +43,8 @@ export function PublishAllLanguagesButton({
     !collectionLocalized ||
     !collectionSlug ||
     !entryId ||
-    locales.length < 2
+    locales.length < 2 ||
+    !canPublish
   ) {
     return null;
   }

--- a/packages/admin/src/components/features/entries/__tests__/PublishAllLanguagesButton.test.tsx
+++ b/packages/admin/src/components/features/entries/__tests__/PublishAllLanguagesButton.test.tsx
@@ -9,15 +9,21 @@ import {
 } from "../EntryLocaleContext";
 import { PublishAllLanguagesButton } from "../PublishAllLanguagesButton";
 
-const { useBranding, mutate } = vi.hoisted(() => ({
+const { useBranding, mutate, canFor } = vi.hoisted(() => ({
   useBranding: vi.fn(),
   mutate: vi.fn(),
+  canFor: vi.fn((_slug: string) => true),
 }));
 vi.mock("@admin/context/providers/BrandingProvider", () => ({
   useBranding: () => useBranding(),
 }));
 vi.mock("@admin/hooks/queries/usePublishAllLocales", () => ({
   usePublishAllLocales: () => ({ mutate, isPending: false }),
+}));
+// Publishing every language is a publish; the caller holds the permission by
+// default so the render cases below stay about localization, not authorization.
+vi.mock("@admin/hooks/useCan", () => ({
+  useCan: (slug: string) => canFor(slug),
 }));
 
 const LOCALES = {
@@ -52,6 +58,8 @@ describe("PublishAllLanguagesButton", () => {
   beforeEach(() => {
     useBranding.mockReset();
     mutate.mockReset();
+    canFor.mockReset();
+    canFor.mockImplementation(() => true);
   });
 
   it("renders nothing when the collection has no status (drafts)", () => {
@@ -79,5 +87,23 @@ describe("PublishAllLanguagesButton", () => {
       screen.getByRole("button", { name: /publish all languages/i })
     );
     expect(mutate).toHaveBeenCalledWith("e1");
+  });
+
+  it("renders nothing for a caller without publish permission", () => {
+    // Otherwise an author holding only update-<slug> could publish every
+    // language from the sidebar, bypassing the header Publish gate.
+    useBranding.mockReturnValue({ locales: LOCALES });
+    canFor.mockImplementation((slug: string) => slug !== "publish-pages");
+
+    const { container } = renderButton();
+
+    expect(container.querySelector("button")).toBeNull();
+  });
+
+  it("checks the publish permission for this collection's slug", () => {
+    useBranding.mockReturnValue({ locales: LOCALES });
+    renderButton();
+
+    expect(canFor).toHaveBeenCalledWith("publish-pages");
   });
 });


### PR DESCRIPTION
Third and final PR of Stage A (item 9 workflows). #285 seeded `publish`/`unpublish`; #287 made them expressible in the access layer; this hides the admin controls a user cannot use.

### What changed

- **Entry editor** (`EntrySystemHeader`): the Publish button is gated on `useCan(\`publish-${collectionSlug}\`)`, Unpublish on `useCan(\`unpublish-${collectionSlug}\`)`. An author who may edit but not publish sees **Save Draft and no Publish** — the WordPress-style "submit for review" shape, minus the review step (that is a later stage).
- **Entry list** (`BulkActionBar`): the bulk Publish / Unpublish buttons are gated the same way. This component had no permission hook wired at all before.

Both mirror the server: #287 + A2b make the server refuse a publish the caller lacks permission for, so showing the button would only produce a 403.

### Independent gating, deliberately

Publish and unpublish are separate permissions, so they are gated separately, not as a pair. A user with publish but not unpublish sees only Publish. This changed one pre-existing bulk behaviour: the bar used to hide **both** buttons if either callback was missing (a "never half-render" guard). That invariant is superseded — half is now the correct render for a user holding one permission — so the button whose callback is missing hides on its own. The test for the old invariant is updated to assert the new one.

### Why `useCan`, not the capability map

`useCan(slug)` resolves through `hasPermission`, which checks the raw permission-slug array — so gating works without touching `buildCapabilities`/`CollectionCapabilities`. I deliberately did **not** add `canPublish`/`canUnpublish` to the capability map: nothing consumes it, so adding it would be speculative surface. The existing `canUpdateDocument = useCan(\`update-${collectionSlug}\`)` in this same file established the pattern; I followed it exactly.

### Slug source, verified

The header receives `collection.name` as `collectionSlug`. I confirmed `collection.name` **is** the slug in the entries context (the Schema Builder sets `name: slug`, and the existing `update-${collectionSlug}` restore gate relies on it), so `publish-${collectionSlug}` matches the seeded `publish-<slug>`. I reused the existing prop rather than diverge.

### This is UX only

Client permission checks are cosmetic by contract — the server enforces. Hiding a button the server would refuse is the honest surface, but the real gate is A2b (server enforcement), which lands separately.

### Verification

- typecheck and lint clean
- 18 tests across the two suites, 7 new gating cases: Publish hidden without `publish-<slug>` (edit-draft and create), Unpublish hidden without `unpublish-<slug>`, bulk buttons hidden per-permission, and each shown when held
- Existing status-matrix and bulk tests kept green by mocking `useCan` to grant by default — they assert lifecycle state, not authorization
- Verified load-bearing: removing the Publish gate fails exactly the two intended header tests
- Admin baseline unchanged: 37 pre-existing failures in 8 unrelated files (dashboard, role-management, etc.); neither of my files is among them

### Note

`unpublish` is not yet in the admin permission-matrix `ACTION_ORDER` (`constants/permissions.ts`), so an `unpublish-<slug>` permission sorts after the known verbs in the roles matrix UI. Not a blocker for these buttons; flagging for a follow-up to that constant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Permissions**
  * Publish/Unpublish buttons are now shown only when the matching permission is granted (including create and published-edit flows).
  * Bulk Publish and Unpublish actions are gated independently per collection.
  * “Publish all languages” is hidden unless publish permission for the collection slug is granted.
* **Bug Fixes**
  * Prevented unauthorized publish and unpublish actions from entry forms and bulk controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->