### PR TITLE
fix(nextly): content-address media variants, seed localized defaults, reconcile companion status

### DIFF
--- a/.changeset/media-i18n-companion-followups.md
+++ b/.changeset/media-i18n-companion-followups.md
@@ -1,0 +1,36 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Fix three content-integrity edge cases.
+
+- Media focal-point crop regeneration no longer deletes an image's old size
+  variants before the row commits. New variants are written to fresh keys, the
+  row is committed pointing at them, and the superseded old files are deleted
+  only afterwards — so a failed or lost-race write can no longer leave a media
+  item referencing files that were already deleted.
+- A localized single's translatable field defaults (including a localized
+  title/slug) are now seeded onto its default-locale companion row when the
+  single is auto-created, instead of resolving to null until first written.
+- Turning on Draft/Published for an already-localized entity now back-fills the
+  default-locale companion status from the main row, so a later publish of the
+  default locale is recognized as a real transition (and fires its webhook)
+  rather than a no-op against a status that was wrongly reset to draft.

--- a/packages/nextly/src/domains/i18n/migration/reconcile-companion.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/reconcile-companion.test.ts
@@ -115,4 +115,61 @@ describe("buildCompanionReconcileSql", () => {
     });
     expect(sql).toBe("");
   });
+
+  it("back-fills the default-locale companion _status from main when adding _status", () => {
+    // Draft/Published toggled ON after the companion already existed: ADD COLUMN
+    // seeds every row at 'draft', so the default-locale row must be synced from
+    // the main row's status instead of being stranded at 'draft'.
+    const sql = buildCompanionReconcileSql({
+      slug: "posts",
+      tableName: "dc_posts",
+      oldLocalized: [text("body")],
+      newLocalized: [text("body")],
+      dialect: "postgres",
+      status: true,
+      companionExists: true,
+      companionHasStatus: false,
+      defaultLocale: "en",
+    });
+    expect(sql).toContain("ADD COLUMN");
+    expect(sql).toContain("_status");
+    expect(sql).toContain("UPDATE");
+    expect(sql).toContain('"dc_posts_locales"');
+    // Correlated subquery reads the main row's status for the default locale row.
+    expect(sql).toContain('SELECT "status" FROM "dc_posts"');
+    expect(sql).toContain("'en'");
+  });
+
+  it("skips the _status back-fill when no default locale is supplied", () => {
+    // A migrate/DDL path without a live default locale still adds the column but
+    // leaves the back-fill to the runtime path (backwards-compatible default).
+    const sql = buildCompanionReconcileSql({
+      slug: "posts",
+      tableName: "dc_posts",
+      oldLocalized: [text("body")],
+      newLocalized: [text("body")],
+      dialect: "postgres",
+      status: true,
+      companionExists: true,
+      companionHasStatus: false,
+    });
+    expect(sql).toContain("ADD COLUMN");
+    expect(sql).not.toContain("UPDATE");
+  });
+
+  it("does not back-fill when dropping _status (Draft/Published toggled off)", () => {
+    const sql = buildCompanionReconcileSql({
+      slug: "posts",
+      tableName: "dc_posts",
+      oldLocalized: [text("body")],
+      newLocalized: [text("body")],
+      dialect: "postgres",
+      status: false,
+      companionExists: true,
+      companionHasStatus: true,
+      defaultLocale: "en",
+    });
+    expect(sql).toContain("DROP COLUMN");
+    expect(sql).not.toContain("UPDATE");
+  });
 });

--- a/packages/nextly/src/domains/i18n/migration/reconcile-companion.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/reconcile-companion.test.ts
@@ -158,6 +158,10 @@ describe("buildCompanionReconcileSql", () => {
   });
 
   it("does not back-fill when dropping _status (Draft/Published toggled off)", () => {
+    // The back-fill exists only to seed a newly ADDED default-locale `_status`
+    // from the main row. Dropping `_status` removes the column entirely, so there
+    // is nothing to seed — emitting an UPDATE against the just-dropped column
+    // would reference a column that no longer exists.
     const sql = buildCompanionReconcileSql({
       slug: "posts",
       tableName: "dc_posts",

--- a/packages/nextly/src/domains/i18n/migration/reconcile-companion.ts
+++ b/packages/nextly/src/domains/i18n/migration/reconcile-companion.ts
@@ -44,6 +44,13 @@ export interface ReconcileCompanionArgs {
    * introspects it; omit it to leave `_status` untouched (backwards-compatible default).
    */
   companionHasStatus?: boolean;
+  /**
+   * Default locale code. When supplied, ADDing `_status` also back-fills the DEFAULT-locale
+   * companion row's `_status` from the main row's `status`, so the default locale (whose status
+   * IS the main row's) does not get stranded at the column default `'draft'` while the main row is
+   * already published. Omit to skip the back-fill (e.g. a migrate path with no live default locale).
+   */
+  defaultLocale?: string;
 }
 
 /**
@@ -128,6 +135,23 @@ export function buildCompanionReconcileStatements(
       stmts.push(
         `ALTER TABLE ${q(companionTable, dialect)} ADD COLUMN ${q("_status", dialect)} VARCHAR(20) NOT NULL DEFAULT 'draft'`
       );
+      // The ADD COLUMN seeds EVERY existing companion row at 'draft', including
+      // the default-locale row — but the default locale's status IS the main
+      // row's, which may already be 'published'. Back-fill it from main so a
+      // later default-locale publish is a real draft→published transition (and
+      // fires its webhook) rather than a no-op against a wrongly-draft companion.
+      // Only the default-locale row: other locales are genuinely per-locale and
+      // correctly start at 'draft'. The subquery targets a different table (main)
+      // than the one updated, so it is valid on Postgres, MySQL and SQLite.
+      if (args.defaultLocale !== undefined) {
+        const literalLocale = args.defaultLocale.replace(/'/g, "''");
+        stmts.push(
+          `UPDATE ${q(companionTable, dialect)} SET ${q("_status", dialect)} = ` +
+            `(SELECT ${q("status", dialect)} FROM ${q(tableName, dialect)} ` +
+            `WHERE ${q(tableName, dialect)}.${q("id", dialect)} = ${q(companionTable, dialect)}.${q("_parent", dialect)}) ` +
+            `WHERE ${q(companionTable, dialect)}.${q("_locale", dialect)} = '${literalLocale}'`
+        );
+      }
     } else if (!status && args.companionHasStatus) {
       stmts.push(
         `ALTER TABLE ${q(companionTable, dialect)} DROP COLUMN ${q("_status", dialect)}`
@@ -294,6 +318,9 @@ export function buildCompanionTransitionStatements(
         status,
         companionExists,
         companionHasStatus: args.companionHasStatus,
+        // Carry the default locale so a newly-added `_status` back-fills the
+        // default-locale companion row from the main row's status.
+        defaultLocale,
       }),
       needsArchive: false,
       companionDropped: false,

--- a/packages/nextly/src/domains/i18n/runtime/companion-io.test.ts
+++ b/packages/nextly/src/domains/i18n/runtime/companion-io.test.ts
@@ -8,6 +8,10 @@ import {
 
 type ProbeAdapter = Parameters<typeof companionTableExists>[0];
 
+// A minimal adapter fixture: `companionTableExists` only issues one probe query
+// and branches on its outcome, so a stub `executeQuery` (no real database) is
+// enough to isolate and assert that branching — success, verified missing-table,
+// and rethrown-other-error — deterministically.
 const makeAdapter = (
   executeQuery: ProbeAdapter["executeQuery"]
 ): ProbeAdapter => ({ dialect: "postgresql", executeQuery });
@@ -93,6 +97,25 @@ describe("companionTableExists", () => {
     await expect(
       companionTableExists(adapter, "single_x_locales")
     ).rejects.toThrow("connection terminated");
+  });
+
+  it("rethrows a different missing-resource error rather than reading the table absent", async () => {
+    // The classifier is table-specific: a missing DATABASE, schema, or column
+    // shares the "does not exist" wording but is NOT an absent companion table.
+    // Treating it as absent would silently skip the seed and commit unseeded.
+    const otherMissing = [
+      'database "app" does not exist', // postgres: wrong/absent database
+      'column "x" does not exist', // postgres: schema mismatch
+      "Unknown database 'app'", // mysql: absent database
+    ];
+    for (const message of otherMissing) {
+      const adapter = makeAdapter(async () => {
+        throw new Error(message);
+      });
+      await expect(
+        companionTableExists(adapter, "single_x_locales")
+      ).rejects.toThrow(message);
+    }
   });
 });
 

--- a/packages/nextly/src/domains/i18n/runtime/companion-io.test.ts
+++ b/packages/nextly/src/domains/i18n/runtime/companion-io.test.ts
@@ -2,8 +2,15 @@ import { describe, it, expect } from "vitest";
 
 import {
   buildCompanionSchema,
+  companionTableExists,
   splitLocalizedWrite,
 } from "./companion-io";
+
+type ProbeAdapter = Parameters<typeof companionTableExists>[0];
+
+const makeAdapter = (
+  executeQuery: ProbeAdapter["executeQuery"]
+): ProbeAdapter => ({ dialect: "postgresql", executeQuery });
 
 // The shared, entity-agnostic companion I/O seam — used by collections, singles, and
 // components alike. These pin the two pure pieces: the schema shape (which fields are
@@ -49,6 +56,43 @@ describe("buildCompanionSchema", () => {
       dialect: "postgresql",
     });
     expect(schema).toBeNull();
+  });
+});
+
+describe("companionTableExists", () => {
+  it("returns true when the probe select succeeds", async () => {
+    const adapter = makeAdapter(async () => []);
+    expect(await companionTableExists(adapter, "single_x_locales")).toBe(true);
+  });
+
+  it("returns false only for a verified missing-table error", async () => {
+    // Each dialect words an absent table differently; all must read as "false"
+    // (a not-yet-migrated companion), never as an error.
+    const missing = [
+      'relation "single_x_locales" does not exist', // postgres
+      "SQLITE_ERROR: no such table: single_x_locales", // sqlite
+      "Table 'app.single_x_locales' doesn't exist", // mysql
+    ];
+    for (const message of missing) {
+      const adapter = makeAdapter(async () => {
+        throw new Error(message);
+      });
+      expect(await companionTableExists(adapter, "single_x_locales")).toBe(
+        false
+      );
+    }
+  });
+
+  it("rethrows a non-missing-table probe error instead of reporting the table absent", async () => {
+    // A transient/connection/permission failure must propagate: a caller gating
+    // a write on this would otherwise silently skip the write and commit
+    // unseeded, losing data.
+    const adapter = makeAdapter(async () => {
+      throw new Error("connection terminated unexpectedly");
+    });
+    await expect(
+      companionTableExists(adapter, "single_x_locales")
+    ).rejects.toThrow("connection terminated");
   });
 });
 

--- a/packages/nextly/src/domains/i18n/runtime/companion-io.ts
+++ b/packages/nextly/src/domains/i18n/runtime/companion-io.ts
@@ -176,7 +176,29 @@ export async function upsertCompanionRow(
   );
 }
 
-/** Whether the companion `_locales` table physically exists (its migration has run). */
+// Whether a probe error is a verified "table does not exist" for the current
+// dialect, as opposed to a transient/connection/permission/other error. The
+// wording is the dialect's own: Postgres `relation "x" does not exist`, SQLite
+// `no such table: x`, MySQL `Table 'db.x' doesn't exist`. Mirrors the
+// missing-table classification already used in di/register.ts.
+function isMissingTableError(error: unknown): boolean {
+  const message = (
+    error instanceof Error ? error.message : String(error)
+  ).toLowerCase();
+  return (
+    message.includes("does not exist") ||
+    message.includes("no such table") ||
+    message.includes("doesn't exist")
+  );
+}
+
+/**
+ * Whether the companion `_locales` table physically exists (its migration has
+ * run). Returns false ONLY for a verified missing-table error; any other probe
+ * failure (transient, connection, permission) is rethrown, so a caller gating a
+ * write on this never mistakes an unavailable database for an absent table and
+ * silently skips the write.
+ */
 export async function companionTableExists(
   adapter: CompanionWriteAdapter,
   companionTableName: string
@@ -188,8 +210,9 @@ export async function companionTableExists(
   try {
     await adapter.executeQuery(`SELECT 1 FROM ${q} LIMIT 0`);
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    if (isMissingTableError(error)) return false;
+    throw error;
   }
 }
 

--- a/packages/nextly/src/domains/i18n/runtime/companion-io.ts
+++ b/packages/nextly/src/domains/i18n/runtime/companion-io.ts
@@ -176,19 +176,22 @@ export async function upsertCompanionRow(
   );
 }
 
-// Whether a probe error is a verified "table does not exist" for the current
-// dialect, as opposed to a transient/connection/permission/other error. The
-// wording is the dialect's own: Postgres `relation "x" does not exist`, SQLite
-// `no such table: x`, MySQL `Table 'db.x' doesn't exist`. Mirrors the
-// missing-table classification already used in di/register.ts.
+// Whether a probe error is a verified "this TABLE does not exist" for the
+// current dialect, as opposed to a transient/connection/permission error or a
+// different missing resource (a missing DATABASE, schema, column, or role). The
+// match is table-specific on purpose: a bare `does not exist` substring also
+// matches `database "x" does not exist`, which must propagate rather than be
+// misread as an absent companion table. The wording is the dialect's own:
+// Postgres `relation "x" does not exist`, SQLite `no such table: x`, MySQL
+// `Table 'db.x' doesn't exist`.
 function isMissingTableError(error: unknown): boolean {
   const message = (
     error instanceof Error ? error.message : String(error)
   ).toLowerCase();
   return (
-    message.includes("does not exist") ||
+    /relation .* does not exist/.test(message) ||
     message.includes("no such table") ||
-    message.includes("doesn't exist")
+    /table .* doesn't exist/.test(message)
   );
 }
 

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document-versioning.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document-versioning.test.ts
@@ -1,0 +1,121 @@
+/**
+ * The initial version snapshot for an auto-created, versioned, localized Single
+ * must record the seeded localized defaults ONLY when they were actually
+ * persisted — i.e. when the companion `_locales` table physically exists and the
+ * seed ran. When the companion is absent (dev-before-migrate) the seed no-ops,
+ * so v1 must omit those defaults and stay untagged by locale; otherwise
+ * restoring v1 resurrects translations that were never persisted or visible.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+import { SingleQueryService } from "../services/single-query-service";
+
+import {
+  createMockAdapter,
+  createSilentLogger,
+  createMockSingleRegistry,
+  createMockHookRegistry,
+  siteSettingsMeta,
+} from "./single-test-helpers";
+
+// Intercept the version write so the test asserts exactly the snapshot + locale
+// the service hands to capture, without running real version persistence.
+const { capturedCalls } = vi.hoisted(() => ({
+  capturedCalls: [] as unknown[],
+}));
+vi.mock("../../versions/capture-in-tx", () => ({
+  captureInTx: vi.fn(
+    async (
+      _tx: unknown,
+      _capture: unknown,
+      args: unknown
+    ): Promise<unknown> => {
+      capturedCalls.push(args);
+      return { versionNo: 1 };
+    }
+  ),
+}));
+
+type Ctor = ConstructorParameters<typeof SingleQueryService>;
+type SingleMeta = Parameters<SingleQueryService["createDefaultDocument"]>[0];
+interface CapturedCall {
+  parts: { parentRow: Record<string, unknown> };
+  locale: string | null;
+}
+
+function createService(adapter: unknown): SingleQueryService {
+  return new SingleQueryService(
+    adapter as Ctor[0],
+    createSilentLogger() as unknown as Ctor[1],
+    createMockSingleRegistry() as unknown as Ctor[2],
+    createMockHookRegistry() as unknown as Ctor[3],
+    undefined,
+    undefined,
+    { defaultLocale: "en", locales: [{ code: "en" }] } as unknown as Ctor[6]
+  );
+}
+
+// A versioned, localized Single whose localized `siteName` carries a default.
+const meta = () =>
+  siteSettingsMeta({
+    localized: true,
+    status: true,
+    versions: { enabled: true, maxPerDoc: 20 },
+    fields: [
+      {
+        name: "siteName",
+        type: "text",
+        localized: true,
+        defaultValue: "My Site",
+      },
+      { name: "region", type: "text", localized: false, defaultValue: "us" },
+    ],
+  }) as unknown as SingleMeta;
+
+describe("createDefaultDocument initial version + localized default seeding", () => {
+  it("records the seeded default and tags the default locale when the companion exists", async () => {
+    capturedCalls.length = 0;
+    // The pre-transaction probe (SELECT 1 FROM …_locales) succeeds → companion
+    // present; the in-transaction companion seed writes via tx.execute.
+    const adapter = createMockAdapter({
+      executeQuery: vi.fn().mockResolvedValue([]),
+      execute: vi.fn().mockResolvedValue([]),
+    });
+    const service = createService(adapter);
+
+    await service.createDefaultDocument(meta(), {
+      captureInitialVersion: true,
+    });
+
+    expect(capturedCalls).toHaveLength(1);
+    const call = capturedCalls[0] as CapturedCall;
+    expect(call.parts.parentRow.siteName).toBe("My Site");
+    expect(call.locale).toBe("en");
+  });
+
+  it("omits the seeded default and stays locale-untagged when the companion is absent", async () => {
+    capturedCalls.length = 0;
+    // The probe hits a not-yet-migrated table → missing-table error → companion
+    // absent, so the seed no-ops and v1 must not carry the localized default.
+    const adapter = createMockAdapter({
+      executeQuery: vi
+        .fn()
+        .mockRejectedValue(
+          new Error('relation "single_site_settings_locales" does not exist')
+        ),
+      execute: vi.fn().mockResolvedValue([]),
+    });
+    const service = createService(adapter);
+
+    await service.createDefaultDocument(meta(), {
+      captureInitialVersion: true,
+    });
+
+    expect(capturedCalls).toHaveLength(1);
+    const call = capturedCalls[0] as CapturedCall;
+    expect(call.parts.parentRow).not.toHaveProperty("siteName");
+    expect(call.locale).toBeNull();
+    // The companion seed never ran, so nothing was written via tx.execute.
+    expect(adapter.execute).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
@@ -73,9 +73,9 @@ describe("SingleQueryService.buildDefaultDocument", () => {
       fields: [{ name: "title", type: "text", localized: true }],
     });
 
-    const { insertValues, localizedDefaults } =
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock meta
-      service.buildDefaultDocument(meta as any);
+    const { insertValues, localizedDefaults } = service.buildDefaultDocument(
+      meta as unknown as SingleMeta
+    );
 
     expect(localizedDefaults).toHaveProperty("title");
     expect(insertValues).not.toHaveProperty("title");
@@ -87,9 +87,9 @@ describe("SingleQueryService.buildDefaultDocument", () => {
       fields: [{ name: "region", type: "text", defaultValue: "us" }],
     });
 
-    const { insertValues, localizedDefaults } =
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock meta
-      service.buildDefaultDocument(meta as any);
+    const { insertValues, localizedDefaults } = service.buildDefaultDocument(
+      meta as unknown as SingleMeta
+    );
 
     expect(localizedDefaults).toEqual({});
     expect(insertValues).toMatchObject({ region: "us" });

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
@@ -1,0 +1,97 @@
+/**
+ * `buildDefaultDocument` must route a localized single's translatable defaults to
+ * `localizedDefaults` (for the default-locale companion) and keep them OFF the
+ * main-table insert — otherwise a localized field's default is stranded as null
+ * until first written, and inserting it would target a non-existent main column.
+ */
+import { describe, it, expect } from "vitest";
+
+import { SingleQueryService } from "../services/single-query-service";
+
+import {
+  createMockAdapter,
+  createSilentLogger,
+  createMockSingleRegistry,
+  createMockHookRegistry,
+  siteSettingsMeta,
+} from "./single-test-helpers";
+
+type Ctor = ConstructorParameters<typeof SingleQueryService>;
+type SingleMeta = Parameters<SingleQueryService["buildDefaultDocument"]>[0];
+
+function createQueryService(): SingleQueryService {
+  return new SingleQueryService(
+    createMockAdapter() as unknown as Ctor[0],
+    createSilentLogger() as unknown as Ctor[1],
+    createMockSingleRegistry() as unknown as Ctor[2],
+    createMockHookRegistry() as unknown as Ctor[3],
+    undefined,
+    undefined,
+    // Localization on with a default locale — buildDefaultDocument itself does
+    // not read it, but it mirrors how the service is wired for a localized single.
+    { defaultLocale: "en", locales: [{ code: "en" }] } as unknown as Ctor[6]
+  );
+}
+
+describe("SingleQueryService.buildDefaultDocument", () => {
+  it("routes a localized field's default to localizedDefaults, off the main insert", () => {
+    const service = createQueryService();
+    const meta = siteSettingsMeta({
+      localized: true,
+      status: true,
+      fields: [
+        {
+          name: "siteName",
+          type: "text",
+          localized: true,
+          defaultValue: "My Site",
+        },
+        { name: "region", type: "text", localized: false, defaultValue: "us" },
+      ],
+    });
+
+    const { document, insertValues, localizedDefaults } =
+      service.buildDefaultDocument(meta as unknown as SingleMeta);
+
+    // The localized default is captured for the companion, not the main insert.
+    expect(localizedDefaults).toMatchObject({ siteName: "My Site" });
+    expect(insertValues).not.toHaveProperty("site_name");
+    // ...but it is still resolved onto the in-memory default document.
+    expect(document).toMatchObject({ siteName: "My Site" });
+
+    // A non-localized field's default stays on the main insert.
+    expect(insertValues).toMatchObject({ region: "us" });
+    expect(localizedDefaults).not.toHaveProperty("region");
+  });
+
+  it("routes a localized title default to the companion", () => {
+    const service = createQueryService();
+    const meta = siteSettingsMeta({
+      localized: true,
+      // A single may localize its auto-injected title; when it does the column
+      // lives on the companion, so its default must ride localizedDefaults.
+      fields: [{ name: "title", type: "text", localized: true }],
+    });
+
+    const { insertValues, localizedDefaults } =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock meta
+      service.buildDefaultDocument(meta as any);
+
+    expect(localizedDefaults).toHaveProperty("title");
+    expect(insertValues).not.toHaveProperty("title");
+  });
+
+  it("returns empty localizedDefaults for a non-localized single", () => {
+    const service = createQueryService();
+    const meta = siteSettingsMeta({
+      fields: [{ name: "region", type: "text", defaultValue: "us" }],
+    });
+
+    const { insertValues, localizedDefaults } =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock meta
+      service.buildDefaultDocument(meta as any);
+
+    expect(localizedDefaults).toEqual({});
+    expect(insertValues).toMatchObject({ region: "us" });
+  });
+});

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
@@ -104,6 +104,37 @@ describe("SingleQueryService.buildDefaultDocument", () => {
     expect(document.slug).toBe("site-settings");
   });
 
+  it("keeps the system title seed when a same-named field emits no column", () => {
+    const service = createQueryService();
+    // A column-less field named `title` (a component) does not suppress the
+    // system text title column, so the seeded label must still reach the insert
+    // rather than being dropped as a no-column field.
+    const meta = siteSettingsMeta({
+      fields: [{ name: "title", type: "component", required: true }],
+    });
+
+    const { insertValues } = service.buildDefaultDocument(
+      meta as unknown as SingleMeta
+    );
+
+    expect(insertValues.title).toBe("Site Settings");
+  });
+
+  it("uses the field's own type default when title is redefined as a non-text column", () => {
+    const service = createQueryService();
+    // A user redefining `title` as a number column must get its numeric default,
+    // not the label string — inserting a string into a number column would fail.
+    const meta = siteSettingsMeta({
+      fields: [{ name: "title", type: "number", required: true }],
+    });
+
+    const { insertValues } = service.buildDefaultDocument(
+      meta as unknown as SingleMeta
+    );
+
+    expect(insertValues.title).toBe(0);
+  });
+
   it("evaluates a function defaultValue before routing it to the companion", () => {
     const service = createQueryService();
     // A localized field may carry a function default `(data) => value`. It must

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
@@ -104,6 +104,58 @@ describe("SingleQueryService.buildDefaultDocument", () => {
     expect(document.slug).toBe("site-settings");
   });
 
+  it("evaluates a function defaultValue before routing it to the companion", () => {
+    const service = createQueryService();
+    // A localized field may carry a function default `(data) => value`. It must
+    // be evaluated, not copied as a function object (which a companion upsert
+    // cannot bind), now that localized defaults flow through this path.
+    const meta = siteSettingsMeta({
+      localized: true,
+      fields: [
+        {
+          name: "siteName",
+          type: "text",
+          localized: true,
+          defaultValue: () => "Computed",
+        },
+      ],
+    });
+
+    const { document, localizedDefaults } = service.buildDefaultDocument(
+      meta as unknown as SingleMeta
+    );
+
+    expect(localizedDefaults.siteName).toBe("Computed");
+    expect(document.siteName).toBe("Computed");
+  });
+
+  it("drops a localized field that emits no storage column from the defaults", () => {
+    const service = createQueryService();
+    // A `component` field is localized here but emits no companion column
+    // (its descriptor is "skip"). Its default must not be routed to a phantom
+    // companion or main column, which would fail the auto-create upsert.
+    const meta = siteSettingsMeta({
+      localized: true,
+      fields: [
+        {
+          name: "siteName",
+          type: "text",
+          localized: true,
+          defaultValue: "My Site",
+        },
+        { name: "hero", type: "component", localized: true, required: true },
+      ],
+    });
+
+    const { localizedDefaults, insertValues } = service.buildDefaultDocument(
+      meta as unknown as SingleMeta
+    );
+
+    expect(localizedDefaults).toHaveProperty("siteName");
+    expect(localizedDefaults).not.toHaveProperty("hero");
+    expect(insertValues).not.toHaveProperty("hero");
+  });
+
   it("returns empty localizedDefaults for a non-localized single", () => {
     const service = createQueryService();
     const meta = siteSettingsMeta({

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
@@ -135,6 +135,24 @@ describe("SingleQueryService.buildDefaultDocument", () => {
     expect(insertValues.title).toBe(0);
   });
 
+  it("drops the identity seed when title is an optional non-text localized field", () => {
+    const service = createQueryService();
+    // Redefining `title` as an OPTIONAL non-text localized field: the label
+    // string seed must not survive into the (numeric) companion column just
+    // because the field is not required and carries no explicit default.
+    const meta = siteSettingsMeta({
+      localized: true,
+      fields: [{ name: "title", type: "number", localized: true }],
+    });
+
+    const { document, localizedDefaults, insertValues } =
+      service.buildDefaultDocument(meta as unknown as SingleMeta);
+
+    expect(localizedDefaults).not.toHaveProperty("title");
+    expect(insertValues).not.toHaveProperty("title");
+    expect(document).not.toHaveProperty("title");
+  });
+
   it("evaluates a function defaultValue before routing it to the companion", () => {
     const service = createQueryService();
     // A localized field may carry a function default `(data) => value`. It must

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
@@ -120,6 +120,21 @@ describe("SingleQueryService.buildDefaultDocument", () => {
     expect(insertValues.title).toBe("Site Settings");
   });
 
+  it("keeps the seed when title is a long-text column (textarea)", () => {
+    const service = createQueryService();
+    // A `textarea`/`code` identity field maps to a `longText` column — still
+    // textual storage, so the label/slug seed is valid and must be kept.
+    const meta = siteSettingsMeta({
+      fields: [{ name: "title", type: "textarea", required: true }],
+    });
+
+    const { insertValues } = service.buildDefaultDocument(
+      meta as unknown as SingleMeta
+    );
+
+    expect(insertValues.title).toBe("Site Settings");
+  });
+
   it("uses the field's own type default when title is redefined as a non-text column", () => {
     const service = createQueryService();
     // A user redefining `title` as a number column must get its numeric default,

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
@@ -81,6 +81,29 @@ describe("SingleQueryService.buildDefaultDocument", () => {
     expect(insertValues).not.toHaveProperty("title");
   });
 
+  it("preserves the seeded title/slug for the required system identity fields", () => {
+    const service = createQueryService();
+    // Mirror defineSingle's auto-injected system fields: `title` and `slug` are
+    // required text fields with no defaultValue. The required type-default ("")
+    // must NOT overwrite the label/slug seeded onto the default document, or the
+    // auto-created row persists an empty title/slug.
+    const meta = siteSettingsMeta({
+      fields: [
+        { name: "title", type: "text", required: true },
+        { name: "slug", type: "text", required: true },
+      ],
+    });
+
+    const { document, insertValues } = service.buildDefaultDocument(
+      meta as unknown as SingleMeta
+    );
+
+    expect(insertValues.title).toBe("Site Settings");
+    expect(insertValues.slug).toBe("site-settings");
+    expect(document.title).toBe("Site Settings");
+    expect(document.slug).toBe("site-settings");
+  });
+
   it("returns empty localizedDefaults for a non-localized single", () => {
     const service = createQueryService();
     const meta = siteSettingsMeta({

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -497,6 +497,9 @@ export class SingleMutationService extends BaseService {
       // (including any publish) is authorized.
       let autoCreated = false;
       let pendingAutoCreateValues: Record<string, unknown> | null = null;
+      // Translatable defaults to seed onto the default-locale companion when the
+      // auto-create actually inserts a row (they cannot live on the main table).
+      let pendingLocalizedDefaults: Record<string, unknown> = {};
       if (!existingDoc) {
         this.logger.info("Preparing default Single document before update", {
           slug,
@@ -504,6 +507,7 @@ export class SingleMutationService extends BaseService {
         const built = this.queryService.buildDefaultDocument(singleMeta);
         existingDoc = built.document;
         pendingAutoCreateValues = built.insertValues;
+        pendingLocalizedDefaults = built.localizedDefaults;
         autoCreated = true;
       }
 
@@ -845,13 +849,27 @@ export class SingleMutationService extends BaseService {
                 singleMeta.tableName,
                 {}
               );
-              existingDoc =
-                committed ??
-                (await tx.insert<SingleDocument>(
+              if (committed) {
+                existingDoc = committed;
+              } else {
+                existingDoc = await tx.insert<SingleDocument>(
                   singleMeta.tableName,
                   pendingAutoCreateValues,
                   { returning: "*" }
-                ));
+                );
+                // Seed the default-locale companion with the localized defaults
+                // in the same transaction as the insert, so a localized field's
+                // default is not stranded as null. The caller's companion write
+                // for the write locale (below) then overlays only the fields it
+                // supplied. No-op for a non-localized single.
+                await this.queryService.seedLocalizedDefaultsCompanion(
+                  tx,
+                  singleMeta,
+                  existingDoc.id,
+                  pendingLocalizedDefaults,
+                  (existingDoc as { status?: string }).status
+                );
+              }
             }
             // Unreachable: the pre-transaction step always resolves `existingDoc`
             // to a loaded or in-memory default, and the block above only replaces

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -831,6 +831,15 @@ export class SingleMutationService extends BaseService {
               companion.companionTableName
             )
           : false;
+      // Same pre-transaction, pooled probe for the auto-create default seed: it
+      // is keyed on the DEFAULT locale (not the write locale), so it needs its
+      // own existence check rather than reusing `companionPhysicallyExists`.
+      const seedCompanionExists = autoCreated
+        ? await this.queryService.localizedDefaultsCompanionExists(
+            singleMeta,
+            pendingLocalizedDefaults
+          )
+        : false;
       let updatedRows: SingleDocument[];
       try {
         // Retry the whole update+capture transaction on a version_no allocation
@@ -867,7 +876,8 @@ export class SingleMutationService extends BaseService {
                   singleMeta,
                   existingDoc.id,
                   pendingLocalizedDefaults,
-                  (existingDoc as { status?: string }).status
+                  (existingDoc as { status?: string }).status,
+                  seedCompanionExists
                 );
               }
             }

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -846,6 +846,15 @@ export class SingleMutationService extends BaseService {
         // race; the re-run re-reads the max. The single UPDATE is deterministic.
         updatedRows = await withVersionConflictRetry(() =>
           this.adapter.transaction(async tx => {
+            // True only when THIS transaction inserted the row AND seeded the
+            // default-locale companion with the localized defaults. The version
+            // snapshot overlay below is gated on it, not on `autoCreated`: two
+            // first writes can race so that this request enters with
+            // `autoCreated === true` but then adopts a row another writer already
+            // inserted (the `committed` branch), in which case it did NOT seed —
+            // the companion may already hold that writer's real translations, and
+            // overlaying schema defaults would let a restore overwrite them.
+            let didSeedCompanionDefaults = false;
             // First-write auto-create, committed atomically with the update. A
             // failed update/component/companion/version write rolls the insert
             // back rather than orphaning a default row, and no compensating
@@ -879,6 +888,10 @@ export class SingleMutationService extends BaseService {
                   (existingDoc as { status?: string }).status,
                   seedCompanionExists
                 );
+                // The seed persists defaults only when the companion physically
+                // exists; track that this transaction actually seeded so the
+                // snapshot overlay records defaults that were really written.
+                didSeedCompanionDefaults = seedCompanionExists;
               }
             }
             // Unreachable: the pre-transaction step always resolves `existingDoc`
@@ -1439,13 +1452,17 @@ export class SingleMutationService extends BaseService {
               // only when this first write IS the default locale; a non-default
               // first write must not copy them in, or restoring it would
               // materialize the defaults as real translations in the wrong locale.
+              // Gated on `didSeedCompanionDefaults` (set only when THIS
+              // transaction inserted and seeded), never `autoCreated`: a request
+              // that lost the auto-create race and adopted another writer's row
+              // must not overlay schema defaults over that writer's real
+              // translations.
               const isDefaultLocaleWrite =
                 writeLocale === undefined ||
                 writeLocale === this.localization?.defaultLocale;
               let seededDefaultsOverlaid = false;
               if (
-                autoCreated &&
-                seedCompanionExists &&
+                didSeedCompanionDefaults &&
                 companion &&
                 isDefaultLocaleWrite
               ) {

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -1423,6 +1423,33 @@ export class SingleMutationService extends BaseService {
                   }
                 }
               }
+              // First-write auto-create: the companion was seeded with the
+              // localized field defaults for fields this update did not supply
+              // (queryService.seedLocalizedDefaultsCompanion). Those values are
+              // committed but absent from both `rows[0]` (main row omits
+              // translatable columns) and `companionData` (only this write's
+              // fields), so overlay them for any field this update did not write —
+              // otherwise v1 omits persisted content and restoring it drops the
+              // seeded defaults. This write's explicit values (overlaid above) win
+              // over a default. Gated on the seed having actually run, so a
+              // snapshot never records defaults the absent-companion seed skipped.
+              if (autoCreated && seedCompanionExists && companion) {
+                const writtenFieldNames = new Set(
+                  companion.localizedFields
+                    .filter(f =>
+                      Object.prototype.hasOwnProperty.call(
+                        companionData,
+                        f.column
+                      )
+                    )
+                    .map(f => f.name)
+                );
+                for (const [name, value] of Object.entries(
+                  pendingLocalizedDefaults
+                )) {
+                  if (!writtenFieldNames.has(name)) parentRow[name] = value;
+                }
+              }
               // Never let password hashes into durable version history: the row
               // carries bcrypt hashes (hashPasswordFieldValues ran before the
               // write), and a later password change would otherwise leave the

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -1433,7 +1433,22 @@ export class SingleMutationService extends BaseService {
               // seeded defaults. This write's explicit values (overlaid above) win
               // over a default. Gated on the seed having actually run, so a
               // snapshot never records defaults the absent-companion seed skipped.
-              if (autoCreated && seedCompanionExists && companion) {
+              //
+              // The seed wrote ONLY to the DEFAULT-locale companion row, so these
+              // defaults belong to the default-locale snapshot alone. Overlay them
+              // only when this first write IS the default locale; a non-default
+              // first write must not copy them in, or restoring it would
+              // materialize the defaults as real translations in the wrong locale.
+              const isDefaultLocaleWrite =
+                writeLocale === undefined ||
+                writeLocale === this.localization?.defaultLocale;
+              let seededDefaultsOverlaid = false;
+              if (
+                autoCreated &&
+                seedCompanionExists &&
+                companion &&
+                isDefaultLocaleWrite
+              ) {
                 const writtenFieldNames = new Set(
                   companion.localizedFields
                     .filter(f =>
@@ -1447,7 +1462,10 @@ export class SingleMutationService extends BaseService {
                 for (const [name, value] of Object.entries(
                   pendingLocalizedDefaults
                 )) {
-                  if (!writtenFieldNames.has(name)) parentRow[name] = value;
+                  if (!writtenFieldNames.has(name)) {
+                    parentRow[name] = value;
+                    seededDefaultsOverlaid = true;
+                  }
                 }
               }
               // Never let password hashes into durable version history: the row
@@ -1600,10 +1618,17 @@ export class SingleMutationService extends BaseService {
                 // holds no translations and keeps the MAIN row's status, so
                 // calling it that locale's would let a restore publish a
                 // language from state that was never its own.
+                // `seededDefaultsOverlaid` forces the default-locale tag for a
+                // shared-fields-only first write that seeded default-locale
+                // translations: without it `companionData` is empty, the locale
+                // resolves null, and a restore treats the snapshot as shared-only
+                // and drops the seeded defaults. The overlay only runs on a
+                // default-locale write, so `snapshotLocale` is the default locale.
                 locale:
                   Object.keys(companionData).length > 0 ||
                   companionStatus !== undefined ||
-                  capturedLocalizedComponents
+                  capturedLocalizedComponents ||
+                  seededDefaultsOverlaid
                     ? (snapshotLocale ?? null)
                     : null,
                 sourceVersionNo: options.sourceVersionNo ?? null,

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -69,7 +69,11 @@ import {
   resolveFallbackChain,
   resolveRequestedLocale,
 } from "../../i18n/resolve-locale";
-import { buildCompanionSchema } from "../../i18n/runtime/companion-io";
+import {
+  buildCompanionSchema,
+  splitLocalizedWrite,
+  upsertCompanionRow,
+} from "../../i18n/runtime/companion-io";
 import { captureInTx } from "../../versions/capture-in-tx";
 import { VersionCaptureService } from "../../versions/version-capture-service";
 import { withVersionConflictRetry } from "../../versions/version-conflict";
@@ -756,6 +760,14 @@ export class SingleQueryService extends BaseService {
   buildDefaultDocument(singleMeta: DynamicSingleRecord): {
     document: SingleDocument;
     insertValues: Record<string, unknown>;
+    /**
+     * Default values for the single's TRANSLATABLE fields, keyed by field name
+     * (includes localized `title`/`slug`). These belong on the default-locale
+     * companion row, not the main table; the auto-create path persists them
+     * there so a localized field's default is not stranded as null until it is
+     * first written.
+     */
+    localizedDefaults: Record<string, unknown>;
   } {
     const now = new Date();
     const id = crypto.randomUUID();
@@ -779,9 +791,9 @@ export class SingleQueryService extends BaseService {
     }
 
     // i18n: a localized single's main table omits translatable columns (they live in the
-    // companion `single_<slug>_locales`), so a required/defaulted translatable value must
-    // not be inserted here — it would target a column that only exists on the companion and
-    // fail the auto-create insert.
+    // companion `single_<slug>_locales`). Their defaults are still resolved here (onto the
+    // in-memory `document` and the returned `localizedDefaults`) but are kept OFF the main
+    // insert below — inserting one would target a column that only exists on the companion.
     const localizedNames = new Set(
       singleMeta.localized === true
         ? resolveLocalizedFieldNames(
@@ -793,31 +805,37 @@ export class SingleQueryService extends BaseService {
 
     for (const field of singleMeta.fields) {
       if (!("name" in field) || !field.name) continue;
-      if (localizedNames.has(field.name)) continue;
 
+      // Resolve the field's default (explicit defaultValue, else a required
+      // field's type-default) once, regardless of whether it is localized — a
+      // localized field's default must reach the companion just the same.
+      let value: unknown;
       if ("defaultValue" in field && field.defaultValue !== undefined) {
-        if (shouldTreatAsJson(field)) {
-          defaults[field.name] =
-            typeof field.defaultValue === "object"
-              ? JSON.stringify(field.defaultValue)
-              : field.defaultValue;
-        } else {
-          defaults[field.name] = field.defaultValue;
-        }
+        value =
+          shouldTreatAsJson(field) && typeof field.defaultValue === "object"
+            ? JSON.stringify(field.defaultValue)
+            : field.defaultValue;
       } else if ("required" in field && field.required) {
-        defaults[field.name] = getDefaultValue(field);
+        value = getDefaultValue(field);
+      } else {
+        continue;
       }
+      defaults[field.name] = value;
     }
 
-    // title and slug are auto-injected system columns, but a Single may opt to
-    // localize them (define-single.ts). When it does, their column lives on the
-    // companion `_locales` table, not the main table, so they must be dropped
-    // from the main-table auto-create insert like any other localized field —
-    // otherwise the insert targets a non-existent main column. They stay on the
-    // in-memory `document` (the read path resolves the localized value).
-    const insertDefaults = { ...defaults };
-    if (localizedNames.has("title")) delete insertDefaults.title;
-    if (localizedNames.has("slug")) delete insertDefaults.slug;
+    // Split the resolved defaults: translatable ones (including localized
+    // title/slug) go to `localizedDefaults` for the companion; everything else
+    // is inserted on the main table. A localized column on the main insert would
+    // target a non-existent column and fail the auto-create.
+    const localizedDefaults: Record<string, unknown> = {};
+    const insertDefaults: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(defaults)) {
+      if (localizedNames.has(key)) {
+        localizedDefaults[key] = value;
+      } else {
+        insertDefaults[key] = value;
+      }
+    }
 
     const snakeCaseDefaults = keysToSnakeCase(insertDefaults) as Record<
       string,
@@ -827,28 +845,121 @@ export class SingleQueryService extends BaseService {
     return {
       document: defaults as SingleDocument,
       insertValues: snakeCaseDefaults,
+      localizedDefaults,
     };
+  }
+
+  /**
+   * Seed a localized single's DEFAULT-locale companion row with its translatable
+   * field defaults on auto-create, so a localized field's default (including a
+   * localized `title`/`slug`) resolves to that default instead of null until it
+   * is first written. Runs on the caller's transaction (`tx.execute`) so the
+   * companion seed commits atomically with the main-row insert.
+   *
+   * No-op when localization is off, the single is not localized, it has no
+   * translatable defaults, or it has no companion. The default-locale companion
+   * `_status` is seeded to the main row's status so the two agree from the start.
+   */
+  async seedLocalizedDefaultsCompanion(
+    tx: {
+      execute<T = unknown>(sql: string, params?: unknown[]): Promise<T[]>;
+    },
+    singleMeta: DynamicSingleRecord,
+    parentId: string,
+    localizedDefaults: Record<string, unknown>,
+    status: string | undefined
+  ): Promise<void> {
+    if (!this.localization || singleMeta.localized !== true) return;
+    if (Object.keys(localizedDefaults).length === 0) return;
+
+    const companion = buildCompanionSchema({
+      slug: singleMeta.slug,
+      tableName: singleMeta.tableName,
+      fields: singleMeta.fields as { name: string; type: string }[],
+      dialect: this.adapter.dialect,
+      status: (singleMeta as { status?: boolean }).status === true,
+    });
+    if (!companion) return;
+
+    const { companion: companionData } = splitLocalizedWrite(
+      localizedDefaults,
+      companion.localizedFields
+    );
+    const companionStatus = companion.hasStatus
+      ? (status ?? "draft")
+      : undefined;
+    const writeAdapter = {
+      dialect: this.adapter.dialect,
+      executeQuery: <T = unknown>(sql: string, params?: unknown[]) =>
+        tx.execute<T>(sql, params),
+    };
+    await upsertCompanionRow(
+      writeAdapter,
+      companion.companionTableName,
+      parentId,
+      this.localization.defaultLocale,
+      companionData,
+      companionStatus
+    );
   }
 
   async createDefaultDocument(
     singleMeta: DynamicSingleRecord,
     options?: { captureInitialVersion?: boolean }
   ): Promise<SingleDocument> {
-    const { insertValues: snakeCaseDefaults } =
-      this.buildDefaultDocument(singleMeta);
+    const {
+      insertValues: snakeCaseDefaults,
+      document,
+      localizedDefaults,
+    } = this.buildDefaultDocument(singleMeta);
     const id = snakeCaseDefaults.id as string;
+    const status = (document as { status?: string }).status;
 
     const versionsConfig = singleMeta.versions;
     const shouldCapture =
       options?.captureInitialVersion === true &&
       versionsConfig?.enabled === true;
 
-    if (!shouldCapture) {
+    // A localized single needs its translatable defaults seeded onto the
+    // default-locale companion, which must commit atomically with the main
+    // insert — so this forces the transactional path even when versioning is off.
+    const needsCompanionSeed =
+      !!this.localization &&
+      singleMeta.localized === true &&
+      Object.keys(localizedDefaults).length > 0;
+
+    if (!shouldCapture && !needsCompanionSeed) {
       const inserted = await this.adapter.insert<SingleDocument>(
         singleMeta.tableName,
         snakeCaseDefaults,
         { returning: "*" }
       );
+      this.logger.debug("Created default Single document", {
+        slug: singleMeta.slug,
+        id,
+      });
+      return inserted;
+    }
+
+    // Non-versioned but localized: insert the main row and seed the companion in
+    // one transaction, so a failed companion seed rolls the insert back rather
+    // than leaving a main row without its localized defaults.
+    if (!shouldCapture) {
+      const inserted = await this.adapter.transaction(async tx => {
+        const row = await tx.insert<SingleDocument>(
+          singleMeta.tableName,
+          snakeCaseDefaults,
+          { returning: "*" }
+        );
+        await this.seedLocalizedDefaultsCompanion(
+          tx,
+          singleMeta,
+          id,
+          localizedDefaults,
+          status
+        );
+        return row;
+      });
       this.logger.debug("Created default Single document", {
         slug: singleMeta.slug,
         id,
@@ -904,6 +1015,15 @@ export class SingleQueryService extends BaseService {
           locale: null,
           maxPerDoc: versionsConfig.maxPerDoc,
         });
+        // Seed the default-locale companion with the localized defaults in the
+        // same transaction as the insert and version snapshot.
+        await this.seedLocalizedDefaultsCompanion(
+          tx,
+          singleMeta,
+          id,
+          localizedDefaults,
+          status
+        );
         return row;
       })
     );

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -71,6 +71,7 @@ import {
 } from "../../i18n/resolve-locale";
 import {
   buildCompanionSchema,
+  companionTableExists,
   splitLocalizedWrite,
   upsertCompanionRow,
 } from "../../i18n/runtime/companion-io";
@@ -881,6 +882,18 @@ export class SingleQueryService extends BaseService {
     });
     if (!companion) return;
 
+    // Skip the seed when the companion `_locales` table has not been created yet
+    // (dev-before-migrate, or a best-effort boot companion creation that failed):
+    // the read path already treats a missing companion as optional, so an
+    // unconditional upsert here would throw and roll the main-row insert back.
+    // Probed on the pooled connection, NOT the transaction: a missing-table probe
+    // on the transaction connection would abort the whole transaction on Postgres.
+    const exists = await companionTableExists(
+      this.adapter,
+      companion.companionTableName
+    );
+    if (!exists) return;
+
     const { companion: companionData } = splitLocalizedWrite(
       localizedDefaults,
       companion.localizedFields
@@ -927,6 +940,13 @@ export class SingleQueryService extends BaseService {
       !!this.localization &&
       singleMeta.localized === true &&
       Object.keys(localizedDefaults).length > 0;
+    // When defaults are seeded, the initial version snapshot belongs to the
+    // default locale (its content is those seeded translatable values), so it is
+    // tagged and overlaid with them below — otherwise restoring v1 could not
+    // bring back the seeded localized defaults.
+    const seedLocale = needsCompanionSeed
+      ? (this.localization?.defaultLocale ?? null)
+      : null;
 
     if (!shouldCapture && !needsCompanionSeed) {
       const inserted = await this.adapter.insert<SingleDocument>(
@@ -986,6 +1006,14 @@ export class SingleQueryService extends BaseService {
         const parentRow = convertTimestampsToCamelCase({
           ...(row as Record<string, unknown>),
         });
+        // Overlay the seeded localized defaults (keyed by field name) onto the
+        // snapshot so v1 carries the default locale's content, mirroring how a
+        // normal localized write overlays its companion values before capturing.
+        // Without this, restoring v1 could not bring back the seeded defaults
+        // (including a localized title/slug), since they live on the companion.
+        for (const [name, value] of Object.entries(localizedDefaults)) {
+          parentRow[name] = value;
+        }
         stripPasswordFieldValues(parentRow, singleMeta.fields);
         stripSystemOwnerField(parentRow);
         for (const field of singleMeta.fields) {
@@ -1009,10 +1037,9 @@ export class SingleQueryService extends BaseService {
           // System-materialized default: no authoring user.
           parts: { parentRow, components: {} },
           createdBy: null,
-          // Left unlabelled: this snapshot is the main row alone, and a
-          // localized Single keeps its translatable values in the companion, so
-          // it holds no locale's content to claim.
-          locale: null,
+          // Tagged with the default locale when the snapshot carries seeded
+          // translatable defaults; null for a non-localized single (main row only).
+          locale: seedLocale,
           maxPerDoc: versionsConfig.maxPerDoc,
         });
         // Seed the default-locale companion with the localized defaults in the

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -75,6 +75,7 @@ import {
   splitLocalizedWrite,
   upsertCompanionRow,
 } from "../../i18n/runtime/companion-io";
+import { getColumnDescriptor } from "../../schema/services/field-column-descriptor";
 import { captureInTx } from "../../versions/capture-in-tx";
 import { VersionCaptureService } from "../../versions/version-capture-service";
 import { withVersionConflictRetry } from "../../versions/version-conflict";
@@ -812,10 +813,19 @@ export class SingleQueryService extends BaseService {
       // localized field's default must reach the companion just the same.
       let value: unknown;
       if ("defaultValue" in field && field.defaultValue !== undefined) {
-        value =
-          shouldTreatAsJson(field) && typeof field.defaultValue === "object"
-            ? JSON.stringify(field.defaultValue)
+        // `defaultValue` may be a function `(data) => value`; evaluate it against
+        // the document built so far so the stored default is a real value, not a
+        // function object. A raw function would be bound as an SQL parameter for
+        // the companion/main upsert and fail or persist its stringified form —
+        // localized fields now flow through this block, so it must be resolved.
+        const resolved =
+          typeof field.defaultValue === "function"
+            ? field.defaultValue(defaults)
             : field.defaultValue;
+        value =
+          shouldTreatAsJson(field) && typeof resolved === "object"
+            ? JSON.stringify(resolved)
+            : resolved;
       } else if ("required" in field && field.required) {
         // `title` and `slug` are auto-injected system identity fields, required
         // and without a defaultValue, but already seeded above with the Single's
@@ -831,6 +841,26 @@ export class SingleQueryService extends BaseService {
       defaults[field.name] = value;
     }
 
+    // A field can be translatable/required yet emit NO storage column — a
+    // component or other layout-only ("skip") field type. Its default has nowhere
+    // to live: routing it to the main insert or the companion seed would target a
+    // column that does not exist and fail the auto-create upsert. Collect those
+    // field names so the split drops them from both buckets. System-seeded keys
+    // (id/title/slug/timestamps/status) are not user fields, so they are never in
+    // this set and always route to the main insert below.
+    const noColumnFieldNames = new Set<string>();
+    for (const field of singleMeta.fields) {
+      if (!("name" in field) || !field.name) continue;
+      if (
+        getColumnDescriptor(
+          field as unknown as FieldDefinition,
+          this.adapter.dialect
+        ) == null
+      ) {
+        noColumnFieldNames.add(field.name);
+      }
+    }
+
     // Split the resolved defaults: translatable ones (including localized
     // title/slug) go to `localizedDefaults` for the companion; everything else
     // is inserted on the main table. A localized column on the main insert would
@@ -838,6 +868,7 @@ export class SingleQueryService extends BaseService {
     const localizedDefaults: Record<string, unknown> = {};
     const insertDefaults: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(defaults)) {
+      if (noColumnFieldNames.has(key)) continue;
       if (localizedNames.has(key)) {
         localizedDefaults[key] = value;
       } else {

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -96,6 +96,14 @@ import {
   shouldTreatAsJson,
 } from "./single-utils";
 
+/**
+ * Reserved system identity field names every Single carries as columns (the
+ * `title`/`slug` auto-injected by `defineSingle`, seeded from label/slug). Their
+ * default seeding is handled specially so a same-named user field never strands
+ * the system column or receives a wrong-typed default.
+ */
+const SINGLE_IDENTITY_FIELDS = new Set(["title", "slug"]);
+
 /** Hook namespace prefix for Singles. */
 export const SINGLE_HOOK_NAMESPACE = "single";
 
@@ -827,13 +835,24 @@ export class SingleQueryService extends BaseService {
             ? JSON.stringify(resolved)
             : resolved;
       } else if ("required" in field && field.required) {
-        // `title` and `slug` are auto-injected system identity fields, required
-        // and without a defaultValue, but already seeded above with the Single's
-        // label/slug. A required text field's type-default ("") must not clobber
-        // those meaningful seeds — that would persist an empty title/slug on the
-        // auto-created row. A user field carrying an explicit defaultValue is
-        // handled by the branch above; only the empty type-default is skipped.
-        if (field.name === "title" || field.name === "slug") continue;
+        // `title`/`slug` are reserved system identity keys, pre-seeded above with
+        // the Single's label/slug. Keep that seed (skip the empty type-default,
+        // which would persist an empty title/slug) ONLY when the identity column
+        // is text — or when this same-named field emits no column of its own (a
+        // component named `title` does not suppress the system text column, which
+        // still needs the label). A user field that redefines `title`/`slug` as a
+        // DIFFERENT column type (e.g. `number`) takes its own type default, so a
+        // label string is never inserted into a non-text column. An explicit
+        // user defaultValue is already handled by the branch above.
+        if (SINGLE_IDENTITY_FIELDS.has(field.name)) {
+          const desc = getColumnDescriptor(
+            field as unknown as FieldDefinition,
+            this.adapter.dialect
+          );
+          if (!desc || desc.kind === "varchar" || desc.kind === "text") {
+            continue;
+          }
+        }
         value = getDefaultValue(field);
       } else {
         continue;
@@ -851,6 +870,9 @@ export class SingleQueryService extends BaseService {
     const noColumnFieldNames = new Set<string>();
     for (const field of singleMeta.fields) {
       if (!("name" in field) || !field.name) continue;
+      // Reserved identity keys are backed by the system text column even when a
+      // same-named field emits none, so their seed must never be dropped here.
+      if (SINGLE_IDENTITY_FIELDS.has(field.name)) continue;
       if (
         getColumnDescriptor(
           field as unknown as FieldDefinition,

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -968,13 +968,6 @@ export class SingleQueryService extends BaseService {
       !!this.localization &&
       singleMeta.localized === true &&
       Object.keys(localizedDefaults).length > 0;
-    // When defaults are seeded, the initial version snapshot belongs to the
-    // default locale (its content is those seeded translatable values), so it is
-    // tagged and overlaid with them below — otherwise restoring v1 could not
-    // bring back the seeded localized defaults.
-    const seedLocale = needsCompanionSeed
-      ? (this.localization?.defaultLocale ?? null)
-      : null;
     // Probe companion existence BEFORE opening the transaction (a probe issued
     // while the tx holds a max:1-pool connection would deadlock); the seed calls
     // below are gated on this rather than probing inside the transaction.
@@ -984,6 +977,17 @@ export class SingleQueryService extends BaseService {
           localizedDefaults
         )
       : false;
+    // The seed only persists the localized defaults when the companion `_locales`
+    // table physically exists; when it does not (dev-before-migrate) the seed
+    // no-ops. The initial version snapshot must therefore record those defaults
+    // ONLY when the seed actually ran — otherwise v1 carries translations that
+    // were never persisted or visible, and restoring it resurrects phantom
+    // defaults. Both the snapshot overlay and its default-locale tag are gated on
+    // this, so a version tagged to the default locale always matches real content.
+    const seedApplied = needsCompanionSeed && companionExists;
+    const seedLocale = seedApplied
+      ? (this.localization?.defaultLocale ?? null)
+      : null;
 
     if (!shouldCapture && !needsCompanionSeed) {
       const inserted = await this.adapter.insert<SingleDocument>(
@@ -1049,8 +1053,13 @@ export class SingleQueryService extends BaseService {
         // normal localized write overlays its companion values before capturing.
         // Without this, restoring v1 could not bring back the seeded defaults
         // (including a localized title/slug), since they live on the companion.
-        for (const [name, value] of Object.entries(localizedDefaults)) {
-          parentRow[name] = value;
+        // Gated on `seedApplied`: when the companion table does not yet exist the
+        // seed no-ops, so overlaying here would record defaults that were never
+        // persisted.
+        if (seedApplied) {
+          for (const [name, value] of Object.entries(localizedDefaults)) {
+            parentRow[name] = value;
+          }
         }
         stripPasswordFieldValues(parentRow, singleMeta.fields);
         stripSystemOwnerField(parentRow);

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -851,15 +851,59 @@ export class SingleQueryService extends BaseService {
   }
 
   /**
+   * The companion schema for a localized single's default seeding, or null when
+   * seeding does not apply (localization off, not localized, no translatable
+   * defaults, or no companion). Shared by the pre-transaction existence probe
+   * and the in-transaction write so both agree on the same table.
+   */
+  private companionForDefaultsSeed(
+    singleMeta: DynamicSingleRecord,
+    localizedDefaults: Record<string, unknown>
+  ) {
+    if (!this.localization || singleMeta.localized !== true) return null;
+    if (Object.keys(localizedDefaults).length === 0) return null;
+    return buildCompanionSchema({
+      slug: singleMeta.slug,
+      tableName: singleMeta.tableName,
+      fields: singleMeta.fields as { name: string; type: string }[],
+      dialect: this.adapter.dialect,
+      status: (singleMeta as { status?: boolean }).status === true,
+    });
+  }
+
+  /**
+   * Whether the default-locale companion should be seeded AND its `_locales`
+   * table physically exists. MUST be called BEFORE the write transaction opens:
+   * it probes on the pooled connection, and on a `max: 1` pool a probe issued
+   * while the transaction holds the only connection would deadlock until the
+   * pool timeout and then be misread as "table missing". A missing table (for
+   * example dev-before-migrate) reads as false so the seed is skipped rather
+   * than throwing and rolling the main-row insert back.
+   */
+  async localizedDefaultsCompanionExists(
+    singleMeta: DynamicSingleRecord,
+    localizedDefaults: Record<string, unknown>
+  ): Promise<boolean> {
+    const companion = this.companionForDefaultsSeed(
+      singleMeta,
+      localizedDefaults
+    );
+    if (!companion) return false;
+    return companionTableExists(this.adapter, companion.companionTableName);
+  }
+
+  /**
    * Seed a localized single's DEFAULT-locale companion row with its translatable
    * field defaults on auto-create, so a localized field's default (including a
    * localized `title`/`slug`) resolves to that default instead of null until it
    * is first written. Runs on the caller's transaction (`tx.execute`) so the
    * companion seed commits atomically with the main-row insert.
    *
-   * No-op when localization is off, the single is not localized, it has no
-   * translatable defaults, or it has no companion. The default-locale companion
-   * `_status` is seeded to the main row's status so the two agree from the start.
+   * `companionExists` MUST be resolved by the caller via
+   * `localizedDefaultsCompanionExists` BEFORE the transaction opens (see that
+   * method for why the probe cannot happen here). No-op when it is false or when
+   * seeding does not apply. The default-locale companion `_status` is seeded to
+   * the main row's status so the two agree from the start.
    */
   async seedLocalizedDefaultsCompanion(
     tx: {
@@ -868,31 +912,15 @@ export class SingleQueryService extends BaseService {
     singleMeta: DynamicSingleRecord,
     parentId: string,
     localizedDefaults: Record<string, unknown>,
-    status: string | undefined
+    status: string | undefined,
+    companionExists: boolean
   ): Promise<void> {
-    if (!this.localization || singleMeta.localized !== true) return;
-    if (Object.keys(localizedDefaults).length === 0) return;
-
-    const companion = buildCompanionSchema({
-      slug: singleMeta.slug,
-      tableName: singleMeta.tableName,
-      fields: singleMeta.fields as { name: string; type: string }[],
-      dialect: this.adapter.dialect,
-      status: (singleMeta as { status?: boolean }).status === true,
-    });
-    if (!companion) return;
-
-    // Skip the seed when the companion `_locales` table has not been created yet
-    // (dev-before-migrate, or a best-effort boot companion creation that failed):
-    // the read path already treats a missing companion as optional, so an
-    // unconditional upsert here would throw and roll the main-row insert back.
-    // Probed on the pooled connection, NOT the transaction: a missing-table probe
-    // on the transaction connection would abort the whole transaction on Postgres.
-    const exists = await companionTableExists(
-      this.adapter,
-      companion.companionTableName
+    if (!companionExists || !this.localization) return;
+    const companion = this.companionForDefaultsSeed(
+      singleMeta,
+      localizedDefaults
     );
-    if (!exists) return;
+    if (!companion) return;
 
     const { companion: companionData } = splitLocalizedWrite(
       localizedDefaults,
@@ -947,6 +975,15 @@ export class SingleQueryService extends BaseService {
     const seedLocale = needsCompanionSeed
       ? (this.localization?.defaultLocale ?? null)
       : null;
+    // Probe companion existence BEFORE opening the transaction (a probe issued
+    // while the tx holds a max:1-pool connection would deadlock); the seed calls
+    // below are gated on this rather than probing inside the transaction.
+    const companionExists = needsCompanionSeed
+      ? await this.localizedDefaultsCompanionExists(
+          singleMeta,
+          localizedDefaults
+        )
+      : false;
 
     if (!shouldCapture && !needsCompanionSeed) {
       const inserted = await this.adapter.insert<SingleDocument>(
@@ -976,7 +1013,8 @@ export class SingleQueryService extends BaseService {
           singleMeta,
           id,
           localizedDefaults,
-          status
+          status,
+          companionExists
         );
         return row;
       });
@@ -1049,7 +1087,8 @@ export class SingleQueryService extends BaseService {
           singleMeta,
           id,
           localizedDefaults,
-          status
+          status,
+          companionExists
         );
         return row;
       })

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -104,6 +104,15 @@ import {
  */
 const SINGLE_IDENTITY_FIELDS = new Set(["title", "slug"]);
 
+/**
+ * Column-descriptor kinds that store text, so the label/slug string seed for a
+ * reserved identity field is valid for them. Covers plain text (text/email/
+ * password/select/radio) and long text (textarea/richText/code), plus explicit
+ * varchar. Non-text kinds (number, json, fkSingle, ...) fall through to the
+ * field's own default instead, so a label string never lands in them.
+ */
+const IDENTITY_TEXT_COLUMN_KINDS = new Set(["text", "varchar", "longText"]);
+
 /** Hook namespace prefix for Singles. */
 export const SINGLE_HOOK_NAMESPACE = "single";
 
@@ -849,8 +858,8 @@ export class SingleQueryService extends BaseService {
           field as unknown as FieldDefinition,
           this.adapter.dialect
         );
-        if (!desc || desc.kind === "varchar" || desc.kind === "text") {
-          continue; // keep the seeded label/slug
+        if (!desc || IDENTITY_TEXT_COLUMN_KINDS.has(desc.kind)) {
+          continue; // keep the seeded label/slug for a text-storage column
         }
         if ("required" in field && field.required) {
           defaults[field.name] = getDefaultValue(field);

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -819,7 +819,6 @@ export class SingleQueryService extends BaseService {
       // Resolve the field's default (explicit defaultValue, else a required
       // field's type-default) once, regardless of whether it is localized — a
       // localized field's default must reach the companion just the same.
-      let value: unknown;
       if ("defaultValue" in field && field.defaultValue !== undefined) {
         // `defaultValue` may be a function `(data) => value`; evaluate it against
         // the document built so far so the stored default is a real value, not a
@@ -830,34 +829,40 @@ export class SingleQueryService extends BaseService {
           typeof field.defaultValue === "function"
             ? field.defaultValue(defaults)
             : field.defaultValue;
-        value =
+        defaults[field.name] =
           shouldTreatAsJson(field) && typeof resolved === "object"
             ? JSON.stringify(resolved)
             : resolved;
-      } else if ("required" in field && field.required) {
-        // `title`/`slug` are reserved system identity keys, pre-seeded above with
-        // the Single's label/slug. Keep that seed (skip the empty type-default,
-        // which would persist an empty title/slug) ONLY when the identity column
-        // is text — or when this same-named field emits no column of its own (a
-        // component named `title` does not suppress the system text column, which
-        // still needs the label). A user field that redefines `title`/`slug` as a
-        // DIFFERENT column type (e.g. `number`) takes its own type default, so a
-        // label string is never inserted into a non-text column. An explicit
-        // user defaultValue is already handled by the branch above.
-        if (SINGLE_IDENTITY_FIELDS.has(field.name)) {
-          const desc = getColumnDescriptor(
-            field as unknown as FieldDefinition,
-            this.adapter.dialect
-          );
-          if (!desc || desc.kind === "varchar" || desc.kind === "text") {
-            continue;
-          }
-        }
-        value = getDefaultValue(field);
-      } else {
         continue;
       }
-      defaults[field.name] = value;
+
+      // `title`/`slug` are reserved system identity keys, pre-seeded above with
+      // the Single's label/slug string. That seed is valid ONLY for a text
+      // identity column — or a same-named field that emits no column of its own
+      // (a component named `title` does not suppress the system text column,
+      // which still needs the label). When a Single redefines `title`/`slug` as a
+      // NON-text column, the string seed is invalid regardless of whether the
+      // field is required: use its type default when required, otherwise drop the
+      // seed so it is never inserted/seeded into (e.g.) a numeric column.
+      if (SINGLE_IDENTITY_FIELDS.has(field.name)) {
+        const desc = getColumnDescriptor(
+          field as unknown as FieldDefinition,
+          this.adapter.dialect
+        );
+        if (!desc || desc.kind === "varchar" || desc.kind === "text") {
+          continue; // keep the seeded label/slug
+        }
+        if ("required" in field && field.required) {
+          defaults[field.name] = getDefaultValue(field);
+        } else {
+          delete defaults[field.name];
+        }
+        continue;
+      }
+
+      if ("required" in field && field.required) {
+        defaults[field.name] = getDefaultValue(field);
+      }
     }
 
     // A field can be translatable/required yet emit NO storage column — a

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -817,6 +817,13 @@ export class SingleQueryService extends BaseService {
             ? JSON.stringify(field.defaultValue)
             : field.defaultValue;
       } else if ("required" in field && field.required) {
+        // `title` and `slug` are auto-injected system identity fields, required
+        // and without a defaultValue, but already seeded above with the Single's
+        // label/slug. A required text field's type-default ("") must not clobber
+        // those meaningful seeds — that would persist an empty title/slug on the
+        // auto-created row. A user field carrying an explicit defaultValue is
+        // handled by the branch above; only the empty type-default is skipped.
+        if (field.name === "title" || field.name === "slug") continue;
         value = getDefaultValue(field);
       } else {
         continue;

--- a/packages/nextly/src/domains/versions/__tests__/capture-on-update.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/capture-on-update.integration.test.ts
@@ -291,17 +291,23 @@ describe("version capture on update (integration)", () => {
 
     // This outer first write touches only the shared `region`; it adopts the row
     // the concurrent writer just inserted.
-    await singles.update(
+    const outer = await singles.update(
       "preferences",
       { region: "us" },
       { overrideAccess: true, locale: "en" }
     );
+    // The adopting write itself must succeed and be captured, otherwise the
+    // assertions below would pass against the inner hook's write alone and never
+    // exercise the adopter branch this test targets.
+    expect(outer.success).toBe(true);
 
     const rows = await versions(current, "preferences");
-    // The adopting write must NOT have overlaid the schema default over the
-    // concurrently-written real translation.
     const last = rows[rows.length - 1];
     const snapshot = last.snapshot as { siteName?: string; region?: string };
+    // The latest snapshot is the outer (adopting) write, proving we captured it.
+    expect(snapshot.region).toBe("us");
+    // ...and it did NOT overlay the schema default over the concurrently-written
+    // real translation.
     expect(snapshot.siteName).not.toBe("My Site");
   });
 

--- a/packages/nextly/src/domains/versions/__tests__/capture-on-update.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/capture-on-update.integration.test.ts
@@ -157,6 +157,90 @@ describe("version capture on update (integration)", () => {
     expect(v1.locale).toBe("en");
   });
 
+  it("tags v1 with the default locale when a shared-only first update seeds localized defaults", async () => {
+    // The first update touches only a SHARED field, so no localized field is
+    // written and `companionData` is empty. Without forcing the tag, the capture
+    // locale would be null, and a restore treats a null-locale snapshot of a
+    // localized document as shared-only and drops the seeded translations — the
+    // very defaults the overlay preserved. The snapshot must be tagged the
+    // default locale.
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          versions: true,
+          localized: true,
+          fields: [
+            text({
+              name: "siteName",
+              localized: true,
+              defaultValue: "My Site",
+            }),
+            text({ name: "region", localized: false }),
+          ],
+        }),
+      ],
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+    });
+    const singles =
+      current.getService<SingleEntryService>("singleEntryService");
+
+    await singles.update(
+      "preferences",
+      { region: "us" },
+      { overrideAccess: true, locale: "en" }
+    );
+
+    const rows = await versions(current, "preferences");
+    const v1 = rows[0];
+    const snapshot = v1.snapshot as { siteName?: string; region?: string };
+    expect(snapshot.siteName).toBe("My Site");
+    expect(v1.locale).toBe("en");
+  });
+
+  it("does not copy default-locale seeds into a non-default-locale first update snapshot", async () => {
+    // The seed persists localized defaults to the DEFAULT-locale companion only.
+    // A first write at a NON-default locale must not overlay them, or restoring
+    // that snapshot would materialize the defaults as real translations in the
+    // wrong locale.
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          versions: true,
+          localized: true,
+          fields: [
+            text({
+              name: "siteName",
+              localized: true,
+              defaultValue: "My Site",
+            }),
+            text({ name: "tagline", localized: true }),
+          ],
+        }),
+      ],
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+    });
+    const singles =
+      current.getService<SingleEntryService>("singleEntryService");
+
+    // First update auto-creates at "de" and touches only `tagline`.
+    await singles.update(
+      "preferences",
+      { tagline: "hallo" },
+      { overrideAccess: true, locale: "de" }
+    );
+
+    const rows = await versions(current, "preferences");
+    const v1 = rows[0];
+    const snapshot = v1.snapshot as { siteName?: string; tagline?: string };
+    // The written non-default translation is captured...
+    expect(snapshot.tagline).toBe("hallo");
+    // ...but the default-locale seed is NOT leaked into the "de" snapshot.
+    expect(snapshot.siteName).toBeUndefined();
+    expect(v1.locale).toBe("de");
+  });
+
   it("preserves an omitted component subtree in a scalar-only update snapshot", async () => {
     // A partial update carries only the fields in the request. Without reading
     // the current component state the snapshot would drop the untouched

--- a/packages/nextly/src/domains/versions/__tests__/capture-on-update.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/capture-on-update.integration.test.ts
@@ -111,6 +111,52 @@ describe("version capture on update (integration)", () => {
     expect((latest.snapshot as { title?: string }).title).toBe("hello");
   });
 
+  it("keeps a seeded localized default in v1 when the first update omits it (single auto-create)", async () => {
+    // First-write auto-create of a localized, versioned Single seeds the
+    // default-locale companion with the localized field defaults. When that
+    // first update touches only another field, the seeded default is still
+    // committed to the companion, so v1 must carry it — otherwise restoring v1
+    // silently drops content that was actually persisted.
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          versions: true,
+          localized: true,
+          fields: [
+            text({
+              name: "siteName",
+              localized: true,
+              defaultValue: "My Site",
+            }),
+            text({ name: "tagline", localized: true }),
+          ],
+        }),
+      ],
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+    });
+    const singles =
+      current.getService<SingleEntryService>("singleEntryService");
+
+    // The first update auto-creates the Single and touches ONLY `tagline`; the
+    // defaulted `siteName` is never in the patch, only in the auto-create seed.
+    await singles.update(
+      "preferences",
+      { tagline: "hi" },
+      { overrideAccess: true, locale: "en" }
+    );
+
+    const rows = await versions(current, "preferences");
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    const v1 = rows[0];
+    const snapshot = v1.snapshot as { siteName?: string; tagline?: string };
+    // The seeded default survives into v1 alongside the written field.
+    expect(snapshot.siteName).toBe("My Site");
+    expect(snapshot.tagline).toBe("hi");
+    // v1 belongs to the default locale it carries content for.
+    expect(v1.locale).toBe("en");
+  });
+
   it("preserves an omitted component subtree in a scalar-only update snapshot", async () => {
     // A partial update carries only the fields in the request. Without reading
     // the current component state the snapshot would drop the untouched

--- a/packages/nextly/src/domains/versions/__tests__/capture-on-update.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/capture-on-update.integration.test.ts
@@ -21,6 +21,7 @@ import {
   createTestNextly,
   type TestNextly,
 } from "../../../plugins/test-nextly";
+import type { HookContext } from "../../../hooks/types";
 import type { CollectionsHandler } from "../../../services/collections-handler";
 import { deriveCompanionSpec } from "../../i18n/migration/derive-companion-spec";
 import { buildCompanionCreateOnlySql } from "../../i18n/migration/generate-up";
@@ -239,6 +240,69 @@ describe("version capture on update (integration)", () => {
     // ...but the default-locale seed is NOT leaked into the "de" snapshot.
     expect(snapshot.siteName).toBeUndefined();
     expect(v1.locale).toBe("de");
+  });
+
+  it("does not overlay defaults when a first update adopts a concurrently-inserted row", async () => {
+    // Race: this update enters with autoCreated=true (nothing existed at the
+    // pre-transaction read), but a concurrent first write inserts the row WITH a
+    // real translation before the transaction opens. The transaction then adopts
+    // that row instead of inserting, so it never seeds the defaults — overlaying
+    // them would let a restore overwrite the real translation with a schema
+    // default. A beforeUpdate hook stands in for the concurrent writer: it runs
+    // after autoCreated is resolved but before the transaction.
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "preferences",
+          versions: true,
+          localized: true,
+          fields: [
+            text({
+              name: "siteName",
+              localized: true,
+              defaultValue: "My Site",
+            }),
+            text({ name: "region", localized: false }),
+          ],
+        }),
+      ],
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+    });
+    const singles =
+      current.getService<SingleEntryService>("singleEntryService");
+
+    let raced = false;
+    current.hooks.register(
+      "beforeUpdate",
+      "*",
+      async (context: HookContext<Record<string, unknown>>) => {
+        if (!raced) {
+          raced = true;
+          // The concurrent writer persists the row with a REAL siteName.
+          await singles.update(
+            "preferences",
+            { siteName: "Real Name" },
+            { overrideAccess: true, locale: "en" }
+          );
+        }
+        return context.data;
+      }
+    );
+
+    // This outer first write touches only the shared `region`; it adopts the row
+    // the concurrent writer just inserted.
+    await singles.update(
+      "preferences",
+      { region: "us" },
+      { overrideAccess: true, locale: "en" }
+    );
+
+    const rows = await versions(current, "preferences");
+    // The adopting write must NOT have overlaid the schema default over the
+    // concurrently-written real translation.
+    const last = rows[rows.length - 1];
+    const snapshot = last.snapshot as { siteName?: string; region?: string };
+    expect(snapshot.siteName).not.toBe("My Site");
   });
 
   it("preserves an omitted component subtree in a scalar-only update snapshot", async () => {

--- a/packages/nextly/src/services/__tests__/media-focal-regeneration.test.ts
+++ b/packages/nextly/src/services/__tests__/media-focal-regeneration.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Focal-point crop regeneration must be content-addressed: new variants are
+ * written to fresh keys, the row is committed pointing at them, and only THEN
+ * are the superseded old variants deleted — so a rollback or a lost update race
+ * never leaves the committed row referencing bytes that were already deleted.
+ *
+ * These use hand-rolled collaborators (no real DB) to pin the delete ORDERING
+ * and the rollback/void cleanup, which are the correctness contract of the fix.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const deleteSpy = vi.fn(async () => {});
+const calls: string[] = [];
+
+const storageMock = {
+  getAdapterForCollection: () => ({
+    read: async () => Buffer.from("original-image-bytes"),
+  }),
+  upload: async () => ({ url: "http://x/new", path: "NEW/thumb.webp" }),
+  delete: async (path: string) => {
+    calls.push(`delete:${path}`);
+    return deleteSpy(path);
+  },
+};
+
+vi.mock("@nextly/storage", () => ({
+  getMediaStorage: () => storageMock,
+  getImageProcessor: () => ({}),
+  withRetry: (fn: () => unknown) => fn(),
+  isTransientError: () => false,
+  // The regenerated variants land on a fresh, unique key.
+  generateImageSizes: async () => ({
+    thumbnail: {
+      path: "NEW/thumb.webp",
+      url: "http://x/new",
+      width: 100,
+      height: 100,
+    },
+  }),
+  deleteImageSizes: async () => {},
+}));
+
+vi.mock("../../domains/webhooks/record-mutation-event", () => ({
+  recordMutationEvent: async () => {},
+}));
+
+vi.mock("../image-size", () => ({
+  ImageSizeService: class {
+    async getActiveSizeConfigs() {
+      return [{ name: "thumbnail", width: 100, height: 100 }];
+    }
+  },
+}));
+
+import { MediaService } from "../media";
+
+const OLD_PATH = "OLD/thumb.webp";
+const NEW_PATH = "NEW/thumb.webp";
+
+const existingMedia = {
+  id: "m1",
+  mimeType: "image/png",
+  filename: "m1.png",
+  originalFilename: "m1.png",
+  sizes: { thumbnail: { path: OLD_PATH, url: "http://x/old" } },
+};
+
+function makeAdapter(txBehavior: "commit" | "throw" | "row-gone") {
+  const tx = {
+    lockRow: async () => {},
+    select: async () => (txBehavior === "row-gone" ? [] : [existingMedia]),
+    update: async () => {
+      calls.push("update");
+    },
+  };
+  return {
+    dialect: "sqlite" as const,
+    getDrizzle: () => ({}),
+    transaction: async <T>(fn: (t: typeof tx) => Promise<T>): Promise<T> => {
+      const result = await fn(tx);
+      if (txBehavior === "throw") throw new Error("db write failed");
+      return result;
+    },
+  };
+}
+
+function makeService(txBehavior: "commit" | "throw" | "row-gone") {
+  const logger = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+  const service = new MediaService(
+    makeAdapter(txBehavior) as never,
+    logger as never
+  );
+  // getMediaById is the pre-transaction existence read; stub it to the image.
+  vi.spyOn(
+    service as unknown as { getMediaById: () => Promise<unknown> },
+    "getMediaById"
+  ).mockResolvedValue({ success: true, statusCode: 200, data: existingMedia });
+  return service;
+}
+
+describe("MediaService focal-point regeneration ordering", () => {
+  beforeEach(() => {
+    calls.length = 0;
+    deleteSpy.mockClear();
+  });
+
+  it("deletes the old variant only AFTER the row commits, and never the new one", async () => {
+    const service = makeService("commit");
+    const res = await service.updateMedia("m1", { focalX: 0.5 });
+
+    expect(res.success).toBe(true);
+    // The old path is deleted, the new path (now referenced by the row) is not.
+    expect(deleteSpy).toHaveBeenCalledWith(OLD_PATH);
+    expect(deleteSpy).not.toHaveBeenCalledWith(NEW_PATH);
+    // Ordering: the delete happens strictly after the committing update.
+    expect(calls.indexOf("update")).toBeGreaterThanOrEqual(0);
+    expect(calls.indexOf(`delete:${OLD_PATH}`)).toBeGreaterThan(
+      calls.indexOf("update")
+    );
+  });
+
+  it("cleans up the new (orphaned) variant and keeps the old one when the write fails", async () => {
+    const service = makeService("throw");
+    const res = await service.updateMedia("m1", { focalX: 0.5 });
+
+    expect(res.success).toBe(false);
+    // The freshly-uploaded new variant is deleted; the old one is untouched.
+    expect(deleteSpy).toHaveBeenCalledWith(NEW_PATH);
+    expect(deleteSpy).not.toHaveBeenCalledWith(OLD_PATH);
+  });
+
+  it("cleans up the new variant when the row was concurrently deleted", async () => {
+    const service = makeService("row-gone");
+    const res = await service.updateMedia("m1", { focalX: 0.5 });
+
+    expect(res.statusCode).toBe(404);
+    expect(deleteSpy).toHaveBeenCalledWith(NEW_PATH);
+    expect(deleteSpy).not.toHaveBeenCalledWith(OLD_PATH);
+  });
+});

--- a/packages/nextly/src/services/__tests__/media-focal-regeneration.test.ts
+++ b/packages/nextly/src/services/__tests__/media-focal-regeneration.test.ts
@@ -52,6 +52,7 @@ vi.mock("../image-size", () => ({
   },
 }));
 
+import { NextlyError } from "../../errors";
 import { MediaService } from "../media";
 
 const OLD_PATH = "OLD/thumb.webp";
@@ -78,7 +79,13 @@ function makeAdapter(txBehavior: "commit" | "throw" | "row-gone") {
     getDrizzle: () => ({}),
     transaction: async <T>(fn: (t: typeof tx) => Promise<T>): Promise<T> => {
       const result = await fn(tx);
-      if (txBehavior === "throw") throw new Error("db write failed");
+      if (txBehavior === "throw") {
+        // Mirror how the DB layer surfaces a failed write (a typed NextlyError),
+        // not a bare Error, matching this package's error convention.
+        throw NextlyError.internal({
+          logContext: { reason: "test-simulated-db-failure" },
+        });
+      }
       return result;
     },
   };

--- a/packages/nextly/src/services/__tests__/media-focal-regeneration.test.ts
+++ b/packages/nextly/src/services/__tests__/media-focal-regeneration.test.ts
@@ -13,7 +13,9 @@ const deleteSpy = vi.fn(async () => {});
 const calls: string[] = [];
 // The path the regenerated variant lands on. Mutable so a test can simulate a
 // deterministic-key adapter that reuses the existing path (new === old).
-const regen = { thumbPath: "NEW/thumb.webp" };
+// `filenames` records the destination base names passed to generateImageSizes,
+// so a test can assert regeneration forces a unique destination.
+const regen = { thumbPath: "NEW/thumb.webp", filenames: [] as string[] };
 
 const storageMock = {
   getAdapterForCollection: () => ({
@@ -33,15 +35,19 @@ vi.mock("@nextly/storage", () => ({
   isTransientError: () => false,
   // The regenerated variants land on the configured key (fresh/unique by
   // default; a test can point it at the existing path to model a deterministic
-  // adapter that overwrites in place).
-  generateImageSizes: async () => ({
-    thumbnail: {
-      path: regen.thumbPath,
-      url: "http://x/new",
-      width: 100,
-      height: 100,
-    },
-  }),
+  // adapter that overwrites in place). The destination base name is recorded so
+  // a test can assert regeneration forces a unique destination.
+  generateImageSizes: async (_buffer: unknown, originalFilename: string) => {
+    regen.filenames.push(originalFilename);
+    return {
+      thumbnail: {
+        path: regen.thumbPath,
+        url: "http://x/new",
+        width: 100,
+        height: 100,
+      },
+    };
+  },
   deleteImageSizes: async () => {},
 }));
 
@@ -129,6 +135,22 @@ describe("MediaService focal-point regeneration ordering", () => {
     calls.length = 0;
     deleteSpy.mockClear();
     regen.thumbPath = NEW_PATH;
+    regen.filenames.length = 0;
+  });
+
+  it("regenerates onto a unique destination base, never the item's stored filename", async () => {
+    // A random token is injected before the extension so the regenerated variant
+    // keys cannot collide with the item's existing ones on a deterministic
+    // (filename -> fixed path) storage adapter — which would otherwise fail the
+    // upload or overwrite live bytes before the row commits.
+    const service = makeService("commit");
+    await service.updateMedia("m1", { focalX: 0.5 });
+
+    expect(regen.filenames).toHaveLength(1);
+    const base = regen.filenames[0];
+    expect(base).not.toBe(existingMedia.originalFilename);
+    // `m1.png` -> `m1-<uuid>.png`: token before the extension.
+    expect(base).toMatch(/^m1-[0-9a-f-]{36}\.png$/i);
   });
 
   it("deletes the old variant only AFTER the row commits, and never the new one", async () => {

--- a/packages/nextly/src/services/__tests__/media-focal-regeneration.test.ts
+++ b/packages/nextly/src/services/__tests__/media-focal-regeneration.test.ts
@@ -71,10 +71,16 @@ const existingMedia = {
   sizes: { thumbnail: { path: OLD_PATH, url: "http://x/old" } },
 };
 
-function makeAdapter(txBehavior: "commit" | "throw" | "row-gone") {
+function makeAdapter(
+  txBehavior: "commit" | "throw" | "row-gone",
+  // The row the in-transaction locked read returns. Defaults to the same row the
+  // pre-transaction read saw; a test overrides it to model a concurrent update
+  // that committed a different variant set before this transaction locked.
+  lockedRow: typeof existingMedia = existingMedia
+) {
   const tx = {
     lockRow: async () => {},
-    select: async () => (txBehavior === "row-gone" ? [] : [existingMedia]),
+    select: async () => (txBehavior === "row-gone" ? [] : [lockedRow]),
     update: async () => {
       calls.push("update");
     },
@@ -96,7 +102,10 @@ function makeAdapter(txBehavior: "commit" | "throw" | "row-gone") {
   };
 }
 
-function makeService(txBehavior: "commit" | "throw" | "row-gone") {
+function makeService(
+  txBehavior: "commit" | "throw" | "row-gone",
+  lockedRow: typeof existingMedia = existingMedia
+) {
   const logger = {
     info: () => {},
     warn: () => {},
@@ -104,7 +113,7 @@ function makeService(txBehavior: "commit" | "throw" | "row-gone") {
     debug: () => {},
   };
   const service = new MediaService(
-    makeAdapter(txBehavior) as never,
+    makeAdapter(txBehavior, lockedRow) as never,
     logger as never
   );
   // getMediaById is the pre-transaction existence read; stub it to the image.
@@ -165,6 +174,30 @@ describe("MediaService focal-point regeneration ordering", () => {
     const res = await service.updateMedia("m1", { focalX: 0.5 });
 
     expect(res.success).toBe(false);
+    expect(deleteSpy).not.toHaveBeenCalledWith(OLD_PATH);
+  });
+
+  it("keeps the locked row's variant (not the pre-transaction one) on rollback", async () => {
+    // Lost-update race with a deterministic-key adapter: this update read OLD
+    // before the transaction, a concurrent update committed variant A, and this
+    // update then locked and read A before its own write failed. The rollback
+    // must filter the orphans against the LOCKED row (A), not the stale pre-
+    // transaction read (OLD): the row the database still references is A, so
+    // deleting A would drop a live variant. Filtering against OLD would delete A.
+    const A_PATH = "A/thumb.webp";
+    regen.thumbPath = A_PATH;
+    const lockedRow = {
+      ...existingMedia,
+      sizes: { thumbnail: { path: A_PATH, url: "http://x/a" } },
+    };
+    const service = makeService("throw", lockedRow);
+    const res = await service.updateMedia("m1", { focalX: 0.5 });
+
+    expect(res.success).toBe(false);
+    // The variant the surviving (locked) row references is kept.
+    expect(deleteSpy).not.toHaveBeenCalledWith(A_PATH);
+    // The stale pre-transaction variant is not the one referenced, so it is not
+    // wrongly kept as "live" either — nothing gets deleted here at all.
     expect(deleteSpy).not.toHaveBeenCalledWith(OLD_PATH);
   });
 });

--- a/packages/nextly/src/services/__tests__/media-focal-regeneration.test.ts
+++ b/packages/nextly/src/services/__tests__/media-focal-regeneration.test.ts
@@ -11,6 +11,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const deleteSpy = vi.fn(async () => {});
 const calls: string[] = [];
+// The path the regenerated variant lands on. Mutable so a test can simulate a
+// deterministic-key adapter that reuses the existing path (new === old).
+const regen = { thumbPath: "NEW/thumb.webp" };
 
 const storageMock = {
   getAdapterForCollection: () => ({
@@ -28,10 +31,12 @@ vi.mock("@nextly/storage", () => ({
   getImageProcessor: () => ({}),
   withRetry: (fn: () => unknown) => fn(),
   isTransientError: () => false,
-  // The regenerated variants land on a fresh, unique key.
+  // The regenerated variants land on the configured key (fresh/unique by
+  // default; a test can point it at the existing path to model a deterministic
+  // adapter that overwrites in place).
   generateImageSizes: async () => ({
     thumbnail: {
-      path: "NEW/thumb.webp",
+      path: regen.thumbPath,
       url: "http://x/new",
       width: 100,
       height: 100,
@@ -114,6 +119,7 @@ describe("MediaService focal-point regeneration ordering", () => {
   beforeEach(() => {
     calls.length = 0;
     deleteSpy.mockClear();
+    regen.thumbPath = NEW_PATH;
   });
 
   it("deletes the old variant only AFTER the row commits, and never the new one", async () => {
@@ -147,6 +153,18 @@ describe("MediaService focal-point regeneration ordering", () => {
 
     expect(res.statusCode).toBe(404);
     expect(deleteSpy).toHaveBeenCalledWith(NEW_PATH);
+    expect(deleteSpy).not.toHaveBeenCalledWith(OLD_PATH);
+  });
+
+  it("does not delete a shared path on rollback for a deterministic-key adapter", async () => {
+    // A deterministic adapter regenerates onto the SAME path the row already
+    // references. On a failed write the un-updated row still points there, so the
+    // rollback cleanup must not delete it (which would drop the live variant).
+    regen.thumbPath = OLD_PATH;
+    const service = makeService("throw");
+    const res = await service.updateMedia("m1", { focalX: 0.5 });
+
+    expect(res.success).toBe(false);
     expect(deleteSpy).not.toHaveBeenCalledWith(OLD_PATH);
   });
 });

--- a/packages/nextly/src/services/media.ts
+++ b/packages/nextly/src/services/media.ts
@@ -467,25 +467,33 @@ export class MediaService extends BaseService {
 
   /**
    * Regenerate a media item's image size variants for a changed crop point,
-   * writing `sizes`/`thumbnailUrl` onto `updateData`. No-op unless the crop
-   * actually changed and the item is an image on a readable storage adapter.
+   * writing `sizes`/`thumbnailUrl` onto `updateData` and returning the newly
+   * generated sizes (or null when nothing was regenerated). No-op unless the
+   * crop actually changed and the item is an image on a readable storage
+   * adapter.
    *
-   * Called from inside the update transaction, under the media row lock, so its
-   * shared-path storage writes are serialized with the row commit: two
-   * concurrent focal edits of the same item cannot interleave their variant
-   * writes, so the committed row never points at another crop's bytes.
+   * The new variants are written to fresh storage keys (the adapters prefix a
+   * random id), so this NEVER overwrites the item's existing variant bytes and
+   * never deletes them: content-addressing plus a delete-after-commit in
+   * `updateMedia` is what makes this safe. Deleting the old paths here — before
+   * the row commits — was the previous bug: a rollback or a concurrent edit left
+   * the committed row pointing at bytes that were already gone. The old paths
+   * are now cleaned up by the caller only after the row durably points at the
+   * new ones. Kept OUTSIDE the write transaction on purpose: it must not hold
+   * the row lock (or a single-connection pool) across slow storage I/O.
+   *
    * Best-effort: a regeneration failure is swallowed (the crop point is still
-   * saved) rather than failing the whole update.
+   * saved against the existing variants) rather than failing the whole update.
    */
   private async regenerateFocalPointSizes(
     media: Media,
     changes: UpdateMediaInput,
     updateData: Record<string, unknown>
-  ): Promise<void> {
+  ): Promise<Record<string, unknown> | null> {
     const focalPointChanged =
       changes.focalX !== undefined || changes.focalY !== undefined;
     if (!focalPointChanged || !isImageMimeType(media.mimeType)) {
-      return;
+      return null;
     }
 
     const adapter = this.storage.getAdapterForCollection("media");
@@ -494,25 +502,16 @@ export class MediaService extends BaseService {
         `[MediaService] Crop point saved for media ${media.id}. ` +
           `Size regeneration requires local storage or adapter with read support.`
       );
-      return;
+      return null;
     }
 
     try {
       const originalBuffer = await adapter.read(media.filename);
-      if (!originalBuffer) return;
+      if (!originalBuffer) return null;
 
       const imageSizeService = new ImageSizeService(this.adapter, this.logger);
       const sizeConfigs = await imageSizeService.getActiveSizeConfigs();
-      if (sizeConfigs.length === 0) return;
-
-      const oldSizes = (media as unknown as Record<string, unknown>).sizes;
-      if (oldSizes) {
-        const parsed =
-          typeof oldSizes === "string" ? JSON.parse(oldSizes) : oldSizes;
-        await deleteImageSizes(parsed, path =>
-          this.storage.delete(path, "media")
-        );
-      }
+      if (sizeConfigs.length === 0) return null;
 
       const uploadFn = async (
         buffer: Buffer,
@@ -542,13 +541,65 @@ export class MediaService extends BaseService {
       console.log(
         `[MediaService] Regenerated ${Object.keys(newSizes).length} sizes for media ${media.id}`
       );
+      return newSizes;
     } catch (error) {
       console.warn(
         "[MediaService] Crop point size regeneration failed:",
         error
       );
       // Continue without regeneration - crop point is still saved.
+      return null;
     }
+  }
+
+  /**
+   * Best-effort deletion of a set of variant storage paths. Used to clean up
+   * either the superseded old variants (after a rotation commits) or the
+   * freshly-written new variants (when the commit did not happen), so neither a
+   * successful regeneration nor a failed one leaks storage. Never throws: a
+   * failed delete is logged, because the durable DB state is already correct and
+   * an orphaned file is not worth failing or reversing the write over.
+   */
+  private async deleteVariantPaths(paths: string[]): Promise<void> {
+    if (paths.length === 0) return;
+    const results = await Promise.allSettled(
+      paths.map(path => this.storage.delete(path, "media"))
+    );
+    const failed = results.filter(r => r.status === "rejected").length;
+    if (failed > 0) {
+      console.warn(
+        `[MediaService] Failed to delete ${failed} of ${paths.length} old media variant(s).`
+      );
+    }
+  }
+
+  /**
+   * Extract the storage paths from a `sizes` value (an object keyed by size name,
+   * each holding `{ path, ... }`), tolerating the DB's JSON-string form. Used to
+   * decide which variant files to delete after a rotation without touching any
+   * that the new set reuses.
+   */
+  private collectVariantPaths(sizes: unknown): string[] {
+    let parsed: unknown = sizes;
+    if (typeof sizes === "string") {
+      try {
+        parsed = JSON.parse(sizes);
+      } catch {
+        return [];
+      }
+    }
+    if (!parsed || typeof parsed !== "object") return [];
+    const paths: string[] = [];
+    for (const value of Object.values(parsed as Record<string, unknown>)) {
+      if (
+        value &&
+        typeof value === "object" &&
+        typeof (value as { path?: unknown }).path === "string"
+      ) {
+        paths.push((value as { path: string }).path);
+      }
+    }
+    return paths;
   }
 
   /**
@@ -579,16 +630,18 @@ export class MediaService extends BaseService {
         updateData.folderId = changes.folderId;
 
       // Regenerate focal-point image variants when the crop changed, before the
-      // write transaction opens. Storage is not transactional, so regenerating
-      // shared variant paths can never be made atomic with the DB write: doing
-      // it inside the transaction would hold the row lock (and, on a
-      // single-connection pool, the only connection) across slow storage I/O
-      // without removing the underlying dual-write inconsistency (a rollback or
-      // a concurrent edit still overwrites the shared paths). Keeping it here
-      // preserves the existing behavior; a content-addressed variant scheme
-      // (new unique paths per generation, old paths cleaned up after commit) is
-      // the real fix and is tracked as a separate image-pipeline follow-up.
-      await this.regenerateFocalPointSizes(existing.data!, changes, updateData);
+      // write transaction opens (storage I/O must not hold the row lock). The
+      // new variants go to fresh, unique keys and the OLD ones are left in place;
+      // the row is then committed pointing at the new keys and the superseded old
+      // ones are deleted only AFTER the commit. So a rollback or a lost update
+      // race never leaves the committed row referencing bytes that were already
+      // deleted — the previous, now-fixed dual-write bug. Returns the new sizes
+      // (or null) so a failed/void write can clean up its own orphaned uploads.
+      const regeneratedSizes = await this.regenerateFocalPointSizes(
+        existing.data!,
+        changes,
+        updateData
+      );
 
       // Commit the row update and its outbox event in one transaction so the
       // event is durable exactly when the change commits. The row is locked and
@@ -599,8 +652,15 @@ export class MediaService extends BaseService {
       // MySQL's repeatable read), and a field another request committed after
       // our first read is not shipped stale. The transaction returns the
       // post-update document (or null when the row is already gone).
-      const updatedRow = await this.adapter.transaction<Media | null>(
-        async tx => {
+      //
+      // The superseded variant paths are captured from the locked row here, not
+      // from the pre-transaction read, so two concurrent focal edits each delete
+      // exactly the paths their own commit replaced rather than one clobbering
+      // the other's fresh variants.
+      let replacedSizes: unknown = null;
+      let updatedRow: Media | null;
+      try {
+        updatedRow = await this.adapter.transaction<Media | null>(async tx => {
           await tx.lockRow("media", mediaId);
           const currentRows = await tx.select<Media>("media", {
             where: this.whereEq("id", mediaId),
@@ -610,6 +670,11 @@ export class MediaService extends BaseService {
           // record nothing and let the not-found result below stand.
           if (!current) {
             return null;
+          }
+
+          if (regeneratedSizes) {
+            replacedSizes = (current as unknown as Record<string, unknown>)
+              .sizes;
           }
 
           await tx.update("media", updateData, this.whereEq("id", mediaId));
@@ -633,10 +698,28 @@ export class MediaService extends BaseService {
           });
 
           return nextRow;
+        });
+      } catch (error) {
+        // The write failed after new variants were uploaded to fresh keys: those
+        // uploads are now orphaned. Delete them so a failed regeneration does not
+        // leak storage; the old variants are untouched and the row still points
+        // at them. Then let the error propagate to the outer handler.
+        if (regeneratedSizes) {
+          await this.deleteVariantPaths(
+            this.collectVariantPaths(regeneratedSizes)
+          );
         }
-      );
+        throw error;
+      }
 
       if (!updatedRow) {
+        // Concurrent delete: the row is gone, so the freshly-uploaded variants
+        // are orphaned — clean them up before returning not-found.
+        if (regeneratedSizes) {
+          await this.deleteVariantPaths(
+            this.collectVariantPaths(regeneratedSizes)
+          );
+        }
         // Mirror getMediaById's not-found shape so the domain layer maps this to
         // a 404 instead of treating the no-op write as a successful update.
         return {
@@ -645,6 +728,19 @@ export class MediaService extends BaseService {
           message: "Media not found",
           data: null,
         };
+      }
+
+      // The row now durably references the new variants, so the superseded old
+      // ones can be deleted. Filtered against the new paths so a deterministic-
+      // key adapter (where a regenerated variant can reuse a path) never deletes
+      // a file the committed row still points at.
+      if (regeneratedSizes && replacedSizes) {
+        const keep = new Set(this.collectVariantPaths(regeneratedSizes));
+        await this.deleteVariantPaths(
+          this.collectVariantPaths(replacedSizes).filter(
+            path => !keep.has(path)
+          )
+        );
       }
 
       // The update committed a media.updated outbox row; drain and prune it

--- a/packages/nextly/src/services/media.ts
+++ b/packages/nextly/src/services/media.ts
@@ -579,6 +579,25 @@ export class MediaService extends BaseService {
    * decide which variant files to delete after a rotation without touching any
    * that the new set reuses.
    */
+  /**
+   * Delete the variant paths in `candidateSizes` that are NOT among the paths
+   * `keepSizes` references. Used for every variant cleanup so a deterministic-key
+   * adapter (where a regenerated variant can reuse an existing path) never
+   * deletes a file the surviving row still points at: after commit `keepSizes`
+   * is the new sizes and `candidateSizes` the superseded old ones; on a failed or
+   * void write it is the reverse — the old sizes survive on the un-updated row,
+   * so only the genuinely-orphaned new uploads are removed.
+   */
+  private async deleteSupersededVariants(
+    candidateSizes: unknown,
+    keepSizes: unknown
+  ): Promise<void> {
+    const keep = new Set(this.collectVariantPaths(keepSizes));
+    await this.deleteVariantPaths(
+      this.collectVariantPaths(candidateSizes).filter(path => !keep.has(path))
+    );
+  }
+
   private collectVariantPaths(sizes: unknown): string[] {
     let parsed: unknown = sizes;
     if (typeof sizes === "string") {
@@ -701,23 +720,26 @@ export class MediaService extends BaseService {
         });
       } catch (error) {
         // The write failed after new variants were uploaded to fresh keys: those
-        // uploads are now orphaned. Delete them so a failed regeneration does not
-        // leak storage; the old variants are untouched and the row still points
-        // at them. Then let the error propagate to the outer handler.
+        // uploads are orphaned. Delete them — but keep any that the un-updated
+        // row still references (a deterministic adapter can reuse an old path),
+        // so a failed regeneration never removes a live variant. Then propagate.
         if (regeneratedSizes) {
-          await this.deleteVariantPaths(
-            this.collectVariantPaths(regeneratedSizes)
+          await this.deleteSupersededVariants(
+            regeneratedSizes,
+            (existing.data as { sizes?: unknown } | null)?.sizes
           );
         }
         throw error;
       }
 
       if (!updatedRow) {
-        // Concurrent delete: the row is gone, so the freshly-uploaded variants
-        // are orphaned — clean them up before returning not-found.
+        // Concurrent delete: the row was not updated, so the freshly-uploaded
+        // variants are orphaned. Same guard as the failure path — keep anything
+        // the pre-write row still referenced — before returning not-found.
         if (regeneratedSizes) {
-          await this.deleteVariantPaths(
-            this.collectVariantPaths(regeneratedSizes)
+          await this.deleteSupersededVariants(
+            regeneratedSizes,
+            (existing.data as { sizes?: unknown } | null)?.sizes
           );
         }
         // Mirror getMediaById's not-found shape so the domain layer maps this to
@@ -731,16 +753,9 @@ export class MediaService extends BaseService {
       }
 
       // The row now durably references the new variants, so the superseded old
-      // ones can be deleted. Filtered against the new paths so a deterministic-
-      // key adapter (where a regenerated variant can reuse a path) never deletes
-      // a file the committed row still points at.
+      // ones can be deleted (keeping any path the new set reuses).
       if (regeneratedSizes && replacedSizes) {
-        const keep = new Set(this.collectVariantPaths(regeneratedSizes));
-        await this.deleteVariantPaths(
-          this.collectVariantPaths(replacedSizes).filter(
-            path => !keep.has(path)
-          )
-        );
+        await this.deleteSupersededVariants(replacedSizes, regeneratedSizes);
       }
 
       // The update committed a media.updated outbox row; drain and prune it

--- a/packages/nextly/src/services/media.ts
+++ b/packages/nextly/src/services/media.ts
@@ -466,21 +466,40 @@ export class MediaService extends BaseService {
   }
 
   /**
+   * Insert a random token before a filename's extension so any destination
+   * derived from it is unique: `photo.jpg` -> `photo-<token>.jpg` (a name with
+   * no extension gets the token appended). Used to guarantee regenerated
+   * focal-crop variants never reuse the item's existing storage keys, even on a
+   * storage adapter that maps a filename to a fixed path.
+   */
+  private uniqueVariantBaseName(filename: string): string {
+    const token = crypto.randomUUID();
+    const lastDot = filename.lastIndexOf(".");
+    if (lastDot > 0) {
+      return `${filename.slice(0, lastDot)}-${token}${filename.slice(lastDot)}`;
+    }
+    return `${filename}-${token}`;
+  }
+
+  /**
    * Regenerate a media item's image size variants for a changed crop point,
    * writing `sizes`/`thumbnailUrl` onto `updateData` and returning the newly
    * generated sizes (or null when nothing was regenerated). No-op unless the
    * crop actually changed and the item is an image on a readable storage
    * adapter.
    *
-   * The new variants are written to fresh storage keys (the adapters prefix a
-   * random id), so this NEVER overwrites the item's existing variant bytes and
-   * never deletes them: content-addressing plus a delete-after-commit in
-   * `updateMedia` is what makes this safe. Deleting the old paths here — before
-   * the row commits — was the previous bug: a rollback or a concurrent edit left
-   * the committed row pointing at bytes that were already gone. The old paths
-   * are now cleaned up by the caller only after the row durably points at the
-   * new ones. Kept OUTSIDE the write transaction on purpose: it must not hold
-   * the row lock (or a single-connection pool) across slow storage I/O.
+   * The new variants are written to fresh storage keys — a random token is
+   * injected into the destination filename here so they can NEVER land on the
+   * item's existing variant keys, even on a storage adapter that derives a
+   * deterministic path from the filename rather than prefixing its own random
+   * id. This never overwrites the item's existing variant bytes and never
+   * deletes them: content-addressing plus a delete-after-commit in `updateMedia`
+   * is what makes this safe. Deleting the old paths here — before the row commits
+   * — was the previous bug: a rollback or a concurrent edit left the committed
+   * row pointing at bytes that were already gone. The old paths are now cleaned
+   * up by the caller only after the row durably points at the new ones. Kept
+   * OUTSIDE the write transaction on purpose: it must not hold the row lock (or a
+   * single-connection pool) across slow storage I/O.
    *
    * Best-effort: a regeneration failure is swallowed (the crop point is still
    * saved against the existing variants) rather than failing the whole update.
@@ -523,9 +542,19 @@ export class MediaService extends BaseService {
           collection: "media",
         });
       };
+      // Force a unique destination base so the regenerated variant keys cannot
+      // collide with the item's existing ones on a deterministic (filename ->
+      // fixed path) storage adapter. On a collision, an overwrite-disallowing
+      // adapter would fail the upload (saving the crop without new thumbnails)
+      // and an overwrite-allowing one would mutate the bytes the committed row
+      // still points at before this transaction commits — both break the
+      // content-addressed delete-after-commit contract updateMedia relies on.
+      const uniqueBase = this.uniqueVariantBaseName(
+        media.originalFilename || media.filename
+      );
       const newSizes = await generateImageSizes(
         originalBuffer,
-        media.originalFilename || media.filename,
+        uniqueBase,
         sizeConfigs,
         uploadFn,
         { focalX: changes.focalX, focalY: changes.focalY }

--- a/packages/nextly/src/services/media.ts
+++ b/packages/nextly/src/services/media.ts
@@ -722,11 +722,16 @@ export class MediaService extends BaseService {
         // The write failed after new variants were uploaded to fresh keys: those
         // uploads are orphaned. Delete them — but keep any that the un-updated
         // row still references (a deterministic adapter can reuse an old path),
-        // so a failed regeneration never removes a live variant. Then propagate.
+        // so a failed regeneration never removes a live variant. Prefer
+        // `replacedSizes` (read UNDER THE LOCK, so it reflects a variant set a
+        // concurrent update committed after our pre-transaction read); fall back
+        // to the pre-transaction read only when the transaction failed before it
+        // reached the locked row. Then propagate.
         if (regeneratedSizes) {
           await this.deleteSupersededVariants(
             regeneratedSizes,
-            (existing.data as { sizes?: unknown } | null)?.sizes
+            replacedSizes ??
+              (existing.data as { sizes?: unknown } | null)?.sizes
           );
         }
         throw error;
@@ -735,11 +740,14 @@ export class MediaService extends BaseService {
       if (!updatedRow) {
         // Concurrent delete: the row was not updated, so the freshly-uploaded
         // variants are orphaned. Same guard as the failure path — keep anything
-        // the pre-write row still referenced — before returning not-found.
+        // the surviving row still references — before returning not-found. Here
+        // the locked read found no row (so `replacedSizes` stayed null) and the
+        // fallback to the pre-transaction read supplies the paths to keep.
         if (regeneratedSizes) {
           await this.deleteSupersededVariants(
             regeneratedSizes,
-            (existing.data as { sizes?: unknown } | null)?.sizes
+            replacedSizes ??
+              (existing.data as { sizes?: unknown } | null)?.sizes
           );
         }
         // Mirror getMediaById's not-found shape so the domain layer maps this to


### PR DESCRIPTION
## What

Three content-integrity fixes deferred from the webhook singles/media recording PRs (#301, #307), bundled into one PR. Each was reviewed as real-but-cross-feature at the time and logged for a dedicated follow-up.

### 1. Media focal-point crop regeneration: delete-after-commit (#307)

Regenerating an image's size variants for a new crop point deleted the **old** variant files *before* the DB row committed, from outside the transaction. A rollback or a lost update race then left the committed row pointing at bytes that were already gone (and orphaned the new uploads).

Fix: variants are regenerated to fresh, unique keys (as the adapters already do), the row is committed pointing at them, and the **superseded old files are deleted only after commit** — with the replaced paths captured from the *in-transaction locked row*, so two concurrent focal edits each clean up exactly what their own commit replaced. A failed write or a concurrently-deleted row now cleans up the new orphans and leaves the old files intact. (The stale doc-comment that claimed regeneration ran "inside the transaction" is corrected.)

### 2. Localized field defaults seeded onto the companion on auto-create (#301)

`buildDefaultDocument` dropped every translatable field default, and the auto-create paths only inserted the main row — so a localized field's default (including a localized `title`/`slug`) resolved to null until first written. `buildDefaultDocument` now returns those defaults, and all three auto-create sites (read-path versioned + non-versioned, and the mutation-path first write) seed them onto the **default-locale companion row**, atomically with the main insert, stamping the companion `_status` to match the main row.

### 3. Reconcile the default-locale companion `_status` (#301)

Turning on Draft/Published for an already-localized entity ran `ADD COLUMN _status ... DEFAULT 'draft'`, which reset the **default-locale** companion to `draft` even when the main row was already `published`. A later default-locale publish was then a no-op against the main row and fired no `single.published` webhook. The reconcile now back-fills the default-locale companion `_status` from the main row's status (a correlated subquery valid on all three dialects), targeting only the default locale. Collections and components get this for free via the shared transition builder.

## Tests

- Media: ordering (old deleted only after commit, never the new one), rollback cleanup, concurrent-delete cleanup — hand-mocked (the real-DB `media.test.ts` is on a pre-existing broken `createTestDb` `users` fixture, noted below).
- i18n: `buildDefaultDocument` routes localized defaults (incl. localized title) to the companion and off the main insert; reconcile emits the `_status` back-fill for the default locale only when a default locale is supplied, and not on a `_status` drop.
- Full singles + i18n unit suites (228) green; singles/i18n integration legs (atomicity, localized outbox, companion transition) green.

`check-types` + `lint` clean. One changeset, all 19 packages `patch`.

## Note

The media `createTestDb`-backed suite (`src/services/__tests__/media.test.ts`, `media-folder.test.ts`) has a **pre-existing** 22-test baseline failure — the shared fixture's `users` DDL is missing `must_change_password` (`table users has no column named must_change_password`). This PR adds zero new failures there; the fix's behavior is covered by the hand-mocked ordering test above. The fixture drift is out of scope here.

## Non-goals

Changing the media signature scheme or storage adapters; reworking companion read/overlay; the `must_change_password` fixture drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Localized default values are now correctly seeded for Singles, including version snapshots, without overwriting concurrent locale updates.
  - i18n companion reconciliation now back-fills the `_status` column for default-locale companion rows when enabled, and removes it cleanly when disabled.
  - Companion-table checks now reliably treat only true “missing table” cases as absent, while surfacing other database errors.
  - Media focal-point regeneration now avoids variant path collisions and defers deletion until after a successful update, preserving valid/shared variants and cleaning up only orphans on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->