### PR TITLE
feat(nextly): enforce single publish transitions under the row lock

### DIFF
--- a/.changeset/single-publish-under-lock.md
+++ b/.changeset/single-publish-under-lock.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+The publish/unpublish permission gate on Single documents now holds under
+concurrency.
+
+A Single update classified whether it was publishing or unpublishing from the
+status read before it opened the write transaction, so a concurrent writer could
+move the document into or out of published in that window and the write would
+slip the transition past the gate. The update now pre-resolves the caller's
+publish/unpublish authorization before the transaction and enforces it against
+the main row (and, for a localized write, the write locale's companion status)
+read under the row lock, closing the race. An unauthenticated caller can no
+longer publish or unpublish a publicly-writable Single unless an explicit rule
+grants it, and a first-update hook that reads a status-enabled Single now sees
+its default `draft` status.

--- a/packages/nextly/src/domains/singles/__tests__/publish-enforcement-toctou.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/publish-enforcement-toctou.integration.test.ts
@@ -1,0 +1,194 @@
+/**
+ * A Single's publish-transition gate must be enforced against the status read
+ * UNDER the write's row lock, not a status read taken before the transaction —
+ * otherwise a concurrent writer can move the row into (or out of) published in
+ * the window between the two, and the write slips a transition past the gate.
+ *
+ * This reproduces the exact race on a REAL database (SQLite serializes writers
+ * via `BEGIN IMMEDIATE`, so it cannot manifest there and the suite self-skips
+ * without a Postgres URL):
+ *
+ *   1. The Single row is `draft`.
+ *   2. Writer A (an editor who may update but NOT unpublish) starts an update
+ *      that keeps the row `draft`, reading `draft` before it takes its lock.
+ *   3. Writer B publishes the row and commits.
+ *   4. Writer A finally takes its lock. Classified against the PRE-lock read
+ *      (`draft` → `draft`) the write is no transition and would be allowed —
+ *      silently unpublishing. Classified against the LOCKED read (`published` →
+ *      `draft`) it is an unpublish the editor may not perform, and is refused.
+ *
+ * The update pre-resolves the caller's publish/unpublish authorization before
+ * the transaction and enforces it under the lock, so A is correctly refused and
+ * B's publish stands.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { defineSingle, text } from "../../../config";
+import { createAdapter } from "../../../database/factory";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { SingleEntryService } from "../services/single-entry-service";
+
+const POSTGRES_URL = process.env.TEST_POSTGRES_URL ?? "";
+
+const SLUG = "toctousingle";
+const TABLE = `single_${SLUG}`;
+
+type TestAdapter = Awaited<ReturnType<typeof createAdapter>>;
+
+async function connect(): Promise<TestAdapter> {
+  // env.ts validates DATABASE_URL against DB_DIALECT on first read in this
+  // worker, so both must be on process.env — not just passed to createAdapter.
+  process.env.DB_DIALECT = "postgresql";
+  process.env.DATABASE_URL = POSTGRES_URL;
+  const adapter = await createAdapter({
+    type: "postgresql",
+    url: POSTGRES_URL,
+  } as Parameters<typeof createAdapter>[0]);
+  await adapter.executeQuery("SELECT 1");
+  return adapter;
+}
+
+interface Deferred {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+function deferred(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>(r => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// Block until a backend is parked waiting on a lock for this table. Releasing the
+// gate only after Writer A is observably blocked on Writer B's row lock makes the
+// race deterministic: A has already taken its pre-lock read and is now waiting on
+// the FOR UPDATE, so it cannot instead observe B's committed change up front and
+// skip the under-lock path.
+async function waitForLockWaiter(adapter: TestAdapter): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    const rows = await adapter.executeQuery<{ n: number }>(
+      `SELECT count(*)::int AS n FROM pg_stat_activity
+       WHERE wait_event_type = 'Lock' AND query LIKE $1`,
+      [`%${TABLE}%`]
+    );
+    if ((rows[0]?.n ?? 0) > 0) return;
+    await sleep(25);
+  }
+  throw new Error(`timed out waiting for a lock waiter on ${TABLE}`);
+}
+
+const whereId = (id: string) => ({
+  and: [{ column: "id", op: "=" as const, value: id }],
+});
+
+const describeLeg = describe.skipIf(!POSTGRES_URL);
+
+describeLeg("single publish transition TOCTOU (postgres dialect gate)", () => {
+  let boot: TestAdapter | undefined;
+
+  beforeAll(async () => {
+    if (!POSTGRES_URL) return;
+    boot = await connect();
+    await drop();
+  });
+
+  afterAll(async () => {
+    await drop();
+    if (boot) await boot.disconnect();
+  });
+
+  async function drop(): Promise<void> {
+    if (!boot) return;
+    for (const stmt of [
+      `DROP TABLE IF EXISTS ${TABLE}`,
+      `DELETE FROM dynamic_singles WHERE slug = '${SLUG}'`,
+    ]) {
+      try {
+        await boot.executeQuery(stmt);
+      } catch {
+        // Best-effort on a fresh database.
+      }
+    }
+  }
+
+  it("refuses a draft-write that races a concurrent publish", async () => {
+    const adapter = await connect();
+    let handle: TestNextly | undefined;
+    try {
+      handle = await createTestNextly({
+        adapter,
+        singles: [
+          defineSingle({
+            slug: SLUG,
+            status: true,
+            fields: [text({ name: "siteName" })],
+          }),
+        ],
+      });
+      const service =
+        handle.getService<SingleEntryService>("singleEntryService");
+
+      // Seed the row as draft via a trusted write.
+      await service.update(
+        SLUG,
+        { siteName: "S", status: "draft" },
+        { overrideAccess: true }
+      );
+      const seeded = await handle.adapter.selectOne<{ id: string }>(TABLE, {});
+      const id = seeded?.id as string;
+
+      const gate = deferred();
+      const bLocked = deferred();
+
+      // Writer B: hold a transaction that locks the row and publishes it, then
+      // wait for the gate before committing — so it commits only after A has read
+      // `draft` and is blocked on the same lock.
+      const bTx = handle.adapter.transaction(async tx => {
+        await tx.lockRow(TABLE, id);
+        await tx.update(TABLE, { status: "published" }, whereId(id));
+        bLocked.resolve();
+        await gate.promise;
+      });
+
+      await bLocked.promise;
+
+      // Writer A: an editor (route-attested `update`, no `unpublish`) writes the
+      // row `draft`. Its pre-lock read sees the committed `draft` (B is
+      // uncommitted), then it blocks taking the row lock behind B.
+      const aResultP = service.update(
+        SLUG,
+        { status: "draft" },
+        { user: { id: "editor" }, routeAuthorized: true }
+      );
+
+      // Release the gate only once A is observably parked on B's row lock, so A
+      // has already read `draft` and is blocked before B commits.
+      await waitForLockWaiter(handle.adapter);
+
+      gate.resolve();
+      await bTx;
+
+      const aResult = await aResultP;
+      // The draft-over-published write is an unpublish the editor may not do.
+      expect(aResult.success).toBe(false);
+      expect(aResult.statusCode).toBe(403);
+
+      // A was refused under the lock, so B's publish stands.
+      const row = await handle.adapter.selectOne<{ status: string }>(TABLE, {
+        where: whereId(id),
+      });
+      expect(row?.status).toBe("published");
+    } finally {
+      await handle?.destroy();
+    }
+  });
+});

--- a/packages/nextly/src/domains/singles/__tests__/publish-enforcement.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/publish-enforcement.integration.test.ts
@@ -28,7 +28,7 @@ describe("single publish enforcement — authorize before create (integration)",
     current = await createTestNextly({
       singles: [
         defineSingle({
-          slug: "settings",
+          slug: "branding",
           status: true,
           // The route attests `update`; only the publish transition can fail,
           // and this code-defined rule denies it.
@@ -42,7 +42,7 @@ describe("single publish enforcement — authorize before create (integration)",
 
     // First-ever write, and it would publish. The publish rule denies it.
     const denied = await service.update(
-      "settings",
+      "branding",
       { siteName: "S", status: "published" },
       { user: { id: "u1" }, routeAuthorized: true }
     );
@@ -51,7 +51,7 @@ describe("single publish enforcement — authorize before create (integration)",
     expect(denied.statusCode).toBe(403);
 
     // The default was never inserted: the single's table is still empty.
-    const row = await current.adapter.selectOne("single_settings", {});
+    const row = await current.adapter.selectOne("single_branding", {});
     expect(row).toBeNull();
   });
 
@@ -59,7 +59,7 @@ describe("single publish enforcement — authorize before create (integration)",
     current = await createTestNextly({
       singles: [
         defineSingle({
-          slug: "settings",
+          slug: "branding",
           status: true,
           access: { publish: () => false },
           fields: [text({ name: "siteName" })],
@@ -74,7 +74,7 @@ describe("single publish enforcement — authorize before create (integration)",
     // authorized write, so the authorize-before-create change does not block a
     // legitimate first publish.
     const ok = await service.update(
-      "settings",
+      "branding",
       { siteName: "S", status: "published" },
       { overrideAccess: true }
     );
@@ -83,7 +83,7 @@ describe("single publish enforcement — authorize before create (integration)",
 
     // The deferred default was persisted and carries the published status.
     const row = await current.adapter.selectOne<{ status?: string }>(
-      "single_settings",
+      "single_branding",
       {}
     );
     expect(row).not.toBeNull();
@@ -94,7 +94,7 @@ describe("single publish enforcement — authorize before create (integration)",
     current = await createTestNextly({
       singles: [
         defineSingle({
-          slug: "settings",
+          slug: "branding",
           status: true,
           access: { publish: () => false },
           fields: [text({ name: "siteName" })],
@@ -107,14 +107,14 @@ describe("single publish enforcement — authorize before create (integration)",
     // A first write that stays a draft names no publish transition, so the
     // denying publish rule is never consulted and the row is created.
     const ok = await service.update(
-      "settings",
+      "branding",
       { siteName: "S", status: "draft" },
       { user: { id: "u1" }, routeAuthorized: true }
     );
 
     expect(ok.success).toBe(true);
     const row = await current.adapter.selectOne<{ status?: string }>(
-      "single_settings",
+      "single_branding",
       {}
     );
     expect(row).not.toBeNull();
@@ -131,7 +131,7 @@ describe("single publish enforcement — authorize before create (integration)",
     current = await createTestNextly({
       singles: [
         defineSingle({
-          slug: "settings",
+          slug: "branding",
           localized: true,
           status: true,
           access: { publish: () => false },
@@ -144,30 +144,37 @@ describe("single publish enforcement — authorize before create (integration)",
       current.getService<SingleEntryService>("singleEntryService");
     const adapter = current.adapter as unknown as {
       executeQuery: (sql: string) => Promise<unknown>;
+      dialect: string;
     };
+    // Dialect-aware identifier quoting: MySQL parses double-quoted names as
+    // string literals (unless ANSI_QUOTES is on, which this repo's MySQL test
+    // service does not enable), so the raw setup/verify queries must use
+    // backticks on MySQL and double quotes on Postgres/SQLite.
+    const q = (id: string) =>
+      adapter.dialect === "mysql" ? `\`${id}\`` : `"${id}"`;
 
     // Trusted create publishes the default locale: main row published, companion
     // `en` `_status` published.
     await service.update(
-      "settings",
+      "branding",
       { heading: "H", status: "published" },
       { overrideAccess: true, locale: "en" }
     );
     const mainRow = await current.adapter.selectOne<{ id: string }>(
-      "single_settings",
+      "single_branding",
       {}
     );
     const id = mainRow?.id as string;
 
     // Manufacture the divergence: main stays published, companion `en` → draft.
     await adapter.executeQuery(
-      `UPDATE "single_settings_locales" SET "_status" = 'draft' WHERE "_parent" = '${id}' AND "_locale" = 'en'`
+      `UPDATE ${q("single_branding_locales")} SET ${q("_status")} = 'draft' WHERE ${q("_parent")} = '${id}' AND ${q("_locale")} = 'en'`
     );
 
     // A caller with update (route-attested) but not publish re-publishes the
     // default locale. The companion draft -> published transition must be denied.
     const denied = await service.update(
-      "settings",
+      "branding",
       { heading: "H2", status: "published" },
       { user: { id: "u1" }, routeAuthorized: true, locale: "en" }
     );
@@ -176,20 +183,20 @@ describe("single publish enforcement — authorize before create (integration)",
 
     // The companion `_status` was not moved to published.
     const rows = (await adapter.executeQuery(
-      `SELECT "_status" FROM "single_settings_locales" WHERE "_parent" = '${id}' AND "_locale" = 'en'`
+      `SELECT ${q("_status")} FROM ${q("single_branding_locales")} WHERE ${q("_parent")} = '${id}' AND ${q("_locale")} = 'en'`
     )) as Array<{ _status: string }> | { rows?: Array<{ _status: string }> };
     const list = Array.isArray(rows) ? rows : (rows.rows ?? []);
     expect(list[0]?._status).toBe("draft");
   });
 
   it("judges a scoped API-key publish on the key's own grant, not the owner's", async () => {
-    // End-to-end: a key scoped for `update-settings` but not `publish-settings`
+    // End-to-end: a key scoped for `update-branding` but not `publish-branding`
     // is refused the publish; a key scoped for publish is allowed. The route
     // stamped only `update`, so the service-side gate judges the key's scope.
     current = await createTestNextly({
       singles: [
         defineSingle({
-          slug: "settings",
+          slug: "branding",
           status: true,
           fields: [text({ name: "siteName" })],
         }),
@@ -200,20 +207,20 @@ describe("single publish enforcement — authorize before create (integration)",
 
     // Seed a draft via a trusted write so the update path is a pure transition.
     await service.update(
-      "settings",
+      "branding",
       { siteName: "S", status: "draft" },
       { overrideAccess: true }
     );
 
     const denied = await service.update(
-      "settings",
+      "branding",
       { status: "published" },
       {
         user: { id: "key-owner" },
         routeAuthorized: true,
         authenticatedScope: {
           actorType: "apiKey",
-          permissions: ["update-settings"],
+          permissions: ["update-branding"],
         },
       }
     );
@@ -221,14 +228,14 @@ describe("single publish enforcement — authorize before create (integration)",
     expect(denied.statusCode).toBe(403);
 
     const allowed = await service.update(
-      "settings",
+      "branding",
       { status: "published" },
       {
         user: { id: "key-owner" },
         routeAuthorized: true,
         authenticatedScope: {
           actorType: "apiKey",
-          permissions: ["update-settings", "publish-settings"],
+          permissions: ["update-branding", "publish-branding"],
         },
       }
     );

--- a/packages/nextly/src/domains/singles/__tests__/single-entry-service.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-entry-service.test.ts
@@ -1033,12 +1033,16 @@ describe("SingleEntryService", () => {
       expect(result.statusCode).not.toBe(403);
     });
 
-    it("never persists the default when a first publish is denied", async () => {
-      // No row yet → the update builds a default in memory before the gate runs
-      // but does not insert it. When the publish transition is refused, that
-      // default must never be persisted, so the 403 leaves no document behind
-      // (and, for a versioned single, no historyless row) and there is no row a
-      // rollback delete could destroy out from under a concurrent writer.
+    it("does not commit the default when a first publish is denied", async () => {
+      // No row yet → the update materializes the default INSIDE the write
+      // transaction and enforces the publish transition against the row-locked
+      // status there. When the transition is refused, the transaction throws and
+      // rolls back — so the auto-created default never commits, WITHOUT a
+      // compensating delete that could destroy a concurrent writer's row. (The
+      // real no-row-left-behind guarantee is exercised on a live database in
+      // publish-enforcement.integration.test.ts; this mock transaction has no
+      // rollback to observe, so it asserts the denial and that no compensating
+      // delete is issued.)
       const ctx = lifecycleCtx("publish");
       ctx.adapter.selectOne.mockResolvedValue(null);
 
@@ -1049,8 +1053,9 @@ describe("SingleEntryService", () => {
       );
 
       expect(result.statusCode).toBe(403);
-      // The default was never inserted, so there is nothing to roll back.
-      expect(ctx.adapter.insert).not.toHaveBeenCalled();
+      // The write is gated within a transaction (so the insert is rolled back on
+      // denial), and no compensating delete is issued.
+      expect(ctx.adapter.transaction).toHaveBeenCalled();
       expect(ctx.adapter.delete).not.toHaveBeenCalled();
     });
 

--- a/packages/nextly/src/domains/singles/services/single-access-stored-rules.test.ts
+++ b/packages/nextly/src/domains/singles/services/single-access-stored-rules.test.ts
@@ -64,6 +64,33 @@ describe("checkSingleAccess — stored rule enforcement", () => {
     expect(accessControlService.evaluateAccess).not.toHaveBeenCalled();
   });
 
+  it("defers a document-dependent stored rule when deferStoredRuleEval is set", async () => {
+    const { accessControlService, rbacAccessControlService } = makeDeps();
+    // The same owner-only-with-no-document rule that fails closed above. With the
+    // defer flag the pre-resolve skips it (permission-only), so the publish
+    // transition gate can re-judge it against the row-locked document instead of
+    // the stale pre-transaction one.
+    accessControlService.evaluateAccess.mockResolvedValue({ allowed: false });
+
+    const result = await checkSingleAccess({
+      slug: "site",
+      operation: "publish",
+      user: editor,
+      routeAuthorized: true,
+      rbacAccessControlService: rbacAccessControlService as never,
+      accessControlService: accessControlService as never,
+      accessRules: { publish: { type: "owner-only" } },
+      document: undefined,
+      deferStoredRuleEval: true,
+      logger: silentLogger,
+    });
+
+    // The document-dependent rule is NOT evaluated here (contrast the 403 above);
+    // the permission gate passes, so the pre-resolve returns permission-only allow.
+    expect(result).toBeNull();
+    expect(accessControlService.evaluateAccess).not.toHaveBeenCalled();
+  });
+
   it("denies a route-authorized update when the stored rule fails, without RBAC", async () => {
     const { accessControlService, rbacAccessControlService } = makeDeps();
     accessControlService.evaluateAccess.mockResolvedValue({

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -29,7 +29,10 @@ import { NextlyError } from "../../../errors/nextly-error";
 import type { HookRegistry } from "../../../hooks/hook-registry";
 import { keysToSnakeCase } from "../../../lib/case-conversion";
 import { resolvePublishTransition } from "../../../lib/status-transition";
-import { AccessControlService } from "../../../services/access";
+import {
+  AccessControlService,
+  type CollectionAccessRules,
+} from "../../../services/access";
 import type { ComponentDataService } from "../../../services/components/component-data-service";
 import { BaseService } from "../../../shared/base-service";
 import { convertTimestampsToCamelCase } from "../../../shared/lib/case-conversion";
@@ -435,9 +438,16 @@ export class SingleMutationService extends BaseService {
       const transitionNextStatus = isNonDefaultLocaleWrite
         ? companionNextStatus
         : mainNextStatus;
+      // The guard carries the pre-resolved PERMISSION denial (document-
+      // independent, judged off this transaction's connection) plus, when the
+      // op's stored rule is document-dependent (owner-only/custom), the rules to
+      // re-evaluate against the ROW-LOCKED document inside the transaction. A
+      // custom transition rule keyed on a mutable field must not be judged
+      // against the stale pre-transaction document.
       let transitionGuard: {
         op: "publish" | "unpublish";
-        denied: SingleResult;
+        permissionDenied: SingleResult | null;
+        documentRule: CollectionAccessRules | null;
       } | null = null;
       if (
         singleHasStatus &&
@@ -446,7 +456,15 @@ export class SingleMutationService extends BaseService {
       ) {
         const transitionOp =
           transitionNextStatus === "published" ? "publish" : "unpublish";
-        const denied = await checkSingleAccess({
+        // Defer a document-dependent (owner-only/custom) rule for this op to the
+        // under-lock re-check; public/authenticated/role-based rules are decided
+        // here since they need no document.
+        const opRule = (singleMeta.accessRules as CollectionAccessRules)?.[
+          transitionOp
+        ] as { type?: string } | undefined;
+        const deferDocumentRule =
+          opRule?.type === "owner-only" || opRule?.type === "custom";
+        const permissionDenied = await checkSingleAccess({
           slug,
           operation: transitionOp,
           user: options.user,
@@ -462,9 +480,20 @@ export class SingleMutationService extends BaseService {
           accessControlService: this.accessControlService,
           accessRules: singleMeta.accessRules,
           document: existingDoc ?? undefined,
+          deferStoredRuleEval: deferDocumentRule,
           logger: this.logger,
         });
-        if (denied) transitionGuard = { op: transitionOp, denied };
+        // Only guard under the lock when there is something to enforce there: a
+        // pre-resolved permission denial, or a deferred document rule to re-judge.
+        if (permissionDenied || deferDocumentRule) {
+          transitionGuard = {
+            op: transitionOp,
+            permissionDenied,
+            documentRule: deferDocumentRule
+              ? (singleMeta.accessRules as CollectionAccessRules)
+              : null,
+          };
+        }
       }
 
       // The auto-created default is persisted INSIDE the update transaction
@@ -561,9 +590,10 @@ export class SingleMutationService extends BaseService {
             // concurrent writer that changed the published state after that read,
             // AND a hook/concurrent writer whose row was just adopted above (the
             // `committed ?? insert` branch) — the transition is judged against the
-            // row this update actually mutates. The permission (and any owner-only/
-            // custom rule) was pre-resolved into `transitionGuard` off this
-            // transaction's connection, so no permission read happens here. Runs
+            // row this update actually mutates. The PERMISSION was pre-resolved
+            // into `transitionGuard` off this transaction's connection (no
+            // permission read here); a document-dependent (owner-only/custom)
+            // rule is re-evaluated against the row-locked document below. Runs
             // before the UPDATE, so throwing rolls the transaction back — including
             // any auto-create insert above — with nothing persisted and no
             // compensating delete.
@@ -595,7 +625,7 @@ export class SingleMutationService extends BaseService {
                     )
                   : null;
               // The guard fires if EITHER the main row or the companion `_status`
-              // makes the denied transition against its row-locked prior status.
+              // makes the guarded transition against its row-locked prior status.
               const firesOnMainRow =
                 mainNextStatus !== undefined &&
                 resolvePublishTransition(lockedMainStatus, mainNextStatus) ===
@@ -607,8 +637,48 @@ export class SingleMutationService extends BaseService {
                   companionNextStatus
                 ) === transitionGuard.op;
               if (firesOnMainRow || firesOnCompanion) {
-                transitionDeniedResult = transitionGuard.denied;
-                throw new SingleStatusTransitionDeniedError();
+                // Permission first (pre-resolved, no DB read): a caller lacking
+                // publish-<slug>/unpublish-<slug> is denied regardless of the row.
+                if (transitionGuard.permissionDenied) {
+                  transitionDeniedResult = transitionGuard.permissionDenied;
+                  throw new SingleStatusTransitionDeniedError();
+                }
+                // Then the deferred document-dependent (owner-only/custom) rule,
+                // judged against the ROW-LOCKED document (`lockedRow`) — not the
+                // stale pre-transaction one — so a custom rule keyed on a mutable
+                // field sees the committed value this update transitions from.
+                // Pure evaluation, no metadata or permission read.
+                if (transitionGuard.documentRule && lockedRow) {
+                  const docResult =
+                    await this.accessControlService.evaluateAccess(
+                      transitionGuard.documentRule,
+                      transitionGuard.op,
+                      {
+                        user: options.user
+                          ? {
+                              id: options.user.id,
+                              role: options.user.role,
+                              roles: options.user.roles,
+                              email: options.user.email,
+                            }
+                          : undefined,
+                      },
+                      typeof (lockedRow as { id?: unknown }).id === "string"
+                        ? (lockedRow as { id: string }).id
+                        : undefined,
+                      lockedRow
+                    );
+                  if (!docResult.allowed) {
+                    transitionDeniedResult = {
+                      success: false,
+                      statusCode: 403,
+                      message:
+                        docResult.reason ??
+                        `Access denied: ${transitionGuard.op} on single "${slug}" is not permitted`,
+                    };
+                    throw new SingleStatusTransitionDeniedError();
+                  }
+                }
               }
             }
 

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -20,6 +20,7 @@
  */
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
 import { and, eq, type Column } from "drizzle-orm";
 
 import { isComponentField } from "../../../collections/fields/guards";
@@ -86,6 +87,24 @@ import {
 } from "./single-utils";
 
 /**
+ * Thrown inside the write transaction when the publish/unpublish transition is
+ * refused against the ROW-LOCKED status, to abort (roll back) the transaction.
+ * The matching 403 is carried out-of-band on `transitionDeniedResult` rather
+ * than on the error, because the adapter re-wraps a thrown error as a
+ * DatabaseError when the transaction rolls back, so an `instanceof` check no
+ * longer identifies it after the throw.
+ */
+class SingleStatusTransitionDeniedError extends NextlyError {
+  constructor() {
+    super({
+      code: "FORBIDDEN",
+      publicMessage: "Publishing this document is not allowed.",
+    });
+    this.name = "SingleStatusTransitionDeniedError";
+  }
+}
+
+/**
  * SingleMutationService
  *
  * Handles the write-path for Single documents. The get-style helpers
@@ -147,6 +166,13 @@ export class SingleMutationService extends BaseService {
     options: UpdateSingleOptions = {}
   ): Promise<SingleResult> {
     this.logger.debug("Updating Single document", { slug, options });
+
+    // Set when the in-transaction transition check refuses the write against the
+    // row-locked status. Declared out here (not in `try`) so the catch can read
+    // it: the adapter wraps the thrown sentinel in a DatabaseError as the
+    // transaction rolls back, so `instanceof` no longer identifies it after the
+    // throw, but this result stays correct regardless of how the error is wrapped.
+    let transitionDeniedResult: SingleResult | undefined;
 
     try {
       // 1. Get Single metadata from registry
@@ -370,97 +396,82 @@ export class SingleMutationService extends BaseService {
       // separate capabilities, mirroring the collection write path. A write
       // targeting a non-default locale publishes through that locale's companion
       // `_status` (only when a string status was provided) and does not move the
-      // main row, so it is gated against the companion's prior status; a
-      // default-locale or non-localized write moves the main-row status. The gate
-      // no-ops when the single has no draft/published lifecycle, and a trusted
-      // write bypasses it (so the companion read that only feeds it is skipped).
+      // main row; a default-locale or non-localized write moves the main-row
+      // status. The gate no-ops when the single has no draft/published lifecycle,
+      // and a trusted write bypasses it.
+      //
+      // TOCTOU-safe: the permission (and any owner-only/custom rule) for the ONE
+      // op this write could require is pre-resolved here, OFF the write
+      // transaction's connection, but the transition is CLASSIFIED against the
+      // status read UNDER THE ROW LOCK inside the transaction (below). Only
+      // "published" can publish; any other explicit value can only unpublish a
+      // currently-published row — so the candidate op is fully determined by the
+      // status this write persists, and a concurrent writer that changes the
+      // published state between now and the lock cannot slip a real transition
+      // past the gate (a stale-status window the pre-transaction classification
+      // left open before).
       const singleHasStatus =
         (singleMeta as { status?: boolean }).status === true;
-      if (singleHasStatus && !options.overrideAccess) {
-        const finalStatus = (currentData as { status?: unknown }).status;
-        const isNonDefaultLocaleWrite =
-          companion?.hasStatus === true &&
-          writeLocale !== undefined &&
-          writeLocale !== this.localization?.defaultLocale;
-        // A write moves the published state in two places, and the gate must
-        // fire if EITHER makes a real transition:
-        //   - the MAIN row `status` (a default-locale or non-localized write; a
-        //     non-default-locale write leaves it untouched — the split strips it
-        //     from the main payload), and
-        //   - the write locale's companion `_status` (any localized write that
-        //     provides a string status, INCLUDING the default locale, whose
-        //     status also lands on the companion row). The split only persists a
-        //     companion `_status` for a string value.
-        // Checking the main row alone would let a default-locale write publish a
-        // still-draft companion `_status` while the main row is already published
-        // (reachable after per-locale status is added to existing content).
-        const mainNextStatus = isNonDefaultLocaleWrite
-          ? undefined
-          : finalStatus;
-        const writesCompanionStatus =
-          companion?.hasStatus === true && typeof finalStatus === "string";
-        const companionNextStatus = writesCompanionStatus
-          ? finalStatus
-          : undefined;
-        const mainPreviousStatus =
-          ((existingDoc as { status?: unknown }).status as
-            | string
-            | undefined) ?? null;
-        const companionPreviousStatus = writesCompanionStatus
-          ? await this.readCompanionStatusPooled(
-              companion,
-              existingDoc.id,
-              writeLocale as string
-            )
-          : null;
-        const mainOp =
-          mainNextStatus !== undefined
-            ? resolvePublishTransition(mainPreviousStatus, mainNextStatus)
-            : null;
-        const companionOp =
-          companionNextStatus !== undefined
-            ? resolvePublishTransition(
-                companionPreviousStatus,
-                companionNextStatus
-              )
-            : null;
-        // Both derive from the same final status, so they can only agree on the
-        // op (publish or unpublish) or be null — never conflict.
-        const transitionOp = mainOp ?? companionOp;
-        if (transitionOp) {
-          const transitionDenied = await checkSingleAccess({
-            slug,
-            operation: transitionOp,
-            user: options.user,
-            overrideAccess: options.overrideAccess,
-            // NOT route-authorized: the route authorizes a Single write as
-            // `update`, never as `publish`/`unpublish`, so the RBAC check for the
-            // transition permission must actually run.
-            routeAuthorized: false,
-            rbacAccessControlService: this.rbacAccessControlService,
-            // A scoped API key is judged on its own publish/unpublish grant, not
-            // the key owner's — the route only checked `update` against the scope.
-            authenticatedScope: options.authenticatedScope,
-            accessControlService: this.accessControlService,
-            accessRules: singleMeta.accessRules,
-            document: existingDoc ?? undefined,
-            logger: this.logger,
-          });
-          if (transitionDenied) {
-            // Nothing is persisted yet — the default is inserted only after this
-            // gate passes (below) — so a refused first publish simply returns
-            // with no row to undo, and cannot race a concurrent writer's row into
-            // a rollback delete.
-            return transitionDenied;
-          }
-        }
+      const finalStatus = (currentData as { status?: unknown }).status;
+      const isNonDefaultLocaleWrite =
+        companion?.hasStatus === true &&
+        writeLocale !== undefined &&
+        writeLocale !== this.localization?.defaultLocale;
+      // The MAIN row status this write moves (a non-default-locale write leaves it
+      // untouched — the split strips it from the main payload).
+      const mainNextStatus = isNonDefaultLocaleWrite ? undefined : finalStatus;
+      // The write locale's companion `_status` — any localized write providing a
+      // string status stamps it, INCLUDING the default locale (whose status also
+      // lands on the companion row). The split only persists a string value.
+      const writesCompanionStatus =
+        companion?.hasStatus === true && typeof finalStatus === "string";
+      const companionNextStatus = writesCompanionStatus
+        ? finalStatus
+        : undefined;
+      // The one status this write persists, keyed to pick the single permission it
+      // could require. For a non-default-locale write it is the companion
+      // `_status`; otherwise the main-row status (both derive from `finalStatus`,
+      // so they can only agree on the op — never conflict).
+      const transitionNextStatus = isNonDefaultLocaleWrite
+        ? companionNextStatus
+        : mainNextStatus;
+      let transitionGuard: {
+        op: "publish" | "unpublish";
+        denied: SingleResult;
+      } | null = null;
+      if (
+        singleHasStatus &&
+        !options.overrideAccess &&
+        transitionNextStatus !== undefined
+      ) {
+        const transitionOp =
+          transitionNextStatus === "published" ? "publish" : "unpublish";
+        const denied = await checkSingleAccess({
+          slug,
+          operation: transitionOp,
+          user: options.user,
+          overrideAccess: options.overrideAccess,
+          // NOT route-authorized: the route authorizes a Single write as
+          // `update`, never as `publish`/`unpublish`, so the RBAC check for the
+          // transition permission must actually run.
+          routeAuthorized: false,
+          rbacAccessControlService: this.rbacAccessControlService,
+          // A scoped API key is judged on its own publish/unpublish grant, not
+          // the key owner's — the route only checked `update` against the scope.
+          authenticatedScope: options.authenticatedScope,
+          accessControlService: this.accessControlService,
+          accessRules: singleMeta.accessRules,
+          document: existingDoc ?? undefined,
+          logger: this.logger,
+        });
+        if (denied) transitionGuard = { op: transitionOp, denied };
       }
 
       // The auto-created default is persisted INSIDE the update transaction
       // below (not here), so the insert commits atomically with the update,
       // component saves, companion upsert, and version capture — a failure in any
       // of them rolls the default back instead of orphaning it, and a refused
-      // publish (handled above) still never inserts a row.
+      // publish (enforced under the lock below) rolls its insert back too.
 
       // 6.4. Extract component field data (stored in separate comp_{slug}
       // tables) AFTER the access/hooks/validation pipeline above has seen
@@ -541,6 +552,66 @@ export class SingleMutationService extends BaseService {
                 },
               });
             }
+
+            // TOCTOU-safe transition enforcement: reclassify the publish/unpublish
+            // transition against the status read UNDER THE ROW LOCK here — the
+            // committed main row, plus the write locale's companion `_status` for a
+            // localized write — not the pre-transaction pooled read. This closes
+            // two windows the earlier pre-transaction classification left open: a
+            // concurrent writer that changed the published state after that read,
+            // AND a hook/concurrent writer whose row was just adopted above (the
+            // `committed ?? insert` branch) — the transition is judged against the
+            // row this update actually mutates. The permission (and any owner-only/
+            // custom rule) was pre-resolved into `transitionGuard` off this
+            // transaction's connection, so no permission read happens here. Runs
+            // before the UPDATE, so throwing rolls the transaction back — including
+            // any auto-create insert above — with nothing persisted and no
+            // compensating delete.
+            if (transitionGuard) {
+              // Lock + read the committed main row in the SAME query (`forUpdate`).
+              // A plain read would, on MySQL's repeatable-read isolation, return
+              // this transaction's snapshot (established by the pre-lock fetch) and
+              // miss a concurrent writer's publish/unpublish; `FOR UPDATE` always
+              // sees the latest committed row. SQLite serializes writers via BEGIN
+              // IMMEDIATE, so the lock is a no-op and its committed read is current.
+              const lockedRow = await tx.selectOne<SingleDocument>(
+                singleMeta.tableName,
+                { where: this.whereEq("id", existingDoc.id), forUpdate: true }
+              );
+              const lockedMainStatus =
+                ((lockedRow as { status?: unknown } | null)?.status as
+                  | string
+                  | undefined) ?? null;
+              // The write locale's committed companion `_status`, read under the
+              // main-row lock: every write to this Single takes the main-row lock
+              // first, so the companion read is serialized with concurrent writers.
+              const lockedCompanionStatus =
+                writesCompanionStatus && companion && writeLocale !== undefined
+                  ? await this.readCompanionStatusInTx(
+                      tx,
+                      companion,
+                      existingDoc.id,
+                      writeLocale
+                    )
+                  : null;
+              // The guard fires if EITHER the main row or the companion `_status`
+              // makes the denied transition against its row-locked prior status.
+              const firesOnMainRow =
+                mainNextStatus !== undefined &&
+                resolvePublishTransition(lockedMainStatus, mainNextStatus) ===
+                  transitionGuard.op;
+              const firesOnCompanion =
+                companionNextStatus !== undefined &&
+                resolvePublishTransition(
+                  lockedCompanionStatus,
+                  companionNextStatus
+                ) === transitionGuard.op;
+              if (firesOnMainRow || firesOnCompanion) {
+                transitionDeniedResult = transitionGuard.denied;
+                throw new SingleStatusTransitionDeniedError();
+              }
+            }
+
             // Build the payload inside the closure so a retried attempt after a
             // concurrent winner stamps a FRESH `updated_at`, rather than reusing
             // a timestamp created before the first attempt (which could commit an
@@ -943,29 +1014,38 @@ export class SingleMutationService extends BaseService {
         data: updatedDoc,
       };
     } catch (error) {
+      // A publish-transition refused against the row-locked status aborts the
+      // write; return the 403 the pre-transaction guard resolved, not a 500.
+      // Read from the out-of-band result rather than `instanceof`: the adapter
+      // wraps the thrown sentinel in a DatabaseError before it reaches here.
+      if (transitionDeniedResult) {
+        return transitionDeniedResult;
+      }
       this.logger.error("Failed to update Single document", { slug, error });
       return buildSingleErrorResult(error, "Failed to update Single document");
     }
   }
 
   /**
-   * The write locale's committed per-locale `_status`, read on the pooled
-   * connection for the publish-transition gate (which runs before the write
-   * transaction opens).
+   * The write locale's committed per-locale `_status`, read INSIDE the write
+   * transaction (on its connection) for the under-lock publish-transition gate.
    *
-   * The companion `_locales` table is a runtime Drizzle table object rather than
-   * part of the static schema, so its columns are reached off the object built
-   * by `buildCompanionSchema` — the same way `populateCompanionFields` queries
-   * it. `(_parent, _locale)` is the companion primary key, so the lookup returns
-   * at most one row.
+   * Reads through `tx.getDrizzle()` so it sees the transaction's own writes and
+   * is serialized with concurrent writers by the main-row lock taken just before
+   * it. The companion `_locales` table is a runtime Drizzle table object rather
+   * than part of the static schema, so its columns are reached off the object
+   * built by `buildCompanionSchema` — the same way `populateCompanionFields`
+   * queries it. `(_parent, _locale)` is the companion primary key, so the lookup
+   * returns at most one row.
    */
-  private async readCompanionStatusPooled(
+  private async readCompanionStatusInTx(
+    tx: TransactionContext,
     companion: { table: unknown },
     parentId: string,
     locale: string
   ): Promise<string | null> {
     const table = companion.table as Record<string, Column>;
-    const drizzle = this.adapter.getDrizzle<{
+    const drizzle = tx.getDrizzle<{
       select: () => {
         from: (t: unknown) => {
           where: (c: unknown) => Promise<Record<string, unknown>[]>;

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -169,6 +169,17 @@ export async function checkSingleAccess(params: {
    * compare ownership; without it they allow (deferring to the DB-level check).
    */
   document?: Record<string, unknown>;
+  /**
+   * Skip the stored-rule evaluation and return after only the RBAC/permission
+   * gate. The publish-transition pre-resolve sets this when the operation's
+   * stored rule is document-dependent (owner-only/custom), so that rule is NOT
+   * judged against the pre-transaction document here — it is re-evaluated against
+   * the row-locked document inside the write transaction instead (see
+   * `evaluateTransitionDocumentRule` on the mutation service). Non-dependent
+   * rules (public/authenticated/role-based) are fully decidable without the row,
+   * so callers leave this false and let them run here.
+   */
+  deferStoredRuleEval?: boolean;
   logger: Logger;
 }): Promise<SingleResult | null> {
   const {
@@ -182,6 +193,7 @@ export async function checkSingleAccess(params: {
     accessControlService,
     accessRules,
     document,
+    deferStoredRuleEval,
     logger,
   } = params;
 
@@ -203,8 +215,10 @@ export async function checkSingleAccess(params: {
   // single global document; public / authenticated / role-based / custom all
   // apply). This runs for both route-authorized and Direct API callers so a
   // caller holding the coarse `update-<single>` permission but failing a
-  // stored rule is still denied.
-  if (accessControlService && accessRules) {
+  // stored rule is still denied. Skipped when `deferStoredRuleEval` is set: the
+  // transition pre-resolve defers a document-dependent (owner-only/custom) rule
+  // to the under-lock re-check so it is not judged against a stale document.
+  if (accessControlService && accessRules && !deferStoredRuleEval) {
     // Owner-only with no loaded document: ownership cannot be evaluated (there
     // is nothing to compare against), and evaluateOwnerAccess would otherwise
     // ALLOW the write for lack of a document — letting a caller with only the

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -258,6 +258,26 @@ export async function checkSingleAccess(params: {
     return null;
   }
 
+  // Secure-by-default publish gate (Option A): publishing/unpublishing changes a
+  // document's privileged published state, so an anonymous caller may do it ONLY
+  // when an explicit rule grants it. With no explicit publish/unpublish rule the
+  // operation would otherwise fall through to the rule-less public default below
+  // (`!user` → allow), letting an unauthenticated caller publish a
+  // publicly-writable Single. An explicit stored rule was evaluated above and
+  // allowed if we reach here, so a developer who deliberately opened publishing
+  // (e.g. a public `publish` rule) is respected; only the implicit default denies.
+  if (
+    !user &&
+    (operation === "publish" || operation === "unpublish") &&
+    !accessRules?.[operation]
+  ) {
+    return {
+      success: false,
+      statusCode: 403,
+      message: `Access denied: ${operation} on single "${slug}" requires an authenticated user`,
+    };
+  }
+
   if (!user) {
     return null;
   }
@@ -731,6 +751,15 @@ export class SingleQueryService extends BaseService {
       created_at: now,
       updated_at: now,
     };
+
+    // Surface the status column's DB default ("draft") on the in-memory default
+    // too. The write path runs first-update hooks against this document BEFORE
+    // the auto-create insert, so without this a hook branching on the initial
+    // draft state would see `undefined` where the persisted row (and the old
+    // insert-first path) has "draft". Only when the Single has a lifecycle.
+    if ((singleMeta as { status?: boolean }).status === true) {
+      defaults.status = "draft";
+    }
 
     // i18n: a localized single's main table omits translatable columns (they live in the
     // companion `single_<slug>_locales`), so a required/defaulted translatable value must


### PR DESCRIPTION
## Summary

Stacked on #302. Closes the singles half of the publish-permission program: a
**Single update now enforces the publish/unpublish transition under the row
lock**, mirroring the collections finding-G work landed in #302. Addresses the
codex/coderabbit/greptile threads on #293 flagging the singles TOCTOU window and
related items.

## The gap (TOCTOU)

`SingleMutationService.update` classified whether it was publishing or
unpublishing from the status read **before** the write transaction — the main
row via the pooled pre-fetch, and the companion `_status` via
`readCompanionStatusPooled` (also pooled). Between that read and the `tx.update`,
a concurrent writer could move the document into or out of published, so a real
transition slipped past the gate (e.g. a caller with `update` but not
`unpublish` writes `status: "draft"` while the row is still draft; another
request publishes it; the first write demotes the now-published row without ever
checking `unpublish-<slug>`). The same window let the transaction **adopt** a
row a hook/concurrent writer had just created (the `committed ?? insert` branch)
without re-checking its status.

## The fix

- **Pre-resolve** the caller's publish/unpublish permission (and any
  owner-only/custom rule) before the transaction, keyed on the one status the
  write persists — off the transaction's connection.
- **Classify under the lock**: inside the transaction, `FOR UPDATE`-read the
  committed main row and the write locale's companion `_status`, then reclassify
  the transition against those locked values. This runs *after* the auto-create
  adoption, so an adopted row is judged on the status this update actually
  mutates. A denied transition throws an out-of-band sentinel and rolls the
  transaction back — including any first-write insert — with **no row left
  behind and no compensating delete**.
- `readCompanionStatusPooled` is replaced by an in-transaction read on the
  locked connection.
- **TFl0l Option A** (founder-approved): an unauthenticated caller can no longer
  publish/unpublish a publicly-writable Single unless an explicit rule grants it.
- A first-update hook on a status-enabled Single now sees the default `draft`
  status (the in-memory default carried the column's DB default).
- The localized companion test now quotes identifiers per dialect so it runs on
  the MySQL CI leg (it previously used Postgres/SQLite double-quotes).

## Tests

- New `publish-enforcement-toctou.integration.test.ts`: a real two-transaction
  Postgres race (writer A reads `draft`, blocks on writer B's row lock, B
  publishes and commits, A takes the lock and is refused the now-`published →
  draft` unpublish). **Proven load-bearing** by breaking the fix (classify
  against the pre-transaction status → A's unpublish slips through).
- Existing `publish-enforcement.integration.test.ts` (5 cases incl. the
  default-locale companion gate) still passes; the reserved slug `settings`
  (a system resource that fails config validation) was renamed to `branding` so
  the file runs.
- `single-entry-service.test.ts` updated: the first-write default now
  materializes inside the transaction and is covered by rollback, so the unit
  test asserts the denial + no compensating delete (the real no-row guarantee is
  the integration test).

## Notes

- One changeset (all 19 fixed-group packages, patch), separate from #302's.
- Merge order: #290 → #293 → #302 → #303.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Single publishing and unpublishing authorization to prevent unauthorized status changes, including during concurrent edits.
  - Anonymous requests are now denied publishing or unpublishing unless explicitly allowed by access rules.
  - Denied first-publish attempts no longer leave behind partially created default content.
  - Default Single content now correctly starts in draft status when lifecycle tracking is enabled.
  - API-key permissions for branding publishing are now enforced against the key’s granted scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->