### PR TITLE
feat(nextly): kick an immediate webhook drain after a write via Next after()

### DIFF
--- a/.changeset/webhook-after-fastpath.md
+++ b/.changeset/webhook-after-fastpath.md
@@ -1,0 +1,31 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Deliver webhooks immediately after a content write instead of waiting for the
+next scheduled drain.
+
+After a write records an event, Nextly now schedules a bounded delivery pass via
+Next.js `after()`, so the first attempt runs as soon as the response is sent —
+without adding any latency to the write. It degrades gracefully: it does nothing
+when there are no enabled endpoints, when the runtime has no `after()` (Next 14,
+or a non-Next context like the CLI), or on any failure — the scheduled
+`/webhooks/drain` trigger remains the backstop and owns retries and the backlog.

--- a/packages/nextly/src/di/registrations/register-collections.ts
+++ b/packages/nextly/src/di/registrations/register-collections.ts
@@ -21,6 +21,7 @@
 import type { PermissionSeedService } from "../../domains/auth/services/permission-seed-service";
 import type { RBACAccessControlService } from "../../domains/auth/services/rbac-access-control-service";
 import { DynamicCollectionService } from "../../domains/dynamic-collections";
+import type { WebhookFastDrainScheduler } from "../../domains/webhooks/after-drain";
 import { MetaRetentionGate } from "../../domains/webhooks/retention-gate";
 import { WebhookRetentionRunner } from "../../domains/webhooks/retention-runner";
 import { AccessControlService } from "../../services/access";
@@ -171,6 +172,11 @@ export function registerCollectionServices(ctx: RegistrationContext): void {
             gate: new MetaRetentionGate(adapter),
             logger,
           })
+        : undefined,
+      // Shared post-response drain fast path (registered by the webhook
+      // services). Absent only when webhooks were never registered.
+      container.has("webhookFastDrainScheduler")
+        ? container.get<WebhookFastDrainScheduler>("webhookFastDrainScheduler")
         : undefined
     );
 

--- a/packages/nextly/src/di/registrations/register-webhooks.ts
+++ b/packages/nextly/src/di/registrations/register-webhooks.ts
@@ -12,7 +12,11 @@
  * expired.
  */
 
-import type { RunWebhookDrainOptions } from "../../domains/webhooks/drain-runner";
+import { WebhookFastDrainScheduler } from "../../domains/webhooks/after-drain";
+import type {
+  RunWebhookDrainOptions,
+  WebhookDrainDatabase,
+} from "../../domains/webhooks/drain-runner";
 import {
   WebhookEndpointRegistry,
   type WebhookEndpointReader,
@@ -62,6 +66,19 @@ export function registerWebhookServices(ctx: RegistrationContext): void {
   container.registerSingleton<WebhookDeliveryQueryService>(
     "webhookDeliveryQueryService",
     () => new WebhookDeliveryQueryService(adapter, logger)
+  );
+
+  // Post-response drain fast path, shared by every content-write path. The
+  // adapter satisfies the fan-out + delivery surfaces; resolve it as exactly
+  // that. Self-gates on Next `after()` support and on there being a subscriber.
+  container.registerSingleton<WebhookFastDrainScheduler>(
+    "webhookFastDrainScheduler",
+    () =>
+      new WebhookFastDrainScheduler(
+        container.get<WebhookDrainDatabase>("adapter"),
+        container.get<WebhookEndpointRegistry>("webhookEndpointRegistry"),
+        logger
+      )
   );
 
   // Retention deps the drain route runs after delivery. Content writes already

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -88,7 +88,16 @@ function legacyEnvelopeToFailureFields(result: {
  */
 type PerItemOutcome<T> =
   | { kind: "success"; record: T }
-  | { kind: "failure"; failure: { id: string; code: string; message: string } };
+  | {
+      kind: "failure";
+      failure: { id: string; code: string; message: string };
+      /**
+       * Set when the item committed its row + outbox event but a post-commit
+       * hook then threw, so it is reported as a failure yet still owes a
+       * delivery. Aggregated into the batch result's `eventRecorded`.
+       */
+      eventRecorded?: boolean;
+    };
 
 /**
  * Build a canonical per-item failure entry from a thrown error.
@@ -148,6 +157,9 @@ function partitionOutcomes<T>(
       } else {
         result.failures.push(value.failure);
         result.failedCount++;
+        // A "failure" that still committed its outbox event (a post-commit hook
+        // threw) owes a delivery even though it is not a success.
+        if (value.eventRecorded) result.eventRecorded = true;
       }
     } else {
       // Per-item closure rejected unexpectedly. Defensive: report as
@@ -352,6 +364,9 @@ export class CollectionBulkService extends BaseService {
             return {
               kind: "failure",
               failure: { id: entryId, code, message },
+              // A delete that committed its row + event but failed a post-commit
+              // hook still owes a delivery.
+              eventRecorded: deleteResult.eventRecorded,
             };
           } catch (error: unknown) {
             // NextlyError thrown from below the boundary: preserve its code +
@@ -432,6 +447,9 @@ export class CollectionBulkService extends BaseService {
             return {
               kind: "failure",
               failure: { id: entryId, code, message },
+              // An update that committed its row + event but failed a post-commit
+              // hook still owes a delivery.
+              eventRecorded: updateResult.eventRecorded,
             };
           } catch (error: unknown) {
             return {

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -1559,6 +1559,11 @@ export class CollectionBulkService extends BaseService {
       };
     }
 
+    // Whether any item appended an outbox event in the shared transaction. Read
+    // back onto the result only after the transaction commits (below), so a
+    // rollback — which undoes every delete and its event — never reports a
+    // durable event that isn't there.
+    let anyRecorded = false;
     // Process all entries within a single transaction
     try {
       await this.adapter.transaction(async tx => {
@@ -1580,6 +1585,9 @@ export class CollectionBulkService extends BaseService {
                   entryId,
                   skipHooks
                 );
+              // A committed item owes a delivery even if its afterDelete hook
+              // then threw (returned success:false).
+              if (deleteResult.eventRecorded) anyRecorded = true;
 
               if (deleteResult.success) {
                 result.successful++;
@@ -1622,6 +1630,9 @@ export class CollectionBulkService extends BaseService {
           }
         }
       });
+      // The transaction committed (this line is skipped if it rejected), so any
+      // events it recorded are durable; surface that for the post-write drain.
+      result.eventRecorded = anyRecorded;
     } catch (error: unknown) {
       // The shared transaction rolled back — either stopOnError tripped on a
       // returned failure, or an unexpected error (e.g. a failed outbox insert

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1821,10 +1821,11 @@ export class CollectionMutationService extends BaseService {
           fields: webhookFields,
           actor: actorForWrite(params.actor, params.user),
         });
-        // The event commits with the entry; from here a post-commit hook failure
-        // must not hide that a delivery is owed.
-        eventRecorded = true;
       });
+      // Set only after the transaction resolves (this line is skipped if it
+      // rejected), so a commit failure never flags a durable event that isn't
+      // there; from here a post-commit hook failure must not hide the delivery.
+      eventRecorded = true;
 
       // Execute afterCreate hooks (code-registered)
       // Hooks run after database insert completes (for side effects)
@@ -2749,8 +2750,13 @@ export class CollectionMutationService extends BaseService {
       // by the per-locale status event below. Re-read inside each attempt (like
       // committedPreviousStatus) so a retry reports the true prior state.
       let localizedPreviousStatus: string | null = null;
+      // Reset at the start of each attempt and read back only after the retry
+      // resolves, so a rolled-back attempt (a version conflict) or a commit
+      // failure never flags a durable event that isn't there.
+      let recorded = false;
       await withVersionConflictRetry(() =>
         this.adapter.transaction(async tx => {
+          recorded = false;
           const updatePayload = {
             ...stripImmutableSystemFields(finalData),
             updatedAt: new Date(),
@@ -3166,13 +3172,14 @@ export class CollectionMutationService extends BaseService {
                 fields: webhookFields,
                 actor: actorForWrite(params.actor, params.user),
               });
-              // The event commits with the update; a later hook failure must not
-              // hide that a delivery is owed.
-              eventRecorded = true;
+              recorded = true;
             }
           }
         })
       );
+      // The transaction committed (skipped if the retry ultimately threw), so
+      // the event is durable; a later hook failure must not hide the delivery.
+      eventRecorded = recorded;
 
       // Fetch the updated entry to return it and use in hooks
       const [updated] = await this.db
@@ -3582,10 +3589,11 @@ export class CollectionMutationService extends BaseService {
           fields: webhookFields,
           actor: actorForWrite(params.actor, params.user),
         });
-        // The delete + event commit together; a later hook failure must not
-        // hide that a delivery is owed.
-        eventRecorded = true;
       });
+      // Set only after the transaction resolves: `deletedRow` is true exactly
+      // when the delete + event committed, so a commit failure never flags a
+      // durable event that isn't there; a later hook failure must not hide it.
+      eventRecorded = deletedRow;
 
       // A concurrent delete removed the row first: report not-found rather than
       // a second success (and a duplicate event) for a deletion this call did

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1935,6 +1935,7 @@ export class CollectionMutationService extends BaseService {
         statusCode: 201,
         message: "Entry created successfully",
         data: responseEntry,
+        eventRecorded,
       };
     } catch (error: unknown) {
       // Legacy per-kind override messages ("Duplicate value: ...",
@@ -3194,6 +3195,9 @@ export class CollectionMutationService extends BaseService {
           statusCode: 404,
           message: "Entry not found",
           data: null,
+          // The event may already be durable (the row vanished only after the
+          // update committed), so still signal a delivery is owed.
+          eventRecorded,
         };
       }
 
@@ -3362,6 +3366,9 @@ export class CollectionMutationService extends BaseService {
         statusCode: 200,
         message: "Entry updated successfully",
         data: responseEntry,
+        // Reflects whether this update actually recorded an event (a no-op
+        // update commits without one), so a no-op does not kick the drain.
+        eventRecorded,
       };
     } catch (error: unknown) {
       // See createEntry's catch — legacy override messages are dropped in
@@ -3648,6 +3655,7 @@ export class CollectionMutationService extends BaseService {
         statusCode: 200,
         message: "Entry deleted successfully",
         data: { deleted: true },
+        eventRecorded,
       };
     } catch (error: unknown) {
       return {

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -5454,6 +5454,9 @@ export class CollectionMutationService extends BaseService {
     // recorded — a later failure (e.g. an afterDelete hook) is a per-item
     // side-effect issue, not an eventless delete, and must NOT roll the batch back.
     let deleteNeedsRollback = false;
+    // Set once the event is appended to the shared transaction; the batch caller
+    // reads it back and applies it only after the transaction commits.
+    let eventRecorded = false;
     try {
       // Get collection metadata early
       const collection = await this.collectionService.getCollection(
@@ -5669,6 +5672,7 @@ export class CollectionMutationService extends BaseService {
       // The event is recorded, so the delete + event are now consistent; a later
       // failure no longer needs to force a rollback.
       deleteNeedsRollback = false;
+      eventRecorded = true;
 
       // Execute afterDelete hooks (unless skipped)
       if (!skipHooks) {
@@ -5706,6 +5710,7 @@ export class CollectionMutationService extends BaseService {
         statusCode: 200,
         message: "Entry deleted successfully",
         data: { deleted: true },
+        eventRecorded,
       };
     } catch (error: unknown) {
       // Only a failure in the delete→event window propagates (to roll back an
@@ -5719,6 +5724,7 @@ export class CollectionMutationService extends BaseService {
         message:
           error instanceof Error ? error.message : "Failed to delete entry",
         data: null,
+        eventRecorded,
       };
     }
   }

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1232,6 +1232,10 @@ export class CollectionMutationService extends BaseService {
     body: Record<string, unknown>,
     depth?: number
   ): Promise<CollectionServiceResult> {
+    // Set once the outbox event is appended (below), so the catch can report a
+    // committed-but-hook-failed write as `eventRecorded` even when `success` is
+    // false. Declared out here so both the success and catch returns see it.
+    let eventRecorded = false;
     try {
       // reject an unknown write locale before doing anything else.
       const badLocale = this.rejectInvalidWriteLocale(params.locale);
@@ -1817,6 +1821,9 @@ export class CollectionMutationService extends BaseService {
           fields: webhookFields,
           actor: actorForWrite(params.actor, params.user),
         });
+        // The event commits with the entry; from here a post-commit hook failure
+        // must not hide that a delivery is owed.
+        eventRecorded = true;
       });
 
       // Execute afterCreate hooks (code-registered)
@@ -1935,11 +1942,14 @@ export class CollectionMutationService extends BaseService {
       // wire never reveals which constraint or column failed. The original
       // DbError is preserved on the NextlyError as `cause` for log lines.
       // Pass dialect explicitly so the helper can normalise raw driver errors.
-      return errorToServiceResult(
-        error,
-        { defaultMessage: "Failed to create entry" },
-        this.dialect
-      );
+      return {
+        ...errorToServiceResult(
+          error,
+          { defaultMessage: "Failed to create entry" },
+          this.dialect
+        ),
+        eventRecorded,
+      };
     }
   }
 
@@ -2291,6 +2301,10 @@ export class CollectionMutationService extends BaseService {
     body: Record<string, unknown>,
     depth?: number
   ): Promise<CollectionServiceResult> {
+    // Set once the outbox event is appended (below); lets the catch report a
+    // committed-but-hook-failed update as `eventRecorded` even when `success` is
+    // false. Declared out here so both the success and catch returns see it.
+    let eventRecorded = false;
     try {
       // reject an unknown write locale before doing anything else.
       const badLocale = this.rejectInvalidWriteLocale(params.locale);
@@ -3152,6 +3166,9 @@ export class CollectionMutationService extends BaseService {
                 fields: webhookFields,
                 actor: actorForWrite(params.actor, params.user),
               });
+              // The event commits with the update; a later hook failure must not
+              // hide that a delivery is owed.
+              eventRecorded = true;
             }
           }
         })
@@ -3343,11 +3360,14 @@ export class CollectionMutationService extends BaseService {
       // See createEntry's catch — legacy override messages are dropped in
       // favour of fromDatabaseError's spec-compliant generic strings.
       // Pass dialect explicitly so the helper can normalise raw driver errors.
-      return errorToServiceResult(
-        error,
-        { defaultMessage: "Failed to update entry" },
-        this.dialect
-      );
+      return {
+        ...errorToServiceResult(
+          error,
+          { defaultMessage: "Failed to update entry" },
+          this.dialect
+        ),
+        eventRecorded,
+      };
     }
   }
 
@@ -3375,6 +3395,10 @@ export class CollectionMutationService extends BaseService {
     /** Arbitrary data passed to hooks via context */
     context?: Record<string, unknown>;
   }): Promise<CollectionServiceResult> {
+    // Set once the outbox event is appended (below); lets the catch report a
+    // committed-but-hook-failed delete as `eventRecorded` even when `success` is
+    // false. Declared out here so both the success and catch returns see it.
+    let eventRecorded = false;
     try {
       const accessUser = params.overrideAccess ? undefined : params.user;
 
@@ -3558,6 +3582,9 @@ export class CollectionMutationService extends BaseService {
           fields: webhookFields,
           actor: actorForWrite(params.actor, params.user),
         });
+        // The delete + event commit together; a later hook failure must not
+        // hide that a delivery is owed.
+        eventRecorded = true;
       });
 
       // A concurrent delete removed the row first: report not-found rather than
@@ -3621,6 +3648,7 @@ export class CollectionMutationService extends BaseService {
         message:
           error instanceof Error ? error.message : "Failed to delete entry",
         data: null,
+        eventRecorded,
       };
     }
   }

--- a/packages/nextly/src/domains/collections/services/collection-types.ts
+++ b/packages/nextly/src/domains/collections/services/collection-types.ts
@@ -98,6 +98,15 @@ export interface BulkOperationResult<T = { id: string }> {
   successCount: number;
   /** Count of failed operations. */
   failedCount: number;
+  /**
+   * Whether any item appended a durable outbox event, independent of
+   * `successCount`. A per-item write can commit its row + event and still be
+   * counted a failure when a post-commit hook throws (it returns
+   * `success: false`), so a batch where every committed item hit that path has
+   * `successCount === 0` yet owes deliveries. Post-write side effects key off
+   * this so those events still get the immediate drain.
+   */
+  eventRecorded?: boolean;
 }
 
 /**

--- a/packages/nextly/src/domains/collections/services/collection-types.ts
+++ b/packages/nextly/src/domains/collections/services/collection-types.ts
@@ -22,6 +22,16 @@ export interface CollectionServiceResult<T = unknown> {
    * canonical VALIDATION_ERROR envelope with field paths intact.
    */
   errors?: Array<{ path: string; code: string; message: string }>;
+  /**
+   * Whether this write appended a durable outbox event, independent of
+   * `success`. A create/update/delete records the event inside its transaction,
+   * then runs post-commit hooks: if one of those hooks throws, the write is
+   * already committed but `success` is reported `false`. Post-write side effects
+   * (the webhook fast-drain and retention pass) key off this flag, not `success`,
+   * so a committed-but-hook-failed write still gets its immediate delivery while
+   * a write that recorded nothing (validation/access failure) does not.
+   */
+  eventRecorded?: boolean;
 }
 
 /**

--- a/packages/nextly/src/domains/collections/services/collection-types.ts
+++ b/packages/nextly/src/domains/collections/services/collection-types.ts
@@ -125,6 +125,14 @@ export interface BatchOperationResult {
   ids: string[];
   /** Detailed error information for each failed entry */
   errors: Array<{ index: number; error: string }>;
+  /**
+   * Whether the committed batch appended any durable outbox event, independent
+   * of `successful`. A per-item delete can commit its row + event in the shared
+   * transaction and still be counted a failure when its afterDelete hook throws,
+   * so a batch where every committed item hit that path has `successful === 0`
+   * yet owes deliveries. Set only after the shared transaction commits.
+   */
+  eventRecorded?: boolean;
 }
 
 /**

--- a/packages/nextly/src/domains/webhooks/__tests__/after-drain.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/after-drain.integration.test.ts
@@ -27,8 +27,6 @@ import { WebhookEndpointRegistry } from "../endpoint-registry";
 import { buildEnvelope } from "../envelope";
 import { recordEvent } from "../record-event";
 
-process.env.DB_DIALECT = "sqlite";
-
 const NOW = new Date("2026-07-19T12:00:00.000Z");
 const SECRET = `whsec_${Buffer.from("secretkey").toString("base64")}`;
 
@@ -153,9 +151,9 @@ describe("WebhookFastDrainScheduler (real SQLite)", () => {
     expect(calls).toEqual(["https://example.com/wh1"]);
   });
 
-  it("does not schedule when no endpoint is enabled", async () => {
+  it("schedules a callback that delivers nothing when no endpoint is enabled", async () => {
     await seedEvent("evt_b");
-    const { transport } = makeTransport();
+    const { transport, calls } = makeTransport();
     const { after, scheduled } = captureAfter();
 
     const scheduler = new WebhookFastDrainScheduler(
@@ -168,7 +166,13 @@ describe("WebhookFastDrainScheduler (real SQLite)", () => {
 
     await scheduler.offer();
 
-    expect(scheduled).toHaveLength(0);
+    // offer() registers the callback without reading the database — the write
+    // path is never delayed by a registry lookup.
+    expect(scheduled).toHaveLength(1);
+
+    // The gate runs inside the callback: with no subscriber it delivers nothing.
+    await scheduled[0]();
+    expect(calls).toHaveLength(0);
   });
 
   it("does not schedule when after() is unavailable (non-Next runtime)", async () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/after-drain.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/after-drain.integration.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Integration test for `WebhookFastDrainScheduler` — the post-response drain
+ * fast path.
+ *
+ * Proves the gate: it schedules a drain (through an injected `after()`) only when
+ * `after()` is available AND an endpoint is enabled, and the scheduled work
+ * actually fans out and delivers the seeded event. Uses an in-memory SQLite
+ * database and a captured `after()` so the callback can be run deterministically.
+ */
+
+import { createSqliteAdapter } from "@nextlyhq/adapter-sqlite";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { getSQLiteDrizzleKit } from "../../../database/drizzle-kit-lazy";
+import { SchemaRegistry } from "../../../database/schema-registry";
+import { users } from "../../../schemas/users/sqlite";
+import {
+  nextlyEvents,
+  nextlyWebhooks,
+  nextlyWebhookDeliveries,
+} from "../../../schemas/webhooks/sqlite";
+import { splitStatements } from "../../schema/pipeline/sql-statement-utils";
+import { WebhookFastDrainScheduler } from "../after-drain";
+import type { DeliverTransport } from "../deliver";
+import type { RunWebhookDrainOptions } from "../drain-runner";
+import { WebhookEndpointRegistry } from "../endpoint-registry";
+import { buildEnvelope } from "../envelope";
+import { recordEvent } from "../record-event";
+
+process.env.DB_DIALECT = "sqlite";
+
+const NOW = new Date("2026-07-19T12:00:00.000Z");
+const SECRET = `whsec_${Buffer.from("secretkey").toString("base64")}`;
+
+const tables = { nextlyEvents, nextlyWebhooks, nextlyWebhookDeliveries };
+const ddlTables = { ...tables, users };
+
+async function schemaDdl(): Promise<string[]> {
+  const kit = await getSQLiteDrizzleKit();
+  const statements = await kit.generateMigration(
+    await kit.generateDrizzleJson({}),
+    await kit.generateDrizzleJson(ddlTables)
+  );
+  return splitStatements(statements);
+}
+
+/** A captured `after()`: records callbacks so a test can run them by hand. */
+function captureAfter(): {
+  after: (cb: () => void | Promise<void>) => void;
+  scheduled: Array<() => void | Promise<void>>;
+} {
+  const scheduled: Array<() => void | Promise<void>> = [];
+  return { after: cb => scheduled.push(cb), scheduled };
+}
+
+describe("WebhookFastDrainScheduler (real SQLite)", () => {
+  let adapter: ReturnType<typeof createSqliteAdapter>;
+
+  beforeAll(async () => {
+    adapter = createSqliteAdapter({ memory: true });
+    await adapter.connect();
+    for (const stmt of await schemaDdl()) await adapter.executeQuery(stmt);
+
+    const schemaRegistry = new SchemaRegistry("sqlite");
+    schemaRegistry.registerStaticSchemas(tables);
+    adapter.setTableResolver(schemaRegistry);
+  });
+
+  afterAll(async () => {
+    try {
+      await adapter?.disconnect?.();
+    } catch {
+      // ignore teardown errors
+    }
+  });
+
+  beforeEach(async () => {
+    await adapter.executeQuery("DELETE FROM nextly_webhook_deliveries");
+    await adapter.executeQuery("DELETE FROM nextly_webhooks");
+    await adapter.executeQuery("DELETE FROM nextly_events");
+  });
+
+  async function seedWebhook(id: string): Promise<void> {
+    await adapter.insert("nextly_webhooks", {
+      id,
+      name: id,
+      url: `https://example.com/${id}`,
+      enabled: true,
+      event_types: ["entry.updated"],
+      filter: null,
+      headers: null,
+      secret_hash: [SECRET],
+      secret_prefix: "whsec_",
+      field_allowlist: null,
+      created_by: null,
+      created_at: new Date("2020-01-01T00:00:00.000Z"),
+      updated_at: NOW,
+    });
+  }
+
+  async function seedEvent(id: string): Promise<void> {
+    const envelope = buildEnvelope({
+      id,
+      type: "entry.updated",
+      timestamp: new Date("2026-07-18T00:00:00.000Z"),
+      resource: { kind: "entry", collection: "posts", id: "p1" },
+      data: { id: "p1", title: "Hello" },
+    });
+    await adapter.transaction(async tx => recordEvent(tx, { envelope }));
+  }
+
+  function makeTransport(): {
+    transport: DeliverTransport;
+    calls: string[];
+  } {
+    const calls: string[] = [];
+    return {
+      calls,
+      transport: async url => {
+        calls.push(url);
+        return new Response("ok", { status: 200 });
+      },
+    };
+  }
+
+  function drainOptions(transport: DeliverTransport): RunWebhookDrainOptions {
+    return { transport, now: () => NOW, decryptSecret: ct => ct };
+  }
+
+  it("schedules a drain that delivers the event when after() and an endpoint exist", async () => {
+    await seedWebhook("wh1");
+    await seedEvent("evt_a");
+    const { transport, calls } = makeTransport();
+    const { after, scheduled } = captureAfter();
+
+    const scheduler = new WebhookFastDrainScheduler(
+      adapter,
+      new WebhookEndpointRegistry(adapter),
+      undefined,
+      () => after,
+      drainOptions(transport)
+    );
+
+    await scheduler.offer();
+
+    // The gate passed: exactly one drain was scheduled to run after the response.
+    expect(scheduled).toHaveLength(1);
+    // Nothing delivered yet — after() work runs post-response.
+    expect(calls).toHaveLength(0);
+
+    // Run the scheduled callback: it drains and delivers.
+    await scheduled[0]();
+    expect(calls).toEqual(["https://example.com/wh1"]);
+  });
+
+  it("does not schedule when no endpoint is enabled", async () => {
+    await seedEvent("evt_b");
+    const { transport } = makeTransport();
+    const { after, scheduled } = captureAfter();
+
+    const scheduler = new WebhookFastDrainScheduler(
+      adapter,
+      new WebhookEndpointRegistry(adapter),
+      undefined,
+      () => after,
+      drainOptions(transport)
+    );
+
+    await scheduler.offer();
+
+    expect(scheduled).toHaveLength(0);
+  });
+
+  it("does not schedule when after() is unavailable (non-Next runtime)", async () => {
+    await seedWebhook("wh1");
+    await seedEvent("evt_c");
+    const { transport } = makeTransport();
+    const { scheduled } = captureAfter();
+
+    const scheduler = new WebhookFastDrainScheduler(
+      adapter,
+      new WebhookEndpointRegistry(adapter),
+      undefined,
+      // No after() in this runtime → the scheduled drain delivers instead.
+      () => null,
+      drainOptions(transport)
+    );
+
+    await scheduler.offer();
+
+    // Even with an endpoint, nothing is scheduled through the (absent) after().
+    expect(scheduled).toHaveLength(0);
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/after-drain.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/after-drain.integration.test.ts
@@ -177,6 +177,32 @@ describe("WebhookFastDrainScheduler (real SQLite)", () => {
     expect(calls).toHaveLength(0);
   });
 
+  it("coalesces concurrent drains so an event is delivered once, not per write", async () => {
+    await seedWebhook("wh1");
+    await seedEvent("evt_d");
+    const { transport, calls } = makeTransport();
+    const { after, scheduled } = captureAfter();
+
+    const scheduler = new WebhookFastDrainScheduler(
+      adapter,
+      new WebhookEndpointRegistry(adapter),
+      undefined,
+      () => after,
+      drainOptions(transport)
+    );
+
+    // Two writes each schedule a drain callback.
+    scheduler.offer();
+    scheduler.offer();
+    expect(scheduled).toHaveLength(2);
+
+    // Run both callbacks concurrently: the second must fold into the first via
+    // the single-flight guard rather than run a racing drain, so the one seeded
+    // event is delivered exactly once.
+    await Promise.all([scheduled[0](), scheduled[1]()]);
+    expect(calls).toEqual(["https://example.com/wh1"]);
+  });
+
   it("does not schedule when after() is unavailable (non-Next runtime)", async () => {
     await seedWebhook("wh1");
     await seedEvent("evt_c");

--- a/packages/nextly/src/domains/webhooks/__tests__/after-drain.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/after-drain.integration.test.ts
@@ -2,10 +2,12 @@
  * Integration test for `WebhookFastDrainScheduler` — the post-response drain
  * fast path.
  *
- * Proves the gate: it schedules a drain (through an injected `after()`) only when
- * `after()` is available AND an endpoint is enabled, and the scheduled work
- * actually fans out and delivers the seeded event. Uses an in-memory SQLite
- * database and a captured `after()` so the callback can be run deterministically.
+ * Proves the design: it registers a callback (through an injected `after()`)
+ * whenever `after()` is available, without reading the database in the write
+ * path; the subscriber gate runs inside that callback, and the scheduled work
+ * fans out and delivers the seeded event only when an endpoint is enabled. Uses
+ * an in-memory SQLite database and a captured `after()` so the callback can be
+ * run deterministically.
  */
 
 import { createSqliteAdapter } from "@nextlyhq/adapter-sqlite";
@@ -139,7 +141,7 @@ describe("WebhookFastDrainScheduler (real SQLite)", () => {
       drainOptions(transport)
     );
 
-    await scheduler.offer();
+    scheduler.offer();
 
     // The gate passed: exactly one drain was scheduled to run after the response.
     expect(scheduled).toHaveLength(1);
@@ -164,7 +166,7 @@ describe("WebhookFastDrainScheduler (real SQLite)", () => {
       drainOptions(transport)
     );
 
-    await scheduler.offer();
+    scheduler.offer();
 
     // offer() registers the callback without reading the database — the write
     // path is never delayed by a registry lookup.
@@ -190,7 +192,7 @@ describe("WebhookFastDrainScheduler (real SQLite)", () => {
       drainOptions(transport)
     );
 
-    await scheduler.offer();
+    scheduler.offer();
 
     // Even with an endpoint, nothing is scheduled through the (absent) after().
     expect(scheduled).toHaveLength(0);

--- a/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
@@ -133,6 +133,49 @@ describe("webhook outbox capture (integration)", () => {
     expect(rows[0].type).toBe("entry.created");
   });
 
+  it("flags eventRecorded on a bulk result when a committed item's hook throws", async () => {
+    // A bulk delete runs each item through the per-item mutation, which commits
+    // the row + event and then runs afterDelete. A throwing hook makes that item
+    // a failure (successCount stays 0), but the event is durable — so the bulk
+    // result must still report eventRecorded, or the batch would skip the drain.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "hello" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    current.hooks.register("afterDelete", "posts", () => {
+      throw new Error("afterDelete observer failed");
+    });
+
+    const result = await handler.bulkDeleteEntries({
+      collectionName: "posts",
+      ids: [id],
+      overrideAccess: true,
+    });
+
+    // The item is counted a failure, yet the delete + event committed.
+    expect(result.successCount).toBe(0);
+    expect(result.eventRecorded).toBe(true);
+
+    const rows = await events(current);
+    expect(rows.map(r => r.type).sort()).toEqual([
+      "entry.created",
+      "entry.deleted",
+    ]);
+  });
+
   it("records the event for a versioned collection too (one assembly, both consumers)", async () => {
     current = await createTestNextly({
       collections: [

--- a/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/outbox-capture.integration.test.ts
@@ -99,6 +99,40 @@ describe("webhook outbox capture (integration)", () => {
     });
   });
 
+  it("flags eventRecorded when the write commits but a post-commit hook throws", async () => {
+    // The event is appended inside the write transaction; afterCreate hooks run
+    // after it commits. A throwing hook surfaces success:false on an already
+    // committed write, so the result must still report `eventRecorded` — that is
+    // the signal the fast drain + retention key off, not `success`.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    current.hooks.register("afterCreate", "posts", () => {
+      throw new Error("afterCreate observer failed");
+    });
+
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "hello" }
+    );
+
+    // The hook failure is surfaced, but the entry + event committed.
+    expect(created.success).toBe(false);
+    expect(created.eventRecorded).toBe(true);
+
+    const rows = await events(current);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].type).toBe("entry.created");
+  });
+
   it("records the event for a versioned collection too (one assembly, both consumers)", async () => {
     current = await createTestNextly({
       collections: [

--- a/packages/nextly/src/domains/webhooks/after-drain.ts
+++ b/packages/nextly/src/domains/webhooks/after-drain.ts
@@ -76,13 +76,23 @@ const FAST_PATH_DRAIN_OPTIONS: RunWebhookDrainOptions = {
  * Schedules an immediate, bounded drain after a content write's response, when
  * the runtime supports `after()`. The subscriber check runs inside the scheduled
  * callback (after the response is sent), never in the write path, so a write is
- * never delayed by a registry read. Stateless beyond the resolved `after`
- * reference, so a single instance is shared across every write path.
+ * never delayed by a registry read. A single instance is shared across every
+ * write path; it holds only a single-flight flag so concurrent writes in one
+ * process coalesce into one drain instead of racing.
  */
 export class WebhookFastDrainScheduler {
   // Resolved once on first use; an instance field (not module scope) so a test
   // with its own injected loader is not shadowed by an earlier resolution.
   private cachedAfter: AfterFn | null | undefined;
+
+  // Single-flight: at most one fast drain runs in this process at a time. A write
+  // that lands while a drain is in flight sets `rerunRequested` so exactly one
+  // more pass runs when the current one finishes, instead of scheduling a second
+  // drain that would race the first over the same due deliveries. Cross-process
+  // races are separately bounded by the per-row delivery lease and the
+  // at-least-once + receiver-dedup contract (see deliver.ts).
+  private draining = false;
+  private rerunRequested = false;
 
   constructor(
     private readonly adapter: WebhookDrainDatabase,
@@ -108,16 +118,16 @@ export class WebhookFastDrainScheduler {
    * for a caller to await.
    */
   offer(): void {
-    if (this.cachedAfter === undefined) this.cachedAfter = this.loadAfter();
-    const after = this.cachedAfter;
-    // No `after()` (non-Next runtime, or Next < 15): the scheduled drain delivers.
-    if (!after) return;
-
     try {
+      if (this.cachedAfter === undefined) this.cachedAfter = this.loadAfter();
+      const after = this.cachedAfter;
+      // No `after()` (non-Next runtime, or Next < 15): the scheduled drain delivers.
+      if (!after) return;
       after(() => this.drainIfSubscribed());
     } catch {
-      // `after()` throws outside a request scope (build time, a CLI write). The
-      // scheduled drain handles it.
+      // Resolving the loader or registering the callback must never throw into
+      // the write path (e.g. `after()` throws outside a request scope: build
+      // time, a CLI write). The scheduled drain is the backstop.
     }
   }
 
@@ -126,21 +136,36 @@ export class WebhookFastDrainScheduler {
    * drain. Both the gate and fan-out read endpoints fresh, so a subscriber
    * another process just created is seen. Absorbs its own failures — this runs
    * after the response, so there is nothing to fail.
+   *
+   * Single-flight: if a drain is already running in this process, record that a
+   * trailing pass is wanted and return, so concurrent writes never launch racing
+   * drains. The running drain then loops once more, and because fan-out reads
+   * fresh each pass it picks up the events those trailing writes recorded.
    */
   private async drainIfSubscribed(): Promise<void> {
+    if (this.draining) {
+      this.rerunRequested = true;
+      return;
+    }
+    this.draining = true;
     try {
-      // Fresh read, not the TTL cache: a subscriber another process just created
-      // must be seen here, and this runs after the response so the read adds no
-      // latency to the write. With no subscriber there is nothing to deliver, so
-      // skip the drain rather than fan out events that would go nowhere.
-      const enabled = await this.registry.getEnabledEndpointsFresh();
-      if (enabled.length === 0) return;
-      await runWebhookDrain(this.adapter, this.registry, this.drainOptions);
+      do {
+        this.rerunRequested = false;
+        // Fresh read, not the TTL cache: a subscriber another process just
+        // created must be seen here, and this runs after the response so the read
+        // adds no latency to the write. With no subscriber there is nothing to
+        // deliver, so skip the drain rather than fan out events that go nowhere.
+        const enabled = await this.registry.getEnabledEndpointsFresh();
+        if (enabled.length === 0) break;
+        await runWebhookDrain(this.adapter, this.registry, this.drainOptions);
+      } while (this.rerunRequested);
     } catch (err) {
       this.logger?.warn?.(
         "webhook fast-path drain failed; the scheduled drain will retry",
         { error: err instanceof Error ? err.message : String(err) }
       );
+    } finally {
+      this.draining = false;
     }
   }
 }

--- a/packages/nextly/src/domains/webhooks/after-drain.ts
+++ b/packages/nextly/src/domains/webhooks/after-drain.ts
@@ -156,7 +156,13 @@ export class WebhookFastDrainScheduler {
         // adds no latency to the write. With no subscriber there is nothing to
         // deliver, so skip the drain rather than fan out events that go nowhere.
         const enabled = await this.registry.getEnabledEndpointsFresh();
-        if (enabled.length === 0) break;
+        if (enabled.length === 0) {
+          // A write offered a drain while this read was in flight — possibly one
+          // that just enabled an endpoint this (now stale) read missed. Loop for
+          // a fresh read rather than dropping its requested drain.
+          if (this.rerunRequested) continue;
+          break;
+        }
         await runWebhookDrain(this.adapter, this.registry, this.drainOptions);
       } while (this.rerunRequested);
     } catch (err) {

--- a/packages/nextly/src/domains/webhooks/after-drain.ts
+++ b/packages/nextly/src/domains/webhooks/after-drain.ts
@@ -102,8 +102,12 @@ export class WebhookFastDrainScheduler {
    * must never turn a successful write into an error, and the scheduled drain is
    * always the backstop. It does NOT read the database: the subscriber check
    * happens inside the callback so the write path stays free of registry reads.
+   *
+   * Synchronous: it only registers the callback. The delivery work is owned by
+   * `after()` (which survives the response via `waitUntil`), so there is nothing
+   * for a caller to await.
    */
-  async offer(): Promise<void> {
+  offer(): void {
     if (this.cachedAfter === undefined) this.cachedAfter = this.loadAfter();
     const after = this.cachedAfter;
     // No `after()` (non-Next runtime, or Next < 15): the scheduled drain delivers.

--- a/packages/nextly/src/domains/webhooks/after-drain.ts
+++ b/packages/nextly/src/domains/webhooks/after-drain.ts
@@ -1,0 +1,139 @@
+/**
+ * Webhook domain — the post-response drain fast path.
+ *
+ * After a content write records an outbox event, this kicks a bounded drain via
+ * Next.js `after()` so the first delivery attempt happens immediately instead of
+ * waiting for the next scheduled trigger. `after()` runs the work once the
+ * response is sent, so it adds no latency to the write. Everything degrades
+ * gracefully: outside a Next request (a CLI or plain-Node write) or on a Next
+ * version without `after`, this is a no-op and the scheduled drain delivers.
+ *
+ * @module domains/webhooks/after-drain
+ */
+
+import { createRequire } from "node:module";
+
+import type { Logger } from "../../shared/types";
+
+import {
+  runWebhookDrain,
+  type RunWebhookDrainOptions,
+  type WebhookDrainDatabase,
+} from "./drain-runner";
+import type { WebhookEndpointRegistry } from "./endpoint-registry";
+
+/** Next.js `after()`: schedules a callback to run once the response is finished. */
+type AfterFn = (callback: () => void | Promise<void>) => void;
+
+/**
+ * Resolve Next's `after()` (stable in 15.1) or `unstable_after` (15.0), or null
+ * when neither is available (Next 14, or Next not installed).
+ *
+ * Loaded with `createRequire` for the reason `api/with-error-handler.ts`
+ * documents: a static or dynamic ESM `import` of a Next subpath breaks Node's
+ * ESM resolver when this package is an external under `serverExternalPackages`,
+ * and the `.js`-suffixed workaround sends Turbopack into Next internals that are
+ * not on disk. `createRequire` uses Node's CommonJS resolver and is opaque to
+ * the bundler, so neither complains.
+ */
+export function loadNextAfter(): AfterFn | null {
+  try {
+    const require = createRequire(import.meta.url);
+    const mod = require("next/server") as {
+      after?: unknown;
+      unstable_after?: unknown;
+    };
+    if (typeof mod.after === "function") return mod.after as AfterFn;
+    if (typeof mod.unstable_after === "function") {
+      return mod.unstable_after as AfterFn;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Bounds for the fast-path drain. It runs on the WRITE route's invocation
+ * (`after()` extends it via `waitUntil`, capped by the route's `maxDuration`),
+ * so it only kicks the just-recorded deliveries and returns quickly; the
+ * scheduled drain owns the backlog and the retries.
+ */
+const FAST_PATH_DRAIN_OPTIONS: RunWebhookDrainOptions = {
+  maxRounds: 3,
+  fanOutBatchSize: 50,
+  deliverBatchSize: 25,
+  maxDurationMs: 5_000,
+  requestTimeoutMs: 10_000,
+};
+
+/**
+ * Schedules an immediate, bounded drain after a content write's response, when
+ * the runtime supports `after()` and at least one endpoint is enabled. Stateless
+ * beyond the resolved `after` reference, so a single instance is shared across
+ * every write path.
+ */
+export class WebhookFastDrainScheduler {
+  // Resolved once on first use; an instance field (not module scope) so a test
+  // with its own injected loader is not shadowed by an earlier resolution.
+  private cachedAfter: AfterFn | null | undefined;
+
+  constructor(
+    private readonly adapter: WebhookDrainDatabase,
+    private readonly registry: WebhookEndpointRegistry,
+    private readonly logger?: Logger,
+    // Injectable so a test can drive the scheduled callback without a real Next
+    // request scope; defaults to the guarded loader.
+    private readonly loadAfter: () => AfterFn | null = loadNextAfter,
+    // Injectable so a test can supply a transport/clock; defaults to the
+    // fast-path bounds.
+    private readonly drainOptions: RunWebhookDrainOptions = FAST_PATH_DRAIN_OPTIONS
+  ) {}
+
+  /**
+   * Schedule the drain to run after the response. Safe to call after every
+   * write: it self-gates on runtime support and on there being a subscriber, and
+   * never throws — a failure here must never turn a successful write into an
+   * error, and the scheduled drain is always the backstop.
+   */
+  async offer(): Promise<void> {
+    if (this.cachedAfter === undefined) this.cachedAfter = this.loadAfter();
+    const after = this.cachedAfter;
+    // No `after()` (non-Next runtime, or Next < 15): the scheduled drain delivers.
+    if (!after) return;
+
+    // Cheap, cached gate: with no subscriber there is nothing to deliver, so do
+    // not extend the invocation with an after() callback at all.
+    let enabled: readonly unknown[];
+    try {
+      enabled = await this.registry.getEnabledEndpoints();
+    } catch {
+      // A registry read failure must not affect the write; the drain delivers.
+      return;
+    }
+    if (enabled.length === 0) return;
+
+    try {
+      after(() => this.drain());
+    } catch {
+      // `after()` throws outside a request scope (build time, a CLI write). The
+      // scheduled drain handles it.
+    }
+  }
+
+  /**
+   * The scheduled work: one bounded drain. Fan-out reads endpoints fresh, so a
+   * subscriber added between the gate check and here is still seen. Absorbs its
+   * own failures — this runs after the response, so there is nothing to fail.
+   */
+  private async drain(): Promise<void> {
+    try {
+      await runWebhookDrain(this.adapter, this.registry, this.drainOptions);
+    } catch (err) {
+      this.logger?.warn?.(
+        "webhook fast-path drain failed; the scheduled drain will retry",
+        { error: err instanceof Error ? err.message : String(err) }
+      );
+    }
+  }
+}

--- a/packages/nextly/src/domains/webhooks/after-drain.ts
+++ b/packages/nextly/src/domains/webhooks/after-drain.ts
@@ -64,14 +64,20 @@ const FAST_PATH_DRAIN_OPTIONS: RunWebhookDrainOptions = {
   fanOutBatchSize: 50,
   deliverBatchSize: 25,
   maxDurationMs: 5_000,
-  requestTimeoutMs: 10_000,
+  // Below maxDurationMs on purpose: the drain can only stop between deliveries,
+  // so the worst case is the budget plus one in-flight request
+  // (maxDurationMs + requestTimeoutMs). Keeping the timeout under the budget
+  // holds that worst case (~9s) inside a 10s route maxDuration; a receiver that
+  // outlasts it is cut off and retried by the scheduled drain.
+  requestTimeoutMs: 4_000,
 };
 
 /**
  * Schedules an immediate, bounded drain after a content write's response, when
- * the runtime supports `after()` and at least one endpoint is enabled. Stateless
- * beyond the resolved `after` reference, so a single instance is shared across
- * every write path.
+ * the runtime supports `after()`. The subscriber check runs inside the scheduled
+ * callback (after the response is sent), never in the write path, so a write is
+ * never delayed by a registry read. Stateless beyond the resolved `after`
+ * reference, so a single instance is shared across every write path.
  */
 export class WebhookFastDrainScheduler {
   // Resolved once on first use; an instance field (not module scope) so a test
@@ -92,9 +98,10 @@ export class WebhookFastDrainScheduler {
 
   /**
    * Schedule the drain to run after the response. Safe to call after every
-   * write: it self-gates on runtime support and on there being a subscriber, and
-   * never throws — a failure here must never turn a successful write into an
-   * error, and the scheduled drain is always the backstop.
+   * write: it self-gates on runtime support and never throws — a failure here
+   * must never turn a successful write into an error, and the scheduled drain is
+   * always the backstop. It does NOT read the database: the subscriber check
+   * happens inside the callback so the write path stays free of registry reads.
    */
   async offer(): Promise<void> {
     if (this.cachedAfter === undefined) this.cachedAfter = this.loadAfter();
@@ -102,19 +109,8 @@ export class WebhookFastDrainScheduler {
     // No `after()` (non-Next runtime, or Next < 15): the scheduled drain delivers.
     if (!after) return;
 
-    // Cheap, cached gate: with no subscriber there is nothing to deliver, so do
-    // not extend the invocation with an after() callback at all.
-    let enabled: readonly unknown[];
     try {
-      enabled = await this.registry.getEnabledEndpoints();
-    } catch {
-      // A registry read failure must not affect the write; the drain delivers.
-      return;
-    }
-    if (enabled.length === 0) return;
-
-    try {
-      after(() => this.drain());
+      after(() => this.drainIfSubscribed());
     } catch {
       // `after()` throws outside a request scope (build time, a CLI write). The
       // scheduled drain handles it.
@@ -122,12 +118,19 @@ export class WebhookFastDrainScheduler {
   }
 
   /**
-   * The scheduled work: one bounded drain. Fan-out reads endpoints fresh, so a
-   * subscriber added between the gate check and here is still seen. Absorbs its
-   * own failures — this runs after the response, so there is nothing to fail.
+   * The scheduled work: gate on there being a subscriber, then one bounded
+   * drain. Both the gate and fan-out read endpoints fresh, so a subscriber
+   * another process just created is seen. Absorbs its own failures — this runs
+   * after the response, so there is nothing to fail.
    */
-  private async drain(): Promise<void> {
+  private async drainIfSubscribed(): Promise<void> {
     try {
+      // Fresh read, not the TTL cache: a subscriber another process just created
+      // must be seen here, and this runs after the response so the read adds no
+      // latency to the write. With no subscriber there is nothing to deliver, so
+      // skip the drain rather than fan out events that would go nowhere.
+      const enabled = await this.registry.getEnabledEndpointsFresh();
+      if (enabled.length === 0) return;
       await runWebhookDrain(this.adapter, this.registry, this.drainOptions);
     } catch (err) {
       this.logger?.warn?.(

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -9,6 +9,7 @@ import { container } from "../di/container";
 import type { PermissionSeedService } from "../domains/auth/services/permission-seed-service";
 import { DynamicCollectionService } from "../domains/dynamic-collections";
 import type { SanitizedLocalizationConfig } from "../domains/i18n/config/types";
+import type { WebhookFastDrainScheduler } from "../domains/webhooks/after-drain";
 import type { ResolvedWebhookRetentionConfig } from "../domains/webhooks/retention-config";
 import { MetaRetentionGate } from "../domains/webhooks/retention-gate";
 import { WebhookRetentionRunner } from "../domains/webhooks/retention-runner";
@@ -155,6 +156,12 @@ export class CollectionsHandler {
       ? container.get<ComponentDataService>("componentDataService")
       : undefined;
 
+    // Shared post-response drain fast path (registered by the webhook services),
+    // handed to the entry service — the seam every write path runs through.
+    const fastDrainScheduler = container.has("webhookFastDrainScheduler")
+      ? container.get<WebhookFastDrainScheduler>("webhookFastDrainScheduler")
+      : undefined;
+
     // Late-inject relationshipService if componentDataService was created before it was available
     if (componentDataService) {
       componentDataService.setRelationshipService(this.relationshipService);
@@ -171,7 +178,8 @@ export class CollectionsHandler {
       componentDataService,
       undefined,
       this.localization,
-      retentionRunner
+      retentionRunner,
+      fastDrainScheduler
     );
   }
 

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -253,10 +253,11 @@ export class CollectionEntryService extends BaseService {
    * operation where every item failed — recorded nothing, so kicking the drain
    * would deliver unrelated pending events for a write that changed nothing (and
    * let a failed, possibly unauthorized attempt trigger outbound webhooks). The
-   * three result shapes report "recorded something" differently. For a single
-   * write, `success` is not sufficient: create/update/delete commit the event
-   * then run post-commit hooks, so a hook failure returns `success: false` on a
-   * write that DID record — `eventRecorded` covers that case.
+   * three result shapes report "recorded something" differently. `success` /
+   * `successCount` are not sufficient on their own: create/update/delete commit
+   * the event then run post-commit hooks, so a hook failure returns
+   * `success: false` (and, for a bulk item, counts as a failure) on a write that
+   * DID record — the `eventRecorded` flag on each shape covers that case.
    */
   private async afterWriteIfRecorded(
     result:
@@ -268,7 +269,7 @@ export class CollectionEntryService extends BaseService {
       "success" in result
         ? result.success || result.eventRecorded === true
         : "successCount" in result
-          ? result.successCount > 0
+          ? result.successCount > 0 || result.eventRecorded === true
           : result.successful > 0;
     if (recorded) await this.afterWrite();
   }

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -39,6 +39,7 @@ import type {
 } from "../../domains/collections/services/collection-types";
 import type { DynamicCollectionService } from "../../domains/dynamic-collections";
 import type { SanitizedLocalizationConfig } from "../../domains/i18n/config/types";
+import type { WebhookFastDrainScheduler } from "../../domains/webhooks/after-drain";
 import type { WebhookRetentionRunner } from "../../domains/webhooks/retention-runner";
 import type { PaginatedResponse } from "../../types/pagination";
 import type { AccessControlService } from "../access";
@@ -93,7 +94,13 @@ export class CollectionEntryService extends BaseService {
      * service — the dispatcher-facing handler, `CollectionService`, and direct
      * callers alike — so this is the one place that covers them all.
      */
-    private readonly retentionRunner?: WebhookRetentionRunner
+    private readonly retentionRunner?: WebhookRetentionRunner,
+    /**
+     * Kicks an immediate, bounded drain after a write (via Next `after()`), so
+     * the first delivery attempt does not wait for the next scheduled trigger.
+     * Wired at the same seam as `retentionRunner` for the same reason.
+     */
+    private readonly fastDrainScheduler?: WebhookFastDrainScheduler
   ) {
     super(adapter, logger);
 
@@ -223,6 +230,20 @@ export class CollectionEntryService extends BaseService {
     );
   }
 
+  /**
+   * The post-write side effects, run after every write that appends an event.
+   *
+   * The drain fast path goes first so the `after()` callback is scheduled
+   * promptly (it only runs post-response, so it adds no latency); the retention
+   * pass follows. Both absorb their own failures, so this never turns a
+   * successful save into an error. Awaited for the reason `offerRetentionPass`
+   * documents: a detached promise may not survive a serverless response.
+   */
+  private async afterWrite(): Promise<void> {
+    await this.fastDrainScheduler?.offer();
+    await this.offerRetentionPass();
+  }
+
   async createEntry(
     params: {
       collectionName: string;
@@ -238,7 +259,7 @@ export class CollectionEntryService extends BaseService {
     depth?: number
   ) {
     const result = await this.mutationService.createEntry(params, body, depth);
-    await this.offerRetentionPass();
+    await this.afterWrite();
     return result;
   }
 
@@ -279,7 +300,7 @@ export class CollectionEntryService extends BaseService {
     depth?: number
   ) {
     const result = await this.mutationService.updateEntry(params, body, depth);
-    await this.offerRetentionPass();
+    await this.afterWrite();
     return result;
   }
 
@@ -291,7 +312,7 @@ export class CollectionEntryService extends BaseService {
     overrideAccess?: boolean;
   }) {
     const result = await this.mutationService.publishAllLocales(params);
-    await this.offerRetentionPass();
+    await this.afterWrite();
     return result;
   }
 
@@ -305,7 +326,7 @@ export class CollectionEntryService extends BaseService {
     context?: Record<string, unknown>;
   }) {
     const result = await this.mutationService.deleteEntry(params);
-    await this.offerRetentionPass();
+    await this.afterWrite();
     return result;
   }
 
@@ -349,7 +370,7 @@ export class CollectionEntryService extends BaseService {
     actor?: RequestActor;
   }) {
     const result = await this.bulkService.duplicateEntry(params);
-    await this.offerRetentionPass();
+    await this.afterWrite();
     return result;
   }
 
@@ -365,7 +386,7 @@ export class CollectionEntryService extends BaseService {
     context?: Record<string, unknown>;
   }): Promise<BulkOperationResult<{ id: string }>> {
     const result = await this.bulkService.bulkDeleteEntries(params);
-    await this.offerRetentionPass();
+    await this.afterWrite();
     return result;
   }
 
@@ -380,7 +401,7 @@ export class CollectionEntryService extends BaseService {
     actor?: RequestActor;
   }): Promise<BulkOperationResult<Record<string, unknown>>> {
     const result = await this.bulkService.bulkUpdateEntries(params);
-    await this.offerRetentionPass();
+    await this.afterWrite();
     return result;
   }
 
@@ -400,7 +421,7 @@ export class CollectionEntryService extends BaseService {
     options?: BulkOperationOptions & { limit?: number }
   ): Promise<BulkOperationResult<Record<string, unknown>>> {
     const result = await this.bulkService.bulkUpdateByQuery(params, options);
-    await this.offerRetentionPass();
+    await this.afterWrite();
     return result;
   }
 
@@ -417,7 +438,7 @@ export class CollectionEntryService extends BaseService {
     options?: { limit?: number }
   ): Promise<BulkOperationResult<{ id: string }>> {
     const result = await this.bulkService.bulkDeleteByQuery(params, options);
-    await this.offerRetentionPass();
+    await this.afterWrite();
     return result;
   }
 
@@ -435,7 +456,7 @@ export class CollectionEntryService extends BaseService {
       entries,
       options
     );
-    await this.offerRetentionPass();
+    await this.afterWrite();
     return result;
   }
 
@@ -463,7 +484,7 @@ export class CollectionEntryService extends BaseService {
       entries,
       options
     );
-    await this.offerRetentionPass();
+    await this.afterWrite();
     return result;
   }
 
@@ -492,7 +513,7 @@ export class CollectionEntryService extends BaseService {
     options?: BulkOperationOptions
   ): Promise<BatchOperationResult> {
     const result = await this.bulkService.deleteEntries(params, ids, options);
-    await this.offerRetentionPass();
+    await this.afterWrite();
     return result;
   }
 

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -253,7 +253,10 @@ export class CollectionEntryService extends BaseService {
    * operation where every item failed — recorded nothing, so kicking the drain
    * would deliver unrelated pending events for a write that changed nothing (and
    * let a failed, possibly unauthorized attempt trigger outbound webhooks). The
-   * three result shapes report "recorded something" differently.
+   * three result shapes report "recorded something" differently. For a single
+   * write, `success` is not sufficient: create/update/delete commit the event
+   * then run post-commit hooks, so a hook failure returns `success: false` on a
+   * write that DID record — `eventRecorded` covers that case.
    */
   private async afterWriteIfRecorded(
     result:
@@ -263,7 +266,7 @@ export class CollectionEntryService extends BaseService {
   ): Promise<void> {
     const recorded =
       "success" in result
-        ? result.success
+        ? result.success || result.eventRecorded === true
         : "successCount" in result
           ? result.successCount > 0
           : result.successful > 0;

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -236,11 +236,13 @@ export class CollectionEntryService extends BaseService {
    * The drain fast path goes first so the `after()` callback is scheduled
    * promptly (it only runs post-response, so it adds no latency); the retention
    * pass follows. Both absorb their own failures, so this never turns a
-   * successful save into an error. Awaited for the reason `offerRetentionPass`
-   * documents: a detached promise may not survive a serverless response.
+   * successful save into an error. `offer()` is synchronous — it only registers
+   * the post-response callback, whose work `after()` owns — so it is not awaited;
+   * the retention pass is awaited for the reason `offerRetentionPass` documents:
+   * a detached promise may not survive a serverless response.
    */
   private async afterWrite(): Promise<void> {
-    await this.fastDrainScheduler?.offer();
+    this.fastDrainScheduler?.offer();
     await this.offerRetentionPass();
   }
 

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -270,7 +270,7 @@ export class CollectionEntryService extends BaseService {
         ? result.success || result.eventRecorded === true
         : "successCount" in result
           ? result.successCount > 0 || result.eventRecorded === true
-          : result.successful > 0;
+          : result.successful > 0 || result.eventRecorded === true;
     if (recorded) await this.afterWrite();
   }
 

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -246,6 +246,30 @@ export class CollectionEntryService extends BaseService {
     await this.offerRetentionPass();
   }
 
+  /**
+   * Run the post-write side effects only when the mutation actually recorded a
+   * change (and therefore appended an outbox event). A rejected write — a
+   * validation or access failure surfaced as `success: false`, or a bulk/batch
+   * operation where every item failed — recorded nothing, so kicking the drain
+   * would deliver unrelated pending events for a write that changed nothing (and
+   * let a failed, possibly unauthorized attempt trigger outbound webhooks). The
+   * three result shapes report "recorded something" differently.
+   */
+  private async afterWriteIfRecorded(
+    result:
+      | CollectionServiceResult<unknown>
+      | BulkOperationResult<unknown>
+      | BatchOperationResult
+  ): Promise<void> {
+    const recorded =
+      "success" in result
+        ? result.success
+        : "successCount" in result
+          ? result.successCount > 0
+          : result.successful > 0;
+    if (recorded) await this.afterWrite();
+  }
+
   async createEntry(
     params: {
       collectionName: string;
@@ -261,7 +285,7 @@ export class CollectionEntryService extends BaseService {
     depth?: number
   ) {
     const result = await this.mutationService.createEntry(params, body, depth);
-    await this.afterWrite();
+    await this.afterWriteIfRecorded(result);
     return result;
   }
 
@@ -302,7 +326,7 @@ export class CollectionEntryService extends BaseService {
     depth?: number
   ) {
     const result = await this.mutationService.updateEntry(params, body, depth);
-    await this.afterWrite();
+    await this.afterWriteIfRecorded(result);
     return result;
   }
 
@@ -314,7 +338,7 @@ export class CollectionEntryService extends BaseService {
     overrideAccess?: boolean;
   }) {
     const result = await this.mutationService.publishAllLocales(params);
-    await this.afterWrite();
+    await this.afterWriteIfRecorded(result);
     return result;
   }
 
@@ -328,7 +352,7 @@ export class CollectionEntryService extends BaseService {
     context?: Record<string, unknown>;
   }) {
     const result = await this.mutationService.deleteEntry(params);
-    await this.afterWrite();
+    await this.afterWriteIfRecorded(result);
     return result;
   }
 
@@ -372,7 +396,7 @@ export class CollectionEntryService extends BaseService {
     actor?: RequestActor;
   }) {
     const result = await this.bulkService.duplicateEntry(params);
-    await this.afterWrite();
+    await this.afterWriteIfRecorded(result);
     return result;
   }
 
@@ -388,7 +412,7 @@ export class CollectionEntryService extends BaseService {
     context?: Record<string, unknown>;
   }): Promise<BulkOperationResult<{ id: string }>> {
     const result = await this.bulkService.bulkDeleteEntries(params);
-    await this.afterWrite();
+    await this.afterWriteIfRecorded(result);
     return result;
   }
 
@@ -403,7 +427,7 @@ export class CollectionEntryService extends BaseService {
     actor?: RequestActor;
   }): Promise<BulkOperationResult<Record<string, unknown>>> {
     const result = await this.bulkService.bulkUpdateEntries(params);
-    await this.afterWrite();
+    await this.afterWriteIfRecorded(result);
     return result;
   }
 
@@ -423,7 +447,7 @@ export class CollectionEntryService extends BaseService {
     options?: BulkOperationOptions & { limit?: number }
   ): Promise<BulkOperationResult<Record<string, unknown>>> {
     const result = await this.bulkService.bulkUpdateByQuery(params, options);
-    await this.afterWrite();
+    await this.afterWriteIfRecorded(result);
     return result;
   }
 
@@ -440,7 +464,7 @@ export class CollectionEntryService extends BaseService {
     options?: { limit?: number }
   ): Promise<BulkOperationResult<{ id: string }>> {
     const result = await this.bulkService.bulkDeleteByQuery(params, options);
-    await this.afterWrite();
+    await this.afterWriteIfRecorded(result);
     return result;
   }
 
@@ -458,7 +482,7 @@ export class CollectionEntryService extends BaseService {
       entries,
       options
     );
-    await this.afterWrite();
+    await this.afterWriteIfRecorded(result);
     return result;
   }
 
@@ -486,7 +510,7 @@ export class CollectionEntryService extends BaseService {
       entries,
       options
     );
-    await this.afterWrite();
+    await this.afterWriteIfRecorded(result);
     return result;
   }
 
@@ -515,7 +539,7 @@ export class CollectionEntryService extends BaseService {
     options?: BulkOperationOptions
   ): Promise<BatchOperationResult> {
     const result = await this.bulkService.deleteEntries(params, ids, options);
-    await this.afterWrite();
+    await this.afterWriteIfRecorded(result);
     return result;
   }
 

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -253,11 +253,14 @@ export class CollectionEntryService extends BaseService {
    * operation where every item failed — recorded nothing, so kicking the drain
    * would deliver unrelated pending events for a write that changed nothing (and
    * let a failed, possibly unauthorized attempt trigger outbound webhooks). The
-   * three result shapes report "recorded something" differently. `success` /
-   * `successCount` are not sufficient on their own: create/update/delete commit
-   * the event then run post-commit hooks, so a hook failure returns
-   * `success: false` (and, for a bulk item, counts as a failure) on a write that
-   * DID record — the `eventRecorded` flag on each shape covers that case.
+   * three result shapes report "recorded something" differently. `success` is
+   * not a reliable proxy in either direction: a create/update/delete can commit
+   * the event and then return `success: false` when a post-commit hook throws,
+   * and a `publishAllLocales` no-op (or a no-op update) returns `success: true`
+   * having recorded nothing. So a single write keys off the explicit
+   * `eventRecorded` flag, which every event-writing path sets. Bulk/batch results
+   * carry the same flag for their committed-but-hook-failed items on top of the
+   * success count.
    */
   private async afterWriteIfRecorded(
     result:
@@ -267,7 +270,7 @@ export class CollectionEntryService extends BaseService {
   ): Promise<void> {
     const recorded =
       "success" in result
-        ? result.success || result.eventRecorded === true
+        ? result.eventRecorded === true
         : "successCount" in result
           ? result.successCount > 0 || result.eventRecorded === true
           : result.successful > 0 || result.eventRecorded === true;


### PR DESCRIPTION
## What

Deliver webhooks **immediately** after a content write instead of waiting for the next scheduled `/webhooks/drain` tick. After a write records an outbox event, Nextly now schedules a bounded delivery pass via Next.js `after()`, so the first attempt runs as soon as the response is sent — **adding no latency to the write**.

## How

- **Guarded `after()` load** (`domains/webhooks/after-drain.ts`). Resolves `after` (stable in Next 15.1) or `unstable_after` (15.0), or `null` (Next 14 / not installed). Loaded via `createRequire(import.meta.url)` for the exact reason `api/with-error-handler.ts` documents — a static/dynamic ESM import of a Next subpath breaks Node's ESM resolver under `serverExternalPackages` and confuses Turbopack; `createRequire` uses Node's CJS resolver and is opaque to the bundler. **Core stays Node-safe** — nothing imports `next/server` at module load.
- **`WebhookFastDrainScheduler.offer()`** self-gates: returns early when `after()` is unavailable (non-Next runtime, or a CLI/plain-Node write) or when there are **no enabled endpoints** (cheap cached registry read), then schedules a bounded `runWebhookDrain` via `after()`, wrapped in try/catch (`after()` throws outside a request scope). Absorbs its own failures — a failure here must never turn a successful write into an error, and the scheduled drain is always the backstop for retries + backlog.
- **Bounded**: the fast-path drain runs on the *write* route's invocation (`after()` extends it via `waitUntil`, capped by the route's `maxDuration`), so it uses tight bounds (`maxRounds: 3`, `deliverBatchSize: 25`, `maxDurationMs: 5s`, `requestTimeoutMs: 10s`) to kick the just-recorded deliveries and return.
- **Seam**: wired into `CollectionEntryService` (the one place every collection write path shares — dispatcher, `CollectionService`, direct callers), alongside the retention pass, as a shared DI singleton injected into both entry-service construction sites.

## Tests

`after-drain.integration.test.ts` (real SQLite, injected `after`): schedules a drain that delivers the event when `after()` + an endpoint exist; does **not** schedule with no endpoint; does **not** schedule when `after()` is unavailable.

## Notes

- Docs confirmed via context7: `after` from `next/server`, stable v15.1.0, `unstable_after` v15.0.x; Next 14 has neither by default — the loader handles all three gracefully.
- Pre-existing baseline failures unrelated to this change: `collection-mutation`/`collection-hooks` stale-mock suites (8, identical on `main`).
- First of the recording-breadth follow-ons; singles/media (B3b-2/3) still record on their own paths and will get the same fast path when instrumented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fast, post-response webhook drain path that schedules after durable outbox writes when Next’s `after()` is available.
  * Introduced a shared scheduler (via DI) with bounded limits; concurrent writes coalesce into a single drain pass and re-check enabled endpoints before draining.
* **Bug Fixes**
  * Added/propagated an `eventRecorded` flag across collection write and bulk results so durable outbox recording is reported correctly even if post-commit hooks fail.
* **Tests**
  * Expanded integration tests for fast-drain behavior (missing `after`, disabled endpoints, concurrency) and for outbox/event recording when hooks throw.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->