### PR TITLE
feat(blocks-engine): add document validation with machine-readable issues

### DIFF
--- a/.changeset/blocks-engine-validation.md
+++ b/.changeset/blocks-engine-validation.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+`@nextlyhq/blocks-engine` now validates page documents and reports problems in a machine-readable form. Each issue carries a precise location in the document, a stable code, and a suggested fix, so tools and AI agents can pinpoint and repair exactly what is wrong. Validation runs in a strict mode (used when publishing, where unknown blocks or missing breakpoints are errors) or a forgiving mode (used when rendering, where those become warnings so a page still displays what it can).

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -65,3 +65,13 @@ export {
   updateNode,
 } from "./tree";
 export type { NodeLocation, TreePosition } from "./tree";
+
+export { validate, ISSUE_CODES } from "./validation";
+export type {
+  BlockTypeLookup,
+  IssueCode,
+  IssueSeverity,
+  ValidationContext,
+  ValidationIssue,
+  ValidationMode,
+} from "./validation";

--- a/packages/blocks-engine/src/limits.ts
+++ b/packages/blocks-engine/src/limits.ts
@@ -62,7 +62,13 @@ export function treeDepth(nodes: BlockNode[]): number {
     const entry = stack.pop();
     if (!entry) continue;
     if (entry.depth > deepest) deepest = entry.depth;
-    if (entry.node.slots) {
+    // A malformed array element (null, or a non-object) has no slots and must
+    // not be dereferenced: validation runs this over untrusted documents.
+    if (
+      typeof entry.node === "object" &&
+      entry.node !== null &&
+      entry.node.slots
+    ) {
       // Skip malformed (non-array) slot values so untrusted documents passed in
       // during validation cannot make this throw.
       for (const children of Object.values(entry.node.slots)) {

--- a/packages/blocks-engine/src/limits.ts
+++ b/packages/blocks-engine/src/limits.ts
@@ -41,7 +41,11 @@ export function countNodes(nodes: BlockNode[]): number {
     if (!node) continue;
     count++;
     if (node.slots) {
-      for (const children of Object.values(node.slots)) stack.push(...children);
+      // Guard against malformed slots (a non-array value): these helpers run
+      // over untrusted documents during validation and must not throw.
+      for (const children of Object.values(node.slots)) {
+        if (Array.isArray(children)) stack.push(...children);
+      }
     }
   }
   return count;
@@ -59,7 +63,10 @@ export function treeDepth(nodes: BlockNode[]): number {
     if (!entry) continue;
     if (entry.depth > deepest) deepest = entry.depth;
     if (entry.node.slots) {
+      // Skip malformed (non-array) slot values so untrusted documents passed in
+      // during validation cannot make this throw.
       for (const children of Object.values(entry.node.slots)) {
+        if (!Array.isArray(children)) continue;
         for (const child of children) {
           stack.push({ node: child, depth: entry.depth + 1 });
         }

--- a/packages/blocks-engine/src/limits.ts
+++ b/packages/blocks-engine/src/limits.ts
@@ -35,16 +35,19 @@ export const DEFAULT_LIMITS: DocumentLimits = {
 /** Total node count across the forest, slots included. */
 export function countNodes(nodes: BlockNode[]): number {
   let count = 0;
-  const stack: BlockNode[] = [...nodes];
-  while (stack.length > 0) {
-    const node = stack.pop();
-    if (!node) continue;
+  // Index-based walk so every array element is counted, including malformed
+  // ones (null, a primitive): the node cap must reflect the real element count
+  // so an array padded with junk cannot slip past it. Only well-formed objects
+  // are descended into.
+  const queue: BlockNode[] = [...nodes];
+  for (let i = 0; i < queue.length; i++) {
+    const node = queue[i];
     count++;
-    if (node.slots) {
+    if (typeof node === "object" && node !== null && node.slots) {
       // Guard against malformed slots (a non-array value): these helpers run
       // over untrusted documents during validation and must not throw.
       for (const children of Object.values(node.slots)) {
-        if (Array.isArray(children)) stack.push(...children);
+        if (Array.isArray(children)) queue.push(...children);
       }
     }
   }

--- a/packages/blocks-engine/src/validation.fixtures.ts
+++ b/packages/blocks-engine/src/validation.fixtures.ts
@@ -4,8 +4,8 @@
  * assert precise (path, code) pairs, not just pass/fail, so a change in what
  * validation accepts is a visible change here.
  *
- * Not a test file itself; consumed by validation.test.ts. Kept as data so the
- * same corpus can seed the renderer and repair-loop suites in later plans.
+ * Not a test file itself; consumed by validation.test.ts. Kept as reusable
+ * data rather than inline test cases so other suites can share the corpus.
  */
 import type { BlockDocument, BreakpointSet } from "./document";
 

--- a/packages/blocks-engine/src/validation.fixtures.ts
+++ b/packages/blocks-engine/src/validation.fixtures.ts
@@ -377,6 +377,55 @@ export const VALIDATION_FIXTURES: ValidationFixture[] = [
     ],
   },
   {
+    name: "a null element in the nodes array is reported, not a crash",
+    mode: "strict",
+    doc: invalid({ formatVersion: 1, kind: "page", nodes: [null] }),
+    expected: [{ path: "/nodes/0", code: "invalid-node" }],
+  },
+  {
+    name: "a visibility condition without an operator is rejected",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: {},
+          visibility: { conditions: [[{ field: "status" }]] },
+        },
+      ],
+    }),
+    expected: [
+      { path: "/nodes/0/visibility/conditions", code: "invalid-visibility" },
+    ],
+  },
+  {
+    name: "a non-boolean visibility device value is rejected",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: {},
+          visibility: { devices: { mobile: "false" } },
+        },
+      ],
+    }),
+    expected: [
+      {
+        path: "/nodes/0/visibility/devices/mobile",
+        code: "invalid-visibility",
+      },
+    ],
+  },
+  {
     name: "single binding without sourceKey",
     mode: "strict",
     doc: invalid({

--- a/packages/blocks-engine/src/validation.fixtures.ts
+++ b/packages/blocks-engine/src/validation.fixtures.ts
@@ -525,6 +525,55 @@ export const VALIDATION_FIXTURES: ValidationFixture[] = [
     expected: [{ path: "/nodes/0/bindings/text", code: "invalid-binding" }],
   },
   {
+    name: "two nodes with the same cssId are a duplicate DOM id",
+    mode: "strict",
+    doc: {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "n1", type: "core/text", version: 1, props: {}, cssId: "hero" },
+        { id: "n2", type: "core/text", version: 1, props: {}, cssId: "hero" },
+      ],
+    },
+    expected: [{ path: "/nodes/1/cssId", code: "duplicate-dom-id" }],
+  },
+  {
+    name: "a cssId colliding with an attributes id is a duplicate DOM id",
+    mode: "strict",
+    doc: {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "n1", type: "core/text", version: 1, props: {}, cssId: "hero" },
+        {
+          id: "n2",
+          type: "core/text",
+          version: 1,
+          props: {},
+          attributes: { id: "hero" },
+        },
+      ],
+    },
+    expected: [{ path: "/nodes/1/attributes/id", code: "duplicate-dom-id" }],
+  },
+  {
+    name: "component instance with malformed props reports only invalid-props",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "nextly/component-instance",
+          version: 1,
+          props: null,
+        },
+      ],
+    }),
+    expected: [{ path: "/nodes/0/props", code: "invalid-props" }],
+  },
+  {
     name: "component instance without componentId",
     mode: "strict",
     doc: {

--- a/packages/blocks-engine/src/validation.fixtures.ts
+++ b/packages/blocks-engine/src/validation.fixtures.ts
@@ -1,0 +1,461 @@
+/**
+ * The validation fixture corpus: documents paired with the exact issues they
+ * should produce. This is the format's living spec — adversarial fixtures
+ * assert precise (path, code) pairs, not just pass/fail, so a change in what
+ * validation accepts is a visible change here.
+ *
+ * Not a test file itself; consumed by validation.test.ts. Kept as data so the
+ * same corpus can seed the renderer and repair-loop suites in later plans.
+ */
+import type { BlockDocument, BreakpointSet } from "./document";
+
+/**
+ * Coerce a deliberately-malformed shape to `BlockDocument` at the boundary.
+ * Validation exists precisely to check untrusted input that does not satisfy
+ * the type (database rows, agent output), so the invalid fixtures model that
+ * input; this single named boundary keeps them free of scattered casts while
+ * the valid fixtures stay fully type-checked.
+ */
+function invalid(doc: unknown): BlockDocument {
+  return doc as BlockDocument;
+}
+
+/** A site breakpoint set the fixtures validate against. */
+export const FIXTURE_BREAKPOINTS: BreakpointSet = {
+  viewport: [
+    { id: "base", label: "Desktop" },
+    { id: "tablet", label: "Tablet", maxWidth: 1024 },
+    { id: "mobile", label: "Mobile", maxWidth: 640 },
+  ],
+  container: [
+    { id: "card-base", label: "Card" },
+    { id: "card-narrow", label: "Card narrow", maxWidth: 320 },
+  ],
+};
+
+/** One expected issue: the (path, code) pair a fixture must produce. */
+export interface ExpectedIssue {
+  path: string;
+  code: string;
+}
+
+export interface ValidationFixture {
+  name: string;
+  mode: "strict" | "forgiving";
+  /** Set when the fixture exercises unknown-type checks. */
+  registeredTypes?: string[];
+  doc: BlockDocument;
+  /** Exact issues expected (order-independent). Empty = a valid document. */
+  expected: ExpectedIssue[];
+}
+
+// A small valid page reused as the base for several fixtures.
+function validPage(): BlockDocument {
+  return {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      {
+        id: "n1",
+        type: "core/section",
+        version: 1,
+        props: {},
+        slots: {
+          children: [
+            {
+              id: "n2",
+              type: "core/heading",
+              version: 1,
+              props: { text: "Hi" },
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+export const VALIDATION_FIXTURES: ValidationFixture[] = [
+  {
+    name: "a well-formed page has no issues",
+    mode: "strict",
+    doc: validPage(),
+    expected: [],
+  },
+  {
+    name: "a fully-featured node validates clean",
+    mode: "strict",
+    doc: {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "root",
+          type: "core/section",
+          version: 2,
+          props: {},
+          classes: ["cls_hero"],
+          attributes: { "data-role": "banner" },
+          styles: {
+            base: { base: { color: "#111" }, mobile: { color: "#222" } },
+            hover: { "card-narrow": { color: "#333" } },
+          },
+          visibility: {
+            conditions: [[{ field: "status", op: "eq", value: "vip" }]],
+            devices: { mobile: false },
+          },
+          bindings: {
+            title: { $bind: "title", source: "entry" },
+            tagline: { $bind: "tagline", source: "single", sourceKey: "site" },
+          },
+        },
+      ],
+    },
+    expected: [],
+  },
+  {
+    name: "wrong format version",
+    mode: "strict",
+    doc: invalid({ ...validPage(), formatVersion: 2 }),
+    expected: [{ path: "/formatVersion", code: "invalid-format-version" }],
+  },
+  {
+    name: "unknown kind",
+    mode: "strict",
+    doc: invalid({ ...validPage(), kind: "widget" }),
+    expected: [{ path: "/kind", code: "invalid-kind" }],
+  },
+  {
+    name: "nodes not an array",
+    mode: "strict",
+    doc: invalid({ formatVersion: 1, kind: "page", nodes: {} }),
+    expected: [{ path: "/nodes", code: "nodes-not-array" }],
+  },
+  {
+    name: "missing node id",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "", type: "core/text", version: 1, props: {} }],
+    }),
+    expected: [{ path: "/nodes/0/id", code: "missing-node-id" }],
+  },
+  {
+    name: "duplicate ids across nesting",
+    mode: "strict",
+    doc: {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "dup",
+          type: "core/section",
+          version: 1,
+          props: {},
+          slots: {
+            children: [{ id: "dup", type: "core/text", version: 1, props: {} }],
+          },
+        },
+      ],
+    },
+    expected: [
+      { path: "/nodes/0/slots/children/0/id", code: "duplicate-node-id" },
+    ],
+  },
+  {
+    name: "non-namespaced type",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "n1", type: "heading", version: 1, props: {} }],
+    }),
+    expected: [{ path: "/nodes/0/type", code: "invalid-node-type" }],
+  },
+  {
+    name: "non-integer version",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "n1", type: "core/text", version: 1.5, props: {} }],
+    }),
+    expected: [{ path: "/nodes/0/version", code: "invalid-node-version" }],
+  },
+  {
+    name: "props not an object",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "n1", type: "core/text", version: 1, props: [] }],
+    }),
+    expected: [{ path: "/nodes/0/props", code: "invalid-props" }],
+  },
+  {
+    name: "slot value not an array",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/section",
+          version: 1,
+          props: {},
+          slots: { children: {} },
+        },
+      ],
+    }),
+    expected: [{ path: "/nodes/0/slots/children", code: "invalid-slots" }],
+  },
+  {
+    name: "classes not string array",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "n1", type: "core/text", version: 1, props: {}, classes: [1] },
+      ],
+    }),
+    expected: [{ path: "/nodes/0/classes", code: "invalid-classes" }],
+  },
+  {
+    name: "attributes not a string map",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: {},
+          attributes: { tabindex: 0 },
+        },
+      ],
+    }),
+    expected: [{ path: "/nodes/0/attributes", code: "invalid-attributes" }],
+  },
+  {
+    name: "slots not an object",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "n1", type: "core/section", version: 1, props: {}, slots: [] },
+      ],
+    }),
+    expected: [{ path: "/nodes/0/slots", code: "invalid-slots" }],
+  },
+  {
+    name: "style values not an object",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: {},
+          styles: { base: { base: "red" } },
+        },
+      ],
+    }),
+    expected: [
+      { path: "/nodes/0/styles/base/base", code: "invalid-style-values" },
+    ],
+  },
+  {
+    name: "visibility devices reference an unknown breakpoint",
+    mode: "strict",
+    doc: {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: {},
+          visibility: { devices: { wide: false } },
+        },
+      ],
+    },
+    expected: [
+      {
+        path: "/nodes/0/visibility/devices/wide",
+        code: "unknown-breakpoint",
+      },
+    ],
+  },
+  {
+    name: "unknown style state",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: {},
+          styles: { visited: { base: { color: "#000" } } },
+        },
+      ],
+    }),
+    expected: [
+      { path: "/nodes/0/styles/visited", code: "invalid-style-state" },
+    ],
+  },
+  {
+    name: "dangling breakpoint ref is an error in strict mode",
+    mode: "strict",
+    doc: {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: {},
+          styles: { base: { wide: { color: "#000" } } },
+        },
+      ],
+    },
+    expected: [
+      { path: "/nodes/0/styles/base/wide", code: "unknown-breakpoint" },
+    ],
+  },
+  {
+    name: "dangling breakpoint ref is a warning in forgiving mode",
+    mode: "forgiving",
+    doc: {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: {},
+          styles: { base: { wide: { color: "#000" } } },
+        },
+      ],
+    },
+    expected: [
+      { path: "/nodes/0/styles/base/wide", code: "unknown-breakpoint" },
+    ],
+  },
+  {
+    name: "malformed visibility conditions",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: {},
+          visibility: { conditions: [{ field: "x" }] },
+        },
+      ],
+    }),
+    expected: [
+      { path: "/nodes/0/visibility/conditions", code: "invalid-visibility" },
+    ],
+  },
+  {
+    name: "single binding without sourceKey",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: {},
+          bindings: { text: { $bind: "title", source: "single" } },
+        },
+      ],
+    }),
+    expected: [
+      { path: "/nodes/0/bindings/text/sourceKey", code: "missing-source-key" },
+    ],
+  },
+  {
+    name: "malformed binding ($bind not a string)",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: {},
+          bindings: { text: { $bind: 5 } },
+        },
+      ],
+    }),
+    expected: [{ path: "/nodes/0/bindings/text", code: "invalid-binding" }],
+  },
+  {
+    name: "component instance without componentId",
+    mode: "strict",
+    doc: {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "nextly/component-instance",
+          version: 1,
+          props: {},
+        },
+      ],
+    },
+    expected: [
+      {
+        path: "/nodes/0/props/componentId",
+        code: "invalid-component-instance",
+      },
+    ],
+  },
+  {
+    name: "unknown node type is an error in strict mode when a registry is present",
+    mode: "strict",
+    registeredTypes: ["core/section", "core/heading"],
+    doc: {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "n1", type: "core/mystery", version: 1, props: {} }],
+    },
+    expected: [{ path: "/nodes/0/type", code: "unknown-node-type" }],
+  },
+  {
+    name: "unknown node type is a warning in forgiving mode",
+    mode: "forgiving",
+    registeredTypes: ["core/section"],
+    doc: {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "n1", type: "core/mystery", version: 1, props: {} }],
+    },
+    expected: [{ path: "/nodes/0/type", code: "unknown-node-type" }],
+  },
+];

--- a/packages/blocks-engine/src/validation.fixtures.ts
+++ b/packages/blocks-engine/src/validation.fixtures.ts
@@ -446,6 +446,67 @@ export const VALIDATION_FIXTURES: ValidationFixture[] = [
     ],
   },
   {
+    name: "document-level settings.styles are validated too",
+    mode: "strict",
+    doc: {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [],
+      settings: { styles: { base: { wide: { color: "#000" } } } },
+    },
+    expected: [
+      { path: "/settings/styles/base/wide", code: "unknown-breakpoint" },
+    ],
+  },
+  {
+    name: "an expression-like binding path is rejected",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: {},
+          bindings: { text: { $bind: "price * 2", source: "entry" } },
+        },
+      ],
+    }),
+    expected: [
+      { path: "/nodes/0/bindings/text/$bind", code: "invalid-binding" },
+    ],
+  },
+  {
+    name: "sourceKey on a non-single binding is rejected",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: {},
+          bindings: {
+            text: { $bind: "title", source: "entry", sourceKey: "site" },
+          },
+        },
+      ],
+    }),
+    expected: [
+      { path: "/nodes/0/bindings/text/sourceKey", code: "invalid-binding" },
+    ],
+  },
+  {
+    name: "an unknown kind is a warning in forgiving mode",
+    mode: "forgiving",
+    doc: invalid({ ...validPage(), kind: "widget" }),
+    expected: [{ path: "/kind", code: "invalid-kind" }],
+  },
+  {
     name: "malformed binding ($bind not a string)",
     mode: "strict",
     doc: invalid({

--- a/packages/blocks-engine/src/validation.fixtures.ts
+++ b/packages/blocks-engine/src/validation.fixtures.ts
@@ -224,6 +224,36 @@ export const VALIDATION_FIXTURES: ValidationFixture[] = [
     expected: [{ path: "/nodes/0/classes", code: "invalid-classes" }],
   },
   {
+    name: "a non-string cssId is rejected",
+    mode: "strict",
+    doc: invalid({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "n1", type: "core/text", version: 1, props: {}, cssId: 5 }],
+    }),
+    expected: [{ path: "/nodes/0/cssId", code: "invalid-css-id" }],
+  },
+  {
+    name: "an event-handler attribute is rejected as inline JS",
+    mode: "strict",
+    doc: {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: {},
+          attributes: { onclick: "alert(1)" },
+        },
+      ],
+    },
+    expected: [
+      { path: "/nodes/0/attributes/onclick", code: "invalid-attributes" },
+    ],
+  },
+  {
     name: "attributes not a string map",
     mode: "strict",
     doc: invalid({

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -284,6 +284,62 @@ describe("validation never throws on adversarial input", () => {
     expect(issues.some(i => i.code === "invalid-format-version")).toBe(true);
   });
 
+  it("reports a null binding value instead of throwing", () => {
+    const doc = invalidDoc({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: {},
+          bindings: { text: null },
+        },
+      ],
+    });
+    let issues: ReturnType<typeof validate> = [];
+    expect(() => {
+      issues = validate(doc, {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode: "strict",
+      });
+    }).not.toThrow();
+    expect(
+      issues.some(
+        i => i.code === "invalid-binding" && i.path === "/nodes/0/bindings/text"
+      )
+    ).toBe(true);
+  });
+
+  it("does not throw on a malformed breakpoint definition", () => {
+    const malformedSet = invalidDoc({
+      viewport: [{ id: "base", label: "Desktop" }, null],
+      container: [],
+    }) as unknown as BreakpointSet;
+    expect(() => {
+      validate(
+        { formatVersion: 1, kind: "page", nodes: [] },
+        { breakpoints: malformedSet, mode: "strict" }
+      );
+    }).not.toThrow();
+  });
+
+  it("reports holes in a sparse nodes array instead of throwing", () => {
+    const sparse: unknown[] = [];
+    sparse[2] = { id: "n1", type: "core/text", version: 1, props: {} };
+    const doc = invalidDoc({ formatVersion: 1, kind: "page", nodes: sparse });
+    let issues: ReturnType<typeof validate> = [];
+    expect(() => {
+      issues = validate(doc, {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode: "strict",
+      });
+    }).not.toThrow();
+    // The two holes are reported as invalid nodes; the real node at index 2 is fine.
+    expect(issues.filter(i => i.code === "invalid-node")).toHaveLength(2);
+  });
+
   it("counts malformed array elements toward the node cap", () => {
     const doc = invalidDoc({
       formatVersion: 1,

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest";
+
+import type { BlockDocument, BreakpointSet } from "./document";
+import {
+  FIXTURE_BREAKPOINTS,
+  VALIDATION_FIXTURES,
+} from "./validation.fixtures";
+import type { BlockTypeLookup } from "./validation";
+import { ISSUE_CODES, validate } from "./validation";
+
+function lookup(types: string[]): BlockTypeLookup {
+  const set = new Set(types);
+  return { has: type => set.has(type) };
+}
+
+/** Resolve an RFC 6901 JSON-Pointer against a value; undefined if it misses. */
+function resolvePointer(root: unknown, path: string): unknown {
+  if (path === "") return root;
+  let current: unknown = root;
+  for (const rawToken of path.split("/").slice(1)) {
+    const token = rawToken.replace(/~1/g, "/").replace(/~0/g, "~");
+    if (Array.isArray(current)) {
+      current = current[Number(token)];
+    } else if (current && typeof current === "object") {
+      current = (current as Record<string, unknown>)[token];
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+}
+
+describe("validation fixture corpus", () => {
+  for (const fixture of VALIDATION_FIXTURES) {
+    it(fixture.name, () => {
+      const issues = validate(fixture.doc, {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode: fixture.mode,
+        registry: fixture.registeredTypes
+          ? lookup(fixture.registeredTypes)
+          : undefined,
+      });
+      // Assert the exact (path, code) set — order-independent.
+      const actual = issues.map(i => `${i.path}\t${i.code}`).sort();
+      const expected = fixture.expected.map(e => `${e.path}\t${e.code}`).sort();
+      expect(actual).toEqual(expected);
+    });
+  }
+});
+
+describe("issue-code vocabulary is stable and complete", () => {
+  it("every code emitted by the corpus is documented in ISSUE_CODES", () => {
+    for (const fixture of VALIDATION_FIXTURES) {
+      const issues = validate(fixture.doc, {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode: fixture.mode,
+        registry: fixture.registeredTypes
+          ? lookup(fixture.registeredTypes)
+          : undefined,
+      });
+      for (const issue of issues) {
+        expect(ISSUE_CODES).toHaveProperty(issue.code);
+      }
+    }
+  });
+
+  it("every documented code is a non-empty description", () => {
+    for (const [code, description] of Object.entries(ISSUE_CODES)) {
+      expect(description.length, `${code} needs a description`).toBeGreaterThan(
+        0
+      );
+    }
+  });
+});
+
+describe("every issue carries a JSON-Pointer anchored in the document", () => {
+  it("each emitted path resolves, or (for a missing field) its parent does", () => {
+    for (const fixture of VALIDATION_FIXTURES) {
+      const issues = validate(fixture.doc, {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode: fixture.mode,
+        registry: fixture.registeredTypes
+          ? lookup(fixture.registeredTypes)
+          : undefined,
+      });
+      for (const issue of issues) {
+        // Document-level issues (size) use the empty root pointer; breakpoint
+        // config issues point into the context, not the document.
+        if (issue.path === "" || issue.path.startsWith("/breakpoints"))
+          continue;
+        const resolved = resolvePointer(fixture.doc, issue.path);
+        if (resolved !== undefined) continue;
+        // A "missing field" issue addresses an absent leaf, telling a fixer
+        // WHERE the field belongs; its parent location must resolve.
+        const parentPath = issue.path.slice(0, issue.path.lastIndexOf("/"));
+        const parent =
+          parentPath === ""
+            ? fixture.doc
+            : resolvePointer(fixture.doc, parentPath);
+        expect(
+          parent,
+          `${fixture.name}: neither ${issue.path} nor its parent (${issue.code}) resolved`
+        ).not.toBeUndefined();
+      }
+    }
+  });
+});
+
+describe("severity depends on mode for preservable problems", () => {
+  const danglingDoc: BlockDocument = {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      {
+        id: "n1",
+        type: "core/text",
+        version: 1,
+        props: {},
+        styles: { base: { wide: { color: "#000" } } },
+      },
+    ],
+  };
+
+  it("dangling breakpoint ref is an error in strict, a warning in forgiving", () => {
+    const strict = validate(danglingDoc, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      mode: "strict",
+    });
+    expect(strict[0]?.severity).toBe("error");
+    const forgiving = validate(danglingDoc, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      mode: "forgiving",
+    });
+    expect(forgiving[0]?.severity).toBe("warning");
+  });
+
+  it("structural corruption is an error in both modes", () => {
+    const broken: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "", type: "core/text", version: 1, props: {} }],
+    };
+    for (const mode of ["strict", "forgiving"] as const) {
+      const issues = validate(broken, {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode,
+      });
+      expect(issues.every(i => i.severity === "error")).toBe(true);
+    }
+  });
+});
+
+describe("breakpoint sets are validated for cross-axis id collisions", () => {
+  it("reports a breakpoint id shared by the viewport and container axes", () => {
+    const collidingSet: BreakpointSet = {
+      viewport: [
+        { id: "base", label: "Desktop" },
+        { id: "sm", label: "Small" },
+      ],
+      container: [{ id: "sm", label: "Card small" }],
+    };
+    const issues = validate(
+      { formatVersion: 1, kind: "page", nodes: [] },
+      { breakpoints: collidingSet, mode: "strict" }
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.code).toBe("breakpoint-id-not-unique");
+    expect(issues[0]?.path).toBe("/breakpoints/container/0");
+    expect(issues[0]?.severity).toBe("error");
+  });
+});
+
+describe("limits", () => {
+  it("flags a document that exceeds the byte cap", () => {
+    const big = "x".repeat(2000);
+    const nodes = Array.from({ length: 50 }, (_, i) => ({
+      id: `n${i}`,
+      type: "core/text",
+      version: 1,
+      props: { text: big },
+    }));
+    const issues = validate(
+      { formatVersion: 1, kind: "page", nodes },
+      {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode: "strict",
+        limits: { maxDepth: 12, maxNodes: 5000, maxBytes: 1000 },
+      }
+    );
+    expect(issues.some(i => i.code === "document-too-large")).toBe(true);
+  });
+
+  it("warns when the document approaches the byte cap", () => {
+    const nodes = [
+      {
+        id: "n1",
+        type: "core/text",
+        version: 1,
+        props: { text: "x".repeat(850) },
+      },
+    ];
+    const issues = validate(
+      { formatVersion: 1, kind: "page", nodes },
+      {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode: "strict",
+        limits: { maxDepth: 12, maxNodes: 5000, maxBytes: 1000 },
+      }
+    );
+    const sizeIssue = issues.find(i => i.code === "document-size-warning");
+    expect(sizeIssue?.severity).toBe("warning");
+  });
+
+  it("flags too many nodes and too much depth", () => {
+    const nodes = Array.from({ length: 6 }, (_, i) => ({
+      id: `n${i}`,
+      type: "core/text",
+      version: 1,
+      props: {},
+    }));
+    const issues = validate(
+      { formatVersion: 1, kind: "page", nodes },
+      {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode: "strict",
+        limits: { maxDepth: 12, maxNodes: 5, maxBytes: 1_000_000 },
+      }
+    );
+    expect(issues.some(i => i.code === "node-count-exceeded")).toBe(true);
+  });
+});

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -247,6 +247,74 @@ describe("validation never throws on adversarial input", () => {
     }).not.toThrow();
     expect(issues.filter(i => i.code === "invalid-node")).toHaveLength(3);
   });
+
+  it("reports a wholly-malformed document instead of dereferencing it", () => {
+    for (const bad of [null, undefined, 42, [1, 2, 3]]) {
+      let issues: ReturnType<typeof validate> = [];
+      expect(() => {
+        issues = validate(invalidDoc(bad), {
+          breakpoints: FIXTURE_BREAKPOINTS,
+          mode: "strict",
+        });
+      }).not.toThrow();
+      expect(issues).toEqual([
+        {
+          path: "",
+          code: "invalid-document",
+          severity: "error",
+          message: "The document must be an object.",
+        },
+      ]);
+    }
+  });
+
+  it("does not throw when a malformed field holds a deeply nested object", () => {
+    // formatVersion is rendered into a message; a deep object there must not
+    // make the message builder overflow via JSON.stringify.
+    let deep: Record<string, unknown> = {};
+    for (let i = 0; i < 20_000; i++) deep = { nested: deep };
+    const doc = invalidDoc({ formatVersion: deep, kind: "page", nodes: [] });
+    let issues: ReturnType<typeof validate> = [];
+    expect(() => {
+      issues = validate(doc, {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode: "strict",
+      });
+    }).not.toThrow();
+    expect(issues.some(i => i.code === "invalid-format-version")).toBe(true);
+  });
+
+  it("counts malformed array elements toward the node cap", () => {
+    const doc = invalidDoc({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [null, null, null],
+    });
+    const issues = validate(doc, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      mode: "strict",
+      limits: { maxDepth: 12, maxNodes: 2, maxBytes: 1_000_000 },
+    });
+    expect(issues.some(i => i.code === "node-count-exceeded")).toBe(true);
+  });
+});
+
+describe("unknown kind severity follows the mode", () => {
+  it("errors in strict, warns in forgiving", () => {
+    const doc = invalidDoc({ formatVersion: 1, kind: "widget", nodes: [] });
+    const strict = validate(doc, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      mode: "strict",
+    });
+    expect(strict.find(i => i.code === "invalid-kind")?.severity).toBe("error");
+    const forgiving = validate(doc, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      mode: "forgiving",
+    });
+    expect(forgiving.find(i => i.code === "invalid-kind")?.severity).toBe(
+      "warning"
+    );
+  });
 });
 
 describe("limits", () => {

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -13,6 +13,11 @@ function lookup(types: string[]): BlockTypeLookup {
   return { has: type => set.has(type) };
 }
 
+/** Coerce deliberately-malformed input to BlockDocument for the validator. */
+function invalidDoc(doc: unknown): BlockDocument {
+  return doc as BlockDocument;
+}
+
 /** Resolve an RFC 6901 JSON-Pointer against a value; undefined if it misses. */
 function resolvePointer(root: unknown, path: string): unknown {
   if (path === "") return root;
@@ -150,7 +155,7 @@ describe("severity depends on mode for preservable problems", () => {
   });
 });
 
-describe("breakpoint sets are validated for cross-axis id collisions", () => {
+describe("breakpoint sets are validated for duplicate ids", () => {
   it("reports a breakpoint id shared by the viewport and container axes", () => {
     const collidingSet: BreakpointSet = {
       viewport: [
@@ -167,6 +172,80 @@ describe("breakpoint sets are validated for cross-axis id collisions", () => {
     expect(issues[0]?.code).toBe("breakpoint-id-not-unique");
     expect(issues[0]?.path).toBe("/breakpoints/container/0");
     expect(issues[0]?.severity).toBe("error");
+  });
+
+  it("reports a breakpoint id repeated within a single axis", () => {
+    const dupWithinAxis: BreakpointSet = {
+      viewport: [
+        { id: "base", label: "Desktop" },
+        { id: "mobile", label: "Mobile", maxWidth: 640 },
+        { id: "mobile", label: "Mobile again", maxWidth: 480 },
+      ],
+      container: [],
+    };
+    const issues = validate(
+      { formatVersion: 1, kind: "page", nodes: [] },
+      { breakpoints: dupWithinAxis, mode: "strict" }
+    );
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.code).toBe("breakpoint-id-not-unique");
+    expect(issues[0]?.path).toBe("/breakpoints/viewport/2");
+  });
+});
+
+describe("validation never throws on adversarial input", () => {
+  it("returns a depth issue for a document nested far beyond any stack limit", () => {
+    // Build a chain ~20k deep — enough to overflow a recursive walk or
+    // JSON.stringify. Validation must return issues, not throw.
+    let node: Record<string, unknown> = {
+      id: "leaf",
+      type: "core/text",
+      version: 1,
+      props: {},
+    };
+    for (let i = 0; i < 20_000; i++) {
+      node = {
+        id: `n${i}`,
+        type: "core/section",
+        version: 1,
+        props: {},
+        slots: { children: [node] },
+      };
+    }
+    const doc = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [node],
+    } as BlockDocument;
+    let issues: ReturnType<typeof validate> = [];
+    expect(() => {
+      issues = validate(doc, {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode: "strict",
+      });
+    }).not.toThrow();
+    expect(issues.some(i => i.code === "depth-exceeded")).toBe(true);
+  });
+
+  it("returns issues for a nodes array full of malformed elements", () => {
+    const doc = invalidDoc({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        null,
+        5,
+        "x",
+        { id: "ok", type: "core/text", version: 1, props: {} },
+      ],
+    });
+    let issues: ReturnType<typeof validate> = [];
+    expect(() => {
+      issues = validate(doc, {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode: "strict",
+      });
+    }).not.toThrow();
+    expect(issues.filter(i => i.code === "invalid-node")).toHaveLength(3);
   });
 });
 

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -407,6 +407,32 @@ describe("validation never throws on adversarial input", () => {
     expect(Date.now() - start).toBeLessThan(2000);
   });
 
+  it("rejects an oversized string prop by byte size without materializing it", () => {
+    // A single node well under the node/depth caps but carrying a ~50MB string:
+    // the bounded byte counter must reject it quickly, not allocate a full copy.
+    const doc = invalidDoc({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: { text: "x".repeat(50_000_000) },
+        },
+      ],
+    });
+    const start = Date.now();
+    const issues = validate(doc, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      mode: "strict",
+      limits: { maxDepth: 12, maxNodes: 5000, maxBytes: 2 * 1024 * 1024 },
+    });
+    expect(issues.some(i => i.code === "document-too-large")).toBe(true);
+    // Bounded: aborts near the 2MiB cap rather than walking all 50MB.
+    expect(Date.now() - start).toBeLessThan(2000);
+  });
+
   it("bounds the size of an untrusted string echoed into a message", () => {
     const huge = "x".repeat(5_000_000);
     const doc = invalidDoc({ formatVersion: huge, kind: "page", nodes: [] });

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -407,6 +407,69 @@ describe("validation never throws on adversarial input", () => {
     expect(Date.now() - start).toBeLessThan(2000);
   });
 
+  it("bounds the size of an untrusted string echoed into a message", () => {
+    const huge = "x".repeat(5_000_000);
+    const doc = invalidDoc({ formatVersion: huge, kind: "page", nodes: [] });
+    const issues = validate(doc, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      mode: "strict",
+    });
+    const issue = issues.find(i => i.code === "invalid-format-version");
+    expect(issue).toBeDefined();
+    // The message must not embed the whole 5MB string.
+    expect(issue!.message.length).toBeLessThan(300);
+  });
+
+  it("does not invoke a malicious toString on an invalid node type", () => {
+    const hostileType = {
+      toString() {
+        throw new Error("boom");
+      },
+    };
+    const doc = invalidDoc({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "n1", type: hostileType, version: 1, props: {} }],
+    });
+    let issues: ReturnType<typeof validate> = [];
+    expect(() => {
+      issues = validate(doc, {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode: "strict",
+      });
+    }).not.toThrow();
+    expect(issues.some(i => i.code === "invalid-node-type")).toBe(true);
+  });
+
+  it("rejects a sparse visibility condition array (holes are not skipped)", () => {
+    const group: unknown[] = [];
+    group[1] = { field: "status", op: "eq" };
+    const doc = invalidDoc({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: {},
+          visibility: { conditions: [group] },
+        },
+      ],
+    });
+    const issues = validate(doc, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      mode: "strict",
+    });
+    expect(
+      issues.some(
+        i =>
+          i.code === "invalid-visibility" &&
+          i.path === "/nodes/0/visibility/conditions"
+      )
+    ).toBe(true);
+  });
+
   it("counts malformed array elements toward the node cap", () => {
     const doc = invalidDoc({
       formatVersion: 1,

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -407,6 +407,50 @@ describe("validation never throws on adversarial input", () => {
     expect(Date.now() - start).toBeLessThan(2000);
   });
 
+  it("rejects a huge array in props by byte size without enqueuing it all", () => {
+    // A 20M-element array under the node cap: its comma bytes alone exceed the
+    // 2MiB cap, so the byte counter must bail before pushing 20M stack entries.
+    const doc = invalidDoc({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: { items: new Array(20_000_000).fill(0) },
+        },
+      ],
+    });
+    const start = Date.now();
+    const issues = validate(doc, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      mode: "strict",
+      limits: { maxDepth: 12, maxNodes: 5000, maxBytes: 2 * 1024 * 1024 },
+    });
+    expect(issues.some(i => i.code === "document-too-large")).toBe(true);
+    expect(Date.now() - start).toBeLessThan(2000);
+  });
+
+  it("rejects a sparse classes array (holes are not skipped)", () => {
+    const classes: unknown[] = [];
+    classes[1] = "cls";
+    const doc = invalidDoc({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "n1", type: "core/text", version: 1, props: {}, classes }],
+    });
+    const issues = validate(doc, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      mode: "strict",
+    });
+    expect(
+      issues.some(
+        i => i.code === "invalid-classes" && i.path === "/nodes/0/classes"
+      )
+    ).toBe(true);
+  });
+
   it("rejects an oversized string prop by byte size without materializing it", () => {
     // A single node well under the node/depth caps but carrying a ~50MB string:
     // the bounded byte counter must reject it quickly, not allocate a full copy.

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -325,6 +325,36 @@ describe("validation never throws on adversarial input", () => {
     }).not.toThrow();
   });
 
+  it("reports a hole inside a slot array as an invalid node", () => {
+    const children: unknown[] = [];
+    children[1] = { id: "n2", type: "core/text", version: 1, props: {} };
+    const doc = invalidDoc({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/section",
+          version: 1,
+          props: {},
+          slots: { children },
+        },
+      ],
+    });
+    let issues: ReturnType<typeof validate> = [];
+    expect(() => {
+      issues = validate(doc, {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode: "strict",
+      });
+    }).not.toThrow();
+    expect(
+      issues.some(
+        i => i.code === "invalid-node" && i.path === "/nodes/0/slots/children/0"
+      )
+    ).toBe(true);
+  });
+
   it("reports holes in a sparse nodes array instead of throwing", () => {
     const sparse: unknown[] = [];
     sparse[2] = { id: "n1", type: "core/text", version: 1, props: {} };
@@ -338,6 +368,43 @@ describe("validation never throws on adversarial input", () => {
     }).not.toThrow();
     // The two holes are reported as invalid nodes; the real node at index 2 is fine.
     expect(issues.filter(i => i.code === "invalid-node")).toHaveLength(2);
+  });
+
+  it("bounds work on an oversized forest instead of exhausting resources", () => {
+    // One parent with a very wide child array: with the node cap at 100, the
+    // walk and the measurement must both stay bounded and still return the
+    // node-count issue rather than processing all 500k children.
+    const children = Array.from({ length: 500_000 }, (_, i) => ({
+      id: `c${i}`,
+      type: "core/text",
+      version: 1,
+      props: {},
+    }));
+    const doc = invalidDoc({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "root",
+          type: "core/section",
+          version: 1,
+          props: {},
+          slots: { children },
+        },
+      ],
+    });
+    const start = Date.now();
+    let issues: ReturnType<typeof validate> = [];
+    expect(() => {
+      issues = validate(doc, {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode: "strict",
+        limits: { maxDepth: 12, maxNodes: 100, maxBytes: 1_000_000 },
+      });
+    }).not.toThrow();
+    expect(issues.some(i => i.code === "node-count-exceeded")).toBe(true);
+    // Sanity bound: a capped walk finishes fast even though the forest is huge.
+    expect(Date.now() - start).toBeLessThan(2000);
   });
 
   it("counts malformed array elements toward the node cap", () => {

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -17,13 +17,7 @@ import {
   DOCUMENT_KINDS,
   STYLE_STATES,
 } from "./document";
-import {
-  DEFAULT_LIMITS,
-  LIMIT_WARNING_RATIO,
-  countNodes,
-  documentBytes,
-  treeDepth,
-} from "./limits";
+import { DEFAULT_LIMITS, LIMIT_WARNING_RATIO, documentBytes } from "./limits";
 import type { DocumentLimits } from "./limits";
 
 /** Severity of a validation issue. `error` blocks a strict publish. */
@@ -86,6 +80,7 @@ export const ISSUE_CODES = {
     "The serialized document is approaching the byte limit.",
   "missing-node-id": "A node is missing its id or the id is empty.",
   "duplicate-node-id": "Two or more nodes share the same id.",
+  "duplicate-dom-id": "Two or more nodes render the same HTML id.",
   "invalid-node-type": "A node type is missing or not a namespaced string.",
   "invalid-node-version":
     "A node version is missing or not a positive integer.",
@@ -224,6 +219,7 @@ export function validate(
     knownBreakpoints,
     unknownSeverity,
     seenIds: new Map<string, string>(),
+    seenDomIds: new Map<string, string>(),
   };
 
   // Document-level styles use the same envelope as node styles but have no
@@ -241,12 +237,17 @@ export function validate(
   // depth issue instead of throwing. It also stops after visiting maxNodes
   // nodes (the node-count issue is already recorded by checkLimits), so an
   // oversized document cannot make the walk do unbounded work.
-  // Array.from (not .map) so a sparse array's holes become explicit undefined
-  // entries and get reported as invalid nodes rather than skipped or throwing.
-  const queue: Array<{ node: BlockNode; path: string }> = Array.from(
-    doc.nodes,
-    (node, index) => ({ node, path: pointer("/nodes", index) })
-  );
+  // Index-based reads (not .map/.forEach) so a sparse array's holes become
+  // explicit undefined entries reported as invalid nodes, and the queue is
+  // capped at maxNodes so an oversized forest cannot grow it without bound.
+  const queue: Array<{ node: BlockNode; path: string }> = [];
+  for (
+    let i = 0;
+    i < doc.nodes.length && queue.length <= limits.maxNodes;
+    i++
+  ) {
+    queue.push({ node: doc.nodes[i], path: pointer("/nodes", i) });
+  }
   for (let i = 0; i < queue.length && i < limits.maxNodes; i++) {
     const { node, path } = queue[i];
     validateNode(node, path, nodeState);
@@ -254,9 +255,13 @@ export function validate(
       for (const [slot, children] of Object.entries(node.slots)) {
         if (Array.isArray(children)) {
           const slotPath = pointer(pointer(path, "slots"), slot);
-          children.forEach((child, childIndex) =>
-            queue.push({ node: child, path: pointer(slotPath, childIndex) })
-          );
+          for (
+            let c = 0;
+            c < children.length && queue.length <= limits.maxNodes;
+            c++
+          ) {
+            queue.push({ node: children[c], path: pointer(slotPath, c) });
+          }
         }
       }
     }
@@ -307,29 +312,70 @@ function collectBreakpointIds(
   return ids;
 }
 
+/**
+ * Count nodes and detect depth-exceedance in one bounded pass. An oversized
+ * document costs O(maxNodes), not O(document): once the node cap is passed the
+ * traversal stops (the document is already rejected) and the frontier is never
+ * allowed to grow past the cap, so a rejected forest cannot exhaust memory.
+ */
+function measureForest(
+  nodes: BlockNode[],
+  maxNodes: number,
+  maxDepth: number
+): { count: number; exceededDepth: boolean } {
+  let count = 0;
+  let exceededDepth = false;
+  const queue: Array<{ node: BlockNode; depth: number }> = [];
+  for (let i = 0; i < nodes.length && queue.length <= maxNodes; i++) {
+    queue.push({ node: nodes[i], depth: 1 });
+  }
+  for (let i = 0; i < queue.length; i++) {
+    count++;
+    const { node, depth } = queue[i];
+    if (depth > maxDepth) exceededDepth = true;
+    if (count > maxNodes) break; // already over the cap; no need to count more
+    if (typeof node === "object" && node !== null && node.slots) {
+      for (const children of Object.values(node.slots)) {
+        if (!Array.isArray(children)) continue;
+        for (let c = 0; c < children.length && queue.length <= maxNodes; c++) {
+          queue.push({ node: children[c], depth: depth + 1 });
+        }
+      }
+    }
+  }
+  return { count, exceededDepth };
+}
+
 function checkLimits(
   doc: BlockDocument,
   limits: DocumentLimits,
   issues: ValidationIssue[]
 ): void {
-  const depth = treeDepth(doc.nodes);
-  if (depth > limits.maxDepth) {
+  const { count, exceededDepth } = measureForest(
+    doc.nodes,
+    limits.maxNodes,
+    limits.maxDepth
+  );
+  if (exceededDepth) {
     issues.push({
       path: "/nodes",
       code: "depth-exceeded",
       severity: "error",
-      message: `Node tree is ${depth} levels deep; the maximum is ${limits.maxDepth}.`,
+      message: `Node tree is nested deeper than the maximum of ${limits.maxDepth}.`,
     });
   }
-  const nodeCount = countNodes(doc.nodes);
-  if (nodeCount > limits.maxNodes) {
+  if (count > limits.maxNodes) {
     issues.push({
       path: "/nodes",
       code: "node-count-exceeded",
       severity: "error",
-      message: `Document has ${nodeCount} nodes; the maximum is ${limits.maxNodes}.`,
+      message: `Document exceeds the maximum of ${limits.maxNodes} nodes.`,
     });
   }
+  // A structurally over-cap document is already rejected; skip the O(n)
+  // serialization so an oversized forest never gets stringified in full.
+  if (exceededDepth || count > limits.maxNodes) return;
+
   // Serialization can throw on a document too deeply nested for JSON.stringify;
   // a validator must return an issue, never propagate that as an exception.
   let bytes: number;
@@ -370,6 +416,8 @@ interface NodeCheckState {
   knownBreakpoints: Set<string>;
   unknownSeverity: IssueSeverity;
   seenIds: Map<string, string>;
+  /** Non-empty DOM ids seen so far (from `cssId` or `attributes.id`) → pointer. */
+  seenDomIds: Map<string, string>;
 }
 
 function validateNode(
@@ -459,6 +507,44 @@ function validateNode(
   validateVisibility(node, path, state);
   validateBindings(node, path, issues);
   validateComponentInstance(node, path, issues);
+  validateDomIds(node, path, state);
+}
+
+/**
+ * A rendered node's DOM id — from `cssId` or the `attributes.id` escape hatch —
+ * must be unique across the document, or the page emits duplicate HTML `id`
+ * attributes (breaking anchors, labels, and CSS selectors). Preservable, so the
+ * severity follows the mode.
+ */
+function validateDomIds(
+  node: BlockNode,
+  path: string,
+  state: NodeCheckState
+): void {
+  const report = (domId: string, at: string): void => {
+    const firstAt = state.seenDomIds.get(domId);
+    if (firstAt !== undefined) {
+      state.issues.push({
+        path: at,
+        code: "duplicate-dom-id",
+        severity: state.unknownSeverity,
+        message: `HTML id "${domId}" is already used at ${firstAt}.`,
+        suggestion: "Give each element a unique id.",
+      });
+    } else {
+      state.seenDomIds.set(domId, at);
+    }
+  };
+  if (typeof node.cssId === "string" && node.cssId.length > 0) {
+    report(node.cssId, pointer(path, "cssId"));
+  }
+  if (isPlainObject(node.attributes)) {
+    for (const [key, value] of Object.entries(node.attributes)) {
+      if (key.toLowerCase() === "id" && typeof value === "string" && value) {
+        report(value, pointer(pointer(path, "attributes"), key));
+      }
+    }
+  }
 }
 
 function validateSlots(
@@ -776,8 +862,11 @@ function validateComponentInstance(
   issues: ValidationIssue[]
 ): void {
   if (node.type !== COMPONENT_INSTANCE_TYPE) return;
-  const componentId = (node.props as { componentId?: unknown } | undefined)
-    ?.componentId;
+  // Only check componentId once props is an object: if props is missing or
+  // malformed, `invalid-props` already covers it and a `/props/componentId`
+  // pointer would target a location a fixer cannot edit.
+  if (!isPlainObject(node.props)) return;
+  const componentId = node.props.componentId;
   if (typeof componentId !== "string" || componentId.length === 0) {
     issues.push({
       path: pointer(pointer(path, "props"), "componentId"),

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -76,6 +76,7 @@ export const ISSUE_CODES = {
     "The document formatVersion is not the supported version.",
   "invalid-kind": "The document kind is not one of the known kinds.",
   "nodes-not-array": "The document nodes field is not an array.",
+  "invalid-node": "A node is not an object.",
   "depth-exceeded": "The node tree is nested deeper than the allowed maximum.",
   "node-count-exceeded":
     "The document has more nodes than the allowed maximum.",
@@ -198,59 +199,70 @@ export function validate(
 
   checkLimits(doc, limits, issues);
 
-  // Duplicate-id detection spans the whole forest, so gather ids with their
-  // pointers first, then report every node that repeats an already-seen id.
-  const seenIds = new Map<string, string>();
-  const walkForValidation = (nodes: BlockNode[], basePath: string): void => {
-    nodes.forEach((node, index) => {
-      const path = pointer(basePath, index);
-      validateNode(node, path, {
-        ctx,
-        issues,
-        knownBreakpoints,
-        unknownSeverity,
-        seenIds,
-      });
-      if (node && typeof node === "object" && isPlainObject(node.slots)) {
-        for (const [slot, children] of Object.entries(node.slots)) {
-          if (Array.isArray(children)) {
-            walkForValidation(children, pointer(pointer(path, "slots"), slot));
-          }
+  const nodeState: NodeCheckState = {
+    ctx,
+    issues,
+    knownBreakpoints,
+    unknownSeverity,
+    seenIds: new Map<string, string>(),
+  };
+  // Iterative breadth-first walk. It never recurses, so a document nested
+  // arbitrarily deep cannot overflow the call stack — validation returns the
+  // depth issue instead of throwing. It also stops after visiting maxNodes
+  // nodes (the node-count issue is already recorded by checkLimits), so an
+  // oversized document cannot make the walk do unbounded work.
+  const queue: Array<{ node: BlockNode; path: string }> = doc.nodes.map(
+    (node, index) => ({ node, path: pointer("/nodes", index) })
+  );
+  for (let i = 0; i < queue.length && i < limits.maxNodes; i++) {
+    const { node, path } = queue[i];
+    validateNode(node, path, nodeState);
+    if (isPlainObject(node) && isPlainObject(node.slots)) {
+      for (const [slot, children] of Object.entries(node.slots)) {
+        if (Array.isArray(children)) {
+          const slotPath = pointer(pointer(path, "slots"), slot);
+          children.forEach((child, childIndex) =>
+            queue.push({ node: child, path: pointer(slotPath, childIndex) })
+          );
         }
       }
-    });
-  };
-  walkForValidation(doc.nodes, "/nodes");
+    }
+  }
 
   return issues;
 }
 
 /**
- * Collect every breakpoint id, reporting any id shared across the two axes.
- * This is the one check about the CONTEXT rather than the document: its issue
- * path (`/breakpoints/container/<i>`) points into the supplied breakpoint set,
- * not the validated document, because a cross-axis id collision is a site-
- * settings problem that makes every style breakpoint key ambiguous.
+ * Collect every breakpoint id, reporting any id that repeats — whether within a
+ * single axis or across the two. This is the one check about the CONTEXT rather
+ * than the document: its issue path (`/breakpoints/<axis>/<i>`) points into the
+ * supplied breakpoint set, not the validated document, because a duplicate id
+ * is a site-settings problem that makes every flat style breakpoint key
+ * ambiguous.
  */
 function collectBreakpointIds(
   breakpoints: BreakpointSet,
   issues: ValidationIssue[]
 ): Set<string> {
   const ids = new Set<string>();
-  const viewportIds = new Set(breakpoints.viewport.map(b => b.id));
-  for (const def of breakpoints.viewport) ids.add(def.id);
-  breakpoints.container.forEach((def, index) => {
-    if (viewportIds.has(def.id)) {
-      issues.push({
-        path: pointer("/breakpoints/container", index),
-        code: "breakpoint-id-not-unique",
-        severity: "error",
-        message: `Breakpoint id "${def.id}" is defined on both the viewport and container axes.`,
-        suggestion: "Give viewport and container breakpoints distinct ids.",
-      });
-    }
-    ids.add(def.id);
-  });
+  const scanAxis = (axis: "viewport" | "container"): void => {
+    const defs = breakpoints[axis];
+    if (!Array.isArray(defs)) return;
+    defs.forEach((def, index) => {
+      if (ids.has(def.id)) {
+        issues.push({
+          path: pointer(pointer("/breakpoints", axis), index),
+          code: "breakpoint-id-not-unique",
+          severity: "error",
+          message: `Breakpoint id "${def.id}" is defined more than once.`,
+          suggestion: "Give every breakpoint a unique id across both axes.",
+        });
+      }
+      ids.add(def.id);
+    });
+  };
+  scanAxis("viewport");
+  scanAxis("container");
   return ids;
 }
 
@@ -277,7 +289,21 @@ function checkLimits(
       message: `Document has ${nodeCount} nodes; the maximum is ${limits.maxNodes}.`,
     });
   }
-  const bytes = documentBytes(doc);
+  // Serialization can throw on a document too deeply nested for JSON.stringify;
+  // a validator must return an issue, never propagate that as an exception.
+  let bytes: number;
+  try {
+    bytes = documentBytes(doc);
+  } catch {
+    issues.push({
+      path: "",
+      code: "document-too-large",
+      severity: "error",
+      message:
+        "Document could not be serialized (too large or too deeply nested).",
+    });
+    return;
+  }
   if (bytes > limits.maxBytes) {
     issues.push({
       path: "",
@@ -314,7 +340,7 @@ function validateNode(
   if (!isPlainObject(node)) {
     issues.push({
       path,
-      code: "invalid-props",
+      code: "invalid-node",
       severity: "error",
       message: "A node must be an object.",
     });
@@ -537,6 +563,9 @@ function validateVisibility(
     return;
   }
   if (vis.conditions !== undefined) {
+    // Each condition needs a string `field` AND a string `op`; the optional
+    // `value` may be anything. Accepting a condition without an operator would
+    // pass a shape downstream evaluation cannot act on.
     const ok =
       Array.isArray(vis.conditions) &&
       vis.conditions.every(
@@ -545,7 +574,8 @@ function validateVisibility(
           group.every(
             c =>
               isPlainObject(c) &&
-              typeof (c as { field?: unknown }).field === "string"
+              typeof (c as { field?: unknown }).field === "string" &&
+              typeof (c as { op?: unknown }).op === "string"
           )
       );
     if (!ok) {
@@ -567,13 +597,24 @@ function validateVisibility(
         message: "visibility.devices must map breakpoint ids to booleans.",
       });
     } else {
-      for (const breakpointId of Object.keys(vis.devices)) {
+      for (const [breakpointId, value] of Object.entries(vis.devices)) {
+        const devicePath = pointer(pointer(visPath, "devices"), breakpointId);
         if (!state.knownBreakpoints.has(breakpointId)) {
           state.issues.push({
-            path: pointer(pointer(visPath, "devices"), breakpointId),
+            path: devicePath,
             code: "unknown-breakpoint",
             severity: state.unknownSeverity,
             message: `Breakpoint "${breakpointId}" is not defined for this site.`,
+          });
+        }
+        // The stored shape is Record<breakpointId, boolean>; a truthy string or
+        // number would render differently from the author's intent.
+        if (typeof value !== "boolean") {
+          state.issues.push({
+            path: devicePath,
+            code: "invalid-visibility",
+            severity: "error",
+            message: `visibility.devices["${breakpointId}"] must be a boolean.`,
           });
         }
       }

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -17,7 +17,7 @@ import {
   DOCUMENT_KINDS,
   STYLE_STATES,
 } from "./document";
-import { DEFAULT_LIMITS, LIMIT_WARNING_RATIO, documentBytes } from "./limits";
+import { DEFAULT_LIMITS, LIMIT_WARNING_RATIO } from "./limits";
 import type { DocumentLimits } from "./limits";
 
 /** Severity of a validation issue. `error` blocks a strict publish. */
@@ -88,6 +88,7 @@ export const ISSUE_CODES = {
   "invalid-slots": "A node slots field or one of its slot arrays is malformed.",
   "invalid-classes": "A node classes field is not an array of strings.",
   "invalid-attributes": "A node attributes field is not a string map.",
+  "invalid-css-id": "A node cssId is not a string.",
   "unknown-node-type": "A node type is not registered.",
   "invalid-style-state": "A style state key is not a known interactive state.",
   "invalid-style-values": "A style values entry is not an object.",
@@ -355,6 +356,64 @@ function measureForest(
   return { count, exceededDepth };
 }
 
+/**
+ * UTF-8 byte length of a string, counted code unit by code unit so a huge
+ * string is never materialized into a buffer, stopping once `budget` is passed.
+ */
+function utf8ByteLength(s: string, budget: number): number {
+  let bytes = 0;
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    if (code < 0x80) bytes += 1;
+    else if (code < 0x800) bytes += 2;
+    else if (code >= 0xd800 && code <= 0xdbff) {
+      bytes += 4; // surrogate pair → one 4-byte code point
+      i++;
+    } else bytes += 3;
+    if (bytes > budget) return bytes;
+  }
+  return bytes;
+}
+
+/**
+ * Estimate a document's serialized byte size, aborting as soon as `limit` is
+ * passed and WITHOUT materializing the full JSON string — so a document that
+ * stays under the node/depth caps but hides a huge string cannot force a giant
+ * allocation before being rejected. Iterative, so deep nesting cannot overflow.
+ * When the walk completes under the limit, `bytes` is an exact-enough estimate;
+ * when `exceeded` is true it stopped early.
+ */
+function measureBytes(
+  root: unknown,
+  limit: number
+): { bytes: number; exceeded: boolean } {
+  let bytes = 0;
+  const stack: unknown[] = [root];
+  while (stack.length > 0) {
+    const value = stack.pop();
+    if (typeof value === "string") {
+      bytes += 2 + utf8ByteLength(value, limit - bytes);
+    } else if (typeof value === "number" || typeof value === "boolean") {
+      bytes += String(value).length;
+    } else if (value === null || value === undefined) {
+      bytes += 4;
+    } else if (Array.isArray(value)) {
+      bytes += 2 + Math.max(0, value.length - 1); // brackets + commas
+      for (const item of value) stack.push(item);
+    } else if (typeof value === "object") {
+      bytes += 2; // braces
+      for (const [key, val] of Object.entries(
+        value as Record<string, unknown>
+      )) {
+        bytes += utf8ByteLength(key, limit) + 3; // quotes + colon + comma
+        stack.push(val);
+      }
+    }
+    if (bytes > limit) return { bytes, exceeded: true };
+  }
+  return { bytes, exceeded: false };
+}
+
 function checkLimits(
   doc: BlockDocument,
   limits: DocumentLimits,
@@ -381,31 +440,20 @@ function checkLimits(
       message: `Document exceeds the maximum of ${limits.maxNodes} nodes.`,
     });
   }
-  // A structurally over-cap document is already rejected; skip the O(n)
-  // serialization so an oversized forest never gets stringified in full.
+  // A structurally over-cap document is already rejected; skip the byte pass so
+  // an oversized forest is never measured in full.
   if (exceededDepth || count > limits.maxNodes) return;
 
-  // Serialization can throw on a document too deeply nested for JSON.stringify;
-  // a validator must return an issue, never propagate that as an exception.
-  let bytes: number;
-  try {
-    bytes = documentBytes(doc);
-  } catch {
+  // Measure serialized size with a bounded, non-materializing counter: a
+  // document that stays under the node/depth caps but hides a huge string must
+  // still be rejected without allocating a full JSON copy of it.
+  const { bytes, exceeded } = measureBytes(doc, limits.maxBytes);
+  if (exceeded) {
     issues.push({
       path: "",
       code: "document-too-large",
       severity: "error",
-      message:
-        "Document could not be serialized (too large or too deeply nested).",
-    });
-    return;
-  }
-  if (bytes > limits.maxBytes) {
-    issues.push({
-      path: "",
-      code: "document-too-large",
-      severity: "error",
-      message: `Document is ${bytes} bytes; the maximum is ${limits.maxBytes}.`,
+      message: `Document exceeds the maximum of ${limits.maxBytes} bytes.`,
     });
   } else if (bytes > limits.maxBytes * LIMIT_WARNING_RATIO) {
     issues.push({
@@ -544,7 +592,14 @@ function validateDomIds(
       state.seenDomIds.set(domId, at);
     }
   };
-  if (typeof node.cssId === "string" && node.cssId.length > 0) {
+  if (node.cssId !== undefined && typeof node.cssId !== "string") {
+    state.issues.push({
+      path: pointer(path, "cssId"),
+      code: "invalid-css-id",
+      severity: "error",
+      message: "A node cssId must be a string.",
+    });
+  } else if (typeof node.cssId === "string" && node.cssId.length > 0) {
     report(node.cssId, pointer(path, "cssId"));
   }
   if (isPlainObject(node.attributes)) {
@@ -619,6 +674,20 @@ function validateAttributes(
       severity: "error",
       message: "A node attributes field must be a string-to-string map.",
     });
+    return;
+  }
+  // Event-handler attributes are inline JS, which blocks never allow; reject
+  // them at the gate. The broader render-safe attribute allowlist is shared
+  // with the renderer (Plan 03) to avoid a divergent second list here.
+  for (const key of Object.keys(node.attributes)) {
+    if (/^on/i.test(key)) {
+      issues.push({
+        path: pointer(pointer(path, "attributes"), key),
+        code: "invalid-attributes",
+        severity: "error",
+        message: `Attribute "${key}" is an event handler; inline JavaScript is not allowed.`,
+      });
+    }
   }
 }
 

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -123,15 +123,24 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/** Longest untrusted string echoed into an issue message. */
+const MAX_MESSAGE_VALUE_LENGTH = 120;
+
 /**
- * A safe string form of an untrusted value for issue messages. Validation
- * inspects data that may not match the declared types, so values are widened to
- * `unknown` at the point of reading. Objects and arrays are rendered as a short
- * label rather than serialized: a deeply nested value would make JSON.stringify
- * overflow, and messages never need the full structure.
+ * A safe, bounded string form of an untrusted value for issue messages.
+ * Validation inspects data that may not match the declared types, so values are
+ * widened to `unknown` at the point of reading and rendered here without: (a)
+ * calling a possibly-throwing `toString` (objects/arrays become a short label,
+ * never serialized — a deep value would overflow JSON.stringify anyway), or (b)
+ * embedding an unbounded string, which an oversized malformed field could use
+ * to force huge allocations. Long strings are truncated.
  */
 function describeValue(value: unknown): string {
-  if (typeof value === "string") return value;
+  if (typeof value === "string") {
+    return value.length > MAX_MESSAGE_VALUE_LENGTH
+      ? `${value.slice(0, MAX_MESSAGE_VALUE_LENGTH)}…`
+      : value;
+  }
   if (
     typeof value === "number" ||
     typeof value === "boolean" ||
@@ -465,7 +474,7 @@ function validateNode(
       path: pointer(path, "type"),
       code: "invalid-node-type",
       severity: "error",
-      message: `Node type "${String(node.type)}" must be a namespaced slug like "core/heading".`,
+      message: `Node type "${describeValue(node.type)}" must be a namespaced slug like "core/heading".`,
     });
   } else if (state.ctx.registry && !state.ctx.registry.has(node.type)) {
     issues.push({
@@ -703,20 +712,9 @@ function validateVisibility(
   }
   if (vis.conditions !== undefined) {
     // Each condition needs a string `field` AND a string `op`; the optional
-    // `value` may be anything. Accepting a condition without an operator would
-    // pass a shape downstream evaluation cannot act on.
-    const ok =
-      Array.isArray(vis.conditions) &&
-      vis.conditions.every(
-        group =>
-          Array.isArray(group) &&
-          group.every(
-            c =>
-              isPlainObject(c) &&
-              typeof (c as { field?: unknown }).field === "string" &&
-              typeof (c as { op?: unknown }).op === "string"
-          )
-      );
+    // `value` may be anything. Index-based loops (not `.every`, which skips
+    // holes) so a sparse array's undefined entries are rejected, not passed.
+    const ok = isConditionsShapeValid(vis.conditions);
     if (!ok) {
       state.issues.push({
         path: pointer(visPath, "conditions"),
@@ -759,6 +757,30 @@ function validateVisibility(
       }
     }
   }
+}
+
+/**
+ * True if `conditions` is a well-formed OR-of-AND array of `{field, op}`.
+ * Iterates by index rather than with `.every`, which skips array holes, so a
+ * sparse array's `undefined` entries are treated as invalid, not passed over.
+ */
+function isConditionsShapeValid(conditions: unknown): boolean {
+  if (!Array.isArray(conditions)) return false;
+  for (let g = 0; g < conditions.length; g++) {
+    const group: unknown = conditions[g];
+    if (!Array.isArray(group)) return false;
+    for (let c = 0; c < group.length; c++) {
+      const cond: unknown = group[c];
+      if (
+        !isPlainObject(cond) ||
+        typeof cond.field !== "string" ||
+        typeof cond.op !== "string"
+      ) {
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 const BINDING_SOURCES = ["entry", "item", "single", "site"];

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -1,0 +1,661 @@
+/**
+ * Document validation. Produces machine-readable issues so both humans and
+ * agents can locate and fix problems: every issue carries a JSON-Pointer into
+ * the document, a stable code from {@link ISSUE_CODES}, a message, and an
+ * optional suggestion. This is the contract the AI repair loop (the
+ * `validate_page` tool) wraps unchanged, and the same issue shape the style
+ * compiler and custom-CSS validator emit in later plans.
+ *
+ * Runtime-free like the rest of the engine: it reads the document and a caller-
+ * supplied context (breakpoints, mode, and — once it exists — a block-type
+ * lookup); it never touches storage or a framework.
+ */
+import type { BlockDocument, BlockNode, BreakpointSet } from "./document";
+import {
+  COMPONENT_INSTANCE_TYPE,
+  DOCUMENT_FORMAT_VERSION,
+  DOCUMENT_KINDS,
+  STYLE_STATES,
+} from "./document";
+import {
+  DEFAULT_LIMITS,
+  LIMIT_WARNING_RATIO,
+  countNodes,
+  documentBytes,
+  treeDepth,
+} from "./limits";
+import type { DocumentLimits } from "./limits";
+
+/** Severity of a validation issue. `error` blocks a strict publish. */
+export type IssueSeverity = "error" | "warning";
+
+/** How strictly to validate. */
+export type ValidationMode = "strict" | "forgiving";
+
+/**
+ * One validation finding. `path` is an RFC 6901 JSON-Pointer that resolves into
+ * the validated document (e.g. `/nodes/0/slots/children/1/id`); `code` is a
+ * stable machine key from {@link ISSUE_CODES}.
+ */
+export interface ValidationIssue {
+  path: string;
+  code: IssueCode;
+  message: string;
+  severity: IssueSeverity;
+  suggestion?: string;
+}
+
+/**
+ * A minimal block-type lookup. The boot registry (a later PR) satisfies this;
+ * until then callers omit it and node-type existence is not checked (structure
+ * still is). Keeping it an interface avoids coupling validation to the registry.
+ */
+export interface BlockTypeLookup {
+  has(type: string): boolean;
+}
+
+/**
+ * Everything validation needs beyond the document itself. The engine never
+ * reads storage: the caller supplies the site breakpoints and mode, and
+ * optionally a block-type lookup and non-default limits.
+ */
+export interface ValidationContext {
+  breakpoints: BreakpointSet;
+  mode: ValidationMode;
+  registry?: BlockTypeLookup;
+  limits?: DocumentLimits;
+}
+
+/**
+ * The stable issue-code vocabulary, each with a one-line description. Tests
+ * assert that every code emitted appears here and vice versa, so the repair-
+ * loop vocabulary cannot drift silently.
+ */
+export const ISSUE_CODES = {
+  "invalid-format-version":
+    "The document formatVersion is not the supported version.",
+  "invalid-kind": "The document kind is not one of the known kinds.",
+  "nodes-not-array": "The document nodes field is not an array.",
+  "depth-exceeded": "The node tree is nested deeper than the allowed maximum.",
+  "node-count-exceeded":
+    "The document has more nodes than the allowed maximum.",
+  "document-too-large": "The serialized document exceeds the byte limit.",
+  "document-size-warning":
+    "The serialized document is approaching the byte limit.",
+  "missing-node-id": "A node is missing its id or the id is empty.",
+  "duplicate-node-id": "Two or more nodes share the same id.",
+  "invalid-node-type": "A node type is missing or not a namespaced string.",
+  "invalid-node-version":
+    "A node version is missing or not a positive integer.",
+  "invalid-props": "A node props field is not an object.",
+  "invalid-slots": "A node slots field or one of its slot arrays is malformed.",
+  "invalid-classes": "A node classes field is not an array of strings.",
+  "invalid-attributes": "A node attributes field is not a string map.",
+  "unknown-node-type": "A node type is not registered.",
+  "invalid-style-state": "A style state key is not a known interactive state.",
+  "invalid-style-values": "A style values entry is not an object.",
+  "unknown-breakpoint":
+    "A style or visibility breakpoint id is not defined for the site.",
+  "breakpoint-id-not-unique":
+    "A breakpoint id is defined on more than one axis.",
+  "invalid-visibility": "A node visibility structure is malformed.",
+  "invalid-binding": "A binding is malformed.",
+  "missing-source-key":
+    "A single-sourced binding does not name which single it reads.",
+  "invalid-component-instance":
+    "A component-instance node does not reference a component.",
+} as const;
+
+/** A stable validation issue code. */
+export type IssueCode = keyof typeof ISSUE_CODES;
+
+/** Escape a JSON-Pointer reference token (RFC 6901: `~` → `~0`, `/` → `~1`). */
+function escapePointer(token: string): string {
+  return token.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+/** Join a parent pointer with a child token. */
+function pointer(parent: string, token: string | number): string {
+  return `${parent}/${escapePointer(String(token))}`;
+}
+
+/** A node type is a namespaced slug, e.g. "core/heading". */
+const NODE_TYPE_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * A safe string form of an untrusted value for issue messages. Validation
+ * inspects data that may not match the declared types, so values are widened
+ * to `unknown` at the point of reading and rendered here without risking
+ * `[object Object]` or a throw.
+ */
+function describeValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    value === null ||
+    value === undefined
+  ) {
+    return String(value);
+  }
+  return JSON.stringify(value) ?? "";
+}
+
+/**
+ * Validate a document. Returns every issue found (empty array = valid). In
+ * `strict` mode, preservable-but-unknown problems (unknown node type, dangling
+ * breakpoint reference) are errors; in `forgiving` mode they are warnings, so a
+ * renderer can still show what it can. Structural corruption (missing ids,
+ * malformed shapes, exceeded limits) is always an error.
+ */
+export function validate(
+  doc: BlockDocument,
+  ctx: ValidationContext
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const limits = ctx.limits ?? DEFAULT_LIMITS;
+  const unknownSeverity: IssueSeverity =
+    ctx.mode === "strict" ? "error" : "warning";
+  const knownBreakpoints = collectBreakpointIds(ctx.breakpoints, issues);
+
+  // Read fields validation must scrutinise as untrusted: the declared type says
+  // they are well-formed, but the whole job here is to catch when they are not.
+  const formatVersion: unknown = doc.formatVersion;
+  if (formatVersion !== DOCUMENT_FORMAT_VERSION) {
+    issues.push({
+      path: "/formatVersion",
+      code: "invalid-format-version",
+      severity: "error",
+      message: `Unsupported document formatVersion ${describeValue(formatVersion)}.`,
+      suggestion: `Use formatVersion ${DOCUMENT_FORMAT_VERSION}.`,
+    });
+  }
+
+  if (!DOCUMENT_KINDS.includes(doc.kind)) {
+    issues.push({
+      path: "/kind",
+      code: "invalid-kind",
+      severity: "error",
+      message: `Unknown document kind "${String(doc.kind)}".`,
+      suggestion: `Use one of: ${DOCUMENT_KINDS.join(", ")}.`,
+    });
+  }
+
+  if (!Array.isArray(doc.nodes)) {
+    issues.push({
+      path: "/nodes",
+      code: "nodes-not-array",
+      severity: "error",
+      message: "The document nodes field must be an array.",
+    });
+    // Nothing further to check without a node forest.
+    return issues;
+  }
+
+  checkLimits(doc, limits, issues);
+
+  // Duplicate-id detection spans the whole forest, so gather ids with their
+  // pointers first, then report every node that repeats an already-seen id.
+  const seenIds = new Map<string, string>();
+  const walkForValidation = (nodes: BlockNode[], basePath: string): void => {
+    nodes.forEach((node, index) => {
+      const path = pointer(basePath, index);
+      validateNode(node, path, {
+        ctx,
+        issues,
+        knownBreakpoints,
+        unknownSeverity,
+        seenIds,
+      });
+      if (node && typeof node === "object" && isPlainObject(node.slots)) {
+        for (const [slot, children] of Object.entries(node.slots)) {
+          if (Array.isArray(children)) {
+            walkForValidation(children, pointer(pointer(path, "slots"), slot));
+          }
+        }
+      }
+    });
+  };
+  walkForValidation(doc.nodes, "/nodes");
+
+  return issues;
+}
+
+/**
+ * Collect every breakpoint id, reporting any id shared across the two axes.
+ * This is the one check about the CONTEXT rather than the document: its issue
+ * path (`/breakpoints/container/<i>`) points into the supplied breakpoint set,
+ * not the validated document, because a cross-axis id collision is a site-
+ * settings problem that makes every style breakpoint key ambiguous.
+ */
+function collectBreakpointIds(
+  breakpoints: BreakpointSet,
+  issues: ValidationIssue[]
+): Set<string> {
+  const ids = new Set<string>();
+  const viewportIds = new Set(breakpoints.viewport.map(b => b.id));
+  for (const def of breakpoints.viewport) ids.add(def.id);
+  breakpoints.container.forEach((def, index) => {
+    if (viewportIds.has(def.id)) {
+      issues.push({
+        path: pointer("/breakpoints/container", index),
+        code: "breakpoint-id-not-unique",
+        severity: "error",
+        message: `Breakpoint id "${def.id}" is defined on both the viewport and container axes.`,
+        suggestion: "Give viewport and container breakpoints distinct ids.",
+      });
+    }
+    ids.add(def.id);
+  });
+  return ids;
+}
+
+function checkLimits(
+  doc: BlockDocument,
+  limits: DocumentLimits,
+  issues: ValidationIssue[]
+): void {
+  const depth = treeDepth(doc.nodes);
+  if (depth > limits.maxDepth) {
+    issues.push({
+      path: "/nodes",
+      code: "depth-exceeded",
+      severity: "error",
+      message: `Node tree is ${depth} levels deep; the maximum is ${limits.maxDepth}.`,
+    });
+  }
+  const nodeCount = countNodes(doc.nodes);
+  if (nodeCount > limits.maxNodes) {
+    issues.push({
+      path: "/nodes",
+      code: "node-count-exceeded",
+      severity: "error",
+      message: `Document has ${nodeCount} nodes; the maximum is ${limits.maxNodes}.`,
+    });
+  }
+  const bytes = documentBytes(doc);
+  if (bytes > limits.maxBytes) {
+    issues.push({
+      path: "",
+      code: "document-too-large",
+      severity: "error",
+      message: `Document is ${bytes} bytes; the maximum is ${limits.maxBytes}.`,
+    });
+  } else if (bytes > limits.maxBytes * LIMIT_WARNING_RATIO) {
+    issues.push({
+      path: "",
+      code: "document-size-warning",
+      severity: "warning",
+      message: `Document is ${bytes} bytes, over ${Math.round(
+        LIMIT_WARNING_RATIO * 100
+      )}% of the ${limits.maxBytes}-byte limit.`,
+    });
+  }
+}
+
+interface NodeCheckState {
+  ctx: ValidationContext;
+  issues: ValidationIssue[];
+  knownBreakpoints: Set<string>;
+  unknownSeverity: IssueSeverity;
+  seenIds: Map<string, string>;
+}
+
+function validateNode(
+  node: BlockNode,
+  path: string,
+  state: NodeCheckState
+): void {
+  const { issues } = state;
+  if (!isPlainObject(node)) {
+    issues.push({
+      path,
+      code: "invalid-props",
+      severity: "error",
+      message: "A node must be an object.",
+    });
+    return;
+  }
+
+  // id: present, non-empty, unique across the whole document.
+  if (typeof node.id !== "string" || node.id.length === 0) {
+    issues.push({
+      path: pointer(path, "id"),
+      code: "missing-node-id",
+      severity: "error",
+      message: "Every node needs a non-empty string id.",
+    });
+  } else {
+    const firstSeenAt = state.seenIds.get(node.id);
+    if (firstSeenAt !== undefined) {
+      issues.push({
+        path: pointer(path, "id"),
+        code: "duplicate-node-id",
+        severity: "error",
+        message: `Node id "${node.id}" is already used at ${firstSeenAt}.`,
+        suggestion: "Give every node a unique id.",
+      });
+    } else {
+      state.seenIds.set(node.id, pointer(path, "id"));
+    }
+  }
+
+  // type: namespaced slug, and — if a registry is supplied — registered.
+  if (typeof node.type !== "string" || !NODE_TYPE_RE.test(node.type)) {
+    issues.push({
+      path: pointer(path, "type"),
+      code: "invalid-node-type",
+      severity: "error",
+      message: `Node type "${String(node.type)}" must be a namespaced slug like "core/heading".`,
+    });
+  } else if (state.ctx.registry && !state.ctx.registry.has(node.type)) {
+    issues.push({
+      path: pointer(path, "type"),
+      code: "unknown-node-type",
+      severity: state.unknownSeverity,
+      message: `Node type "${node.type}" is not registered.`,
+      suggestion: "Register the block or remove the node.",
+    });
+  }
+
+  // version: positive integer.
+  if (
+    typeof node.version !== "number" ||
+    !Number.isInteger(node.version) ||
+    node.version < 1
+  ) {
+    issues.push({
+      path: pointer(path, "version"),
+      code: "invalid-node-version",
+      severity: "error",
+      message: "A node version must be a positive integer.",
+    });
+  }
+
+  if (!isPlainObject(node.props)) {
+    issues.push({
+      path: pointer(path, "props"),
+      code: "invalid-props",
+      severity: "error",
+      message: "A node props field must be an object.",
+    });
+  }
+
+  validateSlots(node, path, state);
+  validateClasses(node, path, issues);
+  validateAttributes(node, path, issues);
+  validateStyles(node, path, state);
+  validateVisibility(node, path, state);
+  validateBindings(node, path, issues);
+  validateComponentInstance(node, path, issues);
+}
+
+function validateSlots(
+  node: BlockNode,
+  path: string,
+  state: NodeCheckState
+): void {
+  if (node.slots === undefined) return;
+  if (!isPlainObject(node.slots)) {
+    state.issues.push({
+      path: pointer(path, "slots"),
+      code: "invalid-slots",
+      severity: "error",
+      message: "A node slots field must be an object of node arrays.",
+    });
+    return;
+  }
+  for (const [slot, children] of Object.entries(node.slots)) {
+    if (!Array.isArray(children)) {
+      state.issues.push({
+        path: pointer(pointer(path, "slots"), slot),
+        code: "invalid-slots",
+        severity: "error",
+        message: `Slot "${slot}" must be an array of nodes.`,
+      });
+    }
+    // Child nodes themselves are validated by the recursive walk in validate().
+  }
+}
+
+function validateClasses(
+  node: BlockNode,
+  path: string,
+  issues: ValidationIssue[]
+): void {
+  if (node.classes === undefined) return;
+  if (
+    !Array.isArray(node.classes) ||
+    !node.classes.every(c => typeof c === "string")
+  ) {
+    issues.push({
+      path: pointer(path, "classes"),
+      code: "invalid-classes",
+      severity: "error",
+      message: "A node classes field must be an array of class-id strings.",
+    });
+  }
+}
+
+function validateAttributes(
+  node: BlockNode,
+  path: string,
+  issues: ValidationIssue[]
+): void {
+  if (node.attributes === undefined) return;
+  if (
+    !isPlainObject(node.attributes) ||
+    !Object.values(node.attributes).every(v => typeof v === "string")
+  ) {
+    issues.push({
+      path: pointer(path, "attributes"),
+      code: "invalid-attributes",
+      severity: "error",
+      message: "A node attributes field must be a string-to-string map.",
+    });
+  }
+}
+
+function validateStyles(
+  node: BlockNode,
+  path: string,
+  state: NodeCheckState
+): void {
+  if (node.styles === undefined) return;
+  if (!isPlainObject(node.styles)) {
+    state.issues.push({
+      path: pointer(path, "styles"),
+      code: "invalid-style-values",
+      severity: "error",
+      message: "A node styles field must be an object.",
+    });
+    return;
+  }
+  const stylesPath = pointer(path, "styles");
+  for (const [stateKey, byBreakpoint] of Object.entries(node.styles)) {
+    const statePath = pointer(stylesPath, stateKey);
+    if (!STYLE_STATES.includes(stateKey as (typeof STYLE_STATES)[number])) {
+      state.issues.push({
+        path: statePath,
+        code: "invalid-style-state",
+        severity: "error",
+        message: `"${stateKey}" is not a known style state.`,
+        suggestion: `Use one of: ${STYLE_STATES.join(", ")}.`,
+      });
+      continue;
+    }
+    if (!isPlainObject(byBreakpoint)) {
+      state.issues.push({
+        path: statePath,
+        code: "invalid-style-values",
+        severity: "error",
+        message: `Style state "${stateKey}" must map breakpoint ids to values.`,
+      });
+      continue;
+    }
+    for (const [breakpointId, values] of Object.entries(byBreakpoint)) {
+      const bpPath = pointer(statePath, breakpointId);
+      if (!state.knownBreakpoints.has(breakpointId)) {
+        state.issues.push({
+          path: bpPath,
+          code: "unknown-breakpoint",
+          severity: state.unknownSeverity,
+          message: `Breakpoint "${breakpointId}" is not defined for this site.`,
+        });
+      }
+      if (!isPlainObject(values)) {
+        state.issues.push({
+          path: bpPath,
+          code: "invalid-style-values",
+          severity: "error",
+          message: `Style values at "${breakpointId}" must be an object.`,
+        });
+      }
+    }
+  }
+}
+
+function validateVisibility(
+  node: BlockNode,
+  path: string,
+  state: NodeCheckState
+): void {
+  if (node.visibility === undefined) return;
+  const vis = node.visibility;
+  const visPath = pointer(path, "visibility");
+  if (!isPlainObject(vis)) {
+    state.issues.push({
+      path: visPath,
+      code: "invalid-visibility",
+      severity: "error",
+      message: "A node visibility field must be an object.",
+    });
+    return;
+  }
+  if (vis.conditions !== undefined) {
+    const ok =
+      Array.isArray(vis.conditions) &&
+      vis.conditions.every(
+        group =>
+          Array.isArray(group) &&
+          group.every(
+            c =>
+              isPlainObject(c) &&
+              typeof (c as { field?: unknown }).field === "string"
+          )
+      );
+    if (!ok) {
+      state.issues.push({
+        path: pointer(visPath, "conditions"),
+        code: "invalid-visibility",
+        severity: "error",
+        message:
+          "visibility.conditions must be an OR-array of AND-arrays of {field, op, value?}.",
+      });
+    }
+  }
+  if (vis.devices !== undefined) {
+    if (!isPlainObject(vis.devices)) {
+      state.issues.push({
+        path: pointer(visPath, "devices"),
+        code: "invalid-visibility",
+        severity: "error",
+        message: "visibility.devices must map breakpoint ids to booleans.",
+      });
+    } else {
+      for (const breakpointId of Object.keys(vis.devices)) {
+        if (!state.knownBreakpoints.has(breakpointId)) {
+          state.issues.push({
+            path: pointer(pointer(visPath, "devices"), breakpointId),
+            code: "unknown-breakpoint",
+            severity: state.unknownSeverity,
+            message: `Breakpoint "${breakpointId}" is not defined for this site.`,
+          });
+        }
+      }
+    }
+  }
+}
+
+const BINDING_SOURCES = ["entry", "item", "single", "site"];
+
+function validateBindings(
+  node: BlockNode,
+  path: string,
+  issues: ValidationIssue[]
+): void {
+  if (node.bindings === undefined) return;
+  if (!isPlainObject(node.bindings)) {
+    issues.push({
+      path: pointer(path, "bindings"),
+      code: "invalid-binding",
+      severity: "error",
+      message: "A node bindings field must be an object keyed by prop name.",
+    });
+    return;
+  }
+  const bindingsPath = pointer(path, "bindings");
+  for (const [prop, binding] of Object.entries(node.bindings)) {
+    const bPath = pointer(bindingsPath, prop);
+    if (
+      !isPlainObject(binding) ||
+      typeof (binding as { $bind?: unknown }).$bind !== "string"
+    ) {
+      issues.push({
+        path: bPath,
+        code: "invalid-binding",
+        severity: "error",
+        message: "A binding must be an object with a string $bind path.",
+      });
+      continue;
+    }
+    const source: unknown = (binding as { source?: unknown }).source;
+    if (
+      source !== undefined &&
+      (typeof source !== "string" || !BINDING_SOURCES.includes(source))
+    ) {
+      issues.push({
+        path: pointer(bPath, "source"),
+        code: "invalid-binding",
+        severity: "error",
+        message: `Binding source "${describeValue(source)}" is not one of: ${BINDING_SOURCES.join(", ")}.`,
+      });
+    }
+    if (source === "single") {
+      const sourceKey = (binding as { sourceKey?: unknown }).sourceKey;
+      if (typeof sourceKey !== "string" || sourceKey.length === 0) {
+        issues.push({
+          path: pointer(bPath, "sourceKey"),
+          code: "missing-source-key",
+          severity: "error",
+          message:
+            'A binding with source "single" must name the single via sourceKey.',
+          suggestion: "Set sourceKey to the single's slug.",
+        });
+      }
+    }
+  }
+}
+
+function validateComponentInstance(
+  node: BlockNode,
+  path: string,
+  issues: ValidationIssue[]
+): void {
+  if (node.type !== COMPONENT_INSTANCE_TYPE) return;
+  const componentId = (node.props as { componentId?: unknown } | undefined)
+    ?.componentId;
+  if (typeof componentId !== "string" || componentId.length === 0) {
+    issues.push({
+      path: pointer(pointer(path, "props"), "componentId"),
+      code: "invalid-component-instance",
+      severity: "error",
+      message:
+        "A component-instance node must set props.componentId to the component's id.",
+    });
+  }
+}

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -2,13 +2,12 @@
  * Document validation. Produces machine-readable issues so both humans and
  * agents can locate and fix problems: every issue carries a JSON-Pointer into
  * the document, a stable code from {@link ISSUE_CODES}, a message, and an
- * optional suggestion. This is the contract the AI repair loop (the
- * `validate_page` tool) wraps unchanged, and the same issue shape the style
- * compiler and custom-CSS validator emit in later plans.
+ * optional suggestion. The issue shape is the stable contract external tools
+ * consume to locate and repair problems.
  *
  * Runtime-free like the rest of the engine: it reads the document and a caller-
- * supplied context (breakpoints, mode, and — once it exists — a block-type
- * lookup); it never touches storage or a framework.
+ * supplied context (breakpoints, mode, and an optional block-type lookup); it
+ * never touches storage or a framework.
  */
 import type { BlockDocument, BlockNode, BreakpointSet } from "./document";
 import {
@@ -40,9 +39,9 @@ export interface ValidationIssue {
 }
 
 /**
- * A minimal block-type lookup. The boot registry (a later PR) satisfies this;
- * until then callers omit it and node-type existence is not checked (structure
- * still is). Keeping it an interface avoids coupling validation to the registry.
+ * A minimal block-type lookup so validation is not coupled to a concrete
+ * registry. When a caller supplies one, unregistered node types are reported;
+ * when omitted, node-type existence is not checked but structure still is.
  */
 export interface BlockTypeLookup {
   has(type: string): boolean;
@@ -62,8 +61,8 @@ export interface ValidationContext {
 
 /**
  * The stable issue-code vocabulary, each with a one-line description. Tests
- * assert that every code emitted appears here and vice versa, so the repair-
- * loop vocabulary cannot drift silently.
+ * assert that every code emitted appears here and vice versa, so the emitted
+ * vocabulary cannot drift silently.
  */
 export const ISSUE_CODES = {
   "invalid-format-version":
@@ -300,8 +299,8 @@ function collectBreakpointIds(
     const defs = isPlainObject(set) ? set[axis] : undefined;
     if (!Array.isArray(defs)) return;
     defs.forEach((def, index) => {
-      // A malformed definition (null, missing id) is skipped rather than
-      // dereferenced; the settings layer validates the breakpoint set on save.
+      // A malformed definition (null, missing id) contributes no usable
+      // breakpoint id, so it is skipped rather than dereferenced.
       const rawDef: unknown = def;
       if (!isPlainObject(rawDef) || typeof rawDef.id !== "string") return;
       const id = rawDef.id;
@@ -310,7 +309,7 @@ function collectBreakpointIds(
           path: pointer(pointer("/breakpoints", axis), index),
           code: "breakpoint-id-not-unique",
           severity: "error",
-          message: `Breakpoint id "${id}" is defined more than once.`,
+          message: `Breakpoint id "${describeValue(id)}" is defined more than once.`,
           suggestion: "Give every breakpoint a unique id across both axes.",
         });
       }
@@ -398,14 +397,20 @@ function measureBytes(
     } else if (value === null || value === undefined) {
       bytes += 4;
     } else if (Array.isArray(value)) {
-      bytes += 2 + Math.max(0, value.length - 1); // brackets + commas
+      // Count the array's own structural bytes (brackets + commas) and bail
+      // BEFORE enqueuing elements: a huge array's comma count alone can exceed
+      // the cap, so millions of entries must never be pushed first.
+      bytes += 2 + Math.max(0, value.length - 1);
+      if (bytes > limit) return { bytes, exceeded: true };
       for (const item of value) stack.push(item);
     } else if (typeof value === "object") {
       bytes += 2; // braces
+      if (bytes > limit) return { bytes, exceeded: true };
       for (const [key, val] of Object.entries(
         value as Record<string, unknown>
       )) {
         bytes += utf8ByteLength(key, limit) + 3; // quotes + colon + comma
+        if (bytes > limit) return { bytes, exceeded: true };
         stack.push(val);
       }
     }
@@ -508,7 +513,7 @@ function validateNode(
         path: pointer(path, "id"),
         code: "duplicate-node-id",
         severity: "error",
-        message: `Node id "${node.id}" is already used at ${firstSeenAt}.`,
+        message: `Node id "${describeValue(node.id)}" is already used at ${firstSeenAt}.`,
         suggestion: "Give every node a unique id.",
       });
     } else {
@@ -585,7 +590,7 @@ function validateDomIds(
         path: at,
         code: "duplicate-dom-id",
         severity: state.unknownSeverity,
-        message: `HTML id "${domId}" is already used at ${firstAt}.`,
+        message: `HTML id "${describeValue(domId)}" is already used at ${firstAt}.`,
         suggestion: "Give each element a unique id.",
       });
     } else {
@@ -632,7 +637,7 @@ function validateSlots(
         path: pointer(pointer(path, "slots"), slot),
         code: "invalid-slots",
         severity: "error",
-        message: `Slot "${slot}" must be an array of nodes.`,
+        message: `Slot "${describeValue(slot)}" must be an array of nodes.`,
       });
     }
     // Child nodes themselves are validated by the recursive walk in validate().
@@ -645,10 +650,18 @@ function validateClasses(
   issues: ValidationIssue[]
 ): void {
   if (node.classes === undefined) return;
-  if (
-    !Array.isArray(node.classes) ||
-    !node.classes.every(c => typeof c === "string")
-  ) {
+  // Index-based, not `.every` (which skips array holes), so a sparse classes
+  // array — which serializes to `[null, …]` — is rejected, not accepted.
+  let valid = Array.isArray(node.classes);
+  if (valid) {
+    for (let i = 0; i < node.classes.length; i++) {
+      if (typeof node.classes[i] !== "string") {
+        valid = false;
+        break;
+      }
+    }
+  }
+  if (!valid) {
     issues.push({
       path: pointer(path, "classes"),
       code: "invalid-classes",
@@ -677,8 +690,9 @@ function validateAttributes(
     return;
   }
   // Event-handler attributes are inline JS, which blocks never allow; reject
-  // them at the gate. The broader render-safe attribute allowlist is shared
-  // with the renderer (Plan 03) to avoid a divergent second list here.
+  // them at the gate. The broader render-safe attribute allowlist is owned by
+  // the renderer; validation does not duplicate it here to avoid two lists
+  // drifting apart.
   for (const key of Object.keys(node.attributes)) {
     if (/^on/i.test(key)) {
       issues.push({
@@ -726,7 +740,7 @@ function validateStyleEnvelope(
         path: statePath,
         code: "invalid-style-state",
         severity: "error",
-        message: `"${stateKey}" is not a known style state.`,
+        message: `"${describeValue(stateKey)}" is not a known style state.`,
         suggestion: `Use one of: ${STYLE_STATES.join(", ")}.`,
       });
       continue;
@@ -736,7 +750,7 @@ function validateStyleEnvelope(
         path: statePath,
         code: "invalid-style-values",
         severity: "error",
-        message: `Style state "${stateKey}" must map breakpoint ids to values.`,
+        message: `Style state "${describeValue(stateKey)}" must map breakpoint ids to values.`,
       });
       continue;
     }
@@ -747,7 +761,7 @@ function validateStyleEnvelope(
           path: bpPath,
           code: "unknown-breakpoint",
           severity: state.unknownSeverity,
-          message: `Breakpoint "${breakpointId}" is not defined for this site.`,
+          message: `Breakpoint "${describeValue(breakpointId)}" is not defined for this site.`,
         });
       }
       if (!isPlainObject(values)) {
@@ -755,7 +769,7 @@ function validateStyleEnvelope(
           path: bpPath,
           code: "invalid-style-values",
           severity: "error",
-          message: `Style values at "${breakpointId}" must be an object.`,
+          message: `Style values at "${describeValue(breakpointId)}" must be an object.`,
         });
       }
     }
@@ -810,7 +824,7 @@ function validateVisibility(
             path: devicePath,
             code: "unknown-breakpoint",
             severity: state.unknownSeverity,
-            message: `Breakpoint "${breakpointId}" is not defined for this site.`,
+            message: `Breakpoint "${describeValue(breakpointId)}" is not defined for this site.`,
           });
         }
         // The stored shape is Record<breakpointId, boolean>; a truthy string or
@@ -820,7 +834,7 @@ function validateVisibility(
             path: devicePath,
             code: "invalid-visibility",
             severity: "error",
-            message: `visibility.devices["${breakpointId}"] must be a boolean.`,
+            message: `visibility.devices["${describeValue(breakpointId)}"] must be a boolean.`,
           });
         }
       }
@@ -856,10 +870,9 @@ const BINDING_SOURCES = ["entry", "item", "single", "site"];
 
 /**
  * A binding path is a dot-joined chain of field identifiers, e.g. "title" or
- * "author.name". This rejects expression-like or otherwise malformed strings
- * (never eval, per the binding design). The one-hop RELATION limit is semantic
- * and needs the schema, so it is enforced in the binding-resolution plan, not
- * here.
+ * "author.name". This rejects expression-like or otherwise malformed strings so
+ * nothing evaluable is ever stored. The one-hop RELATION limit is semantic and
+ * needs the schema, so it is enforced where bindings are resolved, not here.
  */
 const BIND_PATH_RE = /^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/;
 

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -75,6 +75,7 @@ export const ISSUE_CODES = {
   "invalid-format-version":
     "The document formatVersion is not the supported version.",
   "invalid-kind": "The document kind is not one of the known kinds.",
+  "invalid-document": "The document is not an object.",
   "nodes-not-array": "The document nodes field is not an array.",
   "invalid-node": "A node is not an object.",
   "depth-exceeded": "The node tree is nested deeper than the allowed maximum.",
@@ -129,9 +130,10 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 /**
  * A safe string form of an untrusted value for issue messages. Validation
- * inspects data that may not match the declared types, so values are widened
- * to `unknown` at the point of reading and rendered here without risking
- * `[object Object]` or a throw.
+ * inspects data that may not match the declared types, so values are widened to
+ * `unknown` at the point of reading. Objects and arrays are rendered as a short
+ * label rather than serialized: a deeply nested value would make JSON.stringify
+ * overflow, and messages never need the full structure.
  */
 function describeValue(value: unknown): string {
   if (typeof value === "string") return value;
@@ -143,7 +145,7 @@ function describeValue(value: unknown): string {
   ) {
     return String(value);
   }
-  return JSON.stringify(value) ?? "";
+  return Array.isArray(value) ? "[array]" : "[object]";
 }
 
 /**
@@ -161,11 +163,25 @@ export function validate(
   const limits = ctx.limits ?? DEFAULT_LIMITS;
   const unknownSeverity: IssueSeverity =
     ctx.mode === "strict" ? "error" : "warning";
+
+  // A wholly-malformed document (null, an array, a primitive) is reported as a
+  // structural issue rather than crashing on the field reads below. `rawDoc`
+  // aliases the same value as `unknown`: reads through it are legitimately
+  // untrusted, while `doc` keeps its declared type for the typed helper calls.
+  const rawDoc: unknown = doc;
+  if (!isPlainObject(rawDoc)) {
+    issues.push({
+      path: "",
+      code: "invalid-document",
+      severity: "error",
+      message: "The document must be an object.",
+    });
+    return issues;
+  }
+
   const knownBreakpoints = collectBreakpointIds(ctx.breakpoints, issues);
 
-  // Read fields validation must scrutinise as untrusted: the declared type says
-  // they are well-formed, but the whole job here is to catch when they are not.
-  const formatVersion: unknown = doc.formatVersion;
+  const formatVersion = rawDoc.formatVersion;
   if (formatVersion !== DOCUMENT_FORMAT_VERSION) {
     issues.push({
       path: "/formatVersion",
@@ -176,17 +192,20 @@ export function validate(
     });
   }
 
-  if (!DOCUMENT_KINDS.includes(doc.kind)) {
+  // An unknown kind is preserved in forgiving mode (a warning) and rejected in
+  // strict mode, matching the unknown-block-type policy.
+  const kind = rawDoc.kind;
+  if (!DOCUMENT_KINDS.includes(kind as (typeof DOCUMENT_KINDS)[number])) {
     issues.push({
       path: "/kind",
       code: "invalid-kind",
-      severity: "error",
-      message: `Unknown document kind "${String(doc.kind)}".`,
+      severity: unknownSeverity,
+      message: `Unknown document kind "${describeValue(kind)}".`,
       suggestion: `Use one of: ${DOCUMENT_KINDS.join(", ")}.`,
     });
   }
 
-  if (!Array.isArray(doc.nodes)) {
+  if (!Array.isArray(rawDoc.nodes)) {
     issues.push({
       path: "/nodes",
       code: "nodes-not-array",
@@ -206,6 +225,17 @@ export function validate(
     unknownSeverity,
     seenIds: new Map<string, string>(),
   };
+
+  // Document-level styles use the same envelope as node styles but have no
+  // owning node, so validate them here or they would go unchecked.
+  if (isPlainObject(rawDoc.settings) && rawDoc.settings.styles !== undefined) {
+    validateStyleEnvelope(
+      rawDoc.settings.styles,
+      "/settings/styles",
+      nodeState
+    );
+  }
+
   // Iterative breadth-first walk. It never recurses, so a document nested
   // arbitrarily deep cannot overflow the call stack — validation returns the
   // depth issue instead of throwing. It also stops after visiting maxNodes
@@ -492,17 +522,29 @@ function validateStyles(
   state: NodeCheckState
 ): void {
   if (node.styles === undefined) return;
-  if (!isPlainObject(node.styles)) {
+  validateStyleEnvelope(node.styles, pointer(path, "styles"), state);
+}
+
+/**
+ * Validate a `NodeStyles` envelope (states × breakpoints × values) at any path.
+ * Shared by node styles and document-level `settings.styles`, which use the
+ * same shape.
+ */
+function validateStyleEnvelope(
+  styles: unknown,
+  stylesPath: string,
+  state: NodeCheckState
+): void {
+  if (!isPlainObject(styles)) {
     state.issues.push({
-      path: pointer(path, "styles"),
+      path: stylesPath,
       code: "invalid-style-values",
       severity: "error",
-      message: "A node styles field must be an object.",
+      message: "A styles field must be an object.",
     });
     return;
   }
-  const stylesPath = pointer(path, "styles");
-  for (const [stateKey, byBreakpoint] of Object.entries(node.styles)) {
+  for (const [stateKey, byBreakpoint] of Object.entries(styles)) {
     const statePath = pointer(stylesPath, stateKey);
     if (!STYLE_STATES.includes(stateKey as (typeof STYLE_STATES)[number])) {
       state.issues.push({
@@ -624,6 +666,15 @@ function validateVisibility(
 
 const BINDING_SOURCES = ["entry", "item", "single", "site"];
 
+/**
+ * A binding path is a dot-joined chain of field identifiers, e.g. "title" or
+ * "author.name". This rejects expression-like or otherwise malformed strings
+ * (never eval, per the binding design). The one-hop RELATION limit is semantic
+ * and needs the schema, so it is enforced in the binding-resolution plan, not
+ * here.
+ */
+const BIND_PATH_RE = /^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/;
+
 function validateBindings(
   node: BlockNode,
   path: string,
@@ -642,10 +693,8 @@ function validateBindings(
   const bindingsPath = pointer(path, "bindings");
   for (const [prop, binding] of Object.entries(node.bindings)) {
     const bPath = pointer(bindingsPath, prop);
-    if (
-      !isPlainObject(binding) ||
-      typeof (binding as { $bind?: unknown }).$bind !== "string"
-    ) {
+    const bindPath = (binding as { $bind?: unknown }).$bind;
+    if (!isPlainObject(binding) || typeof bindPath !== "string") {
       issues.push({
         path: bPath,
         code: "invalid-binding",
@@ -653,6 +702,14 @@ function validateBindings(
         message: "A binding must be an object with a string $bind path.",
       });
       continue;
+    }
+    if (!BIND_PATH_RE.test(bindPath)) {
+      issues.push({
+        path: pointer(bPath, "$bind"),
+        code: "invalid-binding",
+        severity: "error",
+        message: `Binding path "${describeValue(bindPath)}" must be a dot-joined field path (never an expression).`,
+      });
     }
     const source: unknown = (binding as { source?: unknown }).source;
     if (
@@ -666,8 +723,8 @@ function validateBindings(
         message: `Binding source "${describeValue(source)}" is not one of: ${BINDING_SOURCES.join(", ")}.`,
       });
     }
+    const sourceKey = (binding as { sourceKey?: unknown }).sourceKey;
     if (source === "single") {
-      const sourceKey = (binding as { sourceKey?: unknown }).sourceKey;
       if (typeof sourceKey !== "string" || sourceKey.length === 0) {
         issues.push({
           path: pointer(bPath, "sourceKey"),
@@ -678,6 +735,15 @@ function validateBindings(
           suggestion: "Set sourceKey to the single's slug.",
         });
       }
+    } else if (sourceKey !== undefined) {
+      // sourceKey is reserved for single-sourced bindings; on any other source
+      // it is an ambiguous, unresolvable field.
+      issues.push({
+        path: pointer(bPath, "sourceKey"),
+        code: "invalid-binding",
+        severity: "error",
+        message: 'sourceKey is only allowed when source is "single".',
+      });
     }
   }
 }

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -241,7 +241,10 @@ export function validate(
   // depth issue instead of throwing. It also stops after visiting maxNodes
   // nodes (the node-count issue is already recorded by checkLimits), so an
   // oversized document cannot make the walk do unbounded work.
-  const queue: Array<{ node: BlockNode; path: string }> = doc.nodes.map(
+  // Array.from (not .map) so a sparse array's holes become explicit undefined
+  // entries and get reported as invalid nodes rather than skipped or throwing.
+  const queue: Array<{ node: BlockNode; path: string }> = Array.from(
+    doc.nodes,
     (node, index) => ({ node, path: pointer("/nodes", index) })
   );
   for (let i = 0; i < queue.length && i < limits.maxNodes; i++) {
@@ -275,20 +278,28 @@ function collectBreakpointIds(
   issues: ValidationIssue[]
 ): Set<string> {
   const ids = new Set<string>();
+  // The breakpoint set comes from stored settings, so treat it as untrusted: a
+  // null/malformed set or axis is skipped rather than dereferenced.
+  const set: unknown = breakpoints;
   const scanAxis = (axis: "viewport" | "container"): void => {
-    const defs = breakpoints[axis];
+    const defs = isPlainObject(set) ? set[axis] : undefined;
     if (!Array.isArray(defs)) return;
     defs.forEach((def, index) => {
-      if (ids.has(def.id)) {
+      // A malformed definition (null, missing id) is skipped rather than
+      // dereferenced; the settings layer validates the breakpoint set on save.
+      const rawDef: unknown = def;
+      if (!isPlainObject(rawDef) || typeof rawDef.id !== "string") return;
+      const id = rawDef.id;
+      if (ids.has(id)) {
         issues.push({
           path: pointer(pointer("/breakpoints", axis), index),
           code: "breakpoint-id-not-unique",
           severity: "error",
-          message: `Breakpoint id "${def.id}" is defined more than once.`,
+          message: `Breakpoint id "${id}" is defined more than once.`,
           suggestion: "Give every breakpoint a unique id across both axes.",
         });
       }
-      ids.add(def.id);
+      ids.add(id);
     });
   };
   scanAxis("viewport");
@@ -693,8 +704,19 @@ function validateBindings(
   const bindingsPath = pointer(path, "bindings");
   for (const [prop, binding] of Object.entries(node.bindings)) {
     const bPath = pointer(bindingsPath, prop);
-    const bindPath = (binding as { $bind?: unknown }).$bind;
-    if (!isPlainObject(binding) || typeof bindPath !== "string") {
+    // Check the shape BEFORE reading any field: a null/primitive binding value
+    // must produce an issue, not a thrown property access.
+    if (!isPlainObject(binding)) {
+      issues.push({
+        path: bPath,
+        code: "invalid-binding",
+        severity: "error",
+        message: "A binding must be an object with a string $bind path.",
+      });
+      continue;
+    }
+    const bindPath = binding.$bind;
+    if (typeof bindPath !== "string") {
       issues.push({
         path: bPath,
         code: "invalid-binding",
@@ -711,7 +733,7 @@ function validateBindings(
         message: `Binding path "${describeValue(bindPath)}" must be a dot-joined field path (never an expression).`,
       });
     }
-    const source: unknown = (binding as { source?: unknown }).source;
+    const source: unknown = binding.source;
     if (
       source !== undefined &&
       (typeof source !== "string" || !BINDING_SOURCES.includes(source))
@@ -723,7 +745,7 @@ function validateBindings(
         message: `Binding source "${describeValue(source)}" is not one of: ${BINDING_SOURCES.join(", ")}.`,
       });
     }
-    const sourceKey = (binding as { sourceKey?: unknown }).sourceKey;
+    const sourceKey = binding.sourceKey;
     if (source === "single") {
       if (typeof sourceKey !== "string" || sourceKey.length === 0) {
         issues.push({


### PR DESCRIPTION
## What

PR-2 of the page-builder rebuild (Plan-01 series; follows #320). Adds `validate(doc, ctx) → ValidationIssue[]` to `@nextlyhq/blocks-engine` — the validation core.

- **Machine-readable issues**: each `ValidationIssue` carries an RFC 6901 `path` (JSON-Pointer into the document, e.g. `/nodes/0/slots/children/1/id`), a stable `code` from a documented `ISSUE_CODES` vocabulary, a `message`, a `severity`, and an optional `suggestion`. This is the exact contract the AI repair-loop (`validate_page`) will wrap unchanged, and the same issue shape the style compiler and custom-CSS validator emit in later plans.
- **Strict vs forgiving modes**: preservable-but-unknown problems (unknown block type, dangling breakpoint reference) are **errors** in `strict` (publish) and **warnings** in `forgiving` (render, so a page still shows what it can). Structural corruption (missing ids, malformed shapes, exceeded limits) is always an error.
- **Checks**: format version; document kind; nodes-is-array; depth/count/byte limits (with an 80% size warning); per-node id presence + **document-wide duplicate-id detection**; namespaced type + optional registry existence; positive-integer version; props/slots/classes/attributes shape; style state + values shape + **breakpoint-ref checks**; visibility (OR-of-AND conditions + device breakpoints); bindings (incl. **`sourceKey` required for `source: "single"`**); component-instance `componentId`; and **breakpoint-id uniqueness across the viewport+container axes** (the invariant that keeps the style envelope flat — a context-scoped check).
- **Registry is optional**: node-type existence is only checked when a `BlockTypeLookup` is supplied (the boot registry lands in a later PR); structure is always checked. Kept as a minimal interface to avoid coupling validation to the registry.

## Why

The rebuilt builder stores typed JSON documents produced by humans and AI agents; both need to know *precisely* what is wrong and *where*, in a form a machine can act on. Strict/forgiving modes let the same validator gate publishing and drive resilient rendering.

## Tests (73 total, all green)

- **Fixture corpus** (`validation.fixtures.ts`): ~26 documents paired with their exact expected `(path, code)` issue sets — the format's living spec, asserted order-independently (valid docs, and adversarial invalid ones covering every code).
- **Contract tests**: every emitted code is documented in `ISSUE_CODES` and vice versa (vocabulary can't drift); every issue's JSON-Pointer resolves into the document, or — for a missing field — its parent does (so a fixer knows where the field belongs).
- **Mode + limits**: strict-vs-forgiving severity, always-error structural corruption, byte/node/depth caps, size warning, and the cross-axis breakpoint-id collision case.
- Also hardened `limits.ts` (`countNodes`/`treeDepth`) to skip malformed non-array slots, since validation runs them over untrusted input.

Local: type-check + lint clean; `@nextlyhq/blocks-engine` 73 tests pass; full repo build green. One changeset (all packages, patch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added document validation with structured issues, severity levels, JSON-pointer paths, and stable issue codes.
  * Added checks for document structure, node properties, styles, bindings, visibility, breakpoints, component instances, and resource limits.
  * Exposed validation APIs and related types for broader use.

* **Bug Fixes**
  * Improved handling of malformed documents, sparse arrays, invalid slot data, excessive depth, and oversized content without throwing errors.

* **Tests**
  * Added comprehensive validation fixtures and robustness coverage for strict and forgiving modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->