### PR TITLE
feat(nextly): add a read API for an endpoint's webhook delivery log

### DIFF
--- a/.changeset/webhook-delivery-read-api.md
+++ b/.changeset/webhook-delivery-read-api.md
@@ -1,0 +1,37 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Read a webhook endpoint's delivery log over the REST API.
+
+Two new read-only routes back the admin delivery viewer:
+
+- `GET /api/webhooks/:id/deliveries` — a paged, newest-first list of an
+  endpoint's deliveries (joined to their event for type and resource), with
+  optional `status` and `eventType` filters.
+- `GET /api/webhooks/:id/deliveries/:deliveryId` — one delivery with its full
+  attempt history and last response snippet.
+
+Both require `read-webhooks`. Deliveries are scoped by endpoint id and remain
+readable after an endpoint is retired, so its history is not lost. The delivery
+record stores only retry state, status/latency/error, a response snippet, and a
+per-attempt log — never the request headers sent — so this surface cannot leak a
+receiver credential.

--- a/packages/nextly/src/api/webhooks.ts
+++ b/packages/nextly/src/api/webhooks.ts
@@ -32,6 +32,8 @@ import { z } from "zod";
 import { isErrorResponse, requireAnyPermission } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { container } from "../di";
+import { offsetPaginationToMeta } from "../dispatcher/helpers/service-envelope";
+import type { WebhookDeliveryQueryService } from "../domains/webhooks/services/webhook-delivery-query-service";
 import type { WebhookEndpointService } from "../domains/webhooks/services/webhook-endpoint-service";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
@@ -65,6 +67,36 @@ async function getWebhookService(): Promise<WebhookEndpointService> {
   await getCachedNextly();
   return container.get<WebhookEndpointService>("webhookEndpointService");
 }
+
+async function getWebhookDeliveryService(): Promise<WebhookDeliveryQueryService> {
+  await getCachedNextly();
+  return container.get<WebhookDeliveryQueryService>(
+    "webhookDeliveryQueryService"
+  );
+}
+
+/** Delivery statuses a caller may filter on; matches the drain's vocabulary. */
+const DELIVERY_STATUSES = [
+  "pending",
+  "processing",
+  "delivered",
+  "retrying",
+  "failed",
+] as const;
+
+/**
+ * Query parameters for the delivery list. `page`/`limit` are coerced and
+ * bounded (a huge limit would let one request read the whole ledger); an
+ * unknown `status` is a client mistake rather than an empty result, so it is
+ * rejected. `eventType` is passed through — an unknown type simply matches
+ * nothing.
+ */
+const ListDeliveriesQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).catch(1),
+  limit: z.coerce.number().int().min(1).max(100).catch(20),
+  status: z.enum(DELIVERY_STATUSES).optional(),
+  eventType: z.string().min(1).max(100).optional(),
+});
 
 /**
  * `update` is accepted for every action, matching how `api-keys` treats its
@@ -145,6 +177,82 @@ export function getWebhookById(req: Request, id: string): Promise<Response> {
     }
 
     return respondDoc(endpoint);
+  })(req);
+}
+
+/**
+ * List an endpoint's deliveries, newest first, with paging and optional
+ * status/event-type filters.
+ *
+ * Auth: session or API key + `read-webhooks` (or `update-webhooks`).
+ *
+ * Scoped by webhook id alone, so deliveries remain readable after an endpoint
+ * is retired (its history is kept deliberately). A delivery row carries no
+ * credential, so this is a plain read.
+ *
+ * Response: `{ items: WebhookDeliverySummary[], meta: PaginationMeta }`.
+ */
+export function listWebhookDeliveries(
+  req: Request,
+  webhookId: string
+): Promise<Response> {
+  return withErrorHandler(async (request: Request) => {
+    const authResult = await requireWebhookPermission(request, "read");
+    if (isErrorResponse(authResult)) throw toNextlyAuthError(authResult);
+
+    const url = new URL(request.url);
+    const parsed = ListDeliveriesQuerySchema.safeParse({
+      page: url.searchParams.get("page") ?? undefined,
+      limit: url.searchParams.get("limit") ?? undefined,
+      status: url.searchParams.get("status") ?? undefined,
+      eventType: url.searchParams.get("eventType") ?? undefined,
+    });
+    if (!parsed.success) throw nextlyValidationFromZod(parsed.error);
+    const { page, limit, status, eventType } = parsed.data;
+
+    const service = await getWebhookDeliveryService();
+    const { items, total } = await service.listDeliveries(webhookId, {
+      page,
+      limit,
+      status,
+      eventType,
+    });
+
+    return respondList(
+      items,
+      offsetPaginationToMeta({ total, limit, offset: (page - 1) * limit })
+    );
+  })(req);
+}
+
+/**
+ * Fetch one delivery (with its attempt history and response snippet) for an
+ * endpoint.
+ *
+ * Auth: session or API key + `read-webhooks` (or `update-webhooks`).
+ *
+ * Response: bare `WebhookDeliveryDetail` via `respondDoc`. 404 when no delivery
+ * with this id belongs to this endpoint.
+ */
+export function getWebhookDelivery(
+  req: Request,
+  webhookId: string,
+  deliveryId: string
+): Promise<Response> {
+  return withErrorHandler(async (request: Request) => {
+    const authResult = await requireWebhookPermission(request, "read");
+    if (isErrorResponse(authResult)) throw toNextlyAuthError(authResult);
+
+    const service = await getWebhookDeliveryService();
+    const delivery = await service.getDelivery(webhookId, deliveryId);
+
+    if (!delivery) {
+      throw NextlyError.notFound({
+        logContext: { entity: "webhook-delivery", webhookId, deliveryId },
+      });
+    }
+
+    return respondDoc(delivery);
   })(req);
 }
 

--- a/packages/nextly/src/api/webhooks.ts
+++ b/packages/nextly/src/api/webhooks.ts
@@ -41,6 +41,7 @@ import {
   CreateWebhookSchema,
   UpdateWebhookSchema,
 } from "../schemas/_zod/webhooks";
+import { SKIP_TIMEZONE_FORMAT_HEADER } from "../shared/lib/date-formatting";
 
 import { readJsonBody } from "./read-json-body";
 import {
@@ -218,9 +219,12 @@ export function listWebhookDeliveries(
       eventType,
     });
 
+    // Opt this response out of timezone rewriting: a delivery's lastError and
+    // response snippet are opaque captured text that must survive verbatim.
     return respondList(
       items,
-      offsetPaginationToMeta({ total, limit, offset: (page - 1) * limit })
+      offsetPaginationToMeta({ total, limit, offset: (page - 1) * limit }),
+      { headers: { [SKIP_TIMEZONE_FORMAT_HEADER]: "1" } }
     );
   })(req);
 }
@@ -252,7 +256,11 @@ export function getWebhookDelivery(
       });
     }
 
-    return respondDoc(delivery);
+    // Opt out of timezone rewriting so the raw response snippet and attempt
+    // errors are returned exactly as the receiver sent them.
+    return respondDoc(delivery, {
+      headers: { [SKIP_TIMEZONE_FORMAT_HEADER]: "1" },
+    });
   })(req);
 }
 

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -59,6 +59,7 @@ import type {
 import { resolveVersionsConfig } from "../domains/versions/resolve-config";
 import type { VersionsService } from "../domains/versions/versions-service";
 import type { ResolvedWebhookRetentionConfig } from "../domains/webhooks/retention-config";
+import type { WebhookDeliveryQueryService } from "../domains/webhooks/services/webhook-delivery-query-service";
 import type { WebhookEndpointService } from "../domains/webhooks/services/webhook-endpoint-service";
 import { getEventBus } from "../events/event-bus";
 import { registerActivityLogHooks } from "../hooks/activity-log-hooks";
@@ -295,6 +296,8 @@ export interface ServiceMap {
   apiKeyService: ApiKeyService;
   /** Webhook endpoint management, resolved by the webhooks REST handlers. */
   webhookEndpointService: WebhookEndpointService;
+  /** Read-only webhook delivery log, resolved by the webhooks REST handlers. */
+  webhookDeliveryQueryService: WebhookDeliveryQueryService;
   authService: AuthService;
   generalSettingsService: GeneralSettingsService;
   activityLogService: ActivityLogService;

--- a/packages/nextly/src/di/registrations/register-webhooks.ts
+++ b/packages/nextly/src/di/registrations/register-webhooks.ts
@@ -12,6 +12,7 @@
  * REST surface will not be seen by a running drain until its cache expires.
  */
 
+import { WebhookDeliveryQueryService } from "../../domains/webhooks/services/webhook-delivery-query-service";
 import { WebhookEndpointService } from "../../domains/webhooks/services/webhook-endpoint-service";
 import { container } from "../container";
 
@@ -23,5 +24,11 @@ export function registerWebhookServices(ctx: RegistrationContext): void {
   container.registerSingleton<WebhookEndpointService>(
     "webhookEndpointService",
     () => new WebhookEndpointService(adapter, logger)
+  );
+
+  // Read-only surface for the admin delivery log; the drain owns every write.
+  container.registerSingleton<WebhookDeliveryQueryService>(
+    "webhookDeliveryQueryService",
+    () => new WebhookDeliveryQueryService(adapter, logger)
   );
 }

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-delivery-query-service.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-delivery-query-service.integration.test.ts
@@ -227,6 +227,8 @@ describe("WebhookDeliveryQueryService (real SQLite)", () => {
         kind: "entry",
         collection: "posts",
         id: "p1",
+        // No locale on a non-localized event.
+        locale: null,
       });
       expect(delivered.status).toBe("delivered");
       expect(delivered.lastStatusCode).toBe(200);
@@ -239,6 +241,28 @@ describe("WebhookDeliveryQueryService (real SQLite)", () => {
       expect(delivered.createdAt.toISOString()).toBe(
         "2026-07-18T00:00:01.000Z"
       );
+    });
+
+    it("surfaces the resource locale from the event payload", async () => {
+      await seedWebhook("wh1");
+      // locale lives only in the stored envelope, not a denormalized column;
+      // two locales of the same document must be distinguishable in the log.
+      await seedEvent("evt_de", "entry.updated", {
+        kind: "entry",
+        collection: "posts",
+        id: "p1",
+        locale: "de",
+      });
+      await seedDelivery("d_de", "wh1", "evt_de", {
+        status: "delivered",
+        createdAt: new Date("2026-07-18T00:00:05.000Z"),
+      });
+
+      const { items } = await service.listDeliveries("wh1", {
+        page: 1,
+        limit: 20,
+      });
+      expect(items[0].resource.locale).toBe("de");
     });
 
     it("filters by status", async () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-delivery-query-service.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-delivery-query-service.integration.test.ts
@@ -301,8 +301,10 @@ describe("WebhookDeliveryQueryService (real SQLite)", () => {
         });
         seen.push(...items.map(i => i.id));
       }
-      // Every delivery appears exactly once across the four single-row pages.
-      expect(seen.sort()).toEqual(["da", "db", "dc", "dd"]);
+      // Not just "each appears once": with a shared created_at the id DESC
+      // tiebreaker fixes the exact order, so assert the sequence to pin the
+      // (created_at DESC, id DESC) contract.
+      expect(seen).toEqual(["dd", "dc", "db", "da"]);
     });
 
     it("returns an empty page for an endpoint with no deliveries", async () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-delivery-query-service.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-delivery-query-service.integration.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Integration test for the webhook delivery read service against real SQLite.
+ *
+ * Seeds webhooks, events, and delivery rows, then exercises the admin delivery
+ * log: paged listing newest-first, status and event-type filters, endpoint
+ * scoping, and single-delivery detail (attempt history + response snippet)
+ * joined to the event. Uses an in-memory database built from the production
+ * table definitions via drizzle-kit (never hand-copied DDL).
+ */
+
+import { createSqliteAdapter } from "@nextlyhq/adapter-sqlite";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { getSQLiteDrizzleKit } from "../../../database/drizzle-kit-lazy";
+import { SchemaRegistry } from "../../../database/schema-registry";
+import { users } from "../../../schemas/users/sqlite";
+import {
+  nextlyEvents,
+  nextlyWebhooks,
+  nextlyWebhookDeliveries,
+} from "../../../schemas/webhooks/sqlite";
+import { splitStatements } from "../../schema/pipeline/sql-statement-utils";
+import { buildEnvelope } from "../envelope";
+import { recordEvent } from "../record-event";
+import { WebhookDeliveryQueryService } from "../services/webhook-delivery-query-service";
+import type { WebhookEventType } from "../types";
+
+process.env.DB_DIALECT = "sqlite";
+
+const tables = { nextlyEvents, nextlyWebhooks, nextlyWebhookDeliveries };
+// nextly_webhooks.created_by references users, so the FK target table must
+// exist for SQLite's foreign-key enforcement even though we store null here.
+const ddlTables = { ...tables, users };
+
+async function schemaDdl(): Promise<string[]> {
+  const kit = await getSQLiteDrizzleKit();
+  const statements = await kit.generateMigration(
+    await kit.generateDrizzleJson({}),
+    await kit.generateDrizzleJson(ddlTables)
+  );
+  return splitStatements(statements);
+}
+
+const logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+describe("WebhookDeliveryQueryService (real SQLite)", () => {
+  let adapter: ReturnType<typeof createSqliteAdapter>;
+  let service: WebhookDeliveryQueryService;
+
+  beforeAll(async () => {
+    adapter = createSqliteAdapter({ memory: true });
+    await adapter.connect();
+    for (const stmt of await schemaDdl()) await adapter.executeQuery(stmt);
+
+    const schemaRegistry = new SchemaRegistry("sqlite");
+    schemaRegistry.registerStaticSchemas(tables);
+    adapter.setTableResolver(schemaRegistry);
+
+    service = new WebhookDeliveryQueryService(adapter, logger as never);
+  });
+
+  afterAll(async () => {
+    try {
+      await adapter?.disconnect?.();
+    } catch {
+      // ignore teardown errors
+    }
+  });
+
+  beforeEach(async () => {
+    await adapter.executeQuery("DELETE FROM nextly_webhook_deliveries");
+    await adapter.executeQuery("DELETE FROM nextly_webhooks");
+    await adapter.executeQuery("DELETE FROM nextly_events");
+  });
+
+  async function seedWebhook(id: string): Promise<void> {
+    await adapter.insert("nextly_webhooks", {
+      id,
+      name: id,
+      url: `https://example.com/${id}`,
+      enabled: true,
+      event_types: ["entry.updated"],
+      filter: null,
+      headers: null,
+      secret_hash: ["whsec_x"],
+      secret_prefix: "whsec_",
+      field_allowlist: null,
+      created_by: null,
+      created_at: new Date("2020-01-01T00:00:00.000Z"),
+      updated_at: new Date("2020-01-01T00:00:00.000Z"),
+    });
+  }
+
+  async function seedEvent(
+    id: string,
+    type: WebhookEventType,
+    resource: Parameters<typeof buildEnvelope>[0]["resource"]
+  ): Promise<void> {
+    const envelope = buildEnvelope({
+      id,
+      type,
+      timestamp: new Date("2026-07-18T00:00:00.000Z"),
+      resource,
+      data: { id: "x", title: "Hello" },
+    });
+    await adapter.transaction(async tx => recordEvent(tx, { envelope }));
+  }
+
+  interface SeedDeliveryOpts {
+    status: string;
+    attemptCount?: number;
+    lastStatusCode?: number | null;
+    lastLatencyMs?: number | null;
+    lastError?: string | null;
+    lastResponseSnippet?: string | null;
+    attempts?: unknown;
+    nextAttemptAt?: Date | null;
+    createdAt: Date;
+  }
+
+  async function seedDelivery(
+    id: string,
+    webhookId: string,
+    eventId: string,
+    opts: SeedDeliveryOpts
+  ): Promise<void> {
+    await adapter.insert("nextly_webhook_deliveries", {
+      id,
+      webhook_id: webhookId,
+      event_id: eventId,
+      status: opts.status,
+      attempt_count: opts.attemptCount ?? 0,
+      next_attempt_at: opts.nextAttemptAt ?? null,
+      locked_by: null,
+      locked_until: null,
+      last_status_code: opts.lastStatusCode ?? null,
+      last_latency_ms: opts.lastLatencyMs ?? null,
+      last_error: opts.lastError ?? null,
+      last_response_snippet: opts.lastResponseSnippet ?? null,
+      attempts: opts.attempts ?? null,
+      created_at: opts.createdAt,
+      updated_at: opts.createdAt,
+    });
+  }
+
+  /** Seed one webhook with three deliveries across distinct event types/times. */
+  async function seedLog(): Promise<void> {
+    await seedWebhook("wh1");
+    await seedWebhook("wh2");
+    await seedEvent("evt_a", "entry.updated", {
+      kind: "entry",
+      collection: "posts",
+      id: "p1",
+    });
+    await seedEvent("evt_b", "entry.published", {
+      kind: "entry",
+      collection: "posts",
+      id: "p2",
+    });
+    await seedEvent("evt_c", "media.uploaded", { kind: "media", id: "m1" });
+
+    await seedDelivery("d1", "wh1", "evt_a", {
+      status: "delivered",
+      attemptCount: 1,
+      lastStatusCode: 200,
+      lastLatencyMs: 42,
+      lastResponseSnippet: "ok",
+      attempts: [
+        {
+          at: "2026-07-18T00:00:01.000Z",
+          outcome: "delivered",
+          statusCode: 200,
+          latencyMs: 42,
+        },
+      ],
+      createdAt: new Date("2026-07-18T00:00:01.000Z"),
+    });
+    await seedDelivery("d2", "wh1", "evt_b", {
+      status: "failed",
+      attemptCount: 5,
+      lastStatusCode: 500,
+      lastError: "boom",
+      lastResponseSnippet: "server error",
+      attempts: [
+        {
+          at: "2026-07-18T00:00:02.000Z",
+          outcome: "failed",
+          statusCode: 500,
+          error: "boom",
+        },
+      ],
+      createdAt: new Date("2026-07-18T00:00:02.000Z"),
+    });
+    await seedDelivery("d3", "wh1", "evt_c", {
+      status: "pending",
+      attemptCount: 0,
+      nextAttemptAt: new Date("2026-07-18T00:05:00.000Z"),
+      createdAt: new Date("2026-07-18T00:00:03.000Z"),
+    });
+    // A delivery on a different endpoint, to prove list/get scoping.
+    await seedDelivery("d_other", "wh2", "evt_a", {
+      status: "delivered",
+      createdAt: new Date("2026-07-18T00:00:04.000Z"),
+    });
+  }
+
+  describe("listDeliveries", () => {
+    it("returns an endpoint's deliveries newest-first, joined to the event", async () => {
+      await seedLog();
+      const { items, total } = await service.listDeliveries("wh1", {
+        page: 1,
+        limit: 20,
+      });
+
+      expect(total).toBe(3);
+      // Newest createdAt first: d3, d2, d1. wh2's delivery is excluded.
+      expect(items.map(i => i.id)).toEqual(["d3", "d2", "d1"]);
+
+      const delivered = items.find(i => i.id === "d1")!;
+      expect(delivered.eventType).toBe("entry.updated");
+      expect(delivered.resource).toEqual({
+        kind: "entry",
+        collection: "posts",
+        id: "p1",
+      });
+      expect(delivered.status).toBe("delivered");
+      expect(delivered.lastStatusCode).toBe(200);
+      expect(delivered.lastLatencyMs).toBe(42);
+      // Timestamps come back as ISO-8601 UTC strings. Absolute values are not
+      // asserted here: a naive-datetime column round-trips through the runner's
+      // local timezone, so the exact instant is environment-dependent — the
+      // newest-first ordering above is what pins the createdAt semantics.
+      expect(delivered.eventCreatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
+      expect(delivered.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
+    });
+
+    it("filters by status", async () => {
+      await seedLog();
+      const { items, total } = await service.listDeliveries("wh1", {
+        page: 1,
+        limit: 20,
+        status: "failed",
+      });
+      expect(total).toBe(1);
+      expect(items.map(i => i.id)).toEqual(["d2"]);
+    });
+
+    it("filters by event type", async () => {
+      await seedLog();
+      const { items } = await service.listDeliveries("wh1", {
+        page: 1,
+        limit: 20,
+        eventType: "media.uploaded",
+      });
+      expect(items.map(i => i.id)).toEqual(["d3"]);
+    });
+
+    it("paginates while reporting the full total", async () => {
+      await seedLog();
+      const first = await service.listDeliveries("wh1", { page: 1, limit: 2 });
+      expect(first.total).toBe(3);
+      expect(first.items.map(i => i.id)).toEqual(["d3", "d2"]);
+
+      const second = await service.listDeliveries("wh1", { page: 2, limit: 2 });
+      expect(second.total).toBe(3);
+      expect(second.items.map(i => i.id)).toEqual(["d1"]);
+    });
+
+    it("returns an empty page for an endpoint with no deliveries", async () => {
+      await seedLog();
+      const { items, total } = await service.listDeliveries("nope", {
+        page: 1,
+        limit: 20,
+      });
+      expect(total).toBe(0);
+      expect(items).toEqual([]);
+    });
+  });
+
+  describe("getDelivery", () => {
+    it("returns one delivery with its attempt history and response snippet", async () => {
+      await seedLog();
+      const detail = await service.getDelivery("wh1", "d2");
+      expect(detail).not.toBeNull();
+      expect(detail!.id).toBe("d2");
+      expect(detail!.eventType).toBe("entry.published");
+      expect(detail!.lastError).toBe("boom");
+      expect(detail!.lastResponseSnippet).toBe("server error");
+      expect(detail!.attempts).toEqual([
+        {
+          at: "2026-07-18T00:00:02.000Z",
+          outcome: "failed",
+          statusCode: 500,
+          error: "boom",
+        },
+      ]);
+    });
+
+    it("returns null for a delivery id that belongs to another endpoint", async () => {
+      await seedLog();
+      // d_other belongs to wh2; asking for it under wh1 must not leak it.
+      expect(await service.getDelivery("wh1", "d_other")).toBeNull();
+    });
+
+    it("returns null for an unknown delivery id", async () => {
+      await seedLog();
+      expect(await service.getDelivery("wh1", "missing")).toBeNull();
+    });
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-delivery-query-service.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-delivery-query-service.integration.test.ts
@@ -231,12 +231,14 @@ describe("WebhookDeliveryQueryService (real SQLite)", () => {
       expect(delivered.status).toBe("delivered");
       expect(delivered.lastStatusCode).toBe(200);
       expect(delivered.lastLatencyMs).toBe(42);
-      // Timestamps come back as ISO-8601 UTC strings. Absolute values are not
-      // asserted here: a naive-datetime column round-trips through the runner's
-      // local timezone, so the exact instant is environment-dependent — the
-      // newest-first ordering above is what pins the createdAt semantics.
-      expect(delivered.eventCreatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
-      expect(delivered.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
+      // Timestamps are raw Date values (the response layer serializes them). The
+      // exact instant must survive the round-trip regardless of the runner's
+      // timezone — a regression guard against re-introducing a timezone shift.
+      expect(delivered.eventCreatedAt).toBeInstanceOf(Date);
+      expect(delivered.createdAt).toBeInstanceOf(Date);
+      expect(delivered.createdAt.toISOString()).toBe(
+        "2026-07-18T00:00:01.000Z"
+      );
     });
 
     it("filters by status", async () => {
@@ -269,6 +271,38 @@ describe("WebhookDeliveryQueryService (real SQLite)", () => {
       const second = await service.listDeliveries("wh1", { page: 2, limit: 2 });
       expect(second.total).toBe(3);
       expect(second.items.map(i => i.id)).toEqual(["d1"]);
+    });
+
+    it("pages stably when several deliveries share a created_at", async () => {
+      await seedWebhook("wh1");
+      // Four deliveries with the SAME created_at (each for a distinct event, so
+      // the unique (webhook,event) constraint is satisfied): only the id
+      // tiebreaker keeps paging from duplicating or skipping rows across page
+      // boundaries.
+      const tie = new Date("2026-07-18T00:00:00.000Z");
+      const ids = ["da", "db", "dc", "dd"];
+      for (const id of ids) {
+        await seedEvent(`evt_${id}`, "entry.updated", {
+          kind: "entry",
+          collection: "posts",
+          id,
+        });
+        await seedDelivery(id, "wh1", `evt_${id}`, {
+          status: "delivered",
+          createdAt: tie,
+        });
+      }
+
+      const seen: string[] = [];
+      for (let page = 1; page <= 4; page++) {
+        const { items } = await service.listDeliveries("wh1", {
+          page,
+          limit: 1,
+        });
+        seen.push(...items.map(i => i.id));
+      }
+      // Every delivery appears exactly once across the four single-row pages.
+      expect(seen.sort()).toEqual(["da", "db", "dc", "dd"]);
     });
 
     it("returns an empty page for an endpoint with no deliveries", async () => {

--- a/packages/nextly/src/domains/webhooks/services/webhook-delivery-query-service.ts
+++ b/packages/nextly/src/domains/webhooks/services/webhook-delivery-query-service.ts
@@ -32,6 +32,7 @@ import {
   nextlyWebhookDeliveries as deliveriesSqlite,
 } from "../../../schemas/webhooks/sqlite";
 import { BaseService } from "../../../shared/base-service";
+import { dbTimestampToInstant } from "../../../shared/lib/date-formatting";
 
 type DeliveriesTable =
   | typeof deliveriesPg
@@ -276,14 +277,14 @@ export class WebhookDeliveryQueryService extends BaseService {
       lastStatusCode: row.lastStatusCode,
       lastLatencyMs: row.lastLatencyMs,
       lastError: row.lastError,
-      // Raw Date values, matching WebhookEndpointService.toSummary. The response
-      // layer serializes a Date to its correct ISO-8601 instant; running these
-      // through normalizeDbTimestamp would wrongly shift a SQLite epoch-based
-      // Date by the server's timezone (it un-offsets naive PG/MySQL Dates).
-      nextAttemptAt: row.nextAttemptAt,
-      eventCreatedAt: row.eventCreatedAt,
-      createdAt: row.createdAt,
-      updatedAt: row.updatedAt,
+      // Dialect-aware instant recovery: a SQLite epoch Date is already correct,
+      // while a naive Postgres/MySQL Date is reinterpreted as UTC. Returning the
+      // corrected Date lets the response layer serialize the right ISO-8601
+      // instant on every dialect, on a UTC or non-UTC server alike.
+      nextAttemptAt: dbTimestampToInstant(row.nextAttemptAt, this.dialect),
+      eventCreatedAt: dbTimestampToInstant(row.eventCreatedAt, this.dialect),
+      createdAt: dbTimestampToInstant(row.createdAt, this.dialect),
+      updatedAt: dbTimestampToInstant(row.updatedAt, this.dialect),
     };
   }
 

--- a/packages/nextly/src/domains/webhooks/services/webhook-delivery-query-service.ts
+++ b/packages/nextly/src/domains/webhooks/services/webhook-delivery-query-service.ts
@@ -76,11 +76,11 @@ export interface WebhookDeliverySummary {
   lastLatencyMs: number | null;
   lastError: string | null;
   /** When the next retry is due, or null when the delivery is terminal. */
-  nextAttemptAt: string | null;
+  nextAttemptAt: Date | null;
   /** When the underlying event was recorded (event row's created_at). */
-  eventCreatedAt: string | null;
-  createdAt: string | null;
-  updatedAt: string | null;
+  eventCreatedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 /** A single delivery with its full attempt history and response snippet. */
@@ -110,14 +110,14 @@ interface DeliveryJoinRow {
   lastError: string | null;
   lastResponseSnippet: string | null;
   attempts: unknown;
-  nextAttemptAt: unknown;
-  createdAt: unknown;
-  updatedAt: unknown;
+  nextAttemptAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
   eventType: string;
   resourceKind: string;
   resourceCollection: string | null;
   resourceId: string | null;
-  eventCreatedAt: unknown;
+  eventCreatedAt: Date;
 }
 
 export class WebhookDeliveryQueryService extends BaseService {
@@ -220,7 +220,10 @@ export class WebhookDeliveryQueryService extends BaseService {
         .from(this.deliveries)
         .innerJoin(this.events, eq(this.deliveries.eventId, this.events.id))
         .where(where)
-        .orderBy(desc(this.deliveries.createdAt))
+        // The id tiebreaker keeps offset paging stable when several deliveries
+        // share a created_at: without it, adjacent pages could duplicate or
+        // skip rows the database returns in an arbitrary order within a tie.
+        .orderBy(desc(this.deliveries.createdAt), desc(this.deliveries.id))
         .limit(opts.limit)
         .offset(offset)) as DeliveryJoinRow[];
 
@@ -273,10 +276,14 @@ export class WebhookDeliveryQueryService extends BaseService {
       lastStatusCode: row.lastStatusCode,
       lastLatencyMs: row.lastLatencyMs,
       lastError: row.lastError,
-      nextAttemptAt: this.normalizeDbTimestamp(row.nextAttemptAt),
-      eventCreatedAt: this.normalizeDbTimestamp(row.eventCreatedAt),
-      createdAt: this.normalizeDbTimestamp(row.createdAt),
-      updatedAt: this.normalizeDbTimestamp(row.updatedAt),
+      // Raw Date values, matching WebhookEndpointService.toSummary. The response
+      // layer serializes a Date to its correct ISO-8601 instant; running these
+      // through normalizeDbTimestamp would wrongly shift a SQLite epoch-based
+      // Date by the server's timezone (it un-offsets naive PG/MySQL Dates).
+      nextAttemptAt: row.nextAttemptAt,
+      eventCreatedAt: row.eventCreatedAt,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
     };
   }
 

--- a/packages/nextly/src/domains/webhooks/services/webhook-delivery-query-service.ts
+++ b/packages/nextly/src/domains/webhooks/services/webhook-delivery-query-service.ts
@@ -53,6 +53,12 @@ export interface WebhookDeliveryResource {
   kind: string;
   collection: string | null;
   id: string | null;
+  /**
+   * Which translation changed, for a localized resource. Two writes to the
+   * same document in different locales share kind/collection/id and are only
+   * told apart by this, so the log would otherwise collapse them.
+   */
+  locale: string | null;
 }
 
 /** One recorded attempt, as stored on the delivery row's `attempts` log. */
@@ -118,7 +124,23 @@ interface DeliveryJoinRow {
   resourceKind: string;
   resourceCollection: string | null;
   resourceId: string | null;
+  // The full stored envelope; only `resource.locale` (not a denormalized event
+  // column) is read from it.
+  payload: unknown;
   eventCreatedAt: Date;
+}
+
+/**
+ * Read `resource.locale` from a stored event envelope. `locale` lives only in
+ * the JSON payload (there is no denormalized event column for it), so a
+ * malformed or absent value reads as null rather than throwing.
+ */
+function localeFromPayload(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const resource = (payload as { resource?: unknown }).resource;
+  if (!resource || typeof resource !== "object") return null;
+  const locale = (resource as { locale?: unknown }).locale;
+  return typeof locale === "string" ? locale : null;
 }
 
 export class WebhookDeliveryQueryService extends BaseService {
@@ -179,6 +201,7 @@ export class WebhookDeliveryQueryService extends BaseService {
       resourceKind: this.events.resourceKind,
       resourceCollection: this.events.resourceCollection,
       resourceId: this.events.resourceId,
+      payload: this.events.payload,
       eventCreatedAt: this.events.createdAt,
     };
   }
@@ -271,6 +294,7 @@ export class WebhookDeliveryQueryService extends BaseService {
         kind: row.resourceKind,
         collection: row.resourceCollection,
         id: row.resourceId,
+        locale: localeFromPayload(row.payload),
       },
       status: row.status as WebhookDeliveryStatus,
       attemptCount: row.attemptCount,

--- a/packages/nextly/src/domains/webhooks/services/webhook-delivery-query-service.ts
+++ b/packages/nextly/src/domains/webhooks/services/webhook-delivery-query-service.ts
@@ -1,0 +1,310 @@
+/**
+ * Webhook domain — delivery read service.
+ *
+ * Backs the admin delivery log: lists an endpoint's delivery attempts and reads
+ * one delivery's attempt history. Read-only; the drain owns every write to
+ * `nextly_webhook_deliveries`. Each delivery row carries only its `event_id`, so
+ * the event type and resource come from a join to `nextly_events`.
+ *
+ * Nothing here is credential-bearing: a delivery row records retry state, the
+ * last response status/latency/error, a truncated response snippet, and a
+ * per-attempt log of `{ at, outcome, statusCode, latencyMs, error }`. The
+ * request headers actually sent (which may include a receiver credential) are
+ * never persisted, so this read surface cannot leak one.
+ *
+ * @module domains/webhooks/services/webhook-delivery-query-service
+ */
+
+import { and, count, desc, eq } from "drizzle-orm";
+
+import { toDbError } from "../../../database/errors";
+import { NextlyError } from "../../../errors";
+import {
+  nextlyEvents as eventsMysql,
+  nextlyWebhookDeliveries as deliveriesMysql,
+} from "../../../schemas/webhooks/mysql";
+import {
+  nextlyEvents as eventsPg,
+  nextlyWebhookDeliveries as deliveriesPg,
+} from "../../../schemas/webhooks/postgres";
+import {
+  nextlyEvents as eventsSqlite,
+  nextlyWebhookDeliveries as deliveriesSqlite,
+} from "../../../schemas/webhooks/sqlite";
+import { BaseService } from "../../../shared/base-service";
+
+type DeliveriesTable =
+  | typeof deliveriesPg
+  | typeof deliveriesMysql
+  | typeof deliveriesSqlite;
+type EventsTable = typeof eventsPg | typeof eventsMysql | typeof eventsSqlite;
+
+/** Lifecycle state of a delivery, mirroring the drain's status vocabulary. */
+export type WebhookDeliveryStatus =
+  | "pending"
+  | "processing"
+  | "delivered"
+  | "retrying"
+  | "failed";
+
+/** The resource an event was about, surfaced from the joined event row. */
+export interface WebhookDeliveryResource {
+  kind: string;
+  collection: string | null;
+  id: string | null;
+}
+
+/** One recorded attempt, as stored on the delivery row's `attempts` log. */
+export interface WebhookDeliveryAttempt {
+  at: string;
+  outcome: string;
+  statusCode?: number;
+  latencyMs?: number;
+  error?: string;
+}
+
+/** A delivery as the log list shows it (joined to its event). */
+export interface WebhookDeliverySummary {
+  id: string;
+  webhookId: string;
+  eventId: string;
+  eventType: string;
+  resource: WebhookDeliveryResource;
+  status: WebhookDeliveryStatus;
+  attemptCount: number;
+  lastStatusCode: number | null;
+  lastLatencyMs: number | null;
+  lastError: string | null;
+  /** When the next retry is due, or null when the delivery is terminal. */
+  nextAttemptAt: string | null;
+  /** When the underlying event was recorded (event row's created_at). */
+  eventCreatedAt: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+/** A single delivery with its full attempt history and response snippet. */
+export interface WebhookDeliveryDetail extends WebhookDeliverySummary {
+  attempts: WebhookDeliveryAttempt[];
+  /** Truncated response body from the last attempt, or null. */
+  lastResponseSnippet: string | null;
+}
+
+/** Filters and paging for a delivery list. `page`/`limit` are 1-based/bounded. */
+export interface ListDeliveriesOptions {
+  page: number;
+  limit: number;
+  status?: WebhookDeliveryStatus;
+  eventType?: string;
+}
+
+/** The joined row shape the fluent builder returns for a delivery + its event. */
+interface DeliveryJoinRow {
+  id: string;
+  webhookId: string;
+  eventId: string;
+  status: string;
+  attemptCount: number;
+  lastStatusCode: number | null;
+  lastLatencyMs: number | null;
+  lastError: string | null;
+  lastResponseSnippet: string | null;
+  attempts: unknown;
+  nextAttemptAt: unknown;
+  createdAt: unknown;
+  updatedAt: unknown;
+  eventType: string;
+  resourceKind: string;
+  resourceCollection: string | null;
+  resourceId: string | null;
+  eventCreatedAt: unknown;
+}
+
+export class WebhookDeliveryQueryService extends BaseService {
+  private readonly deliveries: DeliveriesTable;
+  private readonly events: EventsTable;
+
+  constructor(
+    adapter: ConstructorParameters<typeof BaseService>[0],
+    logger: ConstructorParameters<typeof BaseService>[1]
+  ) {
+    super(adapter, logger);
+    switch (this.adapter.getCapabilities().dialect) {
+      case "postgresql":
+        this.deliveries = deliveriesPg;
+        this.events = eventsPg;
+        break;
+      case "mysql":
+        this.deliveries = deliveriesMysql;
+        this.events = eventsMysql;
+        break;
+      default:
+        this.deliveries = deliveriesSqlite;
+        this.events = eventsSqlite;
+        break;
+    }
+  }
+
+  /**
+   * Turn a driver error into the canonical envelope so a raw driver exception
+   * never escapes `packages/nextly`.
+   */
+  private async query<T>(run: () => Promise<T>): Promise<T> {
+    try {
+      return await run();
+    } catch (err) {
+      if (err instanceof NextlyError) throw err;
+      throw NextlyError.fromDatabaseError(toDbError(this.dialect, err));
+    }
+  }
+
+  /** The columns pulled from the delivery+event join, shared by list and get. */
+  private get selection() {
+    return {
+      id: this.deliveries.id,
+      webhookId: this.deliveries.webhookId,
+      eventId: this.deliveries.eventId,
+      status: this.deliveries.status,
+      attemptCount: this.deliveries.attemptCount,
+      lastStatusCode: this.deliveries.lastStatusCode,
+      lastLatencyMs: this.deliveries.lastLatencyMs,
+      lastError: this.deliveries.lastError,
+      lastResponseSnippet: this.deliveries.lastResponseSnippet,
+      attempts: this.deliveries.attempts,
+      nextAttemptAt: this.deliveries.nextAttemptAt,
+      createdAt: this.deliveries.createdAt,
+      updatedAt: this.deliveries.updatedAt,
+      eventType: this.events.type,
+      resourceKind: this.events.resourceKind,
+      resourceCollection: this.events.resourceCollection,
+      resourceId: this.events.resourceId,
+      eventCreatedAt: this.events.createdAt,
+    };
+  }
+
+  /** WHERE fragments shared by the list page query and its count. */
+  private listConditions(webhookId: string, opts: ListDeliveriesOptions) {
+    const conditions = [eq(this.deliveries.webhookId, webhookId)];
+    if (opts.status) {
+      conditions.push(eq(this.deliveries.status, opts.status));
+    }
+    if (opts.eventType) {
+      conditions.push(eq(this.events.type, opts.eventType));
+    }
+    return and(...conditions);
+  }
+
+  /**
+   * A page of an endpoint's deliveries, newest first, plus the total for paging.
+   *
+   * Scoped by `webhookId` alone: deliveries outlive their endpoint (a retired
+   * endpoint keeps its history), so this deliberately does not require the
+   * endpoint to still be live.
+   */
+  async listDeliveries(
+    webhookId: string,
+    opts: ListDeliveriesOptions
+  ): Promise<{ items: WebhookDeliverySummary[]; total: number }> {
+    const where = this.listConditions(webhookId, opts);
+    const offset = (opts.page - 1) * opts.limit;
+
+    const { rows, total } = await this.query(async () => {
+      const countRows = (await this.db
+        .select({ value: count() })
+        .from(this.deliveries)
+        .innerJoin(this.events, eq(this.deliveries.eventId, this.events.id))
+        .where(where)) as Array<{ value: number | string | bigint }>;
+
+      const pageRows = (await this.db
+        .select(this.selection)
+        .from(this.deliveries)
+        .innerJoin(this.events, eq(this.deliveries.eventId, this.events.id))
+        .where(where)
+        .orderBy(desc(this.deliveries.createdAt))
+        .limit(opts.limit)
+        .offset(offset)) as DeliveryJoinRow[];
+
+      // count() returns string/bigint on some drivers; coerce to a number.
+      return { rows: pageRows, total: Number(countRows[0]?.value ?? 0) };
+    });
+
+    return { items: rows.map(row => this.toSummary(row)), total };
+  }
+
+  /**
+   * One delivery with its attempt history, or null when no delivery with this
+   * id belongs to this endpoint.
+   */
+  async getDelivery(
+    webhookId: string,
+    deliveryId: string
+  ): Promise<WebhookDeliveryDetail | null> {
+    const rows = await this.query(
+      async () =>
+        (await this.db
+          .select(this.selection)
+          .from(this.deliveries)
+          .innerJoin(this.events, eq(this.deliveries.eventId, this.events.id))
+          .where(
+            and(
+              eq(this.deliveries.id, deliveryId),
+              eq(this.deliveries.webhookId, webhookId)
+            )
+          )
+          .limit(1)) as DeliveryJoinRow[]
+    );
+    return rows[0] ? this.toDetail(rows[0]) : null;
+  }
+
+  /** Map a joined row to the list summary, normalizing timestamps to ISO-UTC. */
+  private toSummary(row: DeliveryJoinRow): WebhookDeliverySummary {
+    return {
+      id: row.id,
+      webhookId: row.webhookId,
+      eventId: row.eventId,
+      eventType: row.eventType,
+      resource: {
+        kind: row.resourceKind,
+        collection: row.resourceCollection,
+        id: row.resourceId,
+      },
+      status: row.status as WebhookDeliveryStatus,
+      attemptCount: row.attemptCount,
+      lastStatusCode: row.lastStatusCode,
+      lastLatencyMs: row.lastLatencyMs,
+      lastError: row.lastError,
+      nextAttemptAt: this.normalizeDbTimestamp(row.nextAttemptAt),
+      eventCreatedAt: this.normalizeDbTimestamp(row.eventCreatedAt),
+      createdAt: this.normalizeDbTimestamp(row.createdAt),
+      updatedAt: this.normalizeDbTimestamp(row.updatedAt),
+    };
+  }
+
+  /** Map a joined row to the detail shape, including the attempt log. */
+  private toDetail(row: DeliveryJoinRow): WebhookDeliveryDetail {
+    return {
+      ...this.toSummary(row),
+      attempts: this.normalizeAttempts(row.attempts),
+      lastResponseSnippet: row.lastResponseSnippet,
+    };
+  }
+
+  /**
+   * Coerce the stored attempt log to the public shape. A malformed or missing
+   * value (a legacy or manual write) reads as an empty history rather than
+   * throwing, so one bad row cannot break the whole log view.
+   */
+  private normalizeAttempts(value: unknown): WebhookDeliveryAttempt[] {
+    if (!Array.isArray(value)) return [];
+    return value.flatMap(entry => {
+      if (!entry || typeof entry !== "object") return [];
+      const e = entry as Record<string, unknown>;
+      if (typeof e.at !== "string" || typeof e.outcome !== "string") return [];
+      const attempt: WebhookDeliveryAttempt = { at: e.at, outcome: e.outcome };
+      if (typeof e.statusCode === "number") attempt.statusCode = e.statusCode;
+      if (typeof e.latencyMs === "number") attempt.latencyMs = e.latencyMs;
+      if (typeof e.error === "string") attempt.error = e.error;
+      return [attempt];
+    });
+  }
+}

--- a/packages/nextly/src/route-handler/__tests__/route-parser.webhooks.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.webhooks.test.ts
@@ -97,26 +97,34 @@ describe("webhook routes", () => {
   });
 
   it("parses the delivery list", () => {
+    // The list operation drives the paginated `respondList` dispatch, so pin
+    // `operation` alongside the method and the endpoint-scoping param.
     expect(
       parseRestRoute(["webhooks", "wh_1", "deliveries"], "GET")
     ).toMatchObject({
       service: "webhooks",
+      operation: "list",
       method: "listWebhookDeliveries",
       routeParams: { webhookId: "wh_1" },
     });
   });
 
   it("parses a single delivery", () => {
+    // The two-segment case carries both ids; `operation: single` routes it to
+    // the document (`respondDoc`) dispatch rather than the list.
     expect(
       parseRestRoute(["webhooks", "wh_1", "deliveries", "del_1"], "GET")
     ).toMatchObject({
       service: "webhooks",
+      operation: "single",
       method: "getWebhookDelivery",
       routeParams: { webhookId: "wh_1", deliveryId: "del_1" },
     });
   });
 
   it("does not route a write to a delivery path", () => {
+    // Deliveries are read-only over REST; the drain owns every write, so a
+    // mutating method on either delivery path must not resolve to a route.
     for (const method of ["POST", "PATCH", "DELETE"] as const) {
       expect(
         parseRestRoute(["webhooks", "wh_1", "deliveries"], method)
@@ -128,6 +136,8 @@ describe("webhook routes", () => {
   });
 
   it("does not match a path nested deeper than a single delivery", () => {
+    // A segment past the deliveryId is not a route; without the depth guard it
+    // could fall through and mis-resolve to the single-delivery handler.
     expect(
       parseRestRoute(["webhooks", "wh_1", "deliveries", "del_1", "x"], "GET")
     ).toEqual({});

--- a/packages/nextly/src/route-handler/__tests__/route-parser.webhooks.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.webhooks.test.ts
@@ -93,9 +93,44 @@ describe("webhook routes", () => {
   it("does not fall through an unknown sub-path to the endpoint itself", () => {
     // Without the sub-resource guard this would parse as GET /webhooks/wh_1
     // and serve the endpoint document.
-    expect(parseRestRoute(["webhooks", "wh_1", "deliveries"], "GET")).toEqual(
-      {}
-    );
+    expect(parseRestRoute(["webhooks", "wh_1", "unknown"], "GET")).toEqual({});
+  });
+
+  it("parses the delivery list", () => {
+    expect(
+      parseRestRoute(["webhooks", "wh_1", "deliveries"], "GET")
+    ).toMatchObject({
+      service: "webhooks",
+      method: "listWebhookDeliveries",
+      routeParams: { webhookId: "wh_1" },
+    });
+  });
+
+  it("parses a single delivery", () => {
+    expect(
+      parseRestRoute(["webhooks", "wh_1", "deliveries", "del_1"], "GET")
+    ).toMatchObject({
+      service: "webhooks",
+      method: "getWebhookDelivery",
+      routeParams: { webhookId: "wh_1", deliveryId: "del_1" },
+    });
+  });
+
+  it("does not route a write to a delivery path", () => {
+    for (const method of ["POST", "PATCH", "DELETE"] as const) {
+      expect(
+        parseRestRoute(["webhooks", "wh_1", "deliveries"], method)
+      ).toEqual({});
+      expect(
+        parseRestRoute(["webhooks", "wh_1", "deliveries", "del_1"], method)
+      ).toEqual({});
+    }
+  });
+
+  it("does not match a path nested deeper than a single delivery", () => {
+    expect(
+      parseRestRoute(["webhooks", "wh_1", "deliveries", "del_1", "x"], "GET")
+    ).toEqual({});
   });
 
   it("does not route an unsupported method on the collection", () => {

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -1741,10 +1741,42 @@ function parseWebhookRoutes(
   httpMethod: string,
   routeParams: Record<string, string>
 ): ParsedRoute | null {
-  // Nothing here nests further than one level, so any deeper path is not a
+  // GET /api/webhooks/:id/deliveries/:deliveryId → one delivery with its
+  // attempt history. Handled before the one-level depth guard below, which is
+  // the only two-segment route under an endpoint.
+  if (
+    id &&
+    subresource === "deliveries" &&
+    subId &&
+    additionalParams.length === 0
+  ) {
+    if (httpMethod !== "GET") return null;
+    routeParams.webhookId = id;
+    routeParams.deliveryId = subId;
+    return {
+      service: "webhooks",
+      operation: "single",
+      method: "getWebhookDelivery",
+      routeParams,
+    };
+  }
+
+  // Nothing else here nests further than one level, so any deeper path is not a
   // route. Without this, `/webhooks/:id/secret/anything` would still match the
   // secret branch and hand back active signing secrets.
   if (subId || additionalParams.length > 0) return null;
+
+  if (id && subresource === "deliveries") {
+    // GET /api/webhooks/:id/deliveries → the endpoint's delivery log (paged).
+    if (httpMethod !== "GET") return null;
+    routeParams.webhookId = id;
+    return {
+      service: "webhooks",
+      operation: "list",
+      method: "listWebhookDeliveries",
+      routeParams,
+    };
+  }
 
   if (id && subresource === "secret") {
     // GET /api/webhooks/:id/secret → reveal active signing secrets.

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -66,6 +66,8 @@ import {
   updateWebhook,
   deleteWebhook,
   revealWebhookSecret,
+  listWebhookDeliveries,
+  getWebhookDelivery,
 } from "./api/webhooks";
 import { readAccessTokenCookie } from "./auth/cookies/access-token-cookie";
 import type { SanitizedNextlyConfig } from "./collections/config/define-config";
@@ -323,6 +325,10 @@ async function handleWebhookRequest(
       return deleteWebhook(req, id);
     case "revealWebhookSecret":
       return revealWebhookSecret(req, id);
+    case "listWebhookDeliveries":
+      return listWebhookDeliveries(req, id);
+    case "getWebhookDelivery":
+      return getWebhookDelivery(req, id, routeParams?.deliveryId ?? "");
     default:
       return new Response(
         JSON.stringify({ error: "Unknown webhook operation" }),

--- a/packages/nextly/src/schemas/webhooks/mysql.ts
+++ b/packages/nextly/src/schemas/webhooks/mysql.ts
@@ -130,5 +130,14 @@ export const nextlyWebhookDeliveries = mysqlTable(
     index("nextly_webhook_deliveries_event_idx").on(t.eventId),
     // Retention scans terminal rows oldest-first; see the PostgreSQL definition.
     index("nextly_webhook_deliveries_retention_idx").on(t.status, t.updatedAt),
+    // The admin delivery log lists one endpoint's deliveries newest-first,
+    // paged. This composite matches the (webhook_id, created_at DESC, id DESC)
+    // access pattern so a page reads an index range instead of sorting every
+    // row for the endpoint as its history grows.
+    index("nextly_webhook_deliveries_webhook_created_idx").on(
+      t.webhookId,
+      t.createdAt,
+      t.id
+    ),
   ]
 );

--- a/packages/nextly/src/schemas/webhooks/postgres.ts
+++ b/packages/nextly/src/schemas/webhooks/postgres.ts
@@ -173,5 +173,14 @@ export const nextlyWebhookDeliveries = pgTable(
     // Retention scans terminal rows oldest-first; without this the prune would
     // sequentially scan the fastest-growing table in the system.
     index("nextly_webhook_deliveries_retention_idx").on(t.status, t.updatedAt),
+    // The admin delivery log lists one endpoint's deliveries newest-first,
+    // paged. This composite matches the (webhook_id, created_at DESC, id DESC)
+    // access pattern so a page reads an index range instead of sorting every
+    // row for the endpoint as its history grows.
+    index("nextly_webhook_deliveries_webhook_created_idx").on(
+      t.webhookId,
+      t.createdAt,
+      t.id
+    ),
   ]
 );

--- a/packages/nextly/src/schemas/webhooks/sqlite.ts
+++ b/packages/nextly/src/schemas/webhooks/sqlite.ts
@@ -128,5 +128,14 @@ export const nextlyWebhookDeliveries = sqliteTable(
     index("nextly_webhook_deliveries_event_idx").on(t.eventId),
     // Retention scans terminal rows oldest-first; see the PostgreSQL definition.
     index("nextly_webhook_deliveries_retention_idx").on(t.status, t.updatedAt),
+    // The admin delivery log lists one endpoint's deliveries newest-first,
+    // paged. This composite matches the (webhook_id, created_at DESC, id DESC)
+    // access pattern so a page reads an index range instead of sorting every
+    // row for the endpoint as its history grows.
+    index("nextly_webhook_deliveries_webhook_created_idx").on(
+      t.webhookId,
+      t.createdAt,
+      t.id
+    ),
   ]
 );

--- a/packages/nextly/src/shared/lib/__tests__/date-formatting.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/date-formatting.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Unit tests for `dbTimestampToInstant` — the dialect-aware recovery of the
+ * correct instant from a database timestamp `Date`.
+ *
+ * The assertions are written to be timezone-independent: the naive-dialect
+ * inputs are built with the local-parts `Date` constructor (the shape a
+ * Postgres/MySQL driver produces for a `timestamp without time zone` /
+ * `datetime` column), and the SQLite input is an epoch-correct `Date`. So they
+ * pass on a UTC and a non-UTC runner alike, which is exactly the case a fixed
+ * offset would hide.
+ */
+import { describe, it, expect } from "vitest";
+
+import { dbTimestampToInstant } from "../date-formatting";
+
+describe("dbTimestampToInstant", () => {
+  it("returns a SQLite epoch Date unchanged (already the correct instant)", () => {
+    const epochCorrect = new Date("2026-07-18T12:00:00.000Z");
+    const result = dbTimestampToInstant(epochCorrect, "sqlite");
+    expect(result.toISOString()).toBe("2026-07-18T12:00:00.000Z");
+  });
+
+  it("reinterprets a naive Postgres Date's local fields as UTC", () => {
+    // What node-postgres builds for a stored naive "2026-07-18 12:00:00": a Date
+    // whose LOCAL calendar fields are those values (local-parts constructor).
+    const naiveLocal = new Date(2026, 6, 18, 12, 0, 0);
+    const result = dbTimestampToInstant(naiveLocal, "postgresql");
+    expect(result.toISOString()).toBe("2026-07-18T12:00:00.000Z");
+  });
+
+  it("reinterprets a naive MySQL Date's local fields as UTC", () => {
+    const naiveLocal = new Date(2026, 0, 2, 3, 4, 5, 6);
+    const result = dbTimestampToInstant(naiveLocal, "mysql");
+    expect(result.toISOString()).toBe("2026-01-02T03:04:05.006Z");
+  });
+
+  it("passes null through and returns null for an invalid Date", () => {
+    expect(dbTimestampToInstant(null, "postgresql")).toBeNull();
+    expect(dbTimestampToInstant(new Date("nonsense"), "mysql")).toBeNull();
+  });
+});

--- a/packages/nextly/src/shared/lib/date-formatting.ts
+++ b/packages/nextly/src/shared/lib/date-formatting.ts
@@ -1,4 +1,5 @@
 import { container } from "../../di/container";
+import type { SupportedDialect } from "../../types/database";
 
 // ============================================================================
 // Global API Date/Time Formatting Constants
@@ -204,6 +205,51 @@ export function normalizeDbTimestamp(value: unknown): string | null {
 
   // eslint-disable-next-line @typescript-eslint/no-base-to-string
   return String(value);
+}
+
+/**
+ * Recover the correct instant from a database timestamp `Date`, across dialects.
+ *
+ * SQLite stores timestamps as epoch integers, so its driver builds a `Date` that
+ * already holds the right instant — it is returned unchanged. Postgres
+ * (`timestamp without time zone`) and MySQL (`datetime`) are naive columns whose
+ * drivers construct a `Date` from the stored calendar fields in the server's
+ * local timezone; that `Date`'s UTC value is therefore shifted by the local
+ * offset. Its calendar fields are reinterpreted as UTC to recover the stored
+ * instant, so later JSON serialization emits the correct time on a non-UTC
+ * server instead of one shifted by the server's timezone.
+ *
+ * Unlike {@link normalizeDbTimestamp} (which assumes every `Date` is naive and
+ * always un-offsets), this is dialect-aware and safe for SQLite.
+ */
+export function dbTimestampToInstant(
+  value: Date,
+  dialect: SupportedDialect
+): Date;
+export function dbTimestampToInstant(
+  value: Date | null,
+  dialect: SupportedDialect
+): Date | null;
+export function dbTimestampToInstant(
+  value: Date | null,
+  dialect: SupportedDialect
+): Date | null {
+  if (value == null) return null;
+  if (Number.isNaN(value.getTime())) return null;
+  // SQLite's epoch-backed Date is already the correct instant.
+  if (dialect === "sqlite") return value;
+  // Postgres/MySQL naive Date: reinterpret its local calendar fields as UTC.
+  return new Date(
+    Date.UTC(
+      value.getFullYear(),
+      value.getMonth(),
+      value.getDate(),
+      value.getHours(),
+      value.getMinutes(),
+      value.getSeconds(),
+      value.getMilliseconds()
+    )
+  );
 }
 
 export function normalizeTimestampsInPayload(

--- a/packages/nextly/src/shared/lib/date-formatting.ts
+++ b/packages/nextly/src/shared/lib/date-formatting.ts
@@ -13,6 +13,19 @@ export const MYSQL_DATE_TIME_REGEX =
 
 export const HAS_EXPLICIT_TIMEZONE_REGEX = /(?:Z|[+-]\d{2}:\d{2})$/i;
 
+/**
+ * Response header opting a JSON body out of server-side timezone normalization.
+ *
+ * `withTimezoneFormatting` rewrites any string that looks like a date, by value,
+ * not just known timestamp fields. Set this on a response whose body carries
+ * opaque captured text that must survive verbatim — a webhook delivery's raw
+ * response snippet, for example, which is a debugging record and could itself be
+ * a bare date string. Timestamps in such a response are returned in UTC for the
+ * client to localize. The header is internal and stripped before the response
+ * leaves the formatter.
+ */
+export const SKIP_TIMEZONE_FORMAT_HEADER = "x-nextly-skip-timezone-format";
+
 // Restrict normalization to known timestamp-like keys to avoid mutating
 // user content fields that merely look like dates.
 export const TIMESTAMP_KEY_REGEX =
@@ -296,6 +309,18 @@ export async function withTimezoneFormatting(
   const contentType = response.headers.get("content-type") || "";
   if (!contentType.toLowerCase().includes("application/json")) {
     return response;
+  }
+
+  // Opt-out: a handler marked this body as carrying opaque text that must not be
+  // rewritten. Strip the internal marker and return the body verbatim.
+  if (response.headers.get(SKIP_TIMEZONE_FORMAT_HEADER) === "1") {
+    const headers = new Headers(response.headers);
+    headers.delete(SKIP_TIMEZONE_FORMAT_HEADER);
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
   }
 
   // Keep error payloads untouched to avoid accidental message mutation.

--- a/packages/nextly/src/shared/lib/date-formatting.ts
+++ b/packages/nextly/src/shared/lib/date-formatting.ts
@@ -306,13 +306,9 @@ export function normalizeTimestampsInPayload(
 export async function withTimezoneFormatting(
   response: Response
 ): Promise<Response> {
-  const contentType = response.headers.get("content-type") || "";
-  if (!contentType.toLowerCase().includes("application/json")) {
-    return response;
-  }
-
   // Opt-out: a handler marked this body as carrying opaque text that must not be
-  // rewritten. Strip the internal marker and return the body verbatim.
+  // rewritten. Checked first, before any early return, so the internal marker is
+  // always stripped and never reaches the client (even on a non-JSON body).
   if (response.headers.get(SKIP_TIMEZONE_FORMAT_HEADER) === "1") {
     const headers = new Headers(response.headers);
     headers.delete(SKIP_TIMEZONE_FORMAT_HEADER);
@@ -321,6 +317,11 @@ export async function withTimezoneFormatting(
       statusText: response.statusText,
       headers,
     });
+  }
+
+  const contentType = response.headers.get("content-type") || "";
+  if (!contentType.toLowerCase().includes("application/json")) {
+    return response;
   }
 
   // Keep error payloads untouched to avoid accidental message mutation.


### PR DESCRIPTION
## What

Adds a read-only REST API for an endpoint's **webhook delivery log**, backing the admin delivery viewer (second backend slice of the webhook admin-UI program, S2c). Building the read surface first keeps the eventual UI complete.

Depends conceptually on the delivery engine that already exists; the log is populated once recording + drain are wired (a later slice), but the API and its tests stand on their own against seeded rows.

## Routes

- `GET /api/webhooks/:id/deliveries` — paged (`page`/`limit`, bounded), newest-first list of an endpoint's deliveries, joined to their event for `eventType` + `resource`, with optional `status` and `eventType` filters. Returns `{ items, meta }`.
- `GET /api/webhooks/:id/deliveries/:deliveryId` — one delivery with its full attempt history + last response snippet. Returns the bare doc; 404 when no delivery with that id belongs to the endpoint.

Both require `read-webhooks` (or `update-webhooks`).

## Design notes

- New `WebhookDeliveryQueryService` (`domains/webhooks/services/`) reads `nextly_webhook_deliveries` with a dialect-switched Drizzle join to `nextly_events` (the delivery row carries only `event_id`). Registered as a DI singleton next to the endpoint service.
- **Scoping:** deliveries are queried by endpoint id alone and stay readable after an endpoint is retired — its history is kept deliberately (matches #288). `getDelivery` refuses a delivery id that belongs to another endpoint.
- **No credential exposure:** a delivery record stores only retry state, status/latency/error, a response snippet, and a per-attempt log (`{at, outcome, statusCode, latencyMs, error}`) — never the request headers sent — so this surface cannot leak a receiver credential. (Full GitHub-style request/response-body capture would be a separate engine change.)
- Route parsing handles the two `/deliveries` paths; the two-segment `:deliveryId` case is matched **before** the existing one-level depth guard.
- Query params validated with Zod (unknown `status` → 400; `page`/`limit` coerced + bounded so one request can't read the whole ledger).

## Tests

`webhook-delivery-query-service.integration.test.ts` (SQLite, 8 cases): newest-first join + fields, status filter, eventType filter, pagination with full total, empty page for unknown endpoint, detail with attempt history, and scoping (a delivery id from another endpoint / an unknown id → null). `check-types` + lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added webhook delivery log endpoints to list deliveries (newest-first with pagination, filters by status and optional event type).
  - Added an endpoint to view a single webhook delivery with attempt history and last response details.
- **Bug Fixes**
  - Improved robustness when delivery attempt history is missing or malformed.
  - Improved timestamp interpretation consistency across supported database dialects.
- **Tests**
  - Added integration tests for listing/getting delivery logs, filtering, pagination stability, empty results, and access scoping.
  - Added/updated routing and date-formatting tests for reliable endpoint matching and dialect timestamp handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->