### PR TITLE
feat: add blocks-engine package with document model and tree utilities

### DIFF
--- a/.changeset/blocks-engine-scaffold.md
+++ b/.changeset/blocks-engine-scaffold.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+New package `@nextlyhq/blocks-engine`: the foundation of the rebuilt page builder. It ships the stored document format (pages as a plain list of blocks with typed styles, data bindings, visibility rules, and locale-overlay support) plus the pure tree operations editors and tools build on. It is dependency-free and works in any JavaScript runtime, so page documents can be created and edited outside the admin too.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,7 @@
       "create-nextly-app",
       "@nextlyhq/admin",
       "@nextlyhq/admin-css",
+      "@nextlyhq/blocks-engine",
       "@nextlyhq/ui",
       "@nextlyhq/adapter-drizzle",
       "@nextlyhq/adapter-postgres",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,7 @@ jobs:
       - name: Test
         run: >-
           pnpm turbo test
+          --filter=@nextlyhq/blocks-engine
           --filter=@nextlyhq/plugin-page-builder
           --filter=@nextlyhq/plugin-form-builder
           --filter=@nextlyhq/plugin-sdk

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -46,6 +46,7 @@ jobs:
             storage-s3
             storage-vercel-blob
             storage-uploadthing
+            blocks-engine
             plugin-form-builder
             plugin-page-builder
             plugin-sdk

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ Before editing a package, read its README.md and check for a nested AGENTS.md.
   Allowed PR scopes are package-based (`nextly`, `admin`, `ui`,
   `adapter-postgres`, `adapter-mysql`, `adapter-sqlite`, `adapter-drizzle`,
   `storage-s3`, `storage-vercel-blob`, `storage-uploadthing`,
-  `plugin-form-builder`, `plugin-page-builder`, `plugin-sdk`,
+  `plugin-form-builder`, `plugin-page-builder`, `plugin-sdk`, `blocks-engine`,
   `create-nextly-app`, `eslint-config`, `prettier-config`, `tsconfig`,
   `telemetry`, `client`) plus `playground`, `root`, `ci`, `docs`, `deps`,
   `release`. Scope is optional; the subject must not start with an uppercase

--- a/packages/blocks-engine/README.md
+++ b/packages/blocks-engine/README.md
@@ -1,0 +1,31 @@
+# @nextlyhq/blocks-engine
+
+The runtime-free core of the Nextly page builder: the stored document format
+and the pure operations over it.
+
+## What lives here
+
+- **The document model** — `BlockDocument` (a `kind`-discriminated envelope
+  over a plain `nodes[]` array) and `BlockNode` (namespaced type, required
+  schema version, literal props, per-prop `Binding`s, slots-in-node, typed
+  styles keyed by state × breakpoint, visibility, locks, custom CSS).
+- **Tree operations** — pure, immutable, ID-addressed functions over the node
+  forest: `walkNodes`, `findNode`, `locateNode`, `insertNode`, `removeNode`,
+  `moveNode`, `duplicateNode`, `updateNode`, `reidSubtree`.
+- **Limits** — depth, node-count, and byte caps with a warning threshold.
+
+## What deliberately does NOT live here
+
+- No React, no Next.js, no Nextly runtime imports — enforced by test. The
+  engine must be usable from Node scripts, edge runtimes, browsers, and
+  external agents alike.
+- No storage access: breakpoint definitions and other site-level data are
+  passed in as context by callers, never read from a database here.
+- Style **property** validation and CSS emission (the style compiler), block
+  rendering, and the editor are separate packages; this package only owns the
+  stored shapes they share.
+
+## Stability
+
+Alpha. The document format carries `formatVersion` and changes to stored
+shapes ship with format migrations once the format is frozen.

--- a/packages/blocks-engine/eslint.config.js
+++ b/packages/blocks-engine/eslint.config.js
@@ -1,0 +1,3 @@
+import { config } from "@nextlyhq/eslint-config/base";
+
+export default [...config];

--- a/packages/blocks-engine/eslint.config.js
+++ b/packages/blocks-engine/eslint.config.js
@@ -1,3 +1,5 @@
+// Reuse the repository's shared ESLint base so this package lints under the
+// same rules as every other package; there is nothing engine-specific to add.
 import { config } from "@nextlyhq/eslint-config/base";
 
 export default [...config];

--- a/packages/blocks-engine/package.json
+++ b/packages/blocks-engine/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@nextlyhq/blocks-engine",
+  "version": "0.0.2-alpha.39",
+  "description": "Nextly blocks engine — the runtime-free document model, tree operations, validation, and block-definition contracts behind the Nextly page builder.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nextlyhq/nextly.git",
+    "directory": "packages/blocks-engine"
+  },
+  "homepage": "https://nextlyhq.com/docs",
+  "bugs": {
+    "url": "https://github.com/nextlyhq/nextly/issues"
+  },
+  "type": "module",
+  "main": "dist/index.mjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "check-types": "tsc --noEmit",
+    "lint": "eslint . --max-warnings 0",
+    "lint:fix": "eslint . --fix",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rimraf dist"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "devDependencies": {
+    "@nextlyhq/eslint-config": "workspace:*",
+    "@nextlyhq/tsconfig": "workspace:*",
+    "@types/node": "^20.19.17",
+    "eslint": "^9.39.1",
+    "rimraf": "^6.1.3",
+    "tsup": "^8.5.0",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
+  },
+  "keywords": [
+    "nextly",
+    "blocks",
+    "page-builder",
+    "document-model"
+  ]
+}

--- a/packages/blocks-engine/src/document.test.ts
+++ b/packages/blocks-engine/src/document.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import type { BlockDocument } from "./document";
+import {
+  COMPONENT_INSTANCE_TYPE,
+  DOCUMENT_FORMAT_VERSION,
+  DOCUMENT_KINDS,
+  isComponentInstance,
+  isTokenRef,
+} from "./document";
+import {
+  DEFAULT_MAX_DOCUMENT_BYTES,
+  LIMIT_WARNING_RATIO,
+  MAX_DEPTH,
+  MAX_NODES,
+  documentBytes,
+} from "./limits";
+import { makeNode } from "./tree";
+
+describe("document constants", () => {
+  it("pins the format version and the closed kind enum", () => {
+    expect(DOCUMENT_FORMAT_VERSION).toBe(1);
+    expect(DOCUMENT_KINDS).toEqual([
+      "page",
+      "pattern",
+      "component",
+      "region",
+      "template",
+    ]);
+  });
+
+  it("pins the limits the format spec documents", () => {
+    expect(MAX_DEPTH).toBe(12);
+    expect(MAX_NODES).toBe(5000);
+    expect(DEFAULT_MAX_DOCUMENT_BYTES).toBe(2 * 1024 * 1024);
+    expect(LIMIT_WARNING_RATIO).toBe(0.8);
+  });
+});
+
+describe("guards", () => {
+  it("isTokenRef accepts only { $token: string }", () => {
+    expect(isTokenRef({ $token: "color.primary" })).toBe(true);
+    expect(isTokenRef({ token: "color.primary" })).toBe(false);
+    expect(isTokenRef("var(--x)")).toBe(false);
+    expect(isTokenRef(null)).toBe(false);
+    expect(isTokenRef({ $token: 3 })).toBe(false);
+  });
+
+  it("isComponentInstance keys on the reserved node type", () => {
+    const instance = makeNode(COMPONENT_INSTANCE_TYPE, 1, {
+      componentId: "cmp-1",
+    });
+    expect(isComponentInstance(instance)).toBe(true);
+    expect(isComponentInstance(makeNode("core/heading", 1))).toBe(false);
+  });
+});
+
+describe("JSON round-trip", () => {
+  it("a full document survives serialize → parse structurally unchanged", () => {
+    // Exercises every envelope feature at once: bindings, styles on both
+    // states, breakpoint-keyed values, token refs, visibility, slots.
+    const doc: BlockDocument = {
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "page",
+      nodes: [
+        {
+          ...makeNode(
+            "core/section",
+            2,
+            {},
+            {
+              children: [
+                {
+                  ...makeNode("core/heading", 1, { text: "Fallback title" }),
+                  bindings: {
+                    text: {
+                      $bind: "title",
+                      source: "entry",
+                      fallback: "Untitled",
+                      format: { type: "date", options: { dateStyle: "long" } },
+                    },
+                  },
+                  styles: {
+                    base: { base: { color: { $token: "color.text" } } },
+                    hover: { base: { color: "#ff0000" } },
+                  },
+                  visibility: {
+                    conditions: [[{ field: "status", op: "eq", value: "vip" }]],
+                    devices: { mobile: false },
+                  },
+                  name: "Hero heading",
+                },
+              ],
+            }
+          ),
+          classes: ["cls_hero"],
+          locked: true,
+        },
+      ],
+      settings: { customCss: ".page { scroll-behavior: smooth; }" },
+      assets: { mediaIds: ["media-1"] },
+    };
+
+    const parsed = JSON.parse(JSON.stringify(doc)) as BlockDocument;
+    expect(parsed).toEqual(doc);
+    expect(documentBytes(doc)).toBeGreaterThan(0);
+    expect(documentBytes(doc)).toBeLessThan(DEFAULT_MAX_DOCUMENT_BYTES);
+  });
+
+  it("documentBytes measures UTF-8 bytes, not string length", () => {
+    const ascii: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [makeNode("core/text", 1, { text: "aaaa" })],
+    };
+    const cjk: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [makeNode("core/text", 1, { text: "字字字字" })],
+    };
+    // Same JSON string length per character, but CJK is 3 UTF-8 bytes each.
+    expect(documentBytes(cjk)).toBeGreaterThan(documentBytes(ascii));
+  });
+});

--- a/packages/blocks-engine/src/document.test.ts
+++ b/packages/blocks-engine/src/document.test.ts
@@ -79,6 +79,12 @@ describe("JSON round-trip", () => {
                       fallback: "Untitled",
                       format: { type: "date", options: { dateStyle: "long" } },
                     },
+                    // A single-sourced binding names which single via sourceKey.
+                    subtitle: {
+                      $bind: "tagline",
+                      source: "single",
+                      sourceKey: "site-settings",
+                    },
                   },
                   styles: {
                     base: { base: { color: { $token: "color.text" } } },

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -1,0 +1,331 @@
+/**
+ * The block document model — the stored shape of everything the page builder
+ * produces: page content, patterns, components, Layout regions, and collection
+ * templates.
+ *
+ * This module is data-only. It has zero runtime dependencies and no imports
+ * from React or Nextly: documents must be readable and writable from any
+ * runtime (Node scripts, edge, browser, external agents) without pulling in
+ * a framework.
+ */
+
+/**
+ * Engine document-format version. Bumped only when the envelope shape itself
+ * changes incompatibly; per-block schema changes use per-node `version` plus
+ * block migrations instead.
+ */
+export type DocumentFormatVersion = 1;
+
+/** The current document-format version new documents are written with. */
+export const DOCUMENT_FORMAT_VERSION: DocumentFormatVersion = 1;
+
+/**
+ * What a stored builder document IS:
+ * - `page`      — an entry's blocks-field content
+ * - `pattern`   — a copy-on-insert saved subtree (including full-page patterns)
+ * - `component` — a linked, reusable definition with exposed props/slots/variants
+ * - `region`    — a Layout region document (header, footer, ...); a Layout is a
+ *                 named bundle REFERENCING region documents, so it is not a kind
+ * - `template`  — a collection template ("template" is reserved for exactly this)
+ *
+ * The enum is closed: an unknown kind is a validation error in strict mode and
+ * preserved untouched in forgiving mode, the same policy as unknown block types.
+ */
+export type DocumentKind =
+  | "page"
+  | "pattern"
+  | "component"
+  | "region"
+  | "template";
+
+/** Every legal `kind`, for validation and exhaustive iteration. */
+export const DOCUMENT_KINDS: readonly DocumentKind[] = [
+  "page",
+  "pattern",
+  "component",
+  "region",
+  "template",
+];
+
+/**
+ * Document-level settings. Deliberately minimal: SEO and publishing state are
+ * core-entry concerns, not document concerns. Page-level presentation that has
+ * no owning node (e.g. a page background) lives here rather than on a fake
+ * root block.
+ */
+export interface DocumentSettings {
+  /** Page-scoped styles with no owning node; same envelope as node styles. */
+  styles?: NodeStyles;
+  /** Sanitized document-scoped custom CSS (CSS only — custom JS never exists). */
+  customCss?: string;
+}
+
+/**
+ * The stored value of a `blocks` field and the body of every builder document.
+ *
+ * The top level is a plain array of nodes: a page IS a list of sections.
+ * There is no synthetic root block — document-level concerns live on this
+ * envelope, so no algorithm ever needs to special-case an undeletable,
+ * unmovable pseudo-node.
+ */
+export interface BlockDocument {
+  formatVersion: DocumentFormatVersion;
+  kind: DocumentKind;
+  nodes: BlockNode[];
+  settings?: DocumentSettings;
+  /**
+   * Usage index for media referenced anywhere in the document, so reference
+   * tracking never requires a full tree walk.
+   */
+  assets?: { mediaIds?: string[] };
+}
+
+/**
+ * One block instance in a document.
+ *
+ * `id` is a stable UUID and is the ONLY way anything addresses a node:
+ * editor operations, locale overlays, scoped-CSS class derivation, and
+ * selection all key on it. Positional addressing is never part of any stored
+ * or public contract.
+ */
+export interface BlockNode {
+  /** Stable unique id; survives moves, duplication re-ids the copy. */
+  id: string;
+  /** Namespaced block type, e.g. "core/heading". */
+  type: string;
+  /**
+   * The block definition's schema version this node was written against.
+   * Required on every node: forgiving rendering and the manifest version
+   * stamp both depend on it unconditionally.
+   */
+  version: number;
+  /** Literal content/config values. Bound values live in `bindings`, never here. */
+  props: Record<string, unknown>;
+  /** Per-prop data bindings; a bound prop's literal stays in `props` as the fallback shown on unbind. */
+  bindings?: Record<string, Binding>;
+  /** Named child regions, stored in the node. Only container blocks declare slots. */
+  slots?: Record<string, BlockNode[]>;
+  /** Typed style overrides: states × breakpoints (see `NodeStyles`). */
+  styles?: NodeStyles;
+  /** References to site-global named classes (by class id, not by CSS name). */
+  classes?: string[];
+  /** Conditional and per-breakpoint visibility. */
+  visibility?: NodeVisibility;
+  /** Author lock: the node cannot be moved or deleted while true. */
+  locked?: boolean;
+  /** Author-facing instance label, shown in the Layers panel. */
+  name?: string;
+  /** Per-node raw custom CSS (CSS only); sanitized and scoped at compile time. */
+  customCss?: string;
+  /** CSS id applied to the node's root element. */
+  cssId?: string;
+  /** Sanitized custom HTML attributes applied to the node's root element. */
+  attributes?: Record<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Bindings — typed field paths, never expressions
+// ---------------------------------------------------------------------------
+
+/**
+ * A typed field-path binding. `$bind` is a dot path into the source object
+ * with at most one relation hop (e.g. "title", "author.name"). Bindings are
+ * data, never code: there is no expression language and nothing is evaluated.
+ */
+export interface Binding {
+  /** Dot path into the binding source, one relation traversal max. */
+  $bind: string;
+  /**
+   * Where the path resolves from:
+   * - `entry` — the entry that owns the document (the default)
+   * - `item`  — the current item inside a collection-loop block
+   * - `single` — a named single (global) document
+   * - `site`  — site-level settings
+   */
+  source?: BindingSource;
+  /** Rendered when the bound value is empty or the path cannot resolve. */
+  fallback?: unknown;
+  /** Locale-aware display formatting applied after resolution. */
+  format?: BindingFormat;
+}
+
+export type BindingSource = "entry" | "item" | "single" | "site";
+
+/**
+ * Structured, locale-aware formatting for bound values. Each variant maps to
+ * the matching `Intl` formatter; `options` passes through to it. Formatting is
+ * declarative data so documents stay language-neutral and agent-writable.
+ */
+export type BindingFormat =
+  | { type: "date"; options?: Record<string, unknown> }
+  | { type: "number"; options?: Record<string, unknown> }
+  | { type: "currency"; currency: string; options?: Record<string, unknown> }
+  | { type: "relativeTime"; options?: Record<string, unknown> }
+  | { type: "list"; options?: Record<string, unknown> };
+
+// ---------------------------------------------------------------------------
+// Visibility — entry-field conditions + per-breakpoint device visibility
+// ---------------------------------------------------------------------------
+
+/**
+ * Node visibility. `conditions` is stored as OR-of-AND from day one (outer
+ * array = OR, inner arrays = AND groups) even while editing UIs expose only a
+ * single AND group, so richer UIs never need a storage migration.
+ * Conditionally hidden nodes are OMITTED from server output, not CSS-hidden.
+ *
+ * `devices` is separate and CSS-based on purpose: per-breakpoint hiding is a
+ * presentation concern, and the two must not be conflated.
+ */
+export interface NodeVisibility {
+  conditions?: Condition[][];
+  /** Per-breakpoint visibility; `false` hides at that breakpoint id. */
+  devices?: Record<BreakpointId, boolean>;
+}
+
+/** One entry-field predicate, e.g. { field: "status", op: "eq", value: "vip" }. */
+export interface Condition {
+  field: string;
+  op: string;
+  value?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Styles — the envelope only; the property catalog belongs to the compiler
+// ---------------------------------------------------------------------------
+
+/**
+ * Interactive states styles can target. A closed set: extending it after the
+ * format freeze is a document-format migration, not an edit.
+ */
+export type StyleState = "base" | "hover" | "focus" | "active";
+
+export const STYLE_STATES: readonly StyleState[] = [
+  "base",
+  "hover",
+  "focus",
+  "active",
+];
+
+/**
+ * A breakpoint id referencing the site-level breakpoint definitions (viewport
+ * and container axes). Documents store values keyed by id; the definitions
+ * themselves live once in site settings and arrive via validation context.
+ */
+export type BreakpointId = string;
+
+/**
+ * A design-token reference usable anywhere a style scalar is. The `$token`
+ * marker keeps token refs self-describing in raw JSON, parallel to `$bind`.
+ */
+export interface TokenRef {
+  $token: string;
+}
+
+/**
+ * One style value: a literal, a token reference, or a structured object whose
+ * leaves are again style values (box sides, structured backgrounds, ...).
+ */
+export type StyleValue =
+  | string
+  | number
+  | TokenRef
+  | { [key: string]: StyleValue };
+
+/**
+ * The style properties set at one state × breakpoint. The envelope is frozen
+ * here; the legal property CATALOG (names, value shapes, physical→logical
+ * mapping) is the style compiler's contract and is validated there.
+ */
+export type StyleValues = Record<string, StyleValue>;
+
+/**
+ * A node's complete style data: states × breakpoints × values. Both axes are
+ * sparse — omitted states/breakpoints simply inherit.
+ */
+export type NodeStyles = Partial<
+  Record<StyleState, Partial<Record<BreakpointId, StyleValues>>>
+>;
+
+/** True if a style value is a design-token reference. */
+export function isTokenRef(value: unknown): value is TokenRef {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as TokenRef).$token === "string"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Breakpoint definitions — stored once at site level, consumed via context
+// ---------------------------------------------------------------------------
+
+/** One breakpoint definition. Desktop-first: `base` has no max width. */
+export interface BreakpointDef {
+  id: BreakpointId;
+  label: string;
+  /** Upper bound in CSS pixels; the base breakpoint omits it. */
+  maxWidth?: number;
+}
+
+/**
+ * The site's breakpoint definitions on both axes. The engine never reads
+ * storage: callers load this from the builder settings and pass it into
+ * validation/compilation context.
+ */
+export interface BreakpointSet {
+  viewport: BreakpointDef[];
+  container: BreakpointDef[];
+}
+
+/** Maximum breakpoints per axis (the base breakpoint included). */
+export const MAX_BREAKPOINTS_PER_AXIS = 7;
+
+// ---------------------------------------------------------------------------
+// Component instances — a distinguished node type
+// ---------------------------------------------------------------------------
+
+/**
+ * The node type marking a linked component instance. The node's `props` carry
+ * the reference; instance-provided slot content lives in `node.slots` like any
+ * container. Resolution (definition lookup, variant application, per-instance
+ * overrides) happens where components are stored and rendered, not here.
+ */
+export const COMPONENT_INSTANCE_TYPE = "nextly/component-instance";
+
+/** The props a component-instance node stores. */
+export interface ComponentInstanceProps {
+  /** The referenced component document's id. */
+  componentId: string;
+  /** The selected variant name, when the component defines variants. */
+  variant?: string;
+}
+
+/** True if a node is a linked component instance. */
+export function isComponentInstance(node: BlockNode): boolean {
+  return node.type === COMPONENT_INSTANCE_TYPE;
+}
+
+// ---------------------------------------------------------------------------
+// Locale overlays — per-locale prop values over one base tree
+// ---------------------------------------------------------------------------
+
+/**
+ * A locale's overlay over a base document: per-node, per-prop replacement
+ * values keyed by stable node id. `src` records a hash of the base value the
+ * translation was made from, so staleness ("the base text changed since this
+ * was translated") is detectable automatically.
+ *
+ * `content_mode` reserves the door to a full per-locale fork of the tree;
+ * only "overlay" is produced today.
+ */
+export interface LocaleOverlay {
+  content_mode: "overlay" | "fork";
+  props: Record<string, Record<string, LocaleOverlayValue>>;
+}
+
+/** One overlaid prop value plus the base-value hash it was translated from. */
+export interface LocaleOverlayValue {
+  value: unknown;
+  /** Hash of the base-locale value at translation time; absent = never checked. */
+  src?: string;
+}

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -111,7 +111,12 @@ export interface BlockNode {
   classes?: string[];
   /** Conditional and per-breakpoint visibility. */
   visibility?: NodeVisibility;
-  /** Author lock: the node cannot be moved or deleted while true. */
+  /**
+   * Author lock. While true, the editor command layer must not let the author
+   * move or delete this node. It is an author-facing policy flag, not a
+   * data-layer guarantee: system transforms (migrations, overlays, restore)
+   * still operate on locked nodes, and the pure tree primitives do not read it.
+   */
   locked?: boolean;
   /** Author-facing instance label, shown in the Layers panel. */
   name?: string;

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -215,6 +215,13 @@ export const STYLE_STATES: readonly StyleState[] = [
  * A breakpoint id referencing the site-level breakpoint definitions (viewport
  * and container axes). Documents store values keyed by id; the definitions
  * themselves live once in site settings and arrive via validation context.
+ *
+ * Breakpoint ids are unique across BOTH axes (an invariant validation enforces
+ * on the breakpoint settings). That is what lets a node's styles be keyed by id
+ * alone: the id resolves to exactly one `BreakpointDef`, and thus one axis, via
+ * the context — so the style envelope stays flat (state × breakpoint) instead
+ * of carrying a redundant axis level on every value, and a viewport and a
+ * container breakpoint can never collide on the same id.
  */
 export type BreakpointId = string;
 
@@ -244,8 +251,11 @@ export type StyleValue =
 export type StyleValues = Record<string, StyleValue>;
 
 /**
- * A node's complete style data: states × breakpoints × values. Both axes are
- * sparse — omitted states/breakpoints simply inherit.
+ * A node's complete style data: states × breakpoints × values, both levels
+ * sparse — omitted states/breakpoints simply inherit. The breakpoint key spans
+ * both axes (viewport and container); because breakpoint ids are unique across
+ * axes (see {@link BreakpointId}), the id alone identifies the axis, so no
+ * separate axis level is needed here.
  */
 export type NodeStyles = Partial<
   Record<StyleState, Partial<Record<BreakpointId, StyleValues>>>
@@ -275,7 +285,9 @@ export interface BreakpointDef {
 /**
  * The site's breakpoint definitions on both axes. The engine never reads
  * storage: callers load this from the builder settings and pass it into
- * validation/compilation context.
+ * validation/compilation context. Ids MUST be unique across the two axes
+ * combined (not just within each axis), so a node's style breakpoint key
+ * resolves to exactly one definition; validation enforces this.
  */
 export interface BreakpointSet {
   viewport: BreakpointDef[];

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -132,34 +132,42 @@ export interface BlockNode {
 // Bindings — typed field paths, never expressions
 // ---------------------------------------------------------------------------
 
-/**
- * A typed field-path binding. `$bind` is a dot path into the source object
- * with at most one relation hop (e.g. "title", "author.name"). Bindings are
- * data, never code: there is no expression language and nothing is evaluated.
- */
-export interface Binding {
+/** Fields every binding carries, regardless of source. */
+interface BindingBase {
   /** Dot path into the binding source, one relation traversal max. */
   $bind: string;
-  /**
-   * Where the path resolves from:
-   * - `entry` — the entry that owns the document (the default)
-   * - `item`  — the current item inside a collection-loop block
-   * - `single` — a named single (global) document
-   * - `site`  — site-level settings
-   */
-  source?: BindingSource;
-  /**
-   * Which specific source document the path reads from. REQUIRED when
-   * `source` is `"single"` (its slug), since a site can define many singles
-   * and `$bind` alone would be ambiguous. Unused for `entry`/`item`/`site`,
-   * which each have exactly one resolution context.
-   */
-  sourceKey?: string;
   /** Rendered when the bound value is empty or the path cannot resolve. */
   fallback?: unknown;
   /** Locale-aware display formatting applied after resolution. */
   format?: BindingFormat;
 }
+
+/**
+ * A typed field-path binding. `$bind` is a dot path into the source object
+ * with at most one relation hop (e.g. "title", "author.name"). Bindings are
+ * data, never code: there is no expression language and nothing is evaluated.
+ *
+ * Modeled as a discriminated union on `source` so the `single` variant REQUIRES
+ * `sourceKey` (which global document to read) while the others forbid it: a
+ * site can define many singles, so an ambiguous single binding must be
+ * unrepresentable, not merely discouraged.
+ *
+ * Sources:
+ * - `entry`  — the entry that owns the document (the default when omitted)
+ * - `item`   — the current item inside a collection-loop block
+ * - `single` — a named single (global) document, addressed by `sourceKey`
+ * - `site`   — site-level settings
+ */
+export type Binding =
+  | (BindingBase & {
+      source?: "entry" | "item" | "site";
+      sourceKey?: never;
+    })
+  | (BindingBase & {
+      source: "single";
+      /** Slug of the single (global) document this binding reads from. */
+      sourceKey: string;
+    });
 
 export type BindingSource = "entry" | "item" | "single" | "site";
 

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -148,6 +148,13 @@ export interface Binding {
    * - `site`  — site-level settings
    */
   source?: BindingSource;
+  /**
+   * Which specific source document the path reads from. REQUIRED when
+   * `source` is `"single"` (its slug), since a site can define many singles
+   * and `$bind` alone would be ambiguous. Unused for `entry`/`item`/`site`,
+   * which each have exactly one resolution context.
+   */
+  sourceKey?: string;
   /** Rendered when the bound value is empty or the path cannot resolve. */
   fallback?: unknown;
   /** Locale-aware display formatting applied after resolution. */

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -320,11 +320,11 @@ export function isComponentInstance(node: BlockNode): boolean {
  * translation was made from, so staleness ("the base text changed since this
  * was translated") is detectable automatically.
  *
- * `content_mode` reserves the door to a full per-locale fork of the tree;
+ * `contentMode` reserves the door to a full per-locale fork of the tree;
  * only "overlay" is produced today.
  */
 export interface LocaleOverlay {
-  content_mode: "overlay" | "fork";
+  contentMode: "overlay" | "fork";
   props: Record<string, Record<string, LocaleOverlayValue>>;
 }
 

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -1,0 +1,67 @@
+/**
+ * @nextlyhq/blocks-engine — the runtime-free core of the Nextly page builder.
+ *
+ * This package owns the stored document format and the pure operations over
+ * it. It never imports React or Nextly at runtime, so documents can be
+ * created, inspected, and transformed from any JavaScript environment.
+ */
+export {
+  DOCUMENT_FORMAT_VERSION,
+  DOCUMENT_KINDS,
+  COMPONENT_INSTANCE_TYPE,
+  STYLE_STATES,
+  MAX_BREAKPOINTS_PER_AXIS,
+  isTokenRef,
+  isComponentInstance,
+} from "./document";
+export type {
+  BlockDocument,
+  BlockNode,
+  Binding,
+  BindingSource,
+  BindingFormat,
+  BreakpointDef,
+  BreakpointId,
+  BreakpointSet,
+  ComponentInstanceProps,
+  Condition,
+  DocumentFormatVersion,
+  DocumentKind,
+  DocumentSettings,
+  LocaleOverlay,
+  LocaleOverlayValue,
+  NodeStyles,
+  NodeVisibility,
+  StyleState,
+  StyleValue,
+  StyleValues,
+  TokenRef,
+} from "./document";
+
+export {
+  MAX_DEPTH,
+  MAX_NODES,
+  DEFAULT_MAX_DOCUMENT_BYTES,
+  LIMIT_WARNING_RATIO,
+  DEFAULT_SLOT,
+  DEFAULT_LIMITS,
+  countNodes,
+  treeDepth,
+  documentBytes,
+} from "./limits";
+export type { DocumentLimits } from "./limits";
+
+export {
+  newId,
+  makeNode,
+  walkNodes,
+  findNode,
+  locateNode,
+  insertNode,
+  removeNode,
+  moveNode,
+  reidSubtree,
+  duplicateNode,
+  updateNode,
+} from "./tree";
+export type { NodeLocation, TreePosition } from "./tree";

--- a/packages/blocks-engine/src/limits.ts
+++ b/packages/blocks-engine/src/limits.ts
@@ -1,0 +1,78 @@
+/**
+ * Document limits. Hard caps reject a document outright; the warning ratio
+ * lets tooling surface "approaching the limit" before authors hit a wall.
+ */
+import type { BlockDocument, BlockNode } from "./document";
+
+/** Maximum nesting depth of nodes (top-level nodes are depth 1). */
+export const MAX_DEPTH = 12;
+
+/** Maximum total nodes in one document. */
+export const MAX_NODES = 5000;
+
+/** Default maximum serialized document size in bytes (2 MiB). */
+export const DEFAULT_MAX_DOCUMENT_BYTES = 2 * 1024 * 1024;
+
+/** Fraction of a cap at which tooling should warn (80%). */
+export const LIMIT_WARNING_RATIO = 0.8;
+
+/** The default slot name for container blocks with a single child region. */
+export const DEFAULT_SLOT = "children";
+
+/** Effective limits for one validation/compile run; callers may raise the byte cap. */
+export interface DocumentLimits {
+  maxDepth: number;
+  maxNodes: number;
+  maxBytes: number;
+}
+
+export const DEFAULT_LIMITS: DocumentLimits = {
+  maxDepth: MAX_DEPTH,
+  maxNodes: MAX_NODES,
+  maxBytes: DEFAULT_MAX_DOCUMENT_BYTES,
+};
+
+/** Total node count across the forest, slots included. */
+export function countNodes(nodes: BlockNode[]): number {
+  let count = 0;
+  const stack: BlockNode[] = [...nodes];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node) continue;
+    count++;
+    if (node.slots) {
+      for (const children of Object.values(node.slots)) stack.push(...children);
+    }
+  }
+  return count;
+}
+
+/** Deepest nesting level in the forest; an empty forest is depth 0. */
+export function treeDepth(nodes: BlockNode[]): number {
+  let deepest = 0;
+  const stack: Array<{ node: BlockNode; depth: number }> = nodes.map(node => ({
+    node,
+    depth: 1,
+  }));
+  while (stack.length > 0) {
+    const entry = stack.pop();
+    if (!entry) continue;
+    if (entry.depth > deepest) deepest = entry.depth;
+    if (entry.node.slots) {
+      for (const children of Object.values(entry.node.slots)) {
+        for (const child of children) {
+          stack.push({ node: child, depth: entry.depth + 1 });
+        }
+      }
+    }
+  }
+  return deepest;
+}
+
+/**
+ * Serialized size of a document in bytes (UTF-8 of its JSON form — the same
+ * bytes that hit storage, so the cap measures what actually gets persisted).
+ */
+export function documentBytes(doc: BlockDocument): number {
+  return new TextEncoder().encode(JSON.stringify(doc)).length;
+}

--- a/packages/blocks-engine/src/runtime-free.test.ts
+++ b/packages/blocks-engine/src/runtime-free.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The engine's core contract: no React and no Nextly at runtime, ever.
+ * Documents must be usable from Node scripts, edge runtimes, browsers, and
+ * external agents without a framework install. Type-only imports are fine
+ * (they erase at build); runtime imports are a contract violation this test
+ * turns into a hard failure.
+ */
+
+const SRC_DIR = join(import.meta.dirname, ".");
+
+/** Import specifiers the engine must never depend on at runtime. */
+const FORBIDDEN_RUNTIME_IMPORTS = [
+  "react",
+  "react-dom",
+  "nextly",
+  "next",
+  "@nextlyhq/admin",
+  "@nextlyhq/ui",
+];
+
+function sourceFiles(): string[] {
+  return readdirSync(SRC_DIR)
+    .filter(name => name.endsWith(".ts") && !name.endsWith(".test.ts"))
+    .map(name => join(SRC_DIR, name));
+}
+
+describe("the engine is runtime-free", () => {
+  it("has no runtime imports of React, Next.js, or Nextly packages", () => {
+    for (const file of sourceFiles()) {
+      const source = readFileSync(file, "utf8");
+      // Matches `import ... from "x"` and `export ... from "x"` but not
+      // `import type ...` — type-only imports erase at build and are allowed.
+      const runtimeImports = [
+        ...source.matchAll(
+          /^\s*(?:import|export)\s+(?!type\s)[^;]*?\sfrom\s+["']([^"']+)["']/gm
+        ),
+        ...source.matchAll(/import\s*\(\s*["']([^"']+)["']\s*\)/g),
+      ].map(match => match[1]);
+
+      for (const specifier of runtimeImports) {
+        if (specifier === undefined) continue;
+        const forbidden = FORBIDDEN_RUNTIME_IMPORTS.some(
+          pkg => specifier === pkg || specifier.startsWith(`${pkg}/`)
+        );
+        expect(
+          forbidden,
+          `${file} imports "${specifier}" at runtime — the engine must stay runtime-free (use "import type" if only types are needed)`
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("declares zero runtime dependencies in package.json", () => {
+    const pkg = JSON.parse(
+      readFileSync(join(SRC_DIR, "..", "package.json"), "utf8")
+    ) as { dependencies?: object; peerDependencies?: object };
+    expect(pkg.dependencies ?? {}).toEqual({});
+    expect(pkg.peerDependencies ?? {}).toEqual({});
+  });
+});

--- a/packages/blocks-engine/src/runtime-free.test.ts
+++ b/packages/blocks-engine/src/runtime-free.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
+import type { Dirent } from "node:fs";
 
 import { describe, expect, it } from "vitest";
 
@@ -23,10 +24,21 @@ const FORBIDDEN_RUNTIME_IMPORTS = [
   "@nextlyhq/ui",
 ];
 
-function sourceFiles(): string[] {
-  return readdirSync(SRC_DIR)
-    .filter(name => name.endsWith(".ts") && !name.endsWith(".test.ts"))
-    .map(name => join(SRC_DIR, name));
+// Walk the whole src tree, not just its top level: a forbidden import in a
+// future subdirectory must fail this guard too, not slip past because the scan
+// only looked at immediate children.
+function sourceFiles(dir: string = SRC_DIR): string[] {
+  const entries: Dirent[] = readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...sourceFiles(full));
+    } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      files.push(full);
+    }
+  }
+  return files;
 }
 
 describe("the engine is runtime-free", () => {
@@ -35,10 +47,13 @@ describe("the engine is runtime-free", () => {
       const source = readFileSync(file, "utf8");
       // Matches `import ... from "x"` and `export ... from "x"` but not
       // `import type ...` — type-only imports erase at build and are allowed.
+      // Also matches bare side-effect imports (`import "x";`) and dynamic
+      // imports, so every runtime import FORM the engine forbids is caught.
       const runtimeImports = [
         ...source.matchAll(
           /^\s*(?:import|export)\s+(?!type\s)[^;]*?\sfrom\s+["']([^"']+)["']/gm
         ),
+        ...source.matchAll(/^\s*import\s+["']([^"']+)["']/gm),
         ...source.matchAll(/import\s*\(\s*["']([^"']+)["']\s*\)/g),
       ].map(match => match[1]);
 
@@ -58,8 +73,13 @@ describe("the engine is runtime-free", () => {
   it("declares zero runtime dependencies in package.json", () => {
     const pkg = JSON.parse(
       readFileSync(join(SRC_DIR, "..", "package.json"), "utf8")
-    ) as { dependencies?: object; peerDependencies?: object };
+    ) as {
+      dependencies?: object;
+      peerDependencies?: object;
+      optionalDependencies?: object;
+    };
     expect(pkg.dependencies ?? {}).toEqual({});
     expect(pkg.peerDependencies ?? {}).toEqual({});
+    expect(pkg.optionalDependencies ?? {}).toEqual({});
   });
 });

--- a/packages/blocks-engine/src/runtime-free.test.ts
+++ b/packages/blocks-engine/src/runtime-free.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { Dirent } from "node:fs";
 
 import { describe, expect, it } from "vitest";
@@ -12,7 +13,10 @@ import { describe, expect, it } from "vitest";
  * turns into a hard failure.
  */
 
-const SRC_DIR = join(import.meta.dirname, ".");
+// `import.meta.dirname` only exists from Node 20.11; the package floor is
+// Node >=20.0, so derive the directory from the module URL to stay runnable
+// across the whole supported range.
+const SRC_DIR = dirname(fileURLToPath(import.meta.url));
 
 /** Import specifiers the engine must never depend on at runtime. */
 const FORBIDDEN_RUNTIME_IMPORTS = [

--- a/packages/blocks-engine/src/tree.property.test.ts
+++ b/packages/blocks-engine/src/tree.property.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import type { BlockNode } from "./document";
+import { countNodes, treeDepth } from "./limits";
+import {
+  duplicateNode,
+  findNode,
+  insertNode,
+  makeNode,
+  moveNode,
+  removeNode,
+  walkNodes,
+} from "./tree";
+
+// Deterministic PRNG — no Math.random, so failures reproduce exactly by seed.
+function prng(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => (s = (s * 1664525 + 1013904223) >>> 0) / 2 ** 32;
+}
+
+function allIds(nodes: BlockNode[]): string[] {
+  const out: string[] = [];
+  walkNodes(nodes, n => out.push(n.id));
+  return out;
+}
+
+function hasDuplicates(ids: string[]): boolean {
+  return new Set(ids).size !== ids.length;
+}
+
+describe("forest ops preserve invariants under random operations", () => {
+  it("no duplicate ids, valid structure, bounded growth over 250 ops (x5 seeds)", () => {
+    for (let seed = 1; seed <= 5; seed++) {
+      const rnd = prng(seed);
+      let nodes: BlockNode[] = [
+        makeNode("core/section", 1, {}, { children: [] }),
+      ];
+
+      for (let i = 0; i < 250; i++) {
+        const ids = allIds(nodes);
+        const pick = ids[Math.floor(rnd() * ids.length)];
+        const op = Math.floor(rnd() * 5);
+
+        if (pick === undefined || op === 0) {
+          // Insert a fresh container at the top level.
+          nodes = insertNode(
+            nodes,
+            makeNode("core/section", 1, {}, { children: [] }),
+            { index: Math.floor(rnd() * (nodes.length + 1)) }
+          );
+        } else if (op === 1) {
+          // Insert a fresh child under the picked node's "children" slot.
+          nodes = insertNode(nodes, makeNode("core/text", 1, { text: "t" }), {
+            parentId: pick,
+            slot: "children",
+            index: 0,
+          });
+        } else if (op === 2) {
+          // Move the picked node to a random destination (top level or a slot).
+          const targetIds = allIds(nodes);
+          const target = targetIds[Math.floor(rnd() * targetIds.length)];
+          nodes =
+            rnd() < 0.5 || target === undefined
+              ? moveNode(nodes, pick, {
+                  index: Math.floor(rnd() * (nodes.length + 1)),
+                })
+              : moveNode(nodes, pick, {
+                  parentId: target,
+                  slot: "children",
+                  index: 0,
+                });
+        } else if (op === 3) {
+          nodes = removeNode(nodes, pick);
+        } else {
+          nodes = duplicateNode(nodes, pick);
+        }
+
+        // Invariants that must hold after EVERY operation:
+        const idsAfter = allIds(nodes);
+        expect(hasDuplicates(idsAfter)).toBe(false);
+        expect(countNodes(nodes)).toBe(idsAfter.length);
+        expect(treeDepth(nodes)).toBeLessThan(300);
+        // Every node found by walk is reachable by findNode (index integrity).
+        for (const id of idsAfter.slice(0, 3)) {
+          expect(findNode(nodes, id)).toBeDefined();
+        }
+      }
+    }
+  });
+
+  it("a move never loses or gains nodes", () => {
+    const rnd = prng(42);
+    let nodes: BlockNode[] = [
+      makeNode("core/section", 1, {}, { children: [makeNode("core/text", 1)] }),
+      makeNode("core/section", 1, {}, { children: [] }),
+    ];
+    for (let i = 0; i < 100; i++) {
+      const ids = allIds(nodes);
+      const before = countNodes(nodes);
+      const pick = ids[Math.floor(rnd() * ids.length)];
+      const target = ids[Math.floor(rnd() * ids.length)];
+      if (pick === undefined || target === undefined) continue;
+      nodes = moveNode(nodes, pick, {
+        parentId: target,
+        slot: "children",
+        index: 0,
+      });
+      // A refused move (cycle) and an applied move both preserve the count.
+      expect(countNodes(nodes)).toBe(before);
+    }
+  });
+});

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vitest";
+
+import type { BlockNode } from "./document";
+import { countNodes, treeDepth } from "./limits";
+import {
+  duplicateNode,
+  findNode,
+  insertNode,
+  locateNode,
+  makeNode,
+  moveNode,
+  removeNode,
+  reidSubtree,
+  updateNode,
+  walkNodes,
+} from "./tree";
+
+/** A small fixed forest: two sections, the first containing two children. */
+function fixture(): {
+  nodes: BlockNode[];
+  section: BlockNode;
+  heading: BlockNode;
+  text: BlockNode;
+  footer: BlockNode;
+} {
+  const heading = makeNode("core/heading", 1, { text: "Hello" });
+  const text = makeNode("core/text", 1, { text: "World" });
+  const section = makeNode(
+    "core/section",
+    1,
+    {},
+    { children: [heading, text] }
+  );
+  const footer = makeNode("core/section", 1, {}, { children: [] });
+  return { nodes: [section, footer], section, heading, text, footer };
+}
+
+describe("walkNodes / findNode / locateNode", () => {
+  it("walks depth-first with the correct parent", () => {
+    const { nodes, section, heading, text, footer } = fixture();
+    const visited: Array<[string, string | undefined]> = [];
+    walkNodes(nodes, (n, parent) => visited.push([n.id, parent?.id]));
+    expect(visited).toEqual([
+      [section.id, undefined],
+      [heading.id, section.id],
+      [text.id, section.id],
+      [footer.id, undefined],
+    ]);
+  });
+
+  it("finds nested nodes and returns undefined for unknown ids", () => {
+    const { nodes, heading } = fixture();
+    expect(findNode(nodes, heading.id)?.props).toEqual({ text: "Hello" });
+    expect(findNode(nodes, "missing")).toBeUndefined();
+  });
+
+  it("locates top-level and nested nodes", () => {
+    const { nodes, section, text, footer } = fixture();
+    expect(locateNode(nodes, footer.id)).toEqual({ index: 1 });
+    const nested = locateNode(nodes, text.id);
+    expect(nested?.parent?.id).toBe(section.id);
+    expect(nested?.slot).toBe("children");
+    expect(nested?.index).toBe(1);
+    expect(locateNode(nodes, "missing")).toBeUndefined();
+  });
+});
+
+describe("insertNode", () => {
+  it("inserts at the top level with a clamped index", () => {
+    const { nodes } = fixture();
+    const extra = makeNode("core/section", 1);
+    const next = insertNode(nodes, extra, { index: 99 });
+    expect(next.map(n => n.id)).toEqual([...nodes.map(n => n.id), extra.id]);
+    // Immutability: the original forest is untouched.
+    expect(nodes).toHaveLength(2);
+  });
+
+  it("inserts into a parent slot", () => {
+    const { nodes, section, heading } = fixture();
+    const extra = makeNode("core/text", 1);
+    const next = insertNode(nodes, extra, {
+      parentId: section.id,
+      slot: "children",
+      index: 1,
+    });
+    const children = findNode(next, section.id)?.slots?.children ?? [];
+    expect(children.map(n => n.id)[1]).toBe(extra.id);
+    expect(children.map(n => n.id)[0]).toBe(heading.id);
+  });
+
+  it("creates the slot when inserting into an empty one", () => {
+    const { nodes, footer } = fixture();
+    const extra = makeNode("core/text", 1);
+    const next = insertNode(nodes, extra, {
+      parentId: footer.id,
+      slot: "children",
+      index: 0,
+    });
+    expect(findNode(next, footer.id)?.slots?.children).toHaveLength(1);
+  });
+
+  it("returns the forest unchanged for an unknown parent or missing slot", () => {
+    const { nodes } = fixture();
+    const extra = makeNode("core/text", 1);
+    expect(
+      insertNode(nodes, extra, {
+        parentId: "missing",
+        slot: "children",
+        index: 0,
+      })
+    ).toBe(nodes);
+    expect(insertNode(nodes, extra, { parentId: nodes[0]!.id, index: 0 })).toBe(
+      nodes
+    );
+  });
+});
+
+describe("removeNode", () => {
+  it("removes a nested node", () => {
+    const { nodes, section, heading } = fixture();
+    const next = removeNode(nodes, heading.id);
+    expect(findNode(next, heading.id)).toBeUndefined();
+    expect(findNode(next, section.id)?.slots?.children).toHaveLength(1);
+  });
+
+  it("removes a top-level node with its whole subtree", () => {
+    const { nodes, section, heading } = fixture();
+    const next = removeNode(nodes, section.id);
+    expect(next).toHaveLength(1);
+    expect(findNode(next, heading.id)).toBeUndefined();
+  });
+});
+
+describe("moveNode", () => {
+  it("moves a nested node to the top level", () => {
+    const { nodes, heading } = fixture();
+    const next = moveNode(nodes, heading.id, { index: 0 });
+    expect(next[0]!.id).toBe(heading.id);
+    expect(countNodes(next)).toBe(countNodes(nodes));
+  });
+
+  it("moves a top-level node into a slot", () => {
+    const { nodes, footer, section } = fixture();
+    const next = moveNode(nodes, footer.id, {
+      parentId: section.id,
+      slot: "children",
+      index: 0,
+    });
+    expect(next).toHaveLength(1);
+    expect(findNode(next, section.id)?.slots?.children?.[0]?.id).toBe(
+      footer.id
+    );
+  });
+
+  it("refuses cycles: a node cannot move into its own subtree", () => {
+    const { nodes, section, heading } = fixture();
+    expect(
+      moveNode(nodes, section.id, {
+        parentId: heading.id,
+        slot: "children",
+        index: 0,
+      })
+    ).toBe(nodes);
+    expect(
+      moveNode(nodes, section.id, {
+        parentId: section.id,
+        slot: "children",
+        index: 0,
+      })
+    ).toBe(nodes);
+  });
+
+  it("returns the forest unchanged for unknown ids", () => {
+    const { nodes } = fixture();
+    expect(moveNode(nodes, "missing", { index: 0 })).toBe(nodes);
+    expect(
+      moveNode(nodes, nodes[0]!.id, {
+        parentId: "missing",
+        slot: "children",
+        index: 0,
+      })
+    ).toBe(nodes);
+  });
+});
+
+describe("reidSubtree / duplicateNode", () => {
+  it("re-ids every node in the copied subtree and detaches it from the source", () => {
+    const { section, heading } = fixture();
+    const copy = reidSubtree(section);
+    expect(copy.id).not.toBe(section.id);
+    expect(copy.slots?.children?.[0]?.id).not.toBe(heading.id);
+    expect(copy.slots?.children?.[0]?.props).toEqual(heading.props);
+    // structuredClone: mutating the copy's props must not touch the source.
+    (copy.slots!.children![0]!.props as Record<string, unknown>).text =
+      "changed";
+    expect(heading.props.text).toBe("Hello");
+  });
+
+  it("duplicates a node immediately after the original", () => {
+    const { nodes, section, heading } = fixture();
+    const next = duplicateNode(nodes, heading.id);
+    const children = findNode(next, section.id)?.slots?.children ?? [];
+    expect(children).toHaveLength(3);
+    expect(children[0]!.id).toBe(heading.id);
+    expect(children[1]!.id).not.toBe(heading.id);
+    expect(children[1]!.props).toEqual(heading.props);
+  });
+
+  it("duplicates a top-level node in place", () => {
+    const { nodes, section } = fixture();
+    const next = duplicateNode(nodes, section.id);
+    expect(next).toHaveLength(3);
+    expect(next[1]!.type).toBe("core/section");
+    expect(next[1]!.id).not.toBe(section.id);
+  });
+});
+
+describe("updateNode", () => {
+  it("patches a node's fields immutably", () => {
+    const { nodes, heading } = fixture();
+    const next = updateNode(nodes, heading.id, {
+      props: { text: "Patched" },
+      name: "Intro heading",
+    });
+    expect(findNode(next, heading.id)?.props).toEqual({ text: "Patched" });
+    expect(findNode(next, heading.id)?.name).toBe("Intro heading");
+    expect(findNode(nodes, heading.id)?.props).toEqual({ text: "Hello" });
+  });
+
+  it("returns the forest unchanged for unknown ids", () => {
+    const { nodes } = fixture();
+    expect(updateNode(nodes, "missing", { name: "x" })).toBe(nodes);
+  });
+});
+
+describe("counting helpers", () => {
+  it("counts nodes and measures depth", () => {
+    const { nodes } = fixture();
+    expect(countNodes(nodes)).toBe(4);
+    expect(treeDepth(nodes)).toBe(2);
+    expect(countNodes([])).toBe(0);
+    expect(treeDepth([])).toBe(0);
+  });
+});

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -233,6 +233,26 @@ describe("updateNode", () => {
   });
 });
 
+describe("id uniqueness by construction", () => {
+  it("makeNode mints a unique id every call", () => {
+    const ids = new Set(
+      Array.from({ length: 1000 }, () => makeNode("core/text", 1).id)
+    );
+    expect(ids.size).toBe(1000);
+  });
+
+  it("reidSubtree re-ids every node so a re-inserted copy cannot collide", () => {
+    const { nodes, section } = fixture();
+    const copy = reidSubtree(section);
+    const copyIds = new Set<string>();
+    walkNodes([copy], n => copyIds.add(n.id));
+    const originalIds = new Set<string>();
+    walkNodes(nodes, n => originalIds.add(n.id));
+    // No id in the copy overlaps the original forest.
+    for (const id of copyIds) expect(originalIds.has(id)).toBe(false);
+  });
+});
+
 describe("counting helpers", () => {
   it("counts nodes and measures depth", () => {
     const { nodes } = fixture();

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -139,6 +139,22 @@ describe("insertNode", () => {
       })
     ).toBe(nodes);
   });
+
+  it("rejects a fresh subtree that carries an internal duplicate id", () => {
+    const { nodes } = fixture();
+    // A hand-built subtree whose two children share an id: it does not collide
+    // with the forest, but inserting it would still break id uniqueness.
+    const dupChild = makeNode("core/text", 1);
+    const malformed = makeNode(
+      "core/section",
+      1,
+      {},
+      {
+        children: [dupChild, { ...makeNode("core/text", 1), id: dupChild.id }],
+      }
+    );
+    expect(insertNode(nodes, malformed, { index: 0 })).toBe(nodes);
+  });
 });
 
 describe("removeNode", () => {
@@ -252,6 +268,30 @@ describe("reidSubtree / duplicateNode", () => {
     expect(next).toHaveLength(3);
     expect(next[1]!.type).toBe("core/section");
     expect(next[1]!.id).not.toBe(section.id);
+  });
+
+  it("drops the DOM id (cssId) when re-iding so copies never collide on it", () => {
+    const original = {
+      ...makeNode("core/section", 1, {}, { children: [] }),
+      cssId: "hero",
+    };
+    const copy = reidSubtree(original);
+    expect(copy.cssId).toBeUndefined();
+    // A nested cssId is dropped too.
+    const withNested = {
+      ...makeNode(
+        "core/section",
+        1,
+        {},
+        {
+          children: [{ ...makeNode("core/text", 1), cssId: "cta" }],
+        }
+      ),
+      cssId: "wrap",
+    };
+    const nestedCopy = reidSubtree(withNested);
+    expect(nestedCopy.cssId).toBeUndefined();
+    expect(nestedCopy.slots?.children?.[0]?.cssId).toBeUndefined();
   });
 });
 

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -237,6 +237,30 @@ describe("moveNode", () => {
     expect(findNode(next, footer.id)).toBeDefined();
     expect(countNodes(next)).toBe(countNodes(nodes));
   });
+
+  it("leaves an already-malformed subtree in place rather than losing it on move", () => {
+    // A document whose moving subtree carries an internal duplicate id: the
+    // re-insert would refuse, so the move must be atomic and change nothing.
+    const dup = makeNode("core/text", 1);
+    const bad = makeNode(
+      "core/section",
+      1,
+      {},
+      {
+        children: [dup, { ...makeNode("core/text", 1), id: dup.id }],
+      }
+    );
+    const host = makeNode("core/section", 1, {}, { children: [] });
+    const nodes = [bad, host];
+    const next = moveNode(nodes, bad.id, {
+      parentId: host.id,
+      slot: "children",
+      index: 0,
+    });
+    expect(next).toBe(nodes);
+    expect(findNode(next, bad.id)).toBeDefined();
+    expect(countNodes(next)).toBe(countNodes(nodes));
+  });
 });
 
 describe("reidSubtree / duplicateNode", () => {
@@ -292,6 +316,20 @@ describe("reidSubtree / duplicateNode", () => {
     const nestedCopy = reidSubtree(withNested);
     expect(nestedCopy.cssId).toBeUndefined();
     expect(nestedCopy.slots?.children?.[0]?.cssId).toBeUndefined();
+  });
+
+  it("strips an id from custom attributes (case-insensitively) when re-iding", () => {
+    const original = {
+      ...makeNode("core/section", 1),
+      attributes: { id: "hero", "data-role": "banner" },
+    };
+    const copy = reidSubtree(original);
+    expect(copy.attributes).toEqual({ "data-role": "banner" });
+
+    // A capitalized "ID" is the same DOM-id vector and must also go; when it is
+    // the only attribute, the now-empty attributes object is dropped entirely.
+    const upper = { ...makeNode("core/text", 1), attributes: { ID: "x" } };
+    expect(reidSubtree(upper).attributes).toBeUndefined();
   });
 });
 

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -113,6 +113,32 @@ describe("insertNode", () => {
       nodes
     );
   });
+
+  it("rejects re-inserting a node whose id already lives in the forest", () => {
+    const { nodes, footer, heading } = fixture();
+    // Same node object re-inserted, and a fresh node carrying an existing id:
+    // both collide and must no-op rather than corrupt id-addressing.
+    expect(insertNode(nodes, footer, { index: 0 })).toBe(nodes);
+    const clash = { ...makeNode("core/text", 1), id: heading.id };
+    expect(
+      insertNode(nodes, clash, {
+        parentId: footer.id,
+        slot: "children",
+        index: 0,
+      })
+    ).toBe(nodes);
+  });
+
+  it("rejects inserting a node into itself without overflowing", () => {
+    const { nodes, section } = fixture();
+    expect(
+      insertNode(nodes, section, {
+        parentId: section.id,
+        slot: "children",
+        index: 0,
+      })
+    ).toBe(nodes);
+  });
 });
 
 describe("removeNode", () => {
@@ -128,6 +154,11 @@ describe("removeNode", () => {
     const next = removeNode(nodes, section.id);
     expect(next).toHaveLength(1);
     expect(findNode(next, heading.id)).toBeUndefined();
+  });
+
+  it("returns the original forest reference when the id is absent", () => {
+    const { nodes } = fixture();
+    expect(removeNode(nodes, "missing")).toBe(nodes);
   });
 });
 
@@ -180,6 +211,15 @@ describe("moveNode", () => {
         index: 0,
       })
     ).toBe(nodes);
+  });
+
+  it("never loses a node when a slot position omits its slot", () => {
+    const { nodes, footer, section } = fixture();
+    // parentId set without a slot: must no-op, not remove-then-fail-to-insert.
+    const next = moveNode(nodes, footer.id, { parentId: section.id, index: 0 });
+    expect(next).toBe(nodes);
+    expect(findNode(next, footer.id)).toBeDefined();
+    expect(countNodes(next)).toBe(countNodes(nodes));
   });
 });
 

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -1,0 +1,220 @@
+/**
+ * Pure, immutable, ID-addressed operations over a document's node forest.
+ *
+ * The document's top level is a plain array of nodes, so every operation works
+ * on a `BlockNode[]` and treats "no parent id" as the top level. Every
+ * mutation returns a new forest; inputs are never modified. Nodes are always
+ * addressed by id — positional addressing exists only as the insertion index
+ * within a destination, never as a way to identify a node.
+ */
+import type { BlockNode } from "./document";
+
+/** Stable unique node id. `crypto.randomUUID` exists in Node ≥ 20 and browsers. */
+export function newId(): string {
+  return crypto.randomUUID();
+}
+
+/** Build a node with a fresh id. `version` is the block definition's schema version. */
+export function makeNode(
+  type: string,
+  version: number,
+  props: Record<string, unknown> = {},
+  slots?: Record<string, BlockNode[]>
+): BlockNode {
+  const node: BlockNode = { id: newId(), type, version, props };
+  if (slots) node.slots = slots;
+  return node;
+}
+
+/** Where an insert or move lands: a parent's slot, or the top level when `parentId` is absent. */
+export interface TreePosition {
+  parentId?: string;
+  /** Required when `parentId` is set; ignored for top-level positions. */
+  slot?: string;
+  index: number;
+}
+
+/** Depth-first visit over the forest: each node, then its slots' children in order. */
+export function walkNodes(
+  nodes: BlockNode[],
+  fn: (node: BlockNode, parent: BlockNode | undefined) => void,
+  parent?: BlockNode
+): void {
+  for (const node of nodes) {
+    fn(node, parent);
+    if (node.slots) {
+      for (const children of Object.values(node.slots)) {
+        walkNodes(children, fn, node);
+      }
+    }
+  }
+}
+
+/** Find a node anywhere in the forest by id. */
+export function findNode(
+  nodes: BlockNode[],
+  id: string
+): BlockNode | undefined {
+  for (const node of nodes) {
+    if (node.id === id) return node;
+    if (node.slots) {
+      for (const children of Object.values(node.slots)) {
+        const hit = findNode(children, id);
+        if (hit) return hit;
+      }
+    }
+  }
+  return undefined;
+}
+
+/** A found node's placement: its parent (undefined at top level), slot, and index. */
+export interface NodeLocation {
+  parent?: BlockNode;
+  slot?: string;
+  index: number;
+}
+
+/** Locate a node's parent, slot, and index; undefined when the id is absent. */
+export function locateNode(
+  nodes: BlockNode[],
+  id: string
+): NodeLocation | undefined {
+  const topIndex = nodes.findIndex(node => node.id === id);
+  if (topIndex !== -1) return { index: topIndex };
+  let found: NodeLocation | undefined;
+  walkNodes(nodes, node => {
+    if (found || !node.slots) return;
+    for (const [slot, children] of Object.entries(node.slots)) {
+      const index = children.findIndex(child => child.id === id);
+      if (index !== -1) {
+        found = { parent: node, slot, index };
+        return;
+      }
+    }
+  });
+  return found;
+}
+
+/** Immutably rebuild the forest, applying `fn` to every node (parents before children). */
+function mapForest(
+  nodes: BlockNode[],
+  fn: (node: BlockNode) => BlockNode
+): BlockNode[] {
+  return nodes.map(node => {
+    const mapped = fn(node);
+    if (!mapped.slots) return mapped;
+    const slots: Record<string, BlockNode[]> = {};
+    for (const [name, children] of Object.entries(mapped.slots)) {
+      slots[name] = mapForest(children, fn);
+    }
+    return { ...mapped, slots };
+  });
+}
+
+/** Clamp an insertion index into a list's valid range. */
+function clampIndex(index: number, length: number): number {
+  return Math.max(0, Math.min(index, length));
+}
+
+/**
+ * Insert a node at a position. Inserting under an unknown parent id returns
+ * the forest unchanged rather than silently dropping the node somewhere else.
+ */
+export function insertNode(
+  nodes: BlockNode[],
+  node: BlockNode,
+  at: TreePosition
+): BlockNode[] {
+  if (at.parentId === undefined) {
+    const next = [...nodes];
+    next.splice(clampIndex(at.index, next.length), 0, node);
+    return next;
+  }
+  const { parentId, slot, index } = at;
+  if (slot === undefined) return nodes;
+  if (!findNode(nodes, parentId)) return nodes;
+  return mapForest(nodes, current => {
+    if (current.id !== parentId) return current;
+    const slots = { ...(current.slots ?? {}) };
+    const children = [...(slots[slot] ?? [])];
+    children.splice(clampIndex(index, children.length), 0, node);
+    slots[slot] = children;
+    return { ...current, slots };
+  });
+}
+
+/** Remove a node (and its subtree) wherever it lives, including the top level. */
+export function removeNode(nodes: BlockNode[], id: string): BlockNode[] {
+  const withoutTop = nodes.filter(node => node.id !== id);
+  return mapForest(withoutTop, node => {
+    if (!node.slots) return node;
+    const slots: Record<string, BlockNode[]> = {};
+    for (const [name, children] of Object.entries(node.slots)) {
+      slots[name] = children.filter(child => child.id !== id);
+    }
+    return { ...node, slots };
+  });
+}
+
+/**
+ * Move a node to a new position. Moves that would create a cycle (into the
+ * node itself or its own subtree) or reference a missing node/parent return
+ * the forest unchanged.
+ */
+export function moveNode(
+  nodes: BlockNode[],
+  id: string,
+  to: TreePosition
+): BlockNode[] {
+  const moving = findNode(nodes, id);
+  if (!moving) return nodes;
+  if (to.parentId !== undefined) {
+    // Cycle guard: the destination parent must not be the node or inside it.
+    if (to.parentId === id || findNode([moving], to.parentId)) return nodes;
+    if (!findNode(nodes, to.parentId)) return nodes;
+  }
+  const without = removeNode(nodes, id);
+  return insertNode(without, moving, to);
+}
+
+/** Deep-clone a subtree, assigning fresh ids to every node (copy/paste, patterns). */
+export function reidSubtree(node: BlockNode): BlockNode {
+  const copy: BlockNode = { ...structuredClone(node), id: newId() };
+  if (node.slots) {
+    const slots: Record<string, BlockNode[]> = {};
+    for (const [name, children] of Object.entries(node.slots)) {
+      slots[name] = children.map(reidSubtree);
+    }
+    copy.slots = slots;
+  }
+  return copy;
+}
+
+/** Insert a re-id'd copy of a node immediately after the original. */
+export function duplicateNode(nodes: BlockNode[], id: string): BlockNode[] {
+  const found = findNode(nodes, id);
+  if (!found) return nodes;
+  const location = locateNode(nodes, id);
+  if (!location) return nodes;
+  return insertNode(nodes, reidSubtree(found), {
+    parentId: location.parent?.id,
+    slot: location.slot,
+    index: location.index + 1,
+  });
+}
+
+/**
+ * Patch a node's own fields. `id`, `type`, and `slots` are not patchable here:
+ * ids are immutable, type changes are conversions with their own semantics,
+ * and children change through insert/remove/move.
+ */
+export function updateNode(
+  nodes: BlockNode[],
+  id: string,
+  patch: Partial<Omit<BlockNode, "id" | "type" | "slots">>
+): BlockNode[] {
+  if (!findNode(nodes, id)) return nodes;
+  return mapForest(nodes, node =>
+    node.id === id ? { ...node, ...patch } : node
+  );
+}

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -6,6 +6,20 @@
  * mutation returns a new forest; inputs are never modified. Nodes are always
  * addressed by id — positional addressing exists only as the insertion index
  * within a destination, never as a way to identify a node.
+ *
+ * These are mechanism, not policy: they enforce structural safety (no cycles,
+ * clamped indices, no-op on missing targets) but DELIBERATELY do not enforce
+ * author policy. Two invariants are owned elsewhere on purpose:
+ * - Author locks (`node.locked`) are enforced by the editor command layer, not
+ *   here. System paths — migrations, locale-overlay application, `reidSubtree`,
+ *   version restore — must be able to transform locked nodes; a lock check in
+ *   these primitives would either block those paths or force a bypass flag onto
+ *   every call site. Centralizing the check in the op store is the correct seam.
+ * - Node id uniqueness is a document validation invariant, checked by
+ *   `validate()` before a document is persisted. Callers build nodes with
+ *   `makeNode`/`reidSubtree`, which mint fresh ids, so within a session ids are
+ *   unique by construction; a hand-injected duplicate is caught by validation
+ *   with a machine-readable path, not silently corrected here.
  */
 import type { BlockNode } from "./document";
 

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -228,7 +228,13 @@ export function moveNode(
     if (!findNode(nodes, to.parentId)) return nodes;
   }
   const without = removeNode(nodes, id);
-  return insertNode(without, moving, to);
+  const next = insertNode(without, moving, to);
+  // The move must be atomic. If the re-insert refused — which happens only when
+  // the moving subtree is itself already malformed (an internal duplicate id) —
+  // `insertNode` returns the `without` forest unchanged; committing that would
+  // drop the subtree. Fall back to the original forest so a bad document is
+  // left as-is rather than losing content.
+  return next === without ? nodes : next;
 }
 
 /** Deep-clone a subtree, assigning fresh ids to every node (copy/paste, patterns). */
@@ -238,9 +244,19 @@ export function reidSubtree(node: BlockNode): BlockNode {
   const { slots, ...own } = node;
   const copy: BlockNode = { ...structuredClone(own), id: newId() };
   // A re-id'd node is a distinct element: it must not carry the original's DOM
-  // id, or the two would emit duplicate HTML `id` attributes. Drop it so the
-  // copy has no cssId until the author sets a new one.
+  // id, or the two would emit duplicate HTML `id` attributes. The id can arrive
+  // two ways — the dedicated `cssId` field and the custom-attributes escape
+  // hatch (`attributes.id`, matched case-insensitively) — so drop both.
   delete copy.cssId;
+  if (copy.attributes) {
+    const attributes = Object.fromEntries(
+      Object.entries(copy.attributes).filter(
+        ([key]) => key.toLowerCase() !== "id"
+      )
+    );
+    if (Object.keys(attributes).length > 0) copy.attributes = attributes;
+    else delete copy.attributes;
+  }
   if (slots) {
     const newSlots: Record<string, BlockNode[]> = {};
     for (const [name, children] of Object.entries(slots)) {

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -130,32 +130,47 @@ function clampIndex(index: number, length: number): number {
   return Math.max(0, Math.min(index, length));
 }
 
-/** True if any id in `node`'s subtree already appears in `nodes`. */
-function subtreeCollidesWith(nodes: BlockNode[], node: BlockNode): boolean {
+/**
+ * True if inserting `node` into `nodes` would break id uniqueness — either the
+ * incoming subtree carries a duplicate id WITHIN itself, or one of its ids
+ * already lives in the destination forest. Both are rejected: collapsing
+ * duplicate incoming ids into the set would let an internally malformed subtree
+ * through and corrupt id-addressing after insertion.
+ */
+function insertionBreaksIdUniqueness(
+  nodes: BlockNode[],
+  node: BlockNode
+): boolean {
   const incoming = new Set<string>();
-  walkNodes([node], n => incoming.add(n.id));
-  let collides = false;
-  walkNodes(nodes, n => {
-    if (incoming.has(n.id)) collides = true;
+  let internalDuplicate = false;
+  walkNodes([node], n => {
+    if (incoming.has(n.id)) internalDuplicate = true;
+    incoming.add(n.id);
   });
-  return collides;
+  if (internalDuplicate) return true;
+  let overlapsForest = false;
+  walkNodes(nodes, n => {
+    if (incoming.has(n.id)) overlapsForest = true;
+  });
+  return overlapsForest;
 }
 
 /**
  * Insert a node at a position. Returns the forest unchanged (the no-op contract
  * used across these primitives) when the target is invalid: an unknown parent
- * id, a slot position missing its slot, or a node whose id — or any id in its
- * subtree — already lives in the forest. The last guard is what makes the
- * primitive safe: re-inserting an existing node would corrupt id-addressing
- * and, for a self/descendant target, make `mapForest` recurse into the object
- * just inserted. Callers duplicating content pass a `reidSubtree` clone.
+ * id, a slot position missing its slot, or a node that would break id
+ * uniqueness — a subtree with an internal duplicate id, or an id that already
+ * lives in the forest. The uniqueness guard is what makes the primitive safe:
+ * re-inserting an existing node would corrupt id-addressing and, for a
+ * self/descendant target, make `mapForest` recurse into the object just
+ * inserted. Callers duplicating content pass a `reidSubtree` clone.
  */
 export function insertNode(
   nodes: BlockNode[],
   node: BlockNode,
   at: TreePosition
 ): BlockNode[] {
-  if (subtreeCollidesWith(nodes, node)) return nodes;
+  if (insertionBreaksIdUniqueness(nodes, node)) return nodes;
   if (at.parentId === undefined) {
     const next = [...nodes];
     next.splice(clampIndex(at.index, next.length), 0, node);
@@ -222,6 +237,10 @@ export function reidSubtree(node: BlockNode): BlockNode {
   // calls below, so cloning `slots` here too would deep-copy them twice.
   const { slots, ...own } = node;
   const copy: BlockNode = { ...structuredClone(own), id: newId() };
+  // A re-id'd node is a distinct element: it must not carry the original's DOM
+  // id, or the two would emit duplicate HTML `id` attributes. Drop it so the
+  // copy has no cssId until the author sets a new one.
+  delete copy.cssId;
   if (slots) {
     const newSlots: Record<string, BlockNode[]> = {};
     for (const [name, children] of Object.entries(slots)) {

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -130,15 +130,32 @@ function clampIndex(index: number, length: number): number {
   return Math.max(0, Math.min(index, length));
 }
 
+/** True if any id in `node`'s subtree already appears in `nodes`. */
+function subtreeCollidesWith(nodes: BlockNode[], node: BlockNode): boolean {
+  const incoming = new Set<string>();
+  walkNodes([node], n => incoming.add(n.id));
+  let collides = false;
+  walkNodes(nodes, n => {
+    if (incoming.has(n.id)) collides = true;
+  });
+  return collides;
+}
+
 /**
- * Insert a node at a position. Inserting under an unknown parent id returns
- * the forest unchanged rather than silently dropping the node somewhere else.
+ * Insert a node at a position. Returns the forest unchanged (the no-op contract
+ * used across these primitives) when the target is invalid: an unknown parent
+ * id, a slot position missing its slot, or a node whose id — or any id in its
+ * subtree — already lives in the forest. The last guard is what makes the
+ * primitive safe: re-inserting an existing node would corrupt id-addressing
+ * and, for a self/descendant target, make `mapForest` recurse into the object
+ * just inserted. Callers duplicating content pass a `reidSubtree` clone.
  */
 export function insertNode(
   nodes: BlockNode[],
   node: BlockNode,
   at: TreePosition
 ): BlockNode[] {
+  if (subtreeCollidesWith(nodes, node)) return nodes;
   if (at.parentId === undefined) {
     const next = [...nodes];
     next.splice(clampIndex(at.index, next.length), 0, node);
@@ -157,8 +174,13 @@ export function insertNode(
   });
 }
 
-/** Remove a node (and its subtree) wherever it lives, including the top level. */
+/**
+ * Remove a node (and its subtree) wherever it lives, including the top level.
+ * Returns the original forest reference untouched when the id is absent, so a
+ * no-op delete never produces a spurious new tree for change-tracking callers.
+ */
 export function removeNode(nodes: BlockNode[], id: string): BlockNode[] {
+  if (!findNode(nodes, id)) return nodes;
   const withoutTop = nodes.filter(node => node.id !== id);
   return mapForest(withoutTop, node => {
     if (!node.slots) return node;
@@ -183,6 +205,9 @@ export function moveNode(
   const moving = findNode(nodes, id);
   if (!moving) return nodes;
   if (to.parentId !== undefined) {
+    // A slot position must name its slot; without this guard the remove below
+    // would succeed and the re-insert would no-op, silently losing the node.
+    if (to.slot === undefined) return nodes;
     // Cycle guard: the destination parent must not be the node or inside it.
     if (to.parentId === id || findNode([moving], to.parentId)) return nodes;
     if (!findNode(nodes, to.parentId)) return nodes;
@@ -193,13 +218,16 @@ export function moveNode(
 
 /** Deep-clone a subtree, assigning fresh ids to every node (copy/paste, patterns). */
 export function reidSubtree(node: BlockNode): BlockNode {
-  const copy: BlockNode = { ...structuredClone(node), id: newId() };
-  if (node.slots) {
-    const slots: Record<string, BlockNode[]> = {};
-    for (const [name, children] of Object.entries(node.slots)) {
-      slots[name] = children.map(reidSubtree);
+  // Clone only this node's own fields; descendants are cloned by the recursive
+  // calls below, so cloning `slots` here too would deep-copy them twice.
+  const { slots, ...own } = node;
+  const copy: BlockNode = { ...structuredClone(own), id: newId() };
+  if (slots) {
+    const newSlots: Record<string, BlockNode[]> = {};
+    for (const [name, children] of Object.entries(slots)) {
+      newSlots[name] = children.map(reidSubtree);
     }
-    copy.slots = slots;
+    copy.slots = newSlots;
   }
   return copy;
 }

--- a/packages/blocks-engine/tsconfig.json
+++ b/packages/blocks-engine/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@nextlyhq/tsconfig/base-bundler.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts"]
+}

--- a/packages/blocks-engine/tsup.config.ts
+++ b/packages/blocks-engine/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "tsup";
+
+// The engine is runtime-free by contract: it ships no dependencies and must
+// stay importable from Node scripts, edge runtimes, and the browser alike, so
+// it bundles nothing and targets plain ESM.
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  treeshake: true,
+  outExtension() {
+    return { js: ".mjs" };
+  },
+});

--- a/packages/blocks-engine/vitest.config.ts
+++ b/packages/blocks-engine/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/blocks-engine/vitest.config.ts
+++ b/packages/blocks-engine/vitest.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "vitest/config";
 
+// The engine is plain Node with no globals: tests import from vitest explicitly
+// and run in the node environment, scoped to this package's own src suites.
 export default defineConfig({
   test: {
     globals: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -733,6 +733,33 @@ importers:
         specifier: ^4.1.0
         version: 4.1.10(@types/node@24.10.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@24.10.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/blocks-engine:
+    devDependencies:
+      '@nextlyhq/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@nextlyhq/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^20.19.17
+        version: 20.19.17
+      eslint:
+        specifier: ^9.39.1
+        version: 9.39.1(jiti@2.7.0)
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.0(jiti@2.7.0)(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.10(@types/node@20.19.17)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.9.0)(jsdom@27.1.0)(vite@7.3.6(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/create-nextly-app:
     dependencies:
       '@clack/prompts':
@@ -11831,6 +11858,11 @@ snapshots:
       esbuild: 0.25.12
       load-tsconfig: 0.2.5
 
+  bundle-require@5.1.0(esbuild@0.28.1):
+    dependencies:
+      esbuild: 0.28.1
+      load-tsconfig: 0.2.5
+
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -14898,12 +14930,12 @@ snapshots:
 
   tsup@8.5.0(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.12)
+      bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.25.12
+      esbuild: 0.28.1
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
@@ -14926,12 +14958,12 @@ snapshots:
 
   tsup@8.5.0(jiti@2.7.0)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.12)
+      bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.25.12
+      esbuild: 0.28.1
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1


### PR DESCRIPTION
## What

First PR of the page-builder rebuild: the new `@nextlyhq/blocks-engine` package — the runtime-free core that owns the stored document format and pure operations over it.

- **Package scaffold**: `packages/blocks-engine` (published, lockstep alpha version, zero runtime dependencies, ESM via tsup, vitest, shared eslint/tsconfig presets).
- **Document model**: `BlockDocument` (a `kind`-discriminated envelope — `page | pattern | component | region | template` — over a plain top-level `nodes[]` array; no synthetic root node) and `BlockNode` (namespaced `type`, **required** per-node schema `version`, literal `props`, per-prop `Binding` slots with structured Intl `format`, slots-in-node, typed `styles` keyed by state × breakpoint on both viewport and container axes, `classes` refs, OR-of-AND visibility conditions + per-breakpoint device visibility, locks, custom CSS/attributes). Plus locale-overlay envelope types (`content_mode`, per-node per-prop values with `src` staleness hashes), breakpoint-set types, and the reserved component-instance node type.
- **Limits**: depth 12, 5000 nodes, 2 MiB default byte cap with an 80% warning threshold, plus `countNodes` / `treeDepth` / `documentBytes` helpers.
- **Tree utilities**: pure, immutable, ID-addressed operations over the node forest — `walkNodes`, `findNode`, `locateNode`, `insertNode`, `removeNode`, `moveNode` (cycle-guarded), `duplicateNode`, `updateNode`, `reidSubtree`.

## Why

The rebuilt page builder stores typed JSON documents that must be creatable and editable from any JavaScript runtime — Node scripts, edge, browser, external AI agents — without a framework install. This package is that foundation; the field type, registry, validation, renderer, and editor all build on these shapes in follow-up PRs.

## Tests

- 29 tests: tree op unit tests (insert/remove/move/duplicate/update, cycle refusal, unknown-id no-ops, immutability), a seeded property test running 250 random ops × 5 seeds asserting no duplicate ids / count integrity / bounded depth after every op, document JSON round-trip exercising every envelope feature, UTF-8 byte measurement, and an enforcement test that fails if any source file gains a runtime import of React/Next/Nextly or the package gains a runtime dependency.
- `pnpm --filter @nextlyhq/blocks-engine build && check-types && lint && test` all green; full repo `pnpm build` green.

## Repo wiring

- `blocks-engine` added to the PR-title scope list; `@nextlyhq/blocks-engine` added to the changesets fixed (lockstep) group; one changeset covering all packages (patch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Blocks Engine package for defining and manipulating page-builder documents.
  * Added support for structured blocks, slots, bindings, styles, breakpoints, localization, and component instances.
  * Added immutable tree operations for finding, inserting, moving, removing, duplicating, and updating blocks.
  * Added document size, depth, and node-count safeguards.
  * Published a runtime-free package with build, type-checking, linting, and testing support.

* **Documentation**
  * Added package documentation describing the document format, capabilities, and boundaries.

* **Tests**
  * Added comprehensive coverage for document validation, serialization, limits, tree operations, and runtime-free guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->