### PR TITLE
fix(nextly): bind companion schema loading to the transaction

### DIFF
--- a/.changeset/companion-schema-tx.md
+++ b/.changeset/companion-schema-tx.md
@@ -1,0 +1,31 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Bind localized companion schema loading to the caller's transaction.
+
+Deleting or updating a row in a localized collection assembles its document
+from the companion `<table>_locales` table, which loads that companion's
+runtime schema. That metadata read previously went back to the connection pool
+even when the write ran inside a caller-owned transaction, so on a small or
+exhausted pool it could stall the write while the transaction held the only
+connection. The companion schema load now runs on the transaction's own
+connection, completing the transaction-bound write path for localized content.

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
@@ -5,8 +5,9 @@
  * returns, so against a single-connection pool it blocks forever and the write
  * deadlocks. The transactional bulk and single-entry write paths do this for the
  * publish/unpublish RBAC check, the collection metadata and owner-constraint
- * reads, and the DB-reading hooks (the built-in sanitization hook loads field
- * metadata), all bound to the caller's transaction.
+ * reads, the DB-reading hooks (the built-in sanitization hook loads field
+ * metadata), and the localized delete's companion-schema and default-locale
+ * reads, all bound to the caller's transaction.
  *
  * These pin the fix on a REAL database with a single-connection pool
  * (`pool.max = 1`): the RBAC preflight and each full bulk / direct in-transaction
@@ -46,6 +47,7 @@ const AFTER_HOOK_SLUG = "poolreentryafter";
 const DELETE_SLUG = "poolreentrydelete";
 const DIRECT_DELETE_SLUG = "poolreentrydirdel";
 const BEFOREOP_SLUG = "poolreentrybeforeop";
+const LOCALIZED_DELETE_SLUG = "poolreentrylocdel";
 const SLUGS = [
   RBAC_SLUG,
   BULK_CREATE_SLUG,
@@ -57,6 +59,7 @@ const SLUGS = [
   DELETE_SLUG,
   DIRECT_DELETE_SLUG,
   BEFOREOP_SLUG,
+  LOCALIZED_DELETE_SLUG,
 ];
 
 type TestAdapter = Awaited<ReturnType<typeof createAdapter>>;
@@ -140,6 +143,9 @@ describePg(
       if (!boot) return;
       for (const slug of SLUGS) {
         for (const stmt of [
+          // Drop the localized companion (`<table>_locales`) before the main
+          // table so a companion-to-main foreign key never blocks the drop.
+          `DROP TABLE IF EXISTS dc_${slug}_locales`,
           `DROP TABLE IF EXISTS dc_${slug}`,
           `DELETE FROM dynamic_collections WHERE slug = '${slug}'`,
         ]) {
@@ -570,6 +576,64 @@ describePg(
         expect(result.failed).toBe(0);
       } finally {
         unregisterHook("beforeOperation", BEFOREOP_SLUG, beforeOpHook);
+        await handle?.destroy();
+      }
+    }, 30_000);
+
+    it("completes a localized bulk delete inside a caller-owned transaction", async () => {
+      const adapter = await connectSingleConnection();
+      let handle: TestNextly | undefined;
+      try {
+        handle = await createTestNextly({
+          adapter,
+          // A localized collection keeps translatable values in a companion
+          // `<table>_locales`. Deleting a row assembles the removed document,
+          // which loads the companion schema and reads its default-locale
+          // values — both metadata/companion reads that must run on the
+          // caller's transaction, not a second pooled connection.
+          collections: [
+            defineCollection({
+              slug: LOCALIZED_DELETE_SLUG,
+              status: true,
+              localized: true,
+              access: {
+                create: () => true,
+                read: () => true,
+                update: () => true,
+                delete: () => true,
+                publish: () => true,
+              },
+              fields: [text({ name: "title", localized: true })],
+            }),
+          ],
+          localization: { locales: ["en", "de"], defaultLocale: "en" },
+        });
+        const h = handle.getService<CollectionsHandler>("collectionsHandler");
+        const entries = h.getEntryService() as CollectionEntryService;
+        const created = await h.createEntry(
+          { collectionName: LOCALIZED_DELETE_SLUG, overrideAccess: true },
+          { title: "doomed", status: "draft" }
+        );
+        const id = (created.data as { id: string }).id;
+
+        // The delete builds the removed document via loadCompanionSchema +
+        // readCompanionLocalizedValues; both run on the transaction connection
+        // and COMPLETE. Drop either binding and this deadlocks on the second
+        // checkout against the single-connection pool.
+        const result = await withTimeout(
+          handle.adapter.transaction(tx =>
+            entries.deleteEntriesInTransaction(
+              tx,
+              { collectionName: LOCALIZED_DELETE_SLUG, user: { id: "editor" } },
+              [id]
+            )
+          ),
+          15_000
+        );
+
+        expect(result.successful).toBe(1);
+        expect(result.failed).toBe(0);
+      } finally {
         await handle?.destroy();
       }
     }, 30_000);

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
@@ -47,6 +47,10 @@ const AFTER_HOOK_SLUG = "poolreentryafter";
 const DELETE_SLUG = "poolreentrydelete";
 const DIRECT_DELETE_SLUG = "poolreentrydirdel";
 const BEFOREOP_SLUG = "poolreentrybeforeop";
+// A localized collection: its delete assembles the removed document from the
+// companion `<table>_locales`, which loads the companion schema on the caller's
+// transaction — the binding this fixture exercises. Its teardown also drops the
+// companion table (see `drop`).
 const LOCALIZED_DELETE_SLUG = "poolreentrylocdel";
 const SLUGS = [
   RBAC_SLUG,

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -370,9 +370,13 @@ export class CollectionMutationService extends BaseService {
     let appliedLocale: string | undefined;
     if (locale && this.localization) {
       // A companion schema means the collection is localized; only then does the
-      // locale disambiguate the payload, so only then is it recorded.
-      const companion =
-        await this.fileManager.loadCompanionSchema(collectionName);
+      // locale disambiguate the payload, so only then is it recorded. Bound to
+      // the transaction connection so the metadata read does not re-enter the
+      // pool from inside the caller's transaction.
+      const companion = await this.fileManager.loadCompanionSchema(
+        collectionName,
+        tx.getDrizzle()
+      );
       if (companion) {
         appliedLocale = locale;
         Object.assign(
@@ -719,8 +723,12 @@ export class CollectionMutationService extends BaseService {
     entryId: string,
     locale: string
   ): Promise<Record<string, unknown>> {
-    const companion =
-      await this.fileManager.loadCompanionSchema(collectionName);
+    // Bound to the transaction connection so the companion metadata read does not
+    // re-enter the pool from inside the caller's transaction.
+    const companion = await this.fileManager.loadCompanionSchema(
+      collectionName,
+      tx.getDrizzle()
+    );
     if (!companion) return {};
 
     const row: Record<string, unknown> = { id: entryId };

--- a/packages/nextly/src/services/collection-file-manager.ts
+++ b/packages/nextly/src/services/collection-file-manager.ts
@@ -317,10 +317,14 @@ export class CollectionFileManager {
    * The result is cached under the companion's SQL name so repeated reads reuse one table object.
    */
   async loadCompanionSchema(
-    collectionName: string
+    collectionName: string,
+    // Optional transaction-bound executor so the metadata read runs on the
+    // caller's transaction connection instead of taking a second pooled one when
+    // a localized write/delete loads the companion schema inside a transaction.
+    executor?: unknown
   ): Promise<CompanionSchema | null> {
     if (!this.adapter || !this.metadataFetcher) return null;
-    const metadata = await this.metadataFetcher(collectionName);
+    const metadata = await this.metadataFetcher(collectionName, executor);
     if (!metadata || metadata.localized !== true) return null;
 
     const tableName =


### PR DESCRIPTION
## What

Loading a localized collection's companion schema (`<table>_locales`) went back
to the connection pool even when the write ran inside a caller-owned
transaction. On a small or exhausted pool that stalled the write while the
transaction held the only connection — the same pool-reentry class the
transaction-bound write path (#309) already closed for RBAC, collection
metadata, owner constraints, and the DB-reading hooks.

This is the final piece of that pattern: a localized delete assembles the
removed document from the companion table, and a localized update reads its
per-locale values, both loading the companion schema. Those metadata reads now
run on the caller's transaction connection instead of a second pooled one.

## How

- `CollectionFileManager.loadCompanionSchema` takes an optional
  transaction-bound `executor` and forwards it to the metadata fetcher (which
  already accepts and threads it, from #309).
- `buildDeletedDocument` and `readCompanionLocalizedValues` — both already hold
  the `TransactionContext` — pass `tx.getDrizzle()`.
- The pool-before-tx callers (`localizedRequiredContext`, `splitLocalizedWriteData`,
  `publishAllLocales`) load the companion on the pool before any transaction
  opens and are intentionally left unbound.

## Test

Adds a load-bearing case to `publish-enforcement-pool-reentry.integration.test.ts`:
a localized collection with a `deleteEntriesInTransaction` inside a caller-owned
transaction on a `max: 1` Postgres pool that completes. Proven load-bearing —
dropping either `tx.getDrizzle()` binding independently deadlocks the delete on
the second checkout (~16s timeout). Full pool-reentry + rbac + batch + owner-only
+ toctou + singles + permissions-executor-cache suites pass (44 tests).

## Changeset

One changeset, all lockstep packages, `patch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed localized bulk deletes and version snapshot reads that could stall or deadlock when run inside an active transaction.
  * Ensured companion-schema/localized metadata reads and related teardown steps execute on the caller’s transaction connection.
* **Tests**
  * Expanded integration coverage for single-connection pools, including localized bulk delete success checks with timeout protection and improved cleanup ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->