### PR TITLE
fix(admin): guard webhook secret lifecycle panel against missing secrets

### DIFF
--- a/.changeset/webhook-secret-lifecycle-guard.md
+++ b/.changeset/webhook-secret-lifecycle-guard.md
@@ -1,0 +1,27 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Fix the webhook endpoint edit page crashing with "Cannot read properties of
+undefined (reading 'some')" when the endpoint summary arrives without the
+`secrets` lifecycle field (for example an admin bundle newer than the backend it
+is talking to). The signing-secrets panel now degrades to an empty state instead
+of throwing.

--- a/packages/admin/src/components/features/webhooks/SecretLifecycle.test.tsx
+++ b/packages/admin/src/components/features/webhooks/SecretLifecycle.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+import type { WebhookSecretInfo } from "@admin/types/webhooks";
+
+import { SecretLifecycle } from "./SecretLifecycle";
+
+const primary: WebhookSecretInfo = {
+  prefix: "whsec_ab",
+  isPrimary: true,
+  createdAt: "2026-07-24T00:00:00.000Z",
+  expiresAt: null,
+};
+
+describe("SecretLifecycle", () => {
+  it("renders the active secrets and marks the primary", () => {
+    render(
+      <SecretLifecycle
+        secrets={[primary]}
+        canManage
+        onExpireOld={vi.fn()}
+        isExpiring={false}
+      />
+    );
+    expect(screen.getByText("Primary")).toBeInTheDocument();
+    expect(screen.getByText(/whsec_ab/)).toBeInTheDocument();
+  });
+
+  it("degrades to an empty state instead of crashing when secrets is missing", () => {
+    // A summary from a backend older than the admin bundle can omit `secrets`;
+    // the panel must not throw on `.some`/`.map`.
+    render(
+      <SecretLifecycle
+        secrets={undefined as unknown as WebhookSecretInfo[]}
+        canManage
+        onExpireOld={vi.fn()}
+        isExpiring={false}
+      />
+    );
+    expect(screen.getByText(/no active signing secrets/i)).toBeInTheDocument();
+  });
+
+  it("hides the Expire control when there is no overlapping secret", () => {
+    render(
+      <SecretLifecycle
+        secrets={[primary]}
+        canManage
+        onExpireOld={vi.fn()}
+        isExpiring={false}
+      />
+    );
+    expect(
+      screen.queryByRole("button", { name: /expire old secret/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/features/webhooks/SecretLifecycle.tsx
+++ b/packages/admin/src/components/features/webhooks/SecretLifecycle.tsx
@@ -42,11 +42,15 @@ export interface SecretLifecycleProps {
 }
 
 export const SecretLifecycle: React.FC<SecretLifecycleProps> = ({
-  secrets,
+  secrets = [],
   canManage,
   onExpireOld,
   isExpiring,
 }) => {
+  // Default to an empty list so a summary that arrived without `secrets` — for
+  // example an admin bundle newer than the backend it is talking to, before the
+  // `secrets` field was added to the endpoint response — degrades to an empty
+  // state instead of crashing the whole edit page on `.some`/`.map`.
   const hasOverlap = secrets.some(secret => !secret.isPrimary);
 
   return (
@@ -70,6 +74,11 @@ export const SecretLifecycle: React.FC<SecretLifecycleProps> = ({
       </div>
 
       <ul className="divide-y divide-foreground/10 rounded-md border border-input bg-card">
+        {secrets.length === 0 && (
+          <li className="px-4 py-3 text-sm text-muted-foreground">
+            No active signing secrets to show.
+          </li>
+        )}
         {secrets.map(secret => (
           <li
             key={`${secret.prefix}-${secret.createdAt}`}


### PR DESCRIPTION
## What

The webhook endpoint **edit page** crashed with `Cannot read properties of undefined (reading 'some')` in `SecretLifecycle` when the endpoint summary arrived **without** the `secrets` lifecycle field — e.g. an admin bundle newer than the backend it is talking to (the `secrets` field was added to the endpoint response in the secret-rotation work). A UI panel must not hard-crash the whole page on a missing field.

## Fix

`SecretLifecycle` now defaults `secrets` to `[]` and renders a graceful "No active signing secrets to show." empty state instead of throwing on `.some`/`.map`.

## Tests

Added `SecretLifecycle.test.tsx`: renders active secrets + primary badge, degrades to the empty state when `secrets` is missing (the regression), and hides Expire-now without an overlap. `check-types` + `lint` clean.

One changeset, all 19 packages `patch`.