### PR TITLE
fix(nextly): enforce publish transitions under the row lock (finding-G)

### DIFF
--- a/.changeset/publish-transition-under-lock.md
+++ b/.changeset/publish-transition-under-lock.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+The publish/unpublish permission gate now holds under concurrency and for
+batch writes.
+
+A batch or transactional write classified whether it was publishing or
+unpublishing from the document's status read before it took the row's write
+lock, so a concurrent writer could move the row into or out of published in that
+window and the write would slip the transition past the gate. Batch and
+transactional writes now resolve the caller's publish/unpublish authorization
+once before the transaction and enforce it against the status read under the row
+lock, closing the race. A scoped API key running a bulk update or duplicate is
+also judged on its own publish grant, matching the single-write path.

--- a/.changeset/publish-transition-under-lock.md
+++ b/.changeset/publish-transition-under-lock.md
@@ -29,5 +29,7 @@ lock, so a concurrent writer could move the row into or out of published in that
 window and the write would slip the transition past the gate. Batch and
 transactional writes now resolve the caller's publish/unpublish authorization
 once before the transaction and enforce it against the status read under the row
-lock, closing the race. A scoped API key running a bulk update or duplicate is
-also judged on its own publish grant, matching the single-write path.
+lock, closing the race. A scoped API key is also judged on its own grant across
+the remaining write surfaces — bulk update, duplicate, delete, and version-label
+edits — so a super-admin-owned key cannot use those paths to bypass the key's
+scope or the collection's stored owner/role rules.

--- a/packages/adapter-drizzle/src/__tests__/adapter.test.ts
+++ b/packages/adapter-drizzle/src/__tests__/adapter.test.ts
@@ -268,4 +268,55 @@ describe("DrizzleAdapter", () => {
       expect(result.current).toBeNull();
     });
   });
+
+  describe("forUpdate lock safety", () => {
+    // A SELECT ... FOR UPDATE row lock only holds for the life of a transaction.
+    // Requesting one on the pooled connection is silent false safety — the lock
+    // releases the instant the statement autocommits — so the adapter must reject
+    // it rather than let a caller believe a row is guarded when it is not.
+    class LockAdapter extends MockAdapter {
+      // Minimal Drizzle stub: the guard throws during query construction (before
+      // execution) in the rejection case, so select()/from() only need to be
+      // chainable; the resolve case awaits this same chainable stub.
+      override getDrizzle<U = unknown>(): U {
+        const chain: Record<string, unknown> = {};
+        const self = () => chain;
+        chain.select = self;
+        chain.from = self;
+        chain.where = self;
+        chain.orderBy = self;
+        chain.limit = self;
+        chain.offset = self;
+        chain.for = self;
+        return chain as U;
+      }
+    }
+
+    let lockAdapter: LockAdapter;
+
+    beforeEach(() => {
+      lockAdapter = new LockAdapter();
+      // Any non-null table object routes select() through the Drizzle query path,
+      // where the forUpdate handling lives.
+      lockAdapter.setTableResolver({ getTable: () => ({}) } as never);
+    });
+
+    it("rejects forUpdate on the pooled connection (no transaction executor)", async () => {
+      await expect(
+        lockAdapter.select("posts", { forUpdate: true })
+      ).rejects.toThrow(/forUpdate requires a transaction executor/);
+    });
+
+    it("allows forUpdate when a transaction executor is supplied", async () => {
+      // Same options, but with the transaction executor the lock is meaningful,
+      // so the guard passes and the query proceeds.
+      await expect(
+        lockAdapter.select(
+          "posts",
+          { forUpdate: true },
+          lockAdapter.getDrizzle()
+        )
+      ).resolves.toBeDefined();
+    });
+  });
 });

--- a/packages/adapter-drizzle/src/__tests__/adapter.test.ts
+++ b/packages/adapter-drizzle/src/__tests__/adapter.test.ts
@@ -318,5 +318,19 @@ describe("DrizzleAdapter", () => {
         )
       ).resolves.toBeDefined();
     });
+
+    it("rejects forUpdate on the pooled connection for SQLite too", async () => {
+      // On SQLite the lock IS the transaction (BEGIN IMMEDIATE), so a pooled
+      // forUpdate takes no lock at all — it must fail fast like the row-locking
+      // dialects rather than silently succeed with no serialization.
+      class SqliteLockAdapter extends LockAdapter {
+        override readonly dialect = "sqlite" as const;
+      }
+      const sqliteAdapter = new SqliteLockAdapter();
+      sqliteAdapter.setTableResolver({ getTable: () => ({}) } as never);
+      await expect(
+        sqliteAdapter.select("posts", { forUpdate: true })
+      ).rejects.toThrow(/forUpdate requires a transaction executor/);
+    });
   });
 });

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -691,16 +691,17 @@ export abstract class DrizzleAdapter {
           query = query.offset(options.offset);
         }
 
-        // A FOR UPDATE lock only holds for the life of a transaction. On the
-        // pooled connection the surrounding statement autocommits, releasing the
-        // lock the instant the SELECT returns — so a lock request without a
+        // A lock request is only meaningful inside a transaction, on EVERY
+        // dialect. On the row-locking dialects the pooled connection autocommits
+        // the SELECT, releasing the lock the instant it returns; on SQLite the
+        // lock IS the transaction (BEGIN IMMEDIATE serializes writers), so a
+        // pooled call takes no lock at all. Either way a `forUpdate` without a
         // transaction executor is silent false safety and reopens the TOCTOU
-        // window it was meant to close. Fail fast instead. SQLite is exempt: it
-        // takes no row lock (BEGIN IMMEDIATE already serializes its writers).
-        if (options?.forUpdate && this.dialect !== "sqlite" && !executor) {
+        // window it was meant to close, so fail fast regardless of dialect.
+        if (options?.forUpdate && !executor) {
           throw this.createDatabaseError(
             "query",
-            "forUpdate requires a transaction executor: a row lock on the pooled connection releases immediately and cannot prevent a concurrent write.",
+            "forUpdate requires a transaction executor: a lock request on the pooled connection takes no durable lock and cannot prevent a concurrent write.",
             undefined
           );
         }

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -691,6 +691,15 @@ export abstract class DrizzleAdapter {
           query = query.offset(options.offset);
         }
 
+        // Row-lock the selected rows for the rest of the transaction and read the
+        // latest committed values (not the transaction's snapshot). SQLite has no
+        // FOR UPDATE and needs none (BEGIN IMMEDIATE serializes its writers), so
+        // it is skipped there. Requires an executor to be meaningful — a lock on
+        // the pooled connection would be released immediately.
+        if (options?.forUpdate && this.dialect !== "sqlite") {
+          query = query.for("update");
+        }
+
         return (await query) as T[];
       } catch (error) {
         throw this.handleQueryError(error, "select", table);

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -691,11 +691,24 @@ export abstract class DrizzleAdapter {
           query = query.offset(options.offset);
         }
 
+        // A FOR UPDATE lock only holds for the life of a transaction. On the
+        // pooled connection the surrounding statement autocommits, releasing the
+        // lock the instant the SELECT returns — so a lock request without a
+        // transaction executor is silent false safety and reopens the TOCTOU
+        // window it was meant to close. Fail fast instead. SQLite is exempt: it
+        // takes no row lock (BEGIN IMMEDIATE already serializes its writers).
+        if (options?.forUpdate && this.dialect !== "sqlite" && !executor) {
+          throw this.createDatabaseError(
+            "query",
+            "forUpdate requires a transaction executor: a row lock on the pooled connection releases immediately and cannot prevent a concurrent write.",
+            undefined
+          );
+        }
+
         // Row-lock the selected rows for the rest of the transaction and read the
         // latest committed values (not the transaction's snapshot). SQLite has no
         // FOR UPDATE and needs none (BEGIN IMMEDIATE serializes its writers), so
-        // it is skipped there. Requires an executor to be meaningful — a lock on
-        // the pooled connection would be released immediately.
+        // it is skipped there.
         if (options?.forUpdate && this.dialect !== "sqlite") {
           query = query.for("update");
         }

--- a/packages/adapter-drizzle/src/types/crud.ts
+++ b/packages/adapter-drizzle/src/types/crud.ts
@@ -42,6 +42,18 @@ export interface SelectOptions {
 
   /** Return distinct rows only */
   distinct?: boolean;
+
+  /**
+   * Take a `FOR UPDATE` row lock on the selected rows for the rest of the
+   * transaction, and read the latest committed values rather than the
+   * transaction's snapshot. Use for read-modify-write sequences that must not
+   * interleave (e.g. re-reading a status under the lock the write will take).
+   *
+   * Requires a transaction executor. No-ops on SQLite, which has no `FOR UPDATE`
+   * and needs none — its transactions open with `BEGIN IMMEDIATE`, already
+   * serializing writers.
+   */
+  forUpdate?: boolean;
 }
 
 /**

--- a/packages/nextly/src/api/__tests__/singles-detail-auth.test.ts
+++ b/packages/nextly/src/api/__tests__/singles-detail-auth.test.ts
@@ -88,6 +88,10 @@ describe("singles-detail PATCH route auth forwarding", () => {
         },
         overrideAccess: false,
         routeAuthorized: true,
+        // The route forwards the caller's authenticated scope so a scoped API
+        // key is judged on its own publish grant; a session user carries an
+        // empty-permission user scope.
+        authenticatedScope: { actorType: "user", permissions: [] },
       }
     );
   });

--- a/packages/nextly/src/api/versions-access.ts
+++ b/packages/nextly/src/api/versions-access.ts
@@ -15,6 +15,7 @@
  * @module api/versions-access
  */
 
+import type { AuthenticatedScope } from "../auth/authenticated-scope";
 import type { FieldConfig } from "../collections/fields/types";
 import { getService } from "../di";
 import { checkSingleAccess } from "../domains/singles";
@@ -125,11 +126,15 @@ export async function assertVersionDocumentUpdatable(
   scopeKind: VersionScopeKind,
   slug: string,
   entryId: string,
-  user: UserContext
+  user: UserContext,
+  // The caller's authenticated scope. A version-label edit is a route-authorized
+  // `update`, so a scoped API key is judged on its OWN update grant here and a
+  // super-admin-owned key does not skip stored owner/role update rules.
+  authenticatedScope?: AuthenticatedScope
 ): Promise<void> {
   const allowed =
     scopeKind === "single"
-      ? await canUpdateLiveSingle(slug, entryId, user)
+      ? await canUpdateLiveSingle(slug, entryId, user, authenticatedScope)
       : await getService("collectionsHandler").canUpdateEntry({
           collectionName: slug,
           entryId,
@@ -138,6 +143,7 @@ export async function assertVersionDocumentUpdatable(
           // only the redundant coarse re-check. The stored per-document rules
           // this gate exists for still run.
           routeAuthorized: true,
+          authenticatedScope,
         });
 
   if (!allowed) {
@@ -165,7 +171,8 @@ export async function assertVersionDocumentUpdatable(
 async function canUpdateLiveSingle(
   slug: string,
   entryId: string,
-  user: UserContext
+  user: UserContext,
+  authenticatedScope?: AuthenticatedScope
 ): Promise<boolean> {
   const registry = getService("singleRegistryService");
   const record = await registry.getSingleBySlug(slug);
@@ -195,6 +202,9 @@ async function canUpdateLiveSingle(
     accessControlService: new AccessControlService(),
     accessRules: record.accessRules,
     document,
+    // A scoped API key is judged on its own update grant, so a super-admin-owned
+    // key does not skip stored owner/role rules on a version-label edit.
+    authenticatedScope,
     logger: getService("logger"),
   });
   return denied === null;

--- a/packages/nextly/src/dispatcher/handlers/__tests__/versions-label.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/versions-label.test.ts
@@ -254,7 +254,10 @@ describe("setVersionLabelForDocument — document-level update rules", () => {
       "collection",
       "posts",
       "e1",
-      expect.objectContaining({ id: "u1" })
+      expect.objectContaining({ id: "u1" }),
+      // The label gate now forwards the caller's authenticated scope so a scoped
+      // API key is judged on its own grant; this request carries no scope.
+      undefined
     );
   });
 

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -1198,6 +1198,10 @@ const COLLECTIONS_METHODS: Record<
         // the handler skips only that redundant re-check (stored rules +
         // field-level write access still run). Never inferred from userId.
         routeAuthorized: true,
+        // The route authorized `delete` against the key's scope; carry the scope
+        // so a super-admin-owned key's delete is judged on the key's OWN grant
+        // and does not skip stored owner/role delete rules.
+        authenticatedScope: readAuthenticatedScope(p),
       });
       const entry = unwrapServiceResult(result, {
         collectionName: p.collectionName,
@@ -1237,6 +1241,9 @@ const COLLECTIONS_METHODS: Record<
         // the handler skips only that redundant re-check (stored rules +
         // field-level write access still run). Never inferred from userId.
         routeAuthorized: true,
+        // Carry the key's scope so each per-id delete is judged on the key's OWN
+        // grant, not the key owner's super-admin roles.
+        authenticatedScope: readAuthenticatedScope(p),
       });
       // Compose a server-authored toast string. Total here is the
       // request's id count, not just the success count, so the message

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -1285,6 +1285,10 @@ const COLLECTIONS_METHODS: Record<
         // the handler skips only that redundant re-check (stored rules +
         // field-level write access still run). Never inferred from userId.
         routeAuthorized: true,
+        // The route authorized `update` against the key's scope, never
+        // publish/unpublish — carry the scope so each per-id transition is
+        // judged on the key's OWN grants.
+        authenticatedScope: readAuthenticatedScope(p),
       });
       const message =
         result.failures.length === 0
@@ -1348,6 +1352,10 @@ const COLLECTIONS_METHODS: Record<
           // so the handler skips only that redundant re-check (stored rules +
           // field-level write access still run). Never inferred from userId.
           routeAuthorized: true,
+          // The route authorized `update` against the key's scope, never
+          // publish/unpublish — carry the scope so the collection-level gate and
+          // each per-row transition are judged on the key's OWN grants.
+          authenticatedScope: readAuthenticatedScope(p),
         },
         { limit: b.limit }
       );
@@ -1389,6 +1397,9 @@ const COLLECTIONS_METHODS: Record<
         // the handler skips only that redundant re-check (stored rules +
         // field-level write access still run). Never inferred from userId.
         routeAuthorized: true,
+        // A duplicate is a create; carry the scope so a create-as-published is
+        // judged on the key's OWN publish grant, never the key owner's.
+        authenticatedScope: readAuthenticatedScope(p),
       });
       const entry = unwrapServiceResult(result, {
         collectionName: p.collectionName,

--- a/packages/nextly/src/dispatcher/handlers/versions-methods.ts
+++ b/packages/nextly/src/dispatcher/handlers/versions-methods.ts
@@ -381,7 +381,11 @@ export async function setVersionLabelForDocument(
     args.scopeKind,
     args.slug,
     args.entryId,
-    args.user
+    args.user,
+    // The route authorized `update` against the key's scope; judge the label
+    // edit on the key's OWN grant so a super-admin-owned key does not skip
+    // stored owner/role update rules.
+    readAuthenticatedScope(args.params)
   );
 
   const versions = getService("versionsService");

--- a/packages/nextly/src/domains/collections/__tests__/api-key-scope-coverage.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/api-key-scope-coverage.integration.test.ts
@@ -121,4 +121,53 @@ describe("API-key scope coverage on delete + version-label gates", () => {
     });
     expect(sessionCanUpdate).toBe(true);
   });
+
+  it("judges the duplicate source read on the key's own read grant", async () => {
+    // A duplicate copies the source row's fields, so the source must be readable
+    // under the KEY's scope. A super-admin-owned key scoped for create but not
+    // read must not be able to copy from a row it cannot see.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const source = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "source" }
+    );
+    const sourceId = (source.data as { id: string }).id;
+
+    // create-only scope, no read: the source read is judged on the key and
+    // refused (the super-admin bypass is skipped because the scope reaches it).
+    const denied = await handler.duplicateEntry({
+      collectionName: "posts",
+      entryId: sourceId,
+      userId: "admin",
+      userRoles: ["super-admin"],
+      authenticatedScope: {
+        actorType: "apiKey",
+        permissions: ["create-posts"],
+      },
+    });
+    expect(denied.success).toBe(false);
+
+    // Adding read to the scope lets the source read pass, and the create
+    // proceeds.
+    const allowed = await handler.duplicateEntry({
+      collectionName: "posts",
+      entryId: sourceId,
+      userId: "admin",
+      userRoles: ["super-admin"],
+      authenticatedScope: {
+        actorType: "apiKey",
+        permissions: ["create-posts", "read-posts"],
+      },
+    });
+    expect(allowed.success).toBe(true);
+  });
 });

--- a/packages/nextly/src/domains/collections/__tests__/api-key-scope-coverage.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/api-key-scope-coverage.integration.test.ts
@@ -1,0 +1,124 @@
+/**
+ * A scoped API key must be judged on its OWN grants on every write surface, not
+ * only create/update/publish. The session super-admin bypass (which lets a
+ * super-admin skip a code-defined access rule) is skipped when the caller is a
+ * scoped API key, so a super-admin who OWNS a narrowly-scoped key cannot use it
+ * to bypass that rule.
+ *
+ * This pins two surfaces that previously did not forward the scope to
+ * `checkCollectionAccess`:
+ *   - `deleteEntry`
+ *   - the version-label update gate (`canUpdateEntry`, used by
+ *     `assertVersionDocumentUpdatable`)
+ *
+ * Each uses a collection whose code-defined rule refuses the operation. A
+ * super-admin caller WITHOUT a scope bypasses the rule; the same super-admin
+ * arriving as a scoped API key is judged on the key and refused — which only
+ * holds if the scope is threaded through to the gate.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+describe("API-key scope coverage on delete + version-label gates", () => {
+  it("skips the super-admin bypass for a scoped key on deleteEntry", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          // A code rule that refuses delete. A session super-admin bypasses it;
+          // a scoped API key is judged on the key and must not.
+          access: { read: () => true, delete: () => false },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "t" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    // Super-admin owner of a delete-scoped key: the scope reaches the gate, so
+    // the super-admin bypass is skipped and the refusing code rule applies.
+    const denied = await handler.deleteEntry({
+      collectionName: "posts",
+      entryId: id,
+      userId: "admin",
+      userRoles: ["super-admin"],
+      authenticatedScope: {
+        actorType: "apiKey",
+        permissions: ["delete-posts"],
+      },
+    });
+    expect(denied.success).toBe(false);
+    expect(denied.statusCode).toBe(403);
+
+    // The same super-admin as a session caller (no scope) bypasses the rule —
+    // proving the scope, not the role, decides.
+    const allowed = await handler.deleteEntry({
+      collectionName: "posts",
+      entryId: id,
+      userId: "admin",
+      userRoles: ["super-admin"],
+    });
+    expect(allowed.success).toBe(true);
+  });
+
+  it("skips the super-admin bypass for a scoped key on the update gate (version labels)", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          access: { read: () => true, update: () => false },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "t" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    // `canUpdateEntry` is the gate `assertVersionDocumentUpdatable` runs before a
+    // version-label edit. A super-admin owning an update-scoped key: the scope
+    // reaches the gate, the super-admin bypass is skipped, and the refusing rule
+    // applies — the key may NOT edit labels.
+    const scopedCanUpdate = await handler.canUpdateEntry({
+      collectionName: "posts",
+      entryId: id,
+      user: { id: "admin", roles: ["super-admin"] },
+      authenticatedScope: {
+        actorType: "apiKey",
+        permissions: ["update-posts"],
+      },
+    });
+    expect(scopedCanUpdate).toBe(false);
+
+    // The same super-admin as a session caller bypasses the rule.
+    const sessionCanUpdate = await handler.canUpdateEntry({
+      collectionName: "posts",
+      entryId: id,
+      user: { id: "admin", roles: ["super-admin"] },
+    });
+    expect(sessionCanUpdate).toBe(true);
+  });
+});

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-batch.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-batch.integration.test.ts
@@ -1,0 +1,130 @@
+/**
+ * The publish gate must hold on the Direct-API BATCH worker paths, not only the
+ * single-write path.
+ *
+ * `createMany` / `updateMany` funnel every row through
+ * `create/updateSingleEntryInTransaction` inside one shared transaction. Those
+ * workers resolve the caller's publish/unpublish authorization ONCE on the pooled
+ * connection before the transaction, then enforce each row's transition against
+ * the status read under the row lock — so a batch cannot become a way around the
+ * gate, and no permission read runs inside the shared transaction. This pins that
+ * behaviour with a collection whose code-defined `access.publish` refuses: a batch
+ * that lands rows on `published` fails every row; a batch that keeps them draft
+ * succeeds.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+import type { CollectionService } from "../services/collection-service";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+describe("publish enforcement on the batch worker paths (integration)", () => {
+  it("refuses a batch CREATE that lands rows on published without publish", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          status: true,
+          // Allow create/update/read but refuse publish, so the batch reaches the
+          // worker (create/update pass) and only the publish transition is gated.
+          access: {
+            create: () => true,
+            update: () => true,
+            read: () => true,
+            publish: () => false,
+          },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const collectionService =
+      current.getService<CollectionService>("collectionService");
+
+    // Non-trusted caller (no overrideAccess) → the create worker enforces the
+    // create-as-published against access.publish and refuses every row.
+    const publishAttempt = await collectionService.createMany(
+      "posts",
+      [
+        { title: "a", status: "published" },
+        { title: "b", status: "published" },
+      ],
+      { user: { id: "author" } }
+    );
+    expect(publishAttempt.successful).toBe(0);
+    expect(publishAttempt.failed).toBe(2);
+
+    // The same batch kept as draft is allowed — only the publish transition is
+    // gated, not the create itself.
+    const draftBatch = await collectionService.createMany(
+      "posts",
+      [
+        { title: "c", status: "draft" },
+        { title: "d", status: "draft" },
+      ],
+      { user: { id: "author" } }
+    );
+    expect(draftBatch.successful).toBe(2);
+    expect(draftBatch.failed).toBe(0);
+  });
+
+  it("refuses a batch UPDATE that publishes drafts without publish", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          status: true,
+          access: {
+            create: () => true,
+            update: () => true,
+            read: () => true,
+            publish: () => false,
+          },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const entryService = handler.getEntryService();
+
+    // Seed two drafts with a trusted write (setup, not under test).
+    const seeded = await handler
+      .getEntryService()
+      .createEntries({ collectionName: "posts", overrideAccess: true }, [
+        { title: "a", status: "draft" },
+        { title: "b", status: "draft" },
+      ]);
+    const ids = seeded.ids;
+    expect(ids).toHaveLength(2);
+
+    // A non-trusted batch update that moves the drafts to published must fail
+    // every row: the update worker classifies the transition under the row lock
+    // and consults the pre-resolved publish denial.
+    const publishAttempt = await entryService.updateEntries(
+      { collectionName: "posts", user: { id: "author" } },
+      ids.map(id => ({ id, data: { status: "published" } }))
+    );
+    expect(publishAttempt.successful).toBe(0);
+    expect(publishAttempt.failed).toBe(2);
+
+    // A content-only batch update (no status change) is untouched by the gate.
+    const contentEdit = await entryService.updateEntries(
+      { collectionName: "posts", user: { id: "author" } },
+      ids.map(id => ({ id, data: { title: "edited" } }))
+    );
+    expect(contentEdit.successful).toBe(2);
+    expect(contentEdit.failed).toBe(0);
+  });
+});

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-owner-only.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-owner-only.integration.test.ts
@@ -60,6 +60,34 @@ async function bootOwnerOnlyPosts(): Promise<TestNextly> {
 }
 
 describe("owner-only publish enforcement on batch paths (integration)", () => {
+  it("refuses a create that lands directly on published without an owner", async () => {
+    current = await bootOwnerOnlyPosts();
+    const entryService = current
+      .getService<CollectionsHandler>("collectionsHandler")
+      .getEntryService();
+
+    // An anonymous create landing directly on `published`: the create itself is
+    // allowed, and the docless permission pre-resolve defers the owner-only
+    // publish rule — so the rule must be judged against the row this create will
+    // persist (no owner to satisfy) and refuse it, rather than being skipped for
+    // lack of a locked row.
+    const anonPublish = await entryService.createEntries(
+      { collectionName: "posts" },
+      [{ title: "x", status: "published" }]
+    );
+    expect(anonPublish.successful).toBe(0);
+    expect(anonPublish.failed).toBe(1);
+
+    // The owner creating their own published row satisfies owner-only (the
+    // creator is the owner), so it is allowed.
+    const ownerCreate = await entryService.createEntries(
+      { collectionName: "posts", user: { id: "author" } },
+      [{ title: "y", status: "published" }]
+    );
+    expect(ownerCreate.successful).toBe(1);
+    expect(ownerCreate.failed).toBe(0);
+  });
+
   it("refuses a batch UPDATE that publishes another user's rows", async () => {
     current = await bootOwnerOnlyPosts();
     const entryService = current

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-owner-only.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-owner-only.integration.test.ts
@@ -1,0 +1,132 @@
+/**
+ * A document-dependent (owner-only) publish/unpublish rule must be enforced
+ * against the SPECIFIC row on the transaction and batch write paths, not only on
+ * the single-write path.
+ *
+ * The transaction/batch paths pre-resolve the caller's publish PERMISSION once on
+ * the pooled connection before the transaction. That pre-resolve has no document,
+ * so an owner-only rule (which allows until the row is known) passes there. If the
+ * gate stopped at the pre-resolved permission, a caller who may update another
+ * user's row could batch-publish it. This pins that the owner-only rule is
+ * re-evaluated against the row-locked document inside the transaction: the owner
+ * may publish their own row; a non-owner who can update it still cannot publish
+ * it. The permission level allows (code `access.publish` returns true), so the
+ * owner-only DOCUMENT rule is the only thing under test.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+async function bootOwnerOnlyPosts(): Promise<TestNextly> {
+  return createTestNextly({
+    collections: [
+      defineCollection({
+        slug: "posts",
+        status: true,
+        // Permission level allows every op, so only the stored owner-only
+        // document rule below decides whether a publish transition is allowed.
+        access: {
+          create: () => true,
+          update: () => true,
+          read: () => true,
+          publish: () => true,
+          unpublish: () => true,
+        },
+        fields: [text({ name: "title" })],
+      }),
+    ],
+    // Stored rule the Schema Builder would persist: only the row's owner may
+    // move it into or out of published.
+    collectionAccessRules: {
+      posts: {
+        publish: { type: "owner-only" },
+        unpublish: { type: "owner-only" },
+      },
+    },
+  });
+}
+
+describe("owner-only publish enforcement on batch paths (integration)", () => {
+  it("refuses a batch UPDATE that publishes another user's rows", async () => {
+    current = await bootOwnerOnlyPosts();
+    const entryService = current
+      .getService<CollectionsHandler>("collectionsHandler")
+      .getEntryService();
+
+    // Seed two drafts OWNED by "author" (created_by = author). Draft creates do
+    // not trip the publish gate, so this is plain setup.
+    const seeded = await entryService.createEntries(
+      { collectionName: "posts", user: { id: "author" } },
+      [
+        { title: "a", status: "draft" },
+        { title: "b", status: "draft" },
+      ]
+    );
+    const ids = seeded.ids;
+    expect(ids).toHaveLength(2);
+
+    // A different user who may update the rows tries to publish them. The
+    // permission pre-resolve allows publish (access.publish → true), but the
+    // owner-only rule, judged against each row-locked document, denies a
+    // non-owner: every row fails.
+    const foreignPublish = await entryService.updateEntries(
+      { collectionName: "posts", user: { id: "intruder" } },
+      ids.map(id => ({ id, data: { status: "published" } }))
+    );
+    expect(foreignPublish.successful).toBe(0);
+    expect(foreignPublish.failed).toBe(2);
+
+    // The owner publishing their own rows is allowed.
+    const ownerPublish = await entryService.updateEntries(
+      { collectionName: "posts", user: { id: "author" } },
+      ids.map(id => ({ id, data: { status: "published" } }))
+    );
+    expect(ownerPublish.successful).toBe(2);
+    expect(ownerPublish.failed).toBe(0);
+  });
+
+  it("refuses a batch UPDATE that unpublishes another user's rows", async () => {
+    current = await bootOwnerOnlyPosts();
+    const entryService = current
+      .getService<CollectionsHandler>("collectionsHandler")
+      .getEntryService();
+
+    // Seed a published row owned by "author" (setup): a create has no prior row,
+    // so the owner-only rule allows the creator to land it published.
+    const seeded = await entryService.createEntries(
+      { collectionName: "posts", user: { id: "author" } },
+      [{ title: "a", status: "published" }]
+    );
+    const [id] = seeded.ids;
+    expect(id).toBeDefined();
+
+    // A non-owner who may update the row tries to unpublish it → denied.
+    const foreignUnpublish = await entryService.updateEntries(
+      { collectionName: "posts", user: { id: "intruder" } },
+      [{ id, data: { status: "draft" } }]
+    );
+    expect(foreignUnpublish.successful).toBe(0);
+    expect(foreignUnpublish.failed).toBe(1);
+
+    // The owner may unpublish their own row.
+    const ownerUnpublish = await entryService.updateEntries(
+      { collectionName: "posts", user: { id: "author" } },
+      [{ id, data: { status: "draft" } }]
+    );
+    expect(ownerUnpublish.successful).toBe(1);
+    expect(ownerUnpublish.failed).toBe(0);
+  });
+});

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-rbac.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-rbac.integration.test.ts
@@ -412,4 +412,55 @@ describe("publish enforcement on the dispatcher path (RBAC wiring)", () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it("judges a scoped API-key BULK publish on the key's own grant", async () => {
+    // A bulk update must not become a way around the single-write publish gate:
+    // the per-id `updateEntry` each row runs through has to see the key's scope,
+    // or an update-only key owned by a publisher could bulk-publish. A key
+    // scoped for `update-posts` only is refused; adding `publish-posts` allows.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          status: true,
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "t", status: "draft" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    const denied = await handler.bulkUpdateEntries({
+      collectionName: "posts",
+      ids: [id],
+      data: { status: "published" },
+      userId: "key-owner",
+      routeAuthorized: true,
+      authenticatedScope: {
+        actorType: "apiKey",
+        permissions: ["update-posts"],
+      },
+    });
+    // Partial-success shape: the row lands in failures with a 403, not successes.
+    expect(denied.successCount).toBe(0);
+    expect(denied.failures).toHaveLength(1);
+
+    const allowed = await handler.bulkUpdateEntries({
+      collectionName: "posts",
+      ids: [id],
+      data: { status: "published" },
+      userId: "key-owner",
+      routeAuthorized: true,
+      authenticatedScope: {
+        actorType: "apiKey",
+        permissions: ["update-posts", "publish-posts"],
+      },
+    });
+    expect(allowed.successCount).toBe(1);
+  });
 });

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-toctou.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-toctou.integration.test.ts
@@ -193,5 +193,75 @@ for (const leg of LEGS) {
         await handle?.destroy();
       }
     });
+
+    it("returns not-found when the row is deleted under the lock", async () => {
+      const adapter = await connect(leg);
+      let handle: TestNextly | undefined;
+      try {
+        handle = await createTestNextly({
+          adapter,
+          collections: [
+            defineCollection({
+              slug: SLUG,
+              status: true,
+              // The editor may update but never publish, so absent the fix a
+              // phantom `null -> published` classification would be refused with a
+              // publish denial rather than not-found.
+              access: {
+                create: () => true,
+                update: () => true,
+                read: () => true,
+                publish: () => false,
+              },
+              fields: [text({ name: "title" })],
+            }),
+          ],
+        });
+        const h = handle.getService<CollectionsHandler>("collectionsHandler");
+        const entryService = h.getEntryService() as CollectionEntryService;
+
+        const created = await h.createEntry(
+          { collectionName: SLUG, overrideAccess: true },
+          { title: "t", status: "draft" }
+        );
+        const id = (created.data as { id: string }).id;
+
+        const gate = deferred();
+        const bLocked = deferred();
+
+        // Writer B: lock and DELETE the row, then hold the transaction open until
+        // the gate — so it commits the delete only after A has read the row and is
+        // blocked on the same lock.
+        const bTx = handle.adapter.transaction(async tx => {
+          await tx.lockRow(TABLE, id);
+          await tx.delete(TABLE, whereId(id));
+          bLocked.resolve();
+          await gate.promise;
+        });
+
+        await bLocked.promise;
+
+        // Writer A: a batch update to `published`. Its plain existence read sees
+        // the still-committed row, then it blocks taking the row lock behind B.
+        const aResultP = entryService.updateEntries(
+          { collectionName: SLUG, user: { id: "editor" } },
+          [{ id, data: { status: "published" } }]
+        );
+
+        await sleep(500);
+
+        gate.resolve();
+        await bTx;
+
+        const aResult = await aResultP;
+        // The row vanished under the lock, so the write is not-found — not a
+        // publish denial for a `null -> published` transition on an absent row.
+        expect(aResult.successful).toBe(0);
+        expect(aResult.failed).toBe(1);
+        expect(aResult.errors[0]?.error ?? "").toMatch(/not found/i);
+      } finally {
+        await handle?.destroy();
+      }
+    });
   });
 }

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-toctou.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-toctou.integration.test.ts
@@ -1,0 +1,197 @@
+/**
+ * The publish-transition gate must be enforced against the status read UNDER the
+ * write's row lock, not a status read before the transaction — otherwise a
+ * concurrent writer can move a row into (or out of) published in the window
+ * between the two, and the write slips a transition past the gate.
+ *
+ * This reproduces the exact race on a REAL database (SQLite serializes writers
+ * via `BEGIN IMMEDIATE`, so it cannot manifest there and the suite self-skips
+ * without a Postgres/MySQL URL):
+ *
+ *   1. A row is `draft`.
+ *   2. Writer A (an editor who may update but NOT unpublish) starts a batch
+ *      update that keeps the row `draft`, reading `draft` before it takes its
+ *      lock.
+ *   3. Writer B publishes the row and commits.
+ *   4. Writer A finally takes its lock. Classified against the PRE-lock read
+ *      (`draft` → `draft`) the write is no transition and would be allowed —
+ *      silently unpublishing. Classified against the LOCKED read (`published` →
+ *      `draft`) it is an unpublish the editor may not perform, and is refused.
+ *
+ * The batch worker resolves the caller's publish/unpublish authorization before
+ * the transaction and enforces it under the lock, so A is correctly refused and
+ * B's publish stands.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import { createAdapter } from "../../../database/factory";
+import type { CollectionEntryService } from "../../../services/collections/collection-entry-service";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+const POSTGRES_URL = process.env.TEST_POSTGRES_URL ?? "";
+
+const SLUG = "toctouposts";
+const TABLE = `dc_${SLUG}`;
+
+type TestAdapter = Awaited<ReturnType<typeof createAdapter>>;
+type Dialect = "postgresql" | "mysql";
+interface Leg {
+  name: string;
+  dialect: Dialect;
+  url: string;
+}
+
+// Postgres is the reference concurrency leg. The enforce-under-lock behaviour is
+// dialect-agnostic (the adapter's row lock no-ops on SQLite, which serializes
+// writers, and applies identically on MySQL), so one real two-transaction leg
+// proves the race closure; a MySQL leg is omitted to keep the suite off shared
+// system-table drift in the test container.
+const LEGS: Leg[] = [
+  { name: "postgres", dialect: "postgresql", url: POSTGRES_URL },
+];
+
+async function connect(leg: Leg): Promise<TestAdapter> {
+  // env.ts validates DATABASE_URL against DB_DIALECT on first read in this
+  // worker, so both must be on process.env — not just passed to createAdapter.
+  process.env.DB_DIALECT = leg.dialect;
+  process.env.DATABASE_URL = leg.url;
+  const adapter = await createAdapter({
+    type: leg.dialect,
+    url: leg.url,
+  } as Parameters<typeof createAdapter>[0]);
+  await adapter.executeQuery("SELECT 1");
+  return adapter;
+}
+
+interface Deferred {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+function deferred(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>(r => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+const whereId = (id: string) => ({
+  and: [{ column: "id", op: "=" as const, value: id }],
+});
+
+for (const leg of LEGS) {
+  const describeLeg = describe.skipIf(!leg.url);
+
+  describeLeg(`publish transition TOCTOU (${leg.name} dialect gate)`, () => {
+    let boot: TestAdapter | undefined;
+
+    beforeAll(async () => {
+      if (!leg.url) return;
+      boot = await connect(leg);
+      await drop();
+    });
+
+    afterAll(async () => {
+      await drop();
+      if (boot) await boot.disconnect();
+    });
+
+    async function drop(): Promise<void> {
+      if (!boot) return;
+      for (const stmt of [
+        `DROP TABLE IF EXISTS ${TABLE}`,
+        `DELETE FROM dynamic_collections WHERE slug = '${SLUG}'`,
+      ]) {
+        try {
+          await boot.executeQuery(stmt);
+        } catch {
+          // Best-effort on a fresh database.
+        }
+      }
+    }
+
+    it("refuses a batch draft-write that races a concurrent publish", async () => {
+      const adapter = await connect(leg);
+      let handle: TestNextly | undefined;
+      try {
+        handle = await createTestNextly({
+          adapter,
+          collections: [
+            defineCollection({
+              slug: SLUG,
+              status: true,
+              // Editors may update and read but never unpublish; only a trusted
+              // (overrideAccess) write may move a row out of published.
+              access: {
+                create: () => true,
+                update: () => true,
+                read: () => true,
+                unpublish: () => false,
+              },
+              fields: [text({ name: "title" })],
+            }),
+          ],
+        });
+        const h = handle.getService<CollectionsHandler>("collectionsHandler");
+        const entryService = h.getEntryService() as CollectionEntryService;
+
+        const created = await h.createEntry(
+          { collectionName: SLUG, overrideAccess: true },
+          { title: "t", status: "draft" }
+        );
+        const id = (created.data as { id: string }).id;
+
+        const gate = deferred();
+        const bLocked = deferred();
+
+        // Writer B: hold a transaction that locks the row and publishes it, then
+        // wait for the gate before committing — so it commits only after A has
+        // read `draft` and is blocked on the same lock.
+        const bTx = handle.adapter.transaction(async tx => {
+          await tx.lockRow(TABLE, id);
+          await tx.update(TABLE, { status: "published" }, whereId(id));
+          bLocked.resolve();
+          await gate.promise;
+        });
+
+        await bLocked.promise;
+
+        // Writer A: a batch update that keeps the row draft. It reads the
+        // committed `draft` (B is uncommitted), then blocks taking the row lock.
+        const aResultP = entryService.updateEntries(
+          { collectionName: SLUG, user: { id: "editor" } },
+          [{ id, data: { status: "draft" } }]
+        );
+
+        // Let A reach its lock and block behind B before B commits.
+        await sleep(500);
+
+        gate.resolve();
+        await bTx;
+
+        const aResult = await aResultP;
+        // The draft-over-published write is an unpublish the editor may not do.
+        expect(aResult.successful).toBe(0);
+        expect(aResult.failed).toBe(1);
+
+        // A was refused under the lock, so B's publish stands.
+        const [row] = await handle.adapter.select<{ status: string }>(TABLE, {
+          where: whereId(id),
+        });
+        expect(row?.status).toBe("published");
+      } finally {
+        await handle?.destroy();
+      }
+    });
+  });
+}

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-toctou.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-toctou.integration.test.ts
@@ -85,6 +85,24 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+// Block until a backend is parked waiting on a lock for this table. Releasing the
+// gate only after Writer A is observably blocked on Writer B's row lock makes the
+// race deterministic: A has already taken its pre-lock read and is now waiting on
+// the FOR UPDATE, so it cannot instead observe B's committed change up front and
+// skip the under-lock path. Postgres-only, matching the single concurrency leg.
+async function waitForLockWaiter(adapter: TestAdapter): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    const rows = await adapter.executeQuery<{ n: number }>(
+      `SELECT count(*)::int AS n FROM pg_stat_activity
+       WHERE wait_event_type = 'Lock' AND query LIKE $1`,
+      [`%${TABLE}%`]
+    );
+    if ((rows[0]?.n ?? 0) > 0) return;
+    await sleep(25);
+  }
+  throw new Error(`timed out waiting for a lock waiter on ${TABLE}`);
+}
+
 const whereId = (id: string) => ({
   and: [{ column: "id", op: "=" as const, value: id }],
 });
@@ -173,8 +191,9 @@ for (const leg of LEGS) {
           [{ id, data: { status: "draft" } }]
         );
 
-        // Let A reach its lock and block behind B before B commits.
-        await sleep(500);
+        // Wait until A is observably parked on B's row lock (not a fixed sleep),
+        // so A has already read `draft` and is blocked before B commits.
+        await waitForLockWaiter(handle.adapter);
 
         gate.resolve();
         await bTx;
@@ -248,7 +267,11 @@ for (const leg of LEGS) {
           [{ id, data: { status: "published" } }]
         );
 
-        await sleep(500);
+        // Release the gate only once A is observably blocked on B's row lock, so
+        // A's pre-lock read has already seen the row and it is parked on the FOR
+        // UPDATE — it cannot instead observe the committed delete and skip the
+        // under-lock guard.
+        await waitForLockWaiter(handle.adapter);
 
         gate.resolve();
         await bTx;

--- a/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
@@ -478,6 +478,53 @@ describe("getOwnerConstraint — scoped API key", () => {
   });
 });
 
+describe("checkCollectionAccess — deferStoredRuleEval", () => {
+  it("skips the docless stored-rule eval when deferred (no cached denial)", async () => {
+    const { service, accessControlService } = buildAccessService();
+    // A document-dependent rule (e.g. custom) that would deny on absent data.
+    accessControlService.evaluateAccess.mockResolvedValue({
+      allowed: false,
+      reason: "custom denied on missing data",
+    });
+    const result = await service.checkCollectionAccess(
+      "posts",
+      "publish",
+      user,
+      undefined,
+      undefined,
+      false, // overrideAccess
+      false, // routeAuthorized
+      undefined, // authenticatedScope
+      true // deferStoredRuleEval
+    );
+    // The RBAC gate still ran (mock allows); the stored rule is left for the
+    // under-lock recheck, so it is NOT evaluated docless here.
+    expect(result).toBeNull();
+    expect(accessControlService.evaluateAccess).not.toHaveBeenCalled();
+  });
+
+  it("evaluates the stored rule when not deferred (denies)", async () => {
+    const { service, accessControlService } = buildAccessService();
+    accessControlService.evaluateAccess.mockResolvedValue({
+      allowed: false,
+      reason: "denied",
+    });
+    const result = await service.checkCollectionAccess(
+      "posts",
+      "publish",
+      user,
+      undefined,
+      undefined,
+      false,
+      false,
+      undefined,
+      false // deferStoredRuleEval
+    );
+    expect(result?.statusCode).toBe(403);
+    expect(accessControlService.evaluateAccess).toHaveBeenCalled();
+  });
+});
+
 describe("resolveTransitionDocumentRule — owner-only transition pre-resolve", () => {
   const ownerOnlyPublish = {
     accessRules: { publish: { type: "owner-only" } },

--- a/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
@@ -425,3 +425,55 @@ describe("checkCollectionAccess — scoped API key", () => {
     expect(rbac.checkAccess).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("getOwnerConstraint — scoped API key", () => {
+  // getOwnerConstraint emits the owner predicate that a read/mutate folds into
+  // its WHERE clause. The session super-admin bypass lifts it — but a scoped API
+  // key owned by a super-admin must still obey a stored owner-only rule, so the
+  // predicate has to survive for the key even though the account is super-admin.
+  function buildWithOwnerOnlyRead() {
+    const accessControlService = createMockAccessControlService();
+    const rbac = {
+      checkAccess: vi.fn().mockResolvedValue(true),
+      getRegisteredAccess: vi.fn().mockReturnValue(undefined),
+    };
+    const collectionService = {
+      getCollection: vi
+        .fn()
+        .mockResolvedValue({ accessRules: { read: { type: "owner-only" } } }),
+      generateId: vi.fn(),
+    };
+    return new CollectionAccessService(
+      createMockAdapter(createMockDb()) as never,
+      silentLogger as never,
+      collectionService as never,
+      accessControlService as never,
+      rbac as never
+    );
+  }
+
+  it("lifts the owner predicate for a session super-admin (no scope)", async () => {
+    const service = buildWithOwnerOnlyRead();
+    const constraint = await service.getOwnerConstraint(
+      "posts",
+      "read",
+      superAdminUser,
+      false
+    );
+    expect(constraint).toBeNull();
+  });
+
+  it("keeps the owner predicate for a super-admin-owned scoped API key", async () => {
+    const service = buildWithOwnerOnlyRead();
+    const constraint = await service.getOwnerConstraint(
+      "posts",
+      "read",
+      superAdminUser,
+      false,
+      { actorType: "apiKey", permissions: ["read-posts"] }
+    );
+    // The scope skips the super-admin bypass, so the owner-only rule still binds
+    // the key to rows it owns.
+    expect(constraint).toEqual({ field: "created_by", value: "user-1" });
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
@@ -30,7 +30,7 @@ function buildAccessService() {
   };
   const collectionService = createMockCollectionService();
   const service = new CollectionAccessService(
-    createMockAdapter(createMockDb()) as never,
+    createMockAdapter(createMockDb({ rows: [] })) as never,
     silentLogger as never,
     collectionService as never,
     accessControlService as never,
@@ -475,5 +475,99 @@ describe("getOwnerConstraint — scoped API key", () => {
     // The scope skips the super-admin bypass, so the owner-only rule still binds
     // the key to rows it owns.
     expect(constraint).toEqual({ field: "created_by", value: "user-1" });
+  });
+});
+
+describe("resolveTransitionDocumentRule — owner-only transition pre-resolve", () => {
+  const ownerOnlyPublish = {
+    accessRules: { publish: { type: "owner-only" } },
+  } as Record<string, unknown>;
+
+  it("returns the pre-fetched rules + user for an owner-only publish rule", () => {
+    const { service } = buildAccessService();
+    const resolved = service.resolveTransitionDocumentRule(
+      ownerOnlyPublish,
+      user
+    );
+    expect(resolved).not.toBeNull();
+    expect(resolved?.user).toBe(user);
+    expect(resolved?.accessRules.publish?.type).toBe("owner-only");
+  });
+
+  it("returns null for a super-admin SESSION (stored rules are bypassed)", () => {
+    const { service } = buildAccessService();
+    expect(
+      service.resolveTransitionDocumentRule(ownerOnlyPublish, superAdminUser)
+    ).toBeNull();
+  });
+
+  it("keeps the rule for a super-admin-owned scoped API key", () => {
+    const { service } = buildAccessService();
+    const resolved = service.resolveTransitionDocumentRule(
+      ownerOnlyPublish,
+      superAdminUser,
+      { actorType: "apiKey", permissions: ["publish-posts"] }
+    );
+    // The scope skips the super-admin bypass, so the owner-only rule still applies.
+    expect(resolved).not.toBeNull();
+  });
+
+  it("returns null when no owner-only publish/unpublish rule exists", () => {
+    const { service } = buildAccessService();
+    // An owner-only READ rule is document-dependent for reads but not for the
+    // publish/unpublish transition, so there is nothing to enforce under the lock.
+    expect(
+      service.resolveTransitionDocumentRule(
+        { accessRules: { read: { type: "owner-only" } } } as Record<
+          string,
+          unknown
+        >,
+        user
+      )
+    ).toBeNull();
+  });
+});
+
+describe("evaluateTransitionDocumentRule — owner-only against a locked row", () => {
+  it("returns null (skips) when the operation has no owner-only rule", async () => {
+    const { service, accessControlService } = buildAccessService();
+    const result = await service.evaluateTransitionDocumentRule(
+      { publish: { type: "role-based", allowedRoles: ["editor"] } },
+      "publish",
+      user,
+      { id: "doc-1", created_by: "someone-else" }
+    );
+    expect(result).toBeNull();
+    // A non-owner-only rule was already decided by the permission pre-resolve, so
+    // the document evaluator must not re-run it.
+    expect(accessControlService.evaluateAccess).not.toHaveBeenCalled();
+  });
+
+  it("returns a 403 when the owner-only rule denies the locked document", async () => {
+    const { service, accessControlService } = buildAccessService();
+    accessControlService.evaluateAccess.mockResolvedValue({
+      allowed: false,
+      reason: "You can only modify your own documents",
+    });
+    const result = await service.evaluateTransitionDocumentRule(
+      { publish: { type: "owner-only" } },
+      "publish",
+      user,
+      { id: "doc-1", created_by: "someone-else" }
+    );
+    expect(result?.statusCode).toBe(403);
+    expect(result?.success).toBe(false);
+  });
+
+  it("returns null when the owner-only rule allows the locked document", async () => {
+    const { service, accessControlService } = buildAccessService();
+    accessControlService.evaluateAccess.mockResolvedValue({ allowed: true });
+    const result = await service.evaluateTransitionDocumentRule(
+      { publish: { type: "owner-only" } },
+      "publish",
+      user,
+      { id: "doc-1", created_by: "user-1" }
+    );
+    expect(result).toBeNull();
   });
 });

--- a/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
@@ -526,6 +526,19 @@ describe("resolveTransitionDocumentRule — owner-only transition pre-resolve", 
       )
     ).toBeNull();
   });
+
+  it("returns the rules for a custom publish rule (may inspect the document)", () => {
+    const { service } = buildAccessService();
+    const resolved = service.resolveTransitionDocumentRule(
+      {
+        accessRules: { publish: { type: "custom", functionPath: "./fn" } },
+      } as Record<string, unknown>,
+      user
+    );
+    // A custom rule can key off id/data, so it must be re-judged under the lock.
+    expect(resolved).not.toBeNull();
+    expect(resolved?.accessRules.publish?.type).toBe("custom");
+  });
 });
 
 describe("evaluateTransitionDocumentRule — owner-only against a locked row", () => {
@@ -569,5 +582,30 @@ describe("evaluateTransitionDocumentRule — owner-only against a locked row", (
       { id: "doc-1", created_by: "user-1" }
     );
     expect(result).toBeNull();
+  });
+
+  it("re-judges a custom rule against the locked row, forwarding its id", async () => {
+    const { service, accessControlService } = buildAccessService();
+    accessControlService.evaluateAccess.mockResolvedValue({
+      allowed: false,
+      reason: "custom denied",
+    });
+    const result = await service.evaluateTransitionDocumentRule(
+      { publish: { type: "custom", functionPath: "./fn" } },
+      "publish",
+      user,
+      { id: "doc-1", title: "hello" }
+    );
+    expect(result?.statusCode).toBe(403);
+    // The locked row's id and full data reach the custom evaluator, so a
+    // row-dependent rule sees the real document instead of the docless default.
+    expect(accessControlService.evaluateAccess).toHaveBeenCalledWith(
+      { publish: { type: "custom", functionPath: "./fn" } },
+      "publish",
+      expect.anything(),
+      "doc-1",
+      { id: "doc-1", title: "hello" },
+      expect.anything()
+    );
   });
 });

--- a/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
@@ -444,7 +444,7 @@ describe("getOwnerConstraint — scoped API key", () => {
       generateId: vi.fn(),
     };
     return new CollectionAccessService(
-      createMockAdapter(createMockDb()) as never,
+      createMockAdapter(createMockDb({ rows: [] })) as never,
       silentLogger as never,
       collectionService as never,
       accessControlService as never,

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -392,10 +392,22 @@ export class CollectionAccessService extends BaseService {
     collectionName: string,
     operation: AccessOperation,
     user?: UserContext,
-    overrideAccess?: boolean
+    overrideAccess?: boolean,
+    // The caller's authenticated scope. A scoped API key is judged on its OWN
+    // grant, so the session super-admin bypass does not lift the owner predicate
+    // for a super-admin-owned key — mirrors checkCollectionAccess.
+    authenticatedScope?: AuthenticatedScope
   ): Promise<{ field: string; value: string } | null> {
-    // Super-admin bypasses the owner predicate on the transactional paths too.
-    if (overrideAccess || !user || isSuperAdminContext(user)) return null;
+    // Super-admin bypasses the owner predicate on the transactional paths too —
+    // EXCEPT via a scoped API key, which must still obey stored owner rules.
+    const isScopedApiKey = authenticatedScope?.actorType === "apiKey";
+    if (
+      overrideAccess ||
+      !user ||
+      (!isScopedApiKey && isSuperAdminContext(user))
+    ) {
+      return null;
+    }
 
     try {
       const collection =

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -328,20 +328,32 @@ export class CollectionAccessService extends BaseService {
   }
 
   /**
-   * Pre-resolve whether a collection has a document-dependent (owner-only)
-   * publish/unpublish rule that must be judged against the specific row being
-   * transitioned. Runs on the pooled connection BEFORE a write transaction, so
-   * the in-transaction check needs no metadata read (mirrors the permission
+   * Whether a stored access rule's decision depends on the specific document —
+   * `owner-only` (compares the owner column) or `custom` (a function that may
+   * inspect `id`/`data`). These must be re-judged against the row-locked row, not
+   * the docless pre-resolve. `public`/`authenticated`/`role-based` are fully
+   * decided without a document, so they are excluded.
+   */
+  private isDocumentDependentRule(
+    rule: { type?: string } | undefined
+  ): boolean {
+    return rule?.type === "owner-only" || rule?.type === "custom";
+  }
+
+  /**
+   * Pre-resolve whether a collection has a document-dependent (owner-only or
+   * custom) publish/unpublish rule that must be judged against the specific row
+   * being transitioned. Runs on the pooled connection BEFORE a write transaction,
+   * so the in-transaction check needs no metadata read (mirrors the permission
    * pre-resolve used by the transaction/batch paths).
    *
    * Returns the already-fetched rules + user when such a rule applies, or null
    * when it does not: a super-admin SESSION bypasses stored rules — but NOT a
    * scoped API key it owns (matching {@link checkCollectionAccess}) — and a
-   * collection with no owner-only publish/unpublish rule has nothing
-   * document-dependent to enforce. Only owner-only inspects the row;
-   * role-based/authenticated/public rules are fully decided by the docless
-   * permission pre-resolve, so they are intentionally excluded here. The caller
-   * is responsible for skipping this on an `overrideAccess` write.
+   * collection with no document-dependent publish/unpublish rule has nothing to
+   * re-enforce. role-based/authenticated/public rules are fully decided by the
+   * docless permission pre-resolve, so they are intentionally excluded here. The
+   * caller is responsible for skipping this on an `overrideAccess` write.
    */
   resolveTransitionDocumentRule(
     collection: Record<string, unknown>,
@@ -358,22 +370,24 @@ export class CollectionAccessService extends BaseService {
     const accessRules = this.getAccessRules(collection);
     if (!accessRules) return null;
     const documentDependent =
-      accessRules.publish?.type === "owner-only" ||
-      accessRules.unpublish?.type === "owner-only";
+      this.isDocumentDependentRule(accessRules.publish) ||
+      this.isDocumentDependentRule(accessRules.unpublish);
     return documentDependent ? { accessRules, user } : null;
   }
 
   /**
-   * Evaluate the stored owner-only publish/unpublish rule for a transition
-   * against an ALREADY-FETCHED (row-locked) document, with no metadata or
-   * permission read — safe to call inside a transaction. Returns a 403 result
-   * when the rule denies (the actor is not the document's owner), or null when
-   * it allows or no owner-only rule governs the operation.
+   * Evaluate the stored document-dependent (owner-only or custom) publish/
+   * unpublish rule for a transition against an ALREADY-FETCHED (row-locked)
+   * document, with no metadata or permission read — safe to call inside a
+   * transaction. Returns a 403 result when the rule denies, or null when it
+   * allows or no document-dependent rule governs the operation.
    *
-   * This closes the gap where the docless permission pre-resolve lets an
-   * owner-only publish/unpublish through (owner checks defer without a document),
-   * so a caller who may update another user's row could otherwise batch-publish
-   * or unpublish it under the transaction.
+   * This closes the gap where the docless permission pre-resolve lets a
+   * document-dependent publish/unpublish through: owner checks defer without a
+   * document, and a custom rule is judged on empty `id`/`data`. So a caller who
+   * may update another user's row could otherwise batch-publish or unpublish it
+   * under the transaction. The row's own `id` is passed so a custom rule that
+   * keys off the document id sees the real value.
    */
   async evaluateTransitionDocumentRule<T = unknown>(
     accessRules: CollectionAccessRules,
@@ -381,14 +395,16 @@ export class CollectionAccessService extends BaseService {
     user: UserContext | undefined,
     document: Record<string, unknown>
   ): Promise<CollectionServiceResult<T> | null> {
-    if (accessRules[operation]?.type !== "owner-only") {
+    if (!this.isDocumentDependentRule(accessRules[operation])) {
       return null;
     }
+    const documentId =
+      typeof document.id === "string" ? document.id : undefined;
     const result = await this.accessControlService.evaluateAccess(
       accessRules,
       operation,
       this.buildRequestContext(user),
-      undefined,
+      documentId,
       document,
       DEFAULT_OWNER_FIELD
     );

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -168,7 +168,15 @@ export class CollectionAccessService extends BaseService {
     // The caller's authenticated scope. For a scoped API key the RBAC gate
     // judges the key's OWN stamped grants rather than the owner's permissions
     // (see auth/authenticated-scope). Undefined for session/system callers.
-    authenticatedScope?: AuthenticatedScope
+    authenticatedScope?: AuthenticatedScope,
+    // Skip the stored-rule evaluation (owner-only/custom/role-based/...) and
+    // return after only the RBAC/permission gate. The transition pre-resolve uses
+    // this so a document-dependent stored rule (owner-only or custom) is NOT
+    // judged against an absent document here — a custom rule that denies on
+    // missing data would otherwise cache a denial that pre-empts the under-lock
+    // recheck. The rule is instead evaluated against the row-locked document via
+    // {@link evaluateTransitionDocumentRule}.
+    deferStoredRuleEval?: boolean
   ): Promise<CollectionServiceResult<T> | null> {
     // Trusted-server / system write: bypass all access control checks.
     if (overrideAccess) {
@@ -268,6 +276,14 @@ export class CollectionAccessService extends BaseService {
       }
     }
 
+    // The caller (transition pre-resolve) will evaluate the document-dependent
+    // stored rule against the row-locked document itself, so the docless
+    // evaluation here is skipped: the RBAC/permission gate above stands, but a
+    // custom rule is not run with an absent document.
+    if (deferStoredRuleEval) {
+      return null;
+    }
+
     try {
       // Get collection metadata to retrieve access rules
       const collection =
@@ -334,9 +350,7 @@ export class CollectionAccessService extends BaseService {
    * the docless pre-resolve. `public`/`authenticated`/`role-based` are fully
    * decided without a document, so they are excluded.
    */
-  private isDocumentDependentRule(
-    rule: { type?: string } | undefined
-  ): boolean {
+  isDocumentDependentRule(rule: { type?: string } | undefined): boolean {
     return rule?.type === "owner-only" || rule?.type === "custom";
   }
 

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -328,6 +328,80 @@ export class CollectionAccessService extends BaseService {
   }
 
   /**
+   * Pre-resolve whether a collection has a document-dependent (owner-only)
+   * publish/unpublish rule that must be judged against the specific row being
+   * transitioned. Runs on the pooled connection BEFORE a write transaction, so
+   * the in-transaction check needs no metadata read (mirrors the permission
+   * pre-resolve used by the transaction/batch paths).
+   *
+   * Returns the already-fetched rules + user when such a rule applies, or null
+   * when it does not: a super-admin SESSION bypasses stored rules — but NOT a
+   * scoped API key it owns (matching {@link checkCollectionAccess}) — and a
+   * collection with no owner-only publish/unpublish rule has nothing
+   * document-dependent to enforce. Only owner-only inspects the row;
+   * role-based/authenticated/public rules are fully decided by the docless
+   * permission pre-resolve, so they are intentionally excluded here. The caller
+   * is responsible for skipping this on an `overrideAccess` write.
+   */
+  resolveTransitionDocumentRule(
+    collection: Record<string, unknown>,
+    user: UserContext | undefined,
+    authenticatedScope?: AuthenticatedScope
+  ): {
+    accessRules: CollectionAccessRules;
+    user: UserContext | undefined;
+  } | null {
+    const isScopedApiKey = authenticatedScope?.actorType === "apiKey";
+    if (!isScopedApiKey && isSuperAdminContext(user)) {
+      return null;
+    }
+    const accessRules = this.getAccessRules(collection);
+    if (!accessRules) return null;
+    const documentDependent =
+      accessRules.publish?.type === "owner-only" ||
+      accessRules.unpublish?.type === "owner-only";
+    return documentDependent ? { accessRules, user } : null;
+  }
+
+  /**
+   * Evaluate the stored owner-only publish/unpublish rule for a transition
+   * against an ALREADY-FETCHED (row-locked) document, with no metadata or
+   * permission read — safe to call inside a transaction. Returns a 403 result
+   * when the rule denies (the actor is not the document's owner), or null when
+   * it allows or no owner-only rule governs the operation.
+   *
+   * This closes the gap where the docless permission pre-resolve lets an
+   * owner-only publish/unpublish through (owner checks defer without a document),
+   * so a caller who may update another user's row could otherwise batch-publish
+   * or unpublish it under the transaction.
+   */
+  async evaluateTransitionDocumentRule<T = unknown>(
+    accessRules: CollectionAccessRules,
+    operation: "publish" | "unpublish",
+    user: UserContext | undefined,
+    document: Record<string, unknown>
+  ): Promise<CollectionServiceResult<T> | null> {
+    if (accessRules[operation]?.type !== "owner-only") {
+      return null;
+    }
+    const result = await this.accessControlService.evaluateAccess(
+      accessRules,
+      operation,
+      this.buildRequestContext(user),
+      undefined,
+      document,
+      DEFAULT_OWNER_FIELD
+    );
+    if (result.allowed) return null;
+    return {
+      success: false,
+      statusCode: 403,
+      message: result.reason || "Access denied",
+      data: null as unknown as T,
+    };
+  }
+
+  /**
    * Get access query constraint for read operations.
    *
    * For owner-only access rules on read operations, the AccessControlService

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -576,7 +576,11 @@ export class CollectionBulkService extends BaseService {
       params.collectionName,
       "update",
       params.user,
-      params.overrideAccess
+      params.overrideAccess,
+      // Scope the enumeration too: a super-admin-owned key on an owner-only
+      // collection must enumerate only its own rows, so the response ids, counts,
+      // and limit check never expose rows the owner constraint should hide.
+      params.authenticatedScope
     );
     const updateEnumerationWhere: WhereFilter = updateOwnerConstraint
       ? {

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -17,6 +17,7 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
 
+import type { AuthenticatedScope } from "../../../auth/authenticated-scope";
 import type { RequestActor } from "../../../auth/request-actor";
 import { NextlyError } from "../../../errors/nextly-error";
 import type { WhereFilter } from "../../../services/collections/query-operators";
@@ -192,6 +193,12 @@ export class CollectionBulkService extends BaseService {
     context?: Record<string, unknown>;
     /** Acting identity from the transport, forwarded to the recorded event. */
     actor?: RequestActor;
+    /**
+     * The caller's authenticated scope. A duplicate is a create, so a
+     * scoped API key that copies a published source into a published row is
+     * judged on the key's OWN publish grant, not the key owner's.
+     */
+    authenticatedScope?: AuthenticatedScope;
   }): Promise<CollectionServiceResult> {
     try {
       // 1. Fetch the source entry with a REAL read check. Duplicating a row is
@@ -269,6 +276,8 @@ export class CollectionBulkService extends BaseService {
           actor: params.actor,
           overrideAccess: params.overrideAccess,
           routeAuthorized: params.routeAuthorized,
+          // Judge the create-as-published on the key's own publish grant.
+          authenticatedScope: params.authenticatedScope,
         },
         duplicateData
       );
@@ -388,6 +397,13 @@ export class CollectionBulkService extends BaseService {
     context?: Record<string, unknown>;
     /** Acting identity from the transport, forwarded to the recorded event. */
     actor?: RequestActor;
+    /**
+     * The caller's authenticated scope. Forwarded to each per-id `updateEntry`
+     * so a scoped API key's publish/unpublish transition is judged on the key's
+     * OWN grants — a bulk update must not become a way around the single-write
+     * gate for a key whose owner could publish but whose scope cannot.
+     */
+    authenticatedScope?: AuthenticatedScope;
   }): Promise<BulkOperationResult<Record<string, unknown>>> {
     // Phase 4.5: successes carry full mutated records (caller needs the
     // post-update values); failures carry canonical NextlyErrorCode.
@@ -409,6 +425,8 @@ export class CollectionBulkService extends BaseService {
                 overrideAccess: params.overrideAccess,
                 routeAuthorized: params.routeAuthorized,
                 context: params.context,
+                // Judge the key's own publish/unpublish grant per row.
+                authenticatedScope: params.authenticatedScope,
               },
               params.data
             );
@@ -489,6 +507,11 @@ export class CollectionBulkService extends BaseService {
       context?: Record<string, unknown>;
       /** Acting identity from the transport, forwarded to the recorded event. */
       actor?: RequestActor;
+      /**
+       * The caller's authenticated scope. Judges the collection-level gate and
+       * each per-row transition on a scoped API key's OWN grants.
+       */
+      authenticatedScope?: AuthenticatedScope;
     },
     options?: BulkOperationOptions & {
       /**
@@ -514,7 +537,10 @@ export class CollectionBulkService extends BaseService {
       undefined,
       undefined,
       params.overrideAccess,
-      params.routeAuthorized
+      params.routeAuthorized,
+      // A scoped API key is judged on its own grants here too, so the session
+      // super-admin bypass does not apply to it on the collection-level gate.
+      params.authenticatedScope
     );
     if (accessDenied) {
       throw NextlyError.forbidden({
@@ -632,6 +658,8 @@ export class CollectionBulkService extends BaseService {
       overrideAccess: params.overrideAccess,
       routeAuthorized: params.routeAuthorized,
       context: params.context,
+      // Carry the key's scope into the per-id transition gate.
+      authenticatedScope: params.authenticatedScope,
     });
   }
 

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -319,6 +319,11 @@ export class CollectionBulkService extends BaseService {
     routeAuthorized?: boolean;
     /** Arbitrary data passed to hooks via context */
     context?: Record<string, unknown>;
+    /**
+     * The caller's authenticated scope. Forwarded to each per-id delete so a
+     * scoped API key is judged on its OWN delete grant, not the key owner's.
+     */
+    authenticatedScope?: AuthenticatedScope;
   }): Promise<BulkOperationResult<{ id: string }>> {
     // Phase 4.5: result carries minimal `{id}` records for delete (the
     // entries are gone; no value in materializing more) and structured
@@ -340,6 +345,8 @@ export class CollectionBulkService extends BaseService {
               overrideAccess: params.overrideAccess,
               routeAuthorized: params.routeAuthorized,
               context: params.context,
+              // Judge the key's own delete grant per row.
+              authenticatedScope: params.authenticatedScope,
             });
 
             if (deleteResult.success) {

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -218,6 +218,9 @@ export class CollectionBulkService extends BaseService {
         overrideAccess: params.overrideAccess,
         status: sourceStatus,
         context: params.context,
+        // Judge the source read on the key's OWN read grant: a create-scoped key
+        // that lacks read must not copy fields from a row it cannot see.
+        authenticatedScope: params.authenticatedScope,
       });
 
       if (!sourceResult.success || !sourceResult.data) {

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -937,6 +937,16 @@ export class CollectionBulkService extends BaseService {
       };
     }
 
+    // Resolve the caller's publish authorization ONCE on the pooled connection
+    // before the shared transaction, so each worker enforces the create-as-
+    // published under its row without a permission read inside the transaction.
+    const transitionAuth =
+      await this.mutationService.resolveTransitionAuthorization({
+        collectionName: params.collectionName,
+        accessUser,
+        overrideAccess: params.overrideAccess,
+      });
+
     // Process all entries within a single transaction
     try {
       await this.adapter.transaction(async tx => {
@@ -957,7 +967,7 @@ export class CollectionBulkService extends BaseService {
               const createResult =
                 await this.mutationService.createSingleEntryInTransaction(
                   tx,
-                  params,
+                  { ...params, transitionAuth },
                   entryData,
                   skipHooks
                 );
@@ -1105,6 +1115,15 @@ export class CollectionBulkService extends BaseService {
       };
     }
 
+    // Resolve the caller's publish authorization ONCE (pooled) before looping the
+    // workers, so each create-as-published is enforced without a permission read
+    // inside the caller's transaction.
+    const transitionAuth =
+      await this.mutationService.resolveTransitionAuthorization({
+        collectionName: params.collectionName,
+        accessUser: params.user,
+      });
+
     // Process in batches for memory efficiency
     for (let i = 0; i < entries.length; i += batchSize) {
       const batch = entries.slice(i, Math.min(i + batchSize, entries.length));
@@ -1118,7 +1137,7 @@ export class CollectionBulkService extends BaseService {
           const createResult =
             await this.mutationService.createSingleEntryInTransaction(
               tx,
-              params,
+              { ...params, transitionAuth },
               entryData,
               skipHooks
             );
@@ -1246,6 +1265,16 @@ export class CollectionBulkService extends BaseService {
       };
     }
 
+    // Resolve the caller's publish/unpublish authorization ONCE on the pooled
+    // connection before the shared transaction, so each worker enforces its
+    // transition under the row lock without a permission read inside the batch's
+    // transaction.
+    const transitionAuth =
+      await this.mutationService.resolveTransitionAuthorization({
+        collectionName: params.collectionName,
+        accessUser: params.user,
+      });
+
     // Process all entries within a single transaction
     try {
       await this.adapter.transaction(async tx => {
@@ -1266,7 +1295,7 @@ export class CollectionBulkService extends BaseService {
               const updateResult =
                 await this.mutationService.updateSingleEntryInTransaction(
                   tx,
-                  params,
+                  { ...params, transitionAuth },
                   id,
                   data,
                   skipHooks
@@ -1414,6 +1443,15 @@ export class CollectionBulkService extends BaseService {
       };
     }
 
+    // Resolve the caller's publish/unpublish authorization ONCE (pooled) before
+    // looping the workers, so each transition is enforced under the row lock
+    // without a permission read inside the caller's transaction.
+    const transitionAuth =
+      await this.mutationService.resolveTransitionAuthorization({
+        collectionName: params.collectionName,
+        accessUser: params.user,
+      });
+
     // Process in batches for memory efficiency
     for (let i = 0; i < entries.length; i += batchSize) {
       const batch = entries.slice(i, Math.min(i + batchSize, entries.length));
@@ -1427,7 +1465,7 @@ export class CollectionBulkService extends BaseService {
           const updateResult =
             await this.mutationService.updateSingleEntryInTransaction(
               tx,
-              params,
+              { ...params, transitionAuth },
               id,
               data,
               skipHooks

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -2483,6 +2483,10 @@ export class CollectionMutationService extends BaseService {
       nextStatus: unknown;
       isCreate: boolean;
       auth: TransitionAuthorization;
+      // The row a create will persist (owner-stamped `created_by` + final
+      // status/data). A create has no prior row to lock, so a deferred
+      // owner-only/custom publish rule is judged against this instead.
+      createDocument?: Record<string, unknown>;
     }
   ): Promise<CollectionServiceResult | null> {
     // No status named in the write: no transition, nothing to enforce.
@@ -2527,17 +2531,21 @@ export class CollectionMutationService extends BaseService {
     const permissionDenied =
       op === "publish" ? args.auth.publishDenied : args.auth.unpublishDenied;
     if (permissionDenied) return permissionDenied;
-    // Then the document-dependent (owner-only) rule against the row-locked
-    // document. Pre-resolved rules + user are carried on `auth`, so this reads no
-    // metadata or permission storage inside the transaction. A create has no
-    // prior row (lockedRow null), and its owner is the creator, so owner-only
-    // allows — the check is skipped there.
-    if (args.auth.documentRule && lockedRow) {
+    // Then the document-dependent (owner-only/custom) rule. Pre-resolved rules +
+    // user are carried on `auth`, so this reads no metadata or permission storage
+    // inside the transaction. For an update it is judged against the row-locked
+    // document; for a create there is no prior row, so it is judged against the
+    // row this create will persist — a deferred owner-only/custom publish rule
+    // must still gate a create that lands directly on published (otherwise a
+    // public create + owner-only publish could anonymously publish, or a custom
+    // publish rule returning false would be skipped on creates).
+    const documentForRule = lockedRow ?? args.createDocument ?? null;
+    if (args.auth.documentRule && documentForRule) {
       return this.accessService.evaluateTransitionDocumentRule(
         args.auth.documentRule.accessRules,
         op,
         args.auth.documentRule.user,
-        lockedRow
+        documentForRule
       );
     }
     return null;
@@ -4271,6 +4279,7 @@ export class CollectionMutationService extends BaseService {
         nextStatus: finalData.status,
         isCreate: true,
         auth: transitionAuth,
+        createDocument: entryData,
       });
       if (transitionDenied) {
         return transitionDenied;
@@ -5224,6 +5233,7 @@ export class CollectionMutationService extends BaseService {
         nextStatus: finalData.status,
         isCreate: true,
         auth: transitionAuth,
+        createDocument: entryData,
       });
       if (transitionDenied) {
         return transitionDenied;

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -2448,11 +2448,26 @@ export class CollectionMutationService extends BaseService {
     if (args.nextStatus === undefined) return null;
     let lockedStatus: string | null = null;
     if (!args.isCreate && args.entryId) {
-      await tx.lockRow(args.tableName, args.entryId);
-      const locked = await tx.selectOne<{ status?: unknown }>(args.tableName, {
-        where: this.whereEq("id", args.entryId),
-      });
-      lockedStatus = (locked?.status as string | undefined) ?? null;
+      // Read the committed status UNDER a row lock, in the SAME query that takes
+      // the lock. A separate plain read would, on MySQL's repeatable-read
+      // isolation, return this transaction's snapshot — established by the
+      // caller's earlier pre-lock fetch of the row — and so miss a concurrent
+      // writer's publish/unpublish committed since, leaving the TOCTOU window
+      // open on MySQL. A `FOR UPDATE` read always sees the latest committed row.
+      // SQLite has no `FOR UPDATE` and needs none: its transactions open with
+      // `BEGIN IMMEDIATE`, which serializes writers, so its committed read is
+      // already current. (Raw `tx.execute` is the same mechanism the UPDATE in
+      // this file uses, so the read runs on the transaction's own connection.)
+      const isMysql = this.dialect === "mysql";
+      const quoteId = (id: string) => (isMysql ? `\`${id}\`` : `"${id}"`);
+      const placeholder = this.dialect === "postgresql" ? "$1" : "?";
+      const forUpdate = this.dialect === "sqlite" ? "" : " FOR UPDATE";
+      const rows = await tx.execute<{ status?: unknown }>(
+        `SELECT ${quoteId("status")} FROM ${quoteId(args.tableName)} ` +
+          `WHERE ${quoteId("id")} = ${placeholder}${forUpdate}`,
+        [args.entryId]
+      );
+      lockedStatus = (rows[0]?.status as string | undefined) ?? null;
     }
     const op = resolvePublishTransition(lockedStatus, args.nextStatus);
     if (!op) return null;

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -2449,25 +2449,18 @@ export class CollectionMutationService extends BaseService {
     let lockedStatus: string | null = null;
     if (!args.isCreate && args.entryId) {
       // Read the committed status UNDER a row lock, in the SAME query that takes
-      // the lock. A separate plain read would, on MySQL's repeatable-read
-      // isolation, return this transaction's snapshot — established by the
-      // caller's earlier pre-lock fetch of the row — and so miss a concurrent
-      // writer's publish/unpublish committed since, leaving the TOCTOU window
-      // open on MySQL. A `FOR UPDATE` read always sees the latest committed row.
-      // SQLite has no `FOR UPDATE` and needs none: its transactions open with
-      // `BEGIN IMMEDIATE`, which serializes writers, so its committed read is
-      // already current. (Raw `tx.execute` is the same mechanism the UPDATE in
-      // this file uses, so the read runs on the transaction's own connection.)
-      const isMysql = this.dialect === "mysql";
-      const quoteId = (id: string) => (isMysql ? `\`${id}\`` : `"${id}"`);
-      const placeholder = this.dialect === "postgresql" ? "$1" : "?";
-      const forUpdate = this.dialect === "sqlite" ? "" : " FOR UPDATE";
-      const rows = await tx.execute<{ status?: unknown }>(
-        `SELECT ${quoteId("status")} FROM ${quoteId(args.tableName)} ` +
-          `WHERE ${quoteId("id")} = ${placeholder}${forUpdate}`,
-        [args.entryId]
-      );
-      lockedStatus = (rows[0]?.status as string | undefined) ?? null;
+      // the lock (`forUpdate`). A separate plain read would, on MySQL's
+      // repeatable-read isolation, return this transaction's snapshot —
+      // established by the caller's earlier pre-lock fetch of the row — and so
+      // miss a concurrent writer's publish/unpublish committed since, leaving the
+      // TOCTOU window open on MySQL. A `FOR UPDATE` read always sees the latest
+      // committed row; SQLite skips the lock (BEGIN IMMEDIATE already serializes
+      // its writers) and its committed read is already current.
+      const locked = await tx.selectOne<{ status?: unknown }>(args.tableName, {
+        where: this.whereEq("id", args.entryId),
+        forUpdate: true,
+      });
+      lockedStatus = (locked?.status as string | undefined) ?? null;
     }
     const op = resolvePublishTransition(lockedStatus, args.nextStatus);
     if (!op) return null;

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -2487,7 +2487,21 @@ export class CollectionMutationService extends BaseService {
         where: this.whereEq("id", args.entryId),
         forUpdate: true,
       });
-      lockedStatus = (lockedRow?.status as string | undefined) ?? null;
+      if (!lockedRow) {
+        // The row was found by the caller's pre-lock read but is gone under the
+        // lock: a concurrent transaction deleted it in that window. There is no
+        // prior state to transition, so the update targets a missing row —
+        // return not-found rather than classifying the absent status as a
+        // `null -> published` publish (which would wrongly demand a publish grant
+        // for a row that no longer exists, or let the write silently no-op).
+        return {
+          success: false,
+          statusCode: 404,
+          message: "Entry not found",
+          data: null,
+        };
+      }
+      lockedStatus = (lockedRow.status as string | undefined) ?? null;
     }
     const op = resolvePublishTransition(lockedStatus, args.nextStatus);
     if (!op) return null;

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -39,6 +39,7 @@ import { getEventBus } from "../../../events/event-bus";
 import { toSnakeCase } from "../../../lib/case-conversion";
 import { resolvePublishTransition } from "../../../lib/status-transition";
 import type { ResolvedVersionsConfig } from "../../../schemas/versions/types";
+import type { CollectionAccessRules } from "../../../services/access";
 import type { CollectionFileManager } from "../../../services/collection-file-manager";
 import type {
   CollectionRelationshipService,
@@ -246,6 +247,20 @@ class StatusTransitionDeniedError extends NextlyError {
 export interface TransitionAuthorization {
   publishDenied: CollectionServiceResult | null;
   unpublishDenied: CollectionServiceResult | null;
+  /**
+   * Pre-fetched inputs for the document-dependent (owner-only) publish/unpublish
+   * check, or `null` when none applies. The permission fields above cannot judge
+   * an owner-only rule up front because it needs the specific row (which is only
+   * known under the lock); this carries the rules + user so the in-transaction
+   * step can evaluate the owner against the row-locked document with no metadata
+   * or permission read. `null` for a trusted write, a super-admin session, or a
+   * collection without an owner-only transition rule — in which case the
+   * transaction path skips the document check entirely.
+   */
+  documentRule: {
+    accessRules: CollectionAccessRules;
+    user: UserContext | undefined;
+  } | null;
 }
 
 export class CollectionMutationService extends BaseService {
@@ -2385,13 +2400,13 @@ export class CollectionMutationService extends BaseService {
     authenticatedScope?: AuthenticatedScope;
   }): Promise<TransitionAuthorization> {
     if (args.overrideAccess) {
-      return { publishDenied: null, unpublishDenied: null };
+      return { publishDenied: null, unpublishDenied: null, documentRule: null };
     }
     const collection = await this.collectionService.getCollection(
       args.collectionName
     );
     if ((collection as { status?: boolean }).status !== true) {
-      return { publishDenied: null, unpublishDenied: null };
+      return { publishDenied: null, unpublishDenied: null, documentRule: null };
     }
     // Resolve both concurrently; each is judged on the caller's own grant (a
     // scoped API key on its scope), never route-authorized — the route attested
@@ -2418,7 +2433,16 @@ export class CollectionMutationService extends BaseService {
         args.authenticatedScope
       ),
     ]);
-    return { publishDenied, unpublishDenied };
+    // Owner-only publish/unpublish rules cannot be judged here because they need
+    // the specific row (only known under the lock). Pre-fetch the rules + user
+    // off the already-loaded collection so the in-transaction step evaluates the
+    // owner against the row-locked document with no further metadata read.
+    const documentRule = this.accessService.resolveTransitionDocumentRule(
+      collection as Record<string, unknown>,
+      args.accessUser,
+      args.authenticatedScope
+    );
+    return { publishDenied, unpublishDenied, documentRule };
   }
 
   /**
@@ -2447,26 +2471,45 @@ export class CollectionMutationService extends BaseService {
     // No status named in the write: no transition, nothing to enforce.
     if (args.nextStatus === undefined) return null;
     let lockedStatus: string | null = null;
+    let lockedRow: Record<string, unknown> | null = null;
     if (!args.isCreate && args.entryId) {
-      // Read the committed status UNDER a row lock, in the SAME query that takes
-      // the lock (`forUpdate`). A separate plain read would, on MySQL's
+      // Read the committed row UNDER a row lock, in the SAME query that takes the
+      // lock (`forUpdate`). A separate plain read would, on MySQL's
       // repeatable-read isolation, return this transaction's snapshot —
       // established by the caller's earlier pre-lock fetch of the row — and so
       // miss a concurrent writer's publish/unpublish committed since, leaving the
       // TOCTOU window open on MySQL. A `FOR UPDATE` read always sees the latest
       // committed row; SQLite skips the lock (BEGIN IMMEDIATE already serializes
-      // its writers) and its committed read is already current.
-      const locked = await tx.selectOne<{ status?: unknown }>(args.tableName, {
+      // its writers) and its committed read is already current. The full row (not
+      // just status) is read so an owner-only rule can be judged against the
+      // locked owner column below.
+      lockedRow = await tx.selectOne<Record<string, unknown>>(args.tableName, {
         where: this.whereEq("id", args.entryId),
         forUpdate: true,
       });
-      lockedStatus = (locked?.status as string | undefined) ?? null;
+      lockedStatus = (lockedRow?.status as string | undefined) ?? null;
     }
     const op = resolvePublishTransition(lockedStatus, args.nextStatus);
     if (!op) return null;
-    return op === "publish"
-      ? args.auth.publishDenied
-      : args.auth.unpublishDenied;
+    // Permission first (pre-resolved, no DB read): a caller lacking publish-<slug>
+    // / unpublish-<slug> is denied regardless of ownership.
+    const permissionDenied =
+      op === "publish" ? args.auth.publishDenied : args.auth.unpublishDenied;
+    if (permissionDenied) return permissionDenied;
+    // Then the document-dependent (owner-only) rule against the row-locked
+    // document. Pre-resolved rules + user are carried on `auth`, so this reads no
+    // metadata or permission storage inside the transaction. A create has no
+    // prior row (lockedRow null), and its owner is the creator, so owner-only
+    // allows — the check is skipped there.
+    if (args.auth.documentRule && lockedRow) {
+      return this.accessService.evaluateTransitionDocumentRule(
+        args.auth.documentRule.accessRules,
+        op,
+        args.auth.documentRule.user,
+        lockedRow
+      );
+    }
+    return null;
   }
 
   async updateEntry(

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -2260,6 +2260,12 @@ export class CollectionMutationService extends BaseService {
     entryId: string;
     user?: UserContext;
     routeAuthorized?: boolean;
+    /**
+     * The caller's authenticated scope. A scoped API key is judged on its OWN
+     * update grant, so the session super-admin bypass does not apply to a
+     * super-admin-owned key when this gate authorizes a version-label edit.
+     */
+    authenticatedScope?: AuthenticatedScope;
   }): Promise<boolean> {
     const schema = await this.fileManager.loadDynamicSchema(
       params.collectionName
@@ -2287,7 +2293,10 @@ export class CollectionMutationService extends BaseService {
       // Never overridden: this exists to APPLY the document's rules, so a
       // caller that could opt out of them would defeat the point.
       false,
-      params.routeAuthorized
+      params.routeAuthorized,
+      // A scoped API key is judged on its own update grant, so the session
+      // super-admin bypass does not apply to a super-admin-owned key here.
+      params.authenticatedScope
     );
     return denied === null;
   }
@@ -3690,6 +3699,12 @@ export class CollectionMutationService extends BaseService {
     routeAuthorized?: boolean;
     /** Arbitrary data passed to hooks via context */
     context?: Record<string, unknown>;
+    /**
+     * The caller's authenticated scope. A scoped API key is judged on its OWN
+     * delete grant here, so the session super-admin bypass does not apply to a
+     * super-admin-owned key on the delete gate.
+     */
+    authenticatedScope?: AuthenticatedScope;
   }): Promise<CollectionServiceResult> {
     try {
       const accessUser = params.overrideAccess ? undefined : params.user;
@@ -3723,7 +3738,10 @@ export class CollectionMutationService extends BaseService {
         params.entryId,
         entry,
         params.overrideAccess,
-        params.routeAuthorized
+        params.routeAuthorized,
+        // A scoped API key is judged on its own delete grant, so the session
+        // super-admin bypass does not apply to a super-admin-owned key here.
+        params.authenticatedScope
       );
       if (accessDenied) {
         return accessDenied;

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -229,6 +229,25 @@ class StatusTransitionDeniedError extends NextlyError {
   }
 }
 
+/**
+ * A caller's publish/unpublish authorization for a collection, resolved ONCE on
+ * the pooled connection BEFORE a write transaction opens. Each field holds the
+ * 403 result to return if that op is attempted, or `null` when the op is allowed
+ * (or the collection has no lifecycle / the write is trusted).
+ *
+ * The transaction/batch write paths consult this under the row lock instead of
+ * reading permission storage inside the transaction: the permission a write can
+ * require is fully determined by the FINAL status it persists (only `"published"`
+ * can publish; any other explicit value can only unpublish a published row), so
+ * resolving both ops up front lets the in-transaction step classify the
+ * transition against the row-locked status and look up the answer with no DB read
+ * — closing both the TOCTOU window and the pooled-read-inside-a-transaction stall.
+ */
+export interface TransitionAuthorization {
+  publishDenied: CollectionServiceResult | null;
+  unpublishDenied: CollectionServiceResult | null;
+}
+
 export class CollectionMutationService extends BaseService {
   constructor(
     adapter: DrizzleAdapter,
@@ -2339,6 +2358,100 @@ export class CollectionMutationService extends BaseService {
     );
   }
 
+  /**
+   * Resolve the caller's publish AND unpublish authorization on the pooled
+   * connection, BEFORE a write transaction opens, so the transaction/batch write
+   * paths can enforce a transition against the row-locked status without reading
+   * permission storage inside the transaction (see {@link TransitionAuthorization}).
+   *
+   * Both ops are resolved because a batch is heterogeneous — one row may publish
+   * while another unpublishes — and the per-row op is only known under the lock.
+   * No-ops (returns all-allowed) for a trusted write or a collection with no
+   * draft/published lifecycle.
+   */
+  async resolveTransitionAuthorization(args: {
+    collectionName: string;
+    accessUser?: UserContext;
+    overrideAccess?: boolean;
+    authenticatedScope?: AuthenticatedScope;
+  }): Promise<TransitionAuthorization> {
+    if (args.overrideAccess) {
+      return { publishDenied: null, unpublishDenied: null };
+    }
+    const collection = await this.collectionService.getCollection(
+      args.collectionName
+    );
+    if ((collection as { status?: boolean }).status !== true) {
+      return { publishDenied: null, unpublishDenied: null };
+    }
+    // Resolve both concurrently; each is judged on the caller's own grant (a
+    // scoped API key on its scope), never route-authorized — the route attested
+    // update/create, never publish/unpublish.
+    const [publishDenied, unpublishDenied] = await Promise.all([
+      this.accessService.checkCollectionAccess(
+        args.collectionName,
+        "publish",
+        args.accessUser,
+        undefined,
+        undefined,
+        args.overrideAccess,
+        false,
+        args.authenticatedScope
+      ),
+      this.accessService.checkCollectionAccess(
+        args.collectionName,
+        "unpublish",
+        args.accessUser,
+        undefined,
+        undefined,
+        args.overrideAccess,
+        false,
+        args.authenticatedScope
+      ),
+    ]);
+    return { publishDenied, unpublishDenied };
+  }
+
+  /**
+   * Enforce a pre-resolved {@link TransitionAuthorization} against the status read
+   * UNDER the row lock, inside a caller-provided transaction. For an update it
+   * locks the row (the write below takes the same lock anyway) and re-reads the
+   * committed status, so a concurrent writer that changed the published state
+   * between the pre-transaction read and this lock is accounted for; classifying
+   * against that locked status, it returns the matching 403 if the transition is
+   * denied, or `null` when the write is allowed. A create has no prior row, so
+   * only a publish is possible and no lock/read is taken.
+   *
+   * Called immediately before the INSERT/UPDATE, so returning a denial leaves
+   * nothing written for this row — no rollback needed.
+   */
+  private async enforceTransitionUnderLock(
+    tx: TransactionContext,
+    args: {
+      tableName: string;
+      entryId?: string;
+      nextStatus: unknown;
+      isCreate: boolean;
+      auth: TransitionAuthorization;
+    }
+  ): Promise<CollectionServiceResult | null> {
+    // No status named in the write: no transition, nothing to enforce.
+    if (args.nextStatus === undefined) return null;
+    let lockedStatus: string | null = null;
+    if (!args.isCreate && args.entryId) {
+      await tx.lockRow(args.tableName, args.entryId);
+      const locked = await tx.selectOne<{ status?: unknown }>(args.tableName, {
+        where: this.whereEq("id", args.entryId),
+      });
+      lockedStatus = (locked?.status as string | undefined) ?? null;
+    }
+    const op = resolvePublishTransition(lockedStatus, args.nextStatus);
+    if (!op) return null;
+    return op === "publish"
+      ? args.auth.publishDenied
+      : args.auth.unpublishDenied;
+  }
+
   async updateEntry(
     params: {
       collectionName: string;
@@ -3782,6 +3895,11 @@ export class CollectionMutationService extends BaseService {
       overrideAccess?: boolean;
       // See createEntry: route-authorized REST responses stay redacted.
       routeAuthorized?: boolean;
+      // Publish/unpublish authorization resolved by the batch caller before this
+      // transaction opened, so the transition is enforced under the row lock with
+      // no permission read inside the transaction. Self-resolved (pooled) when a
+      // direct caller does not provide it.
+      transitionAuth?: TransitionAuthorization;
     },
     body: Record<string, unknown>
   ): Promise<CollectionServiceResult<unknown>> {
@@ -4036,14 +4154,23 @@ export class CollectionMutationService extends BaseService {
       // the caller may not write, is judged on the value actually stored. A create
       // has no prior status, so landing on published needs `publish-<slug>` on top
       // of create; a trusted server write bypasses via overrideAccess.
-      const transitionDenied = await this.checkStatusTransitionAccess({
-        collectionName: params.collectionName,
-        collectionHasStatus:
-          (collection as { status?: boolean }).status === true,
-        previousStatus: null,
+      //
+      // The permission is resolved OUTSIDE this transaction (pre-resolved by a
+      // batch caller, or here on the pooled connection before the insert), then
+      // enforced with no DB read inside the transaction — see
+      // resolveTransitionAuthorization / enforceTransitionUnderLock.
+      const transitionAuth =
+        params.transitionAuth ??
+        (await this.resolveTransitionAuthorization({
+          collectionName: params.collectionName,
+          accessUser: params.overrideAccess ? undefined : params.user,
+          overrideAccess: params.overrideAccess,
+        }));
+      const transitionDenied = await this.enforceTransitionUnderLock(tx, {
+        tableName,
         nextStatus: finalData.status,
-        accessUser: params.overrideAccess ? undefined : params.user,
-        overrideAccess: params.overrideAccess,
+        isCreate: true,
+        auth: transitionAuth,
       });
       if (transitionDenied) {
         return transitionDenied;
@@ -4153,6 +4280,11 @@ export class CollectionMutationService extends BaseService {
       overrideAccess?: boolean;
       // See createEntry: route-authorized REST responses stay redacted.
       routeAuthorized?: boolean;
+      // Publish/unpublish authorization resolved by the batch caller before this
+      // transaction opened, so the transition is enforced under the row lock with
+      // no permission read inside the transaction. Self-resolved (pooled) when a
+      // direct caller does not provide it.
+      transitionAuth?: TransitionAuthorization;
     },
     body: Record<string, unknown>
   ): Promise<CollectionServiceResult<unknown>> {
@@ -4382,22 +4514,28 @@ export class CollectionMutationService extends BaseService {
       // Update using transaction context
       // IMPORTANT: Use UTC ISO string for updatedAt to ensure consistent timezone handling
       // Authorize a change to the document's published state on the post-hook
-      // `finalData`, keyed on the loaded row's status. Publishing or unpublishing
-      // needs `publish`/`unpublish` on top of update; a trusted server write
-      // bypasses via overrideAccess. No-ops when the collection has no lifecycle.
-      const transitionDenied = await this.checkStatusTransitionAccess({
-        collectionName: params.collectionName,
-        collectionHasStatus:
-          (collection as { status?: boolean }).status === true,
-        previousStatus:
-          ((existingEntry as { status?: unknown }).status as
-            | string
-            | undefined) ?? null,
-        nextStatus: finalData.status,
-        accessUser: params.overrideAccess ? undefined : params.user,
+      // `finalData`. Publishing or unpublishing needs `publish`/`unpublish` on top
+      // of update; a trusted server write bypasses via overrideAccess. No-ops when
+      // the collection has no lifecycle.
+      //
+      // Classified against the status read UNDER the row lock (not the pre-lock
+      // `existingEntry`), using authorization resolved before this transaction, so
+      // a concurrent writer that changed the published state between the initial
+      // read and the write cannot slip a transition past the gate — and no
+      // permission read runs inside the transaction.
+      const transitionAuth =
+        params.transitionAuth ??
+        (await this.resolveTransitionAuthorization({
+          collectionName: params.collectionName,
+          accessUser: params.overrideAccess ? undefined : params.user,
+          overrideAccess: params.overrideAccess,
+        }));
+      const transitionDenied = await this.enforceTransitionUnderLock(tx, {
+        tableName,
         entryId: params.entryId,
-        document: existingEntry,
-        overrideAccess: params.overrideAccess,
+        nextStatus: finalData.status,
+        isCreate: false,
+        auth: transitionAuth,
       });
       if (transitionDenied) {
         return transitionDenied;
@@ -4708,6 +4846,11 @@ export class CollectionMutationService extends BaseService {
       overrideAccess?: boolean;
       // See createEntry: route-authorized REST responses stay redacted.
       routeAuthorized?: boolean;
+      // Publish authorization resolved once by the batch caller before this
+      // shared transaction opened, so the create-as-published is enforced with no
+      // permission read inside the transaction. Self-resolved (pooled) when a
+      // direct caller does not provide it.
+      transitionAuth?: TransitionAuthorization;
     },
     body: Record<string, unknown>,
     skipHooks: boolean
@@ -4965,14 +5108,22 @@ export class CollectionMutationService extends BaseService {
       // batch create is a way around the gate. Judged on the post-hook `finalData`
       // (hooks run unless skipped); a create has no prior status, and a trusted
       // server write bypasses via overrideAccess.
-      const transitionDenied = await this.checkStatusTransitionAccess({
-        collectionName: params.collectionName,
-        collectionHasStatus:
-          (collection as { status?: boolean }).status === true,
-        previousStatus: null,
+      //
+      // Authorization is resolved once by the batch caller before this shared
+      // transaction (or here on the pooled connection when called directly), so no
+      // permission read runs inside the transaction.
+      const transitionAuth =
+        params.transitionAuth ??
+        (await this.resolveTransitionAuthorization({
+          collectionName: params.collectionName,
+          accessUser: params.overrideAccess ? undefined : params.user,
+          overrideAccess: params.overrideAccess,
+        }));
+      const transitionDenied = await this.enforceTransitionUnderLock(tx, {
+        tableName,
         nextStatus: finalData.status,
-        accessUser: params.overrideAccess ? undefined : params.user,
-        overrideAccess: params.overrideAccess,
+        isCreate: true,
+        auth: transitionAuth,
       });
       if (transitionDenied) {
         return transitionDenied;
@@ -5095,6 +5246,11 @@ export class CollectionMutationService extends BaseService {
       overrideAccess?: boolean;
       // See createEntry: route-authorized REST responses stay redacted.
       routeAuthorized?: boolean;
+      // Publish/unpublish authorization resolved once by the batch caller before
+      // this shared transaction opened, so the transition is enforced under the
+      // row lock with no permission read inside the transaction. Self-resolved
+      // (pooled) when a direct caller does not provide it.
+      transitionAuth?: TransitionAuthorization;
     },
     entryId: string,
     body: Record<string, unknown>,
@@ -5380,21 +5536,26 @@ export class CollectionMutationService extends BaseService {
       // The Direct-API batch worker writes status like any other field, so a
       // status transition here needs `publish`/`unpublish` the same as a single
       // update — a bulk update must not publish what a single update could not.
-      // Judged on the post-hook `finalData` against the loaded row; a trusted
-      // server write bypasses via overrideAccess.
-      const transitionDenied = await this.checkStatusTransitionAccess({
-        collectionName: params.collectionName,
-        collectionHasStatus:
-          (collection as { status?: boolean }).status === true,
-        previousStatus:
-          ((existingEntry as { status?: unknown }).status as
-            | string
-            | undefined) ?? null,
-        nextStatus: finalData.status,
-        accessUser: params.overrideAccess ? undefined : params.user,
+      // A trusted server write bypasses via overrideAccess.
+      //
+      // Classified against the status read UNDER the row lock (not the pre-lock
+      // `existingEntry`), using authorization resolved once by the batch caller
+      // before this shared transaction, so a concurrent writer cannot slip a
+      // transition past the gate and no permission read runs inside the batch's
+      // transaction.
+      const transitionAuth =
+        params.transitionAuth ??
+        (await this.resolveTransitionAuthorization({
+          collectionName: params.collectionName,
+          accessUser: params.overrideAccess ? undefined : params.user,
+          overrideAccess: params.overrideAccess,
+        }));
+      const transitionDenied = await this.enforceTransitionUnderLock(tx, {
+        tableName,
         entryId,
-        document: existingEntry,
-        overrideAccess: params.overrideAccess,
+        nextStatus: finalData.status,
+        isCreate: false,
+        auth: transitionAuth,
       });
       if (transitionDenied) {
         return transitionDenied;

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -2408,6 +2408,21 @@ export class CollectionMutationService extends BaseService {
     if ((collection as { status?: boolean }).status !== true) {
       return { publishDenied: null, unpublishDenied: null, documentRule: null };
     }
+    // A document-dependent stored rule (owner-only or custom) must NOT be judged
+    // docless here: owner-only would defer anyway, but a custom rule that denies
+    // on absent `id`/`data` would cache a false denial that pre-empts the
+    // under-lock recheck. Skip the stored-rule eval for such ops (the RBAC/
+    // permission gate still runs) and evaluate the rule against the locked row
+    // below via `documentRule`.
+    const accessRules = this.accessService.getAccessRules(
+      collection as Record<string, unknown>
+    );
+    const deferPublish = this.accessService.isDocumentDependentRule(
+      accessRules?.publish
+    );
+    const deferUnpublish = this.accessService.isDocumentDependentRule(
+      accessRules?.unpublish
+    );
     // Resolve both concurrently; each is judged on the caller's own grant (a
     // scoped API key on its scope), never route-authorized — the route attested
     // update/create, never publish/unpublish.
@@ -2420,7 +2435,8 @@ export class CollectionMutationService extends BaseService {
         undefined,
         args.overrideAccess,
         false,
-        args.authenticatedScope
+        args.authenticatedScope,
+        deferPublish
       ),
       this.accessService.checkCollectionAccess(
         args.collectionName,
@@ -2430,13 +2446,14 @@ export class CollectionMutationService extends BaseService {
         undefined,
         args.overrideAccess,
         false,
-        args.authenticatedScope
+        args.authenticatedScope,
+        deferUnpublish
       ),
     ]);
-    // Owner-only publish/unpublish rules cannot be judged here because they need
-    // the specific row (only known under the lock). Pre-fetch the rules + user
-    // off the already-loaded collection so the in-transaction step evaluates the
-    // owner against the row-locked document with no further metadata read.
+    // Owner-only / custom publish/unpublish rules cannot be judged above because
+    // they need the specific row (only known under the lock). Pre-fetch the rules
+    // + user off the already-loaded collection so the in-transaction step
+    // evaluates them against the row-locked document with no further metadata read.
     const documentRule = this.accessService.resolveTransitionDocumentRule(
       collection as Record<string, unknown>,
       args.accessUser,

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -36,6 +36,7 @@ import { transformRichTextFields } from "@nextly/lib/field-transform";
 import type { RichTextOutputFormat } from "@nextly/lib/rich-text-html";
 import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 
+import type { AuthenticatedScope } from "../../../auth/authenticated-scope";
 import type { FieldConfig } from "../../../collections/fields/types";
 import { getFilterRegistry, FilterSeams } from "../../../filters";
 import { toSnakeCase } from "../../../lib/case-conversion";
@@ -1749,6 +1750,13 @@ export class CollectionQueryService extends BaseService {
      * creator's. Owner-only and other document-level rules still apply.
      */
     routeAuthorized?: boolean;
+    /**
+     * The caller's authenticated scope. A scoped API key is judged on its OWN
+     * read grant here, so a super-admin-owned key cannot read a row its scope
+     * excludes (used by duplicate, which reads the source before creating a
+     * copy). Undefined for session/system callers.
+     */
+    authenticatedScope?: AuthenticatedScope;
   }): Promise<CollectionServiceResult> {
     try {
       const accessUser = params.overrideAccess ? undefined : params.user;
@@ -1761,7 +1769,10 @@ export class CollectionQueryService extends BaseService {
         params.entryId,
         undefined,
         params.overrideAccess,
-        params.routeAuthorized
+        params.routeAuthorized,
+        // A scoped API key is judged on its own read grant, so the session
+        // super-admin bypass does not apply to a super-admin-owned key here.
+        params.authenticatedScope
       );
       if (accessDenied) {
         return accessDenied;

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1821,7 +1821,10 @@ export class CollectionQueryService extends BaseService {
         params.collectionName,
         "read",
         accessUser,
-        params.overrideAccess
+        params.overrideAccess,
+        // Scope the owner filter too: a super-admin-owned key must still be
+        // bound by a `read: owner-only` rule, not treated as a session admin.
+        params.authenticatedScope
       );
 
       // Same 404-not-403 reasoning applies to Draft/Published — a public

--- a/packages/nextly/src/plugins/test-nextly.ts
+++ b/packages/nextly/src/plugins/test-nextly.ts
@@ -10,6 +10,8 @@
  * @module plugins/test-nextly
  */
 
+import type { WhereClause } from "@nextlyhq/adapter-drizzle/types";
+
 import type { CollectionConfig } from "../collections/config/define-collection";
 import type { ComponentConfig } from "../components/config/types";
 import { createAdapter } from "../database/factory";
@@ -29,6 +31,7 @@ import {
   clearCachedSnapshot,
   clearLiveSnapshots,
 } from "../init/schema-snapshot-cache";
+import type { CollectionAccessRules } from "../services/access";
 import type { Logger } from "../services/shared";
 import type { SingleConfig } from "../singles/config/types";
 import { getImageProcessor } from "../storage/image-processor";
@@ -55,6 +58,15 @@ export interface CreateTestNextlyOptions {
   adapter?: TestAdapter;
   /** Override the logger (defaults to a near-silent test logger). */
   logger?: Logger;
+  /**
+   * Stored per-collection access rules (`accessRules`) keyed by slug. Code-first
+   * `defineCollection` carries only code `access` functions, so an integration
+   * test that needs a STORED rule (for example an owner-only publish rule) sets
+   * it here. After boot the rule is written to the collection's
+   * `dynamic_collections` row exactly as the Schema Builder would persist it, so
+   * the access path surfaces it through `getCollection`.
+   */
+  collectionAccessRules?: Record<string, CollectionAccessRules>;
 }
 
 export interface TestNextly {
@@ -153,6 +165,21 @@ export async function createTestNextly(
   // Physical tables for code-first + plugin-contributed collections are created
   // non-interactively by the runtime auto-sync during registerServices (the
   // applyDesiredSchema add_table fast-path), so no harness-side DDL is needed.
+
+  // Persist any stored access rules onto the already-synced collection rows. The
+  // access path reads `accessRules` off the collection metadata (getCollection),
+  // which is uncached, so writing the row after boot is enough for it to surface
+  // — no separate cache invalidation is needed.
+  if (opts.collectionAccessRules) {
+    for (const [slug, accessRules] of Object.entries(
+      opts.collectionAccessRules
+    )) {
+      const where: WhereClause = {
+        and: [{ column: "slug", op: "=", value: slug }],
+      };
+      await adapter.update("dynamic_collections", { accessRules }, where);
+    }
+  }
 
   return {
     nextly: getNextly(),

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -770,8 +770,18 @@ export class CollectionsHandler {
     context?: Record<string, unknown>;
     /** Acting identity from the transport, forwarded to the recorded event. */
     actor?: RequestActor;
+    /**
+     * The caller's authenticated scope. For a scoped API-key bulk update each
+     * per-id publish/unpublish transition is judged on the key's OWN grants.
+     */
+    authenticatedScope?: AuthenticatedScope;
   }) {
-    return this.entryService.bulkUpdateEntries(this.resolveUserParam(params));
+    return this.entryService.bulkUpdateEntries({
+      ...this.resolveUserParam(params),
+      // Named explicitly (like updateEntry) so the API-key scope survives the
+      // field-by-field rebuild rather than only via resolveUserParam's rest.
+      authenticatedScope: params.authenticatedScope,
+    });
   }
 
   /**
@@ -801,6 +811,11 @@ export class CollectionsHandler {
       context?: Record<string, unknown>;
       /** Acting identity from the transport, forwarded to the recorded event. */
       actor?: RequestActor;
+      /**
+       * The caller's authenticated scope. Judges the collection-level gate and
+       * each per-row transition on a scoped API key's OWN grants.
+       */
+      authenticatedScope?: AuthenticatedScope;
     },
     options?: { limit?: number }
   ) {
@@ -808,7 +823,12 @@ export class CollectionsHandler {
     // bulkUpdateEntries so the query-based bulk update honors access control
     // and redaction instead of running as an anonymous caller.
     return this.entryService.bulkUpdateByQuery(
-      this.resolveUserParam(params),
+      {
+        ...this.resolveUserParam(params),
+        // Named explicitly so the API-key scope survives the field-by-field
+        // rebuild rather than only via resolveUserParam's rest.
+        authenticatedScope: params.authenticatedScope,
+      },
       options
     );
   }
@@ -875,8 +895,18 @@ export class CollectionsHandler {
     context?: Record<string, unknown>;
     /** Acting identity from the transport, forwarded to the recorded event. */
     actor?: RequestActor;
+    /**
+     * The caller's authenticated scope. A duplicate is a create, so a scoped
+     * API key copying a published source is judged on the key's OWN grant.
+     */
+    authenticatedScope?: AuthenticatedScope;
   }) {
-    return this.entryService.duplicateEntry(this.resolveUserParam(params));
+    return this.entryService.duplicateEntry({
+      ...this.resolveUserParam(params),
+      // Named explicitly so the API-key scope survives the field-by-field
+      // rebuild rather than only via resolveUserParam's rest.
+      authenticatedScope: params.authenticatedScope,
+    });
   }
 
   /**

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -216,6 +216,8 @@ export class CollectionsHandler {
     entryId: string;
     user?: UserContext;
     routeAuthorized?: boolean;
+    /** API-key scope; judges the update gate on the key's own grant. */
+    authenticatedScope?: AuthenticatedScope;
   }): Promise<boolean> {
     return this.entryService.canUpdateEntry(params);
   }
@@ -705,8 +707,18 @@ export class CollectionsHandler {
     routeAuthorized?: boolean;
     /** Arbitrary data passed to hooks via context */
     context?: Record<string, unknown>;
+    /**
+     * The caller's authenticated scope. A scoped API key is judged on its OWN
+     * delete grant, so the session super-admin bypass does not apply to it.
+     */
+    authenticatedScope?: AuthenticatedScope;
   }) {
-    return this.entryService.deleteEntry(this.resolveUserParam(params));
+    return this.entryService.deleteEntry({
+      ...this.resolveUserParam(params),
+      // Named explicitly so the API-key scope survives the field-by-field
+      // rebuild rather than only via resolveUserParam's rest.
+      authenticatedScope: params.authenticatedScope,
+    });
   }
 
   /**
@@ -736,8 +748,18 @@ export class CollectionsHandler {
     routeAuthorized?: boolean;
     /** Arbitrary data passed to hooks via context */
     context?: Record<string, unknown>;
+    /**
+     * The caller's authenticated scope. Each per-id delete is judged on a scoped
+     * API key's OWN delete grant, not the key owner's.
+     */
+    authenticatedScope?: AuthenticatedScope;
   }) {
-    return this.entryService.bulkDeleteEntries(this.resolveUserParam(params));
+    return this.entryService.bulkDeleteEntries({
+      ...this.resolveUserParam(params),
+      // Named explicitly so the API-key scope survives the field-by-field
+      // rebuild rather than only via resolveUserParam's rest.
+      authenticatedScope: params.authenticatedScope,
+    });
   }
 
   /**

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -361,6 +361,8 @@ export class CollectionEntryService extends BaseService {
     context?: Record<string, unknown>;
     /** Acting identity from the transport, forwarded to the recorded event. */
     actor?: RequestActor;
+    /** API-key scope; judges the create-as-published on the key's own grant. */
+    authenticatedScope?: AuthenticatedScope;
   }) {
     const result = await this.bulkService.duplicateEntry(params);
     await this.offerRetentionPass();
@@ -387,9 +389,12 @@ export class CollectionEntryService extends BaseService {
     data: Record<string, unknown>;
     user?: UserContext;
     overrideAccess?: boolean;
+    routeAuthorized?: boolean;
     context?: Record<string, unknown>;
     /** Acting identity from the transport, forwarded to the recorded event. */
     actor?: RequestActor;
+    /** API-key scope; judges each per-id transition on the key's own grant. */
+    authenticatedScope?: AuthenticatedScope;
   }): Promise<BulkOperationResult<Record<string, unknown>>> {
     const result = await this.bulkService.bulkUpdateEntries(params);
     await this.offerRetentionPass();
@@ -408,6 +413,8 @@ export class CollectionEntryService extends BaseService {
       context?: Record<string, unknown>;
       /** Acting identity from the transport, forwarded to the recorded event. */
       actor?: RequestActor;
+      /** API-key scope; judges the collection gate + transitions on the key's own grant. */
+      authenticatedScope?: AuthenticatedScope;
     },
     options?: BulkOperationOptions & { limit?: number }
   ): Promise<BulkOperationResult<Record<string, unknown>>> {

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -260,6 +260,8 @@ export class CollectionEntryService extends BaseService {
     entryId: string;
     user?: UserContext;
     routeAuthorized?: boolean;
+    /** API-key scope; judges the update gate on the key's own grant. */
+    authenticatedScope?: AuthenticatedScope;
   }): Promise<boolean> {
     return this.mutationService.canUpdateEntry(params);
   }
@@ -318,7 +320,10 @@ export class CollectionEntryService extends BaseService {
     entryId: string;
     user?: UserContext;
     overrideAccess?: boolean;
+    routeAuthorized?: boolean;
     context?: Record<string, unknown>;
+    /** API-key scope; judges the delete gate on the key's own grant. */
+    authenticatedScope?: AuthenticatedScope;
   }) {
     const result = await this.mutationService.deleteEntry(params);
     await this.offerRetentionPass();
@@ -376,7 +381,10 @@ export class CollectionEntryService extends BaseService {
     ids: string[];
     user?: UserContext;
     overrideAccess?: boolean;
+    routeAuthorized?: boolean;
     context?: Record<string, unknown>;
+    /** API-key scope; judges each per-id delete on the key's own grant. */
+    authenticatedScope?: AuthenticatedScope;
   }): Promise<BulkOperationResult<{ id: string }>> {
     const result = await this.bulkService.bulkDeleteEntries(params);
     await this.offerRetentionPass();


### PR DESCRIPTION
Stacked on #297 (base `feat/publish-enforcement-apikey-scope`). This is the **finding-G** follow-up for the publish-permission enforcement program — the cross-cutting *enforce-under-lock + tx/bulk scope* concern that was intentionally kept out of #290/#293/#297 and tracked to its own PR.

## What this closes (collections, slices A1–A2)

**A1 — API-key scope for the bulk write paths** (closes #297 bulk-scope threads: `9q6Y`, `-6gm`, `_cDh`, `_uWM`, `_3jO`).
`bulkUpdateEntries` / `bulkUpdateByQuery` / `duplicateEntry` delegate to the already-scope-aware `updateEntry` / `createEntry`; the gap was purely the missing `authenticatedScope` thread from the dispatcher through both service facades. Now a scoped API key's per-row publish/unpublish transition is judged on the key's OWN grants, not the key owner's.

**A2 — enforce publish transitions under the row lock** (closes #290 `5UiT` pooled-read-in-tx, `7nJG` / `9DrJ` recheck-under-lock).
The collection transaction/batch variants (`create/updateEntryInTransaction`, the batch workers `create/updateSingleEntryInTransaction`) classified the transition from a status read taken *before* the write's row lock, and read permission storage *inside* the caller's transaction. A concurrent writer could move a row into/out of published in that window and slip a transition past the gate.

Now: `resolveTransitionAuthorization` resolves the caller's publish/unpublish authorization **once on the pooled connection before the transaction**, and `enforceTransitionUnderLock` classifies the transition against the status read **under the row lock** with no permission read inside the transaction. The bulk service pre-resolves once per batch. Reuses the exact `457208b2` shape already reviewed on `updateEntry`.

## Tests

- `publish-enforcement-rbac.integration.test.ts` — bulk publish judged on the key's own grant (load-bearing: proven by breaking).
- `publish-enforcement-batch.integration.test.ts` — the Direct-API batch create/update workers gate the transition (load-bearing).
- `publish-enforcement-toctou.integration.test.ts` — **deterministic two-transaction Postgres test** reproducing the race: a batch draft-write that races a concurrent publish is refused as an unpublish it may not perform. Self-skips without `TEST_POSTGRES_URL`; load-bearing (proven by disabling the locked re-read → the write is wrongly allowed and silently unpublishes).

## Still to come on this PR (follow-up commits)

- **Slice C** — singles enforce-under-lock (`single-mutation` update path; closes #293 singles-TOCTOU family incl. `5iLt`).
- **Slice D** — `8JIp` document-dependent publish-rule recheck under lock.
- **Slice E** — `-XIT` hook-created-row atomicity (singles; may split — architectural).

Per the founder's scoping, `-B9W` singleton serialization ships as a separate schema PR.

Never self-merge — founder merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened publish/unpublish enforcement for bulk, query-based, duplicate, and batch transition paths (including concurrent TOCTOU scenarios) by re-checking state under row locks.
  - Ensured scoped API keys are evaluated strictly against their own read/update/publish/delete grants for collection entry operations and version-label updates.
  - Improved row-lock behavior support in the database adapter for `FOR UPDATE` operations.
- **Tests**
  - Added integration and RBAC/ownership coverage for publish gating, scoped API-key behavior, and race-condition prevention.
  - Extended the test harness to persist collection access rules for more realistic authorization testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->