### PR TITLE
feat(nextly): add the blocks field surface and block-prop field configs

### DIFF
--- a/.changeset/blocks-field-surface.md
+++ b/.changeset/blocks-field-surface.md
@@ -1,0 +1,24 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Block props now go through the field system: a block declares its editable props with the same field types a collection uses, and their values are validated by the same server-side pass entries get. Binding a data field to a block prop is derived from the prop type, so every compatible prop offers it without the block opting in.

--- a/packages/admin/src/lib/builder/plugin-field-type-entries.test.ts
+++ b/packages/admin/src/lib/builder/plugin-field-type-entries.test.ts
@@ -29,6 +29,7 @@ describe("pluginFieldTypeCatalogEntries", () => {
         {
           type: "rating",
           component: "RatingInput",
+          storage: "text",
           label: "Star Rating",
           description: "A 1-5 star rating",
           icon: "Star",
@@ -52,7 +53,12 @@ describe("pluginFieldTypeCatalogEntries", () => {
   it("fills sensible defaults when presentation fields are omitted", () => {
     const plugins = [
       pluginWith([
-        { type: "star-rating", component: "C", surfaces: ["entries"] },
+        {
+          type: "star-rating",
+          component: "C",
+          storage: "text",
+          surfaces: ["entries"],
+        },
       ]),
     ];
 
@@ -70,7 +76,9 @@ describe("pluginFieldTypeCatalogEntries", () => {
   });
 
   it("treats an omitted surfaces list as the entries surface only", () => {
-    const plugins = [pluginWith([{ type: "rating", component: "C" }])];
+    const plugins = [
+      pluginWith([{ type: "rating", component: "C", storage: "text" }]),
+    ];
 
     expect(pluginFieldTypeCatalogEntries(plugins, "entries")).toHaveLength(1);
     expect(pluginFieldTypeCatalogEntries(plugins, "users")).toEqual([]);
@@ -80,7 +88,12 @@ describe("pluginFieldTypeCatalogEntries", () => {
   it("offers a type only on the surfaces it opted into", () => {
     const plugins = [
       pluginWith([
-        { type: "rating", component: "C", surfaces: ["users", "forms"] },
+        {
+          type: "rating",
+          component: "C",
+          storage: "text",
+          surfaces: ["users", "forms"],
+        },
       ]),
     ];
 
@@ -95,13 +108,27 @@ describe("pluginFieldTypeCatalogEntries", () => {
         name: "@acme/disabled",
         collections: [],
         enabled: false,
-        fieldTypes: [{ type: "rating", component: "C", surfaces: ["entries"] }],
+        fieldTypes: [
+          {
+            type: "rating",
+            component: "C",
+            storage: "text",
+            surfaces: ["entries"],
+          },
+        ],
       },
       {
         name: "@acme/enabled",
         collections: [],
         enabled: true,
-        fieldTypes: [{ type: "color", component: "C", surfaces: ["entries"] }],
+        fieldTypes: [
+          {
+            type: "color",
+            component: "C",
+            storage: "text",
+            surfaces: ["entries"],
+          },
+        ],
       },
     ];
     expect(
@@ -111,8 +138,22 @@ describe("pluginFieldTypeCatalogEntries", () => {
 
   it("flattens field types across multiple plugins in registration order", () => {
     const plugins = [
-      pluginWith([{ type: "rating", component: "C", surfaces: ["entries"] }]),
-      pluginWith([{ type: "color", component: "C", surfaces: ["entries"] }]),
+      pluginWith([
+        {
+          type: "rating",
+          component: "C",
+          storage: "text",
+          surfaces: ["entries"],
+        },
+      ]),
+      pluginWith([
+        {
+          type: "color",
+          component: "C",
+          storage: "text",
+          surfaces: ["entries"],
+        },
+      ]),
     ];
 
     expect(

--- a/packages/admin/src/types/branding.ts
+++ b/packages/admin/src/types/branding.ts
@@ -1,4 +1,8 @@
-import type { FieldSurface, FieldTypeCategory } from "nextly/field-catalog";
+import type {
+  FieldStoragePrimitive,
+  FieldSurface,
+  FieldTypeCategory,
+} from "nextly/field-catalog";
 
 export interface ResolvedBrandingColors {
   primary?: string;
@@ -126,6 +130,8 @@ export interface PluginMetadata {
   fieldTypes?: Array<{
     type: string;
     component: string;
+    /** The primitive this type persists as; decides binding compatibility. */
+    storage: FieldStoragePrimitive;
     layout?: "takeover";
     label?: string;
     description?: string;

--- a/packages/nextly/src/collections/fields/block-props.test.ts
+++ b/packages/nextly/src/collections/fields/block-props.test.ts
@@ -962,6 +962,146 @@ describe("blockPropsToFieldConfigs reference bounds", () => {
   });
 });
 
+describe("blockPropsToFieldConfigs list-only options", () => {
+  it("refuses row bounds on a prop that holds one value", () => {
+    // The bounds would constrain nothing, which is the failure mode this
+    // module exists to prevent: a declaration advertising an unenforced rule.
+    for (const declaration of [
+      { type: "text", minRows: 2 },
+      { type: "number", maxRows: 3 },
+      { type: "upload", relationTo: "media", minRows: 1 },
+      { type: "relationship", relationTo: "posts", maxRows: 2 },
+    ]) {
+      expect(
+        issuesOf(() => blockPropsToFieldConfigs({ props: { p: declaration } })),
+        declaration.type
+      ).toEqual([{ path: "p", code: "INVALID_OPTION" }]);
+    }
+  });
+
+  it("still accepts them on a list-shaped prop", () => {
+    const configs = blockPropsToFieldConfigs({
+      props: { tags: { type: "text", hasMany: true, minRows: 1, maxRows: 4 } },
+    });
+    expect(configs[0]).toMatchObject({ minRows: 1, maxRows: 4 });
+  });
+
+  it("leaves a repeater's own bounds alone", () => {
+    const configs = blockPropsToFieldConfigs({
+      props: {
+        items: {
+          type: "repeater",
+          fields: { note: { type: "text" } },
+          minRows: 1,
+          maxRows: 2,
+        },
+      },
+    });
+    expect(configs[0]).toMatchObject({ minRows: 1, maxRows: 2 });
+  });
+});
+
+describe("validateBlockPropValues skipped sentinels", () => {
+  it("rejects a blank string where the prop cannot hold text", async () => {
+    const source: BlockPropsSource = {
+      props: {
+        count: { type: "number" },
+        rows: { type: "repeater", fields: { note: { type: "text" } } },
+        image: { type: "upload", relationTo: "media" },
+        flag: { type: "checkbox" },
+      },
+    };
+    const issues = await validateBlockPropValues(
+      { count: "", rows: "", image: "   ", flag: "" },
+      source
+    );
+    expect(issues.map(issue => issue.path).sort()).toEqual([
+      "count",
+      "flag",
+      "image",
+      "rows",
+    ]);
+    expect(issues.every(issue => issue.code === "INVALID_TYPE")).toBe(true);
+  });
+
+  it("leaves a blank string alone where the prop does hold text", async () => {
+    const source: BlockPropsSource = {
+      props: { title: { type: "text" }, data: { type: "json" } },
+    };
+    expect(
+      await validateBlockPropValues({ title: "", data: "" }, source)
+    ).toEqual([]);
+  });
+
+  it("enforces required on an explicitly empty list", async () => {
+    // The shared rules route a provided empty list past their required check
+    // so it can reach the bounds rules, so nothing else would report this.
+    const source: BlockPropsSource = {
+      props: {
+        tags: { type: "chips", required: true },
+        items: {
+          type: "repeater",
+          required: true,
+          fields: { note: { type: "text" } },
+        },
+      },
+    };
+    const issues = await validateBlockPropValues(
+      { tags: [], items: [] },
+      source
+    );
+    expect(issues.map(issue => issue.code)).toEqual(["REQUIRED", "REQUIRED"]);
+    expect(
+      await validateBlockPropValues(
+        { tags: ["a"], items: [{ note: "b" }] },
+        source
+      )
+    ).toEqual([]);
+  });
+
+  it("rejects a value whose own encoding makes it disappear", async () => {
+    const source: BlockPropsSource = { props: { data: { type: "json" } } };
+    // JSON.stringify returns undefined here: the prop would vanish from the
+    // document rather than be stored wrongly.
+    const vanishing = { toJSON: () => undefined };
+    expect(
+      await validateBlockPropValues({ data: vanishing }, source)
+    ).toHaveLength(1);
+    // Nested, the containing object survives but the key is dropped.
+    expect(
+      await validateBlockPropValues({ data: { inner: vanishing } }, source)
+    ).toHaveLength(1);
+    // A toJSON producing a value JSON cannot represent is caught the same way.
+    expect(
+      await validateBlockPropValues(
+        { data: { toJSON: () => new Map([["a", 1]]) } },
+        source
+      )
+    ).toHaveLength(1);
+  });
+
+  it("survives a toJSON that throws or returns a fresh object each call", async () => {
+    const source: BlockPropsSource = { props: { data: { type: "json" } } };
+    expect(
+      await validateBlockPropValues(
+        {
+          data: {
+            toJSON: () => {
+              throw new Error("no");
+            },
+          },
+        },
+        source
+      )
+    ).toHaveLength(1);
+    // A new object per call must not make the walk run forever.
+    const churning = { toJSON: () => ({ nested: { value: 1 } }) };
+    expect(await validateBlockPropValues({ data: churning }, source)).toEqual(
+      []
+    );
+  });
+});
+
 describe("plugin field types as block props", () => {
   afterEach(() => {
     clearFieldTypes();

--- a/packages/nextly/src/collections/fields/block-props.test.ts
+++ b/packages/nextly/src/collections/fields/block-props.test.ts
@@ -1157,6 +1157,88 @@ describe("validateBlockPropValues stored shapes", () => {
   });
 });
 
+describe("validateBlockPropValues stored-form fidelity", () => {
+  it("validates only the props record's own keys", async () => {
+    // An inherited value satisfies `field.name in data` but encodes to
+    // nothing, so a required prop would pass while storing an empty object.
+    const source: BlockPropsSource = {
+      props: { title: { type: "text", required: true } },
+    };
+    const inherited = Object.create({ title: "inherited" }) as Record<
+      string,
+      unknown
+    >;
+    const issues = await validateBlockPropValues(inherited, source);
+    expect(issues.map(issue => issue.code)).toEqual(["REQUIRED"]);
+  });
+
+  it("passes the containing key to a serializer that reads it", async () => {
+    const source: BlockPropsSource = { props: { data: { type: "json" } } };
+    // Encoding calls toJSON("data"), which drops the prop; calling it bare
+    // would have made this look safe.
+    const keySensitive = {
+      toJSON: (key?: string) => (key === "data" ? undefined : { ok: true }),
+    };
+    expect(
+      await validateBlockPropValues({ data: keySensitive }, source)
+    ).toHaveLength(1);
+  });
+
+  it("refuses a shape-constrained record that replaces itself on encode", async () => {
+    const source: BlockPropsSource = {
+      props: {
+        meta: { type: "group", fields: { child: { type: "text" } } },
+        items: {
+          type: "repeater",
+          fields: { child: { type: "text" } },
+        },
+        body: { type: "richText" },
+      },
+    };
+    // Each of these satisfies its declared shape and stores something else.
+    expect(
+      await validateBlockPropValues(
+        { meta: { child: "ok", toJSON: () => "lost" } },
+        source
+      )
+    ).toHaveLength(1);
+    expect(
+      await validateBlockPropValues(
+        { items: [{ child: "ok", toJSON: () => "lost" }] },
+        source
+      )
+    ).toHaveLength(1);
+    expect(
+      await validateBlockPropValues(
+        {
+          body: {
+            root: { type: "root", children: [] },
+            toJSON: () => "lost",
+          },
+        },
+        source
+      )
+    ).toHaveLength(1);
+  });
+
+  it("reports one issue when the container shape itself is wrong", async () => {
+    const source: BlockPropsSource = {
+      props: {
+        tags: { type: "chips" },
+        meta: { type: "group", fields: { child: { type: "text" } } },
+      },
+    };
+    // The shared rules own the container-shape failure; the element and
+    // record checks must not restate it.
+    expect(await validateBlockPropValues({ tags: 123 }, source)).toHaveLength(
+      1
+    );
+    expect(await validateBlockPropValues({ meta: 123 }, source)).toHaveLength(
+      1
+    );
+  });
+});
+
 describe("plugin field types as block props", () => {
   afterEach(() => {
     clearFieldTypes();

--- a/packages/nextly/src/collections/fields/block-props.test.ts
+++ b/packages/nextly/src/collections/fields/block-props.test.ts
@@ -1102,6 +1102,61 @@ describe("validateBlockPropValues skipped sentinels", () => {
   });
 });
 
+describe("validateBlockPropValues stored shapes", () => {
+  it("requires document ids to be strings", async () => {
+    const source: BlockPropsSource = {
+      props: {
+        image: { type: "upload", relationTo: "media" },
+        ref: { type: "relationship", relationTo: ["posts", "pages"] },
+      },
+    };
+    // Every canonical contract types an id as a string.
+    expect(await validateBlockPropValues({ image: 42 }, source)).toHaveLength(
+      1
+    );
+    expect(
+      await validateBlockPropValues(
+        { ref: { relationTo: "posts", value: 42 } },
+        source
+      )
+    ).toHaveLength(1);
+    expect(await validateBlockPropValues({ image: "  " }, source)).toHaveLength(
+      1
+    );
+    expect(await validateBlockPropValues({ image: "m1" }, source)).toEqual([]);
+  });
+
+  it("requires a rich-text envelope to be a stored JSON shape", async () => {
+    const source: BlockPropsSource = { props: { body: { type: "richText" } } };
+    // A class instance with the right keys encodes to whatever its own toJSON
+    // decides, so the renderer would read back something else entirely.
+    const disguised = Object.assign(new Date("2026-01-01"), {
+      root: { type: "root", children: [] },
+    });
+    expect(
+      await validateBlockPropValues({ body: disguised }, source)
+    ).not.toEqual([]);
+    expect(
+      await validateBlockPropValues(
+        { body: { root: { type: "root", children: [] } } },
+        source
+      )
+    ).toEqual([]);
+  });
+
+  it("encodes an array through its own toJSON when it declares one", async () => {
+    const source: BlockPropsSource = { props: { data: { type: "json" } } };
+    // Stored as [null], so the declared elements are not what persists.
+    const lying = Object.assign([1, 2], { toJSON: () => [undefined] });
+    expect(await validateBlockPropValues({ data: lying }, source)).toHaveLength(
+      1
+    );
+    // The reverse: unsafe-looking elements, safe encoded output.
+    const safe = Object.assign([() => 1], { toJSON: () => [1] });
+    expect(await validateBlockPropValues({ data: safe }, source)).toEqual([]);
+  });
+});
+
 describe("plugin field types as block props", () => {
   afterEach(() => {
     clearFieldTypes();

--- a/packages/nextly/src/collections/fields/block-props.test.ts
+++ b/packages/nextly/src/collections/fields/block-props.test.ts
@@ -388,7 +388,7 @@ describe("validateBlockPropValues shape checks", () => {
       await validateBlockPropValues(
         {
           image: "media-1",
-          related: [{ relationTo: "posts", value: "p1" }, "p2"],
+          related: [{ relationTo: "posts", value: "p1" }],
         },
         source
       )
@@ -400,6 +400,32 @@ describe("validateBlockPropValues shape checks", () => {
         source
       )
     ).toHaveLength(2);
+  });
+
+  it("ties the stored reference shape to the target arity", async () => {
+    // A single target fixes the collection, so the id stands alone; several
+    // targets make a bare id ambiguous, so the reference must name its own.
+    const single: BlockPropsSource = {
+      props: { image: { type: "upload", relationTo: "media" } },
+    };
+    expect(await validateBlockPropValues({ image: "m1" }, single)).toEqual([]);
+    expect(
+      await validateBlockPropValues(
+        { image: { relationTo: "media", value: "m1" } },
+        single
+      )
+    ).toHaveLength(1);
+
+    const many: BlockPropsSource = {
+      props: { ref: { type: "relationship", relationTo: ["posts", "pages"] } },
+    };
+    expect(
+      await validateBlockPropValues(
+        { ref: { relationTo: "pages", value: "p1" } },
+        many
+      )
+    ).toEqual([]);
+    expect(await validateBlockPropValues({ ref: "p1" }, many)).toHaveLength(1);
   });
 
   it("rejects a json prop value JSON cannot represent", async () => {
@@ -583,6 +609,129 @@ describe("validateBlockPropValues value shapes", () => {
         source
       )
     ).toEqual([]);
+  });
+});
+
+describe("validateBlockPropValues structural shapes", () => {
+  it("enforces the row bounds a scalar list prop advertises", async () => {
+    const source: BlockPropsSource = {
+      props: {
+        tags: { type: "text", hasMany: true, minRows: 2, maxRows: 3 },
+        scores: { type: "number", hasMany: true, maxRows: 1 },
+      },
+    };
+    expect(
+      await validateBlockPropValues({ tags: ["only-one"] }, source)
+    ).toHaveLength(1);
+    expect(
+      await validateBlockPropValues({ tags: ["a", "b", "c", "d"] }, source)
+    ).toHaveLength(1);
+    expect(await validateBlockPropValues({ tags: ["a", "b"] }, source)).toEqual(
+      []
+    );
+    expect(
+      await validateBlockPropValues({ scores: [1, 2] }, source)
+    ).toHaveLength(1);
+  });
+
+  it("requires structured props to hold plain JSON records", async () => {
+    const source: BlockPropsSource = {
+      props: {
+        meta: { type: "group", fields: { note: { type: "text" } } },
+        items: { type: "repeater", fields: { note: { type: "text" } } },
+      },
+    };
+    // A Date survives the shared object check but becomes a string once the
+    // document is encoded.
+    expect(
+      await validateBlockPropValues({ meta: new Date() }, source)
+    ).toHaveLength(1);
+    expect(
+      await validateBlockPropValues({ items: [new Date()] }, source)
+    ).toHaveLength(1);
+    const cyclic: Record<string, unknown> = { note: "a" };
+    cyclic.self = cyclic;
+    expect(
+      await validateBlockPropValues({ meta: cyclic }, source)
+    ).toHaveLength(1);
+    expect(
+      await validateBlockPropValues(
+        { meta: { note: "a" }, items: [{ note: "b" }] },
+        source
+      )
+    ).toEqual([]);
+  });
+
+  it("rejects an empty list supplied for a prop holding one value", async () => {
+    // The shared validator reads [] as an absent value and returns before any
+    // type rule runs, so this is the one array shape it never inspects.
+    const source: BlockPropsSource = {
+      props: {
+        title: { type: "text" },
+        body: { type: "richText" },
+        data: { type: "json" },
+        tags: { type: "chips" },
+      },
+    };
+    expect(await validateBlockPropValues({ title: [] }, source)).toEqual([
+      {
+        path: "title",
+        code: "INVALID_TYPE",
+        message: "title must not be a list.",
+      },
+    ]);
+    expect(await validateBlockPropValues({ body: [] }, source)).toHaveLength(1);
+    // An array is a legitimate JSON value, and chips are a list by definition.
+    expect(
+      await validateBlockPropValues({ data: [], tags: [] }, source)
+    ).toEqual([]);
+  });
+
+  it("reaches empty lists nested inside groups and repeater rows", async () => {
+    const source: BlockPropsSource = {
+      props: {
+        meta: { type: "group", fields: { note: { type: "text" } } },
+        items: { type: "repeater", fields: { note: { type: "text" } } },
+      },
+    };
+    const issues = await validateBlockPropValues(
+      { meta: { note: [] }, items: [{ note: [] }] },
+      source
+    );
+    expect(issues.map(issue => issue.path).sort()).toEqual([
+      "items[0].note",
+      "meta.note",
+    ]);
+  });
+});
+
+describe("blockPropsToFieldConfigs relation targets", () => {
+  it("rejects a relationTo that no collection could be named", () => {
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: { ref: { type: "relationship", relationTo: "Not valid!" } },
+        })
+      )
+    ).toEqual([{ path: "ref", code: "MISSING_RELATION_TARGET" }]);
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: { ref: { type: "upload", relationTo: ["media", "Bad Slug"] } },
+        })
+      )
+    ).toEqual([{ path: "ref", code: "MISSING_RELATION_TARGET" }]);
+  });
+
+  it("accepts canonical slugs in both forms", () => {
+    const configs = blockPropsToFieldConfigs({
+      props: {
+        image: { type: "upload", relationTo: "media_files" },
+        ref: { type: "relationship", relationTo: ["blog-posts", "pages"] },
+      },
+    });
+    expect(configs[0]).toMatchObject({ relationTo: "media_files" });
+    expect(configs[1]).toMatchObject({ relationTo: ["blog-posts", "pages"] });
   });
 });
 

--- a/packages/nextly/src/collections/fields/block-props.test.ts
+++ b/packages/nextly/src/collections/fields/block-props.test.ts
@@ -1221,6 +1221,24 @@ describe("validateBlockPropValues stored-form fidelity", () => {
     ).toHaveLength(1);
   });
 
+  it("rejects a sparse array, whose holes encode as null", async () => {
+    const source: BlockPropsSource = {
+      props: { tags: { type: "chips" }, data: { type: "json" } },
+    };
+    const sparse: unknown[] = [];
+    sparse[2] = "a";
+    // Array methods skip the holes; encoding writes them as null.
+    expect(
+      await validateBlockPropValues({ tags: sparse }, source)
+    ).toHaveLength(1);
+    expect(
+      await validateBlockPropValues({ data: sparse }, source)
+    ).toHaveLength(1);
+    expect(await validateBlockPropValues({ tags: ["a", "b"] }, source)).toEqual(
+      []
+    );
+  });
+
   it("reports one issue when the container shape itself is wrong", async () => {
     const source: BlockPropsSource = {
       props: {

--- a/packages/nextly/src/collections/fields/block-props.test.ts
+++ b/packages/nextly/src/collections/fields/block-props.test.ts
@@ -1257,6 +1257,97 @@ describe("validateBlockPropValues stored-form fidelity", () => {
   });
 });
 
+describe("blockPropsToFieldConfigs localized names", () => {
+  it("rejects a localized name that matches no declared prop", () => {
+    // A typo would otherwise produce a config with nothing translatable and
+    // no sign that the author asked for one.
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          localized: ["titel"],
+          props: { title: { type: "text" } },
+        })
+      )
+    ).toEqual([{ path: "titel", code: "UNKNOWN_LOCALIZED_PROP" }]);
+  });
+
+  it("rejects a localized name that only matches a nested field", () => {
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          localized: ["note"],
+          props: {
+            meta: { type: "group", fields: { note: { type: "text" } } },
+          },
+        })
+      )
+    ).toEqual([{ path: "note", code: "UNKNOWN_LOCALIZED_PROP" }]);
+  });
+});
+
+describe("validateBlockPropValues encoded form", () => {
+  it("refuses a typed prop value that replaces itself on encode", async () => {
+    const source: BlockPropsSource = {
+      props: {
+        ref: { type: "relationship", relationTo: ["posts", "pages"] },
+        tags: { type: "text", hasMany: true },
+      },
+    };
+    // Both satisfy their declared shape and store something else entirely.
+    expect(
+      await validateBlockPropValues(
+        { ref: { relationTo: "posts", value: "p1", toJSON: () => "broken" } },
+        source
+      )
+    ).toHaveLength(1);
+    expect(
+      await validateBlockPropValues(
+        { tags: Object.assign(["a"], { toJSON: () => [123] }) },
+        source
+      )
+    ).toHaveLength(1);
+  });
+
+  it("still lets json and date props choose their stored form", async () => {
+    const source: BlockPropsSource = {
+      props: { data: { type: "json" }, when: { type: "date" } },
+    };
+    expect(
+      await validateBlockPropValues(
+        {
+          data: { toJSON: () => ({ ok: true }) },
+          when: new Date("2026-01-01"),
+        },
+        source
+      )
+    ).toEqual([]);
+  });
+
+  it("treats an explicit null as an unset prop", async () => {
+    // null is not a wrong-typed value: it is how JSON says a prop is unset,
+    // it encodes unchanged, and it reads exactly as an absent key does.
+    const optional: BlockPropsSource = {
+      props: {
+        count: { type: "number" },
+        meta: { type: "group", fields: { note: { type: "text" } } },
+        image: { type: "upload", relationTo: "media" },
+      },
+    };
+    expect(
+      await validateBlockPropValues(
+        { count: null, meta: null, image: null },
+        optional
+      )
+    ).toEqual([]);
+    // A required prop still refuses it, through the shared empty-value rule.
+    const required: BlockPropsSource = {
+      props: { count: { type: "number", required: true } },
+    };
+    const issues = await validateBlockPropValues({ count: null }, required);
+    expect(issues.map(issue => issue.code)).toEqual(["REQUIRED"]);
+  });
+});
+
 describe("plugin field types as block props", () => {
   afterEach(() => {
     clearFieldTypes();

--- a/packages/nextly/src/collections/fields/block-props.test.ts
+++ b/packages/nextly/src/collections/fields/block-props.test.ts
@@ -1,0 +1,370 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  clearFieldTypes,
+  registerFieldType,
+} from "../../domains/schema/field-types/field-type-registry";
+import { NextlyError } from "../../errors/nextly-error";
+
+import {
+  blockPropsToFieldConfigs,
+  validateBlockPropValues,
+  type BlockPropsSource,
+} from "./block-props";
+
+/** The issues carried by a conversion failure, or an empty list. */
+function issuesOf(fn: () => unknown): Array<{ path: string; code: string }> {
+  try {
+    fn();
+  } catch (error) {
+    if (
+      NextlyError.is(error) &&
+      error.publicData &&
+      "errors" in error.publicData
+    ) {
+      return error.publicData.errors.map(issue => ({
+        path: issue.path,
+        code: issue.code,
+      }));
+    }
+    throw error;
+  }
+  return [];
+}
+
+describe("blockPropsToFieldConfigs", () => {
+  it("returns nothing for a block with no props", () => {
+    expect(blockPropsToFieldConfigs({ name: "core/spacer" })).toEqual([]);
+  });
+
+  it("converts declarations in order, keyed by prop name", () => {
+    const configs = blockPropsToFieldConfigs({
+      name: "core/heading",
+      props: {
+        text: { type: "text", maxLength: 120, required: true },
+        level: {
+          type: "select",
+          options: [
+            { label: "H1", value: "h1" },
+            { label: "H2", value: "h2" },
+          ],
+        },
+      },
+    });
+    expect(configs.map(config => config.name)).toEqual(["text", "level"]);
+    expect(configs[0]).toMatchObject({
+      name: "text",
+      type: "text",
+      maxLength: 120,
+      required: true,
+    });
+    expect(configs[1]).toMatchObject({
+      name: "level",
+      type: "select",
+      options: [
+        { label: "H1", value: "h1" },
+        { label: "H2", value: "h2" },
+      ],
+    });
+  });
+
+  it("marks only top-level props named in `localized`", () => {
+    const configs = blockPropsToFieldConfigs({
+      name: "core/card",
+      localized: ["title"],
+      props: {
+        title: { type: "text" },
+        slug: { type: "text" },
+        items: {
+          type: "repeater",
+          // A nested field sharing a localized prop's name is a different
+          // value and must not inherit the flag.
+          fields: { title: { type: "text" } },
+        },
+      },
+    });
+    expect(configs[0]).toMatchObject({ name: "title", localized: true });
+    expect(configs[1]?.localized).toBeUndefined();
+    const repeater = configs[2];
+    expect(repeater?.type).toBe("repeater");
+    expect(
+      repeater && "fields" in repeater ? repeater.fields[0]?.localized : "unset"
+    ).toBeUndefined();
+  });
+
+  it("does not copy defaults onto the field configs", () => {
+    const configs = blockPropsToFieldConfigs({
+      name: "core/heading",
+      props: { text: { type: "text" } },
+    });
+    expect(configs[0]).not.toHaveProperty("defaultValue");
+  });
+
+  it("recurses into repeater and group prop declarations", () => {
+    const configs = blockPropsToFieldConfigs({
+      name: "core/features",
+      props: {
+        items: {
+          type: "repeater",
+          minRows: 1,
+          maxRows: 6,
+          fields: {
+            heading: { type: "text" },
+            body: { type: "textarea", maxLength: 400 },
+          },
+        },
+        meta: {
+          type: "group",
+          fields: { note: { type: "text" } },
+        },
+      },
+    });
+    const repeater = configs[0];
+    expect(repeater).toMatchObject({
+      type: "repeater",
+      minRows: 1,
+      maxRows: 6,
+    });
+    expect(
+      repeater && "fields" in repeater
+        ? repeater.fields.map(field => field.name)
+        : []
+    ).toEqual(["heading", "body"]);
+    const group = configs[1];
+    expect(
+      group && "fields" in group ? group.fields.map(field => field.name) : []
+    ).toEqual(["note"]);
+  });
+
+  it("carries relation targets through for upload and relationship props", () => {
+    const configs = blockPropsToFieldConfigs({
+      name: "core/media",
+      props: {
+        image: { type: "upload", relationTo: "media" },
+        related: {
+          type: "relationship",
+          relationTo: ["posts", "pages"],
+          hasMany: true,
+        },
+      },
+    });
+    expect(configs[0]).toMatchObject({ type: "upload", relationTo: "media" });
+    expect(configs[1]).toMatchObject({
+      type: "relationship",
+      relationTo: ["posts", "pages"],
+      hasMany: true,
+    });
+  });
+});
+
+describe("blockPropsToFieldConfigs rejections", () => {
+  it("rejects a field type a block prop may not declare", () => {
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          name: "core/secret",
+          props: { token: { type: "password" } },
+        })
+      )
+    ).toEqual([{ path: "token", code: "UNKNOWN_FIELD_TYPE" }]);
+  });
+
+  it("rejects a prop name that is not an identifier", () => {
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: { "not a name": { type: "text" } },
+        })
+      )
+    ).toEqual([{ path: "not a name", code: "INVALID_NAME" }]);
+  });
+
+  it("reports every bad declaration at once, not just the first", () => {
+    const issues = issuesOf(() =>
+      blockPropsToFieldConfigs({
+        name: "core/broken",
+        props: {
+          one: { type: "nope" },
+          two: { type: "select" },
+          three: { type: "upload" },
+        },
+      })
+    );
+    expect(issues).toEqual([
+      { path: "one", code: "UNKNOWN_FIELD_TYPE" },
+      { path: "two", code: "MISSING_OPTIONS" },
+      { path: "three", code: "MISSING_RELATION_TARGET" },
+    ]);
+  });
+
+  it("rejects an option whose value has the wrong type", () => {
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: { text: { type: "text", maxLength: "80" } },
+        })
+      )
+    ).toEqual([{ path: "text.maxLength", code: "INVALID_OPTION" }]);
+  });
+
+  it("rejects a non-finite numeric option", () => {
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: { count: { type: "number", max: Number.NaN } },
+        })
+      )
+    ).toEqual([{ path: "count.max", code: "INVALID_OPTION" }]);
+  });
+
+  it("rejects malformed choice entries", () => {
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: { level: { type: "select", options: [{ label: "H1" }] } },
+        })
+      )
+    ).toEqual([{ path: "level", code: "INVALID_OPTIONS" }]);
+  });
+
+  it("rejects a structured prop with no nested fields", () => {
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: { items: { type: "repeater", fields: {} } },
+        })
+      )
+    ).toEqual([{ path: "items", code: "MISSING_FIELDS" }]);
+  });
+
+  it("paths nested failures under their parent prop", () => {
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: {
+            items: { type: "repeater", fields: { bad: { type: "password" } } },
+          },
+        })
+      )
+    ).toEqual([{ path: "items.bad", code: "UNKNOWN_FIELD_TYPE" }]);
+  });
+
+  it("survives a declaration that is not an object", () => {
+    const source = {
+      props: { broken: null },
+    } as unknown as BlockPropsSource;
+    expect(issuesOf(() => blockPropsToFieldConfigs(source))).toEqual([
+      { path: "broken", code: "INVALID_DECLARATION" },
+    ]);
+  });
+});
+
+describe("plugin field types as block props", () => {
+  afterEach(() => {
+    clearFieldTypes();
+  });
+
+  it("admits a plugin type that opted into the blocks surface", () => {
+    registerFieldType({
+      type: "rating",
+      storage: "number",
+      component: "plugin/rating",
+      surfaces: ["blocks"],
+    });
+    const configs = blockPropsToFieldConfigs({
+      name: "core/review",
+      props: { score: { type: "rating", min: 1, max: 5 } },
+    });
+    // The prop keeps its name and validates as the storage primitive the
+    // plugin declared; the plugin's own component renders it.
+    expect(configs).toEqual([
+      { name: "score", type: "number", min: 1, max: 5 },
+    ]);
+  });
+
+  it("refuses a plugin type that did not opt into the blocks surface", () => {
+    registerFieldType({
+      type: "rating",
+      storage: "number",
+      component: "plugin/rating",
+      surfaces: ["forms"],
+    });
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({ props: { score: { type: "rating" } } })
+      )
+    ).toEqual([{ path: "score", code: "UNKNOWN_FIELD_TYPE" }]);
+  });
+
+  it("refuses a plugin type that declared no surfaces", () => {
+    registerFieldType({
+      type: "rating",
+      storage: "number",
+      component: "plugin/rating",
+    });
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({ props: { score: { type: "rating" } } })
+      )
+    ).toEqual([{ path: "score", code: "UNKNOWN_FIELD_TYPE" }]);
+  });
+
+  it("maps every storage primitive to a block prop type", () => {
+    const primitives = [
+      ["text", "text"],
+      ["longText", "textarea"],
+      ["boolean", "checkbox"],
+      ["number", "number"],
+      ["timestamp", "date"],
+      ["json", "json"],
+    ] as const;
+    for (const [storage, expected] of primitives) {
+      clearFieldTypes();
+      registerFieldType({
+        type: "custom",
+        storage,
+        component: "plugin/custom",
+        surfaces: ["blocks"],
+      });
+      const configs = blockPropsToFieldConfigs({
+        props: { value: { type: "custom" } },
+      });
+      expect(configs[0]?.type, storage).toBe(expected);
+    }
+  });
+});
+
+describe("validateBlockPropValues", () => {
+  const source: BlockPropsSource = {
+    name: "core/heading",
+    props: {
+      text: { type: "text", required: true, maxLength: 10 },
+      level: {
+        type: "select",
+        options: [
+          { label: "H1", value: "h1" },
+          { label: "H2", value: "h2" },
+        ],
+      },
+    },
+  };
+
+  it("accepts values that satisfy the declarations", async () => {
+    expect(
+      await validateBlockPropValues({ text: "Hello", level: "h1" }, source)
+    ).toEqual([]);
+  });
+
+  it("enforces the same rules an entry field would", async () => {
+    const issues = await validateBlockPropValues(
+      { text: "far too long to fit", level: "h9" },
+      source
+    );
+    expect(issues.map(issue => issue.path).sort()).toEqual(["level", "text"]);
+  });
+
+  it("treats an absent required prop as missing rather than untouched", async () => {
+    const issues = await validateBlockPropValues({ level: "h1" }, source);
+    expect(issues.map(issue => issue.path)).toEqual(["text"]);
+  });
+});

--- a/packages/nextly/src/collections/fields/block-props.test.ts
+++ b/packages/nextly/src/collections/fields/block-props.test.ts
@@ -92,6 +92,13 @@ describe("blockPropsToFieldConfigs", () => {
     ).toBeUndefined();
   });
 
+  it("leaves built-in props without a plugin identity", () => {
+    const configs = blockPropsToFieldConfigs({
+      props: { text: { type: "text" } },
+    });
+    expect(configs[0]).not.toHaveProperty("custom");
+  });
+
   it("does not copy defaults onto the field configs", () => {
     const configs = blockPropsToFieldConfigs({
       name: "core/heading",
@@ -414,6 +421,171 @@ describe("validateBlockPropValues shape checks", () => {
   });
 });
 
+describe("blockPropsToFieldConfigs unknown options", () => {
+  it("refuses the nested validation object rather than dropping it", () => {
+    // Silently ignoring it would leave a declaration that reads as if it
+    // constrains its values while validating nothing.
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: { text: { type: "text", validation: { maxLength: 5 } } },
+        })
+      )
+    ).toEqual([{ path: "text.validation", code: "UNKNOWN_OPTION" }]);
+  });
+
+  it("refuses a validate function, which cannot reach the manifest", () => {
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: { text: { type: "text", validate: () => "nope" } },
+        })
+      )
+    ).toEqual([{ path: "text.validate", code: "UNKNOWN_OPTION" }]);
+  });
+
+  it("refuses a misspelled option and an option belonging to another type", () => {
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: { text: { type: "text", maxLenght: 5 } },
+        })
+      )
+    ).toEqual([{ path: "text.maxLenght", code: "UNKNOWN_OPTION" }]);
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: { note: { type: "richText", maxLength: 5 } },
+        })
+      )
+    ).toEqual([{ path: "note.maxLength", code: "UNKNOWN_OPTION" }]);
+  });
+
+  it("names every unknown option, not only the first", () => {
+    const issues = issuesOf(() =>
+      blockPropsToFieldConfigs({
+        props: { text: { type: "text", nope: 1, alsoNope: 2 } },
+      })
+    );
+    expect(issues.map(issue => issue.path)).toEqual([
+      "text.nope",
+      "text.alsoNope",
+    ]);
+  });
+});
+
+describe("blockPropsToFieldConfigs cardinality", () => {
+  it("carries hasMany and row bounds onto text and number props", () => {
+    const configs = blockPropsToFieldConfigs({
+      props: {
+        tags: { type: "text", hasMany: true, minRows: 1, maxRows: 3 },
+        scores: { type: "number", hasMany: true, minRows: 2 },
+      },
+    });
+    expect(configs[0]).toMatchObject({
+      type: "text",
+      hasMany: true,
+      minRows: 1,
+      maxRows: 3,
+    });
+    expect(configs[1]).toMatchObject({
+      type: "number",
+      hasMany: true,
+      minRows: 2,
+    });
+  });
+
+  it("keeps validation in step with what the binding API allows", async () => {
+    // canBindFieldToProp accepts a many-valued source for a many-valued prop,
+    // so validation must accept the array that binding would deliver.
+    const source: BlockPropsSource = {
+      props: { tags: { type: "text", hasMany: true } },
+    };
+    expect(await validateBlockPropValues({ tags: ["a", "b"] }, source)).toEqual(
+      []
+    );
+    expect(await validateBlockPropValues({ tags: "a" }, source)).toHaveLength(
+      1
+    );
+  });
+});
+
+describe("validateBlockPropValues value shapes", () => {
+  it("rejects non-finite numbers, which JSON stores as null", async () => {
+    const source: BlockPropsSource = { props: { count: { type: "number" } } };
+    expect(
+      await validateBlockPropValues({ count: Number.POSITIVE_INFINITY }, source)
+    ).toHaveLength(1);
+    expect(
+      await validateBlockPropValues({ count: Number.NEGATIVE_INFINITY }, source)
+    ).toHaveLength(1);
+    expect(await validateBlockPropValues({ count: 42 }, source)).toEqual([]);
+  });
+
+  it("rejects non-finite numbers inside a json prop", async () => {
+    const source: BlockPropsSource = { props: { data: { type: "json" } } };
+    expect(
+      await validateBlockPropValues({ data: { n: Number.NaN } }, source)
+    ).toHaveLength(1);
+    expect(
+      await validateBlockPropValues(
+        { data: [Number.POSITIVE_INFINITY] },
+        source
+      )
+    ).toHaveLength(1);
+  });
+
+  it("requires every chips entry to be text", async () => {
+    const source: BlockPropsSource = { props: { tags: { type: "chips" } } };
+    expect(
+      await validateBlockPropValues({ tags: [1, {}] }, source)
+    ).toHaveLength(1);
+    expect(await validateBlockPropValues({ tags: ["a", "b"] }, source)).toEqual(
+      []
+    );
+  });
+
+  it("requires the rich-text root to be a root node with node children", async () => {
+    const source: BlockPropsSource = { props: { body: { type: "richText" } } };
+    expect(
+      await validateBlockPropValues(
+        { body: { root: { type: "paragraph", children: [] } } },
+        source
+      )
+    ).toHaveLength(1);
+    expect(
+      await validateBlockPropValues(
+        { body: { root: { type: "root", children: [42] } } },
+        source
+      )
+    ).toHaveLength(1);
+    expect(
+      await validateBlockPropValues(
+        { body: { root: { type: "root", children: [{ type: "paragraph" }] } } },
+        source
+      )
+    ).toEqual([]);
+  });
+
+  it("rejects a reference to a collection the prop does not relate to", async () => {
+    const source: BlockPropsSource = {
+      props: { related: { type: "relationship", relationTo: ["posts"] } },
+    };
+    expect(
+      await validateBlockPropValues(
+        { related: { relationTo: "users", value: "u1" } },
+        source
+      )
+    ).toHaveLength(1);
+    expect(
+      await validateBlockPropValues(
+        { related: { relationTo: "posts", value: "p1" } },
+        source
+      )
+    ).toEqual([]);
+  });
+});
+
 describe("plugin field types as block props", () => {
   afterEach(() => {
     clearFieldTypes();
@@ -430,11 +602,17 @@ describe("plugin field types as block props", () => {
       name: "core/review",
       props: { score: { type: "rating", min: 1, max: 5 } },
     });
-    // The prop keeps its name and validates as the storage primitive the
-    // plugin declared; the plugin's own component renders it.
-    expect(configs).toEqual([
-      { name: "score", type: "number", min: 1, max: 5 },
-    ]);
+    // The prop keeps its name, validates as the storage primitive the plugin
+    // declared, and carries the contributed type so an inspector can still
+    // dispatch the plugin's own component instead of the number control.
+    expect(configs).toHaveLength(1);
+    expect(configs[0]).toMatchObject({
+      name: "score",
+      type: "number",
+      min: 1,
+      max: 5,
+      custom: { pluginFieldType: "rating" },
+    });
   });
 
   it("refuses a plugin type that did not opt into the blocks surface", () => {

--- a/packages/nextly/src/collections/fields/block-props.test.ts
+++ b/packages/nextly/src/collections/fields/block-props.test.ts
@@ -810,6 +810,20 @@ describe("blockPropsToFieldConfigs choices", () => {
     ).toEqual([{ path: "level", code: "INVALID_OPTIONS" }]);
   });
 
+  it("rejects a whitespace-only label or value", () => {
+    // The shared rules trim before deciding emptiness, so a blank value is
+    // read as absent exactly like an empty one.
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: {
+            level: { type: "select", options: [{ label: "Sp", value: "   " }] },
+          },
+        })
+      )
+    ).toEqual([{ path: "level", code: "INVALID_OPTIONS" }]);
+  });
+
   it("rejects two options sharing a stored value", () => {
     expect(
       issuesOf(() =>
@@ -841,6 +855,110 @@ describe("blockPropsToFieldConfigs choices", () => {
       },
     });
     expect(configs[0]).toMatchObject({ type: "select" });
+  });
+});
+
+describe("block prop names", () => {
+  it("refuses a name that shadows an Object.prototype member", () => {
+    for (const reserved of ["toString", "constructor", "hasOwnProperty"]) {
+      expect(
+        issuesOf(() =>
+          blockPropsToFieldConfigs({ props: { [reserved]: { type: "text" } } })
+        ),
+        reserved
+      ).toEqual([{ path: reserved, code: "RESERVED_NAME" }]);
+    }
+  });
+
+  it("refuses a reserved name nested inside a structured prop", () => {
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: {
+            meta: { type: "group", fields: { valueOf: { type: "text" } } },
+          },
+        })
+      )
+    ).toEqual([{ path: "meta.valueOf", code: "RESERVED_NAME" }]);
+  });
+});
+
+describe("validateBlockPropValues stored-document safety", () => {
+  it("checks props the declaration does not cover", async () => {
+    // A stored node can carry a key no current declaration knows about; it is
+    // written into the same document, so it answers to the same rule.
+    const source: BlockPropsSource = { props: { title: { type: "text" } } };
+    const issues = await validateBlockPropValues(
+      { title: "ok", legacyExtra: () => 1 },
+      source
+    );
+    expect(issues).toEqual([
+      {
+        path: "legacyExtra",
+        code: "NOT_SERIALIZABLE",
+        message: expect.stringContaining("legacyExtra"),
+      },
+    ]);
+  });
+
+  it("rejects values JSON reshapes instead of rejecting", async () => {
+    const source: BlockPropsSource = { props: { data: { type: "json" } } };
+    // A Map encodes as {} and a Set as {}, losing their contents silently.
+    expect(
+      await validateBlockPropValues({ data: new Map([["a", 1]]) }, source)
+    ).toHaveLength(1);
+    expect(
+      await validateBlockPropValues({ data: { inner: new Set([1]) } }, source)
+    ).toHaveLength(1);
+  });
+
+  it("accepts a value that defines its own encoded form", async () => {
+    // A Date chooses an ISO string through toJSON, which is exactly how dates
+    // are stored, so it is not a reshaping loss.
+    const source: BlockPropsSource = { props: { when: { type: "date" } } };
+    expect(
+      await validateBlockPropValues({ when: new Date("2026-01-01") }, source)
+    ).toEqual([]);
+  });
+
+  it("reports one issue for an empty list on a scalar choice", async () => {
+    const source: BlockPropsSource = {
+      props: {
+        level: {
+          type: "select",
+          options: [{ label: "H1", value: "h1" }],
+        },
+      },
+    };
+    const issues = await validateBlockPropValues({ level: [] }, source);
+    expect(issues).toHaveLength(1);
+  });
+});
+
+describe("blockPropsToFieldConfigs reference bounds", () => {
+  it("accepts and enforces row bounds on a multi-reference prop", async () => {
+    const source: BlockPropsSource = {
+      props: {
+        gallery: {
+          type: "upload",
+          relationTo: "media",
+          hasMany: true,
+          minRows: 2,
+          maxRows: 3,
+        },
+      },
+    };
+    const configs = blockPropsToFieldConfigs(source);
+    expect(configs[0]).toMatchObject({ minRows: 2, maxRows: 3 });
+    expect(
+      await validateBlockPropValues({ gallery: ["a"] }, source)
+    ).toHaveLength(1);
+    expect(
+      await validateBlockPropValues({ gallery: ["a", "b", "c", "d"] }, source)
+    ).toHaveLength(1);
+    expect(
+      await validateBlockPropValues({ gallery: ["a", "b"] }, source)
+    ).toEqual([]);
   });
 });
 

--- a/packages/nextly/src/collections/fields/block-props.test.ts
+++ b/packages/nextly/src/collections/fields/block-props.test.ts
@@ -632,6 +632,15 @@ describe("validateBlockPropValues structural shapes", () => {
     expect(
       await validateBlockPropValues({ scores: [1, 2] }, source)
     ).toHaveLength(1);
+    // An empty list never reaches the shared bounds rules for a hasMany
+    // scalar, so the declared minimum is enforced alongside the shape check.
+    expect(await validateBlockPropValues({ tags: [] }, source)).toEqual([
+      {
+        path: "tags",
+        code: "TOO_FEW_ROWS",
+        message: "tags must have at least 2 entries.",
+      },
+    ]);
   });
 
   it("requires structured props to hold plain JSON records", async () => {
@@ -732,6 +741,106 @@ describe("blockPropsToFieldConfigs relation targets", () => {
     });
     expect(configs[0]).toMatchObject({ relationTo: "media_files" });
     expect(configs[1]).toMatchObject({ relationTo: ["blog-posts", "pages"] });
+  });
+});
+
+describe("validateBlockPropValues serializability", () => {
+  it("rejects rich text that is well formed but cannot be stored", async () => {
+    const source: BlockPropsSource = { props: { body: { type: "richText" } } };
+    const child: Record<string, unknown> = { type: "paragraph" };
+    child.self = child;
+    const issues = await validateBlockPropValues(
+      { body: { root: { type: "root", children: [child] } } },
+      source
+    );
+    // Every structural rule passes; the value still cannot reach the document.
+    expect(issues).toEqual([
+      {
+        path: "body",
+        code: "NOT_SERIALIZABLE",
+        message: expect.stringContaining("body"),
+      },
+    ]);
+  });
+
+  it("covers every prop type from one place", async () => {
+    const source: BlockPropsSource = {
+      props: {
+        title: { type: "text" },
+        image: { type: "upload", relationTo: "media" },
+      },
+    };
+    // An upload reference carrying an unserializable extra still fails.
+    const reference: Record<string, unknown> = { relationTo: "media" };
+    reference.self = reference;
+    expect(
+      await validateBlockPropValues({ image: reference }, source)
+    ).not.toEqual([]);
+  });
+
+  it("does not add a second issue where a type rule already spoke", async () => {
+    const source: BlockPropsSource = { props: { count: { type: "number" } } };
+    const issues = await validateBlockPropValues({ count: Number.NaN }, source);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.code).toBe("INVALID_TYPE");
+  });
+});
+
+describe("blockPropsToFieldConfigs choices", () => {
+  it("rejects an empty label or stored value", () => {
+    // The shared rules read "" as absent, so such an option could never be
+    // selected and would be indistinguishable from leaving the prop unset.
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: {
+            level: { type: "select", options: [{ label: "None", value: "" }] },
+          },
+        })
+      )
+    ).toEqual([{ path: "level", code: "INVALID_OPTIONS" }]);
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: {
+            level: { type: "radio", options: [{ label: "", value: "h1" }] },
+          },
+        })
+      )
+    ).toEqual([{ path: "level", code: "INVALID_OPTIONS" }]);
+  });
+
+  it("rejects two options sharing a stored value", () => {
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: {
+            level: {
+              type: "select",
+              options: [
+                { label: "Heading", value: "h1" },
+                { label: "Title", value: "h1" },
+              ],
+            },
+          },
+        })
+      )
+    ).toEqual([{ path: "level", code: "DUPLICATE_OPTION" }]);
+  });
+
+  it("accepts distinct non-empty choices", () => {
+    const configs = blockPropsToFieldConfigs({
+      props: {
+        level: {
+          type: "select",
+          options: [
+            { label: "H1", value: "h1" },
+            { label: "H2", value: "h2" },
+          ],
+        },
+      },
+    });
+    expect(configs[0]).toMatchObject({ type: "select" });
   });
 });
 

--- a/packages/nextly/src/collections/fields/block-props.test.ts
+++ b/packages/nextly/src/collections/fields/block-props.test.ts
@@ -259,6 +259,161 @@ describe("blockPropsToFieldConfigs rejections", () => {
   });
 });
 
+describe("blockPropsToFieldConfigs bounds", () => {
+  it("rejects a lower bound greater than its upper bound", () => {
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: { text: { type: "text", minLength: 10, maxLength: 5 } },
+        })
+      )
+    ).toEqual([{ path: "text", code: "INVALID_BOUNDS" }]);
+  });
+
+  it("rejects inverted bounds on numbers, chips, and rows", () => {
+    const cases: Array<[string, Record<string, unknown>]> = [
+      ["count", { type: "number", min: 10, max: 1 }],
+      ["tags", { type: "chips", minChips: 3, maxChips: 1 }],
+      [
+        "items",
+        {
+          type: "repeater",
+          fields: { a: { type: "text" } },
+          minRows: 4,
+          maxRows: 2,
+        },
+      ],
+    ];
+    for (const [name, declaration] of cases) {
+      expect(
+        issuesOf(() =>
+          blockPropsToFieldConfigs({ props: { [name]: declaration } })
+        ),
+        name
+      ).toEqual([{ path: name, code: "INVALID_BOUNDS" }]);
+    }
+  });
+
+  it("rejects a negative or fractional count bound", () => {
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: { text: { type: "text", maxLength: -1 } },
+        })
+      )
+    ).toEqual([{ path: "text.maxLength", code: "INVALID_OPTION" }]);
+    expect(
+      issuesOf(() =>
+        blockPropsToFieldConfigs({
+          props: { text: { type: "text", minLength: 1.5 } },
+        })
+      )
+    ).toEqual([{ path: "text.minLength", code: "INVALID_OPTION" }]);
+  });
+
+  it("still allows a number prop to range below zero and hold fractions", () => {
+    const configs = blockPropsToFieldConfigs({
+      props: { offset: { type: "number", min: -10.5, max: 10.5 } },
+    });
+    expect(configs[0]).toMatchObject({ min: -10.5, max: 10.5 });
+  });
+
+  it("accepts equal bounds", () => {
+    const configs = blockPropsToFieldConfigs({
+      props: { code: { type: "text", minLength: 4, maxLength: 4 } },
+    });
+    expect(configs[0]).toMatchObject({ minLength: 4, maxLength: 4 });
+  });
+
+  it("stops recursion at the nesting limit instead of overflowing", () => {
+    // A declaration that contains itself: legal to write, impossible to walk.
+    const cyclic: Record<string, unknown> = { type: "group" };
+    cyclic.fields = { inner: cyclic };
+    const issues = issuesOf(() =>
+      blockPropsToFieldConfigs({
+        props: { root: cyclic as never },
+      })
+    );
+    expect(issues.at(-1)?.code).toBe("NESTING_TOO_DEEP");
+  });
+});
+
+describe("validateBlockPropValues shape checks", () => {
+  it("rejects a rich text value that is not editor content", async () => {
+    const source: BlockPropsSource = { props: { body: { type: "richText" } } };
+    expect(await validateBlockPropValues({ body: 42 }, source)).toHaveLength(1);
+    expect(
+      await validateBlockPropValues({ body: { nope: true } }, source)
+    ).toHaveLength(1);
+    expect(
+      await validateBlockPropValues(
+        { body: { root: { type: "root", children: [] } } },
+        source
+      )
+    ).toEqual([]);
+  });
+
+  it("rejects a malformed reference on upload and relationship props", async () => {
+    const source: BlockPropsSource = {
+      props: {
+        image: { type: "upload", relationTo: "media" },
+        related: { type: "relationship", relationTo: ["posts"], hasMany: true },
+      },
+    };
+    const issues = await validateBlockPropValues(
+      { image: { nonsense: true }, related: [{ bad: 1 }] },
+      source
+    );
+    expect(issues.map(issue => issue.path).sort()).toEqual([
+      "image",
+      "related",
+    ]);
+  });
+
+  it("accepts ids and polymorphic references, honoring cardinality", async () => {
+    const source: BlockPropsSource = {
+      props: {
+        image: { type: "upload", relationTo: "media" },
+        related: { type: "relationship", relationTo: ["posts"], hasMany: true },
+      },
+    };
+    expect(
+      await validateBlockPropValues(
+        {
+          image: "media-1",
+          related: [{ relationTo: "posts", value: "p1" }, "p2"],
+        },
+        source
+      )
+    ).toEqual([]);
+    // A list where a single reference belongs, and the reverse.
+    expect(
+      await validateBlockPropValues(
+        { image: ["media-1"], related: "p1" },
+        source
+      )
+    ).toHaveLength(2);
+  });
+
+  it("rejects a json prop value JSON cannot represent", async () => {
+    const source: BlockPropsSource = { props: { data: { type: "json" } } };
+    expect(
+      await validateBlockPropValues({ data: () => 1 }, source)
+    ).toHaveLength(1);
+    expect(
+      await validateBlockPropValues({ data: { nested: [Symbol("x")] } }, source)
+    ).toHaveLength(1);
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(
+      await validateBlockPropValues({ data: cyclic }, source)
+    ).toHaveLength(1);
+    expect(
+      await validateBlockPropValues({ data: { ok: [1, "two", null] } }, source)
+    ).toEqual([]);
+  });
+});
+
 describe("plugin field types as block props", () => {
   afterEach(() => {
     clearFieldTypes();

--- a/packages/nextly/src/collections/fields/block-props.ts
+++ b/packages/nextly/src/collections/fields/block-props.ts
@@ -1130,9 +1130,11 @@ function containsUnserializable(value: unknown, key: string): boolean {
       continue;
     }
     if (Array.isArray(current)) {
-      current.forEach((item, index) =>
-        pending.push({ value: item, key: String(index) })
-      );
+      // Indexed rather than iterated: a hole is skipped by the array methods
+      // but encoded as `null`, which changes the stored shape silently.
+      for (let index = 0; index < current.length; index++) {
+        pending.push({ value: current[index], key: String(index) });
+      }
       continue;
     }
     // Anything else that is not a plain record is reshaped rather than

--- a/packages/nextly/src/collections/fields/block-props.ts
+++ b/packages/nextly/src/collections/fields/block-props.ts
@@ -147,18 +147,67 @@ export async function validateBlockPropValues(
   // Block props are always written whole: a stored node carries every prop it
   // has, so absent means unset rather than untouched, which is create mode.
   const issues = await validateEntryData(values, fields, { mode: "create" });
+  collectSerializationIssues(fields, values, issues);
   collectEmptyListIssues(fields, values, "", issues);
   return issues;
 }
 
 /**
- * Report an empty array supplied for a prop that holds a single value.
+ * Report a prop value that cannot be written into the block document.
  *
- * The shared validator classifies `[]` as an absent value and returns before
- * any type rule runs, including a field's own `validate`, so `[]` is the one
- * array shape the per-type checks never see. For an entry that is harmless —
- * the value is on its way to a typed column. A block prop is stored as JSON
- * exactly as given, so the empty array would reach a renderer expecting text.
+ * Every prop ends up inside one JSON document, so serializability is a
+ * property of the surface rather than of any one field type. Checking it once
+ * per prop covers the types whose own rules look only at shape — a rich-text
+ * envelope with a cyclic child is well formed by every structural measure and
+ * still cannot be stored — and it keeps future prop types covered without each
+ * having to remember the rule.
+ */
+function collectSerializationIssues(
+  fields: readonly WalkableField[],
+  values: Record<string, unknown>,
+  issues: ConversionIssue[]
+): void {
+  for (const field of fields) {
+    if (!field.name) continue;
+    const value = values[field.name];
+    if (value === undefined) continue;
+    // A prop that already failed a type rule does not need a second, vaguer
+    // issue: the specific one describes the same defect better.
+    if (alreadyReported(issues, field.name)) continue;
+    const result = isSerializable(value);
+    if (result !== true) {
+      issues.push({
+        path: field.name,
+        code: "NOT_SERIALIZABLE",
+        message: `${field.label ?? field.name} ${result}.`,
+      });
+    }
+  }
+}
+
+/** Whether any recorded issue already points at this prop or inside it. */
+function alreadyReported(
+  issues: readonly ConversionIssue[],
+  name: string
+): boolean {
+  return issues.some(
+    issue =>
+      issue.path === name ||
+      issue.path.startsWith(`${name}.`) ||
+      issue.path.startsWith(`${name}[`)
+  );
+}
+
+/**
+ * Report list-shaped values the shared validator skips.
+ *
+ * It classifies `[]` as an absent value and returns before any type rule runs,
+ * including a field's own `validate`, so an empty array is the one shape the
+ * per-type checks never see. Two cases follow from that: an empty array
+ * supplied for a prop that holds a single value, which for an entry is
+ * harmless because the value is on its way to a typed column but for a block
+ * prop reaches the renderer verbatim; and a `hasMany` text or number prop
+ * whose declared `minRows` an empty array violates.
  */
 function collectEmptyListIssues(
   fields: readonly WalkableField[],
@@ -171,12 +220,28 @@ function collectEmptyListIssues(
     const value = values[field.name];
     if (value === undefined) continue;
     const path = basePath ? `${basePath}.${field.name}` : field.name;
-    if (Array.isArray(value) && value.length === 0 && !holdsList(field)) {
-      issues.push({
-        path,
-        code: "INVALID_TYPE",
-        message: `${field.label ?? field.name} must not be a list.`,
-      });
+    if (Array.isArray(value) && value.length === 0) {
+      if (!holdsList(field)) {
+        issues.push({
+          path,
+          code: "INVALID_TYPE",
+          message: `${field.label ?? field.name} must not be a list.`,
+        });
+        continue;
+      }
+      // Repeaters and chips reach their own bounds rules even when empty;
+      // a hasMany scalar does not, so its minimum is enforced here.
+      if (
+        field.hasMany === true &&
+        field.minRows !== undefined &&
+        field.minRows > 0
+      ) {
+        issues.push({
+          path,
+          code: "TOO_FEW_ROWS",
+          message: `${field.label ?? field.name} must have at least ${field.minRows} entries.`,
+        });
+      }
       continue;
     }
     const nested = field.fields;
@@ -215,6 +280,7 @@ interface WalkableField {
   type: string;
   label?: string;
   hasMany?: boolean;
+  minRows?: number;
   fields?: readonly WalkableField[];
 }
 
@@ -424,10 +490,7 @@ const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
       ...orderedPair(min, max, "min", "max", path, ctx),
       hasMany,
       ...rows,
-      validate: allOf(
-        finiteValidator(hasMany),
-        listBoundsValidator(rows.minRows, rows.maxRows)
-      ),
+      validate: listBoundsValidator(rows.minRows, rows.maxRows),
     };
   },
   code: (name, declaration, path, ctx) => ({
@@ -464,7 +527,6 @@ const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
   json: (name, declaration, path, ctx) => ({
     ...base(name, declaration, path, ctx),
     type: "json",
-    validate: isSerializable,
   }),
   chips: (name, declaration, path, ctx) => {
     const minChips = countOption(declaration, "minChips", path, ctx);
@@ -592,6 +654,7 @@ function choiceOptions(
     return null;
   }
   const options: SelectOption[] = [];
+  const seen = new Set<string>();
   for (const entry of raw) {
     if (
       !isPlainObject(entry) ||
@@ -606,6 +669,30 @@ function choiceOptions(
       );
       return null;
     }
+    // An empty stored value is indistinguishable from no value at all: the
+    // shared rules read `""` as absent, so such an option could never be
+    // selected, and an empty label leaves nothing to select in the picker.
+    if (entry.label.length === 0 || entry.value.length === 0) {
+      record(
+        ctx,
+        path,
+        "INVALID_OPTIONS",
+        "Every entry in `options` must have a non-empty `label` and `value`."
+      );
+      return null;
+    }
+    // Two labels sharing one stored value make the choice ambiguous in both
+    // directions: the picker cannot tell which entry a stored value came from.
+    if (seen.has(entry.value)) {
+      record(
+        ctx,
+        path,
+        "DUPLICATE_OPTION",
+        `Two options declare the value "${entry.value}"; stored values must be unique.`
+      );
+      return null;
+    }
+    seen.add(entry.value);
     options.push({ label: entry.label, value: entry.value });
   }
   return options;
@@ -727,25 +814,6 @@ function isTextList(value: unknown): string | true {
     : "must contain only text entries";
 }
 
-/**
- * Finite-value check for a number prop, honoring its cardinality. The shared
- * number rules reject `NaN` but accept the infinities, which JSON writes as
- * `null` — so an accepted value would not survive being stored.
- */
-function finiteValidator(
-  hasMany: boolean | undefined
-): (value: unknown) => string | true {
-  const finite = (entry: unknown) =>
-    typeof entry === "number" && Number.isFinite(entry);
-  return value => {
-    if (!hasMany) {
-      return finite(value) ? true : "must be a finite number";
-    }
-    if (!Array.isArray(value)) return "must be a list of numbers";
-    return value.every(finite) ? true : "must contain only finite numbers";
-  };
-}
-
 /** Whether a value is a document id. */
 function isDocumentId(value: unknown): boolean {
   if (typeof value === "string") return value.length > 0;
@@ -786,19 +854,6 @@ function referenceValidator(
   };
 }
 
-/** Runs validators in order, reporting the first failure. */
-function allOf(
-  ...validators: Array<(value: unknown) => string | true>
-): (value: unknown) => string | true {
-  return value => {
-    for (const validator of validators) {
-      const result = validator(value);
-      if (result !== true) return result;
-    }
-    return true;
-  };
-}
-
 /**
  * Row-count check for a list-shaped scalar prop. The shared rules read row
  * bounds for repeaters and chips but not for a `hasMany` text or number field,
@@ -827,8 +882,7 @@ function listBoundsValidator(
  * the document is encoded — and a cyclic object, which makes encoding throw.
  */
 function isJsonRecord(value: unknown): string | true {
-  if (!isPlainRecord(value)) return "must be a plain object";
-  return isSerializable(value);
+  return isPlainRecord(value) ? true : "must be a plain object";
 }
 
 /**

--- a/packages/nextly/src/collections/fields/block-props.ts
+++ b/packages/nextly/src/collections/fields/block-props.ts
@@ -221,15 +221,19 @@ function alreadyReported(
 }
 
 /**
- * Report list-shaped values the shared validator skips.
+ * Report values the shared validator classifies as empty and therefore skips.
  *
- * It classifies `[]` as an absent value and returns before any type rule runs,
- * including a field's own `validate`, so an empty array is the one shape the
- * per-type checks never see. Two cases follow from that: an empty array
- * supplied for a prop that holds a single value, which for an entry is
- * harmless because the value is on its way to a typed column but for a block
- * prop reaches the renderer verbatim; and a `hasMany` text or number prop
- * whose declared `minRows` an empty array violates.
+ * It returns before any type rule runs — including a field's own `validate` —
+ * for `null`, a blank string, and an empty array, so those are the shapes the
+ * per-type checks never see. For an entry that is harmless, because the value
+ * is on its way to a typed column that would reject it. A block prop is
+ * stored as JSON exactly as given, so the same value reaches the renderer
+ * contradicting its declaration.
+ *
+ * Three cases follow: a value whose JavaScript type the prop cannot hold at
+ * all, an empty list where the prop holds one value or declares a minimum,
+ * and a required list-shaped prop explicitly set to `[]`, which the shared
+ * rules route past their required check in order to reach the bounds rules.
  */
 function collectEmptyListIssues(
   fields: readonly WalkableField[],
@@ -242,6 +246,16 @@ function collectEmptyListIssues(
     const value = ownValue(values, field.name);
     if (value === undefined) continue;
     const path = basePath ? `${basePath}.${field.name}` : field.name;
+    if (typeof value === "string" && value.trim() === "") {
+      if (!alreadyReported(issues, path) && !holdsText(field)) {
+        issues.push({
+          path,
+          code: "INVALID_TYPE",
+          message: `${field.label ?? field.name} must not be text.`,
+        });
+      }
+      continue;
+    }
     if (Array.isArray(value) && value.length === 0) {
       // A scalar select or radio is inspected for arrays by the shared rules,
       // so its issue is already recorded and does not need repeating.
@@ -251,6 +265,17 @@ function collectEmptyListIssues(
           path,
           code: "INVALID_TYPE",
           message: `${field.label ?? field.name} must not be a list.`,
+        });
+        continue;
+      }
+      // The shared rules route a provided empty list past their required
+      // check so it can reach the bounds rules, which leaves a required list
+      // prop accepting no content at all.
+      if (field.required === true) {
+        issues.push({
+          path,
+          code: "REQUIRED",
+          message: `${field.label ?? field.name} is required.`,
         });
         continue;
       }
@@ -289,6 +314,25 @@ function collectEmptyListIssues(
  * Whether a field's value is a list. `json` counts because an array is a
  * legitimate JSON value, not a cardinality mistake.
  */
+/**
+ * Whether a field's value may be a string. A blank string reaching any other
+ * prop contradicts its declared type: a number cannot be text, and an id that
+ * is blank resolves to nothing.
+ */
+function holdsText(field: WalkableField): boolean {
+  return (
+    field.type === "text" ||
+    field.type === "textarea" ||
+    field.type === "email" ||
+    field.type === "code" ||
+    field.type === "select" ||
+    field.type === "radio" ||
+    field.type === "date" ||
+    // An array or a bare string are both legitimate JSON values.
+    field.type === "json"
+  );
+}
+
 function holdsList(field: WalkableField): boolean {
   if (field.type === "chips" || field.type === "repeater") return true;
   if (field.type === "json") return true;
@@ -304,6 +348,7 @@ interface WalkableField {
   name?: string;
   type: string;
   label?: string;
+  required?: boolean;
   hasMany?: boolean;
   minRows?: number;
   fields?: readonly WalkableField[];
@@ -497,7 +542,7 @@ function base(
 const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
   text: (name, declaration, path, ctx) => {
     const hasMany = optionalBoolean(declaration, "hasMany", path, ctx);
-    const rows = rowBounds(declaration, path, ctx);
+    const rows = rowBounds(declaration, path, ctx, hasMany);
     return {
       ...base(name, declaration, path, ctx),
       type: "text",
@@ -525,7 +570,7 @@ const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
     const min = optionalNumber(declaration, "min", path, ctx);
     const max = optionalNumber(declaration, "max", path, ctx);
     const hasMany = optionalBoolean(declaration, "hasMany", path, ctx);
-    const rows = rowBounds(declaration, path, ctx);
+    const rows = rowBounds(declaration, path, ctx, hasMany);
     // A number prop is free to range below zero and to hold fractions, so
     // ordering is the only rule its bounds must satisfy.
     return {
@@ -586,7 +631,7 @@ const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
     const relationTo = relationTarget(declaration, path, ctx);
     if (!relationTo) return null;
     const hasMany = optionalBoolean(declaration, "hasMany", path, ctx);
-    const rows = rowBounds(declaration, path, ctx);
+    const rows = rowBounds(declaration, path, ctx, hasMany);
     return {
       ...base(name, declaration, path, ctx),
       type: "upload",
@@ -603,7 +648,7 @@ const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
     const relationTo = relationTarget(declaration, path, ctx);
     if (!relationTo) return null;
     const hasMany = optionalBoolean(declaration, "hasMany", path, ctx);
-    const rows = rowBounds(declaration, path, ctx);
+    const rows = rowBounds(declaration, path, ctx, hasMany);
     return {
       ...base(name, declaration, path, ctx),
       type: "relationship",
@@ -652,14 +697,28 @@ function lengthBounds(
   return orderedPair(minLength, maxLength, "minLength", "maxLength", path, ctx);
 }
 
-/** Row bounds for the prop types that hold a list of values. */
+/**
+ * Row bounds for a prop that holds several values. They are refused unless the
+ * prop is a list: on a scalar they would constrain nothing, and a declaration
+ * that advertises an unenforceable rule is worse than one that omits it.
+ */
 function rowBounds(
   declaration: BlockPropDeclaration,
   path: string,
-  ctx: ConversionContext
+  ctx: ConversionContext,
+  hasMany: boolean | undefined
 ): { minRows?: number; maxRows?: number } {
   const minRows = countOption(declaration, "minRows", path, ctx);
   const maxRows = countOption(declaration, "maxRows", path, ctx);
+  if (hasMany !== true && (minRows !== undefined || maxRows !== undefined)) {
+    record(
+      ctx,
+      path,
+      "INVALID_OPTION",
+      "`minRows` and `maxRows` apply only to a prop declaring `hasMany: true`."
+    );
+    return {};
+  }
   return orderedPair(minRows, maxRows, "minRows", "maxRows", path, ctx);
 }
 
@@ -980,7 +1039,12 @@ function isJsonRecordList(value: unknown): string | true {
  */
 function isSerializable(value: unknown): string | true {
   try {
-    JSON.stringify(value);
+    // A prop that encodes to nothing is dropped from the document entirely
+    // rather than stored wrongly, so the encoded result is inspected and not
+    // just the absence of a throw.
+    if (JSON.stringify(value) === undefined) {
+      return "must not encode to nothing";
+    }
   } catch {
     return "must be JSON-serializable";
   }
@@ -997,6 +1061,9 @@ function isSerializable(value: unknown): string | true {
  */
 function containsUnserializable(value: unknown): boolean {
   const pending: unknown[] = [value];
+  // Objects can name each other, and a `toJSON` may hand back a fresh object
+  // each call, so the walk remembers what it has already accounted for.
+  const seen = new WeakSet<object>();
   while (pending.length > 0) {
     const current = pending.pop();
     if (
@@ -1012,21 +1079,39 @@ function containsUnserializable(value: unknown): boolean {
       continue;
     }
     if (current === null || typeof current !== "object") continue;
+    if (seen.has(current)) continue;
+    seen.add(current);
     // An object that defines `toJSON` chooses its own stored form, which is
-    // how a Date becomes an ISO string, so it is taken at its word and its
-    // internals are not walked. Anything else that is not a plain record is
-    // reshaped rather than rejected: a Map or a Set encodes as `{}`, losing
-    // its contents without any error to notice.
-    if (definesToJson(current)) continue;
+    // how a Date becomes an ISO string. What it produces is what gets stored,
+    // so the walk follows that result rather than the object: a `toJSON`
+    // returning `undefined` makes the whole prop disappear on encode.
+    const encoded = encodedForm(current);
+    if (encoded !== current) {
+      pending.push(encoded);
+      continue;
+    }
+    // Anything else that is not a plain record is reshaped rather than
+    // rejected: a Map or a Set encodes as `{}`, losing its contents with no
+    // error to notice.
     if (!isPlainRecord(current)) return true;
     pending.push(...Object.values(current));
   }
   return false;
 }
 
-/** Whether a value controls its own encoded form. */
-function definesToJson(value: object): boolean {
-  return typeof (value as { toJSON?: unknown }).toJSON === "function";
+/**
+ * What an object encodes to, or the object itself when it has no say. A
+ * `toJSON` that throws is reported as unserializable, which is what
+ * `JSON.stringify` would do with it anyway.
+ */
+function encodedForm(value: object): unknown {
+  const toJSON = (value as { toJSON?: unknown }).toJSON;
+  if (typeof toJSON !== "function") return value;
+  try {
+    return (toJSON as (key?: string) => unknown).call(value);
+  } catch {
+    return undefined;
+  }
 }
 
 function optionalString(

--- a/packages/nextly/src/collections/fields/block-props.ts
+++ b/packages/nextly/src/collections/fields/block-props.ts
@@ -40,6 +40,7 @@ import {
 } from "../../domains/schema/field-types/field-type-registry";
 import { NextlyError } from "../../errors/nextly-error";
 import type { ValidationPublicData } from "../../errors/public-data";
+import { SLUG_PATTERN } from "../../shared/base-validator";
 import { validateEntryData } from "../../shared/lib/entry-validation";
 
 import type { BlockFieldCatalogType } from "./catalog";
@@ -145,7 +146,76 @@ export async function validateBlockPropValues(
   const fields = blockPropsToFieldConfigs(source);
   // Block props are always written whole: a stored node carries every prop it
   // has, so absent means unset rather than untouched, which is create mode.
-  return validateEntryData(values, fields, { mode: "create" });
+  const issues = await validateEntryData(values, fields, { mode: "create" });
+  collectEmptyListIssues(fields, values, "", issues);
+  return issues;
+}
+
+/**
+ * Report an empty array supplied for a prop that holds a single value.
+ *
+ * The shared validator classifies `[]` as an absent value and returns before
+ * any type rule runs, including a field's own `validate`, so `[]` is the one
+ * array shape the per-type checks never see. For an entry that is harmless —
+ * the value is on its way to a typed column. A block prop is stored as JSON
+ * exactly as given, so the empty array would reach a renderer expecting text.
+ */
+function collectEmptyListIssues(
+  fields: readonly WalkableField[],
+  values: Record<string, unknown>,
+  basePath: string,
+  issues: ConversionIssue[]
+): void {
+  for (const field of fields) {
+    if (!field.name) continue;
+    const value = values[field.name];
+    if (value === undefined) continue;
+    const path = basePath ? `${basePath}.${field.name}` : field.name;
+    if (Array.isArray(value) && value.length === 0 && !holdsList(field)) {
+      issues.push({
+        path,
+        code: "INVALID_TYPE",
+        message: `${field.label ?? field.name} must not be a list.`,
+      });
+      continue;
+    }
+    const nested = field.fields;
+    if (!nested) continue;
+    if (field.type === "group" && isPlainObject(value)) {
+      collectEmptyListIssues(nested, value, path, issues);
+      continue;
+    }
+    if (field.type === "repeater" && Array.isArray(value)) {
+      value.forEach((row, index) => {
+        if (isPlainObject(row)) {
+          collectEmptyListIssues(nested, row, `${path}[${index}]`, issues);
+        }
+      });
+    }
+  }
+}
+
+/**
+ * Whether a field's value is a list. `json` counts because an array is a
+ * legitimate JSON value, not a cardinality mistake.
+ */
+function holdsList(field: WalkableField): boolean {
+  if (field.type === "chips" || field.type === "repeater") return true;
+  if (field.type === "json") return true;
+  return field.hasMany === true;
+}
+
+/**
+ * The part of a field config the empty-list walk reads. Nested fields inside a
+ * group or repeater are typed permissively by their own configs, so the walk
+ * describes what it needs rather than requiring the concrete union.
+ */
+interface WalkableField {
+  name?: string;
+  type: string;
+  label?: string;
+  hasMany?: boolean;
+  fields?: readonly WalkableField[];
 }
 
 function buildFieldConfigs(
@@ -317,12 +387,14 @@ function base(
 const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
   text: (name, declaration, path, ctx) => {
     const hasMany = optionalBoolean(declaration, "hasMany", path, ctx);
+    const rows = rowBounds(declaration, path, ctx);
     return {
       ...base(name, declaration, path, ctx),
       type: "text",
       ...lengthBounds(declaration, path, ctx),
       hasMany,
-      ...rowBounds(declaration, path, ctx),
+      ...rows,
+      validate: listBoundsValidator(rows.minRows, rows.maxRows),
     };
   },
   textarea: (name, declaration, path, ctx) => ({
@@ -343,6 +415,7 @@ const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
     const min = optionalNumber(declaration, "min", path, ctx);
     const max = optionalNumber(declaration, "max", path, ctx);
     const hasMany = optionalBoolean(declaration, "hasMany", path, ctx);
+    const rows = rowBounds(declaration, path, ctx);
     // A number prop is free to range below zero and to hold fractions, so
     // ordering is the only rule its bounds must satisfy.
     return {
@@ -350,8 +423,11 @@ const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
       type: "number",
       ...orderedPair(min, max, "min", "max", path, ctx),
       hasMany,
-      ...rowBounds(declaration, path, ctx),
-      validate: finiteValidator(hasMany),
+      ...rows,
+      validate: allOf(
+        finiteValidator(hasMany),
+        listBoundsValidator(rows.minRows, rows.maxRows)
+      ),
     };
   },
   code: (name, declaration, path, ctx) => ({
@@ -434,6 +510,7 @@ const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
       type: "repeater",
       fields,
       ...orderedPair(minRows, maxRows, "minRows", "maxRows", path, ctx),
+      validate: isJsonRecordList,
     };
   },
   group: (name, declaration, path, ctx, depth) => {
@@ -443,6 +520,7 @@ const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
       ...base(name, declaration, path, ctx),
       type: "group",
       fields,
+      validate: isJsonRecord,
     };
   },
 };
@@ -533,26 +611,28 @@ function choiceOptions(
   return options;
 }
 
-/** The collection(s) an `upload` or `relationship` prop points at. */
+/**
+ * The collection(s) an `upload` or `relationship` prop points at. Targets are
+ * held to the canonical slug rule, so a target no collection could ever have
+ * fails at conversion instead of producing a reference nothing can resolve.
+ */
 function relationTarget(
   declaration: BlockPropDeclaration,
   path: string,
   ctx: ConversionContext
 ): string | string[] | null {
   const raw = declaration.relationTo;
-  if (typeof raw === "string" && raw.length > 0) return raw;
-  if (
-    Array.isArray(raw) &&
-    raw.length > 0 &&
-    raw.every(entry => typeof entry === "string" && entry.length > 0)
-  ) {
+  const isSlug = (entry: unknown): entry is string =>
+    typeof entry === "string" && SLUG_PATTERN.test(entry);
+  if (isSlug(raw)) return raw;
+  if (Array.isArray(raw) && raw.length > 0 && raw.every(isSlug)) {
     return [...raw];
   }
   record(
     ctx,
     path,
     "MISSING_RELATION_TARGET",
-    "An upload or relationship prop must declare `relationTo` as a collection slug or a non-empty array of slugs."
+    "An upload or relationship prop must declare `relationTo` as a collection slug or a non-empty array of slugs, each starting with a lowercase letter and containing only lowercase letters, digits, underscores, and hyphens."
   );
   return null;
 }
@@ -666,40 +746,110 @@ function finiteValidator(
   };
 }
 
-/**
- * Whether a value is a stored reference to one of `targets`: an id, or the
- * polymorphic `{ relationTo, value }` pair a multi-collection relation stores.
- * A polymorphic reference naming a collection the prop does not relate to is
- * rejected, since nothing downstream would resolve it.
- */
-function isReference(value: unknown, targets: readonly string[]): boolean {
+/** Whether a value is a document id. */
+function isDocumentId(value: unknown): boolean {
   if (typeof value === "string") return value.length > 0;
-  if (typeof value === "number") return Number.isFinite(value);
-  if (!isPlainObject(value)) return false;
-  return (
-    typeof value.relationTo === "string" &&
-    targets.includes(value.relationTo) &&
-    (typeof value.value === "string" || typeof value.value === "number")
-  );
+  return typeof value === "number" && Number.isFinite(value);
 }
 
-/** Reference-shape check for one prop, honoring its cardinality and targets. */
+/**
+ * Reference-shape check for one prop, honoring its cardinality and targets.
+ *
+ * The stored shape follows the target arity, the same rule that decides
+ * whether the field needs JSON storage: a single-target relation stores a bare
+ * id, because the collection is already fixed by the declaration, while a
+ * multi-target relation stores `{ relationTo, value }` so the reference
+ * carries the collection identity a bare id could not express.
+ */
 function referenceValidator(
   hasMany: boolean | undefined,
   relationTo: string | string[]
 ): (value: unknown) => string | true {
-  const targets = Array.isArray(relationTo) ? relationTo : [relationTo];
-  const expected = `an id or a { relationTo, value } reference to ${targets.join(" or ")}`;
+  const polymorphic = Array.isArray(relationTo);
+  const expected = polymorphic
+    ? `a { relationTo, value } reference to ${relationTo.join(" or ")}`
+    : `an id of a ${relationTo} document`;
+  const isOne = (entry: unknown): boolean =>
+    polymorphic
+      ? isPlainObject(entry) &&
+        typeof entry.relationTo === "string" &&
+        relationTo.includes(entry.relationTo) &&
+        isDocumentId(entry.value)
+      : isDocumentId(entry);
   return value => {
     if (hasMany) {
       if (!Array.isArray(value)) return "must be a list of references";
-      return value.every(entry => isReference(entry, targets))
-        ? true
-        : `must contain only ${expected}`;
+      return value.every(isOne) ? true : `must contain only ${expected}`;
     }
     if (Array.isArray(value)) return "must be a single reference, not a list";
-    return isReference(value, targets) ? true : `must be ${expected}`;
+    return isOne(value) ? true : `must be ${expected}`;
   };
+}
+
+/** Runs validators in order, reporting the first failure. */
+function allOf(
+  ...validators: Array<(value: unknown) => string | true>
+): (value: unknown) => string | true {
+  return value => {
+    for (const validator of validators) {
+      const result = validator(value);
+      if (result !== true) return result;
+    }
+    return true;
+  };
+}
+
+/**
+ * Row-count check for a list-shaped scalar prop. The shared rules read row
+ * bounds for repeaters and chips but not for a `hasMany` text or number field,
+ * so without this the declaration would advertise a constraint nothing
+ * enforces.
+ */
+function listBoundsValidator(
+  minRows: number | undefined,
+  maxRows: number | undefined
+): (value: unknown) => string | true {
+  return value => {
+    if (!Array.isArray(value)) return true;
+    if (minRows !== undefined && value.length < minRows) {
+      return `must have at least ${minRows} entries`;
+    }
+    if (maxRows !== undefined && value.length > maxRows) {
+      return `must have at most ${maxRows} entries`;
+    }
+    return true;
+  };
+}
+
+/**
+ * Whether a structured value is a plain JSON record. The shared rules accept
+ * any non-array object, which lets a `Date` through — it becomes a string once
+ * the document is encoded — and a cyclic object, which makes encoding throw.
+ */
+function isJsonRecord(value: unknown): string | true {
+  if (!isPlainRecord(value)) return "must be a plain object";
+  return isSerializable(value);
+}
+
+/**
+ * Whether a value is an object literal rather than a class instance. The
+ * looser object check is not enough here: a `Date` or a `Map` passes it while
+ * encoding turns the first into a string and the second into `{}`.
+ */
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!isPlainObject(value)) return false;
+  const prototype = Object.getPrototypeOf(value) as object | null;
+  return prototype === Object.prototype || prototype === null;
+}
+
+/** The same check applied to every row of a repeater value. */
+function isJsonRecordList(value: unknown): string | true {
+  if (!Array.isArray(value)) return true;
+  for (const row of value) {
+    const result = isJsonRecord(row);
+    if (result !== true) return `rows ${result}`;
+  }
+  return true;
 }
 
 /**

--- a/packages/nextly/src/collections/fields/block-props.ts
+++ b/packages/nextly/src/collections/fields/block-props.ts
@@ -1,0 +1,488 @@
+/**
+ * Block props on the field system.
+ *
+ * A block declares its editable props as a record of field-type declarations
+ * (`{ heading: { type: "text", maxLength: 80 } }`). This module turns that
+ * record into ordinary `FieldConfig`s so one declaration drives everything
+ * downstream: server-side value validation runs through the same
+ * `validateEntryData` pass entries use, and later the inspector controls and
+ * the generated manifest read the same configs. Nothing about block props gets
+ * its own parallel validation rules.
+ *
+ * The input shape is described structurally rather than imported, so core does
+ * not depend on the blocks engine to know what a prop declaration looks like.
+ * A block definition's `props` record satisfies `BlockPropDeclaration` by
+ * construction.
+ *
+ * A plugin-contributed field type may be declared as a block prop only when
+ * its author listed the `"blocks"` surface, the same opt-in the form builder
+ * requires for `"forms"`.
+ *
+ * Block props live inside a JSON document, never in their own column, so the
+ * declarations here are checked for what the field system actually consumes
+ * (types, bounds, choices, relation targets) and an unusable declaration
+ * raises at conversion time rather than producing a config that silently
+ * validates nothing.
+ *
+ * @module collections/fields/block-props
+ */
+
+import {
+  getFieldType,
+  isPluginFieldTypeOnSurface,
+} from "../../domains/schema/field-types/field-type-registry";
+import { NextlyError } from "../../errors/nextly-error";
+import type { ValidationPublicData } from "../../errors/public-data";
+import type { PluginFieldType } from "../../plugins/contributions";
+import { validateEntryData } from "../../shared/lib/entry-validation";
+
+import type { BlockFieldCatalogType } from "./catalog";
+import { BLOCK_FIELD_TYPES, isBlockFieldType } from "./catalog";
+import type { FieldConfig, SelectOption } from "./types";
+
+type ConversionIssue = ValidationPublicData["errors"][number];
+
+/**
+ * One prop declaration: a field type plus that type's options. Kept open so a
+ * declaration written against the block API — where options vary by type —
+ * satisfies it without a conversion step.
+ */
+export interface BlockPropDeclaration {
+  type: string;
+  [option: string]: unknown;
+}
+
+/**
+ * The part of a block definition this module reads. A `BlockDefinition`
+ * satisfies it structurally.
+ */
+export interface BlockPropsSource {
+  /** The block's registered name; identifies the block in conversion errors. */
+  name?: string;
+  /** Editable props, keyed by prop name. */
+  props?: Record<string, BlockPropDeclaration>;
+  /** Prop names whose values are translatable. */
+  localized?: readonly string[];
+}
+
+/**
+ * Prop names double as JavaScript identifiers on the render side, so they are
+ * held to identifier rules rather than the column-name rules that apply to
+ * fields backed by a database column.
+ */
+const PROP_NAME_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+interface ConversionContext {
+  blockName: string;
+  localized: ReadonlySet<string>;
+  issues: ConversionIssue[];
+}
+
+/**
+ * Field-config conversion for one prop type. Returns `null` when the
+ * declaration is unusable; the issue explaining why is already recorded.
+ */
+type PropBuilder = (
+  name: string,
+  declaration: BlockPropDeclaration,
+  path: string,
+  ctx: ConversionContext
+) => FieldConfig | null;
+
+/**
+ * Convert a block's prop declarations into field configs, in declaration
+ * order.
+ *
+ * @throws NextlyError validation error listing every unusable declaration.
+ */
+export function blockPropsToFieldConfigs(
+  source: BlockPropsSource
+): FieldConfig[] {
+  const ctx: ConversionContext = {
+    blockName: source.name ?? "(unnamed block)",
+    localized: new Set(source.localized ?? []),
+    issues: [],
+  };
+  const configs = buildFieldConfigs(source.props, "", ctx);
+  if (ctx.issues.length > 0) {
+    throw NextlyError.validation({
+      errors: ctx.issues,
+      logContext: { blockName: ctx.blockName },
+    });
+  }
+  return configs;
+}
+
+/**
+ * Validate a block's prop values against its declarations. Returns every
+ * violation rather than the first, matching the entry validator it delegates
+ * to, so an editor or an agent can repair a whole block in one pass.
+ */
+export async function validateBlockPropValues(
+  values: Record<string, unknown>,
+  source: BlockPropsSource
+): Promise<ConversionIssue[]> {
+  const fields = blockPropsToFieldConfigs(source);
+  // Block props are always written whole: a stored node carries every prop it
+  // has, so absent means unset rather than untouched, which is create mode.
+  return validateEntryData(values, fields, { mode: "create" });
+}
+
+function buildFieldConfigs(
+  props: Record<string, BlockPropDeclaration> | undefined,
+  prefix: string,
+  ctx: ConversionContext
+): FieldConfig[] {
+  if (!props) return [];
+  const configs: FieldConfig[] = [];
+  for (const [name, declaration] of Object.entries(props)) {
+    const path = prefix ? `${prefix}.${name}` : name;
+    if (!PROP_NAME_PATTERN.test(name)) {
+      record(
+        ctx,
+        path,
+        "INVALID_NAME",
+        "Prop names must start with a letter, underscore, or dollar sign and contain only letters, digits, underscores, and dollar signs."
+      );
+      continue;
+    }
+    if (!isPlainObject(declaration)) {
+      record(
+        ctx,
+        path,
+        "INVALID_DECLARATION",
+        "A prop declaration must be an object carrying at least a field type."
+      );
+      continue;
+    }
+    const resolved = resolvePropType(declaration.type);
+    if (!resolved) {
+      record(
+        ctx,
+        path,
+        "UNKNOWN_FIELD_TYPE",
+        `"${String(declaration.type)}" is not a field type a block prop can declare. Available types: ${BLOCK_FIELD_TYPES.join(", ")}.`
+      );
+      continue;
+    }
+    const config = BUILDERS[resolved](name, declaration, path, ctx);
+    if (config) configs.push(config);
+  }
+  return configs;
+}
+
+/**
+ * The block field type a plugin field type's storage primitive validates as.
+ * A plugin type persists as one of the primitives, so its values are checked
+ * by that primitive's rules while its own admin component renders it.
+ */
+const PLUGIN_STORAGE_AS_PROP_TYPE: Readonly<
+  Record<PluginFieldType["storage"], BlockFieldCatalogType>
+> = {
+  text: "text",
+  longText: "textarea",
+  boolean: "checkbox",
+  number: "number",
+  timestamp: "date",
+  json: "json",
+};
+
+/**
+ * The block field type a declaration is built as, or `null` when the type is
+ * not available on the block-prop surface.
+ *
+ * A plugin-contributed type is admitted only when its author opted into the
+ * `"blocks"` surface, the same gate the form builder applies for `"forms"`, so
+ * a type never becomes a block prop where its author did not intend it.
+ */
+function resolvePropType(type: string): BlockFieldCatalogType | null {
+  if (isBlockFieldType(type)) return type;
+  if (!isPluginFieldTypeOnSurface(type, "blocks")) return null;
+  const storage = getFieldType(type)?.storage;
+  return storage ? PLUGIN_STORAGE_AS_PROP_TYPE[storage] : null;
+}
+
+/**
+ * The options every prop type carries. `defaultValue` is deliberately absent:
+ * a block's defaults live in its `defaultProps`, applied by the engine when a
+ * block is inserted, so duplicating them onto the field config would give one
+ * value two sources.
+ */
+function base(
+  name: string,
+  declaration: BlockPropDeclaration,
+  path: string,
+  ctx: ConversionContext
+): { name: string; label?: string; required?: boolean; localized?: boolean } {
+  return {
+    name,
+    label: optionalString(declaration, "label", path, ctx),
+    required: optionalBoolean(declaration, "required", path, ctx),
+    // A block declares its translatable props by top-level name, so the flag
+    // is gated on the prop being top level: a nested field that happens to
+    // share a localized prop's name is a different value.
+    localized: path === name && ctx.localized.has(name) ? true : undefined,
+  };
+}
+
+const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
+  text: (name, declaration, path, ctx) => ({
+    ...base(name, declaration, path, ctx),
+    type: "text",
+    minLength: optionalNumber(declaration, "minLength", path, ctx),
+    maxLength: optionalNumber(declaration, "maxLength", path, ctx),
+  }),
+  textarea: (name, declaration, path, ctx) => ({
+    ...base(name, declaration, path, ctx),
+    type: "textarea",
+    minLength: optionalNumber(declaration, "minLength", path, ctx),
+    maxLength: optionalNumber(declaration, "maxLength", path, ctx),
+  }),
+  richText: (name, declaration, path, ctx) => ({
+    ...base(name, declaration, path, ctx),
+    type: "richText",
+  }),
+  email: (name, declaration, path, ctx) => ({
+    ...base(name, declaration, path, ctx),
+    type: "email",
+  }),
+  number: (name, declaration, path, ctx) => ({
+    ...base(name, declaration, path, ctx),
+    type: "number",
+    min: optionalNumber(declaration, "min", path, ctx),
+    max: optionalNumber(declaration, "max", path, ctx),
+  }),
+  code: (name, declaration, path, ctx) => ({
+    ...base(name, declaration, path, ctx),
+    type: "code",
+  }),
+  date: (name, declaration, path, ctx) => ({
+    ...base(name, declaration, path, ctx),
+    type: "date",
+  }),
+  select: (name, declaration, path, ctx) => {
+    const options = choiceOptions(declaration, path, ctx);
+    if (!options) return null;
+    return {
+      ...base(name, declaration, path, ctx),
+      type: "select",
+      options,
+      hasMany: optionalBoolean(declaration, "hasMany", path, ctx),
+    };
+  },
+  radio: (name, declaration, path, ctx) => {
+    const options = choiceOptions(declaration, path, ctx);
+    if (!options) return null;
+    return {
+      ...base(name, declaration, path, ctx),
+      type: "radio",
+      options,
+    };
+  },
+  checkbox: (name, declaration, path, ctx) => ({
+    ...base(name, declaration, path, ctx),
+    type: "checkbox",
+  }),
+  json: (name, declaration, path, ctx) => ({
+    ...base(name, declaration, path, ctx),
+    type: "json",
+  }),
+  chips: (name, declaration, path, ctx) => ({
+    ...base(name, declaration, path, ctx),
+    type: "chips",
+    minChips: optionalNumber(declaration, "minChips", path, ctx),
+    maxChips: optionalNumber(declaration, "maxChips", path, ctx),
+  }),
+  upload: (name, declaration, path, ctx) => {
+    const relationTo = relationTarget(declaration, path, ctx);
+    if (!relationTo) return null;
+    return {
+      ...base(name, declaration, path, ctx),
+      type: "upload",
+      relationTo,
+      hasMany: optionalBoolean(declaration, "hasMany", path, ctx),
+    };
+  },
+  relationship: (name, declaration, path, ctx) => {
+    const relationTo = relationTarget(declaration, path, ctx);
+    if (!relationTo) return null;
+    return {
+      ...base(name, declaration, path, ctx),
+      type: "relationship",
+      relationTo,
+      hasMany: optionalBoolean(declaration, "hasMany", path, ctx),
+    };
+  },
+  repeater: (name, declaration, path, ctx) => {
+    const fields = nestedFields(declaration, path, ctx);
+    if (!fields) return null;
+    return {
+      ...base(name, declaration, path, ctx),
+      type: "repeater",
+      fields,
+      minRows: optionalNumber(declaration, "minRows", path, ctx),
+      maxRows: optionalNumber(declaration, "maxRows", path, ctx),
+    };
+  },
+  group: (name, declaration, path, ctx) => {
+    const fields = nestedFields(declaration, path, ctx);
+    if (!fields) return null;
+    return {
+      ...base(name, declaration, path, ctx),
+      type: "group",
+      fields,
+    };
+  },
+};
+
+/** The choice list `select` and `radio` cannot be built without. */
+function choiceOptions(
+  declaration: BlockPropDeclaration,
+  path: string,
+  ctx: ConversionContext
+): SelectOption[] | null {
+  const raw = declaration.options;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    record(
+      ctx,
+      path,
+      "MISSING_OPTIONS",
+      "A select or radio prop must declare a non-empty `options` array of `{ label, value }` entries."
+    );
+    return null;
+  }
+  const options: SelectOption[] = [];
+  for (const entry of raw) {
+    if (
+      !isPlainObject(entry) ||
+      typeof entry.label !== "string" ||
+      typeof entry.value !== "string"
+    ) {
+      record(
+        ctx,
+        path,
+        "INVALID_OPTIONS",
+        "Every entry in `options` must be an object with string `label` and `value`."
+      );
+      return null;
+    }
+    options.push({ label: entry.label, value: entry.value });
+  }
+  return options;
+}
+
+/** The collection(s) an `upload` or `relationship` prop points at. */
+function relationTarget(
+  declaration: BlockPropDeclaration,
+  path: string,
+  ctx: ConversionContext
+): string | string[] | null {
+  const raw = declaration.relationTo;
+  if (typeof raw === "string" && raw.length > 0) return raw;
+  if (
+    Array.isArray(raw) &&
+    raw.length > 0 &&
+    raw.every(entry => typeof entry === "string" && entry.length > 0)
+  ) {
+    return [...raw];
+  }
+  record(
+    ctx,
+    path,
+    "MISSING_RELATION_TARGET",
+    "An upload or relationship prop must declare `relationTo` as a collection slug or a non-empty array of slugs."
+  );
+  return null;
+}
+
+/** Nested prop declarations for `repeater` and `group`, keyed like the parent. */
+function nestedFields(
+  declaration: BlockPropDeclaration,
+  path: string,
+  ctx: ConversionContext
+): FieldConfig[] | null {
+  const raw = declaration.fields;
+  if (!isPlainObject(raw) || Object.keys(raw).length === 0) {
+    record(
+      ctx,
+      path,
+      "MISSING_FIELDS",
+      "A repeater or group prop must declare a non-empty `fields` record of nested prop declarations."
+    );
+    return null;
+  }
+  const nested = buildFieldConfigs(
+    raw as Record<string, BlockPropDeclaration>,
+    path,
+    ctx
+  );
+  // An empty result means every nested declaration failed; its own issues are
+  // already recorded, so the parent is dropped without adding noise.
+  return nested.length > 0 ? nested : null;
+}
+
+function optionalString(
+  declaration: BlockPropDeclaration,
+  key: string,
+  path: string,
+  ctx: ConversionContext
+): string | undefined {
+  const value = declaration[key];
+  if (value === undefined) return undefined;
+  if (typeof value === "string") return value;
+  recordOptionType(ctx, path, key, "a string");
+  return undefined;
+}
+
+function optionalNumber(
+  declaration: BlockPropDeclaration,
+  key: string,
+  path: string,
+  ctx: ConversionContext
+): number | undefined {
+  const value = declaration[key];
+  if (value === undefined) return undefined;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  recordOptionType(ctx, path, key, "a finite number");
+  return undefined;
+}
+
+function optionalBoolean(
+  declaration: BlockPropDeclaration,
+  key: string,
+  path: string,
+  ctx: ConversionContext
+): boolean | undefined {
+  const value = declaration[key];
+  if (value === undefined) return undefined;
+  if (typeof value === "boolean") return value;
+  recordOptionType(ctx, path, key, "a boolean");
+  return undefined;
+}
+
+function recordOptionType(
+  ctx: ConversionContext,
+  path: string,
+  key: string,
+  expected: string
+): void {
+  record(
+    ctx,
+    `${path}.${key}`,
+    "INVALID_OPTION",
+    `\`${key}\` must be ${expected}.`
+  );
+}
+
+function record(
+  ctx: ConversionContext,
+  path: string,
+  code: string,
+  message: string
+): void {
+  ctx.issues.push({ path, code, message });
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/nextly/src/collections/fields/block-props.ts
+++ b/packages/nextly/src/collections/fields/block-props.ts
@@ -24,6 +24,13 @@
  * raises at conversion time rather than producing a config that silently
  * validates nothing.
  *
+ * That JSON document is also why the reference-shaped types carry a `validate`
+ * function. The entry validator applies no scalar rules to `richText`,
+ * `upload`, `relationship`, and `json`, because an entry write normalizes and
+ * referentially checks those values in later pipeline stages. A block prop
+ * never enters those stages, so without a shape check here a malformed value
+ * would reach the renderer unexamined.
+ *
  * @module collections/fields/block-props
  */
 
@@ -33,11 +40,14 @@ import {
 } from "../../domains/schema/field-types/field-type-registry";
 import { NextlyError } from "../../errors/nextly-error";
 import type { ValidationPublicData } from "../../errors/public-data";
-import type { PluginFieldType } from "../../plugins/contributions";
 import { validateEntryData } from "../../shared/lib/entry-validation";
 
 import type { BlockFieldCatalogType } from "./catalog";
-import { BLOCK_FIELD_TYPES, isBlockFieldType } from "./catalog";
+import {
+  BLOCK_FIELD_TYPES,
+  STORAGE_PRIMITIVE_AS_FIELD_TYPE,
+  isBlockFieldType,
+} from "./catalog";
 import type { FieldConfig, SelectOption } from "./types";
 
 type ConversionIssue = ValidationPublicData["errors"][number];
@@ -72,6 +82,15 @@ export interface BlockPropsSource {
  */
 const PROP_NAME_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
 
+/**
+ * How deep structured props may nest. Conversion recurses through `repeater`
+ * and `group` declarations, so a bound turns a cyclic or absurdly deep
+ * declaration — trivial to produce by reusing one declaration object, and
+ * unavoidable once declarations arrive from a manifest rather than hand-written
+ * code — into a reported issue instead of a stack overflow.
+ */
+const MAX_PROP_NESTING_DEPTH = 5;
+
 interface ConversionContext {
   blockName: string;
   localized: ReadonlySet<string>;
@@ -86,7 +105,8 @@ type PropBuilder = (
   name: string,
   declaration: BlockPropDeclaration,
   path: string,
-  ctx: ConversionContext
+  ctx: ConversionContext,
+  depth: number
 ) => FieldConfig | null;
 
 /**
@@ -103,7 +123,7 @@ export function blockPropsToFieldConfigs(
     localized: new Set(source.localized ?? []),
     issues: [],
   };
-  const configs = buildFieldConfigs(source.props, "", ctx);
+  const configs = buildFieldConfigs(source.props, "", ctx, 0);
   if (ctx.issues.length > 0) {
     throw NextlyError.validation({
       errors: ctx.issues,
@@ -131,7 +151,8 @@ export async function validateBlockPropValues(
 function buildFieldConfigs(
   props: Record<string, BlockPropDeclaration> | undefined,
   prefix: string,
-  ctx: ConversionContext
+  ctx: ConversionContext,
+  depth: number
 ): FieldConfig[] {
   if (!props) return [];
   const configs: FieldConfig[] = [];
@@ -165,27 +186,11 @@ function buildFieldConfigs(
       );
       continue;
     }
-    const config = BUILDERS[resolved](name, declaration, path, ctx);
+    const config = BUILDERS[resolved](name, declaration, path, ctx, depth);
     if (config) configs.push(config);
   }
   return configs;
 }
-
-/**
- * The block field type a plugin field type's storage primitive validates as.
- * A plugin type persists as one of the primitives, so its values are checked
- * by that primitive's rules while its own admin component renders it.
- */
-const PLUGIN_STORAGE_AS_PROP_TYPE: Readonly<
-  Record<PluginFieldType["storage"], BlockFieldCatalogType>
-> = {
-  text: "text",
-  longText: "textarea",
-  boolean: "checkbox",
-  number: "number",
-  timestamp: "date",
-  json: "json",
-};
 
 /**
  * The block field type a declaration is built as, or `null` when the type is
@@ -199,7 +204,7 @@ function resolvePropType(type: string): BlockFieldCatalogType | null {
   if (isBlockFieldType(type)) return type;
   if (!isPluginFieldTypeOnSurface(type, "blocks")) return null;
   const storage = getFieldType(type)?.storage;
-  return storage ? PLUGIN_STORAGE_AS_PROP_TYPE[storage] : null;
+  return storage ? STORAGE_PRIMITIVE_AS_FIELD_TYPE[storage] : null;
 }
 
 /**
@@ -229,29 +234,33 @@ const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
   text: (name, declaration, path, ctx) => ({
     ...base(name, declaration, path, ctx),
     type: "text",
-    minLength: optionalNumber(declaration, "minLength", path, ctx),
-    maxLength: optionalNumber(declaration, "maxLength", path, ctx),
+    ...lengthBounds(declaration, path, ctx),
   }),
   textarea: (name, declaration, path, ctx) => ({
     ...base(name, declaration, path, ctx),
     type: "textarea",
-    minLength: optionalNumber(declaration, "minLength", path, ctx),
-    maxLength: optionalNumber(declaration, "maxLength", path, ctx),
+    ...lengthBounds(declaration, path, ctx),
   }),
   richText: (name, declaration, path, ctx) => ({
     ...base(name, declaration, path, ctx),
     type: "richText",
+    validate: isEditorContent,
   }),
   email: (name, declaration, path, ctx) => ({
     ...base(name, declaration, path, ctx),
     type: "email",
   }),
-  number: (name, declaration, path, ctx) => ({
-    ...base(name, declaration, path, ctx),
-    type: "number",
-    min: optionalNumber(declaration, "min", path, ctx),
-    max: optionalNumber(declaration, "max", path, ctx),
-  }),
+  number: (name, declaration, path, ctx) => {
+    const min = optionalNumber(declaration, "min", path, ctx);
+    const max = optionalNumber(declaration, "max", path, ctx);
+    // A number prop is free to range below zero and to hold fractions, so
+    // ordering is the only rule its bounds must satisfy.
+    return {
+      ...base(name, declaration, path, ctx),
+      type: "number",
+      ...orderedPair(min, max, "min", "max", path, ctx),
+    };
+  },
   code: (name, declaration, path, ctx) => ({
     ...base(name, declaration, path, ctx),
     type: "code",
@@ -286,46 +295,55 @@ const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
   json: (name, declaration, path, ctx) => ({
     ...base(name, declaration, path, ctx),
     type: "json",
+    validate: isSerializable,
   }),
-  chips: (name, declaration, path, ctx) => ({
-    ...base(name, declaration, path, ctx),
-    type: "chips",
-    minChips: optionalNumber(declaration, "minChips", path, ctx),
-    maxChips: optionalNumber(declaration, "maxChips", path, ctx),
-  }),
+  chips: (name, declaration, path, ctx) => {
+    const minChips = countOption(declaration, "minChips", path, ctx);
+    const maxChips = countOption(declaration, "maxChips", path, ctx);
+    return {
+      ...base(name, declaration, path, ctx),
+      type: "chips",
+      ...orderedPair(minChips, maxChips, "minChips", "maxChips", path, ctx),
+    };
+  },
   upload: (name, declaration, path, ctx) => {
     const relationTo = relationTarget(declaration, path, ctx);
     if (!relationTo) return null;
+    const hasMany = optionalBoolean(declaration, "hasMany", path, ctx);
     return {
       ...base(name, declaration, path, ctx),
       type: "upload",
       relationTo,
-      hasMany: optionalBoolean(declaration, "hasMany", path, ctx),
+      hasMany,
+      validate: referenceValidator(hasMany),
     };
   },
   relationship: (name, declaration, path, ctx) => {
     const relationTo = relationTarget(declaration, path, ctx);
     if (!relationTo) return null;
+    const hasMany = optionalBoolean(declaration, "hasMany", path, ctx);
     return {
       ...base(name, declaration, path, ctx),
       type: "relationship",
       relationTo,
-      hasMany: optionalBoolean(declaration, "hasMany", path, ctx),
+      hasMany,
+      validate: referenceValidator(hasMany),
     };
   },
-  repeater: (name, declaration, path, ctx) => {
-    const fields = nestedFields(declaration, path, ctx);
+  repeater: (name, declaration, path, ctx, depth) => {
+    const fields = nestedFields(declaration, path, ctx, depth);
     if (!fields) return null;
+    const minRows = countOption(declaration, "minRows", path, ctx);
+    const maxRows = countOption(declaration, "maxRows", path, ctx);
     return {
       ...base(name, declaration, path, ctx),
       type: "repeater",
       fields,
-      minRows: optionalNumber(declaration, "minRows", path, ctx),
-      maxRows: optionalNumber(declaration, "maxRows", path, ctx),
+      ...orderedPair(minRows, maxRows, "minRows", "maxRows", path, ctx),
     };
   },
-  group: (name, declaration, path, ctx) => {
-    const fields = nestedFields(declaration, path, ctx);
+  group: (name, declaration, path, ctx, depth) => {
+    const fields = nestedFields(declaration, path, ctx, depth);
     if (!fields) return null;
     return {
       ...base(name, declaration, path, ctx),
@@ -334,6 +352,45 @@ const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
     };
   },
 };
+
+/** Text length bounds, which must be ordered non-negative integers. */
+function lengthBounds(
+  declaration: BlockPropDeclaration,
+  path: string,
+  ctx: ConversionContext
+): { minLength?: number; maxLength?: number } {
+  const minLength = countOption(declaration, "minLength", path, ctx);
+  const maxLength = countOption(declaration, "maxLength", path, ctx);
+  return orderedPair(minLength, maxLength, "minLength", "maxLength", path, ctx);
+}
+
+/**
+ * A lower/upper bound pair, dropped entirely when the lower exceeds the upper.
+ * Such a pair admits no value at all, so it is a declaration defect rather
+ * than a rule to enforce on every subsequent edit.
+ */
+function orderedPair<L extends string, U extends string>(
+  lower: number | undefined,
+  upper: number | undefined,
+  lowerKey: L,
+  upperKey: U,
+  path: string,
+  ctx: ConversionContext
+): Partial<Record<L | U, number>> {
+  if (lower !== undefined && upper !== undefined && lower > upper) {
+    record(
+      ctx,
+      path,
+      "INVALID_BOUNDS",
+      `\`${lowerKey}\` must not be greater than \`${upperKey}\`.`
+    );
+    return {};
+  }
+  const pair: Partial<Record<L | U, number>> = {};
+  if (lower !== undefined) pair[lowerKey] = lower;
+  if (upper !== undefined) pair[upperKey] = upper;
+  return pair;
+}
 
 /** The choice list `select` and `radio` cannot be built without. */
 function choiceOptions(
@@ -399,8 +456,18 @@ function relationTarget(
 function nestedFields(
   declaration: BlockPropDeclaration,
   path: string,
-  ctx: ConversionContext
+  ctx: ConversionContext,
+  depth: number
 ): FieldConfig[] | null {
+  if (depth >= MAX_PROP_NESTING_DEPTH) {
+    record(
+      ctx,
+      path,
+      "NESTING_TOO_DEEP",
+      `Block props may nest at most ${MAX_PROP_NESTING_DEPTH} levels deep.`
+    );
+    return null;
+  }
   const raw = declaration.fields;
   if (!isPlainObject(raw) || Object.keys(raw).length === 0) {
     record(
@@ -414,11 +481,115 @@ function nestedFields(
   const nested = buildFieldConfigs(
     raw as Record<string, BlockPropDeclaration>,
     path,
-    ctx
+    ctx,
+    depth + 1
   );
   // An empty result means every nested declaration failed; its own issues are
   // already recorded, so the parent is dropped without adding noise.
   return nested.length > 0 ? nested : null;
+}
+
+/**
+ * A count-shaped option: lengths, chip counts, and row counts are quantities,
+ * so a fractional or negative value describes a rule no value can satisfy.
+ */
+function countOption(
+  declaration: BlockPropDeclaration,
+  key: string,
+  path: string,
+  ctx: ConversionContext
+): number | undefined {
+  const value = declaration[key];
+  if (value === undefined) return undefined;
+  if (typeof value === "number" && Number.isInteger(value) && value >= 0) {
+    return value;
+  }
+  recordOptionType(ctx, path, key, "a non-negative integer");
+  return undefined;
+}
+
+/** Whether a value is shaped like editor content: a root node with children. */
+function isEditorContent(value: unknown): string | true {
+  if (!isPlainObject(value)) return "must be editor content";
+  const root = value.root;
+  if (!isPlainObject(root) || !Array.isArray(root.children)) {
+    return "must be editor content with a root node";
+  }
+  return true;
+}
+
+/**
+ * Whether a value is a stored reference: an id, or the polymorphic
+ * `{ relationTo, value }` pair a multi-collection relation stores.
+ */
+function isReference(value: unknown): boolean {
+  if (typeof value === "string") return value.length > 0;
+  if (typeof value === "number") return Number.isFinite(value);
+  if (!isPlainObject(value)) return false;
+  return (
+    typeof value.relationTo === "string" &&
+    value.relationTo.length > 0 &&
+    (typeof value.value === "string" || typeof value.value === "number")
+  );
+}
+
+/** Reference-shape check for one prop, honoring its cardinality. */
+function referenceValidator(
+  hasMany: boolean | undefined
+): (value: unknown) => string | true {
+  return value => {
+    if (hasMany) {
+      if (!Array.isArray(value)) return "must be a list of references";
+      return value.every(isReference)
+        ? true
+        : "must contain only ids or { relationTo, value } references";
+    }
+    if (Array.isArray(value)) return "must be a single reference, not a list";
+    return isReference(value)
+      ? true
+      : "must be an id or a { relationTo, value } reference";
+  };
+}
+
+/**
+ * Whether a value survives being written to a block document. The document is
+ * stored as JSON, so anything JSON cannot represent — a function, a symbol, a
+ * bigint, a cycle — would be silently dropped or would throw on write.
+ */
+function isSerializable(value: unknown): string | true {
+  try {
+    JSON.stringify(value);
+  } catch {
+    return "must be JSON-serializable";
+  }
+  return containsUnserializable(value)
+    ? "must not contain functions, symbols, or undefined values"
+    : true;
+}
+
+/**
+ * Whether any part of a value is a type `JSON.stringify` drops rather than
+ * rejects. Stringify succeeds on these by omitting object keys and writing
+ * array holes as `null`, so the loss is invisible without an explicit walk.
+ */
+function containsUnserializable(value: unknown): boolean {
+  const pending: unknown[] = [value];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (
+      typeof current === "function" ||
+      typeof current === "symbol" ||
+      current === undefined
+    ) {
+      return true;
+    }
+    if (Array.isArray(current)) {
+      pending.push(...current);
+      continue;
+    }
+    if (isPlainObject(current)) pending.push(...Object.values(current));
+  }
+  return false;
 }
 
 function optionalString(

--- a/packages/nextly/src/collections/fields/block-props.ts
+++ b/packages/nextly/src/collections/fields/block-props.ts
@@ -904,16 +904,19 @@ function countOption(
  * catalog into the field system.
  */
 function isEditorContent(value: unknown): string | true {
-  if (!isPlainObject(value)) return "must be editor content";
+  // Plain records, not merely objects: a class instance with the right keys
+  // encodes to whatever its own `toJSON` decides, so the renderer would read
+  // back something other than the envelope that was validated.
+  if (!isPlainRecord(value)) return "must be editor content";
   const root = value.root;
-  if (!isPlainObject(root) || root.type !== "root") {
+  if (!isPlainRecord(root) || root.type !== "root") {
     return "must be editor content with a root node";
   }
   if (!Array.isArray(root.children)) {
     return "must be editor content whose root has a list of children";
   }
   return root.children.every(
-    child => isPlainObject(child) && typeof child.type === "string"
+    child => isPlainRecord(child) && typeof child.type === "string"
   )
     ? true
     : "must be editor content whose root children are nodes";
@@ -927,10 +930,13 @@ function isTextList(value: unknown): string | true {
     : "must contain only text entries";
 }
 
-/** Whether a value is a document id. */
+/**
+ * Whether a value is a document id. The canonical contracts type ids as
+ * strings on both the single and polymorphic forms, so a number would reach
+ * reference consumers in a shape they do not accept.
+ */
 function isDocumentId(value: unknown): boolean {
-  if (typeof value === "string") return value.length > 0;
-  return typeof value === "number" && Number.isFinite(value);
+  return typeof value === "string" && value.trim().length > 0;
 }
 
 /**
@@ -1074,20 +1080,21 @@ function containsUnserializable(value: unknown): boolean {
     ) {
       return true;
     }
-    if (Array.isArray(current)) {
-      pending.push(...current);
-      continue;
-    }
     if (current === null || typeof current !== "object") continue;
     if (seen.has(current)) continue;
     seen.add(current);
     // An object that defines `toJSON` chooses its own stored form, which is
     // how a Date becomes an ISO string. What it produces is what gets stored,
-    // so the walk follows that result rather than the object: a `toJSON`
-    // returning `undefined` makes the whole prop disappear on encode.
+    // so the walk follows that result rather than the value it was called on.
+    // Arrays are consulted here too: one carrying a `toJSON` is encoded from
+    // that result, not from its elements.
     const encoded = encodedForm(current);
     if (encoded !== current) {
       pending.push(encoded);
+      continue;
+    }
+    if (Array.isArray(current)) {
+      pending.push(...current);
       continue;
     }
     // Anything else that is not a plain record is reshaped rather than

--- a/packages/nextly/src/collections/fields/block-props.ts
+++ b/packages/nextly/src/collections/fields/block-props.ts
@@ -186,6 +186,7 @@ function buildFieldConfigs(
       );
       continue;
     }
+    if (!rejectUnknownOptions(declaration, resolved, path, ctx)) continue;
     const config = BUILDERS[resolved](name, declaration, path, ctx, depth);
     if (config) configs.push(config);
   }
@@ -208,6 +209,82 @@ function resolvePropType(type: string): BlockFieldCatalogType | null {
 }
 
 /**
+ * The options each prop type accepts, beside its `type`.
+ *
+ * Anything else is refused rather than dropped. A silently ignored option is
+ * the worst outcome available here: a declaration that reads as if it
+ * constrains its values while validating nothing. That covers both misspelled
+ * options and rule shapes this surface does not take — the nested
+ * `validation: { ... }` object the Schema Builder stores, whose flat
+ * equivalents are listed below, and a `validate` function, which a block
+ * declaration cannot carry because it must serialize into the generated
+ * manifest.
+ */
+const ALLOWED_OPTIONS: Readonly<
+  Record<BlockFieldCatalogType, readonly string[]>
+> = {
+  text: [
+    "label",
+    "required",
+    "minLength",
+    "maxLength",
+    "hasMany",
+    "minRows",
+    "maxRows",
+  ],
+  textarea: ["label", "required", "minLength", "maxLength"],
+  richText: ["label", "required"],
+  email: ["label", "required"],
+  number: ["label", "required", "min", "max", "hasMany", "minRows", "maxRows"],
+  code: ["label", "required"],
+  date: ["label", "required"],
+  select: ["label", "required", "options", "hasMany"],
+  radio: ["label", "required", "options"],
+  checkbox: ["label", "required"],
+  json: ["label", "required"],
+  chips: ["label", "required", "minChips", "maxChips"],
+  upload: ["label", "required", "relationTo", "hasMany"],
+  relationship: ["label", "required", "relationTo", "hasMany"],
+  repeater: ["label", "required", "fields", "minRows", "maxRows"],
+  group: ["label", "required", "fields"],
+};
+
+/** Whether every option on a declaration is one its type accepts. */
+function rejectUnknownOptions(
+  declaration: BlockPropDeclaration,
+  resolved: BlockFieldCatalogType,
+  path: string,
+  ctx: ConversionContext
+): boolean {
+  const allowed = ALLOWED_OPTIONS[resolved];
+  let ok = true;
+  for (const key of Object.keys(declaration)) {
+    if (key === "type" || allowed.includes(key)) continue;
+    ok = false;
+    record(
+      ctx,
+      `${path}.${key}`,
+      "UNKNOWN_OPTION",
+      `A ${resolved} prop does not accept \`${key}\`. Accepted options: ${allowed.join(", ")}.`
+    );
+  }
+  return ok;
+}
+
+/**
+ * The plugin type a declaration named, when conversion resolved it to a
+ * storage primitive. Carried on the config so an inspector can still dispatch
+ * the plugin's own component instead of the primitive's built-in control.
+ */
+function pluginIdentity(
+  type: string
+): { custom: { pluginFieldType: string } } | undefined {
+  return isBlockFieldType(type)
+    ? undefined
+    : { custom: { pluginFieldType: type } };
+}
+
+/**
  * The options every prop type carries. `defaultValue` is deliberately absent:
  * a block's defaults live in its `defaultProps`, applied by the engine when a
  * block is inserted, so duplicating them onto the field config would give one
@@ -218,9 +295,16 @@ function base(
   declaration: BlockPropDeclaration,
   path: string,
   ctx: ConversionContext
-): { name: string; label?: string; required?: boolean; localized?: boolean } {
+): {
+  name: string;
+  label?: string;
+  required?: boolean;
+  localized?: boolean;
+  custom?: { pluginFieldType: string };
+} {
   return {
     name,
+    ...pluginIdentity(declaration.type),
     label: optionalString(declaration, "label", path, ctx),
     required: optionalBoolean(declaration, "required", path, ctx),
     // A block declares its translatable props by top-level name, so the flag
@@ -231,11 +315,16 @@ function base(
 }
 
 const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
-  text: (name, declaration, path, ctx) => ({
-    ...base(name, declaration, path, ctx),
-    type: "text",
-    ...lengthBounds(declaration, path, ctx),
-  }),
+  text: (name, declaration, path, ctx) => {
+    const hasMany = optionalBoolean(declaration, "hasMany", path, ctx);
+    return {
+      ...base(name, declaration, path, ctx),
+      type: "text",
+      ...lengthBounds(declaration, path, ctx),
+      hasMany,
+      ...rowBounds(declaration, path, ctx),
+    };
+  },
   textarea: (name, declaration, path, ctx) => ({
     ...base(name, declaration, path, ctx),
     type: "textarea",
@@ -253,12 +342,16 @@ const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
   number: (name, declaration, path, ctx) => {
     const min = optionalNumber(declaration, "min", path, ctx);
     const max = optionalNumber(declaration, "max", path, ctx);
+    const hasMany = optionalBoolean(declaration, "hasMany", path, ctx);
     // A number prop is free to range below zero and to hold fractions, so
     // ordering is the only rule its bounds must satisfy.
     return {
       ...base(name, declaration, path, ctx),
       type: "number",
       ...orderedPair(min, max, "min", "max", path, ctx),
+      hasMany,
+      ...rowBounds(declaration, path, ctx),
+      validate: finiteValidator(hasMany),
     };
   },
   code: (name, declaration, path, ctx) => ({
@@ -304,6 +397,7 @@ const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
       ...base(name, declaration, path, ctx),
       type: "chips",
       ...orderedPair(minChips, maxChips, "minChips", "maxChips", path, ctx),
+      validate: isTextList,
     };
   },
   upload: (name, declaration, path, ctx) => {
@@ -315,7 +409,7 @@ const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
       type: "upload",
       relationTo,
       hasMany,
-      validate: referenceValidator(hasMany),
+      validate: referenceValidator(hasMany, relationTo),
     };
   },
   relationship: (name, declaration, path, ctx) => {
@@ -327,7 +421,7 @@ const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
       type: "relationship",
       relationTo,
       hasMany,
-      validate: referenceValidator(hasMany),
+      validate: referenceValidator(hasMany, relationTo),
     };
   },
   repeater: (name, declaration, path, ctx, depth) => {
@@ -362,6 +456,17 @@ function lengthBounds(
   const minLength = countOption(declaration, "minLength", path, ctx);
   const maxLength = countOption(declaration, "maxLength", path, ctx);
   return orderedPair(minLength, maxLength, "minLength", "maxLength", path, ctx);
+}
+
+/** Row bounds for the prop types that hold a list of values. */
+function rowBounds(
+  declaration: BlockPropDeclaration,
+  path: string,
+  ctx: ConversionContext
+): { minRows?: number; maxRows?: number } {
+  const minRows = countOption(declaration, "minRows", path, ctx);
+  const maxRows = countOption(declaration, "maxRows", path, ctx);
+  return orderedPair(minRows, maxRows, "minRows", "maxRows", path, ctx);
 }
 
 /**
@@ -508,46 +613,92 @@ function countOption(
   return undefined;
 }
 
-/** Whether a value is shaped like editor content: a root node with children. */
+/**
+ * Whether a value is shaped like editor content: a `root` node of type
+ * `"root"` whose children are nodes. The admin hands the stored value to the
+ * editor as-is, so a value that only resembles editor content fails there
+ * instead of here unless the whole envelope is checked.
+ *
+ * The check is one level deep on purpose: node types are open (plugins add
+ * their own), so validating the full tree would encode the editor's node
+ * catalog into the field system.
+ */
 function isEditorContent(value: unknown): string | true {
   if (!isPlainObject(value)) return "must be editor content";
   const root = value.root;
-  if (!isPlainObject(root) || !Array.isArray(root.children)) {
+  if (!isPlainObject(root) || root.type !== "root") {
     return "must be editor content with a root node";
   }
-  return true;
+  if (!Array.isArray(root.children)) {
+    return "must be editor content whose root has a list of children";
+  }
+  return root.children.every(
+    child => isPlainObject(child) && typeof child.type === "string"
+  )
+    ? true
+    : "must be editor content whose root children are nodes";
+}
+
+/** Whether every entry of a list value is text. */
+function isTextList(value: unknown): string | true {
+  if (!Array.isArray(value)) return "must be a list";
+  return value.every(entry => typeof entry === "string")
+    ? true
+    : "must contain only text entries";
 }
 
 /**
- * Whether a value is a stored reference: an id, or the polymorphic
- * `{ relationTo, value }` pair a multi-collection relation stores.
+ * Finite-value check for a number prop, honoring its cardinality. The shared
+ * number rules reject `NaN` but accept the infinities, which JSON writes as
+ * `null` — so an accepted value would not survive being stored.
  */
-function isReference(value: unknown): boolean {
+function finiteValidator(
+  hasMany: boolean | undefined
+): (value: unknown) => string | true {
+  const finite = (entry: unknown) =>
+    typeof entry === "number" && Number.isFinite(entry);
+  return value => {
+    if (!hasMany) {
+      return finite(value) ? true : "must be a finite number";
+    }
+    if (!Array.isArray(value)) return "must be a list of numbers";
+    return value.every(finite) ? true : "must contain only finite numbers";
+  };
+}
+
+/**
+ * Whether a value is a stored reference to one of `targets`: an id, or the
+ * polymorphic `{ relationTo, value }` pair a multi-collection relation stores.
+ * A polymorphic reference naming a collection the prop does not relate to is
+ * rejected, since nothing downstream would resolve it.
+ */
+function isReference(value: unknown, targets: readonly string[]): boolean {
   if (typeof value === "string") return value.length > 0;
   if (typeof value === "number") return Number.isFinite(value);
   if (!isPlainObject(value)) return false;
   return (
     typeof value.relationTo === "string" &&
-    value.relationTo.length > 0 &&
+    targets.includes(value.relationTo) &&
     (typeof value.value === "string" || typeof value.value === "number")
   );
 }
 
-/** Reference-shape check for one prop, honoring its cardinality. */
+/** Reference-shape check for one prop, honoring its cardinality and targets. */
 function referenceValidator(
-  hasMany: boolean | undefined
+  hasMany: boolean | undefined,
+  relationTo: string | string[]
 ): (value: unknown) => string | true {
+  const targets = Array.isArray(relationTo) ? relationTo : [relationTo];
+  const expected = `an id or a { relationTo, value } reference to ${targets.join(" or ")}`;
   return value => {
     if (hasMany) {
       if (!Array.isArray(value)) return "must be a list of references";
-      return value.every(isReference)
+      return value.every(entry => isReference(entry, targets))
         ? true
-        : "must contain only ids or { relationTo, value } references";
+        : `must contain only ${expected}`;
     }
     if (Array.isArray(value)) return "must be a single reference, not a list";
-    return isReference(value)
-      ? true
-      : "must be an id or a { relationTo, value } reference";
+    return isReference(value, targets) ? true : `must be ${expected}`;
   };
 }
 
@@ -563,14 +714,15 @@ function isSerializable(value: unknown): string | true {
     return "must be JSON-serializable";
   }
   return containsUnserializable(value)
-    ? "must not contain functions, symbols, or undefined values"
+    ? "must not contain functions, symbols, undefined, or non-finite numbers"
     : true;
 }
 
 /**
- * Whether any part of a value is a type `JSON.stringify` drops rather than
- * rejects. Stringify succeeds on these by omitting object keys and writing
- * array holes as `null`, so the loss is invisible without an explicit walk.
+ * Whether any part of a value is something `JSON.stringify` drops rather than
+ * rejects. Stringify succeeds on these by omitting object keys, writing array
+ * holes as `null`, and turning `NaN` and the infinities into `null`, so the
+ * loss is invisible without an explicit walk.
  */
 function containsUnserializable(value: unknown): boolean {
   const pending: unknown[] = [value];
@@ -579,7 +731,8 @@ function containsUnserializable(value: unknown): boolean {
     if (
       typeof current === "function" ||
       typeof current === "symbol" ||
-      current === undefined
+      current === undefined ||
+      (typeof current === "number" && !Number.isFinite(current))
     ) {
       return true;
     }

--- a/packages/nextly/src/collections/fields/block-props.ts
+++ b/packages/nextly/src/collections/fields/block-props.ts
@@ -144,12 +144,23 @@ export async function validateBlockPropValues(
   source: BlockPropsSource
 ): Promise<ConversionIssue[]> {
   const fields = blockPropsToFieldConfigs(source);
+  // Only the record's own keys are stored, so only they are validated. A
+  // props object carrying a custom prototype would otherwise let an inherited
+  // value satisfy a required prop while encoding writes nothing for it.
+  const own = ownProperties(values);
   // Block props are always written whole: a stored node carries every prop it
   // has, so absent means unset rather than untouched, which is create mode.
-  const issues = await validateEntryData(values, fields, { mode: "create" });
-  collectSerializationIssues(fields, values, issues);
-  collectEmptyListIssues(fields, values, "", issues);
+  const issues = await validateEntryData(own, fields, { mode: "create" });
+  collectSerializationIssues(fields, own, issues);
+  collectEmptyListIssues(fields, own, "", issues);
   return issues;
+}
+
+/** A shallow copy carrying only a record's own enumerable keys. */
+function ownProperties(
+  values: Record<string, unknown>
+): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(values));
 }
 
 /**
@@ -174,7 +185,7 @@ function collectSerializationIssues(
     // A prop that already failed a type rule does not need a second, vaguer
     // issue: the specific one describes the same defect better.
     if (alreadyReported(issues, field.name)) continue;
-    const result = isSerializable(value);
+    const result = isSerializable(value, field.name);
     if (result !== true) {
       issues.push({
         path: field.name,
@@ -189,7 +200,7 @@ function collectSerializationIssues(
   const declared = new Set(fields.map(field => field.name));
   for (const [name, value] of Object.entries(values)) {
     if (declared.has(name) || alreadyReported(issues, name)) continue;
-    const result = isSerializable(value);
+    const result = isSerializable(value, name);
     if (result !== true) {
       issues.push({
         path: name,
@@ -907,16 +918,21 @@ function isEditorContent(value: unknown): string | true {
   // Plain records, not merely objects: a class instance with the right keys
   // encodes to whatever its own `toJSON` decides, so the renderer would read
   // back something other than the envelope that was validated.
-  if (!isPlainRecord(value)) return "must be editor content";
+  if (!isPlainRecord(value) || definesOwnToJson(value)) {
+    return "must be editor content";
+  }
   const root = value.root;
-  if (!isPlainRecord(root) || root.type !== "root") {
+  if (!isPlainRecord(root) || definesOwnToJson(root) || root.type !== "root") {
     return "must be editor content with a root node";
   }
   if (!Array.isArray(root.children)) {
     return "must be editor content whose root has a list of children";
   }
   return root.children.every(
-    child => isPlainRecord(child) && typeof child.type === "string"
+    child =>
+      isPlainRecord(child) &&
+      !definesOwnToJson(child) &&
+      typeof child.type === "string"
   )
     ? true
     : "must be editor content whose root children are nodes";
@@ -924,7 +940,9 @@ function isEditorContent(value: unknown): string | true {
 
 /** Whether every entry of a list value is text. */
 function isTextList(value: unknown): string | true {
-  if (!Array.isArray(value)) return "must be a list";
+  // The shared rules report a non-list chips value, so this looks only at the
+  // elements of a value that already has the right container shape.
+  if (!Array.isArray(value)) return true;
   return value.every(entry => typeof entry === "string")
     ? true
     : "must contain only text entries";
@@ -1014,7 +1032,20 @@ function listBoundsValidator(
  * the document is encoded — and a cyclic object, which makes encoding throw.
  */
 function isJsonRecord(value: unknown): string | true {
-  return isPlainRecord(value) ? true : "must be a plain object";
+  // The shared rules own the container-shape check for these types, so a
+  // non-object is already reported and repeating it would double the issue.
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return true;
+  }
+  if (!isPlainRecord(value)) return "must be a plain object";
+  // A record whose shape was just validated must be stored as that shape; an
+  // own `toJSON` replaces it with something else entirely on encode.
+  return definesOwnToJson(value) ? "must not define its own toJSON" : true;
+}
+
+/** Whether a value would substitute something else for itself on encode. */
+function definesOwnToJson(value: object): boolean {
+  return typeof (value as { toJSON?: unknown }).toJSON === "function";
 }
 
 /**
@@ -1032,6 +1063,9 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 function isJsonRecordList(value: unknown): string | true {
   if (!Array.isArray(value)) return true;
   for (const row of value) {
+    // A malformed row is reported by the shared rules with its own index, so
+    // only rows that passed that check are examined here.
+    if (typeof row !== "object" || row === null || Array.isArray(row)) continue;
     const result = isJsonRecord(row);
     if (result !== true) return `rows ${result}`;
   }
@@ -1043,7 +1077,7 @@ function isJsonRecordList(value: unknown): string | true {
  * stored as JSON, so anything JSON cannot represent — a function, a symbol, a
  * bigint, a cycle — would be silently dropped or would throw on write.
  */
-function isSerializable(value: unknown): string | true {
+function isSerializable(value: unknown, key: string): string | true {
   try {
     // A prop that encodes to nothing is dropped from the document entirely
     // rather than stored wrongly, so the encoded result is inspected and not
@@ -1054,7 +1088,7 @@ function isSerializable(value: unknown): string | true {
   } catch {
     return "must be JSON-serializable";
   }
-  return containsUnserializable(value)
+  return containsUnserializable(value, key)
     ? "must not contain functions, symbols, undefined, non-finite numbers, or values JSON would reshape"
     : true;
 }
@@ -1065,13 +1099,15 @@ function isSerializable(value: unknown): string | true {
  * holes as `null`, and turning `NaN` and the infinities into `null`, so the
  * loss is invisible without an explicit walk.
  */
-function containsUnserializable(value: unknown): boolean {
-  const pending: unknown[] = [value];
+function containsUnserializable(value: unknown, key: string): boolean {
+  const pending: Array<{ value: unknown; key: string }> = [{ value, key }];
   // Objects can name each other, and a `toJSON` may hand back a fresh object
   // each call, so the walk remembers what it has already accounted for.
   const seen = new WeakSet<object>();
   while (pending.length > 0) {
-    const current = pending.pop();
+    const entry = pending.pop();
+    if (entry === undefined) continue;
+    const current = entry.value;
     if (
       typeof current === "function" ||
       typeof current === "symbol" ||
@@ -1088,20 +1124,24 @@ function containsUnserializable(value: unknown): boolean {
     // so the walk follows that result rather than the value it was called on.
     // Arrays are consulted here too: one carrying a `toJSON` is encoded from
     // that result, not from its elements.
-    const encoded = encodedForm(current);
+    const encoded = encodedForm(current, entry.key);
     if (encoded !== current) {
-      pending.push(encoded);
+      pending.push({ value: encoded, key: entry.key });
       continue;
     }
     if (Array.isArray(current)) {
-      pending.push(...current);
+      current.forEach((item, index) =>
+        pending.push({ value: item, key: String(index) })
+      );
       continue;
     }
     // Anything else that is not a plain record is reshaped rather than
     // rejected: a Map or a Set encodes as `{}`, losing its contents with no
     // error to notice.
     if (!isPlainRecord(current)) return true;
-    pending.push(...Object.values(current));
+    for (const [childKey, childValue] of Object.entries(current)) {
+      pending.push({ value: childValue, key: childKey });
+    }
   }
   return false;
 }
@@ -1111,11 +1151,13 @@ function containsUnserializable(value: unknown): boolean {
  * `toJSON` that throws is reported as unserializable, which is what
  * `JSON.stringify` would do with it anyway.
  */
-function encodedForm(value: object): unknown {
+function encodedForm(value: object, key: string): unknown {
   const toJSON = (value as { toJSON?: unknown }).toJSON;
   if (typeof toJSON !== "function") return value;
   try {
-    return (toJSON as (key?: string) => unknown).call(value);
+    // Encoding passes the containing key, and a serializer is free to read
+    // it, so the walk supplies the same one rather than calling bare.
+    return (toJSON as (key: string) => unknown).call(value, key);
   } catch {
     return undefined;
   }

--- a/packages/nextly/src/collections/fields/block-props.ts
+++ b/packages/nextly/src/collections/fields/block-props.ts
@@ -169,7 +169,7 @@ function collectSerializationIssues(
 ): void {
   for (const field of fields) {
     if (!field.name) continue;
-    const value = values[field.name];
+    const value = ownValue(values, field.name);
     if (value === undefined) continue;
     // A prop that already failed a type rule does not need a second, vaguer
     // issue: the specific one describes the same defect better.
@@ -183,6 +183,28 @@ function collectSerializationIssues(
       });
     }
   }
+  // A stored node may carry keys no current declaration covers — an older
+  // prop kept through a migration, or an extra supplied by an API caller.
+  // They are written into the same document, so they answer to the same rule.
+  const declared = new Set(fields.map(field => field.name));
+  for (const [name, value] of Object.entries(values)) {
+    if (declared.has(name) || alreadyReported(issues, name)) continue;
+    const result = isSerializable(value);
+    if (result !== true) {
+      issues.push({
+        path: name,
+        code: "NOT_SERIALIZABLE",
+        message: `${name} ${result}.`,
+      });
+    }
+  }
+}
+
+/** Reads only a value's own key, never an inherited Object.prototype member. */
+function ownValue(values: Record<string, unknown>, name: string): unknown {
+  return Object.prototype.hasOwnProperty.call(values, name)
+    ? values[name]
+    : undefined;
 }
 
 /** Whether any recorded issue already points at this prop or inside it. */
@@ -217,10 +239,13 @@ function collectEmptyListIssues(
 ): void {
   for (const field of fields) {
     if (!field.name) continue;
-    const value = values[field.name];
+    const value = ownValue(values, field.name);
     if (value === undefined) continue;
     const path = basePath ? `${basePath}.${field.name}` : field.name;
     if (Array.isArray(value) && value.length === 0) {
+      // A scalar select or radio is inspected for arrays by the shared rules,
+      // so its issue is already recorded and does not need repeating.
+      if (alreadyReported(issues, path)) continue;
       if (!holdsList(field)) {
         issues.push({
           path,
@@ -303,6 +328,18 @@ function buildFieldConfigs(
       );
       continue;
     }
+    // A prop named after an Object.prototype member reads back as the
+    // inherited function whenever the prop is absent, so an omitted optional
+    // prop would look like a value of the wrong type to every consumer.
+    if (name in Object.prototype) {
+      record(
+        ctx,
+        path,
+        "RESERVED_NAME",
+        `"${name}" is a member of Object.prototype and cannot be a prop name.`
+      );
+      continue;
+    }
     if (!isPlainObject(declaration)) {
       record(
         ctx,
@@ -379,8 +416,15 @@ const ALLOWED_OPTIONS: Readonly<
   checkbox: ["label", "required"],
   json: ["label", "required"],
   chips: ["label", "required", "minChips", "maxChips"],
-  upload: ["label", "required", "relationTo", "hasMany"],
-  relationship: ["label", "required", "relationTo", "hasMany"],
+  upload: ["label", "required", "relationTo", "hasMany", "minRows", "maxRows"],
+  relationship: [
+    "label",
+    "required",
+    "relationTo",
+    "hasMany",
+    "minRows",
+    "maxRows",
+  ],
   repeater: ["label", "required", "fields", "minRows", "maxRows"],
   group: ["label", "required", "fields"],
 };
@@ -542,24 +586,34 @@ const BUILDERS: Readonly<Record<BlockFieldCatalogType, PropBuilder>> = {
     const relationTo = relationTarget(declaration, path, ctx);
     if (!relationTo) return null;
     const hasMany = optionalBoolean(declaration, "hasMany", path, ctx);
+    const rows = rowBounds(declaration, path, ctx);
     return {
       ...base(name, declaration, path, ctx),
       type: "upload",
       relationTo,
       hasMany,
-      validate: referenceValidator(hasMany, relationTo),
+      ...rows,
+      validate: allOf(
+        referenceValidator(hasMany, relationTo),
+        listBoundsValidator(rows.minRows, rows.maxRows)
+      ),
     };
   },
   relationship: (name, declaration, path, ctx) => {
     const relationTo = relationTarget(declaration, path, ctx);
     if (!relationTo) return null;
     const hasMany = optionalBoolean(declaration, "hasMany", path, ctx);
+    const rows = rowBounds(declaration, path, ctx);
     return {
       ...base(name, declaration, path, ctx),
       type: "relationship",
       relationTo,
       hasMany,
-      validate: referenceValidator(hasMany, relationTo),
+      ...rows,
+      validate: allOf(
+        referenceValidator(hasMany, relationTo),
+        listBoundsValidator(rows.minRows, rows.maxRows)
+      ),
     };
   },
   repeater: (name, declaration, path, ctx, depth) => {
@@ -669,15 +723,15 @@ function choiceOptions(
       );
       return null;
     }
-    // An empty stored value is indistinguishable from no value at all: the
-    // shared rules read `""` as absent, so such an option could never be
-    // selected, and an empty label leaves nothing to select in the picker.
-    if (entry.label.length === 0 || entry.value.length === 0) {
+    // A blank stored value is indistinguishable from no value at all: the
+    // shared rules trim before deciding emptiness, so an option declaring one
+    // could never be selected, and a blank label leaves nothing to click.
+    if (entry.label.trim().length === 0 || entry.value.trim().length === 0) {
       record(
         ctx,
         path,
         "INVALID_OPTIONS",
-        "Every entry in `options` must have a non-empty `label` and `value`."
+        "Every entry in `options` must have a `label` and `value` that are not empty or whitespace."
       );
       return null;
     }
@@ -854,6 +908,19 @@ function referenceValidator(
   };
 }
 
+/** Runs validators in order, reporting the first failure. */
+function allOf(
+  ...validators: Array<(value: unknown) => string | true>
+): (value: unknown) => string | true {
+  return value => {
+    for (const validator of validators) {
+      const result = validator(value);
+      if (result !== true) return result;
+    }
+    return true;
+  };
+}
+
 /**
  * Row-count check for a list-shaped scalar prop. The shared rules read row
  * bounds for repeaters and chips but not for a `hasMany` text or number field,
@@ -918,7 +985,7 @@ function isSerializable(value: unknown): string | true {
     return "must be JSON-serializable";
   }
   return containsUnserializable(value)
-    ? "must not contain functions, symbols, undefined, or non-finite numbers"
+    ? "must not contain functions, symbols, undefined, non-finite numbers, or values JSON would reshape"
     : true;
 }
 
@@ -944,9 +1011,22 @@ function containsUnserializable(value: unknown): boolean {
       pending.push(...current);
       continue;
     }
-    if (isPlainObject(current)) pending.push(...Object.values(current));
+    if (current === null || typeof current !== "object") continue;
+    // An object that defines `toJSON` chooses its own stored form, which is
+    // how a Date becomes an ISO string, so it is taken at its word and its
+    // internals are not walked. Anything else that is not a plain record is
+    // reshaped rather than rejected: a Map or a Set encodes as `{}`, losing
+    // its contents without any error to notice.
+    if (definesToJson(current)) continue;
+    if (!isPlainRecord(current)) return true;
+    pending.push(...Object.values(current));
   }
   return false;
+}
+
+/** Whether a value controls its own encoded form. */
+function definesToJson(value: object): boolean {
+  return typeof (value as { toJSON?: unknown }).toJSON === "function";
 }
 
 function optionalString(

--- a/packages/nextly/src/collections/fields/block-props.ts
+++ b/packages/nextly/src/collections/fields/block-props.ts
@@ -125,6 +125,19 @@ export function blockPropsToFieldConfigs(
     issues: [],
   };
   const configs = buildFieldConfigs(source.props, "", ctx, 0);
+  // A localized name is only meaningful against a declared prop. Left
+  // unchecked, a typo produces a config with nothing marked translatable and
+  // no sign that the author asked for one.
+  for (const name of source.localized ?? []) {
+    if (!Object.prototype.hasOwnProperty.call(source.props ?? {}, name)) {
+      record(
+        ctx,
+        name,
+        "UNKNOWN_LOCALIZED_PROP",
+        `"${name}" is listed as localized but is not a declared prop.`
+      );
+    }
+  }
   if (ctx.issues.length > 0) {
     throw NextlyError.validation({
       errors: ctx.issues,
@@ -245,6 +258,13 @@ function alreadyReported(
  * all, an empty list where the prop holds one value or declares a minimum,
  * and a required list-shaped prop explicitly set to `[]`, which the shared
  * rules route past their required check in order to reach the bounds rules.
+ *
+ * An explicit `null` is not one of them. Unlike a blank string on a number
+ * prop, `null` is not a value of the wrong type — it is how JSON says a prop
+ * is unset, it survives encoding unchanged, and it reads to a consumer
+ * exactly as an absent key does. A required prop still rejects it, because
+ * the shared rules treat it as empty. Refusing it for optional props would
+ * make clearing a prop an error rather than a normal edit.
  */
 function collectEmptyListIssues(
   fields: readonly WalkableField[],
@@ -257,6 +277,20 @@ function collectEmptyListIssues(
     const value = ownValue(values, field.name);
     if (value === undefined) continue;
     const path = basePath ? `${basePath}.${field.name}` : field.name;
+    if (
+      !alreadyReported(issues, path) &&
+      typeof value === "object" &&
+      value !== null &&
+      definesOwnToJson(value) &&
+      !choosesOwnStoredForm(field)
+    ) {
+      issues.push({
+        path,
+        code: "INVALID_TYPE",
+        message: `${field.label ?? field.name} must not define its own toJSON.`,
+      });
+      continue;
+    }
     if (typeof value === "string" && value.trim() === "") {
       if (!alreadyReported(issues, path) && !holdsText(field)) {
         issues.push({
@@ -325,6 +359,20 @@ function collectEmptyListIssues(
  * Whether a field's value is a list. `json` counts because an array is a
  * legitimate JSON value, not a cardinality mistake.
  */
+/**
+ * Whether a field's declared type lets a value choose its own encoded form.
+ *
+ * Only two do. A `json` prop stores whatever shape the value decides, so
+ * `toJSON` is a legitimate way to pick it. A `date` prop accepts a `Date`,
+ * whose `toJSON` produces the ISO string dates are stored as, and its own
+ * rules already reject anything that is not a date. Every other type is
+ * validated by shape, so a value that substitutes something else on encode
+ * would store what was never checked.
+ */
+function choosesOwnStoredForm(field: WalkableField): boolean {
+  return field.type === "json" || field.type === "date";
+}
+
 /**
  * Whether a field's value may be a string. A blank string reaching any other
  * prop contradicts its declared type: a number cannot be text, and an id that

--- a/packages/nextly/src/collections/fields/catalog.test.ts
+++ b/packages/nextly/src/collections/fields/catalog.test.ts
@@ -278,6 +278,53 @@ describe("binding kinds", () => {
     ).toBe(false);
   });
 
+  it("requires reference endpoints to agree on their collections", () => {
+    // Binding does not rewrite a reference, so a users document cannot fill a
+    // prop that relates to posts even though both ends are of kind reference.
+    expect(
+      canBindFieldToProp(
+        { type: "relationship", relationTo: "users" },
+        { type: "relationship", relationTo: "posts" }
+      )
+    ).toBe(false);
+    expect(
+      canBindFieldToProp(
+        { type: "relationship", relationTo: "posts" },
+        { type: "relationship", relationTo: ["posts", "pages"] }
+      )
+    ).toBe(true);
+    // A source that can yield pages cannot fill a posts-only prop.
+    expect(
+      canBindFieldToProp(
+        { type: "relationship", relationTo: ["posts", "pages"] },
+        { type: "relationship", relationTo: "posts" }
+      )
+    ).toBe(false);
+    expect(
+      canBindFieldToProp(
+        { type: "upload", relationTo: "media" },
+        { type: "upload", relationTo: "media" }
+      )
+    ).toBe(true);
+  });
+
+  it("skips the target check when an endpoint declares no collections", () => {
+    // Omitting targets says nothing about collection identity, so it must not
+    // be read as a claim to accept any.
+    expect(
+      canBindFieldToProp(
+        { type: "relationship" },
+        { type: "relationship", relationTo: "posts" }
+      )
+    ).toBe(true);
+    expect(
+      canBindFieldToProp(
+        { type: "relationship", relationTo: "posts" },
+        { type: "relationship" }
+      )
+    ).toBe(true);
+  });
+
   it("rejects unknown types on either side", () => {
     expect(bindingKindOf({ type: "nope" })).toBeNull();
     expect(canBindFieldToProp({ type: "nope" }, { type: "text" })).toBe(false);

--- a/packages/nextly/src/collections/fields/catalog.test.ts
+++ b/packages/nextly/src/collections/fields/catalog.test.ts
@@ -287,12 +287,27 @@ describe("binding kinds", () => {
         { type: "relationship", relationTo: "posts" }
       )
     ).toBe(false);
+    // Same collection, different storage shape: a single target stores a bare
+    // id while a list of targets stores a { relationTo, value } pair, and
+    // binding does not rewrite the value it moves.
     expect(
       canBindFieldToProp(
         { type: "relationship", relationTo: "posts" },
         { type: "relationship", relationTo: ["posts", "pages"] }
       )
+    ).toBe(false);
+    expect(
+      canBindFieldToProp(
+        { type: "relationship", relationTo: ["posts"] },
+        { type: "relationship", relationTo: ["posts", "pages"] }
+      )
     ).toBe(true);
+    expect(
+      canBindFieldToProp(
+        { type: "relationship", relationTo: ["posts"] },
+        { type: "relationship", relationTo: "posts" }
+      )
+    ).toBe(false);
     // A source that can yield pages cannot fill a posts-only prop.
     expect(
       canBindFieldToProp(

--- a/packages/nextly/src/collections/fields/catalog.test.ts
+++ b/packages/nextly/src/collections/fields/catalog.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  BINDABLE_KINDS,
+  BLOCK_FIELD_TYPES,
+  BLOCK_FIELD_TYPE_CATALOG,
+  FIELD_TYPE_BINDING_KIND,
   FIELD_TYPE_CATALOG,
   FORM_FIELD_TYPE_CATALOG,
   USER_FIELD_TYPE_CATALOG,
+  canBindFieldTypeToPropType,
   getFieldTypeCatalogEntry,
+  isBindablePropType,
+  isBlockFieldType,
   narrowFieldTypeCatalog,
 } from "./catalog";
 import { ALL_FIELD_TYPES } from "./types";
@@ -119,5 +126,105 @@ describe("FORM_FIELD_TYPE_CATALOG", () => {
       expect(entry.hint.length).toBeGreaterThan(0);
       expect(entry.icon.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("BLOCK_FIELD_TYPE_CATALOG", () => {
+  it("is the canonical catalog minus password and component", () => {
+    const types = BLOCK_FIELD_TYPE_CATALOG.map(entry => entry.type);
+    expect(new Set(types).size).toBe(types.length);
+    expect([...types].sort()).toEqual(
+      ALL_FIELD_TYPES.filter(
+        type => type !== "password" && type !== "component"
+      ).sort()
+    );
+  });
+
+  it("adds no surface-only types, so every entry maps to a field config", () => {
+    const canonical = new Set(FIELD_TYPE_CATALOG.map(entry => entry.type));
+    for (const entry of BLOCK_FIELD_TYPE_CATALOG) {
+      expect(canonical.has(entry.type), entry.type).toBe(true);
+    }
+  });
+
+  it("lists the same types the type list does, in catalog order", () => {
+    expect(BLOCK_FIELD_TYPE_CATALOG.map(entry => entry.type)).toEqual(
+      FIELD_TYPE_CATALOG.map(entry => entry.type).filter(type =>
+        (BLOCK_FIELD_TYPES as readonly string[]).includes(type)
+      )
+    );
+  });
+
+  it("recognizes block prop types and rejects everything else", () => {
+    expect(isBlockFieldType("richText")).toBe(true);
+    expect(isBlockFieldType("password")).toBe(false);
+    expect(isBlockFieldType("component")).toBe(false);
+    expect(isBlockFieldType("url")).toBe(false);
+    expect(isBlockFieldType("nope")).toBe(false);
+  });
+});
+
+describe("binding kinds", () => {
+  it("assigns a source kind to every canonical field type", () => {
+    for (const type of ALL_FIELD_TYPES) {
+      expect(FIELD_TYPE_BINDING_KIND).toHaveProperty(type);
+    }
+  });
+
+  it("declares accepted kinds for every block prop type", () => {
+    for (const type of BLOCK_FIELD_TYPES) {
+      expect(BINDABLE_KINDS[type]).toBeDefined();
+    }
+  });
+
+  it("never accepts a kind no field type can produce", () => {
+    const producible = new Set(
+      Object.values(FIELD_TYPE_BINDING_KIND).filter(kind => kind !== null)
+    );
+    for (const accepted of Object.values(BINDABLE_KINDS)) {
+      for (const kind of accepted) {
+        expect(producible.has(kind), kind).toBe(true);
+      }
+    }
+  });
+
+  it("makes bindability a property of the prop type", () => {
+    expect(isBindablePropType("text")).toBe(true);
+    expect(isBindablePropType("upload")).toBe(true);
+    // Structured props are composed, not bound.
+    expect(isBindablePropType("repeater")).toBe(false);
+    expect(isBindablePropType("group")).toBe(false);
+    // Not a block prop type at all.
+    expect(isBindablePropType("password")).toBe(false);
+  });
+
+  it("pairs compatible source fields with props", () => {
+    expect(canBindFieldTypeToPropType("text", "text")).toBe(true);
+    expect(canBindFieldTypeToPropType("email", "text")).toBe(true);
+    expect(canBindFieldTypeToPropType("number", "text")).toBe(true);
+    expect(canBindFieldTypeToPropType("select", "radio")).toBe(true);
+    expect(canBindFieldTypeToPropType("upload", "upload")).toBe(true);
+    expect(canBindFieldTypeToPropType("relationship", "relationship")).toBe(
+      true
+    );
+  });
+
+  it("refuses pairs the renderer would have to coerce", () => {
+    // Rich text is structured editor content; a plain string is not it.
+    expect(canBindFieldTypeToPropType("text", "richText")).toBe(false);
+    expect(canBindFieldTypeToPropType("richText", "text")).toBe(false);
+    expect(canBindFieldTypeToPropType("number", "checkbox")).toBe(false);
+    // A to-many repeater is iterated by a loop, never flattened into a prop.
+    expect(canBindFieldTypeToPropType("repeater", "text")).toBe(false);
+    // Secrets never leave the server.
+    expect(canBindFieldTypeToPropType("password", "text")).toBe(false);
+  });
+
+  it("rejects unknown types on either side", () => {
+    expect(canBindFieldTypeToPropType("nope", "text")).toBe(false);
+    expect(canBindFieldTypeToPropType("text", "nope")).toBe(false);
+    expect(canBindFieldTypeToPropType("text", "password")).toBe(false);
+    // A prototype member is not a field type.
+    expect(canBindFieldTypeToPropType("toString", "text")).toBe(false);
   });
 });

--- a/packages/nextly/src/collections/fields/catalog.test.ts
+++ b/packages/nextly/src/collections/fields/catalog.test.ts
@@ -8,7 +8,8 @@ import {
   FIELD_TYPE_CATALOG,
   FORM_FIELD_TYPE_CATALOG,
   USER_FIELD_TYPE_CATALOG,
-  canBindFieldTypeToPropType,
+  bindingKindOf,
+  canBindFieldToProp,
   getFieldTypeCatalogEntry,
   isBindablePropType,
   isBlockFieldType,
@@ -189,42 +190,104 @@ describe("binding kinds", () => {
   });
 
   it("makes bindability a property of the prop type", () => {
-    expect(isBindablePropType("text")).toBe(true);
-    expect(isBindablePropType("upload")).toBe(true);
+    expect(isBindablePropType({ type: "text" })).toBe(true);
+    expect(isBindablePropType({ type: "upload" })).toBe(true);
     // Structured props are composed, not bound.
-    expect(isBindablePropType("repeater")).toBe(false);
-    expect(isBindablePropType("group")).toBe(false);
+    expect(isBindablePropType({ type: "repeater" })).toBe(false);
+    expect(isBindablePropType({ type: "group" })).toBe(false);
     // Not a block prop type at all.
-    expect(isBindablePropType("password")).toBe(false);
+    expect(isBindablePropType({ type: "password" })).toBe(false);
   });
 
   it("pairs compatible source fields with props", () => {
-    expect(canBindFieldTypeToPropType("text", "text")).toBe(true);
-    expect(canBindFieldTypeToPropType("email", "text")).toBe(true);
-    expect(canBindFieldTypeToPropType("number", "text")).toBe(true);
-    expect(canBindFieldTypeToPropType("select", "radio")).toBe(true);
-    expect(canBindFieldTypeToPropType("upload", "upload")).toBe(true);
-    expect(canBindFieldTypeToPropType("relationship", "relationship")).toBe(
+    expect(canBindFieldToProp({ type: "text" }, { type: "text" })).toBe(true);
+    expect(canBindFieldToProp({ type: "email" }, { type: "text" })).toBe(true);
+    expect(canBindFieldToProp({ type: "number" }, { type: "text" })).toBe(true);
+    expect(canBindFieldToProp({ type: "select" }, { type: "radio" })).toBe(
       true
     );
+    expect(canBindFieldToProp({ type: "upload" }, { type: "upload" })).toBe(
+      true
+    );
+    expect(
+      canBindFieldToProp({ type: "relationship" }, { type: "relationship" })
+    ).toBe(true);
   });
 
   it("refuses pairs the renderer would have to coerce", () => {
     // Rich text is structured editor content; a plain string is not it.
-    expect(canBindFieldTypeToPropType("text", "richText")).toBe(false);
-    expect(canBindFieldTypeToPropType("richText", "text")).toBe(false);
-    expect(canBindFieldTypeToPropType("number", "checkbox")).toBe(false);
+    expect(canBindFieldToProp({ type: "text" }, { type: "richText" })).toBe(
+      false
+    );
+    expect(canBindFieldToProp({ type: "richText" }, { type: "text" })).toBe(
+      false
+    );
+    expect(canBindFieldToProp({ type: "number" }, { type: "checkbox" })).toBe(
+      false
+    );
     // A to-many repeater is iterated by a loop, never flattened into a prop.
-    expect(canBindFieldTypeToPropType("repeater", "text")).toBe(false);
+    expect(canBindFieldToProp({ type: "repeater" }, { type: "text" })).toBe(
+      false
+    );
     // Secrets never leave the server.
-    expect(canBindFieldTypeToPropType("password", "text")).toBe(false);
+    expect(canBindFieldToProp({ type: "password" }, { type: "text" })).toBe(
+      false
+    );
+  });
+
+  it("requires the two ends to agree on cardinality", () => {
+    const many = { type: "select", hasMany: true };
+    const single = { type: "select" };
+    expect(canBindFieldToProp(many, single)).toBe(false);
+    expect(canBindFieldToProp(single, many)).toBe(false);
+    expect(canBindFieldToProp(many, many)).toBe(true);
+    expect(canBindFieldToProp(single, single)).toBe(true);
+    // A multi-upload produces an array of references.
+    expect(
+      canBindFieldToProp(
+        { type: "upload", hasMany: true },
+        { type: "upload", hasMany: true }
+      )
+    ).toBe(true);
+    expect(
+      canBindFieldToProp({ type: "upload", hasMany: true }, { type: "upload" })
+    ).toBe(false);
+  });
+
+  it("resolves a plugin type through its storage primitive", () => {
+    // A plugin type is not in the built-in union, so its primitive decides
+    // what it produces and what it accepts.
+    expect(bindingKindOf({ type: "rating", storage: "number" })).toBe("number");
+    expect(
+      canBindFieldToProp(
+        { type: "number" },
+        { type: "rating", storage: "number" }
+      )
+    ).toBe(true);
+    expect(
+      canBindFieldToProp(
+        { type: "rating", storage: "number" },
+        { type: "text" }
+      )
+    ).toBe(true);
+    expect(
+      canBindFieldToProp(
+        { type: "rating", storage: "number" },
+        { type: "checkbox" }
+      )
+    ).toBe(false);
   });
 
   it("rejects unknown types on either side", () => {
-    expect(canBindFieldTypeToPropType("nope", "text")).toBe(false);
-    expect(canBindFieldTypeToPropType("text", "nope")).toBe(false);
-    expect(canBindFieldTypeToPropType("text", "password")).toBe(false);
+    expect(bindingKindOf({ type: "nope" })).toBeNull();
+    expect(canBindFieldToProp({ type: "nope" }, { type: "text" })).toBe(false);
+    expect(canBindFieldToProp({ type: "text" }, { type: "nope" })).toBe(false);
+    expect(canBindFieldToProp({ type: "text" }, { type: "password" })).toBe(
+      false
+    );
     // A prototype member is not a field type.
-    expect(canBindFieldTypeToPropType("toString", "text")).toBe(false);
+    expect(canBindFieldToProp({ type: "toString" }, { type: "text" })).toBe(
+      false
+    );
   });
 });

--- a/packages/nextly/src/collections/fields/catalog.ts
+++ b/packages/nextly/src/collections/fields/catalog.ts
@@ -187,7 +187,7 @@ export const FIELD_TYPE_CATALOG: readonly FieldTypeCatalogEntry[] = [
  * here beside the surface catalogs so both the built-in surface types and
  * plugin-declared `surfaces` reference one definition.
  */
-export type FieldSurface = "entries" | "users" | "forms";
+export type FieldSurface = "entries" | "users" | "forms" | "blocks";
 
 /**
  * The surface a plugin field type targets when its author declares none. Shared
@@ -339,6 +339,164 @@ export const FORM_FIELD_TYPE_CATALOG: readonly FieldTypeCatalogEntry<FormFieldCa
     combined.push(HIDDEN_SURFACE_ENTRY, FILE_SURFACE_ENTRY);
     return combined;
   })();
+
+/**
+ * The block-prop surface's field types: everything a collection can declare
+ * except two deliberate exclusions.
+ *
+ * - `password` is excluded because a block document is public page content
+ *   rendered to every visitor, so a secret must never be authorable as a
+ *   block prop.
+ * - `component` is excluded because reusable composition inside a block
+ *   document happens through slots and component-instance nodes; admitting the
+ *   component field type as well would give one concept two storage shapes.
+ *
+ * Link-shaped props keep using `text` until the dedicated link picker joins
+ * the catalog with its admin component.
+ */
+export type BlockFieldCatalogType = Exclude<
+  FieldType,
+  "password" | "component"
+>;
+
+/** Every block-prop field type, in catalog order. */
+export const BLOCK_FIELD_TYPES: readonly BlockFieldCatalogType[] = [
+  "text",
+  "textarea",
+  "richText",
+  "email",
+  "number",
+  "code",
+  "date",
+  "select",
+  "radio",
+  "checkbox",
+  "json",
+  "chips",
+  "upload",
+  "relationship",
+  "repeater",
+  "group",
+];
+
+/**
+ * The block-prop picker's catalog: the shared catalog narrowed to the types a
+ * block prop may declare. Unlike the user and form surfaces it adds no
+ * surface-only types, so every entry here maps to a real `FieldConfig`.
+ */
+export const BLOCK_FIELD_TYPE_CATALOG: readonly FieldTypeCatalogEntry<BlockFieldCatalogType>[] =
+  narrowFieldTypeCatalog(BLOCK_FIELD_TYPES);
+
+/** Whether a field type may be declared as a block prop. */
+export function isBlockFieldType(type: string): type is BlockFieldCatalogType {
+  return (BLOCK_FIELD_TYPES as readonly string[]).includes(type);
+}
+
+/**
+ * The value shapes a binding can carry. A binding connects a data field to a
+ * block prop, so both sides are described in this one vocabulary and
+ * compatibility is a set membership test rather than a per-pair table.
+ */
+export type BindingValueKind =
+  | "text"
+  | "richText"
+  | "number"
+  | "boolean"
+  | "date"
+  | "media"
+  | "option"
+  | "reference"
+  | "list"
+  | "json";
+
+/**
+ * The kind of value a field of each type produces when it is a binding
+ * SOURCE. `null` means the type cannot be bound from at all: `password` never
+ * leaves the server, `component` and `group` are containers whose parts are
+ * bound individually, and a `repeater` is a to-many collection that a loop
+ * iterates rather than a binding flattens.
+ */
+export const FIELD_TYPE_BINDING_KIND: Readonly<
+  Record<FieldType, BindingValueKind | null>
+> = {
+  text: "text",
+  textarea: "text",
+  richText: "richText",
+  email: "text",
+  password: null,
+  code: "text",
+  number: "number",
+  checkbox: "boolean",
+  date: "date",
+  select: "option",
+  radio: "option",
+  upload: "media",
+  relationship: "reference",
+  repeater: null,
+  group: null,
+  json: "json",
+  component: null,
+  chips: "list",
+};
+
+/**
+ * The value kinds each block-prop type accepts from a binding. This map IS the
+ * bindability rule: a prop's binding affordance is derived from its declared
+ * TYPE and never from a per-block opt-in, so a new block gets binding support
+ * on every compatible prop the moment it is written.
+ *
+ * String-valued props accept numbers and dates because a binding carries an
+ * optional formatter that renders them as text. Rich text accepts only rich
+ * text: its stored value is structured editor content, and a plain string
+ * would not survive the round trip. Structured props (`repeater`, `group`) are
+ * composed rather than bound, so they accept nothing.
+ */
+export const BINDABLE_KINDS: Readonly<
+  Record<BlockFieldCatalogType, readonly BindingValueKind[]>
+> = {
+  text: ["text", "option", "number", "date"],
+  textarea: ["text", "option", "number", "date"],
+  richText: ["richText"],
+  email: ["text"],
+  number: ["number"],
+  code: ["text"],
+  date: ["date"],
+  select: ["option", "text"],
+  radio: ["option", "text"],
+  checkbox: ["boolean"],
+  json: ["json"],
+  chips: ["list"],
+  upload: ["media"],
+  relationship: ["reference"],
+  repeater: [],
+  group: [],
+};
+
+/** Whether a block prop of this type can be bound to a data field at all. */
+export function isBindablePropType(type: string): boolean {
+  return isBlockFieldType(type) && BINDABLE_KINDS[type].length > 0;
+}
+
+/**
+ * Whether a field of `sourceType` can be bound into a block prop of
+ * `propType`. Pickers use this to filter the field list they offer, so a user
+ * is never shown a binding that the renderer would then have to coerce.
+ */
+export function canBindFieldTypeToPropType(
+  sourceType: string,
+  propType: string
+): boolean {
+  if (!isBlockFieldType(propType)) return false;
+  const kind = isFieldType(sourceType)
+    ? FIELD_TYPE_BINDING_KIND[sourceType]
+    : null;
+  return kind !== null && BINDABLE_KINDS[propType].includes(kind);
+}
+
+/** Narrowing guard for the built-in field-type union. */
+function isFieldType(type: string): type is FieldType {
+  return Object.prototype.hasOwnProperty.call(FIELD_TYPE_BINDING_KIND, type);
+}
 
 /** Look up one catalog entry by its type key. */
 export function getFieldTypeCatalogEntry(

--- a/packages/nextly/src/collections/fields/catalog.ts
+++ b/packages/nextly/src/collections/fields/catalog.ts
@@ -510,12 +510,15 @@ export const BINDABLE_KINDS: Readonly<
  * agreement alone does not make two ends compatible. `storage` describes a
  * plugin-contributed type, which is not a member of the built-in union but
  * persists as one of the primitives; supplying it lets a plugin type take part
- * in bindings on the same terms as a built-in.
+ * in bindings on the same terms as a built-in. `relationTo` carries the
+ * collection identity of a reference or media endpoint, which the value kind
+ * alone does not express.
  */
 export interface BindingEndpoint {
   type: string;
   hasMany?: boolean;
   storage?: FieldStoragePrimitive;
+  relationTo?: string | string[];
 }
 
 /**
@@ -558,6 +561,13 @@ export function isBindablePropType(prop: BindingEndpoint): boolean {
  * Both the value kind and the cardinality must agree: a multi-valued source
  * produces an array, which a single-valued prop cannot render, and a
  * single-valued source cannot fill a prop that expects a list.
+ *
+ * Reference and media endpoints must also agree on the collections they point
+ * at. Binding does not rewrite a reference, so a source that can yield a
+ * document the prop does not relate to would put an unresolvable value in the
+ * prop even though both ends are of kind `reference`. The check applies only
+ * when both ends name their targets, since an endpoint that omits them is
+ * saying nothing about collection identity rather than claiming to accept any.
  */
 export function canBindFieldToProp(
   source: BindingEndpoint,
@@ -567,7 +577,27 @@ export function canBindFieldToProp(
   if (propType === null || !isBlockFieldType(propType)) return false;
   if (Boolean(source.hasMany) !== Boolean(prop.hasMany)) return false;
   const kind = bindingKindOf(source);
-  return kind !== null && BINDABLE_KINDS[propType].includes(kind);
+  if (kind === null || !BINDABLE_KINDS[propType].includes(kind)) return false;
+  return targetsAreCompatible(source, prop);
+}
+
+/**
+ * Whether every collection the source can yield is one the prop accepts. An
+ * endpoint without declared targets is not checked.
+ */
+function targetsAreCompatible(
+  source: BindingEndpoint,
+  prop: BindingEndpoint
+): boolean {
+  const sourceTargets = targetList(source.relationTo);
+  const propTargets = targetList(prop.relationTo);
+  if (sourceTargets.length === 0 || propTargets.length === 0) return true;
+  return sourceTargets.every(target => propTargets.includes(target));
+}
+
+function targetList(relationTo: string | string[] | undefined): string[] {
+  if (relationTo === undefined) return [];
+  return Array.isArray(relationTo) ? relationTo : [relationTo];
 }
 
 /** Narrowing guard for the built-in field-type union. */

--- a/packages/nextly/src/collections/fields/catalog.ts
+++ b/packages/nextly/src/collections/fields/catalog.ts
@@ -393,6 +393,36 @@ export function isBlockFieldType(type: string): type is BlockFieldCatalogType {
 }
 
 /**
+ * The storage shapes a plugin-contributed field type can persist as. A plugin
+ * type is not a member of the built-in union, so everything that needs to
+ * reason about its values (validation, bindings) goes through the primitive it
+ * declared.
+ */
+export type FieldStoragePrimitive =
+  | "text"
+  | "longText"
+  | "boolean"
+  | "number"
+  | "timestamp"
+  | "json";
+
+/**
+ * The built-in field type each storage primitive behaves as. A plugin type
+ * validates by its primitive's rules and binds by its primitive's value kind,
+ * while its own admin component renders it.
+ */
+export const STORAGE_PRIMITIVE_AS_FIELD_TYPE: Readonly<
+  Record<FieldStoragePrimitive, BlockFieldCatalogType>
+> = {
+  text: "text",
+  longText: "textarea",
+  boolean: "checkbox",
+  number: "number",
+  timestamp: "date",
+  json: "json",
+};
+
+/**
  * The value shapes a binding can carry. A binding connects a data field to a
  * block prop, so both sides are described in this one vocabulary and
  * compatibility is a set membership test rather than a per-pair table.
@@ -472,24 +502,71 @@ export const BINDABLE_KINDS: Readonly<
   group: [],
 };
 
-/** Whether a block prop of this type can be bound to a data field at all. */
-export function isBindablePropType(type: string): boolean {
-  return isBlockFieldType(type) && BINDABLE_KINDS[type].length > 0;
+/**
+ * One end of a candidate binding: a field being bound from, or a block prop
+ * being bound into.
+ *
+ * `hasMany` matters because a multi-valued field produces an array, so type
+ * agreement alone does not make two ends compatible. `storage` describes a
+ * plugin-contributed type, which is not a member of the built-in union but
+ * persists as one of the primitives; supplying it lets a plugin type take part
+ * in bindings on the same terms as a built-in.
+ */
+export interface BindingEndpoint {
+  type: string;
+  hasMany?: boolean;
+  storage?: FieldStoragePrimitive;
 }
 
 /**
- * Whether a field of `sourceType` can be bound into a block prop of
- * `propType`. Pickers use this to filter the field list they offer, so a user
- * is never shown a binding that the renderer would then have to coerce.
+ * The built-in field type an endpoint resolves to, or `null` when the type is
+ * neither a built-in nor a plugin type whose storage primitive was supplied.
  */
-export function canBindFieldTypeToPropType(
-  sourceType: string,
-  propType: string
-): boolean {
-  if (!isBlockFieldType(propType)) return false;
-  const kind = isFieldType(sourceType)
-    ? FIELD_TYPE_BINDING_KIND[sourceType]
+function resolveEndpointType(endpoint: BindingEndpoint): FieldType | null {
+  if (isFieldType(endpoint.type)) return endpoint.type;
+  return endpoint.storage
+    ? STORAGE_PRIMITIVE_AS_FIELD_TYPE[endpoint.storage]
     : null;
+}
+
+/**
+ * The value kind an endpoint produces when it is a binding source, or `null`
+ * when it cannot be bound from.
+ */
+export function bindingKindOf(
+  endpoint: BindingEndpoint
+): BindingValueKind | null {
+  const resolved = resolveEndpointType(endpoint);
+  return resolved ? FIELD_TYPE_BINDING_KIND[resolved] : null;
+}
+
+/** Whether a block prop can be bound to a data field at all. */
+export function isBindablePropType(prop: BindingEndpoint): boolean {
+  const resolved = resolveEndpointType(prop);
+  return (
+    resolved !== null &&
+    isBlockFieldType(resolved) &&
+    BINDABLE_KINDS[resolved].length > 0
+  );
+}
+
+/**
+ * Whether a field can be bound into a block prop. Pickers use this to filter
+ * the field list they offer, so a user is never shown a binding that the
+ * renderer would then have to coerce.
+ *
+ * Both the value kind and the cardinality must agree: a multi-valued source
+ * produces an array, which a single-valued prop cannot render, and a
+ * single-valued source cannot fill a prop that expects a list.
+ */
+export function canBindFieldToProp(
+  source: BindingEndpoint,
+  prop: BindingEndpoint
+): boolean {
+  const propType = resolveEndpointType(prop);
+  if (propType === null || !isBlockFieldType(propType)) return false;
+  if (Boolean(source.hasMany) !== Boolean(prop.hasMany)) return false;
+  const kind = bindingKindOf(source);
   return kind !== null && BINDABLE_KINDS[propType].includes(kind);
 }
 

--- a/packages/nextly/src/collections/fields/catalog.ts
+++ b/packages/nextly/src/collections/fields/catalog.ts
@@ -563,11 +563,13 @@ export function isBindablePropType(prop: BindingEndpoint): boolean {
  * single-valued source cannot fill a prop that expects a list.
  *
  * Reference and media endpoints must also agree on the collections they point
- * at. Binding does not rewrite a reference, so a source that can yield a
- * document the prop does not relate to would put an unresolvable value in the
- * prop even though both ends are of kind `reference`. The check applies only
- * when both ends name their targets, since an endpoint that omits them is
- * saying nothing about collection identity rather than claiming to accept any.
+ * at, and on how a reference to them is stored. Binding does not rewrite a
+ * reference, so a source that can yield a document the prop does not relate
+ * to would put an unresolvable value in the prop even though both ends are of
+ * kind `reference`, and a source whose target arity differs stores a shape the
+ * prop cannot read. The checks apply only when both ends name their targets,
+ * since an endpoint that omits them is saying nothing about collection
+ * identity rather than claiming to accept any.
  */
 export function canBindFieldToProp(
   source: BindingEndpoint,
@@ -582,17 +584,29 @@ export function canBindFieldToProp(
 }
 
 /**
- * Whether every collection the source can yield is one the prop accepts. An
- * endpoint without declared targets is not checked.
+ * Whether every collection the source can yield is one the prop accepts, and
+ * whether both ends store a reference the same way. An endpoint without
+ * declared targets is not checked.
+ *
+ * Target arity decides the stored shape — a single target stores a bare id, a
+ * list of targets stores a `{ relationTo, value }` pair — so two endpoints
+ * that name the same collection still hold incompatible values when one
+ * declares it as a string and the other as a one-element array.
  */
 function targetsAreCompatible(
   source: BindingEndpoint,
   prop: BindingEndpoint
 ): boolean {
-  const sourceTargets = targetList(source.relationTo);
+  if (source.relationTo === undefined || prop.relationTo === undefined) {
+    return true;
+  }
+  if (Array.isArray(source.relationTo) !== Array.isArray(prop.relationTo)) {
+    return false;
+  }
   const propTargets = targetList(prop.relationTo);
-  if (sourceTargets.length === 0 || propTargets.length === 0) return true;
-  return sourceTargets.every(target => propTargets.includes(target));
+  return targetList(source.relationTo).every(target =>
+    propTargets.includes(target)
+  );
 }
 
 function targetList(relationTo: string | string[] | undefined): string[] {

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -398,11 +398,15 @@ export {
   BLOCK_FIELD_TYPE_CATALOG,
   BINDABLE_KINDS,
   FIELD_TYPE_BINDING_KIND,
+  STORAGE_PRIMITIVE_AS_FIELD_TYPE,
   isBlockFieldType,
   isBindablePropType,
-  canBindFieldTypeToPropType,
+  bindingKindOf,
+  canBindFieldToProp,
   type BlockFieldCatalogType,
+  type BindingEndpoint,
   type BindingValueKind,
+  type FieldStoragePrimitive,
 } from "./collections/fields/catalog";
 
 // Managed-services elevation (D35) — `ctx.services` ServiceOpts + the auth user.

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -380,6 +380,31 @@ export {
   getFieldType as getPluginFieldType,
 } from "./domains/schema/field-types/field-type-registry";
 
+// Block props on the field system — a block's prop declarations become
+// ordinary field configs, so block values validate through the same pass
+// entries do instead of a parallel rule set.
+export {
+  blockPropsToFieldConfigs,
+  validateBlockPropValues,
+  type BlockPropDeclaration,
+  type BlockPropsSource,
+} from "./collections/fields/block-props";
+
+// The block-prop surface: which field types a block prop may declare, and
+// which data fields may be bound into one. Both derive from the prop's type,
+// never from a per-block opt-in.
+export {
+  BLOCK_FIELD_TYPES,
+  BLOCK_FIELD_TYPE_CATALOG,
+  BINDABLE_KINDS,
+  FIELD_TYPE_BINDING_KIND,
+  isBlockFieldType,
+  isBindablePropType,
+  canBindFieldTypeToPropType,
+  type BlockFieldCatalogType,
+  type BindingValueKind,
+} from "./collections/fields/catalog";
+
 // Managed-services elevation (D35) — `ctx.services` ServiceOpts + the auth user.
 export type {
   ServiceOpts,

--- a/packages/nextly/src/plugins/admin-meta.test.ts
+++ b/packages/nextly/src/plugins/admin-meta.test.ts
@@ -67,6 +67,7 @@ describe("buildPluginAdminMeta", () => {
     expect(meta[0].fieldTypes?.[0]).toEqual({
       type: "rating",
       component: "@acme/p/admin#Rating",
+      storage: "number",
       label: "Star Rating",
       description: "A 1-5 star rating",
       icon: "Star",
@@ -92,6 +93,9 @@ describe("buildPluginAdminMeta", () => {
     expect(meta[0].fieldTypes?.[0]).toEqual({
       type: "rating",
       component: "@p#R",
+      // Storage is not presentation: it decides how the type's values behave,
+      // so it always travels even when every optional key is omitted.
+      storage: "number",
     });
   });
 
@@ -311,7 +315,7 @@ describe("buildPluginAdminMeta", () => {
       undefined
     );
     expect(enabled[0].fieldTypes).toEqual([
-      { type: "rating", component: "@acme/p/admin#Rating" },
+      { type: "rating", component: "@acme/p/admin#Rating", storage: "number" },
     ]);
 
     // Disabled plugins keep their collections + custom field types so the admin
@@ -321,7 +325,7 @@ describe("buildPluginAdminMeta", () => {
       undefined
     );
     expect(disabled[0].fieldTypes).toEqual([
-      { type: "rating", component: "@acme/p/admin#Rating" },
+      { type: "rating", component: "@acme/p/admin#Rating", storage: "number" },
     ]);
   });
 

--- a/packages/nextly/src/plugins/admin-meta.ts
+++ b/packages/nextly/src/plugins/admin-meta.ts
@@ -6,7 +6,10 @@
  * @module plugins/admin-meta
  */
 
-import type { FieldTypeCategory } from "../collections/fields/catalog";
+import type {
+  FieldStoragePrimitive,
+  FieldTypeCategory,
+} from "../collections/fields/catalog";
 import type { PluginOverride } from "../shared/types/config";
 
 import type {
@@ -110,6 +113,7 @@ export interface PluginAdminMeta {
   fieldTypes?: Array<{
     type: string;
     component: string;
+    storage: FieldStoragePrimitive;
     layout?: "takeover";
     label?: string;
     description?: string;
@@ -241,6 +245,11 @@ export function buildPluginAdminMeta(
       meta.fieldTypes = fieldTypes.map(ft => ({
         type: ft.type,
         component: ft.component,
+        // The storage primitive travels to the browser because binding
+        // compatibility is decided from it: a plugin type is not in the
+        // built-in union, so a picker cannot tell what its values look like
+        // without it.
+        storage: ft.storage,
         ...(ft.layout ? { layout: ft.layout } : {}),
         ...(ft.label ? { label: ft.label } : {}),
         ...(ft.description ? { description: ft.description } : {}),

--- a/packages/nextly/src/plugins/contributions.ts
+++ b/packages/nextly/src/plugins/contributions.ts
@@ -1,5 +1,6 @@
 import type { CollectionConfig } from "../collections/config/define-collection";
 import type {
+  FieldStoragePrimitive,
   FieldSurface,
   FieldTypeCategory,
 } from "../collections/fields/catalog";
@@ -126,7 +127,7 @@ export interface PluginFieldType {
   /** Field type id used as `field.type` (e.g. `"rating"`). Must not collide with a built-in. */
   type: string;
   /** The existing storage primitive this type persists as. */
-  storage: "text" | "longText" | "boolean" | "number" | "timestamp" | "json";
+  storage: FieldStoragePrimitive;
   /** Admin field-editor component path, resolved via the component registry. */
   component: ComponentPath;
   /**


### PR DESCRIPTION
Plan-01 PR-5. Puts block props on the field system so one declaration drives everything downstream, and settles how binding affordances are derived. First PR of the page-builder rebuild that lands in `packages/nextly` rather than `blocks-engine`.

## What this adds

**The `blocks` field surface.** `FieldSurface` gains `"blocks"` alongside `entries`/`users`/`forms`, plus `BLOCK_FIELD_TYPE_CATALOG` — the canonical catalog minus two deliberate exclusions:

- `password`, because a block document is public page content served to every visitor, so a secret must never be authorable as a block prop;
- `component`, because reusable composition inside a block document happens through slots and component-instance nodes, and admitting the component field type would give one concept two storage shapes.

Unlike the user and form surfaces it adds no surface-only types, so every entry maps to a real `FieldConfig`. Link-shaped props keep using `text` until the dedicated link picker arrives with its admin component.

**Plugin field types are gated exactly like forms.** A plugin type may be declared as a block prop only when its author listed `"blocks"` in `surfaces` — the same opt-in `validate-form.ts` requires for `"forms"`. An admitted plugin type validates as the storage primitive it declared while its own component renders it.

**`blockPropsToFieldConfigs`.** A block's prop declarations become ordinary `FieldConfig`s, so block values validate through the same `validateEntryData` pass entries use instead of a parallel rule set. Declarations are checked for what the field system actually consumes (types, bounds, choices, relation targets, nested fields) and every unusable declaration is reported at once, with paths, rather than failing on the first. `validateBlockPropValues` is the thin wrapper over the entry validator.

Deliberate omissions, both documented in the code: defaults are not copied onto the configs (a block's defaults live in `defaultProps`, applied by the engine on insert, so one value never gets two sources), and the `localized` flag is gated on the prop being top level so a nested field sharing a localized prop's name does not inherit it.

**The bindability map.** `BINDABLE_KINDS` and `FIELD_TYPE_BINDING_KIND` express both sides of a binding in one value-kind vocabulary, so compatibility is a set-membership test rather than a per-pair table. This is the rule the dynamic-data work consumes: a prop's binding affordance derives from its declared TYPE and never from a per-block opt-in, which is the coverage failure that left Elementor with prop types unbindable for years. String-valued props accept numbers and dates because a binding carries a formatter; rich text accepts only rich text because its stored value is structured editor content; structured props accept nothing because they are composed, not bound.

## Not in this PR

The `blocks` field type itself (PR-6), `contributes.blocks` boot wiring (PR-7), and the UI-heavy prop types — slider, icon picker, link picker — which join the catalog in the Inspector plan with their admin components.

## Testing

45 unit tests across `catalog.test.ts` and the new `block-props.test.ts`: catalog composition and ordering, the bindability pairings in both directions (including refusals and unknown types on either side), conversion of every prop shape, nested recursion and its issue paths, the plugin-surface gate in all three states, every storage primitive's mapping, and hostile input (a non-object declaration, a non-finite bound, malformed choices).

`pnpm check-types` passes across all 18 packages; `pnpm lint` is clean.

Pre-existing and unrelated: `src/plugins/schema/caching.test.ts` fails 2 tests on `main` as well.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added block property declaration conversion and stored value validation APIs with strong type/option checking, recursion depth limits, and localized-label handling.
  * Introduced a blocks-focused field type catalog with binding-compatibility helpers, including plugin field type support via storage-to-field mapping.
  * Expanded exported APIs to expose the new blocks catalog and binding utilities; added a required `storage` field to plugin/admin field type metadata.
* **Tests**
  * Expanded coverage for conversion/validation edge cases, aggregated issue reporting with precise paths, nested repeaters/groups, and plugin binding compatibility rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->