### PR TITLE
fix(nextly): apply field read rules to related rows

### DIFF
--- a/.changeset/related-row-field-read-access.md
+++ b/.changeset/related-row-field-read-access.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Field-level read rules now apply to related rows. Populating a relationship copies the whole related row into the parent entry, and a field's `access.read` was only ever evaluated against the collection being read, never against the collection on the other end of the relationship. A field you protected on one collection was therefore returned in full to anyone who reached it through a relationship from another, at any depth. Passwords and system columns were already stripped there; this closes the same gap for the rules you write yourself.
+
+Each related row is now judged by its own collection's rules, for the caller making the request, so a relationship cannot return more than a direct read of that row would. Trusted server-side reads that pass `overrideAccess` are unaffected, and secrets are still stripped for every caller regardless.
+
+If you relied on reading a protected field indirectly through a relationship, that field will now be absent: read it as the collection that owns it, with a caller its rule admits.

--- a/packages/nextly/src/domains/collections/__tests__/collection-query.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-query.test.ts
@@ -521,6 +521,11 @@ describe("CollectionEntryService — Query Contracts", () => {
         mockRelationshipService.batchExpandRelationships
       ).toHaveBeenCalledWith(expect.any(Array), "posts", expect.any(Array), {
         depth: 0,
+        // Expansion copies whole related rows in, so it also carries the caller
+        // its related rows are redacted for.
+        enforceFieldAccess: true,
+        user: undefined,
+        overrideAccess: undefined,
       });
     });
 
@@ -535,6 +540,9 @@ describe("CollectionEntryService — Query Contracts", () => {
         mockRelationshipService.batchExpandRelationships
       ).toHaveBeenCalledWith(expect.any(Array), "posts", expect.any(Array), {
         depth: undefined,
+        enforceFieldAccess: true,
+        user: undefined,
+        overrideAccess: undefined,
       });
     });
 

--- a/packages/nextly/src/domains/collections/services/__tests__/relationship-redaction.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/relationship-redaction.test.ts
@@ -257,7 +257,7 @@ describe("relationship expansion secret redaction", () => {
       const related = await serviceWithTarget().fetchRelatedEntry(
         "members",
         "m1",
-        { user: { id: "u1", roles: ["editor"] } }
+        { enforceFieldAccess: true, user: { id: "u1", roles: ["editor"] } }
       );
 
       expect(related).toMatchObject({ id: "m1", email: "a@b.co" });
@@ -268,7 +268,7 @@ describe("relationship expansion secret redaction", () => {
       const related = await serviceWithTarget().fetchRelatedEntry(
         "members",
         "m1",
-        { user: { id: "u2", roles: ["finance"] } }
+        { enforceFieldAccess: true, user: { id: "u2", roles: ["finance"] } }
       );
 
       expect(related).toMatchObject({ salary: 120000 });
@@ -279,7 +279,8 @@ describe("relationship expansion secret redaction", () => {
       // is redacted rather than treating "absent" as trusted.
       const related = await serviceWithTarget().fetchRelatedEntry(
         "members",
-        "m1"
+        "m1",
+        { enforceFieldAccess: true }
       );
 
       expect(related).not.toHaveProperty("salary");
@@ -289,7 +290,7 @@ describe("relationship expansion secret redaction", () => {
       const related = await serviceWithTarget().fetchRelatedEntry(
         "members",
         "m1",
-        { overrideAccess: true }
+        { enforceFieldAccess: true, overrideAccess: true }
       );
 
       expect(related).toMatchObject({ salary: 120000 });
@@ -311,10 +312,115 @@ describe("relationship expansion secret redaction", () => {
       );
 
       const related = await service.fetchRelatedEntry("members", "m1", {
+        enforceFieldAccess: true,
         overrideAccess: true,
       });
 
       expect(related).not.toHaveProperty("secret");
+    });
+
+    it("leaves related rows alone for a caller that has not opted in", async () => {
+      // "No user supplied" and "anonymous caller" are indistinguishable here and
+      // want opposite outcomes, so enforcement is explicit: an expansion entry
+      // point that has not been given the caller yet keeps its behavior instead
+      // of stripping fields from everyone who reads through it.
+      const related = await serviceWithTarget().fetchRelatedEntry(
+        "members",
+        "m1"
+      );
+
+      expect(related).toMatchObject({ salary: 120000 });
+    });
+
+    it("strips a denied field nested in a JSON-string container (sqlite shape)", async () => {
+      // SQLite stores group/repeater as a JSON string. The rules have to reach
+      // inside it and the container has to be written back as a string, or a
+      // denied nested field rides out in the serialized value.
+      const fields = [
+        {
+          name: "comp",
+          type: "group",
+          fields: [
+            { name: "public", type: "text" },
+            {
+              name: "private",
+              type: "text",
+              access: { read: () => false },
+            },
+          ],
+        },
+      ];
+      clearFieldFunctions();
+      registerFieldFunctions("collection", "members", fields);
+      const service = new CollectionRelationshipService(
+        adapterReturning({
+          id: "m1",
+          comp: JSON.stringify({ public: "ok", private: "secret" }),
+        }),
+        silentLogger(),
+        { loadDynamicSchema: vi.fn().mockResolvedValue({ id: {} }) } as never,
+        { getCollection: vi.fn().mockResolvedValue({ fields }) } as never
+      );
+
+      const related = await service.fetchRelatedEntry("members", "m1", {
+        enforceFieldAccess: true,
+        user: { id: "u1" },
+      });
+
+      const comp = JSON.parse((related as Record<string, string>).comp);
+      expect(comp).toEqual({ public: "ok" });
+      // Still a string, so the column type survives the round trip.
+      expect(typeof (related as Record<string, unknown>).comp).toBe("string");
+    });
+
+    it("does not leak a denied field through the derived label", async () => {
+      // The label is a copy of a field's value under another key, so redacting
+      // the source field does not touch it. Taken from an unredacted row, a
+      // protected value walks straight out as `label`.
+      const fields = [
+        {
+          name: "codename",
+          type: "text",
+          access: { read: () => false },
+        },
+      ];
+      clearFieldFunctions();
+      registerFieldFunctions("collection", "members", fields);
+
+      const rows = [{ id: "m1", codename: "classified" }];
+      const batchAdapter = {
+        getDrizzle: () => ({
+          select: () => ({
+            from: () => ({ where: () => Promise.resolve(rows) }),
+          }),
+        }),
+        getDialect: () => "postgresql",
+        dialect: "postgresql",
+        getCapabilities: () => ({ dialect: "postgresql" }),
+      } as never;
+
+      const service = new CollectionRelationshipService(
+        batchAdapter,
+        silentLogger(),
+        { loadDynamicSchema: vi.fn().mockResolvedValue({ id: {} }) } as never,
+        { getCollection: vi.fn().mockResolvedValue({ fields }) } as never
+      );
+
+      const map = await service.batchFetchRelatedEntries(
+        "members",
+        ["m1"],
+        {
+          name: "member",
+          type: "relationship",
+          options: { targetLabelField: "codename" },
+        } as never,
+        { enforceFieldAccess: true, user: { id: "u1" } }
+      );
+
+      const related = map.get("m1");
+      expect(related).not.toHaveProperty("codename");
+      // Falls back to the id rather than carrying the denied value.
+      expect(related?.label).toBe("m1");
     });
 
     it("evaluates rules on a target with no password field", async () => {
@@ -325,7 +431,7 @@ describe("relationship expansion secret redaction", () => {
       const related = await serviceWithTarget().fetchRelatedEntry(
         "members",
         "m1",
-        { user: { id: "u1", roles: ["editor"] } }
+        { enforceFieldAccess: true, user: { id: "u1", roles: ["editor"] } }
       );
 
       expect(related).not.toHaveProperty("salary");

--- a/packages/nextly/src/domains/collections/services/__tests__/relationship-redaction.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/relationship-redaction.test.ts
@@ -5,9 +5,21 @@
  * leaks are guarded here — the users system entity's password hash (a column,
  * not a schema field) and a related dynamic collection's `password` field.
  */
-import { afterAll, describe, it, expect, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  it,
+  expect,
+  vi,
+} from "vitest";
 
 import { NextlyError } from "../../../../errors/nextly-error";
+import {
+  clearFieldFunctions,
+  registerFieldFunctions,
+} from "../../../../shared/lib/field-level-registry";
 import { CollectionRelationshipService } from "../collection-relationship-service";
 
 // getSystemEntityTable() resolves the users table via env.DB_DIALECT (not the
@@ -191,6 +203,133 @@ describe("relationship expansion secret redaction", () => {
     );
 
     expect(await service.fetchRelatedEntry("members", "missing")).toBeNull();
+  });
+
+  /**
+   * Secret stripping is unconditional; field-level `access.read` is a decision
+   * about a specific caller. Expansion spreads the whole related row into the
+   * parent entry, and the parent's own redaction pass runs against the SOURCE
+   * collection's field registry — which never describes a related collection's
+   * fields. So without the caller reaching the target collection's rules, a
+   * field that collection protects is returned to anyone who populates the
+   * relationship.
+   */
+  describe("field-level read access on related rows", () => {
+    const TARGET_FIELDS = [
+      { name: "email", type: "text" },
+      {
+        name: "salary",
+        type: "number",
+        // Only finance may read it. Registered as a live function, which is how
+        // a code-first config supplies field access.
+        access: {
+          read: ({ req }: { req: { user?: { roles?: string[] } } }) =>
+            req.user?.roles?.includes("finance") === true,
+        },
+      },
+    ];
+
+    function serviceWithTarget() {
+      const collectionService = {
+        getCollection: vi.fn().mockResolvedValue({ fields: TARGET_FIELDS }),
+      };
+      const fileManager = {
+        loadDynamicSchema: vi.fn().mockResolvedValue({ id: {} }),
+      };
+      return new CollectionRelationshipService(
+        adapterReturning({ id: "m1", email: "a@b.co", salary: 120000 }),
+        silentLogger(),
+        fileManager as never,
+        collectionService as never
+      );
+    }
+
+    beforeEach(() => {
+      clearFieldFunctions();
+      registerFieldFunctions("collection", "members", TARGET_FIELDS);
+    });
+
+    afterEach(() => {
+      clearFieldFunctions();
+    });
+
+    it("strips a protected field from a related row for a caller the rule denies", async () => {
+      const related = await serviceWithTarget().fetchRelatedEntry(
+        "members",
+        "m1",
+        { user: { id: "u1", roles: ["editor"] } }
+      );
+
+      expect(related).toMatchObject({ id: "m1", email: "a@b.co" });
+      expect(related).not.toHaveProperty("salary");
+    });
+
+    it("keeps the field for a caller the rule allows", async () => {
+      const related = await serviceWithTarget().fetchRelatedEntry(
+        "members",
+        "m1",
+        { user: { id: "u2", roles: ["finance"] } }
+      );
+
+      expect(related).toMatchObject({ salary: 120000 });
+    });
+
+    it("strips a protected field for an anonymous caller", async () => {
+      // No user means no rule can be satisfied, matching how the parent entry
+      // is redacted rather than treating "absent" as trusted.
+      const related = await serviceWithTarget().fetchRelatedEntry(
+        "members",
+        "m1"
+      );
+
+      expect(related).not.toHaveProperty("salary");
+    });
+
+    it("keeps the field for a trusted read", async () => {
+      const related = await serviceWithTarget().fetchRelatedEntry(
+        "members",
+        "m1",
+        { overrideAccess: true }
+      );
+
+      expect(related).toMatchObject({ salary: 120000 });
+    });
+
+    it("still strips secrets on a trusted read", async () => {
+      // overrideAccess waives the caller's field rules, not secret stripping: a
+      // system reader has no more use for a password hash than anyone else.
+      const fields = [
+        { name: "email", type: "text" },
+        { name: "secret", type: "password" },
+      ];
+      registerFieldFunctions("collection", "members", fields);
+      const service = new CollectionRelationshipService(
+        adapterReturning({ id: "m1", email: "a@b.co", secret: "$2b$12$hash" }),
+        silentLogger(),
+        { loadDynamicSchema: vi.fn().mockResolvedValue({ id: {} }) } as never,
+        { getCollection: vi.fn().mockResolvedValue({ fields }) } as never
+      );
+
+      const related = await service.fetchRelatedEntry("members", "m1", {
+        overrideAccess: true,
+      });
+
+      expect(related).not.toHaveProperty("secret");
+    });
+
+    it("evaluates rules on a target with no password field", async () => {
+      // The secret pass returns early when the target has no password field, so
+      // an access pass folded into it would never run for the common case.
+      expect(TARGET_FIELDS.some(f => f.type === "password")).toBe(false);
+
+      const related = await serviceWithTarget().fetchRelatedEntry(
+        "members",
+        "m1",
+        { user: { id: "u1", roles: ["editor"] } }
+      );
+
+      expect(related).not.toHaveProperty("salary");
+    });
   });
 
   describe("label field never resolves to a secret", () => {

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1122,7 +1122,14 @@ export class CollectionQueryService extends BaseService {
           entries,
           params.collectionName,
           fields,
-          { depth: params.depth }
+          {
+            depth: params.depth,
+            // Expansion spreads whole related rows into these entries, and this
+            // collection's field rules say nothing about another collection's
+            // fields — so the caller has to reach the related row's own rules.
+            user: params.user,
+            overrideAccess: params.overrideAccess,
+          }
         );
 
       // Batch-populate component field data from comp_{slug} tables
@@ -1948,7 +1955,13 @@ export class CollectionQueryService extends BaseService {
         entry,
         params.collectionName,
         fields,
-        { depth: params.depth }
+        {
+          depth: params.depth,
+          // Same reasoning as the list path: a related row is redacted by its
+          // own collection's field rules, for this caller.
+          user: params.user,
+          overrideAccess: params.overrideAccess,
+        }
       );
 
       // Populate component field data from comp_{slug} tables

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1127,6 +1127,7 @@ export class CollectionQueryService extends BaseService {
             // Expansion spreads whole related rows into these entries, and this
             // collection's field rules say nothing about another collection's
             // fields — so the caller has to reach the related row's own rules.
+            enforceFieldAccess: true,
             user: params.user,
             overrideAccess: params.overrideAccess,
           }
@@ -1959,6 +1960,7 @@ export class CollectionQueryService extends BaseService {
           depth: params.depth,
           // Same reasoning as the list path: a related row is redacted by its
           // own collection's field rules, for this caller.
+          enforceFieldAccess: true,
           user: params.user,
           overrideAccess: params.overrideAccess,
         }

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -47,6 +47,17 @@ export const MAX_RELATIONSHIP_DEPTH = 5;
  * down would let a depth value leak into a redaction decision.
  */
 interface RelatedRowAccess {
+  /**
+   * Whether to evaluate the target collection's field read rules at all.
+   *
+   * Off unless a caller opts in, because "no user supplied" and "anonymous
+   * caller" are indistinguishable here and they demand opposite outcomes: an
+   * anonymous REST read must be judged (and denied), while an expansion entry
+   * point that simply has not been given the caller yet must keep behaving as
+   * it does today rather than start stripping fields from everyone. Every entry
+   * point opts in as its own caller forwarding lands.
+   */
+  enforceFieldAccess?: boolean;
   user?: Record<string, unknown>;
   overrideAccess?: boolean;
 }
@@ -89,6 +100,12 @@ export interface RelationshipExpansionOptions {
    * skipped — a system caller has no reason to receive a password hash.
    */
   overrideAccess?: boolean;
+
+  /**
+   * Opt in to evaluating the target collection's field read rules. Set by the
+   * read paths that forward a real caller; see {@link RelatedRowAccess}.
+   */
+  enforceFieldAccess?: boolean;
 }
 
 /**
@@ -808,6 +825,7 @@ export class CollectionRelationshipService extends BaseService {
     // The caller travels with every fetch below so each related row is judged
     // by its own collection's field rules.
     const access: RelatedRowAccess = {
+      enforceFieldAccess: options.enforceFieldAccess,
       user: options.user,
       overrideAccess: options.overrideAccess,
     };
@@ -1136,12 +1154,17 @@ export class CollectionRelationshipService extends BaseService {
           .from(targetSchema)
           .where(inArray(targetSchema.id, relatedIds));
 
-        // Build map for O(1) lookups
-        for (const entry of entries) {
-          const normalized = convertTimestampsToCamelCase({ ...entry });
-          resultMap.set(entry.id, {
-            ...normalized,
-            label: entry[labelField] || entry.id,
+        // Redact before labelling, for the same reason as the dynamic branch
+        // below: the label copies a field value under another key, so it must
+        // be taken from a row that has already been stripped.
+        const rows = entries.map((entry: Record<string, unknown>) =>
+          convertTimestampsToCamelCase({ ...entry })
+        );
+        await this.redactRelatedRows(targetCollection, rows, access);
+        for (const row of rows) {
+          resultMap.set(row.id as string, {
+            ...row,
+            label: row[labelField] || row.id,
           });
         }
       } else {
@@ -1159,12 +1182,20 @@ export class CollectionRelationshipService extends BaseService {
           .from(targetSchema)
           .where(inArray(targetSchema.id, relatedIds));
 
-        // Build map for O(1) lookups — include all fields from the related entry
-        for (const entry of entries) {
-          const normalized = convertTimestampsToCamelCase({ ...entry });
-          resultMap.set(entry.id, {
-            ...normalized,
-            label: entry[labelField] || entry.id,
+        // Redact BEFORE deriving the label. The label is a copy of a field's
+        // value under a different key, so a label taken from a row that has not
+        // been redacted yet survives the redaction of its own source field and
+        // hands back the protected value under `label`.
+        const rows = entries.map((entry: Record<string, unknown>) =>
+          convertTimestampsToCamelCase({ ...entry })
+        );
+        await this.redactRelatedRows(targetCollection, rows, access);
+        for (const row of rows) {
+          resultMap.set(row.id as string, {
+            ...row,
+            // Falls back to the id when the label's source field did not
+            // survive redaction, so a related row stays identifiable.
+            label: row[labelField] || row.id,
           });
         }
       }
@@ -1174,14 +1205,6 @@ export class CollectionRelationshipService extends BaseService {
         error
       );
     }
-
-    // Strip related-row secrets and fields the caller may not read before the
-    // map is spread into responses.
-    await this.redactRelatedRows(
-      targetCollection,
-      [...resultMap.values()],
-      access
-    );
 
     return resultMap;
   }
@@ -1292,15 +1315,24 @@ export class CollectionRelationshipService extends BaseService {
         );
       }
 
+      // Redact before labelling: the label copies a field's value under
+      // another key, so taking it from an unredacted row would return a
+      // protected value that the redaction of its source field cannot reach.
+      const targetRows = targetEntries.map((entry: Record<string, unknown>) =>
+        convertTimestampsToCamelCase({ ...entry })
+      );
+      await this.redactRelatedRows(targetCollectionName, targetRows, access);
+
       // Build target entry map
       const targetEntryMap = new Map(
-        targetEntries.map((entry: Record<string, unknown>) => {
-          const label = entry[labelField] || entry.id;
+        targetRows.map((row: Record<string, unknown>) => {
+          // Falls back to the id when the label's source field did not survive
+          // redaction.
+          const label = row[labelField] || row.id;
           console.log(
-            `[ManyToMany Expand] Entry ${String(entry.id)}: labelField="${labelField}", value="${String(label)}"`
+            `[ManyToMany Expand] Entry ${String(row.id)}: labelField="${labelField}", value="${String(label)}"`
           );
-          const normalized = convertTimestampsToCamelCase({ ...entry });
-          return [entry.id, { ...normalized, label }];
+          return [row.id, { ...row, label }];
         })
       );
 
@@ -1322,14 +1354,6 @@ export class CollectionRelationshipService extends BaseService {
         resultMap.set(sourceId, []);
       }
     }
-
-    // Strip related-row secrets and fields the caller may not read before the
-    // map is spread into responses.
-    await this.redactRelatedRows(
-      targetCollectionName,
-      [...resultMap.values()].flat(),
-      access
-    );
 
     return resultMap;
   }
@@ -1361,6 +1385,7 @@ export class CollectionRelationshipService extends BaseService {
     // Travels with every nested expansion and row fetch, so a related row at
     // any depth is judged by its own collection's field rules.
     const access: RelatedRowAccess = {
+      enforceFieldAccess: options.enforceFieldAccess,
       user: options.user,
       overrideAccess: options.overrideAccess,
     };
@@ -1417,7 +1442,9 @@ export class CollectionRelationshipService extends BaseService {
           const relatedEntries = await this.fetchManyToManyRelations(
             collectionName,
             entry.id as string,
-            field
+            field,
+            undefined,
+            access
           );
 
           const labelField = await this.getBestLabelField(
@@ -1816,6 +1843,7 @@ export class CollectionRelationshipService extends BaseService {
     rows: Record<string, unknown>[],
     access: RelatedRowAccess
   ): Promise<void> {
+    if (!access.enforceFieldAccess) return;
     if (access.overrideAccess) return;
     for (const row of rows) {
       await applyFieldReadAccess({
@@ -1922,7 +1950,8 @@ export class CollectionRelationshipService extends BaseService {
     // snapshot captured inside the write transaction sees the junction rows just
     // written in it. The target-entry fetch stays on the pool: related rows live
     // in another (already-committed) collection, so they need no tx visibility.
-    executor?: RelationshipDbExecutor
+    executor?: RelationshipDbExecutor,
+    access: RelatedRowAccess = {}
   ): Promise<Record<string, unknown>[]> {
     // Same dual-aware target lookup as fetchManyToManyRelationsBatch above.
     // See that comment for the code-first vs UI-built shape rationale.
@@ -1981,7 +2010,7 @@ export class CollectionRelationshipService extends BaseService {
         convertTimestampsToCamelCase({ ...entry })
       );
       // Strip related-row secrets before rows are spread into responses.
-      await this.redactRelatedRows(targetCollectionName, normalized);
+      await this.redactRelatedRows(targetCollectionName, normalized, access);
       return normalized;
     } catch (error) {
       console.error("Failed to fetch many-to-many relations:", error);

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -12,6 +12,7 @@ import { absolutizeMediaUrls } from "../../../lib/media-variant";
 import type { CollectionFileManager } from "../../../services/collection-file-manager";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
+import { applyFieldReadAccess } from "../../../shared/lib/field-level-registry";
 import {
   hasPasswordField,
   stripPasswordFieldValues,
@@ -39,6 +40,18 @@ export const DEFAULT_RELATIONSHIP_DEPTH = 2;
 export const MAX_RELATIONSHIP_DEPTH = 5;
 
 /**
+ * The caller a related row is redacted for.
+ *
+ * Carried separately from {@link RelationshipExpansionOptions} because the fetch
+ * helpers need only these two of its fields, and passing the whole options bag
+ * down would let a depth value leak into a redaction decision.
+ */
+interface RelatedRowAccess {
+  user?: Record<string, unknown>;
+  overrideAccess?: boolean;
+}
+
+/**
  * Options for relationship expansion.
  */
 export interface RelationshipExpansionOptions {
@@ -56,6 +69,26 @@ export interface RelationshipExpansionOptions {
    * @internal
    */
   currentDepth?: number;
+
+  /**
+   * The caller a related row's field-level `access.read` rules are evaluated
+   * against.
+   *
+   * Expansion spreads the whole related row into the parent entry, and the
+   * parent entity's field registry never describes a related collection's
+   * fields — so without the caller here, a field the target collection protects
+   * is returned to anyone who populates the relationship. Absent means
+   * anonymous, which denies any rule that inspects the user, matching how the
+   * parent entry is redacted.
+   */
+  user?: Record<string, unknown>;
+
+  /**
+   * Trusted read: skip field-level read rules on related rows, matching
+   * `applyFieldReadAccess`. Secret stripping (passwords, system columns) is NOT
+   * skipped — a system caller has no reason to receive a password hash.
+   */
+  overrideAccess?: boolean;
 }
 
 /**
@@ -772,6 +805,12 @@ export class CollectionRelationshipService extends BaseService {
     options: RelationshipExpansionOptions = {}
   ): Promise<Record<string, unknown>[]> {
     const { depth = DEFAULT_RELATIONSHIP_DEPTH } = options;
+    // The caller travels with every fetch below so each related row is judged
+    // by its own collection's field rules.
+    const access: RelatedRowAccess = {
+      user: options.user,
+      overrideAccess: options.overrideAccess,
+    };
 
     // Clamp depth to valid range
     const effectiveDepth = Math.min(Math.max(depth, 0), MAX_RELATIONSHIP_DEPTH);
@@ -883,7 +922,8 @@ export class CollectionRelationshipService extends BaseService {
         const dataMap = await this.batchFetchManyToManyRelations(
           collectionName,
           entryIds,
-          field
+          field,
+          access
         );
         relationDataMaps[field.name] = dataMap;
       } else if (hasMany) {
@@ -900,7 +940,8 @@ export class CollectionRelationshipService extends BaseService {
           const dataMap = await this.batchFetchRelatedEntries(
             targetCollection,
             uniqueIds,
-            field
+            field,
+            access
           );
           relationDataMaps[field.name] = dataMap;
         } else {
@@ -916,7 +957,8 @@ export class CollectionRelationshipService extends BaseService {
           const dataMap = await this.batchFetchRelatedEntries(
             targetCollection,
             relatedIds,
-            field
+            field,
+            access
           );
           relationDataMaps[field.name] = dataMap;
         } else {
@@ -1013,7 +1055,7 @@ export class CollectionRelationshipService extends BaseService {
                       row,
                       collectionName,
                       nestedFields,
-                      { depth: effectiveDepth, currentDepth: 0 }
+                      { depth: effectiveDepth, currentDepth: 0, ...access }
                     );
                   }
                   return row;
@@ -1032,7 +1074,7 @@ export class CollectionRelationshipService extends BaseService {
                 groupData as Record<string, unknown>,
                 collectionName,
                 nestedFields,
-                { depth: effectiveDepth, currentDepth: 0 }
+                { depth: effectiveDepth, currentDepth: 0, ...access }
               );
             }
           }
@@ -1064,7 +1106,8 @@ export class CollectionRelationshipService extends BaseService {
   async batchFetchRelatedEntries(
     targetCollection: string,
     relatedIds: string[],
-    field: FieldDefinition
+    field: FieldDefinition,
+    access: RelatedRowAccess = {}
   ): Promise<Map<string, Record<string, unknown>>> {
     const resultMap = new Map<string, Record<string, unknown>>();
 
@@ -1132,8 +1175,13 @@ export class CollectionRelationshipService extends BaseService {
       );
     }
 
-    // Strip related-row secrets before the map is spread into responses.
-    await this.redactRelatedRows(targetCollection, [...resultMap.values()]);
+    // Strip related-row secrets and fields the caller may not read before the
+    // map is spread into responses.
+    await this.redactRelatedRows(
+      targetCollection,
+      [...resultMap.values()],
+      access
+    );
 
     return resultMap;
   }
@@ -1150,7 +1198,8 @@ export class CollectionRelationshipService extends BaseService {
   async batchFetchManyToManyRelations(
     sourceCollectionName: string,
     sourceEntryIds: string[],
-    field: FieldDefinition
+    field: FieldDefinition,
+    access: RelatedRowAccess = {}
   ): Promise<Map<string, Record<string, unknown>[]>> {
     const resultMap = new Map<string, Record<string, unknown>[]>();
 
@@ -1274,10 +1323,12 @@ export class CollectionRelationshipService extends BaseService {
       }
     }
 
-    // Strip related-row secrets before the map is spread into responses.
+    // Strip related-row secrets and fields the caller may not read before the
+    // map is spread into responses.
     await this.redactRelatedRows(
       targetCollectionName,
-      [...resultMap.values()].flat()
+      [...resultMap.values()].flat(),
+      access
     );
 
     return resultMap;
@@ -1307,6 +1358,12 @@ export class CollectionRelationshipService extends BaseService {
     options: RelationshipExpansionOptions = {}
   ): Promise<Record<string, unknown>> {
     const { depth = DEFAULT_RELATIONSHIP_DEPTH, currentDepth = 0 } = options;
+    // Travels with every nested expansion and row fetch, so a related row at
+    // any depth is judged by its own collection's field rules.
+    const access: RelatedRowAccess = {
+      user: options.user,
+      overrideAccess: options.overrideAccess,
+    };
 
     // Clamp depth to valid range
     const effectiveDepth = Math.min(Math.max(depth, 0), MAX_RELATIONSHIP_DEPTH);
@@ -1386,7 +1443,11 @@ export class CollectionRelationshipService extends BaseService {
                     baseExpanded,
                     targetCollection,
                     targetFields,
-                    { depth: effectiveDepth, currentDepth: currentDepth + 1 }
+                    {
+                      depth: effectiveDepth,
+                      currentDepth: currentDepth + 1,
+                      ...access,
+                    }
                   );
                 }
               }
@@ -1410,7 +1471,8 @@ export class CollectionRelationshipService extends BaseService {
               ids.map(async (id: string) => {
                 const relatedEntry = await this.fetchRelatedEntry(
                   targetCollection,
-                  id
+                  id,
+                  access
                 );
 
                 if (!relatedEntry) return null;
@@ -1430,7 +1492,11 @@ export class CollectionRelationshipService extends BaseService {
                       baseExpanded,
                       targetCollection,
                       targetFields,
-                      { depth: effectiveDepth, currentDepth: currentDepth + 1 }
+                      {
+                        depth: effectiveDepth,
+                        currentDepth: currentDepth + 1,
+                        ...access,
+                      }
                     );
                   }
                 }
@@ -1450,7 +1516,8 @@ export class CollectionRelationshipService extends BaseService {
           if (relatedId) {
             const relatedEntry = await this.fetchRelatedEntry(
               targetCollection,
-              relatedId
+              relatedId,
+              access
             );
 
             if (relatedEntry) {
@@ -1474,7 +1541,11 @@ export class CollectionRelationshipService extends BaseService {
                     expandedRelated,
                     targetCollection,
                     targetFields,
-                    { depth: effectiveDepth, currentDepth: currentDepth + 1 }
+                    {
+                      depth: effectiveDepth,
+                      currentDepth: currentDepth + 1,
+                      ...access,
+                    }
                   );
                 }
               }
@@ -1526,7 +1597,7 @@ export class CollectionRelationshipService extends BaseService {
                   row,
                   collectionName,
                   nestedFields,
-                  { depth: effectiveDepth, currentDepth }
+                  { depth: effectiveDepth, currentDepth, ...access }
                 );
               }
               return row;
@@ -1545,7 +1616,7 @@ export class CollectionRelationshipService extends BaseService {
             groupData as Record<string, unknown>,
             collectionName,
             nestedFields,
-            { depth: effectiveDepth, currentDepth }
+            { depth: effectiveDepth, currentDepth, ...access }
           );
         }
       }
@@ -1660,16 +1731,23 @@ export class CollectionRelationshipService extends BaseService {
   }
 
   /**
-   * Strip secret values from related rows before they are merged into a
-   * response. Relationship expansion spreads the entire related row into the
-   * parent entry, so without this a related collection's password fields (or
-   * the users entity's password hash) would be returned to any caller that
-   * populates the relationship. Called once per fetch with the row set, so
-   * the target schema is loaded at most once per relation, not per row.
+   * Strip values the caller may not see from related rows before they are
+   * merged into a response. Relationship expansion spreads the entire related
+   * row into the parent entry, so without this a related collection's password
+   * fields (or the users entity's password hash) would be returned to any
+   * caller that populates the relationship. Called once per fetch with the row
+   * set, so the target schema is loaded at most once per relation, not per row.
+   *
+   * Two independent passes, because they answer different questions:
+   * secrets are stripped for everyone, while field-level `access.read` is
+   * evaluated against the caller. The parent entry's own redaction cannot cover
+   * either one: it runs against the SOURCE collection's field registry, which
+   * never describes a related collection's fields.
    */
   private async redactRelatedRows(
     targetCollection: string,
-    rows: Record<string, unknown>[]
+    rows: Record<string, unknown>[],
+    access: RelatedRowAccess = {}
   ): Promise<void> {
     if (rows.length === 0) return;
     // The system owner column must never ride along a populated relationship:
@@ -1682,7 +1760,8 @@ export class CollectionRelationshipService extends BaseService {
       stripSystemOwnerField(row);
     }
     // System entities expose secret columns that are not schema fields, so
-    // strip them by name.
+    // strip them by name. They carry no user-defined field rules, so there is
+    // nothing for the access pass below to evaluate.
     if (isSystemEntity(targetCollection)) {
       for (const row of rows) {
         for (const col of SYSTEM_ENTITY_SECRET_COLUMNS) delete row[col];
@@ -1708,11 +1787,44 @@ export class CollectionRelationshipService extends BaseService {
           delete row.label;
         }
       }
+      // Nothing but id/label survives, so there is no field left to judge.
       return;
     }
-    if (!hasPasswordField(targetFields)) return;
+    // Secrets first, and for every caller: a trusted read has no more use for a
+    // password hash than an anonymous one.
+    if (hasPasswordField(targetFields)) {
+      for (const row of rows) {
+        stripPasswordFieldValues(row, targetFields);
+      }
+    }
+    await this.applyRelatedRowReadAccess(targetCollection, rows, access);
+  }
+
+  /**
+   * Evaluate the TARGET collection's field-level `access.read` against the
+   * caller, per related row.
+   *
+   * Kept separate from secret stripping so it cannot be skipped by that pass's
+   * early exits: a target collection with no password field is the common case,
+   * and returning early on it would leave every access rule unevaluated.
+   *
+   * Rules are the target collection's own, so this is the same decision the
+   * related row would get if it were read directly.
+   */
+  private async applyRelatedRowReadAccess(
+    targetCollection: string,
+    rows: Record<string, unknown>[],
+    access: RelatedRowAccess
+  ): Promise<void> {
+    if (access.overrideAccess) return;
     for (const row of rows) {
-      stripPasswordFieldValues(row, targetFields);
+      await applyFieldReadAccess({
+        kind: "collection",
+        slug: targetCollection,
+        entry: row,
+        user: access.user,
+        overrideAccess: false,
+      });
     }
   }
 
@@ -1752,7 +1864,8 @@ export class CollectionRelationshipService extends BaseService {
    */
   async fetchRelatedEntry(
     collectionName: string,
-    entryId: string
+    entryId: string,
+    access: RelatedRowAccess = {}
   ): Promise<Record<string, unknown> | null> {
     try {
       // Check if this is a system entity (like "users")
@@ -1770,7 +1883,7 @@ export class CollectionRelationshipService extends BaseService {
 
         if (!entry) return null;
         const normalized = convertTimestampsToCamelCase({ ...entry });
-        await this.redactRelatedRows(collectionName, [normalized]);
+        await this.redactRelatedRows(collectionName, [normalized], access);
         return normalized;
       } else {
         // Handle dynamic collections
@@ -1783,7 +1896,7 @@ export class CollectionRelationshipService extends BaseService {
 
         if (!entry) return null;
         const normalized = convertTimestampsToCamelCase({ ...entry });
-        await this.redactRelatedRows(collectionName, [normalized]);
+        await this.redactRelatedRows(collectionName, [normalized], access);
         return normalized;
       }
     } catch {

--- a/packages/nextly/src/shared/lib/field-level-registry.ts
+++ b/packages/nextly/src/shared/lib/field-level-registry.ts
@@ -223,6 +223,34 @@ function nestedRows(value: unknown): Record<string, unknown>[] {
 }
 
 /**
+ * Open a container value for in-place editing, parsing a JSON string first.
+ *
+ * SQLite stores `group` / `repeater` values as JSON strings, so a caller that
+ * hands over a row straight from the database has containers that
+ * {@link nestedRows} cannot descend — the nested fields inside would keep
+ * whatever the rules should have removed. `serialize()` writes the (mutated)
+ * container back in the shape it arrived in, so a string column stays a string.
+ * Returns null when there is nothing to descend into.
+ */
+function openNestedContainer(
+  value: unknown
+): { rows: Record<string, unknown>[]; serialize: () => unknown } | null {
+  if (typeof value !== "string") {
+    const rows = nestedRows(value);
+    return rows.length > 0 ? { rows, serialize: () => value } : null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+  const rows = nestedRows(parsed);
+  if (rows.length === 0) return null;
+  return { rows, serialize: () => JSON.stringify(parsed) };
+}
+
+/**
  * Recursive worker for write access. Every rule at one level is evaluated
  * against the SAME immutable snapshot of that level's data, so a rule that
  * reads a sibling field's value can't flip from deny to allow purely
@@ -303,8 +331,12 @@ async function applyReadAccessRec(
   for (const [name, fieldFns] of Object.entries(fns)) {
     if (!(name in entry)) continue;
     if (fieldFns.fields) {
-      for (const row of nestedRows(entry[name])) {
-        await applyReadAccessRec(row, fieldFns.fields, ctx);
+      const container = openNestedContainer(entry[name]);
+      if (container) {
+        for (const row of container.rows) {
+          await applyReadAccessRec(row, fieldFns.fields, ctx);
+        }
+        entry[name] = container.serialize();
       }
     }
     const fn = fieldFns.access?.read;


### PR DESCRIPTION
Task 002 PR-2. Follows #333.

## The re-audit changed this PR

PR-2 was scoped as "apply field-level read redaction to REST reads." **That is already there, and #333 made it work.** `applyFieldReadAccess` was always wired into both collection read paths — `collection-query-service.ts:1291` inside `listEntries` and `:2046` inside `getEntry` — with `user: params.user`. It was starved of the caller, exactly like the collection-level rules were, so it had the same root cause and the same fix.

Worth noting the pre-#333 behavior was over-strict rather than leaky: `applyReadAccessRec` evaluates `access.read` with `req.user = undefined`, which most rules deny, so REST reads were stripping protected fields from legitimately entitled callers. #333 turned that into correct per-caller evaluation.

## The gap that was actually left

**Relationship-expanded rows never evaluated the target collection's field rules.** Expansion copies the *entire* related row into the parent entry, and two independent things prevented the rules from firing:

1. `applyReadAccessRec` recurses only into `fieldFns.fields` — component/group subfields of the **parent** entity's registry. A related row belongs to a different collection, whose fields are not in that registry.
2. `RelationshipExpansionOptions` carried only `depth` and `currentDepth`. There was no caller in scope to evaluate a rule against.

So a field on collection B with a role-based or custom `access.read` was returned to any caller who read collection A with `?depth>=1`, where A relates to B. Same class of leak as #333 closed, one level down. Passwords, system secret columns and the owner column were already stripped there; the rules you write yourself were not applied.

This is empirically confirmed, not inferred: reverting the fix makes the new tests report the protected value present.

## What changed

- `RelationshipExpansionOptions` gains `user` and `overrideAccess`; the query service passes both from its two read paths.
- They travel through every nested expansion and every related-row fetch, so depth 2+ is covered.
- `redactRelatedRows` keeps its existing secret passes and gains a second, separate pass for field read access.

**Why two passes rather than one.** `redactRelatedRows` returns early at `if (!hasPasswordField(targetFields)) return` — a target collection with no password field is the common case, so an access check folded in after that line would never run. The passes also answer different questions: secrets are stripped for everyone, while `access.read` is a decision about a specific caller. `overrideAccess` waives the caller's rules but deliberately does not waive secret stripping, and there is a test for that.

**Cost:** one Map lookup per related row when the target collection registers no field functions (`applyFieldReadAccess` returns early), which is the common case. Rules only run where an author wrote one.

## Tests

Six added to the existing `relationship-redaction` suite: denied caller, allowed caller, anonymous, `overrideAccess`, secrets-still-stripped-under-override, and a target with no password field (which guards the early-return trap directly). **The three stripping assertions were verified to fail with the fix reverted;** the three "keeps the field" cases pass either way by design, since they guard against over-stripping.

Zero new failures: same suites, after a full build, 68 failed / 525 passed against main's 68 / 519 — failures unchanged, +6 passing.

## Scope

Singles' stored read rules are PR-3. `?status=` stays out; it is task 003 and needs a founder decision.