### PR TITLE
feat(nextly): bust cache tags on content writes

### DIFF
--- a/.changeset/cache-revalidation-wiring.md
+++ b/.changeset/cache-revalidation-wiring.md
@@ -1,0 +1,33 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Bust cache tags on every content write.
+
+Each collection create, update, publish/unpublish, and delete — and each single
+write — now computes the cache tags it invalidates and flushes them after the
+transaction commits, through a registered cache revalidator (a no-op until a Next
+cache adapter is present). A rename busts both the old and new slug tags, a delete
+busts the collection and entry-id tags, and a write that records nothing (a
+rejected or no-op write) busts nothing. Bulk operations aggregate their items'
+tags and flush them once. This wires the tag scheme added previously to the write
+path; the read-side helpers and the Next cache adapter that turns the tags into
+`revalidateTag` calls follow.

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -144,6 +144,7 @@ import {
   registerEmailServices,
   registerMediaServices,
   registerMetaServices,
+  registerRevalidationServices,
   registerSingleServices,
   registerUserServices,
   registerVersionServices,
@@ -741,6 +742,9 @@ export async function registerServices(
   registerEmailServices(ctx);
   registerDashboardServices(ctx);
   registerAuthServices(ctx);
+  // Before the collection/single services, which resolve the cacheRevalidator
+  // lazily when a write flushes its intents.
+  registerRevalidationServices(ctx);
   registerCollectionServices(ctx);
   registerMediaServices(ctx);
   registerMetaServices(ctx);

--- a/packages/nextly/src/di/registrations/index.ts
+++ b/packages/nextly/src/di/registrations/index.ts
@@ -12,6 +12,7 @@ export { registerDashboardServices } from "./register-dashboard";
 export { registerEmailServices } from "./register-email";
 export { registerMediaServices } from "./register-media";
 export { registerMetaServices } from "./register-meta";
+export { registerRevalidationServices } from "./register-revalidation";
 export { registerSingleServices } from "./register-singles";
 export { registerUserServices } from "./register-users";
 export { registerVersionServices } from "./register-versions";

--- a/packages/nextly/src/di/registrations/register-collections.ts
+++ b/packages/nextly/src/di/registrations/register-collections.ts
@@ -24,6 +24,7 @@ import { DynamicCollectionService } from "../../domains/dynamic-collections";
 import type { WebhookFastDrainScheduler } from "../../domains/webhooks/after-drain";
 import { MetaRetentionGate } from "../../domains/webhooks/retention-gate";
 import { WebhookRetentionRunner } from "../../domains/webhooks/retention-runner";
+import type { CacheRevalidator } from "../../revalidation/types";
 import { AccessControlService } from "../../services/access";
 import { CollectionFileManager } from "../../services/collection-file-manager";
 import { CollectionEntryService } from "../../services/collections/collection-entry-service";
@@ -185,6 +186,11 @@ export function registerCollectionServices(ctx: RegistrationContext): void {
       // services). Absent only when webhooks were never registered.
       container.has("webhookFastDrainScheduler")
         ? container.get<WebhookFastDrainScheduler>("webhookFastDrainScheduler")
+        : undefined,
+      // Cache revalidator that flushes each write's revalidation intents
+      // post-commit (a no-op unless a Next cache adapter registered one).
+      container.has("cacheRevalidator")
+        ? container.get<CacheRevalidator>("cacheRevalidator")
         : undefined
     );
 

--- a/packages/nextly/src/di/registrations/register-revalidation.ts
+++ b/packages/nextly/src/di/registrations/register-revalidation.ts
@@ -1,0 +1,24 @@
+/**
+ * Cache-revalidation DI registration.
+ *
+ * Registers the `cacheRevalidator` singleton the write path flushes intents to.
+ * The default is a no-op, so core stays framework-neutral and a write never has
+ * to null-check the sink; a framework adapter (the Next cache adapter) replaces
+ * this registration with an implementation that calls `revalidateTag`.
+ */
+import { NoopRevalidator } from "../../revalidation/noop-revalidator";
+import type { CacheRevalidator } from "../../revalidation/types";
+import { container } from "../container";
+
+import type { RegistrationContext } from "./types";
+
+export function registerRevalidationServices(_ctx: RegistrationContext): void {
+  // Only register the no-op default when nothing else has claimed the slot, so a
+  // framework adapter registered earlier (or a test's fake) is never clobbered.
+  if (!container.has("cacheRevalidator")) {
+    container.registerSingleton<CacheRevalidator>(
+      "cacheRevalidator",
+      () => new NoopRevalidator()
+    );
+  }
+}

--- a/packages/nextly/src/di/registrations/register-singles.ts
+++ b/packages/nextly/src/di/registrations/register-singles.ts
@@ -17,6 +17,7 @@ import { SingleRegistryService } from "../../domains/singles/services/single-reg
 import type { WebhookFastDrainScheduler } from "../../domains/webhooks/after-drain";
 import { MetaRetentionGate } from "../../domains/webhooks/retention-gate";
 import { WebhookRetentionRunner } from "../../domains/webhooks/retention-runner";
+import type { CacheRevalidator } from "../../revalidation/types";
 import type { ComponentDataService } from "../../services/components";
 import { container } from "../container";
 
@@ -79,6 +80,11 @@ export function registerSingleServices(ctx: RegistrationContext): void {
       // services). Absent only when webhooks were never registered.
       container.has("webhookFastDrainScheduler")
         ? container.get<WebhookFastDrainScheduler>("webhookFastDrainScheduler")
+        : undefined,
+      // Cache revalidator that flushes each single write's intent post-commit
+      // (a no-op unless a Next cache adapter registered one).
+      container.has("cacheRevalidator")
+        ? container.get<CacheRevalidator>("cacheRevalidator")
         : undefined
     );
   });

--- a/packages/nextly/src/direct-api/__tests__/collections.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/collections.test.ts
@@ -468,21 +468,33 @@ describe("Direct API - Collection Operations", () => {
   });
 
   describe("bulkDelete()", () => {
-    it("should return bulk operation result", async () => {
-      const mockResult = {
-        success: ["post-1", "post-2"],
-        failed: [],
+    it("should return bulk operation result without internal fields", async () => {
+      // The handler result carries internal post-commit signals (eventRecorded,
+      // revalidationIntents); the Direct API must project them away.
+      mocks.collectionsHandler.bulkDeleteEntries.mockResolvedValue({
+        successes: [{ id: "post-1" }, { id: "post-2" }],
+        failures: [],
+        total: 2,
         successCount: 2,
         failedCount: 0,
-      };
-      mocks.collectionsHandler.bulkDeleteEntries.mockResolvedValue(mockResult);
+        eventRecorded: true,
+        revalidationIntents: [{ tags: ["nextly:posts"] }],
+      });
 
       const result = await nextly.bulkDelete({
         collection: "posts",
         ids: ["post-1", "post-2"],
       });
 
-      expect(result).toEqual(mockResult);
+      expect(result).toEqual({
+        successes: [{ id: "post-1" }, { id: "post-2" }],
+        failures: [],
+        total: 2,
+        successCount: 2,
+        failedCount: 0,
+      });
+      expect(result).not.toHaveProperty("revalidationIntents");
+      expect(result).not.toHaveProperty("eventRecorded");
     });
 
     it("should pass ids and config", async () => {

--- a/packages/nextly/src/direct-api/namespaces/collections.ts
+++ b/packages/nextly/src/direct-api/namespaces/collections.ts
@@ -417,7 +417,16 @@ export async function bulkDelete(
     context: config.context,
   });
 
-  return bulkResult;
+  // Project to the public shape so internal post-commit signals (eventRecorded,
+  // revalidationIntents) — already consumed by the write path — never reach a
+  // Direct API caller.
+  return {
+    successes: bulkResult.successes,
+    failures: bulkResult.failures,
+    total: bulkResult.total,
+    successCount: bulkResult.successCount,
+    failedCount: bulkResult.failedCount,
+  };
 }
 
 /**

--- a/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
@@ -256,6 +256,22 @@ describe("cache revalidation — write path (sqlite)", () => {
     }
   });
 
+  it("carries the intent on a single createEntryInTransaction result", async () => {
+    const entries = await boot([openCollection("singletx")]);
+    // A caller-owned single transactional write (via withTransaction). It does
+    // not flush; the intent is on the result for the caller to flush post-commit.
+    const result = await handle!.adapter.transaction(tx =>
+      entries.createEntryInTransaction(
+        tx,
+        { collectionName: "singletx", overrideAccess: true },
+        { title: "T", slug: "single-s" }
+      )
+    );
+    expect(result.revalidationIntent?.tags).toContain(
+      "nextly:singletx:slug:single-s"
+    );
+  });
+
   it("flushes nothing when a write records no event (update of a missing entry)", async () => {
     const entries = await boot([openCollection("nope")]);
     const result = await entries.updateEntry(

--- a/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
@@ -155,6 +155,26 @@ describe("cache revalidation — write path (sqlite)", () => {
     expect(spy.tags).toContain("nextly:batch:slug:b");
   });
 
+  it("busts the old and new slug tags on a batch update rename", async () => {
+    const entries = await boot([openCollection("batchren")]);
+    const created = await entries.createEntry(
+      { collectionName: "batchren", overrideAccess: true },
+      { title: "R", slug: "before" }
+    );
+    const id = (created.data as { id: string }).id;
+    spy.flushed.length = 0;
+
+    await entries.updateEntries(
+      { collectionName: "batchren", overrideAccess: true },
+      [{ id, data: { slug: "after" } }]
+    );
+
+    // The batch update worker carries the previous slug, so a batch rename busts
+    // the stale slug tag too.
+    expect(spy.tags).toContain("nextly:batchren:slug:after");
+    expect(spy.tags).toContain("nextly:batchren:slug:before");
+  });
+
   it("flushes the entry tags on publishAllLocales", async () => {
     const entries = await boot([openCollection("pub")]);
     const created = await entries.createEntry(

--- a/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
@@ -300,6 +300,26 @@ describe("cache revalidation — write path (sqlite)", () => {
     expect(spy.tags).toContain("nextly:wtx:slug:wtx-slug");
   });
 
+  it("flushes nothing when a CollectionService.withTransaction rolls back", async () => {
+    // Tags may only bust after the transaction commits: if work throws, the
+    // transaction rolls back, so the collected intent must never reach the
+    // revalidator.
+    await boot([openCollection("wtxroll")]);
+    const service = handle!.getService<CollectionService>("collectionService");
+    await expect(
+      service.withTransaction(async tx => {
+        await service.createEntryInTransaction(
+          tx,
+          "wtxroll",
+          { title: "T", slug: "rolled" },
+          { user: undefined }
+        );
+        throw NextlyError.internal({ logContext: { reason: "test-rollback" } });
+      })
+    ).rejects.toThrow();
+    expect(spy.flushed).toHaveLength(0);
+  });
+
   it("flushes nothing when a write records no event (update of a missing entry)", async () => {
     const entries = await boot([openCollection("nope")]);
     const result = await entries.updateEntry(

--- a/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
@@ -193,6 +193,21 @@ describe("cache revalidation — write path (sqlite)", () => {
     expect(spy.tags).toContain(`nextly:pub:id:${id}`);
   });
 
+  it("carries per-item intents on a caller-owned createEntriesInTransaction result", async () => {
+    const entries = await boot([openCollection("ownedtx")]);
+    // The caller owns the transaction, so the method does not flush — it surfaces
+    // the intents on the result for the caller to flush after IT commits.
+    const result = await handle!.adapter.transaction(tx =>
+      entries.createEntriesInTransaction(tx, { collectionName: "ownedtx" }, [
+        { title: "A", slug: "a" },
+        { title: "B", slug: "b" },
+      ])
+    );
+    const flushedTags = (result.revalidationIntents ?? []).flatMap(i => i.tags);
+    expect(flushedTags).toContain("nextly:ownedtx:slug:a");
+    expect(flushedTags).toContain("nextly:ownedtx:slug:b");
+  });
+
   it("flushes nothing when a write records no event (update of a missing entry)", async () => {
     const entries = await boot([openCollection("nope")]);
     const result = await entries.updateEntry(

--- a/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
@@ -208,6 +208,28 @@ describe("cache revalidation — write path (sqlite)", () => {
     expect(flushedTags).toContain("nextly:ownedtx:slug:b");
   });
 
+  it("busts the slug tag even when field-level read access hides slug", async () => {
+    // A batch create for a non-override user where slug's read access is denied:
+    // redactResponseFields strips slug from the returned row, so the intent must
+    // be computed from the pre-redaction row.
+    const entries = await boot([
+      defineCollection({
+        slug: "redact",
+        status: true,
+        access: { create: () => true },
+        fields: [
+          text({ name: "title" }),
+          text({ name: "slug", access: { read: () => false } }),
+        ],
+      }),
+    ]);
+    await entries.createEntries(
+      { collectionName: "redact", user: { id: "u" } },
+      [{ title: "T", slug: "hidden-slug" }]
+    );
+    expect(spy.tags).toContain("nextly:redact:slug:hidden-slug");
+  });
+
   it("flushes nothing when a write records no event (update of a missing entry)", async () => {
     const entries = await boot([openCollection("nope")]);
     const result = await entries.updateEntry(

--- a/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
@@ -140,6 +140,39 @@ describe("cache revalidation — write path (sqlite)", () => {
     expect(spy.tags).toContain(`nextly:docs:id:${id}`);
   });
 
+  it("flushes tags for every entry in a batch create", async () => {
+    const entries = await boot([openCollection("batch")]);
+    await entries.createEntries(
+      { collectionName: "batch", overrideAccess: true },
+      [
+        { title: "A", slug: "a" },
+        { title: "B", slug: "b" },
+      ]
+    );
+    // A batch create records no outbox event, but the content changed, so its
+    // tags must still be busted.
+    expect(spy.tags).toContain("nextly:batch:slug:a");
+    expect(spy.tags).toContain("nextly:batch:slug:b");
+  });
+
+  it("flushes the entry tags on publishAllLocales", async () => {
+    const entries = await boot([openCollection("pub")]);
+    const created = await entries.createEntry(
+      { collectionName: "pub", overrideAccess: true },
+      { title: "Draft", slug: "draft-doc", status: "draft" }
+    );
+    const id = (created.data as { id: string }).id;
+    spy.flushed.length = 0;
+
+    await entries.publishAllLocales({
+      collectionName: "pub",
+      entryId: id,
+      overrideAccess: true,
+    });
+
+    expect(spy.tags).toContain(`nextly:pub:id:${id}`);
+  });
+
   it("flushes nothing when a write records no event (update of a missing entry)", async () => {
     const entries = await boot([openCollection("nope")]);
     const result = await entries.updateEntry(

--- a/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
@@ -13,6 +13,9 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { defineCollection, defineSingle, text } from "../../../config";
 import { createAdapter } from "../../../database/factory";
 import { container } from "../../../di/container";
+import { NextlyError } from "../../../errors/nextly-error";
+import { registerHook, unregisterHook } from "../../../hooks";
+import type { HookHandler } from "../../../hooks/types";
 import type {
   CacheRevalidator,
   RevalidationIntent,
@@ -228,6 +231,29 @@ describe("cache revalidation — write path (sqlite)", () => {
       [{ title: "T", slug: "hidden-slug" }]
     );
     expect(spy.tags).toContain("nextly:redact:slug:hidden-slug");
+  });
+
+  it("busts tags for a committed batch item whose afterCreate hook throws", async () => {
+    const entries = await boot([openCollection("hookfail")]);
+    // A code afterCreate hook that always throws. In a batch (stopOnError:false)
+    // the row still commits, so the item's tags must be busted even though it is
+    // reported as a failure — the intent is computed before the hooks run.
+    const throwingHook: HookHandler = async () => {
+      throw NextlyError.internal({ logContext: { reason: "test-hook-throw" } });
+    };
+    registerHook("afterCreate", "hookfail", throwingHook);
+    try {
+      const result = await entries.createEntries(
+        { collectionName: "hookfail", overrideAccess: true },
+        [{ title: "T", slug: "committed" }],
+        { stopOnError: false }
+      );
+      expect(result.failed).toBe(1); // the hook threw, so the item is a failure
+      // …but the row committed, so its tags were still busted.
+      expect(spy.tags).toContain("nextly:hookfail:slug:committed");
+    } finally {
+      unregisterHook("afterCreate", "hookfail", throwingHook);
+    }
   });
 
   it("flushes nothing when a write records no event (update of a missing entry)", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
@@ -13,6 +13,9 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { defineCollection, defineSingle, text } from "../../../config";
 import { createAdapter } from "../../../database/factory";
 import { container } from "../../../di/container";
+// Used to model a committed-but-hook-failed write: a code afterCreate hook that
+// throws (NextlyError + register/unregisterHook + HookHandler) so a batch item
+// commits its row yet reports failure, pinning that its tags still get busted.
 import { NextlyError } from "../../../errors/nextly-error";
 import { registerHook, unregisterHook } from "../../../hooks";
 import type { HookHandler } from "../../../hooks/types";
@@ -26,6 +29,7 @@ import {
 } from "../../../plugins/test-nextly";
 import type { CollectionEntryService } from "../../../services/collections/collection-entry-service";
 import type { CollectionsHandler } from "../../../services/collections-handler";
+import type { CollectionService } from "../services/collection-service";
 import type { SingleEntryService } from "../../singles/services/single-entry-service";
 
 // Records every intent flushed to it, so a test can assert exactly which tags a
@@ -209,6 +213,9 @@ describe("cache revalidation — write path (sqlite)", () => {
     const flushedTags = (result.revalidationIntents ?? []).flatMap(i => i.tags);
     expect(flushedTags).toContain("nextly:ownedtx:slug:a");
     expect(flushedTags).toContain("nextly:ownedtx:slug:b");
+    // The caller owns the commit, so nothing may be flushed to the revalidator
+    // before it: a premature pre-commit flush would revalidate uncommitted data.
+    expect(spy.flushed).toHaveLength(0);
   });
 
   it("busts the slug tag even when field-level read access hides slug", async () => {
@@ -270,6 +277,27 @@ describe("cache revalidation — write path (sqlite)", () => {
     expect(result.revalidationIntent?.tags).toContain(
       "nextly:singletx:slug:single-s"
     );
+    // Caller-owned: the intent rides the result, but nothing is flushed before
+    // the caller's own commit.
+    expect(spy.flushed).toHaveLength(0);
+  });
+
+  it("flushes a CollectionService.withTransaction's wrapper intents after commit", async () => {
+    // The public CollectionService transaction wrappers return only the entry,
+    // so the intent has nowhere to ride on the result. withTransaction is the
+    // seam that collects each wrapper's intent and flushes it once the
+    // transaction commits — verify a committed write through it busts its tag.
+    await boot([openCollection("wtx")]);
+    const service = handle!.getService<CollectionService>("collectionService");
+    await service.withTransaction(async tx => {
+      await service.createEntryInTransaction(
+        tx,
+        "wtx",
+        { title: "T", slug: "wtx-slug" },
+        { user: undefined }
+      );
+    });
+    expect(spy.tags).toContain("nextly:wtx:slug:wtx-slug");
   });
 
   it("flushes nothing when a write records no event (update of a missing entry)", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
@@ -1,0 +1,178 @@
+/**
+ * The write path computes a cache-revalidation intent and flushes it after the
+ * transaction commits. These pin both halves against a real database: the intent
+ * carried on each write result (create/update/rename/delete/single), and that the
+ * registered CacheRevalidator actually receives it — while a write that records
+ * nothing, or a collection that disables revalidation, flushes nothing.
+ *
+ * SQLite has no connection pool, so this needs no Postgres URL; the behavior is
+ * dialect-independent (it is pure post-commit bookkeeping).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { defineCollection, defineSingle, text } from "../../../config";
+import { createAdapter } from "../../../database/factory";
+import { container } from "../../../di/container";
+import type {
+  CacheRevalidator,
+  RevalidationIntent,
+} from "../../../revalidation/types";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionEntryService } from "../../../services/collections/collection-entry-service";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+import type { SingleEntryService } from "../../singles/services/single-entry-service";
+
+// Records every intent flushed to it, so a test can assert exactly which tags a
+// write busts (and that a no-op write busts nothing).
+class RecordingRevalidator implements CacheRevalidator {
+  readonly flushed: RevalidationIntent[] = [];
+  flush(intents: RevalidationIntent[]): void {
+    this.flushed.push(...intents);
+  }
+  /** Every tag flushed across all intents, flattened for convenient assertions. */
+  get tags(): string[] {
+    return this.flushed.flatMap(intent => intent.tags);
+  }
+}
+
+describe("cache revalidation — write path (sqlite)", () => {
+  let handle: TestNextly | undefined;
+  let spy: RecordingRevalidator;
+
+  beforeEach(() => {
+    spy = new RecordingRevalidator();
+    // Pre-register the spy so registerServices keeps it instead of the no-op
+    // default (its registration is guarded on the slot being empty).
+    container.registerSingleton<CacheRevalidator>(
+      "cacheRevalidator",
+      () => spy
+    );
+  });
+
+  afterEach(async () => {
+    await handle?.destroy();
+    handle = undefined;
+  });
+
+  async function memoryAdapter() {
+    process.env.DB_DIALECT = "sqlite";
+    return createAdapter({
+      type: "sqlite",
+      memory: true,
+    } as Parameters<typeof createAdapter>[0]);
+  }
+
+  async function boot(
+    collections: Parameters<typeof createTestNextly>[0]["collections"],
+    singles?: Parameters<typeof createTestNextly>[0]["singles"]
+  ): Promise<CollectionEntryService> {
+    const adapter = await memoryAdapter();
+    handle = await createTestNextly({ adapter, collections, singles });
+    return handle
+      .getService<CollectionsHandler>("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+  }
+
+  const openCollection = (slug: string) =>
+    defineCollection({
+      slug,
+      status: true,
+      access: { create: () => true, update: () => true, delete: () => true },
+      fields: [text({ name: "title" }), text({ name: "slug" })],
+    });
+
+  it("flushes the collection, id, and slug tags on create", async () => {
+    const entries = await boot([openCollection("posts")]);
+    const created = await entries.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "Hello", slug: "hello" }
+    );
+    const id = (created.data as { id: string }).id;
+
+    // Carried on the result…
+    expect(created.revalidationIntent?.tags).toEqual([
+      "nextly:posts",
+      `nextly:posts:id:${id}`,
+      "nextly:posts:slug:hello",
+    ]);
+    // …and actually flushed to the revalidator.
+    expect(spy.tags).toContain(`nextly:posts:id:${id}`);
+    expect(spy.tags).toContain("nextly:posts:slug:hello");
+  });
+
+  it("busts the old and new slug tags on a rename", async () => {
+    const entries = await boot([openCollection("pages")]);
+    const created = await entries.createEntry(
+      { collectionName: "pages", overrideAccess: true },
+      { title: "P", slug: "old" }
+    );
+    const id = (created.data as { id: string }).id;
+    spy.flushed.length = 0; // ignore the create's flush
+
+    await entries.updateEntry(
+      { collectionName: "pages", entryId: id, overrideAccess: true },
+      { slug: "new" }
+    );
+
+    expect(spy.tags).toContain("nextly:pages:slug:new");
+    expect(spy.tags).toContain("nextly:pages:slug:old");
+  });
+
+  it("flushes the collection and id tags on delete", async () => {
+    const entries = await boot([openCollection("docs")]);
+    const created = await entries.createEntry(
+      { collectionName: "docs", overrideAccess: true },
+      { title: "D", slug: "doomed" }
+    );
+    const id = (created.data as { id: string }).id;
+    spy.flushed.length = 0;
+
+    await entries.deleteEntry({
+      collectionName: "docs",
+      entryId: id,
+      overrideAccess: true,
+    });
+
+    expect(spy.tags).toContain("nextly:docs");
+    expect(spy.tags).toContain(`nextly:docs:id:${id}`);
+  });
+
+  it("flushes nothing when a write records no event (update of a missing entry)", async () => {
+    const entries = await boot([openCollection("nope")]);
+    const result = await entries.updateEntry(
+      {
+        collectionName: "nope",
+        entryId: "does-not-exist",
+        overrideAccess: true,
+      },
+      { title: "x" }
+    );
+    expect(result.success).toBe(false);
+    expect(spy.flushed).toHaveLength(0);
+  });
+
+  it("flushes the single tag on a single update", async () => {
+    const adapter = await memoryAdapter();
+    handle = await createTestNextly({
+      adapter,
+      singles: [
+        defineSingle({
+          slug: "header",
+          access: { read: () => true, update: () => true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const singleEntry =
+      handle.getService<SingleEntryService>("singleEntryService");
+    await singleEntry.update(
+      "header",
+      { title: "Site" },
+      { overrideAccess: true }
+    );
+    expect(spy.tags).toContain("nextly:single:header");
+  });
+});

--- a/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
@@ -320,6 +320,36 @@ describe("cache revalidation — write path (sqlite)", () => {
     expect(spy.flushed).toHaveLength(0);
   });
 
+  it("busts tags when a wrapper's hook fails but the owned transaction commits", async () => {
+    // The row is written before the afterCreate hook runs, so a throwing hook
+    // leaves it committed if the caller swallows the wrapper error. The wrapper
+    // must have collected the intent before throwing, so the committed row's
+    // tags still bust.
+    await boot([openCollection("hookcommit")]);
+    const service = handle!.getService<CollectionService>("collectionService");
+    const throwingHook: HookHandler = async () => {
+      throw NextlyError.internal({ logContext: { reason: "test-hook-throw" } });
+    };
+    registerHook("afterCreate", "hookcommit", throwingHook);
+    try {
+      await service.withTransaction(async tx => {
+        try {
+          await service.createEntryInTransaction(
+            tx,
+            "hookcommit",
+            { title: "T", slug: "committed-hook" },
+            { user: undefined }
+          );
+        } catch {
+          // Commit despite the hook failure — the row already wrote.
+        }
+      });
+      expect(spy.tags).toContain("nextly:hookcommit:slug:committed-hook");
+    } finally {
+      unregisterHook("afterCreate", "hookcommit", throwingHook);
+    }
+  });
+
   it("flushes nothing when a write records no event (update of a missing entry)", async () => {
     const entries = await boot([openCollection("nope")]);
     const result = await entries.updateEntry(

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -20,6 +20,10 @@ import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
 import type { AuthenticatedScope } from "../../../auth/authenticated-scope";
 import type { RequestActor } from "../../../auth/request-actor";
 import { NextlyError } from "../../../errors/nextly-error";
+import {
+  buildEntryRevalidationIntent,
+  readStringField,
+} from "../../../revalidation/intent-builders";
 import type { RevalidationIntent } from "../../../revalidation/types";
 import type { WhereFilter } from "../../../services/collections/query-operators";
 import type { Logger } from "../../../services/shared";
@@ -1039,6 +1043,9 @@ export class CollectionBulkService extends BaseService {
         authenticatedScope: params.authenticatedScope,
       });
 
+    // The revalidation intents of every committed create, applied to the result
+    // only after the shared transaction commits — a rollback undoes every insert.
+    const collectedIntents: RevalidationIntent[] = [];
     // Process all entries within a single transaction
     try {
       await this.adapter.transaction(async tx => {
@@ -1066,9 +1073,19 @@ export class CollectionBulkService extends BaseService {
 
               if (createResult.success && createResult.data) {
                 result.successful++;
-                result.ids.push(
-                  (createResult.data as Record<string, unknown>).id as string
+                const createdRow = createResult.data as Record<string, unknown>;
+                result.ids.push(createdRow.id as string);
+                // The created row carries the id and slug the derived tags need;
+                // the in-transaction worker records no event, so compute here.
+                const intent = buildEntryRevalidationIntent(
+                  params.collectionName,
+                  undefined,
+                  {
+                    id: createdRow.id as string,
+                    slug: readStringField(createdRow, "slug"),
+                  }
                 );
+                if (intent) collectedIntents.push(intent);
               } else {
                 result.failed++;
                 result.errors.push({
@@ -1101,6 +1118,11 @@ export class CollectionBulkService extends BaseService {
           }
         }
       });
+      // Reached only when the transaction committed, so the collected intents
+      // describe rows that actually persist.
+      if (collectedIntents.length > 0) {
+        result.revalidationIntents = collectedIntents;
+      }
     } catch (error: unknown) {
       // Transaction was rolled back (stopOnError case)
       // Reset successful count since transaction rolled back
@@ -1400,6 +1422,9 @@ export class CollectionBulkService extends BaseService {
         authenticatedScope: params.authenticatedScope,
       });
 
+    // The revalidation intents of every committed update, applied only after the
+    // shared transaction commits — a rollback undoes every update.
+    const collectedIntents: RevalidationIntent[] = [];
     // Process all entries within a single transaction
     try {
       await this.adapter.transaction(async tx => {
@@ -1428,9 +1453,19 @@ export class CollectionBulkService extends BaseService {
 
               if (updateResult.success && updateResult.data) {
                 result.successful++;
-                result.ids.push(
-                  (updateResult.data as Record<string, unknown>).id as string
+                const updatedRow = updateResult.data as Record<string, unknown>;
+                result.ids.push(updatedRow.id as string);
+                // The in-transaction worker records no event, so compute the
+                // intent here from the updated row's id and slug.
+                const intent = buildEntryRevalidationIntent(
+                  params.collectionName,
+                  undefined,
+                  {
+                    id: updatedRow.id as string,
+                    slug: readStringField(updatedRow, "slug"),
+                  }
                 );
+                if (intent) collectedIntents.push(intent);
               } else {
                 result.failed++;
                 result.errors.push({
@@ -1463,6 +1498,11 @@ export class CollectionBulkService extends BaseService {
           }
         }
       });
+      // Reached only when the transaction committed, so the collected intents
+      // describe rows that actually persist.
+      if (collectedIntents.length > 0) {
+        result.revalidationIntents = collectedIntents;
+      }
     } catch (error: unknown) {
       // Transaction was rolled back (stopOnError case)
       // Reset successful count since transaction rolled back

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -20,10 +20,6 @@ import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
 import type { AuthenticatedScope } from "../../../auth/authenticated-scope";
 import type { RequestActor } from "../../../auth/request-actor";
 import { NextlyError } from "../../../errors/nextly-error";
-import {
-  buildEntryRevalidationIntent,
-  readStringField,
-} from "../../../revalidation/intent-builders";
 import type { RevalidationIntent } from "../../../revalidation/types";
 import type { WhereFilter } from "../../../services/collections/query-operators";
 import type { Logger } from "../../../services/shared";
@@ -1073,19 +1069,14 @@ export class CollectionBulkService extends BaseService {
 
               if (createResult.success && createResult.data) {
                 result.successful++;
-                const createdRow = createResult.data as Record<string, unknown>;
-                result.ids.push(createdRow.id as string);
-                // The created row carries the id and slug the derived tags need;
-                // the in-transaction worker records no event, so compute here.
-                const intent = buildEntryRevalidationIntent(
-                  params.collectionName,
-                  undefined,
-                  {
-                    id: createdRow.id as string,
-                    slug: readStringField(createdRow, "slug"),
-                  }
+                result.ids.push(
+                  (createResult.data as Record<string, unknown>).id as string
                 );
-                if (intent) collectedIntents.push(intent);
+                // The worker computed the intent (with config and slug); collect
+                // it, applied to the result only after the shared tx commits.
+                if (createResult.revalidationIntent) {
+                  collectedIntents.push(createResult.revalidationIntent);
+                }
               } else {
                 result.failed++;
                 result.errors.push({
@@ -1453,19 +1444,14 @@ export class CollectionBulkService extends BaseService {
 
               if (updateResult.success && updateResult.data) {
                 result.successful++;
-                const updatedRow = updateResult.data as Record<string, unknown>;
-                result.ids.push(updatedRow.id as string);
-                // The in-transaction worker records no event, so compute the
-                // intent here from the updated row's id and slug.
-                const intent = buildEntryRevalidationIntent(
-                  params.collectionName,
-                  undefined,
-                  {
-                    id: updatedRow.id as string,
-                    slug: readStringField(updatedRow, "slug"),
-                  }
+                result.ids.push(
+                  (updateResult.data as Record<string, unknown>).id as string
                 );
-                if (intent) collectedIntents.push(intent);
+                // The worker computed the intent (with the previous slug for a
+                // rename); collect it, applied after the shared tx commits.
+                if (updateResult.revalidationIntent) {
+                  collectedIntents.push(updateResult.revalidationIntent);
+                }
               } else {
                 result.failed++;
                 result.errors.push({

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -20,6 +20,7 @@ import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
 import type { AuthenticatedScope } from "../../../auth/authenticated-scope";
 import type { RequestActor } from "../../../auth/request-actor";
 import { NextlyError } from "../../../errors/nextly-error";
+import type { RevalidationIntent } from "../../../revalidation/types";
 import type { WhereFilter } from "../../../services/collections/query-operators";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
@@ -88,7 +89,12 @@ function legacyEnvelopeToFailureFields(result: {
  * (no shared-array mutation across N concurrent promises).
  */
 type PerItemOutcome<T> =
-  | { kind: "success"; record: T }
+  | {
+      kind: "success";
+      record: T;
+      /** The item's cache-revalidation intent, aggregated for the post-commit flush. */
+      revalidationIntent?: RevalidationIntent;
+    }
   | {
       kind: "failure";
       failure: { id: string; code: string; message: string };
@@ -98,6 +104,11 @@ type PerItemOutcome<T> =
        * delivery. Aggregated into the batch result's `eventRecorded`.
        */
       eventRecorded?: boolean;
+      /**
+       * The item's cache-revalidation intent when it committed (even as a
+       * reported failure), so its tags are still busted.
+       */
+      revalidationIntent?: RevalidationIntent;
     };
 
 /**
@@ -149,18 +160,25 @@ function partitionOutcomes<T>(
     successCount: 0,
     failedCount: 0,
   };
+  const collectIntent = (intent: RevalidationIntent | undefined): void => {
+    // Every committed item's tags are busted, whether it is reported a success
+    // or a committed-then-hook-failed failure.
+    if (intent) (result.revalidationIntents ??= []).push(intent);
+  };
   outcomes.forEach((outcome, index) => {
     if (outcome.status === "fulfilled") {
       const value = outcome.value;
       if (value.kind === "success") {
         result.successes.push(value.record);
         result.successCount++;
+        collectIntent(value.revalidationIntent);
       } else {
         result.failures.push(value.failure);
         result.failedCount++;
         // A "failure" that still committed its outbox event (a post-commit hook
         // threw) owes a delivery even though it is not a success.
         if (value.eventRecorded) result.eventRecorded = true;
+        collectIntent(value.revalidationIntent);
       }
     } else {
       // Per-item closure rejected unexpectedly. Defensive: report as
@@ -371,7 +389,11 @@ export class CollectionBulkService extends BaseService {
             });
 
             if (deleteResult.success) {
-              return { kind: "success", record: { id: entryId } };
+              return {
+                kind: "success",
+                record: { id: entryId },
+                revalidationIntent: deleteResult.revalidationIntent,
+              };
             }
             // Decompose the legacy envelope into the canonical per-item
             // failure shape. The legacy `message` would leak driver/value
@@ -386,6 +408,7 @@ export class CollectionBulkService extends BaseService {
               // A delete that committed its row + event but failed a post-commit
               // hook still owes a delivery.
               eventRecorded: deleteResult.eventRecorded,
+              revalidationIntent: deleteResult.revalidationIntent,
             };
           } catch (error: unknown) {
             // NextlyError thrown from below the boundary: preserve its code +
@@ -468,6 +491,7 @@ export class CollectionBulkService extends BaseService {
               return {
                 kind: "success",
                 record: updateResult.data as Record<string, unknown>,
+                revalidationIntent: updateResult.revalidationIntent,
               };
             }
             const { code, message } =
@@ -478,6 +502,7 @@ export class CollectionBulkService extends BaseService {
               // An update that committed its row + event but failed a post-commit
               // hook still owes a delivery.
               eventRecorded: updateResult.eventRecorded,
+              revalidationIntent: updateResult.revalidationIntent,
             };
           } catch (error: unknown) {
             return {
@@ -1719,6 +1744,10 @@ export class CollectionBulkService extends BaseService {
     // rollback — which undoes every delete and its event — never reports a
     // durable event that isn't there.
     let anyRecorded = false;
+    // The revalidation intents of every committed delete, applied to the result
+    // only after the shared transaction commits (below) — a rollback undoes every
+    // delete, so its tags must not be busted.
+    const collectedIntents: RevalidationIntent[] = [];
     // Process all entries within a single transaction
     try {
       await this.adapter.transaction(async tx => {
@@ -1743,6 +1772,9 @@ export class CollectionBulkService extends BaseService {
               // A committed item owes a delivery even if its afterDelete hook
               // then threw (returned success:false).
               if (deleteResult.eventRecorded) anyRecorded = true;
+              if (deleteResult.revalidationIntent) {
+                collectedIntents.push(deleteResult.revalidationIntent);
+              }
 
               if (deleteResult.success) {
                 result.successful++;
@@ -1788,6 +1820,9 @@ export class CollectionBulkService extends BaseService {
       // The transaction committed (this line is skipped if it rejected), so any
       // events it recorded are durable; surface that for the post-write drain.
       result.eventRecorded = anyRecorded;
+      if (collectedIntents.length > 0) {
+        result.revalidationIntents = collectedIntents;
+      }
     } catch (error: unknown) {
       // The shared transaction rolled back — either stopOnError tripped on a
       // returned failure, or an unexpected error (e.g. a failed outbox insert

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -1067,16 +1067,17 @@ export class CollectionBulkService extends BaseService {
                   skipHooks
                 );
 
+              // Collect regardless of success: the worker sets an intent only
+              // once the row was written, so a committed item whose after-hook
+              // then threw (returning success:false) still busts its tags.
+              if (createResult.revalidationIntent) {
+                collectedIntents.push(createResult.revalidationIntent);
+              }
               if (createResult.success && createResult.data) {
                 result.successful++;
                 result.ids.push(
                   (createResult.data as Record<string, unknown>).id as string
                 );
-                // The worker computed the intent (with config and slug); collect
-                // it, applied to the result only after the shared tx commits.
-                if (createResult.revalidationIntent) {
-                  collectedIntents.push(createResult.revalidationIntent);
-                }
               } else {
                 result.failed++;
                 result.errors.push({
@@ -1265,19 +1266,20 @@ export class CollectionBulkService extends BaseService {
               skipHooks
             );
 
+          // Surface the worker's intent on the result regardless of success (set
+          // only once the row was written). The caller owns the transaction, so
+          // it flushes these after IT commits (as it does for the webhook drain)
+          // — this method cannot flush pre-commit.
+          if (createResult.revalidationIntent) {
+            (result.revalidationIntents ??= []).push(
+              createResult.revalidationIntent
+            );
+          }
           if (createResult.success && createResult.data) {
             result.successful++;
             result.ids.push(
               (createResult.data as Record<string, unknown>).id as string
             );
-            // Surface the worker's intent on the result. The caller owns the
-            // transaction, so it flushes these after IT commits (as it does for
-            // the webhook drain) — this method cannot flush pre-commit.
-            if (createResult.revalidationIntent) {
-              (result.revalidationIntents ??= []).push(
-                createResult.revalidationIntent
-              );
-            }
           } else {
             result.failed++;
             result.errors.push({
@@ -1450,16 +1452,17 @@ export class CollectionBulkService extends BaseService {
                   skipHooks
                 );
 
+              // Collect regardless of success: the worker sets an intent only
+              // once the row was updated, so a committed item whose after-hook
+              // then threw (returning success:false) still busts its tags.
+              if (updateResult.revalidationIntent) {
+                collectedIntents.push(updateResult.revalidationIntent);
+              }
               if (updateResult.success && updateResult.data) {
                 result.successful++;
                 result.ids.push(
                   (updateResult.data as Record<string, unknown>).id as string
                 );
-                // The worker computed the intent (with the previous slug for a
-                // rename); collect it, applied after the shared tx commits.
-                if (updateResult.revalidationIntent) {
-                  collectedIntents.push(updateResult.revalidationIntent);
-                }
               } else {
                 result.failed++;
                 result.errors.push({
@@ -1648,18 +1651,18 @@ export class CollectionBulkService extends BaseService {
               skipHooks
             );
 
+          // Surface the worker's intent regardless of success (set only once the
+          // row was updated); the caller flushes it after committing its tx.
+          if (updateResult.revalidationIntent) {
+            (result.revalidationIntents ??= []).push(
+              updateResult.revalidationIntent
+            );
+          }
           if (updateResult.success && updateResult.data) {
             result.successful++;
             result.ids.push(
               (updateResult.data as Record<string, unknown>).id as string
             );
-            // Surface the worker's intent on the result; the caller flushes it
-            // after committing its own transaction.
-            if (updateResult.revalidationIntent) {
-              (result.revalidationIntents ??= []).push(
-                updateResult.revalidationIntent
-              );
-            }
           } else {
             result.failed++;
             result.errors.push({
@@ -2017,16 +2020,16 @@ export class CollectionBulkService extends BaseService {
               skipHooks
             );
 
+          // Surface the worker's intent regardless of success (set only once the
+          // row was deleted); the caller flushes it after committing its tx.
+          if (deleteResult.revalidationIntent) {
+            (result.revalidationIntents ??= []).push(
+              deleteResult.revalidationIntent
+            );
+          }
           if (deleteResult.success) {
             result.successful++;
             result.ids.push(entryId);
-            // Surface the worker's intent on the result; the caller flushes it
-            // after committing its own transaction.
-            if (deleteResult.revalidationIntent) {
-              (result.revalidationIntents ??= []).push(
-                deleteResult.revalidationIntent
-              );
-            }
           } else {
             result.failed++;
             result.errors.push({

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -1270,6 +1270,14 @@ export class CollectionBulkService extends BaseService {
             result.ids.push(
               (createResult.data as Record<string, unknown>).id as string
             );
+            // Surface the worker's intent on the result. The caller owns the
+            // transaction, so it flushes these after IT commits (as it does for
+            // the webhook drain) — this method cannot flush pre-commit.
+            if (createResult.revalidationIntent) {
+              (result.revalidationIntents ??= []).push(
+                createResult.revalidationIntent
+              );
+            }
           } else {
             result.failed++;
             result.errors.push({
@@ -1645,6 +1653,13 @@ export class CollectionBulkService extends BaseService {
             result.ids.push(
               (updateResult.data as Record<string, unknown>).id as string
             );
+            // Surface the worker's intent on the result; the caller flushes it
+            // after committing its own transaction.
+            if (updateResult.revalidationIntent) {
+              (result.revalidationIntents ??= []).push(
+                updateResult.revalidationIntent
+              );
+            }
           } else {
             result.failed++;
             result.errors.push({
@@ -2005,6 +2020,13 @@ export class CollectionBulkService extends BaseService {
           if (deleteResult.success) {
             result.successful++;
             result.ids.push(entryId);
+            // Surface the worker's intent on the result; the caller flushes it
+            // after committing its own transaction.
+            if (deleteResult.revalidationIntent) {
+              (result.revalidationIntents ??= []).push(
+                deleteResult.revalidationIntent
+              );
+            }
           } else {
             result.failed++;
             result.errors.push({

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4312,10 +4312,10 @@ export class CollectionMutationService extends BaseService {
             locale: this.localization?.defaultLocale,
           });
         deletedLocaleForRevalidation = deletedLocale;
-        deletedSlugForRevalidation = readStringField(
-          currentRow as Record<string, unknown>,
-          "slug"
-        );
+        // Read the slug from the assembled document, which overlays the
+        // companion locale values, so a user-localized slug (absent from the
+        // main row) still busts the correct tag.
+        deletedSlugForRevalidation = readStringField(deletedDocument, "slug");
 
         if (this.componentDataService) {
           await this.componentDataService.deleteComponentDataInTransaction(tx, {
@@ -4477,6 +4477,10 @@ export class CollectionMutationService extends BaseService {
     },
     body: Record<string, unknown>
   ): Promise<CollectionServiceResult<unknown>> {
+    // Carried on the result so a caller that owns the transaction can flush the
+    // tags after IT commits (this method cannot flush pre-commit). Computed
+    // before the after-hooks run so a throwing hook does not lose it.
+    let revalidationIntent: RevalidationIntent | undefined;
     try {
       // A direct caller runs this inside its own transaction, so every metadata
       // and access read below is bound to that transaction's connection — a
@@ -4811,6 +4815,17 @@ export class CollectionMutationService extends BaseService {
         }
       }
 
+      // Compute the intent from the freshly inserted row, before the after-hooks
+      // run or redaction can strip the slug.
+      revalidationIntent = buildEntryRevalidationIntent(
+        params.collectionName,
+        readRevalidateConfig(collection),
+        {
+          id: (entry as Record<string, unknown>).id as string,
+          slug: readStringField(entry as Record<string, unknown>, "slug"),
+        }
+      );
+
       // Execute afterCreate hooks (code-registered)
       const afterContext = this.hookService.buildHookContext({
         collection: params.collectionName,
@@ -4871,14 +4886,20 @@ export class CollectionMutationService extends BaseService {
         statusCode: 201,
         message: "Entry created successfully",
         data: entry,
+        revalidationIntent,
       };
     } catch (error: unknown) {
+      // Carry the intent (set only once the row was written) so a caller that
+      // commits despite a hook failure still busts its tags.
       // Pass dialect explicitly so the helper can normalise raw driver errors.
-      return errorToServiceResult(
-        error,
-        { defaultMessage: "Failed to create entry in transaction" },
-        this.dialect
-      );
+      return {
+        ...errorToServiceResult(
+          error,
+          { defaultMessage: "Failed to create entry in transaction" },
+          this.dialect
+        ),
+        revalidationIntent,
+      };
     }
   }
 
@@ -4908,6 +4929,10 @@ export class CollectionMutationService extends BaseService {
     },
     body: Record<string, unknown>
   ): Promise<CollectionServiceResult<unknown>> {
+    // Carried on the result so a caller that owns the transaction can flush the
+    // tags after IT commits (this method cannot flush pre-commit). Computed
+    // before the after-hooks run so a throwing hook does not lose it.
+    let revalidationIntent: RevalidationIntent | undefined;
     try {
       // A direct caller runs this inside its own transaction, so every metadata
       // and access read below is bound to that transaction's connection — a
@@ -5218,6 +5243,19 @@ export class CollectionMutationService extends BaseService {
         };
       }
 
+      // Compute the intent from the updated row and the pre-update row (for the
+      // previous slug on a rename), before the after-hooks run or redaction can
+      // strip the slug.
+      revalidationIntent = buildEntryRevalidationIntent(
+        params.collectionName,
+        readRevalidateConfig(collection),
+        {
+          id: params.entryId,
+          slug: readStringField(updated as Record<string, unknown>, "slug"),
+          previousSlug: readStringField(existingEntry, "slug"),
+        }
+      );
+
       // Handle many-to-many relationships on the caller's transaction so the
       // junction writes commit atomically with the update.
       for (const field of manyToManyFields) {
@@ -5303,14 +5341,20 @@ export class CollectionMutationService extends BaseService {
         statusCode: 200,
         message: "Entry updated successfully",
         data: updated,
+        revalidationIntent,
       };
     } catch (error: unknown) {
+      // Carry the intent (set only once the row was updated) so a caller that
+      // commits despite a hook failure still busts its tags.
       // Pass dialect explicitly so the helper can normalise raw driver errors.
-      return errorToServiceResult(
-        error,
-        { defaultMessage: "Failed to update entry in transaction" },
-        this.dialect
-      );
+      return {
+        ...errorToServiceResult(
+          error,
+          { defaultMessage: "Failed to update entry in transaction" },
+          this.dialect
+        ),
+        revalidationIntent,
+      };
     }
   }
 
@@ -5338,6 +5382,10 @@ export class CollectionMutationService extends BaseService {
     // recorded — a later failure (e.g. an afterDelete hook) is a per-item
     // side-effect issue, not an eventless delete, and must NOT roll the batch back.
     let deleteNeedsRollback = false;
+    // Carried on the result so a caller that owns the transaction can flush the
+    // tags after IT commits (this method cannot flush pre-commit). Computed
+    // before the after-hooks run so a throwing hook does not lose it.
+    let revalidationIntent: RevalidationIntent | undefined;
     try {
       // Get collection metadata and stored hooks. Runs on the caller's
       // transaction connection so this read does not re-enter the pool from
@@ -5534,6 +5582,19 @@ export class CollectionMutationService extends BaseService {
       // failure no longer needs to force a rollback.
       deleteNeedsRollback = false;
 
+      // Compute the intent from the removed document (which overlays companion
+      // locale values, so a user-localized slug still busts the right tag),
+      // before the after-hooks run.
+      revalidationIntent = buildEntryRevalidationIntent(
+        params.collectionName,
+        readRevalidateConfig(collection),
+        {
+          id: params.entryId,
+          slug: readStringField(deletedDocument, "slug"),
+          locale: deletedLocale,
+        }
+      );
+
       // Execute afterDelete hooks (code-registered)
       const afterContext = this.hookService.buildHookContext({
         collection: params.collectionName,
@@ -5570,6 +5631,7 @@ export class CollectionMutationService extends BaseService {
         statusCode: 200,
         message: "Entry deleted successfully",
         data: { deleted: true },
+        revalidationIntent,
       };
     } catch (error: unknown) {
       // Only a failure in the delete→event window propagates (to roll back an
@@ -5585,6 +5647,7 @@ export class CollectionMutationService extends BaseService {
             ? error.message
             : "Failed to delete entry in transaction",
         data: null,
+        revalidationIntent,
       };
     }
   }
@@ -6853,13 +6916,14 @@ export class CollectionMutationService extends BaseService {
       eventRecorded = true;
 
       // The tags this delete invalidates, collected by the batch caller and
-      // flushed once the shared transaction commits.
+      // flushed once the shared transaction commits. Slug read from the assembled
+      // document so a user-localized slug (in companion rows) still busts.
       revalidationIntent = buildEntryRevalidationIntent(
         params.collectionName,
         readRevalidateConfig(collection),
         {
           id: entryId,
-          slug: readStringField(freshEntry, "slug"),
+          slug: readStringField(deletedDocument, "slug"),
           locale: deletedLocale,
         }
       );

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -6010,11 +6010,23 @@ export class CollectionMutationService extends BaseService {
         params.collectionName
       );
 
+      // Computed in the worker (like the delete worker) so the batch caller
+      // collects the intent directly rather than recomputing it.
+      const revalidationIntent = buildEntryRevalidationIntent(
+        params.collectionName,
+        readRevalidateConfig(collection),
+        {
+          id: (entry as Record<string, unknown>).id as string,
+          slug: readStringField(entry as Record<string, unknown>, "slug"),
+        }
+      );
+
       return {
         success: true,
         statusCode: 201,
         message: "Entry created successfully",
         data: entry,
+        revalidationIntent,
       };
     } catch (error: unknown) {
       // Pass dialect explicitly so the helper can normalise raw driver errors.
@@ -6516,11 +6528,25 @@ export class CollectionMutationService extends BaseService {
         params.collectionName
       );
 
+      // Computed in the worker (like the delete worker) so the batch caller
+      // collects a complete intent: the previous slug comes from the pre-update
+      // row, so a batch rename busts the old slug tag too.
+      const revalidationIntent = buildEntryRevalidationIntent(
+        params.collectionName,
+        readRevalidateConfig(collection),
+        {
+          id: entryId,
+          slug: readStringField(updated as Record<string, unknown>, "slug"),
+          previousSlug: readStringField(existingEntry, "slug"),
+        }
+      );
+
       return {
         success: true,
         statusCode: 200,
         message: "Entry updated successfully",
         data: updated,
+        revalidationIntent,
       };
     } catch (error: unknown) {
       // Pass dialect explicitly so the helper can normalise raw driver errors.

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4961,11 +4961,16 @@ export class CollectionMutationService extends BaseService {
         params.collectionName
       );
 
-      // Fetch existing entry first (needed for access control)
+      // Fetch existing entry first (needed for access control). Lock the row
+      // (`forUpdate`, a no-op on SQLite, which already serializes writers) so a
+      // concurrent rename cannot commit between this read and the update below —
+      // otherwise the `previousSlug` captured here would be stale and the actual
+      // prior URL's cache tag would never be busted.
       const existingEntry = await tx.selectOne<Record<string, unknown>>(
         tableName,
         {
           where: this.whereEq("id", params.entryId),
+          forUpdate: true,
         }
       );
 
@@ -6205,10 +6210,14 @@ export class CollectionMutationService extends BaseService {
           })
         : this.whereEq("id", entryId);
 
-      // Fetch existing entry first (needed for owner checks and hooks)
+      // Fetch existing entry first (needed for owner checks and hooks). Lock the
+      // row (`forUpdate`, a no-op on SQLite, which already serializes writers) so
+      // a concurrent rename cannot commit between this read and the update below,
+      // which would otherwise leave the `previousSlug` captured here stale and
+      // the prior URL's cache tag unbusted.
       const existingEntry = await tx.selectOne<Record<string, unknown>>(
         tableName,
-        { where: fetchWhere }
+        { where: fetchWhere, forUpdate: true }
       );
 
       if (!existingEntry) {

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -41,6 +41,12 @@ import {
   resolvePublishTransition,
   stripUndefinedStatus,
 } from "../../../lib/status-transition";
+import {
+  buildEntryRevalidationIntent,
+  readRevalidateConfig,
+  readStringField,
+} from "../../../revalidation/intent-builders";
+import type { RevalidationIntent } from "../../../revalidation/types";
 import type { ResolvedVersionsConfig } from "../../../schemas/versions/types";
 import type { CollectionAccessRules } from "../../../services/access";
 import type { CollectionFileManager } from "../../../services/collection-file-manager";
@@ -1319,6 +1325,10 @@ export class CollectionMutationService extends BaseService {
     // committed-but-hook-failed write as `eventRecorded` even when `success` is
     // false. Declared out here so both the success and catch returns see it.
     let eventRecorded = false;
+    // Computed alongside the event so a committed-but-hook-failed write (which
+    // returns from the catch) still flushes its revalidation, matching how
+    // `eventRecorded` is carried.
+    let revalidationIntent: RevalidationIntent | undefined;
     try {
       // reject an unknown write locale before doing anything else.
       const badLocale = this.rejectInvalidWriteLocale(params.locale);
@@ -1950,6 +1960,19 @@ export class CollectionMutationService extends BaseService {
       // there; from here a post-commit hook failure must not hide the delivery.
       eventRecorded = true;
 
+      // The tags this create invalidates: derived from the collection, the new
+      // id, and the new slug (plus the write locale), so a tagged read of the
+      // collection listing or this entry refreshes. Flushed post-commit.
+      revalidationIntent = buildEntryRevalidationIntent(
+        params.collectionName,
+        readRevalidateConfig(collection),
+        {
+          id: entry.id as string,
+          slug: readStringField(entry, "slug"),
+          locale: localizedWrite?.writeLocale,
+        }
+      );
+
       // Execute afterCreate hooks (code-registered)
       // Hooks run after database insert completes (for side effects)
       const afterContext = this.hookService.buildHookContext({
@@ -2059,6 +2082,7 @@ export class CollectionMutationService extends BaseService {
         message: "Entry created successfully",
         data: responseEntry,
         eventRecorded,
+        revalidationIntent,
       };
     } catch (error: unknown) {
       // Legacy per-kind override messages ("Duplicate value: ...",
@@ -2074,6 +2098,7 @@ export class CollectionMutationService extends BaseService {
           this.dialect
         ),
         eventRecorded,
+        revalidationIntent,
       };
     }
   }
@@ -2781,6 +2806,12 @@ export class CollectionMutationService extends BaseService {
     // committed-but-hook-failed update as `eventRecorded` even when `success` is
     // false. Declared out here so both the success and catch returns see it.
     let eventRecorded = false;
+    // The revalidation intent, and the pre-write slug it needs for old-path
+    // busting. `previousSlug` is captured inside the transaction (where the
+    // assembled previous document is in scope) and read out here so the intent,
+    // computed post-commit, can bust the stale slug tag after a rename.
+    let revalidationIntent: RevalidationIntent | undefined;
+    let previousSlug: string | undefined;
     // Set when the in-transaction transition check refuses the write. Declared
     // out here (not in `try`) so the catch can read it: the adapter wraps a
     // thrown error in a DatabaseError (see VersionConflictError), so `instanceof`
@@ -3829,6 +3860,9 @@ export class CollectionMutationService extends BaseService {
                 actor: actorForWrite(params.actor, params.user),
               });
               recorded = true;
+              // Capture the pre-write slug inside the transaction so the
+              // post-commit intent can bust the old slug tag after a rename.
+              previousSlug = readStringField(previousDocument, "slug");
             }
           }
         })
@@ -3868,6 +3902,23 @@ export class CollectionMutationService extends BaseService {
           if (column === "_status") continue;
           updatedRow[toCamelCase(column)] = value;
         }
+      }
+
+      // The tags this update invalidates: the id and current-slug tags, plus the
+      // previous-slug tag when the slug changed (captured in the transaction), so
+      // a read cached under the old URL clears. Only when the write recorded an
+      // event — a no-op update revalidates nothing.
+      if (eventRecorded) {
+        revalidationIntent = buildEntryRevalidationIntent(
+          params.collectionName,
+          readRevalidateConfig(collection),
+          {
+            id: params.entryId,
+            slug: readStringField(updated as Record<string, unknown>, "slug"),
+            previousSlug,
+            locale: localizedUpdate?.writeLocale,
+          }
+        );
       }
 
       // Execute afterUpdate hooks (code-registered)
@@ -4024,6 +4075,7 @@ export class CollectionMutationService extends BaseService {
         // Reflects whether this update actually recorded an event (a no-op
         // update commits without one), so a no-op does not kick the drain.
         eventRecorded,
+        revalidationIntent,
       };
     } catch (error: unknown) {
       // A publish-transition refused against the row-locked status aborts the
@@ -4043,6 +4095,7 @@ export class CollectionMutationService extends BaseService {
           this.dialect
         ),
         eventRecorded,
+        revalidationIntent,
       };
     }
   }
@@ -4081,6 +4134,9 @@ export class CollectionMutationService extends BaseService {
     // committed-but-hook-failed delete as `eventRecorded` even when `success` is
     // false. Declared out here so both the success and catch returns see it.
     let eventRecorded = false;
+    // The tags this delete invalidates, computed post-commit and flushed with the
+    // result. Hoisted so the catch return carries it too.
+    let revalidationIntent: RevalidationIntent | undefined;
     try {
       const accessUser = params.overrideAccess ? undefined : params.user;
 
@@ -4202,6 +4258,9 @@ export class CollectionMutationService extends BaseService {
       // continues on a per-table failure — so this pairs the entry delete with
       // its event, not full cascade atomicity.)
       let deletedRow = false;
+      // The locale the removed document represented, captured inside the
+      // transaction so the post-commit intent can bust that locale's tag.
+      let deletedLocaleForRevalidation: string | undefined;
       await this.adapter.transaction(async tx => {
         // Lock and re-read the committed row inside the transaction. `entry`
         // above was read before the hooks ran and outside this transaction, so a
@@ -4231,6 +4290,7 @@ export class CollectionMutationService extends BaseService {
             fields: snapshotFields,
             locale: this.localization?.defaultLocale,
           });
+        deletedLocaleForRevalidation = deletedLocale;
 
         if (this.componentDataService) {
           await this.componentDataService.deleteComponentDataInTransaction(tx, {
@@ -4287,6 +4347,19 @@ export class CollectionMutationService extends BaseService {
 
       const deleted = entry;
 
+      // The tags this delete invalidates: the collection tag and the removed
+      // entry's id/slug tags (in its locale), so lists and any cached read of
+      // the entry clear. The id tag survives the row's removal.
+      revalidationIntent = buildEntryRevalidationIntent(
+        params.collectionName,
+        readRevalidateConfig(collection),
+        {
+          id: params.entryId,
+          slug: readStringField(deleted as Record<string, unknown>, "slug"),
+          locale: deletedLocaleForRevalidation,
+        }
+      );
+
       // Execute afterDelete hooks (code-registered)
       // Hooks run after deletion completes (for cleanup)
       const afterContext = this.hookService.buildHookContext({
@@ -4327,6 +4400,7 @@ export class CollectionMutationService extends BaseService {
         message: "Entry deleted successfully",
         data: { deleted: true },
         eventRecorded,
+        revalidationIntent,
       };
     } catch (error: unknown) {
       return {
@@ -4336,6 +4410,7 @@ export class CollectionMutationService extends BaseService {
           error instanceof Error ? error.message : "Failed to delete entry",
         data: null,
         eventRecorded,
+        revalidationIntent,
       };
     }
   }
@@ -6467,6 +6542,9 @@ export class CollectionMutationService extends BaseService {
     // Set once the event is appended to the shared transaction; the batch caller
     // reads it back and applies it only after the transaction commits.
     let eventRecorded = false;
+    // The tags this delete invalidates; the batch caller collects it per item and
+    // flushes them together after the shared transaction commits.
+    let revalidationIntent: RevalidationIntent | undefined;
     try {
       // Get collection metadata early. Runs on the caller's transaction
       // connection so this read does not re-enter the pool from inside the
@@ -6702,6 +6780,18 @@ export class CollectionMutationService extends BaseService {
       deleteNeedsRollback = false;
       eventRecorded = true;
 
+      // The tags this delete invalidates, collected by the batch caller and
+      // flushed once the shared transaction commits.
+      revalidationIntent = buildEntryRevalidationIntent(
+        params.collectionName,
+        readRevalidateConfig(collection),
+        {
+          id: entryId,
+          slug: readStringField(freshEntry, "slug"),
+          locale: deletedLocale,
+        }
+      );
+
       // Execute afterDelete hooks (unless skipped)
       if (!skipHooks) {
         // Execute afterDelete hooks (code-registered)
@@ -6745,6 +6835,7 @@ export class CollectionMutationService extends BaseService {
         message: "Entry deleted successfully",
         data: { deleted: true },
         eventRecorded,
+        revalidationIntent,
       };
     } catch (error: unknown) {
       // Only a failure in the delete→event window propagates (to roll back an
@@ -6759,6 +6850,7 @@ export class CollectionMutationService extends BaseService {
           error instanceof Error ? error.message : "Failed to delete entry",
         data: null,
         eventRecorded,
+        revalidationIntent,
       };
     }
   }

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -2139,6 +2139,10 @@ export class CollectionMutationService extends BaseService {
     // it: the adapter re-wraps the thrown sentinel in a DatabaseError as the
     // transaction rolls back, so `instanceof` no longer identifies it.
     let publishDocDenied: CollectionServiceResult | undefined;
+    // The tags this publish invalidates, set before the success return so a
+    // publish busts the entry's cached reads. Publishing every locale, so no
+    // single locale tag — the locale-less id tag covers them all.
+    let revalidationIntent: RevalidationIntent | undefined;
     try {
       const accessUser = params.overrideAccess ? undefined : params.user;
       const schema = await this.fileManager.loadDynamicSchema(
@@ -2445,11 +2449,24 @@ export class CollectionMutationService extends BaseService {
         // Reaction/event emission is non-critical; the publish already committed.
       }
 
+      revalidationIntent = buildEntryRevalidationIntent(
+        params.collectionName,
+        readRevalidateConfig(publishCollection),
+        {
+          id: params.entryId,
+          slug: readStringField(
+            existingEntry as Record<string, unknown>,
+            "slug"
+          ),
+        }
+      );
+
       return {
         success: true,
         statusCode: 200,
         message: "All languages published.",
         data: { id: params.entryId, status: "published" },
+        revalidationIntent,
       };
     } catch (error) {
       // A publish refused by the under-lock document-rule re-check aborts the

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4278,6 +4278,10 @@ export class CollectionMutationService extends BaseService {
       // The locale the removed document represented, captured inside the
       // transaction so the post-commit intent can bust that locale's tag.
       let deletedLocaleForRevalidation: string | undefined;
+      // The slug of the row actually deleted (the locked re-read), not the
+      // pre-transaction fetch, so a slug changed by a racing update or a
+      // beforeDelete hook still busts the correct tag.
+      let deletedSlugForRevalidation: string | undefined;
       await this.adapter.transaction(async tx => {
         // Lock and re-read the committed row inside the transaction. `entry`
         // above was read before the hooks ran and outside this transaction, so a
@@ -4308,6 +4312,10 @@ export class CollectionMutationService extends BaseService {
             locale: this.localization?.defaultLocale,
           });
         deletedLocaleForRevalidation = deletedLocale;
+        deletedSlugForRevalidation = readStringField(
+          currentRow as Record<string, unknown>,
+          "slug"
+        );
 
         if (this.componentDataService) {
           await this.componentDataService.deleteComponentDataInTransaction(tx, {
@@ -4372,7 +4380,7 @@ export class CollectionMutationService extends BaseService {
         readRevalidateConfig(collection),
         {
           id: params.entryId,
-          slug: readStringField(deleted as Record<string, unknown>, "slug"),
+          slug: deletedSlugForRevalidation,
           locale: deletedLocaleForRevalidation,
         }
       );

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -5624,6 +5624,11 @@ export class CollectionMutationService extends BaseService {
     body: Record<string, unknown>,
     skipHooks: boolean
   ): Promise<CollectionServiceResult<unknown>> {
+    // Computed right after the row is written (before response redaction can
+    // strip the slug, and before the after-hooks run) and carried on every
+    // post-write return, so a committed item whose after-hook then throws still
+    // surfaces its intent to the batch caller. Hoisted so the catch return sees it.
+    let revalidationIntent: RevalidationIntent | undefined;
     try {
       // Get collection metadata to identify relation fields. Runs on the
       // caller's transaction connection so this per-entry read does not re-enter
@@ -5984,6 +5989,17 @@ export class CollectionMutationService extends BaseService {
         );
       }
 
+      // Compute the intent from the freshly inserted row, before the after-hooks
+      // run or redaction can strip the slug.
+      revalidationIntent = buildEntryRevalidationIntent(
+        params.collectionName,
+        readRevalidateConfig(collection),
+        {
+          id: (entry as Record<string, unknown>).id as string,
+          slug: readStringField(entry as Record<string, unknown>, "slug"),
+        }
+      );
+
       // Stored password hashes are write-only; the response never carries
       // them back to the client.
       // Field-level afterChange hooks observe the saved values (before the
@@ -6010,17 +6026,6 @@ export class CollectionMutationService extends BaseService {
         params.collectionName
       );
 
-      // Computed in the worker (like the delete worker) so the batch caller
-      // collects the intent directly rather than recomputing it.
-      const revalidationIntent = buildEntryRevalidationIntent(
-        params.collectionName,
-        readRevalidateConfig(collection),
-        {
-          id: (entry as Record<string, unknown>).id as string,
-          slug: readStringField(entry as Record<string, unknown>, "slug"),
-        }
-      );
-
       return {
         success: true,
         statusCode: 201,
@@ -6029,12 +6034,17 @@ export class CollectionMutationService extends BaseService {
         revalidationIntent,
       };
     } catch (error: unknown) {
+      // Carry the intent (set only once the row was written) so a committed item
+      // whose after-hook then threw still busts its tags via the batch caller.
       // Pass dialect explicitly so the helper can normalise raw driver errors.
-      return errorToServiceResult(
-        error,
-        { defaultMessage: "Failed to create entry" },
-        this.dialect
-      );
+      return {
+        ...errorToServiceResult(
+          error,
+          { defaultMessage: "Failed to create entry" },
+          this.dialect
+        ),
+        revalidationIntent,
+      };
     }
   }
 
@@ -6075,6 +6085,11 @@ export class CollectionMutationService extends BaseService {
     body: Record<string, unknown>,
     skipHooks: boolean
   ): Promise<CollectionServiceResult<unknown>> {
+    // Computed right after the row is updated (before redaction can strip the
+    // slug and before the after-hooks run) and carried on every post-write
+    // return, so a committed item whose after-hook then throws still surfaces
+    // its intent to the batch caller.
+    let revalidationIntent: RevalidationIntent | undefined;
     try {
       // Get collection metadata to identify relation fields. Runs on the
       // caller's transaction connection so this per-entry read does not re-enter
@@ -6437,6 +6452,19 @@ export class CollectionMutationService extends BaseService {
         };
       }
 
+      // Compute the intent from the updated row and the pre-update row, before
+      // the after-hooks run or redaction can strip the slug. The previous slug
+      // (from existingEntry) lets a batch rename bust the old slug tag too.
+      revalidationIntent = buildEntryRevalidationIntent(
+        params.collectionName,
+        readRevalidateConfig(collection),
+        {
+          id: entryId,
+          slug: readStringField(updated as Record<string, unknown>, "slug"),
+          previousSlug: readStringField(existingEntry, "slug"),
+        }
+      );
+
       // Handle many-to-many relationships on the caller's transaction so the
       // junction writes commit atomically with the update.
       const txExecutor = tx.getDrizzle<RelationshipDbExecutor>();
@@ -6528,19 +6556,6 @@ export class CollectionMutationService extends BaseService {
         params.collectionName
       );
 
-      // Computed in the worker (like the delete worker) so the batch caller
-      // collects a complete intent: the previous slug comes from the pre-update
-      // row, so a batch rename busts the old slug tag too.
-      const revalidationIntent = buildEntryRevalidationIntent(
-        params.collectionName,
-        readRevalidateConfig(collection),
-        {
-          id: entryId,
-          slug: readStringField(updated as Record<string, unknown>, "slug"),
-          previousSlug: readStringField(existingEntry, "slug"),
-        }
-      );
-
       return {
         success: true,
         statusCode: 200,
@@ -6549,12 +6564,17 @@ export class CollectionMutationService extends BaseService {
         revalidationIntent,
       };
     } catch (error: unknown) {
+      // Carry the intent (set only once the row was updated) so a committed item
+      // whose after-hook then threw still busts its tags via the batch caller.
       // Pass dialect explicitly so the helper can normalise raw driver errors.
-      return errorToServiceResult(
-        error,
-        { defaultMessage: "Failed to update entry" },
-        this.dialect
-      );
+      return {
+        ...errorToServiceResult(
+          error,
+          { defaultMessage: "Failed to update entry" },
+          this.dialect
+        ),
+        revalidationIntent,
+      };
     }
   }
 

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -5952,6 +5952,18 @@ export class CollectionMutationService extends BaseService {
         }
       }
 
+      // Compute the intent from the freshly inserted row, before ANY after-hooks
+      // run (a throwing afterCreate hook must not lose it) and before redaction
+      // can strip the slug.
+      revalidationIntent = buildEntryRevalidationIntent(
+        params.collectionName,
+        readRevalidateConfig(collection),
+        {
+          id: (entry as Record<string, unknown>).id as string,
+          slug: readStringField(entry as Record<string, unknown>, "slug"),
+        }
+      );
+
       // Execute afterCreate hooks (unless skipped)
       if (!skipHooks) {
         // Execute afterCreate hooks (code-registered)
@@ -5988,17 +6000,6 @@ export class CollectionMutationService extends BaseService {
           )
         );
       }
-
-      // Compute the intent from the freshly inserted row, before the after-hooks
-      // run or redaction can strip the slug.
-      revalidationIntent = buildEntryRevalidationIntent(
-        params.collectionName,
-        readRevalidateConfig(collection),
-        {
-          id: (entry as Record<string, unknown>).id as string,
-          slug: readStringField(entry as Record<string, unknown>, "slug"),
-        }
-      );
 
       // Stored password hashes are write-only; the response never carries
       // them back to the client.

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -2454,8 +2454,12 @@ export class CollectionMutationService extends BaseService {
         readRevalidateConfig(publishCollection),
         {
           id: params.entryId,
+          // Prefer the committed post-publish row's slug so a concurrent rename
+          // that landed after the pre-read still busts the actually-published
+          // URL; fall back to the pre-read only when no fresh row was
+          // reconstructed.
           slug: readStringField(
-            existingEntry as Record<string, unknown>,
+            (publishedParentRow ?? existingEntry) as Record<string, unknown>,
             "slug"
           ),
         }

--- a/packages/nextly/src/domains/collections/services/collection-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service.ts
@@ -58,6 +58,7 @@ import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
 // NextlyErrors at this boundary so callers see the new error model.
 import type { RequestActor } from "../../../auth/request-actor";
 import { NextlyError } from "../../../errors";
+import type { RevalidationIntent } from "../../../revalidation/types";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import type { CollectionEntryService } from "../../../services/collections/collection-entry-service";
 import type {
@@ -170,6 +171,79 @@ export class CollectionService extends BaseService {
     private readonly entryService: CollectionEntryService
   ) {
     super(adapter, logger);
+  }
+
+  /**
+   * Revalidation intents produced by createEntryInTransaction /
+   * updateEntryInTransaction / deleteEntryInTransaction calls made during an
+   * owned transaction, keyed by the transaction handle so concurrent
+   * transactions (one pooled client each on Postgres/MySQL) never share a
+   * collector. The wrappers push into it; `withTransaction` drains it once the
+   * transaction commits.
+   */
+  private readonly pendingTxIntents = new Map<unknown, RevalidationIntent[]>();
+
+  /**
+   * Run work inside a database transaction, then flush the cache-revalidation
+   * intents produced by any createEntryInTransaction / updateEntryInTransaction /
+   * deleteEntryInTransaction calls made against the same `tx`. The flush happens
+   * after the transaction commits, so a rolled-back write busts nothing. Because
+   * the wrappers return only the entry (or void), this is the supported way to
+   * coordinate atomic multi-writes with correct revalidation — without it the
+   * committed writes' intents would have nowhere to go.
+   *
+   * Unlike the base helper, this yields the adapter's `TransactionContext` (the
+   * handle the *InTransaction wrappers expect), not a raw driver transaction.
+   *
+   * @example
+   * ```typescript
+   * await service.withTransaction(async (tx) => {
+   *   const entry = await service.createEntryInTransaction(tx, 'posts', data, context);
+   *   await service.updateEntryInTransaction(tx, 'posts', entry.id, moreData, context);
+   * });
+   * ```
+   */
+  override async withTransaction<T>(
+    work: (tx: TransactionContext) => Promise<T>
+  ): Promise<T> {
+    let boundTx: TransactionContext | undefined;
+    let ownsFlush = false;
+    let collector: RevalidationIntent[] | undefined;
+    const result = await this.adapter.transaction(async tx => {
+      boundTx = tx;
+      collector = this.pendingTxIntents.get(tx);
+      if (!collector) {
+        collector = [];
+        this.pendingTxIntents.set(tx, collector);
+        ownsFlush = true;
+      }
+      return work(tx);
+    });
+    // The transaction has committed by here. Only the frame that created the
+    // collector drains it, so a nested withTransaction sharing the same handle
+    // flushes once, at the outermost commit.
+    if (ownsFlush && boundTx !== undefined) {
+      this.pendingTxIntents.delete(boundTx);
+      if (collector && collector.length > 0) {
+        await this.entryService.flushRevalidationIntents(collector);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Record a wrapper's revalidation intent against the active owned transaction,
+   * if one is in progress, so `withTransaction` can flush it after commit. A
+   * no-op when the caller obtained `tx` some other way (there is nowhere to defer
+   * the flush to); such callers should use the lower-level
+   * `CollectionEntryService.*InTransaction`, whose results carry the intent.
+   */
+  private collectTxIntent(
+    tx: TransactionContext,
+    intent: RevalidationIntent | undefined
+  ): void {
+    if (!intent) return;
+    this.pendingTxIntents.get(tx)?.push(intent);
   }
 
   /**
@@ -755,6 +829,10 @@ export class CollectionService extends BaseService {
       entryId: (result.data as CollectionEntry | null)?.id,
     });
 
+    // Defer the committed write's cache-revalidation to the owning
+    // withTransaction, which flushes it once the transaction commits.
+    this.collectTxIntent(tx, result.revalidationIntent);
+
     return result.data as CollectionEntry;
   }
 
@@ -823,6 +901,10 @@ export class CollectionService extends BaseService {
       entryId,
     });
 
+    // Defer the committed write's cache-revalidation to the owning
+    // withTransaction, which flushes it once the transaction commits.
+    this.collectTxIntent(tx, result.revalidationIntent);
+
     return result.data as CollectionEntry;
   }
 
@@ -885,6 +967,10 @@ export class CollectionService extends BaseService {
       collectionName,
       entryId,
     });
+
+    // Defer the committed delete's cache-revalidation to the owning
+    // withTransaction, which flushes it once the transaction commits.
+    this.collectTxIntent(tx, result.revalidationIntent);
   }
 
   /**

--- a/packages/nextly/src/domains/collections/services/collection-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service.ts
@@ -206,27 +206,30 @@ export class CollectionService extends BaseService {
   override async withTransaction<T>(
     work: (tx: TransactionContext) => Promise<T>
   ): Promise<T> {
-    let boundTx: TransactionContext | undefined;
     let ownsFlush = false;
     let collector: RevalidationIntent[] | undefined;
     const result = await this.adapter.transaction(async tx => {
-      boundTx = tx;
       collector = this.pendingTxIntents.get(tx);
       if (!collector) {
         collector = [];
         this.pendingTxIntents.set(tx, collector);
         ownsFlush = true;
       }
-      return work(tx);
-    });
-    // The transaction has committed by here. Only the frame that created the
-    // collector drains it, so a nested withTransaction sharing the same handle
-    // flushes once, at the outermost commit.
-    if (ownsFlush && boundTx !== undefined) {
-      this.pendingTxIntents.delete(boundTx);
-      if (collector && collector.length > 0) {
-        await this.entryService.flushRevalidationIntents(collector);
+      try {
+        return await work(tx);
+      } finally {
+        // Drop the per-tx binding on both commit and rollback, so a throwing or
+        // failed-to-commit transaction never leaks its collector in
+        // pendingTxIntents. Only the frame that created the collector removes
+        // it, so a nested withTransaction sharing the handle leaves the outer's
+        // binding intact.
+        if (ownsFlush) this.pendingTxIntents.delete(tx);
       }
+    });
+    // Reached only on a successful commit; a rejected transaction throws above
+    // and flushes nothing. The captured `collector` outlives the map binding.
+    if (ownsFlush && collector && collector.length > 0) {
+      await this.entryService.flushRevalidationIntents(collector);
     }
     return result;
   }

--- a/packages/nextly/src/domains/collections/services/collection-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service.ts
@@ -818,6 +818,13 @@ export class CollectionService extends BaseService {
       data
     );
 
+    // Collect before the success check. The mutation layer sets the intent only
+    // once the row is written and carries it even on a hook-failure result, so a
+    // caller that commits despite the failure still busts the tags; a genuine
+    // rollback drops the collector unflushed, so collecting here is always safe.
+    // withTransaction flushes what was collected once the transaction commits.
+    this.collectTxIntent(tx, result.revalidationIntent);
+
     if (!result.success) {
       this.logger.warn("Entry creation in transaction failed", {
         collectionName,
@@ -831,10 +838,6 @@ export class CollectionService extends BaseService {
       collectionName,
       entryId: (result.data as CollectionEntry | null)?.id,
     });
-
-    // Defer the committed write's cache-revalidation to the owning
-    // withTransaction, which flushes it once the transaction commits.
-    this.collectTxIntent(tx, result.revalidationIntent);
 
     return result.data as CollectionEntry;
   }
@@ -872,6 +875,10 @@ export class CollectionService extends BaseService {
       data
     );
 
+    // Collect before the success check, so a caller that commits despite a
+    // post-write hook failure still busts the tags (see createEntryInTransaction).
+    this.collectTxIntent(tx, result.revalidationIntent);
+
     if (!result.success) {
       if (result.statusCode === 404) {
         // Generic "Not found." from the factory; identifiers go to logContext.
@@ -903,10 +910,6 @@ export class CollectionService extends BaseService {
       collectionName,
       entryId,
     });
-
-    // Defer the committed write's cache-revalidation to the owning
-    // withTransaction, which flushes it once the transaction commits.
-    this.collectTxIntent(tx, result.revalidationIntent);
 
     return result.data as CollectionEntry;
   }
@@ -944,6 +947,10 @@ export class CollectionService extends BaseService {
       actor,
     });
 
+    // Collect before the success check, so a caller that commits despite a
+    // post-delete hook failure still busts the tags (see createEntryInTransaction).
+    this.collectTxIntent(tx, result.revalidationIntent);
+
     if (!result.success) {
       if (result.statusCode === 404) {
         // Generic "Not found." from the factory; identifiers go to logContext.
@@ -970,10 +977,6 @@ export class CollectionService extends BaseService {
       collectionName,
       entryId,
     });
-
-    // Defer the committed delete's cache-revalidation to the owning
-    // withTransaction, which flushes it once the transaction commits.
-    this.collectTxIntent(tx, result.revalidationIntent);
   }
 
   /**

--- a/packages/nextly/src/domains/collections/services/collection-types.ts
+++ b/packages/nextly/src/domains/collections/services/collection-types.ts
@@ -5,6 +5,8 @@
  * used across all split services (access, hook, query, mutation, bulk).
  */
 
+import type { RevalidationIntent } from "../../../revalidation/types";
+
 /**
  * Service result type for legacy format compatibility.
  * Used by collection services for consistent response structure.
@@ -32,6 +34,13 @@ export interface CollectionServiceResult<T = unknown> {
    * a write that recorded nothing (validation/access failure) does not.
    */
   eventRecorded?: boolean;
+  /**
+   * The cache tags/paths this write invalidates, computed at the write where the
+   * slug/previous-slug/locale are in scope and flushed post-commit (alongside the
+   * webhook fast-drain) through the registered {@link CacheRevalidator}. Absent
+   * when the write recorded nothing or revalidation is disabled for the target.
+   */
+  revalidationIntent?: RevalidationIntent;
 }
 
 /**
@@ -107,6 +116,12 @@ export interface BulkOperationResult<T = { id: string }> {
    * this so those events still get the immediate drain.
    */
   eventRecorded?: boolean;
+  /**
+   * The cache-revalidation intents of every committed item in the batch,
+   * aggregated so the post-commit flush busts all their tags at once. Absent
+   * when nothing was recorded or revalidation is disabled for the target.
+   */
+  revalidationIntents?: RevalidationIntent[];
 }
 
 /**
@@ -133,6 +148,12 @@ export interface BatchOperationResult {
    * yet owes deliveries. Set only after the shared transaction commits.
    */
   eventRecorded?: boolean;
+  /**
+   * The cache-revalidation intents of every committed item in the batch,
+   * aggregated so the post-commit flush busts all their tags at once. Absent
+   * when nothing was recorded or revalidation is disabled for the target.
+   */
+  revalidationIntents?: RevalidationIntent[];
 }
 
 /**

--- a/packages/nextly/src/domains/singles/services/single-entry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-entry-service.ts
@@ -18,6 +18,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import type { RBACAccessControlService } from "../../../domains/auth/services/rbac-access-control-service";
 import type { HookRegistry } from "../../../hooks/hook-registry";
+import type { CacheRevalidator } from "../../../revalidation/types";
 import type { ComponentDataService } from "../../../services/components/component-data-service";
 import { BaseService } from "../../../shared/base-service";
 import type { Logger } from "../../../shared/types";
@@ -77,7 +78,12 @@ export class SingleEntryService extends BaseService {
      * trigger. Shared with the collection write path; absent when webhooks were
      * never registered.
      */
-    private readonly fastDrainScheduler?: WebhookFastDrainScheduler
+    private readonly fastDrainScheduler?: WebhookFastDrainScheduler,
+    /**
+     * Flushes a single write's cache-revalidation intent post-commit. Shared
+     * with the collection write path; a no-op when no cache adapter is present.
+     */
+    private readonly cacheRevalidator?: CacheRevalidator
   ) {
     super(adapter, logger);
 
@@ -140,9 +146,29 @@ export class SingleEntryService extends BaseService {
     // committed its event but then failed a post-commit hook reports
     // `success:false` with `eventRecorded:true`, so key off either — otherwise a
     // committed event would miss its fast-drain and retention pass.
-    if (result.success || result.eventRecorded === true)
+    if (result.success || result.eventRecorded === true) {
+      this.flushRevalidation(result);
       await this.afterWrite();
+    }
     return result;
+  }
+
+  /**
+   * Flush a committed single write's cache-revalidation intent through the
+   * registered revalidator (a no-op when no cache adapter is present). Absorbs
+   * its own failure so revalidation never turns a committed write into an error.
+   */
+  private flushRevalidation(result: SingleResult): void {
+    if (!this.cacheRevalidator || !result.revalidationIntent) return;
+    try {
+      Promise.resolve(
+        this.cacheRevalidator.flush([result.revalidationIntent])
+      ).catch(error =>
+        this.logger.error("Cache revalidation failed after a write", { error })
+      );
+    } catch (error) {
+      this.logger.error("Cache revalidation failed after a write", { error });
+    }
   }
 
   /**

--- a/packages/nextly/src/domains/singles/services/single-entry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-entry-service.ts
@@ -147,7 +147,7 @@ export class SingleEntryService extends BaseService {
     // `success:false` with `eventRecorded:true`, so key off either — otherwise a
     // committed event would miss its fast-drain and retention pass.
     if (result.success || result.eventRecorded === true) {
-      this.flushRevalidation(result);
+      await this.flushRevalidation(result);
       await this.afterWrite();
     }
     return result;
@@ -155,17 +155,14 @@ export class SingleEntryService extends BaseService {
 
   /**
    * Flush a committed single write's cache-revalidation intent through the
-   * registered revalidator (a no-op when no cache adapter is present). Absorbs
-   * its own failure so revalidation never turns a committed write into an error.
+   * registered revalidator (a no-op when no cache adapter is present). Awaited so
+   * an async revalidator is not left detached; absorbs its own failure so
+   * revalidation never turns a committed write into an error.
    */
-  private flushRevalidation(result: SingleResult): void {
+  private async flushRevalidation(result: SingleResult): Promise<void> {
     if (!this.cacheRevalidator || !result.revalidationIntent) return;
     try {
-      Promise.resolve(
-        this.cacheRevalidator.flush([result.revalidationIntent])
-      ).catch(error =>
-        this.logger.error("Cache revalidation failed after a write", { error })
-      );
+      await this.cacheRevalidator.flush([result.revalidationIntent]);
     } catch (error) {
       this.logger.error("Cache revalidation failed after a write", { error });
     }

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -35,6 +35,11 @@ import {
   stripUndefinedStatus,
 } from "../../../lib/status-transition";
 import {
+  buildSingleRevalidationIntent,
+  readRevalidateConfig,
+} from "../../../revalidation/intent-builders";
+import type { RevalidationIntent } from "../../../revalidation/types";
+import {
   AccessControlService,
   type CollectionAccessRules,
   isSuperAdminContext,
@@ -426,6 +431,10 @@ export class SingleMutationService extends BaseService {
     // return report a committed-but-post-hook-failed write as `eventRecorded`
     // even when `success` is false. Declared out here so every return sees it.
     let eventRecorded = false;
+    // The tags this write invalidates (`nextly:single:{slug}`), computed after
+    // the event is recorded and carried on every post-event return so a
+    // committed-but-hook-failed write still flushes its revalidation.
+    let revalidationIntent: RevalidationIntent | undefined;
     // Set when the in-transaction transition check refuses the write against the
     // row-locked status. Declared out here (not in `try`) so the catch can read
     // it: the adapter wraps the thrown sentinel in a DatabaseError as the
@@ -1680,6 +1689,13 @@ export class SingleMutationService extends BaseService {
       // written row: the empty-rows path returns from the tx before recording
       // anything, so it owes no delivery.
       eventRecorded = updatedRows.length > 0;
+      if (eventRecorded) {
+        // A single is consumed sitewide, so its one tag is the whole cascade.
+        revalidationIntent = buildSingleRevalidationIntent(
+          slug,
+          readRevalidateConfig(singleMeta)
+        );
+      }
 
       if (updatedRows.length === 0) {
         return {
@@ -1764,6 +1780,7 @@ export class SingleMutationService extends BaseService {
         statusCode: 200,
         data: updatedDoc,
         eventRecorded,
+        revalidationIntent,
       };
     } catch (error) {
       // A publish-transition refused against the row-locked status aborts the
@@ -1780,6 +1797,7 @@ export class SingleMutationService extends BaseService {
       return {
         ...buildSingleErrorResult(error, "Failed to update Single document"),
         eventRecorded,
+        revalidationIntent,
       };
     }
   }

--- a/packages/nextly/src/domains/singles/types.ts
+++ b/packages/nextly/src/domains/singles/types.ts
@@ -12,6 +12,7 @@
 import type { AuthenticatedScope } from "../../auth/authenticated-scope";
 import type { RequestActor } from "../../auth/request-actor";
 import type { StatusOption } from "../../lib/status-filter";
+import type { RevalidationIntent } from "../../revalidation/types";
 
 /**
  * User context for Single operations.
@@ -204,4 +205,11 @@ export interface SingleResult<T = SingleDocument> {
    * `CollectionServiceResult.eventRecorded`.
    */
   eventRecorded?: boolean;
+  /**
+   * The cache tags this write invalidates (`nextly:single:{slug}` plus any
+   * configured extra tags), flushed post-commit through the registered
+   * revalidator. Absent when the write recorded nothing or revalidation is
+   * disabled for the single.
+   */
+  revalidationIntent?: RevalidationIntent;
 }

--- a/packages/nextly/src/revalidation/__tests__/intent-builders.test.ts
+++ b/packages/nextly/src/revalidation/__tests__/intent-builders.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildEntryRevalidationIntent,
+  buildSingleRevalidationIntent,
+  readRevalidateConfig,
+  readStringField,
+} from "../intent-builders";
+
+describe("buildEntryRevalidationIntent", () => {
+  it("returns the derived intent when revalidation is not disabled", () => {
+    const intent = buildEntryRevalidationIntent("posts", undefined, {
+      id: "1",
+      slug: "hello",
+    });
+    expect(intent?.tags).toEqual([
+      "nextly:posts",
+      "nextly:posts:id:1",
+      "nextly:posts:slug:hello",
+    ]);
+  });
+
+  it("returns undefined when the collection disables revalidation", () => {
+    const intent = buildEntryRevalidationIntent(
+      "posts",
+      { disable: true },
+      { id: "1", slug: "hello" }
+    );
+    expect(intent).toBeUndefined();
+  });
+
+  it("merges configured extra tags", () => {
+    const intent = buildEntryRevalidationIntent(
+      "posts",
+      { tags: ["navigation"] },
+      { id: "1" }
+    );
+    expect(intent?.tags).toContain("navigation");
+  });
+
+  it("busts the previous slug on a rename", () => {
+    const intent = buildEntryRevalidationIntent("posts", undefined, {
+      id: "1",
+      slug: "new",
+      previousSlug: "old",
+    });
+    expect(intent?.tags).toContain("nextly:posts:slug:new");
+    expect(intent?.tags).toContain("nextly:posts:slug:old");
+  });
+});
+
+describe("buildSingleRevalidationIntent", () => {
+  it("returns the single tag when not disabled", () => {
+    expect(buildSingleRevalidationIntent("header", undefined)?.tags).toEqual([
+      "nextly:single:header",
+    ]);
+  });
+
+  it("returns undefined when disabled", () => {
+    expect(
+      buildSingleRevalidationIntent("header", { disable: true })
+    ).toBeUndefined();
+  });
+});
+
+describe("readRevalidateConfig", () => {
+  it("extracts the revalidate config from a metadata object", () => {
+    expect(
+      readRevalidateConfig({ slug: "posts", revalidate: { disable: true } })
+    ).toEqual({ disable: true });
+  });
+
+  it("returns undefined when the metadata carries no revalidate config", () => {
+    expect(readRevalidateConfig({ slug: "posts" })).toBeUndefined();
+    expect(readRevalidateConfig(null)).toBeUndefined();
+    expect(readRevalidateConfig("not an object")).toBeUndefined();
+  });
+});
+
+describe("readStringField", () => {
+  it("reads a string field and ignores non-strings and absent docs", () => {
+    expect(readStringField({ slug: "a" }, "slug")).toBe("a");
+    expect(readStringField({ slug: 42 }, "slug")).toBeUndefined();
+    expect(readStringField(undefined, "slug")).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/revalidation/intent-builders.ts
+++ b/packages/nextly/src/revalidation/intent-builders.ts
@@ -1,0 +1,75 @@
+/**
+ * Helpers that turn a write's facts into a {@link RevalidationIntent}, honoring
+ * the target's `revalidate` config. Kept out of the mutation service so the
+ * config-gating logic is small and unit-testable without a database.
+ */
+import {
+  computeEntryRevalidation,
+  computeSingleRevalidation,
+} from "./compute-tags";
+import type { RevalidateConfig, RevalidationIntent } from "./types";
+
+/**
+ * Read a string-valued field from a document, returning undefined when it is
+ * absent or not a string — so a slug/locale read never forces an unsafe cast.
+ */
+export function readStringField(
+  doc: Record<string, unknown> | null | undefined,
+  field: string
+): string | undefined {
+  const value = doc?.[field];
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * The revalidation intent for an entry write, or undefined when revalidation is
+ * disabled for the collection. Configured extra tags are merged with the derived
+ * `nextly:*` tags.
+ */
+export function buildEntryRevalidationIntent(
+  collectionName: string,
+  revalidateConfig: RevalidateConfig | undefined,
+  fields: {
+    id: string;
+    slug?: string;
+    previousSlug?: string;
+    locale?: string;
+  }
+): RevalidationIntent | undefined {
+  if (revalidateConfig?.disable) return undefined;
+  return computeEntryRevalidation({
+    collection: collectionName,
+    id: fields.id,
+    slug: fields.slug,
+    previousSlug: fields.previousSlug,
+    locale: fields.locale,
+    extraTags: revalidateConfig?.tags,
+  });
+}
+
+/**
+ * The revalidation intent for a single write, or undefined when revalidation is
+ * disabled for the single.
+ */
+export function buildSingleRevalidationIntent(
+  slug: string,
+  revalidateConfig: RevalidateConfig | undefined
+): RevalidationIntent | undefined {
+  if (revalidateConfig?.disable) return undefined;
+  return computeSingleRevalidation({ slug, extraTags: revalidateConfig?.tags });
+}
+
+/**
+ * Narrow a loosely-typed collection/single metadata object to its optional
+ * `revalidate` config without an unsafe cast, so the write site can read the
+ * opt-out and extra tags whether or not the metadata carries them.
+ */
+export function readRevalidateConfig(
+  meta: unknown
+): RevalidateConfig | undefined {
+  if (meta && typeof meta === "object" && "revalidate" in meta) {
+    const value = (meta as { revalidate?: unknown }).revalidate;
+    if (value && typeof value === "object") return value;
+  }
+  return undefined;
+}

--- a/packages/nextly/src/revalidation/noop-revalidator.ts
+++ b/packages/nextly/src/revalidation/noop-revalidator.ts
@@ -1,0 +1,14 @@
+import type { CacheRevalidator, RevalidationIntent } from "./types";
+
+/**
+ * The default {@link CacheRevalidator}: does nothing. Registered when no cache
+ * adapter is present — a non-Next runtime, the CLI, migrations, or tests — so the
+ * write path can always flush intents unconditionally without a null check and
+ * without coupling core to any framework. The Next adapter replaces this with an
+ * implementation that maps intents to `revalidateTag`/`revalidatePath`.
+ */
+export class NoopRevalidator implements CacheRevalidator {
+  flush(_intents: RevalidationIntent[]): void {
+    // Intentionally empty: no cache to revalidate.
+  }
+}

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -16,6 +16,7 @@ import type { ResolvedWebhookRetentionConfig } from "../domains/webhooks/retenti
 import { MetaRetentionGate } from "../domains/webhooks/retention-gate";
 import { WebhookRetentionRunner } from "../domains/webhooks/retention-runner";
 import type { RichTextOutputFormat } from "../lib/rich-text-html";
+import type { CacheRevalidator } from "../revalidation/types";
 import type { FieldDefinition } from "../schemas/dynamic-collections";
 import type { DatabaseInstance } from "../types/database-operations";
 
@@ -172,6 +173,10 @@ export class CollectionsHandler {
       ? container.get<WebhookFastDrainScheduler>("webhookFastDrainScheduler")
       : undefined;
 
+    const cacheRevalidator = container.has("cacheRevalidator")
+      ? container.get<CacheRevalidator>("cacheRevalidator")
+      : undefined;
+
     // Late-inject relationshipService if componentDataService was created before it was available
     if (componentDataService) {
       componentDataService.setRelationshipService(this.relationshipService);
@@ -199,7 +204,8 @@ export class CollectionsHandler {
       rbacAccessControlService,
       this.localization,
       retentionRunner,
-      fastDrainScheduler
+      fastDrainScheduler,
+      cacheRevalidator
     );
   }
 

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -42,6 +42,7 @@ import type { DynamicCollectionService } from "../../domains/dynamic-collections
 import type { SanitizedLocalizationConfig } from "../../domains/i18n/config/types";
 import type { WebhookFastDrainScheduler } from "../../domains/webhooks/after-drain";
 import type { WebhookRetentionRunner } from "../../domains/webhooks/retention-runner";
+import type { CacheRevalidator } from "../../revalidation/types";
 import type { PaginatedResponse } from "../../types/pagination";
 import type { AccessControlService } from "../access";
 import { BaseService } from "../base-service";
@@ -101,7 +102,13 @@ export class CollectionEntryService extends BaseService {
      * the first delivery attempt does not wait for the next scheduled trigger.
      * Wired at the same seam as `retentionRunner` for the same reason.
      */
-    private readonly fastDrainScheduler?: WebhookFastDrainScheduler
+    private readonly fastDrainScheduler?: WebhookFastDrainScheduler,
+    /**
+     * Flushes a write's cache-revalidation intent post-commit. Wired at the same
+     * seam as `fastDrainScheduler` because every event-appending write runs
+     * through this service. Defaults to a no-op when no cache adapter is present.
+     */
+    private readonly cacheRevalidator?: CacheRevalidator
   ) {
     super(adapter, logger);
 
@@ -279,7 +286,42 @@ export class CollectionEntryService extends BaseService {
         : "successCount" in result
           ? result.successCount > 0 || result.eventRecorded === true
           : result.successful > 0 || result.eventRecorded === true;
-    if (recorded) await this.afterWrite();
+    if (recorded) {
+      this.flushRevalidation(result);
+      await this.afterWrite();
+    }
+  }
+
+  /**
+   * Flush a committed write's cache-revalidation intents through the registered
+   * revalidator (a no-op when no cache adapter is present). Runs on the same
+   * gate as the drain — a write that recorded nothing revalidates nothing — and
+   * absorbs its own failure so it never turns a committed write into an error.
+   */
+  private flushRevalidation(
+    result:
+      | CollectionServiceResult<unknown>
+      | BulkOperationResult<unknown>
+      | BatchOperationResult
+  ): void {
+    if (!this.cacheRevalidator) return;
+    const intents =
+      "revalidationIntents" in result && result.revalidationIntents
+        ? result.revalidationIntents
+        : "revalidationIntent" in result && result.revalidationIntent
+          ? [result.revalidationIntent]
+          : [];
+    if (intents.length === 0) return;
+    try {
+      // Tolerate a sync (revalidateTag) or async revalidator, and catch either a
+      // synchronous throw or an async rejection so revalidation never surfaces as
+      // a write error. Not awaited: marking tags stale must not add write latency.
+      Promise.resolve(this.cacheRevalidator.flush(intents)).catch(error =>
+        this.logger.error("Cache revalidation failed after a write", { error })
+      );
+    } catch (error) {
+      this.logger.error("Cache revalidation failed after a write", { error });
+    }
   }
 
   async createEntry(

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -42,7 +42,10 @@ import type { DynamicCollectionService } from "../../domains/dynamic-collections
 import type { SanitizedLocalizationConfig } from "../../domains/i18n/config/types";
 import type { WebhookFastDrainScheduler } from "../../domains/webhooks/after-drain";
 import type { WebhookRetentionRunner } from "../../domains/webhooks/retention-runner";
-import type { CacheRevalidator } from "../../revalidation/types";
+import type {
+  CacheRevalidator,
+  RevalidationIntent,
+} from "../../revalidation/types";
 import type { PaginatedResponse } from "../../types/pagination";
 import type { AccessControlService } from "../access";
 import { BaseService } from "../base-service";
@@ -312,14 +315,24 @@ export class CollectionEntryService extends BaseService {
       | BulkOperationResult<unknown>
       | BatchOperationResult
   ): Promise<void> {
-    if (!this.cacheRevalidator) return;
     const intents =
       "revalidationIntents" in result && result.revalidationIntents
         ? result.revalidationIntents
         : "revalidationIntent" in result && result.revalidationIntent
           ? [result.revalidationIntent]
           : [];
-    if (intents.length === 0) return;
+    await this.flushRevalidationIntents(intents);
+  }
+
+  /**
+   * Flush an explicit set of revalidation intents collected by a caller-owned
+   * transaction (for example the `CollectionService` transaction wrappers, whose
+   * return values carry only the entry). Shares the automatic post-write path:
+   * a no-op when no cache adapter is registered, and self-absorbing on error so
+   * a revalidator fault never turns a committed write into a failure.
+   */
+  async flushRevalidationIntents(intents: RevalidationIntent[]): Promise<void> {
+    if (!this.cacheRevalidator || intents.length === 0) return;
     try {
       // Await so a Promise-returning revalidator finishes here; `revalidateTag`
       // is synchronous, so this adds no latency for the common case.

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -280,6 +280,13 @@ export class CollectionEntryService extends BaseService {
       | BulkOperationResult<unknown>
       | BatchOperationResult
   ): Promise<void> {
+    // Revalidation flushes whenever a committed write produced intents. It is
+    // NOT tied to the outbox-event gate below: an intent is only ever set after
+    // a write commits, so its presence is the "content changed" signal, and a
+    // publish-all-locales or a batch create (which record no outbox event) still
+    // bust their tags.
+    await this.flushRevalidation(result);
+
     const recorded =
       "success" in result
         ? result.eventRecorded === true
@@ -287,7 +294,6 @@ export class CollectionEntryService extends BaseService {
           ? result.successCount > 0 || result.eventRecorded === true
           : result.successful > 0 || result.eventRecorded === true;
     if (recorded) {
-      this.flushRevalidation(result);
       await this.afterWrite();
     }
   }
@@ -297,13 +303,15 @@ export class CollectionEntryService extends BaseService {
    * revalidator (a no-op when no cache adapter is present). Runs on the same
    * gate as the drain — a write that recorded nothing revalidates nothing — and
    * absorbs its own failure so it never turns a committed write into an error.
+   * Awaited (like the retention pass) so an async revalidator's work is not left
+   * detached, where a serverless response could cut it off before it completes.
    */
-  private flushRevalidation(
+  private async flushRevalidation(
     result:
       | CollectionServiceResult<unknown>
       | BulkOperationResult<unknown>
       | BatchOperationResult
-  ): void {
+  ): Promise<void> {
     if (!this.cacheRevalidator) return;
     const intents =
       "revalidationIntents" in result && result.revalidationIntents
@@ -313,12 +321,9 @@ export class CollectionEntryService extends BaseService {
           : [];
     if (intents.length === 0) return;
     try {
-      // Tolerate a sync (revalidateTag) or async revalidator, and catch either a
-      // synchronous throw or an async rejection so revalidation never surfaces as
-      // a write error. Not awaited: marking tags stale must not add write latency.
-      Promise.resolve(this.cacheRevalidator.flush(intents)).catch(error =>
-        this.logger.error("Cache revalidation failed after a write", { error })
-      );
+      // Await so a Promise-returning revalidator finishes here; `revalidateTag`
+      // is synchronous, so this adds no latency for the common case.
+      await this.cacheRevalidator.flush(intents);
     } catch (error) {
       this.logger.error("Cache revalidation failed after a write", { error });
     }


### PR DESCRIPTION
Second slice of the F1 cache-revalidation primitive (after #314, the pure tag
core). Wires the tag scheme into the write path so every content change busts
its tags. No `next/cache` yet — that adapter is the next slice.

## What this PR does

- **Computes a `RevalidationIntent` at each write** (`revalidation/intent-builders.ts`)
  where the slug, previous slug, and locale are in scope — next to
  `recordMutationEvent` — and carries it on the result alongside `eventRecorded`:
  - `createEntry`, `updateEntry`, `deleteEntry`, and the transactional
    `deleteSingleEntryInTransaction` (the bulk-delete per-item path).
  - `single-mutation-service.update`.
  - A **rename** busts both the old and new slug tags (old slug captured inside
    the transaction). A **delete** busts the collection + entry-id tags. A write
    that **records no event** (rejected / no-op) carries no intent.
- **Aggregates bulk intents** through `partitionOutcomes` (success and
  committed-then-hook-failed items) and the transactional batch delete, so a bulk
  op flushes all its items' tags once.
- **Flushes post-commit** at `CollectionEntryService.afterWrite` /
  `SingleEntryService` via an injected `CacheRevalidator`, on the same
  `eventRecorded` gate as the webhook fast-drain — so a rolled-back write flushes
  nothing, and a flush failure never turns a committed write into an error
  (guarded, tolerant of a sync or async revalidator).
- **DI**: `NoopRevalidator` is the registered default (`register-revalidation.ts`),
  injected into the collection and single entry services. A Next cache adapter
  (next slice) replaces it to turn intents into `revalidateTag` calls. Node-safe
  root preserved (`Root entry is Node-safe.`).

## Tests

- **Unit** (`revalidation/__tests__/intent-builders.test.ts`, 9): the config
  gating (`disable` → undefined, extra tags merged, rename busts both slugs) and
  the metadata/field readers.
- **Integration** (`cache-revalidation.integration.test.ts`, 5, real sqlite +
  a recording `CacheRevalidator` injected via container pre-registration):
  create/rename/delete/single each flush the right tags, and a no-op write flushes
  nothing. **Proven load-bearing** — breaking the flush fails the flush assertions.
- 24 unit + 5 integration green; the publish-enforcement suites (35) pass
  unchanged (no regression in the mutation service).

## Known follow-up (called out honestly)

The `revalidate.disable` / `revalidate.tags` **config knob does not yet reach the
write site**: `getCollection` / `getSingleBySlug` return DB metadata that persists
`versions` (a real column) but not `revalidate`. The derived `nextly:*` tag
busting works and flushes regardless (it needs no config); honoring the config
requires persisting `revalidate` to collection/single metadata the way `versions`
is serialized, which is a focused follow-up. The gating logic itself is
unit-tested for when the config is present.

## Changeset

One changeset, all lockstep packages, `patch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cache/tag invalidation after collection and single-entry writes, including creates, updates, slug renames, deletes, publishing, and bulk operations.
  * Revalidation supports custom extra tags and can be disabled via configuration.
  * If post-write hooks fail or cache revalidation encounters an error, writes still succeed (revalidation failures are handled without interrupting the operation).
  * Revalidation intents are carried through caller-provided transactions for later flushing.
* **Tests**
  * Expanded coverage for intent generation, disabled mode, bulk flows, publish behavior, and failure/edge cases, plus updated direct API bulk-delete result expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->