### PR TITLE
fix(nextly): apply collection read rules on REST reads

### DIFF
--- a/.changeset/rest-read-access-rules.md
+++ b/.changeset/rest-read-access-rules.md
@@ -23,4 +23,6 @@
 
 Collection read rules now apply over the REST API. Listing, fetching and counting entries previously ignored who was asking, so a collection configured with an owner-only or role-based **read** rule still returned every row to any caller who could reach the endpoint — the rule only ever held on writes and inside the Direct API. Reads now evaluate the caller against the collection's stored rules, with owner-only scoping applied in the database query so pagination and totals stay correct, and a count can no longer describe rows the caller is not allowed to see.
 
+Role-based read rules are evaluated against the caller's resolved roles, and a super-admin keeps the bypass they already have everywhere else. A scoped API key is judged on its own read grant rather than on the permissions of the account that issued it, so a read-only key issued by an administrator is no longer treated as that administrator's full session.
+
 If you configured a read rule expecting it to be enforced, this closes that gap. If instead something in your app depended on reads returning unfiltered data, it will now see only the rows its rule allows: check any integration that reads with a user session or API key against a collection whose read rule is not `public`.

--- a/.changeset/rest-read-access-rules.md
+++ b/.changeset/rest-read-access-rules.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Collection read rules now apply over the REST API. Listing, fetching and counting entries previously ignored who was asking, so a collection configured with an owner-only or role-based **read** rule still returned every row to any caller who could reach the endpoint — the rule only ever held on writes and inside the Direct API. Reads now evaluate the caller against the collection's stored rules, with owner-only scoping applied in the database query so pagination and totals stay correct, and a count can no longer describe rows the caller is not allowed to see.
+
+If you configured a read rule expecting it to be enforced, this closes that gap. If instead something in your app depended on reads returning unfiltered data, it will now see only the rows its rule allows: check any integration that reads with a user session or API key against a collection whose read rule is not `public`.

--- a/packages/nextly/src/__tests__/routeHandler-direct-branches.test.ts
+++ b/packages/nextly/src/__tests__/routeHandler-direct-branches.test.ts
@@ -128,9 +128,11 @@ import {
   createJsonErrorResponse,
 } from "../auth/middleware";
 import { container } from "../di/container";
+import { readAuthenticatedUser } from "../dispatcher/helpers/authenticated-user";
 import {
   _handleAdminMetaRequestForTest,
   _handleAdminMetaSidebarGroupsForTest,
+  _needsResolvedRolesForTest,
   _setAuthenticatedRouteParamsForTest,
 } from "../routeHandler";
 import { resolveRoleSlugs } from "../services/lib/permissions";
@@ -439,5 +441,88 @@ describe("setAuthenticatedRouteParams", () => {
 
     expect(routeParams._authenticatedUserId).toBeUndefined();
     expect(routeParams._authenticatedUserRoles).toBeUndefined();
+  });
+});
+
+/**
+ * The role-resolution decision, tested apart from the stamping it drives.
+ *
+ * The suite above supplies `needsRoles` directly, so it can only prove that
+ * stamping honors the flag — never that a given request computes it correctly.
+ * Any service or method whose access check reads roles has to be listed in the
+ * decision, and a method missing from it fails silently: roles are simply absent
+ * downstream, and a role-based rule then denies a caller who should be allowed.
+ */
+describe("needsResolvedRoles", () => {
+  const resolveRoleSlugsMock = vi.mocked(resolveRoleSlugs);
+  const sessionUser = {
+    userId: "u1",
+    roles: ["role-id-1"],
+    permissions: [],
+    authMethod: "session" as const,
+  };
+
+  it("resolves roles for the entry reads that evaluate stored read rules", () => {
+    // These forward the caller into the query service, which evaluates the
+    // collection's stored read rules (role-based matching and the super-admin
+    // bypass) against the forwarded role set.
+    for (const method of ["listEntries", "getEntry", "countEntries"]) {
+      expect(_needsResolvedRolesForTest("collections", method, "GET")).toBe(
+        true
+      );
+    }
+  });
+
+  it("resolves roles for version reads", () => {
+    for (const method of [
+      "listEntryVersions",
+      "getEntryVersion",
+      "listSingleVersions",
+      "getSingleVersion",
+    ]) {
+      const service = method.includes("Single") ? "singles" : "collections";
+      expect(_needsResolvedRolesForTest(service, method, "GET")).toBe(true);
+    }
+  });
+
+  it("resolves roles for collection and single mutations", () => {
+    expect(
+      _needsResolvedRolesForTest("collections", "createEntry", "POST")
+    ).toBe(true);
+    expect(
+      _needsResolvedRolesForTest("collections", "deleteEntry", "DELETE")
+    ).toBe(true);
+    expect(_needsResolvedRolesForTest("singles", "updateSingle", "PATCH")).toBe(
+      true
+    );
+  });
+
+  it("skips the lookup for reads that consume no roles", () => {
+    // A permissions query on every one of these would be paid for nothing.
+    expect(_needsResolvedRolesForTest("media", "listMedia", "GET")).toBe(false);
+    expect(_needsResolvedRolesForTest("singles", "getSingle", "GET")).toBe(
+      false
+    );
+    expect(_needsResolvedRolesForTest("users", "listUsers", "GET")).toBe(false);
+    // A collection preflight carries no access decision of its own.
+    expect(
+      _needsResolvedRolesForTest("collections", "listMeta", "OPTIONS")
+    ).toBe(false);
+  });
+
+  it("carries the caller's roles all the way to the dispatcher for an entry read", async () => {
+    // The full chain the entry reads depend on: decide, stamp, then decode.
+    // Asserting only the first or last link lets a break in the middle pass.
+    resolveRoleSlugsMock.mockResolvedValue(["editor"]);
+    const routeParams: Record<string, string> = { collectionName: "posts" };
+
+    await _setAuthenticatedRouteParamsForTest(
+      routeParams,
+      sessionUser,
+      _needsResolvedRolesForTest("collections", "listEntries", "GET")
+    );
+
+    const user = readAuthenticatedUser(routeParams);
+    expect(user).toMatchObject({ id: "u1", roles: ["editor"], role: "editor" });
   });
 });

--- a/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-read-access.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-read-access.test.ts
@@ -1,0 +1,184 @@
+// The read handlers must hand the caller's identity to the query service, or the
+// collection's stored read rules cannot be evaluated for them: the service falls
+// back to the rule-less default and an admin-configured "owner-only read"
+// silently returns every row over HTTP.
+//
+// These assert the forwarding contract rather than the enforcement itself
+// (enforcement lives in the query/access services and is covered there), because
+// the defect these guard against was a missing argument, not a wrong rule.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The read handlers go through the legacy `services.collections` fallback and
+// never touch DI; stubbing these keeps that path unchanged.
+vi.mock("../../helpers/di", () => ({
+  getAdapterFromDI: vi.fn(),
+  getCollectionRegistryFromDI: vi.fn(),
+  getCollectionsHandlerFromDI: vi.fn(),
+  getMigrationJournalFromDI: vi.fn(),
+}));
+
+import type { ServiceContainer } from "../../../services";
+import { dispatchCollections } from "../collection-dispatcher";
+
+function makeContainer(
+  collections: Record<string, ReturnType<typeof vi.fn>>
+): ServiceContainer {
+  return { collections } as unknown as ServiceContainer;
+}
+
+const listResult = {
+  success: true,
+  statusCode: 200,
+  message: "ok",
+  data: {
+    docs: [],
+    totalDocs: 0,
+    limit: 10,
+    page: 1,
+    totalPages: 0,
+    pagingCounter: 1,
+    hasPrevPage: false,
+    hasNextPage: false,
+    prevPage: null,
+    nextPage: null,
+  },
+};
+
+const docResult = {
+  success: true,
+  statusCode: 200,
+  message: "ok",
+  data: { id: "e1" },
+};
+
+const countResult = {
+  success: true,
+  statusCode: 200,
+  message: "ok",
+  data: { totalDocs: 0 },
+};
+
+/** The reserved params the route handler stamps once it has authenticated. */
+const authedParams = {
+  collectionName: "posts",
+  _authenticatedUserId: "u1",
+  _authenticatedUserName: "Ada",
+  _authenticatedUserEmail: "ada@example.com",
+  _authenticatedUserRoles: JSON.stringify(["editor", "author"]),
+};
+
+describe("collection read handlers forward the caller to the query service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("listEntries passes the authenticated user and attests route authorization", async () => {
+    const listEntries = vi.fn().mockResolvedValue(listResult);
+    await dispatchCollections(
+      makeContainer({ listEntries }),
+      "listEntries",
+      { ...authedParams },
+      undefined
+    );
+
+    expect(listEntries).toHaveBeenCalledTimes(1);
+    const args = listEntries.mock.calls[0][0];
+    expect(args.user).toEqual({
+      id: "u1",
+      name: "Ada",
+      email: "ada@example.com",
+      roles: ["editor", "author"],
+      // Rules and field callbacks written against a single-role model read
+      // `user.role`; without it an authorized caller would have fields stripped.
+      role: "editor",
+    });
+    // The route ran the coarse RBAC gate already; stored rules still run.
+    expect(args.routeAuthorized).toBe(true);
+  });
+
+  it("listEntries sends no user for an anonymous caller", async () => {
+    const listEntries = vi.fn().mockResolvedValue(listResult);
+    await dispatchCollections(
+      makeContainer({ listEntries }),
+      "listEntries",
+      { collectionName: "posts" },
+      undefined
+    );
+
+    const args = listEntries.mock.calls[0][0];
+    // An absent user must never be mistaken for a trusted one: the service
+    // treats `undefined` as anonymous, and nothing attests authorization.
+    expect(args.user).toBeUndefined();
+    expect(args.routeAuthorized).toBe(false);
+  });
+
+  it("getEntry passes the user, route attestation, and the API-key scope", async () => {
+    const getEntry = vi.fn().mockResolvedValue(docResult);
+    await dispatchCollections(
+      makeContainer({ getEntry }),
+      "getEntry",
+      { ...authedParams, entryId: "e1" },
+      undefined
+    );
+
+    const args = getEntry.mock.calls[0][0];
+    expect(args.user).toMatchObject({ id: "u1", roles: ["editor", "author"] });
+    expect(args.routeAuthorized).toBe(true);
+    // Present as a key on every call so a scoped key is judged on its own read
+    // grant rather than on the permissions of the user that owns it.
+    expect(args).toHaveProperty("authenticatedScope");
+  });
+
+  it("countEntries counts under the same caller context listEntries filters by", async () => {
+    const listEntries = vi.fn().mockResolvedValue(listResult);
+    const countEntries = vi.fn().mockResolvedValue(countResult);
+    const container = makeContainer({ listEntries, countEntries });
+
+    await dispatchCollections(
+      container,
+      "listEntries",
+      { ...authedParams },
+      undefined
+    );
+    await dispatchCollections(
+      container,
+      "countEntries",
+      { ...authedParams },
+      undefined
+    );
+
+    const listArgs = listEntries.mock.calls[0][0];
+    const countArgs = countEntries.mock.calls[0][0];
+    // Assert the context is actually present before comparing: two `undefined`
+    // values are trivially equal, so an equality check alone would still pass if
+    // both handlers forwarded nothing.
+    expect(countArgs.user).toMatchObject({ id: "u1" });
+    expect(countArgs.routeAuthorized).toBe(true);
+    // A total computed under weaker rules than the list would report rows the
+    // caller cannot see, leaking how much data exists and breaking pagination.
+    expect(countArgs.user).toEqual(listArgs.user);
+    expect(countArgs.routeAuthorized).toBe(listArgs.routeAuthorized);
+  });
+
+  it("ignores a malformed role payload rather than forwarding a partial set", async () => {
+    const listEntries = vi.fn().mockResolvedValue(listResult);
+    await dispatchCollections(
+      makeContainer({ listEntries }),
+      "listEntries",
+      {
+        collectionName: "posts",
+        _authenticatedUserId: "u1",
+        // Route params are strings, so roles arrive JSON-encoded; a mixed-type
+        // array must degrade to "no roles" instead of granting a partial set.
+        _authenticatedUserRoles: JSON.stringify(["editor", 7]),
+      },
+      undefined
+    );
+
+    const args = listEntries.mock.calls[0][0];
+    expect(args.user.id).toBe("u1");
+    expect(args.user.roles).toBeUndefined();
+    expect(args.user.role).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-read-access.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-read-access.test.ts
@@ -68,6 +68,18 @@ const authedParams = {
   _authenticatedUserRoles: JSON.stringify(["editor", "author"]),
 };
 
+/**
+ * The same caller arriving through a scoped API key. The key's own grants are
+ * stamped separately from the owner's roles, which is the whole point: the key
+ * is authoritative on its scope, never on the account that issued it.
+ */
+const apiKeyParams = {
+  ...authedParams,
+  _authenticatedActorType: "apiKey",
+  _authenticatedActorId: "key-1",
+  _authenticatedPermissions: JSON.stringify(["collections:read"]),
+};
+
 describe("collection read handlers forward the caller to the query service", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -159,6 +171,44 @@ describe("collection read handlers forward the caller to the query service", () 
     // caller cannot see, leaking how much data exists and breaking pagination.
     expect(countArgs.user).toEqual(listArgs.user);
     expect(countArgs.routeAuthorized).toBe(listArgs.routeAuthorized);
+  });
+
+  it("forwards the API-key scope on every read, not just getEntry", async () => {
+    // Without the scope the access service treats a super-admin-owned key as an
+    // unscoped super-admin session and lifts the stored owner-only predicate, so
+    // the key reads rows outside its own grant. getEntry alone forwarding it is
+    // not enough: list and count are the paths that return rows in bulk.
+    const listEntries = vi.fn().mockResolvedValue(listResult);
+    const countEntries = vi.fn().mockResolvedValue(countResult);
+    const getEntry = vi.fn().mockResolvedValue(docResult);
+    const container = makeContainer({ listEntries, countEntries, getEntry });
+
+    await dispatchCollections(
+      container,
+      "listEntries",
+      { ...apiKeyParams },
+      undefined
+    );
+    await dispatchCollections(
+      container,
+      "countEntries",
+      { ...apiKeyParams },
+      undefined
+    );
+    await dispatchCollections(
+      container,
+      "getEntry",
+      { ...apiKeyParams, entryId: "e1" },
+      undefined
+    );
+
+    const expected = {
+      actorType: "apiKey",
+      permissions: ["collections:read"],
+    };
+    expect(listEntries.mock.calls[0][0].authenticatedScope).toEqual(expected);
+    expect(countEntries.mock.calls[0][0].authenticatedScope).toEqual(expected);
+    expect(getEntry.mock.calls[0][0].authenticatedScope).toEqual(expected);
   });
 
   it("ignores a malformed role payload rather than forwarding a partial set", async () => {

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -77,6 +77,7 @@ import {
   readAuthenticatedScope,
 } from "../helpers/authenticated-actor";
 import { readAuthenticatedRoles } from "../helpers/authenticated-roles";
+import { readAuthenticatedUser } from "../helpers/authenticated-user";
 import { buildFullDesiredSchema } from "../helpers/desired-schema";
 import {
   getAdapterFromDI,
@@ -958,8 +959,19 @@ const COLLECTIONS_METHODS: Record<
           ? p.status
           : "all";
 
+      // Forward the caller so the service evaluates the collection's stored
+      // read rules for them: role-based rules, and owner-only scoping folded
+      // into the SQL predicate. Without a user the service can only apply the
+      // rule-less default, so an admin-configured "owner-only read" silently
+      // returned every row over HTTP. `routeAuthorized` attests that the route
+      // already ran the coarse RBAC gate, so only that re-check is skipped:
+      // stored rules still run (mirrors the write paths and singles).
+      const user = readAuthenticatedUser(p);
+
       const result = await svc.listEntries({
         collectionName: p.collectionName,
+        user,
+        routeAuthorized: !!user,
         page: p.page !== undefined ? parseInt(String(p.page), 10) : undefined,
         limit:
           rawLimit !== undefined ? parseInt(String(rawLimit), 10) : undefined,
@@ -1004,8 +1016,16 @@ const COLLECTIONS_METHODS: Record<
         p.status === "all" || p.status === "draft" || p.status === "published"
           ? p.status
           : "all";
+      // The same caller context listEntries forwards. A count that ignored the
+      // read rules while the list obeyed them would report totals for rows the
+      // caller cannot see, which both leaks how much data exists and breaks
+      // pagination in the UI.
+      const user = readAuthenticatedUser(p);
+
       const result = await svc.countEntries({
         collectionName: p.collectionName,
+        user,
+        routeAuthorized: !!user,
         search: p.search,
         where: parseWhereParam(p.where),
         status,
@@ -1071,9 +1091,22 @@ const COLLECTIONS_METHODS: Record<
         p.status === "all" || p.status === "draft" || p.status === "published"
           ? p.status
           : "all";
+      // Same caller context as listEntries. Fetching one document by id is the
+      // path where a missing user matters most: without it an owner-only rule
+      // could not deny a direct read of someone else's entry.
+      const user = readAuthenticatedUser(p);
+
       const result = await svc.getEntry({
         collectionName: p.collectionName,
         entryId: p.entryId,
+        user,
+        routeAuthorized: !!user,
+        // A scoped API key is judged on its own read grant rather than on the
+        // permissions of the user that owns it, matching the publish gate from
+        // #290/#297. Only getEntry takes this today; list/count judge the owning
+        // user, so a scoped key can still inherit a stored rule written for
+        // them there (tracked as a follow-up, not widened here).
+        authenticatedScope: readAuthenticatedScope(p),
         depth:
           p.depth !== undefined ? parseInt(String(p.depth), 10) : undefined,
         select: parseSelectParam(p.select),

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -972,6 +972,10 @@ const COLLECTIONS_METHODS: Record<
         collectionName: p.collectionName,
         user,
         routeAuthorized: !!user,
+        // A scoped API key is judged on its own read grant rather than on the
+        // permissions of the user that owns it, so a super-admin-owned key
+        // cannot read past its scope by inheriting the session bypass.
+        authenticatedScope: readAuthenticatedScope(p),
         page: p.page !== undefined ? parseInt(String(p.page), 10) : undefined,
         limit:
           rawLimit !== undefined ? parseInt(String(rawLimit), 10) : undefined,
@@ -1026,6 +1030,9 @@ const COLLECTIONS_METHODS: Record<
         collectionName: p.collectionName,
         user,
         routeAuthorized: !!user,
+        // Same scope judgement as listEntries: a count that ignored the key's
+        // own grant would disclose how many rows exist beyond it.
+        authenticatedScope: readAuthenticatedScope(p),
         search: p.search,
         where: parseWhereParam(p.where),
         status,
@@ -1102,10 +1109,8 @@ const COLLECTIONS_METHODS: Record<
         user,
         routeAuthorized: !!user,
         // A scoped API key is judged on its own read grant rather than on the
-        // permissions of the user that owns it, matching the publish gate from
-        // #290/#297. Only getEntry takes this today; list/count judge the owning
-        // user, so a scoped key can still inherit a stored rule written for
-        // them there (tracked as a follow-up, not widened here).
+        // permissions of the user that owns it, matching listEntries, countEntries
+        // and the publish gate.
         authenticatedScope: readAuthenticatedScope(p),
         depth:
           p.depth !== undefined ? parseInt(String(p.depth), 10) : undefined,

--- a/packages/nextly/src/dispatcher/helpers/authenticated-user.ts
+++ b/packages/nextly/src/dispatcher/helpers/authenticated-user.ts
@@ -1,0 +1,34 @@
+import type { UserContext } from "../../domains/collections/services/collection-types";
+import type { Params } from "../types";
+
+import { readAuthenticatedRoles } from "./authenticated-roles";
+
+/**
+ * Build the caller's `UserContext` from the reserved `_authenticated*` route
+ * params the route handler stamps after authenticating a request.
+ *
+ * Returns `undefined` for an unauthenticated caller, which the services read as
+ * "anonymous" — so an absent user is never mistaken for a trusted one.
+ *
+ * Access rules are evaluated against this object: `roles` drives role-based
+ * rules and field-level `access.read` callbacks, and `id` drives owner-only
+ * scoping. `role` repeats the first role because rules and field callbacks
+ * written against a single-role model read `user.role`; without it a
+ * legitimately authorized caller would have fields stripped.
+ */
+export function readAuthenticatedUser(p: Params): UserContext | undefined {
+  if (!p._authenticatedUserId) return undefined;
+
+  const roles = readAuthenticatedRoles(p);
+  return {
+    id: String(p._authenticatedUserId),
+    name: p._authenticatedUserName
+      ? String(p._authenticatedUserName)
+      : undefined,
+    email: p._authenticatedUserEmail
+      ? String(p._authenticatedUserEmail)
+      : undefined,
+    roles,
+    role: roles?.[0],
+  };
+}

--- a/packages/nextly/src/domains/collections/__tests__/collection-query.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-query.test.ts
@@ -460,6 +460,53 @@ describe("CollectionEntryService — Query Contracts", () => {
       );
     });
 
+    it("should count under the same caller and route attestation the rows were listed under", async () => {
+      selectData.rows = [];
+      const countSpy = vi.spyOn(
+        CollectionQueryService.prototype,
+        "countEntries"
+      );
+      const user = { id: "user-1", roles: ["editor"] };
+
+      await service.listEntries({
+        collectionName: "posts",
+        user,
+        routeAuthorized: true,
+      });
+
+      // A count evaluated for a different caller than the rows would report a
+      // total the caller cannot page through.
+      expect(countSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ user, routeAuthorized: true })
+      );
+    });
+
+    it("should count under the same API-key scope the rows were listed under", async () => {
+      selectData.rows = [];
+      const countSpy = vi.spyOn(
+        CollectionQueryService.prototype,
+        "countEntries"
+      );
+      const authenticatedScope = {
+        actorType: "apiKey" as const,
+        permissions: ["read-posts"],
+      };
+
+      await service.listEntries({
+        collectionName: "posts",
+        // A super-admin owns the key. The scope is what keeps the owner-only
+        // predicate in place, so a count taken without it takes the account's
+        // bypass and reports the unscoped total beside filtered rows.
+        user: { id: "user-1", roles: ["super-admin"] },
+        routeAuthorized: true,
+        authenticatedScope,
+      });
+
+      expect(countSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ authenticatedScope })
+      );
+    });
+
     // ── Depth / Relationship expansion ──────────────────────────────────
 
     it("should pass depth parameter to relationship expansion", async () => {

--- a/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-route-authorized.test.ts
@@ -478,6 +478,78 @@ describe("getOwnerConstraint — scoped API key", () => {
   });
 });
 
+describe("getAccessQueryConstraint — scoped API key", () => {
+  // The list/count reads fold their owner predicate in through this method
+  // rather than getOwnerConstraint, so the scoped-key carve-out has to hold here
+  // too. Without it a super-admin-owned key takes the session bypass and the
+  // predicate is lifted before it ever reaches SQL, returning every row in the
+  // collection to a key whose grant covers only its own.
+  const OWNER_QUERY = { created_by: { equals: "user-1" } };
+
+  function buildWithOwnerOnlyRead() {
+    const accessControlService = createMockAccessControlService();
+    accessControlService.evaluateAccess.mockResolvedValue({
+      allowed: true,
+      query: OWNER_QUERY,
+    });
+    const rbac = {
+      checkAccess: vi.fn().mockResolvedValue(true),
+      getRegisteredAccess: vi.fn().mockReturnValue(undefined),
+    };
+    const collectionService = {
+      getCollection: vi
+        .fn()
+        .mockResolvedValue({ accessRules: { read: { type: "owner-only" } } }),
+      generateId: vi.fn(),
+    };
+    return new CollectionAccessService(
+      createMockAdapter(createMockDb({ rows: [] })) as never,
+      silentLogger as never,
+      collectionService as never,
+      accessControlService as never,
+      rbac as never
+    );
+  }
+
+  it("emits the owner constraint for an ordinary caller", async () => {
+    const service = buildWithOwnerOnlyRead();
+    expect(
+      await service.getAccessQueryConstraint("posts", user, false)
+    ).toEqual(OWNER_QUERY);
+  });
+
+  it("lifts the constraint for a session super-admin (no scope)", async () => {
+    const service = buildWithOwnerOnlyRead();
+    expect(
+      await service.getAccessQueryConstraint("posts", superAdminUser, false)
+    ).toBeNull();
+  });
+
+  it("keeps the constraint for a super-admin-owned scoped API key", async () => {
+    const service = buildWithOwnerOnlyRead();
+    const constraint = await service.getAccessQueryConstraint(
+      "posts",
+      superAdminUser,
+      false,
+      { actorType: "apiKey", permissions: ["read-posts"] }
+    );
+    expect(constraint).toEqual(OWNER_QUERY);
+  });
+
+  it("still lifts the constraint for a session caller arriving with a scope", async () => {
+    const service = buildWithOwnerOnlyRead();
+    // A session caller gets a scope with an empty permission list, which must not
+    // be mistaken for a key: the super-admin bypass belongs to the session path.
+    const constraint = await service.getAccessQueryConstraint(
+      "posts",
+      superAdminUser,
+      false,
+      { actorType: "user", permissions: [] }
+    );
+    expect(constraint).toBeNull();
+  });
+});
+
 describe("checkCollectionAccess — deferStoredRuleEval", () => {
   it("skips the docless stored-rule eval when deferred (no cached denial)", async () => {
     const { service, accessControlService } = buildAccessService();

--- a/packages/nextly/src/domains/collections/services/collection-access-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-access-service.ts
@@ -470,11 +470,22 @@ export class CollectionAccessService extends BaseService {
   async getAccessQueryConstraint(
     collectionName: string,
     user?: UserContext,
-    overrideAccess?: boolean
+    overrideAccess?: boolean,
+    // The caller's authenticated scope. A scoped API key is judged on its OWN
+    // grant, so the session super-admin bypass does not lift the owner predicate
+    // for a super-admin-owned key — mirrors checkCollectionAccess and
+    // getOwnerConstraint. Undefined for session/system callers.
+    authenticatedScope?: AuthenticatedScope
   ): Promise<Record<string, unknown> | null> {
     // Super-admin reads are unfiltered too, matching the write-side bypass so
-    // "super-admins bypass stored rules on every transport" holds for reads.
-    if (overrideAccess || !user || isSuperAdminContext(user)) {
+    // "super-admins bypass stored rules on every transport" holds for reads —
+    // except through a scoped key, which is authoritative only on its own scope.
+    const isScopedApiKey = authenticatedScope?.actorType === "apiKey";
+    if (
+      overrideAccess ||
+      !user ||
+      (!isScopedApiKey && isSuperAdminContext(user))
+    ) {
       return null;
     }
 

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -622,6 +622,13 @@ export class CollectionQueryService extends BaseService {
      */
     routeAuthorized?: boolean;
     /**
+     * The caller's authenticated scope. A scoped API key is judged on its OWN
+     * read grant, so a super-admin-owned key stays bound by a `read: owner-only`
+     * rule instead of inheriting the owner's session bypass. Undefined for
+     * session/system callers. Mirrors getEntry.
+     */
+    authenticatedScope?: AuthenticatedScope;
+    /**
      * Draft/Published filter override. Only takes effect when the collection
      * has Draft/Published enabled (collection.status === true).
      * - 'published' (default for public callers): only published rows
@@ -660,7 +667,10 @@ export class CollectionQueryService extends BaseService {
         undefined,
         undefined,
         params.overrideAccess,
-        params.routeAuthorized
+        params.routeAuthorized,
+        // A scoped API key is judged on its own read grant, so the session
+        // super-admin bypass does not apply to a super-admin-owned key here.
+        params.authenticatedScope
       );
       if (accessDenied) {
         return accessDenied;
@@ -745,7 +755,11 @@ export class CollectionQueryService extends BaseService {
         await this.accessService.getAccessQueryConstraint(
           params.collectionName,
           accessUser,
-          params.overrideAccess
+          params.overrideAccess,
+          // Scope the owner filter too: without this a super-admin-owned scoped
+          // key takes the session bypass and reads past its own grant, the
+          // predicate having been lifted before it ever reached SQL.
+          params.authenticatedScope
         );
 
       // Apply access constraint if present
@@ -1404,6 +1418,11 @@ export class CollectionQueryService extends BaseService {
      */
     routeAuthorized?: boolean;
     /**
+     * The caller's authenticated scope, mirroring listEntries so a scoped key
+     * counts exactly the rows it can list.
+     */
+    authenticatedScope?: AuthenticatedScope;
+    /**
      * Draft/Published filter override (only effective when collection.status === true).
      * See listEntries for full semantics.
      */
@@ -1439,7 +1458,10 @@ export class CollectionQueryService extends BaseService {
         undefined,
         undefined,
         params.overrideAccess,
-        params.routeAuthorized
+        params.routeAuthorized,
+        // Same scope judgement as listEntries, so a count cannot describe rows
+        // the key itself is not allowed to list.
+        params.authenticatedScope
       );
       if (accessDenied) {
         return accessDenied;
@@ -1470,7 +1492,10 @@ export class CollectionQueryService extends BaseService {
         await this.accessService.getAccessQueryConstraint(
           params.collectionName,
           accessUser,
-          params.overrideAccess
+          params.overrideAccess,
+          // Scoped the same way as listEntries, so the total matches the rows a
+          // scoped key can actually page through.
+          params.authenticatedScope
         );
 
       // Apply access constraint if present

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1054,6 +1054,12 @@ export class CollectionQueryService extends BaseService {
             // denied here and totalDocs silently falls back to 0 — breaking the
             // bulk-by-query limit guard and pagination.
             routeAuthorized: params.routeAuthorized,
+            // The scope has to travel with it for the same reason. The rows
+            // above are filtered by the key's own grant, so a count taken
+            // without the scope takes the owner's super-admin bypass instead
+            // and reports the unscoped total beside correctly filtered rows —
+            // disclosing how many rows exist outside the grant.
+            authenticatedScope: params.authenticatedScope,
           }),
         ]);
 

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -540,23 +540,55 @@ const SINGLE_DOCUMENT_METHODS = new Set([
  * Read methods that still need resolved role slugs, even though reads normally
  * skip the lookup.
  *
- * All four run the version access gate, which reads the live document through
- * `checkCollectionAccess`. That evaluates roles twice over: the super-admin
- * bypass is keyed on the role set (`isSuperAdminContext`), and stored
- * role-based access rules match against the roles forwarded in the request
- * context. A caller arriving without roles would therefore be treated as a
- * non-super-admin with no roles and wrongly denied — surfaced as a 404, since
- * the gate does not disclose existence.
+ * Every method here evaluates the caller's stored access rules through
+ * `checkCollectionAccess`, which reads roles twice over: the super-admin bypass
+ * is keyed on the role set (`isSuperAdminContext`), and stored role-based rules
+ * match against the roles forwarded in the request context. A caller arriving
+ * without roles is therefore treated as a non-super-admin holding no roles, so
+ * a role-based rule denies a legitimately permitted reader and a super-admin
+ * loses the bypass and gets owner-filtered instead.
  *
- * The two `get*` methods additionally return a snapshot that is redacted by
- * field-level `access.read`, which reads the same role set.
+ * The version methods surface that denial as a 404, since their gate does not
+ * disclose existence, and the two version `get*` methods additionally return a
+ * snapshot redacted by field-level `access.read`, which reads the same set.
+ *
+ * The three entry reads are here because they forward the caller into the query
+ * service, which evaluates the collection's stored read rules for them.
+ * Resolving roles costs a permissions lookup on every entry read; a read that
+ * silently ignores the rule it was configured with is the worse tradeoff.
  */
 const ROLE_AWARE_READ_METHODS = new Set([
+  "listEntries",
+  "getEntry",
+  "countEntries",
   "listEntryVersions",
   "getEntryVersion",
   "listSingleVersions",
   "getSingleVersion",
 ]);
+
+/**
+ * Decide whether a request needs its role slugs resolved before dispatch.
+ *
+ * Resolving roles costs a permissions query for session auth, so it is opt-in:
+ * collection and single mutations consume them for hook context and access
+ * rules, and the reads in {@link ROLE_AWARE_READ_METHODS} consume them to
+ * evaluate stored rules. Every other route reads no roles and must not pay for
+ * the lookup.
+ */
+function needsResolvedRoles(
+  service: string,
+  method: string,
+  httpMethod: string
+): boolean {
+  if (ROLE_AWARE_READ_METHODS.has(method)) return true;
+  if (service !== "collections" && service !== "singles") return false;
+  return (
+    httpMethod !== "GET" && httpMethod !== "HEAD" && httpMethod !== "OPTIONS"
+  );
+}
+
+export const _needsResolvedRolesForTest = needsResolvedRoles;
 
 /**
  * Centralized permission resolver for all API service endpoints.
@@ -972,18 +1004,11 @@ async function handleServiceRequest(
   // are silently skipped.
   // NOTE: We use _authenticatedUserId (not userId) to avoid colliding with
   // the existing routeParams.userId which is the target user ID from URL params.
-  // Roles are consumed only by collection and single mutation dispatch; skip
-  // the lookup for reads and every other service so they don't incur a
-  // permissions query.
-  const needsRoles =
-    ((service === "collections" || service === "singles") &&
-      httpMethod !== "GET" &&
-      httpMethod !== "HEAD" &&
-      httpMethod !== "OPTIONS") ||
-    // Version reads are GETs but still redact per field-level `access.read`,
-    // which needs the caller's roles to evaluate role-based rules.
-    ROLE_AWARE_READ_METHODS.has(method);
-  await setAuthenticatedRouteParams(routeParams, authorizedUser, needsRoles);
+  await setAuthenticatedRouteParams(
+    routeParams,
+    authorizedUser,
+    needsResolvedRoles(service, method, httpMethod)
+  );
 
   const dispatchRequest: DispatchRequest = {
     service,
@@ -1588,9 +1613,10 @@ export const _handleAdminMetaSidebarGroupsForTest =
 async function setAuthenticatedRouteParams(
   routeParams: Record<string, string> | undefined,
   authorizedUser: AuthContext | undefined,
-  // Only the collection mutation dispatch consumes `_authenticatedUserRoles`.
-  // Roles are resolved (a DB query for session auth) only when needed, so other
-  // authenticated routes don't pay for a permissions lookup they never read.
+  // Whether `_authenticatedUserRoles` is consumed downstream, per
+  // {@link needsResolvedRoles}. Roles are resolved (a DB query for session auth)
+  // only when needed, so routes that never read them don't pay for a
+  // permissions lookup.
   needsRoles: boolean
 ): Promise<void> {
   if (!routeParams) return;

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -465,6 +465,14 @@ export class CollectionsHandler {
     /** When true, bypass all access control checks */
     overrideAccess?: boolean;
     /**
+     * The route already ran the coarse RBAC gate, so skip only that redundant
+     * re-check while the stored read rules (owner-only scoping, role-based,
+     * custom) still run. The query service folds an owner-only rule into the SQL
+     * predicate rather than filtering rows afterwards, so pagination and totals
+     * stay correct.
+     */
+    routeAuthorized?: boolean;
+    /**
      * Draft/Published filter override (only effective when collection.status
      * === true). Public callers default to 'published'; trusted callers can
      * pass 'all' to see drafts too. Forwarded to query service as-is.
@@ -603,6 +611,14 @@ export class CollectionsHandler {
     user?: UserContext;
     /** When true, bypass all access control checks */
     overrideAccess?: boolean;
+    /**
+     * The route already ran the coarse RBAC gate, so skip only that redundant
+     * re-check while the stored read rules (owner-only scoping, role-based,
+     * custom) still run. Forwarded to the query service, which counts under the
+     * same constraint listEntries filters by, so a total can never describe rows
+     * the caller may not read.
+     */
+    routeAuthorized?: boolean;
     /**
      * Draft/Published filter override (only effective when collection.status
      * === true). Same semantics as listEntries.

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -473,6 +473,12 @@ export class CollectionsHandler {
      */
     routeAuthorized?: boolean;
     /**
+     * The caller's authenticated scope. A scoped API key is judged on its own
+     * read grant rather than on the permissions of the user that owns it, so a
+     * super-admin-owned key stays bound by a stored owner-only read rule.
+     */
+    authenticatedScope?: AuthenticatedScope;
+    /**
      * Draft/Published filter override (only effective when collection.status
      * === true). Public callers default to 'published'; trusted callers can
      * pass 'all' to see drafts too. Forwarded to query service as-is.
@@ -619,6 +625,11 @@ export class CollectionsHandler {
      * the caller may not read.
      */
     routeAuthorized?: boolean;
+    /**
+     * The caller's authenticated scope, mirroring listEntries so a scoped key's
+     * count matches the rows it can list.
+     */
+    authenticatedScope?: AuthenticatedScope;
     /**
      * Draft/Published filter override (only effective when collection.status
      * === true). Same semantics as listEntries.

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -172,6 +172,10 @@ export class CollectionEntryService extends BaseService {
     /** Fallback control (`false`/`"none"` disables fallback). */
     fallbackLocale?: string | false;
     context?: Record<string, unknown>;
+    /** Route authorization already ran the coarse RBAC gate; stored rules run. */
+    routeAuthorized?: boolean;
+    /** Caller's authenticated scope; a scoped key is judged on its read grant. */
+    authenticatedScope?: AuthenticatedScope;
   }): Promise<CollectionServiceResult<PaginatedResponse<unknown>>> {
     return this.queryService.listEntries(params);
   }
@@ -187,6 +191,10 @@ export class CollectionEntryService extends BaseService {
     /** Fallback control (`false`/`"none"` disables fallback). */
     fallbackLocale?: string | false;
     context?: Record<string, unknown>;
+    /** Route authorization already ran the coarse RBAC gate; stored rules run. */
+    routeAuthorized?: boolean;
+    /** Caller's authenticated scope; a scoped key is judged on its read grant. */
+    authenticatedScope?: AuthenticatedScope;
   }): Promise<CollectionServiceResult<{ totalDocs: number }>> {
     return this.queryService.countEntries(params);
   }


### PR DESCRIPTION
Task 002 (access-control "PR3"), first of three. Closes the read half of the access-control program: PR #213/#214/#231/#235 shipped the write half, and the planned read PR never landed.

## The defect

`listEntries`, `getEntry` and `countEntries` never told the query service **who was asking**. With no user, the service can only apply the rule-less default — so a collection configured with an **owner-only** or **role-based read** rule returned every row to any caller who could reach the endpoint. The rule held on writes and inside the Direct API, but not on the API those callers actually hit.

Scoped honestly: the route's coarse permission gate still applied, so an unauthorized caller got nothing. This was **over-sharing among authorized readers** — the difference between "see only your own records" and "see everyone's" — not open access. Still a real defect, because the admin UI offers a control that silently did nothing over HTTP.

## Why the diff is small

The enforcement already existed; only the last wire was missing. Verified in `collection-query-service.ts`:

- `listEntries` (:658) already calls `checkCollectionAccess(..., "read", accessUser, ...)`
- `getAccessQueryConstraint` (:743) folds an owner-only rule into the Drizzle `where` as `eq(schema[field], value)` — real SQL filtering, not JS post-filtering, so pagination stays correct
- `countEntries` (:1468) applies the same constraint, by explicit design ("Mirrors listEntries")
- `getEntry` (:1816) folds ownership and 404s a non-owner

All three already accepted `user?: UserContext` and `routeAuthorized?: boolean`. The dispatcher just never passed them. So this connects the wire and adds the guard that was missing, rather than building enforcement.

## What changed

- The three read handlers forward the authenticated user plus `routeAuthorized`, which attests the route already ran the coarse RBAC gate so **only that redundant re-check** is skipped while stored rules still run (same contract the write paths and singles use).
- `getEntry` also forwards the API-key scope, matching the publish gate from #290/#297, so a scoped key is judged on its own read grant rather than on its owner's permissions. **List and count have no such parameter yet** and still judge the owning user; I left that gap unchanged rather than widening this PR's blast radius — flagged below as a follow-up.
- Two facade param types in `collections-handler.ts` gained `routeAuthorized` (it was already on `getEntry`).
- Building the user context from the reserved `_authenticated*` route params was open-coded in **four** places, so it moves to a shared `readAuthenticatedUser` helper per the repo's promotion rule. The existing four call sites are untouched here.

## Verification

Five forwarding tests, and I checked they are real guards rather than tautologies — **all 5 fail against the pre-change dispatcher and pass after**:

```
=== vs ORIGINAL dispatcher ===        === vs FIXED dispatcher ===
Tests  5 failed (5)                   Tests  5 passed (5)
```

One of them initially passed both ways (comparing two `undefined` values is trivially true), so it now asserts the context is actually present before comparing list-vs-count.

**No regressions.** The dispatcher + collection-service suites show the *identical* 9 pre-existing failures across the same 4 files with and without this change — part of the known stale-mock baseline (task 049), measured both ways:

| | Test Files | Tests |
|---|---|---|
| baseline (`origin/main`) | 4 failed, 19 passed | 9 failed, 225 passed |
| this branch | 4 failed, 20 passed | 9 failed, **230** passed |

Lint clean on the touched files; `pnpm --filter nextly build` green.

## Cache-leak question, checked and clear

Per-user read filtering must never poison a shared cache. Verified that the REST read path has **no** Next.js caching today — no `unstable_cache`, `cacheTag`, `revalidateTag` or fetch tags in `routeHandler.ts` or `route-handler/`; the F1 revalidation machinery is write-side only. So there is no leak now.

**This becomes live with task 008** (F1 read helpers): any read-side caching added there must key on the caller or bypass the cache for user-varying responses. I've noted it on that task.

## Deliberately out of scope

- `?status=` semantics (task 003) — a separate contract change; coupling them would make both un-reviewable.
- Field-level read redaction (next PR) — the helper exists but only versions use it.
- Singles' stored read rules (third PR).
- API-key scope for list/count, per above.

The changeset is honest that this is a behavior change: installs that depended on unfiltered reads will now see only the rows their rule allows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved collection read access checks for authenticated and anonymous requests.
  - Ensured scoped API keys consistently honor owner-only and read restrictions, including result counts.
  - Prevented malformed role data from granting unintended permissions.
  - Expanded role resolution for read operations requiring authorization-aware filtering.

- **Tests**
  - Added coverage for role resolution, authenticated read context, scoped-key behavior, and access constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->