### PR TITLE
feat(nextly): add webhook signing-secret rotation with overlap window

### DIFF
--- a/.changeset/webhook-secret-rotation.md
+++ b/.changeset/webhook-secret-rotation.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Add webhook signing-secret rotation with a configurable overlap window. An
+endpoint's secret can now be rotated from the admin: a fresh secret becomes the
+primary and the previous one keeps signing for a chosen window (immediately,
+24h, 48h — the default, 7d, or 30d) so a receiver can switch over without
+dropping a delivery. Deliveries in the window carry a signature for both
+secrets, and the old one can be expired early. The endpoint edit page shows each
+active secret's lifecycle.

--- a/packages/admin/src/components/features/webhooks/RotateSecretDialog.test.tsx
+++ b/packages/admin/src/components/features/webhooks/RotateSecretDialog.test.tsx
@@ -1,0 +1,44 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+import { WEBHOOK_ROTATION_DEFAULT_OVERLAP_SECONDS } from "@admin/types/webhooks";
+
+import { RotateSecretDialog } from "./RotateSecretDialog";
+
+describe("RotateSecretDialog", () => {
+  it("confirms with the default (48h) overlap when nothing is changed", async () => {
+    const onConfirm = vi.fn();
+    render(
+      <RotateSecretDialog
+        open
+        onOpenChange={vi.fn()}
+        webhookName="Orders"
+        onConfirm={onConfirm}
+        isPending={false}
+      />
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /rotate secret/i })
+    );
+    expect(onConfirm).toHaveBeenCalledWith(
+      WEBHOOK_ROTATION_DEFAULT_OVERLAP_SECONDS
+    );
+  });
+
+  it("disables the actions while a rotation is pending", () => {
+    render(
+      <RotateSecretDialog
+        open
+        onOpenChange={vi.fn()}
+        webhookName="Orders"
+        onConfirm={vi.fn()}
+        isPending
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /rotating/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeDisabled();
+  });
+});

--- a/packages/admin/src/components/features/webhooks/RotateSecretDialog.tsx
+++ b/packages/admin/src/components/features/webhooks/RotateSecretDialog.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+/**
+ * RotateSecretDialog — confirms rotating an endpoint's signing secret and picks
+ * the overlap window. A rotation mints a new primary secret and keeps the old
+ * one valid for the chosen window so a receiver can switch over without dropping
+ * a delivery; "Expire immediately" gives no overlap. The parent owns the
+ * mutation and receives the chosen window on confirm.
+ */
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@nextlyhq/ui";
+import type React from "react";
+import { useEffect, useState } from "react";
+
+import { Loader2 } from "@admin/components/icons";
+import {
+  WEBHOOK_ROTATION_DEFAULT_OVERLAP_SECONDS,
+  WEBHOOK_ROTATION_WINDOWS,
+} from "@admin/types/webhooks";
+
+export interface RotateSecretDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Endpoint name, shown so the operator knows what they are rotating. */
+  webhookName: string;
+  onConfirm: (overlapSeconds: number) => void;
+  isPending: boolean;
+}
+
+export const RotateSecretDialog: React.FC<RotateSecretDialogProps> = ({
+  open,
+  onOpenChange,
+  webhookName,
+  onConfirm,
+  isPending,
+}) => {
+  const [overlapSeconds, setOverlapSeconds] = useState<number>(
+    WEBHOOK_ROTATION_DEFAULT_OVERLAP_SECONDS
+  );
+
+  // Reset to the default window each time the dialog opens, so a previous
+  // selection does not silently carry into the next rotation.
+  useEffect(() => {
+    if (open) setOverlapSeconds(WEBHOOK_ROTATION_DEFAULT_OVERLAP_SECONDS);
+  }, [open]);
+
+  return (
+    <Dialog open={open} onOpenChange={isPending ? undefined : onOpenChange}>
+      <DialogContent
+        className="sm:max-w-md"
+        aria-describedby="rotate-secret-description"
+      >
+        <DialogHeader>
+          <DialogTitle>Rotate signing secret?</DialogTitle>
+          <DialogDescription id="rotate-secret-description">
+            A new signing secret becomes the primary for{" "}
+            <strong>&ldquo;{webhookName}&rdquo;</strong> and is shown once. The
+            current secret keeps working for the overlap window below so your
+            receiver can switch over, then stops signing. Deliveries during the
+            window are signed with both.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          <label
+            htmlFor="rotate-overlap"
+            className="text-sm font-medium text-foreground"
+          >
+            Keep the old secret valid for
+          </label>
+          <Select
+            value={String(overlapSeconds)}
+            onValueChange={value => setOverlapSeconds(Number(value))}
+            disabled={isPending}
+          >
+            <SelectTrigger id="rotate-overlap" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {WEBHOOK_ROTATION_WINDOWS.map(window => (
+                <SelectItem key={window.seconds} value={String(window.seconds)}>
+                  {window.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => onConfirm(overlapSeconds)}
+            disabled={isPending}
+          >
+            {isPending ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Rotating…
+              </>
+            ) : (
+              "Rotate secret"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/packages/admin/src/components/features/webhooks/SecretLifecycle.tsx
+++ b/packages/admin/src/components/features/webhooks/SecretLifecycle.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+/**
+ * SecretLifecycle — shows an endpoint's active signing secrets and their state
+ * during a rotation: the primary that new deliveries are prefixed by, and any
+ * overlapping secret still valid until it expires. When an overlapping secret
+ * exists a manager can retire it early. Values are display prefixes only; the
+ * real secrets are read through the separate reveal action.
+ */
+
+import { Badge, Button } from "@nextlyhq/ui";
+import type React from "react";
+
+import { Loader2 } from "@admin/components/icons";
+import type { WebhookSecretInfo } from "@admin/types/webhooks";
+
+/**
+ * A short "in 2 days" / "in 5 hours" for a future instant, or "soon" when it is
+ * essentially now. Rendered in the viewer's frame from the ISO instant.
+ */
+function formatExpiresIn(iso: string): string {
+  const diffMs = new Date(iso).getTime() - Date.now();
+  if (!Number.isFinite(diffMs) || diffMs <= 0) return "expiring";
+  const minutes = Math.floor(diffMs / 60_000);
+  const hours = Math.floor(diffMs / 3_600_000);
+  const days = Math.floor(diffMs / 86_400_000);
+  if (minutes < 60) {
+    return `in ${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+  if (hours < 48) {
+    return `in ${hours} hour${hours === 1 ? "" : "s"}`;
+  }
+  return `in ${days} day${days === 1 ? "" : "s"}`;
+}
+
+export interface SecretLifecycleProps {
+  secrets: WebhookSecretInfo[];
+  /** Update permission gates the "Expire now" control. */
+  canManage: boolean;
+  onExpireOld: () => void;
+  isExpiring: boolean;
+}
+
+export const SecretLifecycle: React.FC<SecretLifecycleProps> = ({
+  secrets,
+  canManage,
+  onExpireOld,
+  isExpiring,
+}) => {
+  const hasOverlap = secrets.some(secret => !secret.isPrimary);
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-[11px] font-semibold tracking-[0.08em] uppercase text-muted-foreground">
+          Signing secrets
+        </p>
+        {hasOverlap && canManage && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onExpireOld}
+            disabled={isExpiring}
+          >
+            {isExpiring ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+            Expire old secret now
+          </Button>
+        )}
+      </div>
+
+      <ul className="divide-y divide-foreground/10 rounded-md border border-input bg-card">
+        {secrets.map(secret => (
+          <li
+            key={`${secret.prefix}-${secret.createdAt}`}
+            className="flex flex-wrap items-center gap-3 px-4 py-3"
+          >
+            <code className="rounded-none bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground">
+              {secret.prefix}
+              {"•".repeat(6)}
+            </code>
+            {secret.isPrimary ? (
+              <Badge variant="success">Primary</Badge>
+            ) : (
+              <Badge variant="warning">
+                Expiring
+                {secret.expiresAt
+                  ? ` ${formatExpiresIn(secret.expiresAt)}`
+                  : ""}
+              </Badge>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      {hasOverlap && (
+        <p className="text-xs text-muted-foreground">
+          Deliveries are signed with both secrets until the old one expires, so
+          a receiver holding either verifies.
+        </p>
+      )}
+    </section>
+  );
+};

--- a/packages/admin/src/hooks/queries/index.ts
+++ b/packages/admin/src/hooks/queries/index.ts
@@ -136,6 +136,8 @@ export {
   useCreateWebhook,
   useUpdateWebhook,
   useDeleteWebhook,
+  useRotateSecret,
+  useExpireOldSecrets,
   useRevealSecret,
   useTestEndpoint,
 } from "./useWebhooks";

--- a/packages/admin/src/hooks/queries/useWebhooks.ts
+++ b/packages/admin/src/hooks/queries/useWebhooks.ts
@@ -16,6 +16,7 @@ import { webhookApi } from "@admin/services/webhookApi";
 import type {
   CreateWebhookInput,
   CreatedWebhook,
+  RotateWebhookInput,
   UpdateWebhookInput,
   WebhookEndpointSummary,
   WebhookTestResult,
@@ -84,6 +85,36 @@ export function useDeleteWebhook() {
   const queryClient = useQueryClient();
   return useMutation<void, Error, string>({
     mutationFn: id => webhookApi.deleteWebhook(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: webhookKeys.all() });
+    },
+  });
+}
+
+/**
+ * Rotate the signing secret. Invalidates the endpoint cache so the secret
+ * lifecycle (primary + any overlapping secret) refetches; the page captures the
+ * one-time new secret from the result in `onSuccess`.
+ */
+export function useRotateSecret() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    CreatedWebhook,
+    Error,
+    { id: string; input: RotateWebhookInput }
+  >({
+    mutationFn: ({ id, input }) => webhookApi.rotateSecret(id, input),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: webhookKeys.all() });
+    },
+  });
+}
+
+/** Retire overlapping secrets now; refetch so the lifecycle reflects it. */
+export function useExpireOldSecrets() {
+  const queryClient = useQueryClient();
+  return useMutation<WebhookEndpointSummary, Error, string>({
+    mutationFn: id => webhookApi.expireOldSecrets(id),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: webhookKeys.all() });
     },

--- a/packages/admin/src/lib/webhook-validation.test.ts
+++ b/packages/admin/src/lib/webhook-validation.test.ts
@@ -28,6 +28,14 @@ const endpoint: WebhookEndpointSummary = {
   eventTypes: ["entry.created"],
   headers: null,
   secretPrefix: "whsec_ab",
+  secrets: [
+    {
+      prefix: "whsec_ab",
+      isPrimary: true,
+      createdAt: "2026-07-24T00:00:00.000Z",
+      expiresAt: null,
+    },
+  ],
   createdBy: "u1",
   createdAt: "2026-07-24T00:00:00.000Z",
   updatedAt: "2026-07-24T00:00:00.000Z",

--- a/packages/admin/src/pages/dashboard/settings/webhooks/edit/[id].tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/edit/[id].tsx
@@ -6,9 +6,11 @@ import { useCallback, useState } from "react";
 
 import { SettingsLayout } from "@admin/components/features/settings/SettingsLayout";
 import { DeleteWebhookDialog } from "@admin/components/features/webhooks/DeleteWebhookDialog";
+import { RotateSecretDialog } from "@admin/components/features/webhooks/RotateSecretDialog";
+import { SecretLifecycle } from "@admin/components/features/webhooks/SecretLifecycle";
 import { WebhookForm } from "@admin/components/features/webhooks/WebhookForm";
 import { WebhookSecretModal } from "@admin/components/features/webhooks/WebhookSecretModal";
-import { Eye, List, Loader2 } from "@admin/components/icons";
+import { Eye, List, Loader2, RefreshCw } from "@admin/components/icons";
 import { PageContainer } from "@admin/components/layout/page-container";
 import { PageErrorFallback } from "@admin/components/shared/error-fallbacks";
 import { QueryErrorBoundary } from "@admin/components/shared/query-error-boundary";
@@ -17,7 +19,9 @@ import { Link } from "@admin/components/ui/link";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import {
   useDeleteWebhook,
+  useExpireOldSecrets,
   useRevealSecret,
+  useRotateSecret,
   useUpdateWebhook,
   useWebhook,
 } from "@admin/hooks/queries/useWebhooks";
@@ -35,9 +39,14 @@ const EditWebhookContent: React.FC<{ id: string }> = ({ id }) => {
   const { data: webhook, isLoading, isError, error } = useWebhook(id);
   const { mutate: doUpdate, isPending } = useUpdateWebhook();
   const { mutate: doReveal, isPending: isRevealing } = useRevealSecret();
+  const { mutate: doRotate, isPending: isRotating } = useRotateSecret();
+  const { mutate: doExpireOld, isPending: isExpiring } = useExpireOldSecrets();
   const { mutate: doDelete, isPending: isDeleting } = useDeleteWebhook();
 
   const [secrets, setSecrets] = useState<string[] | null>(null);
+  // The one-time secret minted by a rotation, shown once in its own modal.
+  const [rotatedSecret, setRotatedSecret] = useState<string | null>(null);
+  const [confirmRotate, setConfirmRotate] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   // Reaching this page requires update-webhooks (registry-gated). Delete is a
@@ -87,6 +96,49 @@ const EditWebhookContent: React.FC<{ id: string }> = ({ id }) => {
     });
   }, [doReveal, id]);
 
+  const handleRotate = useCallback(
+    (overlapSeconds: number) => {
+      doRotate(
+        { id, input: { overlapSeconds } },
+        {
+          onSuccess: result => {
+            setConfirmRotate(false);
+            // The fresh secret is shown once here; the reveal action can return
+            // it again later while it remains the primary.
+            setRotatedSecret(result.secret);
+            toast.success("Signing secret rotated", {
+              description:
+                overlapSeconds > 0
+                  ? "The previous secret keeps working until the overlap window ends."
+                  : "The previous secret was retired immediately.",
+            });
+          },
+          onError: (err: Error) => {
+            toast.error("Could not rotate the secret", {
+              description: apiErrorMessage(err),
+            });
+          },
+        }
+      );
+    },
+    [doRotate, id]
+  );
+
+  const handleExpireOld = useCallback(() => {
+    doExpireOld(id, {
+      onSuccess: () => {
+        toast.success("Old signing secret expired", {
+          description: "Only the current secret can sign deliveries now.",
+        });
+      },
+      onError: (err: Error) => {
+        toast.error("Could not expire the old secret", {
+          description: apiErrorMessage(err),
+        });
+      },
+    });
+  }, [doExpireOld, id]);
+
   const handleConfirmDelete = useCallback(() => {
     if (!webhook) return;
     const name = webhook.name;
@@ -128,7 +180,16 @@ const EditWebhookContent: React.FC<{ id: string }> = ({ id }) => {
         pendingLabel="Saving…"
       />
 
-      <div className="mt-8 flex flex-col gap-3 border-t border-border pt-6 sm:flex-row sm:items-center sm:justify-between">
+      <div className="mt-8 border-t border-border pt-6">
+        <SecretLifecycle
+          secrets={webhook.secrets}
+          canManage={canManageWebhooks}
+          onExpireOld={handleExpireOld}
+          isExpiring={isExpiring}
+        />
+      </div>
+
+      <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
           <Button
             type="button"
@@ -142,6 +203,20 @@ const EditWebhookContent: React.FC<{ id: string }> = ({ id }) => {
               <Eye className="h-4 w-4" />
             )}
             Reveal signing secret
+          </Button>
+
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setConfirmRotate(true)}
+            disabled={isRotating}
+          >
+            {isRotating ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="h-4 w-4" />
+            )}
+            Rotate signing secret
           </Button>
 
           <Link href={buildRoute(ROUTES.SETTINGS_WEBHOOKS_DELIVERIES, { id })}>
@@ -172,6 +247,22 @@ const EditWebhookContent: React.FC<{ id: string }> = ({ id }) => {
         secrets={secrets}
         oneTime={false}
         onClose={() => setSecrets(null)}
+      />
+
+      <WebhookSecretModal
+        open={rotatedSecret !== null}
+        secrets={rotatedSecret !== null ? [rotatedSecret] : null}
+        oneTime
+        canRevealLater
+        onClose={() => setRotatedSecret(null)}
+      />
+
+      <RotateSecretDialog
+        open={confirmRotate}
+        onOpenChange={setConfirmRotate}
+        webhookName={webhook.name}
+        onConfirm={handleRotate}
+        isPending={isRotating}
       />
 
       <DeleteWebhookDialog

--- a/packages/admin/src/services/webhookApi.test.ts
+++ b/packages/admin/src/services/webhookApi.test.ts
@@ -67,6 +67,33 @@ describe("webhookApi", () => {
     );
   });
 
+  it("rotates the secret and unwraps doc + new secret", async () => {
+    fetcherSpy.mockResolvedValue({
+      message: "Rotated.",
+      item: { doc: summary, secret: "whsec_new" },
+    });
+    const result = await webhookApi.rotateSecret("wh_1", {
+      overlapSeconds: 3600,
+    });
+    expect(fetcherSpy).toHaveBeenCalledWith(
+      "/webhooks/wh_1/secret/rotate",
+      { method: "POST", body: JSON.stringify({ overlapSeconds: 3600 }) },
+      true
+    );
+    expect(result).toEqual({ doc: summary, secret: "whsec_new" });
+  });
+
+  it("expires old secrets and unwraps the updated endpoint", async () => {
+    fetcherSpy.mockResolvedValue({ message: "Expired.", item: summary });
+    const result = await webhookApi.expireOldSecrets("wh_1");
+    expect(fetcherSpy).toHaveBeenCalledWith(
+      "/webhooks/wh_1/secret/expire-old",
+      { method: "POST" },
+      true
+    );
+    expect(result).toBe(summary);
+  });
+
   it("reveals the signing secrets", async () => {
     fetcherSpy.mockResolvedValue({ secrets: ["whsec_a", "whsec_b"] });
     const result = await webhookApi.revealSecret("wh_1");

--- a/packages/admin/src/services/webhookApi.ts
+++ b/packages/admin/src/services/webhookApi.ts
@@ -16,6 +16,7 @@ import type {
 import type {
   CreateWebhookInput,
   CreatedWebhook,
+  RotateWebhookInput,
   UpdateWebhookInput,
   WebhookEndpointSummary,
   WebhookTestResult,
@@ -70,6 +71,34 @@ export async function deleteWebhook(id: string): Promise<void> {
   );
 }
 
+/**
+ * Rotate the signing secret with an overlap window. Returns the new endpoint
+ * plus the fresh secret, shown once (same shape as create).
+ */
+export async function rotateSecret(
+  id: string,
+  input: RotateWebhookInput
+): Promise<CreatedWebhook> {
+  const result = await fetcher<MutationResponse<CreatedWebhook>>(
+    `/webhooks/${id}/secret/rotate`,
+    { method: "POST", body: JSON.stringify(input) },
+    true
+  );
+  return result.item;
+}
+
+/** Retire every overlapping (rotated-away) secret now, leaving only the primary. */
+export async function expireOldSecrets(
+  id: string
+): Promise<WebhookEndpointSummary> {
+  const result = await fetcher<MutationResponse<WebhookEndpointSummary>>(
+    `/webhooks/${id}/secret/expire-old`,
+    { method: "POST" },
+    true
+  );
+  return result.item;
+}
+
 /** Reveal the active signing secret(s) — rotation can keep more than one alive. */
 export async function revealSecret(id: string): Promise<string[]> {
   const result = await fetcher<{ secrets: string[] }>(
@@ -102,6 +131,8 @@ export const webhookApi = {
   createWebhook,
   updateWebhook,
   deleteWebhook,
+  rotateSecret,
+  expireOldSecrets,
   revealSecret,
   testEndpoint,
 } as const;

--- a/packages/admin/src/types/webhooks.ts
+++ b/packages/admin/src/types/webhooks.ts
@@ -40,6 +40,19 @@ export type WebhookEventSubscription =
 export const REDACTED_HEADER_VALUE = "<redacted>";
 
 /**
+ * One signing secret described without revealing it. `isPrimary` marks the
+ * secret new deliveries are prefixed by; `expiresAt` is when an overlapping
+ * (rotated-away) secret stops signing, or null for the primary. Timestamps are
+ * ISO strings on the wire.
+ */
+export interface WebhookSecretInfo {
+  prefix: string;
+  isPrimary: boolean;
+  createdAt: string;
+  expiresAt: string | null;
+}
+
+/**
  * Endpoint summary returned by list and get. Carries no secret or ciphertext;
  * static header values are redacted to `REDACTED_HEADER_VALUE` (names survive).
  */
@@ -50,11 +63,34 @@ export interface WebhookEndpointSummary {
   enabled: boolean;
   eventTypes: WebhookEventSubscription[];
   headers: Record<string, string> | null;
-  /** Display-only prefix of the signing secret. */
+  /** Display-only prefix of the current primary signing secret. */
   secretPrefix: string;
+  /** Non-sensitive lifecycle of every active signing secret, primary first. */
+  secrets: WebhookSecretInfo[];
   createdBy: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+/**
+ * Overlap-window presets offered when rotating a signing secret, in seconds.
+ * "Expire immediately" is 0; the rest let the rotated-away secret keep signing
+ * for a while so a receiver can switch over. The default matches the backend.
+ */
+export const WEBHOOK_ROTATION_WINDOWS = [
+  { seconds: 0, label: "Expire immediately" },
+  { seconds: 24 * 60 * 60, label: "24 hours" },
+  { seconds: 48 * 60 * 60, label: "48 hours" },
+  { seconds: 7 * 24 * 60 * 60, label: "7 days" },
+  { seconds: 30 * 24 * 60 * 60, label: "30 days" },
+] as const;
+
+/** The default overlap window (48 hours), mirroring the backend default. */
+export const WEBHOOK_ROTATION_DEFAULT_OVERLAP_SECONDS = 48 * 60 * 60;
+
+export interface RotateWebhookInput {
+  /** How long the rotated-away secret stays valid, in seconds. */
+  overlapSeconds: number;
 }
 
 export interface CreateWebhookInput {

--- a/packages/nextly/src/api/webhooks.ts
+++ b/packages/nextly/src/api/webhooks.ts
@@ -50,6 +50,7 @@ import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
 import {
   CreateWebhookSchema,
+  RotateWebhookSchema,
   UpdateWebhookSchema,
 } from "../schemas/_zod/webhooks";
 import { SKIP_TIMEZONE_FORMAT_HEADER } from "../shared/lib/date-formatting";
@@ -132,7 +133,15 @@ async function requireWebhookPermission(
  * live in `logContext` for operator triage.
  */
 function denySessionOnly(
-  action: "create" | "update" | "delete" | "reveal" | "test" | "redeliver"
+  action:
+    | "create"
+    | "update"
+    | "delete"
+    | "reveal"
+    | "test"
+    | "redeliver"
+    | "rotate"
+    | "expire-secrets"
 ): never {
   throw NextlyError.forbidden({
     logContext: { reason: "session-only", action },
@@ -660,5 +669,94 @@ export function revealWebhookSecret(
     const secrets = await service.revealSecrets(id);
 
     return respondData({ secrets }, { headers: PRIVATE_NO_STORE_HEADERS });
+  })(req);
+}
+
+/**
+ * Rotate an endpoint's signing secret with an overlap window.
+ *
+ * A fresh secret becomes the primary; the previous one stays valid for
+ * `overlapSeconds` (default when omitted, 0 to retire it at once) so a receiver
+ * can switch over without dropping a delivery. Deliveries in the window carry a
+ * signature for both, so either secret verifies.
+ *
+ * Auth: **session only** + `update-webhooks` — rotation mints new key material.
+ *
+ * Response: `{ message, item: { doc, secret } }` via `respondMutation`. The new
+ * secret is returned here once, the same as on create, and is retrievable after
+ * through the reveal action until it is rotated away.
+ */
+export function rotateWebhookSecret(
+  req: Request,
+  id: string
+): Promise<Response> {
+  return withErrorHandler(async (request: Request) => {
+    const authResult = await requireWebhookPermission(request, "update");
+    if (isErrorResponse(authResult)) throw toNextlyAuthError(authResult);
+
+    if (authResult.authMethod !== "session") denySessionOnly("rotate");
+
+    // The body is optional: a rotate with no body takes the default overlap. An
+    // empty body reads as `{}` rather than failing JSON parsing.
+    const raw = await request.text();
+    let body: unknown = {};
+    if (raw.trim() !== "") {
+      try {
+        body = JSON.parse(raw);
+      } catch {
+        throw NextlyError.validation({
+          errors: [
+            {
+              path: "",
+              code: "invalid_json",
+              message: "Request body is not valid JSON.",
+            },
+          ],
+          logContext: { reason: "invalid-json-body", entity: "webhook-rotate" },
+        });
+      }
+    }
+
+    let validated: z.infer<typeof RotateWebhookSchema>;
+    try {
+      validated = RotateWebhookSchema.parse(body);
+    } catch (err) {
+      if (err instanceof z.ZodError) throw nextlyValidationFromZod(err);
+      throw err;
+    }
+
+    const service = await getWebhookService();
+    const { endpoint, secret } = await service.rotateSecret(id, validated);
+
+    return respondMutation("Webhook signing secret rotated.", {
+      doc: endpoint,
+      secret,
+    });
+  })(req);
+}
+
+/**
+ * Retire every overlapping (rotated-away) signing secret immediately, leaving
+ * only the primary. The way to cut a rotation's overlap short once the receiver
+ * has switched to the new secret.
+ *
+ * Auth: **session only** + `update-webhooks`.
+ *
+ * Response: `{ message, item: WebhookEndpointSummary }` via `respondMutation`.
+ */
+export function expireWebhookOldSecrets(
+  req: Request,
+  id: string
+): Promise<Response> {
+  return withErrorHandler(async (request: Request) => {
+    const authResult = await requireWebhookPermission(request, "update");
+    if (isErrorResponse(authResult)) throw toNextlyAuthError(authResult);
+
+    if (authResult.authMethod !== "session") denySessionOnly("expire-secrets");
+
+    const service = await getWebhookService();
+    const updated = await service.expireOldSecrets(id);
+
+    return respondMutation("Old signing secrets expired.", updated);
   })(req);
 }

--- a/packages/nextly/src/domains/webhooks/__tests__/secret-entries.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/secret-entries.test.ts
@@ -1,0 +1,155 @@
+/**
+ * The stored signing-secret entry lifecycle. The crypto is stubbed so these
+ * assert the shape and rotation rules (normalize, liveness, ordering) without an
+ * encryption key: `secret.ts` owns and separately tests the AES-GCM round trip.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../secret", () => ({
+  encryptWebhookSecret: (plaintext: string) => `enc(${plaintext})`,
+  webhookSecretPrefix: (secret: string) => secret.slice(0, 8),
+}));
+
+import {
+  isSecretEntryLive,
+  liveSecretEntries,
+  newSecretEntry,
+  normalizeSecretEntries,
+  WEBHOOK_ROTATION_DEFAULT_OVERLAP_SECONDS,
+  WEBHOOK_ROTATION_MAX_OVERLAP_SECONDS,
+  type StoredSecretEntry,
+} from "../secret-entries";
+
+const FALLBACK = { prefix: "whsec_fb", createdAt: "2026-01-01T00:00:00.000Z" };
+
+function entry(over: Partial<StoredSecretEntry> = {}): StoredSecretEntry {
+  return {
+    ciphertext: "ct",
+    prefix: "whsec_ab",
+    createdAt: "2026-07-24T00:00:00.000Z",
+    expiresAt: null,
+    ...over,
+  };
+}
+
+describe("normalizeSecretEntries", () => {
+  it("reads a legacy bare-string entry as a never-expiring primary", () => {
+    expect(normalizeSecretEntries(["ct-legacy"], FALLBACK)).toEqual([
+      {
+        ciphertext: "ct-legacy",
+        prefix: FALLBACK.prefix,
+        createdAt: FALLBACK.createdAt,
+        expiresAt: null,
+      },
+    ]);
+  });
+
+  it("reads the current object form, filling gaps from the fallback", () => {
+    const stored = [
+      {
+        ciphertext: "a",
+        prefix: "whsec_aa",
+        createdAt: "2026-07-01T00:00:00.000Z",
+        expiresAt: null,
+      },
+      { ciphertext: "b" },
+    ];
+    expect(normalizeSecretEntries(stored, FALLBACK)).toEqual([
+      {
+        ciphertext: "a",
+        prefix: "whsec_aa",
+        createdAt: "2026-07-01T00:00:00.000Z",
+        expiresAt: null,
+      },
+      {
+        ciphertext: "b",
+        prefix: FALLBACK.prefix,
+        createdAt: FALLBACK.createdAt,
+        expiresAt: null,
+      },
+    ]);
+  });
+
+  it("drops malformed entries and non-array cells", () => {
+    expect(
+      normalizeSecretEntries(["", null, 3, { prefix: "x" }], FALLBACK)
+    ).toEqual([]);
+    expect(normalizeSecretEntries(null, FALLBACK)).toEqual([]);
+    expect(normalizeSecretEntries("nope", FALLBACK)).toEqual([]);
+  });
+});
+
+describe("isSecretEntryLive", () => {
+  const now = new Date("2026-07-24T12:00:00.000Z");
+
+  it("treats a null expiry (primary) as always live", () => {
+    expect(isSecretEntryLive(entry({ expiresAt: null }), now)).toBe(true);
+  });
+
+  it("is live before the expiry and dead after", () => {
+    expect(
+      isSecretEntryLive(entry({ expiresAt: "2026-07-24T13:00:00.000Z" }), now)
+    ).toBe(true);
+    expect(
+      isSecretEntryLive(entry({ expiresAt: "2026-07-24T11:00:00.000Z" }), now)
+    ).toBe(false);
+  });
+
+  it("treats a malformed expiry as dead rather than eternal", () => {
+    expect(isSecretEntryLive(entry({ expiresAt: "not-a-date" }), now)).toBe(
+      false
+    );
+  });
+});
+
+describe("liveSecretEntries", () => {
+  const now = new Date("2026-07-24T12:00:00.000Z");
+
+  it("drops expired entries and puts the primary first", () => {
+    const entries = [
+      entry({ ciphertext: "overlap", expiresAt: "2026-07-25T00:00:00.000Z" }),
+      entry({ ciphertext: "primary", expiresAt: null }),
+      entry({ ciphertext: "dead", expiresAt: "2026-07-01T00:00:00.000Z" }),
+    ];
+    const live = liveSecretEntries(entries, now);
+    expect(live.map(e => e.ciphertext)).toEqual(["primary", "overlap"]);
+  });
+
+  it("orders overlapping secrets latest-expiry first", () => {
+    const entries = [
+      entry({ ciphertext: "soon", expiresAt: "2026-07-24T13:00:00.000Z" }),
+      entry({ ciphertext: "later", expiresAt: "2026-07-26T00:00:00.000Z" }),
+    ];
+    expect(liveSecretEntries(entries, now).map(e => e.ciphertext)).toEqual([
+      "later",
+      "soon",
+    ]);
+  });
+});
+
+describe("newSecretEntry", () => {
+  const now = new Date("2026-07-24T00:00:00.000Z");
+
+  it("builds a never-expiring primary from a plaintext secret", () => {
+    expect(newSecretEntry("whsec_abcdefgh", now)).toEqual({
+      ciphertext: "enc(whsec_abcdefgh)",
+      prefix: "whsec_ab",
+      createdAt: "2026-07-24T00:00:00.000Z",
+      expiresAt: null,
+    });
+  });
+
+  it("stamps an overlap expiry when one is passed", () => {
+    const expiresAt = "2026-07-26T00:00:00.000Z";
+    expect(newSecretEntry("whsec_abcdefgh", now, expiresAt).expiresAt).toBe(
+      expiresAt
+    );
+  });
+});
+
+describe("rotation window constants", () => {
+  it("defaults to 48 hours and caps at 30 days", () => {
+    expect(WEBHOOK_ROTATION_DEFAULT_OVERLAP_SECONDS).toBe(48 * 60 * 60);
+    expect(WEBHOOK_ROTATION_MAX_OVERLAP_SECONDS).toBe(30 * 24 * 60 * 60);
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-endpoint-service.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-endpoint-service.integration.test.ts
@@ -596,4 +596,83 @@ describe("webhook endpoint management (real SQLite)", () => {
       expect(listed.map(e => e.id)).toContain(second.endpoint.id);
     });
   });
+
+  describe("rotating the secret", () => {
+    it("keeps the old secret live during the overlap and makes the new one primary", async () => {
+      const { endpoint, secret: original } = await create();
+
+      const { endpoint: rotated, secret: fresh } = await service.rotateSecret(
+        endpoint.id,
+        { overlapSeconds: 3600 }
+      );
+
+      // A new secret, distinct from the original, is now the primary.
+      expect(fresh).not.toBe(original);
+      expect(rotated.secretPrefix).toBe(fresh.slice(0, 14));
+
+      // Both are live during the overlap; reveal returns them, new one first.
+      const revealed = await service.revealSecrets(endpoint.id);
+      expect(revealed).toHaveLength(2);
+      expect(revealed[0]).toBe(fresh);
+      expect(revealed).toContain(original);
+
+      // The lifecycle summary marks exactly one primary and one expiring secret.
+      expect(rotated.secrets).toHaveLength(2);
+      expect(rotated.secrets.filter(s => s.isPrimary)).toHaveLength(1);
+      const overlap = rotated.secrets.find(s => !s.isPrimary);
+      expect(overlap?.expiresAt).toBeInstanceOf(Date);
+    });
+
+    it("retires the old secret immediately with a zero overlap", async () => {
+      const { endpoint, secret: original } = await create();
+
+      const { secret: fresh } = await service.rotateSecret(endpoint.id, {
+        overlapSeconds: 0,
+      });
+
+      const revealed = await service.revealSecrets(endpoint.id);
+      expect(revealed).toEqual([fresh]);
+      expect(revealed).not.toContain(original);
+    });
+
+    it("never keeps more than two secrets live across repeated rotations", async () => {
+      const { endpoint } = await create();
+      await service.rotateSecret(endpoint.id, { overlapSeconds: 3600 });
+      await service.rotateSecret(endpoint.id, { overlapSeconds: 3600 });
+      const { endpoint: latest } = await service.rotateSecret(endpoint.id, {
+        overlapSeconds: 3600,
+      });
+
+      expect(await service.revealSecrets(endpoint.id)).toHaveLength(2);
+      expect(latest.secrets).toHaveLength(2);
+    });
+
+    it("rejects an out-of-range overlap window", async () => {
+      const { endpoint } = await create();
+      await expect(
+        service.rotateSecret(endpoint.id, { overlapSeconds: -1 })
+      ).rejects.toThrow(NextlyError);
+    });
+
+    it("reports an unknown endpoint as not found", async () => {
+      await expect(service.rotateSecret("missing")).rejects.toThrow(
+        NextlyError
+      );
+    });
+  });
+
+  describe("expiring old secrets", () => {
+    it("drops the overlapping secret and leaves only the primary", async () => {
+      const { endpoint } = await create();
+      const { secret: fresh } = await service.rotateSecret(endpoint.id, {
+        overlapSeconds: 3600,
+      });
+      expect(await service.revealSecrets(endpoint.id)).toHaveLength(2);
+
+      const summary = await service.expireOldSecrets(endpoint.id);
+      expect(summary.secrets).toHaveLength(1);
+      expect(summary.secrets[0]?.isPrimary).toBe(true);
+      expect(await service.revealSecrets(endpoint.id)).toEqual([fresh]);
+    });
+  });
 });

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-endpoint-service.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-endpoint-service.integration.test.ts
@@ -654,6 +654,31 @@ describe("webhook endpoint management (real SQLite)", () => {
       ).rejects.toThrow(NextlyError);
     });
 
+    it("serializes concurrent rotations so neither new secret is lost", async () => {
+      const { endpoint } = await create();
+
+      // Both rotations start from the same endpoint. Under the row lock they
+      // serialize, so the second reads the first's committed state and keeps its
+      // new secret as the overlap rather than overwriting it from a stale row.
+      const [a, b] = await Promise.all([
+        service.rotateSecret(endpoint.id, { overlapSeconds: 3600 }),
+        service.rotateSecret(endpoint.id, { overlapSeconds: 3600 }),
+      ]);
+
+      const revealed = await service.revealSecrets(endpoint.id);
+      expect(revealed).toHaveLength(2);
+      expect(revealed).toContain(a.secret);
+      expect(revealed).toContain(b.secret);
+    });
+
+    it("refuses to rotate a retired endpoint", async () => {
+      const { endpoint } = await create();
+      await service.deleteEndpoint(endpoint.id);
+      await expect(service.rotateSecret(endpoint.id)).rejects.toThrow(
+        NextlyError
+      );
+    });
+
     it("reports an unknown endpoint as not found", async () => {
       await expect(service.rotateSecret("missing")).rejects.toThrow(
         NextlyError
@@ -673,6 +698,16 @@ describe("webhook endpoint management (real SQLite)", () => {
       expect(summary.secrets).toHaveLength(1);
       expect(summary.secrets[0]?.isPrimary).toBe(true);
       expect(await service.revealSecrets(endpoint.id)).toEqual([fresh]);
+    });
+
+    it("refuses to write a secret back onto a retired endpoint", async () => {
+      const { endpoint } = await create();
+      await service.deleteEndpoint(endpoint.id);
+      // The retired-row check inside the lock stops a receiver credential being
+      // restored onto a soft-deleted endpoint that delete already cleared.
+      await expect(service.expireOldSecrets(endpoint.id)).rejects.toThrow(
+        NextlyError
+      );
     });
   });
 });

--- a/packages/nextly/src/domains/webhooks/deliver.ts
+++ b/packages/nextly/src/domains/webhooks/deliver.ts
@@ -31,6 +31,7 @@ import {
   decideDelivery,
   type AttemptOutcome,
 } from "./delivery-policy";
+import { liveSecretEntries, normalizeSecretEntries } from "./secret-entries";
 import { buildSignatureHeaders } from "./signing";
 
 /** Default number of due deliveries a single `deliverDueDeliveries` call claims. */
@@ -73,8 +74,12 @@ interface WebhookRow {
   id: string;
   url: string;
   headers: Record<string, string> | null;
-  /** Encrypted (not hashed) active signing secrets, primary first. */
-  secretHash: string[];
+  /**
+   * The raw `secret_hash` JSON cell: a list of encrypted signing-secret entries
+   * (or the legacy bare-ciphertext form). Normalized and filtered to the live
+   * entries at sign time, so an expired overlap secret is never signed with.
+   */
+  secretHash: unknown;
   /** Stored as an integer on SQLite, so it is coerced before it is trusted. */
   enabled: unknown;
 }
@@ -443,11 +448,24 @@ async function attemptDelivery(
     );
   }
 
-  // A webhook with no stored secret can never be signed (buildSignatureHeaders
+  // Resolve the live signing secrets: normalize the stored cell (tolerating the
+  // legacy bare-string form) and drop any overlap secret whose window has
+  // closed, so a rotated-away key stops signing exactly when it expires. The
+  // prefix/createdAt fallbacks are immaterial here — only the ciphertext of a
+  // live entry is used.
+  const liveEntries = liveSecretEntries(
+    normalizeSecretEntries(webhook.secretHash, {
+      prefix: "",
+      createdAt: claimedAt.toISOString(),
+    }),
+    now()
+  );
+
+  // A webhook with no live secret can never be signed (buildSignatureHeaders
   // rejects an empty secret list, which every conformant receiver would too).
   // That is a permanent misconfiguration, so fail rather than throw uncaught
   // and strand the leased row.
-  if (webhook.secretHash.length === 0) {
+  if (liveEntries.length === 0) {
     deps.logger?.warn(
       `webhook delivery ${row.id} undeliverable (webhook has no signing secret); marking failed`
     );
@@ -473,7 +491,7 @@ async function attemptDelivery(
   const timestamp = Math.floor(claimedAt.getTime() / 1000).toString();
   let secrets: string[];
   try {
-    secrets = webhook.secretHash.map(ct => deps.decryptSecret(ct));
+    secrets = liveEntries.map(entry => deps.decryptSecret(entry.ciphertext));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     deps.logger?.warn(

--- a/packages/nextly/src/domains/webhooks/endpoint-registry.ts
+++ b/packages/nextly/src/domains/webhooks/endpoint-registry.ts
@@ -10,6 +10,7 @@
  * @module domains/webhooks/endpoint-registry
  */
 
+import { normalizeSecretEntries } from "./secret-entries";
 import type {
   FilterSpec,
   WebhookEndpoint,
@@ -70,9 +71,15 @@ function toEndpoint(row: Record<string, unknown>): WebhookEndpoint {
       : [],
     filter: normalizeFilter(row.filter),
     headers: (row.headers as Record<string, string> | null) ?? null,
-    secretHash: Array.isArray(row.secretHash)
-      ? (row.secretHash as string[])
-      : [],
+    // Normalized to the entry shape (tolerating the legacy bare-string form).
+    // Carried for completeness only; delivery signs from its own row read.
+    secretHash: normalizeSecretEntries(row.secretHash, {
+      prefix: (row.secretPrefix as string) ?? "",
+      createdAt:
+        row.createdAt instanceof Date
+          ? row.createdAt.toISOString()
+          : new Date(0).toISOString(),
+    }),
     secretPrefix: (row.secretPrefix as string) ?? "",
     fieldAllowlist: Array.isArray(row.fieldAllowlist)
       ? (row.fieldAllowlist as string[])

--- a/packages/nextly/src/domains/webhooks/secret-entries.ts
+++ b/packages/nextly/src/domains/webhooks/secret-entries.ts
@@ -1,0 +1,153 @@
+/**
+ * Webhook domain — the stored signing-secret entry shape and its lifecycle.
+ *
+ * `secret.ts` owns the crypto (generate, encrypt, decrypt, display prefix). This
+ * module owns the SHAPE of what a `nextly_webhooks.secret_hash` cell holds and
+ * the rules for a rotation with an overlap window.
+ *
+ * The column is a JSON array so rotation is additive without a migration. It
+ * started life as an array of bare ciphertext strings; this module widens each
+ * entry to carry its display prefix and lifecycle timestamps, and reads the old
+ * bare-string form back transparently so existing endpoints keep signing without
+ * a data migration.
+ *
+ * A secret with `expiresAt === null` is the live primary — the one new
+ * deliveries are prefixed by and the one a reveal reports first. A rotation
+ * stamps the previous primary with an `expiresAt` in the future (the overlap
+ * window) so a receiver that has not yet switched still verifies; once that
+ * passes the entry is no longer live and is pruned on the next write.
+ *
+ * @module domains/webhooks/secret-entries
+ */
+
+import { encryptWebhookSecret, webhookSecretPrefix } from "./secret";
+
+/**
+ * One stored signing secret. `ciphertext` is the AES-GCM value `secret.ts`
+ * produces; `prefix` is the display-only fragment shown in the admin so an
+ * operator can tell secrets apart during a rotation; `createdAt`/`expiresAt` are
+ * ISO-8601 instants. `expiresAt === null` marks the live primary.
+ */
+export interface StoredSecretEntry {
+  ciphertext: string;
+  prefix: string;
+  createdAt: string;
+  expiresAt: string | null;
+}
+
+/** No overlap: the previous secret is retired immediately on rotation. */
+export const WEBHOOK_ROTATION_MIN_OVERLAP_SECONDS = 0;
+
+/**
+ * The longest overlap a rotation may request. A month is generous slack for a
+ * receiver to redeploy with the new secret; beyond it the old key is a standing
+ * liability rather than a migration aid.
+ */
+export const WEBHOOK_ROTATION_MAX_OVERLAP_SECONDS = 30 * 24 * 60 * 60;
+
+/**
+ * The default overlap when a rotation does not name one: two days, enough to
+ * span a weekend deploy freeze without keeping the old key alive for a week.
+ */
+export const WEBHOOK_ROTATION_DEFAULT_OVERLAP_SECONDS = 48 * 60 * 60;
+
+/** Whether an entry is still usable for signing at `now`. */
+export function isSecretEntryLive(
+  entry: StoredSecretEntry,
+  now: Date
+): boolean {
+  if (entry.expiresAt === null) return true;
+  const expiresMs = Date.parse(entry.expiresAt);
+  // A malformed expiry cannot be trusted to be in the future, so treat it as
+  // expired rather than let an unparseable value keep a secret alive forever.
+  if (Number.isNaN(expiresMs)) return false;
+  return expiresMs > now.getTime();
+}
+
+/**
+ * Build a fresh primary entry from a plaintext secret. `expiresAt` defaults to
+ * null (a primary); a rotation passes a future instant to make it an
+ * overlapping, soon-to-retire secret instead.
+ */
+export function newSecretEntry(
+  secret: string,
+  now: Date,
+  expiresAt: string | null = null
+): StoredSecretEntry {
+  return {
+    ciphertext: encryptWebhookSecret(secret),
+    prefix: webhookSecretPrefix(secret),
+    createdAt: now.toISOString(),
+    expiresAt,
+  };
+}
+
+/** A stored value read as one entry, or null when it is unusable. */
+function coerceEntry(
+  value: unknown,
+  fallback: { prefix: string; createdAt: string }
+): StoredSecretEntry | null {
+  // Legacy form: a bare ciphertext string. It is the single primary the
+  // endpoint was created with, so it inherits the row's display prefix and
+  // creation time and never auto-expires.
+  if (typeof value === "string") {
+    if (value.length === 0) return null;
+    return {
+      ciphertext: value,
+      prefix: fallback.prefix,
+      createdAt: fallback.createdAt,
+      expiresAt: null,
+    };
+  }
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.ciphertext !== "string" || record.ciphertext.length === 0) {
+    return null;
+  }
+  return {
+    ciphertext: record.ciphertext,
+    prefix: typeof record.prefix === "string" ? record.prefix : fallback.prefix,
+    createdAt:
+      typeof record.createdAt === "string"
+        ? record.createdAt
+        : fallback.createdAt,
+    expiresAt: typeof record.expiresAt === "string" ? record.expiresAt : null,
+  };
+}
+
+/**
+ * Read a stored `secret_hash` cell into entries, tolerating both the current
+ * object form and the legacy bare-string form. `fallback` supplies the prefix
+ * and creation time a legacy entry lacks (the row's own `secret_prefix` and
+ * `created_at`). A non-array or fully-malformed cell reads as no entries.
+ */
+export function normalizeSecretEntries(
+  stored: unknown,
+  fallback: { prefix: string; createdAt: string }
+): StoredSecretEntry[] {
+  if (!Array.isArray(stored)) return [];
+  const entries: StoredSecretEntry[] = [];
+  for (const value of stored) {
+    const entry = coerceEntry(value, fallback);
+    if (entry) entries.push(entry);
+  }
+  return entries;
+}
+
+/**
+ * The entries still usable at `now`, primary first. Ordering matters: the
+ * signing path prefixes with the first secret, and a reveal reports it as the
+ * current one, so the never-expiring primary is always placed ahead of the
+ * overlapping secrets (themselves ordered soonest-to-expire last).
+ */
+export function liveSecretEntries(
+  entries: StoredSecretEntry[],
+  now: Date
+): StoredSecretEntry[] {
+  const live = entries.filter(entry => isSecretEntryLive(entry, now));
+  const primary = live.filter(entry => entry.expiresAt === null);
+  const overlapping = live
+    .filter(entry => entry.expiresAt !== null)
+    .sort((a, b) => Date.parse(b.expiresAt!) - Date.parse(a.expiresAt!));
+  return [...primary, ...overlapping];
+}

--- a/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
+++ b/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
@@ -293,7 +293,7 @@ export class WebhookEndpointService extends BaseService {
    * decrypt), so expired overlap secrets are never surfaced or signed with.
    */
   private liveSecretEntries(
-    row: WebhookRow,
+    row: { secretHash: unknown; secretPrefix: string; createdAt: Date },
     now: Date = new Date()
   ): StoredSecretEntry[] {
     const entries = normalizeSecretEntries(row.secretHash, {
@@ -618,19 +618,56 @@ export class WebhookEndpointService extends BaseService {
     return value;
   }
 
-  /** Read one live (non-retired) row for a secret write, or throw not-found. */
-  private async loadLiveRow(id: string): Promise<WebhookRow> {
-    const rows = await this.query(
-      async () =>
-        (await this.db
-          .select()
-          .from(this.table)
-          .where(and(eq(this.table.id, id), isNull(this.table.deletedAt)))
-          .limit(1)) as WebhookRow[]
+  /**
+   * Read the endpoint's secrets under a `FOR UPDATE` row lock, let `mutate`
+   * compute the next entry list, and write it back in the same transaction.
+   *
+   * The lock serializes concurrent secret writes: a second rotation blocks until
+   * the first commits, then reads the updated row, so it can never overwrite the
+   * first's freshly-issued primary from a stale snapshot. The retired-row check
+   * runs inside the lock as well, so a rotation or expiry cannot write a secret
+   * back onto an endpoint a concurrent `deleteEndpoint` just soft-deleted and
+   * cleared. `secret_prefix` follows the new primary (the first entry). A missing
+   * or retired row throws not-found.
+   */
+  private async withLockedSecrets<T>(
+    id: string,
+    mutate: (
+      row: { secretHash: unknown; secretPrefix: string; createdAt: Date },
+      now: Date
+    ) => { entries: StoredSecretEntry[]; result: T }
+  ): Promise<T> {
+    const outcome = await this.query(() =>
+      this.adapter.transaction(async tx => {
+        const rows = await tx.select<{
+          secretHash: unknown;
+          secretPrefix: string;
+          createdAt: Date;
+          deletedAt: Date | null;
+        }>("nextly_webhooks", {
+          where: { and: [{ column: "id", op: "=", value: id }] },
+          limit: 1,
+          forUpdate: true,
+        });
+        const row = rows[0];
+        if (!row || row.deletedAt != null) return null;
+
+        const now = new Date();
+        const { entries, result } = mutate(row, now);
+        await tx.update(
+          "nextly_webhooks",
+          {
+            secret_hash: entries,
+            secret_prefix: entries[0]?.prefix ?? row.secretPrefix,
+            updated_at: now,
+          },
+          { and: [{ column: "id", op: "=", value: id }] }
+        );
+        return { result };
+      })
     );
-    const row = rows[0];
-    if (!row) throw this.notFound(id);
-    return row;
+    if (outcome === null) throw this.notFound(id);
+    return outcome.result;
   }
 
   /**
@@ -643,44 +680,39 @@ export class WebhookEndpointService extends BaseService {
    * until then; `overlapSeconds = 0` retires it at once. At most one overlapping
    * secret is kept — rotating again while one is still overlapping retires the
    * older one — so a delivery never carries more than two signatures, and
-   * already-expired entries are pruned. The new secret is returned once.
+   * already-expired entries are pruned. The read-modify-write runs under a row
+   * lock, so concurrent rotations serialize rather than lose a secret. The new
+   * secret is returned once.
    */
   async rotateSecret(
     id: string,
     input: RotateWebhookSecretInput = {}
   ): Promise<CreatedWebhookEndpoint> {
     const overlapSeconds = this.resolveOverlapSeconds(input.overlapSeconds);
-    const row = await this.loadLiveRow(id);
 
-    const now = new Date();
-    const live = this.liveSecretEntries(row, now);
-    const secret = generateWebhookSecret();
-    const primary = newSecretEntry(secret, now);
+    const secret = await this.withLockedSecrets(id, (row, now) => {
+      const fresh = generateWebhookSecret();
+      const primary = newSecretEntry(fresh, now);
 
-    // Only the outgoing primary earns an overlap window. Any other live entry is
-    // already an overlap from an earlier rotation; a new rotation supersedes it,
-    // so it is dropped rather than accumulated — bounding the signature header.
-    const previousPrimary = live.find(entry => entry.expiresAt === null);
-    const nextEntries: StoredSecretEntry[] = [primary];
-    if (previousPrimary && overlapSeconds > 0) {
-      nextEntries.push({
-        ...previousPrimary,
-        expiresAt: new Date(
-          now.getTime() + overlapSeconds * 1000
-        ).toISOString(),
-      });
-    }
+      // Only the outgoing primary earns an overlap window. Any other live entry
+      // is already an overlap from an earlier rotation; a new rotation
+      // supersedes it, so it is dropped rather than accumulated — bounding the
+      // signature header at two.
+      const previousPrimary = this.liveSecretEntries(row, now).find(
+        entry => entry.expiresAt === null
+      );
+      const entries: StoredSecretEntry[] = [primary];
+      if (previousPrimary && overlapSeconds > 0) {
+        entries.push({
+          ...previousPrimary,
+          expiresAt: new Date(
+            now.getTime() + overlapSeconds * 1000
+          ).toISOString(),
+        });
+      }
+      return { entries, result: fresh };
+    });
 
-    await this.query(() =>
-      this.db
-        .update(this.table)
-        .set({
-          secretHash: nextEntries,
-          secretPrefix: primary.prefix,
-          updatedAt: now,
-        })
-        .where(eq(this.table.id, id))
-    );
     // The delivery path reads secrets from its own row, but the cached registry
     // still lists this endpoint; invalidate so nothing serves a stale copy.
     this.registry?.invalidate();
@@ -693,26 +725,16 @@ export class WebhookEndpointService extends BaseService {
   /**
    * Retire every overlapping secret immediately, leaving only the primary. The
    * deliberate way to cut a rotation's overlap short once the receiver has
-   * switched. A no-op (beyond a timestamp touch) when there is nothing to expire.
+   * switched. Runs under the same row lock, so it cannot race a rotation or a
+   * delete. A no-op (beyond a timestamp touch) when there is nothing to expire.
    */
   async expireOldSecrets(id: string): Promise<WebhookEndpointSummary> {
-    const row = await this.loadLiveRow(id);
-
-    const now = new Date();
-    const primaryOnly = this.liveSecretEntries(row, now).filter(
-      entry => entry.expiresAt === null
-    );
-
-    await this.query(() =>
-      this.db
-        .update(this.table)
-        .set({
-          secretHash: primaryOnly,
-          secretPrefix: primaryOnly[0]?.prefix ?? row.secretPrefix,
-          updatedAt: now,
-        })
-        .where(eq(this.table.id, id))
-    );
+    await this.withLockedSecrets(id, (row, now) => {
+      const primaryOnly = this.liveSecretEntries(row, now).filter(
+        entry => entry.expiresAt === null
+      );
+      return { entries: primaryOnly, result: undefined };
+    });
     this.registry?.invalidate();
 
     const updated = await this.getEndpoint(id);

--- a/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
+++ b/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
@@ -48,22 +48,39 @@ import {
 } from "../../../utils/validate-external-url";
 import type { DeliverTransport } from "../deliver";
 import type { WebhookEndpointRegistry } from "../endpoint-registry";
+import { decryptWebhookSecret, generateWebhookSecret } from "../secret";
 import {
-  decryptWebhookSecret,
-  encryptWebhookSecret,
-  generateWebhookSecret,
-  webhookSecretPrefix,
-} from "../secret";
+  liveSecretEntries,
+  newSecretEntry,
+  normalizeSecretEntries,
+  WEBHOOK_ROTATION_DEFAULT_OVERLAP_SECONDS,
+  WEBHOOK_ROTATION_MAX_OVERLAP_SECONDS,
+  type StoredSecretEntry,
+} from "../secret-entries";
 import { runEndpointProbe, type WebhookTestResult } from "../test-endpoint";
 import { REDACTED_HEADER_VALUE } from "../types";
 import type { WebhookEventSubscription } from "../types";
 
 /**
+ * A signing secret described without revealing it: the display prefix and its
+ * lifecycle. `isPrimary` marks the secret new deliveries are prefixed by;
+ * `expiresAt` is when an overlapping (rotated-away) secret stops signing, or
+ * null for the primary. Safe to return on an ordinary read — it carries no key
+ * material, only what the admin needs to show a rotation's state.
+ */
+export interface WebhookSecretInfo {
+  prefix: string;
+  isPrimary: boolean;
+  createdAt: Date;
+  expiresAt: Date | null;
+}
+
+/**
  * An endpoint as any caller after creation sees it.
  *
- * Carries `secretPrefix` but never the secret or its ciphertext: reading the
- * secret is a separate, separately-authorisable act, so it must not ride along
- * on an ordinary list or fetch.
+ * Carries `secretPrefix` and the `secrets` lifecycle summary but never a secret
+ * or its ciphertext: reading a secret is a separate, separately-authorisable
+ * act, so it must not ride along on an ordinary list or fetch.
  */
 export interface WebhookEndpointSummary {
   id: string;
@@ -72,7 +89,10 @@ export interface WebhookEndpointSummary {
   enabled: boolean;
   eventTypes: WebhookEventSubscription[];
   headers: Record<string, string> | null;
+  /** Prefix of the current primary signing secret. */
   secretPrefix: string;
+  /** Every active signing secret's non-sensitive lifecycle, primary first. */
+  secrets: WebhookSecretInfo[];
   createdBy: string | null;
   createdAt: Date;
   updatedAt: Date;
@@ -98,6 +118,14 @@ export interface UpdateWebhookEndpointInput {
   eventTypes?: WebhookEventSubscription[];
   enabled?: boolean;
   headers?: Record<string, string> | null;
+}
+
+export interface RotateWebhookSecretInput {
+  /**
+   * How long the secret being rotated away stays valid, in seconds. 0 retires
+   * it immediately; the default (when omitted) is the standard overlap window.
+   */
+  overlapSeconds?: number;
 }
 
 type WebhooksTable =
@@ -258,8 +286,26 @@ export class WebhookEndpointService extends BaseService {
     }
   }
 
+  /**
+   * The row's signing secrets that are still live at `now`, primary first,
+   * tolerating both the current entry form and the legacy bare-string form.
+   * Shared by the summary (metadata only) and the reveal/test paths (which
+   * decrypt), so expired overlap secrets are never surfaced or signed with.
+   */
+  private liveSecretEntries(
+    row: WebhookRow,
+    now: Date = new Date()
+  ): StoredSecretEntry[] {
+    const entries = normalizeSecretEntries(row.secretHash, {
+      prefix: row.secretPrefix,
+      createdAt: row.createdAt.toISOString(),
+    });
+    return liveSecretEntries(entries, now);
+  }
+
   /** Narrow a stored row to what a caller may see. */
   private toSummary(row: WebhookRow): WebhookEndpointSummary {
+    const secrets = this.liveSecretEntries(row);
     return {
       id: row.id,
       name: row.name,
@@ -272,7 +318,15 @@ export class WebhookEndpointService extends BaseService {
       // values are not, because delivery sends them verbatim and they are
       // routinely a credential for the receiver.
       headers: redactHeaderValues(row.headers),
-      secretPrefix: row.secretPrefix,
+      // Derived from the live primary rather than the stored column so the two
+      // never drift; falls back to the column for a row with no live secret.
+      secretPrefix: secrets[0]?.prefix ?? row.secretPrefix,
+      secrets: secrets.map(entry => ({
+        prefix: entry.prefix,
+        isPrimary: entry.expiresAt === null,
+        createdAt: new Date(entry.createdAt),
+        expiresAt: entry.expiresAt ? new Date(entry.expiresAt) : null,
+      })),
       createdBy: row.createdBy,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
@@ -294,6 +348,9 @@ export class WebhookEndpointService extends BaseService {
 
     const secret = generateWebhookSecret();
     const now = new Date();
+    // A single primary entry (never-expiring). List-shaped from the first write,
+    // so a rotation appends an overlapping secret rather than migrating a shape.
+    const entry = newSecretEntry(secret, now);
     const row = {
       id: crypto.randomUUID(),
       name: input.name,
@@ -302,10 +359,8 @@ export class WebhookEndpointService extends BaseService {
       eventTypes: input.eventTypes,
       filter: null,
       headers: input.headers ?? null,
-      // List-shaped from the first write, so adding a second active secret
-      // during a rotation is an append rather than a migration.
-      secretHash: [encryptWebhookSecret(secret)],
-      secretPrefix: webhookSecretPrefix(secret),
+      secretHash: [entry],
+      secretPrefix: entry.prefix,
       fieldAllowlist: null,
       createdBy,
       createdAt: now,
@@ -530,8 +585,139 @@ export class WebhookEndpointService extends BaseService {
     const row = rows[0];
     if (!row) throw this.notFound(id);
 
-    const stored = Array.isArray(row.secretHash) ? row.secretHash : [];
-    return stored.map(value => decryptWebhookSecret(String(value)));
+    // Only live secrets are revealed: an expired overlap secret no longer signs
+    // anything, so returning it would just be a stale key to reconcile against.
+    return this.liveSecretEntries(row).map(entry =>
+      decryptWebhookSecret(entry.ciphertext)
+    );
+  }
+
+  /**
+   * Validate a requested overlap window, defaulting when omitted. Enforced in
+   * the service (not only the route) so a Direct-API caller cannot store an
+   * out-of-range window that would keep an old key alive indefinitely.
+   */
+  private resolveOverlapSeconds(value: number | undefined): number {
+    if (value === undefined) return WEBHOOK_ROTATION_DEFAULT_OVERLAP_SECONDS;
+    if (
+      !Number.isInteger(value) ||
+      value < 0 ||
+      value > WEBHOOK_ROTATION_MAX_OVERLAP_SECONDS
+    ) {
+      throw NextlyError.validation({
+        errors: [
+          {
+            path: "overlapSeconds",
+            code: "out_of_range",
+            message: `Overlap must be a whole number of seconds between 0 and ${WEBHOOK_ROTATION_MAX_OVERLAP_SECONDS}.`,
+          },
+        ],
+        logContext: { reason: "webhook-overlap-out-of-range", value },
+      });
+    }
+    return value;
+  }
+
+  /** Read one live (non-retired) row for a secret write, or throw not-found. */
+  private async loadLiveRow(id: string): Promise<WebhookRow> {
+    const rows = await this.query(
+      async () =>
+        (await this.db
+          .select()
+          .from(this.table)
+          .where(and(eq(this.table.id, id), isNull(this.table.deletedAt)))
+          .limit(1)) as WebhookRow[]
+    );
+    const row = rows[0];
+    if (!row) throw this.notFound(id);
+    return row;
+  }
+
+  /**
+   * Rotate the signing secret, keeping the previous one valid for an overlap
+   * window so a receiver can switch over without dropping a delivery.
+   *
+   * A fresh secret becomes the primary that new deliveries are prefixed by. The
+   * previous primary is stamped `expiresAt = now + overlapSeconds` and stays
+   * live (and signed with, via the Standard Webhooks multi-signature header)
+   * until then; `overlapSeconds = 0` retires it at once. At most one overlapping
+   * secret is kept — rotating again while one is still overlapping retires the
+   * older one — so a delivery never carries more than two signatures, and
+   * already-expired entries are pruned. The new secret is returned once.
+   */
+  async rotateSecret(
+    id: string,
+    input: RotateWebhookSecretInput = {}
+  ): Promise<CreatedWebhookEndpoint> {
+    const overlapSeconds = this.resolveOverlapSeconds(input.overlapSeconds);
+    const row = await this.loadLiveRow(id);
+
+    const now = new Date();
+    const live = this.liveSecretEntries(row, now);
+    const secret = generateWebhookSecret();
+    const primary = newSecretEntry(secret, now);
+
+    // Only the outgoing primary earns an overlap window. Any other live entry is
+    // already an overlap from an earlier rotation; a new rotation supersedes it,
+    // so it is dropped rather than accumulated — bounding the signature header.
+    const previousPrimary = live.find(entry => entry.expiresAt === null);
+    const nextEntries: StoredSecretEntry[] = [primary];
+    if (previousPrimary && overlapSeconds > 0) {
+      nextEntries.push({
+        ...previousPrimary,
+        expiresAt: new Date(
+          now.getTime() + overlapSeconds * 1000
+        ).toISOString(),
+      });
+    }
+
+    await this.query(() =>
+      this.db
+        .update(this.table)
+        .set({
+          secretHash: nextEntries,
+          secretPrefix: primary.prefix,
+          updatedAt: now,
+        })
+        .where(eq(this.table.id, id))
+    );
+    // The delivery path reads secrets from its own row, but the cached registry
+    // still lists this endpoint; invalidate so nothing serves a stale copy.
+    this.registry?.invalidate();
+
+    const updated = await this.getEndpoint(id);
+    if (!updated) throw this.notFound(id);
+    return { endpoint: updated, secret };
+  }
+
+  /**
+   * Retire every overlapping secret immediately, leaving only the primary. The
+   * deliberate way to cut a rotation's overlap short once the receiver has
+   * switched. A no-op (beyond a timestamp touch) when there is nothing to expire.
+   */
+  async expireOldSecrets(id: string): Promise<WebhookEndpointSummary> {
+    const row = await this.loadLiveRow(id);
+
+    const now = new Date();
+    const primaryOnly = this.liveSecretEntries(row, now).filter(
+      entry => entry.expiresAt === null
+    );
+
+    await this.query(() =>
+      this.db
+        .update(this.table)
+        .set({
+          secretHash: primaryOnly,
+          secretPrefix: primaryOnly[0]?.prefix ?? row.secretPrefix,
+          updatedAt: now,
+        })
+        .where(eq(this.table.id, id))
+    );
+    this.registry?.invalidate();
+
+    const updated = await this.getEndpoint(id);
+    if (!updated) throw this.notFound(id);
+    return updated;
   }
 
   /**
@@ -561,8 +747,9 @@ export class WebhookEndpointService extends BaseService {
     const row = rows[0];
     if (!row) throw this.notFound(id);
 
-    const stored = Array.isArray(row.secretHash) ? row.secretHash : [];
-    const secrets = stored.map(value => decryptWebhookSecret(String(value)));
+    const secrets = this.liveSecretEntries(row).map(entry =>
+      decryptWebhookSecret(entry.ciphertext)
+    );
     if (secrets.length === 0) {
       // A delivery must be signed; without a secret there is nothing to sign.
       throw NextlyError.conflict({

--- a/packages/nextly/src/domains/webhooks/types.ts
+++ b/packages/nextly/src/domains/webhooks/types.ts
@@ -10,6 +10,8 @@
  * @module domains/webhooks/types
  */
 
+import type { StoredSecretEntry } from "./secret-entries";
+
 /**
  * Canonical webhook event types, grouped by resource. Stable string ids; the
  * envelope's `specversion` (not renames) carries breaking changes. A webhook
@@ -193,8 +195,12 @@ export interface WebhookEndpoint {
   filter: FilterSpec | null;
   /** Static request headers merged into every delivery. */
   headers: Record<string, string> | null;
-  /** List of active signing-secret hashes (list-shaped for rotation). */
-  secretHash: string[];
+  /**
+   * Stored signing-secret entries (list-shaped for rotation). Carried for
+   * completeness; the delivery path reads and signs from its own row rather
+   * than this cached copy.
+   */
+  secretHash: StoredSecretEntry[];
   secretPrefix: string;
   /** Reserved per-endpoint field projection; not applied yet. */
   fieldAllowlist: string[] | null;

--- a/packages/nextly/src/route-handler/__tests__/route-parser.webhooks.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.webhooks.test.ts
@@ -86,6 +86,39 @@ describe("webhook routes", () => {
     ).toEqual({});
   });
 
+  it("parses a secret rotation", () => {
+    expect(
+      parseRestRoute(["webhooks", "wh_1", "secret", "rotate"], "POST")
+    ).toMatchObject({
+      service: "webhooks",
+      method: "rotateWebhookSecret",
+      routeParams: { webhookId: "wh_1" },
+    });
+  });
+
+  it("parses expiring the old secret", () => {
+    expect(
+      parseRestRoute(["webhooks", "wh_1", "secret", "expire-old"], "POST")
+    ).toMatchObject({
+      service: "webhooks",
+      method: "expireWebhookOldSecrets",
+      routeParams: { webhookId: "wh_1" },
+    });
+  });
+
+  it("routes rotate and expire-old only under POST", () => {
+    // Both mint or retire key material, so a non-POST (including a CSRF-driven
+    // top-level GET navigation) must not reach them.
+    for (const method of ["GET", "PATCH", "DELETE"]) {
+      expect(
+        parseRestRoute(["webhooks", "wh_1", "secret", "rotate"], method)
+      ).toEqual({});
+      expect(
+        parseRestRoute(["webhooks", "wh_1", "secret", "expire-old"], method)
+      ).toEqual({});
+    }
+  });
+
   it("does not match a path nested deeper than an endpoint", () => {
     expect(parseRestRoute(["webhooks", "wh_1", "a", "b"], "GET")).toEqual({});
   });

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -1782,6 +1782,43 @@ function parseWebhookRoutes(
     };
   }
 
+  // POST /api/webhooks/:id/secret/rotate → rotate the signing secret with an
+  // overlap window (session-only). Handled before the one-level guard because
+  // it nests a level under `secret`.
+  if (
+    id &&
+    subresource === "secret" &&
+    subId === "rotate" &&
+    additionalParams.length === 0
+  ) {
+    if (httpMethod !== "POST") return null;
+    routeParams.webhookId = id;
+    return {
+      service: "webhooks",
+      operation: "single",
+      method: "rotateWebhookSecret",
+      routeParams,
+    };
+  }
+
+  // POST /api/webhooks/:id/secret/expire-old → immediately retire every
+  // overlapping (rotated-away) secret, leaving only the primary (session-only).
+  if (
+    id &&
+    subresource === "secret" &&
+    subId === "expire-old" &&
+    additionalParams.length === 0
+  ) {
+    if (httpMethod !== "POST") return null;
+    routeParams.webhookId = id;
+    return {
+      service: "webhooks",
+      operation: "single",
+      method: "expireWebhookOldSecrets",
+      routeParams,
+    };
+  }
+
   // Nothing else here nests further than one level, so any deeper path is not a
   // route. Without this, `/webhooks/:id/secret/anything` would still match the
   // secret branch and hand back active signing secrets.

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -66,6 +66,8 @@ import {
   updateWebhook,
   deleteWebhook,
   revealWebhookSecret,
+  rotateWebhookSecret,
+  expireWebhookOldSecrets,
   listWebhookDeliveries,
   getWebhookDelivery,
   testWebhookEndpoint,
@@ -328,6 +330,10 @@ async function handleWebhookRequest(
       return deleteWebhook(req, id);
     case "revealWebhookSecret":
       return revealWebhookSecret(req, id);
+    case "rotateWebhookSecret":
+      return rotateWebhookSecret(req, id);
+    case "expireWebhookOldSecrets":
+      return expireWebhookOldSecrets(req, id);
     case "listWebhookDeliveries":
       return listWebhookDeliveries(req, id);
     case "getWebhookDelivery":

--- a/packages/nextly/src/schemas/_zod/__tests__/webhooks.test.ts
+++ b/packages/nextly/src/schemas/_zod/__tests__/webhooks.test.ts
@@ -13,7 +13,12 @@ import {
   REDACTED_HEADER_VALUE,
   WEBHOOK_EVENT_TYPES,
 } from "../../../domains/webhooks/types";
-import { CreateWebhookSchema, UpdateWebhookSchema } from "../webhooks";
+import {
+  CreateWebhookSchema,
+  RotateWebhookSchema,
+  UpdateWebhookSchema,
+} from "../webhooks";
+import { WEBHOOK_ROTATION_MAX_OVERLAP_SECONDS } from "../../../domains/webhooks/secret-entries";
 
 const valid = {
   name: "Orders",
@@ -162,5 +167,36 @@ describe("UpdateWebhookSchema", () => {
       headers: { "webhook-signature": "forged" },
     });
     expect(parsed.success).toBe(false);
+  });
+});
+
+describe("RotateWebhookSchema", () => {
+  it("accepts an empty body (default overlap) and a zero window", () => {
+    expect(RotateWebhookSchema.safeParse({}).success).toBe(true);
+    expect(RotateWebhookSchema.safeParse({ overlapSeconds: 0 }).success).toBe(
+      true
+    );
+  });
+
+  it("accepts a window up to the ceiling", () => {
+    expect(
+      RotateWebhookSchema.safeParse({
+        overlapSeconds: WEBHOOK_ROTATION_MAX_OVERLAP_SECONDS,
+      }).success
+    ).toBe(true);
+  });
+
+  it("rejects a negative, fractional, or over-ceiling window", () => {
+    expect(RotateWebhookSchema.safeParse({ overlapSeconds: -1 }).success).toBe(
+      false
+    );
+    expect(RotateWebhookSchema.safeParse({ overlapSeconds: 1.5 }).success).toBe(
+      false
+    );
+    expect(
+      RotateWebhookSchema.safeParse({
+        overlapSeconds: WEBHOOK_ROTATION_MAX_OVERLAP_SECONDS + 1,
+      }).success
+    ).toBe(false);
   });
 });

--- a/packages/nextly/src/schemas/_zod/webhooks.ts
+++ b/packages/nextly/src/schemas/_zod/webhooks.ts
@@ -20,6 +20,7 @@
 
 import { z } from "zod";
 
+import { WEBHOOK_ROTATION_MAX_OVERLAP_SECONDS } from "../../domains/webhooks/secret-entries";
 import {
   REDACTED_HEADER_VALUE,
   WEBHOOK_EVENT_TYPES,
@@ -168,5 +169,22 @@ export const UpdateWebhookSchema = z
     message: "Provide at least one field to update.",
   });
 
+/**
+ * Rotating a signing secret. `overlapSeconds` is how long the rotated-away
+ * secret stays valid so a receiver can switch over: 0 retires it immediately,
+ * omitting it uses the service default, and the ceiling stops an old key being
+ * kept alive indefinitely. The body is optional, so a plain rotate with no body
+ * takes the default overlap.
+ */
+export const RotateWebhookSchema = z.object({
+  overlapSeconds: z
+    .number()
+    .int("Overlap must be a whole number of seconds.")
+    .min(0, "Overlap cannot be negative.")
+    .max(WEBHOOK_ROTATION_MAX_OVERLAP_SECONDS, "Overlap window is too long.")
+    .optional(),
+});
+
 export type CreateWebhookInput = z.infer<typeof CreateWebhookSchema>;
 export type UpdateWebhookInput = z.infer<typeof UpdateWebhookSchema>;
+export type RotateWebhookInput = z.infer<typeof RotateWebhookSchema>;


### PR DESCRIPTION
## What

Adds **webhook signing-secret rotation with a configurable overlap window** — the last piece of the webhook product surface (after the engine, endpoint management #313, and the delivery log #315).

An endpoint's signing secret can now be rotated from the admin: a fresh secret becomes the **primary** and the previous one keeps signing for a chosen **overlap window** so a receiver can switch over without dropping a delivery. Deliveries in the window carry a signature for **both** secrets (Standard-Webhooks multi-signature), so a receiver holding either verifies. The old secret can be expired early.

## Key finding

The engine was already rotation-capable: `deliver.ts` signs each delivery with every active secret and `verifySignature` accepts any match; `secret_hash` was a JSONB array "list-shaped for rotation." So this PR is the **lifecycle**, not new crypto.

## Backend

- **Secret entries** (`secret-entries.ts`): each `secret_hash` entry widens from a bare ciphertext string to `{ ciphertext, prefix, createdAt, expiresAt }` (`expiresAt: null` = primary). A legacy bare string is read back transparently — **no data migration** (JSONB). Helpers: `normalizeSecretEntries`, `liveSecretEntries` (primary-first, drops expired), `newSecretEntry`, window constants.
- **Service**: `rotateSecret(id, { overlapSeconds })` (new primary, previous primary stamped `expiresAt = now + overlap`, **capped at 2 live secrets** so a delivery never carries >2 signatures, prunes expired) and `expireOldSecrets(id)`. `overlapSeconds` validated `0…30d` in the service (not just the route). The endpoint summary gains a non-sensitive `secrets[]` lifecycle (prefix + timestamps + `isPrimary`); create/reveal/test updated to the entry shape; reveal/sign use only **live** secrets.
- **Delivery** (`deliver.ts`): normalizes + filters to live entries at sign time, so a rotated-away secret stops signing exactly when it expires.
- **REST** (session-only + `update-webhooks`): `POST /webhooks/:id/secret/rotate` `{ overlapSeconds? }` → `{ message, item: { doc, secret } }`; `POST /webhooks/:id/secret/expire-old` → `{ message, item }`. Routes are POST-only (a CSRF-driven GET can't mint/retire key material). `RotateWebhookSchema` added.

## Admin UI

- Edit page: **"Rotate signing secret"** → window-picker dialog (Expire immediately / 24h / **48h default** / 7d / 30d) → one-time secret modal.
- A **"Signing secrets"** lifecycle panel: each active secret's prefix + "Primary" / "Expiring in Xh", with **"Expire old secret now"** when an overlap exists.
- New `rotateSecret` / `expireOldSecrets` service + `useRotateSecret` / `useExpireOldSecrets` hooks; `secrets[]` added to the admin summary type.

## Tests

- `secret-entries` unit (normalize legacy+object, liveness, ordering, window consts)
- route-parser (rotate/expire-old parse; POST-only)
- `RotateWebhookSchema` (default/zero/ceiling/negative/fractional/over-ceiling)
- endpoint-service integration (SQLite): overlap keeps old live + new primary; zero overlap retires immediately; ≤2 live across repeated rotations; out-of-range rejected; expire-old drops overlap
- admin: `webhookApi` rotate/expire; `RotateSecretDialog` (default 48h confirm, pending-disable)

`check-types` + `lint` clean on both packages; delivery/signing/registry regression suites green; full admin suite unchanged at the known 8-file/37-test baseline (zero new failures).

## Changeset

One, all 19 packages `patch` (lockstep alpha).

## Non-goals

Changing the signature scheme; per-secret scopes; incoming-webhook verification.
