### PR TITLE
fix(nextly): judge scoped API keys on their own publish grant

### DIFF
--- a/.changeset/publish-permission-api-key-scope.md
+++ b/.changeset/publish-permission-api-key-scope.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Scoped API keys are now judged on their own grants when publishing.
+
+A REST write authenticated with an API key is authorized at the route only as
+`update`, so the service-side publish/unpublish gate previously fell back to the
+key owner's permissions. An update-only key owned by a publisher could publish,
+and a publish-scoped key owned by a non-publisher was refused. The publish
+transition now judges the key's own stamped scope for both collections and
+singles, matching how reads already work.

--- a/packages/nextly/src/api/singles-detail.ts
+++ b/packages/nextly/src/api/singles-detail.ts
@@ -244,6 +244,13 @@ export const PATCH = withErrorHandler(
       // Guard on a resolved user id (matches the dispatcher) so the
       // RBAC-skip only applies to an authenticated caller.
       routeAuthorized: !!user.id,
+      // Build the scope from the auth context so a publish transition (and the
+      // super-admin gate) judges an API key on its OWN stamped grants, not the
+      // owner's — the route only authorized `update`. Mirrors the dispatcher.
+      authenticatedScope: {
+        actorType: auth.authMethod === "api-key" ? "apiKey" : "user",
+        permissions: auth.permissions,
+      },
     });
 
     if (!result.success) {

--- a/packages/nextly/src/auth/authenticated-scope.test.ts
+++ b/packages/nextly/src/auth/authenticated-scope.test.ts
@@ -1,0 +1,78 @@
+/**
+ * `apiKeyScopeAllows` judges a scoped API key on its own grants and defers for
+ * everyone else; `readAuthenticatedScope` decodes the scope the route stamps.
+ */
+import { describe, it, expect } from "vitest";
+
+import { readAuthenticatedScope } from "../dispatcher/helpers/authenticated-actor";
+
+import { apiKeyScopeAllows } from "./authenticated-scope";
+
+describe("apiKeyScopeAllows", () => {
+  it("allows when the API key holds the `{operation}-{resource}` grant", () => {
+    const scope = {
+      actorType: "apiKey" as const,
+      permissions: ["update-posts", "publish-posts"],
+    };
+    expect(apiKeyScopeAllows(scope, "publish", "posts")).toBe(true);
+  });
+
+  it("denies when the API key lacks the grant", () => {
+    const scope = {
+      actorType: "apiKey" as const,
+      permissions: ["update-posts"],
+    };
+    expect(apiKeyScopeAllows(scope, "publish", "posts")).toBe(false);
+  });
+
+  it("returns null (defer to RBAC) for a session caller", () => {
+    const scope = { actorType: "user" as const, permissions: [] };
+    expect(apiKeyScopeAllows(scope, "publish", "posts")).toBeNull();
+  });
+
+  it("returns null (defer to RBAC) when no scope is present", () => {
+    expect(apiKeyScopeAllows(undefined, "publish", "posts")).toBeNull();
+  });
+
+  it("does not confuse resources whose names share a prefix", () => {
+    const scope = {
+      actorType: "apiKey" as const,
+      permissions: ["publish-posts-archive"],
+    };
+    // `publish-posts` must not be satisfied by `publish-posts-archive`.
+    expect(apiKeyScopeAllows(scope, "publish", "posts")).toBe(false);
+  });
+});
+
+describe("readAuthenticatedScope", () => {
+  it("decodes an API key's stamped permission list", () => {
+    const scope = readAuthenticatedScope({
+      _authenticatedActorType: "apiKey",
+      _authenticatedPermissions: JSON.stringify([
+        "update-posts",
+        "publish-posts",
+      ]),
+    });
+    expect(scope).toEqual({
+      actorType: "apiKey",
+      permissions: ["update-posts", "publish-posts"],
+    });
+  });
+
+  it("yields an empty permission list for a session caller", () => {
+    const scope = readAuthenticatedScope({ _authenticatedActorType: "user" });
+    expect(scope).toEqual({ actorType: "user", permissions: [] });
+  });
+
+  it("returns undefined when no actor type is stamped", () => {
+    expect(readAuthenticatedScope({})).toBeUndefined();
+  });
+
+  it("denies safely (empty list) when the permissions value is corrupt", () => {
+    const scope = readAuthenticatedScope({
+      _authenticatedActorType: "apiKey",
+      _authenticatedPermissions: "{not json",
+    });
+    expect(scope).toEqual({ actorType: "apiKey", permissions: [] });
+  });
+});

--- a/packages/nextly/src/auth/authenticated-scope.ts
+++ b/packages/nextly/src/auth/authenticated-scope.ts
@@ -13,6 +13,12 @@
  * @module auth/authenticated-scope
  */
 
+import type {
+  CollectionAccessControl,
+  SingleAccessControl,
+} from "../shared/types/access";
+
+import { codeAccessAllows } from "./entity-read-access";
 import type { RequestActorType } from "./request-actor";
 
 /**
@@ -44,4 +50,44 @@ export function apiKeyScopeAllows(
 ): boolean | null {
   if (scope?.actorType !== "apiKey") return null;
   return scope.permissions.includes(`${operation}-${resource}`);
+}
+
+/** The RBAC surface `apiKeyWriteAllowed` needs — the registered code access. */
+interface CodeAccessSource {
+  getRegisteredAccess(
+    slug: string
+  ): CollectionAccessControl | SingleAccessControl | undefined;
+}
+
+/**
+ * Whether a scoped API key may perform a write `operation` on `resource`.
+ *
+ * The full mirror of `canReadEntity` for the write side: a scoped key must hold
+ * the `{operation}-{resource}` grant AND satisfy the code-defined access rule
+ * (`defineCollection/defineSingle({ access: { publish/unpublish/... } })`),
+ * evaluated against the KEY's own scope — not the owner's. The permission check
+ * alone is not enough: `rbac.checkAccess` (which the API-key path replaces) is
+ * also where the code-defined rule runs, so skipping it would let a key with the
+ * grant bypass an `access.publish` that returns false.
+ *
+ * Returns `null` for a non-API-key caller, so the caller falls back to its normal
+ * RBAC resolution (which already composes the code-defined rule for that path).
+ */
+export async function apiKeyWriteAllowed(
+  scope: AuthenticatedScope | undefined,
+  operation: "create" | "read" | "update" | "delete" | "publish" | "unpublish",
+  resource: string,
+  user: { id: string; roles?: string[] },
+  rbac: CodeAccessSource | undefined
+): Promise<boolean | null> {
+  if (scope?.actorType !== "apiKey") return null;
+  if (!scope.permissions.includes(`${operation}-${resource}`)) return false;
+  const codeAccess = rbac?.getRegisteredAccess(resource);
+  if (!codeAccess) return true;
+  return codeAccessAllows(codeAccess, operation, resource, {
+    userId: user.id,
+    authMethod: "api-key",
+    permissions: scope.permissions,
+    roles: user.roles ?? [],
+  });
 }

--- a/packages/nextly/src/auth/authenticated-scope.ts
+++ b/packages/nextly/src/auth/authenticated-scope.ts
@@ -1,0 +1,47 @@
+/**
+ * A scoped API key is authorized on ITS OWN stamped grants, not its owner's.
+ *
+ * The route middleware authenticates an API-key request and stamps the key's
+ * scoped permission list on the dispatcher params. A service-side access re-check
+ * (for example the publish/unpublish transition gate, which the route never
+ * authorized because it only saw the write as `update`) must judge the key on
+ * that stamped scope. Resolving the permission from the key OWNER's `userId`
+ * instead — as the ordinary RBAC path does — would let an update-only key issued
+ * by a publisher publish, and deny a publish-scoped key issued by a non-publisher.
+ * This mirrors `auth/entity-read-access.ts` (`canReadEntity`) for the write side.
+ *
+ * @module auth/authenticated-scope
+ */
+
+import type { RequestActorType } from "./request-actor";
+
+/**
+ * The authenticated caller's scope, as a service access check needs it.
+ *
+ * `permissions` are the API key's OWN scoped grants in `{action}-{resource}`
+ * form (the same format the route stamps and `canReadEntity` consumes), e.g.
+ * `publish-posts`. Only meaningful when `actorType` is `apiKey`; a session or
+ * system caller carries none here and resolves its grants the normal way.
+ */
+export interface AuthenticatedScope {
+  actorType: RequestActorType;
+  permissions: string[];
+}
+
+/**
+ * Whether a scoped API key's OWN grants authorize `operation` on `resource`.
+ *
+ * Returns `null` when the caller is not a scoped API key, so the caller falls
+ * back to its normal RBAC resolution (the owner's / session's database grants).
+ * Returns a boolean for an API key: the stamped scope is authoritative, in both
+ * directions — a key without the grant is denied however privileged its owner,
+ * and a key with it is allowed however unprivileged.
+ */
+export function apiKeyScopeAllows(
+  scope: AuthenticatedScope | undefined,
+  operation: string,
+  resource: string
+): boolean | null {
+  if (scope?.actorType !== "apiKey") return null;
+  return scope.permissions.includes(`${operation}-${resource}`);
+}

--- a/packages/nextly/src/auth/entity-read-access.ts
+++ b/packages/nextly/src/auth/entity-read-access.ts
@@ -61,7 +61,7 @@ function getRBACService(): RBACAccessControlService | undefined {
  */
 export async function codeAccessAllows(
   codeAccess: CollectionAccessControl | SingleAccessControl,
-  operation: "create" | "read" | "update" | "delete",
+  operation: "create" | "read" | "update" | "delete" | "publish" | "unpublish",
   resource: string,
   caller: ReadAccessCaller
 ): Promise<boolean> {

--- a/packages/nextly/src/dispatcher/handlers/__tests__/versions-restore-access.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/versions-restore-access.test.ts
@@ -120,6 +120,31 @@ describe("restoreVersionForDocument — identity assembly", () => {
     });
   });
 
+  it("forwards the API-key scope to the write, so a restore-to-published is gated", async () => {
+    // A restore replays the snapshot through the update path; when it sets
+    // status published it hits the publish gate, which for a scoped key must
+    // judge the key's own grant. The scope must reach the write.
+    await restoreVersionForDocument(
+      argsFor({
+        ...baseParams,
+        _authenticatedActorType: "apiKey",
+        _authenticatedPermissions: JSON.stringify([
+          "read-posts",
+          "update-posts",
+        ]),
+      })
+    );
+
+    expect(restoreSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authenticatedScope: {
+          actorType: "apiKey",
+          permissions: ["read-posts", "update-posts"],
+        },
+      })
+    );
+  });
+
   it("treats a session caller as carrying no scoped permissions", async () => {
     // Their grants are resolved from the database by the decision itself;
     // forwarding an empty list keeps the two paths from being confused.

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -1044,6 +1044,9 @@ const COLLECTIONS_METHODS: Record<
           // so the handler skips only that redundant re-check (stored rules +
           // field-level write access still run). Never inferred from userId.
           routeAuthorized: true,
+          // The route authorized only `create` against an API key's scope; a
+          // create-as-published publish gate judges the key's own grants.
+          authenticatedScope: readAuthenticatedScope(p),
         },
         body as Record<string, unknown>
       );

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -72,7 +72,10 @@ import {
   isSuperAdmin,
   listEffectivePermissions,
 } from "../../services/lib/permissions";
-import { readAuthenticatedActor } from "../helpers/authenticated-actor";
+import {
+  readAuthenticatedActor,
+  readAuthenticatedScope,
+} from "../helpers/authenticated-actor";
 import { readAuthenticatedRoles } from "../helpers/authenticated-roles";
 import { buildFullDesiredSchema } from "../helpers/desired-schema";
 import {
@@ -1116,6 +1119,9 @@ const COLLECTIONS_METHODS: Record<
           // so the handler skips only that redundant re-check (stored rules +
           // field-level write access still run). Never inferred from userId.
           routeAuthorized: true,
+          // The route authorized only `update` against an API key's scope; the
+          // service-side publish/unpublish gate judges the key's own grants.
+          authenticatedScope: readAuthenticatedScope(p),
         },
         body as Record<string, unknown>
       );
@@ -1152,6 +1158,9 @@ const COLLECTIONS_METHODS: Record<
         // the handler skips only that redundant re-check (stored rules +
         // field-level write access still run). Never inferred from userId.
         routeAuthorized: true,
+        // The route authorized this POST as `update`; the publish check judges a
+        // scoped API key's own `publish-<slug>` grant.
+        authenticatedScope: readAuthenticatedScope(p),
       });
       const entry = unwrapServiceResult(result, {
         collectionName: p.collectionName,

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -76,7 +76,10 @@ import {
   isSuperAdmin,
   listEffectivePermissions,
 } from "../../services/lib/permissions";
-import { readAuthenticatedActor } from "../helpers/authenticated-actor";
+import {
+  readAuthenticatedActor,
+  readAuthenticatedScope,
+} from "../helpers/authenticated-actor";
 import { readAuthenticatedRoles } from "../helpers/authenticated-roles";
 import { buildFullDesiredSchema } from "../helpers/desired-schema";
 import {
@@ -791,6 +794,9 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
           // still run for this user (overrideAccess stays false).
           overrideAccess: false,
           routeAuthorized: !!user,
+          // The route authorized only `update` against an API key's scope; the
+          // service-side publish/unpublish gate judges the key's own grants.
+          authenticatedScope: readAuthenticatedScope(p),
         }
       );
       const doc = unwrapServiceResult(result, { slug });

--- a/packages/nextly/src/dispatcher/handlers/versions-methods.ts
+++ b/packages/nextly/src/dispatcher/handlers/versions-methods.ts
@@ -30,6 +30,7 @@ import { restoreVersion } from "../../domains/versions/restore-version";
 import type { VersionRow } from "../../domains/versions/versions-repository";
 import { NextlyError } from "../../errors/nextly-error";
 import type { VersionScopeKind } from "../../schemas/versions/types";
+import { readAuthenticatedScope } from "../helpers/authenticated-actor";
 import type { Params } from "../types";
 
 /** Page size when the caller does not ask for one. */
@@ -465,5 +466,8 @@ export async function restoreVersionForDocument(
     // Forwarded so an API-key restore is attributed to the key on the outbox
     // event rather than to the person who owns it.
     ...(args.actor ? { actor: args.actor } : {}),
+    // The publish gate a restore-to-published triggers must judge the key's own
+    // scope, not the owner's RBAC.
+    authenticatedScope: readAuthenticatedScope(args.params),
   });
 }

--- a/packages/nextly/src/dispatcher/helpers/authenticated-actor.ts
+++ b/packages/nextly/src/dispatcher/helpers/authenticated-actor.ts
@@ -30,8 +30,10 @@ export function readAuthenticatedActor(p: Params): RequestActor | undefined {
  * For an API key the route stamps its OWN scoped grants on the params; a service
  * check (e.g. the publish/unpublish transition gate) must judge the key on those
  * rather than the owner's RBAC. A corrupt permissions value reads as an empty
- * list, which denies — the safe direction. Returns `undefined` for a non-API-key
- * caller so the check falls back to normal RBAC resolution.
+ * list, which denies — the safe direction. Missing or invalid actor metadata
+ * returns `undefined`; a non-API-key (e.g. session) caller receives a scope with
+ * an empty permission list, so the API-key branch is skipped and the check falls
+ * back to normal RBAC resolution.
  */
 export function readAuthenticatedScope(
   p: Params

--- a/packages/nextly/src/dispatcher/helpers/authenticated-actor.ts
+++ b/packages/nextly/src/dispatcher/helpers/authenticated-actor.ts
@@ -1,3 +1,4 @@
+import type { AuthenticatedScope } from "../../auth/authenticated-scope";
 import type { RequestActor, RequestActorType } from "../../auth/request-actor";
 import type { Params } from "../types";
 
@@ -21,4 +22,32 @@ export function readAuthenticatedActor(p: Params): RequestActor | undefined {
   if (!type || !isActorType(type)) return undefined;
   const id = p._authenticatedActorId;
   return id ? { type, id } : { type };
+}
+
+/**
+ * Decode the caller's authenticated scope for a service-side access re-check.
+ *
+ * For an API key the route stamps its OWN scoped grants on the params; a service
+ * check (e.g. the publish/unpublish transition gate) must judge the key on those
+ * rather than the owner's RBAC. A corrupt permissions value reads as an empty
+ * list, which denies — the safe direction. Returns `undefined` for a non-API-key
+ * caller so the check falls back to normal RBAC resolution.
+ */
+export function readAuthenticatedScope(
+  p: Params
+): AuthenticatedScope | undefined {
+  const type = p._authenticatedActorType;
+  if (!type || !isActorType(type)) return undefined;
+
+  let permissions: string[] = [];
+  if (type === "apiKey" && p._authenticatedPermissions) {
+    try {
+      const parsed: unknown = JSON.parse(String(p._authenticatedPermissions));
+      if (Array.isArray(parsed)) permissions = parsed as string[];
+    } catch {
+      permissions = [];
+    }
+  }
+
+  return { actorType: type, permissions };
 }

--- a/packages/nextly/src/domains/collections/__tests__/collection-access.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-access.test.ts
@@ -1053,4 +1053,42 @@ describe("publish-transition access control", () => {
       expect.objectContaining({ operation: "publish", resource: "posts" })
     );
   });
+
+  it("does not let a super-admin-owned key bypass a stored rule on a plain update", async () => {
+    // The primary update gate must also receive the API-key scope, so the
+    // session super-admin bypass does not apply to a scoped key on a non-status
+    // write — otherwise a super-admin-owned, update-only key would skip the
+    // collection's stored owner/role rules.
+    const acs = createMockAccessControlService();
+    acs.evaluateAccess.mockResolvedValue({
+      allowed: false,
+      reason: "owner-only",
+    });
+    const rbac = {
+      checkAccess: vi.fn().mockResolvedValue(true),
+      getRegisteredAccess: vi.fn().mockReturnValue(undefined),
+    };
+    const { service, selectData } = buildService({
+      accessControlService: acs,
+      rbacAccessControlService: rbac,
+    });
+    selectData.rows = [createSampleEntry({ status: "draft" })];
+
+    const result = await service.updateEntry(
+      {
+        collectionName: "posts",
+        entryId: "entry-1",
+        // The key's resolved roles carry super-admin, but it is a scoped key.
+        user: { id: "admin-1", roles: ["super-admin"] },
+        authenticatedScope: {
+          actorType: "apiKey",
+          permissions: ["update-posts"],
+        },
+      },
+      { title: "no status change" }
+    );
+
+    // The stored rule ran and denied — the super-admin bypass did not fire.
+    expect(result.statusCode).toBe(403);
+  });
 });

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-rbac.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-rbac.integration.test.ts
@@ -314,4 +314,123 @@ describe("publish enforcement on the dispatcher path (RBAC wiring)", () => {
     );
     expect(allowed.success).toBe(true);
   });
+
+  it("judges a scoped API-key create-as-published on the key's own grant", async () => {
+    // The create path also gates publish (creating directly as published). A key
+    // scoped for `create-posts` but not `publish-posts` cannot create a published
+    // entry; adding `publish-posts` allows it — regardless of the owner's grants.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          status: true,
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const denied = await handler.createEntry(
+      {
+        collectionName: "posts",
+        userId: "key-owner",
+        routeAuthorized: true,
+        authenticatedScope: {
+          actorType: "apiKey",
+          permissions: ["create-posts"],
+        },
+      },
+      { title: "t", status: "published" }
+    );
+    expect(denied.success).toBe(false);
+    expect(denied.statusCode).toBe(403);
+
+    const allowed = await handler.createEntry(
+      {
+        collectionName: "posts",
+        userId: "key-owner",
+        routeAuthorized: true,
+        authenticatedScope: {
+          actorType: "apiKey",
+          permissions: ["create-posts", "publish-posts"],
+        },
+      },
+      { title: "t2", status: "published" }
+    );
+    expect(allowed.success).toBe(true);
+  });
+
+  it("does not let a code-defined access.publish be bypassed by a scoped key", async () => {
+    // A scoped key holding `publish-posts` must still satisfy the collection's
+    // code-defined `access.publish` rule — the grant is not a bypass.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          status: true,
+          access: { publish: () => false },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "t", status: "draft" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    const denied = await handler.updateEntry(
+      {
+        collectionName: "posts",
+        entryId: id,
+        userId: "key-owner",
+        routeAuthorized: true,
+        authenticatedScope: {
+          actorType: "apiKey",
+          permissions: ["update-posts", "publish-posts"],
+        },
+      },
+      { status: "published" }
+    );
+    expect(denied.success).toBe(false);
+    expect(denied.statusCode).toBe(403);
+  });
+
+  it("route-authorizes publish-all's update gate for a scoped key", async () => {
+    // publish-all runs a preliminary `update` gate before the publish check. For
+    // a REST API-key request the route already authorized `update` on the key's
+    // scope, so that gate must honor route authorization + the key scope rather
+    // than fall back to the owner's RBAC (which the key owner lacks here).
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          status: true,
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "t", status: "draft" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    const result = await handler.publishAllLocales({
+      collectionName: "posts",
+      entryId: id,
+      userId: "key-owner",
+      routeAuthorized: true,
+      authenticatedScope: {
+        actorType: "apiKey",
+        permissions: ["update-posts", "publish-posts"],
+      },
+    });
+    expect(result.success).toBe(true);
+  });
 });

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-rbac.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-rbac.integration.test.ts
@@ -258,4 +258,60 @@ describe("publish enforcement on the dispatcher path (RBAC wiring)", () => {
     const list = Array.isArray(rows) ? rows : (rows.rows ?? []);
     expect(list[0]?._status).toBe("draft");
   });
+
+  it("judges a scoped API-key publish on the key's own grant, not the owner's", async () => {
+    // End-to-end threading: the dispatcher stamps the key's scoped permissions,
+    // the handler forwards them, and the transition gate judges the key rather
+    // than the key owner. A key scoped for update but not publish is refused; a
+    // key scoped for publish is allowed — regardless of the owner's grants.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          status: true,
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "t", status: "draft" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    // Key scoped for `update-posts` only → publish denied.
+    const denied = await handler.updateEntry(
+      {
+        collectionName: "posts",
+        entryId: id,
+        userId: "key-owner",
+        routeAuthorized: true,
+        authenticatedScope: {
+          actorType: "apiKey",
+          permissions: ["update-posts"],
+        },
+      },
+      { status: "published" }
+    );
+    expect(denied.success).toBe(false);
+    expect(denied.statusCode).toBe(403);
+
+    // Same owner, key scoped WITH `publish-posts` → allowed.
+    const allowed = await handler.updateEntry(
+      {
+        collectionName: "posts",
+        entryId: id,
+        userId: "key-owner",
+        routeAuthorized: true,
+        authenticatedScope: {
+          actorType: "apiKey",
+          permissions: ["update-posts", "publish-posts"],
+        },
+      },
+      { status: "published" }
+    );
+    expect(allowed.success).toBe(true);
+  });
 });

--- a/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
@@ -22,7 +22,12 @@ import {
 
 function buildAccessService() {
   const accessControlService = createMockAccessControlService();
-  const rbac = { checkAccess: vi.fn().mockResolvedValue(true) };
+  const rbac = {
+    checkAccess: vi.fn().mockResolvedValue(true),
+    // No code-defined access by default: a scoped API key is judged on its
+    // permission grant alone unless a test registers a rule.
+    getRegisteredAccess: vi.fn().mockReturnValue(undefined),
+  };
   const collectionService = createMockCollectionService();
   const service = new CollectionAccessService(
     createMockAdapter(createMockDb()) as never,
@@ -318,6 +323,45 @@ describe("checkCollectionAccess — scoped API key", () => {
     expect(result?.statusCode).toBe(403);
     // The owner's RBAC is never consulted for a scoped key.
     expect(rbac.checkAccess).not.toHaveBeenCalled();
+  });
+
+  it("still enforces a code-defined access rule for a scoped key that holds the grant", async () => {
+    const { service, rbac } = buildAccessService();
+    // The key HAS publish-posts, but the collection's code-defined
+    // `access.publish` denies. The grant must not bypass that rule (which
+    // `rbac.checkAccess` — the path the API-key branch replaces — would have run).
+    rbac.getRegisteredAccess.mockReturnValue({ publish: () => false });
+
+    const result = await service.checkCollectionAccess(
+      "posts",
+      "publish",
+      apiKeyOwner,
+      "doc-1",
+      { id: "doc-1" },
+      false,
+      false,
+      { actorType: "apiKey", permissions: ["publish-posts"] }
+    );
+
+    expect(result?.statusCode).toBe(403);
+  });
+
+  it("allows a scoped key with the grant when the code-defined rule allows", async () => {
+    const { service, rbac } = buildAccessService();
+    rbac.getRegisteredAccess.mockReturnValue({ publish: () => true });
+
+    const result = await service.checkCollectionAccess(
+      "posts",
+      "publish",
+      apiKeyOwner,
+      "doc-1",
+      { id: "doc-1" },
+      false,
+      false,
+      { actorType: "apiKey", permissions: ["publish-posts"] }
+    );
+
+    expect(result).toBeNull();
   });
 
   it("allows a publish the key IS scoped for, even when the owner's RBAC denies", async () => {

--- a/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
@@ -325,6 +325,25 @@ describe("checkCollectionAccess — scoped API key", () => {
     expect(rbac.checkAccess).not.toHaveBeenCalled();
   });
 
+  it("does not let a super-admin-owned key bypass its scope for publish", async () => {
+    const { service } = buildAccessService();
+    // The key's resolved role set carries super-admin (from its owner), but the
+    // session super-admin bypass must NOT apply to a scoped key — otherwise an
+    // update-only key issued by an admin could publish.
+    const result = await service.checkCollectionAccess(
+      "posts",
+      "publish",
+      { id: "admin-1", roles: ["super-admin"] },
+      "doc-1",
+      { id: "doc-1" },
+      false,
+      false,
+      { actorType: "apiKey", permissions: ["update-posts"] }
+    );
+
+    expect(result?.statusCode).toBe(403);
+  });
+
   it("still enforces a code-defined access rule for a scoped key that holds the grant", async () => {
     const { service, rbac } = buildAccessService();
     // The key HAS publish-posts, but the collection's code-defined

--- a/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
@@ -290,3 +290,75 @@ describe("getAccessRules normalizes collection owner fields", () => {
     expect(rules?.read?.ownerField).toBeUndefined();
   });
 });
+
+describe("checkCollectionAccess — scoped API key", () => {
+  // The publish/unpublish transition gate runs NOT route-authorized (the route
+  // only attested `update`). For a scoped API key it must judge the key's OWN
+  // stamped grants, never the key owner's RBAC — otherwise an update-only key
+  // owned by a publisher could publish.
+  const apiKeyOwner = { id: "publisher-1", roles: ["editor"] };
+
+  it("denies a publish the key is not scoped for, even when the owner's RBAC allows", async () => {
+    const { service, rbac } = buildAccessService();
+    // The OWNER can publish...
+    rbac.checkAccess.mockResolvedValue(true);
+
+    const result = await service.checkCollectionAccess(
+      "posts",
+      "publish",
+      apiKeyOwner,
+      "doc-1",
+      { id: "doc-1" },
+      false, // overrideAccess
+      false, // routeAuthorized (transition check)
+      // ...but the KEY is scoped for update only.
+      { actorType: "apiKey", permissions: ["update-posts"] }
+    );
+
+    expect(result?.statusCode).toBe(403);
+    // The owner's RBAC is never consulted for a scoped key.
+    expect(rbac.checkAccess).not.toHaveBeenCalled();
+  });
+
+  it("allows a publish the key IS scoped for, even when the owner's RBAC denies", async () => {
+    const { service, rbac } = buildAccessService();
+    // The OWNER cannot publish...
+    rbac.checkAccess.mockResolvedValue(false);
+
+    const result = await service.checkCollectionAccess(
+      "posts",
+      "publish",
+      apiKeyOwner,
+      "doc-1",
+      { id: "doc-1" },
+      false,
+      false,
+      // ...but the KEY carries the publish grant.
+      { actorType: "apiKey", permissions: ["update-posts", "publish-posts"] }
+    );
+
+    expect(result).toBeNull();
+    expect(rbac.checkAccess).not.toHaveBeenCalled();
+  });
+
+  it("falls through to the owner's RBAC for a session caller (no api-key scope)", async () => {
+    const { service, rbac } = buildAccessService();
+    rbac.checkAccess.mockResolvedValue(false);
+
+    const result = await service.checkCollectionAccess(
+      "posts",
+      "publish",
+      apiKeyOwner,
+      "doc-1",
+      { id: "doc-1" },
+      false,
+      false,
+      // A session caller carries a scope with actorType "user" (or none), so the
+      // owner/session RBAC decides.
+      { actorType: "user", permissions: [] }
+    );
+
+    expect(result?.statusCode).toBe(403);
+    expect(rbac.checkAccess).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -176,10 +176,15 @@ export class CollectionAccessService extends BaseService {
     }
 
     // Super-admin bypasses BOTH the RBAC gate and the stored rules (including
-    // owner-only) so an admin can act on any record on every transport. Keyed
-    // on the authorized role set (see isSuperAdminContext), so a scoped API key
-    // cannot inherit its owner's super-admin bypass.
-    if (isSuperAdminContext(user)) {
+    // owner-only) so an admin can act on any record on every transport — EXCEPT
+    // via a scoped API key. The bypass belongs to the session path: a key is
+    // authoritative on its OWN stamped scope, never on the owner's roles, so a
+    // read/update-only key issued by an administrator is not equivalent to their
+    // full account (mirrors canReadEntity). Applying the bypass here would let a
+    // super-admin-owned, update-only key publish, recreating the very hole this
+    // scope check closes.
+    const isScopedApiKey = authenticatedScope?.actorType === "apiKey";
+    if (!isScopedApiKey && isSuperAdminContext(user)) {
       return null;
     }
 

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -15,6 +15,10 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import type { RequestContext } from "@nextly/collections/fields/types/base";
 
+import {
+  apiKeyScopeAllows,
+  type AuthenticatedScope,
+} from "../../../auth/authenticated-scope";
 import type { RBACAccessControlService } from "../../../domains/auth/services/rbac-access-control-service";
 import type {
   AccessControlService,
@@ -160,7 +164,11 @@ export class CollectionAccessService extends BaseService {
     documentId?: string,
     document?: Record<string, unknown>,
     overrideAccess?: boolean,
-    routeAuthorized?: boolean
+    routeAuthorized?: boolean,
+    // The caller's authenticated scope. For a scoped API key the RBAC gate
+    // judges the key's OWN stamped grants rather than the owner's permissions
+    // (see auth/authenticated-scope). Undefined for session/system callers.
+    authenticatedScope?: AuthenticatedScope
   ): Promise<CollectionServiceResult<T> | null> {
     // Trusted-server / system write: bypass all access control checks.
     if (overrideAccess) {
@@ -194,7 +202,26 @@ export class CollectionAccessService extends BaseService {
     // permissions. Skipped when routeAuthorized, because the route middleware
     // (requireCollectionAccess) already performed this exact check; the stored
     // rules below still run.
-    if (!routeAuthorized && this.rbacAccessControlService && user) {
+    //
+    // For a scoped API key the gate judges the key's OWN stamped grants, not the
+    // owner's DB permissions: the route only authorized the write as `update`,
+    // so this publish/unpublish re-check must consult the key's scope or an
+    // update-only key owned by a publisher could publish. `apiKeyScopeAllows`
+    // returns null for a non-API-key caller, which falls through to RBAC.
+    const scopeDecision =
+      !routeAuthorized && user
+        ? apiKeyScopeAllows(authenticatedScope, operation, collectionName)
+        : null;
+    if (!routeAuthorized && user && scopeDecision !== null) {
+      if (!scopeDecision) {
+        return {
+          success: false,
+          statusCode: 403,
+          message: `Access denied: insufficient permissions for ${operation} on ${collectionName}`,
+          data: null as unknown as T,
+        };
+      }
+    } else if (!routeAuthorized && this.rbacAccessControlService && user) {
       try {
         const allowed = await this.rbacAccessControlService.checkAccess({
           userId: user.id,

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -16,7 +16,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { RequestContext } from "@nextly/collections/fields/types/base";
 
 import {
-  apiKeyScopeAllows,
+  apiKeyWriteAllowed,
   type AuthenticatedScope,
 } from "../../../auth/authenticated-scope";
 import type { RBACAccessControlService } from "../../../domains/auth/services/rbac-access-control-service";
@@ -210,7 +210,13 @@ export class CollectionAccessService extends BaseService {
     // returns null for a non-API-key caller, which falls through to RBAC.
     const scopeDecision =
       !routeAuthorized && user
-        ? apiKeyScopeAllows(authenticatedScope, operation, collectionName)
+        ? await apiKeyWriteAllowed(
+            authenticatedScope,
+            operation,
+            collectionName,
+            user,
+            this.rbacAccessControlService
+          )
         : null;
     if (!routeAuthorized && user && scopeDecision !== null) {
       if (!scopeDecision) {

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -206,8 +206,10 @@ export class CollectionAccessService extends BaseService {
     // For a scoped API key the gate judges the key's OWN stamped grants, not the
     // owner's DB permissions: the route only authorized the write as `update`,
     // so this publish/unpublish re-check must consult the key's scope or an
-    // update-only key owned by a publisher could publish. `apiKeyScopeAllows`
-    // returns null for a non-API-key caller, which falls through to RBAC.
+    // update-only key owned by a publisher could publish. `apiKeyWriteAllowed`
+    // evaluates both the key's permission grant AND the code-defined access rule
+    // against that scope, and returns null for a non-API-key caller, which falls
+    // through to RBAC.
     const scopeDecision =
       !routeAuthorized && user
         ? await apiKeyWriteAllowed(

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1277,7 +1277,10 @@ export class CollectionMutationService extends BaseService {
         undefined,
         undefined,
         params.overrideAccess,
-        params.routeAuthorized
+        params.routeAuthorized,
+        // A scoped API key is judged on its own grants here too, so the session
+        // super-admin bypass does not apply to it on the create gate.
+        params.authenticatedScope
       );
       if (accessDenied) {
         return accessDenied;
@@ -2509,7 +2512,10 @@ export class CollectionMutationService extends BaseService {
         params.entryId,
         existingEntry,
         params.overrideAccess,
-        params.routeAuthorized
+        params.routeAuthorized,
+        // A scoped API key is judged on its own grants here too, so the session
+        // super-admin bypass does not apply to it on the update gate.
+        params.authenticatedScope
       );
       if (accessDenied) {
         return accessDenied;

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -22,6 +22,7 @@ import { eq, ne, and, like, ilike } from "drizzle-orm";
 import type { BeforeOperationArgs } from "@nextly/hooks/types";
 import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 
+import type { AuthenticatedScope } from "../../../auth/authenticated-scope";
 import { actorForWrite, type RequestActor } from "../../../auth/request-actor";
 import { isComponentField } from "../../../collections/fields/guards";
 import type { FieldConfig } from "../../../collections/fields/types";
@@ -2020,6 +2021,9 @@ export class CollectionMutationService extends BaseService {
     entryId: string;
     user?: UserContext;
     overrideAccess?: boolean;
+    // A scoped API key is judged on its own `publish-<slug>` grant, not the key
+    // owner's — the route authorized this POST only as `update`.
+    authenticatedScope?: AuthenticatedScope;
   }): Promise<CollectionServiceResult> {
     try {
       const accessUser = params.overrideAccess ? undefined : params.user;
@@ -2093,7 +2097,12 @@ export class CollectionMutationService extends BaseService {
         accessUser,
         params.entryId,
         existingEntry,
-        params.overrideAccess
+        params.overrideAccess,
+        // Not route-authorized as publish: the POST was authorized as `update`,
+        // so the publish permission is checked here.
+        false,
+        // Judge a scoped API key on its own `publish-<slug>` grant.
+        params.authenticatedScope
       );
       if (publishDenied) return publishDenied;
 
@@ -2427,6 +2436,10 @@ export class CollectionMutationService extends BaseService {
        * restore is an ordinary write that happens to reproduce an earlier state.
        */
       sourceVersionNo?: number;
+      // The caller's authenticated scope. For a scoped API-key REST write the
+      // publish/unpublish transition gate judges the key's OWN grants, since the
+      // route only authorized `update` against the key's scope.
+      authenticatedScope?: AuthenticatedScope;
     },
     body: Record<string, unknown>,
     depth?: number
@@ -2914,7 +2927,11 @@ export class CollectionMutationService extends BaseService {
           params.overrideAccess,
           // Never route-authorized: the route authorizes the write as `update`,
           // never as `publish`/`unpublish`, so the RBAC check must run.
-          false
+          false,
+          // A scoped API key is judged on its OWN publish/unpublish grant here,
+          // not the key owner's — the route only checked `update` against the
+          // key's scope.
+          params.authenticatedScope
         );
         if (denied) transitionGuard = { op: transitionOp, denied };
       }

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1250,6 +1250,10 @@ export class CollectionMutationService extends BaseService {
       // to what this user may read (this is not a trusted-server read).
       routeAuthorized?: boolean;
       context?: Record<string, unknown>;
+      // The caller's authenticated scope. For a scoped API-key REST create the
+      // publish transition gate (a create-as-published) judges the key's OWN
+      // grants — the route only authorized `create` against the key's scope.
+      authenticatedScope?: AuthenticatedScope;
     },
     body: Record<string, unknown>,
     depth?: number
@@ -1650,6 +1654,7 @@ export class CollectionMutationService extends BaseService {
         nextStatus: finalData.status,
         accessUser,
         overrideAccess: params.overrideAccess,
+        authenticatedScope: params.authenticatedScope,
       });
       if (createTransitionDenied) {
         return createTransitionDenied;
@@ -2021,6 +2026,10 @@ export class CollectionMutationService extends BaseService {
     entryId: string;
     user?: UserContext;
     overrideAccess?: boolean;
+    // Set by the REST dispatcher: the route already authorized this POST as
+    // `update`, so the preliminary update gate below skips its redundant RBAC
+    // re-check (its stored rules still run). The publish gate is unaffected.
+    routeAuthorized?: boolean;
     // A scoped API key is judged on its own `publish-<slug>` grant, not the key
     // owner's — the route authorized this POST only as `update`.
     authenticatedScope?: AuthenticatedScope;
@@ -2051,7 +2060,12 @@ export class CollectionMutationService extends BaseService {
         accessUser,
         params.entryId,
         existingEntry,
-        params.overrideAccess
+        params.overrideAccess,
+        // The route already ran the `update` gate (against the API key's scope,
+        // when applicable), so skip the redundant RBAC re-check here; the publish
+        // gate below still runs.
+        params.routeAuthorized,
+        params.authenticatedScope
       );
       if (accessDenied) return accessDenied;
 
@@ -2384,6 +2398,7 @@ export class CollectionMutationService extends BaseService {
     entryId?: string;
     document?: Record<string, unknown>;
     overrideAccess?: boolean;
+    authenticatedScope?: AuthenticatedScope;
   }): Promise<CollectionServiceResult | null> {
     // No draft/published lifecycle → `status` is an ordinary field, not a
     // publish signal, so there is no transition to authorize.
@@ -2404,11 +2419,15 @@ export class CollectionMutationService extends BaseService {
       args.overrideAccess,
       // NOT route-authorized, even on a REST write. `routeAuthorized` means the
       // route middleware already ran this exact RBAC check — but the route
-      // authorizes a document PATCH as `update`, never as `publish`/`unpublish`,
-      // so for the transition operation that assertion does not hold. Passing it
-      // through would skip the RBAC check for the very permission this gate
-      // exists to enforce, letting any caller who may update also publish.
-      false
+      // authorizes a document PATCH/create as `update`/`create`, never as
+      // `publish`/`unpublish`, so for the transition operation that assertion
+      // does not hold. Passing it through would skip the RBAC check for the very
+      // permission this gate exists to enforce, letting any caller who may
+      // update/create also publish.
+      false,
+      // A scoped API key is judged on its own publish/unpublish grant here, not
+      // the key owner's.
+      args.authenticatedScope
     );
   }
 

--- a/packages/nextly/src/domains/singles/__tests__/publish-enforcement.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/publish-enforcement.integration.test.ts
@@ -181,4 +181,57 @@ describe("single publish enforcement — authorize before create (integration)",
     const list = Array.isArray(rows) ? rows : (rows.rows ?? []);
     expect(list[0]?._status).toBe("draft");
   });
+
+  it("judges a scoped API-key publish on the key's own grant, not the owner's", async () => {
+    // End-to-end: a key scoped for `update-settings` but not `publish-settings`
+    // is refused the publish; a key scoped for publish is allowed. The route
+    // stamped only `update`, so the service-side gate judges the key's scope.
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "settings",
+          status: true,
+          fields: [text({ name: "siteName" })],
+        }),
+      ],
+    });
+    const service =
+      current.getService<SingleEntryService>("singleEntryService");
+
+    // Seed a draft via a trusted write so the update path is a pure transition.
+    await service.update(
+      "settings",
+      { siteName: "S", status: "draft" },
+      { overrideAccess: true }
+    );
+
+    const denied = await service.update(
+      "settings",
+      { status: "published" },
+      {
+        user: { id: "key-owner" },
+        routeAuthorized: true,
+        authenticatedScope: {
+          actorType: "apiKey",
+          permissions: ["update-settings"],
+        },
+      }
+    );
+    expect(denied.success).toBe(false);
+    expect(denied.statusCode).toBe(403);
+
+    const allowed = await service.update(
+      "settings",
+      { status: "published" },
+      {
+        user: { id: "key-owner" },
+        routeAuthorized: true,
+        authenticatedScope: {
+          actorType: "apiKey",
+          permissions: ["update-settings", "publish-settings"],
+        },
+      }
+    );
+    expect(allowed.success).toBe(true);
+  });
 });

--- a/packages/nextly/src/domains/singles/__tests__/single-entry-service.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-entry-service.test.ts
@@ -1106,5 +1106,33 @@ describe("SingleEntryService", () => {
       // No duplicate insert — the existing (hook-created) row was reused.
       expect(ctx.adapter.insert).not.toHaveBeenCalled();
     });
+
+    it("does not let a super-admin-owned key bypass a stored rule on update", async () => {
+      // The primary update gate must also receive the API-key scope, so the
+      // session super-admin bypass does not apply to a scoped key — otherwise a
+      // super-admin-owned, update-only key would skip the Single's stored rules.
+      const ctx = createCtx({ withRbac: true });
+      ctx.registry.registerSingle(
+        "site-settings",
+        siteSettingsMeta({ accessRules: { update: { type: "owner-only" } } })
+      );
+      // No document yet, so the owner-only rule has no ownership to compare and
+      // fails closed — but only if the super-admin bypass did not fire first.
+      ctx.adapter.selectOne.mockResolvedValue(null);
+
+      const result = await ctx.service.update(
+        "site-settings",
+        { siteName: "x" },
+        {
+          user: { id: "admin-1", roles: ["super-admin"] },
+          authenticatedScope: {
+            actorType: "apiKey",
+            permissions: ["update-site-settings"],
+          },
+        }
+      );
+
+      expect(result.statusCode).toBe(403);
+    });
   });
 });

--- a/packages/nextly/src/domains/singles/__tests__/single-test-helpers.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-test-helpers.ts
@@ -156,6 +156,9 @@ export function createMockComponentDataService(): MockRecord {
 export function createMockRBACService(allowed: boolean = true): MockRecord {
   return {
     checkAccess: vi.fn().mockResolvedValue(allowed),
+    // Consulted by the API-key scope path to evaluate a code-defined access
+    // rule; no rule by default.
+    getRegisteredAccess: vi.fn().mockReturnValue(undefined),
   };
 }
 

--- a/packages/nextly/src/domains/singles/services/single-access-stored-rules.test.ts
+++ b/packages/nextly/src/domains/singles/services/single-access-stored-rules.test.ts
@@ -241,3 +241,79 @@ describe("checkSingleAccess — stored rule enforcement", () => {
     expect(rbacAccessControlService.checkAccess).not.toHaveBeenCalled();
   });
 });
+
+describe("checkSingleAccess — scoped API key", () => {
+  // The publish/unpublish transition gate runs NOT route-authorized (the route
+  // attested only `update`). For a scoped API key it judges the key's OWN
+  // stamped grants, not the key owner's RBAC.
+  const apiKeyOwner = { id: "publisher-1", roles: ["editor"] };
+
+  it("denies a publish the key is not scoped for, even when the owner's RBAC allows", async () => {
+    const { accessControlService, rbacAccessControlService } = makeDeps();
+    accessControlService.evaluateAccess.mockResolvedValue({ allowed: true });
+    rbacAccessControlService.checkAccess.mockResolvedValue(true); // owner can publish
+
+    const result = await checkSingleAccess({
+      slug: "site",
+      operation: "publish",
+      user: apiKeyOwner,
+      overrideAccess: false,
+      routeAuthorized: false,
+      rbacAccessControlService: rbacAccessControlService as never,
+      authenticatedScope: { actorType: "apiKey", permissions: ["update-site"] },
+      accessControlService: accessControlService as never,
+      accessRules: undefined,
+      logger: silentLogger,
+    });
+
+    expect(result?.statusCode).toBe(403);
+    expect(rbacAccessControlService.checkAccess).not.toHaveBeenCalled();
+  });
+
+  it("allows a publish the key IS scoped for, even when the owner's RBAC denies", async () => {
+    const { accessControlService, rbacAccessControlService } = makeDeps();
+    accessControlService.evaluateAccess.mockResolvedValue({ allowed: true });
+    rbacAccessControlService.checkAccess.mockResolvedValue(false); // owner cannot publish
+
+    const result = await checkSingleAccess({
+      slug: "site",
+      operation: "publish",
+      user: apiKeyOwner,
+      overrideAccess: false,
+      routeAuthorized: false,
+      rbacAccessControlService: rbacAccessControlService as never,
+      authenticatedScope: {
+        actorType: "apiKey",
+        permissions: ["update-site", "publish-site"],
+      },
+      accessControlService: accessControlService as never,
+      accessRules: undefined,
+      logger: silentLogger,
+    });
+
+    expect(result).toBeNull();
+    expect(rbacAccessControlService.checkAccess).not.toHaveBeenCalled();
+  });
+
+  it("falls through to the owner's RBAC for a session caller (no api-key scope)", async () => {
+    const { accessControlService, rbacAccessControlService } = makeDeps();
+    accessControlService.evaluateAccess.mockResolvedValue({ allowed: true });
+    rbacAccessControlService.checkAccess.mockResolvedValue(false);
+
+    const result = await checkSingleAccess({
+      slug: "site",
+      operation: "publish",
+      user: apiKeyOwner,
+      overrideAccess: false,
+      routeAuthorized: false,
+      rbacAccessControlService: rbacAccessControlService as never,
+      authenticatedScope: { actorType: "user", permissions: [] },
+      accessControlService: accessControlService as never,
+      accessRules: undefined,
+      logger: silentLogger,
+    });
+
+    expect(result?.statusCode).toBe(403);
+    expect(rbacAccessControlService.checkAccess).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/nextly/src/domains/singles/services/single-access-stored-rules.test.ts
+++ b/packages/nextly/src/domains/singles/services/single-access-stored-rules.test.ts
@@ -25,6 +25,9 @@ function makeDeps() {
   const accessControlService = { evaluateAccess: vi.fn() };
   const rbacAccessControlService = {
     checkAccess: vi.fn().mockResolvedValue(true),
+    // No code-defined access by default; a scoped API key is judged on its
+    // permission grant alone unless a test registers a rule.
+    getRegisteredAccess: vi.fn().mockReturnValue(undefined),
   };
   return { accessControlService, rbacAccessControlService };
 }
@@ -268,6 +271,34 @@ describe("checkSingleAccess — scoped API key", () => {
 
     expect(result?.statusCode).toBe(403);
     expect(rbacAccessControlService.checkAccess).not.toHaveBeenCalled();
+  });
+
+  it("still enforces a code-defined access rule for a scoped key that holds the grant", async () => {
+    const { accessControlService, rbacAccessControlService } = makeDeps();
+    accessControlService.evaluateAccess.mockResolvedValue({ allowed: true });
+    // The key HAS publish-site, but the Single's code-defined access.publish
+    // denies — the grant must not bypass it.
+    rbacAccessControlService.getRegisteredAccess.mockReturnValue({
+      publish: () => false,
+    });
+
+    const result = await checkSingleAccess({
+      slug: "site",
+      operation: "publish",
+      user: apiKeyOwner,
+      overrideAccess: false,
+      routeAuthorized: false,
+      rbacAccessControlService: rbacAccessControlService as never,
+      authenticatedScope: {
+        actorType: "apiKey",
+        permissions: ["publish-site"],
+      },
+      accessControlService: accessControlService as never,
+      accessRules: undefined,
+      logger: silentLogger,
+    });
+
+    expect(result?.statusCode).toBe(403);
   });
 
   it("allows a publish the key IS scoped for, even when the owner's RBAC denies", async () => {

--- a/packages/nextly/src/domains/singles/services/single-access-stored-rules.test.ts
+++ b/packages/nextly/src/domains/singles/services/single-access-stored-rules.test.ts
@@ -273,6 +273,28 @@ describe("checkSingleAccess — scoped API key", () => {
     expect(rbacAccessControlService.checkAccess).not.toHaveBeenCalled();
   });
 
+  it("does not let a super-admin-owned key bypass its scope for publish", async () => {
+    const { accessControlService, rbacAccessControlService } = makeDeps();
+    accessControlService.evaluateAccess.mockResolvedValue({ allowed: true });
+
+    const result = await checkSingleAccess({
+      slug: "site",
+      operation: "publish",
+      // The key's resolved role set carries super-admin, but a scoped key must
+      // not get the session super-admin bypass.
+      user: { id: "admin-1", roles: ["super-admin"] },
+      overrideAccess: false,
+      routeAuthorized: false,
+      rbacAccessControlService: rbacAccessControlService as never,
+      authenticatedScope: { actorType: "apiKey", permissions: ["update-site"] },
+      accessControlService: accessControlService as never,
+      accessRules: undefined,
+      logger: silentLogger,
+    });
+
+    expect(result?.statusCode).toBe(403);
+  });
+
   it("still enforces a code-defined access rule for a scoped key that holds the grant", async () => {
     const { accessControlService, rbacAccessControlService } = makeDeps();
     accessControlService.evaluateAccess.mockResolvedValue({ allowed: true });

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -191,6 +191,9 @@ export class SingleMutationService extends BaseService {
         overrideAccess: options.overrideAccess,
         routeAuthorized: options.routeAuthorized,
         rbacAccessControlService: this.rbacAccessControlService,
+        // A scoped API key is judged on its own grants here too, so the session
+        // super-admin bypass does not apply to it on the primary update gate.
+        authenticatedScope: options.authenticatedScope,
         accessControlService: this.accessControlService,
         accessRules: singleMeta.accessRules,
         document: existingDoc ?? undefined,

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -435,6 +435,9 @@ export class SingleMutationService extends BaseService {
             // transition permission must actually run.
             routeAuthorized: false,
             rbacAccessControlService: this.rbacAccessControlService,
+            // A scoped API key is judged on its own publish/unpublish grant, not
+            // the key owner's — the route only checked `update` against the scope.
+            authenticatedScope: options.authenticatedScope,
             accessControlService: this.accessControlService,
             accessRules: singleMeta.accessRules,
             document: existingDoc ?? undefined,

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -21,7 +21,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import { sql } from "drizzle-orm";
 
 import {
-  apiKeyScopeAllows,
+  apiKeyWriteAllowed,
   type AuthenticatedScope,
 } from "../../../auth/authenticated-scope";
 import type { FieldConfig } from "../../../collections/fields/types";
@@ -263,7 +263,13 @@ export async function checkSingleAccess(params: {
   // publish/unpublish re-check must consult the key's own permission list.
   // `apiKeyScopeAllows` returns null for a non-API-key caller, falling through
   // to the owner/session RBAC path below.
-  const scopeDecision = apiKeyScopeAllows(authenticatedScope, operation, slug);
+  const scopeDecision = await apiKeyWriteAllowed(
+    authenticatedScope,
+    operation,
+    slug,
+    user,
+    rbacAccessControlService
+  );
   if (scopeDecision !== null) {
     return scopeDecision
       ? null

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -260,9 +260,10 @@ export async function checkSingleAccess(params: {
 
   // A scoped API key is authorized on its OWN stamped grants, not the key
   // owner's: the route only checked `update` against the key's scope, so this
-  // publish/unpublish re-check must consult the key's own permission list.
-  // `apiKeyScopeAllows` returns null for a non-API-key caller, falling through
-  // to the owner/session RBAC path below.
+  // publish/unpublish re-check must consult the key's own permission list AND
+  // the code-defined access rule against that scope. `apiKeyWriteAllowed`
+  // returns null for a non-API-key caller, falling through to the owner/session
+  // RBAC path below.
   const scopeDecision = await apiKeyWriteAllowed(
     authenticatedScope,
     operation,

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -20,6 +20,10 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import { sql } from "drizzle-orm";
 
+import {
+  apiKeyScopeAllows,
+  type AuthenticatedScope,
+} from "../../../auth/authenticated-scope";
 import type { FieldConfig } from "../../../collections/fields/types";
 import { container } from "../../../di/container";
 import type { Nextly as NextlyDirectAPI } from "../../../direct-api/nextly";
@@ -153,6 +157,9 @@ export async function checkSingleAccess(params: {
   overrideAccess?: boolean;
   routeAuthorized?: boolean;
   rbacAccessControlService?: RBACAccessControlService;
+  // The caller's authenticated scope. A scoped API key is judged on its OWN
+  // stamped grants for the publish/unpublish transition, not the owner's RBAC.
+  authenticatedScope?: AuthenticatedScope;
   /** Evaluator for the Single's stored access rules. */
   accessControlService?: AccessControlService;
   /** The Single's stored access rules (from the registry metadata). */
@@ -171,6 +178,7 @@ export async function checkSingleAccess(params: {
     overrideAccess,
     routeAuthorized,
     rbacAccessControlService,
+    authenticatedScope,
     accessControlService,
     accessRules,
     document,
@@ -246,7 +254,27 @@ export async function checkSingleAccess(params: {
     return null;
   }
 
-  if (!rbacAccessControlService || !user) {
+  if (!user) {
+    return null;
+  }
+
+  // A scoped API key is authorized on its OWN stamped grants, not the key
+  // owner's: the route only checked `update` against the key's scope, so this
+  // publish/unpublish re-check must consult the key's own permission list.
+  // `apiKeyScopeAllows` returns null for a non-API-key caller, falling through
+  // to the owner/session RBAC path below.
+  const scopeDecision = apiKeyScopeAllows(authenticatedScope, operation, slug);
+  if (scopeDecision !== null) {
+    return scopeDecision
+      ? null
+      : {
+          success: false,
+          statusCode: 403,
+          message: `Access denied: insufficient permissions for ${operation} on single "${slug}"`,
+        };
+  }
+
+  if (!rbacAccessControlService) {
     return null;
   }
 

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -189,9 +189,13 @@ export async function checkSingleAccess(params: {
     return null;
   }
 
-  // Super-admins bypass the stored rules on every transport, keyed on the
-  // authorized role set (never the account id).
-  if (isSuperAdminContext(user)) {
+  // Super-admins bypass the stored rules on every transport — EXCEPT via a
+  // scoped API key. The bypass belongs to the session path: a key is
+  // authoritative on its OWN stamped scope, never on the owner's roles, so a
+  // read/update-only key issued by an admin is not equivalent to their full
+  // account (mirrors canReadEntity). Otherwise a super-admin-owned, update-only
+  // key could publish.
+  if (authenticatedScope?.actorType !== "apiKey" && isSuperAdminContext(user)) {
     return null;
   }
 

--- a/packages/nextly/src/domains/singles/types.ts
+++ b/packages/nextly/src/domains/singles/types.ts
@@ -9,6 +9,7 @@
  * @since 1.0.0
  */
 
+import type { AuthenticatedScope } from "../../auth/authenticated-scope";
 import type { StatusOption } from "../../lib/status-filter";
 
 /**
@@ -133,6 +134,13 @@ export interface UpdateSingleOptions {
 
   /** Arbitrary data passed to hooks via context. */
   context?: Record<string, unknown>;
+
+  /**
+   * The caller's authenticated scope. For a scoped API-key REST write, the
+   * publish/unpublish transition gate judges the key's OWN grants rather than
+   * the key owner's RBAC.
+   */
+  authenticatedScope?: AuthenticatedScope;
 }
 
 /**

--- a/packages/nextly/src/domains/versions/restore-version.ts
+++ b/packages/nextly/src/domains/versions/restore-version.ts
@@ -14,6 +14,7 @@
  * @module domains/versions/restore-version
  */
 
+import type { AuthenticatedScope } from "../../auth/authenticated-scope";
 import type { RequestActor } from "../../auth/request-actor";
 import type { FieldConfig } from "../../collections/fields/types";
 import { getService } from "../../di";
@@ -46,6 +47,13 @@ export interface RestoreVersionArgs {
    * would make it indistinguishable from that person editing by hand.
    */
   actor?: RequestActor;
+  /**
+   * The caller's authenticated scope. A restore replays a snapshot through the
+   * update path, so when the snapshot sets `status: "published"` it hits the
+   * publish transition gate — which for a scoped API key must judge the key's
+   * OWN `publish-<slug>` grant, not the owner's RBAC.
+   */
+  authenticatedScope?: AuthenticatedScope;
 }
 
 export interface RestoreVersionResult {
@@ -472,6 +480,11 @@ export async function restoreVersion(
       // The route authorized the caller for this document; the update still
       // runs its own document-level rules.
       routeAuthorized: true,
+      // A snapshot that restores `status: "published"` must satisfy the key's
+      // own publish grant, not the owner's RBAC.
+      ...(args.authenticatedScope
+        ? { authenticatedScope: args.authenticatedScope }
+        : {}),
       ...(writeLocale ? { locale: writeLocale } : {}),
       sourceVersionNo: args.versionNo,
     });
@@ -485,6 +498,11 @@ export async function restoreVersion(
         user: args.user,
         overrideAccess: false,
         routeAuthorized: true,
+        // A snapshot that restores `status: "published"` must satisfy the key's
+        // own publish grant, not the owner's RBAC.
+        ...(args.authenticatedScope
+          ? { authenticatedScope: args.authenticatedScope }
+          : {}),
         // See the note above the Single branch.
         ...(writeLocale ? { locale: writeLocale } : {}),
         ...(args.actor ? { actor: args.actor } : {}),

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -4,6 +4,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import { getHookRegistry } from "@nextly/hooks/hook-registry";
 
+import type { AuthenticatedScope } from "../auth/authenticated-scope";
 import type { RequestActor } from "../auth/request-actor";
 import { container } from "../di/container";
 import type { PermissionSeedService } from "../domains/auth/services/permission-seed-service";
@@ -624,6 +625,11 @@ export class CollectionsHandler {
        * version it captures.
        */
       sourceVersionNo?: number;
+      /**
+       * The caller's authenticated scope. For a scoped API-key REST write, the
+       * publish/unpublish transition gate judges the key's OWN grants.
+       */
+      authenticatedScope?: AuthenticatedScope;
     },
     body: Record<string, unknown>
   ) {
@@ -638,6 +644,9 @@ export class CollectionsHandler {
         // a silently dropped lineage marker would leave a restore
         // indistinguishable from an ordinary edit.
         sourceVersionNo: params.sourceVersionNo,
+        // The API-key scope gates the publish transition; naming it explicitly
+        // (like sourceVersionNo) keeps it from being silently dropped.
+        authenticatedScope: params.authenticatedScope,
       },
       body,
       params.depth
@@ -665,6 +674,8 @@ export class CollectionsHandler {
      * re-check. Never inferred from a userId.
      */
     routeAuthorized?: boolean;
+    /** API-key scope; gates the unconditional publish check. */
+    authenticatedScope?: AuthenticatedScope;
   }) {
     return this.entryService.publishAllLocales(this.resolveUserParam(params));
   }

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -497,6 +497,11 @@ export class CollectionsHandler {
       routeAuthorized?: boolean;
       /** Arbitrary data passed to hooks via context */
       context?: Record<string, unknown>;
+      /**
+       * The caller's authenticated scope. For a scoped API-key REST create the
+       * publish transition gate (create-as-published) judges the key's OWN grants.
+       */
+      authenticatedScope?: AuthenticatedScope;
     },
     body: Record<string, unknown>
   ) {
@@ -505,6 +510,9 @@ export class CollectionsHandler {
         ...this.resolveUserParam(params),
         locale: params.locale,
         actor: params.actor,
+        // Named explicitly (like updateEntry) so the API-key scope survives the
+        // field-by-field rebuild rather than only via resolveUserParam's rest.
+        authenticatedScope: params.authenticatedScope,
       },
       body,
       params.depth

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -22,6 +22,7 @@ import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
 import type { HookRegistry } from "@nextly/hooks/hook-registry";
 import type { RichTextOutputFormat } from "@nextly/lib/rich-text-html";
 
+import type { AuthenticatedScope } from "../../auth/authenticated-scope";
 import type { RequestActor } from "../../auth/request-actor";
 import type { RBACAccessControlService } from "../../domains/auth/services/rbac-access-control-service";
 import { CollectionAccessService } from "../../domains/collections/services/collection-access-service";
@@ -328,6 +329,11 @@ export class CollectionEntryService extends BaseService {
        * version it captures.
        */
       sourceVersionNo?: number;
+      /**
+       * The caller's authenticated scope. For a scoped API-key REST write the
+       * publish/unpublish transition gate judges the key's OWN grants.
+       */
+      authenticatedScope?: AuthenticatedScope;
     },
     body: Record<string, unknown>,
     depth?: number
@@ -343,6 +349,8 @@ export class CollectionEntryService extends BaseService {
     entryId: string;
     user?: UserContext;
     overrideAccess?: boolean;
+    /** API-key scope; gates the unconditional publish check. */
+    authenticatedScope?: AuthenticatedScope;
   }) {
     const result = await this.mutationService.publishAllLocales(params);
     await this.afterWriteIfRecorded(result);

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -288,6 +288,11 @@ export class CollectionEntryService extends BaseService {
       /** Write locale (i18n M5) — translatable values stored for this language. */
       locale?: string;
       context?: Record<string, unknown>;
+      /**
+       * The caller's authenticated scope. For a scoped API-key REST create the
+       * publish transition gate (create-as-published) judges the key's OWN grants.
+       */
+      authenticatedScope?: AuthenticatedScope;
     },
     body: Record<string, unknown>,
     depth?: number
@@ -349,6 +354,11 @@ export class CollectionEntryService extends BaseService {
     entryId: string;
     user?: UserContext;
     overrideAccess?: boolean;
+    /**
+     * Set by the REST dispatcher: the route already authorized this POST as
+     * `update`, so the preliminary update gate skips its redundant RBAC re-check.
+     */
+    routeAuthorized?: boolean;
     /** API-key scope; gates the unconditional publish check. */
     authenticatedScope?: AuthenticatedScope;
   }) {


### PR DESCRIPTION
## What

The service-side publish/unpublish transition gate now judges a scoped **API key on its own stamped grants**, not the key owner's RBAC — for both collections and singles.

## Why

A REST write authenticated with an API key is authorized at the route only as `update` (the route can't see that the write is a publish). The service then re-checks `publish`/`unpublish`, but resolved RBAC from the key **owner's** `userId`. So:

- an update-only key **owned by a publisher** could publish, and
- a publish-scoped key **owned by a non-publisher** was refused.

This mirrors how reads already work (`auth/entity-read-access.ts` / `canReadEntity`): a key is authoritative on its own scope, in both directions, and does not inherit its owner's grants (nor their super-admin bypass).

## How

- New shared `auth/authenticated-scope.ts` — `AuthenticatedScope` + `apiKeyScopeAllows(scope, operation, resource)` (returns `null` for non-API-key callers, so sessions fall through to RBAC).
- New dispatcher helper `readAuthenticatedScope(params)` decoding the key's stamped `_authenticatedActorType` / `_authenticatedPermissions`.
- Threaded the scope route → dispatcher → handler → service into the transition checks: `checkCollectionAccess` and `checkSingleAccess` judge an API key on its scope in the RBAC gate. Covers `updateEntry`, `publishAllLocales`, and the singles `update` path.

## Tests

- Unit: `apiKeyScopeAllows` + `readAuthenticatedScope` (incl. prefix-collision + corrupt-JSON safety).
- Unit: `checkCollectionAccess` / `checkSingleAccess` prove the scope is **authoritative** — denies a publish the key isn't scoped for even when the owner's RBAC allows, and allows one the key is scoped for even when the owner's RBAC denies; a session caller still falls through to RBAC. (Proven load-bearing by disabling the branch.)
- Integration (both entity kinds): a key scoped `update-<slug>` is refused the publish; the same owner with a `publish-<slug>`-scoped key is allowed.

## Notes

- **Stacked on #293** (`feat/publish-enforcement-singles`), not `main`: the fix touches the singles publish gate that only exists on #293, and is one shared decision for both entity kinds. Review after #290 and #293.
- Addresses the API-key P1 threads on #290 (2307/2812/2001) and #293 (404).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scoped API-key authorization for creating, updating, publishing, unpublishing, restoring, and bulk-publishing content.
  * Permissions are evaluated against the API key’s own grants, with code-defined access rules still enforced.
  * Prevented super-admin or owner permissions from bypassing scoped API-key restrictions.

* **Bug Fixes**
  * Improved handling of missing or invalid authentication permissions, denying safely without errors.

* **Tests**
  * Added comprehensive coverage for scoped permissions, publishing workflows, restores, access rules, and permission edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->