### PR TITLE
feat(nextly): emit webhook events on media uploads, edits, and deletes

### DIFF
--- a/.changeset/webhook-media-recording.md
+++ b/.changeset/webhook-media-recording.md
@@ -1,0 +1,30 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/ui": patch
+---
+
+Emit webhook events when media changes.
+
+Uploading, editing, or deleting a media item now records a `media.uploaded`,
+`media.updated`, or `media.deleted` event in the outbox, attributed to the
+acting user or API key, so webhook subscribers are notified of media changes.
+The event is written in the same transaction as the media row, and physical
+file storage is touched outside that transaction (and, for deletes, only after
+it commits) so a failed event never leaves the database and the stored file out
+of sync.

--- a/packages/nextly/src/api/media-bulk.ts
+++ b/packages/nextly/src/api/media-bulk.ts
@@ -29,6 +29,7 @@
  * @module api/media-bulk
  */
 
+import type { RequestActor } from "../auth/request-actor";
 import { getService, isServicesRegistered } from "../di";
 import { NextlyError } from "../errors/nextly-error";
 import type { MediaService } from "../services/media/media-service";
@@ -85,11 +86,14 @@ function createAuthenticatedContext(userId: string | null): RequestContext {
  * @param request - The incoming HTTP request containing `{ mediaIds: string[] }`
  * @param mediaService - Already-resolved MediaService instance
  * @param context - RequestContext for the operation
+ * @param actor - Transport-resolved caller, forwarded so each per-item delete
+ *   event attributes to the real session or API key.
  */
 export async function executeBulkDelete(
   request: Request,
   mediaService: MediaService,
-  context: RequestContext
+  context: RequestContext,
+  actor?: RequestActor
 ): Promise<Response> {
   const body = await readJsonBody<Record<string, unknown>>(request);
   const mediaIds = body.mediaIds;
@@ -106,7 +110,11 @@ export async function executeBulkDelete(
     });
   }
 
-  const result = await mediaService.bulkDelete(mediaIds as string[], context);
+  const result = await mediaService.bulkDelete(
+    mediaIds as string[],
+    context,
+    actor
+  );
 
   const message =
     result.failures.length === 0

--- a/packages/nextly/src/api/media-handlers.ts
+++ b/packages/nextly/src/api/media-handlers.ts
@@ -501,14 +501,17 @@ async function handleDeleteMedia(
 
 async function handleMoveMedia(
   request: Request,
-  mediaId: string
+  mediaId: string,
+  actor?: RequestActor
 ): Promise<Response> {
   const mediaService = await getMediaService();
   const body = await readJsonBody<Record<string, unknown>>(request);
   const folderId = body.folderId as string | null | undefined;
   const context = createRequestContext();
 
-  await mediaService.moveToFolder(mediaId, folderId ?? null, context);
+  // Thread the authenticated actor so the move's media.updated event is
+  // attributed to the real user/API key instead of `system`.
+  await mediaService.moveToFolder(mediaId, folderId ?? null, context, actor);
 
   // Service returns void; echo the target ids so the admin can update the
   // moved record locally without re-fetching the affected folders.
@@ -764,7 +767,11 @@ export function createMediaHandlers(options?: MediaHandlerOptions) {
             );
             break;
           case "move-media":
-            response = await handleMoveMedia(request, route.mediaId!);
+            response = await handleMoveMedia(
+              request,
+              route.mediaId!,
+              gate.actor
+            );
             break;
           case "update-folder":
             response = await handleUpdateFolder(request, route.folderId!);

--- a/packages/nextly/src/api/media-handlers.ts
+++ b/packages/nextly/src/api/media-handlers.ts
@@ -59,6 +59,7 @@ import {
   isErrorResponse,
   requirePermission,
 } from "../auth/middleware";
+import { actorFromAuthContext, type RequestActor } from "../auth/request-actor";
 import type { SanitizedNextlyConfig } from "../collections/config/define-config";
 import { getService } from "../di";
 import { NextlyError } from "../errors/nextly-error";
@@ -176,7 +177,7 @@ async function gateMediaRoute(
   path: string[] | undefined,
   method: string,
   requireAuth: boolean
-): Promise<{ authUserId?: string } | Response> {
+): Promise<{ authUserId?: string; actor?: RequestActor } | Response> {
   if (!requireAuth) {
     if (!READ_ROUTE_TYPES.has(route.type)) {
       throwUnmatchedRoute(path, method);
@@ -197,7 +198,10 @@ async function gateMediaRoute(
   if (isErrorResponse(auth)) {
     return createJsonErrorResponse(auth);
   }
-  return { authUserId: auth.userId };
+  // Surface both the acting user id (for uploader attribution on the DB row)
+  // and the full actor (session vs API key) so media writes record the true
+  // caller on their outbox events.
+  return { authUserId: auth.userId, actor: actorFromAuthContext(auth) };
 }
 
 // ============================================================
@@ -388,7 +392,8 @@ async function handleListMedia(request: Request): Promise<Response> {
 
 async function handleUploadMedia(
   request: Request,
-  authUserId: string
+  authUserId: string,
+  actor?: RequestActor
 ): Promise<Response> {
   const mediaService = await getMediaService();
   const formData = await request.formData();
@@ -436,7 +441,8 @@ async function handleUploadMedia(
       size: file.size,
       folderId: folderId || undefined,
     },
-    context
+    context,
+    actor
   );
 
   return respondMutation("Media uploaded.", mediaFile, { status: 201 });
@@ -453,7 +459,8 @@ async function handleGetMedia(mediaId: string): Promise<Response> {
 
 async function handleUpdateMedia(
   request: Request,
-  mediaId: string
+  mediaId: string,
+  actor?: RequestActor
 ): Promise<Response> {
   const mediaService = await getMediaService();
   const body = await readJsonBody<Record<string, unknown>>(request);
@@ -468,16 +475,24 @@ async function handleUpdateMedia(
 
   const context = createRequestContext();
 
-  const mediaFile = await mediaService.update(mediaId, validated, context);
+  const mediaFile = await mediaService.update(
+    mediaId,
+    validated,
+    context,
+    actor
+  );
 
   return respondMutation("Media updated.", mediaFile);
 }
 
-async function handleDeleteMedia(mediaId: string): Promise<Response> {
+async function handleDeleteMedia(
+  mediaId: string,
+  actor?: RequestActor
+): Promise<Response> {
   const mediaService = await getMediaService();
   const context = createRequestContext();
 
-  await mediaService.delete(mediaId, context);
+  await mediaService.delete(mediaId, context, actor);
 
   // Service returns void; surface the deleted id alongside the toast so the
   // admin can update its local cache without a follow-up fetch.
@@ -503,9 +518,17 @@ async function handleMoveMedia(
   });
 }
 
-async function handleBulkDeleteMedia(request: Request): Promise<Response> {
+async function handleBulkDeleteMedia(
+  request: Request,
+  actor?: RequestActor
+): Promise<Response> {
   const mediaService = await getMediaService();
-  return executeBulkDelete(request, mediaService, createRequestContext());
+  return executeBulkDelete(
+    request,
+    mediaService,
+    createRequestContext(),
+    actor
+  );
 }
 
 // ============================================================
@@ -701,7 +724,11 @@ export function createMediaHandlers(options?: MediaHandlerOptions) {
         let response: Response;
         switch (route.type) {
           case "upload-media":
-            response = await handleUploadMedia(request, gate.authUserId!);
+            response = await handleUploadMedia(
+              request,
+              gate.authUserId!,
+              gate.actor
+            );
             break;
           case "create-folder":
             response = await handleCreateFolder(request, gate.authUserId!);
@@ -730,7 +757,11 @@ export function createMediaHandlers(options?: MediaHandlerOptions) {
         let response: Response;
         switch (route.type) {
           case "update-media":
-            response = await handleUpdateMedia(request, route.mediaId!);
+            response = await handleUpdateMedia(
+              request,
+              route.mediaId!,
+              gate.actor
+            );
             break;
           case "move-media":
             response = await handleMoveMedia(request, route.mediaId!);
@@ -762,13 +793,13 @@ export function createMediaHandlers(options?: MediaHandlerOptions) {
         let response: Response;
         switch (route.type) {
           case "delete-media":
-            response = await handleDeleteMedia(route.mediaId!);
+            response = await handleDeleteMedia(route.mediaId!, gate.actor);
             break;
           case "delete-folder":
             response = await handleDeleteFolder(request, route.folderId!);
             break;
           case "bulk-delete-media":
-            response = await handleBulkDeleteMedia(request);
+            response = await handleBulkDeleteMedia(request, gate.actor);
             break;
           default:
             throwUnmatchedRoute(resolvedParams.path, "DELETE");

--- a/packages/nextly/src/di/registrations/register-media.ts
+++ b/packages/nextly/src/di/registrations/register-media.ts
@@ -9,6 +9,9 @@
  * and registered there so its setup happens before plugin init runs.
  */
 
+import type { WebhookFastDrainScheduler } from "../../domains/webhooks/after-drain";
+import { MetaRetentionGate } from "../../domains/webhooks/retention-gate";
+import { WebhookRetentionRunner } from "../../domains/webhooks/retention-runner";
 import { MediaService as LegacyMediaService } from "../../services/media";
 import { MediaService as UnifiedMediaService } from "../../services/media/media-service";
 import { MediaFolderService } from "../../services/media-folder";
@@ -50,7 +53,23 @@ export function registerMediaServices(ctx: RegistrationContext): void {
       imageProcessor,
       uploadValidator,
       svgCsp,
-      logger
+      logger,
+      // Media writes append outbox events through this service, so it carries
+      // its own retention runner (the webhook handler's is not on this path),
+      // mirroring collections and singles.
+      ctx.config.webhookRetention
+        ? new WebhookRetentionRunner({
+            policy: ctx.config.webhookRetention,
+            prune: { adapter, logger },
+            gate: new MetaRetentionGate(adapter),
+            logger,
+          })
+        : undefined,
+      // Shared post-response drain fast path (registered by the webhook
+      // services). Absent only when webhooks were never registered.
+      container.has("webhookFastDrainScheduler")
+        ? container.get<WebhookFastDrainScheduler>("webhookFastDrainScheduler")
+        : undefined
     );
   });
 }

--- a/packages/nextly/src/domains/media/services/media-service.ts
+++ b/packages/nextly/src/domains/media/services/media-service.ts
@@ -786,32 +786,44 @@ export class MediaService {
   async moveToFolder(
     mediaId: string,
     folderId: string | null,
-    _context: RequestContext
+    context: RequestContext,
+    // The transport-resolved caller, threaded to the outbox event.
+    actor?: RequestActor
   ): Promise<void> {
     this.logger.debug("Moving media to folder", { mediaId, folderId });
 
-    const result = await this.legacyFolderService.moveMediaToFolder(
+    // Validate the target folder up front (throws NOT_FOUND) so a bad folder
+    // fails before the write, preserving the prior move path's 404 behavior.
+    if (folderId) {
+      await this.findFolderById(folderId, context);
+    }
+
+    // Route the move through the update path so the folder change is captured
+    // as a media.updated outbox event — a bare folder write recorded nothing,
+    // leaving subscribers unaware of moves. Attribute it to the transport actor
+    // when present, otherwise the request-context user.
+    const resolvedActor = actorForWrite(actor, context.user);
+    const result = await this.legacyMediaService.updateMedia(
       mediaId,
-      folderId
+      { folderId },
+      resolvedActor
     );
 
     if (!result.success) {
       if (result.statusCode === 404) {
         // Driver text moves into logContext per §13.8 — only generic "Not found."
-        // hits the wire. The legacyMessage is kept operator-side for diagnostics.
+        // hits the wire.
         throw NextlyError.notFound({
-          logContext: {
-            entity: "media",
-            mediaId,
-            folderId,
-            legacyMessage: result.message,
-          },
+          logContext: { entity: "media", mediaId, folderId },
         });
       }
-      throw this.mapSimpleErrorToNextlyError(result);
+      throw this.mapLegacyErrorToNextlyError(result);
     }
 
     this.logger.info("Media moved to folder", { mediaId, folderId });
+
+    // The update committed a media.updated outbox row; drain and prune it.
+    await this.afterWrite();
   }
 
   /**

--- a/packages/nextly/src/domains/media/services/media-service.ts
+++ b/packages/nextly/src/domains/media/services/media-service.ts
@@ -48,6 +48,7 @@
 // PR 4 migration: replaced ServiceError throws + mapLegacy/mapSimple helpers
 // with NextlyError factories. Identifiers (mediaId/folderId/etc) move to
 // logContext per §13.8; public messages remain generic and end with a period.
+import type { RequestActor } from "../../../auth/request-actor";
 import { NextlyError } from "../../../errors";
 import { emitMediaEvent } from "../../../events/domain-events";
 import { normalizeDbTimestamp } from "../../../lib/date-formatting";
@@ -251,7 +252,10 @@ export class MediaService {
    */
   async upload(
     input: UploadMediaInput,
-    context: RequestContext
+    context: RequestContext,
+    // The transport-resolved caller, threaded to the outbox event so an upload
+    // attributes to the real session or API key rather than only the uploader.
+    actor?: RequestActor
   ): Promise<MediaFile> {
     // Ensure storage is configured before upload
     this.ensureStorageConfigured();
@@ -311,18 +315,21 @@ export class MediaService {
     }
     const validated = validation.value;
 
-    const result = await this.legacyMediaService.uploadMedia({
-      file: validated.buffer,
-      filename: validated.filename,
-      mimeType: validated.mimeType,
-      // Use validated buffer length so the DB row matches what's actually
-      // in storage (SVG sanitization can shrink the byte count).
-      size: validated.buffer.length,
-      // Nullable: CLI seeds and system imports run without a user.
-      uploadedBy: context.user?.id ?? null,
-      contentDisposition:
-        validated.isSvg && this.svgCsp ? "attachment" : undefined,
-    });
+    const result = await this.legacyMediaService.uploadMedia(
+      {
+        file: validated.buffer,
+        filename: validated.filename,
+        mimeType: validated.mimeType,
+        // Use validated buffer length so the DB row matches what's actually
+        // in storage (SVG sanitization can shrink the byte count).
+        size: validated.buffer.length,
+        // Nullable: CLI seeds and system imports run without a user.
+        uploadedBy: context.user?.id ?? null,
+        contentDisposition:
+          validated.isSvg && this.svgCsp ? "attachment" : undefined,
+      },
+      actor
+    );
 
     if (!result.success || !result.data) {
       this.logger.warn("Media upload failed", {
@@ -436,18 +443,24 @@ export class MediaService {
   async update(
     mediaId: string,
     input: UpdateMediaInput,
-    _context: RequestContext
+    _context: RequestContext,
+    // The transport-resolved caller, threaded to the outbox event.
+    actor?: RequestActor
   ): Promise<MediaFile> {
     this.logger.debug("Updating media file", { mediaId, input });
 
     // Sanitize metadata fields before storage (defense-in-depth)
     sanitizeMediaInput(input);
 
-    const result = await this.legacyMediaService.updateMedia(mediaId, {
-      altText: input.altText ?? undefined,
-      caption: input.caption ?? undefined,
-      tags: input.tags,
-    });
+    const result = await this.legacyMediaService.updateMedia(
+      mediaId,
+      {
+        altText: input.altText ?? undefined,
+        caption: input.caption ?? undefined,
+        tags: input.tags,
+      },
+      actor
+    );
 
     if (!result.success || !result.data) {
       if (result.statusCode === 404) {
@@ -471,10 +484,15 @@ export class MediaService {
    * @param context - Request context
    * @throws NextlyError if deletion fails.
    */
-  async delete(mediaId: string, _context: RequestContext): Promise<void> {
+  async delete(
+    mediaId: string,
+    _context: RequestContext,
+    // The transport-resolved caller, threaded to the outbox event.
+    actor?: RequestActor
+  ): Promise<void> {
     this.logger.debug("Deleting media file", { mediaId });
 
-    const result = await this.legacyMediaService.deleteMedia(mediaId);
+    const result = await this.legacyMediaService.deleteMedia(mediaId, actor);
 
     if (!result.success) {
       if (result.statusCode === 404) {
@@ -505,7 +523,10 @@ export class MediaService {
    */
   async bulkUpload(
     inputs: UploadMediaInput[],
-    context: RequestContext
+    context: RequestContext,
+    // Forwarded to each per-item upload so every fan-out event attributes to
+    // the same transport-resolved caller.
+    actor?: RequestActor
   ): Promise<BulkUploadOperationResult<MediaFile>> {
     this.logger.debug("Bulk uploading media files", { count: inputs.length });
 
@@ -527,7 +548,7 @@ export class MediaService {
     const outcomes = await Promise.allSettled(
       inputs.map(async (input, i): Promise<UploadOutcome> => {
         try {
-          const file = await this.upload(input, context);
+          const file = await this.upload(input, context, actor);
           return { kind: "success", file };
         } catch (error) {
           // NextlyError thrown from below the boundary preserves canonical
@@ -608,7 +629,10 @@ export class MediaService {
    */
   async bulkDelete(
     mediaIds: string[],
-    context: RequestContext
+    context: RequestContext,
+    // Forwarded to each per-item delete so every fan-out event attributes to
+    // the same transport-resolved caller.
+    actor?: RequestActor
   ): Promise<BulkOperationResult<{ id: string }>> {
     this.logger.debug("Bulk deleting media files", { count: mediaIds.length });
 
@@ -624,7 +648,7 @@ export class MediaService {
     const outcomes = await Promise.allSettled(
       mediaIds.map(async (mediaId): Promise<DeleteOutcome> => {
         try {
-          await this.delete(mediaId, context);
+          await this.delete(mediaId, context, actor);
           return { kind: "success", id: mediaId };
         } catch (error) {
           if (NextlyError.is(error)) {

--- a/packages/nextly/src/domains/media/services/media-service.ts
+++ b/packages/nextly/src/domains/media/services/media-service.ts
@@ -49,6 +49,8 @@
 // with NextlyError factories. Identifiers (mediaId/folderId/etc) move to
 // logContext per §13.8; public messages remain generic and end with a period.
 import { actorForWrite, type RequestActor } from "../../../auth/request-actor";
+import type { WebhookFastDrainScheduler } from "../../../domains/webhooks/after-drain";
+import type { WebhookRetentionRunner } from "../../../domains/webhooks/retention-runner";
 import { NextlyError } from "../../../errors";
 import { emitMediaEvent } from "../../../events/domain-events";
 import { normalizeDbTimestamp } from "../../../lib/date-formatting";
@@ -188,8 +190,39 @@ export class MediaService {
      * `config.security.uploads.svgCsp` (default `true`).
      */
     private readonly svgCsp: boolean = true,
-    private readonly logger: Logger = consoleLogger
+    private readonly logger: Logger = consoleLogger,
+    /**
+     * Prunes the outbox after a media write appends an event. The media write
+     * path records events through this service, so it carries its own runner
+     * (the webhook handler's is not on this path), mirroring collections.
+     */
+    private readonly retentionRunner?: WebhookRetentionRunner,
+    /**
+     * Shared post-response drain fast path. A media write commits its outbox
+     * row inside the DB transaction; `offer()` then schedules the immediate
+     * drain so subscribers are notified without waiting for the periodic
+     * scheduled drain. Absent only when webhooks were never registered.
+     */
+    private readonly fastDrainScheduler?: WebhookFastDrainScheduler
   ) {}
+
+  // A short prune pass on the write path: enough to keep the outbox from
+  // growing unbounded without turning a media write into a long maintenance
+  // job. Mirrors the collection write path.
+  private static readonly WRITE_PATH_PRUNE_BATCHES = 2;
+
+  /**
+   * The post-write side effects, run after a media write that appended an
+   * outbox event. The drain fast path goes first so the post-response
+   * `after()` callback is scheduled promptly (it adds no latency); the
+   * retention pass follows. Both absorb their own failures (`maybeRun` never
+   * throws, `offer` only registers the callback), so this never turns a
+   * committed media write into an error. Mirrors the collection write path.
+   */
+  private async afterWrite(): Promise<void> {
+    this.fastDrainScheduler?.offer();
+    await this.retentionRunner?.maybeRun(MediaService.WRITE_PATH_PRUNE_BATCHES);
+  }
 
   /**
    * Get the storage adapter (supports both direct reference and getter function)
@@ -364,6 +397,9 @@ export class MediaService {
       filename: result.data.filename,
     });
 
+    // The upload committed a media.uploaded outbox row; drain and prune it.
+    await this.afterWrite();
+
     return this.mapToMediaFile(result.data);
   }
 
@@ -490,6 +526,9 @@ export class MediaService {
 
     this.logger.info("Media file updated", { mediaId });
 
+    // The update committed a media.updated outbox row; drain and prune it.
+    await this.afterWrite();
+
     return this.mapToMediaFile(result.data);
   }
 
@@ -532,6 +571,9 @@ export class MediaService {
     this.logger.info("Media file deleted", { mediaId });
 
     emitMediaEvent("deleted", { mediaId });
+
+    // The delete committed a media.deleted outbox row; drain and prune it.
+    await this.afterWrite();
   }
 
   /**

--- a/packages/nextly/src/domains/media/services/media-service.ts
+++ b/packages/nextly/src/domains/media/services/media-service.ts
@@ -48,7 +48,7 @@
 // PR 4 migration: replaced ServiceError throws + mapLegacy/mapSimple helpers
 // with NextlyError factories. Identifiers (mediaId/folderId/etc) move to
 // logContext per §13.8; public messages remain generic and end with a period.
-import type { RequestActor } from "../../../auth/request-actor";
+import { actorForWrite, type RequestActor } from "../../../auth/request-actor";
 import { NextlyError } from "../../../errors";
 import { emitMediaEvent } from "../../../events/domain-events";
 import { normalizeDbTimestamp } from "../../../lib/date-formatting";
@@ -315,6 +315,14 @@ export class MediaService {
     }
     const validated = validation.value;
 
+    // Validate the target folder BEFORE persisting the file so a bad folderId
+    // fails fast (throws NOT_FOUND) instead of leaving an orphaned upload, and
+    // so the folder can be written on the initial insert below rather than via a
+    // separate post-upload move.
+    if (input.folderId) {
+      await this.findFolderById(input.folderId, context);
+    }
+
     const result = await this.legacyMediaService.uploadMedia(
       {
         file: validated.buffer,
@@ -325,6 +333,12 @@ export class MediaService {
         size: validated.buffer.length,
         // Nullable: CLI seeds and system imports run without a user.
         uploadedBy: context.user?.id ?? null,
+        // Persist the target folder on the initial insert so the committed row
+        // and its `media.uploaded` event reflect the final folder atomically,
+        // rather than recording folderId:null and moving the row afterward
+        // (which left subscribers seeing the wrong folder and no move event).
+        // The legacy insert normalizes a missing folder to null itself.
+        folderId: input.folderId ?? undefined,
         contentDisposition:
           validated.isSvg && this.svgCsp ? "attachment" : undefined,
       },
@@ -338,11 +352,6 @@ export class MediaService {
         statusCode: result.statusCode,
       });
       throw this.mapLegacyErrorToNextlyError(result);
-    }
-
-    // Move to folder if specified
-    if (input.folderId) {
-      await this.moveToFolder(result.data.id, input.folderId, context);
     }
 
     this.logger.info("Media file uploaded", {
@@ -443,7 +452,7 @@ export class MediaService {
   async update(
     mediaId: string,
     input: UpdateMediaInput,
-    _context: RequestContext,
+    context: RequestContext,
     // The transport-resolved caller, threaded to the outbox event.
     actor?: RequestActor
   ): Promise<MediaFile> {
@@ -452,6 +461,13 @@ export class MediaService {
     // Sanitize metadata fields before storage (defense-in-depth)
     sanitizeMediaInput(input);
 
+    // Attribute the write to the transport actor when present, otherwise to the
+    // request-context user. A Direct-API call (nextly.media.update({ user }))
+    // carries the user but no transport actor, so without this fallback its
+    // event would record as `system`. Plain-HTTP callers already pass a
+    // resolved `actor`, so this leaves them unchanged.
+    const resolvedActor = actorForWrite(actor, context.user);
+
     const result = await this.legacyMediaService.updateMedia(
       mediaId,
       {
@@ -459,7 +475,7 @@ export class MediaService {
         caption: input.caption ?? undefined,
         tags: input.tags,
       },
-      actor
+      resolvedActor
     );
 
     if (!result.success || !result.data) {
@@ -486,13 +502,22 @@ export class MediaService {
    */
   async delete(
     mediaId: string,
-    _context: RequestContext,
+    context: RequestContext,
     // The transport-resolved caller, threaded to the outbox event.
     actor?: RequestActor
   ): Promise<void> {
     this.logger.debug("Deleting media file", { mediaId });
 
-    const result = await this.legacyMediaService.deleteMedia(mediaId, actor);
+    // Attribute the write to the transport actor when present, otherwise to the
+    // request-context user, so a Direct-API delete (which carries the user but
+    // no transport actor) is not recorded as `system`. Plain-HTTP callers pass
+    // a resolved `actor` and are unaffected.
+    const resolvedActor = actorForWrite(actor, context.user);
+
+    const result = await this.legacyMediaService.deleteMedia(
+      mediaId,
+      resolvedActor
+    );
 
     if (!result.success) {
       if (result.statusCode === 404) {

--- a/packages/nextly/src/domains/media/services/media-service.ts
+++ b/packages/nextly/src/domains/media/services/media-service.ts
@@ -504,12 +504,21 @@ export class MediaService {
     // resolved `actor`, so this leaves them unchanged.
     const resolvedActor = actorForWrite(actor, context.user);
 
+    // A metadata update may also move the item (folderId in the patch). Validate
+    // the target folder up front (throws NOT_FOUND) and forward it, so the move
+    // actually happens and is captured in the media.updated event rather than
+    // silently dropped. `null` moves to root and needs no validation.
+    if (input.folderId) {
+      await this.findFolderById(input.folderId, context);
+    }
+
     const result = await this.legacyMediaService.updateMedia(
       mediaId,
       {
         altText: input.altText ?? undefined,
         caption: input.caption ?? undefined,
         tags: input.tags,
+        ...(input.folderId !== undefined ? { folderId: input.folderId } : {}),
       },
       resolvedActor
     );

--- a/packages/nextly/src/domains/webhooks/__tests__/media-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/media-outbox.integration.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Outbox capture on media writes.
+ *
+ * Proves the media mutation seam appends `nextly_events` rows: `media.uploaded`
+ * on upload, `media.updated` on a metadata edit, `media.deleted` on delete —
+ * each recorded inside the write transaction, carrying the flat media row and
+ * the acting identity, with `resource.kind === "media"`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Storage + image processing are stubbed so the DB write path (and its outbox
+// event) runs without a real backend. Mirrors services/__tests__/media.test.ts.
+vi.mock("@nextly/storage", () => ({
+  getMediaStorage: vi.fn(() => ({
+    upload: vi.fn().mockResolvedValue({
+      url: "https://test.local/cat.jpg",
+      path: "cat.jpg",
+    }),
+    delete: vi.fn().mockResolvedValue(undefined),
+    exists: vi.fn().mockResolvedValue(false),
+    getPublicUrl: vi.fn((p: string) => `https://test.local/${p}`),
+    getStorageType: vi.fn().mockReturnValue("local"),
+  })),
+  getImageProcessor: vi.fn(() => ({
+    isValidImage: vi.fn().mockResolvedValue(false),
+    getDimensions: vi.fn().mockResolvedValue({ width: 0, height: 0 }),
+    generateThumbnail: vi.fn().mockResolvedValue(null),
+    optimizeImage: vi.fn().mockResolvedValue(null),
+  })),
+  withRetry: vi.fn(async (fn: () => unknown) => fn()),
+  isTransientError: vi.fn(() => false),
+}));
+
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import { MediaService } from "../../../services/media";
+import type { WebhookEvent } from "../types";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+  vi.clearAllMocks();
+});
+
+interface EventRow {
+  id: string;
+  type: string;
+  resourceKind: string;
+  resourceCollection: string | null;
+  resourceId: string | null;
+  payload: unknown;
+  actorType: string | null;
+  actorId: string | null;
+}
+
+function envelopeOf(row: EventRow): WebhookEvent {
+  return (
+    typeof row.payload === "string" ? JSON.parse(row.payload) : row.payload
+  ) as WebhookEvent;
+}
+
+async function events(handle: TestNextly): Promise<EventRow[]> {
+  return handle.adapter.select<EventRow>("nextly_events");
+}
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+function service(handle: TestNextly): MediaService {
+  return new MediaService(handle.adapter, noopLogger as never);
+}
+
+describe("webhook outbox capture — media (integration)", () => {
+  beforeEach(async () => {
+    current = await createTestNextly({});
+  });
+
+  it("records media.uploaded on upload", async () => {
+    const media = service(current!);
+    const result = await media.uploadMedia(
+      {
+        file: Buffer.from("not-really-an-image"),
+        filename: "doc.pdf",
+        mimeType: "application/pdf",
+        size: 19,
+        uploadedBy: null,
+      },
+      { type: "user", id: "user-1" }
+    );
+
+    const rows = (await events(current!)).filter(
+      r => r.type === "media.uploaded"
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].resourceKind).toBe("media");
+    expect(rows[0].resourceCollection).toBeNull();
+    expect(rows[0].resourceId).toBe(result.data!.id);
+    expect(rows[0].actorType).toBe("user");
+    expect(rows[0].actorId).toBe("user-1");
+    const env = envelopeOf(rows[0]);
+    expect((env.data as { filename?: string }).filename).toBeTruthy();
+    expect(env.previous).toBeNull();
+  });
+
+  it("records media.updated with the prior state on a metadata edit", async () => {
+    const media = service(current!);
+    const uploaded = await media.uploadMedia(
+      {
+        file: Buffer.from("x"),
+        filename: "doc.pdf",
+        mimeType: "application/pdf",
+        size: 1,
+        uploadedBy: null,
+      },
+      { type: "user", id: "user-1" }
+    );
+    const id = uploaded.data!.id;
+
+    await media.updateMedia(
+      id,
+      { altText: "A cat" },
+      { type: "apiKey", id: "key-9" }
+    );
+
+    const row = (await events(current!)).find(r => r.type === "media.updated");
+    expect(row).toBeDefined();
+    expect(row!.resourceId).toBe(id);
+    expect(row!.actorType).toBe("apiKey");
+    expect(row!.actorId).toBe("key-9");
+    const env = envelopeOf(row!);
+    expect((env.data as { altText?: string }).altText).toBe("A cat");
+    expect(env.previous).not.toBeNull();
+  });
+
+  it("records media.deleted and removes the row", async () => {
+    const media = service(current!);
+    const uploaded = await media.uploadMedia(
+      {
+        file: Buffer.from("x"),
+        filename: "doc.pdf",
+        mimeType: "application/pdf",
+        size: 1,
+        uploadedBy: null,
+      },
+      { type: "user", id: "user-1" }
+    );
+    const id = uploaded.data!.id;
+
+    await media.deleteMedia(id, { type: "user", id: "user-1" });
+
+    const rows = await events(current!);
+    const deleted = rows.find(r => r.type === "media.deleted");
+    expect(deleted).toBeDefined();
+    expect(deleted!.resourceId).toBe(id);
+    expect(envelopeOf(deleted!).previous).toBeNull();
+
+    const remaining = await current!.adapter.select<{ id: string }>("media");
+    expect(remaining.find(m => m.id === id)).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/media-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/media-outbox.integration.test.ts
@@ -31,11 +31,14 @@ vi.mock("@nextly/storage", () => ({
   isTransientError: vi.fn(() => false),
 }));
 
+import { MediaService as UnifiedMediaService } from "../../../domains/media/services/media-service";
 import {
   createTestNextly,
   type TestNextly,
 } from "../../../plugins/test-nextly";
 import { MediaService } from "../../../services/media";
+import type { RequestContext } from "../../../services/shared";
+import type { WebhookFastDrainScheduler } from "../after-drain";
 import type { WebhookEvent } from "../types";
 
 let current: TestNextly | undefined;
@@ -304,6 +307,71 @@ describe("webhook outbox capture — media (integration)", () => {
     expect(updated).toBeDefined();
     expect(updated!.actorType).toBe("user");
     expect(updated!.actorId).toBe("editor-7");
+  });
+
+  it("records media.updated when a media item is moved to a folder", async () => {
+    // A folder move is a folder_id change; it must be captured as a
+    // media.updated event (a bare folder write recorded nothing) so subscribers
+    // see the move.
+    await seedUser(current!, "editor-7");
+    const nextly = current!.nextly;
+    const folder = await nextly.media.folders.create({
+      name: "Archive",
+      user: { id: "editor-7" },
+    });
+    const uploaded = await nextly.media.upload({
+      file: {
+        data: Buffer.from("x"),
+        name: "doc.pdf",
+        mimetype: "application/pdf",
+        size: 1,
+      },
+      user: { id: "editor-7" },
+    });
+
+    const mediaService =
+      current!.getService<UnifiedMediaService>("mediaService");
+    const context: RequestContext = { user: { id: "editor-7" } };
+    await mediaService.moveToFolder(uploaded.id, folder.id, context);
+
+    const moved = (await events(current!)).find(
+      r => r.type === "media.updated" && r.resourceId === uploaded.id
+    );
+    expect(moved).toBeDefined();
+    expect((envelopeOf(moved!).data as { folderId?: string }).folderId).toBe(
+      folder.id
+    );
+    expect(moved!.actorType).toBe("user");
+    expect(moved!.actorId).toBe("editor-7");
+  });
+
+  it("offers the fast-drain from the legacy service when given a scheduler", async () => {
+    // The exported server actions reach the legacy service directly (via
+    // ServiceContainer), so a legacy service constructed WITH the scheduler must
+    // offer the drain after a write — otherwise action-driven media events would
+    // sit until the scheduled drain.
+    const scheduler = current!.getService<WebhookFastDrainScheduler>(
+      "webhookFastDrainScheduler"
+    );
+    const offerSpy = vi.spyOn(scheduler, "offer");
+    const legacy = new MediaService(
+      current!.adapter,
+      noopLogger as never,
+      scheduler
+    );
+
+    await legacy.uploadMedia(
+      {
+        file: Buffer.from("x"),
+        filename: "doc.pdf",
+        mimeType: "application/pdf",
+        size: 1,
+        uploadedBy: null,
+      },
+      { type: "user", id: "user-1" }
+    );
+
+    expect(offerSpy).toHaveBeenCalled();
   });
 
   it("offers the webhook fast-drain after a media write", async () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/media-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/media-outbox.integration.test.ts
@@ -345,6 +345,47 @@ describe("webhook outbox capture — media (integration)", () => {
     expect(moved!.actorId).toBe("editor-7");
   });
 
+  it("moves the item and records media.updated when update carries a folderId", async () => {
+    // A metadata update that includes folderId must actually move the row and
+    // reflect it in the event — not silently drop the folder change.
+    await seedUser(current!, "editor-7");
+    const nextly = current!.nextly;
+    const folder = await nextly.media.folders.create({
+      name: "Reports",
+      user: { id: "editor-7" },
+    });
+    const uploaded = await nextly.media.upload({
+      file: {
+        data: Buffer.from("x"),
+        name: "doc.pdf",
+        mimetype: "application/pdf",
+        size: 1,
+      },
+      user: { id: "editor-7" },
+    });
+
+    await nextly.media.update({
+      id: uploaded.id,
+      data: { folderId: folder.id },
+      user: { id: "editor-7" },
+    });
+
+    const moved = (await events(current!)).find(
+      r => r.type === "media.updated" && r.resourceId === uploaded.id
+    );
+    expect(moved).toBeDefined();
+    expect((envelopeOf(moved!).data as { folderId?: string }).folderId).toBe(
+      folder.id
+    );
+    // The row actually moved.
+    const row = (
+      await current!.adapter.select<{ id: string; folderId: string | null }>(
+        "media"
+      )
+    ).find(m => m.id === uploaded.id);
+    expect(row?.folderId).toBe(folder.id);
+  });
+
   it("offers the fast-drain from the legacy service when given a scheduler", async () => {
     // The exported server actions reach the legacy service directly (via
     // ServiceContainer), so a legacy service constructed WITH the scheduler must

--- a/packages/nextly/src/domains/webhooks/__tests__/media-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/media-outbox.integration.test.ts
@@ -306,6 +306,29 @@ describe("webhook outbox capture — media (integration)", () => {
     expect(updated!.actorId).toBe("editor-7");
   });
 
+  it("offers the webhook fast-drain after a media write", async () => {
+    // A media write commits its outbox row inside the DB transaction; the
+    // domain service must then offer the shared fast-drain so the event is
+    // delivered promptly instead of waiting for the scheduled drain.
+    await seedUser(current!, "editor-7");
+    const scheduler = current!.getService<{ offer: () => void }>(
+      "webhookFastDrainScheduler"
+    );
+    const offerSpy = vi.spyOn(scheduler, "offer");
+
+    await current!.nextly.media.upload({
+      file: {
+        data: Buffer.from("x"),
+        name: "doc.pdf",
+        mimetype: "application/pdf",
+        size: 1,
+      },
+      user: { id: "editor-7" },
+    });
+
+    expect(offerSpy).toHaveBeenCalled();
+  });
+
   it("records the final folder on the media.uploaded event", async () => {
     // A Direct-API upload into a folder must record the folder on the initial
     // insert so the event reflects the final location, rather than recording

--- a/packages/nextly/src/domains/webhooks/__tests__/media-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/media-outbox.integration.test.ts
@@ -67,6 +67,13 @@ async function events(handle: TestNextly): Promise<EventRow[]> {
   return handle.adapter.select<EventRow>("nextly_events");
 }
 
+// Media rows (and folders) reference users via a foreign key, so a Direct-API
+// write attributed to a user needs that user to exist. Seed a minimal row
+// (only id + the NOT NULL unique email are required).
+async function seedUser(handle: TestNextly, id: string): Promise<void> {
+  await handle.adapter.insert("users", { id, email: `${id}@test.local` });
+}
+
 const noopLogger = {
   debug: vi.fn(),
   info: vi.fn(),
@@ -164,5 +171,170 @@ describe("webhook outbox capture — media (integration)", () => {
 
     const remaining = await current!.adapter.select<{ id: string }>("media");
     expect(remaining.find(m => m.id === id)).toBeUndefined();
+  });
+
+  it("records exactly one media.deleted when two deletes race the same row", async () => {
+    // Two callers read the row (both see it present), then serialize on the
+    // write. The first delete removes the row; the second finds zero rows
+    // affected inside its transaction and must skip the event and report
+    // not-found, so the outbox never carries a duplicate media.deleted.
+    const media = service(current!);
+    const uploaded = await media.uploadMedia(
+      {
+        file: Buffer.from("x"),
+        filename: "doc.pdf",
+        mimeType: "application/pdf",
+        size: 1,
+        uploadedBy: null,
+      },
+      { type: "user", id: "user-1" }
+    );
+    const id = uploaded.data!.id;
+
+    const [a, b] = await Promise.all([
+      media.deleteMedia(id, { type: "user", id: "user-1" }),
+      media.deleteMedia(id, { type: "user", id: "user-1" }),
+    ]);
+
+    // Exactly one caller wins the delete; the loser gets a 404 no-op.
+    const outcomes = [a.success, b.success].sort();
+    expect(outcomes).toEqual([false, true]);
+    const loser = a.success ? b : a;
+    expect(loser.statusCode).toBe(404);
+
+    const deletedEvents = (await events(current!)).filter(
+      r => r.type === "media.deleted"
+    );
+    expect(deletedEvents).toHaveLength(1);
+  });
+
+  it("does not record media.updated for an update to an already-deleted row", async () => {
+    // A metadata edit whose target row is gone must not append a false
+    // media.updated event; the write reports zero affected rows and returns
+    // not-found instead of a successful no-op.
+    const media = service(current!);
+    const uploaded = await media.uploadMedia(
+      {
+        file: Buffer.from("x"),
+        filename: "doc.pdf",
+        mimeType: "application/pdf",
+        size: 1,
+        uploadedBy: null,
+      },
+      { type: "user", id: "user-1" }
+    );
+    const id = uploaded.data!.id;
+
+    await media.deleteMedia(id, { type: "user", id: "user-1" });
+    const result = await media.updateMedia(
+      id,
+      { altText: "too late" },
+      { type: "user", id: "user-1" }
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBe(404);
+    const updatedEvents = (await events(current!)).filter(
+      r => r.type === "media.updated"
+    );
+    expect(updatedEvents).toHaveLength(0);
+  });
+
+  it("keeps untouched metadata in the media.updated payload", async () => {
+    // A Direct-API edit forwards omitted fields as `undefined`. The event row
+    // must overlay only the columns actually written, so a field set earlier
+    // (caption) survives a later edit that touches only altText — instead of
+    // being wrongly reported as changed and dropped from `data`.
+    const nextly = current!.nextly;
+    await seedUser(current!, "editor-7");
+    const uploaded = await nextly.media.upload({
+      file: {
+        data: Buffer.from("x"),
+        name: "doc.pdf",
+        mimetype: "application/pdf",
+        size: 1,
+      },
+      user: { id: "editor-7" },
+    });
+
+    await nextly.media.update({
+      id: uploaded.id,
+      data: { caption: "keep-me", altText: "first" },
+      user: { id: "editor-7" },
+    });
+    await nextly.media.update({
+      id: uploaded.id,
+      data: { altText: "second" },
+      user: { id: "editor-7" },
+    });
+
+    const latest = (await events(current!))
+      .filter(r => r.type === "media.updated")
+      .map(envelopeOf)
+      .find(e => (e.data as { altText?: string }).altText === "second");
+    expect(latest).toBeDefined();
+    expect((latest!.data as { caption?: string }).caption).toBe("keep-me");
+  });
+
+  it("attributes a Direct-API media edit to the request user", async () => {
+    // nextly.media.update carries the user via the request context but no
+    // transport actor; without the actor fallback the event would record as
+    // `system` instead of the acting user.
+    const nextly = current!.nextly;
+    await seedUser(current!, "editor-7");
+    const uploaded = await nextly.media.upload({
+      file: {
+        data: Buffer.from("x"),
+        name: "doc.pdf",
+        mimetype: "application/pdf",
+        size: 1,
+      },
+      user: { id: "editor-7" },
+    });
+
+    await nextly.media.update({
+      id: uploaded.id,
+      data: { altText: "Edited" },
+      user: { id: "editor-7" },
+    });
+
+    const updated = (await events(current!)).find(
+      r => r.type === "media.updated"
+    );
+    expect(updated).toBeDefined();
+    expect(updated!.actorType).toBe("user");
+    expect(updated!.actorId).toBe("editor-7");
+  });
+
+  it("records the final folder on the media.uploaded event", async () => {
+    // A Direct-API upload into a folder must record the folder on the initial
+    // insert so the event reflects the final location, rather than recording
+    // folderId:null and moving the row afterward (which fired the event with
+    // the wrong folder and no move event).
+    const nextly = current!.nextly;
+    await seedUser(current!, "editor-7");
+    const folder = await nextly.media.folders.create({
+      name: "Reports",
+      user: { id: "editor-7" },
+    });
+
+    const uploaded = await nextly.media.upload({
+      file: {
+        data: Buffer.from("x"),
+        name: "doc.pdf",
+        mimetype: "application/pdf",
+        size: 1,
+      },
+      folder: folder.id,
+      user: { id: "editor-7" },
+    });
+
+    const uploadedEvent = (await events(current!)).find(
+      r => r.type === "media.uploaded" && r.resourceId === uploaded.id
+    );
+    expect(uploadedEvent).toBeDefined();
+    expect(
+      (envelopeOf(uploadedEvent!).data as { folderId?: string }).folderId
+    ).toBe(folder.id);
   });
 });

--- a/packages/nextly/src/services/index.ts
+++ b/packages/nextly/src/services/index.ts
@@ -12,6 +12,8 @@ import { RolePermissionService } from "../domains/auth/services/role-permission-
 import { RoleService } from "../domains/auth/services/role-service";
 import { UserRoleService } from "../domains/auth/services/user-role-service";
 import type { WebhookFastDrainScheduler } from "../domains/webhooks/after-drain";
+import { MetaRetentionGate } from "../domains/webhooks/retention-gate";
+import { WebhookRetentionRunner } from "../domains/webhooks/retention-runner";
 import type { DatabaseInstance } from "../types/database-operations";
 
 import { CollectionsHandler } from "./collections-handler";
@@ -364,13 +366,30 @@ export class ServiceContainer {
       // scheduled drain (which also owns retention pruning). Resolved from DI
       // when the app has booted webhooks; a bare container (e.g. a CLI/test
       // build) gets none and simply relies on the scheduled drain.
+      const logger = this.getLogger();
       const fastDrainScheduler = container.has("webhookFastDrainScheduler")
         ? container.get<WebhookFastDrainScheduler>("webhookFastDrainScheduler")
         : undefined;
+      // Prune the outbox on the action write path too: the fast drain only
+      // prunes when it actually runs a delivery pass (endpoints exist and a
+      // runtime `after()` is available), so without its own runner an
+      // action-only install's media events could accumulate unpruned.
+      const config = container.has("config")
+        ? container.get<NextlyServiceConfig>("config")
+        : undefined;
+      const retentionRunner = config?.webhookRetention
+        ? new WebhookRetentionRunner({
+            policy: config.webhookRetention,
+            prune: { adapter: this.adapter, logger },
+            gate: new MetaRetentionGate(this.adapter),
+            logger,
+          })
+        : undefined;
       this._media = new LegacyMediaService(
         this.adapter,
-        this.getLogger(),
-        fastDrainScheduler
+        logger,
+        fastDrainScheduler,
+        retentionRunner
       );
     }
     return this._media;

--- a/packages/nextly/src/services/index.ts
+++ b/packages/nextly/src/services/index.ts
@@ -11,6 +11,7 @@ import { RoleInheritanceService } from "../domains/auth/services/role-inheritanc
 import { RolePermissionService } from "../domains/auth/services/role-permission-service";
 import { RoleService } from "../domains/auth/services/role-service";
 import { UserRoleService } from "../domains/auth/services/user-role-service";
+import type { WebhookFastDrainScheduler } from "../domains/webhooks/after-drain";
 import type { DatabaseInstance } from "../types/database-operations";
 
 import { CollectionsHandler } from "./collections-handler";
@@ -357,7 +358,20 @@ export class ServiceContainer {
    */
   get media(): LegacyMediaService {
     if (!this._media) {
-      this._media = new LegacyMediaService(this.adapter, this.getLogger());
+      // Server actions reach media through this container rather than the
+      // unified media service, so inject the shared drain fast path directly —
+      // otherwise action-driven media events would sit in the outbox until the
+      // scheduled drain (which also owns retention pruning). Resolved from DI
+      // when the app has booted webhooks; a bare container (e.g. a CLI/test
+      // build) gets none and simply relies on the scheduled drain.
+      const fastDrainScheduler = container.has("webhookFastDrainScheduler")
+        ? container.get<WebhookFastDrainScheduler>("webhookFastDrainScheduler")
+        : undefined;
+      this._media = new LegacyMediaService(
+        this.adapter,
+        this.getLogger(),
+        fastDrainScheduler
+      );
     }
     return this._media;
   }

--- a/packages/nextly/src/services/media.ts
+++ b/packages/nextly/src/services/media.ts
@@ -526,24 +526,42 @@ export class MediaService extends BaseService {
         }
       }
 
-      // The updated row in read shape: prior values overlaid with the caller's
-      // changes and the computed update payload (any regenerated sizes/thumbnail
-      // plus the fresh updatedAt). Reused as both the event `data` and the
-      // response body so the two never drift.
-      const updatedRow = {
+      // The updated row in read shape: the prior values overlaid with ONLY the
+      // computed update payload. `updateData` already holds every column being
+      // written (each supplied change plus any regenerated sizes/thumbnail and
+      // the fresh updatedAt) in the same camelCase keys as the read row, so it
+      // is the correct post-update document. The caller's raw `changes` are NOT
+      // spread in: an omitted field arrives as `undefined` and would overwrite
+      // an untouched column, making the event's computed changedFields wrongly
+      // report it as changed and drop its real value.
+      const updatedRow: Media = {
         ...mediaData,
-        ...changes,
         ...updateData,
-        updatedAt: updateData.updatedAt,
-      } as Media;
+      };
 
       // Commit the row update and its outbox event in one transaction so the
       // event is durable exactly when the change commits. tx.update delegates to
       // the same Drizzle write the fluent path used, so column casing and JSON
       // serialization are unchanged; the positional form is needed only so the
-      // event shares the adapter TransactionContext.
+      // event shares the adapter TransactionContext. `returning` makes the write
+      // report the rows it actually touched so a row removed by a concurrent
+      // delete between the read above and this write is detected.
+      let updatedCount = 0;
       await this.adapter.transaction(async tx => {
-        await tx.update("media", updateData, this.whereEq("id", mediaId));
+        const updated = await tx.update(
+          "media",
+          updateData,
+          this.whereEq("id", mediaId),
+          { returning: ["id"] }
+        );
+        updatedCount = updated.length;
+
+        // Lost an update race: the row was deleted after our read, so nothing
+        // was written. Skip the event so we never record a false `media.updated`
+        // for a no-op, and fall through to the not-found result below.
+        if (updatedCount === 0) {
+          return;
+        }
 
         // `previous` is the row read before the write; `data` is the new state.
         // Media has no field schema, so `fields` is empty (nothing to strip).
@@ -556,6 +574,17 @@ export class MediaService extends BaseService {
           actor: actorForWrite(actor, null),
         });
       });
+
+      if (updatedCount === 0) {
+        // Mirror getMediaById's not-found shape so the domain layer maps this to
+        // a 404 instead of treating the no-op write as a successful update.
+        return {
+          success: false,
+          statusCode: 404,
+          message: "Media not found",
+          data: null,
+        };
+      }
 
       return {
         success: true,
@@ -601,8 +630,18 @@ export class MediaService extends BaseService {
       // already-deleted file (a real read bug). The positional adapter
       // transaction is required so the event shares the adapter
       // TransactionContext; tx.delete replaces the prior raw `sql` template.
+      // tx.delete returns how many rows it actually removed, so a row already
+      // deleted by a concurrent request (between our read above and this write)
+      // is detected as a zero-row no-op.
+      let deletedCount = 0;
       await this.adapter.transaction(async tx => {
-        await tx.delete("media", this.whereEq("id", mediaId));
+        deletedCount = await tx.delete("media", this.whereEq("id", mediaId));
+
+        // Lost a delete race: nothing was removed here, so skip the event. Only
+        // the request that actually deleted the row records `media.deleted`.
+        if (deletedCount === 0) {
+          return;
+        }
 
         // The removed row's final state ships as `data`; there is no post-delete
         // state, so `previous` is null (mirroring create). Media has no field
@@ -616,6 +655,17 @@ export class MediaService extends BaseService {
           actor: actorForWrite(actor, null),
         });
       });
+
+      // The row was gone before we could delete it: report not-found and skip
+      // physical cleanup (the winning request owns the file) rather than
+      // returning a false success for a no-op delete.
+      if (deletedCount === 0) {
+        return {
+          success: false,
+          statusCode: 404,
+          message: "Media not found",
+        };
+      }
 
       // Best-effort physical cleanup AFTER the row + event have committed.
       // Swallow-and-warn: a storage failure must not fail a delete whose

--- a/packages/nextly/src/services/media.ts
+++ b/packages/nextly/src/services/media.ts
@@ -41,7 +41,9 @@ import {
 // Actor threading + outbox recording for media writes. Each write records a
 // durable `media.*` event in the same transaction as the row change.
 import { actorForWrite, type RequestActor } from "../auth/request-actor";
+import type { WebhookFastDrainScheduler } from "../domains/webhooks/after-drain";
 import { recordMutationEvent } from "../domains/webhooks/record-mutation-event";
+import type { WebhookRetentionRunner } from "../domains/webhooks/retention-runner";
 import { keysToSnakeCase } from "../lib/case-conversion";
 import { isImageMimeType, validateFileSize } from "../types/media";
 import type {
@@ -68,8 +70,41 @@ export class MediaService extends BaseService {
     return getImageProcessor();
   }
 
-  constructor(adapter: DrizzleAdapter, logger: Logger) {
+  // A short prune pass on the write path: enough to keep the outbox from
+  // growing unbounded without turning a media write into a long maintenance job.
+  private static readonly WRITE_PATH_PRUNE_BATCHES = 2;
+
+  constructor(
+    adapter: DrizzleAdapter,
+    logger: Logger,
+    /**
+     * Shared post-response drain fast path. This service records media outbox
+     * events directly, so callers that reach it WITHOUT the unified media
+     * service (the exported server actions via `ServiceContainer.media`) still
+     * get the immediate drain. Left undefined when the unified service wraps
+     * this one (that wrapper offers the drain itself), so the drain is offered
+     * exactly once per write.
+     */
+    private readonly fastDrainScheduler?: WebhookFastDrainScheduler,
+    /** Prunes the outbox after a write, paired with the drain fast path. */
+    private readonly retentionRunner?: WebhookRetentionRunner
+  ) {
     super(adapter, logger);
+  }
+
+  /**
+   * Post-write webhook maintenance for callers that use this service directly:
+   * offer the fast drain, then a short retention pass. No-op when no scheduler
+   * was injected (the unified media service handles the drain in that path).
+   * Both absorb their own failures, so this never turns a committed write into
+   * an error.
+   */
+  private async afterWrite(): Promise<void> {
+    if (!this.fastDrainScheduler && !this.retentionRunner) {
+      return;
+    }
+    this.fastDrainScheduler?.offer();
+    await this.retentionRunner?.maybeRun(MediaService.WRITE_PATH_PRUNE_BATCHES);
   }
 
   /**
@@ -409,6 +444,10 @@ export class MediaService extends BaseService {
         });
       });
 
+      // The upload committed a media.uploaded outbox row; drain and prune it
+      // (no-op when the unified media service wraps this one and drains itself).
+      await this.afterWrite();
+
       return {
         success: true,
         statusCode: 201,
@@ -448,6 +487,10 @@ export class MediaService extends BaseService {
       if (changes.tags !== undefined) updateData.tags = changes.tags;
       if (changes.focalX !== undefined) updateData.focalX = changes.focalX;
       if (changes.focalY !== undefined) updateData.focalY = changes.focalY;
+      // A folder move (including to root, `null`) rides the same update path so
+      // the change is captured as a media.updated event.
+      if (changes.folderId !== undefined)
+        updateData.folderId = changes.folderId;
 
       // If crop point changed and media is an image, regenerate sizes immediately
       const focalPointChanged =
@@ -583,6 +626,10 @@ export class MediaService extends BaseService {
         };
       }
 
+      // The update committed a media.updated outbox row; drain and prune it
+      // (no-op when the unified media service wraps this one and drains itself).
+      await this.afterWrite();
+
       return {
         success: true,
         statusCode: 200,
@@ -712,6 +759,10 @@ export class MediaService extends BaseService {
         console.warn("[MediaService] Storage deletion warning:", error);
         // Storage cleanup is best-effort; the row and event are already gone.
       }
+
+      // The delete committed a media.deleted outbox row; drain and prune it
+      // (no-op when the unified media service wraps this one and drains itself).
+      await this.afterWrite();
 
       return {
         success: true,

--- a/packages/nextly/src/services/media.ts
+++ b/packages/nextly/src/services/media.ts
@@ -466,6 +466,92 @@ export class MediaService extends BaseService {
   }
 
   /**
+   * Regenerate a media item's image size variants for a changed crop point,
+   * writing `sizes`/`thumbnailUrl` onto `updateData`. No-op unless the crop
+   * actually changed and the item is an image on a readable storage adapter.
+   *
+   * Called from inside the update transaction, under the media row lock, so its
+   * shared-path storage writes are serialized with the row commit: two
+   * concurrent focal edits of the same item cannot interleave their variant
+   * writes, so the committed row never points at another crop's bytes.
+   * Best-effort: a regeneration failure is swallowed (the crop point is still
+   * saved) rather than failing the whole update.
+   */
+  private async regenerateFocalPointSizes(
+    media: Media,
+    changes: UpdateMediaInput,
+    updateData: Record<string, unknown>
+  ): Promise<void> {
+    const focalPointChanged =
+      changes.focalX !== undefined || changes.focalY !== undefined;
+    if (!focalPointChanged || !isImageMimeType(media.mimeType)) {
+      return;
+    }
+
+    const adapter = this.storage.getAdapterForCollection("media");
+    if (!adapter.read) {
+      console.log(
+        `[MediaService] Crop point saved for media ${media.id}. ` +
+          `Size regeneration requires local storage or adapter with read support.`
+      );
+      return;
+    }
+
+    try {
+      const originalBuffer = await adapter.read(media.filename);
+      if (!originalBuffer) return;
+
+      const imageSizeService = new ImageSizeService(this.adapter, this.logger);
+      const sizeConfigs = await imageSizeService.getActiveSizeConfigs();
+      if (sizeConfigs.length === 0) return;
+
+      const oldSizes = (media as unknown as Record<string, unknown>).sizes;
+      if (oldSizes) {
+        const parsed =
+          typeof oldSizes === "string" ? JSON.parse(oldSizes) : oldSizes;
+        await deleteImageSizes(parsed, path =>
+          this.storage.delete(path, "media")
+        );
+      }
+
+      const uploadFn = async (
+        buffer: Buffer,
+        opts: { filename: string; mimeType: string }
+      ) => {
+        return this.storage.upload(buffer, {
+          filename: opts.filename,
+          mimeType: opts.mimeType,
+          collection: "media",
+        });
+      };
+      const newSizes = await generateImageSizes(
+        originalBuffer,
+        media.originalFilename || media.filename,
+        sizeConfigs,
+        uploadFn,
+        { focalX: changes.focalX, focalY: changes.focalY }
+      );
+
+      updateData.sizes = newSizes;
+      if (newSizes && "thumbnail" in newSizes) {
+        updateData.thumbnailUrl = (
+          newSizes.thumbnail as unknown as { url: string }
+        ).url;
+      }
+
+      console.log(
+        `[MediaService] Regenerated ${Object.keys(newSizes).length} sizes for media ${media.id}`
+      );
+    } catch (error) {
+      console.warn(
+        "[MediaService] Crop point size regeneration failed:",
+        error
+      );
+      // Continue without regeneration - crop point is still saved.
+    }
+  }
+
+  /**
    * Update media metadata (altText, caption, tags)
    */
   async updateMedia(
@@ -492,83 +578,6 @@ export class MediaService extends BaseService {
       if (changes.folderId !== undefined)
         updateData.folderId = changes.folderId;
 
-      // If crop point changed and media is an image, regenerate sizes immediately
-      const focalPointChanged =
-        changes.focalX !== undefined || changes.focalY !== undefined;
-      const mediaData = existing.data!;
-
-      if (focalPointChanged && isImageMimeType(mediaData.mimeType)) {
-        const adapter = this.storage.getAdapterForCollection("media");
-        if (adapter.read) {
-          try {
-            const originalBuffer = await adapter.read(mediaData.filename);
-            if (originalBuffer) {
-              const imageSizeService = new ImageSizeService(
-                this.adapter,
-                this.logger
-              );
-              const sizeConfigs = await imageSizeService.getActiveSizeConfigs();
-
-              if (sizeConfigs.length > 0) {
-                const oldSizes = (
-                  mediaData as unknown as Record<string, unknown>
-                ).sizes;
-                if (oldSizes) {
-                  const parsed =
-                    typeof oldSizes === "string"
-                      ? JSON.parse(oldSizes)
-                      : oldSizes;
-                  await deleteImageSizes(parsed, path =>
-                    this.storage.delete(path, "media")
-                  );
-                }
-
-                const uploadFn = async (
-                  buffer: Buffer,
-                  opts: { filename: string; mimeType: string }
-                ) => {
-                  return this.storage.upload(buffer, {
-                    filename: opts.filename,
-                    mimeType: opts.mimeType,
-                    collection: "media",
-                  });
-                };
-                const newSizes = await generateImageSizes(
-                  originalBuffer,
-                  mediaData.originalFilename || mediaData.filename,
-                  sizeConfigs,
-                  uploadFn,
-                  { focalX: changes.focalX, focalY: changes.focalY }
-                );
-
-                updateData.sizes = newSizes;
-
-                if (newSizes && "thumbnail" in newSizes) {
-                  updateData.thumbnailUrl = (
-                    newSizes.thumbnail as unknown as { url: string }
-                  ).url;
-                }
-
-                console.log(
-                  `[MediaService] Regenerated ${Object.keys(newSizes).length} sizes for media ${mediaId}`
-                );
-              }
-            }
-          } catch (error) {
-            console.warn(
-              "[MediaService] Crop point size regeneration failed:",
-              error
-            );
-            // Continue without regeneration - crop point is still saved
-          }
-        } else {
-          console.log(
-            `[MediaService] Crop point saved for media ${mediaId}. ` +
-              `Size regeneration requires local storage or adapter with read support.`
-          );
-        }
-      }
-
       // Commit the row update and its outbox event in one transaction so the
       // event is durable exactly when the change commits. The row is locked and
       // RE-READ inside the transaction (not reused from the pre-transaction
@@ -590,6 +599,14 @@ export class MediaService extends BaseService {
           if (!current) {
             return null;
           }
+
+          // Regenerate focal-point image variants UNDER the row lock, from the
+          // freshly-read row, so a concurrent focal edit on the SAME item cannot
+          // interleave its shared-path storage writes with this one: the lock
+          // serializes the storage regeneration and the row/event commit
+          // together, so the committed row never describes a different crop than
+          // the bytes in storage. (Runs only when the crop actually changed.)
+          await this.regenerateFocalPointSizes(current, changes, updateData);
 
           await tx.update("media", updateData, this.whereEq("id", mediaId));
 

--- a/packages/nextly/src/services/media.ts
+++ b/packages/nextly/src/services/media.ts
@@ -578,6 +578,18 @@ export class MediaService extends BaseService {
       if (changes.folderId !== undefined)
         updateData.folderId = changes.folderId;
 
+      // Regenerate focal-point image variants when the crop changed, before the
+      // write transaction opens. Storage is not transactional, so regenerating
+      // shared variant paths can never be made atomic with the DB write: doing
+      // it inside the transaction would hold the row lock (and, on a
+      // single-connection pool, the only connection) across slow storage I/O
+      // without removing the underlying dual-write inconsistency (a rollback or
+      // a concurrent edit still overwrites the shared paths). Keeping it here
+      // preserves the existing behavior; a content-addressed variant scheme
+      // (new unique paths per generation, old paths cleaned up after commit) is
+      // the real fix and is tracked as a separate image-pipeline follow-up.
+      await this.regenerateFocalPointSizes(existing.data!, changes, updateData);
+
       // Commit the row update and its outbox event in one transaction so the
       // event is durable exactly when the change commits. The row is locked and
       // RE-READ inside the transaction (not reused from the pre-transaction
@@ -599,14 +611,6 @@ export class MediaService extends BaseService {
           if (!current) {
             return null;
           }
-
-          // Regenerate focal-point image variants UNDER the row lock, from the
-          // freshly-read row, so a concurrent focal edit on the SAME item cannot
-          // interleave its shared-path storage writes with this one: the lock
-          // serializes the storage regeneration and the row/event commit
-          // together, so the committed row never describes a different crop than
-          // the bytes in storage. (Runs only when the crop actually changed.)
-          await this.regenerateFocalPointSizes(current, changes, updateData);
 
           await tx.update("media", updateData, this.whereEq("id", mediaId));
 

--- a/packages/nextly/src/services/media.ts
+++ b/packages/nextly/src/services/media.ts
@@ -526,56 +526,53 @@ export class MediaService extends BaseService {
         }
       }
 
-      // The updated row in read shape: the prior values overlaid with ONLY the
-      // computed update payload. `updateData` already holds every column being
-      // written (each supplied change plus any regenerated sizes/thumbnail and
-      // the fresh updatedAt) in the same camelCase keys as the read row, so it
-      // is the correct post-update document. The caller's raw `changes` are NOT
-      // spread in: an omitted field arrives as `undefined` and would overwrite
-      // an untouched column, making the event's computed changedFields wrongly
-      // report it as changed and drop its real value.
-      const updatedRow: Media = {
-        ...mediaData,
-        ...updateData,
-      };
-
       // Commit the row update and its outbox event in one transaction so the
-      // event is durable exactly when the change commits. tx.update delegates to
-      // the same Drizzle write the fluent path used, so column casing and JSON
-      // serialization are unchanged; the positional form is needed only so the
-      // event shares the adapter TransactionContext. `returning` makes the write
-      // report the rows it actually touched so a row removed by a concurrent
-      // delete between the read above and this write is detected.
-      let updatedCount = 0;
-      await this.adapter.transaction(async tx => {
-        const updated = await tx.update(
-          "media",
-          updateData,
-          this.whereEq("id", mediaId),
-          { returning: ["id"] }
-        );
-        updatedCount = updated.length;
+      // event is durable exactly when the change commits. The row is locked and
+      // RE-READ inside the transaction (not reused from the pre-transaction
+      // read): the fresh read reflects the latest committed state, so a row
+      // removed by a concurrent delete is detected reliably on every dialect
+      // (a bare update-then-select-back can return a stale snapshot row on
+      // MySQL's repeatable read), and a field another request committed after
+      // our first read is not shipped stale. The transaction returns the
+      // post-update document (or null when the row is already gone).
+      const updatedRow = await this.adapter.transaction<Media | null>(
+        async tx => {
+          await tx.lockRow("media", mediaId);
+          const currentRows = await tx.select<Media>("media", {
+            where: this.whereEq("id", mediaId),
+          });
+          const current = currentRows[0];
+          // Lost an update race: the row was deleted after our first read, so
+          // record nothing and let the not-found result below stand.
+          if (!current) {
+            return null;
+          }
 
-        // Lost an update race: the row was deleted after our read, so nothing
-        // was written. Skip the event so we never record a false `media.updated`
-        // for a no-op, and fall through to the not-found result below.
-        if (updatedCount === 0) {
-          return;
+          await tx.update("media", updateData, this.whereEq("id", mediaId));
+
+          // The post-update document: the freshly-read committed row overlaid
+          // with ONLY this write's columns (`updateData` holds each supplied
+          // change plus any regenerated sizes/thumbnail and the fresh
+          // updatedAt, keyed in the same camelCase as the read row). Reused as
+          // both the event `data` and the response body so they never drift.
+          const nextRow: Media = { ...current, ...updateData };
+
+          // `previous` is the freshly-read pre-write row; `data` is the new
+          // state. Media has no field schema, so `fields` is empty.
+          await recordMutationEvent(tx, {
+            type: "media.updated",
+            resource: { kind: "media", id: mediaId },
+            data: nextRow,
+            previous: current,
+            fields: [],
+            actor: actorForWrite(actor, null),
+          });
+
+          return nextRow;
         }
+      );
 
-        // `previous` is the row read before the write; `data` is the new state.
-        // Media has no field schema, so `fields` is empty (nothing to strip).
-        await recordMutationEvent(tx, {
-          type: "media.updated",
-          resource: { kind: "media", id: mediaId },
-          data: updatedRow,
-          previous: mediaData,
-          fields: [],
-          actor: actorForWrite(actor, null),
-        });
-      });
-
-      if (updatedCount === 0) {
+      if (!updatedRow) {
         // Mirror getMediaById's not-found shape so the domain layer maps this to
         // a 404 instead of treating the no-op write as a successful update.
         return {
@@ -620,52 +617,58 @@ export class MediaService extends BaseService {
         };
       }
 
-      const mediaData = existing.data;
-
       // Remove the row and record the outbox event in one transaction FIRST,
       // before touching physical storage. The database is the source of truth,
       // so the row deletion and its durable event commit together; storage
       // cleanup runs afterward. If that cleanup fails it leaves an orphaned FILE
       // (benign, later reclaimable) rather than a surviving ROW pointing at an
-      // already-deleted file (a real read bug). The positional adapter
-      // transaction is required so the event shares the adapter
-      // TransactionContext; tx.delete replaces the prior raw `sql` template.
-      // tx.delete returns how many rows it actually removed, so a row already
-      // deleted by a concurrent request (between our read above and this write)
-      // is detected as a zero-row no-op.
-      let deletedCount = 0;
-      await this.adapter.transaction(async tx => {
-        deletedCount = await tx.delete("media", this.whereEq("id", mediaId));
+      // already-deleted file (a real read bug). The row is locked and RE-READ
+      // inside the transaction so a row already removed by a concurrent request
+      // is detected reliably on every dialect, and the event's `data` carries
+      // the latest committed state rather than the pre-transaction read. The
+      // transaction returns the deleted row (or null when it was already gone).
+      const deletedRow = await this.adapter.transaction<Media | null>(
+        async tx => {
+          await tx.lockRow("media", mediaId);
+          const currentRows = await tx.select<Media>("media", {
+            where: this.whereEq("id", mediaId),
+          });
+          const current = currentRows[0];
+          // Lost a delete race: the row is already gone, so record nothing.
+          // Only the request that actually removes the row emits media.deleted.
+          if (!current) {
+            return null;
+          }
 
-        // Lost a delete race: nothing was removed here, so skip the event. Only
-        // the request that actually deleted the row records `media.deleted`.
-        if (deletedCount === 0) {
-          return;
+          await tx.delete("media", this.whereEq("id", mediaId));
+
+          // The removed row's final state ships as `data`; there is no
+          // post-delete state, so `previous` is null (mirroring create). Media
+          // has no field schema, so `fields` is empty (nothing to strip).
+          await recordMutationEvent(tx, {
+            type: "media.deleted",
+            resource: { kind: "media", id: mediaId },
+            data: current,
+            previous: null,
+            fields: [],
+            actor: actorForWrite(actor, null),
+          });
+
+          return current;
         }
-
-        // The removed row's final state ships as `data`; there is no post-delete
-        // state, so `previous` is null (mirroring create). Media has no field
-        // schema, so `fields` is empty (nothing to strip).
-        await recordMutationEvent(tx, {
-          type: "media.deleted",
-          resource: { kind: "media", id: mediaId },
-          data: mediaData,
-          previous: null,
-          fields: [],
-          actor: actorForWrite(actor, null),
-        });
-      });
+      );
 
       // The row was gone before we could delete it: report not-found and skip
       // physical cleanup (the winning request owns the file) rather than
       // returning a false success for a no-op delete.
-      if (deletedCount === 0) {
+      if (!deletedRow) {
         return {
           success: false,
           statusCode: 404,
           message: "Media not found",
         };
       }
+      const mediaData = deletedRow;
 
       // Best-effort physical cleanup AFTER the row + event have committed.
       // Swallow-and-warn: a storage failure must not fail a delete whose

--- a/packages/nextly/src/services/media.ts
+++ b/packages/nextly/src/services/media.ts
@@ -27,7 +27,7 @@
  */
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
-import { and, count, desc, asc, or, eq, sql } from "drizzle-orm";
+import { and, count, desc, asc, or, sql } from "drizzle-orm";
 
 import {
   getMediaStorage,
@@ -38,6 +38,11 @@ import {
   deleteImageSizes,
 } from "@nextly/storage";
 
+// Actor threading + outbox recording for media writes. Each write records a
+// durable `media.*` event in the same transaction as the row change.
+import { actorForWrite, type RequestActor } from "../auth/request-actor";
+import { recordMutationEvent } from "../domains/webhooks/record-mutation-event";
+import { keysToSnakeCase } from "../lib/case-conversion";
 import { isImageMimeType, validateFileSize } from "../types/media";
 import type {
   Media,
@@ -203,7 +208,10 @@ export class MediaService extends BaseService {
   /**
    * Upload media file with automatic processing and storage
    */
-  async uploadMedia(input: UploadMediaInput): Promise<MediaResponse> {
+  async uploadMedia(
+    input: UploadMediaInput,
+    actor?: RequestActor
+  ): Promise<MediaResponse> {
     try {
       const {
         file,
@@ -345,7 +353,6 @@ export class MediaService extends BaseService {
         }
       }
 
-      const { media } = this.tables;
       const now = new Date();
       const mediaId = crypto.randomUUID();
 
@@ -372,7 +379,35 @@ export class MediaService extends BaseService {
         updatedAt: now,
       };
 
-      await this.db.insert(media).values(mediaRecord);
+      // Persist the row and record the outbox event in one transaction so the
+      // event is durable exactly when the insert commits, and never for a write
+      // that later rolls back. The positional adapter transaction is required
+      // because recordMutationEvent writes through the adapter's
+      // TransactionContext, not the Drizzle fluent transaction. `sizes` is
+      // serialized to a JSON string up front: the positional insert binds
+      // values through the raw driver, which cannot bind a plain object for the
+      // json/jsonb/text `sizes` column consistently across all three dialects.
+      const insertRow = keysToSnakeCase({
+        ...mediaRecord,
+        sizes: sizesData == null ? null : JSON.stringify(sizesData),
+      }) as Record<string, unknown>;
+
+      await this.adapter.transaction(async tx => {
+        await tx.insert("media", insertRow, { returning: [] });
+
+        // `data` is the just-created row in read shape; a fresh upload has no
+        // prior state, so `previous` is null. Media has no field schema, so
+        // `fields` is empty (nothing to strip). The uploader is the recorded
+        // subject when no transport actor was threaded.
+        await recordMutationEvent(tx, {
+          type: "media.uploaded",
+          resource: { kind: "media", id: mediaId },
+          data: mediaRecord,
+          previous: null,
+          fields: [],
+          actor: actorForWrite(actor, uploadedBy ? { id: uploadedBy } : null),
+        });
+      });
 
       return {
         success: true,
@@ -396,11 +431,10 @@ export class MediaService extends BaseService {
    */
   async updateMedia(
     mediaId: string,
-    changes: UpdateMediaInput
+    changes: UpdateMediaInput,
+    actor?: RequestActor
   ): Promise<MediaResponse> {
     try {
-      const { media } = this.tables;
-
       const existing = await this.getMediaById(mediaId);
       if (!existing.success) {
         return existing;
@@ -492,18 +526,42 @@ export class MediaService extends BaseService {
         }
       }
 
-      await this.db.update(media).set(updateData).where(eq(media.id, mediaId));
+      // The updated row in read shape: prior values overlaid with the caller's
+      // changes and the computed update payload (any regenerated sizes/thumbnail
+      // plus the fresh updatedAt). Reused as both the event `data` and the
+      // response body so the two never drift.
+      const updatedRow = {
+        ...mediaData,
+        ...changes,
+        ...updateData,
+        updatedAt: updateData.updatedAt,
+      } as Media;
+
+      // Commit the row update and its outbox event in one transaction so the
+      // event is durable exactly when the change commits. tx.update delegates to
+      // the same Drizzle write the fluent path used, so column casing and JSON
+      // serialization are unchanged; the positional form is needed only so the
+      // event shares the adapter TransactionContext.
+      await this.adapter.transaction(async tx => {
+        await tx.update("media", updateData, this.whereEq("id", mediaId));
+
+        // `previous` is the row read before the write; `data` is the new state.
+        // Media has no field schema, so `fields` is empty (nothing to strip).
+        await recordMutationEvent(tx, {
+          type: "media.updated",
+          resource: { kind: "media", id: mediaId },
+          data: updatedRow,
+          previous: mediaData,
+          fields: [],
+          actor: actorForWrite(actor, null),
+        });
+      });
 
       return {
         success: true,
         statusCode: 200,
         message: "Media updated successfully",
-        data: {
-          ...mediaData,
-          ...changes,
-          ...updateData,
-          updatedAt: updateData.updatedAt,
-        } as Media,
+        data: updatedRow,
       };
     } catch (error) {
       console.error("[MediaService] Update media error:", error);
@@ -519,10 +577,11 @@ export class MediaService extends BaseService {
   /**
    * Delete media file (removes from storage and database)
    */
-  async deleteMedia(mediaId: string): Promise<DeleteMediaResponse> {
+  async deleteMedia(
+    mediaId: string,
+    actor?: RequestActor
+  ): Promise<DeleteMediaResponse> {
     try {
-      const { media } = this.tables;
-
       const existing = await this.getMediaById(mediaId);
       if (!existing.success || !existing.data) {
         return {
@@ -534,6 +593,33 @@ export class MediaService extends BaseService {
 
       const mediaData = existing.data;
 
+      // Remove the row and record the outbox event in one transaction FIRST,
+      // before touching physical storage. The database is the source of truth,
+      // so the row deletion and its durable event commit together; storage
+      // cleanup runs afterward. If that cleanup fails it leaves an orphaned FILE
+      // (benign, later reclaimable) rather than a surviving ROW pointing at an
+      // already-deleted file (a real read bug). The positional adapter
+      // transaction is required so the event shares the adapter
+      // TransactionContext; tx.delete replaces the prior raw `sql` template.
+      await this.adapter.transaction(async tx => {
+        await tx.delete("media", this.whereEq("id", mediaId));
+
+        // The removed row's final state ships as `data`; there is no post-delete
+        // state, so `previous` is null (mirroring create). Media has no field
+        // schema, so `fields` is empty (nothing to strip).
+        await recordMutationEvent(tx, {
+          type: "media.deleted",
+          resource: { kind: "media", id: mediaId },
+          data: mediaData,
+          previous: null,
+          fields: [],
+          actor: actorForWrite(actor, null),
+        });
+      });
+
+      // Best-effort physical cleanup AFTER the row + event have committed.
+      // Swallow-and-warn: a storage failure must not fail a delete whose
+      // authoritative row removal already succeeded.
       try {
         await withRetry(
           () => this.storage.delete(mediaData.filename, "media"),
@@ -571,10 +657,8 @@ export class MediaService extends BaseService {
         }
       } catch (error) {
         console.warn("[MediaService] Storage deletion warning:", error);
-        // Continue with database deletion even if storage fails
+        // Storage cleanup is best-effort; the row and event are already gone.
       }
-
-      await this.db.delete(media).where(sql`${media.id} = ${mediaId}`);
 
       return {
         success: true,

--- a/packages/nextly/src/types/media.ts
+++ b/packages/nextly/src/types/media.ts
@@ -111,6 +111,9 @@ export const UpdateMediaInputSchema = z.object({
   tags: z.array(z.string()).optional(),
   focalX: z.number().int().min(0).max(100).optional(),
   focalY: z.number().int().min(0).max(100).optional(),
+  // A move is a folder_id change: routing it through the update path records a
+  // media.updated event (bare folder writes did not). `null` moves to root.
+  folderId: z.string().nullable().optional(),
 });
 
 export type UpdateMediaInput = z.infer<typeof UpdateMediaInputSchema>;


### PR DESCRIPTION
## What

Records `media.uploaded` / `media.updated` / `media.deleted` outbox events for every media write, so webhook subscribers are notified of media changes (completes the recording breadth alongside collections and singles).

## How

- Each of the three media DB writes (`uploadMedia`, `updateMedia`, `deleteMedia`) moves from the fluent Drizzle API into `this.adapter.transaction(...)` with an in-transaction `recordMutationEvent`, so the event commits atomically with the row and is never recorded for a rolled-back write.
- `resource: { kind: "media", id }`, `fields: []`, no locale — media is a flat row (no components/relations/i18n). `data` is the media row (read shape); `media.updated` carries `previous`, `uploaded`/`deleted` carry `previous: null` (mirroring `entry.deleted`).
- **Storage ordering:** physical file storage stays outside the transaction. Uploads/edits touch it before the DB write (unchanged); deletes now remove the file only *after* the row + event commit — so a storage failure can only orphan a file (cleanable), never leave the DB pointing at a missing file.
- The acting identity is threaded from the media REST handlers (`actorFromAuthContext`) through the domain and legacy media services, so an API-key write attributes to the key.

## Tests

New `media-outbox.integration.test.ts` covering all three event types, actor attribution (user + API key), and transactional row removal — green on SQLite, Postgres 17, and MySQL.

## Note

One incidental correctness improvement: the positional `tx.insert` pre-serializes `sizes` to JSON text, fixing a latent SQLite bug where the prior fluent insert handed a raw object to better-sqlite3 for image-size variants.