### PR TITLE
feat(admin): webhook delivery log and redelivery UI

### DIFF
--- a/.changeset/admin-webhooks-delivery-ui.md
+++ b/.changeset/admin-webhooks-delivery-ui.md
@@ -1,0 +1,28 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Add a webhook delivery log to the admin panel. Each endpoint now has a
+Deliveries view listing its past delivery attempts with status, event type,
+response code, and latency, filterable by status and event type. A dedicated
+detail page shows a delivery's full attempt timeline, the last response
+snippet, and a Redeliver action, and the list offers a "Process queue now"
+action to drain pending deliveries on demand.

--- a/packages/admin/src/components/features/settings/SettingsLayout.tsx
+++ b/packages/admin/src/components/features/settings/SettingsLayout.tsx
@@ -103,6 +103,15 @@ export function SettingsLayout({ children, actions }: SettingsLayoutProps) {
       };
     }
     if (pathname.includes("webhooks")) {
+      if (pathname.includes("/deliveries")) {
+        return {
+          title: "Deliveries",
+          description:
+            "Delivery attempts for this endpoint, with response status and retries",
+          crumb: "Deliveries",
+          parentCrumb: { label: "Webhooks", href: ROUTES.SETTINGS_WEBHOOKS },
+        };
+      }
       if (pathname.includes("/create")) {
         return {
           title: "New Webhook",

--- a/packages/admin/src/components/features/webhooks/DeliveryTable.tsx
+++ b/packages/admin/src/components/features/webhooks/DeliveryTable.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+/**
+ * DeliveryTable — an endpoint's delivery log with server-side pagination and
+ * status/event-type filters. The parent owns the query state (page, size,
+ * filters) so it can drive the `useDeliveries` request; this component is
+ * presentational and reports every change back through callbacks. Clicking a
+ * row opens that delivery's detail page.
+ */
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@nextlyhq/ui";
+import type React from "react";
+import { useMemo } from "react";
+
+import { Pagination } from "@admin/components/shared/pagination";
+import { DataTableView } from "@admin/components/ui/table/data-table";
+import type { NextlyColumn } from "@admin/components/ui/table/data-table";
+import {
+  WEBHOOK_DELIVERY_STATUSES,
+  WEBHOOK_EVENT_TYPES,
+  type WebhookDeliveryStatus,
+  type WebhookDeliverySummary,
+  type WebhookEventType,
+} from "@admin/types/webhooks";
+
+import {
+  DeliveryStatusBadge,
+  describeResource,
+  formatDeliveryTimestamp,
+  formatLatency,
+  formatStatusCode,
+} from "./deliveryStatus";
+
+/** Sentinel for the "no filter" option (Radix Select forbids an empty value). */
+const ALL = "all" as const;
+
+export interface DeliveryTableProps {
+  rows: WebhookDeliverySummary[];
+  isLoading?: boolean;
+  /** Total rows across all pages (from the server meta). */
+  totalItems: number;
+  totalPages: number;
+  /** Current page index (0-based, for the Pagination control). */
+  page: number;
+  pageSize: number;
+  /** Active filters; undefined means unfiltered. */
+  status?: WebhookDeliveryStatus;
+  eventType?: WebhookEventType;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (pageSize: number) => void;
+  onStatusChange: (status?: WebhookDeliveryStatus) => void;
+  onEventTypeChange: (eventType?: WebhookEventType) => void;
+  onRowClick: (delivery: WebhookDeliverySummary) => void;
+}
+
+export const DeliveryTable: React.FC<DeliveryTableProps> = ({
+  rows,
+  isLoading = false,
+  totalItems,
+  totalPages,
+  page,
+  pageSize,
+  status,
+  eventType,
+  onPageChange,
+  onPageSizeChange,
+  onStatusChange,
+  onEventTypeChange,
+  onRowClick,
+}) => {
+  const columns = useMemo(
+    (): NextlyColumn<WebhookDeliverySummary>[] => [
+      {
+        name: "status",
+        header: "Status",
+        cell: ({ row }) => <DeliveryStatusBadge status={row.status} />,
+      },
+      {
+        name: "eventType",
+        header: "Event",
+        cell: ({ row }) => (
+          <span className="font-medium text-foreground">{row.eventType}</span>
+        ),
+      },
+      {
+        name: "resource",
+        header: "Resource",
+        hideOnMobile: true,
+        cell: ({ row }) => (
+          <span
+            className="block max-w-64 truncate text-sm text-muted-foreground"
+            title={describeResource(row.resource)}
+          >
+            {describeResource(row.resource)}
+          </span>
+        ),
+      },
+      {
+        name: "attemptCount",
+        header: "Attempts",
+        hideOnMobile: true,
+        cell: ({ row }) => (
+          <span className="text-sm tabular-nums text-muted-foreground">
+            {row.attemptCount}
+          </span>
+        ),
+      },
+      {
+        name: "lastStatusCode",
+        header: "Last response",
+        hideOnMobile: true,
+        cell: ({ row }) => (
+          <span className="text-sm tabular-nums text-muted-foreground">
+            {formatStatusCode(row.lastStatusCode)}
+            {row.lastLatencyMs !== null
+              ? ` · ${formatLatency(row.lastLatencyMs)}`
+              : ""}
+          </span>
+        ),
+      },
+      {
+        name: "createdAt",
+        header: "Created",
+        hideOnMobile: true,
+        cell: ({ row }) => (
+          <span className="text-sm text-muted-foreground">
+            {formatDeliveryTimestamp(row.createdAt)}
+          </span>
+        ),
+      },
+    ],
+    []
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <Select
+          value={status ?? ALL}
+          onValueChange={value =>
+            onStatusChange(
+              value === ALL ? undefined : (value as WebhookDeliveryStatus)
+            )
+          }
+        >
+          <SelectTrigger
+            className="w-full sm:w-48"
+            aria-label="Filter by status"
+          >
+            <SelectValue placeholder="All statuses" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>All statuses</SelectItem>
+            {WEBHOOK_DELIVERY_STATUSES.map(value => (
+              <SelectItem key={value} value={value}>
+                {value.charAt(0).toUpperCase() + value.slice(1)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={eventType ?? ALL}
+          onValueChange={value =>
+            onEventTypeChange(
+              value === ALL ? undefined : (value as WebhookEventType)
+            )
+          }
+        >
+          <SelectTrigger
+            className="w-full sm:w-64"
+            aria-label="Filter by event"
+          >
+            <SelectValue placeholder="All events" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>All events</SelectItem>
+            {WEBHOOK_EVENT_TYPES.map(value => (
+              <SelectItem key={value} value={value}>
+                {value}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <DataTableView<WebhookDeliverySummary>
+        columns={columns}
+        rows={rows}
+        loading={isLoading}
+        getRowId={row => row.id}
+        onRowClick={onRowClick}
+        primaryColumn="eventType"
+        registryKey="webhook-deliveries"
+        ariaLabel="Webhook deliveries table"
+        emptyMessage="No deliveries match these filters yet."
+      />
+
+      <Pagination
+        currentPage={page}
+        totalPages={Math.max(1, totalPages)}
+        pageSize={pageSize}
+        pageSizeOptions={[20, 50, 100]}
+        onPageChange={onPageChange}
+        onPageSizeChange={onPageSizeChange}
+        totalItems={totalItems}
+        itemLabel="deliveries"
+        isLoading={isLoading}
+      />
+    </div>
+  );
+};

--- a/packages/admin/src/components/features/webhooks/WebhookTable.tsx
+++ b/packages/admin/src/components/features/webhooks/WebhookTable.tsx
@@ -10,7 +10,7 @@
 import type React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { Edit, Power, Send, Trash2 } from "@admin/components/icons";
+import { Edit, List, Power, Send, Trash2 } from "@admin/components/icons";
 import { Pagination } from "@admin/components/shared/pagination";
 import { SearchBar } from "@admin/components/shared/search-bar";
 import { DataTableView } from "@admin/components/ui/table/data-table";
@@ -29,10 +29,13 @@ export interface WebhookTableProps {
   canUpdate: boolean;
   /** Delete permission gates the Delete action. */
   canDelete: boolean;
+  /** Read (or update) gates the "View deliveries" action. */
+  canViewDeliveries: boolean;
   onEdit: (webhook: WebhookEndpointSummary) => void;
   onToggleEnabled: (webhook: WebhookEndpointSummary) => void;
   onTest: (webhook: WebhookEndpointSummary) => void;
   onDelete: (webhook: WebhookEndpointSummary) => void;
+  onViewDeliveries: (webhook: WebhookEndpointSummary) => void;
 }
 
 export const WebhookTable: React.FC<WebhookTableProps> = ({
@@ -40,10 +43,12 @@ export const WebhookTable: React.FC<WebhookTableProps> = ({
   isLoading = false,
   canUpdate,
   canDelete,
+  canViewDeliveries,
   onEdit,
   onToggleEnabled,
   onTest,
   onDelete,
+  onViewDeliveries,
 }) => {
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(0);
@@ -149,6 +154,14 @@ export const WebhookTable: React.FC<WebhookTableProps> = ({
   const rowActions = useCallback(
     (webhook: WebhookEndpointSummary): RowAction<WebhookEndpointSummary>[] => {
       const actions: RowAction<WebhookEndpointSummary>[] = [];
+      if (canViewDeliveries) {
+        actions.push({
+          id: "deliveries",
+          label: "View deliveries",
+          icon: <List className="h-4 w-4" />,
+          onSelect: () => onViewDeliveries(webhook),
+        });
+      }
       if (canUpdate) {
         actions.push(
           {
@@ -182,7 +195,16 @@ export const WebhookTable: React.FC<WebhookTableProps> = ({
       }
       return actions;
     },
-    [canUpdate, canDelete, onEdit, onToggleEnabled, onTest, onDelete]
+    [
+      canUpdate,
+      canDelete,
+      canViewDeliveries,
+      onEdit,
+      onToggleEnabled,
+      onTest,
+      onDelete,
+      onViewDeliveries,
+    ]
   );
 
   return (

--- a/packages/admin/src/components/features/webhooks/deliveryStatus.test.tsx
+++ b/packages/admin/src/components/features/webhooks/deliveryStatus.test.tsx
@@ -4,11 +4,38 @@ import { describe, expect, it } from "vitest";
 import {
   AttemptOutcomeBadge,
   DeliveryStatusBadge,
+  deliveryStatusPresentation,
   describeResource,
   formatDeliveryTimestamp,
   formatLatency,
   formatStatusCode,
 } from "./deliveryStatus";
+
+describe("deliveryStatusPresentation", () => {
+  it("maps each known status to its variant and label", () => {
+    expect(deliveryStatusPresentation("delivered")).toEqual({
+      variant: "success",
+      label: "Delivered",
+    });
+    expect(deliveryStatusPresentation("retrying")).toEqual({
+      variant: "warning",
+      label: "Retrying",
+    });
+    expect(deliveryStatusPresentation("failed")).toEqual({
+      variant: "destructive",
+      label: "Failed",
+    });
+  });
+
+  // The helper takes a plain string precisely so an out-of-union wire value can
+  // be exercised without a type suppression; it should fall back to neutral.
+  it("falls back to a neutral pill showing the raw value for an unknown status", () => {
+    expect(deliveryStatusPresentation("quarantined")).toEqual({
+      variant: "default",
+      label: "quarantined",
+    });
+  });
+});
 
 describe("DeliveryStatusBadge", () => {
   it("renders the human label for each known status", () => {
@@ -18,12 +45,6 @@ describe("DeliveryStatusBadge", () => {
     expect(screen.getByText("Retrying")).toBeInTheDocument();
     rerender(<DeliveryStatusBadge status="failed" />);
     expect(screen.getByText("Failed")).toBeInTheDocument();
-  });
-
-  it("falls back to the raw value for an unknown status", () => {
-    // @ts-expect-error deliberately exercising an out-of-set value
-    render(<DeliveryStatusBadge status="quarantined" />);
-    expect(screen.getByText("quarantined")).toBeInTheDocument();
   });
 });
 

--- a/packages/admin/src/components/features/webhooks/deliveryStatus.test.tsx
+++ b/packages/admin/src/components/features/webhooks/deliveryStatus.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  AttemptOutcomeBadge,
+  DeliveryStatusBadge,
+  describeResource,
+  formatDeliveryTimestamp,
+  formatLatency,
+  formatStatusCode,
+} from "./deliveryStatus";
+
+describe("DeliveryStatusBadge", () => {
+  it("renders the human label for each known status", () => {
+    const { rerender } = render(<DeliveryStatusBadge status="delivered" />);
+    expect(screen.getByText("Delivered")).toBeInTheDocument();
+    rerender(<DeliveryStatusBadge status="retrying" />);
+    expect(screen.getByText("Retrying")).toBeInTheDocument();
+    rerender(<DeliveryStatusBadge status="failed" />);
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+  });
+
+  it("falls back to the raw value for an unknown status", () => {
+    // @ts-expect-error deliberately exercising an out-of-set value
+    render(<DeliveryStatusBadge status="quarantined" />);
+    expect(screen.getByText("quarantined")).toBeInTheDocument();
+  });
+});
+
+describe("AttemptOutcomeBadge", () => {
+  it("shows the raw outcome text", () => {
+    render(<AttemptOutcomeBadge outcome="abandoned" />);
+    expect(screen.getByText("abandoned")).toBeInTheDocument();
+  });
+});
+
+describe("formatting helpers", () => {
+  it("renders a placeholder for a null timestamp and echoes an unparseable one", () => {
+    expect(formatDeliveryTimestamp(null)).toBe("-");
+    expect(formatDeliveryTimestamp("not-a-date")).toBe("not-a-date");
+  });
+
+  it("formats status codes and latency, with placeholders for absent values", () => {
+    expect(formatStatusCode(200)).toBe("200");
+    expect(formatStatusCode(null)).toBe("-");
+    expect(formatLatency(42)).toBe("42ms");
+    expect(formatLatency(null)).toBe("-");
+    expect(formatLatency(undefined)).toBe("-");
+  });
+
+  it("describes a resource with collection, id, and locale", () => {
+    expect(
+      describeResource({
+        kind: "entry",
+        collection: "posts",
+        id: "abc",
+        locale: "fr",
+      })
+    ).toBe("posts · abc (fr)");
+    expect(
+      describeResource({
+        kind: "media",
+        collection: null,
+        id: null,
+        locale: null,
+      })
+    ).toBe("media");
+  });
+});

--- a/packages/admin/src/components/features/webhooks/deliveryStatus.tsx
+++ b/packages/admin/src/components/features/webhooks/deliveryStatus.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+/**
+ * Presentational helpers for the webhook delivery log. Delivery status and
+ * per-attempt outcome map to the existing token-backed Badge variants (already
+ * covered by the UI contrast test), so no new colour pairing is introduced.
+ * Every badge carries text, never colour alone.
+ */
+
+import { Badge } from "@nextlyhq/ui";
+import type React from "react";
+
+import type { WebhookDeliveryStatus } from "@admin/types/webhooks";
+
+type BadgeVariant = "success" | "warning" | "destructive" | "default";
+
+/** Delivery status → badge variant + human label. */
+const STATUS_PRESENTATION: Record<
+  WebhookDeliveryStatus,
+  { variant: BadgeVariant; label: string }
+> = {
+  delivered: { variant: "success", label: "Delivered" },
+  retrying: { variant: "warning", label: "Retrying" },
+  pending: { variant: "warning", label: "Pending" },
+  processing: { variant: "default", label: "Processing" },
+  failed: { variant: "destructive", label: "Failed" },
+};
+
+/** Status pill for a delivery row/detail. */
+export const DeliveryStatusBadge: React.FC<{
+  status: WebhookDeliveryStatus;
+}> = ({ status }) => {
+  // An unrecognized status (a value added server-side ahead of the UI) stays
+  // legible as a neutral pill rather than crashing the row.
+  const presentation = STATUS_PRESENTATION[status] ?? {
+    variant: "default" as const,
+    label: status,
+  };
+  return <Badge variant={presentation.variant}>{presentation.label}</Badge>;
+};
+
+/**
+ * Map a free-text attempt outcome (engine-authored, e.g. `delivered`,
+ * `retrying`, `failed`, `abandoned`) to a badge variant. Unknown outcomes read
+ * as neutral.
+ */
+function attemptVariant(outcome: string): BadgeVariant {
+  const normalized = outcome.toLowerCase();
+  if (normalized === "delivered") return "success";
+  if (normalized === "failed") return "destructive";
+  if (normalized === "retrying" || normalized === "pending") return "warning";
+  return "default";
+}
+
+/** Outcome pill for a single attempt in the timeline. */
+export const AttemptOutcomeBadge: React.FC<{ outcome: string }> = ({
+  outcome,
+}) => <Badge variant={attemptVariant(outcome)}>{outcome}</Badge>;
+
+/**
+ * Render an ISO-8601 instant in the viewer's locale/timezone. The delivery
+ * reads return raw UTC instants (server-side timezone rewriting is skipped so
+ * captured error/response text survives verbatim), so the client formats them.
+ * An absent or unparseable value shows an em-dash-free placeholder.
+ */
+export function formatDeliveryTimestamp(iso: string | null): string {
+  if (!iso) return "-";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString();
+}
+
+/** Compact HTTP status + latency, or a placeholder when not yet attempted. */
+export function formatStatusCode(code: number | null): string {
+  return code === null ? "-" : String(code);
+}
+
+/** Latency in milliseconds, or a placeholder when absent. */
+export function formatLatency(ms: number | null | undefined): string {
+  return ms === null || ms === undefined ? "-" : `${ms}ms`;
+}
+
+/** A one-line description of the resource an event was about. */
+export function describeResource(resource: {
+  kind: string;
+  collection: string | null;
+  id: string | null;
+  locale: string | null;
+}): string {
+  const scope = resource.collection ?? resource.kind;
+  const parts = [scope];
+  if (resource.id) parts.push(resource.id);
+  const base = parts.join(" · ");
+  return resource.locale ? `${base} (${resource.locale})` : base;
+}

--- a/packages/admin/src/components/features/webhooks/deliveryStatus.tsx
+++ b/packages/admin/src/components/features/webhooks/deliveryStatus.tsx
@@ -10,15 +10,20 @@
 import { Badge } from "@nextlyhq/ui";
 import type React from "react";
 
-import type { WebhookDeliveryStatus } from "@admin/types/webhooks";
+import {
+  WEBHOOK_DELIVERY_STATUSES,
+  type WebhookDeliveryStatus,
+} from "@admin/types/webhooks";
 
 type BadgeVariant = "success" | "warning" | "destructive" | "default";
 
+interface StatusPresentation {
+  variant: BadgeVariant;
+  label: string;
+}
+
 /** Delivery status → badge variant + human label. */
-const STATUS_PRESENTATION: Record<
-  WebhookDeliveryStatus,
-  { variant: BadgeVariant; label: string }
-> = {
+const STATUS_PRESENTATION: Record<WebhookDeliveryStatus, StatusPresentation> = {
   delivered: { variant: "success", label: "Delivered" },
   retrying: { variant: "warning", label: "Retrying" },
   pending: { variant: "warning", label: "Pending" },
@@ -26,16 +31,26 @@ const STATUS_PRESENTATION: Record<
   failed: { variant: "destructive", label: "Failed" },
 };
 
+/**
+ * Resolve a delivery status (as it arrives on the wire, i.e. an untrusted
+ * string) to its badge presentation. A status the UI does not know — a value
+ * the server could add ahead of the client — falls back to a neutral pill
+ * showing the raw value rather than crashing. Accepts `string` so this stays
+ * verifiable without asserting an out-of-union value; the lookup is keyed only
+ * through the known-status list, so no type cast is needed.
+ */
+export function deliveryStatusPresentation(status: string): StatusPresentation {
+  const known = WEBHOOK_DELIVERY_STATUSES.find(value => value === status);
+  return known
+    ? STATUS_PRESENTATION[known]
+    : { variant: "default", label: status };
+}
+
 /** Status pill for a delivery row/detail. */
 export const DeliveryStatusBadge: React.FC<{
   status: WebhookDeliveryStatus;
 }> = ({ status }) => {
-  // An unrecognized status (a value added server-side ahead of the UI) stays
-  // legible as a neutral pill rather than crashing the row.
-  const presentation = STATUS_PRESENTATION[status] ?? {
-    variant: "default" as const,
-    label: status,
-  };
+  const presentation = deliveryStatusPresentation(status);
   return <Badge variant={presentation.variant}>{presentation.label}</Badge>;
 };
 

--- a/packages/admin/src/constants/routes.ts
+++ b/packages/admin/src/constants/routes.ts
@@ -97,6 +97,10 @@ export const ROUTES = {
   SETTINGS_WEBHOOKS: "/admin/settings/webhooks",
   SETTINGS_WEBHOOKS_CREATE: "/admin/settings/webhooks/create",
   SETTINGS_WEBHOOKS_EDIT: "/admin/settings/webhooks/edit/[id]",
+  // Delivery log for one endpoint, and one delivery's attempt history.
+  SETTINGS_WEBHOOKS_DELIVERIES: "/admin/settings/webhooks/[id]/deliveries",
+  SETTINGS_WEBHOOKS_DELIVERY_DETAIL:
+    "/admin/settings/webhooks/[id]/deliveries/[deliveryId]",
   SETTINGS_IMAGE_SIZES: "/admin/settings/image-sizes",
   SETTINGS_IMAGE_SIZES_CREATE: "/admin/settings/image-sizes/create",
   SETTINGS_IMAGE_SIZES_EDIT: "/admin/settings/image-sizes/edit/[id]",

--- a/packages/admin/src/hooks/queries/__tests__/useDeliveries.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useDeliveries.test.tsx
@@ -1,0 +1,90 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { listSpy, getSpy, redeliverSpy, drainSpy } = vi.hoisted(() => ({
+  listSpy: vi.fn(),
+  getSpy: vi.fn(),
+  redeliverSpy: vi.fn(),
+  drainSpy: vi.fn(),
+}));
+
+vi.mock("@admin/services/deliveryApi", () => ({
+  deliveryApi: {
+    listDeliveries: listSpy,
+    getDelivery: getSpy,
+    redeliver: redeliverSpy,
+    runDrain: drainSpy,
+  },
+}));
+
+import { useDeliveries, useDelivery, useRunDrain } from "../useDeliveries";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useDeliveries", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("passes the endpoint id and params straight through to the service", async () => {
+    listSpy.mockResolvedValue({ items: [], meta: { total: 0 } });
+    const params = { page: 2, limit: 25, status: "failed" as const };
+
+    const { result } = renderHook(() => useDeliveries("wh_1", params), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(listSpy).toHaveBeenCalledWith("wh_1", params);
+  });
+
+  it("does not fetch while disabled", () => {
+    renderHook(() => useDeliveries("wh_1", { page: 1 }, { enabled: false }), {
+      wrapper,
+    });
+    expect(listSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch without an endpoint id", () => {
+    renderHook(() => useDeliveries("", { page: 1 }), { wrapper });
+    expect(listSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("useDelivery", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("reads one delivery by id", async () => {
+    getSpy.mockResolvedValue({ id: "dlv_1" });
+    const { result } = renderHook(() => useDelivery("wh_1", "dlv_1"), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getSpy).toHaveBeenCalledWith("wh_1", "dlv_1");
+  });
+
+  it("stays idle when a delivery id is missing", () => {
+    renderHook(() => useDelivery("wh_1", ""), { wrapper });
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("useRunDrain", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("invokes the drain service on mutate", async () => {
+    drainSpy.mockResolvedValue({ rounds: 1, delivered: 0 });
+    const { result } = renderHook(() => useRunDrain(), { wrapper });
+
+    result.current.mutate();
+    await waitFor(() => expect(drainSpy).toHaveBeenCalledTimes(1));
+  });
+});

--- a/packages/admin/src/hooks/queries/index.ts
+++ b/packages/admin/src/hooks/queries/index.ts
@@ -139,3 +139,12 @@ export {
   useRevealSecret,
   useTestEndpoint,
 } from "./useWebhooks";
+
+// Webhook delivery-log query and mutation hooks
+export {
+  deliveryKeys, // Query key factory for stable caching
+  useDeliveries,
+  useDelivery,
+  useRedeliver,
+  useRunDrain,
+} from "./useDeliveries";

--- a/packages/admin/src/hooks/queries/useDeliveries.ts
+++ b/packages/admin/src/hooks/queries/useDeliveries.ts
@@ -1,0 +1,102 @@
+"use client";
+
+/**
+ * Webhook delivery query hooks.
+ *
+ * TanStack Query hooks for the delivery log: a server-paginated list, one
+ * delivery's detail, a redelivery action, and a manual drain. The list and
+ * detail keys nest under a per-endpoint delivery namespace so redeliver/drain
+ * can invalidate an endpoint's deliveries without touching the endpoint list.
+ *
+ * `keepPreviousData` keeps the current page visible while the next one loads,
+ * so paging and filtering don't flash an empty table.
+ */
+
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+
+import type { ListResponse } from "@admin/lib/api/response-types";
+import { deliveryApi } from "@admin/services/deliveryApi";
+import type {
+  ListDeliveriesParams,
+  RunDrainResult,
+  WebhookDeliveryDetail,
+  WebhookDeliverySummary,
+} from "@admin/types/webhooks";
+
+export const deliveryKeys = {
+  all: () => ["webhook-deliveries"] as const,
+  endpoint: (webhookId: string) => [...deliveryKeys.all(), webhookId] as const,
+  list: (webhookId: string, params: ListDeliveriesParams) =>
+    [...deliveryKeys.endpoint(webhookId), "list", params] as const,
+  detail: (webhookId: string, deliveryId: string) =>
+    [...deliveryKeys.endpoint(webhookId), "detail", deliveryId] as const,
+};
+
+/**
+ * A page of an endpoint's deliveries. `enabled` lets the caller hold the fetch
+ * until it knows the user may read (the read gate is the same as the endpoint
+ * list).
+ */
+export function useDeliveries(
+  webhookId: string,
+  params: ListDeliveriesParams,
+  options?: { enabled?: boolean }
+) {
+  return useQuery<ListResponse<WebhookDeliverySummary>, Error>({
+    queryKey: deliveryKeys.list(webhookId, params),
+    queryFn: () => deliveryApi.listDeliveries(webhookId, params),
+    enabled: Boolean(webhookId) && (options?.enabled ?? true),
+    placeholderData: keepPreviousData,
+    staleTime: 15_000,
+  });
+}
+
+/** One delivery with its attempt history, for the detail page. */
+export function useDelivery(webhookId: string, deliveryId: string) {
+  return useQuery<WebhookDeliveryDetail, Error>({
+    queryKey: deliveryKeys.detail(webhookId, deliveryId),
+    queryFn: () => deliveryApi.getDelivery(webhookId, deliveryId),
+    enabled: Boolean(webhookId) && Boolean(deliveryId),
+  });
+}
+
+/**
+ * Re-arm a past delivery. Invalidates the endpoint's delivery keys so the list
+ * and the open detail both refetch the reset state (status pending, attempt
+ * count 0).
+ */
+export function useRedeliver() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    WebhookDeliveryDetail,
+    Error,
+    { webhookId: string; deliveryId: string }
+  >({
+    mutationFn: ({ webhookId, deliveryId }) =>
+      deliveryApi.redeliver(webhookId, deliveryId),
+    onSuccess: (_data, { webhookId }) => {
+      void queryClient.invalidateQueries({
+        queryKey: deliveryKeys.endpoint(webhookId),
+      });
+    },
+  });
+}
+
+/**
+ * Run a manual drain pass. A drain can advance deliveries for any endpoint, so
+ * it invalidates every endpoint's delivery keys.
+ */
+export function useRunDrain() {
+  const queryClient = useQueryClient();
+  return useMutation<RunDrainResult, Error, void>({
+    mutationFn: () => deliveryApi.runDrain(),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: deliveryKeys.all() });
+    },
+  });
+}

--- a/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/[deliveryId].tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/[deliveryId].tsx
@@ -36,6 +36,13 @@ const MetaRow: React.FC<{ label: string; children: React.ReactNode }> = ({
   </div>
 );
 
+/**
+ * Renders one delivery's full record and owns the redelivery action. It holds
+ * the delivery query (loading/error) and the redelivery mutation's pending
+ * state here, at the page level, because both the header action and the body
+ * read from the same delivery and must react together: a redelivery invalidates
+ * this delivery's cache, so the timeline and status re-render off the refetch.
+ */
 const DeliveryDetailContent: React.FC<{
   webhookId: string;
   deliveryId: string;
@@ -139,7 +146,12 @@ const DeliveryDetailContent: React.FC<{
               </code>
             </MetaRow>
             <MetaRow label="Attempts">
-              <span className="tabular-nums">{delivery.attemptCount}</span>
+              {/* Count the recorded history, not the row's `attemptCount`: a
+                  redelivery resets that counter to zero for the fresh cycle
+                  while the prior attempts stay in the log, so the counter would
+                  read 0 above a non-empty timeline. The history length always
+                  matches the attempts shown below. */}
+              <span className="tabular-nums">{delivery.attempts.length}</span>
             </MetaRow>
             <MetaRow label="Last response">
               {delivery.lastStatusCode === null ? (
@@ -153,7 +165,7 @@ const DeliveryDetailContent: React.FC<{
             </MetaRow>
             {delivery.lastError && (
               <MetaRow label="Last error">
-                <span className="text-destructive-500 break-words">
+                <span className="text-destructive break-words">
                   {delivery.lastError}
                 </span>
               </MetaRow>
@@ -202,7 +214,7 @@ const DeliveryDetailContent: React.FC<{
                   </span>
                 </div>
                 {attempt.error && (
-                  <p className="mt-2 text-sm text-destructive-500 break-words">
+                  <p className="mt-2 text-sm text-destructive break-words">
                     {attempt.error}
                   </p>
                 )}

--- a/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/[deliveryId].tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/[deliveryId].tsx
@@ -25,6 +25,13 @@ import { useCan } from "@admin/hooks/useCan";
 import { useRouter } from "@admin/hooks/useRouter";
 import { apiErrorMessage } from "@admin/lib/api/parseApiError";
 
+/**
+ * The engine keeps only the most recent attempts on each delivery row (the
+ * `MAX_ATTEMPT_LOG` cap in the webhook deliver pipeline). Mirrored here so the
+ * timeline can say so when the log is full and older attempts are truncated.
+ */
+const ATTEMPT_LOG_LIMIT = 20;
+
 /** One read-only label/value row in a metadata card. */
 const MetaRow: React.FC<{ label: string; children: React.ReactNode }> = ({
   label,
@@ -145,13 +152,15 @@ const DeliveryDetailContent: React.FC<{
                 {delivery.eventId}
               </code>
             </MetaRow>
-            <MetaRow label="Attempts">
-              {/* Count the recorded history, not the row's `attemptCount`: a
-                  redelivery resets that counter to zero for the fresh cycle
-                  while the prior attempts stay in the log, so the counter would
-                  read 0 above a non-empty timeline. The history length always
-                  matches the attempts shown below. */}
-              <span className="tabular-nums">{delivery.attempts.length}</span>
+            <MetaRow label="Attempts (this cycle)">
+              {/* `attemptCount` is the counter for the current delivery cycle;
+                  a redelivery resets it to 0 for the fresh cycle. It is scoped
+                  ("this cycle") precisely so a 0 here does not read as a
+                  contradiction of the retained history below — the two are
+                  different metrics. It is preferred over `attempts.length`
+                  because the stored log is capped (see the timeline note), so
+                  the log length would under-count once the cap is reached. */}
+              <span className="tabular-nums">{delivery.attemptCount}</span>
             </MetaRow>
             <MetaRow label="Last response">
               {delivery.lastStatusCode === null ? (
@@ -192,6 +201,13 @@ const DeliveryDetailContent: React.FC<{
         <p className="text-[11px] font-semibold tracking-[0.08em] uppercase text-muted-foreground">
           Attempts
         </p>
+        {/* The stored log is capped, so once it is full older attempts are
+            dropped; say so rather than implying this is the whole history. */}
+        {attempts.length >= ATTEMPT_LOG_LIMIT && (
+          <p className="text-xs text-muted-foreground">
+            Showing the most recent {ATTEMPT_LOG_LIMIT} attempts.
+          </p>
+        )}
         {attempts.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             No attempts have been recorded yet.

--- a/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/[deliveryId].tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/[deliveryId].tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { Alert, AlertDescription, Button, Skeleton } from "@nextlyhq/ui";
+import type React from "react";
+import { useCallback } from "react";
+
+import { SettingsLayout } from "@admin/components/features/settings/SettingsLayout";
+import {
+  AttemptOutcomeBadge,
+  DeliveryStatusBadge,
+  describeResource,
+  formatDeliveryTimestamp,
+  formatLatency,
+  formatStatusCode,
+} from "@admin/components/features/webhooks/deliveryStatus";
+import { ArrowLeft, Loader2, RefreshCw } from "@admin/components/icons";
+import { PageContainer } from "@admin/components/layout/page-container";
+import { PageErrorFallback } from "@admin/components/shared/error-fallbacks";
+import { QueryErrorBoundary } from "@admin/components/shared/query-error-boundary";
+import { toast } from "@admin/components/ui";
+import { Link } from "@admin/components/ui/link";
+import { ROUTES, buildRoute } from "@admin/constants/routes";
+import { useDelivery, useRedeliver } from "@admin/hooks/queries";
+import { useCan } from "@admin/hooks/useCan";
+import { useRouter } from "@admin/hooks/useRouter";
+import { apiErrorMessage } from "@admin/lib/api/parseApiError";
+
+/** One read-only label/value row in a metadata card. */
+const MetaRow: React.FC<{ label: string; children: React.ReactNode }> = ({
+  label,
+  children,
+}) => (
+  <div className="grid grid-cols-1 gap-1 py-3 sm:grid-cols-[1fr_2fr] sm:gap-4">
+    <span className="text-sm font-medium text-muted-foreground">{label}</span>
+    <span className="text-sm text-foreground">{children}</span>
+  </div>
+);
+
+const DeliveryDetailContent: React.FC<{
+  webhookId: string;
+  deliveryId: string;
+}> = ({ webhookId, deliveryId }) => {
+  const canManage = useCan("update-webhooks");
+  const {
+    data: delivery,
+    isLoading,
+    isError,
+    error,
+  } = useDelivery(webhookId, deliveryId);
+  const { mutate: doRedeliver, isPending: isRedelivering } = useRedeliver();
+
+  const handleRedeliver = useCallback(() => {
+    doRedeliver(
+      { webhookId, deliveryId },
+      {
+        onSuccess: () => {
+          toast.success("Redelivery queued", {
+            description: "The delivery will be attempted again shortly.",
+          });
+        },
+        onError: (err: Error) => {
+          toast.error("Could not queue the redelivery", {
+            description: apiErrorMessage(err),
+          });
+        },
+      }
+    );
+  }, [doRedeliver, webhookId, deliveryId]);
+
+  if (isError) {
+    return (
+      <PageErrorFallback
+        error={error ?? new Error("Failed to load delivery")}
+      />
+    );
+  }
+
+  if (isLoading || !delivery) {
+    return <Skeleton className="h-130 w-full rounded-none" />;
+  }
+
+  // Newest attempt first, without mutating the query cache's array in place.
+  const attempts = [...delivery.attempts].reverse();
+
+  return (
+    <div className="space-y-8">
+      <Link
+        href={buildRoute(ROUTES.SETTINGS_WEBHOOKS_DELIVERIES, {
+          id: webhookId,
+        })}
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to deliveries
+      </Link>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-3">
+            <DeliveryStatusBadge status={delivery.status} />
+            <span className="font-medium text-foreground">
+              {delivery.eventType}
+            </span>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {describeResource(delivery.resource)}
+          </p>
+        </div>
+
+        {canManage && (
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleRedeliver}
+            disabled={isRedelivering}
+          >
+            {isRedelivering ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="h-4 w-4" />
+            )}
+            Redeliver
+          </Button>
+        )}
+      </div>
+
+      <section className="space-y-2">
+        <p className="text-[11px] font-semibold tracking-[0.08em] uppercase text-muted-foreground">
+          Delivery
+        </p>
+        <div className="rounded-md border border-input bg-card px-6">
+          <div className="divide-y divide-foreground/10">
+            <MetaRow label="Delivery ID">
+              <code className="font-mono text-xs break-all">{delivery.id}</code>
+            </MetaRow>
+            <MetaRow label="Event ID">
+              <code className="font-mono text-xs break-all">
+                {delivery.eventId}
+              </code>
+            </MetaRow>
+            <MetaRow label="Attempts">
+              <span className="tabular-nums">{delivery.attemptCount}</span>
+            </MetaRow>
+            <MetaRow label="Last response">
+              {delivery.lastStatusCode === null ? (
+                "Not yet attempted"
+              ) : (
+                <span className="tabular-nums">
+                  {formatStatusCode(delivery.lastStatusCode)} ·{" "}
+                  {formatLatency(delivery.lastLatencyMs)}
+                </span>
+              )}
+            </MetaRow>
+            {delivery.lastError && (
+              <MetaRow label="Last error">
+                <span className="text-destructive-500 break-words">
+                  {delivery.lastError}
+                </span>
+              </MetaRow>
+            )}
+            <MetaRow label="Next attempt">
+              {delivery.nextAttemptAt
+                ? formatDeliveryTimestamp(delivery.nextAttemptAt)
+                : "None scheduled"}
+            </MetaRow>
+            <MetaRow label="Event created">
+              {formatDeliveryTimestamp(delivery.eventCreatedAt)}
+            </MetaRow>
+            <MetaRow label="Created">
+              {formatDeliveryTimestamp(delivery.createdAt)}
+            </MetaRow>
+            <MetaRow label="Updated">
+              {formatDeliveryTimestamp(delivery.updatedAt)}
+            </MetaRow>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-2">
+        <p className="text-[11px] font-semibold tracking-[0.08em] uppercase text-muted-foreground">
+          Attempts
+        </p>
+        {attempts.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No attempts have been recorded yet.
+          </p>
+        ) : (
+          <ol className="space-y-3">
+            {attempts.map((attempt, index) => (
+              <li
+                key={`${attempt.at}-${index}`}
+                className="rounded-md border border-input bg-card p-4"
+              >
+                <div className="flex flex-wrap items-center gap-3">
+                  <AttemptOutcomeBadge outcome={attempt.outcome} />
+                  <span className="text-sm tabular-nums text-muted-foreground">
+                    {formatStatusCode(attempt.statusCode ?? null)} ·{" "}
+                    {formatLatency(attempt.latencyMs)}
+                  </span>
+                  <span className="ml-auto text-xs text-muted-foreground">
+                    {formatDeliveryTimestamp(attempt.at)}
+                  </span>
+                </div>
+                {attempt.error && (
+                  <p className="mt-2 text-sm text-destructive-500 break-words">
+                    {attempt.error}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+
+      <section className="space-y-2">
+        <p className="text-[11px] font-semibold tracking-[0.08em] uppercase text-muted-foreground">
+          Last response
+        </p>
+        {delivery.lastResponseSnippet ? (
+          <pre className="max-h-64 overflow-auto rounded-md border border-input bg-muted p-4 font-mono text-xs whitespace-pre-wrap break-words text-foreground">
+            {delivery.lastResponseSnippet}
+          </pre>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No response body was captured.
+          </p>
+        )}
+      </section>
+
+      <Alert variant="info" role="note">
+        <AlertDescription>
+          The outgoing request body and headers are not stored, so they are not
+          shown here. Only the response status, latency, and a truncated
+          response body are recorded for each attempt.
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+};
+
+export default function WebhookDeliveryDetailPage() {
+  const { route } = useRouter();
+  const id =
+    route?.params?.id && typeof route.params.id === "string"
+      ? route.params.id
+      : null;
+  const deliveryId =
+    route?.params?.deliveryId && typeof route.params.deliveryId === "string"
+      ? route.params.deliveryId
+      : null;
+
+  if (!id || !deliveryId) {
+    return (
+      <PageContainer>
+        <SettingsLayout>
+          <Alert variant="destructive">
+            <AlertDescription>
+              Invalid delivery reference. Please go back and try again.
+            </AlertDescription>
+          </Alert>
+          <div className="mt-4">
+            <Link href={ROUTES.SETTINGS_WEBHOOKS}>
+              <Button variant="outline">Back to Webhooks</Button>
+            </Link>
+          </div>
+        </SettingsLayout>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <QueryErrorBoundary fallback={<PageErrorFallback />}>
+      <PageContainer>
+        <SettingsLayout>
+          <DeliveryDetailContent webhookId={id} deliveryId={deliveryId} />
+        </SettingsLayout>
+      </PageContainer>
+    </QueryErrorBoundary>
+  );
+}
+
+// Exported for the delivery-detail render test, which needs the inner content
+// without the router-param wrapper.
+export { DeliveryDetailContent };

--- a/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/__tests__/deliveryDetail.test.tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/__tests__/deliveryDetail.test.tsx
@@ -87,9 +87,10 @@ describe("DeliveryDetailContent", () => {
     ).toBeTruthy();
   });
 
-  it("shows the recorded-history length, not the reset attemptCount, after a redelivery", () => {
-    // A redelivery resets attemptCount to 0 but keeps the attempt history, so
-    // the Attempts stat must reflect the history (2), never the counter (0).
+  it("scopes the attempt counter to the current cycle without hiding prior history", () => {
+    // A redelivery resets attemptCount to 0 for the new cycle but keeps the
+    // attempt history. The counter is labelled "this cycle" so 0 is not a
+    // contradiction, and the prior attempts still render in the timeline.
     useDelivery.mockReturnValue({
       data: { ...DELIVERY, attemptCount: 0 },
       isLoading: false,
@@ -97,11 +98,27 @@ describe("DeliveryDetailContent", () => {
     });
     render(<DeliveryDetailContent webhookId="wh_1" deliveryId="dlv_1" />);
 
-    // Both recorded attempts still render in the timeline...
+    expect(screen.getByText("Attempts (this cycle)")).toBeInTheDocument();
     expect(screen.getByText("retrying")).toBeInTheDocument();
     expect(screen.getByText("failed")).toBeInTheDocument();
-    // ...and the reset counter value is not surfaced as the attempt count.
-    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("notes truncation when the attempt log is at its cap", () => {
+    const many = Array.from({ length: 20 }, (_, i) => ({
+      at: `2026-07-24T09:${String(i).padStart(2, "0")}:00.000Z`,
+      outcome: "retrying",
+    }));
+    useDelivery.mockReturnValue({
+      data: { ...DELIVERY, attemptCount: 25, attempts: many },
+      isLoading: false,
+      isError: false,
+    });
+    render(<DeliveryDetailContent webhookId="wh_1" deliveryId="dlv_1" />);
+
+    // The scalar reflects the true cycle counter (25), and the timeline is
+    // honest that only the most recent 20 records are shown.
+    expect(screen.getByText("25")).toBeInTheDocument();
+    expect(screen.getByText(/most recent 20 attempts/i)).toBeInTheDocument();
   });
 
   it("fires a redelivery when the button is clicked", async () => {

--- a/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/__tests__/deliveryDetail.test.tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/__tests__/deliveryDetail.test.tsx
@@ -6,6 +6,10 @@ import type { WebhookDeliveryDetail } from "@admin/types/webhooks";
 
 import { DeliveryDetailContent } from "../[deliveryId]";
 
+// The spies are created with `vi.hoisted` because `vi.mock` factories are
+// hoisted above the imports and would otherwise reference these before they
+// exist; hoisting the spy definitions to the same level lets the factories
+// close over them.
 const { useDelivery, useRedeliver, redeliverMutate, canFor } = vi.hoisted(
   () => ({
     useDelivery: vi.fn(),
@@ -81,6 +85,23 @@ describe("DeliveryDetailContent", () => {
       failed.compareDocumentPosition(retrying) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
+  });
+
+  it("shows the recorded-history length, not the reset attemptCount, after a redelivery", () => {
+    // A redelivery resets attemptCount to 0 but keeps the attempt history, so
+    // the Attempts stat must reflect the history (2), never the counter (0).
+    useDelivery.mockReturnValue({
+      data: { ...DELIVERY, attemptCount: 0 },
+      isLoading: false,
+      isError: false,
+    });
+    render(<DeliveryDetailContent webhookId="wh_1" deliveryId="dlv_1" />);
+
+    // Both recorded attempts still render in the timeline...
+    expect(screen.getByText("retrying")).toBeInTheDocument();
+    expect(screen.getByText("failed")).toBeInTheDocument();
+    // ...and the reset counter value is not surfaced as the attempt count.
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
   });
 
   it("fires a redelivery when the button is clicked", async () => {

--- a/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/__tests__/deliveryDetail.test.tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/__tests__/deliveryDetail.test.tsx
@@ -1,0 +1,139 @@
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+import type { WebhookDeliveryDetail } from "@admin/types/webhooks";
+
+import { DeliveryDetailContent } from "../[deliveryId]";
+
+const { useDelivery, useRedeliver, redeliverMutate, canFor } = vi.hoisted(
+  () => ({
+    useDelivery: vi.fn(),
+    useRedeliver: vi.fn(),
+    redeliverMutate: vi.fn(),
+    canFor: vi.fn((_slug: string) => true),
+  })
+);
+
+vi.mock("@admin/hooks/queries", () => ({
+  useDelivery: (webhookId: string, deliveryId: string) =>
+    useDelivery(webhookId, deliveryId),
+  useRedeliver: () => useRedeliver(),
+}));
+vi.mock("@admin/hooks/useCan", () => ({
+  useCan: (slug: string) => canFor(slug),
+}));
+
+const DELIVERY: WebhookDeliveryDetail = {
+  id: "dlv_1",
+  webhookId: "wh_1",
+  eventId: "evt_1",
+  eventType: "entry.created",
+  resource: { kind: "entry", collection: "posts", id: "p1", locale: null },
+  status: "failed",
+  attemptCount: 2,
+  lastStatusCode: 500,
+  lastLatencyMs: 120,
+  lastError: "Internal Server Error",
+  nextAttemptAt: "2026-07-24T10:00:00.000Z",
+  eventCreatedAt: "2026-07-24T09:00:00.000Z",
+  createdAt: "2026-07-24T09:00:01.000Z",
+  updatedAt: "2026-07-24T09:05:00.000Z",
+  lastResponseSnippet: "upstream error body",
+  attempts: [
+    { at: "2026-07-24T09:00:02.000Z", outcome: "retrying", statusCode: 503 },
+    {
+      at: "2026-07-24T09:05:00.000Z",
+      outcome: "failed",
+      statusCode: 500,
+      error: "boom",
+    },
+  ],
+};
+
+describe("DeliveryDetailContent", () => {
+  beforeEach(() => {
+    useDelivery.mockReset();
+    useRedeliver.mockReset();
+    redeliverMutate.mockReset();
+    canFor.mockReset();
+    canFor.mockImplementation(() => true);
+    useRedeliver.mockReturnValue({ mutate: redeliverMutate, isPending: false });
+  });
+
+  it("renders the status, response snippet, and the attempt timeline newest-first", () => {
+    useDelivery.mockReturnValue({
+      data: DELIVERY,
+      isLoading: false,
+      isError: false,
+    });
+    render(<DeliveryDetailContent webhookId="wh_1" deliveryId="dlv_1" />);
+
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(screen.getAllByText("entry.created").length).toBeGreaterThan(0);
+    expect(screen.getByText("upstream error body")).toBeInTheDocument();
+
+    // The two attempt outcomes both render; the failed one (last chronologically)
+    // appears before the retrying one because the timeline is reversed.
+    const failed = screen.getByText("failed");
+    const retrying = screen.getByText("retrying");
+    expect(
+      failed.compareDocumentPosition(retrying) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it("fires a redelivery when the button is clicked", async () => {
+    useDelivery.mockReturnValue({
+      data: DELIVERY,
+      isLoading: false,
+      isError: false,
+    });
+    render(<DeliveryDetailContent webhookId="wh_1" deliveryId="dlv_1" />);
+
+    await userEvent.click(screen.getByRole("button", { name: /redeliver/i }));
+    expect(redeliverMutate).toHaveBeenCalledWith(
+      { webhookId: "wh_1", deliveryId: "dlv_1" },
+      expect.anything()
+    );
+  });
+
+  it("disables Redeliver while a redelivery is in flight", () => {
+    useDelivery.mockReturnValue({
+      data: DELIVERY,
+      isLoading: false,
+      isError: false,
+    });
+    useRedeliver.mockReturnValue({ mutate: redeliverMutate, isPending: true });
+    render(<DeliveryDetailContent webhookId="wh_1" deliveryId="dlv_1" />);
+
+    expect(screen.getByRole("button", { name: /redeliver/i })).toBeDisabled();
+  });
+
+  it("hides Redeliver for a user without update-webhooks", () => {
+    canFor.mockImplementation(() => false);
+    useDelivery.mockReturnValue({
+      data: DELIVERY,
+      isLoading: false,
+      isError: false,
+    });
+    render(<DeliveryDetailContent webhookId="wh_1" deliveryId="dlv_1" />);
+
+    expect(
+      screen.queryByRole("button", { name: /redeliver/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("notes that request payload and headers are not stored", () => {
+    useDelivery.mockReturnValue({
+      data: DELIVERY,
+      isLoading: false,
+      isError: false,
+    });
+    render(<DeliveryDetailContent webhookId="wh_1" deliveryId="dlv_1" />);
+
+    expect(
+      screen.getByText(/request body and headers are not stored/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/__tests__/drainButton.test.tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/__tests__/drainButton.test.tsx
@@ -5,6 +5,8 @@ import { render, screen } from "@admin/__tests__/utils";
 
 import { DeliveriesContent } from "../index";
 
+// Spies are defined via `vi.hoisted` so the hoisted `vi.mock` factories below
+// can close over them (the factories run before the module's own imports).
 const {
   useWebhook,
   useDeliveries,

--- a/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/__tests__/drainButton.test.tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/__tests__/drainButton.test.tsx
@@ -1,0 +1,93 @@
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+import { DeliveriesContent } from "../index";
+
+const {
+  useWebhook,
+  useDeliveries,
+  useRunDrain,
+  drainMutate,
+  canFor,
+  toastSuccess,
+  toastError,
+} = vi.hoisted(() => ({
+  useWebhook: vi.fn(),
+  useDeliveries: vi.fn(),
+  useRunDrain: vi.fn(),
+  drainMutate: vi.fn(),
+  canFor: vi.fn((_slug: string) => true),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock("@admin/hooks/queries", () => ({
+  useWebhook: (id: string) => useWebhook(id),
+  useDeliveries: (id: string, params: unknown, opts: unknown) =>
+    useDeliveries(id, params, opts),
+  useRunDrain: () => useRunDrain(),
+}));
+vi.mock("@admin/hooks/useCan", () => ({
+  useCan: (slug: string) => canFor(slug),
+}));
+vi.mock("@admin/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@admin/components/ui")>(
+    "@admin/components/ui"
+  );
+  return { ...actual, toast: { success: toastSuccess, error: toastError } };
+});
+
+const EMPTY_LIST = {
+  data: { items: [], meta: { total: 0, totalPages: 1 } },
+  isLoading: false,
+  isError: false,
+};
+
+describe("Deliveries page — Process queue now", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canFor.mockImplementation(() => true);
+    useWebhook.mockReturnValue({ data: { id: "wh_1", name: "Orders" } });
+    useDeliveries.mockReturnValue(EMPTY_LIST);
+    useRunDrain.mockReturnValue({ mutate: drainMutate, isPending: false });
+  });
+
+  it("toasts a summary of the drain result on success", async () => {
+    drainMutate.mockImplementation((_arg, opts) => {
+      opts.onSuccess({
+        rounds: 1,
+        eventsProcessed: 2,
+        deliveriesCreated: 2,
+        attempted: 2,
+        delivered: 1,
+        retried: 1,
+        failed: 0,
+        abandoned: 0,
+        pruned: { events: 0, deliveries: 0 },
+      });
+    });
+
+    render(<DeliveriesContent id="wh_1" />);
+    await userEvent.click(
+      screen.getByRole("button", { name: /process queue now/i })
+    );
+
+    expect(drainMutate).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).toHaveBeenCalledWith(
+      "Queue processed",
+      expect.objectContaining({
+        description: expect.stringContaining("2 attempted"),
+      })
+    );
+  });
+
+  it("hides the drain button for a read-only user", () => {
+    canFor.mockImplementation((slug: string) => slug === "read-webhooks");
+    render(<DeliveriesContent id="wh_1" />);
+    expect(
+      screen.queryByRole("button", { name: /process queue now/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/index.tsx
@@ -47,8 +47,8 @@ const DeliveriesContent: React.FC<{ id: string }> = ({ id }) => {
   const [status, setStatus] = useState<WebhookDeliveryStatus | undefined>();
   const [eventType, setEventType] = useState<WebhookEventType | undefined>();
 
-  const { data: endpoint } = useWebhook(id);
-  const { data, isLoading, isError, error } = useDeliveries(
+  const { data: endpoint, isLoading: isEndpointLoading } = useWebhook(id);
+  const { data, isLoading, isError, error, isPlaceholderData } = useDeliveries(
     id,
     // The server is 1-based; the Pagination control is 0-based.
     { page: page + 1, limit: pageSize, status, eventType },
@@ -56,15 +56,22 @@ const DeliveriesContent: React.FC<{ id: string }> = ({ id }) => {
   );
   const { mutate: doDrain, isPending: isDraining } = useRunDrain();
 
+  // While a parameter change is refetching, `keepPreviousData` leaves the prior
+  // page in `data` and `isPlaceholderData` is true. Treat that as busy so the
+  // table and its pager show a loading state and disable paging — otherwise the
+  // stale page reads as if it already matched the new filter, and its old page
+  // count would let a click request a page that no longer exists.
+  const isRefetching = isLoading || isPlaceholderData;
+
   // Keep the page in range when the result set shrinks under us (a filter
   // narrows it, or a drain/prune removes rows) so paging never sticks on an
-  // empty page past the end. `keepPreviousData` keeps `data.meta` valid across
-  // a refetch, so this only clamps against a real, freshly-returned total.
+  // empty page past the end. Only clamp against a freshly-returned total, never
+  // the stale placeholder meta held during a refetch.
   useEffect(() => {
-    if (!data) return;
+    if (!data || isPlaceholderData) return;
     const lastPage = Math.max(0, data.meta.totalPages - 1);
     if (page > lastPage) setPage(lastPage);
-  }, [data, page]);
+  }, [data, isPlaceholderData, page]);
 
   // Filters and page-size changes reset to the first page so the new query
   // never lands past the end of a shorter result set.
@@ -130,18 +137,34 @@ const DeliveriesContent: React.FC<{ id: string }> = ({ id }) => {
     <>
       <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="space-y-1">
-          {endpoint ? (
+          {isEndpointLoading ? (
+            <Skeleton className="h-5 w-48 rounded-none" />
+          ) : endpoint ? (
             <p className="text-sm text-muted-foreground">
               Endpoint:{" "}
-              <Link
-                href={buildRoute(ROUTES.SETTINGS_WEBHOOKS_EDIT, { id })}
-                className="font-medium text-foreground underline-offset-4 hover:underline"
-              >
-                {endpoint.name}
-              </Link>
+              {/* The edit route requires update-webhooks; a read-only viewer
+                  only gets a link they could not open, so link only for a
+                  manager and show plain text otherwise. */}
+              {canManage ? (
+                <Link
+                  href={buildRoute(ROUTES.SETTINGS_WEBHOOKS_EDIT, { id })}
+                  className="font-medium text-foreground underline-offset-4 hover:underline"
+                >
+                  {endpoint.name}
+                </Link>
+              ) : (
+                <span className="font-medium text-foreground">
+                  {endpoint.name}
+                </span>
+              )}
             </p>
           ) : (
-            <Skeleton className="h-5 w-48 rounded-none" />
+            // A retired endpoint keeps its delivery history, but `getWebhook`
+            // 404s for it. Label it by id instead of holding a skeleton forever.
+            <p className="text-sm text-muted-foreground">
+              Endpoint <code className="font-mono text-xs">{id}</code> (no
+              longer active)
+            </p>
           )}
         </div>
 
@@ -167,7 +190,7 @@ const DeliveriesContent: React.FC<{ id: string }> = ({ id }) => {
       ) : (
         <DeliveryTable
           rows={data?.items ?? []}
-          isLoading={isLoading}
+          isLoading={isRefetching}
           totalItems={data?.meta.total ?? 0}
           totalPages={data?.meta.totalPages ?? 1}
           page={page}

--- a/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/[id]/deliveries/index.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import {
+  Alert,
+  AlertDescription,
+  Button,
+  Skeleton,
+  TableSkeleton,
+} from "@nextlyhq/ui";
+import type React from "react";
+import { useCallback, useEffect, useState } from "react";
+
+import { SettingsLayout } from "@admin/components/features/settings/SettingsLayout";
+import { DeliveryTable } from "@admin/components/features/webhooks/DeliveryTable";
+import { Loader2, Zap } from "@admin/components/icons";
+import { PageContainer } from "@admin/components/layout/page-container";
+import { PageErrorFallback } from "@admin/components/shared/error-fallbacks";
+import { QueryErrorBoundary } from "@admin/components/shared/query-error-boundary";
+import { toast } from "@admin/components/ui";
+import { Link } from "@admin/components/ui/link";
+import { ROUTES, buildRoute } from "@admin/constants/routes";
+import { useDeliveries, useRunDrain, useWebhook } from "@admin/hooks/queries";
+import { useCan } from "@admin/hooks/useCan";
+import { useRouter } from "@admin/hooks/useRouter";
+import { apiErrorMessage } from "@admin/lib/api/parseApiError";
+import { navigateTo } from "@admin/lib/navigation";
+import type {
+  RunDrainResult,
+  WebhookDeliveryStatus,
+  WebhookDeliverySummary,
+  WebhookEventType,
+} from "@admin/types/webhooks";
+
+/** A short human summary of a drain pass for the toast. */
+function summarizeDrain(result: RunDrainResult): string {
+  return `${result.attempted} attempted · ${result.delivered} delivered · ${result.retried} retrying · ${result.failed} failed.`;
+}
+
+const DeliveriesContent: React.FC<{ id: string }> = ({ id }) => {
+  // Reads use read-or-update; the drain trigger needs the update umbrella.
+  const canReadWebhooks = useCan("read-webhooks");
+  const canManage = useCan("update-webhooks");
+  const canRead = canReadWebhooks || canManage;
+
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(20);
+  const [status, setStatus] = useState<WebhookDeliveryStatus | undefined>();
+  const [eventType, setEventType] = useState<WebhookEventType | undefined>();
+
+  const { data: endpoint } = useWebhook(id);
+  const { data, isLoading, isError, error } = useDeliveries(
+    id,
+    // The server is 1-based; the Pagination control is 0-based.
+    { page: page + 1, limit: pageSize, status, eventType },
+    { enabled: canRead }
+  );
+  const { mutate: doDrain, isPending: isDraining } = useRunDrain();
+
+  // Keep the page in range when the result set shrinks under us (a filter
+  // narrows it, or a drain/prune removes rows) so paging never sticks on an
+  // empty page past the end. `keepPreviousData` keeps `data.meta` valid across
+  // a refetch, so this only clamps against a real, freshly-returned total.
+  useEffect(() => {
+    if (!data) return;
+    const lastPage = Math.max(0, data.meta.totalPages - 1);
+    if (page > lastPage) setPage(lastPage);
+  }, [data, page]);
+
+  // Filters and page-size changes reset to the first page so the new query
+  // never lands past the end of a shorter result set.
+  const handleStatusChange = useCallback((next?: WebhookDeliveryStatus) => {
+    setStatus(next);
+    setPage(0);
+  }, []);
+  const handleEventTypeChange = useCallback((next?: WebhookEventType) => {
+    setEventType(next);
+    setPage(0);
+  }, []);
+  const handlePageSizeChange = useCallback((next: number) => {
+    setPageSize(next);
+    setPage(0);
+  }, []);
+
+  const handleRowClick = useCallback(
+    (delivery: WebhookDeliverySummary) => {
+      navigateTo(
+        buildRoute(ROUTES.SETTINGS_WEBHOOKS_DELIVERY_DETAIL, {
+          id,
+          deliveryId: delivery.id,
+        })
+      );
+    },
+    [id]
+  );
+
+  const handleDrain = useCallback(() => {
+    doDrain(undefined, {
+      onSuccess: result => {
+        toast.success("Queue processed", {
+          description: summarizeDrain(result),
+        });
+      },
+      onError: (err: Error) => {
+        toast.error("Could not process the queue", {
+          description: apiErrorMessage(err),
+        });
+      },
+    });
+  }, [doDrain]);
+
+  if (!canRead) {
+    return (
+      <Alert variant="info" role="status">
+        <AlertDescription>
+          You do not have permission to view webhook deliveries.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (isError) {
+    return (
+      <PageErrorFallback
+        error={error ?? new Error("Failed to load deliveries")}
+      />
+    );
+  }
+
+  return (
+    <>
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          {endpoint ? (
+            <p className="text-sm text-muted-foreground">
+              Endpoint:{" "}
+              <Link
+                href={buildRoute(ROUTES.SETTINGS_WEBHOOKS_EDIT, { id })}
+                className="font-medium text-foreground underline-offset-4 hover:underline"
+              >
+                {endpoint.name}
+              </Link>
+            </p>
+          ) : (
+            <Skeleton className="h-5 w-48 rounded-none" />
+          )}
+        </div>
+
+        {canManage && (
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleDrain}
+            disabled={isDraining}
+          >
+            {isDraining ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Zap className="h-4 w-4" />
+            )}
+            Process queue now
+          </Button>
+        )}
+      </div>
+
+      {isLoading && !data ? (
+        <TableSkeleton columns={6} rowCount={8} />
+      ) : (
+        <DeliveryTable
+          rows={data?.items ?? []}
+          isLoading={isLoading}
+          totalItems={data?.meta.total ?? 0}
+          totalPages={data?.meta.totalPages ?? 1}
+          page={page}
+          pageSize={pageSize}
+          status={status}
+          eventType={eventType}
+          onPageChange={setPage}
+          onPageSizeChange={handlePageSizeChange}
+          onStatusChange={handleStatusChange}
+          onEventTypeChange={handleEventTypeChange}
+          onRowClick={handleRowClick}
+        />
+      )}
+    </>
+  );
+};
+
+export default function WebhookDeliveriesPage() {
+  const { route } = useRouter();
+  const id =
+    route?.params?.id && typeof route.params.id === "string"
+      ? route.params.id
+      : null;
+
+  if (!id) {
+    return (
+      <PageContainer>
+        <SettingsLayout>
+          <Alert variant="destructive">
+            <AlertDescription>
+              Invalid endpoint ID. Please go back and try again.
+            </AlertDescription>
+          </Alert>
+          <div className="mt-4">
+            <Link href={ROUTES.SETTINGS_WEBHOOKS}>
+              <Button variant="outline">Back to Webhooks</Button>
+            </Link>
+          </div>
+        </SettingsLayout>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <QueryErrorBoundary fallback={<PageErrorFallback />}>
+      <PageContainer>
+        <SettingsLayout>
+          <DeliveriesContent id={id} />
+        </SettingsLayout>
+      </PageContainer>
+    </QueryErrorBoundary>
+  );
+}
+
+// Exported for the drain-button test, which drives the content without the
+// router-param wrapper.
+export { DeliveriesContent };

--- a/packages/admin/src/pages/dashboard/settings/webhooks/edit/[id].tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/edit/[id].tsx
@@ -8,13 +8,13 @@ import { SettingsLayout } from "@admin/components/features/settings/SettingsLayo
 import { DeleteWebhookDialog } from "@admin/components/features/webhooks/DeleteWebhookDialog";
 import { WebhookForm } from "@admin/components/features/webhooks/WebhookForm";
 import { WebhookSecretModal } from "@admin/components/features/webhooks/WebhookSecretModal";
-import { Eye, Loader2 } from "@admin/components/icons";
+import { Eye, List, Loader2 } from "@admin/components/icons";
 import { PageContainer } from "@admin/components/layout/page-container";
 import { PageErrorFallback } from "@admin/components/shared/error-fallbacks";
 import { QueryErrorBoundary } from "@admin/components/shared/query-error-boundary";
 import { toast } from "@admin/components/ui";
 import { Link } from "@admin/components/ui/link";
-import { ROUTES } from "@admin/constants/routes";
+import { ROUTES, buildRoute } from "@admin/constants/routes";
 import {
   useDeleteWebhook,
   useRevealSecret,
@@ -129,19 +129,32 @@ const EditWebhookContent: React.FC<{ id: string }> = ({ id }) => {
       />
 
       <div className="mt-8 flex flex-col gap-3 border-t border-border pt-6 sm:flex-row sm:items-center sm:justify-between">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={handleReveal}
-          disabled={isRevealing}
-        >
-          {isRevealing ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Eye className="h-4 w-4" />
-          )}
-          Reveal signing secret
-        </Button>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleReveal}
+            disabled={isRevealing}
+          >
+            {isRevealing ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
+            Reveal signing secret
+          </Button>
+
+          <Link href={buildRoute(ROUTES.SETTINGS_WEBHOOKS_DELIVERIES, { id })}>
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full sm:w-auto"
+            >
+              <List className="h-4 w-4" />
+              View deliveries
+            </Button>
+          </Link>
+        </div>
 
         {canDelete && (
           <Button

--- a/packages/admin/src/pages/dashboard/settings/webhooks/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/index.tsx
@@ -47,6 +47,15 @@ const WebhooksContent: React.FC = () => {
     navigateTo(buildRoute(ROUTES.SETTINGS_WEBHOOKS_EDIT, { id: webhook.id }));
   }, []);
 
+  const handleViewDeliveries = useCallback(
+    (webhook: WebhookEndpointSummary) => {
+      navigateTo(
+        buildRoute(ROUTES.SETTINGS_WEBHOOKS_DELIVERIES, { id: webhook.id })
+      );
+    },
+    []
+  );
+
   const handleToggleEnabled = useCallback(
     (webhook: WebhookEndpointSummary) => {
       doUpdate(
@@ -138,10 +147,12 @@ const WebhooksContent: React.FC = () => {
         isLoading={isLoading}
         canUpdate={canUpdate}
         canDelete={canDelete}
+        canViewDeliveries={canRead}
         onEdit={handleEdit}
         onToggleEnabled={handleToggleEnabled}
         onTest={handleTest}
         onDelete={setToDelete}
+        onViewDeliveries={handleViewDeliveries}
       />
 
       <DeleteWebhookDialog

--- a/packages/admin/src/pages/registry.ts
+++ b/packages/admin/src/pages/registry.ts
@@ -41,6 +41,8 @@ import EditImageSizePage from "./dashboard/settings/image-sizes/edit/[id]";
 import ImageSizesSettingsPage from "./dashboard/settings/image-sizes/index";
 import SettingsPage from "./dashboard/settings/index";
 import SettingsPermissionsPage from "./dashboard/settings/permissions/index";
+import WebhookDeliveryDetailPage from "./dashboard/settings/webhooks/[id]/deliveries/[deliveryId]";
+import WebhookDeliveriesPage from "./dashboard/settings/webhooks/[id]/deliveries/index";
 import CreateWebhookPage from "./dashboard/settings/webhooks/create";
 import EditWebhookPage from "./dashboard/settings/webhooks/edit/[id]";
 import WebhooksPage from "./dashboard/settings/webhooks/index";
@@ -333,6 +335,18 @@ export const routeConfig: Record<string, RouteConfig> = {
     component: EditWebhookPage,
     type: "private",
     requiredPermission: "update-webhooks",
+  },
+  // Delivery log routes are read surfaces, so a plain reader may open them; the
+  // redeliver and drain actions inside are separately gated on update-webhooks.
+  [ROUTES.SETTINGS_WEBHOOKS_DELIVERIES]: {
+    component: WebhookDeliveriesPage,
+    type: "private",
+    requiredPermission: ["read-webhooks", "update-webhooks"],
+  },
+  [ROUTES.SETTINGS_WEBHOOKS_DELIVERY_DETAIL]: {
+    component: WebhookDeliveryDetailPage,
+    type: "private",
+    requiredPermission: ["read-webhooks", "update-webhooks"],
   },
 
   // Image sizes settings

--- a/packages/admin/src/services/deliveryApi.test.ts
+++ b/packages/admin/src/services/deliveryApi.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetcherSpy } = vi.hoisted(() => ({ fetcherSpy: vi.fn() }));
+
+vi.mock("../lib/api/fetcher", () => ({ fetcher: fetcherSpy }));
+
+import { deliveryApi } from "./deliveryApi";
+
+const delivery = { id: "dlv_1", webhookId: "wh_1", status: "delivered" };
+
+describe("deliveryApi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists deliveries with no filters and returns the raw list envelope", async () => {
+    const envelope = { items: [delivery], meta: { total: 1 } };
+    fetcherSpy.mockResolvedValue(envelope);
+    const result = await deliveryApi.listDeliveries("wh_1");
+    expect(fetcherSpy).toHaveBeenCalledWith(
+      "/webhooks/wh_1/deliveries",
+      {},
+      true
+    );
+    expect(result).toBe(envelope);
+  });
+
+  it("serializes page, limit, status, and eventType into the query string", async () => {
+    fetcherSpy.mockResolvedValue({ items: [], meta: {} });
+    await deliveryApi.listDeliveries("wh_1", {
+      page: 2,
+      limit: 25,
+      status: "failed",
+      eventType: "entry.created",
+    });
+    expect(fetcherSpy).toHaveBeenCalledWith(
+      "/webhooks/wh_1/deliveries?page=2&limit=25&status=failed&eventType=entry.created",
+      {},
+      true
+    );
+  });
+
+  it("omits an empty event-type filter", async () => {
+    fetcherSpy.mockResolvedValue({ items: [], meta: {} });
+    await deliveryApi.listDeliveries("wh_1", { page: 1, eventType: "" });
+    expect(fetcherSpy).toHaveBeenCalledWith(
+      "/webhooks/wh_1/deliveries?page=1",
+      {},
+      true
+    );
+  });
+
+  it("reads one delivery as a bare doc", async () => {
+    fetcherSpy.mockResolvedValue(delivery);
+    const result = await deliveryApi.getDelivery("wh_1", "dlv_1");
+    expect(fetcherSpy).toHaveBeenCalledWith(
+      "/webhooks/wh_1/deliveries/dlv_1",
+      {},
+      true
+    );
+    expect(result).toBe(delivery);
+  });
+
+  it("redelivers and unwraps the item", async () => {
+    fetcherSpy.mockResolvedValue({
+      message: "Redelivery queued.",
+      item: delivery,
+    });
+    const result = await deliveryApi.redeliver("wh_1", "dlv_1");
+    expect(fetcherSpy).toHaveBeenCalledWith(
+      "/webhooks/wh_1/deliveries/dlv_1/redeliver",
+      { method: "POST" },
+      true
+    );
+    expect(result).toBe(delivery);
+  });
+
+  it("runs a drain and unwraps the summary item", async () => {
+    const summary = { rounds: 1, delivered: 3 };
+    fetcherSpy.mockResolvedValue({
+      message: "Webhook drain completed.",
+      item: summary,
+    });
+    const result = await deliveryApi.runDrain();
+    expect(fetcherSpy).toHaveBeenCalledWith(
+      "/webhooks/drain",
+      { method: "POST" },
+      true
+    );
+    expect(result).toBe(summary);
+  });
+});

--- a/packages/admin/src/services/deliveryApi.ts
+++ b/packages/admin/src/services/deliveryApi.ts
@@ -1,0 +1,86 @@
+/**
+ * Webhook delivery API service.
+ *
+ * Thin typed wrappers over the shared `fetcher` for the delivery log surface:
+ * list an endpoint's deliveries (server-paginated), read one delivery with its
+ * attempt history, re-arm a past delivery, and trigger a manual drain pass.
+ *
+ * Reads are session-or-key; redeliver and drain are session-only writes (the
+ * fetcher's protected mode sends the cookie). No delivery shape carries a
+ * credential — request headers actually sent are never persisted server-side.
+ */
+
+import { fetcher } from "../lib/api/fetcher";
+import type { ListResponse, MutationResponse } from "../lib/api/response-types";
+import type {
+  ListDeliveriesParams,
+  RunDrainResult,
+  WebhookDeliveryDetail,
+  WebhookDeliverySummary,
+} from "../types/webhooks";
+
+/** Build the delivery list query string, omitting unset filters. */
+function toQuery(params: ListDeliveriesParams): string {
+  const search = new URLSearchParams();
+  if (params.page !== undefined) search.set("page", String(params.page));
+  if (params.limit !== undefined) search.set("limit", String(params.limit));
+  if (params.status) search.set("status", params.status);
+  // A blank event-type filter is "no filter"; only send a non-empty value.
+  if (params.eventType) search.set("eventType", params.eventType);
+  const query = search.toString();
+  return query ? `?${query}` : "";
+}
+
+/** A page of an endpoint's deliveries plus the pagination meta. */
+export function listDeliveries(
+  webhookId: string,
+  params: ListDeliveriesParams = {}
+): Promise<ListResponse<WebhookDeliverySummary>> {
+  return fetcher<ListResponse<WebhookDeliverySummary>>(
+    `/webhooks/${webhookId}/deliveries${toQuery(params)}`,
+    {},
+    true
+  );
+}
+
+/** Read one delivery (bare doc with attempt history; 404 if not this endpoint's). */
+export function getDelivery(
+  webhookId: string,
+  deliveryId: string
+): Promise<WebhookDeliveryDetail> {
+  return fetcher<WebhookDeliveryDetail>(
+    `/webhooks/${webhookId}/deliveries/${deliveryId}`,
+    {},
+    true
+  );
+}
+
+/** Re-arm a past delivery for another attempt; returns the reset delivery. */
+export async function redeliver(
+  webhookId: string,
+  deliveryId: string
+): Promise<WebhookDeliveryDetail> {
+  const result = await fetcher<MutationResponse<WebhookDeliveryDetail>>(
+    `/webhooks/${webhookId}/deliveries/${deliveryId}/redeliver`,
+    { method: "POST" },
+    true
+  );
+  return result.item;
+}
+
+/** Run one manual drain pass; returns its summary counts. */
+export async function runDrain(): Promise<RunDrainResult> {
+  const result = await fetcher<MutationResponse<RunDrainResult>>(
+    "/webhooks/drain",
+    { method: "POST" },
+    true
+  );
+  return result.item;
+}
+
+export const deliveryApi = {
+  listDeliveries,
+  getDelivery,
+  redeliver,
+  runDrain,
+} as const;

--- a/packages/admin/src/types/webhooks.ts
+++ b/packages/admin/src/types/webhooks.ts
@@ -88,3 +88,96 @@ export interface WebhookTestResult {
   error?: string;
   responseSnippet?: string;
 }
+
+/**
+ * Lifecycle state of a delivery, mirroring the drain's status vocabulary
+ * (`packages/nextly/src/domains/webhooks`). These are the only values the list
+ * status filter offers.
+ */
+export const WEBHOOK_DELIVERY_STATUSES = [
+  "pending",
+  "processing",
+  "delivered",
+  "retrying",
+  "failed",
+] as const;
+
+export type WebhookDeliveryStatus = (typeof WEBHOOK_DELIVERY_STATUSES)[number];
+
+/** The resource an event was about, surfaced from the joined event row. */
+export interface WebhookDeliveryResource {
+  kind: string;
+  collection: string | null;
+  id: string | null;
+  /** Which translation changed, for a localized resource; null otherwise. */
+  locale: string | null;
+}
+
+/**
+ * One recorded delivery attempt. `outcome` is free text from the engine (e.g.
+ * `delivered`, `retrying`, `failed`) rather than the delivery-level status set,
+ * so it is typed as a string, not `WebhookDeliveryStatus`.
+ */
+export interface WebhookDeliveryAttempt {
+  at: string;
+  outcome: string;
+  statusCode?: number;
+  latencyMs?: number;
+  error?: string;
+}
+
+/**
+ * A delivery as the log list shows it (joined to its event). Timestamps arrive
+ * as ISO-8601 UTC strings: the delivery reads opt out of server-side timezone
+ * rewriting so opaque captured text (errors, snippets) survives verbatim, so
+ * the client renders these instants itself.
+ */
+export interface WebhookDeliverySummary {
+  id: string;
+  webhookId: string;
+  eventId: string;
+  eventType: string;
+  resource: WebhookDeliveryResource;
+  status: WebhookDeliveryStatus;
+  attemptCount: number;
+  lastStatusCode: number | null;
+  lastLatencyMs: number | null;
+  lastError: string | null;
+  /** When the next retry is due, or null when the delivery is terminal. */
+  nextAttemptAt: string | null;
+  /** When the underlying event was recorded. */
+  eventCreatedAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** A single delivery with its full attempt history and last response snippet. */
+export interface WebhookDeliveryDetail extends WebhookDeliverySummary {
+  attempts: WebhookDeliveryAttempt[];
+  /** Truncated response body from the last attempt, or null. */
+  lastResponseSnippet: string | null;
+}
+
+/** Filters and paging for a delivery list request. `page`/`limit` are 1-based. */
+export interface ListDeliveriesParams {
+  page?: number;
+  limit?: number;
+  status?: WebhookDeliveryStatus;
+  eventType?: string;
+}
+
+/**
+ * Summary of one manual/scheduled drain pass (the `item` of the drain mutation
+ * envelope). Mirrors the backend `RunDrainResult`.
+ */
+export interface RunDrainResult {
+  rounds: number;
+  eventsProcessed: number;
+  deliveriesCreated: number;
+  attempted: number;
+  delivered: number;
+  retried: number;
+  failed: number;
+  abandoned: number;
+  pruned: { events: number; deliveries: number };
+}


### PR DESCRIPTION
## What

Adds the **webhook delivery log** to the admin panel — the read/observe half of the webhook product surface, on top of the endpoint-management UI (#313) and the delivery engine.

Each endpoint now has a **Deliveries** view:

- **List** (server-paginated) of its past delivery attempts: status, event type, resource, attempt count, last response code/latency, created. Filterable by **status** (pending/processing/delivered/retrying/failed) and **event type**; filters and page-size reset paging to the first page, and the page clamps if the result set shrinks under you.
- **Detail page** for one delivery: status/event/resource header, a metadata card (ids, attempt count, last response, next attempt, timestamps), the full **attempt timeline** (newest first, with per-attempt outcome/status/latency/error), and the **last response snippet**. It is honest that the outgoing request body and headers are not persisted, so they are not shown.
- **Redeliver** button on the detail page (re-arms the delivery and nudges the drain).
- **Process queue now** button on the list (manual drain), toasting a summary of the pass.

Entry points: a **View deliveries** row action on the endpoints list and a button on the endpoint edit page.

## Contract

Consumes the delivery REST surface already shipped in the engine:

| Op | Method · path | Perm |
|---|---|---|
| List deliveries | `GET /webhooks/:id/deliveries?page&limit&status&eventType` | read-or-update |
| Delivery detail | `GET /webhooks/:id/deliveries/:deliveryId` | read-or-update |
| Redeliver | `POST /webhooks/:id/deliveries/:deliveryId/redeliver` | update |
| Drain now | `POST /webhooks/drain` | update + same-origin |

Delivery reads opt out of server-side timezone rewriting (so captured error/response text survives verbatim), so timestamps arrive as ISO-UTC instants and are formatted client-side.

## RBAC

Reuses the model established in #313: deliveries pages are read surfaces, gated `read-webhooks` **or** `update-webhooks` (any-of via `PermissionGuard`); the **Redeliver** and **Process queue now** actions are gated on `update-webhooks`. No new nav/capability wiring — the pages are children of the existing Webhooks settings section.

## Tests

- `deliveryApi` (query serialization, envelope unwrapping)
- `useDeliveries` / `useDelivery` / `useRunDrain` (param passthrough, enabled-gating)
- `deliveryStatus` (status/outcome badge mapping, formatting helpers)
- Detail page render (timeline order newest-first, Redeliver disabled-while-pending, hidden without update, the not-stored note)
- Drain button (toast summary, hidden for read-only)

`check-types` + `lint` clean; full admin suite adds **zero** new failures over the known pre-existing baseline (8 files / 37 tests).

## Changeset

One, all 19 packages `patch` (lockstep alpha).

## Non-goals

Editing filter/allowlist; showing request payload/headers (not persisted); secret rotation (tracked separately).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook delivery history pages with filtering, pagination, status details, response information, and attempt timelines.
  * Added delivery detail views with permission-based redelivery actions.
  * Added “View deliveries” navigation from webhook lists and edit pages.
  * Added a “Process queue now” action for authorized users.
  * Added clear delivery statuses, timestamps, response codes, latency, and resource details.

* **Bug Fixes**
  * Added correct Deliveries breadcrumbs and page titles.

* **Tests**
  * Added coverage for delivery lists, details, redelivery, queue processing, formatting, and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->