### PR TITLE
feat(nextly): emit an entry.deleted webhook event on collection delete

### DIFF
--- a/.changeset/webhook-entry-deleted.md
+++ b/.changeset/webhook-entry-deleted.md
@@ -24,9 +24,11 @@ Emit an `entry.deleted` webhook event when a collection entry is deleted.
 
 Deleting an entry now records a durable outbox event carrying the removed
 document in the same read shape the `entry.created`/`entry.updated` events use —
-component subtrees and many-to-many ids populated, password and hidden fields
-stripped — so a subscriber sees a consistent payload for every lifecycle event.
-The delete, its component cascade, and the event now run in one transaction, so
-the event never fires for a deletion that rolled back and a cascade failure no
-longer leaves orphaned component rows. The event is attributed to the acting
-identity (user or API key), matching create/update.
+component subtrees, many-to-many ids, and localized companion values populated,
+password and hidden fields stripped — so a subscriber sees a consistent payload
+for every lifecycle event, including on localized collections. The delete and
+its event run in one transaction (the event never fires for a deletion that
+rolled back), and the row is locked and re-read inside that transaction so two
+concurrent deletes cannot both emit — only the delete that actually removed the
+row records the event. The event is attributed to the acting identity (user or
+API key), for single and bulk deletes alike.

--- a/.changeset/webhook-entry-deleted.md
+++ b/.changeset/webhook-entry-deleted.md
@@ -1,0 +1,32 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Emit an `entry.deleted` webhook event when a collection entry is deleted.
+
+Deleting an entry now records a durable outbox event carrying the removed
+document in the same read shape the `entry.created`/`entry.updated` events use —
+component subtrees and many-to-many ids populated, password and hidden fields
+stripped — so a subscriber sees a consistent payload for every lifecycle event.
+The delete, its component cascade, and the event now run in one transaction, so
+the event never fires for a deletion that rolled back and a cascade failure no
+longer leaves orphaned component rows. The event is attributed to the acting
+identity (user or API key), matching create/update.

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -1182,6 +1182,9 @@ const COLLECTIONS_METHODS: Record<
           ? String(p._authenticatedUserEmail)
           : undefined,
         userRoles: readAuthenticatedRoles(p),
+        // Who performed the delete (user vs API key), recorded on the
+        // `entry.deleted` outbox event — same attribution as create/update.
+        actor: readAuthenticatedActor(p),
         // Route middleware already ran the RBAC/code-access gate; attest it so
         // the handler skips only that redundant re-check (stored rules +
         // field-level write access still run). Never inferred from userId.

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -1224,6 +1224,9 @@ const COLLECTIONS_METHODS: Record<
           ? String(p._authenticatedUserEmail)
           : undefined,
         userRoles: readAuthenticatedRoles(p),
+        // Who performed the bulk delete (user vs API key), recorded on each
+        // entry's `entry.deleted` event — same attribution as single delete.
+        actor: readAuthenticatedActor(p),
         // Route middleware already ran the RBAC/code-access gate; attest it so
         // the handler skips only that redundant re-check (stored rules +
         // field-level write access still run). Never inferred from userId.

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -1603,21 +1603,28 @@ export class CollectionBulkService extends BaseService {
       // The shared transaction rolled back — either stopOnError tripped on a
       // returned failure, or an unexpected error (e.g. a failed outbox insert
       // after a row delete) aborted the batch. Every delete in the transaction
-      // was undone, so no item actually succeeded, regardless of stopOnError.
-      if (result.successful > 0) {
+      // was undone, so nothing committed: report ALL requested ids as failed
+      // (not just those processed before the abort) and surface the batch error,
+      // so a caller is not told 0 succeeded / 1 failed for a 3-id request.
+      const rolledBackCount = result.successful;
+      if (rolledBackCount > 0) {
         this.logger.warn("Bulk delete rolled back", {
           collectionName: params.collectionName,
-          successfulBeforeRollback: result.successful,
+          successfulBeforeRollback: rolledBackCount,
           error: error instanceof Error ? error.message : String(error),
         });
-        // Clear successful entries since they were rolled back
-        const rolledBackCount = result.successful;
-        result.successful = 0;
-        result.ids = [];
-        // Add rollback info to first error
-        if (result.errors.length > 0) {
-          result.errors[0].error += ` (${rolledBackCount} successful entries were rolled back)`;
-        }
+      }
+      result.successful = 0;
+      result.ids = [];
+      result.failed = ids.length;
+      const batchError = error instanceof Error ? error.message : String(error);
+      if (result.errors.length > 0) {
+        result.errors[0].error += ` (batch rolled back; ${rolledBackCount} earlier delete(s) undone)`;
+      } else {
+        result.errors.push({
+          index: 0,
+          error: `Batch rolled back: ${batchError}`,
+        });
       }
     }
 

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -1623,14 +1623,18 @@ export class CollectionBulkService extends BaseService {
       result.ids = [];
       result.failed = ids.length;
       const batchError = error instanceof Error ? error.message : String(error);
-      if (result.errors.length > 0) {
-        result.errors[0].error += ` (batch rolled back; ${rolledBackCount} earlier delete(s) undone)`;
-      } else {
-        result.errors.push({
-          index: 0,
-          error: `Batch rolled back: ${batchError}`,
-        });
+      const rollbackNote = `Batch rolled back; no entries were deleted: ${batchError}`;
+      // Every requested id failed (the transaction was undone), but only the ids
+      // processed before the abort have per-index error detail. Add a rollback
+      // error for every remaining index so `failed` and `errors` agree and a
+      // caller relying on per-id detail still sees each rolled-back id.
+      const covered = new Set(result.errors.map(e => e.index));
+      for (let i = 0; i < ids.length; i += 1) {
+        if (!covered.has(i)) {
+          result.errors.push({ index: i, error: rollbackNote });
+        }
       }
+      result.errors.sort((a, b) => a.index - b.index);
     }
 
     this.logger.info("Bulk delete completed", {

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -1576,7 +1576,15 @@ export class CollectionBulkService extends BaseService {
                 }
               }
             } catch (error: unknown) {
-              // Handle unexpected errors during entry deletion
+              // A THROWN error (as opposed to a returned {success:false}) is
+              // unexpected and may have left a partial write in this SHARED
+              // transaction — e.g. the row was deleted but its entry.deleted
+              // outbox event failed to insert. A shared transaction cannot
+              // partially roll back, so committing would break the outbox
+              // guarantee (a delete with no event). Abort the whole batch rather
+              // than soft-failing this item and committing the rest. Expected
+              // per-item failures (access denied, not found) are RETURNED above,
+              // not thrown, so partial success is unaffected.
               result.failed++;
               result.errors.push({
                 index: entryIndex,
@@ -1586,18 +1594,18 @@ export class CollectionBulkService extends BaseService {
                     : "Unknown error occurred",
               });
 
-              if (stopOnError) {
-                throw error; // Re-throw to trigger transaction rollback
-              }
+              throw error; // Roll the whole batch back.
             }
           }
         }
       });
     } catch (error: unknown) {
-      // Transaction was rolled back (stopOnError case)
-      // Reset successful count since transaction rolled back
-      if (stopOnError && result.successful > 0) {
-        this.logger.warn("Bulk delete rolled back due to stopOnError", {
+      // The shared transaction rolled back — either stopOnError tripped on a
+      // returned failure, or an unexpected error (e.g. a failed outbox insert
+      // after a row delete) aborted the batch. Every delete in the transaction
+      // was undone, so no item actually succeeded, regardless of stopOnError.
+      if (result.successful > 0) {
+        this.logger.warn("Bulk delete rolled back", {
           collectionName: params.collectionName,
           successfulBeforeRollback: result.successful,
           error: error instanceof Error ? error.message : String(error),
@@ -1733,6 +1741,11 @@ export class CollectionBulkService extends BaseService {
             }
           }
         } catch (error: unknown) {
+          // A THROWN error may have left a partial write in the CALLER'S
+          // transaction — e.g. a row deleted but its entry.deleted outbox event
+          // failed to insert. Propagate it so the caller's transaction rolls
+          // back rather than committing a delete with no event. Expected per-item
+          // failures are RETURNED above, not thrown, so partial success stands.
           result.failed++;
           result.errors.push({
             index: entryIndex,
@@ -1740,9 +1753,7 @@ export class CollectionBulkService extends BaseService {
               error instanceof Error ? error.message : "Unknown error occurred",
           });
 
-          if (stopOnError) {
-            throw error; // Caller's transaction will be rolled back
-          }
+          throw error; // Caller's transaction will be rolled back.
         }
       }
     }

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -1491,7 +1491,12 @@ export class CollectionBulkService extends BaseService {
    * ```
    */
   async deleteEntries(
-    params: { collectionName: string; user?: UserContext },
+    params: {
+      collectionName: string;
+      user?: UserContext;
+      /** Who performed the delete, recorded on each entry's outbox event. */
+      actor?: RequestActor;
+    },
     ids: string[],
     options?: BulkOperationOptions
   ): Promise<BatchOperationResult> {
@@ -1671,7 +1676,12 @@ export class CollectionBulkService extends BaseService {
    */
   async deleteEntriesInTransaction(
     tx: TransactionContext,
-    params: { collectionName: string; user?: UserContext },
+    params: {
+      collectionName: string;
+      user?: UserContext;
+      /** Who performed the delete, recorded on each entry's outbox event. */
+      actor?: RequestActor;
+    },
     ids: string[],
     options?: BulkOperationOptions
   ): Promise<BatchOperationResult> {

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -676,6 +676,8 @@ export class CollectionBulkService extends BaseService {
       collectionName: string;
       where: WhereFilter;
       user?: UserContext;
+      /** Who performed the delete, recorded on each entry's outbox event. */
+      actor?: RequestActor;
       /** When true, bypass all access control checks */
       overrideAccess?: boolean;
       /** When true, the route middleware already ran the RBAC gate; stored
@@ -810,6 +812,9 @@ export class CollectionBulkService extends BaseService {
       collectionName: params.collectionName,
       ids,
       user: params.user,
+      // Carry the acting identity into the per-entry deletes so a where-clause
+      // bulk delete attributes its events like the id-based one.
+      actor: params.actor,
       overrideAccess: params.overrideAccess,
       routeAuthorized: params.routeAuthorized,
       context: params.context,

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -1624,17 +1624,19 @@ export class CollectionBulkService extends BaseService {
       result.failed = ids.length;
       const batchError = error instanceof Error ? error.message : String(error);
       const rollbackNote = `Batch rolled back; no entries were deleted: ${batchError}`;
-      // Every requested id failed (the transaction was undone), but only the ids
-      // processed before the abort have per-index error detail. Add a rollback
-      // error for every remaining index so `failed` and `errors` agree and a
-      // caller relying on per-id detail still sees each rolled-back id.
-      const covered = new Set(result.errors.map(e => e.index));
-      for (let i = 0; i < ids.length; i += 1) {
-        if (!covered.has(i)) {
-          result.errors.push({ index: i, error: rollbackNote });
-        }
+      // Rebuild errors as exactly one entry per requested id, in index order.
+      // A `stopOnError` returned-failure pushes both the item error and a thrown
+      // wrapper for the same index, so dedupe (first wins) before filling the
+      // rolled-back ids that had no entry — otherwise `errors` would exceed
+      // `failed` and give a client duplicate detail for one id.
+      const byIndex = new Map<number, string>();
+      for (const e of result.errors) {
+        if (!byIndex.has(e.index)) byIndex.set(e.index, e.error);
       }
-      result.errors.sort((a, b) => a.index - b.index);
+      result.errors = [];
+      for (let i = 0; i < ids.length; i += 1) {
+        result.errors.push({ index: i, error: byIndex.get(i) ?? rollbackNote });
+      }
     }
 
     this.logger.info("Bulk delete completed", {

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -303,6 +303,8 @@ export class CollectionBulkService extends BaseService {
     collectionName: string;
     ids: string[];
     user?: UserContext;
+    /** Who performed the delete, recorded on each entry's outbox event. */
+    actor?: RequestActor;
     /** When true, bypass all access control checks */
     overrideAccess?: boolean;
     /** When true, the route middleware already ran the RBAC gate; forwarded to
@@ -328,6 +330,10 @@ export class CollectionBulkService extends BaseService {
               collectionName: params.collectionName,
               entryId,
               user: params.user,
+              // Forward the acting identity so each bulk-deleted entry's
+              // `entry.deleted` event is attributed to the API key/user that
+              // performed the bulk delete, not the key owner or system.
+              actor: params.actor,
               overrideAccess: params.overrideAccess,
               routeAuthorized: params.routeAuthorized,
               context: params.context,

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -257,11 +257,16 @@ export class CollectionMutationService extends BaseService {
    * inside a component and their values would ship in the event payload.
    */
   private async webhookFieldTree(
-    fields: readonly SensitiveFieldSource[]
+    fields: readonly SensitiveFieldSource[],
+    // Executor to resolve component schemas on. When called inside an open
+    // transaction, pass `tx.getDrizzle()`: resolving on the default pooled
+    // connection would take a second connection while the tx holds one and can
+    // starve a small pool. Omit it (the default) when no transaction is open.
+    executor?: unknown
   ): Promise<SensitiveFieldSource[]> {
     const dataService = this.componentDataService;
     return expandComponentFields(fields, async slug =>
-      dataService ? await dataService.getComponentFields(slug) : null
+      dataService ? await dataService.getComponentFields(slug, executor) : null
     );
   }
 
@@ -4432,13 +4437,34 @@ export class CollectionMutationService extends BaseService {
         collection.fields ||
         []) as FieldDefinition[];
 
+      // Lock and re-read the committed row before snapshotting it: `entry` above
+      // was read before the hooks ran, so a concurrent update could otherwise
+      // make the event describe values other than the row this delete removes.
+      // The adapter no-ops the lock where row locking is unavailable (SQLite,
+      // itself serialized).
+      await tx.lockRow(tableName, params.entryId);
+      const freshEntry = await tx.selectOne<Record<string, unknown>>(
+        tableName,
+        {
+          where: this.whereEq("id", params.entryId),
+        }
+      );
+      if (!freshEntry) {
+        return {
+          success: false,
+          statusCode: 404,
+          message: "Entry not found",
+          data: null,
+        };
+      }
+
       // Assemble the removed document before the cascade removes its relations,
       // in the read shape create/update events use.
       const deletedDocument = await this.buildDeletedDocument(tx, {
         collectionName: params.collectionName,
         entryId: params.entryId,
         tableName,
-        row: entry,
+        row: freshEntry,
         fields: snapshotFields,
         locale: this.localization?.defaultLocale,
       });
@@ -4469,7 +4495,8 @@ export class CollectionMutationService extends BaseService {
 
       // Append the outbox event in the same transaction so a delete performed
       // through this helper (batch/cascade/internal) is observable too, in the
-      // same shape as the single-delete path.
+      // same shape as the single-delete path. Resolve component schemas on this
+      // transaction's connection to avoid taking a second pooled connection.
       await recordMutationEvent(tx, {
         type: "entry.deleted",
         resource: {
@@ -4479,7 +4506,7 @@ export class CollectionMutationService extends BaseService {
         },
         data: deletedDocument,
         previous: null,
-        fields: await this.webhookFieldTree(snapshotFields),
+        fields: await this.webhookFieldTree(snapshotFields, tx.getDrizzle()),
         actor: actorForWrite(params.actor, params.user),
       });
 
@@ -5486,13 +5513,34 @@ export class CollectionMutationService extends BaseService {
         collection.fields ||
         []) as FieldDefinition[];
 
+      // Lock and re-read the committed row before snapshotting it: `entry` above
+      // was read before the hooks ran, so a concurrent update could otherwise
+      // make the event describe values other than the row this delete removes.
+      // The adapter no-ops the lock where row locking is unavailable (SQLite,
+      // itself serialized).
+      await tx.lockRow(tableName, entryId);
+      const freshEntry = await tx.selectOne<Record<string, unknown>>(
+        tableName,
+        {
+          where: this.whereEq("id", entryId),
+        }
+      );
+      if (!freshEntry) {
+        return {
+          success: false,
+          statusCode: 404,
+          message: `Entry not found: ${entryId}`,
+          data: null,
+        };
+      }
+
       // Assemble the removed document before the cascade removes its relations,
       // in the read shape create/update events use.
       const deletedDocument = await this.buildDeletedDocument(tx, {
         collectionName: params.collectionName,
         entryId,
         tableName,
-        row: entry,
+        row: freshEntry,
         fields: snapshotFields,
         locale: this.localization?.defaultLocale,
       });
@@ -5523,7 +5571,8 @@ export class CollectionMutationService extends BaseService {
 
       // Append the outbox event in the same transaction so a batch delete
       // through this helper is observable too, in the same shape as the
-      // single-delete path.
+      // single-delete path. Resolve component schemas on this transaction's
+      // connection to avoid taking a second pooled connection.
       await recordMutationEvent(tx, {
         type: "entry.deleted",
         resource: {
@@ -5533,7 +5582,7 @@ export class CollectionMutationService extends BaseService {
         },
         data: deletedDocument,
         previous: null,
-        fields: await this.webhookFieldTree(snapshotFields),
+        fields: await this.webhookFieldTree(snapshotFields, tx.getDrizzle()),
         actor: actorForWrite(params.actor, params.user),
       });
 

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4346,6 +4346,11 @@ export class CollectionMutationService extends BaseService {
       actor?: RequestActor;
     }
   ): Promise<CollectionServiceResult<{ deleted: boolean }>> {
+    // Set once the row is actually removed. A failure AFTER this point (e.g. the
+    // outbox insert) has left this shared transaction with a delete but no event;
+    // the catch below re-throws instead of swallowing it into a soft failure, so
+    // the caller rolls back rather than committing an eventless delete.
+    let rowDeleted = false;
     try {
       // Get collection metadata and stored hooks
       const collection = await this.collectionService.getCollection(
@@ -4492,6 +4497,7 @@ export class CollectionMutationService extends BaseService {
           data: null,
         };
       }
+      rowDeleted = true;
 
       // Append the outbox event in the same transaction so a delete performed
       // through this helper (batch/cascade/internal) is observable too, in the
@@ -4542,6 +4548,12 @@ export class CollectionMutationService extends BaseService {
         data: { deleted: true },
       };
     } catch (error: unknown) {
+      // A failure after the row was deleted leaves the transaction inconsistent
+      // (row gone, no event), so propagate it and let the caller roll back
+      // rather than reporting a soft per-item failure the loop would commit.
+      // Pre-delete failures stay soft: the row is untouched, so a returned
+      // failure is safe.
+      if (rowDeleted) throw error;
       return {
         success: false,
         statusCode: 500,
@@ -5377,6 +5389,11 @@ export class CollectionMutationService extends BaseService {
     entryId: string,
     skipHooks: boolean
   ): Promise<CollectionServiceResult<{ deleted: boolean }>> {
+    // Set once the row is actually removed. A failure AFTER this point (e.g. the
+    // outbox insert) has left this shared transaction with a delete but no event;
+    // the catch below re-throws instead of swallowing it into a soft failure, so
+    // the caller rolls back rather than committing an eventless delete.
+    let rowDeleted = false;
     try {
       // Get collection metadata early
       const collection = await this.collectionService.getCollection(
@@ -5568,6 +5585,7 @@ export class CollectionMutationService extends BaseService {
           data: null,
         };
       }
+      rowDeleted = true;
 
       // Append the outbox event in the same transaction so a batch delete
       // through this helper is observable too, in the same shape as the
@@ -5624,6 +5642,12 @@ export class CollectionMutationService extends BaseService {
         data: { deleted: true },
       };
     } catch (error: unknown) {
+      // A failure after the row was deleted leaves the transaction inconsistent
+      // (row gone, no event), so propagate it and let the caller roll back
+      // rather than reporting a soft per-item failure the loop would commit.
+      // Pre-delete failures stay soft: the row is untouched, so a returned
+      // failure is safe.
+      if (rowDeleted) throw error;
       return {
         success: false,
         statusCode: 500,

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -265,6 +265,48 @@ export class CollectionMutationService extends BaseService {
     );
   }
 
+  /**
+   * Assemble a removed entry as the read shape the create/update events carry —
+   * JSON container fields parsed, component subtrees and many-to-many id arrays
+   * populated, password and system-owner fields stripped — so a delete event
+   * reports the document in a shape consistent with every other event. Reads the
+   * relations on the delete transaction, so the caller MUST build this BEFORE the
+   * cascade delete removes them.
+   */
+  private async buildDeletedDocument(
+    tx: TransactionContext,
+    args: {
+      collectionName: string;
+      entryId: string;
+      tableName: string;
+      row: Record<string, unknown>;
+      fields: FieldDefinition[];
+    }
+  ): Promise<Record<string, unknown>> {
+    const { collectionName, entryId, tableName, row, fields } = args;
+    const manyToManyFields = fields.filter(
+      f => f.type === "relationship" && f.options?.relationType === "manyToMany"
+    );
+
+    const parentRow = this.deserializeJsonFieldsForSnapshot(
+      convertTimestampsToCamelCase({ ...row }),
+      fields
+    );
+    stripPasswordFieldValues(parentRow, fields);
+    stripSystemOwnerField(parentRow);
+
+    const { components, manyToMany } = await this.buildFullSnapshotRelations(
+      tx,
+      entryId,
+      collectionName,
+      tableName,
+      fields,
+      manyToManyFields
+    );
+
+    return assembleDocument({ parentRow, components, manyToMany });
+  }
+
   private transitionStatus(args: {
     collection: string;
     id: unknown;
@@ -3282,6 +3324,8 @@ export class CollectionMutationService extends BaseService {
     collectionName: string;
     entryId: string;
     user?: UserContext;
+    /** Who performed the delete, recorded on the outbox event. */
+    actor?: RequestActor;
     /** When true, bypass all access control checks */
     overrideAccess?: boolean;
     /** When true, the route middleware already ran the RBAC gate; stored rules
@@ -3388,20 +3432,61 @@ export class CollectionMutationService extends BaseService {
         )
       );
 
-      // Cascade delete component data before deleting the main entry
-      if (this.componentDataService) {
-        const collectionFields = (collection.schemaDefinition?.fields ||
-          collection.fields ||
-          []) as FieldConfig[];
-        await this.componentDataService.deleteComponentData({
-          parentId: params.entryId,
-          parentTable: tableName,
-          fields: collectionFields,
-        });
-      }
+      // The collection schema, viewed two ways: the component cascade takes
+      // FieldConfig, the outbox snapshot takes FieldDefinition. Both are the
+      // same underlying array off the loosely-typed collection.
+      const collectionFields = (collection.schemaDefinition?.fields ||
+        collection.fields ||
+        []) as FieldConfig[];
+      const snapshotFields = (collection.schemaDefinition?.fields ||
+        collection.fields ||
+        []) as FieldDefinition[];
+      // Resolved before the transaction opens: the expansion reads the component
+      // registry on the pooled connection (see the create/update paths).
+      const webhookFields = await this.webhookFieldTree(snapshotFields);
 
-      await this.db.delete(schema).where(eq(schema.id, params.entryId));
-      // .returning();
+      // Delete the entry, cascade its component subtrees, and append the
+      // `entry.deleted` event in one transaction so the event commits with the
+      // deletion (never recorded for a delete that rolls back) and a
+      // component-cascade failure rolls the whole thing back instead of leaving
+      // orphaned component rows.
+      await this.adapter.transaction(async tx => {
+        // Read the removed document before the cascade delete removes its
+        // relations, in the read shape create/update events use.
+        const deletedDocument = await this.buildDeletedDocument(tx, {
+          collectionName: params.collectionName,
+          entryId: params.entryId,
+          tableName,
+          row: entry as Record<string, unknown>,
+          fields: snapshotFields,
+        });
+
+        if (this.componentDataService) {
+          await this.componentDataService.deleteComponentDataInTransaction(tx, {
+            parentId: params.entryId,
+            parentTable: tableName,
+            fields: collectionFields,
+          });
+        }
+
+        await tx.delete(tableName, this.whereEq("id", params.entryId));
+
+        // The removed document's final state ships as `data`; there is no
+        // post-delete state, so `previous` is null (mirroring create, which
+        // carries only `data`).
+        await recordMutationEvent(tx, {
+          type: "entry.deleted",
+          resource: {
+            kind: "entry",
+            collection: params.collectionName,
+            id: params.entryId,
+          },
+          data: deletedDocument,
+          previous: null,
+          fields: webhookFields,
+          actor: actorForWrite(params.actor, params.user),
+        });
+      });
 
       const deleted = entry;
 

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -281,17 +281,38 @@ export class CollectionMutationService extends BaseService {
       tableName: string;
       row: Record<string, unknown>;
       fields: FieldDefinition[];
+      /**
+       * Locale whose companion translations to merge into the snapshot. For a
+       * migrated localized collection the main row holds no translatable values,
+       * so without this the payload omits every localized field.
+       */
+      locale?: string;
     }
   ): Promise<Record<string, unknown>> {
-    const { collectionName, entryId, tableName, row, fields } = args;
+    const { collectionName, entryId, tableName, row, fields, locale } = args;
     const manyToManyFields = fields.filter(
       f => f.type === "relationship" && f.options?.relationType === "manyToMany"
     );
 
-    const parentRow = this.deserializeJsonFieldsForSnapshot(
-      convertTimestampsToCamelCase({ ...row }),
-      fields
-    );
+    // Overlay the locale's translatable values from the companion table before
+    // deserializing, so a localized field still held as a JSON string is parsed
+    // to the read shape too — matching how the update path builds `previous`.
+    const merged: Record<string, unknown> = {
+      ...convertTimestampsToCamelCase({ ...row }),
+    };
+    if (locale && this.localization) {
+      Object.assign(
+        merged,
+        await this.readCompanionLocalizedValues(
+          tx,
+          collectionName,
+          entryId,
+          locale
+        )
+      );
+    }
+
+    const parentRow = this.deserializeJsonFieldsForSnapshot(merged, fields);
     stripPasswordFieldValues(parentRow, fields);
     stripSystemOwnerField(parentRow);
 
@@ -301,7 +322,8 @@ export class CollectionMutationService extends BaseService {
       collectionName,
       tableName,
       fields,
-      manyToManyFields
+      manyToManyFields,
+      locale
     );
 
     return assembleDocument({ parentRow, components, manyToMany });
@@ -3446,19 +3468,39 @@ export class CollectionMutationService extends BaseService {
       const webhookFields = await this.webhookFieldTree(snapshotFields);
 
       // Delete the entry, cascade its component subtrees, and append the
-      // `entry.deleted` event in one transaction so the event commits with the
-      // deletion (never recorded for a delete that rolls back) and a
-      // component-cascade failure rolls the whole thing back instead of leaving
-      // orphaned component rows.
+      // `entry.deleted` event in one transaction, so the event commits with the
+      // deletion and is never recorded for a delete that rolled back. (The
+      // component cascade is best-effort inside the shared helper — it logs and
+      // continues on a per-table failure — so this pairs the entry delete with
+      // its event, not full cascade atomicity.)
+      let deletedRow = false;
       await this.adapter.transaction(async tx => {
+        // Lock and re-read the committed row inside the transaction. `entry`
+        // above was read before the hooks ran and outside this transaction, so a
+        // concurrent write may have changed or removed it; the event must
+        // describe the row actually deleted, and the lock serializes a racing
+        // delete so only one of them records the event. The adapter no-ops the
+        // lock where row locking is unavailable (e.g. SQLite, itself serialized).
+        await tx.lockRow(tableName, params.entryId);
+        const [currentRow] = await tx
+          .getDrizzle<typeof this.db>()
+          .select()
+          .from(schema)
+          .where(eq(schema.id, params.entryId))
+          .limit(1);
+        if (!currentRow) return; // a concurrent delete won the race.
+
         // Read the removed document before the cascade delete removes its
-        // relations, in the read shape create/update events use.
+        // relations, in the read shape create/update events use. A localized
+        // collection keeps translatable values in the companion, so overlay the
+        // default locale's.
         const deletedDocument = await this.buildDeletedDocument(tx, {
           collectionName: params.collectionName,
           entryId: params.entryId,
           tableName,
-          row: entry as Record<string, unknown>,
+          row: currentRow as Record<string, unknown>,
           fields: snapshotFields,
+          locale: this.localization?.defaultLocale,
         });
 
         if (this.componentDataService) {
@@ -3469,7 +3511,15 @@ export class CollectionMutationService extends BaseService {
           });
         }
 
-        await tx.delete(tableName, this.whereEq("id", params.entryId));
+        const deletedCount = await tx.delete(
+          tableName,
+          this.whereEq("id", params.entryId)
+        );
+        // With the lock held a found row always deletes; the guard still covers
+        // the lock-less dialects and keeps a racing delete from recording a
+        // duplicate `entry.deleted` for a row it did not remove.
+        if (deletedCount === 0) return;
+        deletedRow = true;
 
         // The removed document's final state ships as `data`; there is no
         // post-delete state, so `previous` is null (mirroring create, which
@@ -3488,9 +3538,10 @@ export class CollectionMutationService extends BaseService {
         });
       });
 
-      const deleted = entry;
-
-      if (!deleted) {
+      // A concurrent delete removed the row first: report not-found rather than
+      // a second success (and a duplicate event) for a deletion this call did
+      // not perform.
+      if (!deletedRow) {
         return {
           success: false,
           statusCode: 404,
@@ -3498,6 +3549,8 @@ export class CollectionMutationService extends BaseService {
           data: null,
         };
       }
+
+      const deleted = entry;
 
       // Execute afterDelete hooks (code-registered)
       // Hooks run after deletion completes (for cleanup)

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -293,7 +293,10 @@ export class CollectionMutationService extends BaseService {
        */
       locale?: string;
     }
-  ): Promise<Record<string, unknown>> {
+    // Returns the assembled document plus the locale that actually applied — set
+    // only when the collection is localized — so the caller tags `resource.locale`
+    // with the same locale the payload represents (and omits it otherwise).
+  ): Promise<{ document: Record<string, unknown>; locale?: string }> {
     const { collectionName, entryId, tableName, row, fields, locale } = args;
     const manyToManyFields = fields.filter(
       f => f.type === "relationship" && f.options?.relationType === "manyToMany"
@@ -305,16 +308,24 @@ export class CollectionMutationService extends BaseService {
     const merged: Record<string, unknown> = {
       ...convertTimestampsToCamelCase({ ...row }),
     };
+    let appliedLocale: string | undefined;
     if (locale && this.localization) {
-      Object.assign(
-        merged,
-        await this.readCompanionLocalizedValues(
-          tx,
-          collectionName,
-          entryId,
-          locale
-        )
-      );
+      // A companion schema means the collection is localized; only then does the
+      // locale disambiguate the payload, so only then is it recorded.
+      const companion =
+        await this.fileManager.loadCompanionSchema(collectionName);
+      if (companion) {
+        appliedLocale = locale;
+        Object.assign(
+          merged,
+          await this.readCompanionLocalizedValues(
+            tx,
+            collectionName,
+            entryId,
+            locale
+          )
+        );
+      }
     }
 
     const parentRow = this.deserializeJsonFieldsForSnapshot(merged, fields);
@@ -328,10 +339,13 @@ export class CollectionMutationService extends BaseService {
       tableName,
       fields,
       manyToManyFields,
-      locale
+      appliedLocale
     );
 
-    return assembleDocument({ parentRow, components, manyToMany });
+    return {
+      document: assembleDocument({ parentRow, components, manyToMany }),
+      locale: appliedLocale,
+    };
   }
 
   private transitionStatus(args: {
@@ -3499,14 +3513,15 @@ export class CollectionMutationService extends BaseService {
         // relations, in the read shape create/update events use. A localized
         // collection keeps translatable values in the companion, so overlay the
         // default locale's.
-        const deletedDocument = await this.buildDeletedDocument(tx, {
-          collectionName: params.collectionName,
-          entryId: params.entryId,
-          tableName,
-          row: currentRow as Record<string, unknown>,
-          fields: snapshotFields,
-          locale: this.localization?.defaultLocale,
-        });
+        const { document: deletedDocument, locale: deletedLocale } =
+          await this.buildDeletedDocument(tx, {
+            collectionName: params.collectionName,
+            entryId: params.entryId,
+            tableName,
+            row: currentRow as Record<string, unknown>,
+            fields: snapshotFields,
+            locale: this.localization?.defaultLocale,
+          });
 
         if (this.componentDataService) {
           await this.componentDataService.deleteComponentDataInTransaction(tx, {
@@ -3528,13 +3543,15 @@ export class CollectionMutationService extends BaseService {
 
         // The removed document's final state ships as `data`; there is no
         // post-delete state, so `previous` is null (mirroring create, which
-        // carries only `data`).
+        // carries only `data`). `locale` is set only for a localized collection,
+        // so a receiver knows which translation the payload represents.
         await recordMutationEvent(tx, {
           type: "entry.deleted",
           resource: {
             kind: "entry",
             collection: params.collectionName,
             id: params.entryId,
+            ...(deletedLocale ? { locale: deletedLocale } : {}),
           },
           data: deletedDocument,
           previous: null,
@@ -4465,14 +4482,15 @@ export class CollectionMutationService extends BaseService {
 
       // Assemble the removed document before the cascade removes its relations,
       // in the read shape create/update events use.
-      const deletedDocument = await this.buildDeletedDocument(tx, {
-        collectionName: params.collectionName,
-        entryId: params.entryId,
-        tableName,
-        row: freshEntry,
-        fields: snapshotFields,
-        locale: this.localization?.defaultLocale,
-      });
+      const { document: deletedDocument, locale: deletedLocale } =
+        await this.buildDeletedDocument(tx, {
+          collectionName: params.collectionName,
+          entryId: params.entryId,
+          tableName,
+          row: freshEntry,
+          fields: snapshotFields,
+          locale: this.localization?.defaultLocale,
+        });
 
       // Cascade delete component data before deleting the main entry
       if (this.componentDataService) {
@@ -4503,12 +4521,14 @@ export class CollectionMutationService extends BaseService {
       // through this helper (batch/cascade/internal) is observable too, in the
       // same shape as the single-delete path. Resolve component schemas on this
       // transaction's connection to avoid taking a second pooled connection.
+      // `locale` is set only for a localized collection.
       await recordMutationEvent(tx, {
         type: "entry.deleted",
         resource: {
           kind: "entry",
           collection: params.collectionName,
           id: params.entryId,
+          ...(deletedLocale ? { locale: deletedLocale } : {}),
         },
         data: deletedDocument,
         previous: null,
@@ -5553,14 +5573,15 @@ export class CollectionMutationService extends BaseService {
 
       // Assemble the removed document before the cascade removes its relations,
       // in the read shape create/update events use.
-      const deletedDocument = await this.buildDeletedDocument(tx, {
-        collectionName: params.collectionName,
-        entryId,
-        tableName,
-        row: freshEntry,
-        fields: snapshotFields,
-        locale: this.localization?.defaultLocale,
-      });
+      const { document: deletedDocument, locale: deletedLocale } =
+        await this.buildDeletedDocument(tx, {
+          collectionName: params.collectionName,
+          entryId,
+          tableName,
+          row: freshEntry,
+          fields: snapshotFields,
+          locale: this.localization?.defaultLocale,
+        });
 
       // Cascade delete component data before deleting the main entry
       if (this.componentDataService) {
@@ -5590,13 +5611,15 @@ export class CollectionMutationService extends BaseService {
       // Append the outbox event in the same transaction so a batch delete
       // through this helper is observable too, in the same shape as the
       // single-delete path. Resolve component schemas on this transaction's
-      // connection to avoid taking a second pooled connection.
+      // connection to avoid taking a second pooled connection. `locale` is set
+      // only for a localized collection.
       await recordMutationEvent(tx, {
         type: "entry.deleted",
         resource: {
           kind: "entry",
           collection: params.collectionName,
           id: entryId,
+          ...(deletedLocale ? { locale: deletedLocale } : {}),
         },
         data: deletedDocument,
         previous: null,

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4337,6 +4337,8 @@ export class CollectionMutationService extends BaseService {
       collectionName: string;
       entryId: string;
       user?: UserContext;
+      /** Who performed the delete, recorded on the outbox event. */
+      actor?: RequestActor;
     }
   ): Promise<CollectionServiceResult<{ deleted: boolean }>> {
     try {
@@ -4421,11 +4423,28 @@ export class CollectionMutationService extends BaseService {
         )
       );
 
+      // The collection schema, two views: FieldConfig for the component cascade,
+      // FieldDefinition for the outbox snapshot.
+      const collectionFields = (collection.schemaDefinition?.fields ||
+        collection.fields ||
+        []) as FieldConfig[];
+      const snapshotFields = (collection.schemaDefinition?.fields ||
+        collection.fields ||
+        []) as FieldDefinition[];
+
+      // Assemble the removed document before the cascade removes its relations,
+      // in the read shape create/update events use.
+      const deletedDocument = await this.buildDeletedDocument(tx, {
+        collectionName: params.collectionName,
+        entryId: params.entryId,
+        tableName,
+        row: entry,
+        fields: snapshotFields,
+        locale: this.localization?.defaultLocale,
+      });
+
       // Cascade delete component data before deleting the main entry
       if (this.componentDataService) {
-        const collectionFields = (collection.schemaDefinition?.fields ||
-          collection.fields ||
-          []) as FieldConfig[];
         await this.componentDataService.deleteComponentDataInTransaction(tx, {
           parentId: params.entryId,
           parentTable: tableName,
@@ -4447,6 +4466,22 @@ export class CollectionMutationService extends BaseService {
           data: null,
         };
       }
+
+      // Append the outbox event in the same transaction so a delete performed
+      // through this helper (batch/cascade/internal) is observable too, in the
+      // same shape as the single-delete path.
+      await recordMutationEvent(tx, {
+        type: "entry.deleted",
+        resource: {
+          kind: "entry",
+          collection: params.collectionName,
+          id: params.entryId,
+        },
+        data: deletedDocument,
+        previous: null,
+        fields: await this.webhookFieldTree(snapshotFields),
+        actor: actorForWrite(params.actor, params.user),
+      });
 
       // Execute afterDelete hooks (code-registered)
       const afterContext = this.hookService.buildHookContext({
@@ -5309,6 +5344,8 @@ export class CollectionMutationService extends BaseService {
       collectionName: string;
       user?: UserContext;
       overrideAccess?: boolean;
+      /** Who performed the delete, recorded on the outbox event. */
+      actor?: RequestActor;
     },
     entryId: string,
     skipHooks: boolean
@@ -5440,11 +5477,28 @@ export class CollectionMutationService extends BaseService {
         );
       }
 
+      // The collection schema, two views: FieldConfig for the component cascade,
+      // FieldDefinition for the outbox snapshot.
+      const collectionFields = (collection.schemaDefinition?.fields ||
+        collection.fields ||
+        []) as FieldConfig[];
+      const snapshotFields = (collection.schemaDefinition?.fields ||
+        collection.fields ||
+        []) as FieldDefinition[];
+
+      // Assemble the removed document before the cascade removes its relations,
+      // in the read shape create/update events use.
+      const deletedDocument = await this.buildDeletedDocument(tx, {
+        collectionName: params.collectionName,
+        entryId,
+        tableName,
+        row: entry,
+        fields: snapshotFields,
+        locale: this.localization?.defaultLocale,
+      });
+
       // Cascade delete component data before deleting the main entry
       if (this.componentDataService) {
-        const collectionFields = (collection.schemaDefinition?.fields ||
-          collection.fields ||
-          []) as FieldConfig[];
         await this.componentDataService.deleteComponentDataInTransaction(tx, {
           parentId: entryId,
           parentTable: tableName,
@@ -5466,6 +5520,22 @@ export class CollectionMutationService extends BaseService {
           data: null,
         };
       }
+
+      // Append the outbox event in the same transaction so a batch delete
+      // through this helper is observable too, in the same shape as the
+      // single-delete path.
+      await recordMutationEvent(tx, {
+        type: "entry.deleted",
+        resource: {
+          kind: "entry",
+          collection: params.collectionName,
+          id: entryId,
+        },
+        data: deletedDocument,
+        previous: null,
+        fields: await this.webhookFieldTree(snapshotFields),
+        actor: actorForWrite(params.actor, params.user),
+      });
 
       // Execute afterDelete hooks (unless skipped)
       if (!skipHooks) {

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4363,11 +4363,12 @@ export class CollectionMutationService extends BaseService {
       actor?: RequestActor;
     }
   ): Promise<CollectionServiceResult<{ deleted: boolean }>> {
-    // Set once the row is actually removed. A failure AFTER this point (e.g. the
-    // outbox insert) has left this shared transaction with a delete but no event;
-    // the catch below re-throws instead of swallowing it into a soft failure, so
-    // the caller rolls back rather than committing an eventless delete.
-    let rowDeleted = false;
+    // True only in the window between the row delete and the outbox insert: a
+    // failure there has left this shared transaction with a delete but no event,
+    // so the catch re-throws to force a rollback. Cleared once the event is
+    // recorded — a later failure (e.g. an afterDelete hook) is a per-item
+    // side-effect issue, not an eventless delete, and must NOT roll the batch back.
+    let deleteNeedsRollback = false;
     try {
       // Get collection metadata and stored hooks
       const collection = await this.collectionService.getCollection(
@@ -4515,7 +4516,7 @@ export class CollectionMutationService extends BaseService {
           data: null,
         };
       }
-      rowDeleted = true;
+      deleteNeedsRollback = true;
 
       // Append the outbox event in the same transaction so a delete performed
       // through this helper (batch/cascade/internal) is observable too, in the
@@ -4535,6 +4536,9 @@ export class CollectionMutationService extends BaseService {
         fields: await this.webhookFieldTree(snapshotFields, tx.getDrizzle()),
         actor: actorForWrite(params.actor, params.user),
       });
+      // The event is recorded, so the delete + event are now consistent; a later
+      // failure no longer needs to force a rollback.
+      deleteNeedsRollback = false;
 
       // Execute afterDelete hooks (code-registered)
       const afterContext = this.hookService.buildHookContext({
@@ -4568,12 +4572,11 @@ export class CollectionMutationService extends BaseService {
         data: { deleted: true },
       };
     } catch (error: unknown) {
-      // A failure after the row was deleted leaves the transaction inconsistent
-      // (row gone, no event), so propagate it and let the caller roll back
-      // rather than reporting a soft per-item failure the loop would commit.
-      // Pre-delete failures stay soft: the row is untouched, so a returned
-      // failure is safe.
-      if (rowDeleted) throw error;
+      // Only a failure in the delete→event window propagates (to roll back an
+      // eventless delete). Pre-delete failures and post-event failures (e.g. an
+      // afterDelete hook) stay soft: the row is either untouched or already
+      // consistent with its event, so a returned failure is safe.
+      if (deleteNeedsRollback) throw error;
       return {
         success: false,
         statusCode: 500,
@@ -5409,11 +5412,12 @@ export class CollectionMutationService extends BaseService {
     entryId: string,
     skipHooks: boolean
   ): Promise<CollectionServiceResult<{ deleted: boolean }>> {
-    // Set once the row is actually removed. A failure AFTER this point (e.g. the
-    // outbox insert) has left this shared transaction with a delete but no event;
-    // the catch below re-throws instead of swallowing it into a soft failure, so
-    // the caller rolls back rather than committing an eventless delete.
-    let rowDeleted = false;
+    // True only in the window between the row delete and the outbox insert: a
+    // failure there has left this shared transaction with a delete but no event,
+    // so the catch re-throws to force a rollback. Cleared once the event is
+    // recorded — a later failure (e.g. an afterDelete hook) is a per-item
+    // side-effect issue, not an eventless delete, and must NOT roll the batch back.
+    let deleteNeedsRollback = false;
     try {
       // Get collection metadata early
       const collection = await this.collectionService.getCollection(
@@ -5606,7 +5610,7 @@ export class CollectionMutationService extends BaseService {
           data: null,
         };
       }
-      rowDeleted = true;
+      deleteNeedsRollback = true;
 
       // Append the outbox event in the same transaction so a batch delete
       // through this helper is observable too, in the same shape as the
@@ -5626,6 +5630,9 @@ export class CollectionMutationService extends BaseService {
         fields: await this.webhookFieldTree(snapshotFields, tx.getDrizzle()),
         actor: actorForWrite(params.actor, params.user),
       });
+      // The event is recorded, so the delete + event are now consistent; a later
+      // failure no longer needs to force a rollback.
+      deleteNeedsRollback = false;
 
       // Execute afterDelete hooks (unless skipped)
       if (!skipHooks) {
@@ -5665,12 +5672,11 @@ export class CollectionMutationService extends BaseService {
         data: { deleted: true },
       };
     } catch (error: unknown) {
-      // A failure after the row was deleted leaves the transaction inconsistent
-      // (row gone, no event), so propagate it and let the caller roll back
-      // rather than reporting a soft per-item failure the loop would commit.
-      // Pre-delete failures stay soft: the row is untouched, so a returned
-      // failure is safe.
-      if (rowDeleted) throw error;
+      // Only a failure in the delete→event window propagates (to roll back an
+      // eventless delete). Pre-delete failures and post-event failures (e.g. an
+      // afterDelete hook) stay soft: the row is either untouched or already
+      // consistent with its event, so a returned failure is safe.
+      if (deleteNeedsRollback) throw error;
       return {
         success: false,
         statusCode: 500,

--- a/packages/nextly/src/domains/collections/services/collection-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service.ts
@@ -56,6 +56,7 @@ import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
 // MetadataServiceResult / CollectionServiceResult shapes (returned by
 // metadata/entry services for backward compatibility) into thrown
 // NextlyErrors at this boundary so callers see the new error model.
+import type { RequestActor } from "../../../auth/request-actor";
 import { NextlyError } from "../../../errors";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import type { CollectionEntryService } from "../../../services/collections/collection-entry-service";
@@ -838,7 +839,13 @@ export class CollectionService extends BaseService {
     tx: TransactionContext,
     collectionName: string,
     entryId: string,
-    context: RequestContext
+    context: RequestContext,
+    /**
+     * Acting identity, forwarded to the recorded `entry.deleted` event so an
+     * API-key delete through this wrapper keeps key attribution. `RequestContext`
+     * carries only `user`, so the actor is passed alongside it.
+     */
+    actor?: RequestActor
   ): Promise<void> {
     this.logger.debug("Deleting entry in transaction", {
       collectionName,
@@ -849,6 +856,7 @@ export class CollectionService extends BaseService {
       collectionName,
       entryId,
       user: context.user,
+      actor,
     });
 
     if (!result.success) {

--- a/packages/nextly/src/domains/components/services/component-mutation-service.ts
+++ b/packages/nextly/src/domains/components/services/component-mutation-service.ts
@@ -1129,7 +1129,13 @@ export class ComponentMutationService extends BaseService {
 
     for (const slug of slugs) {
       try {
-        const meta = await this.registryService.getComponent(slug);
+        // Resolve the component on the transaction's own connection: on a small
+        // pool the delete transaction already holds the only connection, so a
+        // pooled registry read here could wait on itself and hang the delete.
+        const meta = await this.registryService.getComponent(
+          slug,
+          tx.getDrizzle()
+        );
         await tx.delete(
           meta.tableName,
           this.whereAnd({

--- a/packages/nextly/src/domains/webhooks/__tests__/outbox-capture-localized.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/outbox-capture-localized.integration.test.ts
@@ -431,6 +431,9 @@ describe("webhook outbox capture, localized (integration)", () => {
     expect(envelope.data.title).toBe("T");
     // The localized field, sourced from the companion rather than absent.
     expect(envelope.data.heading).toBe("English heading");
+    // The payload carries the default locale's values, so the event says so —
+    // otherwise a receiver cannot tell which translation it represents.
+    expect(envelope.resource).toMatchObject({ locale: "en" });
   });
 
   it("reports the per-locale status the write committed, not the stale main-row status", async () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/outbox-capture-localized.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/outbox-capture-localized.integration.test.ts
@@ -404,6 +404,35 @@ describe("webhook outbox capture, localized (integration)", () => {
     expect(envelopeOf(created!).data.status).toBe("published");
   });
 
+  it("carries the default locale's translatable values in the delete payload", async () => {
+    // Translatable fields live only in the companion table, so a delete snapshot
+    // built from the main row alone would omit `heading`. The event must merge
+    // the default locale's companion values, matching create/update.
+    const t = await boot();
+    await migrate(t);
+    const h = handlerOf(t);
+
+    const created = await h.createEntry(
+      { collectionName: "pages", locale: "en", overrideAccess: true },
+      { title: "T", heading: "English heading" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    await h.deleteEntry({
+      collectionName: "pages",
+      entryId: id,
+      overrideAccess: true,
+    });
+
+    const rows = await t.adapter.select<EventRow>("nextly_events");
+    const deleted = rows.find(r => r.type === "entry.deleted");
+    expect(deleted).toBeDefined();
+    const envelope = envelopeOf(deleted!);
+    expect(envelope.data.title).toBe("T");
+    // The localized field, sourced from the companion rather than absent.
+    expect(envelope.data.heading).toBe("English heading");
+  });
+
   it("reports the per-locale status the write committed, not the stale main-row status", async () => {
     const t = await boot();
     await migrate(t);

--- a/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
@@ -533,8 +533,19 @@ describe("webhook outbox capture (integration)", () => {
 
     const collectionService =
       current.getService<CollectionService>("collectionService");
+    // Pass an API-key actor through the public transactional wrapper: it must
+    // forward to the event rather than falling back to the key owner or system.
     await current.adapter.transaction(async tx =>
-      collectionService.deleteEntryInTransaction(tx, "posts", id, {})
+      collectionService.deleteEntryInTransaction(
+        tx,
+        "posts",
+        id,
+        {},
+        {
+          type: "apiKey",
+          id: "key_tx",
+        }
+      )
     );
 
     const rows = await events(current);
@@ -542,6 +553,8 @@ describe("webhook outbox capture (integration)", () => {
     expect(deleted).toBeDefined();
     expect(deleted!.resourceId).toBe(id);
     expect(envelopeOf(deleted!).data.title).toBe("tx-del");
+    expect(deleted!.actorType).toBe("apiKey");
+    expect(deleted!.actorId).toBe("key_tx");
   });
 
   it("writes the event inside the caller's transaction, so a rollback drops it", async () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
@@ -317,6 +317,164 @@ describe("webhook outbox capture (integration)", () => {
     }
   });
 
+  it("records entry.deleted carrying the removed document, and the row is gone", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "doomed" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    const result = await handler.deleteEntry({
+      collectionName: "posts",
+      entryId: id,
+      overrideAccess: true,
+    });
+    expect(result.success).toBe(true);
+
+    const rows = await events(current);
+    const deleted = rows.find(r => r.type === "entry.deleted");
+    expect(deleted).toBeDefined();
+    expect(deleted!.resourceKind).toBe("entry");
+    expect(deleted!.resourceCollection).toBe("posts");
+    expect(deleted!.resourceId).toBe(id);
+
+    const envelope = envelopeOf(deleted!);
+    // The removed document's final state ships as `data`; there is no
+    // post-delete state, so `previous` is null. The event is appended after the
+    // row delete in the same transaction, so its presence proves the delete
+    // committed.
+    expect(envelope.data.title).toBe("doomed");
+    expect(envelope.previous).toBeNull();
+  });
+
+  it("never ships a secret field in the delete payload", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "accounts",
+          fields: [text({ name: "title" }), password({ name: "secret" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const created = await handler.createEntry(
+      { collectionName: "accounts", overrideAccess: true },
+      { title: "acct", secret: "SuperSecret123!" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    await handler.deleteEntry({
+      collectionName: "accounts",
+      entryId: id,
+      overrideAccess: true,
+    });
+
+    const rows = await events(current);
+    const deleted = rows.find(r => r.type === "entry.deleted");
+    const envelope = envelopeOf(deleted!);
+    expect(envelope.data.title).toBe("acct");
+    expect(envelope.data).not.toHaveProperty("secret");
+    expect(JSON.stringify(envelope)).not.toContain("SuperSecret123!");
+  });
+
+  it("never ships a hidden component field in the delete payload", async () => {
+    // The delete payload is assembled with the same component population as the
+    // create/update events, so a field hidden inside a component must be stripped
+    // there too — otherwise a delete would leak what a create never did.
+    current = await createTestNextly({
+      components: [
+        defineComponent({
+          slug: "profile",
+          fields: [
+            text({ name: "heading" }),
+            text({ name: "internalNote", admin: { hidden: true } }),
+          ],
+        }),
+      ],
+      collections: [
+        defineCollection({
+          slug: "pages",
+          fields: [
+            text({ name: "title" }),
+            component({ name: "profile", component: "profile" }),
+          ],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const created = await handler.createEntry(
+      { collectionName: "pages", overrideAccess: true },
+      {
+        title: "page",
+        profile: { heading: "shown", internalNote: "CONFIDENTIAL_NOTE" },
+      }
+    );
+    const id = (created.data as { id: string }).id;
+
+    await handler.deleteEntry({
+      collectionName: "pages",
+      entryId: id,
+      overrideAccess: true,
+    });
+
+    const rows = await events(current);
+    const deleted = rows.find(r => r.type === "entry.deleted");
+    const envelope = envelopeOf(deleted!);
+    // The component's visible value is in the removed document...
+    expect((envelope.data.profile as { heading?: string })?.heading).toBe(
+      "shown"
+    );
+    // ...but the hidden one never leaves the system, even on delete.
+    expect(JSON.stringify(envelope)).not.toContain("CONFIDENTIAL_NOTE");
+  });
+
+  it("attributes the delete to the acting identity, including an API key", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "posts", fields: [text({ name: "title" })] }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "by key" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    await handler.deleteEntry({
+      collectionName: "posts",
+      entryId: id,
+      overrideAccess: true,
+      actor: { type: "apiKey", id: "key_del" },
+    });
+
+    const rows = await events(current);
+    const deleted = rows.find(r => r.type === "entry.deleted");
+    expect(deleted!.actorType).toBe("apiKey");
+    expect(deleted!.actorId).toBe("key_del");
+    expect(envelopeOf(deleted!).actor).toEqual({
+      type: "apiKey",
+      id: "key_del",
+    });
+  });
+
   it("writes the event inside the caller's transaction, so a rollback drops it", async () => {
     // The outbox guarantee: an event must never outlive the change it describes,
     // or a webhook fires for something that never happened. Recording through the

--- a/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
@@ -475,6 +475,44 @@ describe("webhook outbox capture (integration)", () => {
     });
   });
 
+  it("attributes each bulk-deleted entry's event to the acting API key", async () => {
+    // The REST bulk delete fans out to the single-entry delete, which now emits
+    // entry.deleted; the actor must be threaded through the bulk stack too, or
+    // every bulk-delete event is misattributed to the key owner or system.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "posts", fields: [text({ name: "title" })] }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const a = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "a" }
+    );
+    const b = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "b" }
+    );
+    const ids = [(a.data as { id: string }).id, (b.data as { id: string }).id];
+
+    await handler.bulkDeleteEntries({
+      collectionName: "posts",
+      ids,
+      overrideAccess: true,
+      actor: { type: "apiKey", id: "key_bulk" },
+    });
+
+    const rows = await events(current);
+    const deletes = rows.filter(r => r.type === "entry.deleted");
+    expect(deletes).toHaveLength(2);
+    for (const row of deletes) {
+      expect(row.actorType).toBe("apiKey");
+      expect(row.actorId).toBe("key_bulk");
+    }
+  });
+
   it("writes the event inside the caller's transaction, so a rollback drops it", async () => {
     // The outbox guarantee: an event must never outlive the change it describes,
     // or a webhook fires for something that never happened. Recording through the

--- a/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
@@ -20,6 +20,7 @@ import {
   type TestNextly,
 } from "../../../plugins/test-nextly";
 import { NextlyError } from "../../../errors";
+import type { CollectionService } from "../../collections/services/collection-service";
 import type { CollectionsHandler } from "../../../services/collections-handler";
 import { recordMutationEvent } from "../record-mutation-event";
 import type { WebhookEvent } from "../types";
@@ -511,6 +512,36 @@ describe("webhook outbox capture (integration)", () => {
       expect(row.actorType).toBe("apiKey");
       expect(row.actorId).toBe("key_bulk");
     }
+  });
+
+  it("emits entry.deleted from the transactional delete helper too", async () => {
+    // The batch/cascade delete paths go through the transactional helpers rather
+    // than the single-delete method, so they must record the event as well — a
+    // delete that removes rows silently is invisible to subscribers.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "posts", fields: [text({ name: "title" })] }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "tx-del" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    const collectionService =
+      current.getService<CollectionService>("collectionService");
+    await current.adapter.transaction(async tx =>
+      collectionService.deleteEntryInTransaction(tx, "posts", id, {})
+    );
+
+    const rows = await events(current);
+    const deleted = rows.find(r => r.type === "entry.deleted");
+    expect(deleted).toBeDefined();
+    expect(deleted!.resourceId).toBe(id);
+    expect(envelopeOf(deleted!).data.title).toBe("tx-del");
   });
 
   it("writes the event inside the caller's transaction, so a rollback drops it", async () => {

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -664,6 +664,8 @@ export class CollectionsHandler {
     userRoles?: string[];
     /** User context for access control */
     user?: UserContext;
+    /** Who performed the delete, recorded on the outbox event. */
+    actor?: RequestActor;
     /** When true, bypass all access control checks */
     overrideAccess?: boolean;
     /**

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -800,6 +800,8 @@ export class CollectionsHandler {
       where: WhereFilter;
       /** User context for access control */
       user?: UserContext;
+      /** Who performed the delete, recorded on each entry's outbox event. */
+      actor?: RequestActor;
       /** When true, bypass all access control checks */
       overrideAccess?: boolean;
       /**

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -697,6 +697,8 @@ export class CollectionsHandler {
     userRoles?: string[];
     /** User context for access control */
     user?: UserContext;
+    /** Who performed the delete, recorded on each entry's outbox event. */
+    actor?: RequestActor;
     /** When true, bypass all access control checks */
     overrideAccess?: boolean;
     /**

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -331,6 +331,8 @@ export class CollectionEntryService extends BaseService {
       collectionName: string;
       entryId: string;
       user?: UserContext;
+      /** Who performed the delete, recorded on the outbox event. */
+      actor?: RequestActor;
     }
   ): Promise<CollectionServiceResult<{ deleted: boolean }>> {
     return this.mutationService.deleteEntryInTransaction(tx, params);
@@ -480,7 +482,12 @@ export class CollectionEntryService extends BaseService {
   }
 
   async deleteEntries(
-    params: { collectionName: string; user?: UserContext },
+    params: {
+      collectionName: string;
+      user?: UserContext;
+      /** Who performed the delete, recorded on each entry's outbox event. */
+      actor?: RequestActor;
+    },
     ids: string[],
     options?: BulkOperationOptions
   ): Promise<BatchOperationResult> {
@@ -491,7 +498,12 @@ export class CollectionEntryService extends BaseService {
 
   async deleteEntriesInTransaction(
     tx: TransactionContext,
-    params: { collectionName: string; user?: UserContext },
+    params: {
+      collectionName: string;
+      user?: UserContext;
+      /** Who performed the delete, recorded on each entry's outbox event. */
+      actor?: RequestActor;
+    },
     ids: string[],
     options?: BulkOperationOptions
   ): Promise<BatchOperationResult> {

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -299,6 +299,8 @@ export class CollectionEntryService extends BaseService {
     collectionName: string;
     entryId: string;
     user?: UserContext;
+    /** Who performed the delete, recorded on the outbox event. */
+    actor?: RequestActor;
     overrideAccess?: boolean;
     context?: Record<string, unknown>;
   }) {

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -357,6 +357,8 @@ export class CollectionEntryService extends BaseService {
     collectionName: string;
     ids: string[];
     user?: UserContext;
+    /** Who performed the delete, recorded on each entry's outbox event. */
+    actor?: RequestActor;
     overrideAccess?: boolean;
     context?: Record<string, unknown>;
   }): Promise<BulkOperationResult<{ id: string }>> {

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -407,6 +407,8 @@ export class CollectionEntryService extends BaseService {
       collectionName: string;
       where: WhereFilter;
       user?: UserContext;
+      /** Who performed the delete, recorded on each entry's outbox event. */
+      actor?: RequestActor;
       overrideAccess?: boolean;
       context?: Record<string, unknown>;
     },


### PR DESCRIPTION
## What

Emit an `entry.deleted` webhook event when a collection entry is deleted. Until now the recording seam was wired only for collection create/update, so deletions were invisible to the delivery pipeline.

## How

- **Transactional delete.** `deleteEntry` now runs the component cascade, the row delete, and the outbox write in a single `adapter.transaction`. Previously the cascade + delete ran as two un-wrapped statements. This gives the outbox guarantee (the event commits with the deletion, never fires for a delete that rolled back) and, as a side benefit, makes the delete + cascade atomic so a cascade failure no longer orphans component rows.
- **Read-shape payload.** A new `buildDeletedDocument` helper assembles the removed entry in the same read shape the create/update events use — JSON containers parsed, component subtrees and many-to-many ids populated, password + system-owner fields stripped — read from the transaction **before** the cascade removes the relations. This matters for security: a simpler raw-row payload would leak a sensitive field nested inside a JSON-container component. The delivered document's final state ships as `data`; `previous` is null (mirroring create).
- **Actor attribution.** Threaded `actor?: RequestActor` through the delete path (dispatcher → handler → facade → mutation service), so an API-key delete attributes to the key, matching create/update. The Direct API path attributes via `user`, exactly as its `create` does.

## Tests

Added to `outbox-capture.integration.test.ts`: `entry.deleted` carries the removed document; a secret field never ships in the delete payload; a hidden field nested in a component never ships (proves the full-parity population + stripping); the delete is attributed to an API key. Verified the component cascade delete + collection-events suites still pass.

## Scope

First of three recording-breadth slices (B3b). Singles and media follow in their own PRs.

## Notes

- Pre-existing baseline failures unrelated to this change: `direct-api/__tests__/collections.test.ts` "update()/delete() by where clause" (2, `bulkResult.successes` undefined) — confirmed present on `origin/main`.
- Per-dialect: the outbox capture suite runs on SQLite in-memory locally; the CI matrix covers Postgres + MySQL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete webhooks/outbox now include a read-shaped snapshot of the removed entry, including default-locale localized companion fields.
  * `entry.deleted` outbox events are attributed to the acting authenticated actor, including per-entry attribution for bulk deletes and bulk delete-by-query.
* **Bug Fixes**
  * Delete processing and `entry.deleted` recording are now performed atomically with an in-transaction re-check to prevent stale/deleted races.
* **Tests**
  * Expanded integration coverage for delete envelopes, secret/hidden field stripping, localization, actor attribution (single/bulk/transactional), and transactional helper deletes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->