### PR TITLE
test(nextly): cover webhook secret rotation on postgres and mysql

### DIFF
--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-secret-rotation-dialects.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-secret-rotation-dialects.integration.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Signing-secret rotation against a real Postgres/MySQL database.
+ *
+ * The endpoint-service integration suite exercises rotation on in-memory SQLite
+ * only, so the `SELECT … FOR UPDATE` re-read and the `secret_hash` JSON write in
+ * `rotateSecret`/`expireOldSecrets` were never run on the pooled Postgres/MySQL
+ * drivers, whose transaction + JSON handling differs. This leg closes that gap.
+ *
+ * The webhook system tables are provisioned from the production table definitions
+ * via drizzle-kit (never hand-copied DDL), dropped-then-recreated so a shared
+ * test database starts clean for this file.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  getMySQLDrizzleKit,
+  getPgDrizzleKit,
+} from "../../../database/drizzle-kit-lazy";
+import { createAdapter } from "../../../database/factory";
+import { SchemaRegistry } from "../../../database/schema-registry";
+import {
+  nextlyEvents as eventsMysql,
+  nextlyWebhooks as webhooksMysql,
+  nextlyWebhookDeliveries as deliveriesMysql,
+} from "../../../schemas/webhooks/mysql";
+import {
+  nextlyEvents as eventsPg,
+  nextlyWebhooks as webhooksPg,
+  nextlyWebhookDeliveries as deliveriesPg,
+} from "../../../schemas/webhooks/postgres";
+import { users as usersMysql } from "../../../schemas/users/mysql";
+import { users as usersPg } from "../../../schemas/users/postgres";
+import { splitStatements } from "../../schema/pipeline/sql-statement-utils";
+import { WebhookEndpointService } from "../services/webhook-endpoint-service";
+import type { WebhookEventType } from "../types";
+
+type Dialect = "postgresql" | "mysql";
+
+interface Leg {
+  name: string;
+  dialect: Dialect;
+  url: string;
+  schemas: Record<string, unknown>;
+  kit: () => Promise<{
+    generateDrizzleJson: (s: Record<string, unknown>) => Promise<unknown>;
+    generateMigration: (a: unknown, b: unknown) => Promise<string[]>;
+  }>;
+}
+
+const LEGS: Leg[] = [
+  {
+    name: "postgres",
+    dialect: "postgresql",
+    url: process.env.TEST_POSTGRES_URL ?? "",
+    schemas: {
+      users: usersPg,
+      nextlyEvents: eventsPg,
+      nextlyWebhooks: webhooksPg,
+      nextlyWebhookDeliveries: deliveriesPg,
+    },
+    kit: getPgDrizzleKit as never,
+  },
+  {
+    name: "mysql",
+    dialect: "mysql",
+    url: process.env.TEST_MYSQL_URL ?? "",
+    schemas: {
+      users: usersMysql,
+      nextlyEvents: eventsMysql,
+      nextlyWebhooks: webhooksMysql,
+      nextlyWebhookDeliveries: deliveriesMysql,
+    },
+    kit: getMySQLDrizzleKit as never,
+  },
+];
+
+const EVENTS: WebhookEventType[] = ["entry.created", "entry.updated"];
+// An address literal, not a hostname, so the URL validator never hits DNS.
+const PUBLIC_URL = "https://93.184.216.34/hooks";
+
+const logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+// Child-first so foreign keys never block a drop; `users` is referenced by
+// `nextly_webhooks.created_by`.
+const TABLES = [
+  "nextly_webhook_deliveries",
+  "nextly_webhooks",
+  "nextly_events",
+  "users",
+];
+
+for (const leg of LEGS) {
+  const describeLeg = describe.skipIf(!leg.url);
+
+  describeLeg(`webhook secret rotation (${leg.name})`, () => {
+    let adapter: Awaited<ReturnType<typeof createAdapter>>;
+    let service: WebhookEndpointService;
+
+    beforeAll(async () => {
+      if (!leg.url) return;
+      process.env.DB_DIALECT = leg.dialect;
+      process.env.DATABASE_URL = leg.url;
+      process.env.NEXTLY_SECRET = "integration-test-application-secret";
+
+      adapter = await createAdapter({
+        type: leg.dialect,
+        url: leg.url,
+      } as Parameters<typeof createAdapter>[0]);
+
+      const isMysql = leg.dialect === "mysql";
+      const quote = (t: string) => (isMysql ? `\`${t}\`` : `"${t}"`);
+
+      // Drop existing tables so the shared DB starts clean. MySQL cannot express
+      // a cross-table CASCADE on DROP, so foreign-key checks are disabled around
+      // the drops instead.
+      if (isMysql) {
+        await adapter.executeQuery("SET FOREIGN_KEY_CHECKS = 0");
+      }
+      for (const table of TABLES) {
+        await adapter.executeQuery(
+          `DROP TABLE IF EXISTS ${quote(table)}${isMysql ? "" : " CASCADE"}`
+        );
+      }
+      if (isMysql) {
+        await adapter.executeQuery("SET FOREIGN_KEY_CHECKS = 1");
+      }
+
+      const kit = await leg.kit();
+      const statements = await kit.generateMigration(
+        await kit.generateDrizzleJson({}),
+        await kit.generateDrizzleJson(leg.schemas)
+      );
+      for (const stmt of splitStatements(statements)) {
+        await adapter.executeQuery(stmt);
+      }
+
+      const registry = new SchemaRegistry(leg.dialect);
+      registry.registerStaticSchemas(leg.schemas as never);
+      adapter.setTableResolver(registry as never);
+
+      service = new WebhookEndpointService(adapter as never, logger as never);
+    });
+
+    afterAll(async () => {
+      await adapter?.disconnect?.();
+    });
+
+    // `created_by` is left null so the test needs no seeded user row.
+    const create = (name: string) =>
+      service.createEndpoint(
+        { name, url: PUBLIC_URL, eventTypes: EVENTS } as never,
+        null
+      );
+
+    it("rotates with an overlap window and keeps both secrets live", async () => {
+      const { endpoint, secret: original } = await create("Rotate A");
+
+      const { endpoint: rotated, secret: fresh } = await service.rotateSecret(
+        endpoint.id,
+        { overlapSeconds: 3600 }
+      );
+
+      expect(fresh).not.toBe(original);
+      expect(rotated.secretPrefix).toBe(fresh.slice(0, 14));
+
+      const revealed = await service.revealSecrets(endpoint.id);
+      expect(revealed).toHaveLength(2);
+      expect(revealed).toContain(fresh);
+      expect(revealed).toContain(original);
+    });
+
+    it("expires the overlapping secret, leaving only the primary", async () => {
+      const { endpoint } = await create("Rotate B");
+      const { secret: fresh } = await service.rotateSecret(endpoint.id, {
+        overlapSeconds: 3600,
+      });
+      expect(await service.revealSecrets(endpoint.id)).toHaveLength(2);
+
+      await service.expireOldSecrets(endpoint.id);
+      expect(await service.revealSecrets(endpoint.id)).toEqual([fresh]);
+    });
+  });
+}

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-secret-rotation-dialects.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-secret-rotation-dialects.integration.test.ts
@@ -6,10 +6,20 @@
  * `rotateSecret`/`expireOldSecrets` were never run on the pooled Postgres/MySQL
  * drivers, whose transaction + JSON handling differs. This leg closes that gap.
  *
- * The webhook system tables are provisioned from the production table definitions
- * via drizzle-kit (never hand-copied DDL), dropped-then-recreated so a shared
- * test database starts clean for this file.
+ * Isolation: each dialect leg provisions the webhook system tables into a
+ * throwaway namespace it creates and drops itself — a dedicated SCHEMA on
+ * Postgres, a dedicated DATABASE on MySQL — instead of dropping and recreating
+ * production-named tables in the shared test database. So the suite never
+ * cascades through a shared `users` table (which would strip foreign keys other
+ * single-fork suites rely on), needs no `FOREIGN_KEY_CHECKS` toggling, and is
+ * safe against a misconfigured URL because it only ever drops the namespace it
+ * just created. The namespace name is random per run and the connection URL
+ * pins every pooled connection to it (Postgres `search_path` startup option;
+ * MySQL database in the URL path), so DDL and DML land in the throwaway
+ * namespace no matter which pooled connection serves the query.
  */
+import { randomBytes } from "node:crypto";
+
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import {
@@ -34,7 +44,32 @@ import { splitStatements } from "../../schema/pipeline/sql-statement-utils";
 import { WebhookEndpointService } from "../services/webhook-endpoint-service";
 import type { WebhookEventType } from "../types";
 
+// Seed the process environment at module load, before any import can read the
+// lazily-cached `env` proxy. `??=` never clobbers a value the environment
+// already provides, and neither is ever mutated per dialect leg, so a leg can
+// never poison the cached env for a later one.
+//   - NEXTLY_SECRET: webhook signing secrets are encrypted under it, so
+//     `createEndpoint` throws without it.
+//   - DATABASE_URL: `createAdapter` reads validated env for pool defaults, and
+//     that validation requires a DATABASE_URL for any non-sqlite dialect. Each
+//     adapter here connects with its own explicit per-namespace URL, so this
+//     only has to be a syntactically valid placeholder for validation to pass.
+process.env.NEXTLY_SECRET ??= "integration-test-application-secret";
+process.env.DATABASE_URL ??=
+  process.env.TEST_POSTGRES_URL ??
+  process.env.TEST_MYSQL_URL ??
+  "postgres://placeholder:placeholder@localhost:5432/placeholder";
+
 type Dialect = "postgresql" | "mysql";
+
+type Adapter = Awaited<ReturnType<typeof createAdapter>>;
+
+interface Namespace {
+  /** Connection URL pinned to the throwaway namespace for every connection. */
+  scopedUrl: string;
+  /** Drops the throwaway namespace and closes the admin connection. */
+  drop: () => Promise<void>;
+}
 
 interface Leg {
   name: string;
@@ -45,6 +80,53 @@ interface Leg {
     generateDrizzleJson: (s: Record<string, unknown>) => Promise<unknown>;
     generateMigration: (a: unknown, b: unknown) => Promise<string[]>;
   }>;
+  isolate: (baseUrl: string) => Promise<Namespace>;
+}
+
+const makeAdapter = (dialect: Dialect, url: string): Promise<Adapter> =>
+  createAdapter({ type: dialect, url } as Parameters<typeof createAdapter>[0]);
+
+// A random, prefixed identifier is safe to interpolate directly (hex only), so
+// no external input ever reaches these DDL strings.
+const namespaceName = () => `test_wh_${randomBytes(8).toString("hex")}`;
+
+// Postgres: a dedicated schema whose name is pushed onto every connection's
+// `search_path` via the URL's `options` startup parameter. The space in
+// `-c search_path=…` must be percent-encoded as %20 — URLSearchParams would
+// emit `+`, which libpq passes through literally and would not set the path.
+async function isolatePostgres(baseUrl: string): Promise<Namespace> {
+  const schema = namespaceName();
+  const admin = await makeAdapter("postgresql", baseUrl);
+  await admin.executeQuery(`CREATE SCHEMA "${schema}"`);
+  const sep = baseUrl.includes("?") ? "&" : "?";
+  const scopedUrl = `${baseUrl}${sep}options=${encodeURIComponent(
+    `-c search_path=${schema}`
+  )}`;
+  return {
+    scopedUrl,
+    async drop() {
+      await admin.executeQuery(`DROP SCHEMA "${schema}" CASCADE`);
+      await admin.disconnect?.();
+    },
+  };
+}
+
+// MySQL: a dedicated database selected by the URL path, so every pooled
+// connection runs against it. Dropping the whole database is cheaper and safer
+// than per-table drops and never needs foreign-key checks disabled.
+async function isolateMysql(baseUrl: string): Promise<Namespace> {
+  const db = namespaceName();
+  const admin = await makeAdapter("mysql", baseUrl);
+  await admin.executeQuery(`CREATE DATABASE \`${db}\``);
+  const scopedUrl = new URL(baseUrl);
+  scopedUrl.pathname = `/${db}`;
+  return {
+    scopedUrl: scopedUrl.toString(),
+    async drop() {
+      await admin.executeQuery(`DROP DATABASE \`${db}\``);
+      await admin.disconnect?.();
+    },
+  };
 }
 
 const LEGS: Leg[] = [
@@ -59,6 +141,7 @@ const LEGS: Leg[] = [
       nextlyWebhookDeliveries: deliveriesPg,
     },
     kit: getPgDrizzleKit as never,
+    isolate: isolatePostgres,
   },
   {
     name: "mysql",
@@ -71,6 +154,7 @@ const LEGS: Leg[] = [
       nextlyWebhookDeliveries: deliveriesMysql,
     },
     kit: getMySQLDrizzleKit as never,
+    isolate: isolateMysql,
   },
 ];
 
@@ -85,51 +169,25 @@ const logger = {
   debug: () => {},
 };
 
-// Child-first so foreign keys never block a drop; `users` is referenced by
-// `nextly_webhooks.created_by`.
-const TABLES = [
-  "nextly_webhook_deliveries",
-  "nextly_webhooks",
-  "nextly_events",
-  "users",
-];
-
 for (const leg of LEGS) {
   const describeLeg = describe.skipIf(!leg.url);
 
   describeLeg(`webhook secret rotation (${leg.name})`, () => {
-    let adapter: Awaited<ReturnType<typeof createAdapter>>;
+    let adapter: Adapter;
+    let namespace: Namespace;
     let service: WebhookEndpointService;
 
     beforeAll(async () => {
       if (!leg.url) return;
-      process.env.DB_DIALECT = leg.dialect;
-      process.env.DATABASE_URL = leg.url;
-      process.env.NEXTLY_SECRET = "integration-test-application-secret";
 
-      adapter = await createAdapter({
-        type: leg.dialect,
-        url: leg.url,
-      } as Parameters<typeof createAdapter>[0]);
+      // Provision into a throwaway namespace this leg owns, so nothing in the
+      // shared test database is dropped or cascaded.
+      namespace = await leg.isolate(leg.url);
+      adapter = await makeAdapter(leg.dialect, namespace.scopedUrl);
 
-      const isMysql = leg.dialect === "mysql";
-      const quote = (t: string) => (isMysql ? `\`${t}\`` : `"${t}"`);
-
-      // Drop existing tables so the shared DB starts clean. MySQL cannot express
-      // a cross-table CASCADE on DROP, so foreign-key checks are disabled around
-      // the drops instead.
-      if (isMysql) {
-        await adapter.executeQuery("SET FOREIGN_KEY_CHECKS = 0");
-      }
-      for (const table of TABLES) {
-        await adapter.executeQuery(
-          `DROP TABLE IF EXISTS ${quote(table)}${isMysql ? "" : " CASCADE"}`
-        );
-      }
-      if (isMysql) {
-        await adapter.executeQuery("SET FOREIGN_KEY_CHECKS = 1");
-      }
-
+      // The webhook system tables come from the production table definitions via
+      // drizzle-kit (never hand-copied DDL). Generated unqualified, they land in
+      // the namespace the connection is pinned to.
       const kit = await leg.kit();
       const statements = await kit.generateMigration(
         await kit.generateDrizzleJson({}),
@@ -147,7 +205,9 @@ for (const leg of LEGS) {
     });
 
     afterAll(async () => {
+      // Close the pooled connections before dropping the namespace they used.
       await adapter?.disconnect?.();
+      await namespace?.drop();
     });
 
     // `created_by` is left null so the test needs no seeded user row.


### PR DESCRIPTION
## What

Adds a Postgres + MySQL integration leg for webhook signing-secret rotation. The existing endpoint-service integration suite exercises `rotateSecret`/`expireOldSecrets` on **in-memory SQLite only**, so the `SELECT … FOR UPDATE` re-read and the `secret_hash` JSON write were never run on the pooled Postgres/MySQL drivers — whose transaction and JSON handling differ.

## Why

A report that the admin "Rotate signing secret" action failed prompted a cross-dialect check. Rotation turned out to be correct on all three dialects (the reported failure was an unrelated stale-backend/version skew), but the coverage gap it exposed is real — this closes it.

## Coverage

Per dialect (self-skips when the dialect URL is unset): provisions the webhook system tables from the production table definitions via drizzle-kit (drop-then-recreate for the shared DB), then asserts a rotation with an overlap window keeps **both** secrets live and `expireOldSecrets` leaves only the primary. Verified green locally on Postgres 17 (:5435) and MySQL (:3307).

Test-only — no changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added integration coverage for webhook signing-secret rotation across PostgreSQL and MySQL.
  - Verified that overlapping rotation windows accept both the previous and newly issued secrets.
  - Confirmed expired secrets are rejected after the overlap period, while the newest secret remains valid.
  - Improved confidence in consistent webhook security behavior across supported database systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->