### PR TITLE
feat(nextly): record webhook events on single writes

### DIFF
--- a/.changeset/webhook-singles-recording.md
+++ b/.changeset/webhook-singles-recording.md
@@ -1,0 +1,31 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Emit webhook events when a Single changes.
+
+Updating a Single now records a `single.updated` event carrying the written
+document and its prior state, and a status change additionally records
+`single.published` or `single.unpublished` — so a publish delivers both
+`single.updated` and `single.published`, and a consumer can subscribe to
+whichever it needs. Events fire whether or not the Single has versioning
+enabled, name the locale for a per-language write, and never carry secret
+field values.

--- a/packages/nextly/src/api/__tests__/singles-detail-auth.test.ts
+++ b/packages/nextly/src/api/__tests__/singles-detail-auth.test.ts
@@ -88,6 +88,9 @@ describe("singles-detail PATCH route auth forwarding", () => {
         },
         overrideAccess: false,
         routeAuthorized: true,
+        // Acting identity for the outbox event, resolved from the same auth
+        // context; a session caller attributes to the user.
+        actor: { type: "user", id: "u-1" },
       }
     );
   });

--- a/packages/nextly/src/api/singles-detail.ts
+++ b/packages/nextly/src/api/singles-detail.ts
@@ -17,6 +17,7 @@
  * @module api/singles-detail
  */
 
+import { actorFromAuthContext } from "../auth/request-actor";
 import { getService } from "../di";
 import type { SingleResult } from "../domains/singles/types";
 import { NextlyError } from "../errors/nextly-error";
@@ -240,6 +241,10 @@ export const PATCH = withErrorHandler(
     const result = await service.update(slug, body, {
       locale,
       user,
+      // Record who performed the write on the outbox event: an API-key caller
+      // attributes to the key itself, not the user that owns it. Resolved from
+      // the same auth context the route already verified.
+      actor: actorFromAuthContext(auth),
       overrideAccess: false,
       // Guard on a resolved user id (matches the dispatcher) so the
       // RBAC-skip only applies to an authenticated caller.

--- a/packages/nextly/src/di/registrations/register-singles.ts
+++ b/packages/nextly/src/di/registrations/register-singles.ts
@@ -14,6 +14,9 @@ import type { PermissionSeedService } from "../../domains/auth/services/permissi
 import type { RBACAccessControlService } from "../../domains/auth/services/rbac-access-control-service";
 import { SingleEntryService } from "../../domains/singles/services/single-entry-service";
 import { SingleRegistryService } from "../../domains/singles/services/single-registry-service";
+import type { WebhookFastDrainScheduler } from "../../domains/webhooks/after-drain";
+import { MetaRetentionGate } from "../../domains/webhooks/retention-gate";
+import { WebhookRetentionRunner } from "../../domains/webhooks/retention-runner";
 import type { ComponentDataService } from "../../services/components";
 import { container } from "../container";
 
@@ -60,7 +63,23 @@ export function registerSingleServices(ctx: RegistrationContext): void {
       rbacAccessControlService,
       // i18n: forward the normalized localization config so localized singles resolve
       // and write translatable fields via their companion table (mirrors collections).
-      ctx.config.localization
+      ctx.config.localization,
+      // The single write path appends outbox events through this service, so it
+      // gets its own retention runner (the handler's is not on this path),
+      // matching the collection write path.
+      ctx.config.webhookRetention
+        ? new WebhookRetentionRunner({
+            policy: ctx.config.webhookRetention,
+            prune: { adapter, logger },
+            gate: new MetaRetentionGate(adapter),
+            logger,
+          })
+        : undefined,
+      // Shared post-response drain fast path (registered by the webhook
+      // services). Absent only when webhooks were never registered.
+      container.has("webhookFastDrainScheduler")
+        ? container.get<WebhookFastDrainScheduler>("webhookFastDrainScheduler")
+        : undefined
     );
   });
 }

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -786,6 +786,10 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         {
           locale: p.locale,
           user,
+          // Who performed the write, recorded on the outbox event: an API-key
+          // caller attributes to the key itself rather than the user that owns
+          // it. Mirrors the collection update handler.
+          actor: readAuthenticatedActor(p),
           // Route auth already ran the RBAC gate; `routeAuthorized` skips only
           // that re-check while field-level write access + response redaction
           // still run for this user (overrideAccess stays false).

--- a/packages/nextly/src/domains/components/services/component-data-service.ts
+++ b/packages/nextly/src/domains/components/services/component-data-service.ts
@@ -76,6 +76,26 @@ export class ComponentDataService {
     return record?.fields ?? null;
   }
 
+  /**
+   * Whether the component's OWN definition is localized — i.e. its translatable
+   * field values route to the per-locale companion (`comp_<slug>_locales`)
+   * table. Mirrors the storage gate in the component mutation service
+   * (`meta.localized !== true` keeps all data on the shared main table
+   * regardless of inner field types), so a caller can tell a per-locale
+   * component write apart from a shared one without re-deriving it from the
+   * inner field types.
+   */
+  async isComponentLocalized(
+    slug: string,
+    executor?: unknown
+  ): Promise<boolean> {
+    const record = await this.registryService.getComponentBySlug(
+      slug,
+      executor
+    );
+    return record?.localized === true;
+  }
+
   setRelationshipService(service: CollectionRelationshipService): void {
     this.queryService.setRelationshipService(service);
   }

--- a/packages/nextly/src/domains/components/services/component-query-service.ts
+++ b/packages/nextly/src/domains/components/services/component-query-service.ts
@@ -79,6 +79,14 @@ export interface PopulateComponentDataParams {
    * written in it. Omitted for ordinary reads (pooled connection).
    */
   executor?: unknown;
+  /**
+   * When true, a component read failure propagates instead of being caught and
+   * replaced with a default (`null`/`[]`). Callers whose result feeds a durable
+   * write — a webhook payload or version snapshot assembled inside the write
+   * transaction — set this so a real read failure rolls the write back rather
+   * than shipping a payload with silently-missing component data.
+   */
+  strict?: boolean;
 }
 
 /**
@@ -299,6 +307,7 @@ export class ComponentQueryService extends BaseService {
       locale,
       fallbackLocale,
       executor,
+      strict = false,
     } = params;
     const entryId = entry.id as string;
     if (!entryId) return entry;
@@ -324,7 +333,8 @@ export class ComponentQueryService extends BaseService {
             currentDepth,
             locale,
             fallbackLocale,
-            executor
+            executor,
+            strict
           );
         } else if (field.component) {
           if (field.repeatable) {
@@ -354,6 +364,9 @@ export class ComponentQueryService extends BaseService {
           }
         }
       } catch (error) {
+        // In strict mode a read failure must roll the write back rather than
+        // ship a payload with silently-missing component data.
+        if (strict) throw error;
         this.logger.debug("Could not populate component field", {
           fieldName,
           error: error instanceof Error ? error.message : String(error),
@@ -572,7 +585,8 @@ export class ComponentQueryService extends BaseService {
     currentDepth: number,
     locale?: string,
     fallbackLocale?: string | false,
-    executor?: unknown
+    executor?: unknown,
+    strict = false
   ): Promise<Record<string, unknown>[]> {
     const allowedSlugs = field.components ?? [];
     const allRows: {
@@ -595,6 +609,9 @@ export class ComponentQueryService extends BaseService {
           allRows.push({ row, fields: meta.fields, slug });
         }
       } catch (error) {
+        // In strict mode surface the failure so a durable payload is not built
+        // from a partial dynamic-zone read.
+        if (strict) throw error;
         this.logger.debug("Could not load component for populate", {
           slug,
           error: error instanceof Error ? error.message : String(error),

--- a/packages/nextly/src/domains/components/services/component-query-service.ts
+++ b/packages/nextly/src/domains/components/services/component-query-service.ts
@@ -9,6 +9,7 @@ import { BaseService } from "../../../shared/base-service";
 import { stripPasswordFieldValues } from "../../../shared/lib/password-fields";
 import type { Logger } from "../../../shared/types";
 import {
+  isMissingCompanionTableError,
   populateCompanionFields,
   populateCompanionFieldsAllLocales,
 } from "../../i18n/companion-join";
@@ -145,7 +146,10 @@ export class ComponentQueryService extends BaseService {
     dataArray: Record<string, unknown>[],
     locale: string | undefined,
     fallbackLocale?: string | false,
-    executor?: unknown
+    executor?: unknown,
+    // Propagate a real companion read failure (durable webhook/version reads)
+    // instead of swallowing it and leaving translatable fields unresolved.
+    strict = false
   ): Promise<void> {
     if (
       !this.localization ||
@@ -204,6 +208,7 @@ export class ComponentQueryService extends BaseService {
       rows: dataArray,
       localeChain,
       idKey: "id",
+      strict,
     });
     this.decodeJsonLocalizedValues(
       meta,
@@ -347,7 +352,8 @@ export class ComponentQueryService extends BaseService {
               currentDepth,
               locale,
               fallbackLocale,
-              executor
+              executor,
+              strict
             );
           } else {
             result[fieldName] = await this.populateSingleField(
@@ -359,7 +365,8 @@ export class ComponentQueryService extends BaseService {
               currentDepth,
               locale,
               fallbackLocale,
-              executor
+              executor,
+              strict
             );
           }
         }
@@ -491,7 +498,8 @@ export class ComponentQueryService extends BaseService {
     currentDepth: number,
     locale?: string,
     fallbackLocale?: string | false,
-    executor?: unknown
+    executor?: unknown,
+    strict = false
   ): Promise<Record<string, unknown> | null> {
     const meta = await this.registryService.getComponent(
       componentSlug,
@@ -503,7 +511,8 @@ export class ComponentQueryService extends BaseService {
       parentId,
       parentTable,
       fieldName,
-      executor
+      executor,
+      strict
     );
 
     if (rows.length === 0) return null;
@@ -515,7 +524,8 @@ export class ComponentQueryService extends BaseService {
       [data],
       locale,
       fallbackLocale,
-      executor
+      executor,
+      strict
     );
     data = await this.expandComponentRelationships(
       data,
@@ -537,7 +547,8 @@ export class ComponentQueryService extends BaseService {
     currentDepth: number,
     locale?: string,
     fallbackLocale?: string | false,
-    executor?: unknown
+    executor?: unknown,
+    strict = false
   ): Promise<Record<string, unknown>[]> {
     const meta = await this.registryService.getComponent(
       componentSlug,
@@ -549,7 +560,8 @@ export class ComponentQueryService extends BaseService {
       parentId,
       parentTable,
       fieldName,
-      executor
+      executor,
+      strict
     );
 
     let dataArray = rows.map(row =>
@@ -562,7 +574,8 @@ export class ComponentQueryService extends BaseService {
       dataArray,
       locale,
       fallbackLocale,
-      executor
+      executor,
+      strict
     );
 
     dataArray = await this.expandComponentRelationshipsMany(
@@ -603,7 +616,8 @@ export class ComponentQueryService extends BaseService {
           parentId,
           parentTable,
           fieldName,
-          executor
+          executor,
+          strict
         );
         for (const row of rows) {
           allRows.push({ row, fields: meta.fields, slug });
@@ -633,7 +647,8 @@ export class ComponentQueryService extends BaseService {
         [data],
         locale,
         fallbackLocale,
-        executor
+        executor,
+        strict
       );
       data = await this.expandComponentRelationships(
         data,
@@ -841,7 +856,11 @@ export class ComponentQueryService extends BaseService {
     // transaction's connection (read-your-writes, #226), so a version snapshot
     // captured inside the write transaction sees the components just written in
     // it. Omitted for ordinary reads, which use the pooled connection.
-    executor?: unknown
+    executor?: unknown,
+    // When true, only a MISSING component table is tolerated; any other read
+    // failure propagates so a durable webhook/version payload is not built from
+    // a component silently read as empty.
+    strict = false
   ): Promise<ComponentRow[]> {
     try {
       return await this.adapter.select<ComponentRow>(
@@ -857,6 +876,12 @@ export class ComponentQueryService extends BaseService {
         executor
       );
     } catch (error) {
+      // The comp_* table may not exist yet (a component before its migration
+      // runs) — tolerate that and read as empty. In strict mode a real failure
+      // (transient/permission/schema) instead propagates.
+      if (strict && !isMissingCompanionTableError(error)) {
+        throw error;
+      }
       this.logger.debug("Could not query component table", {
         tableName,
         error: error instanceof Error ? error.message : String(error),

--- a/packages/nextly/src/domains/i18n/companion-join.integration.test.ts
+++ b/packages/nextly/src/domains/i18n/companion-join.integration.test.ts
@@ -77,4 +77,54 @@ describe("populateCompanionFields (real SQLite)", () => {
       })
     ).resolves.toBeUndefined();
   });
+
+  // A db whose read rejects with `err`, reusing the real companion table so the
+  // query builds before the (mocked) execution fails.
+  function rejectingDb(err: Error) {
+    return {
+      select: () => ({
+        from: () => ({ where: () => Promise.reject(err) }),
+      }),
+    };
+  }
+
+  it("swallows a missing-table read error even in strict mode", async () => {
+    const rows: Record<string, unknown>[] = [{ id: "p1" }];
+    await populateCompanionFields({
+      db: rejectingDb(new Error("no such table: dc_pages_locales")) as never,
+      companionTable,
+      localizedFields: [{ name: "body", column: "body" }],
+      rows,
+      localeChain: ["en"],
+      strict: true,
+    });
+    // The unmigrated-table case is tolerated: the row is left untouched so the
+    // main-table value stands.
+    expect(rows[0]).not.toHaveProperty("body");
+  });
+
+  it("propagates a non-missing-table read error in strict mode", async () => {
+    await expect(
+      populateCompanionFields({
+        db: rejectingDb(new Error("deadlock detected")) as never,
+        companionTable,
+        localizedFields: [{ name: "body", column: "body" }],
+        rows: [{ id: "p1" }],
+        localeChain: ["en"],
+        strict: true,
+      })
+    ).rejects.toThrow("deadlock");
+  });
+
+  it("swallows any read error when not strict (default)", async () => {
+    await expect(
+      populateCompanionFields({
+        db: rejectingDb(new Error("deadlock detected")) as never,
+        companionTable,
+        localizedFields: [{ name: "body", column: "body" }],
+        rows: [{ id: "p1" }],
+        localeChain: ["en"],
+      })
+    ).resolves.toBeUndefined();
+  });
 });

--- a/packages/nextly/src/domains/i18n/companion-join.integration.test.ts
+++ b/packages/nextly/src/domains/i18n/companion-join.integration.test.ts
@@ -116,6 +116,36 @@ describe("populateCompanionFields (real SQLite)", () => {
     ).rejects.toThrow("deadlock");
   });
 
+  it("propagates a Postgres missing-COLUMN error in strict mode", async () => {
+    // A migrated-but-mismatched companion (missing column) is a real schema
+    // error strict mode must surface — not the tolerated missing-table case.
+    await expect(
+      populateCompanionFields({
+        db: rejectingDb(new Error('column "body" does not exist')) as never,
+        companionTable,
+        localizedFields: [{ name: "body", column: "body" }],
+        rows: [{ id: "p1" }],
+        localeChain: ["en"],
+        strict: true,
+      })
+    ).rejects.toThrow("does not exist");
+  });
+
+  it("tolerates a Postgres missing-RELATION error in strict mode", async () => {
+    const rows: Record<string, unknown>[] = [{ id: "p1" }];
+    await populateCompanionFields({
+      db: rejectingDb(
+        new Error('relation "dc_pages_locales" does not exist')
+      ) as never,
+      companionTable,
+      localizedFields: [{ name: "body", column: "body" }],
+      rows,
+      localeChain: ["en"],
+      strict: true,
+    });
+    expect(rows[0]).not.toHaveProperty("body");
+  });
+
   it("swallows any read error when not strict (default)", async () => {
     await expect(
       populateCompanionFields({

--- a/packages/nextly/src/domains/i18n/companion-join.ts
+++ b/packages/nextly/src/domains/i18n/companion-join.ts
@@ -12,7 +12,7 @@
  * @module domains/i18n/companion-join
  */
 
-import { and, inArray, sql, type SQL } from "drizzle-orm";
+import { and, eq, inArray, sql, type SQL } from "drizzle-orm";
 
 /** One localized field: its API/row key (camelCase) + its physical companion column (snake_case). */
 export interface LocalizedFieldRef {
@@ -149,6 +149,56 @@ export async function populateCompanionFields(
       }
       row[field.name] = resolveLocalizedValue(perLocaleValue, localeChain);
     }
+  }
+}
+
+/** A Drizzle-select surface that also supports `.limit()` for a single-row read. */
+interface LimitableDb {
+  select: () => {
+    from: (table: unknown) => {
+      where: (cond: unknown) => {
+        limit: (n: number) => Promise<Record<string, unknown>[]>;
+      };
+    };
+  };
+}
+
+/**
+ * Read one companion row's per-locale `_status` for `(parentId, locale)`.
+ *
+ * Goes through the Drizzle companion table object rather than raw SQL, so the
+ * read uses the same typed query builder the populate helpers do. Returns the
+ * `_status` string, or `null` when no companion row exists for the pair (or the
+ * stored value is not a string). Swallows a missing-companion-table error the
+ * same way {@link populateCompanionFields} does, so an entity whose companion
+ * migration has not run yet reads as having no per-locale status instead of
+ * failing the caller.
+ */
+export async function readCompanionLocaleStatus(
+  db: LimitableDb,
+  companionTable: unknown,
+  parentId: string | number,
+  locale: string
+): Promise<string | null> {
+  const table = companionTable as CompanionTable;
+  try {
+    const rows = await db
+      .select()
+      .from(companionTable)
+      .where(
+        and(
+          eq(table._parent as never, parentId),
+          eq(table._locale as never, locale)
+        )
+      )
+      .limit(1);
+    const status = rows[0]?._status;
+    return typeof status === "string" ? status : null;
+  } catch {
+    // The companion `_locales` table may not physically exist yet (dev before
+    // the companion migration runs); treat that as no per-locale status rather
+    // than failing the surrounding read/write.
+    return null;
   }
 }
 

--- a/packages/nextly/src/domains/i18n/companion-join.ts
+++ b/packages/nextly/src/domains/i18n/companion-join.ts
@@ -194,11 +194,27 @@ export async function readCompanionLocaleStatus(
       .limit(1);
     const status = rows[0]?._status;
     return typeof status === "string" ? status : null;
-  } catch {
-    // The companion `_locales` table may not physically exist yet (dev before
-    // the companion migration runs); treat that as no per-locale status rather
-    // than failing the surrounding read/write.
-    return null;
+  } catch (err) {
+    // Tolerate ONLY the companion `_locales` table not existing yet (a localized
+    // entity before its companion migration runs) — matched the same way the
+    // boot sync detects it. Any other failure (a transient connection drop, a
+    // deadlock) must propagate: this value drives the publish/unpublish
+    // transition, so silently reading it as "no per-locale status" could emit a
+    // spurious event. The driver message rides on the error or its cause.
+    const message = [
+      err instanceof Error ? err.message : String(err),
+      err instanceof Error && err.cause instanceof Error
+        ? err.cause.message
+        : "",
+    ].join(" ");
+    if (
+      message.includes("does not exist") ||
+      message.includes("no such table") ||
+      message.includes("doesn't exist")
+    ) {
+      return null;
+    }
+    throw err;
   }
 }
 

--- a/packages/nextly/src/domains/i18n/companion-join.ts
+++ b/packages/nextly/src/domains/i18n/companion-join.ts
@@ -91,7 +91,7 @@ export interface PopulateCompanionArgs {
  * a real failure (transient drop, permission, schema error). The driver message
  * rides on the error or its cause.
  */
-function isMissingCompanionTableError(err: unknown): boolean {
+export function isMissingCompanionTableError(err: unknown): boolean {
   const message = [
     err instanceof Error ? err.message : String(err),
     err instanceof Error && err.cause instanceof Error ? err.cause.message : "",

--- a/packages/nextly/src/domains/i18n/companion-join.ts
+++ b/packages/nextly/src/domains/i18n/companion-join.ts
@@ -23,7 +23,7 @@ export interface LocalizedFieldRef {
 }
 
 /** Blank = "not translated": null, undefined, or empty string fall back. 0/false are real values. */
-function isBlank(value: unknown): boolean {
+export function isBlank(value: unknown): boolean {
   return value === null || value === undefined || value === "";
 }
 

--- a/packages/nextly/src/domains/i18n/companion-join.ts
+++ b/packages/nextly/src/domains/i18n/companion-join.ts
@@ -96,10 +96,16 @@ function isMissingCompanionTableError(err: unknown): boolean {
     err instanceof Error ? err.message : String(err),
     err instanceof Error && err.cause instanceof Error ? err.cause.message : "",
   ].join(" ");
+  // Match ONLY a missing table/relation, not any "does not exist" — on Postgres
+  // a missing COLUMN reads `column "x" does not exist`, a real schema error that
+  // strict mode must surface, whereas a missing table reads
+  // `relation "x" does not exist`. SQLite uses `no such table` (its missing
+  // column is `no such column`), and MySQL uses `Table '...' doesn't exist`
+  // (its missing column is `Unknown column`).
   return (
-    message.includes("does not exist") ||
     message.includes("no such table") ||
-    message.includes("doesn't exist")
+    message.includes("doesn't exist") ||
+    (message.includes("relation") && message.includes("does not exist"))
   );
 }
 

--- a/packages/nextly/src/domains/i18n/companion-join.ts
+++ b/packages/nextly/src/domains/i18n/companion-join.ts
@@ -74,6 +74,33 @@ export interface PopulateCompanionArgs {
    * (admin/`status=all`, or a collection without per-locale status).
    */
   statusValue?: string;
+  /**
+   * When true, only a MISSING companion table is tolerated; any other read
+   * failure (a transient drop, a permission or schema error) propagates instead
+   * of being swallowed. Callers that have already confirmed the table exists and
+   * whose result feeds a durable write (e.g. a webhook payload) set this so a
+   * real error aborts rather than silently emitting nulled translations.
+   */
+  strict?: boolean;
+}
+
+/**
+ * Whether an error is the companion `_locales` table simply not existing yet (a
+ * localized entity before its companion migration runs), matched the same way
+ * the boot sync detects it. Distinguishes the tolerated missing-table case from
+ * a real failure (transient drop, permission, schema error). The driver message
+ * rides on the error or its cause.
+ */
+function isMissingCompanionTableError(err: unknown): boolean {
+  const message = [
+    err instanceof Error ? err.message : String(err),
+    err instanceof Error && err.cause instanceof Error ? err.cause.message : "",
+  ].join(" ");
+  return (
+    message.includes("does not exist") ||
+    message.includes("no such table") ||
+    message.includes("doesn't exist")
+  );
 }
 
 /**
@@ -114,11 +141,17 @@ export async function populateCompanionFields(
           inArray(localeCol as never, localeChain)
         )
       );
-  } catch {
+  } catch (err) {
     // The companion table may not physically exist yet — e.g. a localized collection
     // whose companion migration hasn't been run (dev auto-sync leaves localized columns
     // on the main table until `migrate`). Leave rows untouched (main-table values stand)
     // rather than failing the whole read. Mirrors loadDynamicTables' fresh-DB resilience.
+    // In `strict` mode only that missing-table case is tolerated; any other
+    // failure propagates so a durable write is not committed with a silently
+    // incomplete companion read.
+    if (args.strict && !isMissingCompanionTableError(err)) {
+      throw err;
+    }
     return;
   }
 
@@ -196,22 +229,11 @@ export async function readCompanionLocaleStatus(
     return typeof status === "string" ? status : null;
   } catch (err) {
     // Tolerate ONLY the companion `_locales` table not existing yet (a localized
-    // entity before its companion migration runs) — matched the same way the
-    // boot sync detects it. Any other failure (a transient connection drop, a
-    // deadlock) must propagate: this value drives the publish/unpublish
-    // transition, so silently reading it as "no per-locale status" could emit a
-    // spurious event. The driver message rides on the error or its cause.
-    const message = [
-      err instanceof Error ? err.message : String(err),
-      err instanceof Error && err.cause instanceof Error
-        ? err.cause.message
-        : "",
-    ].join(" ");
-    if (
-      message.includes("does not exist") ||
-      message.includes("no such table") ||
-      message.includes("doesn't exist")
-    ) {
+    // entity before its companion migration runs). Any other failure (a
+    // transient connection drop, a deadlock) must propagate: this value drives
+    // the publish/unpublish transition, so silently reading it as "no per-locale
+    // status" could emit a spurious event.
+    if (isMissingCompanionTableError(err)) {
       return null;
     }
     throw err;

--- a/packages/nextly/src/domains/singles/__tests__/single-entry-service.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-entry-service.test.ts
@@ -463,7 +463,9 @@ describe("SingleEntryService", () => {
         siteName: "Set",
       });
 
-      expect(ctx.adapter.insert).toHaveBeenCalledTimes(1);
+      // Two inserts: the auto-created default document, then the outbox event
+      // appended in the same update transaction.
+      expect(ctx.adapter.insert).toHaveBeenCalledTimes(2);
       expect(ctx.adapter.update).toHaveBeenCalledTimes(1);
       expect(result.data?.siteName).toBe("Set");
     });

--- a/packages/nextly/src/domains/singles/__tests__/single-test-helpers.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-test-helpers.ts
@@ -65,6 +65,9 @@ export function createMockAdapter(overrides: MockRecord = {}): MockRecord {
     // The webhook read-shape assembly reads components on the transaction's
     // Drizzle handle; the component mocks ignore the executor, so a stub is fine.
     getDrizzle: vi.fn().mockReturnValue({}),
+    // The update takes the row lock before its prior-state read; the real
+    // adapter no-ops where locking is unsupported, so a resolved stub matches.
+    lockRow: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
   // Run a transaction callback with the adapter itself as the tx context, so

--- a/packages/nextly/src/domains/singles/__tests__/single-test-helpers.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-test-helpers.ts
@@ -62,6 +62,9 @@ export function createMockAdapter(overrides: MockRecord = {}): MockRecord {
     tableExists: vi.fn().mockResolvedValue(true),
     executeQuery: vi.fn().mockResolvedValue(undefined),
     getDialect: vi.fn().mockReturnValue("postgresql"),
+    // The webhook read-shape assembly reads components on the transaction's
+    // Drizzle handle; the component mocks ignore the executor, so a stub is fine.
+    getDrizzle: vi.fn().mockReturnValue({}),
     ...overrides,
   };
   // Run a transaction callback with the adapter itself as the tx context, so
@@ -148,6 +151,9 @@ export function createMockComponentDataService(): MockRecord {
     saveComponentData: vi.fn().mockResolvedValue(undefined),
     saveComponentDataInTransaction: vi.fn().mockResolvedValue(undefined),
     deleteComponentData: vi.fn().mockResolvedValue(undefined),
+    // The webhook field tree expands component references to find nested
+    // secrets; null = no nested component schema for this slug in the mock.
+    getComponentFields: vi.fn().mockResolvedValue(null),
   };
 }
 

--- a/packages/nextly/src/domains/singles/services/single-entry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-entry-service.ts
@@ -22,6 +22,8 @@ import type { ComponentDataService } from "../../../services/components/componen
 import { BaseService } from "../../../shared/base-service";
 import type { Logger } from "../../../shared/types";
 import type { SanitizedLocalizationConfig } from "../../i18n/config/types";
+import type { WebhookFastDrainScheduler } from "../../webhooks/after-drain";
+import type { WebhookRetentionRunner } from "../../webhooks/retention-runner";
 import type {
   GetSingleOptions,
   SingleResult,
@@ -62,7 +64,20 @@ export class SingleEntryService extends BaseService {
     rbacAccessControlService?: RBACAccessControlService,
     // i18n: normalized localization config so a localized single resolves/writes
     // translatable fields via its companion `single_<slug>_locales` table.
-    localization?: SanitizedLocalizationConfig
+    localization?: SanitizedLocalizationConfig,
+    /**
+     * Webhook-retention pass offered after a write that recorded an event, so a
+     * frequently-written single trims old outbox rows without waiting for a
+     * scheduled drain. Absent when webhook retention is not configured.
+     */
+    private readonly retentionRunner?: WebhookRetentionRunner,
+    /**
+     * Kicks an immediate, bounded drain after a write (via Next `after()`) so a
+     * single's outbox rows are delivered without waiting for the scheduled
+     * trigger. Shared with the collection write path; absent when webhooks were
+     * never registered.
+     */
+    private readonly fastDrainScheduler?: WebhookFastDrainScheduler
   ) {
     super(adapter, logger);
 
@@ -113,11 +128,35 @@ export class SingleEntryService extends BaseService {
    * If the document doesn't exist, it will be auto-created first,
    * then updated with the provided data.
    */
-  update(
+  async update(
     slug: string,
     data: Record<string, unknown>,
     options?: UpdateSingleOptions
   ): Promise<SingleResult> {
-    return this.mutationService.update(slug, data, options);
+    const result = await this.mutationService.update(slug, data, options);
+    // A successful update always appends an outbox event (single.updated, plus a
+    // publish/unpublish transition), so kick the post-write side effects; a
+    // rejected write (access/404) recorded nothing and skips them.
+    if (result.success) await this.afterWrite();
+    return result;
   }
+
+  /**
+   * Post-write side effects run after a write that recorded an outbox event: the
+   * drain fast path goes first so the `after()` callback is scheduled promptly
+   * (it runs post-response, adding no latency), then a bounded retention pass.
+   * Both absorb their own failures, so this never turns a successful save into an
+   * error. `offer()` is synchronous — it only registers the post-response
+   * callback — so it is not awaited; retention is awaited because a detached
+   * promise may not survive a serverless response.
+   */
+  private async afterWrite(): Promise<void> {
+    this.fastDrainScheduler?.offer();
+    await this.retentionRunner?.maybeRun(
+      SingleEntryService.WRITE_PATH_PRUNE_BATCHES
+    );
+  }
+
+  /** Retention batches to attempt per write, matching the collection path. */
+  private static readonly WRITE_PATH_PRUNE_BATCHES = 2;
 }

--- a/packages/nextly/src/domains/singles/services/single-entry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-entry-service.ts
@@ -136,8 +136,12 @@ export class SingleEntryService extends BaseService {
     const result = await this.mutationService.update(slug, data, options);
     // A successful update always appends an outbox event (single.updated, plus a
     // publish/unpublish transition), so kick the post-write side effects; a
-    // rejected write (access/404) recorded nothing and skips them.
-    if (result.success) await this.afterWrite();
+    // rejected write (access/404) recorded nothing and skips them. A write that
+    // committed its event but then failed a post-commit hook reports
+    // `success:false` with `eventRecorded:true`, so key off either — otherwise a
+    // committed event would miss its fast-drain and retention pass.
+    if (result.success || result.eventRecorded === true)
+      await this.afterWrite();
     return result;
   }
 

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -151,11 +151,14 @@ export class SingleMutationService extends BaseService {
    *
    * Reused for BOTH the post-write `data` and the pre-write `previous` so the
    * changed-field diff compares like with like. `companionValues` is keyed by
-   * companion column and holds only the translatable columns this write
-   * touches, so the two documents diff symmetrically — an untouched
-   * translation appears in neither. Components are read on the caller's
+   * companion column and carries the FULL locale state for this side (all
+   * stored translations, not only the columns this write touched), so the two
+   * documents diff symmetrically and a partial edit still reports untouched
+   * translations on both sides. Components are read on the caller's
    * transaction (read-your-writes) so a post-write call sees the subtrees just
-   * saved and a pre-write call sees the prior ones.
+   * saved and a pre-write call sees the prior ones. `localeStatus`, when
+   * provided, overrides the assembled `status` so a per-locale write reports
+   * the write locale's own publish state rather than the main row's.
    */
   private async buildSingleWebhookDoc(
     tx: TransactionContext,
@@ -165,7 +168,8 @@ export class SingleMutationService extends BaseService {
     fieldConfigs: FieldConfig[],
     companion: CompanionSchema | null,
     companionValues: Record<string, unknown>,
-    snapshotLocale: string | undefined
+    snapshotLocale: string | undefined,
+    localeStatus?: string
   ): Promise<Record<string, unknown>> {
     // Keep user field keys (which may contain underscores like `site_title`)
     // exactly; convert only the timestamp columns so the shape matches a read.
@@ -246,7 +250,14 @@ export class SingleMutationService extends BaseService {
         }
       }
     }
-    return { ...parentRow, ...components };
+    const doc: Record<string, unknown> = { ...parentRow, ...components };
+    // Overlay the resolved per-locale status: for a non-default-locale write the
+    // main row keeps the default language's status, so the assembled `status`
+    // above is the wrong one for this locale — replace it with the caller's.
+    if (localeStatus !== undefined) {
+      doc.status = localeStatus;
+    }
+    return doc;
   }
 
   /**
@@ -596,6 +607,12 @@ export class SingleMutationService extends BaseService {
               singleMeta.tableName,
               {}
             );
+            // The main row's prior status, captured before any overlay. Read
+            // once and never mutated onto `preRow`: the per-locale status is
+            // threaded to the `previous` doc via `localeStatus` instead, so the
+            // captured main row stays the true main-table state.
+            const preRowMainStatus =
+              typeof preRow?.status === "string" ? preRow.status : undefined;
 
             const rows = await tx.update<SingleDocument>(
               singleMeta.tableName,
@@ -613,9 +630,11 @@ export class SingleMutationService extends BaseService {
             // Build the outbox `previous` NOW — after the main update but before
             // the component save and companion upsert below — so its component
             // subtrees and companion values are still the prior generation. The
-            // main row was captured into `preRow` before the update. Values are
-            // restricted to the translatable columns this write touches
-            // (`companionData` keys) so `previous` and `data` diff symmetrically.
+            // main row was captured into `preRow` before the update.
+            // `previousCompanionValues` carries EVERY stored translation for the
+            // write locale (not just the touched columns) so a partial localized
+            // edit still reports the untouched translations on both sides and
+            // `previous`/`data` diff symmetrically.
             const previousCompanionValues: Record<string, unknown> = {};
             let previousCompanionStatus: string | null = null;
             if (companion && writeLocale !== undefined) {
@@ -632,13 +651,7 @@ export class SingleMutationService extends BaseService {
                 localeChain: [writeLocale],
               });
               for (const f of companion.localizedFields) {
-                if (
-                  Object.prototype.hasOwnProperty.call(
-                    companionData,
-                    f.column
-                  ) &&
-                  preLocaleRow[f.name] !== undefined
-                ) {
+                if (preLocaleRow[f.name] !== undefined) {
                   previousCompanionValues[f.column] = preLocaleRow[f.name];
                 }
               }
@@ -654,12 +667,47 @@ export class SingleMutationService extends BaseService {
                 );
               }
             }
-            // Overlay this locale's committed status so `previous` reports the
-            // language's own draft/publish rather than the main row's (a German
-            // draft can sit under a published default).
-            if (previousCompanionStatus !== null && preRow) {
-              preRow.status = previousCompanionStatus;
-            }
+            // The full post-write locale state: prior stored translations
+            // overlaid with the columns this write touched. No extra DB read —
+            // the prior values were just read above and `companionData` holds
+            // this write's serialized translatable values.
+            const dataCompanionValues: Record<string, unknown> = {
+              ...previousCompanionValues,
+              ...companionData,
+            };
+
+            // Whether the single stores this write's status per locale. True
+            // only for a non-default-locale write on a status-bearing companion;
+            // the default locale's status lives on the main row.
+            const isPerLocaleStatusWrite =
+              !!companion?.hasStatus &&
+              writeLocale !== undefined &&
+              writeLocale !== this.localization?.defaultLocale;
+            // Does this single have any status concept at all (main-row status
+            // or per-locale companion status)?
+            const singleHasStatus =
+              (singleMeta as { status?: boolean }).status === true ||
+              companion?.hasStatus === true;
+            // The status this write assigns: the patch's status (kept on
+            // `updatePayload` even when the main column is left untouched for a
+            // non-default locale) or the per-locale companion status. Undefined
+            // for a content-only edit, which transitions nothing.
+            const writtenStatus =
+              (typeof (updatePayload as { status?: unknown }).status ===
+              "string"
+                ? ((updatePayload as { status?: unknown }).status as string)
+                : undefined) ?? companionStatus;
+            // The status this write moves away from. For a per-locale write it
+            // is this locale's committed companion `_status`; a non-default
+            // locale with no companion row yet is unpublished ("draft"), NOT the
+            // main row's status. Otherwise it is the main row's prior status.
+            const previousLocaleStatus = isPerLocaleStatusWrite
+              ? (previousCompanionStatus ?? "draft")
+              : preRowMainStatus;
+            // The status the write leaves this locale in: a content-only write
+            // keeps the current status.
+            const dataLocaleStatus = writtenStatus ?? previousLocaleStatus;
+
             const previousDoc = preRow
               ? await this.buildSingleWebhookDoc(
                   tx,
@@ -669,7 +717,8 @@ export class SingleMutationService extends BaseService {
                   fieldConfigs,
                   companion,
                   previousCompanionValues,
-                  snapshotLocale
+                  snapshotLocale,
+                  previousLocaleStatus
                 )
               : null;
 
@@ -930,8 +979,9 @@ export class SingleMutationService extends BaseService {
             // collection write path.
 
             // Assemble the just-written document in the outbox read shape.
-            // `companionData` supplies this locale's written translations;
-            // components are read on the transaction (read-your-writes).
+            // `dataCompanionValues` supplies this locale's FULL post-write
+            // translation state (prior values overlaid with this write's
+            // columns); components are read on the transaction (read-your-writes).
             const dataDoc = await this.buildSingleWebhookDoc(
               tx,
               existingDoc.id,
@@ -939,8 +989,9 @@ export class SingleMutationService extends BaseService {
               rows[0],
               fieldConfigs,
               companion,
-              companionData,
-              snapshotLocale
+              dataCompanionValues,
+              snapshotLocale,
+              dataLocaleStatus
             );
 
             // The single's field tree with component references expanded, so the
@@ -960,47 +1011,50 @@ export class SingleMutationService extends BaseService {
             );
 
             // A publish/unpublish is a status change, so only a write that
-            // ASSIGNS a status can trigger one. `writtenStatus` is the status
-            // this write sets — the patch's status (kept on `updatePayload` even
-            // when the main column is left untouched for a non-default locale) or
-            // the per-locale companion status — and is undefined for a
-            // content-only edit, which then transitions nothing. Skipped entirely
-            // when the single has no status concept.
-            const singleHasStatus =
-              (singleMeta as { status?: boolean }).status === true ||
-              companion?.hasStatus === true;
-            const writtenStatus =
-              (typeof (updatePayload as { status?: unknown }).status ===
-              "string"
-                ? ((updatePayload as { status?: unknown }).status as string)
-                : undefined) ?? companionStatus;
-            // The status this write moves away from: this locale's committed
-            // companion status when the single stores per-locale status, else the
-            // main row's prior status.
-            const priorStatus =
-              previousCompanionStatus !== null
-                ? previousCompanionStatus
-                : typeof preRow?.status === "string"
-                  ? preRow.status
-                  : undefined;
+            // ASSIGNS a status can trigger one — the `writtenStatus` gate keeps
+            // a content-only edit from transitioning. The prior/next states are
+            // this locale's own (`previousLocaleStatus`/`dataLocaleStatus`,
+            // resolved above), so a first non-default-locale publish under a
+            // published default still fires `single.published` and a draft write
+            // never emits a false `single.unpublished`.
             const publishedTransition =
               singleHasStatus &&
-              writtenStatus === "published" &&
-              priorStatus !== "published";
+              dataLocaleStatus === "published" &&
+              previousLocaleStatus !== "published";
             const unpublishedTransition =
               singleHasStatus &&
               writtenStatus !== undefined &&
-              writtenStatus !== "published" &&
-              priorStatus === "published";
+              dataLocaleStatus !== "published" &&
+              previousLocaleStatus === "published";
 
             const actor = actorForWrite(options.actor ?? null, options.user);
+            // A component subtree read at the write locale is per-locale state,
+            // so a component-only translation edit counts as locale-specific.
+            const eventComponentFields = fieldConfigs.filter(
+              (f): f is typeof f & { name: string } =>
+                isComponentField(f) && !!f.name
+            );
+            const eventHasLocalizedComponents =
+              snapshotLocale !== undefined &&
+              eventComponentFields.some(f => dataDoc[f.name] !== undefined);
+            // `locale` rides only when the write genuinely stored per-locale
+            // data: this write touched localized Single columns, set a per-locale
+            // status, or captured localized component state. A plain
+            // non-localized Single gets none. Mirrors the version-capture gate so
+            // the event and the snapshot agree on what is locale-specific.
+            const eventLocale: string | null =
+              Object.keys(companionData).length > 0 ||
+              companionStatus !== undefined ||
+              eventHasLocalizedComponents
+                ? (snapshotLocale ?? null)
+                : null;
             // `single` FORBIDS a `collection` slug; `locale` rides only when the
             // single (or an embedded component) is localized, so a receiver can
             // tell one language's write apart from another's.
             const resource: WebhookResource = {
               kind: "single",
               id: existingDoc.id,
-              ...(snapshotLocale != null ? { locale: snapshotLocale } : {}),
+              ...(eventLocale != null ? { locale: eventLocale } : {}),
             };
             await recordMutationEvent(tx, {
               type: "single.updated",

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -47,6 +47,7 @@ import {
   stripSystemOwnerField,
 } from "../../../shared/lib/password-fields";
 import type { Logger } from "../../../shared/types";
+import { isFieldLocalized } from "../../i18n/classify-fields";
 import {
   isBlank,
   populateCompanionFields,
@@ -191,9 +192,16 @@ export class SingleMutationService extends BaseService {
           .filter((n): n is string => !!n)
       );
       for (const f of companion.localizedFields) {
-        if (Object.prototype.hasOwnProperty.call(companionValues, f.column)) {
-          parentRow[f.name] = companionValues[f.column];
-        }
+        // Every localized field appears in the read shape — its stored/written
+        // value or null (untranslated), matching populateCompanionFields — so a
+        // partial translation write's payload lists all localized fields, not
+        // only the touched ones.
+        parentRow[f.name] = Object.prototype.hasOwnProperty.call(
+          companionValues,
+          f.column
+        )
+          ? companionValues[f.column]
+          : null;
         // The post-write main row may carry the raw snake_case companion column
         // (merged back after the upsert); the read shape keys a translatable
         // value by field name only, so drop the raw column so `data` and
@@ -550,6 +558,20 @@ export class SingleMutationService extends BaseService {
       // from the callback (not assigned to an outer variable), so the value read
       // below is only ever the committed result. A localized single writes
       // `mainPayload` (translatable columns moved to the companion).
+      // Probe the companion `_locales` table's existence on the POOLED adapter
+      // BEFORE the write transaction opens. Two reasons it must be here and not
+      // inside the transaction: with a single-connection pool the transaction
+      // holds the only connection, so a pooled probe inside it would deadlock;
+      // and probing on the transaction connection would abort the whole
+      // transaction on Postgres when the not-yet-migrated table is absent. The
+      // in-transaction companion reads are skipped when this is false.
+      const companionPhysicallyExists =
+        companion && writeLocale !== undefined
+          ? await companionTableExists(
+              this.adapter,
+              companion.companionTableName
+            )
+          : false;
       let updatedRows: SingleDocument[];
       try {
         // Retry the whole update+capture transaction on a version_no allocation
@@ -650,19 +672,8 @@ export class SingleMutationService extends BaseService {
             // `previous`/`data` diff symmetrically.
             const previousCompanionValues: Record<string, unknown> = {};
             let previousCompanionStatus: string | null = null;
-            // A companion read inside THIS write transaction that hits a
-            // not-yet-migrated `_locales` table aborts the whole transaction on
-            // Postgres (it does not merely return empty), which would roll back
-            // even a shared-field update that never needed the companion. Probe
-            // existence on the pooled adapter first — off the transaction — and
-            // skip the reads when the companion is absent.
-            const companionPhysicallyExists =
-              companion && writeLocale !== undefined
-                ? await companionTableExists(
-                    this.adapter,
-                    companion.companionTableName
-                  )
-                : false;
+            // `companionPhysicallyExists` was probed off the transaction above;
+            // skip the in-transaction companion reads when the table is absent.
             if (
               companion &&
               writeLocale !== undefined &&
@@ -760,14 +771,47 @@ export class SingleMutationService extends BaseService {
             // not mistaken for a localized component write. A non-localized
             // component written at a locale is the narrower edge this shares
             // with the version-capture gate.
-            const wroteLocalizedComponents =
+            // A component write is per-locale only when a WRITTEN component
+            // actually declares a localized field. Keying off the Single's own
+            // localization is wrong both ways: a non-localized Single can embed a
+            // localized component (whose write DOES store per-locale data), and a
+            // localized Single can embed a purely shared one. Resolve each
+            // written component's schema on the transaction to decide.
+            let wroteLocalizedComponents = false;
+            if (
               snapshotLocale !== undefined &&
-              // A component write is per-locale only when the Single itself is
-              // localized (has a companion). A non-localized Single stores only
-              // shared component rows, so its component edits are not
-              // locale-specific and must not tag the event with a locale.
-              companion !== null &&
-              Object.keys(componentFieldData).length > 0;
+              this.componentDataService &&
+              Object.keys(componentFieldData).length > 0
+            ) {
+              const appLocalized = this.localization !== undefined;
+              for (const writtenName of Object.keys(componentFieldData)) {
+                const fieldConfig = fieldConfigs.find(
+                  f => "name" in f && f.name === writtenName
+                );
+                if (!fieldConfig || !isComponentField(fieldConfig)) continue;
+                const componentSlug = fieldConfig.component;
+                if (!componentSlug) continue;
+                const componentFields =
+                  await this.componentDataService.getComponentFields(
+                    componentSlug,
+                    tx.getDrizzle()
+                  );
+                const hasLocalizedField = (componentFields ?? []).some(cf =>
+                  isFieldLocalized(
+                    {
+                      type: cf.type,
+                      name: "name" in cf && cf.name ? cf.name : "",
+                      localized: "localized" in cf ? cf.localized : undefined,
+                    },
+                    appLocalized
+                  )
+                );
+                if (hasLocalizedField) {
+                  wroteLocalizedComponents = true;
+                  break;
+                }
+              }
+            }
             // `locale` rides the event only when the write genuinely stored
             // per-locale data: it touched localized Single columns, set a
             // per-locale status, or wrote localized component data. A plain

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -47,7 +47,6 @@ import {
   stripSystemOwnerField,
 } from "../../../shared/lib/password-fields";
 import type { Logger } from "../../../shared/types";
-import { isFieldLocalized } from "../../i18n/classify-fields";
 import {
   isBlank,
   populateCompanionFields,
@@ -146,6 +145,36 @@ export class SingleMutationService extends BaseService {
   // ============================================================
   // Webhook helpers
   // ============================================================
+
+  /**
+   * Read a Single's FULL companion translation state for one locale, keyed by
+   * companion column — every localized field carries its stored value or is
+   * absent (untranslated). Used to assemble the default-locale view for a
+   * shared-field event on a localized Single, whose write locale may differ
+   * from the default and so is not already in hand.
+   */
+  private async readCompanionLocaleValues(
+    tx: TransactionContext,
+    companion: CompanionSchema,
+    entryId: string,
+    locale: string
+  ): Promise<Record<string, unknown>> {
+    const localeRow: Record<string, unknown> = { id: entryId };
+    await populateCompanionFields({
+      db: tx.getDrizzle<Parameters<typeof populateCompanionFields>[0]["db"]>(),
+      companionTable: companion.table,
+      localizedFields: companion.localizedFields,
+      rows: [localeRow],
+      localeChain: [locale],
+    });
+    const values: Record<string, unknown> = {};
+    for (const f of companion.localizedFields) {
+      if (localeRow[f.name] !== undefined) {
+        values[f.column] = localeRow[f.name];
+      }
+    }
+    return values;
+  }
 
   /**
    * Assemble a Single's main row plus its component subtrees into the read
@@ -771,19 +800,21 @@ export class SingleMutationService extends BaseService {
             // not mistaken for a localized component write. A non-localized
             // component written at a locale is the narrower edge this shares
             // with the version-capture gate.
-            // A component write is per-locale only when a WRITTEN component
-            // actually declares a localized field. Keying off the Single's own
-            // localization is wrong both ways: a non-localized Single can embed a
-            // localized component (whose write DOES store per-locale data), and a
-            // localized Single can embed a purely shared one. Resolve each
-            // written component's schema on the transaction to decide.
+            // A component write is per-locale only when a WRITTEN component's OWN
+            // definition is localized. That is the exact gate the storage path
+            // uses (`meta.localized !== true` keeps all of a component's data on
+            // its shared main table), so it holds both ways: a non-localized
+            // Single can embed a localized component (whose write DOES store
+            // per-locale data), and a localized Single can embed a purely shared
+            // one. Reading inner field types instead would over-tag a shared
+            // component that merely carries text fields as locale-specific.
             let wroteLocalizedComponents = false;
             if (
               snapshotLocale !== undefined &&
               this.componentDataService &&
+              this.localization !== undefined &&
               Object.keys(componentFieldData).length > 0
             ) {
-              const appLocalized = this.localization !== undefined;
               for (const writtenName of Object.keys(componentFieldData)) {
                 const fieldConfig = fieldConfigs.find(
                   f => "name" in f && f.name === writtenName
@@ -791,22 +822,12 @@ export class SingleMutationService extends BaseService {
                 if (!fieldConfig || !isComponentField(fieldConfig)) continue;
                 const componentSlug = fieldConfig.component;
                 if (!componentSlug) continue;
-                const componentFields =
-                  await this.componentDataService.getComponentFields(
+                if (
+                  await this.componentDataService.isComponentLocalized(
                     componentSlug,
                     tx.getDrizzle()
-                  );
-                const hasLocalizedField = (componentFields ?? []).some(cf =>
-                  isFieldLocalized(
-                    {
-                      type: cf.type,
-                      name: "name" in cf && cf.name ? cf.name : "",
-                      localized: "localized" in cf ? cf.localized : undefined,
-                    },
-                    appLocalized
                   )
-                );
-                if (hasLocalizedField) {
+                ) {
                   wroteLocalizedComponents = true;
                   break;
                 }
@@ -832,12 +853,42 @@ export class SingleMutationService extends BaseService {
             // to `previous` and `data` so the diff stays like-for-like.
             const overlayLocaleStatus =
               eventLocale != null || writtenStatus !== undefined;
+            // For a shared/non-locale-specific event on a LOCALIZED single, the
+            // payload represents the default view (a no-locale read resolves to
+            // the default locale), so it must carry the default locale's
+            // translations — not null them out (empty companion values) and not
+            // the write locale's content (which would be unlabeled
+            // locale-specific data). A shared-field write never touches any
+            // localized column, so the default locale's translations are the
+            // same before and after; a default-locale (or non-localized) write
+            // already read them into `previousCompanionValues`, while a
+            // non-default write locale needs them read explicitly.
+            const defaultLocale = this.localization?.defaultLocale;
+            let defaultViewCompanion: Record<string, unknown> = {};
+            let defaultViewLocale: string | undefined;
+            if (
+              eventLocale == null &&
+              companion &&
+              companionPhysicallyExists &&
+              defaultLocale !== undefined
+            ) {
+              defaultViewLocale = defaultLocale;
+              defaultViewCompanion =
+                writeLocale === defaultLocale
+                  ? previousCompanionValues
+                  : await this.readCompanionLocaleValues(
+                      tx,
+                      companion,
+                      existingDoc.id,
+                      defaultLocale
+                    );
+            }
+
             // The locale the payload REPRESENTS. A locale-specific event reads
             // component subtrees at, and overlays translations for, the write
-            // locale; a shared/default event reads the default view so
-            // `data`/`previous` never carry locale-specific content without a
-            // matching `resource.locale`.
-            const payloadLocale = eventLocale ?? undefined;
+            // locale; a shared event on a localized single reads the default
+            // view; a non-localized single has no locale.
+            const payloadLocale = eventLocale ?? defaultViewLocale;
 
             const previousDoc = preRow
               ? await this.buildSingleWebhookDoc(
@@ -847,7 +898,9 @@ export class SingleMutationService extends BaseService {
                   preRow,
                   fieldConfigs,
                   companion,
-                  eventLocale != null ? previousCompanionValues : {},
+                  eventLocale != null
+                    ? previousCompanionValues
+                    : defaultViewCompanion,
                   payloadLocale,
                   overlayLocaleStatus ? previousLocaleStatus : undefined
                 )
@@ -1112,7 +1165,9 @@ export class SingleMutationService extends BaseService {
             // Assemble the just-written document in the outbox read shape.
             // `dataCompanionValues` supplies this locale's FULL post-write
             // translation state (prior values overlaid with this write's
-            // columns); components are read on the transaction (read-your-writes).
+            // columns); a shared-field event instead carries the default view
+            // (`defaultViewCompanion`), which the shared write left untouched.
+            // Components are read on the transaction (read-your-writes).
             const dataDoc = await this.buildSingleWebhookDoc(
               tx,
               existingDoc.id,
@@ -1120,7 +1175,7 @@ export class SingleMutationService extends BaseService {
               rows[0],
               fieldConfigs,
               companion,
-              eventLocale != null ? dataCompanionValues : {},
+              eventLocale != null ? dataCompanionValues : defaultViewCompanion,
               payloadLocale,
               overlayLocaleStatus ? dataLocaleStatus : undefined
             );

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -48,6 +48,7 @@ import {
 } from "../../../shared/lib/password-fields";
 import type { Logger } from "../../../shared/types";
 import {
+  isBlank,
   populateCompanionFields,
   readCompanionLocaleStatus,
 } from "../../i18n/companion-join";
@@ -58,6 +59,7 @@ import {
 } from "../../i18n/resolve-locale";
 import {
   buildCompanionSchema,
+  companionTableExists,
   splitLocalizedWrite,
   upsertCompanionRow,
   type CompanionSchema,
@@ -180,6 +182,14 @@ export class SingleMutationService extends BaseService {
     // A localized single's main row omits translatable columns (split to the
     // companion), so overlay this locale's values back on, keyed by field.name.
     if (companion) {
+      // A shared field can legitimately be NAMED like a localized field's
+      // physical column (e.g. a shared `meta_title` next to localized
+      // `metaTitle` → column `meta_title`); never drop such a real field.
+      const mainFieldNames = new Set(
+        fieldConfigs
+          .map(f => ("name" in f ? f.name : undefined))
+          .filter((n): n is string => !!n)
+      );
       for (const f of companion.localizedFields) {
         if (Object.prototype.hasOwnProperty.call(companionValues, f.column)) {
           parentRow[f.name] = companionValues[f.column];
@@ -187,8 +197,13 @@ export class SingleMutationService extends BaseService {
         // The post-write main row may carry the raw snake_case companion column
         // (merged back after the upsert); the read shape keys a translatable
         // value by field name only, so drop the raw column so `data` and
-        // `previous` keep an identical key set.
-        if (f.column !== f.name && f.column in parentRow) {
+        // `previous` keep an identical key set — unless it is itself a declared
+        // shared field, whose value must survive.
+        if (
+          f.column !== f.name &&
+          f.column in parentRow &&
+          !mainFieldNames.has(f.column)
+        ) {
           delete parentRow[f.column];
         }
       }
@@ -635,7 +650,24 @@ export class SingleMutationService extends BaseService {
             // `previous`/`data` diff symmetrically.
             const previousCompanionValues: Record<string, unknown> = {};
             let previousCompanionStatus: string | null = null;
-            if (companion && writeLocale !== undefined) {
+            // A companion read inside THIS write transaction that hits a
+            // not-yet-migrated `_locales` table aborts the whole transaction on
+            // Postgres (it does not merely return empty), which would roll back
+            // even a shared-field update that never needed the companion. Probe
+            // existence on the pooled adapter first — off the transaction — and
+            // skip the reads when the companion is absent.
+            const companionPhysicallyExists =
+              companion && writeLocale !== undefined
+                ? await companionTableExists(
+                    this.adapter,
+                    companion.companionTableName
+                  )
+                : false;
+            if (
+              companion &&
+              writeLocale !== undefined &&
+              companionPhysicallyExists
+            ) {
               const preLocaleRow: Record<string, unknown> = {
                 id: existingDoc.id,
               };
@@ -674,9 +706,20 @@ export class SingleMutationService extends BaseService {
             // overlaid with the columns this write touched. No extra DB read —
             // the prior values were just read above and `companionData` holds
             // this write's serialized translatable values.
+            // Normalize blank written translations ("") to null so `data`
+            // matches the read-shape convention `populateCompanionFields` used
+            // for `previous`; without this a blank→blank edit would show
+            // `data.field === ""` vs `previous === null` and appear in
+            // `changedFields` for a field whose effective value did not change.
+            const normalizedWrittenCompanion: Record<string, unknown> = {};
+            for (const [column, value] of Object.entries(companionData)) {
+              normalizedWrittenCompanion[column] = isBlank(value)
+                ? null
+                : value;
+            }
             const dataCompanionValues: Record<string, unknown> = {
               ...previousCompanionValues,
-              ...companionData,
+              ...normalizedWrittenCompanion,
             };
 
             // Whether the single stores this write's status per locale. True
@@ -719,6 +762,11 @@ export class SingleMutationService extends BaseService {
             // with the version-capture gate.
             const wroteLocalizedComponents =
               snapshotLocale !== undefined &&
+              // A component write is per-locale only when the Single itself is
+              // localized (has a companion). A non-localized Single stores only
+              // shared component rows, so its component edits are not
+              // locale-specific and must not tag the event with a locale.
+              companion !== null &&
               Object.keys(componentFieldData).length > 0;
             // `locale` rides the event only when the write genuinely stored
             // per-locale data: it touched localized Single columns, set a
@@ -740,6 +788,12 @@ export class SingleMutationService extends BaseService {
             // to `previous` and `data` so the diff stays like-for-like.
             const overlayLocaleStatus =
               eventLocale != null || writtenStatus !== undefined;
+            // The locale the payload REPRESENTS. A locale-specific event reads
+            // component subtrees at, and overlays translations for, the write
+            // locale; a shared/default event reads the default view so
+            // `data`/`previous` never carry locale-specific content without a
+            // matching `resource.locale`.
+            const payloadLocale = eventLocale ?? undefined;
 
             const previousDoc = preRow
               ? await this.buildSingleWebhookDoc(
@@ -749,8 +803,8 @@ export class SingleMutationService extends BaseService {
                   preRow,
                   fieldConfigs,
                   companion,
-                  previousCompanionValues,
-                  snapshotLocale,
+                  eventLocale != null ? previousCompanionValues : {},
+                  payloadLocale,
                   overlayLocaleStatus ? previousLocaleStatus : undefined
                 )
               : null;
@@ -1022,8 +1076,8 @@ export class SingleMutationService extends BaseService {
               rows[0],
               fieldConfigs,
               companion,
-              dataCompanionValues,
-              snapshotLocale,
+              eventLocale != null ? dataCompanionValues : {},
+              payloadLocale,
               overlayLocaleStatus ? dataLocaleStatus : undefined
             );
 

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -97,6 +97,37 @@ import {
 } from "./single-utils";
 
 /**
+ * The component slug(s) a written component field value actually stored. A
+ * single-component field (`component`) names one slug on its config; a
+ * dynamic-zone field (`components`) stores a written instance per entry, each
+ * discriminated by `_componentType` — so only the blocks the write used are
+ * returned, never the whole allow-list. Used to decide whether a component
+ * write was per-locale (any written component whose definition is localized).
+ */
+function writtenComponentSlugs(
+  fieldConfig: { component?: string; components?: string[] },
+  value: unknown
+): string[] {
+  if (fieldConfig.component) {
+    return [fieldConfig.component];
+  }
+  const instances = Array.isArray(value) ? value : value != null ? [value] : [];
+  const slugs = new Set<string>();
+  for (const instance of instances) {
+    if (
+      instance &&
+      typeof instance === "object" &&
+      "_componentType" in instance &&
+      typeof (instance as { _componentType?: unknown })._componentType ===
+        "string"
+    ) {
+      slugs.add((instance as { _componentType: string })._componentType);
+    }
+  }
+  return [...slugs];
+}
+
+/**
  * SingleMutationService
  *
  * Handles the write-path for Single documents. The get-style helpers
@@ -166,6 +197,10 @@ export class SingleMutationService extends BaseService {
       localizedFields: companion.localizedFields,
       rows: [localeRow],
       localeChain: [locale],
+      // This read feeds a durable webhook payload and the caller has already
+      // confirmed the companion table exists, so a real read failure must abort
+      // the write rather than silently ship nulled default-view translations.
+      strict: true,
     });
     const values: Record<string, unknown> = {};
     for (const f of companion.localizedFields) {
@@ -202,6 +237,7 @@ export class SingleMutationService extends BaseService {
     row: Record<string, unknown>,
     fieldConfigs: FieldConfig[],
     companion: CompanionSchema | null,
+    companionExists: boolean,
     companionValues: Record<string, unknown>,
     snapshotLocale: string | undefined,
     localeStatus?: string
@@ -211,7 +247,12 @@ export class SingleMutationService extends BaseService {
     const parentRow = convertTimestampsToCamelCase({ ...row });
     // A localized single's main row omits translatable columns (split to the
     // companion), so overlay this locale's values back on, keyed by field.name.
-    if (companion) {
+    // Skip the overlay when the companion table does not physically exist yet
+    // (a localized single before its companion migration runs): in that
+    // unmigrated state the translatable values still live on the main row, so
+    // nulling them here would drop existing translations and report bogus
+    // changed fields.
+    if (companion && companionExists) {
       // A shared field can legitimately be NAMED like a localized field's
       // physical column (e.g. a shared `meta_title` next to localized
       // `metaTitle` → column `meta_title`); never drop such a real field.
@@ -820,14 +861,29 @@ export class SingleMutationService extends BaseService {
                   f => "name" in f && f.name === writtenName
                 );
                 if (!fieldConfig || !isComponentField(fieldConfig)) continue;
-                const componentSlug = fieldConfig.component;
-                if (!componentSlug) continue;
-                if (
-                  await this.componentDataService.isComponentLocalized(
-                    componentSlug,
-                    tx.getDrizzle()
-                  )
-                ) {
+                // The component slug(s) this write actually stored: a
+                // single-component field names one slug on its config; a
+                // dynamic-zone field names each written instance's
+                // `_componentType`, so only the blocks the write used count (a
+                // zone that merely ALLOWS a localized component does not
+                // over-tag a write that used only shared ones).
+                const writtenSlugs = writtenComponentSlugs(
+                  fieldConfig,
+                  componentFieldData[writtenName]
+                );
+                let anyLocalized = false;
+                for (const slug of writtenSlugs) {
+                  if (
+                    await this.componentDataService.isComponentLocalized(
+                      slug,
+                      tx.getDrizzle()
+                    )
+                  ) {
+                    anyLocalized = true;
+                    break;
+                  }
+                }
+                if (anyLocalized) {
                   wroteLocalizedComponents = true;
                   break;
                 }
@@ -898,6 +954,7 @@ export class SingleMutationService extends BaseService {
                   preRow,
                   fieldConfigs,
                   companion,
+                  companionPhysicallyExists,
                   eventLocale != null
                     ? previousCompanionValues
                     : defaultViewCompanion,
@@ -1175,6 +1232,7 @@ export class SingleMutationService extends BaseService {
               rows[0],
               fieldConfigs,
               companion,
+              companionPhysicallyExists,
               eventLocale != null ? dataCompanionValues : defaultViewCompanion,
               payloadLocale,
               overlayLocaleStatus ? dataLocaleStatus : undefined
@@ -1214,11 +1272,15 @@ export class SingleMutationService extends BaseService {
               previousLocaleStatus === "published";
 
             const actor = actorForWrite(options.actor ?? null, options.user);
-            // `single` FORBIDS a `collection` slug; `locale` rides only when the
-            // single (or an embedded component) is localized, so a receiver can
-            // tell one language's write apart from another's.
+            // `slug` identifies WHICH single changed so a receiver can route the
+            // event without scanning for the opaque document id; `single` still
+            // FORBIDS an entry `collection` (the slug never feeds the collections
+            // filter). `locale` rides only when the single (or an embedded
+            // component) is localized, so a receiver can tell one language's
+            // write apart from another's.
             const resource: WebhookResource = {
               kind: "single",
+              slug,
               id: existingDoc.id,
               ...(eventLocale != null ? { locale: eventLocale } : {}),
             };

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -47,7 +47,10 @@ import {
   stripSystemOwnerField,
 } from "../../../shared/lib/password-fields";
 import type { Logger } from "../../../shared/types";
-import { populateCompanionFields } from "../../i18n/companion-join";
+import {
+  populateCompanionFields,
+  readCompanionLocaleStatus,
+} from "../../i18n/companion-join";
 import type { SanitizedLocalizationConfig } from "../../i18n/config/types";
 import {
   isValidLocale,
@@ -266,33 +269,6 @@ export class SingleMutationService extends BaseService {
     return doc;
   }
 
-  /**
-   * The write locale's per-locale `_status`, or null when the companion row
-   * has none.
-   *
-   * Read with raw `tx.execute` (matching upsertCompanionRow): the companion
-   * `_locales` table is not in the Drizzle schema, and the CRUD helpers
-   * camelCase result keys, which would rename `_status`.
-   */
-  private async readCompanionLocaleStatus(
-    tx: TransactionContext,
-    companionTableName: string,
-    entryId: string,
-    locale: string
-  ): Promise<string | null> {
-    const isMysqlDialect = this.adapter.dialect === "mysql";
-    const quote = (id: string) => (isMysqlDialect ? `\`${id}\`` : `"${id}"`);
-    const placeholder = (i: number) =>
-      this.adapter.dialect === "postgresql" ? `$${i}` : "?";
-    const rows = await tx.execute<{ _status?: unknown }>(
-      `SELECT ${quote("_status")} FROM ${quote(companionTableName)} ` +
-        `WHERE ${quote("_parent")} = ${placeholder(1)} AND ${quote("_locale")} = ${placeholder(2)} LIMIT 1`,
-      [entryId, locale]
-    );
-    const status = rows[0]?._status;
-    return typeof status === "string" ? status : null;
-  }
-
   // ============================================================
   // Public API
   // ============================================================
@@ -310,6 +286,11 @@ export class SingleMutationService extends BaseService {
   ): Promise<SingleResult> {
     this.logger.debug("Updating Single document", { slug, options });
 
+    // Set true once the update transaction commits with a real write (which
+    // always appends the outbox event); lets the catch and the `!updated`
+    // return report a committed-but-post-hook-failed write as `eventRecorded`
+    // even when `success` is false. Declared out here so every return sees it.
+    let eventRecorded = false;
     try {
       // 1. Get Single metadata from registry
       const singleMeta = await this.singleRegistryService.getSingleBySlug(slug);
@@ -604,6 +585,17 @@ export class SingleMutationService extends BaseService {
               delete (mainPayload as Record<string, unknown>).status;
             }
 
+            // Take the row lock the UPDATE below needs anyway, before reading
+            // the prior main row and companion values. Without it a concurrent
+            // update can commit between this read and this attempt's UPDATE,
+            // leaving `previous` predating the other writer's fields while the
+            // post-write document carries them — the diff would then attribute
+            // that change to this event. Locking a few statements early costs
+            // little since the UPDATE takes the same lock until commit either
+            // way; the adapter no-ops where row locking is unsupported (SQLite
+            // already serializes writers via BEGIN IMMEDIATE).
+            await tx.lockRow(singleMeta.tableName, existingDoc.id);
+
             // Read the pre-write main row on THIS transaction before the update
             // overwrites it, so the outbox `previous` reports the prior state
             // and the changed-field diff is accurate. Re-read every attempt
@@ -665,9 +657,14 @@ export class SingleMutationService extends BaseService {
               // on `hasStatus`: querying `_status` on a companion without it
               // would fail the whole write.
               if (companion.hasStatus) {
-                previousCompanionStatus = await this.readCompanionLocaleStatus(
-                  tx,
-                  companion.companionTableName,
+                // Read on the write transaction's Drizzle handle (read-your-
+                // writes, no raw SQL) so the prior per-locale status is the one
+                // this attempt sees before the upsert below overwrites it.
+                previousCompanionStatus = await readCompanionLocaleStatus(
+                  tx.getDrizzle<
+                    Parameters<typeof readCompanionLocaleStatus>[0]
+                  >(),
+                  companion.table,
                   existingDoc.id,
                   writeLocale
                 );
@@ -714,6 +711,36 @@ export class SingleMutationService extends BaseService {
             // keeps the current status.
             const dataLocaleStatus = writtenStatus ?? previousLocaleStatus;
 
+            // Whether this write genuinely stored per-locale component data.
+            // Derived from the write INPUT (`componentFieldData`), not the read-
+            // back doc: a scalar-only edit persists no component data, so it is
+            // not mistaken for a localized component write. A non-localized
+            // component written at a locale is the narrower edge this shares
+            // with the version-capture gate.
+            const wroteLocalizedComponents =
+              snapshotLocale !== undefined &&
+              Object.keys(componentFieldData).length > 0;
+            // `locale` rides the event only when the write genuinely stored
+            // per-locale data: it touched localized Single columns, set a
+            // per-locale status, or wrote localized component data. A plain
+            // non-localized Single (or a shared-field-only edit) gets none, so a
+            // receiver can tell one language's write apart from another's.
+            const eventLocale: string | null =
+              Object.keys(companionData).length > 0 ||
+              companionStatus !== undefined ||
+              wroteLocalizedComponents
+                ? (snapshotLocale ?? null)
+                : null;
+            // Only overlay a per-locale status onto the outbox docs for a
+            // genuinely per-locale event — one that rides a `locale` or that
+            // assigned a status. Otherwise leave the assembled MAIN-row status
+            // in place so a non-locale-specific write (e.g. a shared-field edit
+            // on a non-default locale with no companion row) does not report a
+            // per-locale "draft" over a published main row. Applied symmetrically
+            // to `previous` and `data` so the diff stays like-for-like.
+            const overlayLocaleStatus =
+              eventLocale != null || writtenStatus !== undefined;
+
             const previousDoc = preRow
               ? await this.buildSingleWebhookDoc(
                   tx,
@@ -724,7 +751,7 @@ export class SingleMutationService extends BaseService {
                   companion,
                   previousCompanionValues,
                   snapshotLocale,
-                  previousLocaleStatus
+                  overlayLocaleStatus ? previousLocaleStatus : undefined
                 )
               : null;
 
@@ -997,7 +1024,7 @@ export class SingleMutationService extends BaseService {
               companion,
               dataCompanionValues,
               snapshotLocale,
-              dataLocaleStatus
+              overlayLocaleStatus ? dataLocaleStatus : undefined
             );
 
             // The single's field tree with component references expanded, so the
@@ -1034,26 +1061,6 @@ export class SingleMutationService extends BaseService {
               previousLocaleStatus === "published";
 
             const actor = actorForWrite(options.actor ?? null, options.user);
-            // A component subtree read at the write locale is per-locale state,
-            // so a component-only translation edit counts as locale-specific.
-            const eventComponentFields = fieldConfigs.filter(
-              (f): f is typeof f & { name: string } =>
-                isComponentField(f) && !!f.name
-            );
-            const eventHasLocalizedComponents =
-              snapshotLocale !== undefined &&
-              eventComponentFields.some(f => dataDoc[f.name] !== undefined);
-            // `locale` rides only when the write genuinely stored per-locale
-            // data: this write touched localized Single columns, set a per-locale
-            // status, or captured localized component state. A plain
-            // non-localized Single gets none. Mirrors the version-capture gate so
-            // the event and the snapshot agree on what is locale-specific.
-            const eventLocale: string | null =
-              Object.keys(companionData).length > 0 ||
-              companionStatus !== undefined ||
-              eventHasLocalizedComponents
-                ? (snapshotLocale ?? null)
-                : null;
             // `single` FORBIDS a `collection` slug; `locale` rides only when the
             // single (or an embedded component) is localized, so a receiver can
             // tell one language's write apart from another's.
@@ -1109,11 +1116,20 @@ export class SingleMutationService extends BaseService {
         throw error;
       }
 
+      // The transaction committed (a throw would have propagated above), so a
+      // real write is now durable together with its outbox event. Gate on the
+      // written row: the empty-rows path returns from the tx before recording
+      // anything, so it owes no delivery.
+      eventRecorded = updatedRows.length > 0;
+
       if (updatedRows.length === 0) {
         return {
           success: false,
           statusCode: 500,
           message: "Failed to update Single document",
+          // Carries the per-write state; here it is false (nothing was recorded
+          // for an empty write) but is threaded for parity with the other returns.
+          eventRecorded,
         };
       }
 
@@ -1188,10 +1204,17 @@ export class SingleMutationService extends BaseService {
         success: true,
         statusCode: 200,
         data: updatedDoc,
+        eventRecorded,
       };
     } catch (error) {
       this.logger.error("Failed to update Single document", { slug, error });
-      return buildSingleErrorResult(error, "Failed to update Single document");
+      // A post-commit step (afterChange/afterUpdate hook, response expansion)
+      // can throw after the event is already durable; carry `eventRecorded` so
+      // the fast-drain still fires for a committed-but-hook-failed write.
+      return {
+        ...buildSingleErrorResult(error, "Failed to update Single document"),
+        eventRecorded,
+      };
     }
   }
 }

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -47,6 +47,7 @@ import {
   stripSystemOwnerField,
 } from "../../../shared/lib/password-fields";
 import type { Logger } from "../../../shared/types";
+import { resolveLocalizedFieldNames } from "../../i18n/classify-fields";
 import {
   isBlank,
   populateCompanionFields,
@@ -97,22 +98,29 @@ import {
 } from "./single-utils";
 
 /**
- * The component slug(s) a written component field value actually stored. A
- * single-component field (`component`) names one slug on its config; a
- * dynamic-zone field (`components`) stores a written instance per entry, each
- * discriminated by `_componentType` — so only the blocks the write used are
- * returned, never the whole allow-list. Used to decide whether a component
- * write was per-locale (any written component whose definition is localized).
+ * The component instances a written component field value actually stored,
+ * each paired with its slug and its written data. A single-component field
+ * (`component`) yields one instance keyed by its config slug; a dynamic-zone
+ * field (`components`) yields one per written block, each discriminated by
+ * `_componentType` — so only the blocks the write used are returned, never the
+ * whole allow-list. Used to decide whether a component write was per-locale.
  */
-function writtenComponentSlugs(
+function writtenComponentInstances(
   fieldConfig: { component?: string; components?: string[] },
   value: unknown
-): string[] {
+): Array<{ slug: string; data: Record<string, unknown> }> {
   if (fieldConfig.component) {
-    return [fieldConfig.component];
+    return value && typeof value === "object" && !Array.isArray(value)
+      ? [
+          {
+            slug: fieldConfig.component,
+            data: value as Record<string, unknown>,
+          },
+        ]
+      : [];
   }
   const instances = Array.isArray(value) ? value : value != null ? [value] : [];
-  const slugs = new Set<string>();
+  const out: Array<{ slug: string; data: Record<string, unknown> }> = [];
   for (const instance of instances) {
     if (
       instance &&
@@ -121,10 +129,13 @@ function writtenComponentSlugs(
       typeof (instance as { _componentType?: unknown })._componentType ===
         "string"
     ) {
-      slugs.add((instance as { _componentType: string })._componentType);
+      out.push({
+        slug: (instance as { _componentType: string })._componentType,
+        data: instance as Record<string, unknown>,
+      });
     }
   }
-  return [...slugs];
+  return out;
 }
 
 /**
@@ -760,6 +771,11 @@ export class SingleMutationService extends BaseService {
                 localizedFields: companion.localizedFields,
                 rows: [preLocaleRow],
                 localeChain: [writeLocale],
+                // This pre-image read feeds the durable webhook `previous`
+                // payload and the table is already known to exist, so a real
+                // read failure must abort the write rather than silently ship a
+                // nulled `previous` (which would corrupt `changedFields`).
+                strict: true,
               });
               for (const f of companion.localizedFields) {
                 if (preLocaleRow[f.name] !== undefined) {
@@ -861,29 +877,47 @@ export class SingleMutationService extends BaseService {
                   f => "name" in f && f.name === writtenName
                 );
                 if (!fieldConfig || !isComponentField(fieldConfig)) continue;
-                // The component slug(s) this write actually stored: a
-                // single-component field names one slug on its config; a
-                // dynamic-zone field names each written instance's
-                // `_componentType`, so only the blocks the write used count (a
-                // zone that merely ALLOWS a localized component does not
-                // over-tag a write that used only shared ones).
-                const writtenSlugs = writtenComponentSlugs(
+                // The instances this write actually stored: a single-component
+                // field yields one; a dynamic-zone field yields each written
+                // `_componentType` block (only the blocks the write used).
+                const instances = writtenComponentInstances(
                   fieldConfig,
                   componentFieldData[writtenName]
                 );
-                let anyLocalized = false;
-                for (const slug of writtenSlugs) {
+                let anyLocalizedWrite = false;
+                for (const { slug, data } of instances) {
+                  // A component stores per-locale data only when its OWN
+                  // definition is localized AND the write touches one of its
+                  // localized fields — its shared fields stay on the main
+                  // comp_* row for every locale. So a write that changes only a
+                  // localized component's shared fields is NOT per-locale.
                   if (
-                    await this.componentDataService.isComponentLocalized(
+                    !(await this.componentDataService.isComponentLocalized(
                       slug,
                       tx.getDrizzle()
-                    )
+                    ))
                   ) {
-                    anyLocalized = true;
+                    continue;
+                  }
+                  const componentFields =
+                    (await this.componentDataService.getComponentFields(
+                      slug,
+                      tx.getDrizzle()
+                    )) ?? [];
+                  const localizedNames = resolveLocalizedFieldNames(
+                    componentFields.map(cf => ({
+                      type: cf.type,
+                      name: "name" in cf && cf.name ? cf.name : "",
+                      localized: "localized" in cf ? cf.localized : undefined,
+                    })),
+                    true
+                  );
+                  if (localizedNames.some(name => data[name] !== undefined)) {
+                    anyLocalizedWrite = true;
                     break;
                   }
                 }
-                if (anyLocalized) {
+                if (anyLocalizedWrite) {
                   wroteLocalizedComponents = true;
                   break;
                 }

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -110,14 +110,13 @@ function writtenComponentInstances(
   value: unknown
 ): Array<{ slug: string; data: Record<string, unknown> }> {
   if (fieldConfig.component) {
-    return value && typeof value === "object" && !Array.isArray(value)
-      ? [
-          {
-            slug: fieldConfig.component,
-            data: value as Record<string, unknown>,
-          },
-        ]
-      : [];
+    // A fixed single-component field is one instance; with `repeatable: true`
+    // the value is an array of instances, all under the same component slug.
+    const slug = fieldConfig.component;
+    const items = Array.isArray(value) ? value : value != null ? [value] : [];
+    return items
+      .filter((d): d is Record<string, unknown> => !!d && typeof d === "object")
+      .map(d => ({ slug, data: d }));
   }
   const instances = Array.isArray(value) ? value : value != null ? [value] : [];
   const out: Array<{ slug: string; data: Record<string, unknown> }> = [];
@@ -337,6 +336,11 @@ export class SingleMutationService extends BaseService {
               // expanded related entry could smuggle its own hidden/password
               // fields into the payload. Matches the collection snapshot read.
               depth: 0,
+              // This read feeds the durable webhook payload inside the write
+              // transaction, so a component read failure must roll the write
+              // back rather than ship a payload with silently-missing component
+              // data and a corrupted changed-field diff.
+              strict: true,
               // Read as the locale the components were written at, with no
               // fallback, so an embedded localized component reports this
               // language's text rather than another standing in for it.
@@ -1133,6 +1137,10 @@ export class SingleMutationService extends BaseService {
                         parentTable: singleMeta.tableName,
                         fields: fieldConfigs,
                         executor: tx.getDrizzle(),
+                        // Surface a read failure (the catch below fails the
+                        // write) instead of silently capturing an incomplete
+                        // component snapshot in durable version history.
+                        strict: true,
                         // Read as the locale the components were written at,
                         // with no fallback, so an embedded localized component
                         // records this language's text rather than another's

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -20,8 +20,11 @@
  */
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
 
+import { actorForWrite } from "../../../auth/request-actor";
 import { isComponentField } from "../../../collections/fields/guards";
+import type { FieldConfig } from "../../../collections/fields/types";
 import type { RBACAccessControlService } from "../../../domains/auth/services/rbac-access-control-service";
 import { NextlyError } from "../../../errors/nextly-error";
 import type { HookRegistry } from "../../../hooks/hook-registry";
@@ -44,6 +47,7 @@ import {
   stripSystemOwnerField,
 } from "../../../shared/lib/password-fields";
 import type { Logger } from "../../../shared/types";
+import { populateCompanionFields } from "../../i18n/companion-join";
 import type { SanitizedLocalizationConfig } from "../../i18n/config/types";
 import {
   isValidLocale,
@@ -53,6 +57,7 @@ import {
   buildCompanionSchema,
   splitLocalizedWrite,
   upsertCompanionRow,
+  type CompanionSchema,
 } from "../../i18n/runtime/companion-io";
 import { captureInTx } from "../../versions/capture-in-tx";
 import {
@@ -62,6 +67,9 @@ import {
 } from "../../versions/tag-component-types";
 import { VersionCaptureService } from "../../versions/version-capture-service";
 import { withVersionConflictRetry } from "../../versions/version-conflict";
+import { expandComponentFields } from "../../webhooks/expand-component-fields";
+import { recordMutationEvent } from "../../webhooks/record-mutation-event";
+import type { WebhookResource } from "../../webhooks/types";
 import type {
   SingleDocument,
   SingleResult,
@@ -127,6 +135,145 @@ export class SingleMutationService extends BaseService {
       rbacAccessControlService,
       localization
     );
+  }
+
+  // ============================================================
+  // Webhook helpers
+  // ============================================================
+
+  /**
+   * Assemble a Single's main row plus its component subtrees into the read
+   * shape the outbox event carries — timestamps camelCased, this locale's
+   * translatable values overlaid by field name, password and system-owner
+   * columns stripped, JSON-backed fields parsed, and component subtrees
+   * populated. UNtagged (unlike the version snapshot, which tags component
+   * types): the webhook payload ships the plain read shape.
+   *
+   * Reused for BOTH the post-write `data` and the pre-write `previous` so the
+   * changed-field diff compares like with like. `companionValues` is keyed by
+   * companion column and holds only the translatable columns this write
+   * touches, so the two documents diff symmetrically — an untouched
+   * translation appears in neither. Components are read on the caller's
+   * transaction (read-your-writes) so a post-write call sees the subtrees just
+   * saved and a pre-write call sees the prior ones.
+   */
+  private async buildSingleWebhookDoc(
+    tx: TransactionContext,
+    entryId: string,
+    parentTable: string,
+    row: Record<string, unknown>,
+    fieldConfigs: FieldConfig[],
+    companion: CompanionSchema | null,
+    companionValues: Record<string, unknown>,
+    snapshotLocale: string | undefined
+  ): Promise<Record<string, unknown>> {
+    // Keep user field keys (which may contain underscores like `site_title`)
+    // exactly; convert only the timestamp columns so the shape matches a read.
+    const parentRow = convertTimestampsToCamelCase({ ...row });
+    // A localized single's main row omits translatable columns (split to the
+    // companion), so overlay this locale's values back on, keyed by field.name.
+    if (companion) {
+      for (const f of companion.localizedFields) {
+        if (Object.prototype.hasOwnProperty.call(companionValues, f.column)) {
+          parentRow[f.name] = companionValues[f.column];
+        }
+        // The post-write main row may carry the raw snake_case companion column
+        // (merged back after the upsert); the read shape keys a translatable
+        // value by field name only, so drop the raw column so `data` and
+        // `previous` keep an identical key set.
+        if (f.column !== f.name && f.column in parentRow) {
+          delete parentRow[f.column];
+        }
+      }
+    }
+    // Never let password hashes or the system owner column reach a webhook
+    // payload — same redaction the read/response path applies.
+    stripPasswordFieldValues(parentRow, fieldConfigs);
+    stripSystemOwnerField(parentRow);
+    // Parse JSON-backed fields (richtext, group, json, ...) to the read shape:
+    // on SQLite the row holds them as strings, so an unparsed value would not
+    // match a normal read.
+    for (const field of fieldConfigs) {
+      if (!("name" in field) || !field.name) continue;
+      const value = parentRow[field.name];
+      if (shouldTreatAsJson(field) && typeof value === "string") {
+        try {
+          parentRow[field.name] = JSON.parse(value);
+        } catch {
+          // Not valid JSON — keep the raw string.
+        }
+      }
+    }
+    // Read the component subtrees on the transaction so the assembly sees the
+    // right generation (post-write: just saved; pre-write: prior). A read
+    // failure fails the write instead of shipping an incomplete payload.
+    const components: Record<string, unknown> = {};
+    if (this.componentDataService) {
+      const componentFields = fieldConfigs.filter(
+        (f): f is typeof f & { name: string } => isComponentField(f) && !!f.name
+      );
+      if (componentFields.length > 0) {
+        try {
+          const populated =
+            await this.componentDataService.populateComponentData({
+              entry: { id: entryId },
+              parentTable,
+              fields: fieldConfigs,
+              executor: tx.getDrizzle(),
+              // Read as the locale the components were written at, with no
+              // fallback, so an embedded localized component reports this
+              // language's text rather than another standing in for it.
+              ...(snapshotLocale !== undefined
+                ? {
+                    locale: snapshotLocale,
+                    fallbackLocale: false as const,
+                  }
+                : {}),
+            });
+          for (const f of componentFields) {
+            if (populated[f.name] !== undefined) {
+              components[f.name] = populated[f.name];
+            }
+          }
+        } catch (err) {
+          throw NextlyError.internal({
+            cause: err instanceof Error ? err : undefined,
+            logContext: {
+              reason: "webhook-single-component-read",
+              table: parentTable,
+            },
+          });
+        }
+      }
+    }
+    return { ...parentRow, ...components };
+  }
+
+  /**
+   * The write locale's per-locale `_status`, or null when the companion row
+   * has none.
+   *
+   * Read with raw `tx.execute` (matching upsertCompanionRow): the companion
+   * `_locales` table is not in the Drizzle schema, and the CRUD helpers
+   * camelCase result keys, which would rename `_status`.
+   */
+  private async readCompanionLocaleStatus(
+    tx: TransactionContext,
+    companionTableName: string,
+    entryId: string,
+    locale: string
+  ): Promise<string | null> {
+    const isMysqlDialect = this.adapter.dialect === "mysql";
+    const quote = (id: string) => (isMysqlDialect ? `\`${id}\`` : `"${id}"`);
+    const placeholder = (i: number) =>
+      this.adapter.dialect === "postgresql" ? `$${i}` : "?";
+    const rows = await tx.execute<{ _status?: unknown }>(
+      `SELECT ${quote("_status")} FROM ${quote(companionTableName)} ` +
+        `WHERE ${quote("_parent")} = ${placeholder(1)} AND ${quote("_locale")} = ${placeholder(2)} LIMIT 1`,
+      [entryId, locale]
+    );
+    const status = rows[0]?._status;
+    return typeof status === "string" ? status : null;
   }
 
   // ============================================================
@@ -440,6 +587,16 @@ export class SingleMutationService extends BaseService {
               delete (mainPayload as Record<string, unknown>).status;
             }
 
+            // Read the pre-write main row on THIS transaction before the update
+            // overwrites it, so the outbox `previous` reports the prior state
+            // and the changed-field diff is accurate. Re-read every attempt
+            // (deterministic pre-write) so a version-conflict retry still
+            // reports the true prior document.
+            const preRow = await tx.selectOne<Record<string, unknown>>(
+              singleMeta.tableName,
+              {}
+            );
+
             const rows = await tx.update<SingleDocument>(
               singleMeta.tableName,
               mainPayload,
@@ -452,6 +609,69 @@ export class SingleMutationService extends BaseService {
             if (rows.length === 0) {
               return rows;
             }
+
+            // Build the outbox `previous` NOW — after the main update but before
+            // the component save and companion upsert below — so its component
+            // subtrees and companion values are still the prior generation. The
+            // main row was captured into `preRow` before the update. Values are
+            // restricted to the translatable columns this write touches
+            // (`companionData` keys) so `previous` and `data` diff symmetrically.
+            const previousCompanionValues: Record<string, unknown> = {};
+            let previousCompanionStatus: string | null = null;
+            if (companion && writeLocale !== undefined) {
+              const preLocaleRow: Record<string, unknown> = {
+                id: existingDoc.id,
+              };
+              await populateCompanionFields({
+                db: tx.getDrizzle<
+                  Parameters<typeof populateCompanionFields>[0]["db"]
+                >(),
+                companionTable: companion.table,
+                localizedFields: companion.localizedFields,
+                rows: [preLocaleRow],
+                localeChain: [writeLocale],
+              });
+              for (const f of companion.localizedFields) {
+                if (
+                  Object.prototype.hasOwnProperty.call(
+                    companionData,
+                    f.column
+                  ) &&
+                  preLocaleRow[f.name] !== undefined
+                ) {
+                  previousCompanionValues[f.column] = preLocaleRow[f.name];
+                }
+              }
+              // This locale's committed status, read before the upsert. Gated
+              // on `hasStatus`: querying `_status` on a companion without it
+              // would fail the whole write.
+              if (companion.hasStatus) {
+                previousCompanionStatus = await this.readCompanionLocaleStatus(
+                  tx,
+                  companion.companionTableName,
+                  existingDoc.id,
+                  writeLocale
+                );
+              }
+            }
+            // Overlay this locale's committed status so `previous` reports the
+            // language's own draft/publish rather than the main row's (a German
+            // draft can sit under a published default).
+            if (previousCompanionStatus !== null && preRow) {
+              preRow.status = previousCompanionStatus;
+            }
+            const previousDoc = preRow
+              ? await this.buildSingleWebhookDoc(
+                  tx,
+                  existingDoc.id,
+                  singleMeta.tableName,
+                  preRow,
+                  fieldConfigs,
+                  companion,
+                  previousCompanionValues,
+                  snapshotLocale
+                )
+              : null;
 
             // Clone per attempt: saveComponentDataInTransaction mutates the data
             // in place (hashing passwords, assigning ids), so a conflict retry
@@ -699,6 +919,118 @@ export class SingleMutationService extends BaseService {
                     : null,
                 sourceVersionNo: options.sourceVersionNo ?? null,
                 maxPerDoc: versionsConfig.maxPerDoc,
+              });
+            }
+
+            // Append the outbox event(s) in the SAME transaction, so they commit
+            // with the write and are never recorded for a write that rolls back.
+            // Runs whether or not versioning is enabled, and only on a real write
+            // (the empty-rows early return above already bailed). Recorded
+            // unconditionally (the endpoint gate lives at fan-out), mirroring the
+            // collection write path.
+
+            // Assemble the just-written document in the outbox read shape.
+            // `companionData` supplies this locale's written translations;
+            // components are read on the transaction (read-your-writes).
+            const dataDoc = await this.buildSingleWebhookDoc(
+              tx,
+              existingDoc.id,
+              singleMeta.tableName,
+              rows[0],
+              fieldConfigs,
+              companion,
+              companionData,
+              snapshotLocale
+            );
+
+            // The single's field tree with component references expanded, so the
+            // secret/hidden strip descends into fields declared inside a
+            // component. Resolved on the transaction's connection (components
+            // already read on it) to avoid taking a second pooled connection
+            // while this write still holds one.
+            const webhookFields = await expandComponentFields(
+              fieldConfigs,
+              async slug =>
+                this.componentDataService
+                  ? await this.componentDataService.getComponentFields(
+                      slug,
+                      tx.getDrizzle()
+                    )
+                  : null
+            );
+
+            // A publish/unpublish is a status change, so only a write that
+            // ASSIGNS a status can trigger one. `writtenStatus` is the status
+            // this write sets — the patch's status (kept on `updatePayload` even
+            // when the main column is left untouched for a non-default locale) or
+            // the per-locale companion status — and is undefined for a
+            // content-only edit, which then transitions nothing. Skipped entirely
+            // when the single has no status concept.
+            const singleHasStatus =
+              (singleMeta as { status?: boolean }).status === true ||
+              companion?.hasStatus === true;
+            const writtenStatus =
+              (typeof (updatePayload as { status?: unknown }).status ===
+              "string"
+                ? ((updatePayload as { status?: unknown }).status as string)
+                : undefined) ?? companionStatus;
+            // The status this write moves away from: this locale's committed
+            // companion status when the single stores per-locale status, else the
+            // main row's prior status.
+            const priorStatus =
+              previousCompanionStatus !== null
+                ? previousCompanionStatus
+                : typeof preRow?.status === "string"
+                  ? preRow.status
+                  : undefined;
+            const publishedTransition =
+              singleHasStatus &&
+              writtenStatus === "published" &&
+              priorStatus !== "published";
+            const unpublishedTransition =
+              singleHasStatus &&
+              writtenStatus !== undefined &&
+              writtenStatus !== "published" &&
+              priorStatus === "published";
+
+            const actor = actorForWrite(options.actor ?? null, options.user);
+            // `single` FORBIDS a `collection` slug; `locale` rides only when the
+            // single (or an embedded component) is localized, so a receiver can
+            // tell one language's write apart from another's.
+            const resource: WebhookResource = {
+              kind: "single",
+              id: existingDoc.id,
+              ...(snapshotLocale != null ? { locale: snapshotLocale } : {}),
+            };
+            await recordMutationEvent(tx, {
+              type: "single.updated",
+              resource,
+              data: dataDoc,
+              previous: previousDoc,
+              fields: webhookFields,
+              actor,
+            });
+            // A publish emits BOTH `single.updated` and `single.published` (and
+            // an unpublish both `single.updated` and `single.unpublished`), so a
+            // consumer subscribes to whichever it needs.
+            if (publishedTransition) {
+              await recordMutationEvent(tx, {
+                type: "single.published",
+                resource,
+                data: dataDoc,
+                previous: previousDoc,
+                fields: webhookFields,
+                actor,
+              });
+            }
+            if (unpublishedTransition) {
+              await recordMutationEvent(tx, {
+                type: "single.unpublished",
+                resource,
+                data: dataDoc,
+                previous: previousDoc,
+                fields: webhookFields,
+                actor,
               });
             }
 

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -224,6 +224,12 @@ export class SingleMutationService extends BaseService {
               parentTable,
               fields: fieldConfigs,
               executor: tx.getDrizzle(),
+              // Keep a component's relationship/upload references as stored IDs
+              // rather than expanding them into full related entries: the
+              // sensitive-field list is built from this Single's tree only, so an
+              // expanded related entry could smuggle its own hidden/password
+              // fields into the payload. Matches the collection snapshot read.
+              depth: 0,
               // Read as the locale the components were written at, with no
               // fallback, so an embedded localized component reports this
               // language's text rather than another standing in for it.

--- a/packages/nextly/src/domains/singles/types.ts
+++ b/packages/nextly/src/domains/singles/types.ts
@@ -176,4 +176,17 @@ export interface SingleResult<T = SingleDocument> {
 
   /** Error details (on failure) */
   errors?: Array<{ field?: string; message: string }>;
+
+  /**
+   * Whether this write appended a durable outbox event, independent of
+   * `success`. The update records the event inside its transaction, then runs
+   * post-commit steps (afterChange/afterUpdate hooks, response expansion): if
+   * one of those throws, the write is already committed but `success` is
+   * reported `false`. Post-write side effects (the webhook fast-drain and
+   * retention pass) key off this flag, not `success`, so a committed-but-
+   * hook-failed write still gets its immediate delivery while a write that
+   * recorded nothing (validation/access failure) does not. Mirrors
+   * `CollectionServiceResult.eventRecorded`.
+   */
+  eventRecorded?: boolean;
 }

--- a/packages/nextly/src/domains/singles/types.ts
+++ b/packages/nextly/src/domains/singles/types.ts
@@ -9,6 +9,7 @@
  * @since 1.0.0
  */
 
+import type { RequestActor } from "../../auth/request-actor";
 import type { StatusOption } from "../../lib/status-filter";
 
 /**
@@ -117,6 +118,14 @@ export interface UpdateSingleOptions {
 
   /** User context for access control and hooks. */
   user?: UserContext;
+
+  /**
+   * Who performed the write, for webhook/audit attribution. The transport
+   * boundary resolves it (distinguishing a signed-in user from an API key
+   * acting on their behalf); when absent the recorder falls back to `user`.
+   * Parity with the collection write path's actor.
+   */
+  actor?: RequestActor;
 
   /**
    * When true, bypass all RBAC access control checks.

--- a/packages/nextly/src/domains/versions/restore-version.ts
+++ b/packages/nextly/src/domains/versions/restore-version.ts
@@ -472,6 +472,9 @@ export async function restoreVersion(
       // The route authorized the caller for this document; the update still
       // runs its own document-level rules.
       routeAuthorized: true,
+      // Forward the actor so an API-key restore is attributed to the key, not
+      // its owner — mirrors the collection branch below.
+      ...(args.actor ? { actor: args.actor } : {}),
       ...(writeLocale ? { locale: writeLocale } : {}),
       sourceVersionNo: args.versionNo,
     });

--- a/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
@@ -9,7 +9,13 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 
-import { defineSingle, password, text } from "../../../config";
+import {
+  component,
+  defineComponent,
+  defineSingle,
+  password,
+  text,
+} from "../../../config";
 import { NextlyError } from "../../../errors/nextly-error";
 import {
   createTestNextly,
@@ -461,7 +467,13 @@ describe("webhook outbox capture — singles (integration)", () => {
       ],
     });
 
-    // Give German its own translation, then edit only a shared field at `de`.
+    // Give English (default) and German their own translations, then edit only
+    // a shared field at `de`.
+    await singles(current).update(
+      "preferences",
+      { title: "hello" },
+      { overrideAccess: true, locale: "en" }
+    );
     await singles(current).update(
       "preferences",
       { title: "hallo" },
@@ -480,10 +492,83 @@ describe("webhook outbox capture — singles (integration)", () => {
     );
     expect(shared).toBeDefined();
     const env = envelopeOf(shared!);
-    // No locale tag, and the German translation is not leaked into the
-    // locale-agnostic payload.
+    // No locale tag; the payload carries the default (English) view, not the
+    // German translation, and not a nulled-out field.
     expect((env.resource as { locale?: string }).locale).toBeUndefined();
-    expect((env.data as { title?: string }).title).not.toBe("hallo");
+    expect((env.data as { title?: string }).title).toBe("hello");
+  });
+
+  it("omits resource.locale when only a shared component is written at a non-default locale", async () => {
+    // A shared (non-localized) component stores its data on the shared main
+    // table, so writing it is not a per-locale write even in a localized app —
+    // the event must not be tagged with a language.
+    current = await createTestNextly({
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+      components: [
+        defineComponent({
+          slug: "hero",
+          localized: false,
+          fields: [text({ name: "heading" })],
+        }),
+      ],
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          localized: true,
+          fields: [
+            text({ name: "title", localized: true }),
+            component({ name: "hero", component: "hero" }),
+          ],
+        }),
+      ],
+    });
+
+    await singles(current).update(
+      "preferences",
+      { hero: { heading: "Welcome" } },
+      { overrideAccess: true, locale: "de" }
+    );
+
+    const row = (await events(current)).find(r => r.type === "single.updated");
+    expect(row).toBeDefined();
+    expect(
+      (envelopeOf(row!).resource as { locale?: string }).locale
+    ).toBeUndefined();
+  });
+
+  it("tags resource.locale when a localized component is written at a locale", async () => {
+    // A localized component routes its translatable fields to a per-locale
+    // companion, so writing it IS a per-locale write and the event carries the
+    // write locale.
+    current = await createTestNextly({
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+      components: [
+        defineComponent({
+          slug: "hero",
+          localized: true,
+          fields: [text({ name: "heading", localized: true })],
+        }),
+      ],
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          localized: true,
+          fields: [component({ name: "hero", component: "hero" })],
+        }),
+      ],
+    });
+
+    await singles(current).update(
+      "preferences",
+      { hero: { heading: "Willkommen" } },
+      { overrideAccess: true, locale: "de" }
+    );
+
+    const row = (await events(current)).find(r => r.type === "single.updated");
+    expect(row).toBeDefined();
+    expect((envelopeOf(row!).resource as { locale?: string }).locale).toBe(
+      "de"
+    );
   });
 
   it("reports eventRecorded when the write commits but a post-commit hook throws", async () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
@@ -623,6 +623,47 @@ describe("webhook outbox capture — singles (integration)", () => {
     );
   });
 
+  it("tags resource.locale when a repeatable single-component array is written", async () => {
+    // A fixed component field with `repeatable: true` stores an array of
+    // instances under one slug; a localized-field write to any of them is
+    // per-locale even though there is no dynamic-zone `_componentType`.
+    current = await createTestNextly({
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+      components: [
+        defineComponent({
+          slug: "hero_localized",
+          localized: true,
+          fields: [text({ name: "heading", localized: true })],
+        }),
+      ],
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          localized: true,
+          fields: [
+            component({
+              name: "blocks",
+              component: "hero_localized",
+              repeatable: true,
+            }),
+          ],
+        }),
+      ],
+    });
+
+    await singles(current).update(
+      "preferences",
+      { blocks: [{ heading: "Willkommen" }] },
+      { overrideAccess: true, locale: "de" }
+    );
+
+    const row = (await events(current)).find(r => r.type === "single.updated");
+    expect(row).toBeDefined();
+    expect((envelopeOf(row!).resource as { locale?: string }).locale).toBe(
+      "de"
+    );
+  });
+
   it("does not tag resource.locale when only a shared field of a localized component is written", async () => {
     // A localized component keeps its shared (localized:false) fields on the
     // main comp_* row for every locale, so a write touching only those is not
@@ -661,14 +702,22 @@ describe("webhook outbox capture — singles (integration)", () => {
       { overrideAccess: true, locale: "de" }
     );
 
-    const updates = (await events(current)).filter(
-      r => r.type === "single.updated"
-    );
-    const first = envelopeOf(updates[0]);
-    const last = envelopeOf(updates[updates.length - 1]);
+    // Select each event by its component content (row order is not guaranteed
+    // without an ORDER BY), not by index.
+    const heroOf = (e: WebhookEvent) =>
+      (e.data as { hero?: { anchor?: string } }).hero;
+    const updates = (await events(current))
+      .filter(r => r.type === "single.updated")
+      .map(envelopeOf);
+    const localizedWrite = updates.find(e => heroOf(e)?.anchor === "top");
+    const sharedWrite = updates.find(e => heroOf(e)?.anchor === "bottom");
+    expect(localizedWrite).toBeDefined();
+    expect(sharedWrite).toBeDefined();
     // The localized-field write is tagged; the shared-only write is not.
-    expect((first.resource as { locale?: string }).locale).toBe("de");
-    expect((last.resource as { locale?: string }).locale).toBeUndefined();
+    expect((localizedWrite!.resource as { locale?: string }).locale).toBe("de");
+    expect(
+      (sharedWrite!.resource as { locale?: string }).locale
+    ).toBeUndefined();
   });
 
   it("reports eventRecorded when the write commits but a post-commit hook throws", async () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
@@ -250,6 +250,144 @@ describe("webhook outbox capture — singles (integration)", () => {
     expect(rows.some(r => r.type === "single.updated")).toBe(true);
   });
 
+  it("fires single.published for a non-default locale even when the default is already published", async () => {
+    // Regression: a non-default locale with no companion row yet is draft, not
+    // the main row's status — so publishing it under an already-published
+    // default must still emit single.published for that locale.
+    current = await createTestNextly({
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          status: true,
+          localized: true,
+          fields: [text({ name: "title", localized: true })],
+        }),
+      ],
+    });
+
+    // Publish the default locale first (status lands on the main row).
+    await singles(current).update(
+      "preferences",
+      { title: "hi", status: "published" },
+      { overrideAccess: true, locale: "en" }
+    );
+    // Now publish German for the first time.
+    await singles(current).update(
+      "preferences",
+      { title: "hallo", status: "published" },
+      { overrideAccess: true, locale: "de" }
+    );
+
+    const dePublished = (await events(current)).filter(
+      r =>
+        r.type === "single.published" &&
+        (envelopeOf(r).resource as { locale?: string }).locale === "de"
+    );
+    expect(dePublished).toHaveLength(1);
+    // The payload carries this locale's own status, not the main row's.
+    expect(
+      (envelopeOf(dePublished[0]).data as { status?: string }).status
+    ).toBe("published");
+  });
+
+  it("does not emit a false single.unpublished for a first draft write on a non-default locale", async () => {
+    current = await createTestNextly({
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          status: true,
+          localized: true,
+          fields: [text({ name: "title", localized: true })],
+        }),
+      ],
+    });
+
+    await singles(current).update(
+      "preferences",
+      { title: "hi", status: "published" },
+      { overrideAccess: true, locale: "en" }
+    );
+    // German was never published, so drafting it is not an unpublish.
+    await singles(current).update(
+      "preferences",
+      { title: "hallo", status: "draft" },
+      { overrideAccess: true, locale: "de" }
+    );
+
+    const deUnpublished = (await events(current)).filter(
+      r =>
+        r.type === "single.unpublished" &&
+        (envelopeOf(r).resource as { locale?: string }).locale === "de"
+    );
+    expect(deUnpublished).toHaveLength(0);
+  });
+
+  it("carries untouched translations in the payload after a partial localized edit", async () => {
+    current = await createTestNextly({
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          localized: true,
+          fields: [
+            text({ name: "title", localized: true }),
+            text({ name: "body", localized: true }),
+          ],
+        }),
+      ],
+    });
+
+    await singles(current).update(
+      "preferences",
+      { title: "hallo", body: "welt" },
+      { overrideAccess: true, locale: "de" }
+    );
+    // Edit only `title`; `body` is untouched but must still appear in data.
+    await singles(current).update(
+      "preferences",
+      { title: "hallo-2" },
+      { overrideAccess: true, locale: "de" }
+    );
+
+    const rows = (await events(current)).filter(
+      r => r.type === "single.updated"
+    );
+    const last = envelopeOf(rows[rows.length - 1]);
+    expect((last.data as { title?: string }).title).toBe("hallo-2");
+    // The untouched translation is present on both sides of the diff.
+    expect((last.data as { body?: string }).body).toBe("welt");
+    expect((last.previous as { body?: string } | null)?.body).toBe("welt");
+    expect(last.changedFields).toContain("title");
+    expect(last.changedFields).not.toContain("body");
+  });
+
+  it("omits resource.locale for a non-localized single even when localization is configured", async () => {
+    current = await createTestNextly({
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+      singles: [
+        // Not localized: no `localized: true`, no localized fields.
+        defineSingle({
+          slug: "preferences",
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+
+    await singles(current).update(
+      "preferences",
+      { title: "hello" },
+      { overrideAccess: true }
+    );
+
+    const row = (await events(current)).find(r => r.type === "single.updated");
+    expect(row).toBeDefined();
+    expect(
+      (envelopeOf(row!).resource as { locale?: string }).locale
+    ).toBeUndefined();
+  });
+
   it("records the event AND captures a version when versioning is enabled", async () => {
     current = await createTestNextly({
       singles: [

--- a/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
@@ -54,7 +54,7 @@ function singles(handle: TestNextly): SingleEntryService {
 describe("webhook outbox capture — singles (integration)", () => {
   it("records single.updated with the read-shape document and prior state (versioning OFF)", async () => {
     // Versioning off is the case the recording must not depend on: the document
-    // assembly used to live only in the versioning branch.
+    // assembly must run for a non-versioned single as well.
     current = await createTestNextly({
       singles: [
         // "settings" is a reserved slug; this suite uses "preferences".
@@ -251,9 +251,9 @@ describe("webhook outbox capture — singles (integration)", () => {
   });
 
   it("fires single.published for a non-default locale even when the default is already published", async () => {
-    // Regression: a non-default locale with no companion row yet is draft, not
-    // the main row's status — so publishing it under an already-published
-    // default must still emit single.published for that locale.
+    // A non-default locale with no companion row yet is draft, not the main
+    // row's status — so publishing it under an already-published default must
+    // still emit single.published for that locale.
     current = await createTestNextly({
       localization: { locales: ["en", "de"], defaultLocale: "en" },
       singles: [

--- a/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
@@ -84,7 +84,9 @@ describe("webhook outbox capture — singles (integration)", () => {
     );
     expect(rows).toHaveLength(1);
     expect(rows[0].resourceKind).toBe("single");
-    expect(rows[0].resourceCollection).toBeNull();
+    // The single slug is denormalized into the scope column so the delivery log
+    // identifies which single changed.
+    expect(rows[0].resourceCollection).toBe("preferences");
     expect(rows[0].resourceId).toBeTruthy();
 
     const envelope = envelopeOf(rows[0]);
@@ -93,7 +95,15 @@ describe("webhook outbox capture — singles (integration)", () => {
     // prior document is that default and `title` reads as a changed field.
     expect(envelope.previous).not.toBeNull();
     expect(envelope.changedFields).toContain("title");
-    expect(envelope.resource).toMatchObject({ kind: "single" });
+    // The payload resource carries the slug so a receiver can route the event,
+    // but no entry `collection` (which would feed the collections filter).
+    expect(envelope.resource).toMatchObject({
+      kind: "single",
+      slug: "preferences",
+    });
+    expect(
+      (envelope.resource as { collection?: unknown }).collection
+    ).toBeUndefined();
   });
 
   it("emits BOTH single.updated and single.published on a draft→published write", async () => {
@@ -561,6 +571,48 @@ describe("webhook outbox capture — singles (integration)", () => {
     await singles(current).update(
       "preferences",
       { hero: { heading: "Willkommen" } },
+      { overrideAccess: true, locale: "de" }
+    );
+
+    const row = (await events(current)).find(r => r.type === "single.updated");
+    expect(row).toBeDefined();
+    expect((envelopeOf(row!).resource as { locale?: string }).locale).toBe(
+      "de"
+    );
+  });
+
+  it("tags resource.locale when a localized dynamic-zone component is written", async () => {
+    // A dynamic-zone field stores each written block by its `_componentType`.
+    // Writing a localized block routes its translatable data to a per-locale
+    // companion, so the event must carry the write locale even though the field
+    // config names an allow-list rather than a single component slug.
+    current = await createTestNextly({
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+      components: [
+        defineComponent({
+          slug: "hero_localized",
+          localized: true,
+          fields: [text({ name: "heading", localized: true })],
+        }),
+      ],
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          localized: true,
+          fields: [
+            component({
+              name: "blocks",
+              components: ["hero_localized"],
+              repeatable: true,
+            }),
+          ],
+        }),
+      ],
+    });
+
+    await singles(current).update(
+      "preferences",
+      { blocks: [{ _componentType: "hero_localized", heading: "Willkommen" }] },
       { overrideAccess: true, locale: "de" }
     );
 

--- a/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
@@ -10,6 +10,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import { defineSingle, password, text } from "../../../config";
+import { NextlyError } from "../../../errors/nextly-error";
 import {
   createTestNextly,
   type TestNextly,
@@ -439,8 +440,50 @@ describe("webhook outbox capture — singles (integration)", () => {
     const env = envelopeOf(deWrite!);
     expect((env.resource as { locale?: string }).locale).toBeUndefined();
     expect((env.data as { status?: string }).status).toBe("published");
+    // The shared value the write set is present regardless of locale.
+    expect((env.data as { theme?: string }).theme).toBe("dark");
     // The shared-field edit is not a status transition.
     expect(rows.filter(r => r.type === "single.unpublished")).toHaveLength(0);
+  });
+
+  it("ships the default view, not the write locale's translations, on a shared-field write", async () => {
+    current = await createTestNextly({
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          localized: true,
+          fields: [
+            text({ name: "title", localized: true }),
+            text({ name: "theme", localized: false }),
+          ],
+        }),
+      ],
+    });
+
+    // Give German its own translation, then edit only a shared field at `de`.
+    await singles(current).update(
+      "preferences",
+      { title: "hallo" },
+      { overrideAccess: true, locale: "de" }
+    );
+    await singles(current).update(
+      "preferences",
+      { theme: "dark" },
+      { overrideAccess: true, locale: "de" }
+    );
+
+    const shared = (await events(current)).find(
+      r =>
+        r.type === "single.updated" &&
+        (envelopeOf(r).data as { theme?: string }).theme === "dark"
+    );
+    expect(shared).toBeDefined();
+    const env = envelopeOf(shared!);
+    // No locale tag, and the German translation is not leaked into the
+    // locale-agnostic payload.
+    expect((env.resource as { locale?: string }).locale).toBeUndefined();
+    expect((env.data as { title?: string }).title).not.toBe("hallo");
   });
 
   it("reports eventRecorded when the write commits but a post-commit hook throws", async () => {
@@ -458,7 +501,9 @@ describe("webhook outbox capture — singles (integration)", () => {
       "afterUpdate",
       getSingleHookCollection("preferences"),
       () => {
-        throw new Error("afterUpdate observer failed");
+        throw NextlyError.internal({
+          logContext: { reason: "afterUpdate-observer-failed" },
+        });
       }
     );
 

--- a/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
@@ -623,6 +623,54 @@ describe("webhook outbox capture — singles (integration)", () => {
     );
   });
 
+  it("does not tag resource.locale when only a shared field of a localized component is written", async () => {
+    // A localized component keeps its shared (localized:false) fields on the
+    // main comp_* row for every locale, so a write touching only those is not
+    // per-locale even though the component's definition is localized.
+    current = await createTestNextly({
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+      components: [
+        defineComponent({
+          slug: "hero_mixed",
+          localized: true,
+          fields: [
+            text({ name: "heading", localized: true }),
+            text({ name: "anchor", localized: false }),
+          ],
+        }),
+      ],
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          localized: true,
+          fields: [component({ name: "hero", component: "hero_mixed" })],
+        }),
+      ],
+    });
+
+    // Seed a localized heading (this write IS per-locale)...
+    await singles(current).update(
+      "preferences",
+      { hero: { heading: "Willkommen", anchor: "top" } },
+      { overrideAccess: true, locale: "de" }
+    );
+    // ...then change ONLY the shared field.
+    await singles(current).update(
+      "preferences",
+      { hero: { anchor: "bottom" } },
+      { overrideAccess: true, locale: "de" }
+    );
+
+    const updates = (await events(current)).filter(
+      r => r.type === "single.updated"
+    );
+    const first = envelopeOf(updates[0]);
+    const last = envelopeOf(updates[updates.length - 1]);
+    // The localized-field write is tagged; the shared-only write is not.
+    expect((first.resource as { locale?: string }).locale).toBe("de");
+    expect((last.resource as { locale?: string }).locale).toBeUndefined();
+  });
+
   it("reports eventRecorded when the write commits but a post-commit hook throws", async () => {
     current = await createTestNextly({
       singles: [

--- a/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
@@ -15,6 +15,7 @@ import {
   type TestNextly,
 } from "../../../plugins/test-nextly";
 import type { SingleEntryService } from "../../singles/services/single-entry-service";
+import { getSingleHookCollection } from "../../singles/services/single-query-service";
 import type { WebhookEvent } from "../types";
 
 let current: TestNextly | undefined;
@@ -354,7 +355,15 @@ describe("webhook outbox capture — singles (integration)", () => {
     const rows = (await events(current)).filter(
       r => r.type === "single.updated"
     );
-    const last = envelopeOf(rows[rows.length - 1]);
+    expect(rows).toHaveLength(2);
+    // Select the second edit by its content, not by positional order:
+    // `nextly_events` row order is not guaranteed across Postgres/MySQL, so
+    // taking the last row would be flaky.
+    const second = rows.find(
+      r => (envelopeOf(r).data as { title?: string }).title === "hallo-2"
+    );
+    expect(second).toBeDefined();
+    const last = envelopeOf(second!);
     expect((last.data as { title?: string }).title).toBe("hallo-2");
     // The untouched translation is present on both sides of the diff.
     expect((last.data as { body?: string }).body).toBe("welt");
@@ -386,6 +395,85 @@ describe("webhook outbox capture — singles (integration)", () => {
     expect(
       (envelopeOf(row!).resource as { locale?: string }).locale
     ).toBeUndefined();
+  });
+
+  it("keeps the main-row status and omits locale on a shared-field write to a non-default locale", async () => {
+    // A non-default-locale edit that touches only a shared (non-localized) field
+    // stores no per-locale data, so the event is not locale-specific: it must
+    // carry no resource.locale and report the main row's status, not the
+    // locale's absent (draft) one.
+    current = await createTestNextly({
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          status: true,
+          localized: true,
+          fields: [
+            text({ name: "title", localized: true }),
+            // Explicitly shared: text defaults to localized in a localized single.
+            text({ name: "theme", localized: false }),
+          ],
+        }),
+      ],
+    });
+
+    await singles(current).update(
+      "preferences",
+      { title: "hi", theme: "light", status: "published" },
+      { overrideAccess: true, locale: "en" }
+    );
+    await singles(current).update(
+      "preferences",
+      { theme: "dark" },
+      { overrideAccess: true, locale: "de" }
+    );
+
+    const rows = await events(current);
+    const deWrite = rows.find(
+      r =>
+        r.type === "single.updated" &&
+        (envelopeOf(r).data as { theme?: string }).theme === "dark"
+    );
+    expect(deWrite).toBeDefined();
+    const env = envelopeOf(deWrite!);
+    expect((env.resource as { locale?: string }).locale).toBeUndefined();
+    expect((env.data as { status?: string }).status).toBe("published");
+    // The shared-field edit is not a status transition.
+    expect(rows.filter(r => r.type === "single.unpublished")).toHaveLength(0);
+  });
+
+  it("reports eventRecorded when the write commits but a post-commit hook throws", async () => {
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    // afterUpdate runs after the write transaction commits, so a throw here
+    // leaves the entry + outbox event durable while the result reports failure.
+    current.hooks.register(
+      "afterUpdate",
+      getSingleHookCollection("preferences"),
+      () => {
+        throw new Error("afterUpdate observer failed");
+      }
+    );
+
+    const result = await singles(current).update(
+      "preferences",
+      { title: "hello" },
+      { overrideAccess: true }
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.eventRecorded).toBe(true);
+    const rows = (await events(current)).filter(
+      r => r.type === "single.updated"
+    );
+    expect(rows).toHaveLength(1);
   });
 
   it("records the event AND captures a version when versioning is enabled", async () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
@@ -521,6 +521,38 @@ describe("webhook outbox capture — singles (integration)", () => {
     expect(rows).toHaveLength(1);
   });
 
+  it("emits untouched localized fields as null in a partial translation write", async () => {
+    current = await createTestNextly({
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          localized: true,
+          fields: [
+            text({ name: "title", localized: true }),
+            text({ name: "body", localized: true }),
+          ],
+        }),
+      ],
+    });
+
+    // Write only `title` for German; `body` is untranslated.
+    await singles(current).update(
+      "preferences",
+      { title: "hallo" },
+      { overrideAccess: true, locale: "de" }
+    );
+
+    const row = (await events(current)).find(r => r.type === "single.updated");
+    expect(row).toBeDefined();
+    const data = envelopeOf(row!).data as Record<string, unknown>;
+    expect(data.title).toBe("hallo");
+    // The untouched localized field is present as null (read-shape complete),
+    // not omitted — consumers can tell "untranslated" from "not in the schema".
+    expect(data).toHaveProperty("body");
+    expect(data.body).toBeNull();
+  });
+
   it("records the event AND captures a version when versioning is enabled", async () => {
     current = await createTestNextly({
       singles: [

--- a/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/singles-outbox.integration.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Outbox capture on Single writes.
+ *
+ * Proves the singles mutation seam appends `nextly_events` rows for a content
+ * change: `single.updated` on every write (carrying the read-shape document and
+ * an accurate prior state), plus `single.published` / `single.unpublished` when
+ * the status transitions — independent of whether versioning is enabled, and
+ * with secret fields never reaching the payload.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineSingle, password, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { SingleEntryService } from "../../singles/services/single-entry-service";
+import type { WebhookEvent } from "../types";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+/** A `nextly_events` row as read back (Drizzle camelCases the columns). */
+interface EventRow {
+  id: string;
+  type: string;
+  resourceKind: string;
+  resourceCollection: string | null;
+  resourceId: string | null;
+  payload: unknown;
+  actorType: string | null;
+  actorId: string | null;
+}
+
+/** The stored envelope; the payload comes back parsed on some dialects, a JSON string on others. */
+function envelopeOf(row: EventRow): WebhookEvent {
+  return (
+    typeof row.payload === "string" ? JSON.parse(row.payload) : row.payload
+  ) as WebhookEvent;
+}
+
+async function events(handle: TestNextly): Promise<EventRow[]> {
+  return handle.adapter.select<EventRow>("nextly_events");
+}
+
+function singles(handle: TestNextly): SingleEntryService {
+  return handle.getService<SingleEntryService>("singleEntryService");
+}
+
+describe("webhook outbox capture — singles (integration)", () => {
+  it("records single.updated with the read-shape document and prior state (versioning OFF)", async () => {
+    // Versioning off is the case the recording must not depend on: the document
+    // assembly used to live only in the versioning branch.
+    current = await createTestNextly({
+      singles: [
+        // "settings" is a reserved slug; this suite uses "preferences".
+        defineSingle({
+          slug: "preferences",
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+
+    await singles(current).update(
+      "preferences",
+      { title: "hello" },
+      { overrideAccess: true }
+    );
+
+    const rows = (await events(current)).filter(
+      r => r.type === "single.updated"
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].resourceKind).toBe("single");
+    expect(rows[0].resourceCollection).toBeNull();
+    expect(rows[0].resourceId).toBeTruthy();
+
+    const envelope = envelopeOf(rows[0]);
+    expect((envelope.data as { title?: string }).title).toBe("hello");
+    // The single auto-creates a blank default before the first update, so the
+    // prior document is that default and `title` reads as a changed field.
+    expect(envelope.previous).not.toBeNull();
+    expect(envelope.changedFields).toContain("title");
+    expect(envelope.resource).toMatchObject({ kind: "single" });
+  });
+
+  it("emits BOTH single.updated and single.published on a draft→published write", async () => {
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          status: true,
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+
+    // Seed content while still a draft (no transition).
+    await singles(current).update(
+      "preferences",
+      { title: "hello" },
+      { overrideAccess: true }
+    );
+    // Publish: draft → published.
+    await singles(current).update(
+      "preferences",
+      { status: "published" },
+      { overrideAccess: true }
+    );
+
+    const types = (await events(current)).map(r => r.type);
+    // Two updates → two single.updated; the publish additionally emits published.
+    expect(types.filter(t => t === "single.updated")).toHaveLength(2);
+    expect(types.filter(t => t === "single.published")).toHaveLength(1);
+    expect(types).not.toContain("single.unpublished");
+  });
+
+  it("emits single.unpublished on a published→draft write", async () => {
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          status: true,
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+
+    await singles(current).update(
+      "preferences",
+      { title: "hello", status: "published" },
+      { overrideAccess: true }
+    );
+    await singles(current).update(
+      "preferences",
+      { status: "draft" },
+      { overrideAccess: true }
+    );
+
+    const types = (await events(current)).map(r => r.type);
+    expect(types.filter(t => t === "single.published")).toHaveLength(1);
+    expect(types.filter(t => t === "single.unpublished")).toHaveLength(1);
+  });
+
+  it("does not transition on a content-only edit that carries no status", async () => {
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          status: true,
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+
+    await singles(current).update(
+      "preferences",
+      { title: "hello", status: "published" },
+      { overrideAccess: true }
+    );
+    // A later content-only edit must not re-emit a publish event.
+    await singles(current).update(
+      "preferences",
+      { title: "world" },
+      { overrideAccess: true }
+    );
+
+    const types = (await events(current)).map(r => r.type);
+    expect(types.filter(t => t === "single.published")).toHaveLength(1);
+    expect(types.filter(t => t === "single.updated")).toHaveLength(2);
+  });
+
+  it("never ships a secret field in the payload", async () => {
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          fields: [text({ name: "title" }), password({ name: "apiKey" })],
+        }),
+      ],
+    });
+
+    await singles(current).update(
+      "preferences",
+      { title: "hello", apiKey: "s3cr3t-value" },
+      { overrideAccess: true }
+    );
+
+    const row = (await events(current)).find(r => r.type === "single.updated");
+    expect(row).toBeDefined();
+    const serialized = JSON.stringify(envelopeOf(row!));
+    expect(serialized).not.toContain("s3cr3t-value");
+  });
+
+  it("attributes the event to the acting user", async () => {
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+
+    await singles(current).update(
+      "preferences",
+      { title: "hello" },
+      { overrideAccess: true, user: { id: "user-123", email: "e@x.c" } }
+    );
+
+    const row = (await events(current)).find(r => r.type === "single.updated");
+    expect(row).toBeDefined();
+    expect(row!.actorType).toBe("user");
+    expect(row!.actorId).toBe("user-123");
+  });
+
+  it("publishes a single locale: single.published carries that locale and the per-locale status transitions", async () => {
+    // A localized single stores each language's draft/publish on the companion
+    // `_status`, so the transition is detected from the per-locale status the
+    // write assigns, and the event resource names the locale.
+    current = await createTestNextly({
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          status: true,
+          localized: true,
+          fields: [text({ name: "title", localized: true })],
+        }),
+      ],
+    });
+
+    await singles(current).update(
+      "preferences",
+      { title: "hallo", status: "published" },
+      { overrideAccess: true, locale: "de" }
+    );
+
+    const rows = await events(current);
+    const published = rows.find(r => r.type === "single.published");
+    expect(published).toBeDefined();
+    expect(envelopeOf(published!).resource).toMatchObject({
+      kind: "single",
+      locale: "de",
+    });
+    expect(rows.some(r => r.type === "single.updated")).toBe(true);
+  });
+
+  it("records the event AND captures a version when versioning is enabled", async () => {
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          versions: true,
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+
+    await singles(current).update(
+      "preferences",
+      { title: "hello" },
+      { overrideAccess: true }
+    );
+
+    const evRows = (await events(current)).filter(
+      r => r.type === "single.updated"
+    );
+    expect(evRows).toHaveLength(1);
+    const versionRows = await current.adapter.select<{ scopeSlug: string }>(
+      "nextly_versions"
+    );
+    expect(
+      versionRows.filter(v => v.scopeSlug === "preferences").length
+    ).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/nextly/src/domains/webhooks/record-event.ts
+++ b/packages/nextly/src/domains/webhooks/record-event.ts
@@ -28,9 +28,18 @@ function eventRow(envelope: WebhookEvent, now: Date): Record<string, unknown> {
     id: envelope.id,
     type: envelope.type,
     resource_kind: envelope.resource.kind,
-    // `collection` only exists on the entry resource variant.
+    // The denormalized scope column: an entry carries its collection slug; a
+    // single (or other slugged resource) carries its own slug so the delivery
+    // log identifies which resource changed. This is informational only — the
+    // endpoint `collections` filter matches on the PAYLOAD's `resource.collection`
+    // (undefined for a single), so a single slug here never widens a
+    // collection-scoped subscription.
     resource_collection:
-      "collection" in envelope.resource ? envelope.resource.collection : null,
+      "collection" in envelope.resource
+        ? envelope.resource.collection
+        : "slug" in envelope.resource
+          ? (envelope.resource.slug ?? null)
+          : null,
     resource_id: envelope.resource.id ?? null,
     // Serialize the payload here rather than passing the object through: the
     // transactional insert is a raw INSERT, and only some dialect drivers

--- a/packages/nextly/src/domains/webhooks/types.ts
+++ b/packages/nextly/src/domains/webhooks/types.ts
@@ -100,6 +100,14 @@ export type WebhookResource =
   | {
       kind: "single" | "media" | "user" | "form";
       collection?: never;
+      /**
+       * The stable slug of the changed resource (e.g. the Single's slug), so a
+       * receiver can route `single.updated`/`single.published` without scanning
+       * for the opaque document id. Distinct from `entry.collection`: it never
+       * feeds the endpoint `collections` filter (that reads `collection`), so a
+       * single slug cannot be caught by a collection-scoped subscription.
+       */
+      slug?: string;
       id?: string;
       locale?: string;
     };


### PR DESCRIPTION
## What

Adds webhook outbox recording for **Singles** (B3b-2), mirroring the collection outbox pattern established by #298/#296/#300.

- **`single.updated`** — recorded on every write that changes the Single, carrying the written document (`data`) and its prior state (`previous`) so the `changedFields` diff is accurate.
- **`single.published` / `single.unpublished`** — recorded additionally when the status transitions (draft→published / published→draft).

### Event semantics (design decision)
A publish emits **both** `single.updated` and `single.published` (an unpublish, both `single.updated` and `single.unpublished`), so a consumer can subscribe to whichever it needs. A content-only edit that assigns no status transitions nothing. There is no `single.created` (Singles auto-create) or `single.deleted` (Singles aren't deleted).

## How
- The read-shape document assembly (parent row + component subtrees, password/owner stripped, JSON parsed) is factored into a `buildSingleWebhookDoc` helper and now runs **whether or not versioning is enabled** — previously it lived only in the versioning branch, so a non-versioned Single recorded nothing.
- A per-attempt **pre-write** read (main row before the UPDATE, plus the write locale's companion values/`_status`) builds `previous`; the post-write read builds `data`. Both run inside the write transaction, so events commit atomically with the write and roll back with a version-conflict retry.
- Transitions are detected from the status **this write assigns** (patch/companion status), reading the prior per-locale status from the companion `_status`.
- The event resource is `{ kind: "single", id, locale? }` (the `single` kind forbids a collection slug); `actor` comes from `actorForWrite(options.actor ?? null, options.user)` — `actor` is added to `UpdateSingleOptions` for parity with collections.
- The version-snapshot block is unchanged.

## Tests
New `singles-outbox.integration.test.ts` (8 tests, green on **SQLite + Postgres 17 + MySQL**): `single.updated` on a non-versioned Single; publish emits both events; unpublish; content-only edit transitions nothing; secret fields never in the payload; actor attribution; versioned Single records event **and** captures a version; localized per-locale publish carries the locale and reads the companion `_status`. Existing singles unit suite updated for the new in-transaction calls (mock `getDrizzle`/`getComponentFields`, outbox-event insert) — 114/114 singles unit tests pass, versioning capture suite unaffected.

## Follow-ups (noted, out of scope)
- Share the post-write component read between the version snapshot and the webhook `data` assembly (currently two reads when versioning is on).
- `entry.published` / `entry.unpublished` for collections + unifying publish/unpublish across the internal event bus and the outbox is a separate, cross-cutting item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Single write events now emit richer webhook/outbox payloads with read-shaped `previous`/`data`, localized companion values, component subtree fields, and corrected per-locale publish/unpublish transitions.
  - Webhook resources now include an optional stable `slug` to improve routing.

- **Bug Fixes**
  - Improved `previous` generation during version-conflict retries by using the latest pre-update row.
  - Enhanced write-actor attribution across API and dispatcher flows.
  - Outbox events remain recorded even if post-write steps fail; tightened companion table handling with a strict mode.

- **Tests**
  - Added integration coverage for outbox durability, localization edge cases, and field-change reporting; updated auth and helper assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->