### PR TITLE
feat(blocks-engine): add defineBlock api and boot block registry

### DIFF
--- a/.changeset/blocks-engine-registry.md
+++ b/.changeset/blocks-engine-registry.md
@@ -1,0 +1,24 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+`@nextlyhq/blocks-engine` now provides `defineBlock` for declaring a block type — its props, default styles, child slots, style capabilities, and how it renders — plus the registry that collects them when an app boots. Mistakes are caught at startup with a clear message instead of surfacing as broken pages: a duplicate block name names both sources, and bumping a block's version without providing the matching upgrade step is refused outright. Third parties can add new style capabilities through `registerSupport`.

--- a/packages/blocks-engine/src/block.ts
+++ b/packages/blocks-engine/src/block.ts
@@ -98,10 +98,14 @@ export interface BlockExample<P> {
   slots?: Record<string, BlockNode[]>;
 }
 
-/** One block type. */
-export interface BlockDefinition<
-  P extends Record<string, unknown> = Record<string, unknown>,
-> {
+/**
+ * One block type.
+ *
+ * `P` is constrained to `object` rather than a string-index record so ordinary
+ * named interfaces (which carry no implicit index signature) can describe a
+ * block's props without being rewritten.
+ */
+export interface BlockDefinition<P extends object = Record<string, unknown>> {
   /** Namespaced, immutable identity, e.g. "core/heading". */
   name: string;
   /** Schema version stamped onto every node of this type. */
@@ -115,22 +119,33 @@ export interface BlockDefinition<
   description: string;
   /** Required: a worked instance, for previews and few-shot prompting. */
   example: BlockExample<P>;
-  /** Prop schemas keyed by prop name. */
-  props?: Record<string, PropSchema>;
+  /**
+   * Prop schemas, keyed by the block's own prop names so a typo cannot declare
+   * a schema for a prop the block does not have.
+   */
+  props?: Partial<Record<keyof P & string, PropSchema>>;
   /** Default prop values; also the inference source for the block's prop type. */
   defaultProps?: P;
   /** Prop names whose values are translatable. */
-  localized?: string[];
+  localized?: (keyof P & string)[];
   /** Shared default styles for every instance of this block type. */
   baseStyles?: NodeStyles;
   /** Named child regions; only container blocks declare these. */
   slots?: Record<string, SlotSpec>;
   /** Style capabilities this block opts into. */
   supports?: BlockSupports;
-  /** Renders the block. May be async. */
-  render: (args: BlockRenderArgs<P>) => BlockRenderResult;
+  /**
+   * Renders the block. May be async.
+   *
+   * Declared as a method so parameter checking stays bivariant: a registry
+   * holds definitions of many different prop shapes, and each is only ever
+   * called with its own props, so requiring strict contravariance here would
+   * make a typed definition unassignable to the heterogeneous collection
+   * without buying any safety.
+   */
+  render(args: BlockRenderArgs<P>): BlockRenderResult;
   /** Optional editor-side data hydration before rendering. */
-  resolve?: (props: P, ctx: unknown) => unknown;
+  resolve?(props: P, ctx: unknown): unknown;
   /** Editor-only metadata; never serialized. */
   editor?: BlockEditorMeta;
 }
@@ -142,7 +157,7 @@ export interface BlockDefinition<
  * data (name format, version/migration coverage, support keys) are enforced
  * when the block is registered.
  */
-export function defineBlock<P extends Record<string, unknown>>(
+export function defineBlock<P extends object>(
   definition: BlockDefinition<P>
 ): BlockDefinition<P> {
   return definition;
@@ -150,3 +165,27 @@ export function defineBlock<P extends Record<string, unknown>>(
 
 /** The prop type of a block definition. */
 export type InferBlockProps<D> = D extends BlockDefinition<infer P> ? P : never;
+
+/**
+ * A block definition with its prop typing erased.
+ *
+ * `BlockDefinition<P>` uses `P` both to produce values (`example`,
+ * `defaultProps`) and to consume them (`render`), so it is invariant in `P` —
+ * `BlockDefinition<{ text: string }>` is deliberately NOT assignable to
+ * `BlockDefinition<Record<string, unknown>>`. Collections that hold many block
+ * types (the registry above all) accept this erased shape instead, so a fully
+ * typed definition can be registered without discarding its prop types at the
+ * definition site.
+ */
+export interface AnyBlockDefinition
+  extends Omit<
+    BlockDefinition,
+    "example" | "defaultProps" | "props" | "localized" | "render" | "resolve"
+  > {
+  example: { props: object; slots?: Record<string, BlockNode[]> };
+  defaultProps?: object;
+  props?: Partial<Record<string, PropSchema>>;
+  localized?: string[];
+  render(args: BlockRenderArgs<never>): BlockRenderResult;
+  resolve?(props: never, ctx: unknown): unknown;
+}

--- a/packages/blocks-engine/src/block.ts
+++ b/packages/blocks-engine/src/block.ts
@@ -54,7 +54,7 @@ export type BlockSupports = Record<string, boolean | Record<string, unknown>>;
 export type ComponentPath = string;
 
 /** Editor-only metadata. Never serialized into a document. */
-export interface BlockEditorMeta {
+export interface BlockEditorMeta<P extends object = Record<string, unknown>> {
   label?: string;
   icon?: string;
   /** Palette grouping, e.g. "structure" | "content" | "media". */
@@ -62,15 +62,20 @@ export interface BlockEditorMeta {
   /** Extra search terms for the block palette. */
   keywords?: string[];
   /** Named preset variations offered when inserting. */
-  variations?: BlockVariation[];
+  variations?: BlockVariation<P>[];
   /** Custom inspector/canvas component for this block. */
   component?: ComponentPath;
 }
 
-export interface BlockVariation {
+/**
+ * A named preset for inserting a block. Its props are typed against the
+ * block's own props, so a preset cannot introduce a value the renderer does
+ * not accept.
+ */
+export interface BlockVariation<P extends object = Record<string, unknown>> {
   name: string;
   label?: string;
-  props?: Record<string, unknown>;
+  props?: Partial<P>;
 }
 
 /** What a block's `render` receives. */
@@ -147,7 +152,7 @@ export interface BlockDefinition<P extends object = Record<string, unknown>> {
   /** Optional editor-side data hydration before rendering. */
   resolve?(props: P, ctx: unknown): unknown;
   /** Editor-only metadata; never serialized. */
-  editor?: BlockEditorMeta;
+  editor?: BlockEditorMeta<P>;
 }
 
 /**
@@ -176,6 +181,12 @@ export type InferBlockProps<D> = D extends BlockDefinition<infer P> ? P : never;
  * types (the registry above all) accept this erased shape instead, so a fully
  * typed definition can be registered without discarding its prop types at the
  * definition site.
+ *
+ * The prop-consuming members widen to `object` and are declared as methods, so
+ * this type works in both directions: any typed definition is assignable to it
+ * (bivariant parameter checking), and a consumer holding a stored node can
+ * still call `render`/`resolve` with that node's runtime props. Narrowing them
+ * to `never` would make the collection accept definitions it could never use.
  */
 export interface AnyBlockDefinition
   extends Omit<
@@ -186,6 +197,6 @@ export interface AnyBlockDefinition
   defaultProps?: object;
   props?: Partial<Record<string, PropSchema>>;
   localized?: string[];
-  render(args: BlockRenderArgs<never>): BlockRenderResult;
-  resolve?(props: never, ctx: unknown): unknown;
+  render(args: BlockRenderArgs<object>): BlockRenderResult;
+  resolve?(props: object, ctx: unknown): unknown;
 }

--- a/packages/blocks-engine/src/block.ts
+++ b/packages/blocks-engine/src/block.ts
@@ -1,0 +1,152 @@
+/**
+ * The block definition API. `defineBlock` describes one block type: its schema
+ * version and upgrade steps, the props it accepts, the slots it nests children
+ * in, the style capabilities it opts into, how it renders, and the metadata an
+ * editor needs.
+ *
+ * Framework-agnostic by construction. The engine stores definitions (including
+ * their `render` function) but never calls a UI library itself, so `render`'s
+ * return type is opaque here and narrowed by the React binding package. That is
+ * what keeps this package dependency-free and usable from any runtime.
+ */
+import type { BlockNode, NodeStyles } from "./document";
+import type { MigrationMap } from "./migration";
+
+/**
+ * A prop's schema entry. Structural on purpose: the engine only needs each
+ * prop's declared `type` (for the generated manifest and for deriving editor
+ * controls); the full field-configuration vocabulary lives in the field system
+ * that produces these objects.
+ */
+export interface PropSchema {
+  type: string;
+  [option: string]: unknown;
+}
+
+/** How much of a slot is locked against editing. */
+export type SlotLock = "all" | "insert" | "contentOnly" | false;
+
+/** One named child region a container block exposes. */
+export interface SlotSpec {
+  /**
+   * Block names allowed in this slot; a trailing `*` matches a namespace
+   * (`"core/*"`). Omitted means any block is allowed.
+   */
+  allow?: string[];
+  /** Children inserted when the block is first placed. */
+  template?: BlockNode[];
+  /**
+   * Editing restriction for this slot, inherited by its children:
+   * `"all"` locks everything, `"insert"` forbids adding/removing children,
+   * `"contentOnly"` allows editing values but not structure.
+   */
+  lock?: SlotLock;
+}
+
+/**
+ * Style capabilities a block opts into. Each key must be a registered support
+ * (built-in or added via `registerSupport`); `true` enables the whole group and
+ * an object enables individual sub-flags.
+ */
+export type BlockSupports = Record<string, boolean | Record<string, unknown>>;
+
+/** A path to an editor component, resolved through the admin import map. */
+export type ComponentPath = string;
+
+/** Editor-only metadata. Never serialized into a document. */
+export interface BlockEditorMeta {
+  label?: string;
+  icon?: string;
+  /** Palette grouping, e.g. "structure" | "content" | "media". */
+  category?: string;
+  /** Extra search terms for the block palette. */
+  keywords?: string[];
+  /** Named preset variations offered when inserting. */
+  variations?: BlockVariation[];
+  /** Custom inspector/canvas component for this block. */
+  component?: ComponentPath;
+}
+
+export interface BlockVariation {
+  name: string;
+  label?: string;
+  props?: Record<string, unknown>;
+}
+
+/** What a block's `render` receives. */
+export interface BlockRenderArgs<P> {
+  props: P;
+  node: BlockNode;
+  /** Rendered children per slot, keyed by slot name. */
+  slots: Record<string, unknown>;
+  /**
+   * The generated class the block MUST place on its own root element. Blocks
+   * render a single element and never wrap it, so styles target that element.
+   */
+  className: string;
+}
+
+/**
+ * A block's rendered output. Opaque here: the engine stores and passes it
+ * through without inspecting it, so this package needs no UI dependency.
+ */
+export type BlockRenderResult = unknown;
+
+/** An example instance, required so tooling and agents have a worked sample. */
+export interface BlockExample<P> {
+  props: P;
+  slots?: Record<string, BlockNode[]>;
+}
+
+/** One block type. */
+export interface BlockDefinition<
+  P extends Record<string, unknown> = Record<string, unknown>,
+> {
+  /** Namespaced, immutable identity, e.g. "core/heading". */
+  name: string;
+  /** Schema version stamped onto every node of this type. */
+  version: number;
+  /**
+   * Upgrade steps keyed by from-version. A version above 1 requires steps
+   * covering every version below it; registration refuses an uncovered bump.
+   */
+  migrate?: MigrationMap;
+  /** Required: what the block is, for docs, the palette, and agents. */
+  description: string;
+  /** Required: a worked instance, for previews and few-shot prompting. */
+  example: BlockExample<P>;
+  /** Prop schemas keyed by prop name. */
+  props?: Record<string, PropSchema>;
+  /** Default prop values; also the inference source for the block's prop type. */
+  defaultProps?: P;
+  /** Prop names whose values are translatable. */
+  localized?: string[];
+  /** Shared default styles for every instance of this block type. */
+  baseStyles?: NodeStyles;
+  /** Named child regions; only container blocks declare these. */
+  slots?: Record<string, SlotSpec>;
+  /** Style capabilities this block opts into. */
+  supports?: BlockSupports;
+  /** Renders the block. May be async. */
+  render: (args: BlockRenderArgs<P>) => BlockRenderResult;
+  /** Optional editor-side data hydration before rendering. */
+  resolve?: (props: P, ctx: unknown) => unknown;
+  /** Editor-only metadata; never serialized. */
+  editor?: BlockEditorMeta;
+}
+
+/**
+ * Declare a block type. Returns the definition unchanged — its job is to bind
+ * the prop type once so `props`, `example`, `defaultProps`, and `render` are
+ * checked against each other at author time. Shape rules that need runtime
+ * data (name format, version/migration coverage, support keys) are enforced
+ * when the block is registered.
+ */
+export function defineBlock<P extends Record<string, unknown>>(
+  definition: BlockDefinition<P>
+): BlockDefinition<P> {
+  return definition;
+}
+
+/** The prop type of a block definition. */
+export type InferBlockProps<D> = D extends BlockDefinition<infer P> ? P : never;

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -76,6 +76,37 @@ export type {
   ValidationMode,
 } from "./validation";
 
+export { defineBlock } from "./block";
+export type {
+  BlockDefinition,
+  BlockEditorMeta,
+  BlockExample,
+  BlockRenderArgs,
+  BlockRenderResult,
+  BlockSupports,
+  BlockVariation,
+  ComponentPath,
+  InferBlockProps,
+  PropSchema,
+  SlotLock,
+  SlotSpec,
+} from "./block";
+
+export {
+  registerBlocks,
+  registerSupport,
+  getBlock,
+  hasBlock,
+  allBlocks,
+  getBlockSource,
+  getSupport,
+  allSupports,
+  clearBlocks,
+  registryLookup,
+  registryMigrationSource,
+} from "./registry";
+export type { RegisterOptions, SupportDefinition } from "./registry";
+
 export { migrateDocument, migrateProps, findMigrationGaps } from "./migration";
 export type {
   BlockMigrationInfo,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -78,6 +78,7 @@ export type {
 
 export { defineBlock } from "./block";
 export type {
+  AnyBlockDefinition,
   BlockDefinition,
   BlockEditorMeta,
   BlockExample,
@@ -102,6 +103,7 @@ export {
   getSupport,
   allSupports,
   clearBlocks,
+  MAX_BLOCK_VERSION,
   registryLookup,
   registryMigrationSource,
 } from "./registry";

--- a/packages/blocks-engine/src/migration.ts
+++ b/packages/blocks-engine/src/migration.ts
@@ -71,7 +71,7 @@ export interface PropsMigrationResult {
  * increment by one per schema change, so a span this large signals a malformed
  * version rather than a real upgrade; it also bounds the loops below.
  */
-const MAX_MIGRATION_STEPS = 1000;
+export const MAX_MIGRATION_STEPS = 1000;
 
 /** True if a version range is a sane, finite, bounded span of non-negative integers. */
 function isValidVersionRange(fromVersion: number, toVersion: number): boolean {

--- a/packages/blocks-engine/src/registry.test.ts
+++ b/packages/blocks-engine/src/registry.test.ts
@@ -56,6 +56,42 @@ describe("defineBlock typing", () => {
   });
 });
 
+describe("the define-then-register workflow keeps its prop types", () => {
+  it("registers a definition whose props were inferred from a literal", () => {
+    // This is the primary workflow: defineBlock infers { text: string }, and
+    // that fully-typed definition must be registrable without erasing types.
+    const heading = defineBlock({
+      name: "core/typed-heading",
+      version: 1,
+      description: "A heading.",
+      example: { props: { text: "Hi" } },
+      defaultProps: { text: "" },
+      props: { text: { type: "text" } },
+      localized: ["text"],
+      render: args => args.props.text,
+    });
+    expect(() => registerBlocks([heading])).not.toThrow();
+    expect(getBlock("core/typed-heading")).toBeDefined();
+  });
+
+  it("registers a definition whose props come from a named interface", () => {
+    // Interfaces carry no implicit index signature, so the prop constraint has
+    // to accept plain object shapes for ordinary author code to compile.
+    interface CardProps {
+      title: string;
+      count: number;
+    }
+    const card = defineBlock<CardProps>({
+      name: "core/typed-card",
+      version: 1,
+      description: "A card.",
+      example: { props: { title: "a", count: 1 } },
+      render: args => `${args.props.title}${args.props.count}`,
+    });
+    expect(() => registerBlocks([card])).not.toThrow();
+  });
+});
+
 describe("registration rules", () => {
   it("registers and reads back a block with its source", () => {
     registerBlocks([block({ name: "core/text" })], { source: "core" });
@@ -89,6 +125,20 @@ describe("registration rules", () => {
     expect(() =>
       registerBlocks([block({ name: "core/d", version: 1.5 })])
     ).toThrow(/NEXTLY_BLOCK_INVALID/);
+  });
+
+  it("rejects a version beyond the span migration can chain", () => {
+    // Above this, findMigrationGaps cannot report gaps and migration would
+    // reject the range at runtime, so registration must not accept it.
+    expect(() =>
+      registerBlocks([block({ name: "core/huge", version: 5000 })])
+    ).toThrow(/NEXTLY_BLOCK_INVALID.*between 1 and/s);
+  });
+
+  it("refuses to register a name the engine reserves", () => {
+    expect(() =>
+      registerBlocks([block({ name: "nextly/component-instance" })])
+    ).toThrow(/NEXTLY_BLOCK_RESERVED_NAME/);
   });
 
   it("refuses a version bump that has no covering migration", () => {

--- a/packages/blocks-engine/src/registry.test.ts
+++ b/packages/blocks-engine/src/registry.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, expectTypeOf, it } from "vitest";
 
 import type { BlockDefinition, InferBlockProps } from "./block";
+import type { BlockNode } from "./document";
 import { defineBlock } from "./block";
 import { migrateDocument } from "./migration";
 import {
@@ -74,6 +75,48 @@ describe("the define-then-register workflow keeps its prop types", () => {
     expect(getBlock("core/typed-heading")).toBeDefined();
   });
 
+  it("lets a consumer call render on a definition read back from the registry", () => {
+    // The other half of the contract: a renderer holds a stored node and must
+    // be able to invoke the registered block with that node's runtime props.
+    const greeter = defineBlock({
+      name: "core/greeter",
+      version: 1,
+      description: "Greets.",
+      example: { props: { who: "world" } },
+      render: args => `hello ${args.props.who}`,
+    });
+    registerBlocks([greeter]);
+
+    const node: BlockNode = {
+      id: "n1",
+      type: "core/greeter",
+      version: 1,
+      props: { who: "reader" },
+    };
+    const def = getBlock(node.type);
+    const output = def?.render({
+      props: node.props,
+      node,
+      slots: {},
+      className: "nx-pb-x",
+    });
+    expect(output).toBe("hello reader");
+  });
+
+  it("types variation props against the block's own props", () => {
+    const withVariation = defineBlock({
+      name: "core/varied",
+      version: 1,
+      description: "Has presets.",
+      example: { props: { tone: "calm" } },
+      render: args => args.props.tone,
+      editor: {
+        variations: [{ name: "loud", props: { tone: "LOUD" } }],
+      },
+    });
+    expect(withVariation.editor?.variations?.[0]?.props?.tone).toBe("LOUD");
+  });
+
   it("registers a definition whose props come from a named interface", () => {
     // Interfaces carry no implicit index signature, so the prop constraint has
     // to accept plain object shapes for ordinary author code to compile.
@@ -133,6 +176,38 @@ describe("registration rules", () => {
     expect(() =>
       registerBlocks([block({ name: "core/huge", version: 5000 })])
     ).toThrow(/NEXTLY_BLOCK_INVALID.*between 1 and/s);
+  });
+
+  it("rejects an example whose props are not a plain object", () => {
+    // Document validation rejects array props, so such an example could never
+    // become a valid node.
+    expect(() =>
+      registerBlocks([
+        block({
+          name: "core/arr",
+          example: { props: [] as unknown as object },
+        }),
+      ])
+    ).toThrow(/NEXTLY_BLOCK_INVALID.*plain object/s);
+  });
+
+  it("rejects an unknown sub-flag on a support that enumerates its flags", () => {
+    expect(() =>
+      registerBlocks([
+        block({ name: "core/typo", supports: { spacing: { paddding: true } } }),
+      ])
+    ).toThrow(/NEXTLY_BLOCK_UNKNOWN_SUPPORT.*paddding/s);
+  });
+
+  it("accepts known sub-flags", () => {
+    expect(() =>
+      registerBlocks([
+        block({
+          name: "core/ok-flags",
+          supports: { spacing: { padding: true } },
+        }),
+      ])
+    ).not.toThrow();
   });
 
   it("refuses to register a name the engine reserves", () => {

--- a/packages/blocks-engine/src/registry.test.ts
+++ b/packages/blocks-engine/src/registry.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, expectTypeOf, it } from "vitest";
+
+import type { BlockDefinition, InferBlockProps } from "./block";
+import { defineBlock } from "./block";
+import { migrateDocument } from "./migration";
+import {
+  allBlocks,
+  allSupports,
+  clearBlocks,
+  getBlock,
+  getBlockSource,
+  getSupport,
+  hasBlock,
+  registerBlocks,
+  registerSupport,
+  registryLookup,
+  registryMigrationSource,
+} from "./registry";
+import { validate } from "./validation";
+import { FIXTURE_BREAKPOINTS } from "./validation.fixtures";
+
+/** A minimal valid definition; overrides let each test vary one rule. */
+function block(
+  overrides: Partial<BlockDefinition> & { name: string }
+): BlockDefinition {
+  return {
+    version: 1,
+    description: "A test block.",
+    example: { props: {} },
+    render: () => null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  clearBlocks();
+});
+
+describe("defineBlock typing", () => {
+  it("binds one prop type across props, example, defaults, and render", () => {
+    const heading = defineBlock({
+      name: "core/heading",
+      version: 1,
+      description: "A heading.",
+      example: { props: { text: "Hello", level: 2 } },
+      props: { text: { type: "text" }, level: { type: "number" } },
+      defaultProps: { text: "", level: 2 },
+      render: args => args.props.text.toUpperCase(),
+    });
+    expectTypeOf<InferBlockProps<typeof heading>>().toEqualTypeOf<{
+      text: string;
+      level: number;
+    }>();
+    // The definition is returned unchanged.
+    expect(heading.name).toBe("core/heading");
+  });
+});
+
+describe("registration rules", () => {
+  it("registers and reads back a block with its source", () => {
+    registerBlocks([block({ name: "core/text" })], { source: "core" });
+    expect(hasBlock("core/text")).toBe(true);
+    expect(getBlock("core/text")?.description).toBe("A test block.");
+    expect(getBlockSource("core/text")).toBe("core");
+    expect(allBlocks()).toHaveLength(1);
+  });
+
+  it("rejects a non-namespaced name", () => {
+    expect(() => registerBlocks([block({ name: "heading" })])).toThrow(
+      /NEXTLY_BLOCK_INVALID/
+    );
+  });
+
+  it("rejects a missing description or example", () => {
+    expect(() =>
+      registerBlocks([block({ name: "core/a", description: "  " })])
+    ).toThrow(/NEXTLY_BLOCK_INVALID.*description/s);
+    expect(() =>
+      registerBlocks([
+        block({ name: "core/b", example: undefined as unknown as never }),
+      ])
+    ).toThrow(/NEXTLY_BLOCK_INVALID.*example/s);
+  });
+
+  it("rejects a non-integer or zero version", () => {
+    expect(() =>
+      registerBlocks([block({ name: "core/c", version: 0 })])
+    ).toThrow(/NEXTLY_BLOCK_INVALID/);
+    expect(() =>
+      registerBlocks([block({ name: "core/d", version: 1.5 })])
+    ).toThrow(/NEXTLY_BLOCK_INVALID/);
+  });
+
+  it("refuses a version bump that has no covering migration", () => {
+    expect(() =>
+      registerBlocks([block({ name: "core/e", version: 3 })])
+    ).toThrow(/NEXTLY_BLOCK_MIGRATION_GAP.*versions 1, 2/s);
+  });
+
+  it("accepts a version bump whose migration chain is complete", () => {
+    registerBlocks([
+      block({
+        name: "core/f",
+        version: 3,
+        migrate: { 1: p => p, 2: p => p },
+      }),
+    ]);
+    expect(getBlock("core/f")?.version).toBe(3);
+  });
+
+  it("names both sources when two register the same block", () => {
+    registerBlocks([block({ name: "core/dup" })], { source: "core" });
+    expect(() =>
+      registerBlocks([block({ name: "core/dup" })], { source: "plugin-x" })
+    ).toThrow(/NEXTLY_BLOCK_COLLISION.*"core".*"plugin-x"/s);
+  });
+
+  it("rejects a duplicate name inside one batch", () => {
+    expect(() =>
+      registerBlocks([block({ name: "core/g" }), block({ name: "core/g" })])
+    ).toThrow(/NEXTLY_BLOCK_COLLISION/);
+  });
+
+  it("does not partially register a batch containing an invalid block", () => {
+    expect(() =>
+      registerBlocks([block({ name: "core/ok" }), block({ name: "bad-name" })])
+    ).toThrow(/NEXTLY_BLOCK_INVALID/);
+    // The valid sibling must not have been stored.
+    expect(hasBlock("core/ok")).toBe(false);
+  });
+});
+
+describe("supports", () => {
+  it("ships the built-in capabilities and accepts blocks using them", () => {
+    expect(getSupport("spacing")?.flags).toContain("padding");
+    expect(allSupports().length).toBeGreaterThan(5);
+    registerBlocks([
+      block({
+        name: "core/h",
+        supports: { spacing: true, color: { text: true } },
+      }),
+    ]);
+    expect(getBlock("core/h")?.supports?.spacing).toBe(true);
+  });
+
+  it("rejects a block declaring an unregistered support", () => {
+    expect(() =>
+      registerBlocks([block({ name: "core/i", supports: { telepathy: true } })])
+    ).toThrow(/NEXTLY_BLOCK_UNKNOWN_SUPPORT.*telepathy/s);
+  });
+
+  it("accepts that same support once it is registered", () => {
+    registerSupport({ key: "telepathy", label: "Telepathy" });
+    registerBlocks([block({ name: "core/j", supports: { telepathy: true } })]);
+    expect(getBlock("core/j")).toBeDefined();
+  });
+
+  it("rejects a duplicate or malformed support key", () => {
+    expect(() => registerSupport({ key: "spacing" })).toThrow(
+      /NEXTLY_SUPPORT_COLLISION/
+    );
+    expect(() => registerSupport({ key: "not a key" })).toThrow(
+      /NEXTLY_SUPPORT_INVALID/
+    );
+  });
+});
+
+describe("clear-and-rebuild (boot / HMR)", () => {
+  it("lets the same blocks re-register after a clear", () => {
+    registerBlocks([block({ name: "core/k" })], { source: "core" });
+    clearBlocks();
+    expect(hasBlock("core/k")).toBe(false);
+    // Re-registering the same name after a boot reset must not collide.
+    expect(() =>
+      registerBlocks([block({ name: "core/k" })], { source: "core" })
+    ).not.toThrow();
+  });
+
+  it("restores the built-in supports after a clear", () => {
+    registerSupport({ key: "custom", label: "Custom" });
+    clearBlocks();
+    expect(getSupport("custom")).toBeUndefined();
+    expect(getSupport("spacing")).toBeDefined();
+  });
+});
+
+describe("registry adapters", () => {
+  it("drives validation's unknown-type check", () => {
+    registerBlocks([block({ name: "core/known" })]);
+    const doc = {
+      formatVersion: 1 as const,
+      kind: "page" as const,
+      nodes: [
+        { id: "a", type: "core/known", version: 1, props: {} },
+        { id: "b", type: "core/missing", version: 1, props: {} },
+      ],
+    };
+    const issues = validate(doc, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      mode: "strict",
+      registry: registryLookup(),
+    });
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      code: "unknown-node-type",
+      path: "/nodes/1/type",
+    });
+  });
+
+  it("drives migration from each block's declared version and steps", () => {
+    registerBlocks([
+      block({
+        name: "core/m",
+        version: 2,
+        migrate: { 1: p => ({ ...p, added: true }) },
+      }),
+    ]);
+    const { doc, failures } = migrateDocument(
+      {
+        formatVersion: 1,
+        kind: "page",
+        nodes: [{ id: "n", type: "core/m", version: 1, props: {} }],
+      },
+      registryMigrationSource()
+    );
+    expect(failures).toEqual([]);
+    expect(doc.nodes[0]).toMatchObject({ version: 2, props: { added: true } });
+  });
+
+  it("reads through to the live registry rather than a snapshot", () => {
+    const lookup = registryLookup();
+    expect(lookup.has("core/late")).toBe(false);
+    registerBlocks([block({ name: "core/late" })]);
+    expect(lookup.has("core/late")).toBe(true);
+  });
+});

--- a/packages/blocks-engine/src/registry.ts
+++ b/packages/blocks-engine/src/registry.ts
@@ -9,9 +9,10 @@
  * Registration is where definition rules are enforced — a malformed block fails
  * at boot with a named error rather than producing broken pages later.
  */
-import type { BlockDefinition, BlockSupports } from "./block";
+import type { AnyBlockDefinition, BlockSupports } from "./block";
+import { COMPONENT_INSTANCE_TYPE } from "./document";
 import type { MigrationSource } from "./migration";
-import { findMigrationGaps } from "./migration";
+import { MAX_MIGRATION_STEPS, findMigrationGaps } from "./migration";
 import type { BlockTypeLookup } from "./validation";
 
 /** A style capability blocks may opt into. */
@@ -31,7 +32,7 @@ export interface RegisterOptions {
 }
 
 interface RegistryEntry {
-  definition: BlockDefinition;
+  definition: AnyBlockDefinition;
   source: string;
 }
 
@@ -83,6 +84,20 @@ function supportStore(): Map<string, SupportDefinition> {
 /** A block name is a namespaced slug, e.g. "core/heading". */
 const BLOCK_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
+/**
+ * The highest version a block may declare. Migration chains a bounded number of
+ * steps, so a version above this could never carry its oldest stored nodes
+ * forward — registration refuses it rather than promise an upgrade path that
+ * does not exist.
+ */
+export const MAX_BLOCK_VERSION = 1 + MAX_MIGRATION_STEPS;
+
+/**
+ * Names the engine owns. They identify nodes resolved by the engine's own
+ * machinery rather than by a registered block, so a block may not claim one.
+ */
+const RESERVED_BLOCK_NAMES = new Set<string>([COMPONENT_INSTANCE_TYPE]);
+
 /** A support key is a single lowerCamel/slug token. */
 const SUPPORT_KEY_RE = /^[a-zA-Z][a-zA-Z0-9]*$/;
 
@@ -94,17 +109,30 @@ function fail(code: string, message: string): never {
  * Check one definition against the rules registration enforces. Split out so a
  * caller can validate a definition without committing it to the registry.
  */
-function assertValidDefinition(def: BlockDefinition): void {
+function assertValidDefinition(def: AnyBlockDefinition): void {
   if (typeof def.name !== "string" || !BLOCK_NAME_RE.test(def.name)) {
     fail(
       "NEXTLY_BLOCK_INVALID",
       `block name "${String(def.name)}" must be a namespaced slug like "core/heading".`
     );
   }
-  if (!Number.isInteger(def.version) || def.version < 1) {
+  if (RESERVED_BLOCK_NAMES.has(def.name)) {
+    fail(
+      "NEXTLY_BLOCK_RESERVED_NAME",
+      `block name "${def.name}" is reserved by the engine and cannot be registered.`
+    );
+  }
+  if (
+    !Number.isInteger(def.version) ||
+    def.version < 1 ||
+    // A version further above 1 than migration will chain cannot have an
+    // upgrade path for its oldest stored nodes, so accepting it here would
+    // promise something migration cannot honor.
+    def.version > MAX_BLOCK_VERSION
+  ) {
     fail(
       "NEXTLY_BLOCK_INVALID",
-      `block "${def.name}" must declare an integer version of at least 1.`
+      `block "${def.name}" must declare an integer version between 1 and ${MAX_BLOCK_VERSION}.`
     );
   }
   // description and example are required so generated documentation, palette
@@ -172,7 +200,7 @@ function assertKnownSupports(
  * half-populated.
  */
 export function registerBlocks(
-  definitions: BlockDefinition[],
+  definitions: AnyBlockDefinition[],
   options: RegisterOptions = {}
 ): void {
   const source = options.source ?? "app";
@@ -222,7 +250,7 @@ export function registerSupport(support: SupportDefinition): void {
 }
 
 /** A registered block definition, or `undefined`. */
-export function getBlock(name: string): BlockDefinition | undefined {
+export function getBlock(name: string): AnyBlockDefinition | undefined {
   return blockStore().get(name)?.definition;
 }
 
@@ -231,7 +259,7 @@ export function hasBlock(name: string): boolean {
 }
 
 /** Every registered block definition. */
-export function allBlocks(): BlockDefinition[] {
+export function allBlocks(): AnyBlockDefinition[] {
   return [...blockStore().values()].map(entry => entry.definition);
 }
 

--- a/packages/blocks-engine/src/registry.ts
+++ b/packages/blocks-engine/src/registry.ts
@@ -105,6 +105,11 @@ function fail(code: string, message: string): never {
   throw new Error(`${code}: ${message}`);
 }
 
+/** A key/value object — not null, not an array, not a function. */
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /**
  * Check one definition against the rules registration enforces. Split out so a
  * caller can validate a definition without committing it to the registry.
@@ -146,12 +151,20 @@ function assertValidDefinition(def: AnyBlockDefinition): void {
   if (
     typeof def.example !== "object" ||
     def.example === null ||
-    typeof def.example.props !== "object" ||
-    def.example.props === null
+    // Props must be a plain record: a stored node's props are a key/value map,
+    // and document validation rejects an array, so an array-shaped example
+    // could never become a valid node.
+    !isPlainRecord(def.example.props)
   ) {
     fail(
       "NEXTLY_BLOCK_INVALID",
-      `block "${def.name}" must declare an example with props.`
+      `block "${def.name}" must declare an example whose props are a plain object.`
+    );
+  }
+  if (def.defaultProps !== undefined && !isPlainRecord(def.defaultProps)) {
+    fail(
+      "NEXTLY_BLOCK_INVALID",
+      `block "${def.name}" defaultProps must be a plain object.`
     );
   }
   if (typeof def.render !== "function") {
@@ -182,12 +195,26 @@ function assertKnownSupports(
 ): void {
   if (!supports) return;
   const known = supportStore();
-  for (const key of Object.keys(supports)) {
-    if (!known.has(key)) {
+  for (const [key, value] of Object.entries(supports)) {
+    const support = known.get(key);
+    if (!support) {
       fail(
         "NEXTLY_BLOCK_UNKNOWN_SUPPORT",
         `block "${blockName}" declares unknown support "${key}". Register it with registerSupport() first.`
       );
+    }
+    // When a support enumerates its sub-flags, an unrecognized nested flag is
+    // as much a typo as an unknown support key and would silently enable
+    // nothing, so it is rejected the same way.
+    if (support.flags && isPlainRecord(value)) {
+      for (const flag of Object.keys(value)) {
+        if (!support.flags.includes(flag)) {
+          fail(
+            "NEXTLY_BLOCK_UNKNOWN_SUPPORT",
+            `block "${blockName}" declares unknown "${key}" flag "${flag}". Known flags: ${support.flags.join(", ")}.`
+          );
+        }
+      }
     }
   }
 }

--- a/packages/blocks-engine/src/registry.ts
+++ b/packages/blocks-engine/src/registry.ts
@@ -1,0 +1,281 @@
+/**
+ * The block registry: the single place that knows which block types exist in a
+ * running app, and the gate every definition passes through.
+ *
+ * `globalThis`-pinned and cleared per boot (clear-and-rebuild), so a dev-server
+ * hot reload re-registering the same blocks never collides with itself, while a
+ * genuine duplicate name inside one boot still fails loudly.
+ *
+ * Registration is where definition rules are enforced — a malformed block fails
+ * at boot with a named error rather than producing broken pages later.
+ */
+import type { BlockDefinition, BlockSupports } from "./block";
+import type { MigrationSource } from "./migration";
+import { findMigrationGaps } from "./migration";
+import type { BlockTypeLookup } from "./validation";
+
+/** A style capability blocks may opt into. */
+export interface SupportDefinition {
+  /** The key blocks use inside `supports`, e.g. "spacing". */
+  key: string;
+  /** Human label for editor grouping. */
+  label?: string;
+  /** Sub-flags this support recognizes, e.g. ["padding", "margin"]. */
+  flags?: string[];
+}
+
+/** Where a set of blocks came from, for collision messages. */
+export interface RegisterOptions {
+  /** e.g. a plugin name; surfaced when two sources claim the same block name. */
+  source?: string;
+}
+
+interface RegistryEntry {
+  definition: BlockDefinition;
+  source: string;
+}
+
+/** Style capabilities available to every app before any extension. */
+const BUILT_IN_SUPPORTS: SupportDefinition[] = [
+  {
+    key: "spacing",
+    label: "Spacing",
+    flags: ["margin", "padding", "blockGap"],
+  },
+  { key: "layout", label: "Layout" },
+  { key: "dimensions", label: "Dimensions" },
+  { key: "typography", label: "Typography" },
+  { key: "color", label: "Color", flags: ["text", "background", "link"] },
+  { key: "background", label: "Background", flags: ["image", "gradient"] },
+  {
+    key: "border",
+    label: "Border",
+    flags: ["width", "style", "color", "radius"],
+  },
+  { key: "shadow", label: "Shadow" },
+  { key: "effects", label: "Effects" },
+  { key: "position", label: "Position" },
+  { key: "container", label: "Container queries" },
+  { key: "customCss", label: "Custom CSS" },
+];
+
+const globalForBlocks = globalThis as unknown as {
+  __nextly_blocks?: Map<string, RegistryEntry>;
+  __nextly_blockSupports?: Map<string, SupportDefinition>;
+};
+
+function blockStore(): Map<string, RegistryEntry> {
+  globalForBlocks.__nextly_blocks ??= new Map();
+  return globalForBlocks.__nextly_blocks;
+}
+
+function supportStore(): Map<string, SupportDefinition> {
+  if (!globalForBlocks.__nextly_blockSupports) {
+    const map = new Map<string, SupportDefinition>();
+    // Seed here rather than at module load so a cleared store always comes
+    // back with the built-ins present.
+    for (const support of BUILT_IN_SUPPORTS) map.set(support.key, support);
+    globalForBlocks.__nextly_blockSupports = map;
+  }
+  return globalForBlocks.__nextly_blockSupports;
+}
+
+/** A block name is a namespaced slug, e.g. "core/heading". */
+const BLOCK_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/** A support key is a single lowerCamel/slug token. */
+const SUPPORT_KEY_RE = /^[a-zA-Z][a-zA-Z0-9]*$/;
+
+function fail(code: string, message: string): never {
+  throw new Error(`${code}: ${message}`);
+}
+
+/**
+ * Check one definition against the rules registration enforces. Split out so a
+ * caller can validate a definition without committing it to the registry.
+ */
+function assertValidDefinition(def: BlockDefinition): void {
+  if (typeof def.name !== "string" || !BLOCK_NAME_RE.test(def.name)) {
+    fail(
+      "NEXTLY_BLOCK_INVALID",
+      `block name "${String(def.name)}" must be a namespaced slug like "core/heading".`
+    );
+  }
+  if (!Number.isInteger(def.version) || def.version < 1) {
+    fail(
+      "NEXTLY_BLOCK_INVALID",
+      `block "${def.name}" must declare an integer version of at least 1.`
+    );
+  }
+  // description and example are required so generated documentation, palette
+  // entries, and previews are never empty for a registered block.
+  if (typeof def.description !== "string" || def.description.trim() === "") {
+    fail(
+      "NEXTLY_BLOCK_INVALID",
+      `block "${def.name}" must declare a non-empty description.`
+    );
+  }
+  if (
+    typeof def.example !== "object" ||
+    def.example === null ||
+    typeof def.example.props !== "object" ||
+    def.example.props === null
+  ) {
+    fail(
+      "NEXTLY_BLOCK_INVALID",
+      `block "${def.name}" must declare an example with props.`
+    );
+  }
+  if (typeof def.render !== "function") {
+    fail(
+      "NEXTLY_BLOCK_INVALID",
+      `block "${def.name}" must declare a render function.`
+    );
+  }
+
+  // A version above 1 means stored nodes exist at older versions; every step
+  // between must be covered or those nodes could never be upgraded.
+  const gaps = findMigrationGaps(1, def.version, def.migrate);
+  if (gaps.length > 0) {
+    fail(
+      "NEXTLY_BLOCK_MIGRATION_GAP",
+      `block "${def.name}" is at version ${def.version} but has no migration from version${
+        gaps.length > 1 ? "s" : ""
+      } ${gaps.join(", ")}. Add the missing step(s) so stored blocks can be upgraded.`
+    );
+  }
+
+  assertKnownSupports(def.name, def.supports);
+}
+
+function assertKnownSupports(
+  blockName: string,
+  supports: BlockSupports | undefined
+): void {
+  if (!supports) return;
+  const known = supportStore();
+  for (const key of Object.keys(supports)) {
+    if (!known.has(key)) {
+      fail(
+        "NEXTLY_BLOCK_UNKNOWN_SUPPORT",
+        `block "${blockName}" declares unknown support "${key}". Register it with registerSupport() first.`
+      );
+    }
+  }
+}
+
+/**
+ * Register block definitions. Called once per boot per source; a duplicate name
+ * within a boot is a collision, naming both sources so the conflict is
+ * actionable. Registration is all-or-nothing per call: the batch is validated
+ * before anything is stored, so a bad definition cannot leave the registry
+ * half-populated.
+ */
+export function registerBlocks(
+  definitions: BlockDefinition[],
+  options: RegisterOptions = {}
+): void {
+  const source = options.source ?? "app";
+  const map = blockStore();
+
+  const seenInBatch = new Set<string>();
+  for (const def of definitions) {
+    assertValidDefinition(def);
+    const existing = map.get(def.name);
+    if (existing) {
+      fail(
+        "NEXTLY_BLOCK_COLLISION",
+        `block "${def.name}" is already registered by "${existing.source}" and cannot be redefined by "${source}".`
+      );
+    }
+    if (seenInBatch.has(def.name)) {
+      fail(
+        "NEXTLY_BLOCK_COLLISION",
+        `block "${def.name}" is registered twice by "${source}".`
+      );
+    }
+    seenInBatch.add(def.name);
+  }
+
+  for (const def of definitions) map.set(def.name, { definition: def, source });
+}
+
+/**
+ * Add a style capability blocks may opt into. Third parties extend the support
+ * vocabulary through this rather than by editing the engine.
+ */
+export function registerSupport(support: SupportDefinition): void {
+  if (typeof support.key !== "string" || !SUPPORT_KEY_RE.test(support.key)) {
+    fail(
+      "NEXTLY_SUPPORT_INVALID",
+      `support key "${String(support.key)}" must be a single alphanumeric token.`
+    );
+  }
+  const map = supportStore();
+  if (map.has(support.key)) {
+    fail(
+      "NEXTLY_SUPPORT_COLLISION",
+      `support "${support.key}" is already registered.`
+    );
+  }
+  map.set(support.key, support);
+}
+
+/** A registered block definition, or `undefined`. */
+export function getBlock(name: string): BlockDefinition | undefined {
+  return blockStore().get(name)?.definition;
+}
+
+export function hasBlock(name: string): boolean {
+  return blockStore().has(name);
+}
+
+/** Every registered block definition. */
+export function allBlocks(): BlockDefinition[] {
+  return [...blockStore().values()].map(entry => entry.definition);
+}
+
+/** Which source registered a block, for diagnostics. */
+export function getBlockSource(name: string): string | undefined {
+  return blockStore().get(name)?.source;
+}
+
+export function getSupport(key: string): SupportDefinition | undefined {
+  return supportStore().get(key);
+}
+
+export function allSupports(): SupportDefinition[] {
+  return [...supportStore().values()];
+}
+
+/**
+ * Drop every registered block and reset supports to the built-ins. Called at
+ * the start of each boot (and by tests) so re-registration is idempotent.
+ */
+export function clearBlocks(): void {
+  blockStore().clear();
+  globalForBlocks.__nextly_blockSupports = undefined;
+}
+
+/**
+ * The registry as the block-type lookup validation expects, so validating a
+ * document against the running app's blocks needs no adapter at the call site.
+ * Reads through to the live registry, so it stays correct across a re-register.
+ */
+export function registryLookup(): BlockTypeLookup {
+  return { has: hasBlock };
+}
+
+/**
+ * The registry as the migration source, exposing each block's current version
+ * and upgrade steps so a stored document can be brought up to date.
+ */
+export function registryMigrationSource(): MigrationSource {
+  return {
+    get: name => {
+      const definition = getBlock(name);
+      if (!definition) return undefined;
+      return { version: definition.version, migrate: definition.migrate };
+    },
+  };
+}

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { BlockDocument, BreakpointSet } from "./document";
+import { documentBytes } from "./limits";
 import {
   FIXTURE_BREAKPOINTS,
   VALIDATION_FIXTURES,
@@ -627,6 +628,74 @@ describe("byte measurement counts JSON escaping", () => {
       limits: { maxDepth: 12, maxNodes: 5000, maxBytes: 1000 },
     });
     expect(issues.some(i => i.code === "document-too-large")).toBe(true);
+  });
+});
+
+describe("byte estimation agrees with real serialization", () => {
+  // Strings that exercise every escape path: short escapes, other control
+  // characters, quote/backslash, multi-byte, an emoji (surrogate PAIR), and
+  // lone surrogates (which JSON escapes rather than encoding as UTF-8).
+  const tricky = [
+    "plain ascii",
+    "tabs\tand\nnewlines\r\f\b",
+    "",
+    'quote " and backslash \\',
+    "café — ünïcodé",
+    "emoji 👋🏽 家",
+    `lone high \ud800 and low \udc00`,
+  ];
+
+  for (const text of tricky) {
+    it(`matches JSON.stringify size for ${JSON.stringify(text).slice(0, 28)}`, () => {
+      const doc: BlockDocument = {
+        formatVersion: 1,
+        kind: "page",
+        nodes: [{ id: "n1", type: "core/text", version: 1, props: { text } }],
+      };
+      // documentBytes serializes for real; the validator's internal estimate
+      // must not disagree about which side of the cap the document falls on.
+      const actual = documentBytes(doc);
+      const underCap = validate(doc, {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode: "strict",
+        limits: { maxDepth: 12, maxNodes: 5000, maxBytes: actual + 200 },
+      });
+      expect(underCap.some(i => i.code === "document-too-large")).toBe(false);
+
+      const overCap = validate(doc, {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        mode: "strict",
+        limits: {
+          maxDepth: 12,
+          maxNodes: 5000,
+          maxBytes: Math.floor(actual / 2),
+        },
+      });
+      expect(overCap.some(i => i.code === "document-too-large")).toBe(true);
+    });
+  }
+
+  it("does not reject a newline-heavy document that is well under the cap", () => {
+    // Newlines serialize as two-byte short escapes, so ~60k of them is ~120KB
+    // and must stay far below a 2 MiB cap.
+    const doc: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: { text: "\n".repeat(60_000) },
+        },
+      ],
+    };
+    const issues = validate(doc, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      mode: "strict",
+      limits: { maxDepth: 12, maxNodes: 5000, maxBytes: 2 * 1024 * 1024 },
+    });
+    expect(issues.some(i => i.code === "document-too-large")).toBe(false);
   });
 });
 

--- a/packages/blocks-engine/src/validation.test.ts
+++ b/packages/blocks-engine/src/validation.test.ts
@@ -555,6 +555,81 @@ describe("validation never throws on adversarial input", () => {
   });
 });
 
+describe("engine-owned node types", () => {
+  it("does not report a component instance as an unregistered block", () => {
+    // A registry holds authored blocks; the component-instance type is the
+    // engine's own and would never appear in one.
+    const doc: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "nextly/component-instance",
+          version: 1,
+          props: { componentId: "cmp-1" },
+        },
+      ],
+    };
+    const issues = validate(doc, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      mode: "strict",
+      registry: { has: () => false },
+    });
+    expect(issues).toEqual([]);
+  });
+});
+
+describe("dom id collisions", () => {
+  it("does not report one node as colliding with itself", () => {
+    // cssId and attributes.id on the SAME node render one id, not two.
+    const doc: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: {},
+          cssId: "hero",
+          attributes: { id: "hero" },
+        },
+      ],
+    };
+    const issues = validate(doc, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      mode: "strict",
+    });
+    expect(issues.filter(i => i.code === "duplicate-dom-id")).toEqual([]);
+  });
+});
+
+describe("byte measurement counts JSON escaping", () => {
+  it("measures escape-heavy strings at their serialized size", () => {
+    // 400 control characters serialize as \uXXXX (6 bytes each ≈ 2400), which
+    // must exceed a 1000-byte cap even though the raw string is only 400 chars.
+    const doc = invalidDoc({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n1",
+          type: "core/text",
+          version: 1,
+          props: { text: "\u0001".repeat(400) },
+        },
+      ],
+    });
+    const issues = validate(doc, {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      mode: "strict",
+      limits: { maxDepth: 12, maxNodes: 5000, maxBytes: 1000 },
+    });
+    expect(issues.some(i => i.code === "document-too-large")).toBe(true);
+  });
+});
+
 describe("unknown kind severity follows the mode", () => {
   it("errors in strict, warns in forgiving", () => {
     const doc = invalidDoc({ formatVersion: 1, kind: "widget", nodes: [] });
@@ -570,6 +645,20 @@ describe("unknown kind severity follows the mode", () => {
     expect(forgiving.find(i => i.code === "invalid-kind")?.severity).toBe(
       "warning"
     );
+  });
+
+  it("treats a missing or non-string kind as structural corruption in both modes", () => {
+    for (const badKind of [undefined, 5, null]) {
+      for (const mode of ["strict", "forgiving"] as const) {
+        const issues = validate(
+          invalidDoc({ formatVersion: 1, kind: badKind, nodes: [] }),
+          { breakpoints: FIXTURE_BREAKPOINTS, mode }
+        );
+        expect(issues.find(i => i.code === "invalid-kind")?.severity).toBe(
+          "error"
+        );
+      }
+    }
   });
 });
 

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -373,16 +373,34 @@ function utf8ByteLength(s: string, budget: number): number {
   for (let i = 0; i < s.length; i++) {
     const code = s.charCodeAt(i);
     if (code < 0x80) {
-      // Serialized size counts JSON escaping: a control character becomes a
-      // six-byte \uXXXX escape and a quote or backslash becomes two bytes, so
-      // counting one byte each would under-measure an escape-heavy string.
-      if (code < 0x20) bytes += 6;
+      // Serialized size counts JSON escaping. Backspace, tab, newline, form
+      // feed, and carriage return have two-byte short escapes; other control
+      // characters expand to a six-byte \uXXXX; quote and backslash are two.
+      if (
+        code === 0x08 ||
+        code === 0x09 ||
+        code === 0x0a ||
+        code === 0x0c ||
+        code === 0x0d
+      ) {
+        bytes += 2;
+      } else if (code < 0x20) bytes += 6;
       else if (code === 0x22 || code === 0x5c) bytes += 2;
       else bytes += 1;
     } else if (code < 0x800) bytes += 2;
     else if (code >= 0xd800 && code <= 0xdbff) {
-      bytes += 4; // surrogate pair → one 4-byte code point
-      i++;
+      // A high surrogate is a 4-byte code point only when a low surrogate
+      // follows. A lone one is not valid UTF-8 and serializes as a six-byte
+      // \uXXXX escape, and must not consume the next unit.
+      const next = s.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4;
+        i++;
+      } else {
+        bytes += 6;
+      }
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      bytes += 6; // lone low surrogate → \uXXXX
     } else bytes += 3;
     if (bytes > budget) return bytes;
   }

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -119,6 +119,13 @@ function pointer(parent: string, token: string | number): string {
 /** A node type is a namespaced slug, e.g. "core/heading". */
 const NODE_TYPE_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
+/**
+ * Node types the engine defines itself rather than blocks a registry holds.
+ * They are structurally valid and resolved by their own machinery, so a
+ * registry miss on one of them is not an unknown type.
+ */
+const ENGINE_NODE_TYPES = new Set<string>([COMPONENT_INSTANCE_TYPE]);
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -196,14 +203,16 @@ export function validate(
     });
   }
 
-  // An unknown kind is preserved in forgiving mode (a warning) and rejected in
-  // strict mode, matching the unknown-block-type policy.
+  // An unrecognized kind STRING is preserved in forgiving mode (a warning) and
+  // rejected in strict mode, matching the unknown-block-type policy. A missing
+  // or non-string kind is structural corruption, not a future value to
+  // preserve, so it is always an error.
   const kind = rawDoc.kind;
   if (!DOCUMENT_KINDS.includes(kind as (typeof DOCUMENT_KINDS)[number])) {
     issues.push({
       path: "/kind",
       code: "invalid-kind",
-      severity: unknownSeverity,
+      severity: typeof kind === "string" ? unknownSeverity : "error",
       message: `Unknown document kind "${describeValue(kind)}".`,
       suggestion: `Use one of: ${DOCUMENT_KINDS.join(", ")}.`,
     });
@@ -363,8 +372,14 @@ function utf8ByteLength(s: string, budget: number): number {
   let bytes = 0;
   for (let i = 0; i < s.length; i++) {
     const code = s.charCodeAt(i);
-    if (code < 0x80) bytes += 1;
-    else if (code < 0x800) bytes += 2;
+    if (code < 0x80) {
+      // Serialized size counts JSON escaping: a control character becomes a
+      // six-byte \uXXXX escape and a quote or backslash becomes two bytes, so
+      // counting one byte each would under-measure an escape-heavy string.
+      if (code < 0x20) bytes += 6;
+      else if (code === 0x22 || code === 0x5c) bytes += 2;
+      else bytes += 1;
+    } else if (code < 0x800) bytes += 2;
     else if (code >= 0xd800 && code <= 0xdbff) {
       bytes += 4; // surrogate pair → one 4-byte code point
       i++;
@@ -529,12 +544,18 @@ function validateNode(
       severity: "error",
       message: `Node type "${describeValue(node.type)}" must be a namespaced slug like "core/heading".`,
     });
-  } else if (state.ctx.registry && !state.ctx.registry.has(node.type)) {
+  } else if (
+    state.ctx.registry &&
+    // Engine-owned synthetic types are not registrable blocks and so are never
+    // present in a block registry; exempt them from the registration check.
+    !ENGINE_NODE_TYPES.has(node.type) &&
+    !state.ctx.registry.has(node.type)
+  ) {
     issues.push({
       path: pointer(path, "type"),
       code: "unknown-node-type",
       severity: state.unknownSeverity,
-      message: `Node type "${node.type}" is not registered.`,
+      message: `Node type "${describeValue(node.type)}" is not registered.`,
       suggestion: "Register the block or remove the node.",
     });
   }
@@ -610,6 +631,10 @@ function validateDomIds(
   if (isPlainObject(node.attributes)) {
     for (const [key, value] of Object.entries(node.attributes)) {
       if (key.toLowerCase() === "id" && typeof value === "string" && value) {
+        // One node setting the same id through both `cssId` and `attributes.id`
+        // renders a single id, so it must not be reported as colliding with
+        // itself; only a second NODE claiming the id is a duplicate.
+        if (value === node.cssId) continue;
         report(value, pointer(pointer(path, "attributes"), key));
       }
     }
@@ -699,7 +724,7 @@ function validateAttributes(
         path: pointer(pointer(path, "attributes"), key),
         code: "invalid-attributes",
         severity: "error",
-        message: `Attribute "${key}" is an event handler; inline JavaScript is not allowed.`,
+        message: `Attribute "${describeValue(key)}" is an event handler; inline JavaScript is not allowed.`,
       });
     }
   }


### PR DESCRIPTION
## What

PR-4 of the page-builder rebuild (Plan-01; follows #320, #324, #325). Two commits, reviewable separately.

### 1. `defineBlock` + the boot registry (`feat`)

**`defineBlock`** declares one block type: schema `version` + `migrate` steps, `props` schemas, `defaultProps`, `localized` prop names, **`baseStyles`** (the shared per-type style tier from the styling decision), `slots` (with `allow` / `template` / `lock`), `supports`, one `render`, optional `resolve`, and `editor` metadata (never serialized). `description` and `example` are **required**. It's a typed identity function: it binds the prop type once so props/example/defaults/render are checked against each other, and `InferBlockProps<D>` reads that type back.

**The registry** follows the existing `field-type-registry` pattern: `globalThis`-pinned and cleared per boot, so an HMR re-register is idempotent while a genuine duplicate inside one boot fails loudly. Registration is the gate:

- `NEXTLY_BLOCK_INVALID` — non-namespaced name, bad version, missing description/example/render
- `NEXTLY_BLOCK_COLLISION` — duplicate name, **naming both sources** so the conflict is actionable
- `NEXTLY_BLOCK_MIGRATION_GAP` — **wires `findMigrationGaps` from #325**: a block at version N with no covering upgrade step is refused, because its stored nodes could never be upgraded
- `NEXTLY_BLOCK_UNKNOWN_SUPPORT` — a block opting into a capability nobody registered

Registration is **all-or-nothing per call** — the batch is validated before anything is stored, so a bad definition can't half-populate the registry. `registerSupport()` is the public extension point (12 built-in capabilities ship seeded, and a clear restores them).

**Adapters tie the series together**: `registryLookup()` satisfies validation's `BlockTypeLookup` and `registryMigrationSource()` satisfies migration's `MigrationSource`, both reading through to the live registry — so #324's validation and #325's migrations now run against real blocks with no glue at the call site.

Framework-agnostic by construction: `render`'s return type is opaque here, so the package stays dependency-free (the React binding narrows it).

### 2. Validation follow-ups (`fix`)

The small items logged during #324's review, folded in here since this PR already touches validation:

- **Component instances are no longer reported as unregistered blocks** — engine-owned synthetic types are exempt from the registry check (this one was required by the registry work).
- **Missing/non-string `kind` is now always an error**, not a mode-sensitive warning — an absent kind is corruption, not a future value to preserve.
- **A node setting the same id via both `cssId` and `attributes.id` no longer collides with itself** (one element, one id).
- **Byte measurement counts JSON escaping** — control characters serialize as 6-byte `\uXXXX`, so an escape-heavy string is no longer under-measured against the size cap.
- Unbounded untrusted values in two more messages (node type, attribute name) now go through the bounded formatter.

## Tests (143 total, all green)

New registry suite: `defineBlock` prop-type inference (`expectTypeOf`), every registration rule, collision messaging, all-or-nothing batches, built-in + custom supports, clear-and-rebuild/HMR, and the two adapters driving real `validate()` / `migrateDocument()` calls. Plus four validation tests for the follow-ups above.

Local: type-check + lint clean; `@nextlyhq/blocks-engine` 143 tests pass; full repo build green. One changeset (all packages, patch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public API for defining, registering, and discovering content blocks.
  * Added support for block metadata, variations, rendering, migrations, slots, and capability settings.
  * Added registry tools for block and support management.

* **Bug Fixes**
  * Improved validation of invalid block types and serialized document size.
  * Prevented false duplicate-ID and unknown engine-node warnings.
  * Improved safety when displaying invalid attribute names.

* **Tests**
  * Expanded coverage for block registration, validation, migrations, and registry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->