### PR TITLE
fix(nextly): harden publish gate for undefined status and pool reentry

### DIFF
--- a/.changeset/publish-enforcement-followups.md
+++ b/.changeset/publish-enforcement-followups.md
@@ -27,8 +27,10 @@ silently unpublishes a published entry or single. That value means "no status
 change", so it is dropped before the write instead of being sanitized to a
 database `NULL` that moved the row out of published without the publish gate.
 
-Publish/unpublish permission checks performed inside a caller-owned transaction
-(the transactional bulk create/update paths) now run on that transaction's own
-database connection. Previously the permission read went back to the connection
-pool from inside the transaction, which could stall a bulk write against a small
-or exhausted pool.
+Writes performed inside a caller-owned transaction (the transactional bulk and
+single-entry create/update paths) now run every read on that transaction's own
+database connection. Previously the publish/unpublish permission check, the
+collection metadata and owner-constraint reads, and the built-in sanitization
+hook's field-metadata read all went back to the connection pool from inside the
+transaction, which could stall the write against a small or exhausted pool while
+the transaction held the only connection.

--- a/.changeset/publish-enforcement-followups.md
+++ b/.changeset/publish-enforcement-followups.md
@@ -1,0 +1,34 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Harden the publish/unpublish permission gate for two edge cases.
+
+A write that carries an explicit `status: undefined` (something a Direct API
+call, a Server Action, or a hook can produce, though JSON REST cannot) no longer
+silently unpublishes a published entry or single. That value means "no status
+change", so it is dropped before the write instead of being sanitized to a
+database `NULL` that moved the row out of published without the publish gate.
+
+Publish/unpublish permission checks performed inside a caller-owned transaction
+(the transactional bulk create/update paths) now run on that transaction's own
+database connection. Previously the permission read went back to the connection
+pool from inside the transaction, which could stall a bulk write against a small
+or exhausted pool.

--- a/.changeset/publish-enforcement-followups.md
+++ b/.changeset/publish-enforcement-followups.md
@@ -4,6 +4,7 @@
 "@nextlyhq/adapter-postgres": patch
 "@nextlyhq/adapter-sqlite": patch
 "@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
 "create-nextly-app": patch
 "@nextlyhq/eslint-config": patch
 "nextly": patch

--- a/packages/nextly/src/di/registrations/register-collections.ts
+++ b/packages/nextly/src/di/registrations/register-collections.ts
@@ -63,42 +63,50 @@ export function registerCollectionServices(ctx: RegistrationContext): void {
     // Runtime schema generation: UI-created collections work without
     // pre-compiled TypeScript schemas.
     fileManager.setAdapter(adapter);
-    fileManager.setMetadataFetcher(async (collectionName: string) => {
-      try {
-        const result = await adapter.selectOne<{
-          fields: string;
-          tableName: string;
-          status: boolean | number | null;
-          localized: boolean | number | null;
-        }>("dynamic_collections", {
-          where: {
-            and: [{ column: "slug", op: "=", value: collectionName }],
-          },
-        });
+    fileManager.setMetadataFetcher(
+      async (collectionName: string, executor?: unknown) => {
+        try {
+          // Runs on the caller's transaction connection when supplied so an
+          // uncached runtime-schema load inside a transaction stays on it.
+          const result = await adapter.selectOne<{
+            fields: string;
+            tableName: string;
+            status: boolean | number | null;
+            localized: boolean | number | null;
+          }>(
+            "dynamic_collections",
+            {
+              where: {
+                and: [{ column: "slug", op: "=", value: collectionName }],
+              },
+            },
+            executor
+          );
 
-        if (result) {
-          const fields =
-            typeof result.fields === "string"
-              ? JSON.parse(result.fields)
-              : result.fields;
-          return {
-            fields,
-            tableName: result.tableName,
-            // SQLite returns 0/1 for booleans; PG/MySQL return real booleans.
-            status: result.status === true || result.status === 1,
-            // i18n M4: forward the localized flag so loadCompanionSchema can
-            // build the companion table for localized reads.
-            localized: result.localized === true || result.localized === 1,
-          };
+          if (result) {
+            const fields =
+              typeof result.fields === "string"
+                ? JSON.parse(result.fields)
+                : result.fields;
+            return {
+              fields,
+              tableName: result.tableName,
+              // SQLite returns 0/1 for booleans; PG/MySQL return real booleans.
+              status: result.status === true || result.status === 1,
+              // i18n M4: forward the localized flag so loadCompanionSchema can
+              // build the companion table for localized reads.
+              localized: result.localized === true || result.localized === 1,
+            };
+          }
+        } catch (error) {
+          console.error(
+            "[registerCollectionServices] Failed to fetch collection metadata:",
+            error
+          );
         }
-      } catch (error) {
-        console.error(
-          "[registerCollectionServices] Failed to fetch collection metadata:",
-          error
-        );
+        return null;
       }
-      return null;
-    });
+    );
 
     const dynamicCollectionService = new DynamicCollectionService(
       adapter,

--- a/packages/nextly/src/domains/auth/services/rbac-access-control-service.ts
+++ b/packages/nextly/src/domains/auth/services/rbac-access-control-service.ts
@@ -141,13 +141,13 @@ export class RBACAccessControlService {
    * ```
    */
   async checkAccess(params: CheckAccessParams): Promise<boolean> {
-    const { userId, operation, resource } = params;
+    const { userId, operation, resource, executor } = params;
 
     if (!userId) {
       return false;
     }
 
-    if (await isSuperAdmin(userId)) {
+    if (await isSuperAdmin(userId, executor)) {
       return true;
     }
 
@@ -164,7 +164,12 @@ export class RBACAccessControlService {
       }
 
       if (typeof operationAccess === "function") {
-        const ctx = await this.buildContext(userId, operation, resource);
+        const ctx = await this.buildContext(
+          userId,
+          operation,
+          resource,
+          executor
+        );
         try {
           return await operationAccess(ctx);
         } catch (error) {
@@ -178,7 +183,7 @@ export class RBACAccessControlService {
       }
     }
 
-    return hasPermission(userId, operation, resource);
+    return hasPermission(userId, operation, resource, executor);
   }
 
   /**
@@ -197,11 +202,14 @@ export class RBACAccessControlService {
   async buildContext(
     userId: string,
     operation: AccessOperation,
-    resource: string
+    resource: string,
+    // Optional transaction-bound executor so the role/permission reads run on the
+    // caller's transaction connection instead of the pool; see `checkAccess`.
+    executor?: unknown
   ): Promise<AccessControlContext> {
     const [roleSlugs, permissions] = await Promise.all([
-      listRoleSlugsForUser(userId),
-      listEffectivePermissions(userId),
+      listRoleSlugsForUser(userId, executor),
+      listEffectivePermissions(userId, executor),
     ]);
 
     return {

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
@@ -37,12 +37,14 @@ const BULK_CREATE_SLUG = "poolreentrybulkc";
 const BULK_UPDATE_SLUG = "poolreentrybulku";
 const DIRECT_CREATE_SLUG = "poolreentrydirc";
 const DIRECT_UPDATE_SLUG = "poolreentrydiru";
+const HOOK_SLUG = "poolreentryhook";
 const SLUGS = [
   RBAC_SLUG,
   BULK_CREATE_SLUG,
   BULK_UPDATE_SLUG,
   DIRECT_CREATE_SLUG,
   DIRECT_UPDATE_SLUG,
+  HOOK_SLUG,
 ];
 
 type TestAdapter = Awaited<ReturnType<typeof createAdapter>>;
@@ -323,6 +325,62 @@ describePg(
           {}
         );
         expect(row?.status).toBe("published");
+      } finally {
+        await handle?.destroy();
+      }
+    }, 30_000);
+
+    it("completes a create with a stored uniqueness hook inside a caller-owned transaction", async () => {
+      const adapter = await connectSingleConnection();
+      let handle: TestNextly | undefined;
+      try {
+        handle = await createTestNextly({
+          adapter,
+          collections: [openCollection(HOOK_SLUG)],
+        });
+        // Configure the built-in `unique-validation` stored hook on `title`. It
+        // runs on `beforeChange` and calls `context.queryDatabase`, which reads
+        // the collection to check for a duplicate — the read that must run on
+        // the caller's transaction connection, not the pool.
+        await handle.adapter.update(
+          "dynamic_collections",
+          {
+            hooks: [
+              {
+                hookId: "unique-validation",
+                hookType: "beforeChange",
+                enabled: true,
+                config: { field: "title", errorMessage: "duplicate title" },
+              },
+            ],
+          },
+          { and: [{ column: "slug", op: "=", value: HOOK_SLUG }] }
+        );
+
+        const h = handle.getService<CollectionsHandler>("collectionsHandler");
+        const entries = h.getEntryService() as CollectionEntryService;
+        // Seed one row (trusted, on the pool) so the collection is non-empty.
+        await h.createEntry(
+          { collectionName: HOOK_SLUG, overrideAccess: true },
+          { title: "seed", status: "draft" }
+        );
+
+        // Create a second row with a fresh title inside a caller-owned
+        // transaction: the stored uniqueness hook's `queryDatabase` read runs
+        // on the transaction's connection and COMPLETES; a pooled read blocks.
+        const result = await withTimeout(
+          handle.adapter.transaction(tx =>
+            entries.createEntriesInTransaction(
+              tx,
+              { collectionName: HOOK_SLUG, user: { id: "editor" } },
+              [{ title: "fresh", status: "draft" }]
+            )
+          ),
+          15_000
+        );
+
+        expect(result.successful).toBe(1);
+        expect(result.failed).toBe(0);
       } finally {
         await handle?.destroy();
       }

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
@@ -19,13 +19,17 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { defineCollection, text } from "../../../config";
 import { createAdapter } from "../../../database/factory";
+import { container } from "../../../di/container";
 import type { RBACAccessControlService } from "../../../domains/auth/services/rbac-access-control-service";
 import { NextlyError } from "../../../errors/nextly-error";
+import { registerHook, unregisterHook } from "../../../hooks";
+import type { HookHandler } from "../../../hooks/types";
 import {
   createTestNextly,
   type TestNextly,
 } from "../../../plugins/test-nextly";
 import type { CollectionEntryService } from "../../../services/collections/collection-entry-service";
+import type { CollectionRegistryService } from "../../../services/collections/collection-registry-service";
 import type { CollectionsHandler } from "../../../services/collections-handler";
 
 const POSTGRES_URL = process.env.TEST_POSTGRES_URL ?? "";
@@ -38,6 +42,7 @@ const BULK_UPDATE_SLUG = "poolreentrybulku";
 const DIRECT_CREATE_SLUG = "poolreentrydirc";
 const DIRECT_UPDATE_SLUG = "poolreentrydiru";
 const HOOK_SLUG = "poolreentryhook";
+const AFTER_HOOK_SLUG = "poolreentryafter";
 const SLUGS = [
   RBAC_SLUG,
   BULK_CREATE_SLUG,
@@ -45,6 +50,7 @@ const SLUGS = [
   DIRECT_CREATE_SLUG,
   DIRECT_UPDATE_SLUG,
   HOOK_SLUG,
+  AFTER_HOOK_SLUG,
 ];
 
 type TestAdapter = Awaited<ReturnType<typeof createAdapter>>;
@@ -382,6 +388,54 @@ describePg(
         expect(result.successful).toBe(1);
         expect(result.failed).toBe(0);
       } finally {
+        await handle?.destroy();
+      }
+    }, 30_000);
+
+    it("completes when a code afterCreate hook reads via context.executor in a caller-owned transaction", async () => {
+      const adapter = await connectSingleConnection();
+      let handle: TestNextly | undefined;
+      // A code-registered afterCreate hook that reads the collection registry
+      // through the hook context's transaction executor. If the after-hook
+      // context omits the executor, this read falls back to the pool and, on a
+      // single-connection pool, deadlocks while the caller's transaction holds
+      // the only connection.
+      const afterHook: HookHandler = async context => {
+        const registry = container.get<CollectionRegistryService>(
+          "collectionRegistryService"
+        );
+        await registry.getCollectionBySlug(
+          context.collection,
+          context.executor
+        );
+      };
+      try {
+        handle = await createTestNextly({
+          adapter,
+          collections: [openCollection(AFTER_HOOK_SLUG)],
+        });
+        // Registered AFTER boot: createTestNextly resets the hook registry on
+        // startup, and the running services share that same singleton registry.
+        registerHook("afterCreate", AFTER_HOOK_SLUG, afterHook);
+        const entries = handle
+          .getService<CollectionsHandler>("collectionsHandler")
+          .getEntryService() as CollectionEntryService;
+
+        const result = await withTimeout(
+          handle.adapter.transaction(tx =>
+            entries.createEntriesInTransaction(
+              tx,
+              { collectionName: AFTER_HOOK_SLUG, user: { id: "editor" } },
+              [{ title: "t", status: "draft" }]
+            )
+          ),
+          15_000
+        );
+
+        expect(result.successful).toBe(1);
+        expect(result.failed).toBe(0);
+      } finally {
+        unregisterHook("afterCreate", AFTER_HOOK_SLUG, afterHook);
         await handle?.destroy();
       }
     }, 30_000);

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
@@ -1,18 +1,19 @@
 /**
- * The publish/unpublish authorization the transaction/batch write paths resolve
- * reads the RBAC role/permission tables. When a caller-owned transaction already
- * holds a connection, that read must run on the TRANSACTION's own connection, not
- * the pool: a pooled read would try to check out a second connection that the
- * open transaction will not release until its callback returns, so against a
- * single-connection pool the read blocks forever and the write deadlocks.
+ * A write that runs inside a caller-owned transaction must perform EVERY read on
+ * that transaction's own connection, never the pool. A pooled read tries to check
+ * out a second connection the open transaction will not release until its callback
+ * returns, so against a single-connection pool it blocks forever and the write
+ * deadlocks. The transactional bulk and single-entry write paths do this for the
+ * publish/unpublish RBAC check, the collection metadata and owner-constraint
+ * reads, and the DB-reading hooks (the built-in sanitization hook loads field
+ * metadata), all bound to the caller's transaction.
  *
- * This pins the fix on a REAL database with a single-connection pool
- * (`pool.max = 1`): `RBACAccessControlService.checkAccess` — the exact call the
- * collection access service makes to judge a publish transition — is invoked
- * from INSIDE a caller's transaction with that transaction's executor, and it
- * COMPLETES. Break the fix (drop the executor and the RBAC reads fall back to the
- * pool) and it hangs on the second checkout, caught here by a timeout. SQLite has
- * no connection pool, so the suite self-skips without a Postgres URL.
+ * These pin the fix on a REAL database with a single-connection pool
+ * (`pool.max = 1`): the RBAC preflight and each full bulk / direct in-transaction
+ * create-and-update COMPLETE instead of deadlocking. Break any binding (drop the
+ * executor and a read falls back to the pool) and the affected case hangs on the
+ * second checkout, caught by the timeout. SQLite has no connection pool, so the
+ * suite self-skips without a Postgres URL.
  */
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -24,11 +25,25 @@ import {
   createTestNextly,
   type TestNextly,
 } from "../../../plugins/test-nextly";
+import type { CollectionEntryService } from "../../../services/collections/collection-entry-service";
+import type { CollectionsHandler } from "../../../services/collections-handler";
 
 const POSTGRES_URL = process.env.TEST_POSTGRES_URL ?? "";
 
-const SLUG = "poolreentryposts";
-const TABLE = `dc_${SLUG}`;
+// Distinct slugs so each test owns its table and the file's parallel-safe drop
+// never races another case.
+const RBAC_SLUG = "poolreentryrbac";
+const BULK_CREATE_SLUG = "poolreentrybulkc";
+const BULK_UPDATE_SLUG = "poolreentrybulku";
+const DIRECT_CREATE_SLUG = "poolreentrydirc";
+const DIRECT_UPDATE_SLUG = "poolreentrydiru";
+const SLUGS = [
+  RBAC_SLUG,
+  BULK_CREATE_SLUG,
+  BULK_UPDATE_SLUG,
+  DIRECT_CREATE_SLUG,
+  DIRECT_UPDATE_SLUG,
+];
 
 type TestAdapter = Awaited<ReturnType<typeof createAdapter>>;
 
@@ -49,34 +64,49 @@ async function connectSingleConnection(): Promise<TestAdapter> {
   return adapter;
 }
 
-// Reject if the check does not settle in time: a re-entrant pooled read on a
+// Reject if the work does not settle in time: a re-entrant pooled read on a
 // `max: 1` pool never resolves, so without a bound timeout the test would hang
-// instead of failing. The window is far above the completing path's runtime.
+// instead of failing. The timer is cleared once the work settles so a passing
+// run does not keep the worker alive until `ms` elapses.
 function withTimeout<T>(work: Promise<T>, ms: number): Promise<T> {
-  return Promise.race([
-    work,
-    new Promise<T>((_resolve, reject) =>
-      setTimeout(
-        () =>
-          reject(
-            NextlyError.internal({
-              logContext: {
-                reason: "pool-reentry-timeout",
-                table: TABLE,
-                timeoutMs: ms,
-              },
-            })
-          ),
-        ms
-      )
-    ),
-  ]);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(
+          NextlyError.internal({
+            logContext: { reason: "pool-reentry-timeout", timeoutMs: ms },
+          })
+        ),
+      ms
+    );
+  });
+  return Promise.race([work, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+// A collection whose create/read/update/publish are all allowed for a session
+// editor. Judging each of those still reads the RBAC and metadata tables — the
+// reads that must run on the transaction's own connection.
+function openCollection(slug: string) {
+  return defineCollection({
+    slug,
+    status: true,
+    access: {
+      create: () => true,
+      read: () => true,
+      update: () => true,
+      publish: () => true,
+    },
+    fields: [text({ name: "title" })],
+  });
 }
 
 const describePg = describe.skipIf(!POSTGRES_URL);
 
 describePg(
-  "publish enforcement — caller-owned-tx RBAC pool reentry (postgres)",
+  "publish enforcement — caller-owned-tx pool reentry (postgres)",
   () => {
     let boot: TestAdapter | undefined;
 
@@ -93,14 +123,16 @@ describePg(
 
     async function drop(): Promise<void> {
       if (!boot) return;
-      for (const stmt of [
-        `DROP TABLE IF EXISTS ${TABLE}`,
-        `DELETE FROM dynamic_collections WHERE slug = '${SLUG}'`,
-      ]) {
-        try {
-          await boot.executeQuery(stmt);
-        } catch {
-          // Best-effort on a fresh database.
+      for (const slug of SLUGS) {
+        for (const stmt of [
+          `DROP TABLE IF EXISTS dc_${slug}`,
+          `DELETE FROM dynamic_collections WHERE slug = '${slug}'`,
+        ]) {
+          try {
+            await boot.executeQuery(stmt);
+          } catch {
+            // Best-effort on a fresh database.
+          }
         }
       }
     }
@@ -113,7 +145,7 @@ describePg(
           adapter,
           collections: [
             defineCollection({
-              slug: SLUG,
+              slug: RBAC_SLUG,
               status: true,
               fields: [text({ name: "title" })],
             }),
@@ -123,27 +155,174 @@ describePg(
           "rbacAccessControlService"
         );
 
-        // Open a caller-owned transaction (it checks out the single pooled
-        // connection) and judge a publish transition INSIDE it, passing the
-        // transaction's executor. The RBAC reads (super-admin resolution and
-        // the permission lookup) run on that connection; a pooled read would
-        // block forever waiting for a second connection.
+        // Judge a publish transition from INSIDE a caller-owned transaction,
+        // passing the transaction's executor. The RBAC reads run on that
+        // connection; a pooled read would block forever on the second checkout.
         const allowed = await withTimeout(
           handle.adapter.transaction(tx =>
             rbac.checkAccess({
               userId: "editor",
               operation: "publish",
-              resource: SLUG,
+              resource: RBAC_SLUG,
               executor: tx.getDrizzle(),
             })
           ),
           15_000
         );
 
-        // It ran to completion (did not deadlock). The editor holds no roles
-        // and the collection defines no publish rule, so the publish is denied
-        // — the point is that the decision was REACHED on the tx connection.
+        // The editor holds no roles and the collection defines no publish rule,
+        // so publish is denied — the point is the decision was REACHED on the tx.
         expect(allowed).toBe(false);
+      } finally {
+        await handle?.destroy();
+      }
+    }, 30_000);
+
+    it("completes a bulk create-as-published inside a caller-owned transaction", async () => {
+      const adapter = await connectSingleConnection();
+      let handle: TestNextly | undefined;
+      try {
+        handle = await createTestNextly({
+          adapter,
+          collections: [openCollection(BULK_CREATE_SLUG)],
+        });
+        const entries = handle
+          .getService<CollectionsHandler>("collectionsHandler")
+          .getEntryService() as CollectionEntryService;
+
+        const result = await withTimeout(
+          handle.adapter.transaction(tx =>
+            entries.createEntriesInTransaction(
+              tx,
+              { collectionName: BULK_CREATE_SLUG, user: { id: "editor" } },
+              [{ title: "t", status: "published" }]
+            )
+          ),
+          15_000
+        );
+
+        expect(result.successful).toBe(1);
+        expect(result.failed).toBe(0);
+        const [row] = await handle.adapter.select<{ status: string }>(
+          `dc_${BULK_CREATE_SLUG}`,
+          {}
+        );
+        expect(row?.status).toBe("published");
+      } finally {
+        await handle?.destroy();
+      }
+    }, 30_000);
+
+    it("completes a bulk update-to-published inside a caller-owned transaction", async () => {
+      const adapter = await connectSingleConnection();
+      let handle: TestNextly | undefined;
+      try {
+        handle = await createTestNextly({
+          adapter,
+          collections: [openCollection(BULK_UPDATE_SLUG)],
+        });
+        const h = handle.getService<CollectionsHandler>("collectionsHandler");
+        const entries = h.getEntryService() as CollectionEntryService;
+        const created = await h.createEntry(
+          { collectionName: BULK_UPDATE_SLUG, overrideAccess: true },
+          { title: "t", status: "draft" }
+        );
+        const id = (created.data as { id: string }).id;
+
+        const result = await withTimeout(
+          handle.adapter.transaction(tx =>
+            entries.updateEntriesInTransaction(
+              tx,
+              { collectionName: BULK_UPDATE_SLUG, user: { id: "editor" } },
+              [{ id, data: { title: "changed", status: "published" } }]
+            )
+          ),
+          15_000
+        );
+
+        expect(result.successful).toBe(1);
+        expect(result.failed).toBe(0);
+        const [row] = await handle.adapter.select<{ status: string }>(
+          `dc_${BULK_UPDATE_SLUG}`,
+          {}
+        );
+        expect(row?.status).toBe("published");
+      } finally {
+        await handle?.destroy();
+      }
+    }, 30_000);
+
+    it("completes a direct create-as-published inside a caller-owned transaction", async () => {
+      const adapter = await connectSingleConnection();
+      let handle: TestNextly | undefined;
+      try {
+        handle = await createTestNextly({
+          adapter,
+          collections: [openCollection(DIRECT_CREATE_SLUG)],
+        });
+        const entries = handle
+          .getService<CollectionsHandler>("collectionsHandler")
+          .getEntryService() as CollectionEntryService;
+
+        const result = await withTimeout(
+          handle.adapter.transaction(tx =>
+            entries.createEntryInTransaction(
+              tx,
+              { collectionName: DIRECT_CREATE_SLUG, user: { id: "editor" } },
+              { title: "t", status: "published" }
+            )
+          ),
+          15_000
+        );
+
+        expect(result.success).toBe(true);
+        const [row] = await handle.adapter.select<{ status: string }>(
+          `dc_${DIRECT_CREATE_SLUG}`,
+          {}
+        );
+        expect(row?.status).toBe("published");
+      } finally {
+        await handle?.destroy();
+      }
+    }, 30_000);
+
+    it("completes a direct update-to-published inside a caller-owned transaction", async () => {
+      const adapter = await connectSingleConnection();
+      let handle: TestNextly | undefined;
+      try {
+        handle = await createTestNextly({
+          adapter,
+          collections: [openCollection(DIRECT_UPDATE_SLUG)],
+        });
+        const h = handle.getService<CollectionsHandler>("collectionsHandler");
+        const entries = h.getEntryService() as CollectionEntryService;
+        const created = await h.createEntry(
+          { collectionName: DIRECT_UPDATE_SLUG, overrideAccess: true },
+          { title: "t", status: "draft" }
+        );
+        const id = (created.data as { id: string }).id;
+
+        const result = await withTimeout(
+          handle.adapter.transaction(tx =>
+            entries.updateEntryInTransaction(
+              tx,
+              {
+                collectionName: DIRECT_UPDATE_SLUG,
+                entryId: id,
+                user: { id: "editor" },
+              },
+              { title: "changed", status: "published" }
+            )
+          ),
+          15_000
+        );
+
+        expect(result.success).toBe(true);
+        const [row] = await handle.adapter.select<{ status: string }>(
+          `dc_${DIRECT_UPDATE_SLUG}`,
+          {}
+        );
+        expect(row?.status).toBe("published");
       } finally {
         await handle?.destroy();
       }

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
@@ -1,0 +1,152 @@
+/**
+ * The publish/unpublish authorization the transaction/batch write paths resolve
+ * reads the RBAC role/permission tables. When a caller-owned transaction already
+ * holds a connection, that read must run on the TRANSACTION's own connection, not
+ * the pool: a pooled read would try to check out a second connection that the
+ * open transaction will not release until its callback returns, so against a
+ * single-connection pool the read blocks forever and the write deadlocks.
+ *
+ * This pins the fix on a REAL database with a single-connection pool
+ * (`pool.max = 1`): `RBACAccessControlService.checkAccess` — the exact call the
+ * collection access service makes to judge a publish transition — is invoked
+ * from INSIDE a caller's transaction with that transaction's executor, and it
+ * COMPLETES. Break the fix (drop the executor and the RBAC reads fall back to the
+ * pool) and it hangs on the second checkout, caught here by a timeout. SQLite has
+ * no connection pool, so the suite self-skips without a Postgres URL.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import { createAdapter } from "../../../database/factory";
+import type { RBACAccessControlService } from "../../../domains/auth/services/rbac-access-control-service";
+import { NextlyError } from "../../../errors/nextly-error";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+const POSTGRES_URL = process.env.TEST_POSTGRES_URL ?? "";
+
+const SLUG = "poolreentryposts";
+const TABLE = `dc_${SLUG}`;
+
+type TestAdapter = Awaited<ReturnType<typeof createAdapter>>;
+
+// A single-connection pool is the whole point: with `max: 1` the caller's
+// transaction holds the ONLY connection, so any read that re-enters the pool
+// from inside the transaction can never acquire a second one and blocks forever.
+async function connectSingleConnection(): Promise<TestAdapter> {
+  // env.ts validates DATABASE_URL against DB_DIALECT on first read in this
+  // worker, so both must be on process.env — not just passed to createAdapter.
+  process.env.DB_DIALECT = "postgresql";
+  process.env.DATABASE_URL = POSTGRES_URL;
+  const adapter = await createAdapter({
+    type: "postgresql",
+    url: POSTGRES_URL,
+    pool: { max: 1 },
+  } as Parameters<typeof createAdapter>[0]);
+  await adapter.executeQuery("SELECT 1");
+  return adapter;
+}
+
+// Reject if the check does not settle in time: a re-entrant pooled read on a
+// `max: 1` pool never resolves, so without a bound timeout the test would hang
+// instead of failing. The window is far above the completing path's runtime.
+function withTimeout<T>(work: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    work,
+    new Promise<T>((_resolve, reject) =>
+      setTimeout(
+        () =>
+          reject(
+            NextlyError.internal({
+              logContext: {
+                reason: "pool-reentry-timeout",
+                table: TABLE,
+                timeoutMs: ms,
+              },
+            })
+          ),
+        ms
+      )
+    ),
+  ]);
+}
+
+const describePg = describe.skipIf(!POSTGRES_URL);
+
+describePg(
+  "publish enforcement — caller-owned-tx RBAC pool reentry (postgres)",
+  () => {
+    let boot: TestAdapter | undefined;
+
+    beforeAll(async () => {
+      if (!POSTGRES_URL) return;
+      boot = await connectSingleConnection();
+      await drop();
+    });
+
+    afterAll(async () => {
+      await drop();
+      if (boot) await boot.disconnect();
+    });
+
+    async function drop(): Promise<void> {
+      if (!boot) return;
+      for (const stmt of [
+        `DROP TABLE IF EXISTS ${TABLE}`,
+        `DELETE FROM dynamic_collections WHERE slug = '${SLUG}'`,
+      ]) {
+        try {
+          await boot.executeQuery(stmt);
+        } catch {
+          // Best-effort on a fresh database.
+        }
+      }
+    }
+
+    it("resolves a publish RBAC check on the transaction's own connection", async () => {
+      const adapter = await connectSingleConnection();
+      let handle: TestNextly | undefined;
+      try {
+        handle = await createTestNextly({
+          adapter,
+          collections: [
+            defineCollection({
+              slug: SLUG,
+              status: true,
+              fields: [text({ name: "title" })],
+            }),
+          ],
+        });
+        const rbac = handle.getService<RBACAccessControlService>(
+          "rbacAccessControlService"
+        );
+
+        // Open a caller-owned transaction (it checks out the single pooled
+        // connection) and judge a publish transition INSIDE it, passing the
+        // transaction's executor. The RBAC reads (super-admin resolution and
+        // the permission lookup) run on that connection; a pooled read would
+        // block forever waiting for a second connection.
+        const allowed = await withTimeout(
+          handle.adapter.transaction(tx =>
+            rbac.checkAccess({
+              userId: "editor",
+              operation: "publish",
+              resource: SLUG,
+              executor: tx.getDrizzle(),
+            })
+          ),
+          15_000
+        );
+
+        // It ran to completion (did not deadlock). The editor holds no roles
+        // and the collection defines no publish rule, so the publish is denied
+        // — the point is that the decision was REACHED on the tx connection.
+        expect(allowed).toBe(false);
+      } finally {
+        await handle?.destroy();
+      }
+    }, 30_000);
+  }
+);

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
@@ -44,6 +44,8 @@ const DIRECT_UPDATE_SLUG = "poolreentrydiru";
 const HOOK_SLUG = "poolreentryhook";
 const AFTER_HOOK_SLUG = "poolreentryafter";
 const DELETE_SLUG = "poolreentrydelete";
+const DIRECT_DELETE_SLUG = "poolreentrydirdel";
+const BEFOREOP_SLUG = "poolreentrybeforeop";
 const SLUGS = [
   RBAC_SLUG,
   BULK_CREATE_SLUG,
@@ -53,6 +55,8 @@ const SLUGS = [
   HOOK_SLUG,
   AFTER_HOOK_SLUG,
   DELETE_SLUG,
+  DIRECT_DELETE_SLUG,
+  BEFOREOP_SLUG,
 ];
 
 type TestAdapter = Awaited<ReturnType<typeof createAdapter>>;
@@ -487,6 +491,85 @@ describePg(
         expect(result.failed).toBe(0);
       } finally {
         unregisterHook("beforeDelete", DELETE_SLUG, beforeDeleteHook);
+        await handle?.destroy();
+      }
+    }, 30_000);
+
+    it("completes a direct delete inside a caller-owned transaction", async () => {
+      const adapter = await connectSingleConnection();
+      let handle: TestNextly | undefined;
+      try {
+        handle = await createTestNextly({
+          adapter,
+          collections: [openCollection(DIRECT_DELETE_SLUG)],
+        });
+        const h = handle.getService<CollectionsHandler>("collectionsHandler");
+        const entries = h.getEntryService() as CollectionEntryService;
+        const created = await h.createEntry(
+          { collectionName: DIRECT_DELETE_SLUG, overrideAccess: true },
+          { title: "doomed", status: "draft" }
+        );
+        const id = (created.data as { id: string }).id;
+
+        // The direct delete worker's access check + metadata reads must run on
+        // the transaction connection; a pooled read would deadlock here.
+        const result = await withTimeout(
+          handle.adapter.transaction(tx =>
+            entries.deleteEntryInTransaction(tx, {
+              collectionName: DIRECT_DELETE_SLUG,
+              entryId: id,
+              user: { id: "editor" },
+            })
+          ),
+          15_000
+        );
+
+        expect((result.data as { deleted?: boolean } | null)?.deleted).toBe(
+          true
+        );
+      } finally {
+        await handle?.destroy();
+      }
+    }, 30_000);
+
+    it("completes when a code beforeOperation hook reads via context.executor", async () => {
+      const adapter = await connectSingleConnection();
+      let handle: TestNextly | undefined;
+      // A beforeOperation hook that reads the registry via context.executor.
+      const beforeOpHook: HookHandler = async context => {
+        const registry = container.get<CollectionRegistryService>(
+          "collectionRegistryService"
+        );
+        await registry.getCollectionBySlug(
+          context.collection,
+          context.executor
+        );
+      };
+      try {
+        handle = await createTestNextly({
+          adapter,
+          collections: [openCollection(BEFOREOP_SLUG)],
+        });
+        registerHook("beforeOperation", BEFOREOP_SLUG, beforeOpHook);
+        const entries = handle
+          .getService<CollectionsHandler>("collectionsHandler")
+          .getEntryService() as CollectionEntryService;
+
+        const result = await withTimeout(
+          handle.adapter.transaction(tx =>
+            entries.createEntriesInTransaction(
+              tx,
+              { collectionName: BEFOREOP_SLUG, user: { id: "editor" } },
+              [{ title: "t", status: "draft" }]
+            )
+          ),
+          15_000
+        );
+
+        expect(result.successful).toBe(1);
+        expect(result.failed).toBe(0);
+      } finally {
+        unregisterHook("beforeOperation", BEFOREOP_SLUG, beforeOpHook);
         await handle?.destroy();
       }
     }, 30_000);

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
@@ -43,6 +43,7 @@ const DIRECT_CREATE_SLUG = "poolreentrydirc";
 const DIRECT_UPDATE_SLUG = "poolreentrydiru";
 const HOOK_SLUG = "poolreentryhook";
 const AFTER_HOOK_SLUG = "poolreentryafter";
+const DELETE_SLUG = "poolreentrydelete";
 const SLUGS = [
   RBAC_SLUG,
   BULK_CREATE_SLUG,
@@ -51,6 +52,7 @@ const SLUGS = [
   DIRECT_UPDATE_SLUG,
   HOOK_SLUG,
   AFTER_HOOK_SLUG,
+  DELETE_SLUG,
 ];
 
 type TestAdapter = Awaited<ReturnType<typeof createAdapter>>;
@@ -105,6 +107,7 @@ function openCollection(slug: string) {
       create: () => true,
       read: () => true,
       update: () => true,
+      delete: () => true,
       publish: () => true,
     },
     fields: [text({ name: "title" })],
@@ -436,6 +439,54 @@ describePg(
         expect(result.failed).toBe(0);
       } finally {
         unregisterHook("afterCreate", AFTER_HOOK_SLUG, afterHook);
+        await handle?.destroy();
+      }
+    }, 30_000);
+
+    it("completes a bulk delete with a beforeDelete hook in a caller-owned transaction", async () => {
+      const adapter = await connectSingleConnection();
+      let handle: TestNextly | undefined;
+      // A code beforeDelete hook reading the registry via context.executor.
+      // Exercises both bindings of the delete worker: the metadata/owner reads
+      // (getCollection/getOwnerConstraint) and the beforeDelete hook context.
+      const beforeDeleteHook: HookHandler = async context => {
+        const registry = container.get<CollectionRegistryService>(
+          "collectionRegistryService"
+        );
+        await registry.getCollectionBySlug(
+          context.collection,
+          context.executor
+        );
+      };
+      try {
+        handle = await createTestNextly({
+          adapter,
+          collections: [openCollection(DELETE_SLUG)],
+        });
+        registerHook("beforeDelete", DELETE_SLUG, beforeDeleteHook);
+        const h = handle.getService<CollectionsHandler>("collectionsHandler");
+        const entries = h.getEntryService() as CollectionEntryService;
+        const created = await h.createEntry(
+          { collectionName: DELETE_SLUG, overrideAccess: true },
+          { title: "doomed", status: "draft" }
+        );
+        const id = (created.data as { id: string }).id;
+
+        const result = await withTimeout(
+          handle.adapter.transaction(tx =>
+            entries.deleteEntriesInTransaction(
+              tx,
+              { collectionName: DELETE_SLUG, user: { id: "editor" } },
+              [id]
+            )
+          ),
+          15_000
+        );
+
+        expect(result.successful).toBe(1);
+        expect(result.failed).toBe(0);
+      } finally {
+        unregisterHook("beforeDelete", DELETE_SLUG, beforeDeleteHook);
         await handle?.destroy();
       }
     }, 30_000);

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-rbac.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-rbac.integration.test.ts
@@ -17,6 +17,8 @@ import {
   createTestNextly,
   type TestNextly,
 } from "../../../plugins/test-nextly";
+// Concrete entry-service type: the transactional overrideAccess test below casts
+// the handler's entry service to it to call createEntryInTransaction directly.
 import type { CollectionEntryService } from "../../../services/collections/collection-entry-service";
 import type { CollectionsHandler } from "../../../services/collections-handler";
 

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-rbac.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-rbac.integration.test.ts
@@ -17,6 +17,7 @@ import {
   createTestNextly,
   type TestNextly,
 } from "../../../plugins/test-nextly";
+import type { CollectionEntryService } from "../../../services/collections/collection-entry-service";
 import type { CollectionsHandler } from "../../../services/collections-handler";
 
 let current: TestNextly | undefined;
@@ -664,5 +665,41 @@ describe("publish enforcement on the dispatcher path (RBAC wiring)", () => {
     });
     expect(row?.status).toBe("published");
     expect(row?.title).toBe("changed");
+  });
+
+  it("honors overrideAccess on a trusted createEntryInTransaction", async () => {
+    // A caller-owned-tx create with overrideAccess must bypass the collection
+    // access gate, exactly as the non-transaction createEntry does. The coarse
+    // create gate previously ignored the flag, so a trusted transactional write
+    // was still evaluated against the (denying) code access rule and refused.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          status: true,
+          // Code access denies create for any authenticated user; only a trusted
+          // (overrideAccess) write may create.
+          access: { create: () => false },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const entries = handler.getEntryService() as CollectionEntryService;
+
+    const result = await current.adapter.transaction(tx =>
+      entries.createEntryInTransaction(
+        tx,
+        { collectionName: "posts", user: { id: "u1" }, overrideAccess: true },
+        { title: "trusted" }
+      )
+    );
+
+    expect(result.success).toBe(true);
+    const [row] = await current.adapter.select<{ title: string }>("dc_posts", {
+      where: { and: [{ column: "title", op: "=", value: "trusted" }] },
+    });
+    expect(row?.title).toBe("trusted");
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-rbac.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-rbac.integration.test.ts
@@ -605,4 +605,64 @@ describe("publish enforcement on the dispatcher path (RBAC wiring)", () => {
     expect(row?.status).toBe("published");
     expect(row?.title).toBe("changed");
   });
+
+  it("does not unpublish when a field hook reintroduces status: undefined", async () => {
+    // The undefined-status strip must run AFTER field-level hooks, not just on
+    // the caller's payload. A field `beforeChange` hook receives the whole record
+    // and can set an own `status: undefined` as a side effect — which names no
+    // status change but, if it reaches the write, is sanitized to SQL NULL on the
+    // raw-parameter path and silently unpublishes the row. Stripping only before
+    // the hooks would miss it.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          status: true,
+          access: { update: () => true, unpublish: () => false },
+          fields: [
+            text({
+              name: "title",
+              hooks: {
+                beforeChange: [
+                  context => {
+                    // Reintroduce an explicit undefined status on UPDATE only, so
+                    // the published seed still publishes on create.
+                    if (context.operation === "update" && context.data) {
+                      (context.data as Record<string, unknown>).status =
+                        undefined;
+                    }
+                    return undefined;
+                  },
+                ],
+              },
+            }),
+          ],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "t", status: "published" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    // The caller sends NO status; only the field hook introduces the undefined,
+    // after the point where the caller payload would have been stripped.
+    const res = await handler.updateEntry(
+      { collectionName: "posts", entryId: id, userId: "editor" },
+      { title: "changed" }
+    );
+    expect(res.success).toBe(true);
+
+    const [row] = await current.adapter.select<{
+      status: string;
+      title: string;
+    }>("dc_posts", {
+      where: { and: [{ column: "id", op: "=", value: id }] },
+    });
+    expect(row?.status).toBe("published");
+    expect(row?.title).toBe("changed");
+  });
 });

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-rbac.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-rbac.integration.test.ts
@@ -561,4 +561,48 @@ describe("publish enforcement on the dispatcher path (RBAC wiring)", () => {
     );
     expect(afterAllow?.status).toBe("published");
   });
+
+  it("does not unpublish on an explicit status: undefined write", async () => {
+    // A Direct API / server caller (or a hook) can produce an own
+    // `status: undefined` — `{ status: maybeStatus }`. It names no status change,
+    // so the gate reads it as an ordinary update. A published row must stay
+    // published: without stripping, the undefined key is sanitized to SQL NULL on
+    // the raw-parameter path and the row silently leaves published without ever
+    // passing the unpublish gate (which here would refuse it).
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "posts",
+          status: true,
+          // Update allowed; unpublish refused. If the undefined status leaked to
+          // NULL, the row would unpublish despite this rule.
+          access: { update: () => true, unpublish: () => false },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "t", status: "published" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    const res = await handler.updateEntry(
+      { collectionName: "posts", entryId: id, userId: "editor" },
+      { title: "changed", status: undefined }
+    );
+    expect(res.success).toBe(true);
+
+    // The row stays published (status untouched) and the ordinary field wrote.
+    const [row] = await current.adapter.select<{
+      status: string;
+      title: string;
+    }>("dc_posts", {
+      where: { and: [{ column: "id", op: "=", value: id }] },
+    });
+    expect(row?.status).toBe("published");
+    expect(row?.title).toBe("changed");
+  });
 });

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -530,7 +530,11 @@ export class CollectionAccessService extends BaseService {
     // The caller's authenticated scope. A scoped API key is judged on its OWN
     // grant, so the session super-admin bypass does not lift the owner predicate
     // for a super-admin-owned key — mirrors checkCollectionAccess.
-    authenticatedScope?: AuthenticatedScope
+    authenticatedScope?: AuthenticatedScope,
+    // Optional transaction-bound executor so the metadata read runs on the
+    // caller's transaction connection instead of a second pooled one; defaults
+    // to the pool.
+    executor?: unknown
   ): Promise<{ field: string; value: string } | null> {
     // Super-admin bypasses the owner predicate on the transactional paths too —
     // EXCEPT via a scoped API key, which must still obey stored owner rules.
@@ -544,8 +548,10 @@ export class CollectionAccessService extends BaseService {
     }
 
     try {
-      const collection =
-        await this.collectionService.getCollection(collectionName);
+      const collection = await this.collectionService.getCollection(
+        collectionName,
+        executor
+      );
       const accessRules = this.getAccessRules(
         collection as Record<string, unknown>
       );

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -176,7 +176,13 @@ export class CollectionAccessService extends BaseService {
     // missing data would otherwise cache a denial that pre-empts the under-lock
     // recheck. The rule is instead evaluated against the row-locked document via
     // {@link evaluateTransitionDocumentRule}.
-    deferStoredRuleEval?: boolean
+    deferStoredRuleEval?: boolean,
+    // Optional transaction-bound Drizzle executor. Supplied when the caller is
+    // already inside a write transaction (the caller-owned-tx bulk paths) so the
+    // RBAC role/permission reads and the collection-metadata read run on that
+    // transaction's own connection instead of taking a second pooled one, which
+    // can stall against a small pool. Defaults to the pooled connection.
+    executor?: unknown
   ): Promise<CollectionServiceResult<T> | null> {
     // Trusted-server / system write: bypass all access control checks.
     if (overrideAccess) {
@@ -248,6 +254,7 @@ export class CollectionAccessService extends BaseService {
           userId: user.id,
           operation,
           resource: collectionName,
+          executor,
         });
         if (!allowed) {
           return {
@@ -285,9 +292,12 @@ export class CollectionAccessService extends BaseService {
     }
 
     try {
-      // Get collection metadata to retrieve access rules
-      const collection =
-        await this.collectionService.getCollection(collectionName);
+      // Get collection metadata to retrieve access rules. Runs on the caller's
+      // transaction executor when supplied so this read does not re-enter the pool.
+      const collection = await this.collectionService.getCollection(
+        collectionName,
+        executor
+      );
       const accessRules = this.getAccessRules(
         collection as Record<string, unknown>
       );

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -1894,12 +1894,22 @@ export class CollectionBulkService extends BaseService {
       return result;
     }
 
-    // 1. Check collection-level access FIRST (once for all entries)
+    // 1. Check collection-level access FIRST (once for all entries). This runs
+    // inside the caller's transaction, so the RBAC/metadata reads are bound to
+    // the transaction's connection (`tx.getDrizzle()`) rather than taking a
+    // second pooled connection, which can stall against a small pool.
     const accessDenied =
       await this.accessService.checkCollectionAccess<BatchOperationResult>(
         params.collectionName,
         "delete",
-        params.user
+        params.user,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        tx.getDrizzle()
       );
     if (accessDenied) {
       return {

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -1167,7 +1167,10 @@ export class CollectionBulkService extends BaseService {
       return result;
     }
 
-    // 1. Check collection-level access FIRST (once for all entries)
+    // 1. Check collection-level access FIRST (once for all entries). This runs
+    // inside the caller's transaction, so the RBAC/metadata reads are bound to
+    // the transaction's connection (`tx.getDrizzle()`) rather than taking a
+    // second pooled connection, which can stall against a small pool.
     const accessDenied =
       await this.accessService.checkCollectionAccess<BatchOperationResult>(
         params.collectionName,
@@ -1178,7 +1181,9 @@ export class CollectionBulkService extends BaseService {
         undefined,
         undefined,
         // Judge a scoped API key on its OWN create grant, not the key owner's.
-        params.authenticatedScope
+        params.authenticatedScope,
+        undefined,
+        tx.getDrizzle()
       );
     if (accessDenied) {
       return {
@@ -1192,14 +1197,16 @@ export class CollectionBulkService extends BaseService {
       };
     }
 
-    // Resolve the caller's publish authorization ONCE (pooled) before looping the
-    // workers, so each create-as-published is enforced without a permission read
-    // inside the caller's transaction.
+    // Resolve the caller's publish authorization ONCE before looping the workers,
+    // so each create-as-published is enforced without a per-row permission read.
+    // Bound to the caller's transaction connection so this resolution does not
+    // re-enter the pool from inside the transaction.
     const transitionAuth =
       await this.mutationService.resolveTransitionAuthorization({
         collectionName: params.collectionName,
         accessUser: params.user,
         authenticatedScope: params.authenticatedScope,
+        executor: tx.getDrizzle(),
       });
 
     // Process in batches for memory efficiency
@@ -1521,7 +1528,10 @@ export class CollectionBulkService extends BaseService {
       return result;
     }
 
-    // 1. Check collection-level access FIRST (once for all entries)
+    // 1. Check collection-level access FIRST (once for all entries). This runs
+    // inside the caller's transaction, so the RBAC/metadata reads are bound to
+    // the transaction's connection (`tx.getDrizzle()`) rather than taking a
+    // second pooled connection, which can stall against a small pool.
     const accessDenied =
       await this.accessService.checkCollectionAccess<BatchOperationResult>(
         params.collectionName,
@@ -1532,7 +1542,9 @@ export class CollectionBulkService extends BaseService {
         undefined,
         undefined,
         // Judge a scoped API key on its OWN update grant, not the key owner's.
-        params.authenticatedScope
+        params.authenticatedScope,
+        undefined,
+        tx.getDrizzle()
       );
     if (accessDenied) {
       return {
@@ -1546,14 +1558,16 @@ export class CollectionBulkService extends BaseService {
       };
     }
 
-    // Resolve the caller's publish/unpublish authorization ONCE (pooled) before
-    // looping the workers, so each transition is enforced under the row lock
-    // without a permission read inside the caller's transaction.
+    // Resolve the caller's publish/unpublish authorization ONCE before looping
+    // the workers, so each transition is enforced under the row lock without a
+    // per-row permission read. Bound to the caller's transaction connection so
+    // this resolution does not re-enter the pool from inside the transaction.
     const transitionAuth =
       await this.mutationService.resolveTransitionAuthorization({
         collectionName: params.collectionName,
         accessUser: params.user,
         authenticatedScope: params.authenticatedScope,
+        executor: tx.getDrizzle(),
       });
 
     // Process in batches for memory efficiency

--- a/packages/nextly/src/domains/collections/services/collection-hook-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-hook-service.ts
@@ -36,6 +36,10 @@ export interface QueryDatabaseParams {
   value: unknown;
   caseInsensitive?: boolean;
   excludeId?: string;
+  // Transaction-bound executor so a stored hook's uniqueness read (the built-in
+  // unique-validation hook) runs on the caller's transaction connection instead
+  // of the pool when the write is inside a transaction; defaults to the pool.
+  executor?: unknown;
 }
 
 export class CollectionHookService {
@@ -115,6 +119,9 @@ export class CollectionHookService {
           value: params.value,
           caseInsensitive: params.caseInsensitive || false,
           excludeId: params.excludeId,
+          // Forward the context's transaction executor so the uniqueness read
+          // stays on the caller's transaction connection inside a transaction.
+          executor,
         });
       },
     };

--- a/packages/nextly/src/domains/collections/services/collection-hook-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-hook-service.ts
@@ -92,7 +92,11 @@ export class CollectionHookService {
     data: unknown,
     queryDatabase: (params: QueryDatabaseParams) => Promise<boolean>,
     user?: UserContext,
-    sharedContext: Record<string, unknown> = {}
+    sharedContext: Record<string, unknown> = {},
+    // Transaction-bound executor forwarded onto the context when the hook runs
+    // inside a caller-owned transaction, so DB-reading hooks stay on the
+    // transaction's connection (see HookContext.executor). Omitted otherwise.
+    executor?: unknown
   ): PrebuiltHookContext {
     return {
       collection: collectionName,
@@ -100,6 +104,7 @@ export class CollectionHookService {
       data,
       user: user ? { id: user.id, email: user.email } : undefined,
       context: sharedContext,
+      executor,
       req: {
         nextly: this.resolveNextlyForHooks() as NextlyDirectAPI | undefined,
       },

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4358,11 +4358,23 @@ export class CollectionMutationService extends BaseService {
     body: Record<string, unknown>
   ): Promise<CollectionServiceResult<unknown>> {
     try {
+      // A direct caller runs this inside its own transaction, so every metadata
+      // and access read below is bound to that transaction's connection — a
+      // pooled read would take a second connection the transaction is holding,
+      // which stalls against a small pool.
+      const txExecutor = tx.getDrizzle<RelationshipDbExecutor>();
       // 1. Check collection-level access FIRST
       const accessDenied = await this.accessService.checkCollectionAccess(
         params.collectionName,
         "create",
-        params.user
+        params.user,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        txExecutor
       );
       if (accessDenied) {
         return accessDenied;
@@ -4370,7 +4382,8 @@ export class CollectionMutationService extends BaseService {
 
       // Get collection metadata to identify relation fields and hooks
       const collection = await this.collectionService.getCollection(
-        params.collectionName
+        params.collectionName,
+        txExecutor
       );
       const fields =
         ((
@@ -4415,6 +4428,9 @@ export class CollectionMutationService extends BaseService {
         data: currentData,
         user: params.user,
         context: sharedContext,
+        // Bind DB-reading hooks (e.g. the built-in sanitization hook) to the
+        // caller's transaction connection so they do not re-enter the pool.
+        executor: txExecutor,
       });
 
       const modifiedData = await this.hookService.hookRegistry.execute(
@@ -4652,7 +4668,6 @@ export class CollectionMutationService extends BaseService {
 
       // Handle many-to-many relationships on the caller's transaction so the
       // junction writes commit atomically with the entry.
-      const txExecutor = tx.getDrizzle<RelationshipDbExecutor>();
       for (const field of manyToManyFields) {
         const relatedIds = manyToManyData[field.name];
         if (relatedIds && relatedIds.length > 0) {
@@ -4758,9 +4773,15 @@ export class CollectionMutationService extends BaseService {
     body: Record<string, unknown>
   ): Promise<CollectionServiceResult<unknown>> {
     try {
+      // A direct caller runs this inside its own transaction, so every metadata
+      // and access read below is bound to that transaction's connection — a
+      // pooled read would take a second connection the transaction is holding,
+      // which stalls against a small pool.
+      const txExecutor = tx.getDrizzle<RelationshipDbExecutor>();
       // Get collection metadata and hooks first
       const collection = await this.collectionService.getCollection(
-        params.collectionName
+        params.collectionName,
+        txExecutor
       );
       const fields =
         ((
@@ -4802,7 +4823,12 @@ export class CollectionMutationService extends BaseService {
         "update",
         params.user,
         params.entryId,
-        existingEntry
+        existingEntry,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        txExecutor
       );
       if (accessDenied) {
         return accessDenied;
@@ -4835,6 +4861,9 @@ export class CollectionMutationService extends BaseService {
         originalData: existingEntry,
         user: params.user,
         context: sharedContext,
+        // Bind DB-reading hooks (e.g. the built-in sanitization hook) to the
+        // caller's transaction connection so they do not re-enter the pool.
+        executor: txExecutor,
       });
 
       const modifiedData = await this.hookService.hookRegistry.execute(
@@ -5045,7 +5074,6 @@ export class CollectionMutationService extends BaseService {
 
       // Handle many-to-many relationships on the caller's transaction so the
       // junction writes commit atomically with the update.
-      const txExecutor = tx.getDrizzle<RelationshipDbExecutor>();
       for (const field of manyToManyFields) {
         if (manyToManyData[field.name] !== undefined) {
           await this.relationshipService.deleteManyToManyRelations(
@@ -5414,9 +5442,12 @@ export class CollectionMutationService extends BaseService {
     skipHooks: boolean
   ): Promise<CollectionServiceResult<unknown>> {
     try {
-      // Get collection metadata to identify relation fields
+      // Get collection metadata to identify relation fields. Runs on the
+      // caller's transaction connection so this per-entry read does not re-enter
+      // the pool from inside the transaction (which can stall against a small pool).
       const collection = await this.collectionService.getCollection(
-        params.collectionName
+        params.collectionName,
+        tx.getDrizzle()
       );
       const fields =
         ((
@@ -5469,6 +5500,10 @@ export class CollectionMutationService extends BaseService {
           data: currentData,
           user: params.user,
           context: sharedContext,
+          // Bind DB-reading hooks (e.g. the built-in sanitization hook, which
+          // loads field metadata) to the caller's transaction connection so they
+          // do not re-enter the pool from inside the transaction.
+          executor: tx.getDrizzle(),
         });
 
         const modifiedData = await this.hookService.hookRegistry.execute(
@@ -5834,9 +5869,12 @@ export class CollectionMutationService extends BaseService {
     skipHooks: boolean
   ): Promise<CollectionServiceResult<unknown>> {
     try {
-      // Get collection metadata to identify relation fields
+      // Get collection metadata to identify relation fields. Runs on the
+      // caller's transaction connection so this per-entry read does not re-enter
+      // the pool from inside the transaction (which can stall against a small pool).
       const collection = await this.collectionService.getCollection(
-        params.collectionName
+        params.collectionName,
+        tx.getDrizzle()
       );
       const fields =
         ((
@@ -5869,7 +5907,10 @@ export class CollectionMutationService extends BaseService {
         params.overrideAccess,
         // A scoped API key keeps the owner predicate even when owned by a
         // super-admin, so a batch update judges the key on its OWN grant.
-        params.authenticatedScope
+        params.authenticatedScope,
+        // Bound to the caller's transaction connection so the metadata read does
+        // not re-enter the pool from inside the transaction.
+        tx.getDrizzle()
       );
       const fetchWhere = ownerConstraint
         ? this.whereAnd({
@@ -5967,6 +6008,9 @@ export class CollectionMutationService extends BaseService {
           originalData: existingEntry,
           user: params.user,
           context: sharedContext,
+          // Bind DB-reading hooks (e.g. the built-in sanitization hook) to the
+          // caller's transaction connection so they do not re-enter the pool.
+          executor: tx.getDrizzle(),
         });
 
         const modifiedData = await this.hookService.hookRegistry.execute(

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1403,13 +1403,6 @@ export class CollectionMutationService extends BaseService {
       const finalData = (storedBeforeResult.data ??
         dataAfterCodeHooks) as Record<string, unknown>;
 
-      // An explicit `status: undefined` (own key) names no status change; strip
-      // it so the transition gate and the write agree. A kept undefined status
-      // would be sanitized to SQL NULL on the raw-parameter path — silently
-      // unpublishing a published row, or nulling a create's draft default —
-      // without ever passing the publish/unpublish gate.
-      stripUndefinedStatus(finalData);
-
       // Password fields store bcrypt hashes, never the submitted value.
       // Runs after hooks (so hooks see the plaintext they may validate
       // against) and before any serialization touches the column value.
@@ -1493,6 +1486,16 @@ export class CollectionMutationService extends BaseService {
       await this.reSanitizeSlug(finalData, isSlugTaken);
 
       await hashPasswordFieldValues(finalData, fields);
+
+      // Strip an explicit `status: undefined` AFTER every mutating hook has run.
+      // A field-level beforeValidate/beforeChange hook can (re)introduce an own
+      // `status: undefined`, which names no status change but would otherwise be
+      // sanitized to SQL NULL on the raw-parameter path — silently unpublishing a
+      // published row, or nulling a create's draft default — without passing the
+      // publish/unpublish gate. Placed here, the last status-touching step before
+      // the transition classification and the write, so the write payload and the
+      // gate agree even when a hook set the undefined.
+      stripUndefinedStatus(finalData);
 
       // Normalize relationship field values (extract IDs from objects with display properties)
       // This must happen before many-to-many extraction and JSON serialization
@@ -2887,13 +2890,6 @@ export class CollectionMutationService extends BaseService {
       const finalData = (storedBeforeResult.data ??
         dataAfterCodeHooks) as Record<string, unknown>;
 
-      // An explicit `status: undefined` (own key) names no status change; strip
-      // it so the transition gate and the write agree. A kept undefined status
-      // would be sanitized to SQL NULL on the raw-parameter path — silently
-      // unpublishing a published row, or nulling a create's draft default —
-      // without ever passing the publish/unpublish gate.
-      stripUndefinedStatus(finalData);
-
       // Password fields store bcrypt hashes, never the submitted value.
       // Runs after hooks (so hooks see the plaintext they may validate
       // against) and before any serialization touches the column value.
@@ -2960,6 +2956,16 @@ export class CollectionMutationService extends BaseService {
       });
 
       await hashPasswordFieldValues(finalData, fields);
+
+      // Strip an explicit `status: undefined` AFTER every mutating hook has run.
+      // A field-level beforeValidate/beforeChange hook can (re)introduce an own
+      // `status: undefined`, which names no status change but would otherwise be
+      // sanitized to SQL NULL on the raw-parameter path — silently unpublishing a
+      // published row, or nulling a create's draft default — without passing the
+      // publish/unpublish gate. Placed here, the last status-touching step before
+      // the transition classification and the write, so the write payload and the
+      // gate agree even when a hook set the undefined.
+      stripUndefinedStatus(finalData);
 
       // Normalize relationship field values (extract IDs from objects with display properties)
       // This must happen before many-to-many extraction and JSON serialization
@@ -4437,13 +4443,6 @@ export class CollectionMutationService extends BaseService {
       const finalData = (storedBeforeResult.data ??
         dataAfterCodeHooks) as Record<string, unknown>;
 
-      // An explicit `status: undefined` (own key) names no status change; strip
-      // it so the transition gate and the write agree. A kept undefined status
-      // would be sanitized to SQL NULL on the raw-parameter path — silently
-      // unpublishing a published row, or nulling a create's draft default —
-      // without ever passing the publish/unpublish gate.
-      stripUndefinedStatus(finalData);
-
       // Password fields store bcrypt hashes, never the submitted value.
       // Runs after hooks (so hooks see the plaintext they may validate
       // against) and before any serialization touches the column value.
@@ -4525,6 +4524,16 @@ export class CollectionMutationService extends BaseService {
       await this.reSanitizeSlug(finalData, isSlugTaken);
 
       await hashPasswordFieldValues(finalData, fields);
+
+      // Strip an explicit `status: undefined` AFTER every mutating hook has run.
+      // A field-level beforeValidate/beforeChange hook can (re)introduce an own
+      // `status: undefined`, which names no status change but would otherwise be
+      // sanitized to SQL NULL on the raw-parameter path — silently unpublishing a
+      // published row, or nulling a create's draft default — without passing the
+      // publish/unpublish gate. Placed here, the last status-touching step before
+      // the transition classification and the write, so the write payload and the
+      // gate agree even when a hook set the undefined.
+      stripUndefinedStatus(finalData);
 
       // Normalize relationship field values (extract IDs from objects with display properties)
       // This must happen before many-to-many extraction and JSON serialization
@@ -4854,13 +4863,6 @@ export class CollectionMutationService extends BaseService {
       const finalData = (storedBeforeResult.data ??
         dataAfterCodeHooks) as Record<string, unknown>;
 
-      // An explicit `status: undefined` (own key) names no status change; strip
-      // it so the transition gate and the write agree. A kept undefined status
-      // would be sanitized to SQL NULL on the raw-parameter path — silently
-      // unpublishing a published row, or nulling a create's draft default —
-      // without ever passing the publish/unpublish gate.
-      stripUndefinedStatus(finalData);
-
       // Password fields store bcrypt hashes, never the submitted value.
       // Runs after hooks (so hooks see the plaintext they may validate
       // against) and before any serialization touches the column value.
@@ -4919,6 +4921,16 @@ export class CollectionMutationService extends BaseService {
       });
 
       await hashPasswordFieldValues(finalData, fields);
+
+      // Strip an explicit `status: undefined` AFTER every mutating hook has run.
+      // A field-level beforeValidate/beforeChange hook can (re)introduce an own
+      // `status: undefined`, which names no status change but would otherwise be
+      // sanitized to SQL NULL on the raw-parameter path — silently unpublishing a
+      // published row, or nulling a create's draft default — without passing the
+      // publish/unpublish gate. Placed here, the last status-touching step before
+      // the transition classification and the write, so the write payload and the
+      // gate agree even when a hook set the undefined.
+      stripUndefinedStatus(finalData);
 
       // Normalize relationship field values (extract IDs from objects with display properties)
       // This must happen before many-to-many extraction and JSON serialization
@@ -5486,9 +5498,6 @@ export class CollectionMutationService extends BaseService {
       }
 
       const finalData = currentData;
-      // Strip an explicit `status: undefined` so it does not sanitize to SQL NULL
-      // and move the row out of published without the gate (see the other paths).
-      stripUndefinedStatus(finalData);
 
       // Password fields store bcrypt hashes, never the submitted value —
       // same guarantee as the non-transaction paths.
@@ -5573,6 +5582,16 @@ export class CollectionMutationService extends BaseService {
       }
 
       await hashPasswordFieldValues(finalData, fields);
+
+      // Strip an explicit `status: undefined` AFTER every mutating hook has run.
+      // A field-level beforeValidate/beforeChange hook can (re)introduce an own
+      // `status: undefined`, which names no status change but would otherwise be
+      // sanitized to SQL NULL on the raw-parameter path — silently unpublishing a
+      // published row, or nulling a create's draft default — without passing the
+      // publish/unpublish gate. Placed here, the last status-touching step before
+      // the transition classification and the write, so the write payload and the
+      // gate agree even when a hook set the undefined.
+      stripUndefinedStatus(finalData);
 
       // Normalize relationship field values (extract IDs from objects with display properties)
       // This must happen before many-to-many extraction and JSON serialization
@@ -5977,9 +5996,6 @@ export class CollectionMutationService extends BaseService {
       }
 
       const finalData = currentData;
-      // Strip an explicit `status: undefined` so it does not sanitize to SQL NULL
-      // and move the row out of published without the gate (see the other paths).
-      stripUndefinedStatus(finalData);
 
       // Password fields store bcrypt hashes, never the submitted value —
       // same guarantee as the non-transaction paths.
@@ -6042,6 +6058,16 @@ export class CollectionMutationService extends BaseService {
       }
 
       await hashPasswordFieldValues(finalData, fields);
+
+      // Strip an explicit `status: undefined` AFTER every mutating hook has run.
+      // A field-level beforeValidate/beforeChange hook can (re)introduce an own
+      // `status: undefined`, which names no status change but would otherwise be
+      // sanitized to SQL NULL on the raw-parameter path — silently unpublishing a
+      // published row, or nulling a create's draft default — without passing the
+      // publish/unpublish gate. Placed here, the last status-touching step before
+      // the transition classification and the write, so the write payload and the
+      // gate agree even when a hook set the undefined.
+      stripUndefinedStatus(finalData);
 
       // Normalize relationship field values (extract IDs from objects with display properties)
       // This must happen before many-to-many extraction and JSON serialization

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1066,7 +1066,12 @@ export class CollectionMutationService extends BaseService {
   ): Promise<boolean> {
     try {
       // Load the schema for this collection
-      const schema = await this.fileManager.loadDynamicSchema(collectionName);
+      // Forward the executor so an uncached runtime-schema load (UI collection)
+      // stays on the caller's transaction connection rather than the pool.
+      const schema = await this.fileManager.loadDynamicSchema(
+        collectionName,
+        executor
+      );
 
       // Check if the field exists in the schema
       if (!schema[field]) {
@@ -4427,6 +4432,9 @@ export class CollectionMutationService extends BaseService {
             ? { id: params.user.id, email: params.user.email }
             : undefined,
           context: sharedContext,
+          // Bind a beforeOperation hook that reads via context.executor to the
+          // caller's transaction connection so it does not re-enter the pool.
+          executor: tx.getDrizzle(),
         });
 
       // Use modified data if returned by beforeOperation
@@ -4872,6 +4880,9 @@ export class CollectionMutationService extends BaseService {
             ? { id: params.user.id, email: params.user.email }
             : undefined,
           context: sharedContext,
+          // Bind a beforeOperation hook that reads via context.executor to the
+          // caller's transaction connection so it does not re-enter the pool.
+          executor: tx.getDrizzle(),
         });
 
       // Use modified data if returned by beforeOperation
@@ -5253,7 +5264,20 @@ export class CollectionMutationService extends BaseService {
       // 1. Check collection-level access FIRST (with document for owner checks)
       const accessDenied = await this.accessService.checkCollectionAccess<{
         deleted: boolean;
-      }>(params.collectionName, "delete", params.user, params.entryId, entry);
+      }>(
+        params.collectionName,
+        "delete",
+        params.user,
+        params.entryId,
+        entry,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        // Bound to the caller's transaction connection so this RBAC/metadata read
+        // does not re-enter the pool from inside the transaction.
+        tx.getDrizzle()
+      );
       if (accessDenied) {
         return accessDenied;
       }
@@ -5271,6 +5295,9 @@ export class CollectionMutationService extends BaseService {
           ? { id: params.user.id, email: params.user.email }
           : undefined,
         context: sharedContext,
+        // Bind a beforeOperation hook that reads via context.executor to the
+        // caller's transaction connection so it does not re-enter the pool.
+        executor: tx.getDrizzle(),
       });
 
       // Note: For delete, we don't use modified id since we already fetched the entry
@@ -5532,6 +5559,9 @@ export class CollectionMutationService extends BaseService {
               ? { id: params.user.id, email: params.user.email }
               : undefined,
             context: sharedContext,
+            // Bind a beforeOperation hook that reads via context.executor to the
+            // caller's transaction connection so it does not re-enter the pool.
+            executor: tx.getDrizzle(),
           });
 
         // Use modified data if returned by beforeOperation
@@ -6048,6 +6078,9 @@ export class CollectionMutationService extends BaseService {
               ? { id: params.user.id, email: params.user.email }
               : undefined,
             context: sharedContext,
+            // Bind a beforeOperation hook that reads via context.executor to the
+            // caller's transaction connection so it does not re-enter the pool.
+            executor: tx.getDrizzle(),
           });
 
         // Use modified data if returned by beforeOperation
@@ -6528,6 +6561,9 @@ export class CollectionMutationService extends BaseService {
             ? { id: params.user.id, email: params.user.email }
             : undefined,
           context: sharedContext,
+          // Bind a beforeOperation hook that reads via context.executor to the
+          // caller's transaction connection so it does not re-enter the pool.
+          executor: tx.getDrizzle(),
         });
 
         // Note: For delete, we don't use modified id since we already fetched the entry

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -37,7 +37,10 @@ import type { ValidationPublicData } from "../../../errors/public-data";
 import { emitDocumentEvent } from "../../../events/domain-events";
 import { getEventBus } from "../../../events/event-bus";
 import { toSnakeCase } from "../../../lib/case-conversion";
-import { resolvePublishTransition } from "../../../lib/status-transition";
+import {
+  resolvePublishTransition,
+  stripUndefinedStatus,
+} from "../../../lib/status-transition";
 import type { ResolvedVersionsConfig } from "../../../schemas/versions/types";
 import type { CollectionAccessRules } from "../../../services/access";
 import type { CollectionFileManager } from "../../../services/collection-file-manager";
@@ -1400,6 +1403,13 @@ export class CollectionMutationService extends BaseService {
       const finalData = (storedBeforeResult.data ??
         dataAfterCodeHooks) as Record<string, unknown>;
 
+      // An explicit `status: undefined` (own key) names no status change; strip
+      // it so the transition gate and the write agree. A kept undefined status
+      // would be sanitized to SQL NULL on the raw-parameter path — silently
+      // unpublishing a published row, or nulling a create's draft default —
+      // without ever passing the publish/unpublish gate.
+      stripUndefinedStatus(finalData);
+
       // Password fields store bcrypt hashes, never the submitted value.
       // Runs after hooks (so hooks see the plaintext they may validate
       // against) and before any serialization touches the column value.
@@ -2549,12 +2559,20 @@ export class CollectionMutationService extends BaseService {
     accessUser?: UserContext;
     overrideAccess?: boolean;
     authenticatedScope?: AuthenticatedScope;
+    // A transaction-bound Drizzle executor (`tx.getDrizzle()`), supplied when a
+    // caller-owned-tx path resolves the transition authorization from INSIDE its
+    // own transaction. The metadata and RBAC reads below then run on that
+    // transaction's connection instead of taking a second pooled one, which can
+    // stall against a small pool. Omitted (pooled connection) when a path
+    // pre-resolves before opening its transaction, which is the common case.
+    executor?: unknown;
   }): Promise<TransitionAuthorization> {
     if (args.overrideAccess) {
       return { publishDenied: null, unpublishDenied: null, documentRule: null };
     }
     const collection = await this.collectionService.getCollection(
-      args.collectionName
+      args.collectionName,
+      args.executor
     );
     if ((collection as { status?: boolean }).status !== true) {
       return { publishDenied: null, unpublishDenied: null, documentRule: null };
@@ -2587,7 +2605,8 @@ export class CollectionMutationService extends BaseService {
         args.overrideAccess,
         false,
         args.authenticatedScope,
-        deferPublish
+        deferPublish,
+        args.executor
       ),
       this.accessService.checkCollectionAccess(
         args.collectionName,
@@ -2598,7 +2617,8 @@ export class CollectionMutationService extends BaseService {
         args.overrideAccess,
         false,
         args.authenticatedScope,
-        deferUnpublish
+        deferUnpublish,
+        args.executor
       ),
     ]);
     // Owner-only / custom publish/unpublish rules cannot be judged above because
@@ -2866,6 +2886,13 @@ export class CollectionMutationService extends BaseService {
         );
       const finalData = (storedBeforeResult.data ??
         dataAfterCodeHooks) as Record<string, unknown>;
+
+      // An explicit `status: undefined` (own key) names no status change; strip
+      // it so the transition gate and the write agree. A kept undefined status
+      // would be sanitized to SQL NULL on the raw-parameter path — silently
+      // unpublishing a published row, or nulling a create's draft default —
+      // without ever passing the publish/unpublish gate.
+      stripUndefinedStatus(finalData);
 
       // Password fields store bcrypt hashes, never the submitted value.
       // Runs after hooks (so hooks see the plaintext they may validate
@@ -4410,6 +4437,13 @@ export class CollectionMutationService extends BaseService {
       const finalData = (storedBeforeResult.data ??
         dataAfterCodeHooks) as Record<string, unknown>;
 
+      // An explicit `status: undefined` (own key) names no status change; strip
+      // it so the transition gate and the write agree. A kept undefined status
+      // would be sanitized to SQL NULL on the raw-parameter path — silently
+      // unpublishing a published row, or nulling a create's draft default —
+      // without ever passing the publish/unpublish gate.
+      stripUndefinedStatus(finalData);
+
       // Password fields store bcrypt hashes, never the submitted value.
       // Runs after hooks (so hooks see the plaintext they may validate
       // against) and before any serialization touches the column value.
@@ -4586,6 +4620,10 @@ export class CollectionMutationService extends BaseService {
           collectionName: params.collectionName,
           accessUser: params.overrideAccess ? undefined : params.user,
           overrideAccess: params.overrideAccess,
+          // This fallback fires only for a direct caller-owned-tx write (the bulk
+          // paths always pre-resolve and pass transitionAuth), so bind the reads
+          // to this transaction's connection rather than re-entering the pool.
+          executor: tx.getDrizzle(),
         }));
       const transitionDenied = await this.enforceTransitionUnderLock(tx, {
         tableName,
@@ -4816,6 +4854,13 @@ export class CollectionMutationService extends BaseService {
       const finalData = (storedBeforeResult.data ??
         dataAfterCodeHooks) as Record<string, unknown>;
 
+      // An explicit `status: undefined` (own key) names no status change; strip
+      // it so the transition gate and the write agree. A kept undefined status
+      // would be sanitized to SQL NULL on the raw-parameter path — silently
+      // unpublishing a published row, or nulling a create's draft default —
+      // without ever passing the publish/unpublish gate.
+      stripUndefinedStatus(finalData);
+
       // Password fields store bcrypt hashes, never the submitted value.
       // Runs after hooks (so hooks see the plaintext they may validate
       // against) and before any serialization touches the column value.
@@ -4951,6 +4996,10 @@ export class CollectionMutationService extends BaseService {
           collectionName: params.collectionName,
           accessUser: params.overrideAccess ? undefined : params.user,
           overrideAccess: params.overrideAccess,
+          // This fallback fires only for a direct caller-owned-tx write (the bulk
+          // paths always pre-resolve and pass transitionAuth), so bind the reads
+          // to this transaction's connection rather than re-entering the pool.
+          executor: tx.getDrizzle(),
         }));
       const transitionDenied = await this.enforceTransitionUnderLock(tx, {
         tableName,
@@ -5437,6 +5486,9 @@ export class CollectionMutationService extends BaseService {
       }
 
       const finalData = currentData;
+      // Strip an explicit `status: undefined` so it does not sanitize to SQL NULL
+      // and move the row out of published without the gate (see the other paths).
+      stripUndefinedStatus(finalData);
 
       // Password fields store bcrypt hashes, never the submitted value —
       // same guarantee as the non-transaction paths.
@@ -5615,6 +5667,10 @@ export class CollectionMutationService extends BaseService {
           collectionName: params.collectionName,
           accessUser: params.overrideAccess ? undefined : params.user,
           overrideAccess: params.overrideAccess,
+          // This fallback fires only for a direct caller-owned-tx write (the bulk
+          // paths always pre-resolve and pass transitionAuth), so bind the reads
+          // to this transaction's connection rather than re-entering the pool.
+          executor: tx.getDrizzle(),
         }));
       const transitionDenied = await this.enforceTransitionUnderLock(tx, {
         tableName,
@@ -5921,6 +5977,9 @@ export class CollectionMutationService extends BaseService {
       }
 
       const finalData = currentData;
+      // Strip an explicit `status: undefined` so it does not sanitize to SQL NULL
+      // and move the row out of published without the gate (see the other paths).
+      stripUndefinedStatus(finalData);
 
       // Password fields store bcrypt hashes, never the submitted value —
       // same guarantee as the non-transaction paths.
@@ -6060,6 +6119,10 @@ export class CollectionMutationService extends BaseService {
           collectionName: params.collectionName,
           accessUser: params.overrideAccess ? undefined : params.user,
           overrideAccess: params.overrideAccess,
+          // This fallback fires only for a direct caller-owned-tx write (the bulk
+          // paths always pre-resolve and pass transitionAuth), so bind the reads
+          // to this transaction's connection rather than re-entering the pool.
+          executor: tx.getDrizzle(),
         }));
       const transitionDenied = await this.enforceTransitionUnderLock(tx, {
         tableName,

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -5220,9 +5220,12 @@ export class CollectionMutationService extends BaseService {
     // side-effect issue, not an eventless delete, and must NOT roll the batch back.
     let deleteNeedsRollback = false;
     try {
-      // Get collection metadata and stored hooks
+      // Get collection metadata and stored hooks. Runs on the caller's
+      // transaction connection so this read does not re-enter the pool from
+      // inside the transaction (which can stall against a small pool).
       const collection = await this.collectionService.getCollection(
-        params.collectionName
+        params.collectionName,
+        tx.getDrizzle()
       );
       const storedHooks = this.hookService.getStoredHooks(
         collection as Record<string, unknown>
@@ -5280,6 +5283,9 @@ export class CollectionMutationService extends BaseService {
         data: entry,
         user: params.user,
         context: sharedContext,
+        // Bind a code beforeDelete hook that reads via context.executor to the
+        // caller's transaction connection so it does not re-enter the pool.
+        executor: tx.getDrizzle(),
       });
 
       await this.hookService.hookRegistry.execute(
@@ -6421,9 +6427,12 @@ export class CollectionMutationService extends BaseService {
     // reads it back and applies it only after the transaction commits.
     let eventRecorded = false;
     try {
-      // Get collection metadata early
+      // Get collection metadata early. Runs on the caller's transaction
+      // connection so this read does not re-enter the pool from inside the
+      // transaction (which can stall against a small pool).
       const collection = await this.collectionService.getCollection(
-        params.collectionName
+        params.collectionName,
+        tx.getDrizzle()
       );
 
       const tableName = this.resolveTableName(
@@ -6441,7 +6450,13 @@ export class CollectionMutationService extends BaseService {
         params.user,
         // A trusted override must not have an owner predicate forced onto its
         // fetch, or it would 404 rows it is entitled to delete.
-        params.overrideAccess
+        params.overrideAccess,
+        // This worker carries no scoped-API-key context (unlike the update
+        // worker); the owner predicate is resolved from the session user only.
+        undefined,
+        // Bound to the caller's transaction connection so the metadata read does
+        // not re-enter the pool from inside the transaction.
+        tx.getDrizzle()
       );
       const fetchWhere = ownerConstraint
         ? this.whereAnd({
@@ -6525,6 +6540,9 @@ export class CollectionMutationService extends BaseService {
           data: entry,
           user: params.user,
           context: sharedContext,
+          // Bind a code beforeDelete hook that reads via context.executor to the
+          // caller's transaction connection so it does not re-enter the pool.
+          executor: tx.getDrizzle(),
         });
 
         await this.hookService.hookRegistry.execute(

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1031,7 +1031,8 @@ export class CollectionMutationService extends BaseService {
       params.field,
       params.value,
       params.caseInsensitive || false,
-      params.excludeId
+      params.excludeId,
+      params.executor
     );
   };
 
@@ -1057,7 +1058,11 @@ export class CollectionMutationService extends BaseService {
     field: string,
     value: unknown,
     caseInsensitive: boolean = false,
-    excludeId?: string
+    excludeId?: string,
+    // Optional transaction-bound executor so the uniqueness read runs on the
+    // caller's transaction connection (a stored unique-validation hook firing
+    // inside a caller-owned transaction) instead of the pool; defaults to it.
+    executor?: unknown
   ): Promise<boolean> {
     try {
       // Load the schema for this collection
@@ -1071,9 +1076,11 @@ export class CollectionMutationService extends BaseService {
         return false;
       }
 
-      // Build the query
-
-      let query = this.db.select().from(schema);
+      // Build the query. Runs on the caller's transaction connection when an
+      // executor is supplied so this read does not re-enter the pool from inside
+      // the transaction; falls back to the pooled connection otherwise.
+      const db = executor ?? this.db;
+      let query = db.select().from(schema);
 
       // Build the WHERE condition
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle SQL condition accumulator
@@ -4453,7 +4460,10 @@ export class CollectionMutationService extends BaseService {
             dataAfterCodeHooks,
             this.queryDatabaseFn,
             params.user,
-            sharedContext
+            sharedContext,
+            // Bind a stored hook's uniqueness read to the caller's transaction
+            // connection so it does not re-enter the pool from inside the tx.
+            tx.getDrizzle()
           )
         );
       const finalData = (storedBeforeResult.data ??
@@ -4702,7 +4712,10 @@ export class CollectionMutationService extends BaseService {
           entry,
           this.queryDatabaseFn,
           params.user,
-          sharedContext
+          sharedContext,
+          // Bind a stored hook's uniqueness read to the caller's transaction
+          // connection so it does not re-enter the pool from inside the tx.
+          tx.getDrizzle()
         )
       );
 
@@ -4886,7 +4899,10 @@ export class CollectionMutationService extends BaseService {
             dataAfterCodeHooks,
             this.queryDatabaseFn,
             params.user,
-            sharedContext
+            sharedContext,
+            // Bind a stored hook's uniqueness read to the caller's transaction
+            // connection so it does not re-enter the pool from inside the tx.
+            tx.getDrizzle()
           )
         );
       const finalData = (storedBeforeResult.data ??
@@ -5118,7 +5134,10 @@ export class CollectionMutationService extends BaseService {
           updated,
           this.queryDatabaseFn,
           params.user,
-          sharedContext
+          sharedContext,
+          // Bind a stored hook's uniqueness read to the caller's transaction
+          // connection so it does not re-enter the pool from inside the tx.
+          tx.getDrizzle()
         )
       );
 
@@ -5264,7 +5283,10 @@ export class CollectionMutationService extends BaseService {
           entry,
           this.queryDatabaseFn,
           params.user,
-          sharedContext
+          sharedContext,
+          // Bind a stored hook's uniqueness read to the caller's transaction
+          // connection so it does not re-enter the pool from inside the tx.
+          tx.getDrizzle()
         )
       );
 
@@ -5378,7 +5400,10 @@ export class CollectionMutationService extends BaseService {
           entry,
           this.queryDatabaseFn,
           params.user,
-          sharedContext
+          sharedContext,
+          // Bind a stored hook's uniqueness read to the caller's transaction
+          // connection so it does not re-enter the pool from inside the tx.
+          tx.getDrizzle()
         )
       );
 
@@ -5523,7 +5548,10 @@ export class CollectionMutationService extends BaseService {
               currentData,
               this.queryDatabaseFn,
               params.user,
-              sharedContext
+              sharedContext,
+              // Bind a stored hook's uniqueness read to the caller's transaction
+              // connection so it does not re-enter the pool from inside the tx.
+              tx.getDrizzle()
             )
           );
         currentData = (storedBeforeResult.data ?? currentData) as Record<
@@ -5784,7 +5812,10 @@ export class CollectionMutationService extends BaseService {
             entry,
             this.queryDatabaseFn,
             params.user,
-            sharedContext
+            sharedContext,
+            // Bind a stored hook's uniqueness read to the caller's transaction
+            // connection so it does not re-enter the pool from inside the tx.
+            tx.getDrizzle()
           )
         );
       }
@@ -6030,7 +6061,10 @@ export class CollectionMutationService extends BaseService {
               currentData,
               this.queryDatabaseFn,
               params.user,
-              sharedContext
+              sharedContext,
+              // Bind a stored hook's uniqueness read to the caller's transaction
+              // connection so it does not re-enter the pool from inside the tx.
+              tx.getDrizzle()
             )
           );
         currentData = (storedBeforeResult.data ?? currentData) as Record<
@@ -6278,7 +6312,10 @@ export class CollectionMutationService extends BaseService {
             updated,
             this.queryDatabaseFn,
             params.user,
-            sharedContext
+            sharedContext,
+            // Bind a stored hook's uniqueness read to the caller's transaction
+            // connection so it does not re-enter the pool from inside the tx.
+            tx.getDrizzle()
           )
         );
       }
@@ -6482,7 +6519,10 @@ export class CollectionMutationService extends BaseService {
             entry,
             this.queryDatabaseFn,
             params.user,
-            sharedContext
+            sharedContext,
+            // Bind a stored hook's uniqueness read to the caller's transaction
+            // connection so it does not re-enter the pool from inside the tx.
+            tx.getDrizzle()
           )
         );
       }
@@ -6603,7 +6643,10 @@ export class CollectionMutationService extends BaseService {
             entry,
             this.queryDatabaseFn,
             params.user,
-            sharedContext
+            sharedContext,
+            // Bind a stored hook's uniqueness read to the caller's transaction
+            // connection so it does not re-enter the pool from inside the tx.
+            tx.getDrizzle()
           )
         );
       }

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4370,15 +4370,19 @@ export class CollectionMutationService extends BaseService {
       // pooled read would take a second connection the transaction is holding,
       // which stalls against a small pool.
       const txExecutor = tx.getDrizzle<RelationshipDbExecutor>();
-      // 1. Check collection-level access FIRST
+      // 1. Check collection-level access FIRST. Forward the caller's
+      // `overrideAccess`/`routeAuthorized` (as the non-transaction `createEntry`
+      // does): a trusted write must hit the `overrideAccess` bypass rather than
+      // be re-evaluated against RBAC/stored rules, and a route-authorized write
+      // must skip the redundant coarse RBAC re-check.
       const accessDenied = await this.accessService.checkCollectionAccess(
         params.collectionName,
         "create",
         params.user,
         undefined,
         undefined,
-        undefined,
-        undefined,
+        params.overrideAccess,
+        params.routeAuthorized,
         undefined,
         undefined,
         txExecutor
@@ -4833,15 +4837,19 @@ export class CollectionMutationService extends BaseService {
         };
       }
 
-      // 1. Check collection-level access FIRST (with document for owner checks)
+      // 1. Check collection-level access FIRST (with document for owner checks).
+      // Forward the caller's `overrideAccess`/`routeAuthorized` (as the
+      // non-transaction `updateEntry` does): a trusted write must hit the
+      // `overrideAccess` bypass, and a route-authorized write must skip the
+      // redundant coarse RBAC re-check while stored rules still run.
       const accessDenied = await this.accessService.checkCollectionAccess(
         params.collectionName,
         "update",
         params.user,
         params.entryId,
         existingEntry,
-        undefined,
-        undefined,
+        params.overrideAccess,
+        params.routeAuthorized,
         undefined,
         undefined,
         txExecutor

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4698,6 +4698,9 @@ export class CollectionMutationService extends BaseService {
         data: entry,
         user: params.user,
         context: sharedContext,
+        // Bind an after-hook that reads via context.executor to the caller's
+        // transaction connection so it does not re-enter the pool from the tx.
+        executor: tx.getDrizzle(),
       });
 
       await this.hookService.hookRegistry.execute("afterCreate", afterContext);
@@ -5120,6 +5123,9 @@ export class CollectionMutationService extends BaseService {
         originalData: existingEntry,
         user: params.user,
         context: sharedContext,
+        // Bind an after-hook that reads via context.executor to the caller's
+        // transaction connection so it does not re-enter the pool from the tx.
+        executor: tx.getDrizzle(),
       });
 
       await this.hookService.hookRegistry.execute("afterUpdate", afterContext);
@@ -5386,6 +5392,9 @@ export class CollectionMutationService extends BaseService {
         data: entry,
         user: params.user,
         context: sharedContext,
+        // Bind an after-hook that reads via context.executor to the caller's
+        // transaction connection so it does not re-enter the pool from the tx.
+        executor: tx.getDrizzle(),
       });
 
       await this.hookService.hookRegistry.execute("afterDelete", afterContext);
@@ -5795,6 +5804,9 @@ export class CollectionMutationService extends BaseService {
           data: entry,
           user: params.user,
           context: sharedContext,
+          // Bind an after-hook that reads via context.executor to the caller's
+          // transaction connection so it does not re-enter the pool from the tx.
+          executor: tx.getDrizzle(),
         });
 
         await this.hookService.hookRegistry.execute(
@@ -6295,6 +6307,9 @@ export class CollectionMutationService extends BaseService {
           originalData: existingEntry,
           user: params.user,
           context: sharedContext,
+          // Bind an after-hook that reads via context.executor to the caller's
+          // transaction connection so it does not re-enter the pool from the tx.
+          executor: tx.getDrizzle(),
         });
 
         await this.hookService.hookRegistry.execute(
@@ -6626,6 +6641,9 @@ export class CollectionMutationService extends BaseService {
           data: entry,
           user: params.user,
           context: sharedContext,
+          // Bind an after-hook that reads via context.executor to the caller's
+          // transaction connection so it does not re-enter the pool from the tx.
+          executor: tx.getDrizzle(),
         });
 
         await this.hookService.hookRegistry.execute(

--- a/packages/nextly/src/domains/collections/services/collection-registry-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-registry-service.ts
@@ -132,9 +132,12 @@ export class CollectionRegistryService extends BaseRegistryService<
   }
 
   async getCollectionBySlug(
-    slug: string
+    slug: string,
+    // Optional transaction-bound executor so the lookup runs on the caller's
+    // transaction connection instead of taking a second pooled one.
+    executor?: unknown
   ): Promise<DynamicCollectionRecord | null> {
-    return this.getRecordBySlug(slug);
+    return this.getRecordBySlug(slug, executor);
   }
 
   async getCollection(slug: string): Promise<DynamicCollectionRecord> {

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts
@@ -337,8 +337,14 @@ export class DynamicCollectionRegistryService extends BaseService {
     };
   }
 
-  async getCollection(slug: string): Promise<unknown> {
-    const result = await this.db
+  async getCollection(slug: string, executor?: unknown): Promise<unknown> {
+    // Run on the caller's transaction executor when supplied so this metadata
+    // read does not take a second pooled connection from inside the caller's
+    // transaction (which can stall against a small pool); falls back to the
+    // pooled connection otherwise. The transaction-bound Drizzle instance is the
+    // same query-builder shape as `this.db`.
+    const db = executor ?? this.db;
+    const result = await db
       .select()
       .from(this.dynamicCollections)
       .where(eq(this.dynamicCollections.slug, slug))

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -763,10 +763,14 @@ export class DynamicCollectionService extends BaseService {
   }
 
   async getCollection(
-    name: string
+    name: string,
+    // Optional transaction-bound executor so the registry read runs on the
+    // caller's transaction connection instead of the pool; see the base
+    // registry service's `getRecordBySlug`.
+    executor?: unknown
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- callers index dialect-specific row shapes
   ): Promise<any> {
-    return this.registryService.getCollection(name);
+    return this.registryService.getCollection(name, executor);
   }
 
   async unregisterCollection(name: string): Promise<unknown> {

--- a/packages/nextly/src/domains/singles/__tests__/publish-enforcement.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/publish-enforcement.integration.test.ts
@@ -280,4 +280,41 @@ describe("single publish enforcement — authorize before create (integration)",
     );
     expect(ok.success).toBe(true);
   });
+
+  it("does not unpublish a Single on an explicit status: undefined write", async () => {
+    // An own `status: undefined` (Direct API / server / hook) names no status
+    // change; a published Single must stay published rather than being sanitized
+    // to NULL and unpublished without the gate.
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "branding",
+          status: true,
+          fields: [text({ name: "siteName" })],
+        }),
+      ],
+    });
+    const service =
+      current.getService<SingleEntryService>("singleEntryService");
+
+    await service.update(
+      "branding",
+      { siteName: "S", status: "published" },
+      { overrideAccess: true }
+    );
+
+    // A plain field edit that also carries an explicit undefined status.
+    const res = await service.update(
+      "branding",
+      { siteName: "changed", status: undefined },
+      { user: { id: "editor" }, routeAuthorized: true }
+    );
+    expect(res.success).toBe(true);
+
+    const row = await current.adapter.selectOne<{
+      status: string;
+      siteName: string;
+    }>("single_branding", {});
+    expect(row?.status).toBe("published");
+  });
 });

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -30,7 +30,10 @@ import type { RBACAccessControlService } from "../../../domains/auth/services/rb
 import { NextlyError } from "../../../errors/nextly-error";
 import type { HookRegistry } from "../../../hooks/hook-registry";
 import { keysToSnakeCase } from "../../../lib/case-conversion";
-import { resolvePublishTransition } from "../../../lib/status-transition";
+import {
+  resolvePublishTransition,
+  stripUndefinedStatus,
+} from "../../../lib/status-transition";
 import {
   AccessControlService,
   type CollectionAccessRules,
@@ -668,6 +671,11 @@ export class SingleMutationService extends BaseService {
       // left open before).
       const singleHasStatus =
         (singleMeta as { status?: boolean }).status === true;
+      // An explicit `status: undefined` (own key) names no status change; strip
+      // it so the transition gate and the write agree — a kept undefined status
+      // would be sanitized to SQL NULL and silently unpublish a published Single
+      // without the gate.
+      stripUndefinedStatus(currentData);
       const finalStatus = (currentData as { status?: unknown }).status;
       const isNonDefaultLocaleWrite =
         companion?.hasStatus === true &&

--- a/packages/nextly/src/hooks/context-builder.ts
+++ b/packages/nextly/src/hooks/context-builder.ts
@@ -65,6 +65,13 @@ export interface BuildContextOptions<T = any> {
     query?: Record<string, unknown>;
     nextly?: Nextly;
   };
+
+  /**
+   * Transaction-bound Drizzle executor forwarded onto the context, so hooks that
+   * read the database run on the caller's transaction connection instead of the
+   * pool (see {@link HookContext.executor}). Omitted outside a transaction.
+   */
+  executor?: unknown;
 }
 
 /**
@@ -137,6 +144,7 @@ export function buildContext<T = any>(
     user,
     context,
     req: options.req,
+    executor: options.executor,
   };
 }
 

--- a/packages/nextly/src/hooks/sanitization-hooks.ts
+++ b/packages/nextly/src/hooks/sanitization-hooks.ts
@@ -102,8 +102,13 @@ export function createSanitizationHook(
       const registryService = container.get<CollectionRegistryService>(
         "collectionRegistryService"
       );
+      // Run on the caller's transaction executor when the hook fires inside a
+      // transaction, so this metadata read does not take a second pooled
+      // connection while that transaction holds the only one (small/exhausted
+      // pool deadlock). Falls back to the pool outside a transaction.
       const collection = await registryService.getCollectionBySlug(
-        context.collection
+        context.collection,
+        context.executor
       );
       if (!collection) return;
 

--- a/packages/nextly/src/hooks/types.ts
+++ b/packages/nextly/src/hooks/types.ts
@@ -459,6 +459,16 @@ export interface BeforeOperationContext<T = any> {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- shared context is a general-purpose key-value store
   context: Record<string, any>;
+
+  /**
+   * Transaction-bound Drizzle executor for the write this hook participates in.
+   *
+   * Present only when the operation runs inside a caller-owned transaction; a
+   * `beforeOperation` hook that reads the database must use it so the read stays
+   * on the transaction's own connection instead of taking a second pooled one.
+   * See {@link HookContext.executor}. Undefined outside a transaction.
+   */
+  executor?: unknown;
 }
 
 /**

--- a/packages/nextly/src/hooks/types.ts
+++ b/packages/nextly/src/hooks/types.ts
@@ -232,6 +232,19 @@ export interface HookContext<T = any> {
      */
     nextly?: Nextly;
   };
+
+  /**
+   * Transaction-bound Drizzle executor for the write this hook participates in.
+   *
+   * Present only when the hook runs inside a caller-owned transaction (the
+   * transactional bulk / entry write paths). A hook that reads the database (for
+   * example the built-in sanitization hook, which loads field metadata) must use
+   * it so the read runs on the transaction's own connection instead of taking a
+   * second pooled one, which can stall against a small pool while the caller's
+   * transaction holds the only connection. Undefined outside a transaction, where
+   * the pooled connection is correct.
+   */
+  executor?: unknown;
 }
 
 /**

--- a/packages/nextly/src/lib/status-transition.ts
+++ b/packages/nextly/src/lib/status-transition.ts
@@ -51,3 +51,26 @@ export function resolvePublishTransition(
   if (wasPublished && !willBePublished) return "unpublish";
   return null;
 }
+
+/**
+ * Drop an explicit `status: undefined` own-property from a write payload.
+ *
+ * `resolvePublishTransition` treats an undefined next status as "no move", so the
+ * gate reads such a write as an ordinary update. But a write that KEEPS
+ * `status: undefined` in its payload can be sanitized to SQL `NULL` by some
+ * adapters (notably SQLite via the raw parameter list), which moves a published
+ * row OUT of published — an unpublish that never went through the
+ * `unpublish-<slug>` gate. Direct API / server callers and hooks can produce an
+ * own `status: undefined` (`{ status: maybeStatus }`), even though JSON REST
+ * cannot express it. Removing the key makes the write match the gate: an
+ * explicit undefined status leaves the stored value untouched, exactly like an
+ * omitted one. Mutates in place and returns the same object for convenience.
+ */
+export function stripUndefinedStatus<T extends Record<string, unknown>>(
+  data: T
+): T {
+  if ("status" in data && data.status === undefined) {
+    delete data.status;
+  }
+  return data;
+}

--- a/packages/nextly/src/services/collection-file-manager.ts
+++ b/packages/nextly/src/services/collection-file-manager.ts
@@ -30,7 +30,13 @@ export interface FileManagerConfig {
  * the column from `dynamic_collections` / `dynamic_singles` and forwards
  * a coerced boolean to FileManager's runtime generation.
  */
-export type CollectionMetadataFetcher = (collectionName: string) => Promise<{
+export type CollectionMetadataFetcher = (
+  collectionName: string,
+  // Optional transaction-bound executor so the metadata read runs on the
+  // caller's transaction connection instead of taking a second pooled one when
+  // schema loading happens inside a caller-owned transaction.
+  executor?: unknown
+) => Promise<{
   fields: FieldDefinition[];
   tableName: string;
   status?: boolean;
@@ -200,8 +206,14 @@ export class CollectionFileManager {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async loadDynamicSchema(collectionName: string): Promise<any> {
+  async loadDynamicSchema(
+    collectionName: string,
+    // Optional transaction-bound executor forwarded to the metadata fetcher when
+    // the runtime schema is not cached and must be read from the database inside
+    // a caller-owned transaction (see CollectionMetadataFetcher).
+    executor?: unknown
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): Promise<any> {
     const schemaKey = `dc_${collectionName.replace(/-/g, "_")}`;
     console.log(
       "[FileManager] loadDynamicSchema called for:",
@@ -228,7 +240,7 @@ export class CollectionFileManager {
       );
 
       try {
-        const metadata = await this.metadataFetcher(collectionName);
+        const metadata = await this.metadataFetcher(collectionName, executor);
         if (metadata && metadata.fields) {
           const dialect = this.adapter.dialect;
           const tableName =

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -102,41 +102,49 @@ export class CollectionsHandler {
     // Set up the adapter and metadata fetcher for runtime schema generation
     // This allows UI-created collections to work without pre-compiled TypeScript schemas
     this.fileManager.setAdapter(adapter);
-    this.fileManager.setMetadataFetcher(async (collectionName: string) => {
-      try {
-        const result = await adapter.selectOne<{
-          fields: string;
-          tableName: string;
-          status: boolean | number | null;
-          localized: boolean | number | null;
-        }>("dynamic_collections", {
-          where: {
-            and: [{ column: "slug", op: "=", value: collectionName }],
-          },
-        });
+    this.fileManager.setMetadataFetcher(
+      async (collectionName: string, executor?: unknown) => {
+        try {
+          // Runs on the caller's transaction connection when supplied so an
+          // uncached runtime-schema load inside a transaction stays on it.
+          const result = await adapter.selectOne<{
+            fields: string;
+            tableName: string;
+            status: boolean | number | null;
+            localized: boolean | number | null;
+          }>(
+            "dynamic_collections",
+            {
+              where: {
+                and: [{ column: "slug", op: "=", value: collectionName }],
+              },
+            },
+            executor
+          );
 
-        if (result) {
-          const fields =
-            typeof result.fields === "string"
-              ? JSON.parse(result.fields)
-              : result.fields;
-          return {
-            fields,
-            tableName: result.tableName,
-            // SQLite returns 0/1 for booleans; PG/MySQL return real booleans.
-            status: result.status === true || result.status === 1,
-            // i18n M4: forward the localized flag so loadCompanionSchema builds the companion.
-            localized: result.localized === true || result.localized === 1,
-          };
+          if (result) {
+            const fields =
+              typeof result.fields === "string"
+                ? JSON.parse(result.fields)
+                : result.fields;
+            return {
+              fields,
+              tableName: result.tableName,
+              // SQLite returns 0/1 for booleans; PG/MySQL return real booleans.
+              status: result.status === true || result.status === 1,
+              // i18n M4: forward the localized flag so loadCompanionSchema builds the companion.
+              localized: result.localized === true || result.localized === 1,
+            };
+          }
+        } catch (error) {
+          console.error(
+            "[CollectionsHandler] Failed to fetch collection metadata:",
+            error
+          );
         }
-      } catch (error) {
-        console.error(
-          "[CollectionsHandler] Failed to fetch collection metadata:",
-          error
-        );
+        return null;
       }
-      return null;
-    });
+    );
 
     this.relationshipService = new CollectionRelationshipService(
       adapter,

--- a/packages/nextly/src/services/lib/permissions-executor-cache.integration.test.ts
+++ b/packages/nextly/src/services/lib/permissions-executor-cache.integration.test.ts
@@ -1,0 +1,108 @@
+/**
+ * A permission check that runs on a caller-supplied transaction executor reads
+ * through that caller's still-open (uncommitted) transaction, so its result must
+ * be neither served from nor promoted into the process-wide permission cache: if
+ * the transaction rolled back, a grant or denial that never committed would
+ * otherwise be reused by later, non-transactional requests for the cache TTL.
+ *
+ * This pins that on a real database. The cache is exercised directly: a decision
+ * is cached through a pooled check, the underlying grant is then removed WITHOUT
+ * invalidating the cache (a raw row delete, not the role service), and:
+ *   - a pooled check still returns the stale cached decision (cache is live), but
+ *   - an executor-backed check recomputes fresh (bypasses the cache read), and
+ *   - it does NOT overwrite the cache (a later pooled check is still the stale
+ *     value), proving the executor path skips the cache write too.
+ */
+import { createTestNextly, type TestNextly } from "nextly/testing";
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { getDialectTables } from "../../database/index";
+
+import { hasPermission } from "./permissions";
+
+let harness: TestNextly | undefined;
+
+// A raw Drizzle handle for seeding/removing role rows without going through the
+// role service, whose mutations invalidate the permission cache — the whole
+// point here is to leave a stale cache entry in place.
+function rawDb() {
+  return harness!.adapter.getDrizzle() as unknown as {
+    insert: (table: unknown) => { values: (row: unknown) => Promise<unknown> };
+    delete: (table: unknown) => {
+      where: (cond: unknown) => Promise<unknown>;
+    };
+  };
+}
+
+afterEach(async () => {
+  await harness?.destroy();
+  harness = undefined;
+});
+
+beforeEach(async () => {
+  harness = await createTestNextly();
+});
+
+describe("permission cache — transaction executor bypass (integration)", () => {
+  it("bypasses the process-wide cache for executor-backed checks (read and write)", async () => {
+    const db = rawDb();
+    const tables = getDialectTables();
+
+    // A permission and a role that grants it.
+    const readPosts = await harness!.nextly.permissions.create({
+      data: {
+        action: "read",
+        resource: "posts",
+        name: "Read posts",
+        slug: "read-posts",
+      },
+    });
+    const viewer = await harness!.nextly.roles.create({
+      data: {
+        name: "Viewer",
+        slug: "viewer",
+        permissionIds: [readPosts.item.id],
+      },
+    });
+
+    // A unique user id: the permission cache is process-wide and outlives a
+    // single harness, so a shared id could collide with another test's entry.
+    const userId = "cache-exec-user";
+    await db.insert(tables.users).values({
+      id: userId,
+      email: "cache-exec@example.com",
+      name: "cache-exec",
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(tables.userRoles).values({
+      id: "cache-exec-user-role",
+      userId,
+      roleId: viewer.item.id,
+      createdAt: new Date(),
+    });
+
+    // 1. Pooled check grants and caches the decision.
+    expect(await hasPermission(userId, "read", "posts")).toBe(true);
+
+    // 2. Remove the grant WITHOUT invalidating the cache (raw delete).
+    await db
+      .delete(tables.userRoles)
+      .where(eq(tables.userRoles.userId, userId));
+
+    // 3. A pooled check still returns the stale cached grant — the cache is live.
+    expect(await hasPermission(userId, "read", "posts")).toBe(true);
+
+    // 4. An executor-backed check bypasses the cache READ and recomputes against
+    //    the current rows: the grant is gone, so it is denied.
+    const executor = harness!.adapter.getDrizzle();
+    expect(await hasPermission(userId, "read", "posts", executor)).toBe(false);
+
+    // 5. The executor-backed check must NOT have written its `false` into the
+    //    cache: a later pooled check still sees the earlier stale grant, proving
+    //    the executor path skips the cache write too.
+    expect(await hasPermission(userId, "read", "posts")).toBe(true);
+  });
+});

--- a/packages/nextly/src/services/lib/permissions.ts
+++ b/packages/nextly/src/services/lib/permissions.ts
@@ -36,6 +36,35 @@ function getDb(): unknown {
   return adapter.getDrizzle();
 }
 
+/**
+ * A minimal structural view of the Drizzle query builder used by the RBAC reads
+ * below. It exists so the pooled or transaction-bound executor can be typed for
+ * the `select(...).from(...).where(...) / .innerJoin(...) / .limit(...)` chain
+ * these queries use — instead of casting the executor to `any` — while staying
+ * dialect-agnostic (the concrete builder differs per driver). Each chain awaits
+ * to an array of rows; callers narrow a row to the columns they projected.
+ */
+type RbacRow = Record<string, unknown>;
+interface RbacSelectChain extends Promise<RbacRow[]> {
+  from(table: unknown): RbacSelectChain;
+  innerJoin(table: unknown, on: unknown): RbacSelectChain;
+  where(condition: unknown): RbacSelectChain;
+  limit(count: number): RbacSelectChain;
+}
+interface RbacQueryExecutor {
+  select(projection?: Record<string, unknown>): RbacSelectChain;
+}
+
+/**
+ * Resolve the executor for an RBAC read as the typed query builder above:
+ * the caller's transaction-bound instance when supplied, otherwise the pooled
+ * connection. `getDrizzle()` is typed `unknown`, so the cast narrows that opaque
+ * value to the exact chain surface used here (no `any`).
+ */
+function rbacQuery(executor?: unknown): RbacQueryExecutor {
+  return (executor ?? getDb()) as RbacQueryExecutor;
+}
+
 function getAdapter(): DrizzleAdapter {
   return container.get<DrizzleAdapter>("adapter");
 }
@@ -289,8 +318,7 @@ class PermissionChecker {
     while (queue.length > 0) {
       const batch = queue.splice(0, 50);
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const childRows = await ((executor ?? getDb()) as any)
+      const childRows = await rbacQuery(executor)
         .select({ childRoleId: roleInherits.childRoleId })
         .from(roleInherits)
         .where(inArray(roleInherits.parentRoleId, batch));
@@ -323,8 +351,7 @@ class PermissionChecker {
   ): Promise<Set<string>> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { userRoles } = this.t as any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const rows = await ((executor ?? getDb()) as any)
+    const rows = await rbacQuery(executor)
       .select({ roleId: userRoles.roleId })
       .from(userRoles)
       .where(eq(userRoles.userId, userId));
@@ -346,18 +373,15 @@ class PermissionChecker {
 
     // Super Admin bypass: any role with slug 'super-admin' grants all permissions
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const superAdmin = await ((executor ?? getDb()) as any)
+      const superAdmin = await rbacQuery(executor)
         .select({ id: roles.id })
         .from(roles)
         .where(and(inArray(roles.id, roleIds), eq(roles.slug, "super-admin")))
         .limit(1);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      if ((superAdmin as any[]).length > 0) return true;
+      if (superAdmin.length > 0) return true;
 
       // Step 1: resolve permission id by action+resource
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const perm = await ((executor ?? getDb()) as any)
+      const perm = await rbacQuery(executor)
         .select({ id: permissions.id })
         .from(permissions)
         .where(
@@ -367,12 +391,11 @@ class PermissionChecker {
           )
         )
         .limit(1);
-      const permId = (perm?.[0]?.id ?? null) as string | null;
+      const permId = (perm[0]?.id ?? null) as string | null;
       if (!permId) return false;
 
       // Step 2: check existence of mapping for any of the roles
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const rows = await ((executor ?? getDb()) as any)
+      const rows = await rbacQuery(executor)
         .select({ id: rolePermissions.id })
         .from(rolePermissions)
         .where(
@@ -383,8 +406,7 @@ class PermissionChecker {
         )
         .limit(1);
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return (rows as any[]).length > 0;
+      return rows.length > 0;
     } catch {
       return false;
     }
@@ -515,8 +537,7 @@ export async function listEffectivePermissions(
     const { rolePermissions, permissions } = t as any;
 
     // Join role_permissions with permissions to get all permissions for user's roles
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const rows = await ((executor ?? getDb()) as any)
+    const rows = await rbacQuery(executor)
       .select({
         action: permissions.action,
         resource: permissions.resource,
@@ -699,8 +720,7 @@ export async function isSuperAdmin(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { roles } = t as any;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const superAdmin = await ((executor ?? getDb()) as any)
+    const superAdmin = await rbacQuery(executor)
       .select({ id: roles.id })
       .from(roles)
       .where(
@@ -711,8 +731,7 @@ export async function isSuperAdmin(
       )
       .limit(1);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = (superAdmin as any[]).length > 0;
+    const result = superAdmin.length > 0;
 
     // Populate the process-wide cache only for pooled checks; an executor-backed
     // result reflects the caller's uncommitted transaction (see the param note).
@@ -855,8 +874,7 @@ export async function listRoleSlugsForUser(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { roles } = t as any;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const rows = await ((executor ?? getDb()) as any)
+    const rows = await rbacQuery(executor)
       .select({ slug: roles.slug })
       .from(roles)
       .where(inArray(roles.id, Array.from(roleIds)));

--- a/packages/nextly/src/services/lib/permissions.ts
+++ b/packages/nextly/src/services/lib/permissions.ts
@@ -97,7 +97,13 @@ class PermissionChecker {
   async hasPermission(
     userId: string,
     action: string,
-    resource: string
+    resource: string,
+    // A transaction-bound Drizzle executor, supplied when the caller is already
+    // inside a write transaction so the role/permission reads run on that
+    // transaction's own connection instead of taking a second pooled one, which
+    // can stall against a small pool while the caller's transaction holds one.
+    // Defaults to the pooled connection when omitted.
+    executor?: unknown
   ): Promise<boolean> {
     if (!userId || !action || !resource) {
       getAuthLogger()?.log?.("debug", {
@@ -134,8 +140,12 @@ class PermissionChecker {
       userIdToKeys.get(userId)?.delete(key);
     }
 
-    // Tier 2: Database cache (fast ~3-5ms)
-    if (this.cacheService) {
+    // Tier 2: Database cache (fast ~3-5ms). Skipped when a transaction executor
+    // is supplied: this lookup is itself a pooled query, so running it inside the
+    // caller's transaction would re-enter the pool. The in-memory tiers above
+    // still serve hits, and a miss falls through to a fresh computation on the
+    // supplied executor.
+    if (this.cacheService && !executor) {
       try {
         const dbCached = await this.cacheService.getCachedPermission(
           userId,
@@ -164,12 +174,13 @@ class PermissionChecker {
 
     // Tier 3: Fresh computation (~10ms)
     try {
-      const roleIds = await this.getAllRoleIdsForUser(userId);
+      const roleIds = await this.getAllRoleIdsForUser(userId, executor);
 
       if (roleIds.size === 0) {
         this.memo.set(key, false);
-        // Store negative result in DB cache
-        if (this.cacheService) {
+        // Store negative result in DB cache (skipped under a transaction executor
+        // — the write is a pooled query the caller's transaction would block on).
+        if (this.cacheService && !executor) {
           void this.cacheService.setCachedPermission(
             userId,
             action,
@@ -183,15 +194,17 @@ class PermissionChecker {
       const allowed = await this.roleSetHasPermission(
         Array.from(roleIds),
         action,
-        resource
+        resource,
+        executor
       );
 
       // Populate both cache tiers
       this.memo.set(key, allowed);
       setCacheEntry(key, allowed, userId, Array.from(roleIds));
 
-      // Async write to DB cache (don't block response)
-      if (this.cacheService) {
+      // Async write to DB cache (don't block response). Skipped under a
+      // transaction executor for the same pooled-query reason as the read above.
+      if (this.cacheService && !executor) {
         void this.cacheService.setCachedPermission(
           userId,
           action,
@@ -237,8 +250,12 @@ class PermissionChecker {
     return true;
   }
 
-  async getAllRoleIdsForUser(userId: string): Promise<Set<string>> {
-    const direct = await this.getDirectRoleIds(userId);
+  async getAllRoleIdsForUser(
+    userId: string,
+    // Optional transaction-bound executor; see `hasPermission`.
+    executor?: unknown
+  ): Promise<Set<string>> {
+    const direct = await this.getDirectRoleIds(userId, executor);
     if (direct.size === 0) return direct;
 
     const all = new Set<string>(direct);
@@ -259,7 +276,7 @@ class PermissionChecker {
       const batch = queue.splice(0, 50);
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const childRows = await (getDb() as any)
+      const childRows = await ((executor ?? getDb()) as any)
         .select({ childRoleId: roleInherits.childRoleId })
         .from(roleInherits)
         .where(inArray(roleInherits.parentRoleId, batch));
@@ -285,11 +302,15 @@ class PermissionChecker {
     return all;
   }
 
-  private async getDirectRoleIds(userId: string): Promise<Set<string>> {
+  private async getDirectRoleIds(
+    userId: string,
+    // Optional transaction-bound executor; see `hasPermission`.
+    executor?: unknown
+  ): Promise<Set<string>> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { userRoles } = this.t as any;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const rows = await (getDb() as any)
+    const rows = await ((executor ?? getDb()) as any)
       .select({ roleId: userRoles.roleId })
       .from(userRoles)
       .where(eq(userRoles.userId, userId));
@@ -301,7 +322,9 @@ class PermissionChecker {
   private async roleSetHasPermission(
     roleIds: string[],
     action: string,
-    resource: string
+    resource: string,
+    // Optional transaction-bound executor; see `hasPermission`.
+    executor?: unknown
   ): Promise<boolean> {
     if (roleIds.length === 0) return false;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -310,7 +333,7 @@ class PermissionChecker {
     // Super Admin bypass: any role with slug 'super-admin' grants all permissions
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const superAdmin = await (getDb() as any)
+      const superAdmin = await ((executor ?? getDb()) as any)
         .select({ id: roles.id })
         .from(roles)
         .where(and(inArray(roles.id, roleIds), eq(roles.slug, "super-admin")))
@@ -320,7 +343,7 @@ class PermissionChecker {
 
       // Step 1: resolve permission id by action+resource
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const perm = await (getDb() as any)
+      const perm = await ((executor ?? getDb()) as any)
         .select({ id: permissions.id })
         .from(permissions)
         .where(
@@ -335,7 +358,7 @@ class PermissionChecker {
 
       // Step 2: check existence of mapping for any of the roles
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const rows = await (getDb() as any)
+      const rows = await ((executor ?? getDb()) as any)
         .select({ id: rolePermissions.id })
         .from(rolePermissions)
         .where(
@@ -398,11 +421,14 @@ function setCacheEntry(
 export async function hasPermission(
   userId: string,
   action: string,
-  resource: string
+  resource: string,
+  // Optional transaction-bound executor so the reads run on the caller's
+  // transaction connection instead of the pool; see the checker method above.
+  executor?: unknown
 ): Promise<boolean> {
   try {
     const checker = new PermissionChecker();
-    return await checker.hasPermission(userId, action, resource);
+    return await checker.hasPermission(userId, action, resource, executor);
   } catch {
     getAuthLogger()?.log?.("error", {
       category: "auth",
@@ -449,7 +475,9 @@ export async function hasAllPermissions(
  * Uses existing caching and database query optimization.
  */
 export async function listEffectivePermissions(
-  userId: string
+  userId: string,
+  // Optional transaction-bound executor; see `hasPermission`.
+  executor?: unknown
 ): Promise<string[]> {
   if (!userId) {
     getAuthLogger()?.log?.("debug", {
@@ -462,7 +490,7 @@ export async function listEffectivePermissions(
 
   try {
     const checker = new PermissionChecker();
-    const roleIds = await checker.getAllRoleIdsForUser(userId);
+    const roleIds = await checker.getAllRoleIdsForUser(userId, executor);
 
     if (roleIds.size === 0) {
       return [];
@@ -474,7 +502,7 @@ export async function listEffectivePermissions(
 
     // Join role_permissions with permissions to get all permissions for user's roles
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const rows = await (getDb() as any)
+    const rows = await ((executor ?? getDb()) as any)
       .select({
         action: permissions.action,
         resource: permissions.resource,
@@ -619,7 +647,14 @@ const SUPER_ADMIN_CACHE_TTL_MS = 60_000; // 60 seconds
  * }
  * ```
  */
-export async function isSuperAdmin(userId: string): Promise<boolean> {
+export async function isSuperAdmin(
+  userId: string,
+  // Optional transaction-bound executor so the role read runs on the caller's
+  // transaction connection instead of the pool; see `hasPermission`. The
+  // in-memory super-admin cache below is unaffected — a hit still short-circuits
+  // before any DB read.
+  executor?: unknown
+): Promise<boolean> {
   if (!userId) return false;
 
   // Check in-memory cache
@@ -630,7 +665,7 @@ export async function isSuperAdmin(userId: string): Promise<boolean> {
 
   try {
     const checker = new PermissionChecker();
-    const roleIds = await checker.getAllRoleIdsForUser(userId);
+    const roleIds = await checker.getAllRoleIdsForUser(userId, executor);
 
     if (roleIds.size === 0) {
       superAdminCache.set(userId, {
@@ -645,7 +680,7 @@ export async function isSuperAdmin(userId: string): Promise<boolean> {
     const { roles } = t as any;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const superAdmin = await (getDb() as any)
+    const superAdmin = await ((executor ?? getDb()) as any)
       .select({ id: roles.id })
       .from(roles)
       .where(
@@ -779,12 +814,16 @@ export async function containsSuperAdminRole(
  * @param userId - The user ID
  * @returns Array of role slugs (e.g., ['super-admin', 'editor'])
  */
-export async function listRoleSlugsForUser(userId: string): Promise<string[]> {
+export async function listRoleSlugsForUser(
+  userId: string,
+  // Optional transaction-bound executor; see `hasPermission`.
+  executor?: unknown
+): Promise<string[]> {
   if (!userId) return [];
 
   try {
     const checker = new PermissionChecker();
-    const roleIds = await checker.getAllRoleIdsForUser(userId);
+    const roleIds = await checker.getAllRoleIdsForUser(userId, executor);
 
     if (roleIds.size === 0) return [];
 
@@ -793,7 +832,7 @@ export async function listRoleSlugsForUser(userId: string): Promise<string[]> {
     const { roles } = t as any;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const rows = await (getDb() as any)
+    const rows = await ((executor ?? getDb()) as any)
       .select({ slug: roles.slug })
       .from(roles)
       .where(inArray(roles.id, Array.from(roleIds)));

--- a/packages/nextly/src/services/lib/permissions.ts
+++ b/packages/nextly/src/services/lib/permissions.ts
@@ -118,33 +118,40 @@ class PermissionChecker {
 
     const key = `${userId}|${action}|${resource}`;
 
-    // Tier 1: In-memory instance cache (ultra-fast <1ms)
-    const cached = this.memo.get(key);
-    if (typeof cached === "boolean") return cached;
+    // Skip EVERY cache tier when a transaction executor is supplied. Such a check
+    // reads through the caller's still-open (uncommitted) transaction, so its
+    // result must be neither served from nor promoted into the process-wide
+    // caches: if that transaction rolls back, a grant or denial that never
+    // committed would otherwise be reused by later, non-transactional requests
+    // for the cache TTL. An executor-backed check always computes fresh below.
+    if (!executor) {
+      // Tier 1: In-memory instance cache (ultra-fast <1ms)
+      const cached = this.memo.get(key);
+      if (typeof cached === "boolean") return cached;
 
-    // Tier 1b: Process-wide LRU cache (<1ms)
-    const hit = cache.get(key);
-    if (hit) {
-      if (hit.expiresAt > Date.now()) {
-        this.memo.set(key, hit.value);
-        // refresh LRU by deleting+setting
+      // Tier 1b: Process-wide LRU cache (<1ms)
+      const hit = cache.get(key);
+      if (hit) {
+        if (hit.expiresAt > Date.now()) {
+          this.memo.set(key, hit.value);
+          // refresh LRU by deleting+setting
+          cache.delete(key);
+          cache.set(key, hit);
+          return hit.value;
+        }
+        // expired -> clear reverse maps
         cache.delete(key);
-        cache.set(key, hit);
-        return hit.value;
+        const rids = keyToRoleIds.get(key);
+        keyToRoleIds.delete(key);
+        if (rids) for (const rid of rids) roleIdToKeys.get(rid)?.delete(key);
+        userIdToKeys.get(userId)?.delete(key);
       }
-      // expired -> clear reverse maps
-      cache.delete(key);
-      const rids = keyToRoleIds.get(key);
-      keyToRoleIds.delete(key);
-      if (rids) for (const rid of rids) roleIdToKeys.get(rid)?.delete(key);
-      userIdToKeys.get(userId)?.delete(key);
     }
 
     // Tier 2: Database cache (fast ~3-5ms). Skipped when a transaction executor
     // is supplied: this lookup is itself a pooled query, so running it inside the
-    // caller's transaction would re-enter the pool. The in-memory tiers above
-    // still serve hits, and a miss falls through to a fresh computation on the
-    // supplied executor.
+    // caller's transaction would re-enter the pool (and by the rule above must
+    // not serve a cached decision to a transaction-scoped check anyway).
     if (this.cacheService && !executor) {
       try {
         const dbCached = await this.cacheService.getCachedPermission(
@@ -177,17 +184,20 @@ class PermissionChecker {
       const roleIds = await this.getAllRoleIdsForUser(userId, executor);
 
       if (roleIds.size === 0) {
-        this.memo.set(key, false);
-        // Store negative result in DB cache (skipped under a transaction executor
-        // — the write is a pooled query the caller's transaction would block on).
-        if (this.cacheService && !executor) {
-          void this.cacheService.setCachedPermission(
-            userId,
-            action,
-            resource,
-            false,
-            []
-          );
+        // Cache tiers are populated only for pooled (committed-view) checks; an
+        // executor-backed result must not leak into them (see the top-of-method
+        // skip). The DB write is also a pooled query the transaction would block on.
+        if (!executor) {
+          this.memo.set(key, false);
+          if (this.cacheService) {
+            void this.cacheService.setCachedPermission(
+              userId,
+              action,
+              resource,
+              false,
+              []
+            );
+          }
         }
         return false;
       }
@@ -198,9 +208,13 @@ class PermissionChecker {
         executor
       );
 
-      // Populate both cache tiers
-      this.memo.set(key, allowed);
-      setCacheEntry(key, allowed, userId, Array.from(roleIds));
+      // Populate the cache tiers only for pooled checks. An executor-backed
+      // result reflects the caller's uncommitted transaction and must not be
+      // promoted into the process-wide caches (see the top-of-method skip).
+      if (!executor) {
+        this.memo.set(key, allowed);
+        setCacheEntry(key, allowed, userId, Array.from(roleIds));
+      }
 
       // Async write to DB cache (don't block response). Skipped under a
       // transaction executor for the same pooled-query reason as the read above.
@@ -650,17 +664,21 @@ const SUPER_ADMIN_CACHE_TTL_MS = 60_000; // 60 seconds
 export async function isSuperAdmin(
   userId: string,
   // Optional transaction-bound executor so the role read runs on the caller's
-  // transaction connection instead of the pool; see `hasPermission`. The
-  // in-memory super-admin cache below is unaffected — a hit still short-circuits
-  // before any DB read.
+  // transaction connection instead of the pool; see `hasPermission`. When
+  // supplied, the process-wide super-admin cache is bypassed for both read and
+  // write: the check reads through the caller's uncommitted transaction, so its
+  // result must not be served from — nor promoted into — a cache shared with
+  // later requests (a rolled-back transaction would otherwise poison it).
   executor?: unknown
 ): Promise<boolean> {
   if (!userId) return false;
 
-  // Check in-memory cache
-  const cached = superAdminCache.get(userId);
-  if (cached && cached.expiresAt > Date.now()) {
-    return cached.value;
+  // Check in-memory cache (only for pooled, committed-view checks).
+  if (!executor) {
+    const cached = superAdminCache.get(userId);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value;
+    }
   }
 
   try {
@@ -668,10 +686,12 @@ export async function isSuperAdmin(
     const roleIds = await checker.getAllRoleIdsForUser(userId, executor);
 
     if (roleIds.size === 0) {
-      superAdminCache.set(userId, {
-        value: false,
-        expiresAt: Date.now() + SUPER_ADMIN_CACHE_TTL_MS,
-      });
+      if (!executor) {
+        superAdminCache.set(userId, {
+          value: false,
+          expiresAt: Date.now() + SUPER_ADMIN_CACHE_TTL_MS,
+        });
+      }
       return false;
     }
 
@@ -694,15 +714,19 @@ export async function isSuperAdmin(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result = (superAdmin as any[]).length > 0;
 
-    superAdminCache.set(userId, {
-      value: result,
-      expiresAt: Date.now() + SUPER_ADMIN_CACHE_TTL_MS,
-    });
+    // Populate the process-wide cache only for pooled checks; an executor-backed
+    // result reflects the caller's uncommitted transaction (see the param note).
+    if (!executor) {
+      superAdminCache.set(userId, {
+        value: result,
+        expiresAt: Date.now() + SUPER_ADMIN_CACHE_TTL_MS,
+      });
 
-    // Evict oldest if cache grows too large
-    if (superAdminCache.size > 1000) {
-      const oldest = superAdminCache.keys().next().value;
-      if (oldest) superAdminCache.delete(oldest);
+      // Evict oldest if cache grows too large
+      if (superAdminCache.size > 1000) {
+        const oldest = superAdminCache.keys().next().value;
+        if (oldest) superAdminCache.delete(oldest);
+      }
     }
 
     return result;

--- a/packages/nextly/src/shared/types/access.ts
+++ b/packages/nextly/src/shared/types/access.ts
@@ -205,4 +205,11 @@ export interface CheckAccessParams {
   resource: string;
   /** Optional code-defined access control from defineCollection/defineSingle */
   codeAccess?: CollectionAccessControl | SingleAccessControl;
+  /**
+   * Optional transaction-bound Drizzle executor. Supplied when the caller is
+   * already inside a write transaction so the role/permission reads run on that
+   * transaction's own connection rather than taking a second pooled one, which
+   * can stall against a small pool. Defaults to the pooled connection.
+   */
+  executor?: unknown;
 }


### PR DESCRIPTION
Two follow-up hardening fixes for the publish/unpublish permission gate shipped in #290, delivered as one PR.

## 1. Explicit `status: undefined` no longer silently unpublishes

A write payload that carries an explicit `status: undefined` own-property — something a Direct API call, a Server Action, or a hook can produce (`{ status: maybeStatus }`), though JSON REST cannot express it — is now stripped before the write.

`resolvePublishTransition(prev, undefined)` already reads such a write as "no status change", but keeping the key in the payload let some adapters sanitize `undefined` to a SQL `NULL` (notably SQLite via the raw parameter list). That moved a published row out of published **without** passing the `unpublish-<slug>` gate. Stripping the key makes the write match the gate: an explicit undefined status leaves the stored value untouched, exactly like an omitted one.

- New `stripUndefinedStatus` helper in `status-transition.ts`, wired into all collection create/update paths and the single update path.

## 2. Publish RBAC checks are transaction-bound

The transactional bulk create/update paths (`createEntriesInTransaction` / `updateEntriesInTransaction`) resolve the publish/unpublish authorization from **inside** a caller-owned transaction. Previously the RBAC role/permission reads and the collection-metadata read went back to the connection **pool** from inside that transaction, so a bulk write could stall against a small or exhausted pool (the transaction holds a connection the pooled read waits for).

The read chain now threads an **optional** transaction-bound executor, defaulting to the pooled connection (fully backward-compatible):

`resolveTransitionAuthorization` → `checkCollectionAccess` → `RBACAccessControlService.checkAccess` → `isSuperAdmin` / `hasPermission` / `buildContext` and their role/permission queries in `permissions.ts` (`executor ?? getDb()`), plus the collection-metadata read. The in-transaction bulk variants and the direct in-transaction entry fallbacks pass `tx.getDrizzle()`. The Tier-2 DB permission cache is skipped under an executor (it is itself a pooled query); the in-memory tiers still serve hits.

## Tests

- `publish-enforcement-rbac` / `publish-enforcement.integration` (singles): new load-bearing tests that a write carrying `status: undefined` does **not** unpublish a published row.
- `publish-enforcement-pool-reentry.integration` (new, Postgres): a caller-owned transaction on a single-connection pool (`pool.max = 1`) runs the publish RBAC check on the transaction's own connection and completes. Proven load-bearing by breaking it (drop the executor → the read re-enters the pool and deadlocks, caught by a timeout). Self-skips without a Postgres URL.

All publish-enforcement, api-key-scope, owner-only, TOCTOU, and permission-inheritance suites pass (42 tests). The 3 pre-existing stale-mock failures in `collection-access.test.ts` reproduce unchanged on the clean base and are not touched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented published records from being unintentionally transitioned to draft when updates include `status: undefined` (including when introduced via hooks).
  * Avoided transaction hangs/deadlocks by ensuring transaction-scoped reads use the caller’s transaction connection.
* **Enhancements**
  * Added executor-aware access-control, permission checks, and collection/dynamic-collection metadata reads across hook and authorization flows (including executor-bound uniqueness validation).
  * Executor-backed permission checks now bypass shared caches to avoid stale results from uncommitted transactions.
* **Tests**
  * Added/extended integration coverage for publish enforcement, transaction safety with single-connection pools, and executor-aware permission-cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->