### PR TITLE
feat(nextly): add per-collection webhook recording opt-out

### DIFF
--- a/.changeset/form-submission-webhook-gate.md
+++ b/.changeset/form-submission-webhook-gate.md
@@ -1,0 +1,24 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Collections and singles can now opt out of webhook recording with `webhooks: false` (or `{ record: false }`). Form submissions opt out by default, so visitor IP address, user agent, and submission content are no longer recorded to the webhook outbox or delivered to endpoints subscribed to `entry.created` or `*`. Existing installs: submission events recorded before this release remain in the outbox and can be pruned manually; no data is deleted automatically.

--- a/packages/nextly/src/collections/config/define-collection.ts
+++ b/packages/nextly/src/collections/config/define-collection.ts
@@ -789,6 +789,18 @@ export interface CollectionConfig {
   localized?: boolean;
 
   /**
+   * Webhook recording policy for this collection. When `false` (or
+   * `{ record: false }`), writes to this collection record NO event to the
+   * webhook outbox, so nothing is ever delivered to subscribed endpoints. Used
+   * to keep PII-bearing content — form submissions carry `ipAddress`/`userAgent`
+   * — out of the delivery path. The object form leaves room for finer policy
+   * later without a breaking change.
+   *
+   * @default true (writes are recorded)
+   */
+  webhooks?: boolean | { record?: boolean };
+
+  /**
    * Admin panel configuration options.
    */
   admin?: CollectionAdminOptions;

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -58,7 +58,10 @@ import type {
 } from "../domains/singles/services/single-registry-service";
 import { resolveVersionsConfig } from "../domains/versions/resolve-config";
 import type { VersionsService } from "../domains/versions/versions-service";
-import { setWebhookRecording } from "../domains/webhooks/recording-policy";
+import {
+  resetWebhookRecordingPolicy,
+  setWebhookRecording,
+} from "../domains/webhooks/recording-policy";
 import { resolveWebhookRecording } from "../domains/webhooks/resolve-recording-config";
 import type { ResolvedWebhookRetentionConfig } from "../domains/webhooks/retention-config";
 import type { WebhookDeliveryQueryService } from "../domains/webhooks/services/webhook-delivery-query-service";
@@ -458,6 +461,14 @@ export async function registerServices(
   container.registerSingleton<DrizzleAdapter>("adapter", () => adapter);
 
   const schemaRegistry = await initializeSchemaRegistry(adapter);
+
+  // Publish the webhook recording policy from the config INDEPENDENTLY of the
+  // schema registry. `registerConfigTablesInResolver` (below) only runs when the
+  // registry initialized, but the recording opt-out must hold even in the
+  // executeQuery fallback path taken when it does not — otherwise a
+  // `webhooks: false` collection (e.g. form submissions) would silently record
+  // PII-bearing events despite the opt-out.
+  publishWebhookRecordingPolicies(transformedConfig);
 
   // Belt-and-suspenders: also register every code-first collection and
   // single from the supplied config directly into the resolver. The
@@ -1078,6 +1089,39 @@ async function initializeSchemaRegistry(
 }
 
 /**
+ * Publish each code-first collection/single's webhook recording policy from the
+ * live config into the process-level registry. Runs unconditionally at boot
+ * (independent of the schema registry) so a `webhooks: false` opt-out is honored
+ * on every path — including the executeQuery fallback taken when the schema
+ * registry fails to initialize, where `registerConfigTablesInResolver` never
+ * runs.
+ */
+function publishWebhookRecordingPolicies(config: NextlyServiceConfig): void {
+  for (const collection of config.collections ?? []) {
+    const slug = (collection as { slug?: string }).slug;
+    if (!slug) continue;
+    setWebhookRecording(
+      "collection",
+      slug,
+      resolveWebhookRecording(
+        (collection as { webhooks?: boolean | { record?: boolean } }).webhooks
+      ).record
+    );
+  }
+  for (const single of config.singles ?? []) {
+    const slug = (single as { slug?: string }).slug;
+    if (!slug) continue;
+    setWebhookRecording(
+      "single",
+      slug,
+      resolveWebhookRecording(
+        (single as { webhooks?: boolean | { record?: boolean } }).webhooks
+      ).record
+    );
+  }
+}
+
+/**
  * Register every code-first collection and single from the config as a
  * runtime Drizzle schema in the resolver. Complements `loadDynamicTables`
  * which reads the same data from the `dynamic_*` DB registry; having both
@@ -1106,16 +1150,6 @@ async function registerConfigTablesInResolver(
       // which drops functions, so the write/read services resolve them
       // through the field-level registry instead.
       registerFieldFunctions("collection", slug, fields);
-      // Publish the collection's webhook recording policy from the live config
-      // so the outbox choke point can honor a `webhooks: false` opt-out (e.g.
-      // form submissions) without a persisted column.
-      setWebhookRecording(
-        "collection",
-        slug,
-        resolveWebhookRecording(
-          (collection as { webhooks?: boolean | { record?: boolean } }).webhooks
-        ).record
-      );
       const baseTableName = dbName ?? slug.replace(/-/g, "_");
       const tableName = baseTableName.startsWith("dc_")
         ? baseTableName
@@ -1179,14 +1213,6 @@ async function registerConfigTablesInResolver(
       if (!slug || !Array.isArray(fields) || fields.length === 0) continue;
       // Same live-config capture as the collections branch above.
       registerFieldFunctions("single", slug, fields);
-      // Mirror the collection branch: publish the single's recording policy.
-      setWebhookRecording(
-        "single",
-        slug,
-        resolveWebhookRecording(
-          (single as { webhooks?: boolean | { record?: boolean } }).webhooks
-        ).record
-      );
       const tableName = resolveSingleTableName({ slug, dbName });
       // Why: forward the code-first `status: true` flag for singles too —
       // mirrors the collection branch above. Same Draft/Published runtime
@@ -2307,6 +2333,11 @@ export async function shutdownServices(): Promise<void> {
     console.error("Error during service shutdown:", error);
   } finally {
     container.clear();
+    // The recording policy is a process-global registry, so it must be cleared
+    // with the container — otherwise a later instance where a slug is only
+    // DB/Builder-backed inherits a prior instance's stale opt-out and silently
+    // stops recording.
+    resetWebhookRecordingPolicy();
     globalForReg.__nextly_isRegistered = false;
   }
 }
@@ -2318,6 +2349,9 @@ export async function shutdownServices(): Promise<void> {
  */
 export function clearServices(): void {
   container.clear();
+  // Clear the process-global recording policy alongside the container so a
+  // re-initialization does not inherit a prior config's opt-outs.
+  resetWebhookRecordingPolicy();
   globalForReg.__nextly_isRegistered = false;
 }
 

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -1100,23 +1100,36 @@ function publishWebhookRecordingPolicies(config: NextlyServiceConfig): void {
   for (const collection of config.collections ?? []) {
     const slug = (collection as { slug?: string }).slug;
     if (!slug) continue;
+    // A plugin-contributed collection (form-builder submissions, etc.) is
+    // tagged `plugin` so a later code-first HMR reconcile never prunes its
+    // opt-out — plugins do not re-run on reload.
+    const source = (collection as { admin?: { isPlugin?: boolean } }).admin
+      ?.isPlugin
+      ? "plugin"
+      : "code";
     setWebhookRecording(
       "collection",
       slug,
       resolveWebhookRecording(
         (collection as { webhooks?: boolean | { record?: boolean } }).webhooks
-      ).record
+      ).record,
+      source
     );
   }
   for (const single of config.singles ?? []) {
     const slug = (single as { slug?: string }).slug;
     if (!slug) continue;
+    const source = (single as { admin?: { isPlugin?: boolean } }).admin
+      ?.isPlugin
+      ? "plugin"
+      : "code";
     setWebhookRecording(
       "single",
       slug,
       resolveWebhookRecording(
         (single as { webhooks?: boolean | { record?: boolean } }).webhooks
-      ).record
+      ).record,
+      source
     );
   }
 }

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -62,6 +62,7 @@ import {
   resetWebhookRecordingPolicy,
   setWebhookRecording,
 } from "../domains/webhooks/recording-policy";
+import { collectPluginContributedSlugs } from "../domains/webhooks/recording-provenance";
 import { resolveWebhookRecording } from "../domains/webhooks/resolve-recording-config";
 import type { ResolvedWebhookRetentionConfig } from "../domains/webhooks/retention-config";
 import type { WebhookDeliveryQueryService } from "../domains/webhooks/services/webhook-delivery-query-service";
@@ -1097,39 +1098,40 @@ async function initializeSchemaRegistry(
  * runs.
  */
 function publishWebhookRecordingPolicies(config: NextlyServiceConfig): void {
+  // Provenance comes from the plugin contribution list, not the optional
+  // `admin.isPlugin` flag: a plugin's opt-out must be tagged `plugin` (so a
+  // code-first reconcile never prunes it) even when the plugin never sets that
+  // presentation flag.
+  const pluginCollections = collectPluginContributedSlugs(
+    config.plugins,
+    "collections"
+  );
+  const pluginSingles = collectPluginContributedSlugs(
+    config.plugins,
+    "singles"
+  );
   for (const collection of config.collections ?? []) {
     const slug = (collection as { slug?: string }).slug;
     if (!slug) continue;
-    // A plugin-contributed collection (form-builder submissions, etc.) is
-    // tagged `plugin` so a later code-first HMR reconcile never prunes its
-    // opt-out — plugins do not re-run on reload.
-    const source = (collection as { admin?: { isPlugin?: boolean } }).admin
-      ?.isPlugin
-      ? "plugin"
-      : "code";
     setWebhookRecording(
       "collection",
       slug,
       resolveWebhookRecording(
         (collection as { webhooks?: boolean | { record?: boolean } }).webhooks
       ).record,
-      source
+      pluginCollections.has(slug) ? "plugin" : "code"
     );
   }
   for (const single of config.singles ?? []) {
     const slug = (single as { slug?: string }).slug;
     if (!slug) continue;
-    const source = (single as { admin?: { isPlugin?: boolean } }).admin
-      ?.isPlugin
-      ? "plugin"
-      : "code";
     setWebhookRecording(
       "single",
       slug,
       resolveWebhookRecording(
         (single as { webhooks?: boolean | { record?: boolean } }).webhooks
       ).record,
-      source
+      pluginSingles.has(slug) ? "plugin" : "code"
     );
   }
 }

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -58,6 +58,8 @@ import type {
 } from "../domains/singles/services/single-registry-service";
 import { resolveVersionsConfig } from "../domains/versions/resolve-config";
 import type { VersionsService } from "../domains/versions/versions-service";
+import { setWebhookRecording } from "../domains/webhooks/recording-policy";
+import { resolveWebhookRecording } from "../domains/webhooks/resolve-recording-config";
 import type { ResolvedWebhookRetentionConfig } from "../domains/webhooks/retention-config";
 import type { WebhookDeliveryQueryService } from "../domains/webhooks/services/webhook-delivery-query-service";
 import type { WebhookEndpointService } from "../domains/webhooks/services/webhook-endpoint-service";
@@ -1104,6 +1106,16 @@ async function registerConfigTablesInResolver(
       // which drops functions, so the write/read services resolve them
       // through the field-level registry instead.
       registerFieldFunctions("collection", slug, fields);
+      // Publish the collection's webhook recording policy from the live config
+      // so the outbox choke point can honor a `webhooks: false` opt-out (e.g.
+      // form submissions) without a persisted column.
+      setWebhookRecording(
+        "collection",
+        slug,
+        resolveWebhookRecording(
+          (collection as { webhooks?: boolean | { record?: boolean } }).webhooks
+        ).record
+      );
       const baseTableName = dbName ?? slug.replace(/-/g, "_");
       const tableName = baseTableName.startsWith("dc_")
         ? baseTableName
@@ -1167,6 +1179,14 @@ async function registerConfigTablesInResolver(
       if (!slug || !Array.isArray(fields) || fields.length === 0) continue;
       // Same live-config capture as the collections branch above.
       registerFieldFunctions("single", slug, fields);
+      // Mirror the collection branch: publish the single's recording policy.
+      setWebhookRecording(
+        "single",
+        slug,
+        resolveWebhookRecording(
+          (single as { webhooks?: boolean | { record?: boolean } }).webhooks
+        ).record
+      );
       const tableName = resolveSingleTableName({ slug, dbName });
       // Why: forward the code-first `status: true` flag for singles too —
       // mirrors the collection branch above. Same Draft/Published runtime

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -92,6 +92,13 @@ type PerItemOutcome<T> =
   | {
       kind: "success";
       record: T;
+      /**
+       * Whether this item appended an outbox event. A normal write records; an
+       * opted-out (`webhooks: false`) collection does not. Aggregated into the
+       * batch result's `eventRecorded` so the wrapper drains only when at least
+       * one item actually recorded.
+       */
+      eventRecorded?: boolean;
       /** The item's cache-revalidation intent, aggregated for the post-commit flush. */
       revalidationIntent?: RevalidationIntent;
     }
@@ -171,6 +178,9 @@ function partitionOutcomes<T>(
       if (value.kind === "success") {
         result.successes.push(value.record);
         result.successCount++;
+        // Aggregate the outbox signal: a normal item records, an opted-out one
+        // does not — the wrapper drains only when at least one item recorded.
+        if (value.eventRecorded) result.eventRecorded = true;
         collectIntent(value.revalidationIntent);
       } else {
         result.failures.push(value.failure);
@@ -392,6 +402,7 @@ export class CollectionBulkService extends BaseService {
               return {
                 kind: "success",
                 record: { id: entryId },
+                eventRecorded: deleteResult.eventRecorded,
                 revalidationIntent: deleteResult.revalidationIntent,
               };
             }
@@ -491,6 +502,7 @@ export class CollectionBulkService extends BaseService {
               return {
                 kind: "success",
                 record: updateResult.data as Record<string, unknown>,
+                eventRecorded: updateResult.eventRecorded,
                 revalidationIntent: updateResult.revalidationIntent,
               };
             }
@@ -1132,6 +1144,10 @@ export class CollectionBulkService extends BaseService {
         const rolledBackCount = result.successful;
         result.successful = 0;
         result.ids = [];
+        // The outbox events of the rolled-back items were rolled back too, so
+        // clear the aggregated flag — otherwise the wrapper would drain for
+        // events that never committed.
+        result.eventRecorded = false;
         // Add rollback info to first error
         if (result.errors.length > 0) {
           result.errors[0].error += ` (${rolledBackCount} successful entries were rolled back)`;
@@ -1519,6 +1535,10 @@ export class CollectionBulkService extends BaseService {
         const rolledBackCount = result.successful;
         result.successful = 0;
         result.ids = [];
+        // The outbox events of the rolled-back items were rolled back too, so
+        // clear the aggregated flag — otherwise the wrapper would drain for
+        // events that never committed.
+        result.eventRecorded = false;
         // Add rollback info to first error
         if (result.errors.length > 0) {
           result.errors[0].error += ` (${rolledBackCount} successful entries were rolled back)`;
@@ -1895,6 +1915,9 @@ export class CollectionBulkService extends BaseService {
       result.successful = 0;
       result.ids = [];
       result.failed = ids.length;
+      // The rolled-back deletes recorded no committed events, so clear the
+      // aggregated flag to keep the wrapper from draining uncommitted events.
+      result.eventRecorded = false;
       const batchError = error instanceof Error ? error.message : String(error);
       const rollbackNote = `Batch rolled back; no entries were deleted: ${batchError}`;
       // Rebuild errors as exactly one entry per requested id, in index order.

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -1132,7 +1132,12 @@ export class CollectionBulkService extends BaseService {
         result.revalidationIntents = collectedIntents;
       }
     } catch (error: unknown) {
-      // Transaction was rolled back (stopOnError case)
+      // Transaction was rolled back (stopOnError case). Any outbox events an
+      // item recorded before the abort were rolled back too, so clear the
+      // aggregated flag unconditionally — even when the first item recorded and
+      // aborted before ANY item was counted successful, so the wrapper never
+      // drains for events that never committed.
+      result.eventRecorded = false;
       // Reset successful count since transaction rolled back
       if (stopOnError && result.successful > 0) {
         this.logger.warn("Bulk create rolled back due to stopOnError", {
@@ -1144,10 +1149,6 @@ export class CollectionBulkService extends BaseService {
         const rolledBackCount = result.successful;
         result.successful = 0;
         result.ids = [];
-        // The outbox events of the rolled-back items were rolled back too, so
-        // clear the aggregated flag — otherwise the wrapper would drain for
-        // events that never committed.
-        result.eventRecorded = false;
         // Add rollback info to first error
         if (result.errors.length > 0) {
           result.errors[0].error += ` (${rolledBackCount} successful entries were rolled back)`;
@@ -1523,7 +1524,11 @@ export class CollectionBulkService extends BaseService {
         result.revalidationIntents = collectedIntents;
       }
     } catch (error: unknown) {
-      // Transaction was rolled back (stopOnError case)
+      // Transaction was rolled back (stopOnError case). Clear the aggregated
+      // outbox flag unconditionally — an item can record before the abort even
+      // when none is counted successful — so the wrapper never drains for events
+      // that never committed.
+      result.eventRecorded = false;
       // Reset successful count since transaction rolled back
       if (stopOnError && result.successful > 0) {
         this.logger.warn("Bulk update rolled back due to stopOnError", {
@@ -1535,10 +1540,6 @@ export class CollectionBulkService extends BaseService {
         const rolledBackCount = result.successful;
         result.successful = 0;
         result.ids = [];
-        // The outbox events of the rolled-back items were rolled back too, so
-        // clear the aggregated flag — otherwise the wrapper would drain for
-        // events that never committed.
-        result.eventRecorded = false;
         // Add rollback info to first error
         if (result.errors.length > 0) {
           result.errors[0].error += ` (${rolledBackCount} successful entries were rolled back)`;

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -1073,6 +1073,10 @@ export class CollectionBulkService extends BaseService {
               if (createResult.revalidationIntent) {
                 collectedIntents.push(createResult.revalidationIntent);
               }
+              // Aggregate the outbox signal so the wrapper drains only when at
+              // least one item actually recorded — a batch of only opted-out
+              // (`webhooks: false`) creates records nothing and owes no drain.
+              if (createResult.eventRecorded) result.eventRecorded = true;
               if (createResult.success && createResult.data) {
                 result.successful++;
                 result.ids.push(
@@ -1458,6 +1462,8 @@ export class CollectionBulkService extends BaseService {
               if (updateResult.revalidationIntent) {
                 collectedIntents.push(updateResult.revalidationIntent);
               }
+              // Aggregate the outbox signal (see the batch-create loop).
+              if (updateResult.eventRecorded) result.eventRecorded = true;
               if (updateResult.success && updateResult.data) {
                 result.successful++;
                 result.ids.push(
@@ -1658,6 +1664,8 @@ export class CollectionBulkService extends BaseService {
               updateResult.revalidationIntent
             );
           }
+          // Aggregate the outbox signal (see the batch-create loop).
+          if (updateResult.eventRecorded) result.eventRecorded = true;
           if (updateResult.success && updateResult.data) {
             result.successful++;
             result.ids.push(
@@ -1820,6 +1828,8 @@ export class CollectionBulkService extends BaseService {
                 collectedIntents.push(deleteResult.revalidationIntent);
               }
 
+              // Aggregate the outbox signal (see the batch-create loop).
+              if (deleteResult.eventRecorded) result.eventRecorded = true;
               if (deleteResult.success) {
                 result.successful++;
                 result.ids.push(entryId);
@@ -2027,6 +2037,8 @@ export class CollectionBulkService extends BaseService {
               deleteResult.revalidationIntent
             );
           }
+          // Aggregate the outbox signal (see the batch-create loop).
+          if (deleteResult.eventRecorded) result.eventRecorded = true;
           if (deleteResult.success) {
             result.successful++;
             result.ids.push(entryId);

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -94,6 +94,7 @@ import { VersionCaptureService } from "../../versions/version-capture-service";
 import { withVersionConflictRetry } from "../../versions/version-conflict";
 import { expandComponentFields } from "../../webhooks/expand-component-fields";
 import { recordMutationEvent } from "../../webhooks/record-mutation-event";
+import { isWebhookRecordingEnabled } from "../../webhooks/recording-policy";
 import type { SensitiveFieldSource } from "../../webhooks/sensitive-fields";
 
 import type { CollectionAccessService } from "./collection-access-service";
@@ -342,6 +343,23 @@ export class CollectionMutationService extends BaseService {
     return expandComponentFields(fields, async slug =>
       dataService ? await dataService.getComponentFields(slug, executor) : null
     );
+  }
+
+  /**
+   * {@link webhookFieldTree}, but SKIPPED when the collection opted out of
+   * recording. Component expansion issues a registry read per component slug, and
+   * `recordMutationEvent` short-circuits on the opt-out before it ever reads
+   * `fields` — so for a `webhooks: false` collection that work is pure waste, and
+   * a scalar write should never be able to fail on a component/relation read it
+   * does not need. Returns the raw fields unchanged in that case (they go unread).
+   */
+  private async webhookFieldTreeIfRecording(
+    collectionSlug: string,
+    fields: readonly SensitiveFieldSource[],
+    executor?: unknown
+  ): Promise<readonly SensitiveFieldSource[]> {
+    if (!isWebhookRecordingEnabled("collection", collectionSlug)) return fields;
+    return this.webhookFieldTree(fields, executor);
   }
 
   /**
@@ -1404,6 +1422,11 @@ export class CollectionMutationService extends BaseService {
     // committed-but-hook-failed write as `eventRecorded` even when `success` is
     // false. Declared out here so both the success and catch returns see it.
     let eventRecorded = false;
+    // Set once the insert transaction commits, independent of whether the write
+    // recorded an event or produced a revalidation intent — the durable-write
+    // signal the retention pass keys off, so a create that opts out of BOTH still
+    // triggers write-path cleanup.
+    let committedWrite = false;
     // Computed alongside the event so a committed-but-hook-failed write (which
     // returns from the catch) still flushes its revalidation, matching how
     // `eventRecorded` is carried.
@@ -1846,8 +1869,11 @@ export class CollectionMutationService extends BaseService {
       // definitions from the registry on the pooled connection, and doing that
       // inside the transaction would hold this write's connection while waiting
       // for a second one. It depends only on static field config, so nothing is
-      // gained by deferring it.
-      const webhookFields = await this.webhookFieldTree(fields);
+      // gained by deferring it. Skipped entirely when the collection opted out.
+      const webhookFields = await this.webhookFieldTreeIfRecording(
+        params.collectionName,
+        fields
+      );
 
       const entry: Record<string, unknown> = {};
       // Whether the outbox event was actually appended (false when the
@@ -2043,6 +2069,8 @@ export class CollectionMutationService extends BaseService {
       // there; from here a post-commit hook failure must not hide the delivery.
       // False when the collection opted out — nothing was recorded to drain.
       eventRecorded = recorded;
+      // The row is durable regardless of the opt-out flags above.
+      committedWrite = true;
 
       // The tags this create invalidates: derived from the collection, the new
       // id, and the new slug (plus the write locale), so a tagged read of the
@@ -2167,6 +2195,7 @@ export class CollectionMutationService extends BaseService {
         data: responseEntry,
         eventRecorded,
         revalidationIntent,
+        committed: committedWrite,
       };
     } catch (error: unknown) {
       // Legacy per-kind override messages ("Duplicate value: ...",
@@ -2183,6 +2212,7 @@ export class CollectionMutationService extends BaseService {
         ),
         eventRecorded,
         revalidationIntent,
+        committed: committedWrite,
       };
     }
   }
@@ -2920,6 +2950,10 @@ export class CollectionMutationService extends BaseService {
     // committed-but-hook-failed update as `eventRecorded` even when `success` is
     // false. Declared out here so both the success and catch returns see it.
     let eventRecorded = false;
+    // Set once the update transaction commits, independent of the recording and
+    // revalidation opt-outs — the durable-write signal the retention pass keys
+    // off, so an update that opts out of BOTH still triggers write-path cleanup.
+    let committedWrite = false;
     // The revalidation intent, and the pre-write slug it needs for old-path
     // busting. `previousSlug` is captured inside the transaction (where the
     // assembled previous document is in scope) and read out here so the intent,
@@ -3470,8 +3504,11 @@ export class CollectionMutationService extends BaseService {
       // Resolved BEFORE the transaction opens, for the reason given on the
       // create path: expansion reads the component registry on the pooled
       // connection. Hoisting it also keeps a conflict retry from re-running the
-      // same registry reads on every attempt.
-      const webhookFields = await this.webhookFieldTree(fields);
+      // same registry reads on every attempt. Skipped when the collection opted out.
+      const webhookFields = await this.webhookFieldTreeIfRecording(
+        params.collectionName,
+        fields
+      );
 
       // Retry the whole content+capture transaction on a version_no allocation
       // race (concurrent updates to the same doc); the re-run re-reads the max.
@@ -4018,6 +4055,11 @@ export class CollectionMutationService extends BaseService {
         }
       }
 
+      // Past the 404 guard the row exists and the transaction committed, so this
+      // is a durable write — flagged for the retention pass independent of the
+      // recording/revalidation opt-outs below.
+      committedWrite = true;
+
       // The tags this update invalidates: the id and current-slug tags, plus the
       // previous-slug tag when the slug changed (captured in the transaction), so
       // a read cached under the old URL clears. Built on the committed write, NOT
@@ -4190,6 +4232,7 @@ export class CollectionMutationService extends BaseService {
         // update commits without one), so a no-op does not kick the drain.
         eventRecorded,
         revalidationIntent,
+        committed: committedWrite,
       };
     } catch (error: unknown) {
       // A publish-transition refused against the row-locked status aborts the
@@ -4210,6 +4253,7 @@ export class CollectionMutationService extends BaseService {
         ),
         eventRecorded,
         revalidationIntent,
+        committed: committedWrite,
       };
     }
   }
@@ -4248,6 +4292,10 @@ export class CollectionMutationService extends BaseService {
     // committed-but-hook-failed delete as `eventRecorded` even when `success` is
     // false. Declared out here so both the success and catch returns see it.
     let eventRecorded = false;
+    // Set once the row is actually removed, independent of the recording and
+    // revalidation opt-outs — the durable-write signal the retention pass keys
+    // off, so a delete that opts out of BOTH still triggers write-path cleanup.
+    let committedWrite = false;
     // The tags this delete invalidates, computed post-commit and flushed with the
     // result. Hoisted so the catch return carries it too.
     let revalidationIntent: RevalidationIntent | undefined;
@@ -4362,8 +4410,12 @@ export class CollectionMutationService extends BaseService {
         collection.fields ||
         []) as FieldDefinition[];
       // Resolved before the transaction opens: the expansion reads the component
-      // registry on the pooled connection (see the create/update paths).
-      const webhookFields = await this.webhookFieldTree(snapshotFields);
+      // registry on the pooled connection (see the create/update paths). Skipped
+      // when the collection opted out.
+      const webhookFields = await this.webhookFieldTreeIfRecording(
+        params.collectionName,
+        snapshotFields
+      );
 
       // Delete the entry, cascade its component subtrees, and append the
       // `entry.deleted` event in one transaction, so the event commits with the
@@ -4472,6 +4524,9 @@ export class CollectionMutationService extends BaseService {
       // is false when the collection opted out, so an opted-out delete schedules
       // no drain.
       eventRecorded = deletedRow && recorded;
+      // The row is durable-gone exactly when it was removed, independent of the
+      // opt-out flags — the retention-pass signal.
+      committedWrite = deletedRow;
 
       // A concurrent delete removed the row first: report not-found rather than
       // a second success (and a duplicate event) for a deletion this call did
@@ -4542,6 +4597,7 @@ export class CollectionMutationService extends BaseService {
         data: { deleted: true },
         eventRecorded,
         revalidationIntent,
+        committed: committedWrite,
       };
     } catch (error: unknown) {
       return {
@@ -4552,6 +4608,7 @@ export class CollectionMutationService extends BaseService {
         data: null,
         eventRecorded,
         revalidationIntent,
+        committed: committedWrite,
       };
     }
   }
@@ -5702,7 +5759,11 @@ export class CollectionMutationService extends BaseService {
         },
         data: deletedDocument,
         previous: null,
-        fields: await this.webhookFieldTree(snapshotFields, tx.getDrizzle()),
+        fields: await this.webhookFieldTreeIfRecording(
+          params.collectionName,
+          snapshotFields,
+          tx.getDrizzle()
+        ),
         actor: actorForWrite(params.actor, params.user),
       });
       // The event is recorded, so the delete + event are now consistent; a later
@@ -7044,7 +7105,11 @@ export class CollectionMutationService extends BaseService {
         },
         data: deletedDocument,
         previous: null,
-        fields: await this.webhookFieldTree(snapshotFields, tx.getDrizzle()),
+        fields: await this.webhookFieldTreeIfRecording(
+          params.collectionName,
+          snapshotFields,
+          tx.getDrizzle()
+        ),
         actor: actorForWrite(params.actor, params.user),
       });
       // The event is recorded, so the delete + event are now consistent; a later

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4020,20 +4020,20 @@ export class CollectionMutationService extends BaseService {
 
       // The tags this update invalidates: the id and current-slug tags, plus the
       // previous-slug tag when the slug changed (captured in the transaction), so
-      // a read cached under the old URL clears. Only when the write recorded an
-      // event — a no-op update revalidates nothing.
-      if (eventRecorded) {
-        revalidationIntent = buildEntryRevalidationIntent(
-          params.collectionName,
-          readRevalidateConfig(collection),
-          {
-            id: params.entryId,
-            slug: readStringField(updated as Record<string, unknown>, "slug"),
-            previousSlug,
-            locale: localizedUpdate?.writeLocale,
-          }
-        );
-      }
+      // a read cached under the old URL clears. Built on the committed write, NOT
+      // the outbox-event flag: reaching here past the 404 guard means the row was
+      // written, so an opted-out (`webhooks: false`) update — which records no
+      // event — must still bust its tags, exactly as create and delete do.
+      revalidationIntent = buildEntryRevalidationIntent(
+        params.collectionName,
+        readRevalidateConfig(collection),
+        {
+          id: params.entryId,
+          slug: readStringField(updated as Record<string, unknown>, "slug"),
+          previousSlug,
+          locale: localizedUpdate?.writeLocale,
+        }
+      );
 
       // Execute afterUpdate hooks (code-registered)
       // Hooks run after database update completes (for side effects)

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1850,6 +1850,10 @@ export class CollectionMutationService extends BaseService {
       const webhookFields = await this.webhookFieldTree(fields);
 
       const entry: Record<string, unknown> = {};
+      // Whether the outbox event was actually appended (false when the
+      // collection opted out of recording), so the post-commit fast drain is
+      // scheduled only for a write that recorded something.
+      let recorded = false;
       await this.adapter.transaction(async tx => {
         const rawEntry = await tx.insert<unknown>(tableName, entryData, {
           returning: "*",
@@ -2017,7 +2021,7 @@ export class CollectionMutationService extends BaseService {
 
         // Append the outbox event in the same transaction, so it commits with
         // the entry and is never recorded for a write that later rolls back.
-        await recordMutationEvent(tx, {
+        recorded = await recordMutationEvent(tx, {
           type: "entry.created",
           resource: {
             kind: "entry",
@@ -2037,7 +2041,8 @@ export class CollectionMutationService extends BaseService {
       // Set only after the transaction resolves (this line is skipped if it
       // rejected), so a commit failure never flags a durable event that isn't
       // there; from here a post-commit hook failure must not hide the delivery.
-      eventRecorded = true;
+      // False when the collection opted out — nothing was recorded to drain.
+      eventRecorded = recorded;
 
       // The tags this create invalidates: derived from the collection, the new
       // id, and the new slug (plus the write locale), so a tagged read of the
@@ -3952,7 +3957,8 @@ export class CollectionMutationService extends BaseService {
 
               // Append the outbox event in the same transaction, so it commits
               // with the entry and is never recorded for a write that rolls back.
-              await recordMutationEvent(tx, {
+              // `recorded` is false when the collection opted out of recording.
+              recorded = await recordMutationEvent(tx, {
                 type: "entry.updated",
                 resource: {
                   kind: "entry",
@@ -3968,7 +3974,6 @@ export class CollectionMutationService extends BaseService {
                 fields: webhookFields,
                 actor: actorForWrite(params.actor, params.user),
               });
-              recorded = true;
               // Capture the pre-write slug inside the transaction so the
               // post-commit intent can bust the old slug tag after a rename.
               previousSlug = readStringField(previousDocument, "slug");
@@ -4387,6 +4392,9 @@ export class CollectionMutationService extends BaseService {
           params.collectionName,
           params.entryId
         );
+      // False when the collection opted out of recording, so the post-commit
+      // drain is not scheduled for a delete that recorded nothing.
+      let recorded = false;
       await this.adapter.transaction(async tx => {
         // Lock and re-read the committed row inside the transaction. `entry`
         // above was read before the hooks ran and outside this transaction, so a
@@ -4444,7 +4452,7 @@ export class CollectionMutationService extends BaseService {
         // post-delete state, so `previous` is null (mirroring create, which
         // carries only `data`). `locale` is set only for a localized collection,
         // so a receiver knows which translation the payload represents.
-        await recordMutationEvent(tx, {
+        recorded = await recordMutationEvent(tx, {
           type: "entry.deleted",
           resource: {
             kind: "entry",
@@ -4459,9 +4467,11 @@ export class CollectionMutationService extends BaseService {
         });
       });
       // Set only after the transaction resolves: `deletedRow` is true exactly
-      // when the delete + event committed, so a commit failure never flags a
-      // durable event that isn't there; a later hook failure must not hide it.
-      eventRecorded = deletedRow;
+      // when the delete committed, so a commit failure never flags a durable
+      // event that isn't there; a later hook failure must not hide it. `recorded`
+      // is false when the collection opted out, so an opted-out delete schedules
+      // no drain.
+      eventRecorded = deletedRow && recorded;
 
       // A concurrent delete removed the row first: report not-found rather than
       // a second success (and a duplicate event) for a deletion this call did
@@ -7024,7 +7034,7 @@ export class CollectionMutationService extends BaseService {
       // single-delete path. Resolve component schemas on this transaction's
       // connection to avoid taking a second pooled connection. `locale` is set
       // only for a localized collection.
-      await recordMutationEvent(tx, {
+      const deleteRecorded = await recordMutationEvent(tx, {
         type: "entry.deleted",
         resource: {
           kind: "entry",
@@ -7040,7 +7050,8 @@ export class CollectionMutationService extends BaseService {
       // The event is recorded, so the delete + event are now consistent; a later
       // failure no longer needs to force a rollback.
       deleteNeedsRollback = false;
-      eventRecorded = true;
+      // False when the collection opted out — nothing to drain post-commit.
+      eventRecorded = deleteRecorded;
 
       // The tags this delete invalidates, collected by the batch caller and
       // flushed once the shared transaction commits. Slug read from the assembled

--- a/packages/nextly/src/domains/collections/services/collection-types.ts
+++ b/packages/nextly/src/domains/collections/services/collection-types.ts
@@ -41,6 +41,16 @@ export interface CollectionServiceResult<T = unknown> {
    * when the write recorded nothing or revalidation is disabled for the target.
    */
   revalidationIntent?: RevalidationIntent;
+  /**
+   * Whether this operation committed a content write to the database — true for a
+   * create/update/delete that reached and committed its transaction (even one
+   * that opted out of BOTH recording and revalidation, and even one whose
+   * post-commit hook then threw), false for a rejected request (validation /
+   * access / not-found). The write-path retention pass keys off this so it runs
+   * for every durable write yet skips a request that changed nothing, without
+   * conflating `success` (a no-op reports success) with a committed write.
+   */
+  committed?: boolean;
 }
 
 /**

--- a/packages/nextly/src/domains/singles/services/single-entry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-entry-service.ts
@@ -140,14 +140,18 @@ export class SingleEntryService extends BaseService {
     options?: UpdateSingleOptions
   ): Promise<SingleResult> {
     const result = await this.mutationService.update(slug, data, options);
-    // A successful update always appends an outbox event (single.updated, plus a
-    // publish/unpublish transition), so kick the post-write side effects; a
-    // rejected write (access/404) recorded nothing and skips them. A write that
-    // committed its event but then failed a post-commit hook reports
-    // `success:false` with `eventRecorded:true`, so key off either — otherwise a
-    // committed event would miss its fast-drain and retention pass.
+    // Cache revalidation follows the CONTENT write, not the webhook event: a
+    // successful write (even one that opted out of recording) must still bust
+    // its ISR tags. A committed-but-post-hook-failed write reports
+    // `success:false` with `eventRecorded:true`, so key off either.
     if (result.success || result.eventRecorded === true) {
       await this.flushRevalidation(result);
+    }
+    // The fast drain + retention pass only matter when an outbox event was
+    // actually recorded. A successful but opted-out write (`webhooks: false`)
+    // records nothing, so scheduling them would only drain unrelated pending
+    // events — gate strictly on `eventRecorded`.
+    if (result.eventRecorded === true) {
       await this.afterWrite();
     }
     return result;

--- a/packages/nextly/src/domains/singles/services/single-entry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-entry-service.ts
@@ -145,8 +145,15 @@ export class SingleEntryService extends BaseService {
     // opted out of recording) must still bust its ISR tags, and — since the
     // write path is the only prune trigger for installs with no webhook drain —
     // must still offer a retention pass. A committed-but-post-hook-failed write
-    // reports `success:false` with `eventRecorded:true`, so key off either.
-    if (result.success || result.eventRecorded === true) {
+    // reports `success:false`; it sets `eventRecorded:true` when it recorded, but
+    // an OPTED-OUT such write records nothing yet still committed content — a
+    // populated `revalidationIntent` is the durable-write signal in that case, so
+    // key off all three or its ISR tag would be left stale.
+    if (
+      result.success ||
+      result.eventRecorded === true ||
+      result.revalidationIntent != null
+    ) {
       await this.flushRevalidation(result);
       await this.retentionRunner?.maybeRun(
         SingleEntryService.WRITE_PATH_PRUNE_BATCHES

--- a/packages/nextly/src/domains/singles/services/single-entry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-entry-service.ts
@@ -140,19 +140,24 @@ export class SingleEntryService extends BaseService {
     options?: UpdateSingleOptions
   ): Promise<SingleResult> {
     const result = await this.mutationService.update(slug, data, options);
-    // Cache revalidation follows the CONTENT write, not the webhook event: a
-    // successful write (even one that opted out of recording) must still bust
-    // its ISR tags. A committed-but-post-hook-failed write reports
-    // `success:false` with `eventRecorded:true`, so key off either.
+    // Cache revalidation AND the opportunistic retention pass both follow the
+    // CONTENT write, not the webhook event: a successful write (even one that
+    // opted out of recording) must still bust its ISR tags, and — since the
+    // write path is the only prune trigger for installs with no webhook drain —
+    // must still offer a retention pass. A committed-but-post-hook-failed write
+    // reports `success:false` with `eventRecorded:true`, so key off either.
     if (result.success || result.eventRecorded === true) {
       await this.flushRevalidation(result);
+      await this.retentionRunner?.maybeRun(
+        SingleEntryService.WRITE_PATH_PRUNE_BATCHES
+      );
     }
-    // The fast drain + retention pass only matter when an outbox event was
-    // actually recorded. A successful but opted-out write (`webhooks: false`)
-    // records nothing, so scheduling them would only drain unrelated pending
+    // The fast drain, by contrast, only matters when an outbox event was
+    // actually recorded. A successful opted-out write (`webhooks: false`)
+    // records nothing, so scheduling it would only drain unrelated pending
     // events — gate strictly on `eventRecorded`.
     if (result.eventRecorded === true) {
-      await this.afterWrite();
+      this.fastDrainScheduler?.offer();
     }
     return result;
   }
@@ -170,22 +175,6 @@ export class SingleEntryService extends BaseService {
     } catch (error) {
       this.logger.error("Cache revalidation failed after a write", { error });
     }
-  }
-
-  /**
-   * Post-write side effects run after a write that recorded an outbox event: the
-   * drain fast path goes first so the `after()` callback is scheduled promptly
-   * (it runs post-response, adding no latency), then a bounded retention pass.
-   * Both absorb their own failures, so this never turns a successful save into an
-   * error. `offer()` is synchronous — it only registers the post-response
-   * callback — so it is not awaited; retention is awaited because a detached
-   * promise may not survive a serverless response.
-   */
-  private async afterWrite(): Promise<void> {
-    this.fastDrainScheduler?.offer();
-    await this.retentionRunner?.maybeRun(
-      SingleEntryService.WRITE_PATH_PRUNE_BATCHES
-    );
   }
 
   /** Retention batches to attempt per write, matching the collection path. */

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -431,6 +431,11 @@ export class SingleMutationService extends BaseService {
     // return report a committed-but-post-hook-failed write as `eventRecorded`
     // even when `success` is false. Declared out here so every return sees it.
     let eventRecorded = false;
+    // Whether the outbox event was actually appended: false when the Single
+    // opted out of recording (`webhooks: false`), so the post-commit drain is
+    // scheduled only for a write that recorded something. The three single.*
+    // events share one resource, so the first call's result covers them all.
+    let recorded = false;
     // The tags this write invalidates (`nextly:single:{slug}`), computed after
     // the event is recorded and carried on every post-event return so a
     // committed-but-hook-failed write still flushes its revalidation.
@@ -1734,7 +1739,7 @@ export class SingleMutationService extends BaseService {
               id: existingDoc.id,
               ...(eventLocale != null ? { locale: eventLocale } : {}),
             };
-            await recordMutationEvent(tx, {
+            recorded = await recordMutationEvent(tx, {
               type: "single.updated",
               resource,
               data: dataDoc,
@@ -1783,9 +1788,10 @@ export class SingleMutationService extends BaseService {
 
       // The transaction committed (a throw would have propagated above), so a
       // real write is now durable together with its outbox event. Gate on the
-      // written row: the empty-rows path returns from the tx before recording
-      // anything, so it owes no delivery.
-      eventRecorded = updatedRows.length > 0;
+      // written row AND on whether recording actually happened: the empty-rows
+      // path returns from the tx before recording anything, and an opted-out
+      // Single records nothing — either way it owes no delivery.
+      eventRecorded = updatedRows.length > 0 && recorded;
       if (eventRecorded) {
         // A single is consumed sitewide, so its one tag is the whole cascade.
         revalidationIntent = buildSingleRevalidationIntent(

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -89,6 +89,7 @@ import { VersionCaptureService } from "../../versions/version-capture-service";
 import { withVersionConflictRetry } from "../../versions/version-conflict";
 import { expandComponentFields } from "../../webhooks/expand-component-fields";
 import { recordMutationEvent } from "../../webhooks/record-mutation-event";
+import { isWebhookRecordingEnabled } from "../../webhooks/recording-policy";
 import type { WebhookResource } from "../../webhooks/types";
 import type {
   SingleDocument,
@@ -1697,17 +1698,22 @@ export class SingleMutationService extends BaseService {
             // secret/hidden strip descends into fields declared inside a
             // component. Resolved on the transaction's connection (components
             // already read on it) to avoid taking a second pooled connection
-            // while this write still holds one.
-            const webhookFields = await expandComponentFields(
-              fieldConfigs,
-              async slug =>
-                this.componentDataService
-                  ? await this.componentDataService.getComponentFields(
-                      slug,
-                      tx.getDrizzle()
-                    )
-                  : null
-            );
+            // while this write still holds one. Skipped when the single opted out
+            // of recording: recordMutationEvent short-circuits before it reads
+            // `fields`, so the per-component registry reads would be pure waste and
+            // a scalar write should not be able to fail on them.
+            const webhookFields = isWebhookRecordingEnabled("single", slug)
+              ? await expandComponentFields(
+                  fieldConfigs,
+                  async componentSlug =>
+                    this.componentDataService
+                      ? await this.componentDataService.getComponentFields(
+                          componentSlug,
+                          tx.getDrizzle()
+                        )
+                      : null
+                )
+              : fieldConfigs;
 
             // A publish/unpublish is a status change, so only a write that
             // ASSIGNS a status can trigger one — the `writtenStatus` gate keeps

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -1787,12 +1787,16 @@ export class SingleMutationService extends BaseService {
       }
 
       // The transaction committed (a throw would have propagated above), so a
-      // real write is now durable together with its outbox event. Gate on the
-      // written row AND on whether recording actually happened: the empty-rows
-      // path returns from the tx before recording anything, and an opted-out
-      // Single records nothing — either way it owes no delivery.
-      eventRecorded = updatedRows.length > 0 && recorded;
-      if (eventRecorded) {
+      // real write is now durable. Cache revalidation follows the CONTENT write,
+      // so build its intent whenever a row was written — including an opted-out
+      // Single, whose committed content must still bust its ISR tag even though
+      // it records no outbox event.
+      const wroteRow = updatedRows.length > 0;
+      // `eventRecorded` additionally requires that recording actually happened:
+      // the empty-rows path returns before recording, and an opted-out Single
+      // records nothing — either way it owes no delivery/drain.
+      eventRecorded = wroteRow && recorded;
+      if (wroteRow) {
         // A single is consumed sitewide, so its one tag is the whole cascade.
         revalidationIntent = buildSingleRevalidationIntent(
           slug,

--- a/packages/nextly/src/domains/webhooks/__tests__/record-mutation-event.gate.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/record-mutation-event.gate.test.ts
@@ -27,17 +27,19 @@ const entryArgs = (collection: string) => ({
 });
 
 describe("recordMutationEvent recording gate", () => {
-  it("records an outbox event for a collection with no opt-out", async () => {
+  it("records an outbox event and returns true for a collection with no opt-out", async () => {
     const { tx, insert } = makeTx();
-    await recordMutationEvent(tx, entryArgs("posts"));
+    const recorded = await recordMutationEvent(tx, entryArgs("posts"));
     expect(insert).toHaveBeenCalledTimes(1);
+    expect(recorded).toBe(true);
   });
 
-  it("records nothing for a collection that opted out", async () => {
+  it("records nothing and returns false for a collection that opted out", async () => {
     setWebhookRecording("collection", "submissions", false);
     const { tx, insert } = makeTx();
-    await recordMutationEvent(tx, entryArgs("submissions"));
+    const recorded = await recordMutationEvent(tx, entryArgs("submissions"));
     expect(insert).not.toHaveBeenCalled();
+    expect(recorded).toBe(false);
   });
 
   it("records nothing for an opted-out single", async () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/record-mutation-event.gate.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/record-mutation-event.gate.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, it, expect, vi } from "vitest";
+
+import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
+
+import { recordMutationEvent } from "../record-mutation-event";
+import {
+  resetWebhookRecordingPolicy,
+  setWebhookRecording,
+} from "../recording-policy";
+
+afterEach(() => {
+  resetWebhookRecordingPolicy();
+});
+
+// A minimal tx: only `insert` is exercised (recordEvent appends one outbox row).
+function makeTx() {
+  const insert = vi.fn().mockResolvedValue(undefined);
+  return { tx: { insert } as unknown as TransactionContext, insert };
+}
+
+const entryArgs = (collection: string) => ({
+  type: "entry.created" as const,
+  resource: { kind: "entry" as const, collection, id: "e1" },
+  data: { title: "hi" },
+  previous: null,
+  fields: [],
+});
+
+describe("recordMutationEvent recording gate", () => {
+  it("records an outbox event for a collection with no opt-out", async () => {
+    const { tx, insert } = makeTx();
+    await recordMutationEvent(tx, entryArgs("posts"));
+    expect(insert).toHaveBeenCalledTimes(1);
+  });
+
+  it("records nothing for a collection that opted out", async () => {
+    setWebhookRecording("collection", "submissions", false);
+    const { tx, insert } = makeTx();
+    await recordMutationEvent(tx, entryArgs("submissions"));
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("records nothing for an opted-out single", async () => {
+    setWebhookRecording("single", "secret_settings", false);
+    const { tx, insert } = makeTx();
+    await recordMutationEvent(tx, {
+      type: "single.updated",
+      resource: { kind: "single", slug: "secret_settings", id: "s1" },
+      data: { title: "hi" },
+      previous: null,
+      fields: [],
+    });
+    expect(insert).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/recording-gate.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/recording-gate.integration.test.ts
@@ -61,18 +61,22 @@ describe("webhook recording opt-out (integration)", () => {
       { collectionName: "leads", overrideAccess: true },
       { title: "secret" }
     );
+    expect(lead.success).toBe(true);
     const leadId = (lead.data as { id: string }).id;
     // ...nor on update...
-    await handler.updateEntry(
+    const updated = await handler.updateEntry(
       { collectionName: "leads", entryId: leadId, overrideAccess: true },
       { title: "secret-2" }
     );
-    // ...nor on delete.
-    await handler.deleteEntry({
+    expect(updated.success).toBe(true);
+    // ...nor on delete. Asserting each write succeeded keeps the zero-event
+    // check below from passing vacuously on a write that failed pre-recording.
+    const deleted = await handler.deleteEntry({
       collectionName: "leads",
       entryId: leadId,
       overrideAccess: true,
     });
+    expect(deleted.success).toBe(true);
 
     const rows = await events(current);
     // Only the single `posts` create is in the outbox; no `leads` event at all.

--- a/packages/nextly/src/domains/webhooks/__tests__/recording-gate.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/recording-gate.integration.test.ts
@@ -63,12 +63,16 @@ describe("webhook recording opt-out (integration)", () => {
     );
     expect(lead.success).toBe(true);
     const leadId = (lead.data as { id: string }).id;
-    // ...nor on update...
+    // ...nor on update. The update still busts its cache tags, though: recording
+    // is decoupled from revalidation, so an opted-out write that commits content
+    // must still carry a revalidation intent (the tags derive from the write, not
+    // the outbox event) — otherwise ISR consumers would serve the stale value.
     const updated = await handler.updateEntry(
       { collectionName: "leads", entryId: leadId, overrideAccess: true },
       { title: "secret-2" }
     );
     expect(updated.success).toBe(true);
+    expect(updated.revalidationIntent).toBeDefined();
     // ...nor on delete. Asserting each write succeeded keeps the zero-event
     // check below from passing vacuously on a write that failed pre-recording.
     const deleted = await handler.deleteEntry({

--- a/packages/nextly/src/domains/webhooks/__tests__/recording-gate.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/recording-gate.integration.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The per-collection webhook recording opt-out, end to end.
+ *
+ * Proves the privacy contract at the real write path: a collection that sets
+ * `webhooks: false` records NO outbox event on create/update/delete, while a
+ * normal collection records one per write. The opt-out is what keeps PII-bearing
+ * content (form submissions carry ipAddress/userAgent) out of the delivery path.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+interface EventRow {
+  resourceType: string;
+  resourceId: string;
+}
+
+async function events(handle: TestNextly): Promise<EventRow[]> {
+  return handle.adapter.select<EventRow>("nextly_events");
+}
+
+describe("webhook recording opt-out (integration)", () => {
+  it("records no outbox event for a collection with webhooks:false, across create/update/delete", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "leads",
+          webhooks: false,
+          fields: [text({ name: "title" })],
+        }),
+        defineCollection({
+          slug: "posts",
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    // A normal collection records one event per write (baseline).
+    const post = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "hello" }
+    );
+    const postId = (post.data as { id: string }).id;
+
+    // The opted-out collection records nothing on create...
+    const lead = await handler.createEntry(
+      { collectionName: "leads", overrideAccess: true },
+      { title: "secret" }
+    );
+    const leadId = (lead.data as { id: string }).id;
+    // ...nor on update...
+    await handler.updateEntry(
+      { collectionName: "leads", entryId: leadId, overrideAccess: true },
+      { title: "secret-2" }
+    );
+    // ...nor on delete.
+    await handler.deleteEntry({
+      collectionName: "leads",
+      entryId: leadId,
+      overrideAccess: true,
+    });
+
+    const rows = await events(current);
+    // Only the single `posts` create is in the outbox; no `leads` event at all.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].resourceId).toBe(postId);
+    expect(rows.some(r => r.resourceId === leadId)).toBe(false);
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/recording-policy.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/recording-policy.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, it, expect } from "vitest";
 
 import {
   isWebhookRecordingEnabled,
+  pruneRemovedCodeFirstRecording,
   resetWebhookRecordingPolicy,
   setWebhookRecording,
+  webhookRecordingKey,
 } from "../recording-policy";
 
 // The recording policy is a process-level registry populated from code config
@@ -36,5 +38,24 @@ describe("webhook recording policy", () => {
     setWebhookRecording("collection", "submissions", false);
     resetWebhookRecordingPolicy();
     expect(isWebhookRecordingEnabled("collection", "submissions")).toBe(true);
+  });
+
+  it("prunes a removed code-first slug but preserves plugin and present slugs", () => {
+    setWebhookRecording("collection", "leads", false, "code"); // removed below
+    setWebhookRecording("collection", "posts", false, "code"); // still present
+    setWebhookRecording("collection", "form-submissions", false, "plugin");
+
+    // Reconcile against the config that no longer lists `leads`.
+    pruneRemovedCodeFirstRecording(
+      new Set([webhookRecordingKey("collection", "posts")])
+    );
+
+    // The removed code-first slug reverts to the default (record)...
+    expect(isWebhookRecordingEnabled("collection", "leads")).toBe(true);
+    // ...while a still-present code-first slug and the plugin slug keep opt-out.
+    expect(isWebhookRecordingEnabled("collection", "posts")).toBe(false);
+    expect(isWebhookRecordingEnabled("collection", "form-submissions")).toBe(
+      false
+    );
   });
 });

--- a/packages/nextly/src/domains/webhooks/__tests__/recording-policy.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/recording-policy.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, it, expect } from "vitest";
+
+import {
+  isWebhookRecordingEnabled,
+  resetWebhookRecordingPolicy,
+  setWebhookRecording,
+} from "../recording-policy";
+
+// The recording policy is a process-level registry populated from code config
+// at collection/single registration and read at the outbox choke point. It is a
+// module singleton (like the event bus / hook registry) so a fresh boot must
+// reset it — the tests do so between cases.
+afterEach(() => {
+  resetWebhookRecordingPolicy();
+});
+
+describe("webhook recording policy", () => {
+  it("records by default for a slug that was never registered", () => {
+    expect(isWebhookRecordingEnabled("collection", "posts")).toBe(true);
+    expect(isWebhookRecordingEnabled("single", "settings")).toBe(true);
+  });
+
+  it("honors an explicit opt-out and keeps scopes separate", () => {
+    setWebhookRecording("collection", "submissions", false);
+    expect(isWebhookRecordingEnabled("collection", "submissions")).toBe(false);
+    // A single that happens to share the slug is a different scope.
+    expect(isWebhookRecordingEnabled("single", "submissions")).toBe(true);
+  });
+
+  it("records when explicitly enabled", () => {
+    setWebhookRecording("collection", "posts", true);
+    expect(isWebhookRecordingEnabled("collection", "posts")).toBe(true);
+  });
+
+  it("clears all entries on reset", () => {
+    setWebhookRecording("collection", "submissions", false);
+    resetWebhookRecordingPolicy();
+    expect(isWebhookRecordingEnabled("collection", "submissions")).toBe(true);
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/recording-provenance.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/recording-provenance.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { collectPluginContributedSlugs } from "../recording-provenance";
+
+describe("collectPluginContributedSlugs", () => {
+  it("reads slugs from contributes.<kind>", () => {
+    const plugins = [
+      {
+        name: "forms",
+        contributes: { collections: [{ slug: "submissions" }] },
+      },
+      { name: "settings", contributes: { singles: [{ slug: "site-config" }] } },
+    ];
+    expect([...collectPluginContributedSlugs(plugins, "collections")]).toEqual([
+      "submissions",
+    ]);
+    expect([...collectPluginContributedSlugs(plugins, "singles")]).toEqual([
+      "site-config",
+    ]);
+  });
+
+  it("reads the legacy plugin.<kind> shape too", () => {
+    const plugins = [{ name: "legacy", collections: [{ slug: "leads" }] }];
+    expect(
+      collectPluginContributedSlugs(plugins, "collections").has("leads")
+    ).toBe(true);
+  });
+
+  it("does NOT depend on admin.isPlugin — a plugin that omits the flag is still detected", () => {
+    // The whole point: provenance comes from the contribution list, not the
+    // optional presentation flag, so a third-party plugin's opt-out is tagged
+    // `plugin` and survives a code-first reconcile.
+    const plugins = [
+      {
+        name: "third-party",
+        contributes: { collections: [{ slug: "audit-log" }] },
+      },
+    ];
+    expect(
+      collectPluginContributedSlugs(plugins, "collections").has("audit-log")
+    ).toBe(true);
+  });
+
+  it("ignores entries without a slug and tolerates missing plugins", () => {
+    const plugins = [
+      { name: "x", contributes: { collections: [{}, { slug: "" }] } },
+    ];
+    expect(collectPluginContributedSlugs(plugins, "collections").size).toBe(0);
+    expect(collectPluginContributedSlugs(undefined, "collections").size).toBe(
+      0
+    );
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/resolve-recording-config.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/resolve-recording-config.test.ts
@@ -23,4 +23,18 @@ describe("resolveWebhookRecording", () => {
       record: false,
     });
   });
+
+  it("tolerates malformed values from untyped JS configs without throwing", () => {
+    // `null` must not throw (as `null.record` would); a non-boolean `record`
+    // must not escape the boolean return. Both fall back to recording.
+    const asInput = (v: unknown) =>
+      v as boolean | { record?: boolean } | undefined;
+    expect(resolveWebhookRecording(asInput(null))).toEqual({ record: true });
+    expect(resolveWebhookRecording(asInput({ record: "false" }))).toEqual({
+      record: true,
+    });
+    expect(resolveWebhookRecording(asInput({ record: 0 }))).toEqual({
+      record: true,
+    });
+  });
 });

--- a/packages/nextly/src/domains/webhooks/__tests__/resolve-recording-config.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/resolve-recording-config.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+
+import { resolveWebhookRecording } from "../resolve-recording-config";
+
+// The `webhooks` collection/single option normalizes to a single resolved shape
+// so every consumer reads `{ record }` and never branches on the raw union. The
+// default is to RECORD: a collection that never sets the option keeps emitting
+// outbox events, exactly as it did before the option existed.
+describe("resolveWebhookRecording", () => {
+  it("defaults to recording when the option is absent", () => {
+    expect(resolveWebhookRecording(undefined)).toEqual({ record: true });
+  });
+
+  it("treats a boolean as the record flag directly", () => {
+    expect(resolveWebhookRecording(true)).toEqual({ record: true });
+    expect(resolveWebhookRecording(false)).toEqual({ record: false });
+  });
+
+  it("reads `record` from the object form, defaulting to true", () => {
+    expect(resolveWebhookRecording({})).toEqual({ record: true });
+    expect(resolveWebhookRecording({ record: true })).toEqual({ record: true });
+    expect(resolveWebhookRecording({ record: false })).toEqual({
+      record: false,
+    });
+  });
+});

--- a/packages/nextly/src/domains/webhooks/record-mutation-event.ts
+++ b/packages/nextly/src/domains/webhooks/record-mutation-event.ts
@@ -18,11 +18,28 @@ import type { RequestActor } from "../../auth/request-actor";
 
 import { buildEnvelope } from "./envelope";
 import { recordEvent } from "./record-event";
+import { isWebhookRecordingEnabled } from "./recording-policy";
 import {
   sensitiveFieldPaths,
   type SensitiveFieldSource,
 } from "./sensitive-fields";
 import type { WebhookEventType, WebhookResource } from "./types";
+
+/**
+ * Whether the changed resource opted out of webhook recording. Resolves the
+ * per-entity policy from the event `resource`: an entry is gated by its
+ * collection slug, a single by its own slug. Other kinds (media, user, ...)
+ * carry no per-entity opt-out and always record.
+ */
+function resourceRecordingEnabled(resource: WebhookResource): boolean {
+  if (resource.kind === "entry") {
+    return isWebhookRecordingEnabled("collection", resource.collection);
+  }
+  if (resource.kind === "single" && resource.slug !== undefined) {
+    return isWebhookRecordingEnabled("single", resource.slug);
+  }
+  return true;
+}
 
 /** Arguments for recording one mutation as a durable outbox event. */
 export interface RecordMutationEventArgs {
@@ -58,6 +75,14 @@ export async function recordMutationEvent(
   tx: TransactionContext,
   args: RecordMutationEventArgs
 ): Promise<void> {
+  // Collection/single opt-out: a resource whose entity set `webhooks: false`
+  // records nothing, so PII-bearing content (e.g. form submissions carrying
+  // ipAddress/userAgent) never enters the outbox or the delivery path. Enforced
+  // here at the single seam so every write path inherits it.
+  if (!resourceRecordingEnabled(args.resource)) {
+    return;
+  }
+
   const envelope = buildEnvelope({
     id: (args.newId ?? (() => crypto.randomUUID()))(),
     type: args.type,

--- a/packages/nextly/src/domains/webhooks/record-mutation-event.ts
+++ b/packages/nextly/src/domains/webhooks/record-mutation-event.ts
@@ -70,17 +70,21 @@ export interface RecordMutationEventArgs {
  *
  * The insert shares the caller's transaction, so the event commits with the
  * content change and is never recorded for a write that later rolls back.
+ *
+ * @returns `true` when an outbox event was appended; `false` when the resource
+ * opted out of recording. Callers gate their post-commit webhook work (fast
+ * drain, retention pass) on this, so an opted-out write schedules nothing.
  */
 export async function recordMutationEvent(
   tx: TransactionContext,
   args: RecordMutationEventArgs
-): Promise<void> {
+): Promise<boolean> {
   // Collection/single opt-out: a resource whose entity set `webhooks: false`
   // records nothing, so PII-bearing content (e.g. form submissions carrying
   // ipAddress/userAgent) never enters the outbox or the delivery path. Enforced
   // here at the single seam so every write path inherits it.
   if (!resourceRecordingEnabled(args.resource)) {
-    return;
+    return false;
   }
 
   const envelope = buildEnvelope({
@@ -96,4 +100,5 @@ export async function recordMutationEvent(
   });
 
   await recordEvent(tx, { envelope });
+  return true;
 }

--- a/packages/nextly/src/domains/webhooks/recording-policy.ts
+++ b/packages/nextly/src/domains/webhooks/recording-policy.ts
@@ -8,9 +8,8 @@
  * read back by slug at the choke point. Every write path therefore inherits the
  * gate without threading a flag through each call site.
  *
- * A module singleton like the event bus and hook registry: a fresh boot (and
- * each test) must `resetWebhookRecordingPolicy()` so one instance's opt-outs
- * never leak into the next.
+ * A fresh boot (and each test) must `resetWebhookRecordingPolicy()` so one
+ * instance's opt-outs never leak into the next.
  *
  * @module domains/webhooks/recording-policy
  */
@@ -18,20 +17,55 @@
 /** The entity kinds that can carry a per-entity recording opt-out. */
 export type WebhookRecordingScope = "collection" | "single";
 
+/**
+ * Who set a decision. `code` decisions come from the code-first config and are
+ * reconciled on every reload (a slug removed from config is pruned). `plugin`
+ * decisions come from a plugin's contributed config, which is NOT re-evaluated
+ * on HMR, so they must survive a code-first reconcile.
+ */
+export type WebhookRecordingSource = "code" | "plugin";
+
+interface PolicyEntry {
+  record: boolean;
+  source: WebhookRecordingSource;
+}
+
 // Keyed by `${scope}:${slug}`; absence means "record" (the default), so only
 // explicit opt-outs (and opt-ins) are stored.
-const policy = new Map<string, boolean>();
+//
+// Stored on `globalThis`, mirroring the event bus / hook registry: Next.js and
+// Turbopack can evaluate this module in more than one server module graph (and
+// HMR re-evaluates it), so a module-local Map risks `registerServices()`
+// populating one instance while `recordMutationEvent()` reads another — where a
+// missing entry defaults to recording and a `webhooks: false` collection would
+// silently write PII. A single global map keeps the decisions visible to every
+// reader.
+const globalForRecording = globalThis as unknown as {
+  __nextly_webhookRecordingPolicy?: Map<string, PolicyEntry>;
+};
+if (!globalForRecording.__nextly_webhookRecordingPolicy) {
+  globalForRecording.__nextly_webhookRecordingPolicy = new Map<
+    string,
+    PolicyEntry
+  >();
+}
+const policy = globalForRecording.__nextly_webhookRecordingPolicy;
 
 const keyFor = (scope: WebhookRecordingScope, slug: string): string =>
   `${scope}:${slug}`;
 
-/** Publish a collection/single's resolved recording decision. */
+/**
+ * Publish a collection/single's resolved recording decision. `source` defaults
+ * to `code`; pass `plugin` for a plugin-contributed entity so a later code-first
+ * reconcile does not prune it.
+ */
 export function setWebhookRecording(
   scope: WebhookRecordingScope,
   slug: string,
-  record: boolean
+  record: boolean,
+  source: WebhookRecordingSource = "code"
 ): void {
-  policy.set(keyFor(scope, slug), record);
+  policy.set(keyFor(scope, slug), { record, source });
 }
 
 /**
@@ -43,7 +77,30 @@ export function isWebhookRecordingEnabled(
   scope: WebhookRecordingScope,
   slug: string
 ): boolean {
-  return policy.get(keyFor(scope, slug)) ?? true;
+  return policy.get(keyFor(scope, slug))?.record ?? true;
+}
+
+/**
+ * Drop every `code`-sourced decision whose `${scope}:${slug}` key is not in
+ * `presentKeys`. Used on reload to clear a code-first entity removed from the
+ * config: its DB table can survive (the reload merges registered tables back),
+ * so a stale opt-out would otherwise suppress its events until restart. `plugin`
+ * decisions are never pruned here.
+ */
+export function pruneRemovedCodeFirstRecording(presentKeys: Set<string>): void {
+  for (const [key, entry] of policy) {
+    if (entry.source === "code" && !presentKeys.has(key)) {
+      policy.delete(key);
+    }
+  }
+}
+
+/** The `${scope}:${slug}` key for a decision, for building a present-key set. */
+export function webhookRecordingKey(
+  scope: WebhookRecordingScope,
+  slug: string
+): string {
+  return keyFor(scope, slug);
 }
 
 /** Clear every registered decision (boot/test reset). */

--- a/packages/nextly/src/domains/webhooks/recording-policy.ts
+++ b/packages/nextly/src/domains/webhooks/recording-policy.ts
@@ -1,0 +1,52 @@
+/**
+ * Webhook domain — process-level recording policy.
+ *
+ * A collection/single can opt OUT of webhook recording (`webhooks: false`).
+ * Because the outbox choke point (`recordMutationEvent`) is a pure function with
+ * only the event `resource` in hand — not the entity's config — the resolved
+ * policy is published to this process-level registry at registration time and
+ * read back by slug at the choke point. Every write path therefore inherits the
+ * gate without threading a flag through each call site.
+ *
+ * A module singleton like the event bus and hook registry: a fresh boot (and
+ * each test) must `resetWebhookRecordingPolicy()` so one instance's opt-outs
+ * never leak into the next.
+ *
+ * @module domains/webhooks/recording-policy
+ */
+
+/** The entity kinds that can carry a per-entity recording opt-out. */
+export type WebhookRecordingScope = "collection" | "single";
+
+// Keyed by `${scope}:${slug}`; absence means "record" (the default), so only
+// explicit opt-outs (and opt-ins) are stored.
+const policy = new Map<string, boolean>();
+
+const keyFor = (scope: WebhookRecordingScope, slug: string): string =>
+  `${scope}:${slug}`;
+
+/** Publish a collection/single's resolved recording decision. */
+export function setWebhookRecording(
+  scope: WebhookRecordingScope,
+  slug: string,
+  record: boolean
+): void {
+  policy.set(keyFor(scope, slug), record);
+}
+
+/**
+ * Whether writes to this collection/single are recorded to the outbox. Defaults
+ * to true for any slug never registered, so normal collections and un-scoped
+ * resources (media, etc.) always record.
+ */
+export function isWebhookRecordingEnabled(
+  scope: WebhookRecordingScope,
+  slug: string
+): boolean {
+  return policy.get(keyFor(scope, slug)) ?? true;
+}
+
+/** Clear every registered decision (boot/test reset). */
+export function resetWebhookRecordingPolicy(): void {
+  policy.clear();
+}

--- a/packages/nextly/src/domains/webhooks/recording-provenance.ts
+++ b/packages/nextly/src/domains/webhooks/recording-provenance.ts
@@ -1,0 +1,53 @@
+/**
+ * Webhook domain — recording provenance from plugin contributions.
+ *
+ * The recording policy tags each decision `code` or `plugin` so a code-first
+ * HMR reconcile prunes only code-first slugs and never a plugin's opt-out
+ * (plugins do not re-run on reload). Provenance is derived HERE from the actual
+ * plugin contribution list — collections/singles a plugin declares via
+ * `contributes.{collections,singles}` or the legacy `plugin.{collections,
+ * singles}` — NOT from the optional `admin.isPlugin` presentation flag. A
+ * third-party plugin that declares `webhooks: false` without ever setting that
+ * flag would otherwise be tagged `code` and have its opt-out pruned, silently
+ * resuming recording of its (often PII-bearing) content.
+ *
+ * @module domains/webhooks/recording-provenance
+ */
+
+/** Entity kinds that can be contributed by a plugin and carry a recording opt-out. */
+type PluginEntityKind = "collections" | "singles";
+
+interface SluggedEntity {
+  slug?: string;
+}
+
+interface PluginLike {
+  collections?: readonly SluggedEntity[];
+  singles?: readonly SluggedEntity[];
+  contributes?: {
+    collections?: readonly SluggedEntity[];
+    singles?: readonly SluggedEntity[];
+  };
+}
+
+/**
+ * The set of slugs of `kind` contributed by any plugin in `plugins`, reading
+ * both the declarative `contributes.<kind>` and the legacy `plugin.<kind>`
+ * (mirrors how the admin-meta fold reads them). Used to tag recording
+ * provenance so a plugin's opt-out is never pruned by a code-first reconcile.
+ */
+export function collectPluginContributedSlugs(
+  plugins: readonly unknown[] | undefined,
+  kind: PluginEntityKind
+): Set<string> {
+  const slugs = new Set<string>();
+  for (const raw of plugins ?? []) {
+    const plugin = raw as PluginLike;
+    const declared = plugin.contributes?.[kind] ?? [];
+    const legacy = plugin[kind] ?? [];
+    for (const entity of [...declared, ...legacy]) {
+      if (entity?.slug) slugs.add(entity.slug);
+    }
+  }
+  return slugs;
+}

--- a/packages/nextly/src/domains/webhooks/resolve-recording-config.ts
+++ b/packages/nextly/src/domains/webhooks/resolve-recording-config.ts
@@ -26,7 +26,19 @@ export interface ResolvedWebhookRecording {
 export function resolveWebhookRecording(
   webhooks: boolean | { record?: boolean } | undefined
 ): ResolvedWebhookRecording {
-  if (webhooks === undefined) return { record: true };
-  if (typeof webhooks === "boolean") return { record: webhooks };
-  return { record: webhooks.record ?? true };
+  // Only an explicit boolean `false`, or an object whose `record` is exactly
+  // `false`, opts out. Every other value falls back to recording — the safe
+  // default. This tolerates untyped JS configs: a malformed `null` never throws
+  // (as `null.record` would), and a non-boolean `record` (e.g. the string
+  // "false") is ignored rather than escaping the boolean return as a truthy
+  // value. The result is always a real boolean.
+  if (webhooks === false) return { record: false };
+  if (
+    typeof webhooks === "object" &&
+    webhooks !== null &&
+    webhooks.record === false
+  ) {
+    return { record: false };
+  }
+  return { record: true };
 }

--- a/packages/nextly/src/domains/webhooks/resolve-recording-config.ts
+++ b/packages/nextly/src/domains/webhooks/resolve-recording-config.ts
@@ -1,0 +1,32 @@
+/**
+ * Webhook domain — recording-policy normalizer.
+ *
+ * Normalizes a collection/single's `webhooks` option into one resolved shape so
+ * every consumer reads `{ record }` and never branches on the raw
+ * `boolean | { record?: boolean }` union. Mirrors
+ * `domains/versions/resolve-config.ts`: the raw option is author-facing sugar;
+ * the resolved shape is what the runtime reads.
+ *
+ * @module domains/webhooks/resolve-recording-config
+ */
+
+/** The resolved webhook recording policy for one collection/single. */
+export interface ResolvedWebhookRecording {
+  /** Whether writes to this entity are recorded to the webhook outbox. */
+  record: boolean;
+}
+
+/**
+ * Resolve the `webhooks` option to its canonical shape. The default is to
+ * RECORD: an entity that never sets the option keeps emitting outbox events, so
+ * this is a purely additive opt-out. `false` (or `{ record: false }`) suppresses
+ * all outbox recording for the entity — used to keep PII-bearing content (e.g.
+ * form submissions) out of the delivery path.
+ */
+export function resolveWebhookRecording(
+  webhooks: boolean | { record?: boolean } | undefined
+): ResolvedWebhookRecording {
+  if (webhooks === undefined) return { record: true };
+  if (typeof webhooks === "boolean") return { record: webhooks };
+  return { record: webhooks.record ?? true };
+}

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -1077,5 +1077,45 @@ describe("reloadNextlyConfig", () => {
       expect(isWebhookRecordingEnabled("collection", "posts")).toBe(false);
       resetWebhookRecordingPolicy();
     });
+
+    it("keeps a plugin-contributed opt-out through a code-first reconcile, without admin.isPlugin", async () => {
+      const { isWebhookRecordingEnabled, resetWebhookRecordingPolicy } =
+        await import("../../domains/webhooks/recording-policy");
+      resetWebhookRecordingPolicy();
+      // A plugin contributes an opted-out collection via `contributes.collections`
+      // and does NOT set the optional `admin.isPlugin` presentation flag. The
+      // folded reload config lists it (loadConfig folds contributions) AND the
+      // plugin list, so provenance is derived from the contribution — not the
+      // flag — and the prune must never touch it.
+      loadConfigSpy.mockResolvedValue({
+        config: {
+          plugins: [
+            {
+              name: "audit",
+              contributes: { collections: [{ slug: "audit-log" }] },
+            },
+          ],
+          collections: [
+            { slug: "posts", tableName: "dc_posts" },
+            { slug: "audit-log", tableName: "dc_audit_log", webhooks: false },
+          ],
+        },
+      });
+      introspectSpy.mockResolvedValue(
+        buildSnapshot([
+          { name: "dc_posts", columns: SQLITE_RESERVED },
+          { name: "dc_audit_log", columns: SQLITE_RESERVED },
+        ])
+      );
+
+      const { reloadNextlyConfig } = await import("../reload-config");
+      await reloadNextlyConfig({ resolver: buildResolver() });
+
+      // The plugin's opt-out is honored and survives the reconcile...
+      expect(isWebhookRecordingEnabled("collection", "audit-log")).toBe(false);
+      // ...while the plain code collection records by default.
+      expect(isWebhookRecordingEnabled("collection", "posts")).toBe(true);
+      resetWebhookRecordingPolicy();
+    });
   });
 });

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -998,4 +998,37 @@ describe("reloadNextlyConfig", () => {
       expect(pipelineApplySpy).not.toHaveBeenCalled();
     });
   });
+
+  describe("webhook recording policy reconciliation", () => {
+    it("prunes a removed code-first opt-out when the config empties out", async () => {
+      const {
+        setWebhookRecording,
+        isWebhookRecordingEnabled,
+        resetWebhookRecordingPolicy,
+      } = await import("../../domains/webhooks/recording-policy");
+      resetWebhookRecordingPolicy();
+      // A code-first Single/collection previously opted OUT of recording. It is
+      // then deleted from the config, so this reload sees zero managed targets
+      // and takes the empty-target early return.
+      setWebhookRecording("collection", "leads", false, "code");
+      setWebhookRecording("single", "settings", false, "code");
+      // A plugin opt-out must survive the code-first reconcile untouched.
+      setWebhookRecording("collection", "form-submissions", false, "plugin");
+      loadConfigSpy.mockResolvedValue({
+        config: { collections: [], singles: [], components: [] },
+      });
+
+      const { reloadNextlyConfig } = await import("../reload-config");
+      await reloadNextlyConfig({ resolver: buildResolver() });
+
+      // The removed code-first entities revert to the default (record)...
+      expect(isWebhookRecordingEnabled("collection", "leads")).toBe(true);
+      expect(isWebhookRecordingEnabled("single", "settings")).toBe(true);
+      // ...while the plugin opt-out is preserved.
+      expect(isWebhookRecordingEnabled("collection", "form-submissions")).toBe(
+        false
+      );
+      resetWebhookRecordingPolicy();
+    });
+  });
 });

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -109,6 +109,8 @@ describe("reloadNextlyConfig", () => {
       fields?: unknown[];
       source?: string;
     }>;
+    /** Force the metadata-only collection sync to reject, so its scope is unsynced. */
+    failCollectionMetaSync?: boolean;
   }) {
     const withAdapter = opts?.withAdapter ?? true;
     const syncCodeFirstComponentsSpy = vi.fn().mockResolvedValue({});
@@ -129,7 +131,9 @@ describe("reloadNextlyConfig", () => {
           }
         : undefined,
       collectionRegistryService: {
-        syncCodeFirstCollections: vi.fn().mockResolvedValue({}),
+        syncCodeFirstCollections: opts?.failCollectionMetaSync
+          ? vi.fn().mockRejectedValue(new Error("meta sync failed"))
+          : vi.fn().mockResolvedValue({}),
         // Mirrors CollectionRegistryService.getAllCollections — the DB-backed
         // list of every registered collection (code + UI). Defaults to empty.
         getAllCollections: vi
@@ -1028,6 +1032,49 @@ describe("reloadNextlyConfig", () => {
       expect(isWebhookRecordingEnabled("collection", "form-submissions")).toBe(
         false
       );
+      resetWebhookRecordingPolicy();
+    });
+
+    it("applies a new opt-out even when the metadata sync fails, but gates opt-ins", async () => {
+      const {
+        setWebhookRecording,
+        isWebhookRecordingEnabled,
+        resetWebhookRecordingPolicy,
+      } = await import("../../domains/webhooks/recording-policy");
+      resetWebhookRecordingPolicy();
+      // `posts` carries a stale opt-out from a previous decision; the reload now
+      // wants it to record again (an opt-IN). `leads` is newly set to
+      // `webhooks: false` (an opt-OUT). Both diffs are zero-op, so the reload
+      // takes the metadata-only path — where the collection sync then FAILS,
+      // leaving that scope unsynced.
+      setWebhookRecording("collection", "posts", false, "code");
+      loadConfigSpy.mockResolvedValue({
+        config: {
+          collections: [
+            { slug: "posts", tableName: "dc_posts" },
+            { slug: "leads", tableName: "dc_leads", webhooks: false },
+          ],
+        },
+      });
+      introspectSpy.mockResolvedValue(
+        buildSnapshot([
+          { name: "dc_posts", columns: SQLITE_RESERVED },
+          { name: "dc_leads", columns: SQLITE_RESERVED },
+        ])
+      );
+
+      const { reloadNextlyConfig } = await import("../reload-config");
+      await reloadNextlyConfig({
+        resolver: buildResolver({ failCollectionMetaSync: true }),
+      });
+
+      // The opt-OUT applies despite the failed sync — recording off builds no
+      // payload, so the stale field tree is irrelevant, and holding it back would
+      // keep leaking the newly private collection's events.
+      expect(isWebhookRecordingEnabled("collection", "leads")).toBe(false);
+      // The opt-IN is gated: `posts` keeps its stale opt-out until a clean sync,
+      // so payload expansion never runs against a field tree that failed to sync.
+      expect(isWebhookRecordingEnabled("collection", "posts")).toBe(false);
       resetWebhookRecordingPolicy();
     });
   });

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -64,6 +64,7 @@ import {
   setWebhookRecording,
   type WebhookRecordingScope,
 } from "../domains/webhooks/recording-policy";
+import { collectPluginContributedSlugs } from "../domains/webhooks/recording-provenance";
 import { resolveWebhookRecording } from "../domains/webhooks/resolve-recording-config";
 import type { RevalidateConfig } from "../revalidation/types";
 import { getProductionNotifier } from "../runtime/notifications/index";
@@ -387,18 +388,21 @@ function publishScopeRecording(
   entities: Array<{
     slug?: string;
     webhooks?: CollectionDef["webhooks"];
-    admin?: unknown;
   }>,
+  pluginSlugs: Set<string>,
   synced: boolean
 ): void {
-  const sourceOf = (admin: unknown): "code" | "plugin" =>
-    (admin as { isPlugin?: boolean } | undefined)?.isPlugin ? "plugin" : "code";
+  // Provenance comes from the plugin contribution list, not `admin.isPlugin`:
+  // a plugin's opt-out must be tagged `plugin` so the prune below never removes
+  // it, even when the plugin never sets that presentation flag.
+  const sourceOf = (slug: string): "code" | "plugin" =>
+    pluginSlugs.has(slug) ? "plugin" : "code";
 
   // Opt-outs first, always: safe regardless of sync state (recording is off).
   for (const e of entities) {
     if (!e.slug) continue;
     if (resolveWebhookRecording(e.webhooks).record === false) {
-      setWebhookRecording(scope, e.slug, false, sourceOf(e.admin));
+      setWebhookRecording(scope, e.slug, false, sourceOf(e.slug));
     }
   }
 
@@ -412,7 +416,7 @@ function publishScopeRecording(
   for (const e of entities) {
     if (!e.slug) continue;
     if (resolveWebhookRecording(e.webhooks).record === true) {
-      setWebhookRecording(scope, e.slug, true, sourceOf(e.admin));
+      setWebhookRecording(scope, e.slug, true, sourceOf(e.slug));
     }
   }
 }
@@ -430,15 +434,33 @@ function publishScopeRecording(
  * {@link publishScopeRecording}).
  */
 function republishRecordingPolicies(
-  newConfig: { collections?: CollectionDef[]; singles?: SingleDef[] },
+  newConfig: {
+    collections?: CollectionDef[];
+    singles?: SingleDef[];
+    plugins?: unknown[];
+  },
   scopes: { collections: boolean; singles: boolean }
 ): void {
+  const pluginCollections = collectPluginContributedSlugs(
+    newConfig.plugins,
+    "collections"
+  );
+  const pluginSingles = collectPluginContributedSlugs(
+    newConfig.plugins,
+    "singles"
+  );
   publishScopeRecording(
     "collection",
     newConfig.collections ?? [],
+    pluginCollections,
     scopes.collections
   );
-  publishScopeRecording("single", newConfig.singles ?? [], scopes.singles);
+  publishScopeRecording(
+    "single",
+    newConfig.singles ?? [],
+    pluginSingles,
+    scopes.singles
+  );
 }
 
 // Reload entry point. resolver is optional and exists primarily for tests.
@@ -1296,6 +1318,19 @@ export async function reloadNextlyConfig(opts?: {
 
   if (!applyResult.success) {
     const code = applyResult.error.code;
+
+    // The DDL apply failed (needs-TTY confirmation, an executor error, ...), so
+    // the field-tree syncs and the recording republish under `if (success)` were
+    // skipped. Existing tables and services stay writable, though, so a recording
+    // OPT-OUT loaded this cycle must still take effect — recording off builds no
+    // payload, so the un-synced field tree is irrelevant, and leaving the old
+    // record-enabled decision active would keep leaking the newly private
+    // entity's events. Reconcile with both scopes unsynced: opt-outs apply now,
+    // opt-ins stay gated on a later clean apply (mirrors the deferred path above).
+    republishRecordingPolicies(newConfig, {
+      collections: false,
+      singles: false,
+    });
 
     if (code === "CONFIRMATION_REQUIRED_NO_TTY") {
       // Boot-time + HMR runs in a request-handler context where the

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -59,6 +59,8 @@ import { resolveCollectionTableName } from "../domains/schema/utils/resolve-tabl
 // Resolve the versioning config on the HMR sync path so a `versions` change
 // while `next dev` is running persists without a restart (parity with di/register).
 import { resolveVersionsConfig } from "../domains/versions/resolve-config";
+import { setWebhookRecording } from "../domains/webhooks/recording-policy";
+import { resolveWebhookRecording } from "../domains/webhooks/resolve-recording-config";
 import { getProductionNotifier } from "../runtime/notifications/index";
 import type { VersionsConfig } from "../schemas/versions/types";
 import { ComponentSchemaService } from "../services/components/component-schema-service";
@@ -101,6 +103,8 @@ type CollectionDef = {
   localized?: boolean;
   /** Content-versioning option; persisted (resolved) to dynamic_collections.versions. */
   versions?: boolean | VersionsConfig;
+  /** Webhook recording opt-out; resolved into the process-level recording policy. */
+  webhooks?: boolean | { record?: boolean };
 };
 
 type SingleDef = {
@@ -115,6 +119,8 @@ type SingleDef = {
   localized?: boolean;
   /** Content-versioning option; persisted (resolved) to dynamic_singles.versions. */
   versions?: boolean | VersionsConfig;
+  /** Webhook recording opt-out; resolved into the process-level recording policy. */
+  webhooks?: boolean | { record?: boolean };
 };
 
 type ComponentDef = {
@@ -393,6 +399,27 @@ export async function reloadNextlyConfig(opts?: {
   // would crash at runtime).
   const dialect = adapter.dialect;
   const db = adapter.getDrizzle();
+
+  // Keep the webhook recording policy in sync with the reloaded config so a
+  // hot-swapped `webhooks` opt-out/opt-in takes effect without a restart. Runs
+  // before the sync branches below, so BOTH the DDL-diff and the metadata-only
+  // paths honor the change (the boot-time decision would otherwise persist).
+  for (const c of newConfig.collections ?? []) {
+    if (!c.slug) continue;
+    setWebhookRecording(
+      "collection",
+      c.slug,
+      resolveWebhookRecording(c.webhooks).record
+    );
+  }
+  for (const s of newConfig.singles ?? []) {
+    if (!s.slug) continue;
+    setWebhookRecording(
+      "single",
+      s.slug,
+      resolveWebhookRecording(s.webhooks).record
+    );
+  }
 
   // Normalize collections to (slug, tableName, fields, status) tuples. Drop
   // entries without a slug — they can't be addressed. `status` propagates so

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -605,8 +605,18 @@ export async function reloadNextlyConfig(opts?: {
     targets.length === 0 &&
     singleTargets.length === 0 &&
     componentTargets.length === 0
-  )
+  ) {
+    // Nothing managed remains, but a reload that removed the LAST code-first
+    // collection/single still has to reconcile the recording policy before
+    // bailing: the removed entity's DB table can stay writable, so a lingering
+    // `webhooks: false` opt-out would silently suppress its events until
+    // restart. Prune both code-first namespaces against the now-empty config
+    // (present sets are empty, so every code-sourced opt-out is dropped;
+    // plugin decisions are preserved). No metadata to sync here, so this is the
+    // only reconciliation the empty-target path needs.
+    republishRecordingPolicies(newConfig, { collections: true, singles: true });
     return;
+  }
 
   // Extracted once so the same list is passed to introspectLiveSnapshot
   // AND registered in the live-snapshot cache for the pipeline to reuse.

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -912,10 +912,12 @@ export async function reloadNextlyConfig(opts?: {
   });
 
   if (applyResult.success) {
-    // The schema change committed, so publish the (possibly toggled) recording
-    // policy now — this covers a combined `webhooks` + schema-field change,
-    // which takes the DDL path rather than the metadata-only path above.
-    republishRecordingPolicies(newConfig);
+    // Publish the (possibly toggled) recording policy only AFTER the metadata
+    // syncs below succeed (see the assignment after them): the DDL applied, but
+    // if the field-tree sync then fails, activating the new decision while the
+    // mutation services still read stale fields would record/suppress events
+    // against the wrong stripping config.
+    let metadataSynced = true;
     // Sync dynamic_collections metadata so the fields JSON reflects the
     // new config. The pipeline above only applies DDL to dc_<slug>; without
     // this call, admin-UI queries still read the old field list until the
@@ -946,6 +948,7 @@ export async function reloadNextlyConfig(opts?: {
     } catch {
       // Non-fatal: DDL was applied; metadata sync failed. The next boot
       // or HMR cycle will retry via registerServices.
+      metadataSynced = false;
     }
 
     // Mirror the same metadata sync for singles — keeps dynamic_singles.fields
@@ -977,7 +980,13 @@ export async function reloadNextlyConfig(opts?: {
       }
     } catch {
       // Non-fatal: same reasoning as collection metadata sync above.
+      metadataSynced = false;
     }
+
+    // The DDL and the field-tree metadata are now both in step (or the sync
+    // failed and will retry), so it is safe to activate the recording policy —
+    // never before, so a stale field tree can't pair with the new decision.
+    if (metadataSynced) republishRecordingPolicies(newConfig);
 
     // Sync dynamic_components metadata — keeps dynamic_components.fields
     // in step with the DDL changes the pipeline just applied.

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -292,6 +292,37 @@ async function syncCodeFirstMetadataOnly(
   }
 }
 
+/**
+ * Republish the webhook recording policy from the reloaded config, so a live
+ * `webhooks` opt-out/opt-in takes effect without a restart. Called AFTER a sync
+ * path completes successfully — never before it — so a reload whose schema apply
+ * fails does not leave the recording policy ahead of the still-old runtime
+ * config. Overwrites each reloaded slug's decision; a slug removed from the code
+ * config keeps its old entry, but a removed collection/single has no writes, and
+ * a REUSED slug is present in the new config and so is overwritten here.
+ */
+function republishRecordingPolicies(newConfig: {
+  collections?: CollectionDef[];
+  singles?: SingleDef[];
+}): void {
+  for (const c of newConfig.collections ?? []) {
+    if (!c.slug) continue;
+    setWebhookRecording(
+      "collection",
+      c.slug,
+      resolveWebhookRecording(c.webhooks).record
+    );
+  }
+  for (const s of newConfig.singles ?? []) {
+    if (!s.slug) continue;
+    setWebhookRecording(
+      "single",
+      s.slug,
+      resolveWebhookRecording(s.webhooks).record
+    );
+  }
+}
+
 // Reload entry point. resolver is optional and exists primarily for tests.
 // dispatcher is also test-only: injects a fake PromptDispatcher (e.g., one
 // that records prompts and auto-confirms) so tests don't need a real TTY.
@@ -399,27 +430,6 @@ export async function reloadNextlyConfig(opts?: {
   // would crash at runtime).
   const dialect = adapter.dialect;
   const db = adapter.getDrizzle();
-
-  // Keep the webhook recording policy in sync with the reloaded config so a
-  // hot-swapped `webhooks` opt-out/opt-in takes effect without a restart. Runs
-  // before the sync branches below, so BOTH the DDL-diff and the metadata-only
-  // paths honor the change (the boot-time decision would otherwise persist).
-  for (const c of newConfig.collections ?? []) {
-    if (!c.slug) continue;
-    setWebhookRecording(
-      "collection",
-      c.slug,
-      resolveWebhookRecording(c.webhooks).record
-    );
-  }
-  for (const s of newConfig.singles ?? []) {
-    if (!s.slug) continue;
-    setWebhookRecording(
-      "single",
-      s.slug,
-      resolveWebhookRecording(s.webhooks).record
-    );
-  }
 
   // Normalize collections to (slug, tableName, fields, status) tuples. Drop
   // entries without a slug — they can't be addressed. `status` propagates so
@@ -720,6 +730,10 @@ export async function reloadNextlyConfig(opts?: {
     // table, so skip and let a later clean reload / restart reconcile.
     if (!deferredSchemaChange) {
       await syncCodeFirstMetadataOnly(resolve, newConfig, logger);
+      // Metadata-only sync succeeded; publish the (possibly toggled) recording
+      // policy now — a `webhooks` change surfaces as no schema diff, so this is
+      // the path a live opt-out/opt-in toggle flows through.
+      republishRecordingPolicies(newConfig);
     }
     return;
   }
@@ -859,6 +873,10 @@ export async function reloadNextlyConfig(opts?: {
   });
 
   if (applyResult.success) {
+    // The schema change committed, so publish the (possibly toggled) recording
+    // policy now — this covers a combined `webhooks` + schema-field change,
+    // which takes the DDL path rather than the metadata-only path above.
+    republishRecordingPolicies(newConfig);
     // Sync dynamic_collections metadata so the fields JSON reflects the
     // new config. The pipeline above only applies DDL to dc_<slug>; without
     // this call, admin-UI queries still read the old field list until the

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -983,11 +983,6 @@ export async function reloadNextlyConfig(opts?: {
       metadataSynced = false;
     }
 
-    // The DDL and the field-tree metadata are now both in step (or the sync
-    // failed and will retry), so it is safe to activate the recording policy —
-    // never before, so a stale field tree can't pair with the new decision.
-    if (metadataSynced) republishRecordingPolicies(newConfig);
-
     // Sync dynamic_components metadata — keeps dynamic_components.fields
     // in step with the DDL changes the pipeline just applied.
     try {
@@ -1021,7 +1016,15 @@ export async function reloadNextlyConfig(opts?: {
       }
     } catch {
       // Non-fatal: same reasoning as collection/single metadata sync above.
+      metadataSynced = false;
     }
+
+    // Activate the recording policy only once the DDL AND all of the field-tree
+    // metadata (collections, singles, AND components) are in step — never
+    // before. Webhook payload stripping resolves sensitive fields through the
+    // component registry too (webhookFieldTree / expandComponentFields), so a
+    // failed component sync must also hold the new decision back.
+    if (metadataSynced) republishRecordingPolicies(newConfig);
 
     // Pre-compute fresh Drizzle table objects for all affected collections,
     // singles, and components. Synchronous (schema generation, no DB I/O).

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -59,7 +59,11 @@ import { resolveCollectionTableName } from "../domains/schema/utils/resolve-tabl
 // Resolve the versioning config on the HMR sync path so a `versions` change
 // while `next dev` is running persists without a restart (parity with di/register).
 import { resolveVersionsConfig } from "../domains/versions/resolve-config";
-import { setWebhookRecording } from "../domains/webhooks/recording-policy";
+import {
+  pruneRemovedCodeFirstRecording,
+  setWebhookRecording,
+  webhookRecordingKey,
+} from "../domains/webhooks/recording-policy";
 import { resolveWebhookRecording } from "../domains/webhooks/resolve-recording-config";
 import { getProductionNotifier } from "../runtime/notifications/index";
 import type { VersionsConfig } from "../schemas/versions/types";
@@ -259,11 +263,16 @@ function buildSingleSyncPayload(singles: SingleDef[]) {
 // `if (!hasChanges) return` would otherwise skip persistence until a restart.
 // The registry syncs change-detect internally and no-op when nothing changed;
 // this runs only when nextly.config.ts changes (not on every HMR tick).
+// Returns whether BOTH registry syncs succeeded. The caller republishes the
+// recording policy only on success, so a failed metadata sync never leaves the
+// new recording decision active while the mutation services still read the old
+// field tree (which drives sensitive-field stripping).
 async function syncCodeFirstMetadataOnly(
   resolve: ServiceResolver,
   newConfig: { collections?: CollectionDef[]; singles?: SingleDef[] },
   logger?: LoggerLike
-): Promise<void> {
+): Promise<boolean> {
+  let ok = true;
   try {
     const registry = (await resolve(
       "collectionRegistryService"
@@ -271,6 +280,7 @@ async function syncCodeFirstMetadataOnly(
     const payload = buildCollectionSyncPayload(newConfig.collections ?? []);
     if (payload.length > 0) await registry.syncCodeFirstCollections(payload);
   } catch (err) {
+    ok = false;
     logger?.warn(
       `[Nextly HMR] metadata-only collection sync failed: ${
         err instanceof Error ? err.message : String(err)
@@ -284,12 +294,14 @@ async function syncCodeFirstMetadataOnly(
     const payload = buildSingleSyncPayload(newConfig.singles ?? []);
     if (payload.length > 0) await singleReg.syncCodeFirstSingles(payload);
   } catch (err) {
+    ok = false;
     logger?.warn(
       `[Nextly HMR] metadata-only single sync failed: ${
         err instanceof Error ? err.message : String(err)
       }`
     );
   }
+  return ok;
 }
 
 /**
@@ -305,20 +317,41 @@ function republishRecordingPolicies(newConfig: {
   collections?: CollectionDef[];
   singles?: SingleDef[];
 }): void {
+  // Prune code-first decisions for slugs no longer in the config: a removed
+  // code-first collection can remain WRITABLE (the reload merges its registered
+  // DB table back into the desired schema), so a stale `false` would suppress
+  // its events until restart. Plugin-sourced decisions are preserved.
+  const presentKeys = new Set<string>();
+  for (const c of newConfig.collections ?? []) {
+    if (c.slug) presentKeys.add(webhookRecordingKey("collection", c.slug));
+  }
+  for (const s of newConfig.singles ?? []) {
+    if (s.slug) presentKeys.add(webhookRecordingKey("single", s.slug));
+  }
+  pruneRemovedCodeFirstRecording(presentKeys);
+
   for (const c of newConfig.collections ?? []) {
     if (!c.slug) continue;
+    const source = (c.admin as { isPlugin?: boolean } | undefined)?.isPlugin
+      ? "plugin"
+      : "code";
     setWebhookRecording(
       "collection",
       c.slug,
-      resolveWebhookRecording(c.webhooks).record
+      resolveWebhookRecording(c.webhooks).record,
+      source
     );
   }
   for (const s of newConfig.singles ?? []) {
     if (!s.slug) continue;
+    const source = (s.admin as { isPlugin?: boolean } | undefined)?.isPlugin
+      ? "plugin"
+      : "code";
     setWebhookRecording(
       "single",
       s.slug,
-      resolveWebhookRecording(s.webhooks).record
+      resolveWebhookRecording(s.webhooks).record,
+      source
     );
   }
 }
@@ -729,11 +762,17 @@ export async function reloadNextlyConfig(opts?: {
     // threw, syncing would persist `fields` that disagree with the physical
     // table, so skip and let a later clean reload / restart reconcile.
     if (!deferredSchemaChange) {
-      await syncCodeFirstMetadataOnly(resolve, newConfig, logger);
-      // Metadata-only sync succeeded; publish the (possibly toggled) recording
-      // policy now — a `webhooks` change surfaces as no schema diff, so this is
-      // the path a live opt-out/opt-in toggle flows through.
-      republishRecordingPolicies(newConfig);
+      const synced = await syncCodeFirstMetadataOnly(
+        resolve,
+        newConfig,
+        logger
+      );
+      // Publish the (possibly toggled) recording policy ONLY when the metadata
+      // sync actually succeeded — a `webhooks` change surfaces as no schema
+      // diff, so this is the path a live opt-out/opt-in toggle flows through,
+      // but a failed field-tree sync must not activate the new decision while
+      // the mutation services still strip against the old fields.
+      if (synced) republishRecordingPolicies(newConfig);
     }
     return;
   }

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -62,6 +62,7 @@ import { resolveVersionsConfig } from "../domains/versions/resolve-config";
 import {
   pruneRemovedCodeFirstRecording,
   setWebhookRecording,
+  type WebhookRecordingScope,
 } from "../domains/webhooks/recording-policy";
 import { resolveWebhookRecording } from "../domains/webhooks/resolve-recording-config";
 import type { RevalidateConfig } from "../revalidation/types";
@@ -366,61 +367,78 @@ async function syncCodeFirstMetadataOnly(
 }
 
 /**
+ * Publish one scope's recording decisions from the reloaded config. The two
+ * directions have asymmetric safety, so they are gated differently:
+ *
+ * - Opt-OUTS (`record: false`) are applied UNCONDITIONALLY, even when this
+ *   scope's metadata sync failed or was deferred. Turning recording OFF builds
+ *   no payload and reads no field tree, so a just-loaded privacy opt-out is safe
+ *   to honor immediately — and MUST be, or a reload that flips `webhooks` to
+ *   `false` while an unrelated diff is deferred would keep leaking events.
+ * - Opt-INS (`record: true`, including a removed slug reverting to the default)
+ *   DO read the field tree when a payload is later expanded, so they are applied
+ *   ONLY when `synced` is true. Otherwise expansion would strip against a stale
+ *   component/field tree and could emit a value that is now hidden. Pruning a
+ *   removed code-first slug reverts it to the recording default, so it is an
+ *   opt-in and waits on `synced` too. Plugin-sourced decisions are never pruned.
+ */
+function publishScopeRecording(
+  scope: WebhookRecordingScope,
+  entities: Array<{
+    slug?: string;
+    webhooks?: CollectionDef["webhooks"];
+    admin?: unknown;
+  }>,
+  synced: boolean
+): void {
+  const sourceOf = (admin: unknown): "code" | "plugin" =>
+    (admin as { isPlugin?: boolean } | undefined)?.isPlugin ? "plugin" : "code";
+
+  // Opt-outs first, always: safe regardless of sync state (recording is off).
+  for (const e of entities) {
+    if (!e.slug) continue;
+    if (resolveWebhookRecording(e.webhooks).record === false) {
+      setWebhookRecording(scope, e.slug, false, sourceOf(e.admin));
+    }
+  }
+
+  // Opt-ins and removed-slug pruning only once the field tree is in step.
+  if (!synced) return;
+  const present = new Set<string>();
+  for (const e of entities) {
+    if (e.slug) present.add(e.slug);
+  }
+  pruneRemovedCodeFirstRecording(scope, present);
+  for (const e of entities) {
+    if (!e.slug) continue;
+    if (resolveWebhookRecording(e.webhooks).record === true) {
+      setWebhookRecording(scope, e.slug, true, sourceOf(e.admin));
+    }
+  }
+}
+
+/**
  * Republish the webhook recording policy from the reloaded config, so a live
  * `webhooks` opt-out/opt-in takes effect without a restart. Called AFTER a sync
  * path completes — never before it — so a reload whose schema apply fails does
- * not leave the recording policy ahead of the still-old runtime config.
+ * not leave a recording OPT-IN ahead of the still-old runtime field tree.
  *
  * Per-scope on purpose: `scopes` names the entity kinds whose metadata sync
  * actually succeeded, so a PARTIAL reload (collections synced, singles/component
- * failed) still activates the committed collections' decisions instead of
- * holding every decision hostage to an unrelated failure. Each enabled scope
- * prunes removed code-first slugs (a removed-but-DB-backed collection can stay
- * writable, so a stale opt-out would otherwise suppress its events) and
- * overwrites present slugs; plugin-sourced decisions are preserved.
+ * failed) still activates the committed collections' opt-ins instead of holding
+ * them hostage to an unrelated failure. Opt-OUTS ignore the gate entirely (see
+ * {@link publishScopeRecording}).
  */
 function republishRecordingPolicies(
   newConfig: { collections?: CollectionDef[]; singles?: SingleDef[] },
   scopes: { collections: boolean; singles: boolean }
 ): void {
-  if (scopes.collections) {
-    const present = new Set<string>();
-    for (const c of newConfig.collections ?? []) {
-      if (c.slug) present.add(c.slug);
-    }
-    pruneRemovedCodeFirstRecording("collection", present);
-    for (const c of newConfig.collections ?? []) {
-      if (!c.slug) continue;
-      const source = (c.admin as { isPlugin?: boolean } | undefined)?.isPlugin
-        ? "plugin"
-        : "code";
-      setWebhookRecording(
-        "collection",
-        c.slug,
-        resolveWebhookRecording(c.webhooks).record,
-        source
-      );
-    }
-  }
-  if (scopes.singles) {
-    const present = new Set<string>();
-    for (const s of newConfig.singles ?? []) {
-      if (s.slug) present.add(s.slug);
-    }
-    pruneRemovedCodeFirstRecording("single", present);
-    for (const s of newConfig.singles ?? []) {
-      if (!s.slug) continue;
-      const source = (s.admin as { isPlugin?: boolean } | undefined)?.isPlugin
-        ? "plugin"
-        : "code";
-      setWebhookRecording(
-        "single",
-        s.slug,
-        resolveWebhookRecording(s.webhooks).record,
-        source
-      );
-    }
-  }
+  publishScopeRecording(
+    "collection",
+    newConfig.collections ?? [],
+    scopes.collections
+  );
+  publishScopeRecording("single", newConfig.singles ?? [], scopes.singles);
 }
 
 // Reload entry point. resolver is optional and exists primarily for tests.

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -865,15 +865,28 @@ export async function reloadNextlyConfig(opts?: {
       // Publish each scope's (possibly toggled) recording policy ONLY when that
       // scope's metadata sync succeeded — a `webhooks` change surfaces as no
       // schema diff, so this is the path a live opt-out/opt-in toggle flows
-      // through, but a failed field-tree sync must not activate the new decision
+      // through, but a failed field-tree sync must not activate the new opt-IN
       // while the mutation services still strip against the old fields. A
       // referenced component's field tree drives webhook payload stripping, so
-      // also hold BOTH scopes back until the component sync succeeds: otherwise a
-      // reload that both enables recording and hides a component field would
-      // expand payloads against the stale component tree and leak PII.
+      // also hold BOTH scopes' opt-ins back until the component sync succeeds:
+      // otherwise a reload that both enables recording and hides a component
+      // field would expand payloads against the stale component tree and leak
+      // PII. Opt-OUTs ignore this gate (see publishScopeRecording).
       republishRecordingPolicies(newConfig, {
         collections: synced.collections && synced.components,
         singles: synced.singles && synced.components,
+      });
+    } else {
+      // A real schema change was deferred (unsafe / needs review) or a diff
+      // threw, so the field metadata must NOT be synced — the physical table
+      // disagrees. A recording OPT-OUT is still safe to honor now (recording
+      // turns off, no payload is built against any field tree), and skipping it
+      // would keep a newly opted-out entity's events flowing to the outbox until
+      // a later clean reload or restart. Reconcile with both scopes unsynced so
+      // opt-outs apply immediately while opt-ins stay gated on a good sync.
+      republishRecordingPolicies(newConfig, {
+        collections: false,
+        singles: false,
       });
     }
     return;

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -267,6 +267,34 @@ function buildSingleSyncPayload(singles: SingleDef[]) {
     });
 }
 
+// Normalize code-first components to the registry sync shape. Shared by the DDL
+// path and the metadata-only path so a component's metadata (e.g. a `hidden`
+// field flag, which drives webhook payload stripping) stays in step either way.
+function buildComponentSyncPayload(components: ComponentDef[]) {
+  return components
+    .filter((c): c is ComponentDef & { slug: string } => !!c.slug)
+    .map(c => {
+      const labelStr =
+        typeof c.label === "string"
+          ? c.label
+          : (c.label?.singular ??
+            c.slug
+              .split(/[-_]/)
+              .map((w: string) => w.charAt(0).toUpperCase() + w.slice(1))
+              .join(" "));
+      return {
+        slug: c.slug,
+        label: labelStr,
+        fields: c.fields ?? [],
+        description: c.description,
+        admin: c.admin,
+        // i18n: forward the localized master switch — otherwise the reload flips
+        // a localized component's flag OFF every HMR/boot.
+        localized: (c as { localized?: boolean }).localized === true,
+      };
+    });
+}
+
 // Metadata-only registry sync for the no-DDL HMR path: a `versions`/`localized`/
 // status/labels edit produces no schema operations, so the main flow's
 // `if (!hasChanges) return` would otherwise skip persistence until a restart.
@@ -279,11 +307,16 @@ function buildSingleSyncPayload(singles: SingleDef[]) {
 // does not block the other's committed decisions.
 async function syncCodeFirstMetadataOnly(
   resolve: ServiceResolver,
-  newConfig: { collections?: CollectionDef[]; singles?: SingleDef[] },
+  newConfig: {
+    collections?: CollectionDef[];
+    singles?: SingleDef[];
+    components?: ComponentDef[];
+  },
   logger?: LoggerLike
-): Promise<{ collections: boolean; singles: boolean }> {
+): Promise<{ collections: boolean; singles: boolean; components: boolean }> {
   let collections = true;
   let singles = true;
+  let components = true;
   try {
     const registry = (await resolve(
       "collectionRegistryService"
@@ -312,7 +345,24 @@ async function syncCodeFirstMetadataOnly(
       }`
     );
   }
-  return { collections, singles };
+  // A component's metadata (e.g. a `hidden` field flag) can change with no
+  // schema diff and drives webhook payload stripping, so sync it here too — the
+  // caller gates the recording policy on this before activating a new decision.
+  try {
+    const compReg = (await resolve(
+      "componentRegistryService"
+    )) as ComponentRegistrySurface;
+    const payload = buildComponentSyncPayload(newConfig.components ?? []);
+    if (payload.length > 0) await compReg.syncCodeFirstComponents(payload);
+  } catch (err) {
+    components = false;
+    logger?.warn(
+      `[Nextly HMR] metadata-only component sync failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
+  return { collections, singles, components };
 }
 
 /**
@@ -788,9 +838,15 @@ export async function reloadNextlyConfig(opts?: {
       // scope's metadata sync succeeded — a `webhooks` change surfaces as no
       // schema diff, so this is the path a live opt-out/opt-in toggle flows
       // through, but a failed field-tree sync must not activate the new decision
-      // while the mutation services still strip against the old fields. This
-      // path syncs no components, so there is no component gate here.
-      republishRecordingPolicies(newConfig, synced);
+      // while the mutation services still strip against the old fields. A
+      // referenced component's field tree drives webhook payload stripping, so
+      // also hold BOTH scopes back until the component sync succeeds: otherwise a
+      // reload that both enables recording and hides a component field would
+      // expand payloads against the stale component tree and leak PII.
+      republishRecordingPolicies(newConfig, {
+        collections: synced.collections && synced.components,
+        singles: synced.singles && synced.components,
+      });
     }
     return;
   }
@@ -1010,28 +1066,9 @@ export async function reloadNextlyConfig(opts?: {
       const compReg = (await resolve(
         "componentRegistryService"
       )) as ComponentRegistrySurface;
-      const codeFirstComponentConfigs = (newConfig.components ?? [])
-        .filter((c): c is ComponentDef & { slug: string } => !!c.slug)
-        .map(c => {
-          const labelStr =
-            typeof c.label === "string"
-              ? c.label
-              : (c.label?.singular ??
-                c.slug
-                  .split(/[-_]/)
-                  .map((w: string) => w.charAt(0).toUpperCase() + w.slice(1))
-                  .join(" "));
-          return {
-            slug: c.slug,
-            label: labelStr,
-            fields: c.fields ?? [],
-            description: c.description,
-            admin: c.admin,
-            // i18n: forward the localized master switch — otherwise the reload flips a
-            // localized component's flag OFF every HMR/boot.
-            localized: (c as { localized?: boolean }).localized === true,
-          };
-        });
+      const codeFirstComponentConfigs = buildComponentSyncPayload(
+        newConfig.components ?? []
+      );
       if (codeFirstComponentConfigs.length > 0) {
         await compReg.syncCodeFirstComponents(codeFirstComponentConfigs);
       }

--- a/packages/nextly/src/plugins/test-nextly.ts
+++ b/packages/nextly/src/plugins/test-nextly.ts
@@ -22,6 +22,7 @@ import { resetEmailProviderRegistry } from "../domains/email/services/email-prov
 import { normalizeLocalization } from "../domains/i18n/config/normalize";
 import type { LocalizationConfig } from "../domains/i18n/config/types";
 import { clearFieldTypes } from "../domains/schema/field-types/field-type-registry";
+import { resetWebhookRecordingPolicy } from "../domains/webhooks/recording-policy";
 import type { EventBus } from "../events/event-bus";
 import { getEventBus, resetEventBus } from "../events/event-bus";
 import { resetFilterRegistry } from "../filters";
@@ -122,6 +123,7 @@ export async function createTestNextly(
   resetEmailProviderRegistry();
   clearFieldTypes();
   resetFilterRegistry();
+  resetWebhookRecordingPolicy();
   resetPluginRouteRegistry();
   resetNextlyInstance();
   // Each boot is a fresh, distinct in-memory database. The schema-snapshot
@@ -216,6 +218,7 @@ export async function createTestNextly(
       resetEmailProviderRegistry();
       clearFieldTypes();
       resetFilterRegistry();
+      resetWebhookRecordingPolicy();
       resetPluginRouteRegistry();
       resetNextlyInstance();
       clearCachedSnapshot();

--- a/packages/nextly/src/route-handler/auth-handler.ts
+++ b/packages/nextly/src/route-handler/auth-handler.ts
@@ -81,6 +81,13 @@ export async function ensureServicesInitialized(): Promise<void> {
       if (nextlyConfig.plugins) serviceConfig.plugins = nextlyConfig.plugins;
       if (nextlyConfig.collections)
         serviceConfig.collections = nextlyConfig.collections;
+      // Forward singles and components too: the request-path boot otherwise
+      // registers neither, so app-defined Singles never reach registerServices
+      // — their runtime schema, and their webhook recording opt-out, silently
+      // fall back to defaults (a `webhooks: false` Single would record PII).
+      if (nextlyConfig.singles) serviceConfig.singles = nextlyConfig.singles;
+      if (nextlyConfig.components)
+        serviceConfig.components = nextlyConfig.components;
       if (nextlyConfig.storage)
         serviceConfig.storagePlugins = nextlyConfig.storage;
       if (nextlyConfig.email) serviceConfig.email = nextlyConfig.email;

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -254,22 +254,6 @@ export class CollectionEntryService extends BaseService {
   }
 
   /**
-   * The post-write side effects, run after every write that appends an event.
-   *
-   * The drain fast path goes first so the `after()` callback is scheduled
-   * promptly (it only runs post-response, so it adds no latency); the retention
-   * pass follows. Both absorb their own failures, so this never turns a
-   * successful save into an error. `offer()` is synchronous — it only registers
-   * the post-response callback, whose work `after()` owns — so it is not awaited;
-   * the retention pass is awaited for the reason `offerRetentionPass` documents:
-   * a detached promise may not survive a serverless response.
-   */
-  private async afterWrite(): Promise<void> {
-    this.fastDrainScheduler?.offer();
-    await this.offerRetentionPass();
-  }
-
-  /**
    * Run the post-write side effects only when the mutation actually recorded a
    * change (and therefore appended an outbox event). A rejected write — a
    * validation or access failure surfaced as `success: false`, or a bulk/batch
@@ -298,14 +282,20 @@ export class CollectionEntryService extends BaseService {
     // bust their tags.
     await this.flushRevalidation(result);
 
-    // Drain/retention run only when an outbox event was actually recorded. Every
-    // result — single, bulk (`successCount`), and batch (`successful`) — now
-    // carries an aggregated `eventRecorded` (the bulk/batch paths OR it across
-    // their items), so a write of only opted-out (`webhooks: false`) entries
-    // records nothing and schedules nothing, rather than draining unrelated
-    // pending events off a positive success count.
+    // Retention is opportunistic write-path cleanup, NOT tied to the outbox gate:
+    // `retention-runner` documents the write path as the only prune trigger for
+    // installs with no webhook drain, so even a write to only opted-out
+    // (`webhooks: false`) entities must still offer a pass. The runner is
+    // internally rate-limited, so offering on every write is cheap.
+    await this.offerRetentionPass();
+
+    // The fast drain, by contrast, only matters when an outbox event was actually
+    // recorded to deliver. Every result — single, bulk (`successCount`), and
+    // batch (`successful`) — carries an aggregated `eventRecorded`, so a write of
+    // only opted-out entries records nothing and schedules no drain, rather than
+    // draining unrelated pending events off a positive success count.
     if (result.eventRecorded === true) {
-      await this.afterWrite();
+      this.fastDrainScheduler?.offer();
     }
   }
 

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -298,13 +298,13 @@ export class CollectionEntryService extends BaseService {
     // bust their tags.
     await this.flushRevalidation(result);
 
-    const recorded =
-      "success" in result
-        ? result.eventRecorded === true
-        : "successCount" in result
-          ? result.successCount > 0 || result.eventRecorded === true
-          : result.successful > 0 || result.eventRecorded === true;
-    if (recorded) {
+    // Drain/retention run only when an outbox event was actually recorded. Every
+    // result — single, bulk (`successCount`), and batch (`successful`) — now
+    // carries an aggregated `eventRecorded` (the bulk/batch paths OR it across
+    // their items), so a write of only opted-out (`webhooks: false`) entries
+    // records nothing and schedules nothing, rather than draining unrelated
+    // pending events off a positive success count.
+    if (result.eventRecorded === true) {
       await this.afterWrite();
     }
   }

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -306,14 +306,13 @@ export class CollectionEntryService extends BaseService {
 
   /**
    * Whether a mutation result represents at least one committed content write.
-   * Keyed off signals that a row was actually written — an outbox event, a
-   * positive bulk/batch count, or a revalidation intent (built on the committed
-   * write) — NOT on `success`: the method contract lets a no-op update or a
-   * `publishAllLocales` no-op return `success: true` having written nothing, and
-   * running an awaited retention pass for those is the same wasted latency as
-   * running it for a rejected request. An opted-out (`webhooks: false`) write
-   * records no event but still carries its revalidation intent, so it stays
-   * covered. False for a rejected request (validation / access / not-found).
+   * A single create/update/delete carries the explicit `committed` flag (set the
+   * moment its transaction commits, independent of the recording and revalidation
+   * opt-outs), so even a write that opts out of BOTH — no event, no intent — is
+   * covered, while a rejected request (validation / access / not-found) and a
+   * `publishAllLocales` no-op are not. Bulk/batch results use their positive
+   * counts; `eventRecorded` covers a committed-but-hook-failed batch. NOT keyed
+   * off `success`, which a no-op update also reports.
    */
   private static hasCommittedWrite(
     result:
@@ -321,9 +320,12 @@ export class CollectionEntryService extends BaseService {
       | BulkOperationResult<unknown>
       | BatchOperationResult
   ): boolean {
+    if ("committed" in result && result.committed === true) return true;
     if (result.eventRecorded === true) return true;
     if ("successCount" in result && result.successCount > 0) return true;
     if ("successful" in result && result.successful > 0) return true;
+    // Covers single ops that flush an intent without setting `committed` (e.g. a
+    // publish-all-locales transition) — a present intent means content changed.
     if ("revalidationIntent" in result && result.revalidationIntent != null) {
       return true;
     }

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -282,12 +282,17 @@ export class CollectionEntryService extends BaseService {
     // bust their tags.
     await this.flushRevalidation(result);
 
-    // Retention is opportunistic write-path cleanup, NOT tied to the outbox gate:
-    // `retention-runner` documents the write path as the only prune trigger for
-    // installs with no webhook drain, so even a write to only opted-out
-    // (`webhooks: false`) entities must still offer a pass. The runner is
-    // internally rate-limited, so offering on every write is cheap.
-    await this.offerRetentionPass();
+    // Retention is opportunistic write-path cleanup — the write path is the only
+    // prune trigger for installs with no webhook drain, so even a write to only
+    // opted-out (`webhooks: false`) entities must still offer a pass. It is NOT
+    // the outbox gate, but it IS gated on a committed write: a rejected request
+    // (validation / access / not-found) committed nothing, so paying for an
+    // awaited outbox-deletion pass on its behalf is wasted latency. An opted-out
+    // write still qualifies (it reports `success` / a positive count / an intent
+    // even though it recorded no event), so coverage is unchanged.
+    if (CollectionEntryService.hasCommittedWrite(result)) {
+      await this.offerRetentionPass();
+    }
 
     // The fast drain, by contrast, only matters when an outbox event was actually
     // recorded to deliver. Every result — single, bulk (`successCount`), and
@@ -297,6 +302,37 @@ export class CollectionEntryService extends BaseService {
     if (result.eventRecorded === true) {
       this.fastDrainScheduler?.offer();
     }
+  }
+
+  /**
+   * Whether a mutation result represents at least one committed content write.
+   * True for a normal success, for a committed-but-post-hook-failed write (which
+   * reports `success: false` but carries a durable event and/or intent), and for
+   * an opted-out (`webhooks: false`) write (no outbox event, but still a success
+   * / positive count / a revalidation intent). False for a rejected request
+   * (validation / access / not-found) that committed nothing. Covers all three
+   * result shapes so write-path cleanup runs on real writes only.
+   */
+  private static hasCommittedWrite(
+    result:
+      | CollectionServiceResult<unknown>
+      | BulkOperationResult<unknown>
+      | BatchOperationResult
+  ): boolean {
+    if (result.eventRecorded === true) return true;
+    if ("success" in result && result.success === true) return true;
+    if ("successCount" in result && result.successCount > 0) return true;
+    if ("successful" in result && result.successful > 0) return true;
+    if ("revalidationIntent" in result && result.revalidationIntent != null) {
+      return true;
+    }
+    if (
+      "revalidationIntents" in result &&
+      (result.revalidationIntents?.length ?? 0) > 0
+    ) {
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -286,10 +286,10 @@ export class CollectionEntryService extends BaseService {
     // prune trigger for installs with no webhook drain, so even a write to only
     // opted-out (`webhooks: false`) entities must still offer a pass. It is NOT
     // the outbox gate, but it IS gated on a committed write: a rejected request
-    // (validation / access / not-found) committed nothing, so paying for an
-    // awaited outbox-deletion pass on its behalf is wasted latency. An opted-out
-    // write still qualifies (it reports `success` / a positive count / an intent
-    // even though it recorded no event), so coverage is unchanged.
+    // (validation / access / not-found) — and a no-op that wrote nothing —
+    // committed no content, so paying for an awaited outbox-deletion pass on its
+    // behalf is wasted latency. An opted-out write still qualifies (it carries a
+    // revalidation intent even though it recorded no event), so coverage holds.
     if (CollectionEntryService.hasCommittedWrite(result)) {
       await this.offerRetentionPass();
     }
@@ -306,12 +306,14 @@ export class CollectionEntryService extends BaseService {
 
   /**
    * Whether a mutation result represents at least one committed content write.
-   * True for a normal success, for a committed-but-post-hook-failed write (which
-   * reports `success: false` but carries a durable event and/or intent), and for
-   * an opted-out (`webhooks: false`) write (no outbox event, but still a success
-   * / positive count / a revalidation intent). False for a rejected request
-   * (validation / access / not-found) that committed nothing. Covers all three
-   * result shapes so write-path cleanup runs on real writes only.
+   * Keyed off signals that a row was actually written — an outbox event, a
+   * positive bulk/batch count, or a revalidation intent (built on the committed
+   * write) — NOT on `success`: the method contract lets a no-op update or a
+   * `publishAllLocales` no-op return `success: true` having written nothing, and
+   * running an awaited retention pass for those is the same wasted latency as
+   * running it for a rejected request. An opted-out (`webhooks: false`) write
+   * records no event but still carries its revalidation intent, so it stays
+   * covered. False for a rejected request (validation / access / not-found).
    */
   private static hasCommittedWrite(
     result:
@@ -320,7 +322,6 @@ export class CollectionEntryService extends BaseService {
       | BatchOperationResult
   ): boolean {
     if (result.eventRecorded === true) return true;
-    if ("success" in result && result.success === true) return true;
     if ("successCount" in result && result.successCount > 0) return true;
     if ("successful" in result && result.successful > 0) return true;
     if ("revalidationIntent" in result && result.revalidationIntent != null) {

--- a/packages/nextly/src/singles/config/types.ts
+++ b/packages/nextly/src/singles/config/types.ts
@@ -362,6 +362,16 @@ export interface SingleConfig {
   localized?: boolean;
 
   /**
+   * Webhook recording policy for this Single. When `false` (or
+   * `{ record: false }`), writes to this Single record NO event to the webhook
+   * outbox, so nothing is ever delivered to subscribed endpoints. The object
+   * form leaves room for finer policy later without a breaking change.
+   *
+   * @default true (writes are recorded)
+   */
+  webhooks?: boolean | { record?: boolean };
+
+  /**
    * Admin panel configuration options.
    * Controls how the Single appears in the Admin UI.
    */

--- a/packages/plugin-form-builder/README.md
+++ b/packages/plugin-form-builder/README.md
@@ -63,6 +63,10 @@ import "@nextlyhq/plugin-form-builder/admin";
 - **Form lifecycle states:** Draft, Published, Closed
 - **Optional integrations:** email notifications, webhook delivery on submission, spam protection (honeypot, rate limit, reCAPTCHA v3)
 
+### Submission privacy
+
+Submissions carry visitor-entered content plus `ipAddress` and `userAgent`, so the `form-submissions` collection sets `webhooks: false` — its writes are never recorded to the webhook outbox or delivered to endpoints subscribed to `entry.created` or `*`. Any collection or single can opt out the same way (`webhooks: false`, or `{ record: false }`); recording is on by default for everything else. To send submission webhooks deliberately, override the submissions collection with `webhooks: true`.
+
 ## Field types
 
 The plugin ships 13 field types. All are enabled by default; disable any by setting it to `false` in the `fields` option.

--- a/packages/plugin-form-builder/src/__tests__/admin-contributions.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/admin-contributions.test.ts
@@ -35,6 +35,9 @@ describe("form-builder contributes.admin (P5 dogfood)", () => {
   });
 
   it("opts submissions out of webhook recording (they carry ipAddress/userAgent)", () => {
+    // Submission records hold submitted content plus visitor metadata
+    // (ipAddress, userAgent), so they are excluded from the webhook outbox to
+    // keep that PII off the delivery path — hence `webhooks: false`.
     const collection = submissionsCollection(formBuilder().config);
     expect(collection.webhooks).toBe(false);
   });

--- a/packages/plugin-form-builder/src/__tests__/admin-contributions.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/admin-contributions.test.ts
@@ -33,4 +33,9 @@ describe("form-builder contributes.admin (P5 dogfood)", () => {
     );
     expect(collection.admin?.disableCreate).toBe(true);
   });
+
+  it("opts submissions out of webhook recording (they carry ipAddress/userAgent)", () => {
+    const collection = submissionsCollection(formBuilder().config);
+    expect(collection.webhooks).toBe(false);
+  });
 });

--- a/packages/plugin-form-builder/src/collections/submissions.ts
+++ b/packages/plugin-form-builder/src/collections/submissions.ts
@@ -201,6 +201,12 @@ export function submissionsCollection(
     fields: finalFields,
     timestamps: true,
 
+    // Submissions carry visitor-entered content plus ipAddress/userAgent, so
+    // they are never recorded to the webhook outbox — otherwise every submission
+    // would be delivered to any endpoint subscribed to entry.created or `*`. An
+    // operator who wants submission webhooks can override this to `true`.
+    webhooks: false,
+
     admin: {
       isPlugin: true,
       group: "Forms",


### PR DESCRIPTION
## What

Adds a per-collection/single `webhooks` recording opt-out and uses it to stop **form-submission PII from being delivered to webhook endpoints** (task 001, Phase 1).

Form submissions are stored as ordinary collection entries, so since the drain went live every submission was recorded as `entry.created` and delivered to any endpoint subscribed to `entry.created` or `*` — payloads that include visitor content plus `ipAddress` and `userAgent`. This is a live privacy exposure and a pre-alpha must-fix.

## How

- **Config surface:** `webhooks?: boolean | { record?: boolean }` on `CollectionConfig` and `SingleConfig` (default: record). Normalized by `resolveWebhookRecording`.
- **Enforcement at the single choke point:** a process-level recording policy (module singleton with reset, like the event bus / hook registry) is populated from the live code config at registration; `recordMutationEvent` consults it via the event `resource` and returns before writing the outbox row when the entity opted out. Every write path inherits the gate — no per-call-site threading.
- **Form-builder:** the `form-submissions` collection sets `webhooks: false`.
- **No new DB column** (deliberate): a new `dynamic_collections`/`dynamic_singles` column crashes un-migrated boots — the hazard task 007 is fixing. The persisted column + Schema Builder toggle are a **deferred follow-up on top of 007's boot-reconcile safety**. This PR is the code-first privacy fix.

## Tests

- Unit: `resolveWebhookRecording` (all shapes); recording-policy registry; `recordMutationEvent` short-circuits for an opted-out collection/single and still records otherwise; form-builder submissions carry `webhooks: false`.
- Integration (`createTestNextly`): a `webhooks: false` collection records **no** `nextly_events` row across create/update/delete while a normal collection records one.
- No new failures vs the known stale-mock baseline (the 11 collection-access/hooks/mutation failures are pre-existing on `main`).

## Existing data

Submission events recorded before this release remain in the outbox and can be pruned manually; nothing is deleted automatically.

## Follow-up (not this PR)

Persisted `webhooks` column + registry serialization + Schema Builder toggle + upgrade path, built on task 007's additive-core-column boot-reconcile safety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable webhook recording for collections and single resources via `webhooks` (supports `false` / `{ record?: boolean }`), defaulting to recording enabled.
* **Bug Fixes**
  * Ensured outbox/drain/revalidation side effects only trigger when an outbox event was actually recorded; improved bulk and transaction event recording handling.
* **Documentation**
  * Documented webhook recording behavior, including default submissions privacy (webhooks disabled).
* **Tests**
  * Added unit/integration coverage for recording policies, config reload reconciliation, and webhook recording gates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->