### PR TITLE
feat(nextly): let webhook endpoints subscribe to all events via wildcard

### DIFF
--- a/.changeset/webhook-wildcard-event-subscription.md
+++ b/.changeset/webhook-wildcard-event-subscription.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Webhook endpoints can subscribe to all events with a wildcard.
+
+An endpoint's `eventTypes` now accepts `"*"`, meaning it receives every event
+type, including event types added in future versions, without a config edit. The
+wildcard must be used on its own; combining it with specific types is rejected,
+since it already covers them. Fan-out treats a wildcard subscription as matching
+any event type while still honoring the endpoint's enabled state and filter.

--- a/packages/nextly/src/domains/webhooks/__tests__/fan-out.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/fan-out.test.ts
@@ -70,6 +70,37 @@ describe("selectDeliveryTargets", () => {
     expect(targets.map(t => t.id)).toEqual(["sub"]);
   });
 
+  it("delivers to a wildcard subscription for any event type", () => {
+    const targets = selectDeliveryTargets(
+      [
+        endpoint({ id: "all", eventTypes: ["*"] }),
+        endpoint({ id: "specific", eventTypes: ["entry.created"] }),
+      ],
+      // A type the specific endpoint is not subscribed to; the wildcard still
+      // matches it.
+      event({ type: "media.uploaded", resource: { kind: "media", id: "m1" } })
+    );
+    expect(targets.map(t => t.id)).toEqual(["all"]);
+  });
+
+  it("still applies enabled and filter constraints to a wildcard subscription", () => {
+    const targets = selectDeliveryTargets(
+      [
+        endpoint({ id: "off", eventTypes: ["*"], enabled: false }),
+        endpoint({
+          id: "pages-only",
+          eventTypes: ["*"],
+          filter: { version: 1, collections: ["pages"] },
+        }),
+        endpoint({ id: "on", eventTypes: ["*"] }),
+      ],
+      event({ resource: { kind: "entry", collection: "posts", id: "p1" } })
+    );
+    // The wildcard widens which types match, not which endpoints are enabled or
+    // which filters apply.
+    expect(targets.map(t => t.id)).toEqual(["on"]);
+  });
+
   it("excludes endpoints created after the event (no pre-subscription backlog)", () => {
     const targets = selectDeliveryTargets(
       [

--- a/packages/nextly/src/domains/webhooks/endpoint-registry.ts
+++ b/packages/nextly/src/domains/webhooks/endpoint-registry.ts
@@ -10,7 +10,12 @@
  * @module domains/webhooks/endpoint-registry
  */
 
-import type { FilterSpec, WebhookEndpoint, WebhookEventType } from "./types";
+import type {
+  FilterSpec,
+  WebhookEndpoint,
+  WebhookEventSubscription,
+  WebhookEventType,
+} from "./types";
 
 /**
  * Normalize a stored filter so a malformed value can't throw during matching.
@@ -61,7 +66,7 @@ function toEndpoint(row: Record<string, unknown>): WebhookEndpoint {
     url: row.url as string,
     enabled: Boolean(row.enabled),
     eventTypes: Array.isArray(row.eventTypes)
-      ? (row.eventTypes as WebhookEventType[])
+      ? (row.eventTypes as WebhookEventSubscription[])
       : [],
     filter: normalizeFilter(row.filter),
     headers: (row.headers as Record<string, string> | null) ?? null,

--- a/packages/nextly/src/domains/webhooks/fan-out.ts
+++ b/packages/nextly/src/domains/webhooks/fan-out.ts
@@ -19,7 +19,7 @@
 
 import type { SelectOptions } from "@nextlyhq/adapter-drizzle/types";
 
-import { matchesFilter } from "./filter";
+import { matchesFilter, matchesSubscribedTypes } from "./filter";
 import type { WebhookEndpoint, WebhookEvent } from "./types";
 
 /** Default number of un-fanned events a single `fanOutDueEvents` call claims. */
@@ -48,7 +48,7 @@ export function selectDeliveryTargets(
   return endpoints.filter(
     e =>
       e.enabled &&
-      e.eventTypes.includes(envelope.type) &&
+      matchesSubscribedTypes(e.eventTypes, envelope.type) &&
       // Fail closed on an unparseable timestamp: never deliver an event we
       // can't place relative to the subscription cutoff. (The fan-out path
       // rejects such events upstream as poison; this guards direct callers.)

--- a/packages/nextly/src/domains/webhooks/filter.ts
+++ b/packages/nextly/src/domains/webhooks/filter.ts
@@ -8,7 +8,30 @@
  * @module domains/webhooks/filter
  */
 
-import type { FilterSpec, WebhookEvent } from "./types";
+import { WEBHOOK_EVENT_WILDCARD } from "./types";
+import type {
+  FilterSpec,
+  WebhookEvent,
+  WebhookEventSubscription,
+  WebhookEventType,
+} from "./types";
+
+/**
+ * Whether an endpoint's subscription list accepts a concrete event type.
+ *
+ * The wildcard matches every type (including future ones); otherwise the type
+ * must be listed explicitly. Kept here with the other pure matching predicates
+ * so fan-out and any future caller share one definition.
+ */
+export function matchesSubscribedTypes(
+  subscriptions: readonly WebhookEventSubscription[],
+  type: WebhookEventType
+): boolean {
+  return (
+    subscriptions.includes(WEBHOOK_EVENT_WILDCARD) ||
+    subscriptions.includes(type)
+  );
+}
 
 /**
  * Whether `filter` accepts `envelope`.

--- a/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
+++ b/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
@@ -54,7 +54,7 @@ import {
   webhookSecretPrefix,
 } from "../secret";
 import { REDACTED_HEADER_VALUE } from "../types";
-import type { WebhookEventType } from "../types";
+import type { WebhookEventSubscription } from "../types";
 
 /**
  * An endpoint as any caller after creation sees it.
@@ -68,7 +68,7 @@ export interface WebhookEndpointSummary {
   name: string;
   url: string;
   enabled: boolean;
-  eventTypes: WebhookEventType[];
+  eventTypes: WebhookEventSubscription[];
   headers: Record<string, string> | null;
   secretPrefix: string;
   createdBy: string | null;
@@ -85,7 +85,7 @@ export interface CreatedWebhookEndpoint {
 export interface CreateWebhookEndpointInput {
   name: string;
   url: string;
-  eventTypes: WebhookEventType[];
+  eventTypes: WebhookEventSubscription[];
   enabled?: boolean;
   headers?: Record<string, string> | null;
 }
@@ -93,7 +93,7 @@ export interface CreateWebhookEndpointInput {
 export interface UpdateWebhookEndpointInput {
   name?: string;
   url?: string;
-  eventTypes?: WebhookEventType[];
+  eventTypes?: WebhookEventSubscription[];
   enabled?: boolean;
   headers?: Record<string, string> | null;
 }
@@ -265,7 +265,7 @@ export class WebhookEndpointService extends BaseService {
       enabled: row.enabled,
       eventTypes: (Array.isArray(row.eventTypes)
         ? row.eventTypes
-        : []) as WebhookEventType[],
+        : []) as WebhookEventSubscription[],
       // Names are kept so an operator can see which headers are configured;
       // values are not, because delivery sends them verbatim and they are
       // routinely a credential for the receiver.

--- a/packages/nextly/src/domains/webhooks/types.ts
+++ b/packages/nextly/src/domains/webhooks/types.ts
@@ -52,8 +52,25 @@ export const WEBHOOK_EVENT_TYPES = [
  */
 export const REDACTED_HEADER_VALUE = "<redacted>";
 
+/**
+ * Wildcard subscription token. An endpoint subscribed to this receives every
+ * event type, including types added in future versions — so a "subscribe to
+ * all" endpoint keeps working as the catalog grows, without a config edit. It
+ * is a subscription concept only; the finer `FilterSpec` never uses it.
+ */
+export const WEBHOOK_EVENT_WILDCARD = "*";
+
 /** A canonical webhook event type. */
 export type WebhookEventType = (typeof WEBHOOK_EVENT_TYPES)[number];
+
+/**
+ * What an endpoint can subscribe to: a specific event type or the wildcard
+ * (all-and-future). Distinct from {@link WebhookEventType} because only the
+ * subscription list accepts the wildcard.
+ */
+export type WebhookEventSubscription =
+  | WebhookEventType
+  | typeof WEBHOOK_EVENT_WILDCARD;
 
 /** Resource families an event can be about. */
 export type WebhookResourceKind =
@@ -162,8 +179,8 @@ export interface WebhookEndpoint {
   name: string;
   url: string;
   enabled: boolean;
-  /** Subscribed event types. */
-  eventTypes: WebhookEventType[];
+  /** Subscribed event types, or the wildcard for all-and-future. */
+  eventTypes: WebhookEventSubscription[];
   /** Structured filter, or null for "match every subscribed type". */
   filter: FilterSpec | null;
   /** Static request headers merged into every delivery. */

--- a/packages/nextly/src/schemas/_zod/__tests__/webhooks.test.ts
+++ b/packages/nextly/src/schemas/_zod/__tests__/webhooks.test.ts
@@ -58,6 +58,22 @@ describe("CreateWebhookSchema", () => {
     expect(parsed.success).toBe(false);
   });
 
+  it("accepts the wildcard on its own (all-and-future subscription)", () => {
+    expect(
+      CreateWebhookSchema.safeParse({ ...valid, eventTypes: ["*"] }).success
+    ).toBe(true);
+  });
+
+  it("rejects the wildcard combined with specific types", () => {
+    // The wildcard already covers every type, so a mix is contradictory rather
+    // than additive; the UI offers all-or-select, never both.
+    const parsed = CreateWebhookSchema.safeParse({
+      ...valid,
+      eventTypes: ["*", "entry.created"],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
   describe("headers delivery owns", () => {
     it.each([
       ["webhook-signature"],

--- a/packages/nextly/src/schemas/_zod/webhooks.test-d.ts
+++ b/packages/nextly/src/schemas/_zod/webhooks.test-d.ts
@@ -9,16 +9,18 @@
  */
 import { expectTypeOf } from "vitest";
 
-import type { WebhookEventType } from "../../domains/webhooks/types";
+import type { WebhookEventSubscription } from "../../domains/webhooks/types";
 
 import type { CreateWebhookInput, UpdateWebhookInput } from "./webhooks";
 
+// The parsed subscription list preserves its literals — each entry is a
+// specific event type or the wildcard, never a widened `string`.
 expectTypeOf<CreateWebhookInput["eventTypes"]>().toEqualTypeOf<
-  WebhookEventType[]
+  WebhookEventSubscription[]
 >();
 
 expectTypeOf<UpdateWebhookInput["eventTypes"]>().toEqualTypeOf<
-  WebhookEventType[] | undefined
+  WebhookEventSubscription[] | undefined
 >();
 
 // Stated explicitly: this is the shape the widening cast produced, and it is

--- a/packages/nextly/src/schemas/_zod/webhooks.ts
+++ b/packages/nextly/src/schemas/_zod/webhooks.ts
@@ -5,13 +5,15 @@
  * `enabled`, an explicit event-type list, a human `description` — so an
  * integration written against Stripe or Svix reads the same here.
  *
- * Subscription is an explicit list rather than a wildcard. Both models exist in
- * the market, but they fail in opposite directions: adding a new event type to
- * Nextly would immediately change what a wildcard endpoint receives, which
- * breaks a consumer doing exhaustive matching on the type. Explicit costs the
- * consumer an update when they want the new type, and that is the safe
- * direction. Wildcards can be added later without breaking anyone; removing
- * them could not.
+ * Subscription is an explicit list of event types, and also accepts the `"*"`
+ * wildcard for "all-and-future". Both models exist in the market and fail in
+ * opposite directions: a new event type immediately changes what a wildcard
+ * endpoint receives (which can surprise a consumer that matches types
+ * exhaustively), while an explicit list costs the consumer an update to receive
+ * a newly-added type. Wildcard is offered because an operator managing endpoints
+ * usually wants "everything" without editing config as the catalog grows; a
+ * consumer that needs the exhaustive-matching guarantee should list specific
+ * types instead. The wildcard cannot be combined with specific types.
  *
  * @module schemas/_zod/webhooks
  */
@@ -21,6 +23,7 @@ import { z } from "zod";
 import {
   REDACTED_HEADER_VALUE,
   WEBHOOK_EVENT_TYPES,
+  WEBHOOK_EVENT_WILDCARD,
 } from "../../domains/webhooks/types";
 
 /**
@@ -35,6 +38,37 @@ import {
  * `WebhookEventType[]` and reaches the service without a cast at the boundary.
  */
 export const WebhookEventTypeSchema = z.enum(WEBHOOK_EVENT_TYPES);
+
+/**
+ * One subscription entry: a concrete event type or the wildcard for
+ * all-and-future. The wildcard is accepted only in the subscription list, never
+ * in the finer `FilterSpec`.
+ */
+export const WebhookEventSubscriptionSchema = z.union([
+  z.literal(WEBHOOK_EVENT_WILDCARD),
+  WebhookEventTypeSchema,
+]);
+
+/**
+ * The subscription list an endpoint create/update accepts: at least one entry,
+ * no duplicates, and the wildcard cannot be combined with specific types (it
+ * already covers them, so a mix is contradictory rather than additive).
+ */
+const EventSubscriptionsSchema = z
+  .array(WebhookEventSubscriptionSchema)
+  .min(1, "Subscribe to at least one event type.")
+  // A duplicate would not change delivery, but it would make the stored
+  // subscription disagree with what the user typed.
+  .refine(types => new Set(types).size === types.length, {
+    message: "Event types must be unique.",
+  })
+  .refine(
+    types => !types.includes(WEBHOOK_EVENT_WILDCARD) || types.length === 1,
+    {
+      message:
+        'Use "*" on its own to subscribe to all events; do not combine it with specific types.',
+    }
+  );
 
 /** Header names a caller may not set, because delivery owns them. */
 const RESERVED_HEADER_PREFIXES = ["webhook-", "content-type", "user-agent"];
@@ -111,14 +145,7 @@ const UrlSchema = z
 export const CreateWebhookSchema = z.object({
   name: z.string().min(1, "Name is required.").max(255),
   url: UrlSchema,
-  eventTypes: z
-    .array(WebhookEventTypeSchema)
-    .min(1, "Subscribe to at least one event type.")
-    // A duplicate would not change delivery, but it would make the stored
-    // subscription disagree with what the user typed.
-    .refine(types => new Set(types).size === types.length, {
-      message: "Event types must be unique.",
-    }),
+  eventTypes: EventSubscriptionsSchema,
   enabled: z.boolean().optional(),
   headers: HeadersSchema.nullable().optional(),
 });
@@ -133,13 +160,7 @@ export const UpdateWebhookSchema = z
   .object({
     name: z.string().min(1).max(255).optional(),
     url: UrlSchema.optional(),
-    eventTypes: z
-      .array(WebhookEventTypeSchema)
-      .min(1, "Subscribe to at least one event type.")
-      .refine(types => new Set(types).size === types.length, {
-        message: "Event types must be unique.",
-      })
-      .optional(),
+    eventTypes: EventSubscriptionsSchema.optional(),
     enabled: z.boolean().optional(),
     headers: HeadersSchema.nullable().optional(),
   })


### PR DESCRIPTION
## What

Lets a webhook endpoint subscribe to **all events** (including event types added in future versions) with a `"*"` wildcard, instead of only an explicit list.

This is the first backend slice of the webhook admin-UI program (S2c). The admin event-selector will offer an "All events" option that maps to this wildcard; building it in the backend first keeps the eventual UI complete.

## Changes

- **types** (`domains/webhooks/types.ts`): add `WEBHOOK_EVENT_WILDCARD` (`"*"`) and the `WebhookEventSubscription` type. An endpoint's `eventTypes` widens to the subscription type; the finer `FilterSpec.eventTypes` stays specific (no wildcard there).
- **matching** (`domains/webhooks/filter.ts` + `fan-out.ts`): add the pure `matchesSubscribedTypes(subscriptions, type)` predicate (wildcard OR exact) and use it in `selectDeliveryTargets`, so a wildcard subscription matches any event type while the endpoint's `enabled` state and `filter` still apply.
- **validation** (`schemas/_zod/webhooks.ts`): create/update accept the wildcard, but reject combining `"*"` with specific types (it already covers them) and keep the existing min-1 / uniqueness rules. Updated the module doc that previously documented the deliberate no-wildcard decision.
- **registry/service**: `eventTypes` types updated to the subscription type; row hydration unchanged otherwise.

No schema/migration change — `event_types` is already a JSON array; `["*"]` is a valid value.

## Tests

- `fan-out.test.ts`: wildcard delivers for any type; still respects `enabled` + `filter`.
- `_zod/__tests__/webhooks.test.ts`: accepts `["*"]`; rejects `["*", "entry.created"]`.
- `webhooks.test-d.ts`: subscription-type literals preserved at the request→service boundary.
- All 143 webhooks-domain unit tests pass; `check-types` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Webhook subscriptions can now use a wildcard to receive all current and future event types.
  * Wildcard subscriptions still respect endpoint status and filtering rules.
  * Webhook validation now prevents duplicate subscriptions and disallows combining wildcard and specific event types.

* **Bug Fixes**
  * Corrected webhook delivery targeting for wildcard event subscriptions.

* **Tests**
  * Added coverage for wildcard matching, filtering, endpoint status, and request validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->