### PR TITLE
ci: use pnpm for scaffolded app build to honor allowBuilds

### DIFF
--- a/.changeset/fix-issue-228.md
+++ b/.changeset/fix-issue-228.md
@@ -1,0 +1,23 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+ci(smoke): use pnpm for scaffolded app build to honor allowBuilds

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -134,7 +134,7 @@ jobs:
           tarball=$(ls /tmp/nextly-pack/*.tgz | head -1)
           npm exec --yes --package="$tarball" -- create-nextly-app smoke-app --template blank --yes
           cd smoke-app
-          npm run build
+          pnpm run build
 
   # A red nightly must surface without anyone watching the Actions tab.
   report-failure:


### PR DESCRIPTION
### Summary
Fixed the nightly smoke test failure where scaffolded apps were failing to build due to pnpm's allowBuilds restriction. Updated the CI workflow to explicitly use pnpm for the build step to ensure consistency across environments.

### Related issues
Closes #228

### Test plan
- [x] Ran `pnpm run build` locally on a scaffolded app to verify the fix.
- [x] Triggered the nightly smoke test workflow in GitHub Actions to confirm the failure is resolved.

### Checklist
- [x] Changeset added
- [x] Tests passed
