### PR TITLE
fix(nextly): enable localization reliably on existing collections, singles, and components

### DIFF
--- a/.changeset/i18n-enable-add-field.md
+++ b/.changeset/i18n-enable-add-field.md
@@ -1,0 +1,28 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Enabling localization while adding a translatable field in the same save no longer fails.
+
+When a field is added and localized in one save, it is (correctly) kept off the main table and lives only in the companion `_locales` table. The companion enable migration seeded the new companion from the main table with `SELECT <all localized columns> FROM <main>` and then dropped those columns, but a field added in the same save was never on the main table, so the seed failed with `column "..." does not exist` and, on singles and components, the whole apply returned 500.
+
+The enable migration now seeds and drops only the localized columns that already exist on the main table (fields present before this save). A field localized on creation still gets its companion column; it simply has no existing data to copy and nothing to drop.
+
+Listing entries no longer fails after localization is toggled on for an existing collection. Enabling localization moves translatable columns off the main table, and the entry list reads its columns from the file manager's schema cache. The metadata update path refreshed only the adapter's CRUD schema, leaving that read cache holding the pre-toggle table, so the list query selected a column the table no longer had. The metadata path now refreshes the read cache as well, matching the schema-apply path.

--- a/.changeset/i18n-enable-add-field.md
+++ b/.changeset/i18n-enable-add-field.md
@@ -4,6 +4,7 @@
 "@nextlyhq/adapter-postgres": patch
 "@nextlyhq/adapter-sqlite": patch
 "@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
 "create-nextly-app": patch
 "@nextlyhq/eslint-config": patch
 "nextly": patch

--- a/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
@@ -242,6 +242,13 @@ export class CollectionMetadataService extends BaseService {
         // a restart — matching the just-created physical table.
         localized,
       });
+      // The entry-list read resolves its SELECT columns from the file manager's own schema
+      // cache, which is separate from the adapter resolver below. The schema-apply path
+      // refreshes both (CollectionsHandler.refreshCollectionSchema); this metadata path must
+      // too, or a localization toggle updates CRUD but leaves the read selecting the moved
+      // column from a table that no longer has it. Same shared file manager instance, so this
+      // reaches the exact cache the read consumes.
+      this.fileManager.refreshSchema(tableName, table);
       const resolver = (
         this.adapter as unknown as {
           tableResolver?: {

--- a/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
@@ -258,21 +258,33 @@ export class CollectionMetadataService extends BaseService {
       ).tableResolver;
       if (resolver && typeof resolver.registerDynamicSchema === "function") {
         resolver.registerDynamicSchema(tableName, table);
-        // i18n: also register the companion `_locales` runtime table so the current
-        // process can resolve it for localized reads/writes before any restart.
-        if (localized) {
-          const { buildCompanionRuntimeTable } = await import(
-            "../../i18n/runtime/companion-registration"
+      }
+      // i18n: also push the companion `_locales` runtime table into BOTH consumers, so the
+      // current process resolves it for localized reads/writes before any restart. The read
+      // path caches the companion under `<table>_locales` in the same file-manager registry
+      // (loadCompanionSchema), so a metadata change on an already-cached collection must
+      // replace that entry too or entry reads keep the pre-change companion column set.
+      if (localized) {
+        const { buildCompanionRuntimeTable } = await import(
+          "../../i18n/runtime/companion-registration"
+        );
+        const companion = buildCompanionRuntimeTable({
+          slug: tableName,
+          tableName,
+          fields: fields,
+          dialect,
+          localized: true,
+          status: options?.hasStatus === true,
+        });
+        if (companion) {
+          this.fileManager.refreshSchema(
+            companion.companionTableName,
+            companion.table
           );
-          const companion = buildCompanionRuntimeTable({
-            slug: tableName,
-            tableName,
-            fields: fields,
-            dialect,
-            localized: true,
-            status: options?.hasStatus === true,
-          });
-          if (companion) {
+          if (
+            resolver &&
+            typeof resolver.registerDynamicSchema === "function"
+          ) {
             resolver.registerDynamicSchema(
               companion.companionTableName,
               companion.table

--- a/packages/nextly/src/domains/i18n/migration/__tests__/companion-transition.integration.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/__tests__/companion-transition.integration.test.ts
@@ -13,12 +13,15 @@ import { buildCompanionTransitionStatements } from "../reconcile-companion";
 
 let sqlite: Database.Database;
 
-/** A non-localized single's main table with a translatable `heading` column and a shared `views`. */
+/** A non-localized single's main table with a translatable `heading` column and a shared `views`.
+ *  `sub_title` is the physical column for a field NAMED `subTitle` — the storage descriptor
+ *  snake_cases field names, so the enable seed/drop must resolve columns the same way. */
 function createMainTable() {
   sqlite.exec(`CREATE TABLE "single_hero" (
     "id" TEXT PRIMARY KEY,
     "title" TEXT,
     "heading" TEXT,
+    "sub_title" TEXT,
     "views" INTEGER
   )`);
 }
@@ -45,9 +48,9 @@ beforeEach(() => {
   createMainTable();
   sqlite
     .prepare(
-      `INSERT INTO "single_hero" ("id","title","heading","views") VALUES (?,?,?,?)`
+      `INSERT INTO "single_hero" ("id","title","heading","sub_title","views") VALUES (?,?,?,?,?)`
     )
-    .run("h1", "Hero", "Hello", 42);
+    .run("h1", "Hero", "Hello", "Sub", 42);
 });
 
 afterEach(() => sqlite.close());
@@ -85,6 +88,78 @@ describe("buildCompanionTransitionStatements — enable", () => {
     const cols = mainColumns();
     expect(cols).not.toContain("heading");
     expect(cols).toContain("views");
+  });
+
+  it("enables localization while a translatable field is added in the same save", () => {
+    // `description` is added AND localized in this save, so it was never on the main table.
+    // The seed must not read it from main (there is nothing to copy), and the drop must not
+    // target a column that is not there; the companion still gets the column.
+    const plan = buildCompanionTransitionStatements({
+      slug: "hero",
+      tableName: "single_hero",
+      dialect: "sqlite",
+      defaultLocale: "en",
+      status: false,
+      wasLocalized: false,
+      isLocalized: true,
+      oldFields: FIELDS,
+      newFields: [...FIELDS, { name: "description", type: "text" as const }],
+      companionExists: false,
+    });
+
+    // Runs clean: the seed reads only columns that exist on main, so the added-and-localized
+    // `description` is never selected from a table it was never on.
+    run(plan.statements);
+
+    // The companion carries both translatable columns.
+    const companionCols = (
+      sqlite.prepare(`PRAGMA table_info("single_hero_locales")`).all() as {
+        name: string;
+      }[]
+    ).map(c => c.name);
+    expect(companionCols).toContain("heading");
+    expect(companionCols).toContain("description");
+
+    // The pre-existing value seeded; the brand-new field seeds as null (no source data).
+    const companionRow = sqlite
+      .prepare(`SELECT * FROM "single_hero_locales"`)
+      .get() as { heading: string; description: string | null };
+    expect(companionRow.heading).toBe("Hello");
+    expect(companionRow.description).toBeNull();
+
+    // Only the pre-existing translatable column left main; the new one was never there.
+    const cols = mainColumns();
+    expect(cols).not.toContain("heading");
+    expect(cols).toContain("views");
+  });
+
+  it("seeds and drops a camelCase-named field via its snake_case column", () => {
+    // The field is NAMED `subTitle` but stored as `sub_title` (the storage descriptor
+    // snake_cases names). The seed's SELECT and the main-table DROP must address the
+    // physical column, not the raw field name, or the value is stranded on main.
+    const plan = buildCompanionTransitionStatements({
+      slug: "hero",
+      tableName: "single_hero",
+      dialect: "sqlite",
+      defaultLocale: "en",
+      status: false,
+      wasLocalized: false,
+      isLocalized: true,
+      oldFields: [...FIELDS, { name: "subTitle", type: "text" as const }],
+      newFields: [...FIELDS, { name: "subTitle", type: "text" as const }],
+      companionExists: false,
+    });
+    run(plan.statements);
+
+    // The pre-existing value was copied into the companion under the physical column name.
+    const companionRow = sqlite
+      .prepare(`SELECT * FROM "single_hero_locales"`)
+      .get() as { heading: string; sub_title: string };
+    expect(companionRow.heading).toBe("Hello");
+    expect(companionRow.sub_title).toBe("Sub");
+
+    // The physical column was relocated off main.
+    expect(mainColumns()).not.toContain("sub_title");
   });
 });
 

--- a/packages/nextly/src/domains/i18n/migration/__tests__/companion-transition.integration.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/__tests__/companion-transition.integration.test.ts
@@ -161,6 +161,34 @@ describe("buildCompanionTransitionStatements — enable", () => {
     // The physical column was relocated off main.
     expect(mainColumns()).not.toContain("sub_title");
   });
+
+  it("ignores a field whose previous type had no main column", () => {
+    // `gallery` used to be a `component` field (layout-only, no physical column) and becomes
+    // a localized text field in the same save that enables localization. It matches by field
+    // name in the old set, but the main table never carried a `gallery` column, so the seed
+    // and drop must skip it; only its companion column is created.
+    const plan = buildCompanionTransitionStatements({
+      slug: "hero",
+      tableName: "single_hero",
+      dialect: "sqlite",
+      defaultLocale: "en",
+      status: false,
+      wasLocalized: false,
+      isLocalized: true,
+      oldFields: [...FIELDS, { name: "gallery", type: "component" as const }],
+      newFields: [...FIELDS, { name: "gallery", type: "text" as const }],
+      companionExists: false,
+    });
+    run(plan.statements);
+
+    // The companion has the column with no seeded data; the pre-existing field still seeded.
+    const companionRow = sqlite
+      .prepare(`SELECT * FROM "single_hero_locales"`)
+      .get() as { heading: string; gallery: string | null };
+    expect(companionRow.heading).toBe("Hello");
+    expect(companionRow.gallery).toBeNull();
+    expect(mainColumns()).not.toContain("heading");
+  });
 });
 
 describe("buildCompanionTransitionStatements — disable", () => {

--- a/packages/nextly/src/domains/i18n/migration/__tests__/companion-transition.integration.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/__tests__/companion-transition.integration.test.ts
@@ -8,20 +8,43 @@
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { NextlyError } from "../../../../errors";
 import { getI18nArchiveDdl } from "../../../../schemas/nextly-i18n-archive/ddl";
+import { ddlType } from "../ddl-types";
+import { fieldToLocalizedColumnSpec } from "../field-to-column-spec";
 import { buildCompanionTransitionStatements } from "../reconcile-companion";
 
 let sqlite: Database.Database;
 
-/** A non-localized single's main table with a translatable `heading` column and a shared `views`.
- *  `sub_title` is the physical column for a field NAMED `subTitle` — the storage descriptor
- *  snake_cases field names, so the enable seed/drop must resolve columns the same way. */
+/** The camelCase translatable field exercised by the enable tests. */
+const SUB_TITLE_FIELD = { name: "subTitle", type: "text" as const };
+
+/** The field's physical column, resolved through the SAME descriptor + DDL helpers the
+ *  migration generator uses, so the fixture tracks any change to the field-to-column
+ *  mapping instead of hand-copying its current output. */
+function subTitleColumn(): { name: string; ddl: string } {
+  const col = fieldToLocalizedColumnSpec(SUB_TITLE_FIELD, "sqlite");
+  if (!col) {
+    // A text field must map to a physical column; the fixture cannot be built without one.
+    throw NextlyError.internal({
+      logContext: {
+        field: SUB_TITLE_FIELD.name,
+        reason: "no column descriptor",
+      },
+    });
+  }
+  return { name: col.name, ddl: ddlType(col, "sqlite") };
+}
+
+/** A non-localized single's main table with a translatable `heading` column, a shared
+ *  `views`, and the descriptor-derived column for {@link SUB_TITLE_FIELD}. */
 function createMainTable() {
+  const sub = subTitleColumn();
   sqlite.exec(`CREATE TABLE "single_hero" (
     "id" TEXT PRIMARY KEY,
     "title" TEXT,
     "heading" TEXT,
-    "sub_title" TEXT,
+    "${sub.name}" ${sub.ddl},
     "views" INTEGER
   )`);
 }
@@ -48,7 +71,7 @@ beforeEach(() => {
   createMainTable();
   sqlite
     .prepare(
-      `INSERT INTO "single_hero" ("id","title","heading","sub_title","views") VALUES (?,?,?,?,?)`
+      `INSERT INTO "single_hero" ("id","title","heading","${subTitleColumn().name}","views") VALUES (?,?,?,?,?)`
     )
     .run("h1", "Hero", "Hello", "Sub", 42);
 });
@@ -133,10 +156,11 @@ describe("buildCompanionTransitionStatements — enable", () => {
     expect(cols).toContain("views");
   });
 
-  it("seeds and drops a camelCase-named field via its snake_case column", () => {
-    // The field is NAMED `subTitle` but stored as `sub_title` (the storage descriptor
-    // snake_cases names). The seed's SELECT and the main-table DROP must address the
-    // physical column, not the raw field name, or the value is stranded on main.
+  it("seeds and drops a camelCase-named field via its physical column", () => {
+    // The field is NAMED `subTitle` but stored under the descriptor-derived column name.
+    // The seed's SELECT and the main-table DROP must address the physical column, not the
+    // raw field name, or the value is stranded on main.
+    const sub = subTitleColumn();
     const plan = buildCompanionTransitionStatements({
       slug: "hero",
       tableName: "single_hero",
@@ -145,8 +169,8 @@ describe("buildCompanionTransitionStatements — enable", () => {
       status: false,
       wasLocalized: false,
       isLocalized: true,
-      oldFields: [...FIELDS, { name: "subTitle", type: "text" as const }],
-      newFields: [...FIELDS, { name: "subTitle", type: "text" as const }],
+      oldFields: [...FIELDS, SUB_TITLE_FIELD],
+      newFields: [...FIELDS, SUB_TITLE_FIELD],
       companionExists: false,
     });
     run(plan.statements);
@@ -154,12 +178,12 @@ describe("buildCompanionTransitionStatements — enable", () => {
     // The pre-existing value was copied into the companion under the physical column name.
     const companionRow = sqlite
       .prepare(`SELECT * FROM "single_hero_locales"`)
-      .get() as { heading: string; sub_title: string };
+      .get() as Record<string, unknown>;
     expect(companionRow.heading).toBe("Hello");
-    expect(companionRow.sub_title).toBe("Sub");
+    expect(companionRow[sub.name]).toBe("Sub");
 
     // The physical column was relocated off main.
-    expect(mainColumns()).not.toContain("sub_title");
+    expect(mainColumns()).not.toContain(sub.name);
   });
 
   it("ignores a field whose previous type had no main column", () => {

--- a/packages/nextly/src/domains/i18n/migration/generate-down.ts
+++ b/packages/nextly/src/domains/i18n/migration/generate-down.ts
@@ -35,15 +35,25 @@ export function buildLocalizationDownStatements(
   } = spec;
   const stmts: string[] = [];
 
+  // Reversing an ENABLE that dropped only a subset of the localized columns from main
+  // (`columnsOnMain`) must re-add and restore exactly that subset; a column main never
+  // carried has no place to come back to. Undefined means "all of `columns`" — the disable
+  // path, where every localized column belongs on main. The archive step below still spans
+  // ALL columns so no translation is lost when the companion is dropped.
+  const onMainSet = spec.columnsOnMain && new Set(spec.columnsOnMain);
+  const onMain = onMainSet
+    ? columns.filter(c => onMainSet.has(c.name))
+    : columns;
+
   // 1. re-add columns (nullable — localized columns are always nullable)
-  for (const c of columns) {
+  for (const c of onMain) {
     stmts.push(
       `ALTER TABLE ${q(mainTable, dialect)} ADD COLUMN ${q(c.name, dialect)} ${ddlType(c, dialect)}`
     );
   }
 
   // 2. restore default-locale value onto the main row (one correlated UPDATE per column)
-  for (const c of columns) {
+  for (const c of onMain) {
     const col = q(c.name, dialect);
     const comp = q(companionTable, dialect);
     const main = q(mainTable, dialect);

--- a/packages/nextly/src/domains/i18n/migration/generate-up.ts
+++ b/packages/nextly/src/domains/i18n/migration/generate-up.ts
@@ -69,25 +69,43 @@ export function buildLocalizationUpStatements(
   spec: CompanionMigrationSpec
 ): string[] {
   const { dialect, mainTable, companionTable, defaultLocale, columns } = spec;
-  const colNames = columns.map(c => q(c.name, dialect));
 
   const create = buildCompanionCreateStatement(spec);
+
+  // Only columns already on the main table can be seeded from or dropped. A field added and
+  // localized in the same save is in `columns` (so the companion gets it) but not on main, so
+  // it is excluded from the SELECT and the DROP. Undefined `columnsOnMain` means "all" — the
+  // file-migration path, where every localized column pre-exists on main.
+  const onMainSet = spec.columnsOnMain && new Set(spec.columnsOnMain);
+  const onMain = onMainSet
+    ? columns.filter(c => onMainSet.has(c.name))
+    : columns;
+  // A leading ", <col>" per column, so an empty set contributes nothing to the column lists.
+  const onMainCols = onMain.map(c => `, ${q(c.name, dialect)}`).join("");
 
   // When the collection has Draft/Published, the seeded default-locale rows carry the existing
   // main row's `status` into the companion `_status` so enabling localization doesn't silently
   // un-publish live content.
   const statusInsertCol = spec.status ? `, ${q("_status", dialect)}` : "";
   const statusSelectCol = spec.status ? `, ${q("status", dialect)}` : "";
-  const seed =
-    `INSERT INTO ${q(companionTable, dialect)} ` +
-    `(${q("_parent", dialect)}, ${q("_locale", dialect)}${statusInsertCol}, ${colNames.join(", ")}) ` +
-    `SELECT ${q("id", dialect)}, ${lit(defaultLocale)}${statusSelectCol}, ${colNames.join(", ")} ` +
-    `FROM ${q(mainTable, dialect)}`;
 
-  const drops = columns.map(
+  // Skip the seed entirely when there is nothing on main to copy — no pre-existing translatable
+  // columns and no status. An INSERT with an empty value list would be invalid SQL, and there
+  // is no existing content to preserve.
+  const seed =
+    onMain.length > 0 || spec.status
+      ? [
+          `INSERT INTO ${q(companionTable, dialect)} ` +
+            `(${q("_parent", dialect)}, ${q("_locale", dialect)}${statusInsertCol}${onMainCols}) ` +
+            `SELECT ${q("id", dialect)}, ${lit(defaultLocale)}${statusSelectCol}${onMainCols} ` +
+            `FROM ${q(mainTable, dialect)}`,
+        ]
+      : [];
+
+  const drops = onMain.map(
     c =>
       `ALTER TABLE ${q(mainTable, dialect)} DROP COLUMN ${q(c.name, dialect)}`
   );
 
-  return [create, seed, ...drops];
+  return [create, ...seed, ...drops];
 }

--- a/packages/nextly/src/domains/i18n/migration/plan-companion-migration.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/plan-companion-migration.test.ts
@@ -26,6 +26,35 @@ describe("planCompanionMigration", () => {
     expect(plan.downSql).toContain("DROP TABLE"); // reverse
   });
 
+  it("ENABLE seeds and drops only the columns the previous main carried", () => {
+    // `summary` is added and localized in the same config change: it is in `columns`
+    // (the companion CREATE needs it) but was never on the previous main table, so the
+    // seed SELECT and the main-table DROP must skip it or the migration fails on apply.
+    const plan = planCompanionMigration({
+      spec: {
+        ...spec,
+        columns: [
+          { name: "title", kind: "text" },
+          { name: "summary", kind: "text" },
+        ],
+      },
+      prevMainColumnNames: ["id", "title", "price"],
+      companionExisted: false,
+    });
+    expect(plan.kind).toBe("enable");
+    // The companion still gets both columns.
+    expect(plan.upSql).toContain('"summary" TEXT');
+    // Seed and drop touch only the pre-existing column.
+    expect(plan.upSql).toContain('SELECT "id", \'en\', "title"');
+    expect(plan.upSql).toContain('DROP COLUMN "title"');
+    expect(plan.upSql).not.toContain('DROP COLUMN "summary"');
+    // DOWN re-adds and restores only what UP dropped, but still archives every
+    // translation (including `summary`) so no language data is silently lost.
+    expect(plan.downSql).toContain('ADD COLUMN "title"');
+    expect(plan.downSql).not.toContain('ADD COLUMN "summary"');
+    expect(plan.downSql).toContain("'summary'");
+  });
+
   it("CREATE-ONLY for a fresh localized collection (main never had the columns)", () => {
     const plan = planCompanionMigration({
       spec,

--- a/packages/nextly/src/domains/i18n/migration/plan-companion-migration.ts
+++ b/packages/nextly/src/domains/i18n/migration/plan-companion-migration.ts
@@ -80,10 +80,19 @@ export function planCompanionMigration(
   const hadLocalizedColumns = spec.columns.some(c => prev.has(c.name));
 
   if (hadLocalizedColumns) {
+    // Seed from (and drop) only the localized columns the previous main actually carried. A
+    // field added and localized in the same config change is in `spec.columns` (the companion
+    // CREATE needs it) but was never on main, so including it in the seed SELECT or the DROP
+    // list makes the migration fail on apply with "no such column". The DOWN uses the same
+    // subset so it re-adds exactly what the UP dropped.
+    const enableSpec: CompanionMigrationSpec = {
+      ...spec,
+      columnsOnMain: spec.columns.map(c => c.name).filter(n => prev.has(n)),
+    };
     return {
       kind: "enable",
-      upSql: buildLocalizationUpSql(spec),
-      downSql: buildLocalizationDownSql(spec),
+      upSql: buildLocalizationUpSql(enableSpec),
+      downSql: buildLocalizationDownSql(enableSpec),
     };
   }
 

--- a/packages/nextly/src/domains/i18n/migration/reconcile-companion.ts
+++ b/packages/nextly/src/domains/i18n/migration/reconcile-companion.ts
@@ -236,16 +236,21 @@ export function buildCompanionTransitionStatements(
         companionDropped: false,
       };
     }
-    // `wasLocalized` is false here, so every field that existed before this save lived on the
-    // main table; one added in this same save did not, and gets a companion column only. The
-    // names go through the same descriptor that produced `spec.columns`, so the seed/drop
-    // address the physical snake_case column (a field named `subTitle` is stored as
-    // `sub_title` — the raw field name would never match it).
-    const oldNames = new Set(oldFields.map(f => f.name));
-    spec.columnsOnMain = localizedNew
-      .filter(f => oldNames.has(f.name))
-      .map(f => fieldToLocalizedColumnSpec(f, dialect)?.name)
-      .filter((n): n is string => typeof n === "string");
+    // `wasLocalized` is false here, so a physical column a pre-save field produced can only
+    // live on the main table. Resolve the OLD fields through the same descriptor that built
+    // `spec.columns` and keep the new localized columns whose physical column already exists:
+    // a field named `subTitle` is stored as `sub_title`, a `component` field emits no column
+    // at all, and a relationship stores under a different name, so matching raw field names
+    // would seed from (and drop) columns main never had. A field added in this save has no
+    // old column and gets a companion column only.
+    const oldColumnNames = new Set(
+      oldFields
+        .map(f => fieldToLocalizedColumnSpec(f, dialect)?.name)
+        .filter((n): n is string => typeof n === "string")
+    );
+    spec.columnsOnMain = spec.columns
+      .map(c => c.name)
+      .filter(n => oldColumnNames.has(n));
     return {
       statements: buildLocalizationUpStatements(spec),
       needsArchive: false,

--- a/packages/nextly/src/domains/i18n/migration/reconcile-companion.ts
+++ b/packages/nextly/src/domains/i18n/migration/reconcile-companion.ts
@@ -236,6 +236,16 @@ export function buildCompanionTransitionStatements(
         companionDropped: false,
       };
     }
+    // `wasLocalized` is false here, so every field that existed before this save lived on the
+    // main table; one added in this same save did not, and gets a companion column only. The
+    // names go through the same descriptor that produced `spec.columns`, so the seed/drop
+    // address the physical snake_case column (a field named `subTitle` is stored as
+    // `sub_title` — the raw field name would never match it).
+    const oldNames = new Set(oldFields.map(f => f.name));
+    spec.columnsOnMain = localizedNew
+      .filter(f => oldNames.has(f.name))
+      .map(f => fieldToLocalizedColumnSpec(f, dialect)?.name)
+      .filter((n): n is string => typeof n === "string");
     return {
       statements: buildLocalizationUpStatements(spec),
       needsArchive: false,

--- a/packages/nextly/src/domains/i18n/migration/types.ts
+++ b/packages/nextly/src/domains/i18n/migration/types.ts
@@ -45,6 +45,14 @@ export interface CompanionMigrationSpec {
   /** columns being localized (moved main -> companion). */
   columns: LocalizedColumnSpec[];
   /**
+   * Names of `columns` that physically exist on the main table right now, so the ENABLE seed
+   * (`SELECT ... FROM main`) and the main-table DROP only touch real columns. A field added
+   * and localized in the same save is in `columns` (it needs a companion column) but not here
+   * (there is nothing on main to seed from or drop). Undefined means "all of `columns`" — the
+   * file-migration path, where every localized column pre-exists on main.
+   */
+  columnsOnMain?: string[];
+  /**
    * Whether the collection has Draft/Published enabled (i18n M6). When true, the companion gets a
    * per-locale `_status` column (`'draft' | 'published'`, default `'draft'`) so each language
    * publishes independently. On an ENABLE seed, existing rows carry the main row's `status`.


### PR DESCRIPTION
## Problem

Enabling Internationalization on an entity that already exists is broken in three distinct ways:

1. **Enable + add field in one save fails the apply (singles and components return 500).** Creating a single or component without localization, then adding a translatable field (e.g. `description`) and turning on Internationalization in the same save, crashes with `column "description" does not exist`. The enable migration seeds the new companion `_locales` table with `INSERT INTO companion (...) SELECT <all localized columns> FROM main`, but a field added in that same save was never on the main table, so the SELECT references a column that does not exist. On singles and components the whole apply fails; the entity is left half-migrated.

2. **camelCase field names strand data silently.** The seed and the main-table `DROP COLUMN` list were matched by raw field name, but physical columns are snake_cased by the storage descriptor (`subTitle` is stored as `sub_title`). The name never matched, so for any camelCase-named translatable field the enable plan contained no seed and no drop: the existing content stayed on a main column no read path looks at anymore (the value appears wiped in the UI), and the orphaned column became schema drift that the next apply flags as a destructive drop. No error is raised anywhere; the toggle reports success.

3. **Collections apply cleanly but the entry list 500s afterwards.** For collections the toggle goes through the metadata update path, which refreshed only the adapter's CRUD schema resolver. The entry-list read resolves its SELECT columns from the file manager's own schema cache, a separate cache that kept the pre-toggle table shape, so the list query kept selecting a column that had just moved to the companion: `column "description" does not exist` on every entry list load until restart.

## Fixes

### Seed and drop only columns that physically exist on main
`generate-up.ts` / `types.ts` / `reconcile-companion.ts`

`CompanionMigrationSpec` gains an optional `columnsOnMain`: the subset of localized columns that physically exist on the main table right now. The enable seed SELECTs and the main-table DROPs are restricted to that subset, while the companion CREATE still includes every localized column (a field added in the same save gets its companion column; it simply has no existing data to copy and nothing to drop). When nothing is on main and the entity has no Draft/Published status, the seed is skipped entirely rather than emitting an invalid empty INSERT.

The runtime toggle path populates `columnsOnMain` from the fields that existed before the save, resolving each name through the same column descriptor that produced the spec's columns, so the seed and drop always address the physical snake_case column (fix for problem 2 as well).

`columnsOnMain: undefined` means "all columns", which keeps the disable path byte-identical to before.

The file-migration path (`migrate:create`) gets the same treatment (review follow-up, `fbfd881e`): the enable plan populates `columnsOnMain` from the previous committed snapshot's main columns, so a code-first add-and-localize in one config change no longer generates a migration that fails on apply. The DOWN honors the same subset, re-adding and restoring exactly what the UP dropped, while still archiving every column's translations so rollback loses no language data.

### Refresh the read-path schema cache on a localization toggle
`collection-metadata-service.ts`

`registerRuntimeSchema` now calls `fileManager.refreshSchema(tableName, table)` with the freshly generated localized-aware runtime table, in addition to registering it on the adapter resolver. This mirrors exactly what the schema-apply path (`CollectionsHandler.refreshCollectionSchema`) already does; the metadata path was the only writer that skipped the read cache. Both services share the same `CollectionFileManager` instance, so the refresh reaches the exact cache the entry-list read consumes.

## Verification

Test-first: each seed bug was reproduced with a failing test before the fix (the add-in-same-save test failed with `no such column: "description"`, the camelCase test failed with `sub_title` seeded as `null`), and both pass after.

| Check | Result |
| --- | --- |
| i18n integration suite, SQLite | 20 files, 78 passed |
| i18n integration suite, Postgres | 20 files, 82 passed |
| i18n integration suite, MySQL | 20 files, 82 passed |
| Collections integration regression | 14 passed |
| `tsc --noEmit` (packages/nextly) | clean |

New coverage in `companion-transition.integration.test.ts` (runs the generated statements against a real database, not mocks):

- enable while a translatable field is added in the same save: companion gets both columns, the pre-existing value is seeded, the new field seeds as null, only the pre-existing column is dropped from main
- enable with a camelCase-named field: the value is copied under the physical `sub_title` column and the physical column is relocated off main

## Known limitations and deferrals

- **The read-cache fix has no automated test.** The `createTestNextly` harness resolves entry-list reads through a different path than production and never touches the file manager cache, so a test asserting this fix passes with or without it. Rather than ship a vacuous test, the fix is verified by code trace (both cache writers now match) and manual playground verification. Harness parity is a follow-up.

## Changeset

One changeset covering all published packages (patch, lockstep).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed localized enablement when adding new translatable fields in the same save, ensuring companion creation and correct main-table column drops.
  - Improved companion migration planning to only seed and drop localized columns that already exist on the prior main table.
  - Updated runtime schema refresh so localized column changes are reflected immediately in collection entry-list reads.

- **Tests**
  - Expanded SQLite end-to-end coverage for companion transitions, including added columns, camelCase-to-snake_case mapping, and correct handling of fields without main-table equivalents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
