### PR TITLE
feat(blocks-engine): add chained block migrations with failure flagging

### DIFF
--- a/.changeset/blocks-engine-migrations.md
+++ b/.changeset/blocks-engine-migrations.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+`@nextlyhq/blocks-engine` can now upgrade page documents when a block's schema changes. Blocks that were saved against an older version are automatically brought up to date, one version step at a time, so old pages keep working after a block is improved. If a step is missing or fails, that block keeps its last-good content and is marked so the page shows a placeholder for it instead of breaking, and the failure is reported to the caller.

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -126,6 +126,12 @@ export interface BlockNode {
   cssId?: string;
   /** Sanitized custom HTML attributes applied to the node's root element. */
   attributes?: Record<string, string>;
+  /**
+   * Set when upgrading this node to its block's current schema version failed
+   * (a missing migration step or a migration that threw). The node keeps its
+   * last-good props; a renderer shows a placeholder instead of crashing.
+   */
+  migrationFailed?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -75,3 +75,14 @@ export type {
   ValidationIssue,
   ValidationMode,
 } from "./validation";
+
+export { migrateDocument, migrateProps, findMigrationGaps } from "./migration";
+export type {
+  BlockMigrationInfo,
+  MigrateFn,
+  MigrateResult,
+  MigrationFailure,
+  MigrationMap,
+  MigrationSource,
+  PropsMigrationResult,
+} from "./migration";

--- a/packages/blocks-engine/src/migration.test.ts
+++ b/packages/blocks-engine/src/migration.test.ts
@@ -65,6 +65,23 @@ describe("migrateProps", () => {
     expect(result.props).toEqual({ x: 1 });
     expect(result.failure).toBeUndefined();
   });
+
+  it("reports failure.fromVersion as the version the props reached", () => {
+    // 1→2 succeeds, 2→3 missing: props are now at the version-2 shape, so the
+    // failure names version 2 (the from-version of the missing step).
+    const map = { 1: (p: Record<string, unknown>) => ({ ...p, a: 1 }) };
+    const result = migrateProps({}, 1, 3, map);
+    expect(result.props).toEqual({ a: 1 });
+    expect(result.failure?.fromVersion).toBe(2);
+  });
+
+  it("rejects a non-integer or infinite version range instead of looping", () => {
+    expect(migrateProps({}, 1, Infinity, {}).failure).toBeDefined();
+    expect(migrateProps({}, -Infinity, 3, {}).failure).toBeDefined();
+    expect(migrateProps({}, 1.5, 3, {}).failure).toBeDefined();
+    // An absurdly wide span is treated as malformed, not chained.
+    expect(migrateProps({}, 0, 100_000, {}).failure).toBeDefined();
+  });
 });
 
 describe("findMigrationGaps", () => {
@@ -150,6 +167,50 @@ describe("migrateDocument", () => {
       version: 3,
       props: { align: "start" },
     });
+  });
+
+  it("stamps a partially-migrated node at its last-good version", () => {
+    // core/heading is v3 with steps 1→2 and 2→3; a node stored at v2 with a
+    // BROKEN 2→3 step: props advance where they can, version lands at last-good.
+    const partial = source({
+      "core/heading": {
+        version: 3,
+        migrate: {
+          1: (p: Record<string, unknown>) => ({ ...p, level: 2 }),
+          2: () => {
+            throw new Error("2to3 broke");
+          },
+        },
+      },
+    });
+    const doc: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "n1", type: "core/heading", version: 1, props: {} }],
+    };
+    const { doc: out, failures } = migrateDocument(doc, partial);
+    // 1→2 applied, 2→3 failed: props at v2 shape, version stamped to 2.
+    expect(out.nodes[0]).toMatchObject({
+      version: 2,
+      migrationFailed: true,
+      props: { level: 2 },
+    });
+    expect(failures[0]).toMatchObject({ fromVersion: 2, toVersion: 3 });
+  });
+
+  it("leaves a node with a malformed version untouched instead of looping", () => {
+    const doc = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "n1", type: "core/heading", version: -Infinity, props: {} },
+      ],
+    } as unknown as BlockDocument;
+    let out: ReturnType<typeof migrateDocument> | undefined;
+    expect(() => {
+      out = migrateDocument(doc, src);
+    }).not.toThrow();
+    expect(out!.doc.nodes[0]).toMatchObject({ version: -Infinity });
   });
 
   it("flags a node whose migration fails and records the failure", () => {

--- a/packages/blocks-engine/src/migration.test.ts
+++ b/packages/blocks-engine/src/migration.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+
+import type { BlockDocument } from "./document";
+import type { MigrationSource } from "./migration";
+import { findMigrationGaps, migrateDocument, migrateProps } from "./migration";
+
+/** A migration source from a plain record of type → info. */
+function source(
+  info: Record<
+    string,
+    {
+      version: number;
+      migrate?: Record<
+        number,
+        (p: Record<string, unknown>) => Record<string, unknown>
+      >;
+    }
+  >
+): MigrationSource {
+  return { get: type => info[type] };
+}
+
+describe("migrateProps", () => {
+  it("chains steps from the stored version up to the current version", () => {
+    const map = {
+      1: (p: Record<string, unknown>) => ({ ...p, a: 1 }),
+      2: (p: Record<string, unknown>) => ({ ...p, b: 2 }),
+    };
+    const result = migrateProps({ text: "x" }, 1, 3, map);
+    expect(result.failure).toBeUndefined();
+    expect(result.props).toEqual({ text: "x", a: 1, b: 2 });
+  });
+
+  it("stops at a missing step and reports the gap", () => {
+    const map = { 1: (p: Record<string, unknown>) => ({ ...p, a: 1 }) };
+    const result = migrateProps({}, 1, 3, map);
+    expect(result.props).toEqual({ a: 1 }); // last good, after the 1→2 step
+    expect(result.failure).toEqual({
+      fromVersion: 2,
+      message: "No migration from version 2.",
+    });
+  });
+
+  it("stops and reports when a step throws, keeping the last good props", () => {
+    const map = {
+      1: (p: Record<string, unknown>) => ({ ...p, a: 1 }),
+      2: () => {
+        throw new Error("boom");
+      },
+    };
+    const result = migrateProps({}, 1, 3, map);
+    expect(result.props).toEqual({ a: 1 });
+    expect(result.failure?.fromVersion).toBe(2);
+    expect(result.failure?.message).toBe("boom");
+  });
+
+  it("treats a non-object migration return as a failure", () => {
+    const map = { 1: () => 42 as unknown as Record<string, unknown> };
+    const result = migrateProps({}, 1, 2, map);
+    expect(result.failure?.fromVersion).toBe(1);
+  });
+
+  it("is a no-op when already at the target version", () => {
+    const result = migrateProps({ x: 1 }, 3, 3, {});
+    expect(result.props).toEqual({ x: 1 });
+    expect(result.failure).toBeUndefined();
+  });
+});
+
+describe("findMigrationGaps", () => {
+  it("returns the from-versions missing a covering step", () => {
+    const map = { 1: (p: Record<string, unknown>) => p };
+    expect(findMigrationGaps(1, 4, map)).toEqual([2, 3]);
+  });
+
+  it("is empty when the chain is complete", () => {
+    const map = {
+      1: (p: Record<string, unknown>) => p,
+      2: (p: Record<string, unknown>) => p,
+    };
+    expect(findMigrationGaps(1, 3, map)).toEqual([]);
+  });
+
+  it("reports all versions when there is no map", () => {
+    expect(findMigrationGaps(2, 5, undefined)).toEqual([2, 3, 4]);
+  });
+});
+
+describe("migrateDocument", () => {
+  const src = source({
+    "core/heading": {
+      version: 3,
+      migrate: {
+        1: (p: Record<string, unknown>) => ({ ...p, level: p.level ?? 2 }),
+        2: (p: Record<string, unknown>) => ({ ...p, align: "start" }),
+      },
+    },
+    "core/text": { version: 1 },
+    "core/broken": {
+      version: 2,
+      migrate: {
+        1: () => {
+          throw new Error("nope");
+        },
+      },
+    },
+  });
+
+  it("upgrades a node across two steps and bumps its version", () => {
+    const doc: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "n1", type: "core/heading", version: 1, props: { text: "Hi" } },
+      ],
+    };
+    const { doc: out, failures } = migrateDocument(doc, src);
+    expect(failures).toEqual([]);
+    expect(out.nodes[0]).toMatchObject({
+      version: 3,
+      props: { text: "Hi", level: 2, align: "start" },
+    });
+    // Immutability: the input is untouched.
+    expect(doc.nodes[0]!.version).toBe(1);
+  });
+
+  it("upgrades nested nodes and preserves unknown types untouched", () => {
+    const doc: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "root",
+          type: "plugin/unknown",
+          version: 5,
+          props: { keep: true },
+          slots: {
+            children: [
+              { id: "h", type: "core/heading", version: 2, props: {} },
+            ],
+          },
+        },
+      ],
+    };
+    const { doc: out } = migrateDocument(doc, src);
+    // Unknown type: untouched, including its version.
+    expect(out.nodes[0]).toMatchObject({ version: 5, props: { keep: true } });
+    // Nested known node: migrated from 2 → 3.
+    expect(out.nodes[0]!.slots!.children[0]).toMatchObject({
+      version: 3,
+      props: { align: "start" },
+    });
+  });
+
+  it("flags a node whose migration fails and records the failure", () => {
+    const doc: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "b", type: "core/broken", version: 1, props: { keep: 1 } }],
+    };
+    const { doc: out, failures } = migrateDocument(doc, src);
+    expect(out.nodes[0]).toMatchObject({
+      migrationFailed: true,
+      props: { keep: 1 }, // last-good props preserved
+    });
+    // Version is NOT bumped on failure.
+    expect(out.nodes[0]!.version).toBe(1);
+    expect(failures).toEqual([
+      {
+        path: "/nodes/0",
+        type: "core/broken",
+        fromVersion: 1,
+        toVersion: 2,
+        message: "nope",
+      },
+    ]);
+  });
+
+  it("leaves an already-current node unchanged (same reference)", () => {
+    const doc: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "t", type: "core/text", version: 1, props: {} }],
+    };
+    const { doc: out, failures } = migrateDocument(doc, src);
+    expect(failures).toEqual([]);
+    expect(out.nodes[0]).toBe(doc.nodes[0]);
+  });
+
+  it("does not touch a node ahead of the definition version", () => {
+    const doc: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "h", type: "core/heading", version: 9, props: { x: 1 } }],
+    };
+    const { doc: out, failures } = migrateDocument(doc, src);
+    expect(failures).toEqual([]);
+    expect(out.nodes[0]).toMatchObject({ version: 9, props: { x: 1 } });
+  });
+});

--- a/packages/blocks-engine/src/migration.ts
+++ b/packages/blocks-engine/src/migration.ts
@@ -67,15 +67,37 @@ export interface PropsMigrationResult {
 }
 
 /**
+ * The largest version span migration will chain across. Block versions
+ * increment by one per schema change, so a span this large signals a malformed
+ * version rather than a real upgrade; it also bounds the loops below.
+ */
+const MAX_MIGRATION_STEPS = 1000;
+
+/** True if a version range is a sane, finite, bounded span of non-negative integers. */
+function isValidVersionRange(fromVersion: number, toVersion: number): boolean {
+  return (
+    Number.isInteger(fromVersion) &&
+    fromVersion >= 0 &&
+    Number.isInteger(toVersion) &&
+    toVersion >= 0 &&
+    toVersion - fromVersion <= MAX_MIGRATION_STEPS
+  );
+}
+
+/**
  * The version steps missing from `map` to carry a node from `fromVersion` up to
  * `toVersion`. An empty array means the chain is complete. Used to reject a
- * block whose version was bumped without a covering migration.
+ * block whose version was bumped without a covering migration. An out-of-range
+ * or non-integer span returns an empty array; version sanity is a separate
+ * check on the definition.
  */
 export function findMigrationGaps(
   fromVersion: number,
   toVersion: number,
   map: MigrationMap | undefined
 ): number[] {
+  if (fromVersion >= toVersion) return [];
+  if (!isValidVersionRange(fromVersion, toVersion)) return [];
   const gaps: number[] = [];
   for (let v = fromVersion; v < toVersion; v++) {
     if (!map || typeof map[v] !== "function") gaps.push(v);
@@ -95,6 +117,18 @@ export function migrateProps(
   toVersion: number,
   map: MigrationMap | undefined
 ): PropsMigrationResult {
+  if (fromVersion >= toVersion) return { props };
+  // Reject non-integer, negative, or absurdly wide spans before iterating: an
+  // Infinity target would loop forever, a -Infinity start would never advance.
+  if (!isValidVersionRange(fromVersion, toVersion)) {
+    return {
+      props,
+      failure: {
+        fromVersion,
+        message: `Invalid migration version range ${fromVersion}→${toVersion}.`,
+      },
+    };
+  }
   let current = props;
   for (let v = fromVersion; v < toVersion; v++) {
     const step = map?.[v];
@@ -175,7 +209,9 @@ export function migrateDocument(
     const info = source.get(node.type);
     if (
       info !== undefined &&
-      typeof node.version === "number" &&
+      Number.isInteger(node.version) &&
+      node.version >= 0 &&
+      Number.isInteger(info.version) &&
       node.version < info.version
     ) {
       const result = migrateProps(
@@ -192,9 +228,16 @@ export function migrateDocument(
           toVersion: info.version,
           message: result.failure.message,
         });
-        // Keep last-good props at the version they last migrated cleanly to;
-        // flag the node so a renderer can placeholder it.
-        next = { ...node, props: result.props, migrationFailed: true };
+        // Stamp the version at the last-good level (the from-version of the
+        // step that failed): the props are already in that version's shape, so
+        // the version must match or a retry would re-run completed, possibly
+        // non-idempotent steps. Flag the node so a renderer can placeholder it.
+        next = {
+          ...node,
+          props: result.props,
+          version: result.failure.fromVersion,
+          migrationFailed: true,
+        };
       } else {
         next = { ...node, props: result.props, version: info.version };
         if (next.migrationFailed) delete next.migrationFailed;

--- a/packages/blocks-engine/src/migration.ts
+++ b/packages/blocks-engine/src/migration.ts
@@ -1,0 +1,230 @@
+/**
+ * Block migrations. When a stored node was written against an older schema
+ * version of its block than the definition now declares, its props are upgraded
+ * through a chain of per-version functions ({@link MigrationMap}) — one step per
+ * version — until it reaches the current version.
+ *
+ * Runtime-free like the rest of the engine. The upgrade functions are supplied
+ * by the caller (they live on block definitions); this module owns only the
+ * chaining, the failure handling, and the gap detection.
+ *
+ * Policy is split by caller, not by mode here: `migrateDocument` always upgrades
+ * what it can and returns the failures it hit. A publish path treats any failure
+ * as blocking (strict); a render path renders the returned document, showing a
+ * placeholder for each node flagged `migrationFailed` (forgiving).
+ */
+import type { BlockDocument, BlockNode } from "./document";
+
+/** Upgrade a node's props from one schema version to the next. Must be pure. */
+export type MigrateFn = (
+  props: Record<string, unknown>
+) => Record<string, unknown>;
+
+/**
+ * Per-version upgrade functions, keyed by the FROM version. `map[n]` upgrades a
+ * node stored at version `n` to version `n + 1`; chaining them walks a node from
+ * its stored version up to the definition's current version.
+ */
+export type MigrationMap = Record<number, MigrateFn>;
+
+/** What migration needs to know about one block type. */
+export interface BlockMigrationInfo {
+  /** The block definition's current schema version. */
+  version: number;
+  /** Upgrade steps keyed by from-version; omitted when the block never changed. */
+  migrate?: MigrationMap;
+}
+
+/**
+ * A lookup from block type to its migration info. A concrete registry satisfies
+ * this; keeping it an interface avoids coupling migration to that registry. A
+ * type the source does not know is treated as unknown and left untouched.
+ */
+export interface MigrationSource {
+  get(type: string): BlockMigrationInfo | undefined;
+}
+
+/** One node that could not be brought to its block's current version. */
+export interface MigrationFailure {
+  /** JSON-Pointer to the node in the document. */
+  path: string;
+  type: string;
+  fromVersion: number;
+  toVersion: number;
+  message: string;
+}
+
+export interface MigrateResult {
+  doc: BlockDocument;
+  failures: MigrationFailure[];
+}
+
+/** Result of upgrading a single props object. */
+export interface PropsMigrationResult {
+  props: Record<string, unknown>;
+  /** Set when a step was missing or threw; `props` is the last good value. */
+  failure?: { fromVersion: number; message: string };
+}
+
+/**
+ * The version steps missing from `map` to carry a node from `fromVersion` up to
+ * `toVersion`. An empty array means the chain is complete. Used to reject a
+ * block whose version was bumped without a covering migration.
+ */
+export function findMigrationGaps(
+  fromVersion: number,
+  toVersion: number,
+  map: MigrationMap | undefined
+): number[] {
+  const gaps: number[] = [];
+  for (let v = fromVersion; v < toVersion; v++) {
+    if (!map || typeof map[v] !== "function") gaps.push(v);
+  }
+  return gaps;
+}
+
+/**
+ * Upgrade a props object from `fromVersion` to `toVersion` by applying each
+ * step in order. Reusable beyond documents: locale-overlay values run through
+ * the same chain. Never throws — a missing step or a throwing step stops the
+ * chain and returns the last good props with a `failure`.
+ */
+export function migrateProps(
+  props: Record<string, unknown>,
+  fromVersion: number,
+  toVersion: number,
+  map: MigrationMap | undefined
+): PropsMigrationResult {
+  let current = props;
+  for (let v = fromVersion; v < toVersion; v++) {
+    const step = map?.[v];
+    if (typeof step !== "function") {
+      return {
+        props: current,
+        failure: { fromVersion: v, message: `No migration from version ${v}.` },
+      };
+    }
+    try {
+      // Widen to unknown: a step's declared return type does not bind a
+      // plain-JS caller, so its result is validated at runtime.
+      const next: unknown = step(current);
+      // A step must return a props object; anything else is a failed upgrade.
+      if (typeof next !== "object" || next === null || Array.isArray(next)) {
+        return {
+          props: current,
+          failure: {
+            fromVersion: v,
+            message: `Migration from version ${v} did not return a props object.`,
+          },
+        };
+      }
+      current = next as Record<string, unknown>;
+    } catch (error) {
+      return {
+        props: current,
+        failure: {
+          fromVersion: v,
+          message:
+            error instanceof Error
+              ? error.message
+              : `Migration from version ${v} threw.`,
+        },
+      };
+    }
+  }
+  return { props: current };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function escapePointer(token: string): string {
+  return token.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+function pointer(parent: string, token: string | number): string {
+  return `${parent}/${escapePointer(String(token))}`;
+}
+
+/**
+ * Upgrade every node in a document to its block's current schema version.
+ *
+ * - A type the source does not know (an unregistered/plugin block) is preserved
+ *   untouched, including its version — nothing is lost.
+ * - A node already at (or ahead of) the current version is left as is.
+ * - A node behind the current version is chained forward. On success its props
+ *   and version are updated; on failure it keeps its last-good props and is
+ *   flagged `migrationFailed`, and the failure is collected for the caller.
+ *
+ * Immutable: returns a new document; the input is never modified. It recurses
+ * over the node tree, whose depth is bounded by the document limits validation
+ * enforces, so migration is meant to run on structurally-valid documents (pair
+ * it with `validate` for untrusted input).
+ */
+export function migrateDocument(
+  doc: BlockDocument,
+  source: MigrationSource
+): MigrateResult {
+  const failures: MigrationFailure[] = [];
+
+  const migrateNode = (node: BlockNode, path: string): BlockNode => {
+    if (!isPlainObject(node)) return node;
+
+    let next = node;
+    const info = source.get(node.type);
+    if (
+      info !== undefined &&
+      typeof node.version === "number" &&
+      node.version < info.version
+    ) {
+      const result = migrateProps(
+        node.props,
+        node.version,
+        info.version,
+        info.migrate
+      );
+      if (result.failure) {
+        failures.push({
+          path,
+          type: node.type,
+          fromVersion: result.failure.fromVersion,
+          toVersion: info.version,
+          message: result.failure.message,
+        });
+        // Keep last-good props at the version they last migrated cleanly to;
+        // flag the node so a renderer can placeholder it.
+        next = { ...node, props: result.props, migrationFailed: true };
+      } else {
+        next = { ...node, props: result.props, version: info.version };
+        if (next.migrationFailed) delete next.migrationFailed;
+      }
+    }
+
+    if (!isPlainObject(next.slots)) return next;
+    let slotsChanged = false;
+    const slots: Record<string, BlockNode[]> = {};
+    for (const [slot, children] of Object.entries(next.slots)) {
+      if (!Array.isArray(children)) {
+        slots[slot] = children;
+        continue;
+      }
+      const slotPath = pointer(pointer(path, "slots"), slot);
+      const migratedChildren = children.map((child, index) =>
+        migrateNode(child, pointer(slotPath, index))
+      );
+      slots[slot] = migratedChildren;
+      if (migratedChildren.some((c, i) => c !== children[i]))
+        slotsChanged = true;
+    }
+    return slotsChanged || next !== node ? { ...next, slots } : next;
+  };
+
+  const nodes = Array.isArray(doc.nodes)
+    ? doc.nodes.map((node, index) =>
+        migrateNode(node, pointer("/nodes", index))
+      )
+    : doc.nodes;
+
+  return { doc: { ...doc, nodes }, failures };
+}


### PR DESCRIPTION
## What

PR-3 of the page-builder rebuild (Plan-01 series; follows #320, #324). Adds the block migration engine to `@nextlyhq/blocks-engine`.

- **`migrateDocument(doc, source)`** upgrades every node to its block's current schema version by chaining per-version steps (`{1: fn, 2: fn}`, keyed by from-version) — one step per version from the node's stored version up to current. Returns `{ doc, failures }`; immutable (input untouched); an already-current node is returned by reference.
- **Unknown types are preserved untouched** (including their version) — an unregistered/plugin block is never mangled.
- **Failure handling**: a missing step or a step that throws (or returns a non-object) stops that node's chain — it keeps its **last-good props**, is flagged **`migrationFailed`** (a new optional `BlockNode` field a renderer uses to show a placeholder), and the failure is collected in `failures` with a JSON-Pointer path.
- **`migrateProps(props, from, to, map)`** is the reusable core (never throws) — the same chain will drive locale-overlay value migration.
- **`findMigrationGaps(from, to, map)`** returns the from-versions missing a covering step — the check a registry will use to reject a block whose `version` was bumped without a covering migration.

**Policy split by caller, not baked in:** `migrateDocument` always upgrades what it can and reports failures. A publish path treats any failure as blocking (strict); a render path renders the returned doc, placeholdering `migrationFailed` nodes (forgiving).

## Why

Blocks evolve. When a block's schema changes, pages saved against the old shape must keep working — automatically upgraded, and gracefully degraded (never crashing) when an upgrade can't complete.

## Tests (13 new; 116 total, all green)

`migrateProps` chaining / gap-stop / throw-stop / non-object-return / no-op; `findMigrationGaps`; and `migrateDocument` for two-step upgrade + version bump + immutability, nested upgrade + unknown-type preservation, failure flagging with preserved props and no version bump, current-node by-reference, and a node ahead of the definition left untouched.

Local: type-check + lint clean; `@nextlyhq/blocks-engine` 116 tests pass; full repo build green. One changeset (all packages, patch).

## Note

`migrateDocument` recurses over the node tree (depth bounded by the document limits `validate()` enforces); it is meant to run on structurally-valid documents, and the doc comment states that contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic migration of block content across schema versions.
  * Supports multi-step upgrades, nested blocks, and detection of missing migration steps.
  * Preserves unknown or already-current blocks without unnecessary changes.
  * Failed migrations retain the last valid content and display a safe placeholder instead of crashing.
  * Exposes structured migration failure details for troubleshooting.

* **Tests**
  * Added comprehensive coverage for successful migrations, missing steps, failures, nested content, and unchanged blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->