### PR TITLE
feat(nextly): fire due webhook deliveries via a drain trigger route

### DIFF
--- a/.changeset/webhook-drain-trigger.md
+++ b/.changeset/webhook-drain-trigger.md
@@ -22,14 +22,14 @@
 
 Fire due webhook deliveries with a drain trigger.
 
-Adds `POST /api/webhooks/drain`: one request fans out due events into deliveries
-and attempts them, so a scheduler (e.g. Vercel Cron) can drive delivery and
-retries. Until now the delivery engine had no production trigger and the event
-outbox accumulated rows nothing sent.
+Adds `/api/webhooks/drain` (GET or POST): one request fans out due events into
+deliveries and attempts them, so a scheduler (e.g. Vercel Cron, which triggers
+with a GET) can drive delivery and retries. Until now the delivery engine had no
+production trigger and the event outbox accumulated rows nothing sent.
 
-The route is authorized by a shared `NEXTLY_DRAIN_SECRET` presented as a bearer
-token (constant-time compare, matching how Vercel Cron sends `CRON_SECRET`) OR
-by an authenticated admin/API-key caller with `update-webhooks`. The endpoint
-registry is now a shared singleton, so a change made through the webhook admin
-API invalidates the same cache a running drain reads instead of waiting for a
-per-drain cache to expire.
+The route is authorized by a shared secret presented as a bearer token
+(constant-time compare) — either `NEXTLY_DRAIN_SECRET` or Vercel's `CRON_SECRET`
+— OR by an authenticated admin/API-key caller with `update-webhooks`. The
+endpoint registry is now a shared singleton, so a change made through the webhook
+admin API invalidates the same cache a running drain reads instead of waiting for
+a per-drain cache to expire.

--- a/.changeset/webhook-drain-trigger.md
+++ b/.changeset/webhook-drain-trigger.md
@@ -1,0 +1,35 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Fire due webhook deliveries with a drain trigger.
+
+Adds `POST /api/webhooks/drain`: one request fans out due events into deliveries
+and attempts them, so a scheduler (e.g. Vercel Cron) can drive delivery and
+retries. Until now the delivery engine had no production trigger and the event
+outbox accumulated rows nothing sent.
+
+The route is authorized by a shared `NEXTLY_DRAIN_SECRET` presented as a bearer
+token (constant-time compare, matching how Vercel Cron sends `CRON_SECRET`) OR
+by an authenticated admin/API-key caller with `update-webhooks`. The endpoint
+registry is now a shared singleton, so a change made through the webhook admin
+API invalidates the same cache a running drain reads instead of waiting for a
+per-drain cache to expire.

--- a/.changeset/webhook-drain-trigger.md
+++ b/.changeset/webhook-drain-trigger.md
@@ -22,10 +22,14 @@
 
 Fire due webhook deliveries with a drain trigger.
 
-Adds `/api/webhooks/drain` (GET or POST): one request fans out due events into
-deliveries and attempts them, so a scheduler (e.g. Vercel Cron, which triggers
-with a GET) can drive delivery and retries. Until now the delivery engine had no
-production trigger and the event outbox accumulated rows nothing sent.
+Adds a `webhooks/drain` route (GET or POST): one request fans out due events
+into deliveries and attempts them, so a scheduler (e.g. Vercel Cron, which
+triggers with a GET) can drive delivery and retries. Until now the delivery
+engine had no production trigger and the event outbox accumulated rows nothing
+sent. The route resolves under wherever you mount the Nextly catch-all handler;
+in the generated app templates that is `/admin/api`, so the scheduler should hit
+`/admin/api/webhooks/drain`. Each invocation does a bounded slice of work and the
+next tick continues, so it stays within a serverless execution limit.
 
 The route is authorized by a shared secret presented as a bearer token
 (constant-time compare) — either `NEXTLY_DRAIN_SECRET` or Vercel's `CRON_SECRET`

--- a/packages/nextly/src/api/webhooks.ts
+++ b/packages/nextly/src/api/webhooks.ts
@@ -162,9 +162,15 @@ function constantTimeEqual(a: string, b: string): boolean {
  * falls through to be tried as an API key by the permission check.
  */
 async function authorizeDrain(request: Request): Promise<void> {
-  const secret = env.NEXTLY_DRAIN_SECRET;
   const presented = bearerToken(request);
-  if (secret && presented && constantTimeEqual(presented, secret)) return;
+  if (presented) {
+    // A scheduler presents a shared secret as a bearer token — either Nextly's
+    // NEXTLY_DRAIN_SECRET or Vercel Cron's CRON_SECRET (what Vercel actually
+    // sends). Constant-time against each configured value.
+    for (const secret of [env.NEXTLY_DRAIN_SECRET, env.CRON_SECRET]) {
+      if (secret && constantTimeEqual(presented, secret)) return;
+    }
+  }
   const authResult = await requireWebhookPermission(request, "update");
   if (isErrorResponse(authResult)) throw toNextlyAuthError(authResult);
 }
@@ -172,14 +178,16 @@ async function authorizeDrain(request: Request): Promise<void> {
 /**
  * Run one webhook drain: fan out due events into deliveries and attempt the due
  * deliveries. Idempotent and safe to call repeatedly — a scheduler (e.g. Vercel
- * Cron) POSTs here on an interval; retries are advanced on later calls.
+ * Cron, which triggers with a GET) hits this on an interval; retries are
+ * advanced on later calls. Accepts GET or POST.
  *
- * Auth: the shared `NEXTLY_DRAIN_SECRET` (bearer, constant-time) OR an
- * authenticated admin/API-key caller with `update-webhooks`. Not session-only:
- * a scheduler has no session.
+ * Auth: a shared `NEXTLY_DRAIN_SECRET` or Vercel's `CRON_SECRET` (bearer,
+ * constant-time) OR an authenticated admin/API-key caller with
+ * `update-webhooks`. Not session-only: a scheduler has no session.
  *
- * Response: the drain summary (rounds, events processed, deliveries created,
- * attempted/delivered/retried/failed) via `respondData`.
+ * Response: the canonical mutation envelope `{ message, item }`, where `item` is
+ * the drain summary (rounds, events processed, deliveries created,
+ * attempted/delivered/retried/failed).
  */
 export const drainWebhooks = withErrorHandler(
   async (request: Request): Promise<Response> => {
@@ -194,7 +202,9 @@ export const drainWebhooks = withErrorHandler(
     );
 
     const result = await runWebhookDrain(adapter, registry);
-    return respondData({ ...result });
+    // A POST/GET trigger with fan-out + delivery side effects: return the
+    // canonical mutation envelope with the drain summary as the item.
+    return respondMutation("Webhook drain completed.", result);
   }
 );
 

--- a/packages/nextly/src/api/webhooks.ts
+++ b/packages/nextly/src/api/webhooks.ts
@@ -37,6 +37,7 @@ import { container } from "../di";
 import { offsetPaginationToMeta } from "../dispatcher/helpers/service-envelope";
 import {
   runWebhookDrain,
+  type RunWebhookDrainOptions,
   type WebhookDrainDatabase,
 } from "../domains/webhooks/drain-runner";
 import type { WebhookEndpointRegistry } from "../domains/webhooks/endpoint-registry";
@@ -142,6 +143,20 @@ function denySessionOnly(
  */
 const MIN_DRAIN_SECRET_LENGTH = 32;
 
+/**
+ * Per-invocation work bounds for the cron/manual drain trigger. A scheduler tick
+ * runs inside a platform execution limit (Vercel Cron functions default to tens
+ * of seconds), so one request must NOT try to drain an unbounded backlog: it
+ * fans out and delivers a bounded slice and returns, and the next tick continues
+ * where this one left off (the outbox is durable and claims are leased). These
+ * cap the common case; a burst of slow/dead receivers is bounded further by the
+ * delivery lease, which frees a stuck row for a later tick. The per-request
+ * timeout is deliberately left at the engine default so a legitimately slow
+ * receiver is retried, not false-failed.
+ */
+const DRAIN_MAX_ROUNDS = 10;
+const DRAIN_DELIVER_BATCH = 25;
+
 /** The bearer token on the request, or null when there is no bearer header. */
 function bearerToken(request: Request): string | null {
   const header = request.headers.get("authorization");
@@ -229,8 +244,19 @@ export const drainWebhooks = withErrorHandler(
     const registry = container.get<WebhookEndpointRegistry>(
       "webhookEndpointRegistry"
     );
+    // Retention runs after delivery so a cron-only install still prunes its
+    // event/delivery ledger; `undefined` when the operator disabled retention,
+    // in which case the drain skips pruning entirely.
+    const retention = container.get<RunWebhookDrainOptions["retention"]>(
+      "webhookRetentionDeps"
+    );
 
-    const result = await runWebhookDrain(adapter, registry);
+    const result = await runWebhookDrain(adapter, registry, {
+      // Bound the work one scheduler tick performs; the next tick continues.
+      maxRounds: DRAIN_MAX_ROUNDS,
+      deliverBatchSize: DRAIN_DELIVER_BATCH,
+      retention,
+    });
     // A POST/GET trigger with fan-out + delivery side effects: return the
     // canonical mutation envelope with the drain summary as the item.
     return respondMutation("Webhook drain completed.", result);

--- a/packages/nextly/src/api/webhooks.ts
+++ b/packages/nextly/src/api/webhooks.ts
@@ -135,6 +135,13 @@ function denySessionOnly(
   });
 }
 
+/**
+ * Minimum length for a secret that may authorize the drain trigger. Enforced at
+ * the auth boundary so a short platform-wide `CRON_SECRET` is ignored without
+ * failing app boot (see env.ts).
+ */
+const MIN_DRAIN_SECRET_LENGTH = 32;
+
 /** The bearer token on the request, or null when there is no bearer header. */
 function bearerToken(request: Request): string | null {
   const header = request.headers.get("authorization");
@@ -168,8 +175,19 @@ async function authorizeDrain(request: Request): Promise<void> {
     // NEXTLY_DRAIN_SECRET or Vercel Cron's CRON_SECRET (what Vercel actually
     // sends). Constant-time against each configured value. A bearer token is not
     // sent on a cross-site request, so this path is not CSRF-exposed.
+    //
+    // The entropy floor is enforced HERE, not only in the env schema, so a
+    // platform-wide CRON_SECRET that is too short to be a safe authorizer is
+    // ignored rather than accepted — and its length never blocks app boot for a
+    // deployment that doesn't use the drain.
     for (const secret of [env.NEXTLY_DRAIN_SECRET, env.CRON_SECRET]) {
-      if (secret && constantTimeEqual(presented, secret)) return;
+      if (
+        secret &&
+        secret.length >= MIN_DRAIN_SECRET_LENGTH &&
+        constantTimeEqual(presented, secret)
+      ) {
+        return;
+      }
     }
   }
   // GET is authorized ONLY by the shared bearer secret above. A GET can be

--- a/packages/nextly/src/api/webhooks.ts
+++ b/packages/nextly/src/api/webhooks.ts
@@ -147,15 +147,22 @@ const MIN_DRAIN_SECRET_LENGTH = 32;
  * Per-invocation work bounds for the cron/manual drain trigger. A scheduler tick
  * runs inside a platform execution limit (Vercel Cron functions default to tens
  * of seconds), so one request must NOT try to drain an unbounded backlog: it
- * fans out and delivers a bounded slice and returns, and the next tick continues
- * where this one left off (the outbox is durable and claims are leased). These
- * cap the common case; a burst of slow/dead receivers is bounded further by the
- * delivery lease, which frees a stuck row for a later tick. The per-request
- * timeout is deliberately left at the engine default so a legitimately slow
- * receiver is retried, not false-failed.
+ * does a bounded slice and returns, and the next tick continues where this one
+ * left off (the outbox is durable and claims are leased).
+ *
+ * The wall-clock budget is the real bound: the drain stops attempting new
+ * deliveries once it is spent, so even a batch of hung receivers extends the
+ * pass by at most one in-flight request rather than `batch × rounds × timeout`.
+ * The drain also uses a shorter per-request timeout than the engine default —
+ * 10s matches common webhook-receiver expectations (e.g. GitHub) — so that one
+ * in-flight overrun stays small. Together they keep a tick within roughly
+ * `budget + 10s`, comfortably inside a typical serverless window; the round and
+ * batch caps are secondary limits on a healthy, fast backlog.
  */
 const DRAIN_MAX_ROUNDS = 10;
 const DRAIN_DELIVER_BATCH = 25;
+const DRAIN_MAX_DURATION_MS = 25_000;
+const DRAIN_REQUEST_TIMEOUT_MS = 10_000;
 
 /** The bearer token on the request, or null when there is no bearer header. */
 function bearerToken(request: Request): string | null {
@@ -253,8 +260,12 @@ export const drainWebhooks = withErrorHandler(
 
     const result = await runWebhookDrain(adapter, registry, {
       // Bound the work one scheduler tick performs; the next tick continues.
+      // maxDurationMs is the hard bound (stops mid-batch when receivers hang);
+      // the shorter timeout caps the single in-flight overrun past it.
       maxRounds: DRAIN_MAX_ROUNDS,
       deliverBatchSize: DRAIN_DELIVER_BATCH,
+      maxDurationMs: DRAIN_MAX_DURATION_MS,
+      requestTimeoutMs: DRAIN_REQUEST_TIMEOUT_MS,
       retention,
     });
     // A POST/GET trigger with fan-out + delivery side effects: return the

--- a/packages/nextly/src/api/webhooks.ts
+++ b/packages/nextly/src/api/webhooks.ts
@@ -27,12 +27,19 @@
  * @module api/webhooks
  */
 
+import { createHash, timingSafeEqual } from "node:crypto";
+
 import { z } from "zod";
 
 import { isErrorResponse, requireAnyPermission } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { container } from "../di";
 import { offsetPaginationToMeta } from "../dispatcher/helpers/service-envelope";
+import {
+  runWebhookDrain,
+  type WebhookDrainDatabase,
+} from "../domains/webhooks/drain-runner";
+import type { WebhookEndpointRegistry } from "../domains/webhooks/endpoint-registry";
 import type { WebhookDeliveryQueryService } from "../domains/webhooks/services/webhook-delivery-query-service";
 import type { WebhookEndpointService } from "../domains/webhooks/services/webhook-endpoint-service";
 import { NextlyError } from "../errors/nextly-error";
@@ -42,6 +49,7 @@ import {
   UpdateWebhookSchema,
 } from "../schemas/_zod/webhooks";
 import { SKIP_TIMEZONE_FORMAT_HEADER } from "../shared/lib/date-formatting";
+import { env } from "../shared/lib/env";
 
 import { readJsonBody } from "./read-json-body";
 import {
@@ -126,6 +134,69 @@ function denySessionOnly(
     logContext: { reason: "session-only", action },
   });
 }
+
+/** The bearer token on the request, or null when there is no bearer header. */
+function bearerToken(request: Request): string | null {
+  const header = request.headers.get("authorization");
+  if (!header) return null;
+  const [scheme, token] = header.split(" ");
+  return scheme?.toLowerCase() === "bearer" && token ? token : null;
+}
+
+/**
+ * Constant-time string compare. Both sides are hashed to a fixed length first so
+ * `timingSafeEqual` never throws on a length mismatch and the comparison leaks
+ * neither the secret's length nor its content through timing.
+ */
+function constantTimeEqual(a: string, b: string): boolean {
+  const ah = createHash("sha256").update(a).digest();
+  const bh = createHash("sha256").update(b).digest();
+  return timingSafeEqual(ah, bh);
+}
+
+/**
+ * Authorize a drain trigger. The cron path matches the shared drain secret
+ * presented as a bearer token (Vercel Cron sends `Authorization: Bearer
+ * <CRON_SECRET>`); constant-time so it leaks nothing. Anything else must be an
+ * authenticated caller able to manage webhooks — a non-matching bearer simply
+ * falls through to be tried as an API key by the permission check.
+ */
+async function authorizeDrain(request: Request): Promise<void> {
+  const secret = env.NEXTLY_DRAIN_SECRET;
+  const presented = bearerToken(request);
+  if (secret && presented && constantTimeEqual(presented, secret)) return;
+  const authResult = await requireWebhookPermission(request, "update");
+  if (isErrorResponse(authResult)) throw toNextlyAuthError(authResult);
+}
+
+/**
+ * Run one webhook drain: fan out due events into deliveries and attempt the due
+ * deliveries. Idempotent and safe to call repeatedly — a scheduler (e.g. Vercel
+ * Cron) POSTs here on an interval; retries are advanced on later calls.
+ *
+ * Auth: the shared `NEXTLY_DRAIN_SECRET` (bearer, constant-time) OR an
+ * authenticated admin/API-key caller with `update-webhooks`. Not session-only:
+ * a scheduler has no session.
+ *
+ * Response: the drain summary (rounds, events processed, deliveries created,
+ * attempted/delivered/retried/failed) via `respondData`.
+ */
+export const drainWebhooks = withErrorHandler(
+  async (request: Request): Promise<Response> => {
+    await authorizeDrain(request);
+
+    await getCachedNextly();
+    // The runtime adapter satisfies the fan-out + delivery database surfaces;
+    // resolve it as exactly that from the container.
+    const adapter = container.get<WebhookDrainDatabase>("adapter");
+    const registry = container.get<WebhookEndpointRegistry>(
+      "webhookEndpointRegistry"
+    );
+
+    const result = await runWebhookDrain(adapter, registry);
+    return respondData({ ...result });
+  }
+);
 
 /**
  * List every registered webhook endpoint.

--- a/packages/nextly/src/api/webhooks.ts
+++ b/packages/nextly/src/api/webhooks.ts
@@ -166,10 +166,21 @@ async function authorizeDrain(request: Request): Promise<void> {
   if (presented) {
     // A scheduler presents a shared secret as a bearer token — either Nextly's
     // NEXTLY_DRAIN_SECRET or Vercel Cron's CRON_SECRET (what Vercel actually
-    // sends). Constant-time against each configured value.
+    // sends). Constant-time against each configured value. A bearer token is not
+    // sent on a cross-site request, so this path is not CSRF-exposed.
     for (const secret of [env.NEXTLY_DRAIN_SECRET, env.CRON_SECRET]) {
       if (secret && constantTimeEqual(presented, secret)) return;
     }
+  }
+  // GET is authorized ONLY by the shared bearer secret above. A GET can be
+  // driven by a cross-site top-level navigation, which carries the victim's
+  // `SameSite=Lax` session cookie, so falling through to the session/API-key
+  // path here would be a CSRF trigger. The session/API-key path (a manual admin
+  // drain) is therefore POST-only, where CSRF protection applies.
+  if (request.method.toUpperCase() === "GET") {
+    throw NextlyError.forbidden({
+      logContext: { reason: "drain-get-requires-secret" },
+    });
   }
   const authResult = await requireWebhookPermission(request, "update");
   if (isErrorResponse(authResult)) throw toNextlyAuthError(authResult);

--- a/packages/nextly/src/api/webhooks.ts
+++ b/packages/nextly/src/api/webhooks.ts
@@ -31,6 +31,7 @@ import { createHash, timingSafeEqual } from "node:crypto";
 
 import { z } from "zod";
 
+import { validateOrigin } from "../auth/csrf/validate";
 import { isErrorResponse, requireAnyPermission } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { container } from "../di";
@@ -161,6 +162,11 @@ const MIN_DRAIN_SECRET_LENGTH = 32;
  */
 const DRAIN_MAX_ROUNDS = 10;
 const DRAIN_DELIVER_BATCH = 25;
+// Bound fan-out too, not just delivery: at the engine default (100) ten rounds
+// could fan out 1,000 events into 1,000 × endpoints delivery rows in one tick —
+// database work the delivery deadline does not cover. Keep it near the delivery
+// batch so a tick creates roughly what it can attempt; the rest waits.
+const DRAIN_FANOUT_BATCH = 50;
 const DRAIN_MAX_DURATION_MS = 25_000;
 const DRAIN_REQUEST_TIMEOUT_MS = 10_000;
 
@@ -216,7 +222,9 @@ async function authorizeDrain(request: Request): Promise<void> {
   // driven by a cross-site top-level navigation, which carries the victim's
   // `SameSite=Lax` session cookie, so falling through to the session/API-key
   // path here would be a CSRF trigger. The session/API-key path (a manual admin
-  // drain) is therefore POST-only, where CSRF protection applies.
+  // drain) is therefore POST-only: a `SameSite=Lax` cookie is not sent on a
+  // cross-site POST, the same baseline the rest of the session-authenticated
+  // REST API relies on.
   if (request.method.toUpperCase() === "GET") {
     throw NextlyError.forbidden({
       logContext: { reason: "drain-get-requires-secret" },
@@ -224,6 +232,18 @@ async function authorizeDrain(request: Request): Promise<void> {
   }
   const authResult = await requireWebhookPermission(request, "update");
   if (isErrorResponse(authResult)) throw toNextlyAuthError(authResult);
+  // Defense in depth for the cookie path: on top of `SameSite=Lax`, require a
+  // same-origin `Origin`/`Referer` so a same-site or misconfigured browser
+  // context cannot forge this side-effecting trigger. API-key auth carries no
+  // ambient cookie and sends no browser Origin, so it is exempt.
+  if (
+    authResult.authMethod !== "api-key" &&
+    !validateOrigin(request, env.NEXTLY_ALLOWED_ORIGINS_PARSED)
+  ) {
+    throw NextlyError.forbidden({
+      logContext: { reason: "drain-origin-mismatch" },
+    });
+  }
 }
 
 /**
@@ -263,6 +283,7 @@ export const drainWebhooks = withErrorHandler(
       // maxDurationMs is the hard bound (stops mid-batch when receivers hang);
       // the shorter timeout caps the single in-flight overrun past it.
       maxRounds: DRAIN_MAX_ROUNDS,
+      fanOutBatchSize: DRAIN_FANOUT_BATCH,
       deliverBatchSize: DRAIN_DELIVER_BATCH,
       maxDurationMs: DRAIN_MAX_DURATION_MS,
       requestTimeoutMs: DRAIN_REQUEST_TIMEOUT_MS,

--- a/packages/nextly/src/di/registrations/register-webhooks.ts
+++ b/packages/nextly/src/di/registrations/register-webhooks.ts
@@ -12,10 +12,12 @@
  * expired.
  */
 
+import type { RunWebhookDrainOptions } from "../../domains/webhooks/drain-runner";
 import {
   WebhookEndpointRegistry,
   type WebhookEndpointReader,
 } from "../../domains/webhooks/endpoint-registry";
+import { MetaRetentionGate } from "../../domains/webhooks/retention-gate";
 import { WebhookDeliveryQueryService } from "../../domains/webhooks/services/webhook-delivery-query-service";
 import { WebhookEndpointService } from "../../domains/webhooks/services/webhook-endpoint-service";
 import { container } from "../container";
@@ -60,5 +62,24 @@ export function registerWebhookServices(ctx: RegistrationContext): void {
   container.registerSingleton<WebhookDeliveryQueryService>(
     "webhookDeliveryQueryService",
     () => new WebhookDeliveryQueryService(adapter, logger)
+  );
+
+  // Retention deps the drain route runs after delivery. Content writes already
+  // offer a retention pass (register-collections.ts), but an install driven only
+  // by the cron drain never writes on that path, so the drain must be able to
+  // prune too. The gate is DB-backed, so this instance and the content-write
+  // runner's coordinate through the same persisted claim — the interval holds
+  // whichever fires first, and the other's pass is a no-op. `undefined` when the
+  // operator switched retention off (or no app config was supplied).
+  container.registerSingleton<RunWebhookDrainOptions["retention"]>(
+    "webhookRetentionDeps",
+    () =>
+      ctx.config.webhookRetention
+        ? {
+            policy: ctx.config.webhookRetention,
+            prune: { adapter, logger },
+            gate: new MetaRetentionGate(adapter),
+          }
+        : undefined
   );
 }

--- a/packages/nextly/src/di/registrations/register-webhooks.ts
+++ b/packages/nextly/src/di/registrations/register-webhooks.ts
@@ -1,29 +1,59 @@
 /**
  * Webhook DI registrations.
  *
- * Registers the endpoint management service that the REST surface resolves.
- * Delivery, fan-out and retention are assembled elsewhere: retention travels
- * with the services that write events (`register-collections.ts`), because a
- * write is what makes retention due.
+ * Registers the shared endpoint registry and the endpoint management service the
+ * REST surface resolves. Delivery, fan-out and retention are assembled by the
+ * drain orchestrator; retention policy travels with the services that write
+ * events (`register-collections.ts`), because a write is what makes it due.
  *
- * The service takes an optional endpoint registry, which is not passed here.
- * The registry is constructed per drain today, so there is no shared instance
- * to invalidate; once one exists it belongs here, or a change made through the
- * REST surface will not be seen by a running drain until its cache expires.
+ * The registry is a shared singleton so a CRUD change through the REST surface
+ * invalidates the same cache a running drain reads: without it, a per-drain
+ * registry could keep delivering to a disabled endpoint until its own cache
+ * expired.
  */
 
+import {
+  WebhookEndpointRegistry,
+  type WebhookEndpointReader,
+} from "../../domains/webhooks/endpoint-registry";
 import { WebhookDeliveryQueryService } from "../../domains/webhooks/services/webhook-delivery-query-service";
 import { WebhookEndpointService } from "../../domains/webhooks/services/webhook-endpoint-service";
 import { container } from "../container";
 
 import type { RegistrationContext } from "./types";
 
+/**
+ * How long the shared endpoint cache may serve data changed in OTHER processes
+ * before reloading. This instance's own CRUD calls invalidate synchronously; the
+ * TTL only bounds cross-process staleness, so a short value is enough without
+ * reloading on every drain pass.
+ */
+const ENDPOINT_REGISTRY_TTL_MS = 30_000;
+
 export function registerWebhookServices(ctx: RegistrationContext): void {
   const { adapter, logger } = ctx;
 
+  container.registerSingleton<WebhookEndpointRegistry>(
+    "webhookEndpointRegistry",
+    () =>
+      new WebhookEndpointRegistry(
+        // The adapter satisfies the registry's minimal reader surface; resolve
+        // it as exactly that from the container.
+        container.get<WebhookEndpointReader>("adapter"),
+        { ttlMs: ENDPOINT_REGISTRY_TTL_MS }
+      )
+  );
+
   container.registerSingleton<WebhookEndpointService>(
     "webhookEndpointService",
-    () => new WebhookEndpointService(adapter, logger)
+    () =>
+      new WebhookEndpointService(
+        adapter,
+        logger,
+        // Share the one registry singleton so every CRUD mutation invalidates
+        // the cache the drain reads.
+        container.get<WebhookEndpointRegistry>("webhookEndpointRegistry")
+      )
   );
 
   // Read-only surface for the admin delivery log; the drain owns every write.

--- a/packages/nextly/src/domains/webhooks/__tests__/drain-runner.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/drain-runner.integration.test.ts
@@ -173,6 +173,27 @@ describe("runWebhookDrain (real SQLite)", () => {
     expect(calls).toHaveLength(3);
   });
 
+  it("caps events fanned out per round to the fan-out batch", async () => {
+    // Fan-out is bounded too, so one cron tick doesn't turn a huge outbox into
+    // an unbounded burst of delivery-row inserts. Three due events, a fan-out
+    // batch of two, one round: only two are fanned out and the third waits.
+    await seedWebhook("wh1");
+    await seedEvent("evt_1");
+    await seedEvent("evt_2");
+    await seedEvent("evt_3");
+    const { transport } = makeTransport(200);
+
+    const result = await runWebhookDrain(adapter, registryOf(), {
+      transport,
+      now: () => NOW,
+      decryptSecret: ct => ct,
+      maxRounds: 1,
+      fanOutBatchSize: 2,
+    });
+
+    expect(result.deliveriesCreated).toBe(2);
+  });
+
   it("stops attempting new deliveries once the wall-clock budget is spent", async () => {
     // The real bound for a serverless cron tick: with slow receivers the pass
     // must stop mid-batch on a deadline, not run every claimed row to its

--- a/packages/nextly/src/domains/webhooks/__tests__/drain-runner.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/drain-runner.integration.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Integration test for `runWebhookDrain` — the drain wiring that assembles the
+ * fan-out + delivery deps from a live adapter and the shared endpoint registry.
+ *
+ * Proves the assembled drain fans a seeded event out into a delivery and fires
+ * it through the transport (i.e. `loadEndpoints` reads the registry and the
+ * secret is decrypted), and that with no endpoints it is a no-op. Uses an
+ * in-memory SQLite database built from the production table definitions.
+ */
+
+import { createSqliteAdapter } from "@nextlyhq/adapter-sqlite";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { getSQLiteDrizzleKit } from "../../../database/drizzle-kit-lazy";
+import { SchemaRegistry } from "../../../database/schema-registry";
+import { users } from "../../../schemas/users/sqlite";
+import {
+  nextlyEvents,
+  nextlyWebhooks,
+  nextlyWebhookDeliveries,
+} from "../../../schemas/webhooks/sqlite";
+import { splitStatements } from "../../schema/pipeline/sql-statement-utils";
+import type { DeliverTransport } from "../deliver";
+import { WebhookEndpointRegistry } from "../endpoint-registry";
+import { buildEnvelope } from "../envelope";
+import { recordEvent } from "../record-event";
+import { runWebhookDrain } from "../drain-runner";
+
+process.env.DB_DIALECT = "sqlite";
+
+const NOW = new Date("2026-07-19T12:00:00.000Z");
+// A Standard Webhooks secret shape; stored verbatim here because the test
+// injects an identity `decryptSecret`, so no NEXTLY_SECRET is needed.
+const SECRET = `whsec_${Buffer.from("secretkey").toString("base64")}`;
+
+const tables = { nextlyEvents, nextlyWebhooks, nextlyWebhookDeliveries };
+const ddlTables = { ...tables, users };
+
+async function schemaDdl(): Promise<string[]> {
+  const kit = await getSQLiteDrizzleKit();
+  const statements = await kit.generateMigration(
+    await kit.generateDrizzleJson({}),
+    await kit.generateDrizzleJson(ddlTables)
+  );
+  return splitStatements(statements);
+}
+
+function makeTransport(status: number): {
+  transport: DeliverTransport;
+  calls: Array<{ url: string }>;
+} {
+  const calls: Array<{ url: string }> = [];
+  const transport: DeliverTransport = async url => {
+    calls.push({ url });
+    return new Response("ok", { status });
+  };
+  return { transport, calls };
+}
+
+describe("runWebhookDrain (real SQLite)", () => {
+  let adapter: ReturnType<typeof createSqliteAdapter>;
+
+  beforeAll(async () => {
+    adapter = createSqliteAdapter({ memory: true });
+    await adapter.connect();
+    for (const stmt of await schemaDdl()) await adapter.executeQuery(stmt);
+
+    const schemaRegistry = new SchemaRegistry("sqlite");
+    schemaRegistry.registerStaticSchemas(tables);
+    adapter.setTableResolver(schemaRegistry);
+  });
+
+  afterAll(async () => {
+    try {
+      await adapter?.disconnect?.();
+    } catch {
+      // ignore teardown errors
+    }
+  });
+
+  beforeEach(async () => {
+    await adapter.executeQuery("DELETE FROM nextly_webhook_deliveries");
+    await adapter.executeQuery("DELETE FROM nextly_webhooks");
+    await adapter.executeQuery("DELETE FROM nextly_events");
+  });
+
+  async function seedWebhook(id: string): Promise<void> {
+    await adapter.insert("nextly_webhooks", {
+      id,
+      name: id,
+      url: `https://example.com/${id}`,
+      enabled: true,
+      event_types: ["entry.updated"],
+      filter: null,
+      headers: null,
+      secret_hash: [SECRET],
+      secret_prefix: "whsec_",
+      field_allowlist: null,
+      created_by: null,
+      // Before the event time so the pre-subscription cutoff admits it.
+      created_at: new Date("2020-01-01T00:00:00.000Z"),
+      updated_at: NOW,
+    });
+  }
+
+  async function seedEvent(id: string): Promise<void> {
+    const envelope = buildEnvelope({
+      id,
+      type: "entry.updated",
+      timestamp: new Date("2026-07-18T00:00:00.000Z"),
+      resource: { kind: "entry", collection: "posts", id: "p1" },
+      data: { id: "p1", title: "Hello" },
+    });
+    await adapter.transaction(async tx => recordEvent(tx, { envelope }));
+  }
+
+  function registryOf(): WebhookEndpointRegistry {
+    return new WebhookEndpointRegistry(adapter);
+  }
+
+  it("fans out a seeded event and delivers it", async () => {
+    await seedWebhook("wh1");
+    await seedEvent("evt_a");
+    const { transport, calls } = makeTransport(200);
+
+    const result = await runWebhookDrain(adapter, registryOf(), {
+      transport,
+      now: () => NOW,
+      decryptSecret: ct => ct,
+    });
+
+    expect(result.deliveriesCreated).toBe(1);
+    expect(result.delivered).toBe(1);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://example.com/wh1");
+  });
+
+  it("is a no-op when there are no endpoints", async () => {
+    await seedEvent("evt_b");
+    const { transport, calls } = makeTransport(200);
+
+    const result = await runWebhookDrain(adapter, registryOf(), {
+      transport,
+      now: () => NOW,
+      decryptSecret: ct => ct,
+    });
+
+    // The event is marked fanned out, but with no subscriber no delivery is
+    // created and nothing is sent.
+    expect(result.deliveriesCreated).toBe(0);
+    expect(result.delivered).toBe(0);
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/drain-runner.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/drain-runner.integration.test.ts
@@ -173,6 +173,39 @@ describe("runWebhookDrain (real SQLite)", () => {
     expect(calls).toHaveLength(3);
   });
 
+  it("stops attempting new deliveries once the wall-clock budget is spent", async () => {
+    // The real bound for a serverless cron tick: with slow receivers the pass
+    // must stop mid-batch on a deadline, not run every claimed row to its
+    // timeout. A clock that only advances when the transport is called (each
+    // "receiver" eats 20s) plus a 25s budget means the second attempt pushes the
+    // clock past the deadline, so the third is never attempted.
+    await seedWebhook("wh1");
+    await seedEvent("evt_1");
+    await seedEvent("evt_2");
+    await seedEvent("evt_3");
+
+    let ms = NOW.getTime();
+    const clock = () => new Date(ms);
+    const calls: string[] = [];
+    const transport: DeliverTransport = async url => {
+      calls.push(url);
+      ms += 20_000;
+      return new Response("ok", { status: 200 });
+    };
+
+    const result = await runWebhookDrain(adapter, registryOf(), {
+      transport,
+      now: clock,
+      decryptSecret: ct => ct,
+      maxDurationMs: 25_000,
+    });
+
+    // All three fanned out, but only two were attempted before the deadline.
+    expect(result.deliveriesCreated).toBe(3);
+    expect(result.attempted).toBe(2);
+    expect(calls).toHaveLength(2);
+  });
+
   it("runs the retention pass when a policy is supplied", async () => {
     // The cron trigger is the only prune trigger a write-quiescent install has,
     // so a supplied retention policy must reach the gate. A stub gate that

--- a/packages/nextly/src/domains/webhooks/__tests__/drain-runner.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/drain-runner.integration.test.ts
@@ -24,6 +24,8 @@ import type { DeliverTransport } from "../deliver";
 import { WebhookEndpointRegistry } from "../endpoint-registry";
 import { buildEnvelope } from "../envelope";
 import { recordEvent } from "../record-event";
+import type { ResolvedWebhookRetentionConfig } from "../retention-config";
+import type { RetentionGateStore } from "../retention-gate";
 import { runWebhookDrain } from "../drain-runner";
 
 process.env.DB_DIALECT = "sqlite";
@@ -133,6 +135,95 @@ describe("runWebhookDrain (real SQLite)", () => {
     expect(result.delivered).toBe(1);
     expect(calls).toHaveLength(1);
     expect(calls[0].url).toBe("https://example.com/wh1");
+  });
+
+  it("bounds one invocation to the batch and resumes on the next", async () => {
+    // A latency-bounded trigger (a cron tick) caps its work so a single request
+    // stays within its platform limit; the durable outbox lets the next tick
+    // finish the rest. Three due deliveries, a batch of two and a single round:
+    // exactly two are attempted now and the third waits.
+    await seedWebhook("wh1");
+    await seedEvent("evt_1");
+    await seedEvent("evt_2");
+    await seedEvent("evt_3");
+    const { transport, calls } = makeTransport(200);
+
+    const first = await runWebhookDrain(adapter, registryOf(), {
+      transport,
+      now: () => NOW,
+      decryptSecret: ct => ct,
+      maxRounds: 1,
+      deliverBatchSize: 2,
+    });
+
+    // The round fans every due event out, but delivery is capped at the batch.
+    expect(first.deliveriesCreated).toBe(3);
+    expect(first.attempted).toBe(2);
+    expect(calls).toHaveLength(2);
+
+    const second = await runWebhookDrain(adapter, registryOf(), {
+      transport,
+      now: () => NOW,
+      decryptSecret: ct => ct,
+      deliverBatchSize: 2,
+    });
+
+    // The next tick delivers the remaining one; nothing is lost or double-sent.
+    expect(second.delivered).toBe(1);
+    expect(calls).toHaveLength(3);
+  });
+
+  it("runs the retention pass when a policy is supplied", async () => {
+    // The cron trigger is the only prune trigger a write-quiescent install has,
+    // so a supplied retention policy must reach the gate. A stub gate that
+    // declines the claim isolates this to "the drain consulted retention" — the
+    // prune effect itself is covered by the prune/gate/config suites.
+    await seedWebhook("wh1");
+    await seedEvent("evt_r");
+    const { transport } = makeTransport(200);
+
+    let claims = 0;
+    const gate: RetentionGateStore = {
+      claim: async () => {
+        claims += 1;
+        return false;
+      },
+    };
+    const policy: ResolvedWebhookRetentionConfig = {
+      eventsMaxAgeMs: 1,
+      auditEventsMaxAgeMs: 1,
+      deliveriesMaxAgeMs: 1,
+      batchSize: 50,
+      maxBatchesPerRun: 5,
+      intervalMs: 1000,
+    };
+
+    const result = await runWebhookDrain(adapter, registryOf(), {
+      transport,
+      now: () => NOW,
+      decryptSecret: ct => ct,
+      retention: { policy, prune: { adapter, now: () => NOW }, gate },
+    });
+
+    // The gate was consulted exactly once (after the queue quiesced); the
+    // declined claim leaves nothing pruned this call.
+    expect(claims).toBe(1);
+    expect(result.pruned).toEqual({ events: 0, deliveries: 0 });
+  });
+
+  it("skips retention when no policy is supplied", async () => {
+    // Without a policy the drain must not touch the gate at all.
+    await seedWebhook("wh1");
+    await seedEvent("evt_n");
+    const { transport } = makeTransport(200);
+
+    const result = await runWebhookDrain(adapter, registryOf(), {
+      transport,
+      now: () => NOW,
+      decryptSecret: ct => ct,
+    });
+
+    expect(result.pruned).toEqual({ events: 0, deliveries: 0 });
   });
 
   it("is a no-op when there are no endpoints", async () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/endpoint-registry.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/endpoint-registry.test.ts
@@ -125,6 +125,26 @@ describe("WebhookEndpointRegistry", () => {
     expect((await stale).map(e => e.id)).toEqual(["v2"]);
   });
 
+  it("getEnabledEndpointsFresh bypasses a warm cache and reloads", async () => {
+    const reader = new FakeReader();
+    const registry = new WebhookEndpointRegistry(reader, { ttlMs: 60_000 });
+
+    const first = registry.getEnabledEndpoints();
+    reader.resolveNext([row("v1")]);
+    expect((await first).map(e => e.id)).toEqual(["v1"]);
+
+    // A warm cache within the TTL serves v1 again with no query.
+    await registry.getEnabledEndpoints();
+    expect(reader.calls).toBe(1);
+
+    // The fresh read reloads regardless, so fan-out sees a subscriber another
+    // process created before the TTL would have expired.
+    const fresh = registry.getEnabledEndpointsFresh();
+    expect(reader.calls).toBe(2);
+    reader.resolveNext([row("v1"), row("v2")]);
+    expect((await fresh).map(e => e.id)).toEqual(["v1", "v2"]);
+  });
+
   it("does not let a load that finishes after invalidate() repopulate the cache", async () => {
     const reader = new FakeReader();
     const registry = new WebhookEndpointRegistry(reader);

--- a/packages/nextly/src/domains/webhooks/deliver.ts
+++ b/packages/nextly/src/domains/webhooks/deliver.ts
@@ -143,6 +143,15 @@ export interface DeliverDeps {
   leaseMs?: number;
   /** Per-request timeout in ms. Defaults to 15s. */
   requestTimeoutMs?: number;
+  /**
+   * Wall-clock cutoff for this pass. Once reached, no further due delivery is
+   * claimed or attempted; an already in-flight attempt still completes (bounded
+   * by `requestTimeoutMs`). Lets a latency-bounded trigger — a serverless cron
+   * tick — stop cleanly instead of running a full batch of hung receivers to
+   * completion; the leftover rows are picked up on the next pass. Unbounded when
+   * unset.
+   */
+  deadline?: Date;
   /** Clock; injectable for deterministic tests. */
   now?: () => Date;
   /** Unique id for this drain runner, recorded as the lease owner. */
@@ -608,6 +617,11 @@ export async function deliverDueDeliveries(
   );
 
   for (const candidate of candidates) {
+    // Stop before claiming the next row once the wall-clock budget is spent, so
+    // a hung/slow receiver can extend this pass by at most one in-flight request
+    // rather than the whole batch. No row is left claimed-but-unattempted: the
+    // claim and attempt happen together below.
+    if (deps.deadline && now() >= deps.deadline) break;
     const claimedAt = now();
     const row = await claimDelivery(
       deps,

--- a/packages/nextly/src/domains/webhooks/drain-runner.ts
+++ b/packages/nextly/src/domains/webhooks/drain-runner.ts
@@ -27,10 +27,14 @@ import { decryptWebhookSecret } from "./secret";
  */
 export type WebhookDrainDatabase = FanOutDatabase & DeliverDatabase;
 
-/** The registry surface a drain reads: the enabled endpoints for this pass. */
+/**
+ * The registry surface a drain reads. Fan-out uses the FRESH read so a new
+ * subscriber committed by another process is never missed (a fanned-out event is
+ * never reconsidered).
+ */
 export type WebhookDrainRegistry = Pick<
   WebhookEndpointRegistry,
-  "getEnabledEndpoints"
+  "getEnabledEndpointsFresh"
 >;
 
 export interface RunWebhookDrainOptions {
@@ -87,9 +91,10 @@ export function runWebhookDrain(
   return runDrain({
     fanOut: {
       db: adapter,
-      // Reuse the shared registry so a CRUD change is reflected on the next
-      // pass rather than the next cache expiry.
-      loadEndpoints: () => registry.getEnabledEndpoints(),
+      // Read endpoints fresh each pass: fan-out commits an event as done
+      // permanently, so it must see an endpoint another process just created
+      // rather than a cached list that could drop the new subscriber for good.
+      loadEndpoints: () => registry.getEnabledEndpointsFresh(),
       now: options?.now,
       batchSize: options?.fanOutBatchSize,
     },

--- a/packages/nextly/src/domains/webhooks/drain-runner.ts
+++ b/packages/nextly/src/domains/webhooks/drain-runner.ts
@@ -47,11 +47,23 @@ export interface RunWebhookDrainOptions {
    */
   fanOutBatchSize?: number;
   /**
-   * Deliveries attempted per round. Attempts run sequentially with a per-request
-   * timeout, so this is the main lever a cron trigger uses to keep a single tick
-   * within its platform's execution limit; unclaimed rows wait for the next tick.
+   * Deliveries attempted per round before the next fan-out round. Unclaimed rows
+   * wait for the next tick.
    */
   deliverBatchSize?: number;
+  /**
+   * Wall-clock budget for the whole drain. The hard bound a latency-bounded
+   * trigger relies on: the drain returns within about this plus one in-flight
+   * request timeout even when receivers hang, so a serverless cron tick finishes
+   * before its platform kills it and the next tick continues.
+   */
+  maxDurationMs?: number;
+  /**
+   * Per-request delivery timeout. A cron trigger passes a shorter value than the
+   * engine default so a single hung receiver cannot stretch the pass past the
+   * budget by much.
+   */
+  requestTimeoutMs?: number;
   /** Retention housekeeping, when the caller has a policy + gate to run it. */
   retention?: RunDrainDeps["retention"];
   /**
@@ -87,8 +99,10 @@ export function runWebhookDrain(
       transport: options?.transport,
       now: options?.now,
       batchSize: options?.deliverBatchSize,
+      requestTimeoutMs: options?.requestTimeoutMs,
     },
     maxRounds: options?.maxRounds,
+    maxDurationMs: options?.maxDurationMs,
     retention: options?.retention,
   });
 }

--- a/packages/nextly/src/domains/webhooks/drain-runner.ts
+++ b/packages/nextly/src/domains/webhooks/drain-runner.ts
@@ -40,6 +40,18 @@ export interface RunWebhookDrainOptions {
   now?: () => Date;
   /** Max fan-out/deliver rounds before returning. */
   maxRounds?: number;
+  /**
+   * Events fanned out per round. Lowering it (with `maxRounds`) is how a
+   * latency-bounded trigger — a serverless cron tick — caps the work one
+   * invocation does; the outbox is durable, so the next tick continues.
+   */
+  fanOutBatchSize?: number;
+  /**
+   * Deliveries attempted per round. Attempts run sequentially with a per-request
+   * timeout, so this is the main lever a cron trigger uses to keep a single tick
+   * within its platform's execution limit; unclaimed rows wait for the next tick.
+   */
+  deliverBatchSize?: number;
   /** Retention housekeeping, when the caller has a policy + gate to run it. */
   retention?: RunDrainDeps["retention"];
   /**
@@ -67,12 +79,14 @@ export function runWebhookDrain(
       // pass rather than the next cache expiry.
       loadEndpoints: () => registry.getEnabledEndpoints(),
       now: options?.now,
+      batchSize: options?.fanOutBatchSize,
     },
     deliver: {
       db: adapter,
       decryptSecret: options?.decryptSecret ?? decryptWebhookSecret,
       transport: options?.transport,
       now: options?.now,
+      batchSize: options?.deliverBatchSize,
     },
     maxRounds: options?.maxRounds,
     retention: options?.retention,

--- a/packages/nextly/src/domains/webhooks/drain-runner.ts
+++ b/packages/nextly/src/domains/webhooks/drain-runner.ts
@@ -1,0 +1,80 @@
+/**
+ * Webhook domain — drain wiring.
+ *
+ * `runDrain` is pure orchestration over injected deps; this builds those deps
+ * from the runtime adapter and the shared endpoint registry and runs one drain.
+ * It is the single construction site the two triggers share — the cron/manual
+ * `/api/webhooks/drain` route and the post-response `after()` fast path — so they
+ * cannot drift in how the engine is assembled.
+ *
+ * The signing secret is decrypted via `decryptWebhookSecret`, which reads
+ * `env.NEXTLY_SECRET` itself, so no secret is threaded through here.
+ *
+ * @module domains/webhooks/drain-runner
+ */
+
+import type { DeliverDatabase, DeliverTransport } from "./deliver";
+import type { WebhookEndpointRegistry } from "./endpoint-registry";
+import type { FanOutDatabase } from "./fan-out";
+import { runDrain, type RunDrainDeps, type RunDrainResult } from "./run-drain";
+import { decryptWebhookSecret } from "./secret";
+
+/**
+ * The database surface a drain needs: the fan-out and delivery database
+ * interfaces the runtime adapter satisfies. Kept as the minimal intersection
+ * (rather than the concrete adapter type) so a caller resolves it from the DI
+ * container as exactly what the drain uses.
+ */
+export type WebhookDrainDatabase = FanOutDatabase & DeliverDatabase;
+
+/** The registry surface a drain reads: the enabled endpoints for this pass. */
+export type WebhookDrainRegistry = Pick<
+  WebhookEndpointRegistry,
+  "getEnabledEndpoints"
+>;
+
+export interface RunWebhookDrainOptions {
+  /** HTTP transport override; the engine defaults to the SSRF-safe safeFetch. */
+  transport?: DeliverTransport;
+  /** Clock override for deterministic tests. */
+  now?: () => Date;
+  /** Max fan-out/deliver rounds before returning. */
+  maxRounds?: number;
+  /** Retention housekeeping, when the caller has a policy + gate to run it. */
+  retention?: RunDrainDeps["retention"];
+  /**
+   * Signing-secret decryptor. Defaults to {@link decryptWebhookSecret}, which
+   * reads `env.NEXTLY_SECRET`; injectable so a test can drive the delivery path
+   * without a configured secret.
+   */
+  decryptSecret?: (ciphertext: string) => string;
+}
+
+/**
+ * Assemble the drain deps from the adapter + shared registry and run one drain
+ * to quiescence. Deliveries scheduled for a future retry are left for a later
+ * pass; this returns once nothing is immediately actionable.
+ */
+export function runWebhookDrain(
+  adapter: WebhookDrainDatabase,
+  registry: WebhookDrainRegistry,
+  options?: RunWebhookDrainOptions
+): Promise<RunDrainResult> {
+  return runDrain({
+    fanOut: {
+      db: adapter,
+      // Reuse the shared registry so a CRUD change is reflected on the next
+      // pass rather than the next cache expiry.
+      loadEndpoints: () => registry.getEnabledEndpoints(),
+      now: options?.now,
+    },
+    deliver: {
+      db: adapter,
+      decryptSecret: options?.decryptSecret ?? decryptWebhookSecret,
+      transport: options?.transport,
+      now: options?.now,
+    },
+    maxRounds: options?.maxRounds,
+    retention: options?.retention,
+  });
+}

--- a/packages/nextly/src/domains/webhooks/endpoint-registry.ts
+++ b/packages/nextly/src/domains/webhooks/endpoint-registry.ts
@@ -152,6 +152,20 @@ export class WebhookEndpointRegistry {
     this.generation++;
   }
 
+  /**
+   * Enabled endpoints read fresh from the database, bypassing the TTL cache.
+   *
+   * Fan-out uses this rather than {@link getEnabledEndpoints}: a fanned-out
+   * event is marked done permanently and never reconsidered, so serving a stale
+   * cross-process list — an endpoint another instance created within the TTL —
+   * would drop that new subscriber's deliveries forever. Correctness there beats
+   * saving a per-round query; delivery and other readers can still use the cache.
+   */
+  async getEnabledEndpointsFresh(): Promise<readonly WebhookEndpoint[]> {
+    this.invalidate();
+    return this.getEnabledEndpoints();
+  }
+
   private async load(): Promise<WebhookEndpoint[]> {
     const rows = await this.reader.select<Record<string, unknown>>(
       "nextly_webhooks",

--- a/packages/nextly/src/domains/webhooks/run-drain.ts
+++ b/packages/nextly/src/domains/webhooks/run-drain.ts
@@ -25,6 +25,16 @@ export interface RunDrainDeps {
   /** Max fan-out/deliver rounds before returning. Defaults to 100. */
   maxRounds?: number;
   /**
+   * Wall-clock budget for the whole drain. Once exceeded the loop stops starting
+   * new rounds AND the delivery pass stops attempting new deliveries, so a
+   * scheduler tick returns within roughly `maxDurationMs` plus one in-flight
+   * request timeout even when receivers hang — instead of `batch × rounds ×
+   * timeout`. The durable outbox + delivery lease let the next tick continue.
+   * Unbounded when unset (the default; content-write-driven callers do not need
+   * it). Measured with the delivery clock so tests stay deterministic.
+   */
+  maxDurationMs?: number;
+  /**
    * Retention, when configured. The pass runs after delivery so it only ever
    * sees rows this drain has finished with, and it is gated so a frequently
    * invoked drain does not prune on every call.
@@ -57,6 +67,14 @@ export interface RunDrainResult {
  */
 export async function runDrain(deps: RunDrainDeps): Promise<RunDrainResult> {
   const maxRounds = deps.maxRounds ?? DEFAULT_MAX_ROUNDS;
+  // The delivery clock, reused for the budget so the deadline and the delivery
+  // pass compare against the same time source (real in production, pinned in
+  // tests).
+  const now = deps.deliver.now ?? (() => new Date());
+  const deadline =
+    deps.maxDurationMs !== undefined
+      ? new Date(now().getTime() + deps.maxDurationMs)
+      : undefined;
   const result: RunDrainResult = {
     rounds: 0,
     eventsProcessed: 0,
@@ -70,7 +88,9 @@ export async function runDrain(deps: RunDrainDeps): Promise<RunDrainResult> {
 
   for (let round = 0; round < maxRounds; round += 1) {
     const fan = await fanOutDueEvents(deps.fanOut);
-    const del = await deliverDueDeliveries(deps.deliver);
+    const del = await deliverDueDeliveries(
+      deadline ? { ...deps.deliver, deadline } : deps.deliver
+    );
 
     result.rounds += 1;
     result.eventsProcessed += fan.eventsProcessed;
@@ -83,6 +103,8 @@ export async function runDrain(deps: RunDrainDeps): Promise<RunDrainResult> {
     // Nothing was fanned out and nothing was attempted this round → the queue is
     // drained of everything currently due; stop.
     if (fan.eventsProcessed === 0 && del.attempted === 0) break;
+    // Budget spent → stop before starting a new round; the next tick continues.
+    if (deadline && now() >= deadline) break;
   }
 
   // After the queue is quiet, not between rounds: pruning mid-drain would race

--- a/packages/nextly/src/route-handler/__tests__/route-parser.webhooks.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.webhooks.test.ts
@@ -143,6 +143,25 @@ describe("webhook routes", () => {
     ).toEqual({});
   });
 
+  it("parses the drain trigger on GET and POST", () => {
+    // Vercel Cron triggers with a GET; a manual/admin call may POST. Both must
+    // resolve to the drain, and with a truthy `operation` so the pre-dispatch
+    // guard (which rejects a falsy operation) lets it reach the handler.
+    for (const method of ["GET", "POST"] as const) {
+      expect(parseRestRoute(["webhooks", "drain"], method)).toMatchObject({
+        service: "webhooks",
+        operation: "single",
+        method: "drainWebhooks",
+      });
+    }
+  });
+
+  it("does not route a non-GET/POST method to the drain", () => {
+    for (const method of ["PATCH", "DELETE", "PUT"] as const) {
+      expect(parseRestRoute(["webhooks", "drain"], method)).toEqual({});
+    }
+  });
+
   it("does not route an unsupported method on the collection", () => {
     expect(parseRestRoute(["webhooks"], "DELETE")).toEqual({});
   });

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -1778,6 +1778,21 @@ function parseWebhookRoutes(
     };
   }
 
+  // POST /api/webhooks/drain → run one drain pass (cron or manual trigger).
+  // "drain" is a reserved operation path, not an endpoint id: endpoint ids are
+  // generated UUIDs and cannot collide with it, and no other route posts to an
+  // endpoint id.
+  if (id === "drain" && !subresource) {
+    if (httpMethod !== "POST") return null;
+    // No `operation`: the webhook handler dispatches on `method` and does its
+    // own authorization, and a drain is not one of the CRUD OperationTypes.
+    return {
+      service: "webhooks",
+      method: "drainWebhooks",
+      routeParams,
+    };
+  }
+
   if (id && subresource === "secret") {
     // GET /api/webhooks/:id/secret → reveal active signing secrets.
     // Its own path rather than a field on the document, so the route can

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -1778,16 +1778,21 @@ function parseWebhookRoutes(
     };
   }
 
-  // POST /api/webhooks/drain → run one drain pass (cron or manual trigger).
-  // "drain" is a reserved operation path, not an endpoint id: endpoint ids are
-  // generated UUIDs and cannot collide with it, and no other route posts to an
-  // endpoint id.
+  // GET or POST /api/webhooks/drain → run one drain pass. "drain" is a reserved
+  // operation path, not an endpoint id: endpoint ids are generated UUIDs and
+  // cannot collide with it. GET is accepted because Vercel Cron triggers with a
+  // GET; the drain is idempotent, and the route is authorized regardless of
+  // method. Matched before the generic `GET /webhooks/:id` branch so `drain` is
+  // never treated as an endpoint id.
   if (id === "drain" && !subresource) {
-    if (httpMethod !== "POST") return null;
-    // No `operation`: the webhook handler dispatches on `method` and does its
-    // own authorization, and a drain is not one of the CRUD OperationTypes.
+    if (httpMethod !== "POST" && httpMethod !== "GET") return null;
+    // A drain is not a CRUD OperationType, but the dispatch guard rejects a
+    // route with no operation before the direct-dispatch webhooks branch runs;
+    // a truthy value is required. The webhook handler dispatches on `method` and
+    // does its own authorization, so this value is otherwise unused.
     return {
       service: "webhooks",
+      operation: "single",
       method: "drainWebhooks",
       routeParams,
     };

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -68,6 +68,7 @@ import {
   revealWebhookSecret,
   listWebhookDeliveries,
   getWebhookDelivery,
+  drainWebhooks,
 } from "./api/webhooks";
 import { readAccessTokenCookie } from "./auth/cookies/access-token-cookie";
 import type { SanitizedNextlyConfig } from "./collections/config/define-config";
@@ -329,6 +330,8 @@ async function handleWebhookRequest(
       return listWebhookDeliveries(req, id);
     case "getWebhookDelivery":
       return getWebhookDelivery(req, id, routeParams?.deliveryId ?? "");
+    case "drainWebhooks":
+      return drainWebhooks(req);
     default:
       return new Response(
         JSON.stringify({ error: "Unknown webhook operation" }),

--- a/packages/nextly/src/shared/lib/env.ts
+++ b/packages/nextly/src/shared/lib/env.ts
@@ -79,7 +79,7 @@ export const _envSchema = z
       console.warn(
         "⚠️  CRON_SECRET is shorter than 32 characters and will NOT be accepted " +
           "as a webhook drain secret. Use a >= 32-char value (or NEXTLY_DRAIN_SECRET) " +
-          "if you rely on /api/webhooks/drain."
+          "if you rely on the webhooks drain route to authorize scheduled runs."
       );
     }
 

--- a/packages/nextly/src/shared/lib/env.ts
+++ b/packages/nextly/src/shared/lib/env.ts
@@ -47,6 +47,12 @@ export const _envSchema = z
     // and the empty string, which would silently disable the cron path — is
     // rejected at boot rather than accepted. Compared in constant time.
     NEXTLY_DRAIN_SECRET: z.string().min(32).optional(),
+    // Vercel Cron's convention: the platform sends the project's `CRON_SECRET`
+    // as the bearer token on scheduled invocations. Accepted as an alternative
+    // drain secret so the advertised Vercel Cron path works without duplicating
+    // the value into NEXTLY_DRAIN_SECRET. Vercel-managed, so not length-checked
+    // here.
+    CRON_SECRET: z.string().optional(),
     // Additional allowed origins for CSRF validation (comma-separated)
     NEXTLY_ALLOWED_ORIGINS: z.string().optional(),
 

--- a/packages/nextly/src/shared/lib/env.ts
+++ b/packages/nextly/src/shared/lib/env.ts
@@ -42,8 +42,11 @@ export const _envSchema = z
     // Shared secret a scheduler (e.g. Vercel Cron) presents to the webhook
     // drain route. Optional: when unset, the drain route can still be triggered
     // by an authenticated admin/API-key call, but unattended cron triggering is
-    // disabled. Compared in constant time at the route.
-    NEXTLY_DRAIN_SECRET: z.string().optional(),
+    // disabled. When set it must be >= 32 chars (like NEXTLY_SECRET): it
+    // independently authorizes a public trigger, so a short/guessable value —
+    // and the empty string, which would silently disable the cron path — is
+    // rejected at boot rather than accepted. Compared in constant time.
+    NEXTLY_DRAIN_SECRET: z.string().min(32).optional(),
     // Additional allowed origins for CSRF validation (comma-separated)
     NEXTLY_ALLOWED_ORIGINS: z.string().optional(),
 

--- a/packages/nextly/src/shared/lib/env.ts
+++ b/packages/nextly/src/shared/lib/env.ts
@@ -49,13 +49,13 @@ export const _envSchema = z
     NEXTLY_DRAIN_SECRET: z.string().min(32).optional(),
     // Vercel Cron's convention: the platform sends the project's `CRON_SECRET`
     // as the bearer token on scheduled invocations. Accepted as an alternative
-    // drain secret so the advertised Vercel Cron path works without duplicating
-    // the value into NEXTLY_DRAIN_SECRET. It independently authorizes the same
-    // public trigger, so it carries the same >= 32-char floor: a short/guessable
-    // value is rejected at boot, and the empty string (which would pass a bare
-    // `.optional()` but be skipped by the `if (secret)` check, silently failing
-    // cron auth) is refused.
-    CRON_SECRET: z.string().min(32).optional(),
+    // drain secret. Deliberately NOT length-constrained here: `CRON_SECRET` is a
+    // platform-wide variable that may already be set (possibly short) for other
+    // cron routes, so enforcing a length in the global env schema would fail boot
+    // for deployments that don't even use the webhook drain. The entropy floor is
+    // enforced at the drain-auth boundary instead: a `CRON_SECRET` shorter than
+    // the required length is simply not accepted as a drain secret.
+    CRON_SECRET: z.string().optional(),
     // Additional allowed origins for CSRF validation (comma-separated)
     NEXTLY_ALLOWED_ORIGINS: z.string().optional(),
 

--- a/packages/nextly/src/shared/lib/env.ts
+++ b/packages/nextly/src/shared/lib/env.ts
@@ -69,6 +69,18 @@ export const _envSchema = z
   .superRefine((val, ctx) => {
     const isProd = val.NODE_ENV === "production";
 
+    // A CRON_SECRET too short to authorize the drain is ignored at the auth
+    // boundary rather than rejected here (it is a platform-wide variable and
+    // must not fail app boot for deployments that don't use the drain). Warn so
+    // an operator who set it FOR the drain gets a signal instead of silent 403s.
+    if (val.CRON_SECRET && val.CRON_SECRET.length < 32) {
+      console.warn(
+        "⚠️  CRON_SECRET is shorter than 32 characters and will NOT be accepted " +
+          "as a webhook drain secret. Use a >= 32-char value (or NEXTLY_DRAIN_SECRET) " +
+          "if you rely on /api/webhooks/drain."
+      );
+    }
+
     // Production hard requirements
     if (isProd) {
       if (!val.NEXTLY_SECRET || val.NEXTLY_SECRET.length < 32) {

--- a/packages/nextly/src/shared/lib/env.ts
+++ b/packages/nextly/src/shared/lib/env.ts
@@ -73,7 +73,9 @@ export const _envSchema = z
     // boundary rather than rejected here (it is a platform-wide variable and
     // must not fail app boot for deployments that don't use the drain). Warn so
     // an operator who set it FOR the drain gets a signal instead of silent 403s.
-    if (val.CRON_SECRET && val.CRON_SECRET.length < 32) {
+    // `!== undefined` (not truthiness) so an explicit empty string — which also
+    // fails the auth-boundary length gate — still produces the warning.
+    if (val.CRON_SECRET !== undefined && val.CRON_SECRET.length < 32) {
       console.warn(
         "⚠️  CRON_SECRET is shorter than 32 characters and will NOT be accepted " +
           "as a webhook drain secret. Use a >= 32-char value (or NEXTLY_DRAIN_SECRET) " +

--- a/packages/nextly/src/shared/lib/env.ts
+++ b/packages/nextly/src/shared/lib/env.ts
@@ -50,9 +50,12 @@ export const _envSchema = z
     // Vercel Cron's convention: the platform sends the project's `CRON_SECRET`
     // as the bearer token on scheduled invocations. Accepted as an alternative
     // drain secret so the advertised Vercel Cron path works without duplicating
-    // the value into NEXTLY_DRAIN_SECRET. Vercel-managed, so not length-checked
-    // here.
-    CRON_SECRET: z.string().optional(),
+    // the value into NEXTLY_DRAIN_SECRET. It independently authorizes the same
+    // public trigger, so it carries the same >= 32-char floor: a short/guessable
+    // value is rejected at boot, and the empty string (which would pass a bare
+    // `.optional()` but be skipped by the `if (secret)` check, silently failing
+    // cron auth) is refused.
+    CRON_SECRET: z.string().min(32).optional(),
     // Additional allowed origins for CSRF validation (comma-separated)
     NEXTLY_ALLOWED_ORIGINS: z.string().optional(),
 

--- a/packages/nextly/src/shared/lib/env.ts
+++ b/packages/nextly/src/shared/lib/env.ts
@@ -39,6 +39,11 @@ export const _envSchema = z
 
     // Nextly auth secret (required in production, min 32 chars)
     NEXTLY_SECRET: z.string().optional(),
+    // Shared secret a scheduler (e.g. Vercel Cron) presents to the webhook
+    // drain route. Optional: when unset, the drain route can still be triggered
+    // by an authenticated admin/API-key call, but unattended cron triggering is
+    // disabled. Compared in constant time at the route.
+    NEXTLY_DRAIN_SECRET: z.string().optional(),
     // Additional allowed origins for CSRF validation (comma-separated)
     NEXTLY_ALLOWED_ORIGINS: z.string().optional(),
 


### PR DESCRIPTION
## What

Adds `POST /api/webhooks/drain` — the production trigger the webhook delivery engine was missing. One request fans out due events into deliveries and attempts them, so a scheduler drives delivery and retries.

Until now `runDrain` had **no production caller** (only tests), so the event outbox accumulated rows nothing ever delivered. This closes that gap (part of the backend-first webhook admin-UI program; makes the #295 delivery log show real data).

## Auth (a trigger, not data)

`authorizeDrain` accepts either:
- a shared **`NEXTLY_DRAIN_SECRET`** presented as a bearer token — constant-time compare (hash-then-`timingSafeEqual`, so no length/content leak), matching how Vercel Cron sends `CRON_SECRET`; or
- an authenticated **admin session / API-key** caller with `update-webhooks`.

Not session-only (a scheduler has no session). A non-matching bearer falls through to be tried as an API key.

## Changes

- **`domains/webhooks/drain-runner.ts`** — `runWebhookDrain(adapter, registry, opts)` assembles the fan-out + delivery deps (`decryptSecret` defaults to `decryptWebhookSecret`, injectable for tests) and runs one drain to quiescence.
- **`api/webhooks.ts`** — `drainWebhooks` handler + `authorizeDrain`; route wired as `POST /api/webhooks/drain` through the catch-all router (route-parser + routeHandler), consistent with the other webhook routes (no new package export needed).
- **`di/registrations/register-webhooks.ts`** — the endpoint registry is now a **shared DI singleton** passed into `WebhookEndpointService`, so a CRUD change invalidates the same cache the drain reads (previously the optional registry was never passed, so `invalidate()` was a no-op).
- **`env.ts`** — `NEXTLY_DRAIN_SECRET` (optional; enables the cron auth path).

The adapter is typed as the minimal `FanOutDatabase & DeliverDatabase` and resolved via the DI container's generic accessor (`container.get<T>("adapter")`, the pattern already used across the codebase) — no `as any`.

## Tests

`drain-runner.integration.test.ts` (SQLite): the assembled drain fans a seeded event out into a delivery and fires it through the transport (proving `loadEndpoints` reads the registry and the secret decrypts), and is a no-op with no endpoints.

## Usage

```ts
// app/api/webhooks/drain/route.ts  — export the catch-all, or point cron at the path
```
```jsonc
// vercel.json
{ "crons": [{ "path": "/api/webhooks/drain", "schedule": "*/5 * * * *" }] }
```

## Follow-up

The Next.js `after()` immediate-first-attempt fast path (guarded dynamic import, wired into content mutations) follows as a focused change — the cron route already delivers correctness (delivery + retries); `after()` is a latency optimization worth its own small PR to keep the mutation-path wiring clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a webhook drain endpoint at **GET/POST `/api/webhooks/drain`** to trigger managed webhook delivery processing.
  * Added secure drain authentication using **`NEXTLY_DRAIN_SECRET`** (and compatible webhook update authorization).
  * Supports configurable drain behavior (e.g., max rounds/retention), including deterministic timing for testing.
* **Bug Fixes**
  * Ensured the new drain endpoint is correctly parsed and routed, not handled by the generic webhook flow.
  * Improved webhook endpoint availability by sharing a cached endpoint registry aligned with REST-triggered updates.
* **Tests**
  * Added integration tests for drain outcomes and route-parser tests for the new drain endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->