### PR TITLE
fix(release): make the publish train complete or fail loudly

### DIFF
--- a/.claude/skills/release-and-changesets/SKILL.md
+++ b/.claude/skills/release-and-changesets/SKILL.md
@@ -43,6 +43,59 @@ file by hand under `.changeset/` following an existing one.
   the Version PR suddenly lists ancient entries, check for resurrected
   `.changeset/*.md` files and delete them in a cleanup PR.
 - The npm `latest` dist-tag for the unscoped packages is managed manually
-  after publishes; a publish alone does not move it.
+  after publishes; a publish alone does not move it. Only move it once a
+  release is verified complete: promoting a partial train points a bare
+  `npm install` at a version whose siblings never shipped.
 - If the Version PR looks wrong, fix the inputs (changeset files on main);
   never edit the Version PR's generated diff by hand.
+
+## A publish is not atomic
+
+`changeset publish` pushes packages one at a time. When one fails, the rest
+are already live and cannot be unpublished, so a release can end up split
+across versions. Two guards exist:
+
+- `pnpm release:preflight` runs first inside `release:publish`. It refuses to
+  start when a package has incomplete publish metadata, when the versions are
+  not in lockstep, or when a package name has never been published (see
+  bootstrapping below). It costs one registry lookup per package and saves a
+  ten-minute build that could only end in a half-release.
+- `pnpm release:verify` runs after publishing and compares the registry to the
+  workspace. The consolidated tag and GitHub Release are created only when it
+  passes, so git and npm cannot disagree about what shipped.
+
+Run either by hand at any time; both are read-only.
+
+## Recovering a partial release
+
+Publishing is resumable: `changeset publish` skips versions the registry
+already has, so a re-run only attempts the missing packages.
+
+1. `pnpm release:verify` to list exactly which packages are missing and why.
+2. Fix the cause per package (metadata, npm access, trusted publisher).
+3. Re-run the release workflow. The already-published packages are skipped.
+4. Do not bump the version to "get a clean run": that abandons the partial
+   version permanently, leaving a hole where some packages exist at a version
+   and their siblings never do.
+
+## Bootstrapping a brand-new package
+
+A trusted publisher is configured per package on npmjs.com, and it can only be
+attached to a package that exists. A new package therefore cannot publish
+through the normal OIDC flow on its first release, which surfaces as a `404
+… could not be found or you do not have permission to access it`.
+
+For each new package name, in order:
+
+1. Confirm the manifest carries `license`, `repository.directory`,
+   `engines.node`, and `publishConfig.access: "public"`. A scoped package
+   without `access: "public"` is published as restricted and fails.
+2. Make the first publish deliberately, then add the package's Trusted
+   Publisher entry on npmjs.com (repository `nextlyhq/nextly`, workflow
+   `release.yml`, environment `Production` — the environment name must match
+   the workflow's `environment:` exactly).
+3. Re-run the release so the package rejoins the train.
+
+`NEXTLY_RELEASE_ALLOW_BOOTSTRAP=1` relaxes the preflight check for that first
+publish only. Adding a package to the `fixed[]` group without doing this is
+what makes the _next_ release fail.

--- a/.claude/skills/release-and-changesets/SKILL.md
+++ b/.claude/skills/release-and-changesets/SKILL.md
@@ -90,12 +90,25 @@ For each new package name, in order:
 1. Confirm the manifest carries `license`, `repository.directory`,
    `engines.node`, and `publishConfig.access: "public"`. A scoped package
    without `access: "public"` is published as restricted and fails.
-2. Make the first publish deliberately, then add the package's Trusted
-   Publisher entry on npmjs.com (repository `nextlyhq/nextly`, workflow
-   `release.yml`, environment `Production` — the environment name must match
-   the workflow's `environment:` exactly).
-3. Re-run the release so the package rejoins the train.
+2. Claim the name with a placeholder that contains no code:
 
-`NEXTLY_RELEASE_ALLOW_BOOTSTRAP=1` relaxes the preflight check for that first
-publish only. Adding a package to the `fixed[]` group without doing this is
-what makes the _next_ release fail.
+   ```sh
+   npm login
+   node scripts/release/bootstrap-package.mjs @nextlyhq/<name>            # shows the plan
+   node scripts/release/bootstrap-package.mjs @nextlyhq/<name> --publish  # claims 0.0.0
+   ```
+
+   The helper refuses to run against a name that already exists, and publishes
+   only a `package.json` and a README. Real versions are always published by
+   CI. (`nextly` itself was claimed this way with a `0.0.1` stub.)
+
+3. Add the package's Trusted Publisher entry at
+   `https://www.npmjs.com/package/<name>/access`: repository `nextlyhq/nextly`,
+   workflow `release.yml`, environment `Production`. The environment name must
+   match the release workflow's `environment:` exactly, or publishing fails
+   with the same 404.
+4. Re-run the release so the package rejoins the train.
+
+`NEXTLY_RELEASE_ALLOW_BOOTSTRAP=1` relaxes the preflight check when CI itself
+should attempt a first publish. Adding a package to the `fixed[]` group without
+completing the steps above is what makes the _next_ release fail.

--- a/.claude/skills/release-and-changesets/SKILL.md
+++ b/.claude/skills/release-and-changesets/SKILL.md
@@ -73,10 +73,19 @@ already has, so a re-run only attempts the missing packages.
 
 1. `pnpm release:verify` to list exactly which packages are missing and why.
 2. Fix the cause per package (metadata, npm access, trusted publisher).
-3. Re-run the release workflow. The already-published packages are skipped.
+3. Land a commit on `main` that adds no new changeset. In prerelease mode the
+   `.changeset/*.md` files stay on disk after versioning, but the ones already
+   recorded in `pre.json.changesets` do not count as pending, so the action takes
+   the publish path and retries the current version. Adding a changeset instead
+   opens a Version PR and moves the train to the next version.
 4. Do not bump the version to "get a clean run": that abandons the partial
    version permanently, leaving a hole where some packages exist at a version
    and their siblings never do.
+
+Finalization (the consolidated tag and GitHub Release) is gated on the registry
+being complete, not on whether a particular run published something, so a
+recovery run still creates the tag for a release whose packages were published
+earlier.
 
 ## Bootstrapping a brand-new package
 
@@ -109,6 +118,12 @@ For each new package name, in order:
    with the same 404.
 4. Re-run the release so the package rejoins the train.
 
-`NEXTLY_RELEASE_ALLOW_BOOTSTRAP=1` relaxes the preflight check when CI itself
-should attempt a first publish. Adding a package to the `fixed[]` group without
-completing the steps above is what makes the _next_ release fail.
+There is no CI-only path for step 2, and no override for it: OIDC cannot perform
+a package's first publish, and giving CI a long-lived npm token just to claim a
+name would replace short-lived trusted publishing with a standing credential.
+The helper refuses to publish when `CI` is set for that reason. Preflight blocks
+the whole release until the name exists, which is deliberate: the alternative is
+publishing the rest of the train and stranding this package.
+
+Adding a package to the `fixed[]` group without completing the steps above is
+what makes the _next_ release fail.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,28 +103,39 @@ jobs:
       # even when some of them failed, so the only way to know a release is
       # whole is to ask the registry afterwards. Failing here stops the tag and
       # the GitHub Release from being created, which is what keeps npm, git and
-      # the Releases page describing the same release. Publishing is resumable:
-      # re-running skips versions the registry already has.
+      # the Releases page describing the same release.
+      #
+      # Gated on `hasChangesets == 'false'` (this run took the publish path)
+      # rather than on `published == 'true'` (this run published something new).
+      # The two differ during recovery: publishing is resumable, so a re-run
+      # after a partial release skips the versions npm already has and reports
+      # nothing newly published. Keying off `published` would then skip both
+      # verification and finalization forever, leaving a complete npm release
+      # with no tag and no GitHub Release. Both steps below are idempotent, so
+      # running them on an already-finalized release is a no-op.
       - name: Verify every package reached the registry
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.hasChangesets == 'false'
         run: pnpm release:verify
 
       - name: Create consolidated GitHub Release
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.hasChangesets == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
-          PUBLISHED: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
           set -euo pipefail
 
-          # Published packages share a version via `fixed[]`, so the first
-          # entry's version is the canonical monorepo version.
-          VERSION=$(echo "$PUBLISHED" | jq -r '.[0].version')
+          # Build the notes from the workspace manifest, not from the publish
+          # step's output. On a recovery run that output lists only the
+          # stragglers it just published, which would produce a release claiming
+          # three packages shipped and omit the rest of the train's changelogs.
+          # Verification above has already confirmed the whole manifest is live.
+          MANIFEST=$(node scripts/release/manifest.mjs)
+
+          # Every publishable package shares a version via `fixed[]`, so the
+          # first entry's version is the canonical monorepo version.
+          VERSION=$(echo "$MANIFEST" | jq -r '.[0].version')
           TAG="v${VERSION}"
-          # Count the packages that actually published rather than restating a
-          # number in prose: hand-maintained counts drift as packages join the
-          # release train.
-          PKG_COUNT=$(echo "$PUBLISHED" | jq -r 'length')
+          PKG_COUNT=$(echo "$MANIFEST" | jq -r 'length')
 
           # Build the release notes by extracting each package's CHANGELOG
           # section for this version and concatenating them under one
@@ -135,7 +146,7 @@ jobs:
             echo
             echo "## What's changed"
             echo
-            for pkg in $(echo "$PUBLISHED" | jq -r '.[].name'); do
+            for pkg in $(echo "$MANIFEST" | jq -r '.[].name'); do
               pkg_dir="packages/${pkg#@nextlyhq/}"
               CHANGELOG="${pkg_dir}/CHANGELOG.md"
               if [[ -f "$CHANGELOG" ]]; then
@@ -173,15 +184,18 @@ jobs:
             RELEASE_FLAG="--latest"
           fi
 
-          # Idempotent: skip if the release already exists (e.g. a previous
-          # workflow run partially completed)
+          # Idempotent: skip if the release already exists. This step now also
+          # runs on pushes after a release is finalized, so "already done" is a
+          # normal outcome rather than a sign something went wrong.
           if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release $TAG already exists; skipping creation"
+            echo "Release $TAG already exists; nothing to finalize"
           else
-            # Create the unified tag pointing at the publish commit, then
-            # the GitHub Release on top of it
-            git tag "$TAG"
-            git push origin "$TAG"
+            # The tag is created separately from the release, so a previous run
+            # can have pushed it without getting as far as the release.
+            if ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+              git tag "$TAG"
+            fi
+            git push origin "$TAG" || echo "Tag $TAG already on origin"
             gh release create "$TAG" \
               --title "$TAG" \
               --notes-file "$NOTES_FILE" \
@@ -190,7 +204,7 @@ jobs:
 
           # Mirror the notes into the workflow run summary for visibility
           echo "## Released $TAG" >> $GITHUB_STEP_SUMMARY
-          echo '${{ steps.changesets.outputs.publishedPackages }}' \
+          echo "$MANIFEST" \
             | jq -r '.[] | "- **\(.name)** @ `\(.version)`"' \
             >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,9 @@ jobs:
     environment: Production
 
     permissions:
-      contents: write       # create git tags + GitHub Releases
-      pull-requests: write  # open "Version Packages" PR
-      id-token: write       # OIDC token for npm Trusted Publishing (also covers provenance)
+      contents: write # create git tags + GitHub Releases
+      pull-requests: write # open "Version Packages" PR
+      id-token: write # OIDC token for npm Trusted Publishing (also covers provenance)
 
     steps:
       - name: Checkout
@@ -89,16 +89,25 @@ jobs:
           commit: "chore: version packages"
           title: "chore: version packages"
           # Disabled: per-package GitHub Releases (one for every published
-          # package, 12 per cycle: nextly + create-nextly-app + 10 @nextlyhq/*)
-          # made the Releases sidebar noisy and put whichever package
-          # timestamped last as "Latest". The consolidated release step below
-          # creates ONE `vX.Y.Z` release per cycle that matches our `fixed[]`
-          # lockstep model and Payload's release style.
+          # package in the train) made the Releases sidebar noisy and put
+          # whichever package timestamped last as "Latest". The consolidated
+          # release step below creates ONE `vX.Y.Z` release per cycle that
+          # matches our `fixed[]` lockstep model and Payload's release style.
           createGithubReleases: false
 
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
           TURBO_CACHE_DIR: .turbo
+
+      # `changeset publish` pushes packages one at a time and reports success
+      # even when some of them failed, so the only way to know a release is
+      # whole is to ask the registry afterwards. Failing here stops the tag and
+      # the GitHub Release from being created, which is what keeps npm, git and
+      # the Releases page describing the same release. Publishing is resumable:
+      # re-running skips versions the registry already has.
+      - name: Verify every package reached the registry
+        if: steps.changesets.outputs.published == 'true'
+        run: pnpm release:verify
 
       - name: Create consolidated GitHub Release
         if: steps.changesets.outputs.published == 'true'
@@ -108,17 +117,21 @@ jobs:
         run: |
           set -euo pipefail
 
-          # All 12 packages share a version via `fixed[]`, so the first
+          # Published packages share a version via `fixed[]`, so the first
           # entry's version is the canonical monorepo version.
           VERSION=$(echo "$PUBLISHED" | jq -r '.[0].version')
           TAG="v${VERSION}"
+          # Count the packages that actually published rather than restating a
+          # number in prose: hand-maintained counts drift as packages join the
+          # release train.
+          PKG_COUNT=$(echo "$PUBLISHED" | jq -r 'length')
 
           # Build the release notes by extracting each package's CHANGELOG
           # section for this version and concatenating them under one
           # "What's changed" heading.
           NOTES_FILE=$(mktemp)
           {
-            echo "Released all 12 packages at \`${VERSION}\` in lockstep (\`nextly\`, \`create-nextly-app\`, and 10 \`@nextlyhq/*\` packages)."
+            echo "Released ${PKG_COUNT} packages at \`${VERSION}\` in lockstep."
             echo
             echo "## What's changed"
             echo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,13 +190,36 @@ jobs:
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists; nothing to finalize"
           else
-            # The tag is created separately from the release, so a previous run
-            # can have pushed it without getting as far as the release.
-            if ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-              git tag "$TAG"
+            # The tag has to point at the commit whose packages were published.
+            # `gh release create` creates a missing tag from the default branch,
+            # so if `main` moved while this ran, letting it fall back would tag a
+            # commit that was never released. Push the tag first and require it.
+            HEAD_SHA=$(git rev-parse HEAD)
+            # Peeled ref first so an annotated tag resolves to its commit.
+            REMOTE_TAG_SHA=$(git ls-remote origin "refs/tags/${TAG}^{}" | awk '{print $1}')
+            if [[ -z "$REMOTE_TAG_SHA" ]]; then
+              REMOTE_TAG_SHA=$(git ls-remote origin "refs/tags/${TAG}" | awk '{print $1}')
             fi
-            git push origin "$TAG" || echo "Tag $TAG already on origin"
+
+            if [[ -n "$REMOTE_TAG_SHA" && "$REMOTE_TAG_SHA" != "$HEAD_SHA" ]]; then
+              echo "::error::${TAG} already exists on origin at ${REMOTE_TAG_SHA}," \
+                "but this release was built from ${HEAD_SHA}."
+              exit 1
+            fi
+
+            if [[ -z "$REMOTE_TAG_SHA" ]]; then
+              # A previous run can have created the tag locally without pushing.
+              if ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+                git tag "$TAG"
+              fi
+              # No `|| true` here: pushing a tag that already matches the remote
+              # exits zero on its own, so a failure is a real failure (auth, tag
+              # protection, network) and must stop the release.
+              git push origin "refs/tags/${TAG}"
+            fi
+
             gh release create "$TAG" \
+              --verify-tag \
               --title "$TAG" \
               --notes-file "$NOTES_FILE" \
               $RELEASE_FLAG

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,14 @@ Before editing a package, read its README.md and check for a nested AGENTS.md.
 - Test-only, CI-only, or docs-only PRs get NO changeset.
 - Releases are CI-only: the Changesets bot opens a Version PR, and merging it
   publishes via npm trusted publishing. Never attempt to publish locally.
+- ONE narrow exception, for claiming a package name that does not exist on npm
+  yet: npm can only attach a Trusted Publisher to a package that already exists,
+  and OIDC cannot make a package's first publish, so a new package cannot
+  bootstrap itself from CI. `scripts/release/bootstrap-package.mjs` publishes a
+  `0.0.0` placeholder containing no code (`package.json` + `README` only) to
+  claim the name; it refuses to run when `CI` is set, so this never becomes a
+  long-lived npm token in a workflow. Every real version still publishes only
+  from CI. Details: the `release-and-changesets` skill.
 
 ## Git and PR rules
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,12 +52,12 @@ Status updates are posted in the private thread until disclosure.
 
 ## Scope
 
-**In scope:** all packages under `packages/*` of this monorepo. Currently supported: the **`0.x`** series (beta).
+**In scope:** all packages under `packages/*` of this monorepo. Currently supported: the current **`0.0.x-alpha`** prerelease line. Nextly is in alpha: fixes land on the newest alpha release, and there is no backport window for older alphas.
 
 **Out of scope:**
 
 - Vulnerabilities in transitive dependencies that have no proven additional impact via Nextly's surface — please report those upstream first.
-- Versions older than the current `0.x` minor.
+- Alpha releases older than the current one.
 - Intentional misconfiguration (e.g. setting `security.trustProxy: true` without an `TRUSTED_PROXY_IPS` allowlist).
 - Social engineering and phishing of maintainers.
 - Denial of service via legitimate-but-expensive operations whose cost is bounded by configurable limits.

--- a/package.json
+++ b/package.json
@@ -64,7 +64,9 @@
     "_comment_release": "=== Release & Versioning ===",
     "changeset": "changeset",
     "release:version": "changeset version && pnpm install --no-frozen-lockfile",
-    "release:publish": "turbo build --filter='./packages/*' && changeset publish",
+    "release:preflight": "node scripts/release/preflight.mjs",
+    "release:verify": "node scripts/release/verify.mjs",
+    "release:publish": "pnpm release:preflight && turbo build --filter='./packages/*' && changeset publish",
     "release:status": "changeset status",
     "release:dry-run": "changeset publish --dry-run"
   },

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "release:version": "changeset version && pnpm install --no-frozen-lockfile",
     "release:preflight": "node scripts/release/preflight.mjs",
     "release:verify": "node scripts/release/verify.mjs",
+    "release:manifest": "node scripts/release/manifest.mjs",
     "release:publish": "pnpm release:preflight && turbo build --filter='./packages/*' && changeset publish",
     "release:status": "changeset status",
     "release:dry-run": "changeset publish --dry-run"

--- a/packages/admin-css/package.json
+++ b/packages/admin-css/package.json
@@ -2,6 +2,16 @@
   "name": "@nextlyhq/admin-css",
   "version": "0.0.2-alpha.40",
   "description": "Build tooling to scope and compile Nextly admin CSS (shared by the admin build and third-party plugins).",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nextlyhq/nextly.git",
+    "directory": "packages/admin-css"
+  },
+  "homepage": "https://nextlyhq.com/docs",
+  "bugs": {
+    "url": "https://github.com/nextlyhq/nextly/issues"
+  },
   "type": "module",
   "exports": {
     ".": "./src/index.mjs"
@@ -17,6 +27,9 @@
     "test": "vitest run",
     "lint": "eslint ."
   },
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "dependencies": {
     "@tailwindcss/cli": "^4.3.2"
   },
@@ -25,5 +38,16 @@
     "eslint": "^9.39.1",
     "tailwindcss": "^4.3.2",
     "vitest": "^4.1.0"
-  }
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
+  },
+  "keywords": [
+    "nextly",
+    "admin",
+    "css",
+    "tailwind"
+  ]
 }

--- a/scripts/release/bootstrap-package.mjs
+++ b/scripts/release/bootstrap-package.mjs
@@ -17,7 +17,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
 
-import { fetchRegistryState, getReleaseManifest } from "./lib.mjs";
+import { REGISTRY, fetchRegistryState, getReleaseManifest } from "./lib.mjs";
 
 const PLACEHOLDER_VERSION = "0.0.0";
 
@@ -71,6 +71,13 @@ async function main() {
 
   // The placeholder carries identity only. Publishing real code by hand is what
   // the release workflow is for, and a 0.0.0 keeps the alpha line untouched.
+  //
+  // The registry is pinned to the same one the existence check queried. npm runs
+  // this publish from a temporary directory, so the repository's .npmrc is not in
+  // its config chain: a user-level or scope-level registry default would
+  // otherwise send the placeholder to a corporate registry while the check above
+  // looked at npmjs, claiming nothing and reporting success.
+  const registry = entry.pkg.publishConfig?.registry ?? `${REGISTRY}/`;
   const placeholder = {
     name: entry.name,
     version: PLACEHOLDER_VERSION,
@@ -79,7 +86,7 @@ async function main() {
     repository: entry.pkg.repository,
     homepage: entry.pkg.homepage,
     bugs: entry.pkg.bugs,
-    publishConfig: { access: "public" },
+    publishConfig: { access: "public", registry },
   };
 
   const readme =
@@ -93,6 +100,7 @@ async function main() {
 
   console.log(`Bootstrap ${entry.name}@${PLACEHOLDER_VERSION}`);
   console.log("  contents: package.json + README.md only (no code)");
+  console.log(`  registry: ${registry}`);
   console.log(`  workspace version (published later by CI): ${entry.version}`);
 
   if (!shouldPublish) {
@@ -112,10 +120,14 @@ async function main() {
 
   console.log(`\nPublishing from ${stageDir} ...`);
   try {
-    execFileSync("npm", ["publish", "--access", "public"], {
-      cwd: stageDir,
-      stdio: "inherit",
-    });
+    execFileSync(
+      "npm",
+      ["publish", "--access", "public", "--registry", registry],
+      {
+        cwd: stageDir,
+        stdio: "inherit",
+      }
+    );
   } catch {
     fail(
       "\nPublish failed. Common causes: not logged in (`npm login`), or the\n" +

--- a/scripts/release/bootstrap-package.mjs
+++ b/scripts/release/bootstrap-package.mjs
@@ -1,0 +1,127 @@
+// Claims a new package name on npm so trusted publishing can be configured for
+// it. npm requires a package to exist before a Trusted Publisher entry can be
+// attached, and OIDC cannot perform a package's first publish, so a brand-new
+// package cannot bootstrap itself from CI. This publishes a minimal 0.0.0
+// placeholder containing no code, which is the documented way out of that
+// deadlock (`nextly` itself was claimed the same way).
+//
+// Usage:
+//   node scripts/release/bootstrap-package.mjs @nextlyhq/admin-css            # dry run
+//   node scripts/release/bootstrap-package.mjs @nextlyhq/admin-css --publish  # for real
+//
+// After it succeeds, add the package's Trusted Publisher entry on npmjs.com and
+// let the normal release workflow publish every real version from then on.
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { fetchRegistryState, getReleaseManifest } from "./lib.mjs";
+
+const PLACEHOLDER_VERSION = "0.0.0";
+
+const args = process.argv.slice(2);
+const shouldPublish = args.includes("--publish");
+const target = args.find(arg => !arg.startsWith("--"));
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+async function main() {
+  if (!target) {
+    fail(
+      "Usage: node scripts/release/bootstrap-package.mjs <package-name> [--publish]"
+    );
+  }
+
+  const entry = getReleaseManifest().find(pkg => pkg.name === target);
+  if (!entry) {
+    fail(
+      `${target} is not a publishable package in this workspace.\n` +
+        "Publishable packages are the non-private ones under packages/."
+    );
+  }
+
+  // Refuse to touch a name that already exists: this script exists only to
+  // create the very first version, and re-running it against a live package
+  // would try to publish a 0.0.0 over real history.
+  const state = await fetchRegistryState(target);
+  if (state !== null) {
+    fail(
+      `${target} already exists on npm (versions: ${state.versions.join(", ")}).\n` +
+        "Nothing to bootstrap. Configure its Trusted Publisher on npmjs.com instead."
+    );
+  }
+
+  // The placeholder carries identity only. Publishing real code by hand is what
+  // the release workflow is for, and a 0.0.0 keeps the alpha line untouched.
+  const placeholder = {
+    name: entry.name,
+    version: PLACEHOLDER_VERSION,
+    description: `Placeholder to claim the ${entry.name} package name. Install a published alpha instead.`,
+    license: entry.pkg.license,
+    repository: entry.pkg.repository,
+    homepage: entry.pkg.homepage,
+    bugs: entry.pkg.bugs,
+    publishConfig: { access: "public" },
+  };
+
+  const readme =
+    `# ${entry.name}\n\n` +
+    `Placeholder release. This version contains no code: it exists so that npm ` +
+    `trusted publishing can be configured for the package name.\n\n` +
+    `Install a real release from the alpha channel instead:\n\n` +
+    "```sh\n" +
+    `npm install ${entry.name}@alpha\n` +
+    "```\n";
+
+  console.log(`Bootstrap ${entry.name}@${PLACEHOLDER_VERSION}`);
+  console.log("  contents: package.json + README.md only (no code)");
+  console.log(`  workspace version (published later by CI): ${entry.version}`);
+
+  if (!shouldPublish) {
+    console.log(
+      "\nDry run. Nothing was published.\n" +
+        "Re-run with --publish to claim the name (requires `npm login` first)."
+    );
+    return;
+  }
+
+  const stageDir = mkdtempSync(join(tmpdir(), "nextly-bootstrap-"));
+  writeFileSync(
+    join(stageDir, "package.json"),
+    `${JSON.stringify(placeholder, null, 2)}\n`
+  );
+  writeFileSync(join(stageDir, "README.md"), readme);
+
+  console.log(`\nPublishing from ${stageDir} ...`);
+  try {
+    execFileSync("npm", ["publish", "--access", "public"], {
+      cwd: stageDir,
+      stdio: "inherit",
+    });
+  } catch {
+    fail(
+      "\nPublish failed. Common causes: not logged in (`npm login`), or the\n" +
+        "account lacks publish rights on the @nextlyhq scope."
+    );
+  }
+
+  console.log(
+    `\n${entry.name}@${PLACEHOLDER_VERSION} published.\n\n` +
+      "Next, before the release workflow can publish it:\n" +
+      `  1. Open https://www.npmjs.com/package/${entry.name}/access\n` +
+      "  2. Add a Trusted Publisher: repository nextlyhq/nextly, workflow\n" +
+      "     release.yml, environment Production (the environment name must match\n" +
+      "     the release workflow's `environment:` exactly).\n" +
+      "  3. Re-run the release. Publishing is resumable, so only the packages\n" +
+      "     still missing from the registry are attempted."
+  );
+}
+
+main().catch(error => {
+  fail(`bootstrap failed: ${error.message}`);
+});

--- a/scripts/release/bootstrap-package.mjs
+++ b/scripts/release/bootstrap-package.mjs
@@ -37,6 +37,19 @@ async function main() {
     );
   }
 
+  // Refuse to run in CI. Every real release must go through trusted publishing,
+  // and wiring this into a workflow would mean putting a long-lived npm token in
+  // CI purely to claim a name: a standing credential replacing short-lived OIDC.
+  // Claiming a name is a rare, one-time act; it stays a deliberate local one.
+  if (shouldPublish && process.env.CI) {
+    fail(
+      "This script must not publish from CI.\n" +
+        "Real versions are published by the release workflow through trusted\n" +
+        "publishing (OIDC). Claiming a new package name is a one-time manual step;\n" +
+        "run it locally after `npm login`."
+    );
+  }
+
   const entry = getReleaseManifest().find(pkg => pkg.name === target);
   if (!entry) {
     fail(

--- a/scripts/release/lib.mjs
+++ b/scripts/release/lib.mjs
@@ -1,15 +1,17 @@
 // Shared helpers for the release preflight and post-publish verification steps.
 // Both need the same answer to "which packages is this repo supposed to publish,
-// at which version, and what does the registry currently hold?", and that answer
-// must be derived from the workspace rather than hand-maintained: package counts
-// written into prose have drifted from reality repeatedly.
+// at which version, on which dist-tag, and what does the registry currently
+// hold?", and that answer must be derived from the workspace rather than
+// hand-maintained: package counts written into prose have drifted from reality
+// repeatedly.
 
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const PACKAGES_DIR = join(REPO_ROOT, "packages");
+const PRE_STATE_PATH = join(REPO_ROOT, ".changeset", "pre.json");
 const REGISTRY = "https://registry.npmjs.org";
 
 /**
@@ -29,15 +31,37 @@ const REQUIRED_FIELDS = [
   { path: ["engines", "node"], label: "engines.node" },
 ];
 
+/** Parses a JSON file, surfacing the path in the error so callers can report it. */
 function readJson(path) {
-  return JSON.parse(readFileSync(path, "utf8"));
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    throw new Error(`${path} is not readable JSON: ${error.message}`);
+  }
 }
 
+/** Reads a nested value by key path, tolerating missing intermediate objects. */
 function getPath(object, path) {
   return path.reduce(
     (value, key) => (value == null ? undefined : value[key]),
     object
   );
+}
+
+/** True for a SemVer string carrying a prerelease component (`1.0.0-alpha.1`). */
+function isPrerelease(version) {
+  return version.includes("-");
+}
+
+/**
+ * The Changesets prerelease state, or `null` outside prerelease mode. The active
+ * tag decides which dist-tag consumers install from, so verification has to read
+ * it rather than assume `latest`.
+ */
+export function readPreState() {
+  if (!existsSync(PRE_STATE_PATH)) return null;
+  const state = readJson(PRE_STATE_PATH);
+  return state.mode === "pre" ? state : null;
 }
 
 /**
@@ -46,21 +70,22 @@ function getPath(object, path) {
  * still belong to the Changesets `fixed` group (their internal versions track the
  * train) but they are never publishable artifacts, so counting them as part of a
  * release is how "N packages published" claims go wrong.
+ *
+ * A manifest that exists but cannot be parsed is an error rather than a silent
+ * skip: dropping it here would also drop it from every check below.
  */
 export function getReleaseManifest() {
-  const entries = readdirSync(PACKAGES_DIR, { withFileTypes: true })
-    .filter(entry => entry.isDirectory())
-    .map(entry => join(PACKAGES_DIR, entry.name, "package.json"));
-
   const manifest = [];
-  for (const manifestPath of entries) {
-    let pkg;
-    try {
-      pkg = readJson(manifestPath);
-    } catch {
-      continue;
-    }
+
+  for (const entry of readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+
+    const manifestPath = join(PACKAGES_DIR, entry.name, "package.json");
+    if (!existsSync(manifestPath)) continue;
+
+    const pkg = readJson(manifestPath);
     if (pkg.private === true) continue;
+
     manifest.push({
       name: pkg.name,
       version: pkg.version,
@@ -69,6 +94,7 @@ export function getReleaseManifest() {
       pkg,
     });
   }
+
   return manifest.sort((a, b) => a.name.localeCompare(b.name));
 }
 
@@ -88,6 +114,22 @@ export function findMissingPublishFields(pkg) {
     }
   }
   return missing;
+}
+
+/**
+ * The dist-tag `changeset publish` will move for a package, mirroring its
+ * `getReleaseTag`: in prerelease mode the configured tag is used, EXCEPT for a
+ * package whose published history is prereleases only, which Changesets sends to
+ * `latest` instead "because there has not been a regular release of it yet".
+ * Verification has to expect the same tag the publisher chose, or it reports
+ * failures for correctly published packages.
+ */
+export function getExpectedDistTag(registryState, preState) {
+  if (!preState) return "latest";
+  const hasRegularRelease = (registryState?.versions ?? []).some(
+    version => !isPrerelease(version)
+  );
+  return hasRegularRelease ? preState.tag : "latest";
 }
 
 /**

--- a/scripts/release/lib.mjs
+++ b/scripts/release/lib.mjs
@@ -48,9 +48,17 @@ function getPath(object, path) {
   );
 }
 
-/** True for a SemVer string carrying a prerelease component (`1.0.0-alpha.1`). */
-function isPrerelease(version) {
-  return version.includes("-");
+/**
+ * The first prerelease identifier of a SemVer string, or `undefined` for a
+ * stable version: `1.0.0-alpha.4` -> `"alpha"`, `1.0.0` -> `undefined`. Mirrors
+ * `semver.parse(v).prerelease[0]` for the shapes npm accepts, without pulling in
+ * a dependency for one field.
+ */
+function firstPrereleaseId(version) {
+  const withoutBuildMetadata = version.split("+")[0];
+  const separator = withoutBuildMetadata.indexOf("-");
+  if (separator === -1) return undefined;
+  return withoutBuildMetadata.slice(separator + 1).split(".")[0];
 }
 
 /**
@@ -119,17 +127,25 @@ export function findMissingPublishFields(pkg) {
 /**
  * The dist-tag `changeset publish` will move for a package, mirroring its
  * `getReleaseTag`: in prerelease mode the configured tag is used, EXCEPT for a
- * package whose published history is prereleases only, which Changesets sends to
- * `latest` instead "because there has not been a regular release of it yet".
- * Verification has to expect the same tag the publisher chose, or it reports
- * failures for correctly published packages.
+ * package classified `only-pre`, which goes to `latest` instead "because there
+ * has not been a regular release of it yet".
+ *
+ * `only-pre` is narrower than "has no stable version". Changesets requires EVERY
+ * published version to be a prerelease of the *active* tag, so a package
+ * carrying only `-beta.N` versions while the active tag is `alpha` is NOT
+ * only-pre and publishes to `alpha`. Approximating this with "no stable version"
+ * would expect `latest` for such a package and reject a correct publish on every
+ * retry, permanently blocking the consolidated tag.
  */
 export function getExpectedDistTag(registryState, preState) {
   if (!preState) return "latest";
-  const hasRegularRelease = (registryState?.versions ?? []).some(
-    version => !isPrerelease(version)
-  );
-  return hasRegularRelease ? preState.tag : "latest";
+
+  const versions = registryState?.versions ?? [];
+  const onlyPre =
+    versions.length > 0 &&
+    versions.every(version => firstPrereleaseId(version) === preState.tag);
+
+  return onlyPre ? "latest" : preState.tag;
 }
 
 /**
@@ -168,4 +184,4 @@ export async function fetchAllRegistryStates(manifest) {
   return new Map(states);
 }
 
-export { REPO_ROOT };
+export { REGISTRY, REPO_ROOT };

--- a/scripts/release/lib.mjs
+++ b/scripts/release/lib.mjs
@@ -1,0 +1,129 @@
+// Shared helpers for the release preflight and post-publish verification steps.
+// Both need the same answer to "which packages is this repo supposed to publish,
+// at which version, and what does the registry currently hold?", and that answer
+// must be derived from the workspace rather than hand-maintained: package counts
+// written into prose have drifted from reality repeatedly.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const PACKAGES_DIR = join(REPO_ROOT, "packages");
+const REGISTRY = "https://registry.npmjs.org";
+
+/**
+ * Publish metadata every public package must carry. Missing `publishConfig.access`
+ * is fatal for a scoped package: npm defaults scoped publishes to `restricted`,
+ * which a public-only org cannot complete, and the failure surfaces late (during
+ * the publish call) rather than at validation time.
+ */
+const REQUIRED_FIELDS = [
+  { path: ["license"], label: "license" },
+  { path: ["repository", "directory"], label: "repository.directory" },
+  {
+    path: ["publishConfig", "access"],
+    label: "publishConfig.access",
+    equals: "public",
+  },
+  { path: ["engines", "node"], label: "engines.node" },
+];
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function getPath(object, path) {
+  return path.reduce(
+    (value, key) => (value == null ? undefined : value[key]),
+    object
+  );
+}
+
+/**
+ * Every workspace package that `changeset publish` is expected to push to npm:
+ * the contents of `packages/*` minus anything marked private. Private packages
+ * still belong to the Changesets `fixed` group (their internal versions track the
+ * train) but they are never publishable artifacts, so counting them as part of a
+ * release is how "N packages published" claims go wrong.
+ */
+export function getReleaseManifest() {
+  const entries = readdirSync(PACKAGES_DIR, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => join(PACKAGES_DIR, entry.name, "package.json"));
+
+  const manifest = [];
+  for (const manifestPath of entries) {
+    let pkg;
+    try {
+      pkg = readJson(manifestPath);
+    } catch {
+      continue;
+    }
+    if (pkg.private === true) continue;
+    manifest.push({
+      name: pkg.name,
+      version: pkg.version,
+      dir: dirname(manifestPath),
+      manifestPath,
+      pkg,
+    });
+  }
+  return manifest.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Fields a package is missing, so preflight can name them all in one pass. */
+export function findMissingPublishFields(pkg) {
+  const missing = [];
+  for (const field of REQUIRED_FIELDS) {
+    const value = getPath(pkg, field.path);
+    if (value == null || value === "") {
+      missing.push(field.label);
+      continue;
+    }
+    if (field.equals && value !== field.equals) {
+      missing.push(
+        `${field.label} (expected "${field.equals}", found "${value}")`
+      );
+    }
+  }
+  return missing;
+}
+
+/**
+ * Registry state for one package. Returns `null` when the package name has never
+ * been published, which is a materially different situation from "published, but
+ * not at this version": a first publish cannot authenticate through a trusted
+ * publisher that does not exist yet, so it needs a deliberate bootstrap.
+ */
+export async function fetchRegistryState(name) {
+  const response = await fetch(`${REGISTRY}/${name.replace("/", "%2F")}`, {
+    headers: { accept: "application/vnd.npm.install-v1+json" },
+  });
+
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    throw new Error(
+      `registry lookup failed for ${name}: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const body = await response.json();
+  return {
+    versions: Object.keys(body.versions ?? {}),
+    distTags: body["dist-tags"] ?? {},
+  };
+}
+
+/** Resolves registry state for the whole manifest concurrently. */
+export async function fetchAllRegistryStates(manifest) {
+  const states = await Promise.all(
+    manifest.map(async entry => [
+      entry.name,
+      await fetchRegistryState(entry.name),
+    ])
+  );
+  return new Map(states);
+}
+
+export { REPO_ROOT };

--- a/scripts/release/manifest.mjs
+++ b/scripts/release/manifest.mjs
@@ -1,0 +1,17 @@
+// Prints the release manifest as JSON: every package this repo publishes, at the
+// version currently in the workspace.
+//
+// The release workflow builds its notes from this rather than from the publish
+// step's own output. A resumable release only reports the packages it published
+// during that invocation, so on a recovery run the output covers just the
+// stragglers, and notes built from it would claim a three-package release and
+// omit the rest of the train's changelogs.
+
+import { getReleaseManifest } from "./lib.mjs";
+
+const manifest = getReleaseManifest().map(({ name, version }) => ({
+  name,
+  version,
+}));
+
+process.stdout.write(`${JSON.stringify(manifest)}\n`);

--- a/scripts/release/preflight.mjs
+++ b/scripts/release/preflight.mjs
@@ -1,0 +1,134 @@
+// Runs before `changeset publish` and refuses to start a release that cannot
+// finish. A multi-package npm publish is not atomic: when one package fails
+// mid-run the others are already live, which leaves the registry, the git tags
+// and the GitHub release describing three different releases. Everything checked
+// here is knowable before the first byte is published.
+//
+// Exit codes: 0 = safe to publish, 1 = blocked.
+//
+// Set NEXTLY_RELEASE_ALLOW_BOOTSTRAP=1 for the deliberate first publish of a new
+// package name, which is the one case where "this package does not exist on the
+// registry" is expected rather than fatal.
+
+import {
+  fetchAllRegistryStates,
+  findMissingPublishFields,
+  getReleaseManifest,
+} from "./lib.mjs";
+
+const allowBootstrap = process.env.NEXTLY_RELEASE_ALLOW_BOOTSTRAP === "1";
+
+async function main() {
+  const manifest = getReleaseManifest();
+  if (manifest.length === 0) {
+    console.error("preflight: no publishable packages found under packages/");
+    process.exit(1);
+  }
+
+  const registry = await fetchAllRegistryStates(manifest);
+
+  const metadataErrors = [];
+  const bootstrapNeeded = [];
+  const alreadyPublished = [];
+  const toPublish = [];
+  const versionMismatch = [];
+
+  const expectedVersion = manifest[0].version;
+
+  for (const entry of manifest) {
+    const missing = findMissingPublishFields(entry.pkg);
+    if (missing.length > 0) {
+      metadataErrors.push({ name: entry.name, missing });
+    }
+
+    // Every publishable package shares one version through the Changesets
+    // `fixed` group; a package that drifts off it means the release is not the
+    // lockstep train the changelog and release notes will claim it is.
+    if (entry.version !== expectedVersion) {
+      versionMismatch.push({ name: entry.name, version: entry.version });
+    }
+
+    const state = registry.get(entry.name);
+    if (state === null) {
+      bootstrapNeeded.push(entry.name);
+    } else if (state.versions.includes(entry.version)) {
+      alreadyPublished.push(entry.name);
+    } else {
+      toPublish.push(entry.name);
+    }
+  }
+
+  console.log(`Release preflight for ${expectedVersion}`);
+  console.log(`  publishable packages: ${manifest.length}`);
+  console.log(`  to publish:           ${toPublish.length}`);
+  console.log(
+    `  already on registry:  ${alreadyPublished.length} (publish skips these)`
+  );
+  if (bootstrapNeeded.length > 0) {
+    console.log(`  never published:      ${bootstrapNeeded.length}`);
+  }
+
+  let blocked = false;
+
+  if (metadataErrors.length > 0) {
+    blocked = true;
+    console.error("\nBlocked: incomplete publish metadata");
+    for (const { name, missing } of metadataErrors) {
+      console.error(`  ${name}: missing ${missing.join(", ")}`);
+    }
+  }
+
+  if (versionMismatch.length > 0) {
+    blocked = true;
+    console.error(
+      `\nBlocked: packages are not in lockstep at ${expectedVersion}`
+    );
+    for (const { name, version } of versionMismatch) {
+      console.error(`  ${name}: ${version}`);
+    }
+  }
+
+  if (bootstrapNeeded.length > 0 && !allowBootstrap) {
+    blocked = true;
+    console.error("\nBlocked: package has never been published to npm");
+    for (const name of bootstrapNeeded) {
+      console.error(`  ${name}`);
+    }
+    console.error(
+      "\n  A trusted publisher can only be configured against a package that exists,\n" +
+        "  so the first publish of a new name has to be made deliberately. Publish it\n" +
+        "  once, add its trusted publisher entry on npmjs.com, then re-run the release.\n" +
+        "  Set NEXTLY_RELEASE_ALLOW_BOOTSTRAP=1 to run that first publish from CI."
+    );
+  }
+
+  if (blocked) {
+    console.error(
+      "\nRelease aborted before publishing. Nothing was pushed to npm."
+    );
+    process.exit(1);
+  }
+
+  // A bootstrap run publishes the new names too, so report everything the
+  // publish step will attempt rather than only the packages that already exist.
+  const attempting = [...toPublish, ...(allowBootstrap ? bootstrapNeeded : [])];
+
+  if (attempting.length === 0) {
+    console.log(
+      "\nNothing new to publish; the registry already has this version."
+    );
+  } else {
+    console.log(`\nReady to publish: ${attempting.sort().join(", ")}`);
+    if (allowBootstrap && bootstrapNeeded.length > 0) {
+      console.log(
+        `  first publish for: ${bootstrapNeeded.join(", ")} ` +
+          "(add each one's trusted publisher on npmjs.com afterwards)"
+      );
+    }
+  }
+}
+
+main().catch(error => {
+  console.error(`preflight failed: ${error.message}`);
+  process.exit(1);
+});

--- a/scripts/release/preflight.mjs
+++ b/scripts/release/preflight.mjs
@@ -5,10 +5,6 @@
 // here is knowable before the first byte is published.
 //
 // Exit codes: 0 = safe to publish, 1 = blocked.
-//
-// Set NEXTLY_RELEASE_ALLOW_BOOTSTRAP=1 for the deliberate first publish of a new
-// package name, which is the one case where "this package does not exist on the
-// registry" is expected rather than fatal.
 
 import {
   fetchAllRegistryStates,
@@ -16,24 +12,13 @@ import {
   getReleaseManifest,
 } from "./lib.mjs";
 
-const allowBootstrap = process.env.NEXTLY_RELEASE_ALLOW_BOOTSTRAP === "1";
-
-async function main() {
-  const manifest = getReleaseManifest();
-  if (manifest.length === 0) {
-    console.error("preflight: no publishable packages found under packages/");
-    process.exit(1);
-  }
-
-  const registry = await fetchAllRegistryStates(manifest);
-
+/** Groups every package by the reason it can or cannot be published right now. */
+function classify(manifest, registry, expectedVersion) {
   const metadataErrors = [];
+  const versionMismatch = [];
   const bootstrapNeeded = [];
   const alreadyPublished = [];
   const toPublish = [];
-  const versionMismatch = [];
-
-  const expectedVersion = manifest[0].version;
 
   for (const entry of manifest) {
     const missing = findMissingPublishFields(entry.pkg);
@@ -57,6 +42,32 @@ async function main() {
       toPublish.push(entry.name);
     }
   }
+
+  return {
+    metadataErrors,
+    versionMismatch,
+    bootstrapNeeded,
+    alreadyPublished,
+    toPublish,
+  };
+}
+
+async function main() {
+  const manifest = getReleaseManifest();
+  if (manifest.length === 0) {
+    console.error("preflight: no publishable packages found under packages/");
+    process.exit(1);
+  }
+
+  const expectedVersion = manifest[0].version;
+  const registry = await fetchAllRegistryStates(manifest);
+  const {
+    metadataErrors,
+    versionMismatch,
+    bootstrapNeeded,
+    alreadyPublished,
+    toPublish,
+  } = classify(manifest, registry, expectedVersion);
 
   console.log(`Release preflight for ${expectedVersion}`);
   console.log(`  publishable packages: ${manifest.length}`);
@@ -88,17 +99,26 @@ async function main() {
     }
   }
 
-  if (bootstrapNeeded.length > 0 && !allowBootstrap) {
+  // Blocking here is deliberate and cannot be waived from CI. npm requires a
+  // package to exist before a trusted publisher can be attached to it, and OIDC
+  // cannot perform a package's first publish, so this release genuinely cannot
+  // succeed until the name is claimed once by a maintainer. Letting it start
+  // anyway would publish the rest of the train and strand this package.
+  if (bootstrapNeeded.length > 0) {
     blocked = true;
     console.error("\nBlocked: package has never been published to npm");
     for (const name of bootstrapNeeded) {
       console.error(`  ${name}`);
     }
     console.error(
-      "\n  A trusted publisher can only be configured against a package that exists,\n" +
-        "  so the first publish of a new name has to be made deliberately. Publish it\n" +
-        "  once, add its trusted publisher entry on npmjs.com, then re-run the release.\n" +
-        "  Set NEXTLY_RELEASE_ALLOW_BOOTSTRAP=1 to run that first publish from CI."
+      "\n  Claim each name once, then add its trusted publisher:\n" +
+        bootstrapNeeded
+          .map(
+            name =>
+              `    node scripts/release/bootstrap-package.mjs ${name} --publish`
+          )
+          .join("\n") +
+        "\n\n  See the release-and-changesets skill for the full procedure."
     );
   }
 
@@ -109,22 +129,12 @@ async function main() {
     process.exit(1);
   }
 
-  // A bootstrap run publishes the new names too, so report everything the
-  // publish step will attempt rather than only the packages that already exist.
-  const attempting = [...toPublish, ...(allowBootstrap ? bootstrapNeeded : [])];
-
-  if (attempting.length === 0) {
+  if (toPublish.length === 0) {
     console.log(
       "\nNothing new to publish; the registry already has this version."
     );
   } else {
-    console.log(`\nReady to publish: ${attempting.sort().join(", ")}`);
-    if (allowBootstrap && bootstrapNeeded.length > 0) {
-      console.log(
-        `  first publish for: ${bootstrapNeeded.join(", ")} ` +
-          "(add each one's trusted publisher on npmjs.com afterwards)"
-      );
-    }
+    console.log(`\nReady to publish: ${toPublish.join(", ")}`);
   }
 }
 

--- a/scripts/release/verify.mjs
+++ b/scripts/release/verify.mjs
@@ -1,0 +1,98 @@
+// Runs after `changeset publish` and answers one question: did the whole train
+// land? Only when it did may the consolidated git tag and GitHub release be
+// created, because a tag that points at a release the registry never received
+// is worse than no tag: it makes an incomplete release look finished.
+//
+// Exit codes: 0 = registry matches the workspace, 1 = incomplete.
+
+import { fetchAllRegistryStates, getReleaseManifest } from "./lib.mjs";
+
+// npm's read replicas trail a publish by a few seconds, so a package that is
+// genuinely live can 404 immediately afterwards. Retry before calling it missing.
+const ATTEMPTS = 5;
+const RETRY_DELAY_MS = 6000;
+
+const sleep = ms => new Promise(done => setTimeout(done, ms));
+
+function collectMissing(manifest, registry) {
+  const missing = [];
+  for (const entry of manifest) {
+    const state = registry.get(entry.name);
+    if (state === null) {
+      missing.push({
+        name: entry.name,
+        reason: "package not found on registry",
+      });
+    } else if (!state.versions.includes(entry.version)) {
+      missing.push({
+        name: entry.name,
+        reason: `version ${entry.version} not published`,
+      });
+    }
+  }
+  return missing;
+}
+
+async function main() {
+  const manifest = getReleaseManifest();
+  const expectedVersion = manifest[0].version;
+
+  let missing = [];
+  let registry;
+
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt += 1) {
+    registry = await fetchAllRegistryStates(manifest);
+    missing = collectMissing(manifest, registry);
+    if (missing.length === 0) break;
+    if (attempt < ATTEMPTS) {
+      console.log(
+        `Waiting for ${missing.length} package(s) to appear on the registry ` +
+          `(attempt ${attempt}/${ATTEMPTS})...`
+      );
+      await sleep(RETRY_DELAY_MS);
+    }
+  }
+
+  console.log(`Release verification for ${expectedVersion}`);
+  console.log(`  expected packages: ${manifest.length}`);
+  console.log(`  confirmed on npm:  ${manifest.length - missing.length}`);
+
+  // Surfacing dist-tags here keeps the "which version does a bare install get?"
+  // question answerable from the release log itself. `latest` is moved by a
+  // separate deliberate step, never automatically, so it is expected to trail
+  // the alpha channel during prereleases.
+  const distTagReport = manifest
+    .map(entry => {
+      const tags = registry.get(entry.name)?.distTags ?? {};
+      const rendered = Object.entries(tags)
+        .map(([tag, version]) => `${tag}=${version}`)
+        .join(" ");
+      return `  ${entry.name}: ${rendered || "(no dist-tags)"}`;
+    })
+    .join("\n");
+  console.log("\nDist-tags:\n" + distTagReport);
+
+  if (missing.length > 0) {
+    console.error(
+      `\nIncomplete release: ${missing.length} package(s) did not publish`
+    );
+    for (const { name, reason } of missing) {
+      console.error(`  ${name}: ${reason}`);
+    }
+    console.error(
+      "\n  The packages that did publish are already live and cannot be unpublished.\n" +
+        "  Fix the cause, then re-run the release: publishing is resumable because\n" +
+        "  versions already on the registry are skipped."
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `\nComplete release: all ${manifest.length} packages are live at ${expectedVersion}.`
+  );
+}
+
+main().catch(error => {
+  console.error(`verification failed: ${error.message}`);
+  process.exit(1);
+});

--- a/scripts/release/verify.mjs
+++ b/scripts/release/verify.mjs
@@ -1,11 +1,22 @@
 // Runs after `changeset publish` and answers one question: did the whole train
-// land? Only when it did may the consolidated git tag and GitHub release be
-// created, because a tag that points at a release the registry never received
-// is worse than no tag: it makes an incomplete release look finished.
+// land, on the channel consumers actually install from? Only when it did may the
+// consolidated git tag and GitHub release be created, because a tag that points
+// at a release the registry never received is worse than no tag: it makes an
+// incomplete release look finished.
+//
+// Checking that a version merely exists is not enough. A package can publish
+// successfully while its dist-tag still points at an older version, so
+// `pkg@alpha` keeps resolving to the previous release (or to nothing at all) even
+// though the new version is on the registry.
 //
 // Exit codes: 0 = registry matches the workspace, 1 = incomplete.
 
-import { fetchAllRegistryStates, getReleaseManifest } from "./lib.mjs";
+import {
+  fetchAllRegistryStates,
+  getExpectedDistTag,
+  getReleaseManifest,
+  readPreState,
+} from "./lib.mjs";
 
 // npm's read replicas trail a publish by a few seconds, so a package that is
 // genuinely live can 404 immediately afterwards. Retry before calling it missing.
@@ -14,39 +25,64 @@ const RETRY_DELAY_MS = 6000;
 
 const sleep = ms => new Promise(done => setTimeout(done, ms));
 
-function collectMissing(manifest, registry) {
-  const missing = [];
+/**
+ * Packages that are not yet fully released, each with the reason. A missing
+ * version and a stale dist-tag are reported separately because they need
+ * different fixes: the first is a failed publish, the second a tag that was
+ * never moved.
+ */
+function collectProblems(manifest, registry, preState) {
+  const problems = [];
+
   for (const entry of manifest) {
     const state = registry.get(entry.name);
+
     if (state === null) {
-      missing.push({
+      problems.push({
         name: entry.name,
         reason: "package not found on registry",
       });
-    } else if (!state.versions.includes(entry.version)) {
-      missing.push({
+      continue;
+    }
+
+    if (!state.versions.includes(entry.version)) {
+      problems.push({
         name: entry.name,
         reason: `version ${entry.version} not published`,
       });
+      continue;
+    }
+
+    const expectedTag = getExpectedDistTag(state, preState);
+    const actual = state.distTags[expectedTag];
+    if (actual !== entry.version) {
+      problems.push({
+        name: entry.name,
+        reason:
+          `dist-tag "${expectedTag}" points at ${actual ?? "nothing"}, ` +
+          `so ${entry.name}@${expectedTag} does not resolve to ${entry.version}`,
+      });
     }
   }
-  return missing;
+
+  return problems;
 }
 
 async function main() {
   const manifest = getReleaseManifest();
+  const preState = readPreState();
   const expectedVersion = manifest[0].version;
 
-  let missing = [];
+  let problems = [];
   let registry;
 
   for (let attempt = 1; attempt <= ATTEMPTS; attempt += 1) {
     registry = await fetchAllRegistryStates(manifest);
-    missing = collectMissing(manifest, registry);
-    if (missing.length === 0) break;
+    problems = collectProblems(manifest, registry, preState);
+    if (problems.length === 0) break;
     if (attempt < ATTEMPTS) {
       console.log(
-        `Waiting for ${missing.length} package(s) to appear on the registry ` +
+        `Waiting for ${problems.length} package(s) to settle on the registry ` +
           `(attempt ${attempt}/${ATTEMPTS})...`
       );
       await sleep(RETRY_DELAY_MS);
@@ -55,12 +91,15 @@ async function main() {
 
   console.log(`Release verification for ${expectedVersion}`);
   console.log(`  expected packages: ${manifest.length}`);
-  console.log(`  confirmed on npm:  ${manifest.length - missing.length}`);
+  console.log(`  fully released:    ${manifest.length - problems.length}`);
+  if (preState) {
+    console.log(`  prerelease channel: ${preState.tag}`);
+  }
 
-  // Surfacing dist-tags here keeps the "which version does a bare install get?"
-  // question answerable from the release log itself. `latest` is moved by a
-  // separate deliberate step, never automatically, so it is expected to trail
-  // the alpha channel during prereleases.
+  // Printing the tags keeps "which version does an install actually get?"
+  // answerable from the release log itself. `latest` is moved by a separate
+  // deliberate step, never automatically, so during prereleases it is expected
+  // to trail the active channel.
   const distTagReport = manifest
     .map(entry => {
       const tags = registry.get(entry.name)?.distTags ?? {};
@@ -72,15 +111,15 @@ async function main() {
     .join("\n");
   console.log("\nDist-tags:\n" + distTagReport);
 
-  if (missing.length > 0) {
+  if (problems.length > 0) {
     console.error(
-      `\nIncomplete release: ${missing.length} package(s) did not publish`
+      `\nIncomplete release: ${problems.length} package(s) are not fully released`
     );
-    for (const { name, reason } of missing) {
+    for (const { name, reason } of problems) {
       console.error(`  ${name}: ${reason}`);
     }
     console.error(
-      "\n  The packages that did publish are already live and cannot be unpublished.\n" +
+      "\n  Packages that did publish are already live and cannot be unpublished.\n" +
         "  Fix the cause, then re-run the release: publishing is resumable because\n" +
         "  versions already on the registry are skipped."
     );
@@ -88,7 +127,8 @@ async function main() {
   }
 
   console.log(
-    `\nComplete release: all ${manifest.length} packages are live at ${expectedVersion}.`
+    `\nComplete release: all ${manifest.length} packages are live at ${expectedVersion}` +
+      `${preState ? ` on the ${preState.tag} channel` : ""}.`
   );
 }
 


### PR DESCRIPTION
## Why

The alpha.39 and alpha.40 releases both published **13 of 16 packages and stopped**. The same three failed each time, for three different reasons, and because a multi-package publish is not atomic the successful packages were already live and could not be taken back.

The result is a registry that disagrees with itself and with git:

| | state before this PR |
|---|---|
| 13 packages | `alpha` = `0.0.2-alpha.40`, `latest` = `0.0.2-alpha.37` |
| `@nextlyhq/plugin-page-builder` | stuck at `0.0.2-alpha.31`, **no `alpha` dist-tag at all** |
| `@nextlyhq/admin-css` | never published |
| `@nextlyhq/blocks-engine` | never published (joined `fixed[]` in #320) |
| consolidated tags / releases | stop at `v0.0.2-alpha.30` |

Nothing warned about any of it: the failing run reported the packages it *did* publish, and the next release simply tried the same thing again.

## What this changes

**Preflight (`pnpm release:preflight`), wired into `release:publish` so it runs before the build.** It refuses to start a release that cannot finish:

- a public package missing `license`, `repository.directory`, `engines.node` or `publishConfig.access: "public"`
- packages that have drifted off the lockstep version
- a package name that has never been published — a trusted publisher can only be attached to a package that already exists, so a first publish has to be deliberate (`NEXTLY_RELEASE_ALLOW_BOOTSTRAP=1` allows exactly that run)

It costs one registry lookup per package and replaces a ten-minute build that could only end in a half-release.

**Verification (`pnpm release:verify`), a new workflow step after publishing.** It compares the registry to the workspace and prints every package's dist-tags. The consolidated git tag and GitHub Release are now created **only when it passes**, so git and npm can no longer describe different releases.

**`@nextlyhq/admin-css` publish metadata.** It was the only public package with no `license`, `repository`, `engines`, or `publishConfig` — so npm treated a scoped package as a restricted publish and rejected it. This is a real fix for one of the three failures.

**Smaller:** the release notes now count published packages instead of restating "12"; `SECURITY.md` no longer calls the `0.x` line "beta"; the release skill documents partial-release recovery and new-package bootstrapping.

## Verified against the live registry

```
$ pnpm release:preflight
Release preflight for 0.0.2-alpha.40
  publishable packages: 16
  to publish:           1
  already on registry:  13 (publish skips these)
  never published:      2

Blocked: package has never been published to npm
  @nextlyhq/admin-css
  @nextlyhq/blocks-engine
Release aborted before publishing. Nothing was pushed to npm.
```

```
$ pnpm release:verify
  expected packages: 16
  confirmed on npm:  13
Incomplete release: 3 package(s) did not publish
  @nextlyhq/admin-css: package not found on registry
  @nextlyhq/blocks-engine: package not found on registry
  @nextlyhq/plugin-page-builder: version 0.0.2-alpha.40 not published
```

The metadata check was also confirmed to flag the pre-fix `admin-css` manifest (`license, repository.directory, publishConfig.access, engines.node`) and a `publishConfig.access: "restricted"` package.

## No changeset, on purpose

Per `AGENTS.md`, CI/release-config PRs get none — and here it also matters for recovery. A changeset would bump the train to `alpha.41` and permanently abandon the `alpha.40` slot, leaving three packages that never existed at a version their 13 siblings do. Keeping the version put lets the missing three still fill `alpha.40` and heal the train. (Precedent: #249, the `admin-css` lockstep fix, also shipped without one.)

## Merging this does not fix the registry by itself

Two of the three failures need npm-side action that cannot be done from CI:

1. **`@nextlyhq/blocks-engine`** and **`@nextlyhq/admin-css`** — first publish, then add each one's Trusted Publisher entry on npmjs.com (repo `nextlyhq/nextly`, workflow `release.yml`, environment `Production`, which must match the workflow's `environment:` exactly).
2. **`@nextlyhq/plugin-page-builder`** — its `404 … or you do not have permission` on publish is npm's signature for a missing or misconfigured trusted publisher; check its entry against the three values above.

Until those are done, merging simply produces the same failure — except now it aborts before the build with a message naming the cause instead of failing halfway through publishing. Once they are done, a re-run publishes only the missing three at `alpha.40` and the train is whole again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Improvements**
  * Added pre-release checks and post-release verification to help ensure all packages are published successfully.
  * Improved recovery guidance for incomplete or partially published releases.
  * Release summaries now report the actual number of published packages.

* **New Features**
  * Added support for safely bootstrapping new package names into the standard publishing workflow.

* **Documentation**
  * Updated security support policy to reflect the current alpha release line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->