### PR TITLE
feat(nextly): webhook endpoint test-ping and delivery redeliver

### DIFF
--- a/.changeset/webhook-test-redeliver.md
+++ b/.changeset/webhook-test-redeliver.md
@@ -1,0 +1,35 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/ui": patch
+---
+
+Test a webhook endpoint and re-send a past delivery over the REST API.
+
+`POST /api/webhooks/:id/test` sends a signed synthetic ping to the endpoint and
+reports whether it was reachable and accepted (status, latency, response
+snippet), so a receiver can be verified — before or after it is enabled —
+without producing a real event: the test writes nothing to the outbox or the
+delivery log.
+
+`POST /api/webhooks/:id/deliveries/:deliveryId/redeliver` re-attempts a specific
+past delivery from its stored event payload. The existing delivery row is
+re-armed for another attempt (its retry budget reset, its attempt history kept)
+and the drain is nudged so it goes out promptly; the outcome then shows in the
+delivery log. Both actions require the webhook update permission and an
+interactive session.

--- a/.changeset/webhook-test-redeliver.md
+++ b/.changeset/webhook-test-redeliver.md
@@ -32,6 +32,6 @@ past delivery from its stored event payload. The existing delivery row is
 re-armed for another attempt (its retry budget reset, its attempt history kept)
 under a row lock so a delivery that is still being sent is reported as a conflict
 rather than sent twice, and the drain is nudged so it goes out promptly; the
-outcome then shows in the delivery log. A delivery on a disabled or deleted
-endpoint is refused. Both actions require the webhook update permission and an
-interactive session.
+outcome then shows in the delivery log. An unknown delivery or endpoint id is a
+not-found, while a delivery on a disabled or deleted endpoint is a conflict. Both
+actions require the webhook update permission and an interactive session.

--- a/.changeset/webhook-test-redeliver.md
+++ b/.changeset/webhook-test-redeliver.md
@@ -30,6 +30,8 @@ delivery log.
 `POST /api/webhooks/:id/deliveries/:deliveryId/redeliver` re-attempts a specific
 past delivery from its stored event payload. The existing delivery row is
 re-armed for another attempt (its retry budget reset, its attempt history kept)
-and the drain is nudged so it goes out promptly; the outcome then shows in the
-delivery log. Both actions require the webhook update permission and an
+under a row lock so a delivery that is still being sent is reported as a conflict
+rather than sent twice, and the drain is nudged so it goes out promptly; the
+outcome then shows in the delivery log. A delivery on a disabled or deleted
+endpoint is refused. Both actions require the webhook update permission and an
 interactive session.

--- a/packages/nextly/src/api/webhooks.test.ts
+++ b/packages/nextly/src/api/webhooks.test.ts
@@ -23,6 +23,7 @@ vi.mock("../init", () => ({
 vi.mock("../di", () => ({
   container: {
     get: vi.fn(),
+    has: vi.fn().mockReturnValue(false),
   },
 }));
 
@@ -34,7 +35,9 @@ import {
   deleteWebhook,
   getWebhookById,
   listWebhooks,
+  redeliverWebhookDelivery,
   revealWebhookSecret,
+  testWebhookEndpoint,
   updateWebhook,
 } from "./webhooks";
 
@@ -361,5 +364,102 @@ describe("revealWebhookSecret", () => {
 
     expect(res.status).toBe(403);
     expect(revealSecrets).not.toHaveBeenCalled();
+  });
+});
+
+/** Route each container.get to a named service impl. */
+const withServices = (map: Record<string, unknown>): void => {
+  (container.get as ReturnType<typeof vi.fn>).mockImplementation(
+    (key: string) => map[key]
+  );
+};
+
+describe("testWebhookEndpoint", () => {
+  it("sends a test and returns the probe result via respondAction", async () => {
+    asSession();
+    const testEndpoint = vi.fn().mockResolvedValue({
+      delivered: true,
+      statusCode: 200,
+      latencyMs: 42,
+    });
+    withService({ testEndpoint });
+
+    const res = await testWebhookEndpoint(
+      new Request("http://x/api/webhooks/wh_1/test", { method: "POST" }),
+      "wh_1"
+    );
+
+    expect(res.status).toBe(200);
+    expect(testEndpoint).toHaveBeenCalledWith("wh_1");
+    const json = (await res.json()) as {
+      message: string;
+      delivered: boolean;
+      statusCode: number;
+    };
+    expect(json.message).toBe("Test event sent.");
+    expect(json.delivered).toBe(true);
+    expect(json.statusCode).toBe(200);
+  });
+
+  it("rejects an API key (session-only) without testing", async () => {
+    asApiKey();
+    const testEndpoint = vi.fn();
+    withService({ testEndpoint });
+
+    const res = await testWebhookEndpoint(
+      new Request("http://x/api/webhooks/wh_1/test", { method: "POST" }),
+      "wh_1"
+    );
+
+    expect(res.status).toBe(403);
+    expect(testEndpoint).not.toHaveBeenCalled();
+  });
+});
+
+describe("redeliverWebhookDelivery", () => {
+  it("re-arms then returns the delivery via respondMutation", async () => {
+    asSession();
+    const redeliverDelivery = vi.fn().mockResolvedValue(undefined);
+    const getDelivery = vi
+      .fn()
+      .mockResolvedValue({ id: "del_1", status: "pending", attemptCount: 0 });
+    withServices({
+      webhookEndpointService: { redeliverDelivery },
+      webhookDeliveryQueryService: { getDelivery },
+    });
+
+    const res = await redeliverWebhookDelivery(
+      new Request("http://x/api/webhooks/wh_1/deliveries/del_1/redeliver", {
+        method: "POST",
+      }),
+      "wh_1",
+      "del_1"
+    );
+
+    expect(res.status).toBe(200);
+    expect(redeliverDelivery).toHaveBeenCalledWith("wh_1", "del_1");
+    const json = (await res.json()) as {
+      message: string;
+      item: { id: string; status: string };
+    };
+    expect(json.message).toBe("Redelivery queued.");
+    expect(json.item).toMatchObject({ id: "del_1", status: "pending" });
+  });
+
+  it("rejects an API key (session-only) without re-arming", async () => {
+    asApiKey();
+    const redeliverDelivery = vi.fn();
+    withServices({ webhookEndpointService: { redeliverDelivery } });
+
+    const res = await redeliverWebhookDelivery(
+      new Request("http://x/api/webhooks/wh_1/deliveries/del_1/redeliver", {
+        method: "POST",
+      }),
+      "wh_1",
+      "del_1"
+    );
+
+    expect(res.status).toBe(403);
+    expect(redeliverDelivery).not.toHaveBeenCalled();
   });
 });

--- a/packages/nextly/src/api/webhooks.ts
+++ b/packages/nextly/src/api/webhooks.ts
@@ -36,6 +36,7 @@ import { isErrorResponse, requireAnyPermission } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { container } from "../di";
 import { offsetPaginationToMeta } from "../dispatcher/helpers/service-envelope";
+import type { WebhookFastDrainScheduler } from "../domains/webhooks/after-drain";
 import {
   runWebhookDrain,
   type RunWebhookDrainOptions,
@@ -130,7 +131,7 @@ async function requireWebhookPermission(
  * live in `logContext` for operator triage.
  */
 function denySessionOnly(
-  action: "create" | "update" | "delete" | "reveal"
+  action: "create" | "update" | "delete" | "reveal" | "test" | "redeliver"
 ): never {
   throw NextlyError.forbidden({
     logContext: { reason: "session-only", action },
@@ -427,6 +428,94 @@ export function getWebhookDelivery(
     // Opt out of timezone rewriting so the raw response snippet and attempt
     // errors are returned exactly as the receiver sent them.
     return respondDoc(delivery, {
+      headers: { [SKIP_TIMEZONE_FORMAT_HEADER]: "1" },
+    });
+  })(req);
+}
+
+/**
+ * Send a synthetic signed ping to an endpoint and report the outcome.
+ *
+ * A connectivity probe: it makes one outbound request and writes nothing to the
+ * outbox or the delivery queue, so an operator can verify a receiver (reachable
+ * + signature accepted) without producing a real event. Works on a disabled
+ * endpoint too, so a receiver can be verified before it is enabled.
+ *
+ * Auth: **session only** + `update-webhooks` (a side-effecting action, not a read).
+ *
+ * Response: `{ message, result: WebhookTestResult }` via `respondAction`.
+ */
+export function testWebhookEndpoint(
+  req: Request,
+  id: string
+): Promise<Response> {
+  return withErrorHandler(async (request: Request) => {
+    const authResult = await requireWebhookPermission(request, "update");
+    if (isErrorResponse(authResult)) throw toNextlyAuthError(authResult);
+
+    if (authResult.authMethod !== "session") denySessionOnly("test");
+
+    const service = await getWebhookService();
+    const result = await service.testEndpoint(id);
+
+    // The receiver's snippet is echoed verbatim; skip timezone rewriting.
+    // Spread into a fresh object so the typed result satisfies the action
+    // envelope's `Record<string, unknown>` shape.
+    return respondAction(
+      "Test event sent.",
+      { ...result },
+      { headers: { [SKIP_TIMEZONE_FORMAT_HEADER]: "1" } }
+    );
+  })(req);
+}
+
+/**
+ * Re-attempt a specific past delivery.
+ *
+ * Re-arms the existing delivery row for another attempt from its stored event
+ * payload (the unique `(webhook, event)` index forbids a duplicate row, so the
+ * delivery id — the Standard-Webhooks `webhook-id` — is reused and a receiver
+ * that already processed it dedupes), then nudges the drain so it goes out
+ * promptly. The outcome surfaces in the delivery log.
+ *
+ * Auth: **session only** + `update-webhooks`.
+ *
+ * Response: `{ message, item: WebhookDeliveryDetail }` via `respondMutation`.
+ */
+export function redeliverWebhookDelivery(
+  req: Request,
+  webhookId: string,
+  deliveryId: string
+): Promise<Response> {
+  return withErrorHandler(async (request: Request) => {
+    const authResult = await requireWebhookPermission(request, "update");
+    if (isErrorResponse(authResult)) throw toNextlyAuthError(authResult);
+
+    if (authResult.authMethod !== "session") denySessionOnly("redeliver");
+
+    const service = await getWebhookService();
+    await service.redeliverDelivery(webhookId, deliveryId);
+
+    // Offer the post-response fast drain so the re-armed delivery is attempted
+    // promptly; the scheduled drain is the backstop when no runtime `after()`
+    // is available.
+    if (container.has("webhookFastDrainScheduler")) {
+      container
+        .get<WebhookFastDrainScheduler>("webhookFastDrainScheduler")
+        .offer();
+    }
+
+    // Read back the re-armed delivery for the response so the operator sees its
+    // reset state (status `pending`, attempt count 0) and prior attempt history.
+    const deliveryService = await getWebhookDeliveryService();
+    const delivery = await deliveryService.getDelivery(webhookId, deliveryId);
+    if (!delivery) {
+      throw NextlyError.notFound({
+        logContext: { entity: "webhook-delivery", webhookId, deliveryId },
+      });
+    }
+
+    return respondMutation("Redelivery queued.", delivery, {
       headers: { [SKIP_TIMEZONE_FORMAT_HEADER]: "1" },
     });
   })(req);

--- a/packages/nextly/src/api/webhooks.ts
+++ b/packages/nextly/src/api/webhooks.ts
@@ -37,6 +37,7 @@ import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { container } from "../di";
 import { offsetPaginationToMeta } from "../dispatcher/helpers/service-envelope";
 import type { WebhookFastDrainScheduler } from "../domains/webhooks/after-drain";
+import { DRAIN_REQUEST_TIMEOUT_MS } from "../domains/webhooks/deliver";
 import {
   runWebhookDrain,
   type RunWebhookDrainOptions,
@@ -169,7 +170,6 @@ const DRAIN_DELIVER_BATCH = 25;
 // batch so a tick creates roughly what it can attempt; the rest waits.
 const DRAIN_FANOUT_BATCH = 50;
 const DRAIN_MAX_DURATION_MS = 25_000;
-const DRAIN_REQUEST_TIMEOUT_MS = 10_000;
 
 /** The bearer token on the request, or null when there is no bearer header. */
 function bearerToken(request: Request): string | null {

--- a/packages/nextly/src/domains/webhooks/__tests__/deliver.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/deliver.integration.test.ts
@@ -213,7 +213,7 @@ describe("webhook delivery engine (real SQLite)", () => {
       return new Response("ok", { status: 200 });
     };
 
-    await deliverDueDeliveries(deps(stealing));
+    const result = await deliverDueDeliveries(deps(stealing));
 
     // The stale finalize matched nothing: the row keeps its re-armed state
     // rather than being overwritten with the in-flight attempt's "delivered".
@@ -221,6 +221,14 @@ describe("webhook delivery engine (real SQLite)", () => {
     expect(row.status).toBe("pending");
     expect(row.lockedBy).toBeNull();
     expect(row.attemptCount).toBe(0);
+
+    // The dropped outcome is counted as abandoned, never as a committed
+    // delivered — the drain must not over-report progress the ledger never got.
+    expect(result).toMatchObject({
+      attempted: 1,
+      delivered: 0,
+      abandoned: 1,
+    });
   });
 
   it("delivers a 2xx response and signs the request with Standard Webhooks headers", async () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/deliver.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/deliver.integration.test.ts
@@ -195,6 +195,34 @@ describe("webhook delivery engine (real SQLite)", () => {
     };
   }
 
+  it("does not clobber a delivery whose lease was handed off mid-attempt", async () => {
+    await seedWebhook("wh_a");
+    await seedEvent("evt_1");
+    await seedDelivery("dlv_1", "wh_a", "evt_1");
+
+    // Simulate an overrun: while this worker's request is in flight, its lease is
+    // handed off (a redelivery re-arm clears `locked_by` and resets the row).
+    // The claim set `locked_by = "runner-test"`, so the finalize below is fenced
+    // on that owner and must not overwrite the re-armed state.
+    const stealing: DeliverTransport = async () => {
+      await adapter.update(
+        "nextly_webhook_deliveries",
+        { locked_by: null, status: "pending", attempt_count: 0 },
+        { and: [{ column: "id", op: "=", value: "dlv_1" }] }
+      );
+      return new Response("ok", { status: 200 });
+    };
+
+    await deliverDueDeliveries(deps(stealing));
+
+    // The stale finalize matched nothing: the row keeps its re-armed state
+    // rather than being overwritten with the in-flight attempt's "delivered".
+    const row = await getDelivery("dlv_1");
+    expect(row.status).toBe("pending");
+    expect(row.lockedBy).toBeNull();
+    expect(row.attemptCount).toBe(0);
+  });
+
   it("delivers a 2xx response and signs the request with Standard Webhooks headers", async () => {
     await seedWebhook("wh_a");
     await seedEvent("evt_1");

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-test-redeliver.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-test-redeliver.integration.test.ts
@@ -285,6 +285,33 @@ describe("webhook test-ping + redeliver (real SQLite)", () => {
       ).rejects.toBeInstanceOf(NextlyError);
     });
 
+    it("404s a mistyped endpoint id rather than reporting a deleted-endpoint conflict", async () => {
+      // A never-created webhookId yields no scoped delivery, so it must be
+      // not-found — not confused with a soft-deleted endpoint (a 409).
+      await expect(
+        service.redeliverDelivery("wh_never_created", "del_1")
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    });
+
+    it("409s (deleted) when the endpoint is soft-deleted but the delivery survives", async () => {
+      const { endpoint } = await create();
+      const deliveryId = await seedFailedDelivery(endpoint.id);
+      // Soft-delete tombstones the endpoint but keeps terminal delivery rows, so
+      // a redeliver still finds the delivery and must report the endpoint state
+      // as a conflict, distinct from the not-found above.
+      await service.deleteEndpoint(endpoint.id);
+
+      await expect(
+        service.redeliverDelivery(endpoint.id, deliveryId)
+      ).rejects.toMatchObject({ code: "CONFLICT" });
+
+      const rows = await adapter.select<{ status: string }>(
+        "nextly_webhook_deliveries",
+        { where: { and: [{ column: "id", op: "=", value: deliveryId }] } }
+      );
+      expect(rows[0].status).toBe("failed");
+    });
+
     it("404s when the delivery's event was pruned (cascade removes the delivery)", async () => {
       const { endpoint } = await create();
       const deliveryId = await seedFailedDelivery(endpoint.id);

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-test-redeliver.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-test-redeliver.integration.test.ts
@@ -67,9 +67,15 @@ function recordingTransport(response: () => Response) {
     url: string;
     headers: Record<string, string>;
     body: string;
+    timeoutMs: number | undefined;
   }> = [];
   const transport: DeliverTransport = async (url, options) => {
-    calls.push({ url, headers: options.headers, body: options.body });
+    calls.push({
+      url,
+      headers: options.headers,
+      body: options.body,
+      timeoutMs: options.timeoutMs,
+    });
     return response();
   };
   return { transport, calls };
@@ -162,6 +168,10 @@ describe("webhook test-ping + redeliver (real SQLite)", () => {
           secrets: [secret],
         })
       ).toBe(true);
+
+      // The probe waits the durable drain's per-request budget, so its verdict
+      // predicts real deliverability rather than a more lenient library default.
+      expect(calls[0].timeoutMs).toBe(10_000);
 
       // Nothing was written to the outbox or the delivery ledger.
       expect(await adapter.select("nextly_events")).toHaveLength(0);

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-test-redeliver.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-test-redeliver.integration.test.ts
@@ -275,6 +275,26 @@ describe("webhook test-ping + redeliver (real SQLite)", () => {
       ).rejects.toBeInstanceOf(NextlyError);
     });
 
+    it("404s when the delivery's event was pruned (cascade removes the delivery)", async () => {
+      const { endpoint } = await create();
+      const deliveryId = await seedFailedDelivery(endpoint.id);
+      // Retention deletes aged events; `event_id` cascades, so the delivery row
+      // is removed with its event. A re-arm therefore finds nothing rather than
+      // re-queuing a delivery whose payload is gone.
+      await adapter.executeQuery(
+        "DELETE FROM nextly_events WHERE id = 'evt_1'"
+      );
+
+      await expect(
+        service.redeliverDelivery(endpoint.id, deliveryId)
+      ).rejects.toBeInstanceOf(NextlyError);
+
+      const rows = await adapter.select("nextly_webhook_deliveries", {
+        where: { and: [{ column: "id", op: "=", value: deliveryId }] },
+      });
+      expect(rows).toHaveLength(0);
+    });
+
     it("409s when the endpoint is disabled", async () => {
       const { endpoint } = await create();
       const deliveryId = await seedFailedDelivery(endpoint.id);

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-test-redeliver.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-test-redeliver.integration.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Test-ping and redeliver against a real SQLite database.
+ *
+ * test-ping: a synthetic signed `webhook.ping` reaches the endpoint via the
+ * injected transport, carries valid Standard-Webhooks headers, and reports the
+ * outcome — without writing any event or delivery row. redeliver: a terminal
+ * delivery row is RE-ARMED in place (the unique `(webhook, event)` index forbids
+ * a second row), its attempt budget reset while the attempt history is kept, and
+ * the endpoint-state guards refuse a deleted/disabled endpoint or an unknown
+ * delivery.
+ *
+ * Schema comes from the production table definition via drizzle-kit, never a
+ * hand-copied CREATE TABLE (see .claude/rules/integration-tests.md).
+ */
+
+import { createSqliteAdapter } from "@nextlyhq/adapter-sqlite";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { getSQLiteDrizzleKit } from "../../../database/drizzle-kit-lazy";
+import { SchemaRegistry } from "../../../database/schema-registry";
+import { NextlyError } from "../../../errors";
+import { users } from "../../../schemas/users/sqlite";
+import {
+  nextlyEvents,
+  nextlyWebhooks,
+  nextlyWebhookDeliveries,
+} from "../../../schemas/webhooks/sqlite";
+import { splitStatements } from "../../schema/pipeline/sql-statement-utils";
+import type { DeliverTransport } from "../deliver";
+import { WebhookEndpointService } from "../services/webhook-endpoint-service";
+import { verifySignature } from "../signing";
+import type { WebhookEventType } from "../types";
+
+process.env.DB_DIALECT = "sqlite";
+process.env.NEXTLY_SECRET = "integration-test-application-secret";
+
+const EVENTS: WebhookEventType[] = ["entry.created"];
+// An address literal short-circuits DNS in the URL validator (see the endpoint
+// service suite), so the test never needs real name resolution.
+const PUBLIC_URL = "https://93.184.216.34/hooks";
+
+async function schemaDdl(): Promise<string[]> {
+  const kit = await getSQLiteDrizzleKit();
+  const statements = await kit.generateMigration(
+    await kit.generateDrizzleJson({}),
+    await kit.generateDrizzleJson({
+      users,
+      nextlyEvents,
+      nextlyWebhooks,
+      nextlyWebhookDeliveries,
+    })
+  );
+  return splitStatements(statements);
+}
+
+/** A transport that records the last call and returns a canned response. */
+function recordingTransport(response: () => Response) {
+  const calls: Array<{
+    url: string;
+    headers: Record<string, string>;
+    body: string;
+  }> = [];
+  const transport: DeliverTransport = async (url, options) => {
+    calls.push({ url, headers: options.headers, body: options.body });
+    return response();
+  };
+  return { transport, calls };
+}
+
+describe("webhook test-ping + redeliver (real SQLite)", () => {
+  let adapter: ReturnType<typeof createSqliteAdapter>;
+  let service: WebhookEndpointService;
+
+  const logger = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+
+  beforeAll(async () => {
+    adapter = createSqliteAdapter({ memory: true });
+    await adapter.connect();
+    for (const stmt of await schemaDdl()) await adapter.executeQuery(stmt);
+    await adapter.executeQuery(
+      "INSERT INTO users (id, email, created_at, updated_at) VALUES ('user_1', 'dev@example.com', 0, 0)"
+    );
+    const schemaRegistry = new SchemaRegistry("sqlite");
+    schemaRegistry.registerStaticSchemas({
+      users,
+      nextlyEvents,
+      nextlyWebhooks,
+      nextlyWebhookDeliveries,
+    });
+    adapter.setTableResolver(schemaRegistry);
+  });
+
+  afterAll(async () => {
+    try {
+      await adapter?.disconnect?.();
+    } catch {
+      // ignore teardown errors
+    }
+  });
+
+  beforeEach(async () => {
+    await adapter.executeQuery("DELETE FROM nextly_webhook_deliveries");
+    await adapter.executeQuery("DELETE FROM nextly_events");
+    await adapter.executeQuery("DELETE FROM nextly_webhooks");
+    service = new WebhookEndpointService(adapter as never, logger as never);
+  });
+
+  const create = (overrides: Record<string, unknown> = {}) =>
+    service.createEndpoint(
+      {
+        name: "Orders",
+        url: PUBLIC_URL,
+        eventTypes: EVENTS,
+        ...overrides,
+      } as never,
+      "user_1"
+    );
+
+  describe("test-ping", () => {
+    it("sends a validly-signed ping and reports success without persisting", async () => {
+      const { endpoint, secret } = await create();
+      const { transport, calls } = recordingTransport(
+        () => new Response("ok", { status: 200 })
+      );
+
+      const result = await service.testEndpoint(endpoint.id, {
+        transport,
+        pingId: "ping_1",
+      });
+
+      expect(result.delivered).toBe(true);
+      expect(result.statusCode).toBe(200);
+      expect(result.responseSnippet).toBe("ok");
+
+      // One outbound request, to the endpoint's URL, carrying the ping payload.
+      expect(calls).toHaveLength(1);
+      expect(calls[0].url).toBe(PUBLIC_URL);
+      const payload = JSON.parse(calls[0].body);
+      expect(payload.type).toBe("webhook.ping");
+      expect(payload.webhookId).toBe(endpoint.id);
+
+      // The signature is valid for the endpoint's real secret.
+      expect(
+        verifySignature({
+          id: calls[0].headers["webhook-id"],
+          timestamp: calls[0].headers["webhook-timestamp"],
+          body: calls[0].body,
+          signatureHeader: calls[0].headers["webhook-signature"],
+          secrets: [secret],
+        })
+      ).toBe(true);
+
+      // Nothing was written to the outbox or the delivery ledger.
+      expect(await adapter.select("nextly_events")).toHaveLength(0);
+      expect(await adapter.select("nextly_webhook_deliveries")).toHaveLength(0);
+    });
+
+    it("reports not-delivered on a non-2xx without throwing", async () => {
+      const { endpoint } = await create();
+      const { transport } = recordingTransport(
+        () => new Response("nope", { status: 500 })
+      );
+      const result = await service.testEndpoint(endpoint.id, { transport });
+      expect(result.delivered).toBe(false);
+      expect(result.statusCode).toBe(500);
+      expect(result.error).toBe("http 500");
+    });
+
+    it("reports not-delivered when the transport throws (unreachable)", async () => {
+      const { endpoint } = await create();
+      const transport: DeliverTransport = () => {
+        throw new Error("connect ECONNREFUSED");
+      };
+      const result = await service.testEndpoint(endpoint.id, { transport });
+      expect(result.delivered).toBe(false);
+      expect(result.error).toContain("ECONNREFUSED");
+    });
+
+    it("404s an unknown endpoint", async () => {
+      await expect(
+        service.testEndpoint("missing", { transport: vi.fn() as never })
+      ).rejects.toBeInstanceOf(NextlyError);
+    });
+  });
+
+  describe("redeliver", () => {
+    // Seed an event + a terminal delivery row directly (the fan-out/deliver
+    // pipeline is exercised elsewhere; here we only care about the re-arm).
+    async function seedFailedDelivery(webhookId: string): Promise<string> {
+      await adapter.executeQuery(
+        "INSERT INTO nextly_events (id, type, resource_kind, resource_id, payload, created_at) " +
+          "VALUES ('evt_1', 'entry.created', 'entry', 'row_1', '{}', 0)"
+      );
+      await adapter.executeQuery(
+        "INSERT INTO nextly_webhook_deliveries " +
+          "(id, webhook_id, event_id, status, attempt_count, next_attempt_at, last_error, attempts, created_at, updated_at) " +
+          `VALUES ('del_1', '${webhookId}', 'evt_1', 'failed', 6, NULL, 'http 500', ` +
+          `'[{"at":1,"outcome":"failed","statusCode":500}]', 0, 0)`
+      );
+      return "del_1";
+    }
+
+    it("re-arms a failed delivery in place, resetting the budget and keeping history", async () => {
+      const { endpoint } = await create();
+      const deliveryId = await seedFailedDelivery(endpoint.id);
+
+      await service.redeliverDelivery(endpoint.id, deliveryId);
+
+      const rows = await adapter.select<{
+        status: string;
+        attemptCount: number;
+        nextAttemptAt: unknown;
+        lockedBy: unknown;
+        attempts: unknown;
+      }>("nextly_webhook_deliveries", {
+        where: { and: [{ column: "id", op: "=", value: "del_1" }] },
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].status).toBe("pending");
+      expect(rows[0].attemptCount).toBe(0);
+      expect(rows[0].nextAttemptAt).not.toBeNull();
+      expect(rows[0].lockedBy).toBeNull();
+      // The prior failure is still visible.
+      expect(JSON.stringify(rows[0].attempts)).toContain("failed");
+
+      // Still exactly one row — the unique index was respected (no duplicate).
+      const all = await adapter.select("nextly_webhook_deliveries", {
+        where: { and: [{ column: "webhookId", op: "=", value: endpoint.id }] },
+      });
+      expect(all).toHaveLength(1);
+    });
+
+    it("404s an unknown delivery", async () => {
+      const { endpoint } = await create();
+      await expect(
+        service.redeliverDelivery(endpoint.id, "missing")
+      ).rejects.toBeInstanceOf(NextlyError);
+    });
+
+    it("409s when the endpoint is disabled", async () => {
+      const { endpoint } = await create();
+      const deliveryId = await seedFailedDelivery(endpoint.id);
+      await service.setEnabled(endpoint.id, false);
+
+      await expect(
+        service.redeliverDelivery(endpoint.id, deliveryId)
+      ).rejects.toBeInstanceOf(NextlyError);
+
+      // The row was NOT re-armed.
+      const rows = await adapter.select<{ status: string }>(
+        "nextly_webhook_deliveries",
+        { where: { and: [{ column: "id", op: "=", value: "del_1" }] } }
+      );
+      expect(rows[0].status).toBe("failed");
+    });
+
+    it("does not let another endpoint redeliver a foreign delivery", async () => {
+      const { endpoint } = await create();
+      const deliveryId = await seedFailedDelivery(endpoint.id);
+      const other = await create({ name: "Other" });
+
+      await expect(
+        service.redeliverDelivery(other.endpoint.id, deliveryId)
+      ).rejects.toBeInstanceOf(NextlyError);
+    });
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-test-redeliver.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-test-redeliver.integration.test.ts
@@ -243,6 +243,31 @@ describe("webhook test-ping + redeliver (real SQLite)", () => {
       expect(all).toHaveLength(1);
     });
 
+    it("refuses to re-arm a delivery that is still in flight (leased)", async () => {
+      const { endpoint } = await create();
+      const deliveryId = await seedFailedDelivery(endpoint.id);
+      // Simulate a drain worker mid-attempt: the row is claimed with an
+      // unexpired lease (far-future seconds), which is how the drain guards an
+      // active send — not via the status. Re-arming must not revoke it.
+      await adapter.executeQuery(
+        `UPDATE nextly_webhook_deliveries ` +
+          `SET status = 'retrying', locked_by = 'worker_1', locked_until = 9999999999 ` +
+          `WHERE id = '${deliveryId}'`
+      );
+
+      await expect(
+        service.redeliverDelivery(endpoint.id, deliveryId)
+      ).rejects.toBeInstanceOf(NextlyError);
+
+      // The lease and status are intact — the in-flight attempt was not touched.
+      const rows = await adapter.select<{ status: string; lockedBy: unknown }>(
+        "nextly_webhook_deliveries",
+        { where: { and: [{ column: "id", op: "=", value: deliveryId }] } }
+      );
+      expect(rows[0].status).toBe("retrying");
+      expect(rows[0].lockedBy).toBe("worker_1");
+    });
+
     it("404s an unknown delivery", async () => {
       const { endpoint } = await create();
       await expect(

--- a/packages/nextly/src/domains/webhooks/deliver.ts
+++ b/packages/nextly/src/domains/webhooks/deliver.ts
@@ -178,10 +178,19 @@ export interface DeliverResult {
   retried: number;
   /** Deliveries marked permanently failed. */
   failed: number;
+  /**
+   * Attempts whose outcome was NOT recorded because the lease had been handed
+   * off before finalization — a redelivery re-armed the row, or another worker
+   * reclaimed the expired lease. The write is fenced to the lease owner, so this
+   * worker's outcome is dropped and whoever holds the row now owns the result.
+   * Counted separately so it is never conflated with a committed delivered/
+   * retried/failed, which would over-report progress the ledger never received.
+   */
+  abandoned: number;
 }
 
 /** Which per-outcome counter a single attempt should increment. */
-type OutcomeBucket = "delivered" | "retried" | "failed";
+type OutcomeBucket = "delivered" | "retried" | "failed" | "abandoned";
 
 /**
  * Turn a stored event payload into the request body. The payload is the durable
@@ -293,31 +302,54 @@ async function claimDelivery(
 
 /**
  * Finalize a claimed delivery: write the outcome and release the lease, but only
- * while this runner still owns the lease it took at claim time.
+ * while this runner still owns the lease it took at claim time. Returns whether
+ * the write landed — `false` means the lease had been handed off and the outcome
+ * was intentionally dropped.
  *
- * The `locked_by` fence matters when a worker overruns its lease: once
+ * The ownership fence matters when a worker overruns its lease: once
  * `locked_until` passes, a redelivery re-arm (which clears `locked_by`) or
- * another drain can take the row over. Without the fence this worker's late,
- * unconditional write would clobber that fresh state — silently replacing a
- * re-armed `pending` with the stale attempt's outcome. Scoping the write to the
- * lease owner makes it a no-op instead, so whoever holds the row now keeps it.
+ * another drain can take the row over. Without the fence this worker's late write
+ * would clobber that fresh state — silently replacing a re-armed `pending` with
+ * the stale attempt's outcome. The read-check-write runs in one transaction under
+ * `FOR UPDATE` (a no-op on SQLite, whose transactions already serialize writers)
+ * so the ownership check and the write cannot interleave, and the boolean lets
+ * the caller avoid counting a dropped outcome as committed progress.
  */
 async function finalizeDelivery(
   deps: DeliverDeps,
   row: DeliveryRow,
   now: Date,
   update: Record<string, unknown>
-): Promise<void> {
-  await deps.db.update(
-    "nextly_webhook_deliveries",
-    { ...update, locked_by: null, locked_until: null, updated_at: now },
-    {
-      and: [
-        { column: "id", op: "=", value: row.id },
-        { column: "lockedBy", op: "=", value: row.lockedBy },
-      ],
-    }
-  );
+): Promise<boolean> {
+  return deps.db.transaction(async tx => {
+    const rows = await tx.select<{ lockedBy: string | null }>(
+      "nextly_webhook_deliveries",
+      {
+        where: { and: [{ column: "id", op: "=", value: row.id }] },
+        limit: 1,
+        forUpdate: true,
+      }
+    );
+    const current = rows[0];
+    // The lease was handed off (re-arm cleared it, or another worker reclaimed
+    // the expired lease): drop this outcome rather than overwrite the new owner.
+    if (!current || current.lockedBy !== row.lockedBy) return false;
+    await tx.update(
+      "nextly_webhook_deliveries",
+      { ...update, locked_by: null, locked_until: null, updated_at: now },
+      { and: [{ column: "id", op: "=", value: row.id }] }
+    );
+    return true;
+  });
+}
+
+/**
+ * The counter a finalized attempt increments: the committed outcome when the
+ * write landed, else `abandoned` because the lease had been handed off and the
+ * outcome was dropped rather than recorded.
+ */
+function finalized(landed: boolean, committed: OutcomeBucket): OutcomeBucket {
+  return landed ? committed : "abandoned";
 }
 
 /**
@@ -374,18 +406,20 @@ async function attemptDelivery(
     deps.logger?.warn(
       `webhook delivery ${row.id} undeliverable (${reason}); marking failed`
     );
-    await finalizeDelivery(deps, row, now(), {
-      status: "failed",
-      attempt_count: attemptCount,
-      next_attempt_at: null,
-      last_error: reason,
-      attempts: appendAttempt(row.attempts, {
-        at: claimedAt.toISOString(),
-        outcome: "failed",
-        error: reason,
+    return finalized(
+      await finalizeDelivery(deps, row, now(), {
+        status: "failed",
+        attempt_count: attemptCount,
+        next_attempt_at: null,
+        last_error: reason,
+        attempts: appendAttempt(row.attempts, {
+          at: claimedAt.toISOString(),
+          outcome: "failed",
+          error: reason,
+        }),
       }),
-    });
-    return "failed";
+      "failed"
+    );
   }
 
   const body = payloadToBody(event.payload);
@@ -393,18 +427,20 @@ async function attemptDelivery(
     deps.logger?.warn(
       `webhook delivery ${row.id} undeliverable (unusable event payload); marking failed`
     );
-    await finalizeDelivery(deps, row, now(), {
-      status: "failed",
-      attempt_count: attemptCount,
-      next_attempt_at: null,
-      last_error: "unusable event payload",
-      attempts: appendAttempt(row.attempts, {
-        at: claimedAt.toISOString(),
-        outcome: "failed",
-        error: "unusable event payload",
+    return finalized(
+      await finalizeDelivery(deps, row, now(), {
+        status: "failed",
+        attempt_count: attemptCount,
+        next_attempt_at: null,
+        last_error: "unusable event payload",
+        attempts: appendAttempt(row.attempts, {
+          at: claimedAt.toISOString(),
+          outcome: "failed",
+          error: "unusable event payload",
+        }),
       }),
-    });
-    return "failed";
+      "failed"
+    );
   }
 
   // A webhook with no stored secret can never be signed (buildSignatureHeaders
@@ -415,18 +451,20 @@ async function attemptDelivery(
     deps.logger?.warn(
       `webhook delivery ${row.id} undeliverable (webhook has no signing secret); marking failed`
     );
-    await finalizeDelivery(deps, row, now(), {
-      status: "failed",
-      attempt_count: attemptCount,
-      next_attempt_at: null,
-      last_error: "no signing secret",
-      attempts: appendAttempt(row.attempts, {
-        at: claimedAt.toISOString(),
-        outcome: "failed",
-        error: "no signing secret",
+    return finalized(
+      await finalizeDelivery(deps, row, now(), {
+        status: "failed",
+        attempt_count: attemptCount,
+        next_attempt_at: null,
+        last_error: "no signing secret",
+        attempts: appendAttempt(row.attempts, {
+          at: claimedAt.toISOString(),
+          outcome: "failed",
+          error: "no signing secret",
+        }),
       }),
-    });
-    return "failed";
+      "failed"
+    );
   }
 
   // Decrypt the active signing secrets (primary first) and build the Standard
@@ -442,18 +480,20 @@ async function attemptDelivery(
       `webhook delivery ${row.id} could not decrypt signing secret; marking failed`,
       err
     );
-    await finalizeDelivery(deps, row, now(), {
-      status: "failed",
-      attempt_count: attemptCount,
-      next_attempt_at: null,
-      last_error: `secret decrypt failed: ${message}`,
-      attempts: appendAttempt(row.attempts, {
-        at: claimedAt.toISOString(),
-        outcome: "failed",
-        error: "secret decrypt failed",
+    return finalized(
+      await finalizeDelivery(deps, row, now(), {
+        status: "failed",
+        attempt_count: attemptCount,
+        next_attempt_at: null,
+        last_error: `secret decrypt failed: ${message}`,
+        attempts: appendAttempt(row.attempts, {
+          at: claimedAt.toISOString(),
+          outcome: "failed",
+          error: "secret decrypt failed",
+        }),
       }),
-    });
-    return "failed";
+      "failed"
+    );
   }
 
   const signatureHeaders = buildSignatureHeaders({
@@ -527,28 +567,34 @@ async function attemptDelivery(
   };
 
   if (decision.status === "delivered") {
-    await finalizeDelivery(deps, row, now(), {
-      ...common,
-      status: "delivered",
-      next_attempt_at: null,
-    });
-    return "delivered";
+    return finalized(
+      await finalizeDelivery(deps, row, now(), {
+        ...common,
+        status: "delivered",
+        next_attempt_at: null,
+      }),
+      "delivered"
+    );
   }
   if (decision.status === "retrying") {
+    return finalized(
+      await finalizeDelivery(deps, row, now(), {
+        ...common,
+        status: "retrying",
+        next_attempt_at: new Date(now().getTime() + decision.delayMs),
+      }),
+      "retried"
+    );
+  }
+  return finalized(
     await finalizeDelivery(deps, row, now(), {
       ...common,
-      status: "retrying",
-      next_attempt_at: new Date(now().getTime() + decision.delayMs),
-    });
-    return "retried";
-  }
-  await finalizeDelivery(deps, row, now(), {
-    ...common,
-    status: "failed",
-    next_attempt_at: null,
-    last_error: decision.reason,
-  });
-  return "failed";
+      status: "failed",
+      next_attempt_at: null,
+      last_error: decision.reason,
+    }),
+    "failed"
+  );
 }
 
 /**
@@ -596,14 +642,18 @@ async function recoverUnexpectedFailure(
             error: message,
           }),
         };
+  let landed = false;
   try {
-    await finalizeDelivery(deps, row, at, update);
+    landed = await finalizeDelivery(deps, row, at, update);
   } catch (err) {
     deps.logger?.warn(
       `webhook delivery ${row.id} could not be finalized after an unexpected error; lease will expire and it will be retried`,
       err
     );
   }
+  // A dropped or failed write is not a committed outcome: count it as abandoned
+  // so the recovery is never reported as a retry/failure that never landed.
+  if (!landed) return "abandoned";
   return decision.status === "retrying" ? "retried" : "failed";
 }
 
@@ -625,6 +675,7 @@ export async function deliverDueDeliveries(
     delivered: 0,
     retried: 0,
     failed: 0,
+    abandoned: 0,
   };
 
   const claimTime = now();

--- a/packages/nextly/src/domains/webhooks/deliver.ts
+++ b/packages/nextly/src/domains/webhooks/deliver.ts
@@ -63,6 +63,7 @@ interface DeliveryRow {
   status: string;
   attemptCount: number;
   nextAttemptAt: Date | null;
+  lockedBy: string | null;
   lockedUntil: Date | null;
   attempts: unknown;
 }
@@ -271,20 +272,36 @@ async function claimDelivery(
     const leaseFree =
       row.lockedUntil == null || row.lockedUntil.getTime() <= now.getTime();
     if (!isDue || !leaseFree) return null;
+    const lockedUntil = new Date(now.getTime() + leaseMs);
     await tx.update(
       "nextly_webhook_deliveries",
       {
         locked_by: runnerId,
-        locked_until: new Date(now.getTime() + leaseMs),
+        locked_until: lockedUntil,
         updated_at: now,
       },
       { and: [{ column: "id", op: "=", value: id }] }
     );
+    // Reflect the lease just taken onto the returned row so the finalize can
+    // fence on ownership: `row.lockedBy` now identifies this runner, letting
+    // finalizeDelivery refuse to write if the lease has since been handed off.
+    row.lockedBy = runnerId;
+    row.lockedUntil = lockedUntil;
     return row;
   });
 }
 
-/** Finalize a claimed delivery: write the outcome and release the lease. */
+/**
+ * Finalize a claimed delivery: write the outcome and release the lease, but only
+ * while this runner still owns the lease it took at claim time.
+ *
+ * The `locked_by` fence matters when a worker overruns its lease: once
+ * `locked_until` passes, a redelivery re-arm (which clears `locked_by`) or
+ * another drain can take the row over. Without the fence this worker's late,
+ * unconditional write would clobber that fresh state — silently replacing a
+ * re-armed `pending` with the stale attempt's outcome. Scoping the write to the
+ * lease owner makes it a no-op instead, so whoever holds the row now keeps it.
+ */
 async function finalizeDelivery(
   deps: DeliverDeps,
   row: DeliveryRow,
@@ -294,7 +311,12 @@ async function finalizeDelivery(
   await deps.db.update(
     "nextly_webhook_deliveries",
     { ...update, locked_by: null, locked_until: null, updated_at: now },
-    { and: [{ column: "id", op: "=", value: row.id }] }
+    {
+      and: [
+        { column: "id", op: "=", value: row.id },
+        { column: "lockedBy", op: "=", value: row.lockedBy },
+      ],
+    }
   );
 }
 

--- a/packages/nextly/src/domains/webhooks/deliver.ts
+++ b/packages/nextly/src/domains/webhooks/deliver.ts
@@ -242,9 +242,12 @@ function classifyTransportError(err: unknown): {
 /**
  * Claim one due delivery by taking a lease inside a transaction. Returns the row
  * if this runner won the claim, else null (another runner holds it, it is no
- * longer due, or it vanished). The read-check-write runs in one transaction so
- * SQLite's single-writer semantics make it exclusive; the lease bounds the window
- * on other dialects.
+ * longer due, or it vanished). The read-check-write runs in one transaction under
+ * a `FOR UPDATE` row lock (a no-op on SQLite, whose transactions already
+ * serialize writers), so a concurrent claim or a redelivery re-arm cannot slip
+ * between the read and the lease write: the claimed row's state — including its
+ * `attemptCount` — is the committed state this runner then acts on, never a stale
+ * copy a re-arm has since reset.
  */
 async function claimDelivery(
   deps: DeliverDeps,
@@ -257,6 +260,7 @@ async function claimDelivery(
     const rows = await tx.select<DeliveryRow>("nextly_webhook_deliveries", {
       where: { and: [{ column: "id", op: "=", value: id }] },
       limit: 1,
+      forUpdate: true,
     });
     const row = rows[0];
     if (!row) return null;

--- a/packages/nextly/src/domains/webhooks/deliver.ts
+++ b/packages/nextly/src/domains/webhooks/deliver.ts
@@ -40,7 +40,10 @@ const DEFAULT_LEASE_MS = 60_000; // 1 min
 /** Per-request response body cap; a receiver's body is only sampled for diagnostics. */
 const DEFAULT_MAX_RESPONSE_BYTES = 64 * 1024; // 64 KiB
 /** Per-request timeout covering connect + response. */
-const DEFAULT_REQUEST_TIMEOUT_MS = 15_000; // 15s
+// Exported so the connectivity probe waits exactly as long as a real delivery:
+// a receiver that answers within the delivery window must not be reported
+// unreachable by a test that gave up sooner.
+export const DEFAULT_REQUEST_TIMEOUT_MS = 15_000; // 15s
 /** How much of the response body is retained on the row for debugging. */
 const RESPONSE_SNIPPET_LIMIT = 500;
 /** Cap on the retained per-row attempt log so a flapping endpoint can't grow it unbounded. */

--- a/packages/nextly/src/domains/webhooks/deliver.ts
+++ b/packages/nextly/src/domains/webhooks/deliver.ts
@@ -40,10 +40,16 @@ const DEFAULT_LEASE_MS = 60_000; // 1 min
 /** Per-request response body cap; a receiver's body is only sampled for diagnostics. */
 const DEFAULT_MAX_RESPONSE_BYTES = 64 * 1024; // 64 KiB
 /** Per-request timeout covering connect + response. */
-// Exported so the connectivity probe waits exactly as long as a real delivery:
-// a receiver that answers within the delivery window must not be reported
-// unreachable by a test that gave up sooner.
-export const DEFAULT_REQUEST_TIMEOUT_MS = 15_000; // 15s
+// Fallback when a trigger passes no `requestTimeoutMs`; the product drain paths
+// always pass one (see DRAIN_REQUEST_TIMEOUT_MS and the fast-path scheduler).
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000; // 15s
+
+// The per-request budget the durable drain (cron/manual trigger) gives each
+// delivery. Exported so the connectivity probe waits exactly as long as the
+// path that actually persists retries — a receiver that answers within this
+// window is one deliveries reach, and one that exceeds it is not, so the test
+// predicts real deliverability instead of a more lenient library default.
+export const DRAIN_REQUEST_TIMEOUT_MS = 10_000; // 10s
 /** How much of the response body is retained on the row for debugging. */
 const RESPONSE_SNIPPET_LIMIT = 500;
 /** Cap on the retained per-row attempt log so a flapping endpoint can't grow it unbounded. */

--- a/packages/nextly/src/domains/webhooks/run-drain.ts
+++ b/packages/nextly/src/domains/webhooks/run-drain.ts
@@ -54,6 +54,12 @@ export interface RunDrainResult {
   delivered: number;
   retried: number;
   failed: number;
+  /**
+   * Attempts whose outcome was dropped because the lease had been handed off
+   * (a redelivery re-arm or a reclaimed expired lease) — never counted as a
+   * committed delivered/retried/failed.
+   */
+  abandoned: number;
   /** Rows retention removed on this call; zero when the gate held it off. */
   pruned: { events: number; deliveries: number };
 }
@@ -83,6 +89,7 @@ export async function runDrain(deps: RunDrainDeps): Promise<RunDrainResult> {
     delivered: 0,
     retried: 0,
     failed: 0,
+    abandoned: 0,
     pruned: { events: 0, deliveries: 0 },
   };
 
@@ -99,6 +106,7 @@ export async function runDrain(deps: RunDrainDeps): Promise<RunDrainResult> {
     result.delivered += del.delivered;
     result.retried += del.retried;
     result.failed += del.failed;
+    result.abandoned += del.abandoned;
 
     // Nothing was fanned out and nothing was attempted this round → the queue is
     // drained of everything currently due; stop.

--- a/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
+++ b/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
@@ -25,7 +25,7 @@
  * @module domains/webhooks/services/webhook-endpoint-service
  */
 
-import { and, desc, eq, inArray, isNull, lte, or } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 
 import { toDbError } from "../../../database/errors";
 import { NextlyError } from "../../../errors";
@@ -619,44 +619,10 @@ export class WebhookEndpointService extends BaseService {
     webhookId: string,
     deliveryId: string
   ): Promise<void> {
-    const now = new Date();
-    const rows = await this.query(
-      async () =>
-        (await this.db
-          .select({
-            id: this.deliveries.id,
-            lockedUntil: this.deliveries.lockedUntil,
-          })
-          .from(this.deliveries)
-          .where(
-            and(
-              eq(this.deliveries.id, deliveryId),
-              eq(this.deliveries.webhookId, webhookId)
-            )
-          )
-          .limit(1)) as Array<{ id: string; lockedUntil: Date | null }>
-    );
-    const delivery = rows[0];
-    if (!delivery) {
-      throw NextlyError.notFound({
-        logContext: { entity: "webhook-delivery", webhookId, deliveryId },
-      });
-    }
-
-    const leaseHeld =
-      delivery.lockedUntil != null &&
-      delivery.lockedUntil.getTime() > now.getTime();
-    if (leaseHeld) {
-      throw NextlyError.conflict({
-        reason: "state",
-        message:
-          "This delivery is currently being sent; try again once it settles.",
-        logContext: { entity: "webhook-delivery", webhookId, deliveryId },
-      });
-    }
-
     // `getEndpoint` filters soft-deleted rows, so a null means the endpoint was
-    // retired; a disabled endpoint would fail the re-attempt permanently.
+    // retired; a disabled endpoint would fail the re-attempt permanently. The
+    // drain re-checks endpoint state at send time, so a disable/delete racing
+    // this is caught there rather than delivering to a retired endpoint.
     const endpoint = await this.getEndpoint(webhookId);
     if (!endpoint) {
       throw NextlyError.conflict({
@@ -675,31 +641,71 @@ export class WebhookEndpointService extends BaseService {
       });
     }
 
-    // Condition the re-arm on the lease still being free: if a drain worker
-    // claimed the row between the read above and this write, the WHERE matches
-    // nothing and we leave the active attempt untouched rather than revoking it.
-    await this.query(() =>
-      this.db
-        .update(this.deliveries)
-        .set({
-          status: "pending",
-          nextAttemptAt: now,
-          attemptCount: 0,
-          lockedBy: null,
-          lockedUntil: null,
-          updatedAt: now,
-        })
-        .where(
-          and(
-            eq(this.deliveries.id, deliveryId),
-            eq(this.deliveries.webhookId, webhookId),
-            or(
-              isNull(this.deliveries.lockedUntil),
-              lte(this.deliveries.lockedUntil, now)
-            )
-          )
-        )
+    // Re-arm under a row lock so the read-guard-write cannot interleave with a
+    // drain worker claiming the same row. `forUpdate` takes the lock the write
+    // will need (a no-op on SQLite, whose transactions already serialize
+    // writers), so a worker that would claim the delivery blocks until this
+    // commits, and a worker that already holds an unexpired lease is seen here
+    // and refused — never revoked. Selecting the row before writing is also how
+    // the outcome is known, so success is reported only when the row was armed.
+    const outcome = await this.query(() =>
+      this.adapter.transaction(async tx => {
+        const rows = await tx.select<{ lockedUntil: Date | null }>(
+          "nextly_webhook_deliveries",
+          {
+            where: {
+              and: [
+                { column: "id", op: "=", value: deliveryId },
+                { column: "webhookId", op: "=", value: webhookId },
+              ],
+            },
+            limit: 1,
+            forUpdate: true,
+          }
+        );
+        const delivery = rows[0];
+        if (!delivery) return "not-found" as const;
+
+        const leaseHeld =
+          delivery.lockedUntil != null &&
+          delivery.lockedUntil.getTime() > Date.now();
+        if (leaseHeld) return "in-flight" as const;
+
+        const now = new Date();
+        await tx.update(
+          "nextly_webhook_deliveries",
+          {
+            status: "pending",
+            next_attempt_at: now,
+            attempt_count: 0,
+            locked_by: null,
+            locked_until: null,
+            updated_at: now,
+          },
+          {
+            and: [
+              { column: "id", op: "=", value: deliveryId },
+              { column: "webhookId", op: "=", value: webhookId },
+            ],
+          }
+        );
+        return "rearmed" as const;
+      })
     );
+
+    if (outcome === "not-found") {
+      throw NextlyError.notFound({
+        logContext: { entity: "webhook-delivery", webhookId, deliveryId },
+      });
+    }
+    if (outcome === "in-flight") {
+      throw NextlyError.conflict({
+        reason: "state",
+        message:
+          "This delivery is currently being sent; try again once it settles.",
+        logContext: { entity: "webhook-delivery", webhookId, deliveryId },
+      });
+    }
   }
 
   private notFound(id: string): NextlyError {

--- a/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
+++ b/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
@@ -25,7 +25,7 @@
  * @module domains/webhooks/services/webhook-endpoint-service
  */
 
-import { and, desc, eq, inArray, isNull } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, lte, or } from "drizzle-orm";
 
 import { toDbError } from "../../../database/errors";
 import { NextlyError } from "../../../errors";
@@ -565,9 +565,9 @@ export class WebhookEndpointService extends BaseService {
     const secrets = stored.map(value => decryptWebhookSecret(String(value)));
     if (secrets.length === 0) {
       // A delivery must be signed; without a secret there is nothing to sign.
-      throw new NextlyError({
-        code: "CONFLICT",
-        publicMessage:
+      throw NextlyError.conflict({
+        reason: "state",
+        message:
           "This endpoint has no active signing secret to sign a test event.",
         logContext: { entity: "webhook-endpoint", id },
       });
@@ -603,16 +603,30 @@ export class WebhookEndpointService extends BaseService {
    * The caller triggers the drain; the row is now claimable.
    *
    * Guards: 404 if the delivery is not this endpoint's; 409 if the endpoint was
-   * deleted or is disabled (delivering to it would immediately fail).
+   * deleted or is disabled (delivering to it would immediately fail), or if the
+   * delivery is still in flight (a drain worker holds an unexpired lease).
+   *
+   * Never touch an in-flight row: the drain protects an active attempt with a
+   * lease (`locked_until` in the future), not with a status change, so clearing
+   * that lease would let a second worker claim and POST the same delivery while
+   * the first attempt is still open — a duplicate send, and the first worker's
+   * later finalize would clobber this re-arm. The re-arm therefore refuses a
+   * leased row, and the UPDATE itself is conditioned on the lease being free so
+   * a worker that claims the row between the read and the write cannot be
+   * revoked.
    */
   async redeliverDelivery(
     webhookId: string,
     deliveryId: string
   ): Promise<void> {
+    const now = new Date();
     const rows = await this.query(
       async () =>
         (await this.db
-          .select({ id: this.deliveries.id })
+          .select({
+            id: this.deliveries.id,
+            lockedUntil: this.deliveries.lockedUntil,
+          })
           .from(this.deliveries)
           .where(
             and(
@@ -620,10 +634,23 @@ export class WebhookEndpointService extends BaseService {
               eq(this.deliveries.webhookId, webhookId)
             )
           )
-          .limit(1)) as Array<{ id: string }>
+          .limit(1)) as Array<{ id: string; lockedUntil: Date | null }>
     );
-    if (!rows[0]) {
+    const delivery = rows[0];
+    if (!delivery) {
       throw NextlyError.notFound({
+        logContext: { entity: "webhook-delivery", webhookId, deliveryId },
+      });
+    }
+
+    const leaseHeld =
+      delivery.lockedUntil != null &&
+      delivery.lockedUntil.getTime() > now.getTime();
+    if (leaseHeld) {
+      throw NextlyError.conflict({
+        reason: "state",
+        message:
+          "This delivery is currently being sent; try again once it settles.",
         logContext: { entity: "webhook-delivery", webhookId, deliveryId },
       });
     }
@@ -632,23 +659,25 @@ export class WebhookEndpointService extends BaseService {
     // retired; a disabled endpoint would fail the re-attempt permanently.
     const endpoint = await this.getEndpoint(webhookId);
     if (!endpoint) {
-      throw new NextlyError({
-        code: "CONFLICT",
-        publicMessage:
+      throw NextlyError.conflict({
+        reason: "state",
+        message:
           "This endpoint has been deleted; its deliveries cannot be re-sent.",
         logContext: { entity: "webhook-endpoint", id: webhookId },
       });
     }
     if (!endpoint.enabled) {
-      throw new NextlyError({
-        code: "CONFLICT",
-        publicMessage:
+      throw NextlyError.conflict({
+        reason: "state",
+        message:
           "This endpoint is disabled; enable it before re-sending deliveries.",
         logContext: { entity: "webhook-endpoint", id: webhookId },
       });
     }
 
-    const now = new Date();
+    // Condition the re-arm on the lease still being free: if a drain worker
+    // claimed the row between the read above and this write, the WHERE matches
+    // nothing and we leave the active attempt untouched rather than revoking it.
     await this.query(() =>
       this.db
         .update(this.deliveries)
@@ -663,7 +692,11 @@ export class WebhookEndpointService extends BaseService {
         .where(
           and(
             eq(this.deliveries.id, deliveryId),
-            eq(this.deliveries.webhookId, webhookId)
+            eq(this.deliveries.webhookId, webhookId),
+            or(
+              isNull(this.deliveries.lockedUntil),
+              lte(this.deliveries.lockedUntil, now)
+            )
           )
         )
     );

--- a/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
+++ b/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
@@ -602,52 +602,31 @@ export class WebhookEndpointService extends BaseService {
    * `webhook-id`) is reused, so a receiver that already processed it dedupes.
    * The caller triggers the drain; the row is now claimable.
    *
-   * Guards: 404 if the delivery is not this endpoint's; 409 if the endpoint was
-   * deleted or is disabled (delivering to it would immediately fail), or if the
-   * delivery is still in flight (a drain worker holds an unexpired lease).
+   * Guards, resolved in this order: 404 if the delivery is unknown or belongs to
+   * another endpoint (a mistyped or never-created `webhookId` yields no scoped
+   * row and so is a not-found, never mistaken for a deleted endpoint); 409 if the
+   * delivery is still in flight (a drain worker holds an unexpired lease); 409 if
+   * the endpoint has been deleted or is disabled (delivering to it would fail).
    *
-   * Never touch an in-flight row: the drain protects an active attempt with a
-   * lease (`locked_until` in the future), not with a status change, so clearing
-   * that lease would let a second worker claim and POST the same delivery while
-   * the first attempt is still open — a duplicate send, and the first worker's
-   * later finalize would clobber this re-arm. The re-arm therefore refuses a
-   * leased row, and the UPDATE itself is conditioned on the lease being free so
-   * a worker that claims the row between the read and the write cannot be
-   * revoked.
+   * All of it runs in one transaction under a `FOR UPDATE` lock on the delivery
+   * row (a no-op on SQLite, whose transactions already serialize writers). The
+   * lock is the write's own lock, so a drain worker that would claim the delivery
+   * blocks until this commits, and a worker already holding an unexpired lease is
+   * seen and refused rather than revoked. Reading the row before writing is also
+   * how the outcome is known, so success is reported only when the row was armed.
+   *
+   * The endpoint's state is read inside the same transaction rather than through
+   * `getEndpoint` beforehand: `getEndpoint` cannot tell a soft-deleted endpoint
+   * from one that never existed (both read back as null), which would report a
+   * bogus id as a deleted-endpoint conflict instead of a not-found. Because a
+   * delivery row outlives its endpoint's soft-delete (the tombstone only cancels
+   * queued rows), confirming the delivery first and then inspecting the endpoint
+   * row's `deleted_at`/`enabled` distinguishes the three cases cleanly.
    */
   async redeliverDelivery(
     webhookId: string,
     deliveryId: string
   ): Promise<void> {
-    // `getEndpoint` filters soft-deleted rows, so a null means the endpoint was
-    // retired; a disabled endpoint would fail the re-attempt permanently. The
-    // drain re-checks endpoint state at send time, so a disable/delete racing
-    // this is caught there rather than delivering to a retired endpoint.
-    const endpoint = await this.getEndpoint(webhookId);
-    if (!endpoint) {
-      throw NextlyError.conflict({
-        reason: "state",
-        message:
-          "This endpoint has been deleted; its deliveries cannot be re-sent.",
-        logContext: { entity: "webhook-endpoint", id: webhookId },
-      });
-    }
-    if (!endpoint.enabled) {
-      throw NextlyError.conflict({
-        reason: "state",
-        message:
-          "This endpoint is disabled; enable it before re-sending deliveries.",
-        logContext: { entity: "webhook-endpoint", id: webhookId },
-      });
-    }
-
-    // Re-arm under a row lock so the read-guard-write cannot interleave with a
-    // drain worker claiming the same row. `forUpdate` takes the lock the write
-    // will need (a no-op on SQLite, whose transactions already serialize
-    // writers), so a worker that would claim the delivery blocks until this
-    // commits, and a worker that already holds an unexpired lease is seen here
-    // and refused — never revoked. Selecting the row before writing is also how
-    // the outcome is known, so success is reported only when the row was armed.
     const outcome = await this.query(() =>
       this.adapter.transaction(async tx => {
         const rows = await tx.select<{ lockedUntil: Date | null }>(
@@ -670,6 +649,23 @@ export class WebhookEndpointService extends BaseService {
           delivery.lockedUntil != null &&
           delivery.lockedUntil.getTime() > Date.now();
         if (leaseHeld) return "in-flight" as const;
+
+        // The delivery exists, so its endpoint row does too (a hard delete
+        // cascades the delivery away). A tombstone (`deleted_at`) or a cleared
+        // `enabled` flag means the re-attempt would fail permanently.
+        const endpoints = await tx.select<{
+          enabled: boolean | number;
+          deletedAt: Date | null;
+        }>("nextly_webhooks", {
+          where: { and: [{ column: "id", op: "=", value: webhookId }] },
+          limit: 1,
+        });
+        const endpoint = endpoints[0];
+        if (!endpoint || endpoint.deletedAt != null) {
+          return "endpoint-deleted" as const;
+        }
+        // Truthiness, not a strict compare: SQLite stores the flag as 0/1.
+        if (!endpoint.enabled) return "endpoint-disabled" as const;
 
         const now = new Date();
         await tx.update(
@@ -704,6 +700,22 @@ export class WebhookEndpointService extends BaseService {
         message:
           "This delivery is currently being sent; try again once it settles.",
         logContext: { entity: "webhook-delivery", webhookId, deliveryId },
+      });
+    }
+    if (outcome === "endpoint-deleted") {
+      throw NextlyError.conflict({
+        reason: "state",
+        message:
+          "This endpoint has been deleted; its deliveries cannot be re-sent.",
+        logContext: { entity: "webhook-endpoint", id: webhookId },
+      });
+    }
+    if (outcome === "endpoint-disabled") {
+      throw NextlyError.conflict({
+        reason: "state",
+        message:
+          "This endpoint is disabled; enable it before re-sending deliveries.",
+        logContext: { entity: "webhook-endpoint", id: webhookId },
       });
     }
   }

--- a/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
+++ b/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
@@ -46,6 +46,7 @@ import {
   ExternalUrlError,
   validateExternalUrl,
 } from "../../../utils/validate-external-url";
+import type { DeliverTransport } from "../deliver";
 import type { WebhookEndpointRegistry } from "../endpoint-registry";
 import {
   decryptWebhookSecret,
@@ -53,6 +54,7 @@ import {
   generateWebhookSecret,
   webhookSecretPrefix,
 } from "../secret";
+import { runEndpointProbe, type WebhookTestResult } from "../test-endpoint";
 import { REDACTED_HEADER_VALUE } from "../types";
 import type { WebhookEventSubscription } from "../types";
 
@@ -530,6 +532,141 @@ export class WebhookEndpointService extends BaseService {
 
     const stored = Array.isArray(row.secretHash) ? row.secretHash : [];
     return stored.map(value => decryptWebhookSecret(String(value)));
+  }
+
+  /**
+   * Send a signed synthetic `webhook.ping` to the endpoint and report whether it
+   * was reachable and accepted. A pure connectivity probe: it reads the endpoint
+   * RAW (real headers + secrets, unlike the read-redacted summary) and posts
+   * out-of-band, writing nothing to the outbox or the delivery queue. Works on a
+   * disabled endpoint too, so an operator can verify a receiver before enabling
+   * it. `transport` is injectable so tests drive outcomes without real network.
+   */
+  async testEndpoint(
+    id: string,
+    options?: {
+      transport?: DeliverTransport;
+      pingId?: string;
+      now?: () => Date;
+    }
+  ): Promise<WebhookTestResult> {
+    const rows = await this.query(
+      async () =>
+        (await this.db
+          .select()
+          .from(this.table)
+          .where(and(eq(this.table.id, id), isNull(this.table.deletedAt)))
+          .limit(1)) as WebhookRow[]
+    );
+    const row = rows[0];
+    if (!row) throw this.notFound(id);
+
+    const stored = Array.isArray(row.secretHash) ? row.secretHash : [];
+    const secrets = stored.map(value => decryptWebhookSecret(String(value)));
+    if (secrets.length === 0) {
+      // A delivery must be signed; without a secret there is nothing to sign.
+      throw new NextlyError({
+        code: "CONFLICT",
+        publicMessage:
+          "This endpoint has no active signing secret to sign a test event.",
+        logContext: { entity: "webhook-endpoint", id },
+      });
+    }
+
+    const headers =
+      row.headers && typeof row.headers === "object"
+        ? (row.headers as Record<string, string>)
+        : null;
+
+    return runEndpointProbe({
+      webhookId: id,
+      url: row.url,
+      headers,
+      secrets,
+      pingId: options?.pingId ?? crypto.randomUUID(),
+      transport: options?.transport,
+      now: options?.now,
+    });
+  }
+
+  /**
+   * Re-arm a past delivery for another attempt. Scoped by `(webhookId,
+   * deliveryId)` so a delivery can only be re-sent through the endpoint that
+   * owns it.
+   *
+   * The unique `(webhook_id, event_id)` index forbids a second delivery row for
+   * the same event, so this UPDATES the existing row back to a due state rather
+   * than inserting: `pending`, `next_attempt_at = now`, lock cleared, and the
+   * attempt budget reset — while the capped `attempts[]` history is left intact
+   * so the prior failures stay visible. The delivery id (the Standard-Webhooks
+   * `webhook-id`) is reused, so a receiver that already processed it dedupes.
+   * The caller triggers the drain; the row is now claimable.
+   *
+   * Guards: 404 if the delivery is not this endpoint's; 409 if the endpoint was
+   * deleted or is disabled (delivering to it would immediately fail).
+   */
+  async redeliverDelivery(
+    webhookId: string,
+    deliveryId: string
+  ): Promise<void> {
+    const rows = await this.query(
+      async () =>
+        (await this.db
+          .select({ id: this.deliveries.id })
+          .from(this.deliveries)
+          .where(
+            and(
+              eq(this.deliveries.id, deliveryId),
+              eq(this.deliveries.webhookId, webhookId)
+            )
+          )
+          .limit(1)) as Array<{ id: string }>
+    );
+    if (!rows[0]) {
+      throw NextlyError.notFound({
+        logContext: { entity: "webhook-delivery", webhookId, deliveryId },
+      });
+    }
+
+    // `getEndpoint` filters soft-deleted rows, so a null means the endpoint was
+    // retired; a disabled endpoint would fail the re-attempt permanently.
+    const endpoint = await this.getEndpoint(webhookId);
+    if (!endpoint) {
+      throw new NextlyError({
+        code: "CONFLICT",
+        publicMessage:
+          "This endpoint has been deleted; its deliveries cannot be re-sent.",
+        logContext: { entity: "webhook-endpoint", id: webhookId },
+      });
+    }
+    if (!endpoint.enabled) {
+      throw new NextlyError({
+        code: "CONFLICT",
+        publicMessage:
+          "This endpoint is disabled; enable it before re-sending deliveries.",
+        logContext: { entity: "webhook-endpoint", id: webhookId },
+      });
+    }
+
+    const now = new Date();
+    await this.query(() =>
+      this.db
+        .update(this.deliveries)
+        .set({
+          status: "pending",
+          nextAttemptAt: now,
+          attemptCount: 0,
+          lockedBy: null,
+          lockedUntil: null,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(this.deliveries.id, deliveryId),
+            eq(this.deliveries.webhookId, webhookId)
+          )
+        )
+    );
   }
 
   private notFound(id: string): NextlyError {

--- a/packages/nextly/src/domains/webhooks/test-endpoint.ts
+++ b/packages/nextly/src/domains/webhooks/test-endpoint.ts
@@ -12,7 +12,7 @@
  */
 import { safeFetch } from "../../utils/validate-external-url";
 
-import type { DeliverTransport } from "./deliver";
+import { DEFAULT_REQUEST_TIMEOUT_MS, type DeliverTransport } from "./deliver";
 import { classifyResponse } from "./delivery-policy";
 import { buildSignatureHeaders } from "./signing";
 
@@ -20,8 +20,9 @@ import { buildSignatureHeaders } from "./signing";
 const RESPONSE_SNIPPET_LIMIT = 500;
 /** Cap the response we read back, matching the delivery engine. */
 const MAX_RESPONSE_BYTES = 64 * 1024;
-/** A test is interactive; keep the operator's wait short. */
-const TEST_REQUEST_TIMEOUT_MS = 10_000;
+// Wait the same as a real delivery, so a receiver that answers within the
+// delivery window is never falsely reported unreachable by a test.
+const TEST_REQUEST_TIMEOUT_MS = DEFAULT_REQUEST_TIMEOUT_MS;
 
 /**
  * The synthetic payload a test-ping delivers. Intentionally NOT a

--- a/packages/nextly/src/domains/webhooks/test-endpoint.ts
+++ b/packages/nextly/src/domains/webhooks/test-endpoint.ts
@@ -12,7 +12,7 @@
  */
 import { safeFetch } from "../../utils/validate-external-url";
 
-import { DEFAULT_REQUEST_TIMEOUT_MS, type DeliverTransport } from "./deliver";
+import { DRAIN_REQUEST_TIMEOUT_MS, type DeliverTransport } from "./deliver";
 import { classifyResponse } from "./delivery-policy";
 import { buildSignatureHeaders } from "./signing";
 
@@ -20,9 +20,10 @@ import { buildSignatureHeaders } from "./signing";
 const RESPONSE_SNIPPET_LIMIT = 500;
 /** Cap the response we read back, matching the delivery engine. */
 const MAX_RESPONSE_BYTES = 64 * 1024;
-// Wait the same as a real delivery, so a receiver that answers within the
-// delivery window is never falsely reported unreachable by a test.
-const TEST_REQUEST_TIMEOUT_MS = DEFAULT_REQUEST_TIMEOUT_MS;
+// Wait exactly as long as the durable drain gives each real delivery, so the
+// probe predicts deliverability: a receiver inside this window is one deliveries
+// reach, and one outside it is reported unreachable rather than falsely OK.
+const TEST_REQUEST_TIMEOUT_MS = DRAIN_REQUEST_TIMEOUT_MS;
 
 /**
  * The synthetic payload a test-ping delivers. Intentionally NOT a

--- a/packages/nextly/src/domains/webhooks/test-endpoint.ts
+++ b/packages/nextly/src/domains/webhooks/test-endpoint.ts
@@ -1,0 +1,147 @@
+/**
+ * Webhook endpoint connectivity probe ("test ping").
+ *
+ * Sends a synthetic, signed `webhook.ping` payload to an endpoint's URL and
+ * reports the outcome, so an operator can verify — before or after wiring a
+ * receiver — that the endpoint is reachable AND that their signature check
+ * accepts Nextly's `webhook-signature` header. The probe is deliberately
+ * out-of-band: it writes nothing to `nextly_events` or
+ * `nextly_webhook_deliveries`, so a test never fans out, never enters the retry
+ * queue, and never pollutes the real delivery log. Reuses the exact signing and
+ * SSRF-safe transport the delivery engine uses.
+ */
+import { safeFetch } from "../../utils/validate-external-url";
+
+import type { DeliverTransport } from "./deliver";
+import { classifyResponse } from "./delivery-policy";
+import { buildSignatureHeaders } from "./signing";
+
+/** How much of the receiver's response body is retained for the operator. */
+const RESPONSE_SNIPPET_LIMIT = 500;
+/** Cap the response we read back, matching the delivery engine. */
+const MAX_RESPONSE_BYTES = 64 * 1024;
+/** A test is interactive; keep the operator's wait short. */
+const TEST_REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * The synthetic payload a test-ping delivers. Intentionally NOT a
+ * `WebhookEvent`: a ping carries no content and is not a subscribable event
+ * type, so it uses its own minimal, self-describing shape (mirrors GitHub's
+ * distinct `ping` event) rather than widening the content-event catalog.
+ */
+export interface WebhookPingPayload {
+  id: string;
+  type: "webhook.ping";
+  /** Event time, ISO-8601 (the signed `webhook-timestamp` header is unix seconds). */
+  timestamp: string;
+  webhookId: string;
+  message: string;
+}
+
+/** The result of a connectivity probe, surfaced to the operator. */
+export interface WebhookTestResult {
+  /** True only for a 2xx response (per {@link classifyResponse}). */
+  delivered: boolean;
+  /** The HTTP status, when a response was received (absent if the request threw). */
+  statusCode?: number;
+  latencyMs: number;
+  /** A short reason when not delivered: `http <status>` or the transport error. */
+  error?: string;
+  /** A truncated copy of the receiver's response body, when readable. */
+  responseSnippet?: string;
+}
+
+export interface EndpointProbeInput {
+  webhookId: string;
+  url: string;
+  /** The endpoint's stored custom headers (raw values, not the read-redaction). */
+  headers?: Record<string, string> | null;
+  /** Active plaintext signing secrets, primary first (one signature per secret). */
+  secrets: readonly string[];
+  /** A fresh id for this ping; doubles as the `webhook-id` header. */
+  pingId: string;
+  /** Injectable transport (defaults to the SSRF-safe {@link safeFetch}). */
+  transport?: DeliverTransport;
+  /** Injectable clock for deterministic tests. */
+  now?: () => Date;
+}
+
+/**
+ * Build, sign, and POST the ping, returning the outcome. Never throws for a
+ * failed delivery — a connection refusal or an SSRF rejection is a valid,
+ * reportable result, not an error. (The caller must ensure `secrets` is
+ * non-empty; an unsigned delivery is meaningless and `buildSignatureHeaders`
+ * rejects it.)
+ */
+export async function runEndpointProbe(
+  input: EndpointProbeInput
+): Promise<WebhookTestResult> {
+  const transport = input.transport ?? safeFetch;
+  const now = input.now ?? (() => new Date());
+  const at = now();
+
+  const payload: WebhookPingPayload = {
+    id: input.pingId,
+    type: "webhook.ping",
+    timestamp: at.toISOString(),
+    webhookId: input.webhookId,
+    message:
+      "Nextly webhook test event. If your receiver verifies this signature, " +
+      "the endpoint is configured correctly.",
+  };
+  const body = JSON.stringify(payload);
+  // Standard Webhooks signs over the unix-seconds timestamp, matching the
+  // delivery engine, so a receiver's shared verifier accepts a test the same
+  // way it accepts a real delivery.
+  const timestampSeconds = Math.floor(at.getTime() / 1000).toString();
+
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    // Custom headers first; the signature headers are applied LAST so a stored
+    // header can never shadow the signature the receiver must verify.
+    ...(input.headers ?? {}),
+    ...buildSignatureHeaders({
+      id: input.pingId,
+      timestamp: timestampSeconds,
+      body,
+      secrets: input.secrets,
+    }),
+  };
+
+  const sentAt = now().getTime();
+  try {
+    const response = await transport(input.url, {
+      method: "POST",
+      headers,
+      body,
+      maxResponseBytes: MAX_RESPONSE_BYTES,
+      timeoutMs: TEST_REQUEST_TIMEOUT_MS,
+    });
+    const latencyMs = now().getTime() - sentAt;
+    const outcome = classifyResponse(response.status);
+    let responseSnippet: string | undefined;
+    try {
+      responseSnippet = (await response.text()).slice(
+        0,
+        RESPONSE_SNIPPET_LIMIT
+      );
+    } catch {
+      // The status decides the outcome; an unreadable body is simply omitted.
+    }
+    return {
+      delivered: outcome === "delivered",
+      statusCode: response.status,
+      latencyMs,
+      responseSnippet,
+      error: outcome === "delivered" ? undefined : `http ${response.status}`,
+    };
+  } catch (err) {
+    // A thrown request (DNS/SSRF rejection, connection refused, timeout) is a
+    // reportable "not delivered", not a 500 for the operator.
+    return {
+      delivered: false,
+      latencyMs: now().getTime() - sentAt,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/packages/nextly/src/errors/nextly-error.ts
+++ b/packages/nextly/src/errors/nextly-error.ts
@@ -284,11 +284,16 @@ export class NextlyError extends Error {
 
   static conflict(opts?: {
     reason?: "version" | "state";
+    // A domain-specific, actionable message overriding the generic default,
+    // for state conflicts where "refresh and try again" would misdirect the
+    // caller (a disabled endpoint, an in-flight delivery, and so on).
+    message?: string;
     logContext?: Record<string, unknown>;
   }): NextlyError {
     return new NextlyError({
       code: "CONFLICT",
       publicMessage:
+        opts?.message ??
         "The resource has changed since you last loaded it. Please refresh and try again.",
       logContext: { reason: opts?.reason, ...opts?.logContext },
     });

--- a/packages/nextly/src/route-handler/__tests__/route-parser.webhooks.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.webhooks.test.ts
@@ -165,4 +165,51 @@ describe("webhook routes", () => {
   it("does not route an unsupported method on the collection", () => {
     expect(parseRestRoute(["webhooks"], "DELETE")).toEqual({});
   });
+
+  it("parses the endpoint test-ping on POST", () => {
+    expect(parseRestRoute(["webhooks", "wh_1", "test"], "POST")).toMatchObject({
+      service: "webhooks",
+      method: "testWebhookEndpoint",
+      routeParams: { webhookId: "wh_1" },
+    });
+  });
+
+  it("does not route a non-POST method to test-ping", () => {
+    for (const method of ["GET", "PATCH", "DELETE"] as const) {
+      expect(parseRestRoute(["webhooks", "wh_1", "test"], method)).toEqual({});
+    }
+  });
+
+  it("parses a delivery redeliver on POST", () => {
+    expect(
+      parseRestRoute(
+        ["webhooks", "wh_1", "deliveries", "del_1", "redeliver"],
+        "POST"
+      )
+    ).toMatchObject({
+      service: "webhooks",
+      method: "redeliverWebhookDelivery",
+      routeParams: { webhookId: "wh_1", deliveryId: "del_1" },
+    });
+  });
+
+  it("does not route a non-POST method to redeliver", () => {
+    for (const method of ["GET", "PATCH", "DELETE"] as const) {
+      expect(
+        parseRestRoute(
+          ["webhooks", "wh_1", "deliveries", "del_1", "redeliver"],
+          method
+        )
+      ).toEqual({});
+    }
+  });
+
+  it("does not match an unknown action under a delivery", () => {
+    expect(
+      parseRestRoute(
+        ["webhooks", "wh_1", "deliveries", "del_1", "bogus"],
+        "POST"
+      )
+    ).toEqual({});
+  });
 });

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -1761,10 +1761,45 @@ function parseWebhookRoutes(
     };
   }
 
+  // POST /api/webhooks/:id/deliveries/:deliveryId/redeliver → re-arm a past
+  // delivery for another attempt. Handled here (before the one-level guard)
+  // because it is the deepest webhook route.
+  if (
+    id &&
+    subresource === "deliveries" &&
+    subId &&
+    additionalParams.length === 1 &&
+    additionalParams[0] === "redeliver"
+  ) {
+    if (httpMethod !== "POST") return null;
+    routeParams.webhookId = id;
+    routeParams.deliveryId = subId;
+    return {
+      service: "webhooks",
+      operation: "single",
+      method: "redeliverWebhookDelivery",
+      routeParams,
+    };
+  }
+
   // Nothing else here nests further than one level, so any deeper path is not a
   // route. Without this, `/webhooks/:id/secret/anything` would still match the
   // secret branch and hand back active signing secrets.
   if (subId || additionalParams.length > 0) return null;
+
+  // POST /api/webhooks/:id/test → send a synthetic signed ping to the endpoint
+  // and report the outcome. Side-effecting (an outbound request), so it is a
+  // POST and authorized like a mutation.
+  if (id && subresource === "test") {
+    if (httpMethod !== "POST") return null;
+    routeParams.webhookId = id;
+    return {
+      service: "webhooks",
+      operation: "single",
+      method: "testWebhookEndpoint",
+      routeParams,
+    };
+  }
 
   if (id && subresource === "deliveries") {
     // GET /api/webhooks/:id/deliveries → the endpoint's delivery log (paged).

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -68,6 +68,8 @@ import {
   revealWebhookSecret,
   listWebhookDeliveries,
   getWebhookDelivery,
+  testWebhookEndpoint,
+  redeliverWebhookDelivery,
   drainWebhooks,
 } from "./api/webhooks";
 import { readAccessTokenCookie } from "./auth/cookies/access-token-cookie";
@@ -330,6 +332,10 @@ async function handleWebhookRequest(
       return listWebhookDeliveries(req, id);
     case "getWebhookDelivery":
       return getWebhookDelivery(req, id, routeParams?.deliveryId ?? "");
+    case "testWebhookEndpoint":
+      return testWebhookEndpoint(req, id);
+    case "redeliverWebhookDelivery":
+      return redeliverWebhookDelivery(req, id, routeParams?.deliveryId ?? "");
     case "drainWebhooks":
       return drainWebhooks(req);
     default:

--- a/tasks/webhook-b4-HANDOFF.md
+++ b/tasks/webhook-b4-HANDOFF.md
@@ -1,14 +1,16 @@
 # Webhook B4 (test-ping + redeliver) — Session Handoff
 
-**Written:** 2026-07-23. **PR:** https://github.com/nextlyhq/nextly/pull/310
-**Status:** OPEN, CI all green, mergeable but merge-BLOCKED pending codex APPROVED. **1 open review thread** (see §7).
+**Written:** 2026-07-23 (updated 2026-07-24). **PR:** https://github.com/nextlyhq/nextly/pull/310
+**Status:** OPEN, CI all green, mergeable but merge-BLOCKED pending codex APPROVED. **0 open review threads** as of last check.
+
+**Latest HEAD:** `3fb4da1f` (round 5 — finalize lease fence). The §7 "Expired worker clobbers redelivery" thread is RESOLVED (fixed in `3fb4da1f`, see §6 round 5).
 
 ---
 
 ## 0. TL;DR — where to pick up
 
-1. **Immediate:** resolve the newest greptile thread "**Expired worker clobbers redelivery**" (§7). Recommended fix = fence `finalizeDelivery` on lease ownership. Not yet started.
-2. Then keep babysitting #310: work each new review round with a _proper_ solution, push, reply+resolve, re-trigger `@codex @coderabbitai @greptile-apps`.
+1. **Immediate:** re-check open review threads (GraphQL in §8). If codex/greptile/coderabbit posted a new round on `3fb4da1f`, work it with a proper solution. If none and codex has APPROVED, tell the founder it's ready and WAIT for the explicit go-ahead.
+2. Keep babysitting #310: work each new review round with a _proper_ solution, push, reply+resolve, re-trigger `@codex @coderabbitai @greptile-apps`.
 3. **Do NOT merge** until (a) codex posts an APPROVED review AND (b) the founder gives an explicit per-PR go-ahead. Both are required. Codex approval alone is not enough.
 4. After #310 merges → **U1** (admin webhooks UI), then **B5** (webhook secret rotation). See §9.
 
@@ -41,12 +43,13 @@
 - **Worktree:** `/Users/mobeen/Work/Products/nextly-integrations/nextly/nextly-worktrees/webhook-b4`
 - **Branch:** `feat/webhook-test-redeliver` (base `main`).
 - **Monorepo root** (for integration tests): `/Users/mobeen/Work/Products/nextly-integrations/nextly` (the worktree shares the same pnpm workspace; run integration from the worktree root which resolves to the workspace).
-- **Watcher task id:** `bwodbykzq` (persistent Monitor, 15-min poll of #310 for unresolved threads / CI fails / codex approval / merge-close). It has survived the whole session; a re-armed one is fine if it's gone.
+- **Watcher task id:** `b53708drl` (persistent Monitor, 15-min poll of #310 for unresolved threads / CI fails / codex approval / merge-close). It has survived the whole session; a re-armed one is fine if it's gone.
 - **Repo:** `nextlyhq/nextly` (private). `gh` CLI is authenticated.
 
 ### Commits on the branch (newest first)
 
 ```
+3fb4da1f fix(nextly): fence delivery finalize on lease ownership        <- round 5 (open thread §7)
 3e8e3eec fix(nextly): lock the drain claim against a redelivery re-arm
 e933386c fix(nextly): probe with the durable drain timeout
 f16f7b35 fix(nextly): re-arm webhook delivery under a row lock
@@ -146,11 +149,17 @@ Content write → `recordMutationEvent` (writes `nextly_events` outbox) → `fan
 
 - _Stale drain claim after re-arm (codex P2):_ `claimDelivery` SELECT lacked a row lock and cached `attemptCount` in memory; on pg/mysql it could claim a row my re-arm just reset and act on the stale budget (line `attemptCount = row.attemptCount + 1`). **Fixed:** added `forUpdate: true` to `claimDelivery`'s SELECT so claim and re-arm serialize on the row (no-op on SQLite). Follows the existing forUpdate pattern.
 
-All four rounds: check-types + lint clean, full webhook integration suite green (530 passed on SQLite locally; CI runs pg/mysql/sqlite legs — all green as of `3e8e3eec`). Every thread replied + resolved.
+**Round 5 → commit `3fb4da1f`:**
+
+- _Expired worker clobbers redelivery (greptile P1):_ a worker that overruns its lease (lease expired but HTTP still in flight) could `finalizeDelivery` by id and overwrite a row a re-arm/other-drain had taken over. **Fixed:** `claimDelivery` stamps the runner as lease owner on the returned row (`row.lockedBy = runnerId`, plus `lockedBy` added to the `DeliveryRow` interface); `finalizeDelivery` fences its UPDATE with `AND locked_by = row.lockedBy`, so a handed-off row's stale finalize is a no-op. Closes the same clobber between two drain workers too. Deterministic test in `deliver.integration.test.ts` (`does not clobber a delivery whose lease was handed off mid-attempt`) steals the lease during the in-flight request and asserts the re-armed row survives.
+
+All five rounds: check-types + lint clean, full webhook integration suite green (531 passed on SQLite locally as of `3fb4da1f`; CI runs pg/mysql/sqlite legs). Every thread replied + resolved.
 
 ---
 
-## 7. OPEN THREAD — do this first
+## 7. Resolved thread (was "do this first")
+
+**greptile P1 "Expired worker clobbers redelivery"** — RESOLVED in `3fb4da1f` (see round 5 above). Kept here for context in case it re-opens on re-review.
 
 **greptile P1 "Expired worker clobbers redelivery"** — `webhook-endpoint-service.ts:672`, thread id `PRRT_kwDOSYwUJs6TVcjH`, comment db id `3640231506`. Landed 2026-07-23T17:51Z (after `3e8e3eec`).
 

--- a/tasks/webhook-b4-HANDOFF.md
+++ b/tasks/webhook-b4-HANDOFF.md
@@ -3,7 +3,7 @@
 **Written:** 2026-07-23 (updated 2026-07-24). **PR:** https://github.com/nextlyhq/nextly/pull/310
 **Status:** OPEN, CI all green, mergeable but merge-BLOCKED pending codex APPROVED. **0 open review threads** as of last check.
 
-**Latest HEAD:** `3fb4da1f` (round 5 — finalize lease fence). The §7 "Expired worker clobbers redelivery" thread is RESOLVED (fixed in `3fb4da1f`, see §6 round 5).
+**Latest HEAD:** `c0bc7bea` (round 6 — 404 unknown endpoint id on redelivery; round 5 = finalize lease fence). The §7 "Expired worker clobbers redelivery" thread is RESOLVED (fixed in `3fb4da1f`, see §6 round 5).
 
 ---
 
@@ -49,7 +49,8 @@
 ### Commits on the branch (newest first)
 
 ```
-3fb4da1f fix(nextly): fence delivery finalize on lease ownership        <- round 5 (open thread §7)
+c0bc7bea fix(nextly): 404 an unknown endpoint id on redelivery         <- round 6
+3fb4da1f fix(nextly): fence delivery finalize on lease ownership        <- round 5
 3e8e3eec fix(nextly): lock the drain claim against a redelivery re-arm
 e933386c fix(nextly): probe with the durable drain timeout
 f16f7b35 fix(nextly): re-arm webhook delivery under a row lock
@@ -153,7 +154,11 @@ Content write → `recordMutationEvent` (writes `nextly_events` outbox) → `fan
 
 - _Expired worker clobbers redelivery (greptile P1):_ a worker that overruns its lease (lease expired but HTTP still in flight) could `finalizeDelivery` by id and overwrite a row a re-arm/other-drain had taken over. **Fixed:** `claimDelivery` stamps the runner as lease owner on the returned row (`row.lockedBy = runnerId`, plus `lockedBy` added to the `DeliveryRow` interface); `finalizeDelivery` fences its UPDATE with `AND locked_by = row.lockedBy`, so a handed-off row's stale finalize is a no-op. Closes the same clobber between two drain workers too. Deterministic test in `deliver.integration.test.ts` (`does not clobber a delivery whose lease was handed off mid-attempt`) steals the lease during the in-flight request and asserts the re-armed row survives.
 
-All five rounds: check-types + lint clean, full webhook integration suite green (531 passed on SQLite locally as of `3fb4da1f`; CI runs pg/mysql/sqlite legs). Every thread replied + resolved.
+**Round 6 → commit `c0bc7bea`:**
+
+- _Unknown endpoint id returned 409 instead of 404 (codex P2):_ the endpoint check ran before the scoped delivery lookup, and `getEndpoint` returns null for both a missing and a soft-deleted endpoint, so a mistyped `webhookId` got a bogus "endpoint deleted" 409. **Fixed:** reordered so the `FOR UPDATE` delivery lookup runs first (unknown/foreign/bogus id → 404), then the endpoint row is read in the same transaction and its `deleted_at`/`enabled` distinguish deleted (409) from disabled (409). A delivery outlives its endpoint's soft-delete (tombstone only cancels queued rows), so the deleted branch stays reachable. Two tests added.
+
+All six rounds: check-types + lint clean, full webhook integration suite green (533 passed on SQLite locally as of `c0bc7bea`; CI runs pg/mysql/sqlite legs). Every thread replied + resolved.
 
 ---
 

--- a/tasks/webhook-b4-HANDOFF.md
+++ b/tasks/webhook-b4-HANDOFF.md
@@ -1,0 +1,224 @@
+# Webhook B4 (test-ping + redeliver) — Session Handoff
+
+**Written:** 2026-07-23. **PR:** https://github.com/nextlyhq/nextly/pull/310
+**Status:** OPEN, CI all green, mergeable but merge-BLOCKED pending codex APPROVED. **1 open review thread** (see §7).
+
+---
+
+## 0. TL;DR — where to pick up
+
+1. **Immediate:** resolve the newest greptile thread "**Expired worker clobbers redelivery**" (§7). Recommended fix = fence `finalizeDelivery` on lease ownership. Not yet started.
+2. Then keep babysitting #310: work each new review round with a _proper_ solution, push, reply+resolve, re-trigger `@codex @coderabbitai @greptile-apps`.
+3. **Do NOT merge** until (a) codex posts an APPROVED review AND (b) the founder gives an explicit per-PR go-ahead. Both are required. Codex approval alone is not enough.
+4. After #310 merges → **U1** (admin webhooks UI), then **B5** (webhook secret rotation). See §9.
+
+---
+
+## 1. Standing directives (from the founder — treat as law)
+
+- **Prime directive:** "work properly on all the priority order tasks after full in-depth deep research for best architecture, best industry standards, best dx/ux/ui." Latest = deep, correct solutions, not quick patches.
+- **Scope:** "you are only responsible for your PRs" — only the webhook PRs I authored. Don't wander into unrelated work.
+- **Review triggers:** on every push of new commits, post one comment tagging **`@codex @coderabbitai @greptile-apps`** to request re-review.
+- **Merge gate:** "Once codex approves these PRs, then we can only merge." Combined with the hard rule: **never merge without an explicit founder go-ahead for that specific PR**, even after codex approves. I have broad permissions but this gate is absolute.
+- **Review loop:** keep a ~15-min watcher on the PR; fetch unresolved threads; fix real issues with proper solutions + tests; push back with evidence on false positives; reply to and resolve every thread so bots re-verify.
+
+### Conventions (enforced; violations rejected in review — see AGENTS.md)
+
+- `NextlyError` factories only inside `packages/nextly/**` (never bare `Error`). Admin is exempt.
+- **Drizzle ORM only**, no raw SQL in product code. Test fixtures use production DDL helpers (drizzle-kit), never hand-copied CREATE TABLE.
+- **No `as any` / `@ts-expect-error` / eslint-disable.** Fix with real types/guards/generics.
+- API responses use `response-shapes.ts` envelopes (`{items,meta}` / `{message,item}`). Never invent a shape.
+- Every code change gets a **what/why comment**. Comments describe the code ONLY — never reference tasks, plans, PRs, reviews, or findings.
+- **ONE changeset per PR**, all 18 published packages, `patch` (alpha, lockstep). Test/CI/docs-only PRs get none.
+- **Conventional Commits** (`type(scope): subject`, lowercase imperative). Valid scopes are package names + `playground|root|ci|docs|deps|release`. `nextly` is the scope used here.
+- **No AI attribution** anywhere (no Co-Authored-By, no "Generated with Claude").
+- Never `--no-verify`. Husky runs gitleaks + lint-staged + commitlint on commit; lint+build on push. Fix hook failures, don't bypass.
+
+---
+
+## 2. Locations / coordinates
+
+- **Worktree:** `/Users/mobeen/Work/Products/nextly-integrations/nextly/nextly-worktrees/webhook-b4`
+- **Branch:** `feat/webhook-test-redeliver` (base `main`).
+- **Monorepo root** (for integration tests): `/Users/mobeen/Work/Products/nextly-integrations/nextly` (the worktree shares the same pnpm workspace; run integration from the worktree root which resolves to the workspace).
+- **Watcher task id:** `bwodbykzq` (persistent Monitor, 15-min poll of #310 for unresolved threads / CI fails / codex approval / merge-close). It has survived the whole session; a re-armed one is fine if it's gone.
+- **Repo:** `nextlyhq/nextly` (private). `gh` CLI is authenticated.
+
+### Commits on the branch (newest first)
+
+```
+3e8e3eec fix(nextly): lock the drain claim against a redelivery re-arm
+e933386c fix(nextly): probe with the durable drain timeout
+f16f7b35 fix(nextly): re-arm webhook delivery under a row lock
+10d9b464 fix(nextly): guard webhook redelivery against active leases
+a3e6df85 feat(nextly): add webhook endpoint test-ping and delivery redeliver   <- original B4
+```
+
+Main was at `a3e6df85`'s parent when branched. Prior webhook PRs **#301 and #307 are already MERGED** to main.
+
+---
+
+## 3. What B4 is (the feature)
+
+Two new REST endpoints on the webhooks surface, both requiring the webhook **update** permission and an **interactive session** (session-only, no route/bearer):
+
+1. **`POST /api/webhooks/:id/test`** — a pure connectivity probe ("test-ping").
+   - Builds a synthetic `webhook.ping` payload (NOT a real `WebhookEvent` — distinct shape, no event-catalog pollution), signs it with the endpoint's real secret using the exact Standard-Webhooks signing the delivery engine uses, POSTs it via the same SSRF-safe transport.
+   - **Writes nothing** to `nextly_events` or `nextly_webhook_deliveries` — no outbox row, no delivery-log row, no fan-out, no retry.
+   - Returns inline: `{ delivered, statusCode?, latencyMs, error?, responseSnippet? }`. Never throws for a failed delivery (returns `delivered:false`).
+   - Works on a disabled endpoint too (verify a receiver before enabling). 409 if the endpoint has no signing secret.
+
+2. **`POST /api/webhooks/:id/deliveries/:deliveryId/redeliver`** — re-send a past delivery.
+   - The unique `(webhook_id, event_id)` index forbids a second delivery row, so this **re-arms the existing row** (resets it to `pending`, `next_attempt_at=now`, `attempt_count=0`, lock cleared) while keeping the capped `attempts[]` history. Reuses the delivery id (the Standard-Webhooks `webhook-id`), so a receiver that already processed it dedupes.
+   - Nudges the fast drain so it goes out promptly; the outcome then shows in the delivery log.
+   - **Guards:** 404 unknown/foreign delivery; 409 if endpoint deleted or disabled; **409 if the delivery is still in flight** (held under an unexpired lease).
+
+---
+
+## 4. Files in the PR
+
+**New:**
+
+- `packages/nextly/src/domains/webhooks/test-endpoint.ts` — pure probe. Exports `runEndpointProbe(input)`, `WebhookPingPayload`, `WebhookTestResult`, `EndpointProbeInput`. Custom headers first, signature headers LAST (so signature can't be shadowed). Probe timeout = `DRAIN_REQUEST_TIMEOUT_MS` (10s, imported from deliver.ts — see §6 decisions).
+- `packages/nextly/src/domains/webhooks/__tests__/webhook-test-redeliver.integration.test.ts` — real SQLite (in-memory) suite. Manual adapter wiring (`createSqliteAdapter` + drizzle-kit DDL + seeded user). Covers: probe signs validly + persists nothing + 10s timeout + non-2xx/throw/404; redeliver re-arms + budget reset + history kept + unique-index + in-flight-lease refusal + pruned-event-cascade 404 + 404 unknown + 409 disabled + foreign-delivery rejection. **11 redeliver + test-ping cases.**
+- `.changeset/webhook-test-redeliver.md` — all 18 packages, patch.
+- `tasks/webhook-b4-test-redeliver-spec.md` — the B4 spec (local, uncommitted).
+
+**Modified:**
+
+- `packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts` — `testEndpoint(id, opts?)` and `redeliverDelivery(webhookId, deliveryId)`. redeliver runs the read-guard-write in a **transaction with `SELECT ... FOR UPDATE`** (§6).
+- `packages/nextly/src/domains/webhooks/deliver.ts` — exported `DRAIN_REQUEST_TIMEOUT_MS = 10_000`; `claimDelivery` SELECT now uses `forUpdate: true` (§6/§7). `DEFAULT_REQUEST_TIMEOUT_MS` (15s) is back to a private fallback.
+- `packages/nextly/src/api/webhooks.ts` — `testWebhookEndpoint` + `redeliverWebhookDelivery` handlers (update perm + session-only + envelopes). Drain route imports `DRAIN_REQUEST_TIMEOUT_MS` from deliver.ts (was a local const).
+- `packages/nextly/src/errors/nextly-error.ts` — `conflict()` gained an optional `message` for domain-specific state conflicts (default message unchanged).
+- `packages/nextly/src/route-handler/route-parser.ts` + `routeHandler.ts` — parse/dispatch the two new routes.
+- `packages/nextly/src/api/webhooks.test.ts` + `route-handler/__tests__/route-parser.webhooks.test.ts` — unit coverage for handlers + route parsing.
+
+---
+
+## 5. Webhook architecture context (enough to reason about the reviews)
+
+Content write → `recordMutationEvent` (writes `nextly_events` outbox) → `fanOut` (`selectDeliveryTargets`) → `deliver` (Standard-Webhooks HMAC signing, SSRF-safe `safeFetch`, at-least-once + receiver dedup) → `runWebhookDrain` + `WebhookFastDrainScheduler` (Next.js `after()` post-response fast path).
+
+**Three tables** (per-dialect schemas in `packages/nextly/src/schemas/webhooks/{sqlite,pg,mysql}.ts`):
+
+- `nextly_events` — outbox.
+- `nextly_webhooks` — endpoints. `secret_hash` = JSON array of AES-GCM ciphertexts (list-shaped for rotation). `deleted_at` soft-delete.
+- `nextly_webhook_deliveries` — per-endpoint retry state. UNIQUE `(webhook_id, event_id)`. `event_id` FK **`onDelete: cascade`**, `webhook_id` FK cascade. `status` ∈ pending/processing/delivered/retrying/failed. `attempt_count`, `next_attempt_at`, `locked_by`/`locked_until` (lease), `attempts[]` capped at 20.
+
+**Drain concurrency model (critical for the reviews):**
+
+- `claimDelivery(id, runnerId, now, leaseMs)` runs a transaction: SELECT the row (now `forUpdate:true`), check `isDue` (pending/retrying + next_attempt_at ≤ now) and `leaseFree` (locked_until null or ≤ now), then UPDATE the lease (`locked_by`, `locked_until`) keyed by id. Returns the in-memory row.
+- Drain loop: `attemptCount = row.attemptCount + 1`; `attemptDelivery(...)` signs+sends, then `finalizeDelivery` writes the outcome and clears the lease **UNCONDITIONALLY keyed by id** (this is the crux of the open thread §7).
+- **Real per-request timeouts:** cron/manual drain route passes `DRAIN_REQUEST_TIMEOUT_MS` (10s); fast-path scheduler (`after-drain.ts`) passes `4_000` (4s). `DEFAULT_REQUEST_TIMEOUT_MS` (15s) is only a library fallback the product never uses.
+
+**Retention:** `prune.ts` deletes aged rows from `nextly_events` (cascade removes their deliveries) and old `nextly_webhook_deliveries`. It builds a `blocked` set so it never prunes an event that still has a live delivery. ⇒ a delivery referencing a pruned/unusable event **cannot exist** (this is why the "pruned event" review was a false positive — see §6).
+
+**Adapter facts learned this session:**
+
+- Where-clause DSL uses **JS property names** (camelCase: `webhookId`, `lockedUntil`), not DB column names. Ops include `=`, `<=`, `IS NULL`, `or`, `and`.
+- UPDATE `data` object keys are snake_case (mapped internally); WHERE columns are camelCase.
+- `adapter.select`/`executeQuery` return arrays directly (NOT `{rows}`).
+- **`forUpdate: true`** on a SELECT takes a `FOR UPDATE` row lock; **no-op on SQLite** (its transactions open `BEGIN IMMEDIATE`, already serializing writers), correct `FOR UPDATE` on pg/mysql. Requires a transaction executor. Already used by single/collection mutation services with adapter test coverage — a trusted pattern.
+- SQLite `integer{mode:"timestamp"}` stores **Unix seconds**. FK cascades enforced (`PRAGMA foreign_keys = ON` by default).
+- `NextlyError.conflict()` originally had only `{reason?, logContext?}` with a fixed generic message. This PR added an optional `message`.
+
+---
+
+## 6. Review rounds worked + every decision (chronological)
+
+**Round 1 → commit `10d9b464`:**
+
+- _Lease revocation (greptile ×2 + codex P1):_ redeliver unconditionally cleared an active lease → concurrent drain could double-send. **Fixed** (first pass): refuse in-flight lease + conditional update.
+- _Probe timeout 10s vs 15s (greptile P2):_ aligned probe to the delivery timeout. **(Later corrected — see round 3.)**
+- _Use NextlyError factories (codex P1):_ extended `conflict()` with optional `message`; routed all four CONFLICT throws through it. Status still derives centrally from the code. **Fixed.**
+- _Endpoint guard races with rearm (greptile P1):_ **false positive** — `attemptDelivery` re-loads the endpoint at send time and fails deliveries for deleted/disabled endpoints, so a re-armed row is never POSTed to a retired endpoint. Pushed back with evidence.
+
+**Round 2 → commit `f16f7b35`:**
+
+- _False success on lost race (greptile ×2 + codex + coderabbit):_ the conditional UPDATE discarded its result, so on the race the API still said "queued." **Fixed properly:** reworked redeliver into a **transaction with `SELECT ... FOR UPDATE`** — the row lock closes the read/claim interleave; the pre-write SELECT determines the outcome (in-flight → 409, success only after the row is actually armed). Replaced the affected-count-guessing approach. Added the in-flight-lease integration test.
+- _Pruned-event 409 (coderabbit Major):_ **false positive** — `event_id` cascades + retention's blocked-set mean a delivery for a pruned event can't exist → 404. Pushed back AND added a defensive test (`404s when the delivery's event was pruned`) proving the cascade invariant.
+
+**Round 3 → commit `e933386c`:**
+
+- _Probe timeout vs REAL drain timeouts (codex P2):_ codex was sharper than round-1 greptile — the product drain uses 10s (cron) / 4s (fast), not 15s. My 15s was too lenient (false positives). **Fixed:** probe now waits `DRAIN_REQUEST_TIMEOUT_MS` (10s, the durable path). Moved the constant into deliver.ts as the single source; drain route + probe both import it. Added a test asserting the probe issues a 10s timeout. (Reverted the round-1 export of `DEFAULT_REQUEST_TIMEOUT_MS`.)
+
+**Round 4 → commit `3e8e3eec`:**
+
+- _Stale drain claim after re-arm (codex P2):_ `claimDelivery` SELECT lacked a row lock and cached `attemptCount` in memory; on pg/mysql it could claim a row my re-arm just reset and act on the stale budget (line `attemptCount = row.attemptCount + 1`). **Fixed:** added `forUpdate: true` to `claimDelivery`'s SELECT so claim and re-arm serialize on the row (no-op on SQLite). Follows the existing forUpdate pattern.
+
+All four rounds: check-types + lint clean, full webhook integration suite green (530 passed on SQLite locally; CI runs pg/mysql/sqlite legs — all green as of `3e8e3eec`). Every thread replied + resolved.
+
+---
+
+## 7. OPEN THREAD — do this first
+
+**greptile P1 "Expired worker clobbers redelivery"** — `webhook-endpoint-service.ts:672`, thread id `PRRT_kwDOSYwUJs6TVcjH`, comment db id `3640231506`. Landed 2026-07-23T17:51Z (after `3e8e3eec`).
+
+**The claim:** if a drain worker's lease _expires_ while it is still actually processing (slow HTTP), my re-arm sees `locked_until ≤ now` (treats it as idle) and re-arms to `pending`. The still-running original worker then calls `finalizeDelivery`, whose UPDATE is **unconditional by id**, and overwrites the fresh `pending` state with the old attempt's outcome. API said "queued," but the redelivery is silently clobbered.
+
+**My analysis:** this is REAL but it is a property of the drain's lease-expiry + unconditional-finalize design, not something redeliver invented — the _same_ clobber happens if an expired lease is reclaimed by a second drain worker. The clean, canonical fix is a **fencing check on `finalizeDelivery`**: scope its UPDATE to `WHERE id = ? AND locked_by = <this runnerId>`. Then a worker whose lease was stolen (by another drain, or by a re-arm which sets `locked_by = null`) matches zero rows and its stale outcome is dropped.
+
+**Recommended implementation:**
+
+- `finalizeDelivery(deps, row, now, update)` → also thread the current `runnerId` (available in the drain loop / `deps.runnerId`) and add `locked_by = runnerId` to its WHERE `and[]`. (The claimed `row.lockedBy` is the pre-claim value, so use the runnerId this worker set, not `row.lockedBy`.)
+- Consider the same fencing on `recoverUnexpectedFailure`'s finalize path.
+- Verify: an expired-lease worker finalizing after a re-arm (locked_by cleared) is a no-op; a normal finalize (worker still owns the lease) still writes.
+- This touches the core drain finalize path (affects all deliveries), so run the full webhook integration suite. Add a test if it can be made deterministic (SQLite forUpdate no-ops, so a true two-connection race is hard — a targeted test that calls finalize with a mismatched runnerId and asserts no write is the pragmatic version).
+- **Alternative framing if pushing back:** it's a pre-existing at-least-once property mitigated by receiver-side dedup (stable webhook-id). But given the founder wants proper solutions and the fix is small + canonical, **implement the fence** rather than argue.
+
+**Workflow to close it:** fix → `pnpm check-types` + `pnpm lint` (in `packages/nextly`) → run webhook integration (§8) → commit (`fix(nextly): ...`) → push → reply on the thread with the commit sha + what/why → resolve the thread → comment `@codex @coderabbitai @greptile-apps please re-review`.
+
+---
+
+## 8. How to test (learned the hard way)
+
+- **Type/lint** (fast, no build): in `packages/nextly`: `pnpm check-types` and `pnpm lint`.
+- **Unit** (source, fast): `pnpm vitest run <paths>` from `packages/nextly`. Key files: `src/api/webhooks.test.ts`, `src/route-handler/__tests__/route-parser.webhooks.test.ts`, `src/errors`.
+- **Integration** (needs built deps): run from the **worktree root**, NOT `--filter` on an unbuilt tree. Command used all session:
+  `pnpm --filter nextly test:integration -- webhook` (turbo builds deps first; SQLite in-memory; ~4 min). It self-skips pg/mysql when `TEST_*_URL` unset. The redeliver suite runs green at **530 passed / 82 skipped** on SQLite.
+- Integration runs take >120s → they get backgrounded; use a Monitor `until grep -qE "Test Files|failed|Error:" file; do sleep 3; done` to wait.
+- CI matrix (pg15/pg17/mysql/sqlite) runs on push — covers the `FOR UPDATE` legs that no-op locally on SQLite. Don't block on CI locally; the watcher/CI reports it.
+- **Baseline caveat:** the repo has ~412 pre-existing stale-mock unit failures unrelated to this work. Never add to it; only care about the areas you touch.
+
+### Fetch unresolved review threads (the GraphQL that worked)
+
+```bash
+gh api graphql -f query='
+query { repository(owner:"nextlyhq",name:"nextly"){ pullRequest(number:310){
+  reviewThreads(first:90){ nodes{ id isResolved path line
+    comments(first:1){nodes{databaseId author{login} body createdAt}} } } } } }' \
+| python3 -c 'import json,sys,re
+d=json.load(sys.stdin)
+for t in d["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]:
+    if t["isResolved"]: continue
+    c=t["comments"]["nodes"][0]; b=re.sub(r"<details>.*?</details>","[..]",c["body"],flags=re.S)
+    print(t["id"], c["databaseId"], c["author"]["login"], t["path"], t.get("line")); print(b[:1600]); print()'
+```
+
+### Reply + resolve a thread
+
+```bash
+gh api repos/nextlyhq/nextly/pulls/310/comments/<DB_ID>/replies -f body="<reply>"
+gh api graphql -f query='mutation($t:ID!){resolveReviewThread(input:{threadId:$t}){thread{isResolved}}}' -f t="<THREAD_ID>"
+```
+
+---
+
+## 9. Remaining tasks / queue
+
+1. **#310 to merge-ready:** close the open thread (§7) + any further rounds. Then **wait for codex APPROVED + explicit founder go-ahead** before merging (`gh pr merge 310 --repo nextlyhq/nextly --squash --admin` only when both are satisfied).
+2. **U1 — admin webhooks UI** (next feature): manage endpoints (create/edit/enable/disable/delete), delivery log view, and **Test** + **Redeliver** buttons wired to the two B4 endpoints. Token-driven styling, both light/dark, `--nx-*` only. New worktree/branch off main.
+3. **B5 — webhook secret rotation** (overlap window): `secret_hash` is already list-shaped for exactly this; add a rotate action that appends a new secret and retires the old after an overlap.
+
+### Deferred follow-ups (already logged to memory, not part of #310)
+
+- Content-addressed media variant paths [from #307].
+- Persist localized field defaults to the companion on auto-create [#301].
+- Reconcile default-locale companion `_status` consistency [#301].
+- (Webhooks program, separate) admin webhooks UI = U1 above; capture coverage gaps (no delete/singles/status events) tracked in memory `project_webhooks_audit_2026_07_21`.
+
+---
+
+## 10. Broader webhook program state (from memory)
+
+The webhook **engine is real and solid** (outbox + signing + fan-out + deliver + retry + drain + retention all shipped across #290/#301/#307 and earlier). The **product surface** is what's being built out now, in small PRs: B4 (test/redeliver) = this PR; U1 (admin UI) and B5 (rotation) next. Order chosen: secret crypto → CRUD → drain → events → operator actions (test/redeliver) → UI → rotation. Relevant memory files: `project_webhooks_events_research`, `project_webhook_outbox_gate`, `project_webhooks_audit_2026_07_21`, `project_webhook_recording_followups`, `project_priority_roadmap`.

--- a/tasks/webhook-b4-test-redeliver-spec.md
+++ b/tasks/webhook-b4-test-redeliver-spec.md
@@ -1,0 +1,66 @@
+# B4 — Webhook test-ping + redeliver (spec)
+
+Two operator/developer REST endpoints on the existing `webhooks` resource. Both
+side-effecting → gated `update` + session-only, `respondAction`/`respondMutation`.
+
+## 1. test-ping — `POST /webhooks/:id/test`
+
+Verify an endpoint's connectivity + signature **without touching the outbox**.
+
+- Load endpoint (`getEndpoint` for existence/enabled; `revealSecrets(id)` for
+  active plaintext secrets). 404 if missing; 409/422 if no active secret.
+- Build a synthetic **ping** envelope (new `webhook.ping` event type — added to
+  the `WebhookEvent` type union so there is no `as`-cast; documented as
+  system-emitted-only, never written to `nextly_events`, so fan-out/subscription
+  never carries it). Payload identifies it as a test with a timestamp + endpoint
+  id, no content data.
+- `JSON.stringify` body → `buildSignatureHeaders({ id: pingId, timestamp, body,
+secrets })` → merge endpoint custom headers → `safeFetch(url, { method:"POST",
+headers, body, timeoutMs, maxResponseBytes })` → `classifyResponse(status)`.
+- Return `respondAction("Test event sent.", { delivered, statusCode, latencyMs,
+error?, responseSnippet })`. `ExternalUrlError` (SSRF/DNS) → `delivered:false`
+  with a clear message, HTTP 200 (the probe ran; the endpoint is unreachable).
+
+Reuses: `WebhookEndpointService.getEndpoint/revealSecrets`, `buildSignatureHeaders`
+(`signing.ts`), `safeFetch` (`utils/validate-external-url`), `classifyResponse`
+(`delivery-policy.ts`). New: `webhook.ping` type; a `testEndpoint` service method
+returning the probe result; route + handler.
+
+## 2. redeliver — `POST /webhooks/:id/deliveries/:deliveryId/redeliver`
+
+Re-attempt a specific past delivery. Keyed by `(webhookId, deliveryId)` so it
+reuses the existing delivery-log scoping.
+
+- Resolve the delivery scoped by `(webhookId, deliveryId)` (404 if missing).
+- Guard: endpoint not soft-deleted/disabled (409 if disabled); the referenced
+  `nextly_events` row still exists with a payload (409 if pruned by retention).
+- **Re-arm the existing delivery row** (the unique index forbids a second row for
+  the same `(webhook, event)`): `status="pending"`, `next_attempt_at=now`,
+  `locked_by=null`, `locked_until=null`, `attempt_count=0` (fresh retry budget),
+  `updated_at=now`. Preserve the capped `attempts[]` history (append, never wipe).
+  The delivery `id` (the Standard-Webhooks `webhook-id`) is reused, so a receiver
+  that already processed it dedupes — the correct "try again" semantic.
+- Offer the fast-drain so the re-armed row is attempted promptly (consistent with
+  the outbox model); the scheduled drain is the backstop.
+- Return `respondMutation("Redelivery queued.", <delivery summary post-rearm>)`.
+  The outcome surfaces in the delivery log (`GET /webhooks/:id/deliveries[/:id]`).
+
+Reuses: `WebhookDeliveryQueryService.getDelivery` (scoping), `WebhookFastDrainScheduler.offer`.
+New: a `redeliver(webhookId, deliveryId)` mutation (re-arm) on a service; route +
+handler.
+
+## Non-goals (follow-ups)
+
+- Event-scoped redeliver (`/webhooks/events/:id/redeliver` re-fan-out to all
+  endpoints) — this spec does delivery-scoped only.
+- Synchronous single-delivery result for redeliver (would need an exported
+  `deliverOne` seam; the async log-based outcome is sufficient and consistent).
+
+## Tests (per-dialect where SQL-touching)
+
+- Domain integration (manual adapter wiring, frozen clock, fake transport):
+  redeliver re-arms a `failed` row to `pending`/attempt_count 0, preserves
+  attempts history, respects the unique index (no duplicate row), 404/409 guards;
+  test-ping signs with the active secret and posts via an injected transport.
+- REST handler unit tests (`api/webhooks.test.ts`): auth (update + session-only),
+  wire shapes, 404s.


### PR DESCRIPTION
## What

Two operator REST actions on the `webhooks` resource, completing the webhook product surface (B4):

- **`POST /api/webhooks/:id/test`** — send a signed synthetic `webhook.ping` to the endpoint and report the outcome (reachable + signature accepted): status, latency, response snippet. A **pure connectivity probe** — writes nothing to the outbox or the delivery log, so a receiver can be verified before or after it is enabled. Reuses the exact Standard-Webhooks signing and SSRF-safe transport the delivery engine uses.
- **`POST /api/webhooks/:id/deliveries/:deliveryId/redeliver`** — re-attempt a specific past delivery from its stored event payload. The existing delivery row is **re-armed** (the unique `(webhook, event)` index forbids a duplicate; the id is reused so receivers dedupe), the retry budget reset while the attempt history is kept, and the fast drain is offered. The outcome surfaces in the delivery log.

Both are **session-only + `update-webhooks`**.

## Design notes

- `test-ping` sends a **distinct minimal ping payload** (like GitHub's `ping`), not a content `WebhookEvent`, so the subscribable event catalog is unchanged and there is no type workaround.
- `redeliver` re-arms in place rather than inserting because of the unique index; reusing the Standard-Webhooks `webhook-id` is the correct "try again" semantic (receiver dedupes).
- Guards: 404 for an unknown/foreign delivery; 409 for a deleted or disabled endpoint; 409 for a test on a secret-less endpoint (nothing to sign).

## Tests
- Domain integration (real SQLite): ping signs validly + persists nothing + reports non-2xx/throw outcomes; redeliver re-arms + resets budget + keeps history + respects the unique index + all guards.
- REST handler unit: auth (session-only), wire shapes.
- Route-parser: both routes + method/nesting rejection.

Spec: `tasks/webhook-b4-test-redeliver-spec.md` (local).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an endpoint connectivity test that sends a signed synthetic ping and reports delivery status, response details, or connection errors.
  * Added the ability to redeliver a specific failed webhook delivery.
  * Added REST routes for testing endpoints and redelivering deliveries.
  * Added safeguards for disabled, unknown, active, or mismatched deliveries.

* **Bug Fixes**
  * Improved conflict errors with optional custom messages.

* **Documentation**
  * Documented webhook testing, signing behavior, response formats, and redelivery rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->