### PR TITLE
feat(nextly): persist revalidate config with schema builder parity and upgrade safety

### DIFF
--- a/.changeset/f1-persist-revalidate-config.md
+++ b/.changeset/f1-persist-revalidate-config.md
@@ -1,0 +1,24 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Collections and singles created in the Schema Builder now carry their cache-revalidation setting. A new "Cache revalidation" switch on the Advanced tab (on by default) lets you opt a collection or single out of busting cache tags on write, and the setting round-trips through boot, HMR, `db:sync`, and `migrate:create` the same way code-first `revalidate` config does. Existing databases pick up the new registry column via `nextly upgrade` (boot warns until it is run).

--- a/.changeset/f1-persist-revalidate-config.md
+++ b/.changeset/f1-persist-revalidate-config.md
@@ -21,4 +21,4 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-Collections and singles created in the Schema Builder now carry their cache-revalidation setting. A new "Cache revalidation" switch on the Advanced tab (on by default) lets you opt a collection or single out of busting cache tags on write, and the setting round-trips through boot, HMR, `db:sync`, and `migrate:create` the same way code-first `revalidate` config does. Existing databases pick up the new registry column via `nextly upgrade` (boot warns until it is run).
+Collections and singles created in the Schema Builder now carry their cache-revalidation setting. A new "Cache revalidation" switch on the Advanced tab (on by default) lets you opt a collection or single out of busting cache tags on write, and the setting round-trips through boot, HMR, `db:sync`, and `migrate:create` the same way code-first `revalidate` config does. Existing databases pick up the new registry column when you run `nextly migrate` (boot warns until it is run).

--- a/packages/admin/src/components/features/schema-builder/BuilderSettingsModal.tsx
+++ b/packages/admin/src/components/features/schema-builder/BuilderSettingsModal.tsx
@@ -50,6 +50,9 @@ export type BuilderSettingsValues = {
   status?: boolean;
   i18n?: boolean;
   versions?: boolean;
+  // Cache revalidation. Undefined means on (the default): writes bust the
+  // standard tags. False opts the entity out entirely.
+  revalidate?: boolean;
 };
 
 type Props = {

--- a/packages/admin/src/components/features/schema-builder/builder-config.ts
+++ b/packages/admin/src/components/features/schema-builder/builder-config.ts
@@ -20,6 +20,7 @@ export type AdvancedField =
   | "status"
   | "i18n"
   | "versions"
+  | "revalidate"
   | "showSystemFields";
 
 export type BuilderConfig = {

--- a/packages/admin/src/components/features/schema-builder/builder-settings-modal/AdvancedTab.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-settings-modal/AdvancedTab.tsx
@@ -69,6 +69,19 @@ export function AdvancedTab({ fields, values, onChange }: Props) {
         />
       )}
 
+      {fields.includes("revalidate") && (
+        // Revalidation defaults ON, so the switch is checked unless the value is
+        // explicitly false; turning it off stops this entity from busting cache
+        // tags on write.
+        <SwitchRow
+          ariaLabel="Cache revalidation"
+          label="Cache revalidation"
+          help="Bust cached pages when an entry changes so published edits appear without a redeploy. On by default; turn off for content that never renders on cached pages."
+          checked={values.revalidate ?? true}
+          onChange={v => set("revalidate", v)}
+        />
+      )}
+
       {fields.includes("showSystemFields") && <ShowSystemFieldsSwitch />}
     </div>
   );

--- a/packages/admin/src/components/features/schema-builder/builder-settings-modal/__tests__/AdvancedTab.test.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-settings-modal/__tests__/AdvancedTab.test.tsx
@@ -106,6 +106,42 @@ describe("AdvancedTab -- version history", () => {
   });
 });
 
+describe("AdvancedTab -- cache revalidation", () => {
+  it("renders nothing when the kind does not enable it", () => {
+    render(<Controlled fields={["status"]} />);
+    expect(
+      screen.queryByRole("switch", { name: /cache revalidation/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders checked by default because revalidation is on", () => {
+    // Unlike version history, an absent value means ON — the switch must show
+    // checked so the user is not misled into thinking caching is off.
+    render(<Controlled fields={["revalidate"]} />);
+    const sw = screen.getByRole("switch", { name: /cache revalidation/i });
+    expect(sw.getAttribute("data-state")).toBe("checked");
+  });
+
+  it("sets revalidate to false when toggled off", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Controlled fields={["revalidate"]} onChange={onChange} />);
+    await user.click(
+      screen.getByRole("switch", { name: /cache revalidation/i })
+    );
+    const last = onChange.mock.lastCall?.[0] as BuilderSettingsValues;
+    expect(last.revalidate).toBe(false);
+  });
+
+  it("renders unchecked when revalidation was turned off", () => {
+    render(
+      <Controlled fields={["revalidate"]} initial={{ revalidate: false }} />
+    );
+    const sw = screen.getByRole("switch", { name: /cache revalidation/i });
+    expect(sw.getAttribute("data-state")).toBe("unchecked");
+  });
+});
+
 describe("AdvancedTab -- showSystemFields", () => {
   beforeEach(() => {
     localStorage.clear();

--- a/packages/admin/src/lib/builder/__tests__/settings-dirty.test.ts
+++ b/packages/admin/src/lib/builder/__tests__/settings-dirty.test.ts
@@ -41,6 +41,7 @@ describe("settingsAreDirty", () => {
     status: { ...base, status: false },
     i18n: { ...base, i18n: true },
     versions: { ...base, versions: true },
+    revalidate: { ...base, revalidate: false },
   };
 
   for (const [key, next] of Object.entries(changed)) {

--- a/packages/admin/src/lib/builder/settings-dirty.ts
+++ b/packages/admin/src/lib/builder/settings-dirty.ts
@@ -18,6 +18,7 @@ const COMPARED_KEYS = [
   "status",
   "i18n",
   "versions",
+  "revalidate",
 ] as const;
 
 type ComparedKey = (typeof COMPARED_KEYS)[number];

--- a/packages/admin/src/lib/builder/settings-to-manifest.test.ts
+++ b/packages/admin/src/lib/builder/settings-to-manifest.test.ts
@@ -133,3 +133,31 @@ describe("version history in the manifest mirror", () => {
     });
   }
 });
+
+describe("cache revalidation in the manifest mirror", () => {
+  const cases = [
+    ["collection", collectionEntityFromSettings],
+    ["single", singleEntityFromSettings],
+  ] as const;
+
+  const base = {
+    singularName: "Post",
+    pluralName: "Posts",
+    slug: "posts",
+    icon: "FileText",
+  };
+
+  for (const [kind, build] of cases) {
+    it(`${kind}: mirrors the opt-out when off`, () => {
+      const entity = build("posts", { ...base, revalidate: false }, FIELDS);
+      expect(entity.revalidate).toBe(false);
+    });
+
+    it(`${kind}: defaults to on when the setting is absent`, () => {
+      // Revalidation is on unless explicitly disabled, so an absent value must
+      // land as true in the manifest, not undefined (which would drop the key).
+      const entity = build("posts", base, FIELDS);
+      expect(entity.revalidate).toBe(true);
+    });
+  }
+});

--- a/packages/admin/src/lib/builder/settings-to-manifest.ts
+++ b/packages/admin/src/lib/builder/settings-to-manifest.ts
@@ -33,6 +33,9 @@ export function collectionEntityFromSettings(
       // Version history, mirrored into ui-schema.json so the committed
       // manifest matches what the registry was just told.
       versions: settings.versions === true,
+      // Cache revalidation, mirrored into ui-schema.json. Defaults on, so only
+      // an explicit `false` opts the collection out; anything else stays on.
+      revalidate: settings.revalidate !== false,
     },
     fields,
   });
@@ -52,6 +55,9 @@ export function singleEntityFromSettings(
       localized: settings.i18n === true,
       // Version history (mirrors collectionEntityFromSettings).
       versions: settings.versions === true,
+      // Cache revalidation (mirrors collectionEntityFromSettings): defaults on,
+      // only an explicit `false` opts the single out.
+      revalidate: settings.revalidate !== false,
     },
     fields,
   });

--- a/packages/admin/src/lib/builder/to-manifest-entity.ts
+++ b/packages/admin/src/lib/builder/to-manifest-entity.ts
@@ -82,6 +82,8 @@ export interface BuilderSettingsInput {
   localized?: boolean;
   /** Whether every save is recorded as a restorable version. */
   versions?: boolean;
+  /** Whether writes bust cache tags. Defaults on; false opts out. */
+  revalidate?: boolean;
   useAsTitle?: string;
   defaultColumns?: string[];
   group?: string;
@@ -139,6 +141,8 @@ export interface ManifestEntity {
   localized?: boolean;
   /** Whether every save is recorded as a restorable version. */
   versions?: boolean;
+  /** Whether writes bust cache tags. Defaults on; false opts out. */
+  revalidate?: boolean;
   fields: ManifestField[];
 }
 
@@ -202,8 +206,15 @@ export function applyCommonSettings(
   entity: ManifestEntity,
   settings: BuilderSettingsInput
 ): void {
-  const { useAsTitle, defaultColumns, group, status, localized, versions } =
-    settings;
+  const {
+    useAsTitle,
+    defaultColumns,
+    group,
+    status,
+    localized,
+    versions,
+    revalidate,
+  } = settings;
   const admin: NonNullable<ManifestEntity["admin"]> = {};
   if (useAsTitle) admin.useAsTitle = useAsTitle;
   if (defaultColumns && defaultColumns.length > 0) {
@@ -214,6 +225,7 @@ export function applyCommonSettings(
   if (status !== undefined) entity.status = status;
   if (localized !== undefined) entity.localized = localized;
   if (versions !== undefined) entity.versions = versions;
+  if (revalidate !== undefined) entity.revalidate = revalidate;
 }
 
 export function collectionToManifestEntity(

--- a/packages/admin/src/pages/dashboard/collections/builder/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/collections/builder/[slug].tsx
@@ -209,9 +209,7 @@ export default function CollectionBuilderEditPage({
           ?.enabled === true,
       // Cache revalidation is on unless the stored config disables it, so the
       // switch reflects on for both null (default) and an absent-disable config.
-      revalidate:
-        (collection as { revalidate?: { disable?: boolean } | null }).revalidate
-          ?.disable !== true,
+      revalidate: collection.revalidate?.disable !== true,
     };
     setSettings(loadedSettings);
     // Pin a copy as the dirty baseline so settings-only edits enable Save.

--- a/packages/admin/src/pages/dashboard/collections/builder/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/collections/builder/[slug].tsx
@@ -207,6 +207,11 @@ export default function CollectionBuilderEditPage({
       versions:
         (collection as { versions?: { enabled?: boolean } | null }).versions
           ?.enabled === true,
+      // Cache revalidation is on unless the stored config disables it, so the
+      // switch reflects on for both null (default) and an absent-disable config.
+      revalidate:
+        (collection as { revalidate?: { disable?: boolean } | null }).revalidate
+          ?.disable !== true,
     };
     setSettings(loadedSettings);
     // Pin a copy as the dirty baseline so settings-only edits enable Save.
@@ -325,6 +330,9 @@ export default function CollectionBuilderEditPage({
                   status: settings.status === true,
                   localized: settings.i18n === true,
                   versions: settings.versions === true,
+                  // Cache revalidation: on unless explicitly turned off; the
+                  // server normalizes the boolean into the stored config.
+                  revalidate: settings.revalidate !== false,
                 },
               },
               {
@@ -410,6 +418,8 @@ export default function CollectionBuilderEditPage({
             // Version history: the server normalizes this into the resolved
             // config the registry column holds.
             versions: settings.versions === true,
+            // Cache revalidation: on unless explicitly turned off.
+            revalidate: settings.revalidate !== false,
             // Why: useAsTitle + timestamps were removed from the modal in
             // PR B (system title is always the display; timestamps always
             // emitted). Backend defaults take over -- code-first config can

--- a/packages/admin/src/pages/dashboard/collections/builder/builder-config.ts
+++ b/packages/admin/src/pages/dashboard/collections/builder/builder-config.ts
@@ -9,7 +9,13 @@ import type { BuilderConfig } from "@admin/components/features/schema-builder/bu
 export const COLLECTION_BUILDER_CONFIG: BuilderConfig = {
   kind: "collection",
   basicsFields: ["singularName", "pluralName", "slug", "description", "icon"],
-  advancedFields: ["status", "i18n", "versions", "showSystemFields"],
+  advancedFields: [
+    "status",
+    "i18n",
+    "versions",
+    "revalidate",
+    "showSystemFields",
+  ],
   toolbar: { previewSchemaChange: true },
   picker: {},
 };

--- a/packages/admin/src/pages/dashboard/collections/builder/index.tsx
+++ b/packages/admin/src/pages/dashboard/collections/builder/index.tsx
@@ -62,6 +62,9 @@ export default function CollectionBuilderPage(): React.ReactElement | null {
         localized: values.i18n === true,
         // Version history opt-in at create; the server resolves the boolean.
         versions: values.versions === true,
+        // Cache revalidation opt-out at create; on by default, so only an
+        // explicit false is forwarded as off. The server resolves the boolean.
+        revalidate: values.revalidate !== false,
         // Why: useAsTitle + timestamps removed in PR B. Backend defaults
         // (timestamps always on, useAsTitle = system title) take over.
         // Code-first config can still override either.
@@ -90,6 +93,8 @@ export default function CollectionBuilderPage(): React.ReactElement | null {
                     localized: values.i18n === true,
                     // and with version history.
                     versions: values.versions === true,
+                    // and with cache revalidation (on unless explicitly off).
+                    revalidate: values.revalidate !== false,
                   },
                   fields: [],
                 })

--- a/packages/admin/src/pages/dashboard/singles/builder/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/singles/builder/[slug].tsx
@@ -168,6 +168,11 @@ export default function SingleBuilderEditPage({
       versions:
         (single as { versions?: { enabled?: boolean } | null }).versions
           ?.enabled === true,
+      // Cache revalidation is on unless the stored config disables it (mirrors
+      // the collection builder).
+      revalidate:
+        (single as { revalidate?: { disable?: boolean } | null }).revalidate
+          ?.disable !== true,
     };
     setSettings(loadedSettings);
     setOriginalSettings(loadedSettings);
@@ -256,6 +261,8 @@ export default function SingleBuilderEditPage({
                   status: settings.status === true,
                   localized: settings.i18n === true,
                   versions: settings.versions === true,
+                  // Cache revalidation: on unless explicitly turned off.
+                  revalidate: settings.revalidate !== false,
                 },
               },
               {
@@ -337,6 +344,8 @@ export default function SingleBuilderEditPage({
             // Version history: the server normalizes this into the resolved
             // config the registry column holds.
             versions: settings.versions === true,
+            // Cache revalidation: on unless explicitly turned off.
+            revalidate: settings.revalidate !== false,
           },
         },
         {

--- a/packages/admin/src/pages/dashboard/singles/builder/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/singles/builder/[slug].tsx
@@ -170,9 +170,7 @@ export default function SingleBuilderEditPage({
           ?.enabled === true,
       // Cache revalidation is on unless the stored config disables it (mirrors
       // the collection builder).
-      revalidate:
-        (single as { revalidate?: { disable?: boolean } | null }).revalidate
-          ?.disable !== true,
+      revalidate: single.revalidate?.disable !== true,
     };
     setSettings(loadedSettings);
     setOriginalSettings(loadedSettings);

--- a/packages/admin/src/pages/dashboard/singles/builder/builder-config.ts
+++ b/packages/admin/src/pages/dashboard/singles/builder/builder-config.ts
@@ -16,7 +16,13 @@ export const SINGLE_BUILDER_CONFIG: BuilderConfig = {
   kind: "single",
   basicsFields: ["singularName", "slug", "description", "icon"],
   // showSystemFields added in PR B so singles can also surface the toggle.
-  advancedFields: ["status", "i18n", "versions", "showSystemFields"],
+  advancedFields: [
+    "status",
+    "i18n",
+    "versions",
+    "revalidate",
+    "showSystemFields",
+  ],
   toolbar: { previewSchemaChange: false },
   picker: {},
 };

--- a/packages/admin/src/pages/dashboard/singles/builder/index.tsx
+++ b/packages/admin/src/pages/dashboard/singles/builder/index.tsx
@@ -65,6 +65,9 @@ export default function SingleBuilderPage(): React.ReactElement | null {
         ...(values.i18n === true ? { localized: true } : {}),
         // Version history opt-in at create; the server resolves the boolean.
         ...(values.versions === true ? { versions: true } : {}),
+        // Cache revalidation is on by default, so only forward an explicit
+        // opt-out; omitting the key leaves the server default (on).
+        ...(values.revalidate === false ? { revalidate: false } : {}),
         // Empty user-fields list — system columns are auto-injected by
         // the server; user adds custom fields on the next page.
         fields: [],
@@ -86,6 +89,8 @@ export default function SingleBuilderPage(): React.ReactElement | null {
                     localized: values.i18n === true,
                     // and version history.
                     versions: values.versions === true,
+                    // and cache revalidation (on unless explicitly off).
+                    revalidate: values.revalidate !== false,
                   },
                   fields: [],
                 })

--- a/packages/admin/src/types/collection.ts
+++ b/packages/admin/src/types/collection.ts
@@ -334,6 +334,8 @@ export interface CreateCollectionPayload {
   localized?: boolean;
   /** Whether every save is recorded as a restorable version. Default false. */
   versions?: boolean;
+  /** Whether writes bust cache tags. Default true; false opts the collection out. */
+  revalidate?: boolean;
   /** Whether to auto-generate createdAt/updatedAt. Default true. */
   timestamps?: boolean;
   fields: FieldDefinition[];
@@ -356,6 +358,8 @@ export interface UpdateCollectionPayload {
   status?: boolean;
   /** Toggle version history. Every save is recorded as a restorable version. */
   versions?: boolean;
+  /** Toggle cache revalidation. Default true; false opts the collection out. */
+  revalidate?: boolean;
   /** i18n: toggle translatable fields. Toggling on adds the companion `_locales`
    *  table (migration-gated, via the schema-change preview). */
   localized?: boolean;

--- a/packages/admin/src/types/collection.ts
+++ b/packages/admin/src/types/collection.ts
@@ -251,6 +251,13 @@ export interface Collection {
    */
   status?: boolean;
   /**
+   * Resolved cache-revalidation config, or null/absent when revalidation is on
+   * with no override. The server normalizes the Schema Builder's on/off switch
+   * into this shape (off → `{ disable: true }`), so reads carry the object while
+   * writes send a boolean — see `UpdateCollectionPayload`.
+   */
+  revalidate?: { disable?: boolean; tags?: string[] } | null;
+  /**
    * Legacy schema definition format.
    * New API returns `fields` directly at root level.
    */

--- a/packages/admin/src/types/entities.ts
+++ b/packages/admin/src/types/entities.ts
@@ -319,12 +319,16 @@ export interface ApiSingle {
 /**
  * What a Single schema update may send.
  *
- * Most keys mirror the read shape, but `versions` does not: the Schema Builder
- * offers on/off and the server resolves that into the config `ApiSingle`
- * carries back.
+ * Most keys mirror the read shape, but `versions` and `revalidate` do not: the
+ * Schema Builder offers on/off and the server resolves each into the config
+ * `ApiSingle` carries back.
  */
-export type UpdateSinglePayload = Omit<Partial<ApiSingle>, "versions"> & {
+export type UpdateSinglePayload = Omit<
+  Partial<ApiSingle>,
+  "versions" | "revalidate"
+> & {
   versions?: boolean;
+  revalidate?: boolean;
 };
 
 // ==================== COMPONENT TYPES ====================

--- a/packages/admin/src/types/entities.ts
+++ b/packages/admin/src/types/entities.ts
@@ -306,6 +306,14 @@ export interface ApiSingle {
    */
   versions?: { enabled?: boolean } | null;
 
+  /**
+   * Resolved cache-revalidation config, or null/absent when revalidation is on
+   * with no override. The server normalizes the Schema Builder's on/off into
+   * this shape (off → `{ disable: true }`), so reads carry the object while
+   * writes send a boolean — see `UpdateSinglePayload`.
+   */
+  revalidate?: { disable?: boolean; tags?: string[] } | null;
+
   /** Current migration status */
   migrationStatus?: SingleMigrationStatus;
 

--- a/packages/nextly/src/api/collections-schema-detail.ts
+++ b/packages/nextly/src/api/collections-schema-detail.ts
@@ -33,6 +33,7 @@ import {
   applyPluginAdminViews,
   type CollectionWithAdmin,
 } from "../plugins/admin-views";
+import { resolveBuilderRevalidate } from "../revalidation/builder-revalidate";
 import { getHandlerConfig } from "../route-handler/auth-handler";
 import type { CollectionRegistryService } from "../services/collections/collection-registry-service";
 import type { ComponentRegistryService } from "../services/components/component-registry-service";
@@ -213,6 +214,14 @@ export const PATCH = withErrorHandler(
     // collection.
     if (body.versions !== undefined) {
       updateData.versions = resolveBuilderVersions(body.versions === true);
+    }
+
+    // Cache-revalidation toggle, normalized to the resolved config the write
+    // path reads; on writes null (standard tags), off writes the disable config.
+    if (body.revalidate !== undefined) {
+      updateData.revalidate = resolveBuilderRevalidate(
+        body.revalidate === true
+      );
     }
 
     // Admin fields: support both nested admin object and flat top-level

--- a/packages/nextly/src/api/collections-schema.ts
+++ b/packages/nextly/src/api/collections-schema.ts
@@ -24,6 +24,7 @@ import { calculateSchemaHash } from "../domains/schema/services/schema-hash";
 import { resolveBuilderVersions } from "../domains/versions/builder-versions";
 import { getFilterRegistry, FilterSeams } from "../filters";
 import { getCachedNextly } from "../init";
+import { resolveBuilderRevalidate } from "../revalidation/builder-revalidate";
 import type { CollectionRegistryService } from "../services/collections/collection-registry-service";
 import { hasPermission, isSuperAdmin } from "../services/lib/permissions";
 import { requireBuilderEnabled } from "../shared/builder-access";
@@ -84,6 +85,10 @@ const createCollectionSchema = z.object({
   // Version history opt-in. Default off: capture adds a row to nextly_versions
   // on every save, which no existing caller has asked for.
   versions: z.boolean().optional(),
+  // Cache-revalidation opt-out. Default on (absent): writes bust the standard
+  // nextly:* tags; false persists the disable config so this collection busts
+  // nothing.
+  revalidate: z.boolean().optional(),
   admin: z
     .object({
       group: z.string().optional(),
@@ -278,6 +283,9 @@ export const POST = withErrorHandler(async (request: Request) => {
     // Version history opt-in, normalized to the resolved config the column
     // holds and every runtime reader tests.
     versions: resolveBuilderVersions(validated.versions),
+    // Cache-revalidation opt-out, normalized to the resolved config the write
+    // path reads (null = standard tags, { disable: true } = off).
+    revalidate: resolveBuilderRevalidate(validated.revalidate),
     schemaHash,
     hooks: validated.hooks,
   });

--- a/packages/nextly/src/api/singles-schema-detail.ts
+++ b/packages/nextly/src/api/singles-schema-detail.ts
@@ -28,6 +28,7 @@ import { resolveBuilderVersions } from "../domains/versions/builder-versions";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
 import { getNextlyLogger } from "../observability/logger";
+import { resolveBuilderRevalidate } from "../revalidation/builder-revalidate";
 import type { ComponentRegistryService } from "../services/components/component-registry-service";
 import type { SingleRegistryService } from "../services/singles/single-registry-service";
 import { requireBuilderEnabled } from "../shared/builder-access";
@@ -194,6 +195,15 @@ export const PATCH = withErrorHandler(
     // column holds; off writes null. Mirrors the collection detail route.
     if (body.versions !== undefined) {
       updateData.versions = resolveBuilderVersions(body.versions === true);
+    }
+
+    // Cache-revalidation toggle, normalized to the resolved config the write
+    // path reads; on writes null, off writes the disable config. Mirrors the
+    // collection detail route.
+    if (body.revalidate !== undefined) {
+      updateData.revalidate = resolveBuilderRevalidate(
+        body.revalidate === true
+      );
     }
 
     if (body.accessRules !== undefined) {

--- a/packages/nextly/src/cli/commands/dev-build.ts
+++ b/packages/nextly/src/cli/commands/dev-build.ts
@@ -186,6 +186,9 @@ export async function syncSingles(
       status: single.status === true,
       localized: single.localized === true,
       versions: resolveVersionsConfig(single.versions, single.status),
+      // Forward the cache-revalidation config through db:sync too, so a
+      // code-first single's disable/tags reach dynamic_singles.revalidate.
+      revalidate: single.revalidate,
       configPath: `singles/${single.slug}.ts`,
     })
   );

--- a/packages/nextly/src/database/__tests__/dynamic-collections-revalidate-column.test.ts
+++ b/packages/nextly/src/database/__tests__/dynamic-collections-revalidate-column.test.ts
@@ -1,0 +1,27 @@
+// Why: lock the contract that the canonical dialect schemas declare the
+// `revalidate` column on dynamic_collections AND dynamic_singles. Without this
+// column declared, Drizzle's `.select()` silently drops `revalidate` from query
+// results (the same class of bug the versions/status column tests guard), so the
+// mutation read path would never see a collection's persisted `disable`/`tags`.
+import { describe, it, expect } from "vitest";
+
+import { dynamicCollectionsMysql } from "../../schemas/dynamic-collections/mysql";
+import { dynamicCollectionsPg } from "../../schemas/dynamic-collections/postgres";
+import { dynamicCollectionsSqlite } from "../../schemas/dynamic-collections/sqlite";
+import { dynamicSinglesMysql } from "../../schemas/dynamic-singles/mysql";
+import { dynamicSinglesPg } from "../../schemas/dynamic-singles/postgres";
+import { dynamicSinglesSqlite } from "../../schemas/dynamic-singles/sqlite";
+
+describe("canonical dialect schemas declare the revalidate column", () => {
+  it("dynamicCollections exposes revalidate on every dialect", () => {
+    expect(dynamicCollectionsPg.revalidate).toBeDefined();
+    expect(dynamicCollectionsMysql.revalidate).toBeDefined();
+    expect(dynamicCollectionsSqlite.revalidate).toBeDefined();
+  });
+
+  it("dynamicSingles exposes revalidate on every dialect", () => {
+    expect(dynamicSinglesPg.revalidate).toBeDefined();
+    expect(dynamicSinglesMysql.revalidate).toBeDefined();
+    expect(dynamicSinglesSqlite.revalidate).toBeDefined();
+  });
+});

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -1278,6 +1278,10 @@ async function syncCodeFirstCollections(
       // dynamic_collections.versions. `status: true` aliases to a versioned
       // config, so pass both to the resolver.
       versions: resolveVersionsConfig(collection.versions, collection.status),
+      // Forward the cache-revalidation config verbatim so it persists to
+      // dynamic_collections.revalidate; the write path reads it to honor
+      // `disable` and merge extra `tags`.
+      revalidate: collection.revalidate,
       // Forward the i18n master switch (mirrors status) so the boot sync persists
       // dynamic_collections.localized — the read path keys companion resolution off it.
       localized: collection.localized === true,
@@ -1836,6 +1840,10 @@ async function syncCodeFirstSingles(
       // Resolve + forward the versioning config so it persists to
       // dynamic_singles.versions (status:true aliases to a versioned config).
       versions: resolveVersionsConfig(single.versions, single.status),
+      // Forward the cache-revalidation config verbatim so it persists to
+      // dynamic_singles.revalidate; the write path reads it to honor `disable`
+      // and merge extra `tags`.
+      revalidate: single.revalidate,
     }));
 
   try {

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -65,6 +65,7 @@ import type { SingleRegistryService } from "../../domains/singles/services/singl
 import { resolveBuilderVersions } from "../../domains/versions/builder-versions";
 import { NextlyError } from "../../errors";
 import { transformRichTextFields } from "../../lib/field-transform";
+import { resolveBuilderRevalidate } from "../../revalidation/builder-revalidate";
 import { getProductionNotifier } from "../../runtime/notifications/index";
 import { isReservedResourceSlug } from "../../schemas/_zod/rbac";
 import type { FieldDefinition } from "../../schemas/dynamic-collections";
@@ -511,6 +512,8 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
             localized?: boolean;
             // Version history opt-in; persists to dynamic_singles.versions.
             versions?: boolean;
+            // Cache-revalidation opt-out; persists to dynamic_singles.revalidate.
+            revalidate?: boolean;
           }
         | undefined;
 
@@ -668,6 +671,9 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         // created with the switch on is written unversioned and the switch
         // reads as off the moment the editor loads.
         versions: resolveBuilderVersions(b.versions),
+        // Cache-revalidation opt-out from the create payload (null = standard
+        // tags, { disable: true } = off), so the write path reads it back.
+        revalidate: resolveBuilderRevalidate(b.revalidate),
         schemaHash,
         migrationStatus,
       });
@@ -952,6 +958,9 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
             // Version history toggle; honoured when defined, undefined leaves
             // the existing value untouched. Persists to dynamic_singles.versions.
             versions?: boolean;
+            // Cache-revalidation toggle; honoured when defined, undefined leaves
+            // the existing value untouched. Persists to dynamic_singles.revalidate.
+            revalidate?: boolean;
           }
         | undefined;
 
@@ -985,6 +994,11 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       // stop the toggle from turning versioning off on a Draft/Published single.
       if (b.versions !== undefined) {
         updateData.versions = resolveBuilderVersions(b.versions);
+      }
+      // Cache-revalidation toggle, normalized to the resolved config the write
+      // path reads; on writes null (standard tags), off writes the disable config.
+      if (b.revalidate !== undefined) {
+        updateData.revalidate = resolveBuilderRevalidate(b.revalidate);
       }
       const wasLocalized = existing.localized === true;
       const isLocalized =

--- a/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
@@ -350,6 +350,45 @@ describe("cache revalidation — write path (sqlite)", () => {
     }
   });
 
+  it("flushes nothing when the collection's revalidate config is disabled", async () => {
+    // The `revalidate: { disable: true }` config must round-trip through the
+    // registry and reach the write site, so a disabled collection busts nothing.
+    const entries = await boot([
+      defineCollection({
+        slug: "noreval",
+        status: true,
+        access: { create: () => true },
+        revalidate: { disable: true },
+        fields: [text({ name: "title" }), text({ name: "slug" })],
+      }),
+    ]);
+    await entries.createEntry(
+      { collectionName: "noreval", overrideAccess: true },
+      { title: "T", slug: "hidden" }
+    );
+    expect(spy.flushed).toHaveLength(0);
+  });
+
+  it("includes the collection's configured extra revalidate tags", async () => {
+    // The `revalidate: { tags: [...] }` config must round-trip and be merged into
+    // every write's intent.
+    const entries = await boot([
+      defineCollection({
+        slug: "tagged",
+        status: true,
+        access: { create: () => true },
+        revalidate: { tags: ["navigation"] },
+        fields: [text({ name: "title" }), text({ name: "slug" })],
+      }),
+    ]);
+    await entries.createEntry(
+      { collectionName: "tagged", overrideAccess: true },
+      { title: "T", slug: "y" }
+    );
+    expect(spy.tags).toContain("navigation");
+    expect(spy.tags).toContain("nextly:tagged:slug:y");
+  });
+
   it("flushes nothing when a write records no event (update of a missing entry)", async () => {
     const entries = await boot([openCollection("nope")]);
     const result = await entries.updateEntry(
@@ -384,5 +423,30 @@ describe("cache revalidation — write path (sqlite)", () => {
       { overrideAccess: true }
     );
     expect(spy.tags).toContain("nextly:single:header");
+  });
+
+  it("flushes nothing when the single's revalidate config is disabled", async () => {
+    // Singles persist + read `revalidate` through their own registry
+    // deserialize path, so verify a disabled single busts nothing.
+    const adapter = await memoryAdapter();
+    handle = await createTestNextly({
+      adapter,
+      singles: [
+        defineSingle({
+          slug: "footer",
+          access: { read: () => true, update: () => true },
+          revalidate: { disable: true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const singleEntry =
+      handle.getService<SingleEntryService>("singleEntryService");
+    await singleEntry.update(
+      "footer",
+      { title: "Site" },
+      { overrideAccess: true }
+    );
+    expect(spy.flushed).toHaveLength(0);
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
@@ -11,6 +11,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { defineCollection, defineSingle, text } from "../../../config";
+import { resolveBuilderRevalidate } from "../../../revalidation/builder-revalidate";
 import { createAdapter } from "../../../database/factory";
 import { container } from "../../../di/container";
 // Used to model a committed-but-hook-failed write: a code afterCreate hook that
@@ -387,6 +388,46 @@ describe("cache revalidation — write path (sqlite)", () => {
     );
     expect(spy.tags).toContain("navigation");
     expect(spy.tags).toContain("nextly:tagged:slug:y");
+  });
+
+  it("busts nothing for a Builder collection with revalidation turned off", async () => {
+    // Parity: the Schema Builder switch OFF resolves to the disable config, and
+    // once persisted the write path must honor it exactly like a code-first
+    // opt-out. Binding the resolver output here catches a drift in either.
+    const entries = await boot([
+      defineCollection({
+        slug: "builderoff",
+        status: true,
+        access: { create: () => true },
+        revalidate: resolveBuilderRevalidate(false) ?? undefined,
+        fields: [text({ name: "title" }), text({ name: "slug" })],
+      }),
+    ]);
+    await entries.createEntry(
+      { collectionName: "builderoff", overrideAccess: true },
+      { title: "T", slug: "off" }
+    );
+    expect(spy.flushed).toHaveLength(0);
+  });
+
+  it("busts the standard tags for a Builder collection with revalidation on", async () => {
+    // The Builder switch ON resolves to null (no override), so a Builder-created
+    // collection busts the same derived tags a code-first one does.
+    const entries = await boot([
+      defineCollection({
+        slug: "builderon",
+        status: true,
+        access: { create: () => true },
+        revalidate: resolveBuilderRevalidate(true) ?? undefined,
+        fields: [text({ name: "title" }), text({ name: "slug" })],
+      }),
+    ]);
+    await entries.createEntry(
+      { collectionName: "builderon", overrideAccess: true },
+      { title: "T", slug: "on" }
+    );
+    expect(spy.tags).toContain("nextly:builderon");
+    expect(spy.tags).toContain("nextly:builderon:slug:on");
   });
 
   it("flushes nothing when a write records no event (update of a missing entry)", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/collection-registry-service.status-persist.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-registry-service.status-persist.test.ts
@@ -285,3 +285,76 @@ describe("CollectionRegistryService.deserializeRecord — status normalisation",
     expect(result.status).toBe(false);
   });
 });
+
+// ────────────────────────────────────────────────────────────────────────
+// revalidate persistence (F1 PR 2.5) — the write path reads this back to
+// honor `disable` / extra `tags`, and code-first sync must be able to CLEAR it
+// when the config removes it (send null, not undefined).
+// ────────────────────────────────────────────────────────────────────────
+
+describe("CollectionRegistryService — revalidate persistence", () => {
+  let ctx: ReturnType<typeof createCtx>;
+
+  beforeEach(() => {
+    ctx = createCtx();
+  });
+
+  function mockExisting(row: Record<string, unknown>) {
+    ctx.adapter.selectOne.mockImplementation(async (table: string) => {
+      if (table === "dynamic_collections") return row;
+      return null;
+    });
+  }
+
+  function existingRow(): Record<string, unknown> {
+    return {
+      id: "1",
+      slug: "posts",
+      labels: { singular: "Post", plural: "Posts" },
+      table_name: "dc_posts",
+      fields: "[]",
+      source: "ui",
+      locked: 0,
+      status: 0,
+      schema_hash: "h",
+      schema_version: 1,
+      migration_status: "applied",
+      created_at: "2026-01-01",
+      updated_at: "2026-01-01",
+    };
+  }
+
+  it("writes revalidate JSON on registerCollection", async () => {
+    await ctx.service.registerCollection({
+      slug: "posts",
+      labels: { singular: "Post", plural: "Posts" },
+      tableName: "dc_posts",
+      fields: [],
+      source: "ui",
+      schemaHash: "h",
+      revalidate: { disable: true },
+    });
+
+    expect(ctx.insertCalls[0].row.revalidate).toBe(
+      JSON.stringify({ disable: true })
+    );
+  });
+
+  it("clears revalidate (writes null) when updateCollection is sent null", async () => {
+    mockExisting(existingRow());
+
+    // The clear-on-removal path: code-first sync sends `revalidate: null` (not
+    // undefined) when the config drops `revalidate`.
+    await ctx.service.updateCollection("posts", { revalidate: null });
+
+    expect(ctx.updateCalls[0].data.revalidate).toBe(null);
+  });
+
+  it("omits revalidate from the update when the caller omits it", async () => {
+    mockExisting(existingRow());
+
+    await ctx.service.updateCollection("posts", { description: "new desc" });
+
+    expect("revalidate" in ctx.updateCalls[0].data).toBe(false);
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
@@ -341,6 +341,8 @@ export class CollectionMetadataService extends BaseService {
     localized?: boolean;
     /** Whether every save is recorded as a restorable version. */
     versions?: boolean;
+    /** Whether writes bust cache tags. Default on; false opts out entirely. */
+    revalidate?: boolean;
     fields: FieldDefinition[];
     hooks?: Record<string, unknown>[];
     createdBy?: string;
@@ -683,6 +685,8 @@ export class CollectionMetadataService extends BaseService {
       localized?: boolean;
       /** Toggle version history. Honoured when defined; undefined leaves it unchanged. */
       versions?: boolean;
+      /** Toggle cache revalidation. Honoured when defined; undefined leaves it unchanged. */
+      revalidate?: boolean;
       fields?: FieldDefinition[];
       hooks?: Record<string, unknown>[];
     }

--- a/packages/nextly/src/domains/collections/services/collection-registry-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-registry-service.ts
@@ -56,6 +56,8 @@ export interface CodeFirstCollectionConfig {
   status?: boolean;
   /** Resolved content-versioning config (or null when unversioned). */
   versions?: DynamicCollectionInsert["versions"];
+  /** Cache-revalidation config (or null when the collection sets none). */
+  revalidate?: DynamicCollectionInsert["revalidate"];
   /** Whether collection-level i18n is enabled (mirrors `status`). */
   localized?: boolean;
   admin?: DynamicCollectionInsert["admin"];
@@ -233,6 +235,8 @@ export class CollectionRegistryService extends BaseRegistryService<
       // Persist the resolved versioning config as JSON (or null), the same way
       // `admin`/`hooks` are written on this raw-insert path.
       versions: data.versions ? JSON.stringify(data.versions) : null,
+      // Persist the cache-revalidation config as JSON (or null), like `versions`.
+      revalidate: data.revalidate ? JSON.stringify(data.revalidate) : null,
       localized: data.localized === true ? 1 : 0,
       config_path: data.configPath,
       schema_hash: schemaHash,
@@ -384,6 +388,12 @@ export class CollectionRegistryService extends BaseRegistryService<
         ? JSON.stringify(data.versions)
         : null;
     }
+    // Cache-revalidation config: same explicit-provide semantics as `versions`.
+    if (data.revalidate !== undefined) {
+      updateData.revalidate = data.revalidate
+        ? JSON.stringify(data.revalidate)
+        : null;
+    }
     if (data.localized !== undefined) {
       updateData.localized = data.localized === true ? 1 : 0;
     }
@@ -491,6 +501,8 @@ export class CollectionRegistryService extends BaseRegistryService<
             status: config.status === true,
             // Forward the resolved versioning config on first sync.
             versions: config.versions,
+            // Forward the cache-revalidation config on first sync.
+            revalidate: config.revalidate,
             localized: config.localized === true,
             configPath: config.configPath,
             schemaHash,
@@ -504,6 +516,9 @@ export class CollectionRegistryService extends BaseRegistryService<
           // normalized JSON, so a stable string compare detects a real change).
           JSON.stringify(config.versions ?? null) !==
             JSON.stringify(existing.versions ?? null) ||
+          // Re-sync when the cache-revalidation config changed.
+          JSON.stringify(config.revalidate ?? null) !==
+            JSON.stringify(existing.revalidate ?? null) ||
           (config.localized === true) !== (existing.localized === true) ||
           desiredTableName !== existing.tableName
         ) {
@@ -530,6 +545,10 @@ export class CollectionRegistryService extends BaseRegistryService<
               locked: true,
               status: config.status === true,
               versions: config.versions,
+              // Send explicit null (not undefined) when the config removed
+              // `revalidate`, so updateCollection actually clears the column
+              // instead of leaving the stale config persisted.
+              revalidate: config.revalidate ?? null,
               localized: config.localized === true,
               tableName: desiredTableName,
             },
@@ -607,6 +626,7 @@ export class CollectionRegistryService extends BaseRegistryService<
                 // collection recovered here does not silently lose localization.
                 localized: config.localized === true,
                 versions: config.versions,
+                revalidate: config.revalidate,
                 configPath: config.configPath,
                 schemaHash: retrySchemaHash,
               });
@@ -678,6 +698,8 @@ export class CollectionRegistryService extends BaseRegistryService<
       status: data.status === true ? 1 : 0,
       // Same as registerCollection — persist the resolved versioning config.
       versions: data.versions ? JSON.stringify(data.versions) : null,
+      // Same as registerCollection — persist the cache-revalidation config.
+      revalidate: data.revalidate ? JSON.stringify(data.revalidate) : null,
       localized: data.localized === true ? 1 : 0,
       config_path: data.configPath,
       schema_hash: data.schemaHash,
@@ -789,6 +811,7 @@ export class CollectionRegistryService extends BaseRegistryService<
     const fields = (r.fields || r.fields) as string | object;
     const admin = (r.admin || r.admin) as string | object | null;
     const versions = r.versions as string | object | null | undefined;
+    const revalidate = r.revalidate as string | object | null | undefined;
     const hooks = (r.hooks || r.hooks) as string | object | null;
     const tableName = (r.table_name || r.tableName) as string;
     const configPath = (r.config_path || r.configPath) as string | undefined;
@@ -834,6 +857,14 @@ export class CollectionRegistryService extends BaseRegistryService<
         ? typeof versions === "string"
           ? JSON.parse(versions)
           : versions
+        : null,
+      // Parse the cache-revalidation config (JSON string on the raw-insert path
+      // / SQLite; already an object on pg/mysql jsonb). null when unset or on
+      // rows written before this column existed.
+      revalidate: revalidate
+        ? typeof revalidate === "string"
+          ? JSON.parse(revalidate)
+          : revalidate
         : null,
       localized: r.localized === 1 || r.localized === true,
       configPath,

--- a/packages/nextly/src/domains/collections/services/collection-sync-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-sync-service.ts
@@ -654,6 +654,9 @@ export class CollectionSyncService extends BaseService {
       status: config.status === true,
       localized: config.localized === true,
       versions: resolveVersionsConfig(config.versions, config.status),
+      // Forward the cache-revalidation config verbatim (no resolver — the
+      // authored `{ tags?, disable? }` shape is persisted as-is).
+      revalidate: config.revalidate,
       admin: config.admin
         ? {
             group: config.admin.group,

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-registry-service.ts
@@ -2,6 +2,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import { eq, and, or, like, asc, desc, count } from "drizzle-orm";
 
 import { NextlyError } from "../../../errors";
+import type { RevalidateConfig } from "../../../revalidation/types";
 import { isReservedResourceSlug } from "../../../schemas/_zod/rbac";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import type { MigrationStatus } from "../../../schemas/dynamic-collections/types";
@@ -35,6 +36,12 @@ export interface CollectionMetadata {
    * the `dynamic_collections.versions` JSON column.
    */
   versions?: ResolvedVersionsConfig | null;
+  /**
+   * Cache-revalidation config, or null when the collection sets none. Backed by
+   * the `dynamic_collections.revalidate` JSON column; the write path reads it to
+   * honor `disable` and merge extra `tags`.
+   */
+  revalidate?: RevalidateConfig | null;
   admin?: {
     group?: string;
     icon?: string;
@@ -186,6 +193,8 @@ export class DynamicCollectionRegistryService extends BaseService {
       // Resolved versioning config (or null when unversioned). Stored as JSON
       // the same way `admin` is; Drizzle serializes the object per dialect.
       versions: metadata.versions ?? null,
+      // Cache-revalidation config (or null). Stored as JSON like `versions`.
+      revalidate: metadata.revalidate ?? null,
       configPath: metadata.configPath,
       schemaHash: metadata.schemaHash,
       schemaVersion: metadata.schemaVersion ?? 1,

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -8,6 +8,7 @@ import { createHash, randomBytes } from "crypto";
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import { NextlyError } from "../../../errors";
+import { resolveBuilderRevalidate } from "../../../revalidation/builder-revalidate";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import type { MigrationStatus } from "../../../schemas/dynamic-collections/types";
 import { getI18nArchiveDdl } from "../../../schemas/nextly-i18n-archive";
@@ -80,6 +81,8 @@ export interface CreateCollectionInput {
   localized?: boolean;
   /** Whether every save is recorded as a restorable version. */
   versions?: boolean;
+  /** Whether writes bust cache tags. Default on; false opts out entirely. */
+  revalidate?: boolean;
   fields: FieldDefinition[];
   hooks?: Record<string, unknown>[];
   createdBy?: string;
@@ -101,6 +104,8 @@ export interface UpdateCollectionInput {
   localized?: boolean;
   /** Toggle version history. Honoured when defined; undefined leaves it unchanged. */
   versions?: boolean;
+  /** Toggle cache revalidation. Honoured when defined; undefined leaves it unchanged. */
+  revalidate?: boolean;
   fields?: FieldDefinition[];
   hooks?: Record<string, unknown>[];
 }
@@ -282,6 +287,9 @@ export class DynamicCollectionService extends BaseService {
       // collection created with the switch on is written unversioned and the
       // switch reads as off the moment the editor loads.
       versions: resolveBuilderVersions(data.versions),
+      // Persist the cache-revalidation opt-out from the create payload (null =
+      // standard tags, { disable: true } = off) so the write path reads it back.
+      revalidate: resolveBuilderRevalidate(data.revalidate),
       schemaHash,
       schemaVersion: 1,
       migrationStatus: "pending" as const,
@@ -507,6 +515,12 @@ export class DynamicCollectionService extends BaseService {
     // toggle from ever turning versioning off on a Draft/Published entity.
     if (updates.versions !== undefined) {
       metadataUpdates.versions = resolveBuilderVersions(updates.versions);
+    }
+    // Cache-revalidation toggle. The column holds the resolved config the write
+    // path reads, so the boolean is normalized before storing; off writes the
+    // disable config, on writes null.
+    if (updates.revalidate !== undefined) {
+      metadataUpdates.revalidate = resolveBuilderRevalidate(updates.revalidate);
     }
 
     let migrationSQL: string | null = null;

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
@@ -150,6 +150,17 @@ const addsVersionsColumn = (stmt: string): boolean =>
     stmt.trim()
   );
 
+// The `revalidate` config column is additive (nullable) on the pre-existing
+// dynamic_collections / dynamic_singles registry tables, exactly like
+// `versions` above, so a v1 upgrade of a schema captured before it emits one
+// additive `ADD COLUMN revalidate` per table. Accept it rather than mistaking
+// it for a phantom diff. Scoped to the two registry tables (revalidate is added
+// nowhere else). Tolerant of pg/MySQL quoting and the optional COLUMN keyword.
+const addsRevalidateColumn = (stmt: string): boolean =>
+  /^ALTER TABLE [`"]?(dynamic_collections|dynamic_singles)[`"]? ADD (COLUMN )?[`"]?revalidate[`"]?\b/i.test(
+    stmt.trim()
+  );
+
 // Positive guard: the sim must actually create each new table (an empty first
 // pass would otherwise satisfy the additive-only check vacuously).
 const hasCreateTableFor = (stmts: string[], table: string): boolean =>
@@ -254,7 +265,8 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
           expect(
             isPost045TableStatement(s) ||
               addsOwnerColumn(s) ||
-              addsVersionsColumn(s),
+              addsVersionsColumn(s) ||
+              addsRevalidateColumn(s),
             `phantom diff: ${s}`
           ).toBe(true);
         }
@@ -327,7 +339,8 @@ describe("existing-user upgrade sim (0.45 DDL → v1)", () => {
             isDefaultReconcile ||
               isPost045TableStatement(s) ||
               addsOwnerColumn(s) ||
-              addsVersionsColumn(s),
+              addsVersionsColumn(s) ||
+              addsRevalidateColumn(s),
             `unexpected reconcile statement shape: ${s}`
           ).toBe(true);
         }

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.test.ts
@@ -224,3 +224,98 @@ describe("versions column", () => {
     expect(sql).not.toContain('"enabled":true');
   });
 });
+
+describe("revalidate column", () => {
+  // Revalidation is on by default, so the manifest boolean is inverted from
+  // versions: false persists the disable config, true/absent persists NULL.
+  const off = uiSchemaManifest.parse({
+    collections: [
+      {
+        slug: "posts",
+        revalidate: false,
+        fields: [{ name: "t", type: "text" }],
+      },
+    ],
+    singles: [
+      {
+        slug: "about",
+        revalidate: false,
+        fields: [{ name: "t", type: "text" }],
+      },
+    ],
+    components: [],
+  });
+
+  const on = uiSchemaManifest.parse({
+    collections: [
+      {
+        slug: "posts",
+        revalidate: true,
+        fields: [{ name: "t", type: "text" }],
+      },
+    ],
+    singles: [
+      {
+        slug: "about",
+        revalidate: true,
+        fields: [{ name: "t", type: "text" }],
+      },
+    ],
+    components: [],
+  });
+
+  const cases = [
+    ["collection", buildCollectionMetadataUpsert, off.collections[0]],
+    ["single", buildSingleMetadataUpsert, off.singles[0]],
+  ] as const;
+
+  for (const [kind, build, entity] of cases) {
+    it(`${kind}: stores the disable config when revalidation is off`, () => {
+      // The write path reads `revalidate.disable`, so an off entity must land
+      // the resolved config, not a bare boolean.
+      const sql = build(entity, "sqlite");
+      expect(sql).toContain('"revalidate"');
+      expect(sql).toContain('"disable":true');
+    });
+
+    it(`${kind}: keeps the column updatable on conflict`, () => {
+      const sql = build(entity, "postgresql");
+      expect(sql).toContain('"revalidate" = EXCLUDED."revalidate"');
+    });
+  }
+
+  const onCases = [
+    ["collection", buildCollectionMetadataUpsert, on.collections[0]],
+    ["single", buildSingleMetadataUpsert, on.singles[0]],
+  ] as const;
+
+  for (const [kind, build, entity] of onCases) {
+    it(`${kind}: writes NULL when revalidation is on`, () => {
+      // On is the default (standard tag busting), stored as NULL so no override
+      // is persisted. The column must still be written, so flipping off later
+      // is not left untouched by the upsert's DO UPDATE SET.
+      const sql = build(entity, "sqlite");
+      expect(sql).toContain('"revalidate"');
+      expect(sql).not.toContain('"disable"');
+      expect(sql).toMatch(/NULL/);
+    });
+  }
+
+  it("rejects revalidate on a component", () => {
+    // Components hold no entries and no registry row, so the key would persist
+    // a setting nothing reads.
+    const parsed = uiSchemaManifest.safeParse({
+      collections: [],
+      singles: [],
+      components: [
+        {
+          slug: "seo",
+          revalidate: false,
+          fields: [{ name: "t", type: "text" }],
+        },
+      ],
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
@@ -25,6 +25,7 @@ import { createHash } from "node:crypto";
 
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
+import { resolveBuilderRevalidate } from "../../../revalidation/builder-revalidate";
 import type { UiSchemaEntity } from "../../../schemas/_zod/ui-schema";
 import {
   toPluralLabel,
@@ -71,6 +72,22 @@ function versionsLiteral(
   dialect: Dialect
 ): string {
   const resolved = resolveBuilderVersions(versions);
+  return resolved === null ? "NULL" : jsonLiteral(resolved, dialect);
+}
+
+/**
+ * The `revalidate` column value for a manifest entity.
+ *
+ * The column holds the resolved `{ tags?, disable? }` config the write path
+ * reads, so the manifest's on/off boolean is normalized through the same
+ * mapping the Builder's write paths use: on → NULL (standard revalidation),
+ * off → the disable config.
+ */
+function revalidateLiteral(
+  revalidate: boolean | undefined,
+  dialect: Dialect
+): string {
+  const resolved = resolveBuilderRevalidate(revalidate);
   return resolved === null ? "NULL" : jsonLiteral(resolved, dialect);
 }
 
@@ -196,6 +213,14 @@ export function buildCollectionMetadataUpsert(
       value: versionsLiteral(entity.versions, dialect),
       update: true,
     },
+    {
+      // Always written, including when off (same reason as versions): flipping
+      // the switch off must clear the column, and a column left out of the
+      // upsert is untouched by its DO UPDATE SET.
+      name: "revalidate",
+      value: revalidateLiteral(entity.revalidate, dialect),
+      update: true,
+    },
     { name: "migration_status", value: sqlStr("applied") },
   ];
   if (entity.admin !== undefined) {
@@ -246,6 +271,12 @@ export function buildSingleMetadataUpsert(
       // DO UPDATE SET.
       name: "versions",
       value: versionsLiteral(entity.versions, dialect),
+      update: true,
+    },
+    {
+      // Mirror the collection upsert: always written so flipping off clears it.
+      name: "revalidate",
+      value: revalidateLiteral(entity.revalidate, dialect),
       update: true,
     },
     { name: "migration_status", value: sqlStr("applied") },

--- a/packages/nextly/src/domains/singles/services/single-registry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-registry-service.ts
@@ -108,6 +108,9 @@ export interface CodeFirstSingleConfig {
   /** Resolved content-versioning config (or null when unversioned). */
   versions?: DynamicSingleInsert["versions"];
 
+  /** Cache-revalidation config (or null when the single sets none). */
+  revalidate?: DynamicSingleInsert["revalidate"];
+
   /** Admin UI configuration */
   admin?: DynamicSingleInsert["admin"];
 
@@ -429,6 +432,12 @@ export class SingleRegistryService extends BaseRegistryService<
         ? JSON.stringify(data.versions)
         : null;
     }
+    // Cache-revalidation config: same explicit-provide semantics as `versions`.
+    if (data.revalidate !== undefined) {
+      updateData.revalidate = data.revalidate
+        ? JSON.stringify(data.revalidate)
+        : null;
+    }
 
     try {
       const results = await this.adapter.update<DynamicSingleRecord>(
@@ -590,6 +599,8 @@ export class SingleRegistryService extends BaseRegistryService<
             status: config.status === true,
             // Forward the resolved versioning config on first sync.
             versions: config.versions,
+            // Forward the cache-revalidation config on first sync.
+            revalidate: config.revalidate,
             localized: config.localized === true,
             configPath: config.configPath,
             schemaHash,
@@ -603,6 +614,9 @@ export class SingleRegistryService extends BaseRegistryService<
           // normalized JSON, so a stable string compare detects a real change).
           JSON.stringify(config.versions ?? null) !==
             JSON.stringify(existing.versions ?? null) ||
+          // Re-sync when the cache-revalidation config changed.
+          JSON.stringify(config.revalidate ?? null) !==
+            JSON.stringify(existing.revalidate ?? null) ||
           (config.localized === true) !== (existing.localized === true)
         ) {
           // Either fields changed or the status toggle flipped — both warrant
@@ -620,6 +634,10 @@ export class SingleRegistryService extends BaseRegistryService<
               locked: true,
               status: config.status === true,
               versions: config.versions,
+              // Send explicit null (not undefined) when the config removed
+              // `revalidate`, so updateSingle actually clears the column instead
+              // of leaving the stale config persisted.
+              revalidate: config.revalidate ?? null,
               localized: config.localized === true,
             },
             { source: "code" }
@@ -672,6 +690,7 @@ export class SingleRegistryService extends BaseRegistryService<
     const fields = r.fields as string | object;
     const admin = r.admin as string | object | null;
     const versions = r.versions as string | object | null;
+    const revalidate = r.revalidate as string | object | null;
     const accessRules = (r.access_rules ?? r.accessRules) as
       | string
       | object
@@ -717,6 +736,14 @@ export class SingleRegistryService extends BaseRegistryService<
         ? typeof versions === "string"
           ? JSON.parse(versions)
           : versions
+        : null,
+      // Parse the cache-revalidation config (JSON string on SQLite / raw
+      // inserts; already an object on pg/mysql). null when unset or on rows
+      // written before this column existed.
+      revalidate: revalidate
+        ? typeof revalidate === "string"
+          ? JSON.parse(revalidate)
+          : revalidate
         : null,
       localized: Boolean(r.localized),
       configPath,
@@ -797,6 +824,8 @@ export class SingleRegistryService extends BaseRegistryService<
       // Persist the resolved versioning config (JSON-serialized like admin) so
       // the mutation service can read it back and capture version snapshots.
       versions: data.versions ? JSON.stringify(data.versions) : null,
+      // Persist the cache-revalidation config (JSON-serialized like `versions`).
+      revalidate: data.revalidate ? JSON.stringify(data.revalidate) : null,
       localized: data.localized === true ? 1 : 0,
       config_path: data.configPath,
       schema_hash: schemaHash,

--- a/packages/nextly/src/init/__tests__/core-schema-drift.test.ts
+++ b/packages/nextly/src/init/__tests__/core-schema-drift.test.ts
@@ -26,16 +26,27 @@ function snapshot(tables: Record<string, string[]>): NextlySchemaSnapshot {
 
 describe("findCoreSchemaDrift", () => {
   it("reports a column the code expects that the database lacks", () => {
-    // A collection table created before the localization columns existed.
+    // A collection table created before the localization / config columns
+    // existed. `revalidate` is an additive nullable registry column reported
+    // by the same generic drift check as `versions`, so an install upgraded
+    // without `nextly migrate` is warned to reconcile it.
     const drift = findCoreSchemaDrift(
       snapshot({ dynamic_collections: ["id", "slug"] }),
-      snapshot({ dynamic_collections: ["id", "slug", "localized", "versions"] })
+      snapshot({
+        dynamic_collections: [
+          "id",
+          "slug",
+          "localized",
+          "versions",
+          "revalidate",
+        ],
+      })
     );
 
     expect(drift).toEqual([
       {
         table: "dynamic_collections",
-        missingColumns: ["localized", "versions"],
+        missingColumns: ["localized", "revalidate", "versions"],
       },
     ]);
   });

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -59,6 +59,7 @@ import { resolveCollectionTableName } from "../domains/schema/utils/resolve-tabl
 // Resolve the versioning config on the HMR sync path so a `versions` change
 // while `next dev` is running persists without a restart (parity with di/register).
 import { resolveVersionsConfig } from "../domains/versions/resolve-config";
+import type { RevalidateConfig } from "../revalidation/types";
 import { getProductionNotifier } from "../runtime/notifications/index";
 import type { VersionsConfig } from "../schemas/versions/types";
 import { ComponentSchemaService } from "../services/components/component-schema-service";
@@ -101,6 +102,8 @@ type CollectionDef = {
   localized?: boolean;
   /** Content-versioning option; persisted (resolved) to dynamic_collections.versions. */
   versions?: boolean | VersionsConfig;
+  /** Cache-revalidation config; persisted to dynamic_collections.revalidate. */
+  revalidate?: RevalidateConfig;
 };
 
 type SingleDef = {
@@ -115,6 +118,8 @@ type SingleDef = {
   localized?: boolean;
   /** Content-versioning option; persisted (resolved) to dynamic_singles.versions. */
   versions?: boolean | VersionsConfig;
+  /** Cache-revalidation config; persisted to dynamic_singles.revalidate. */
+  revalidate?: RevalidateConfig;
 };
 
 type ComponentDef = {
@@ -218,6 +223,9 @@ function buildCollectionSyncPayload(collections: CollectionDef[]) {
       // reload and desyncing the registry from the companion table.
       localized: c.localized === true,
       versions: resolveVersionsConfig(c.versions, c.status),
+      // Forward the cache-revalidation config verbatim (no resolver — the
+      // authored `{ tags?, disable? }` shape is persisted as-is).
+      revalidate: c.revalidate,
     }));
 }
 
@@ -244,6 +252,8 @@ function buildSingleSyncPayload(singles: SingleDef[]) {
         status: s.status === true,
         localized: s.localized === true,
         versions: resolveVersionsConfig(s.versions, s.status),
+        // Forward the cache-revalidation config verbatim (no resolver).
+        revalidate: s.revalidate,
       };
     });
 }

--- a/packages/nextly/src/revalidation/__tests__/builder-revalidate.test.ts
+++ b/packages/nextly/src/revalidation/__tests__/builder-revalidate.test.ts
@@ -1,0 +1,23 @@
+/**
+ * The one mapping every Builder write path uses for the cache-revalidation
+ * switch. Revalidation is on by default, so the boolean is inverted from the
+ * versions switch: off is the only value that persists a config.
+ */
+import { describe, expect, it } from "vitest";
+
+import { resolveBuilderRevalidate } from "../builder-revalidate";
+
+describe("resolveBuilderRevalidate", () => {
+  it("resolves off to the disable config", () => {
+    // The write path reads `revalidate.disable`, so turning the switch off has
+    // to land a config that sets it — a null column would still bust tags.
+    expect(resolveBuilderRevalidate(false)).toEqual({ disable: true });
+  });
+
+  it("resolves on and absent to no config at all", () => {
+    // On is the default: null means the write path computes the standard
+    // nextly:* tags with no override. Absent is treated the same as on.
+    expect(resolveBuilderRevalidate(true)).toBeNull();
+    expect(resolveBuilderRevalidate(undefined)).toBeNull();
+  });
+});

--- a/packages/nextly/src/revalidation/builder-revalidate.ts
+++ b/packages/nextly/src/revalidation/builder-revalidate.ts
@@ -1,0 +1,27 @@
+/**
+ * The Schema Builder's cache-revalidation switch, as the registry stores it.
+ *
+ * Every path that persists the switch goes through here so they cannot drift:
+ * the builder's create and update handlers, the standalone schema routes, and
+ * the `ui-schema.json` metadata upserts. Mirrors `resolveBuilderVersions`.
+ *
+ * @module revalidation/builder-revalidate
+ */
+
+import type { RevalidateConfig } from "./types";
+
+/**
+ * Resolve the switch into the config the registry column holds.
+ *
+ * The switch is a plain on/off, and revalidation is on by default: an entity
+ * that never touches the control busts the standard derived `nextly:*` tags on
+ * every write. On is therefore stored as null (no override) so the write path
+ * computes the derived tags; off is stored as `{ disable: true }` so the
+ * collection/single busts nothing. Extra custom tags remain a code-first-only
+ * control (`revalidate: { tags: [...] }`), which the Builder does not surface.
+ */
+export function resolveBuilderRevalidate(
+  enabled: boolean | undefined
+): RevalidateConfig | null {
+  return enabled === false ? { disable: true } : null;
+}

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -358,6 +358,13 @@ function entity(kind?: "collection" | "single" | "component") {
        * write would vanish on the next parse.
        */
       versions: z.boolean().optional(),
+      /**
+       * Whether writes to this entity bust cache tags. Boolean rather than the
+       * code-first `{ tags?, disable? }`: the Schema Builder offers on/off
+       * (custom extra tags stay a code-first control). On is the default, so an
+       * absent key means revalidation on; false persists `{ disable: true }`.
+       */
+      revalidate: z.boolean().optional(),
       fields: z.array(uiSchemaFieldSchema),
     })
     .superRefine((e, ctx) => {
@@ -397,6 +404,16 @@ function entity(kind?: "collection" | "single" | "component") {
           code: z.ZodIssueCode.custom,
           message: "'versions' is not supported on components",
           path: ["versions"],
+        });
+      }
+      // Components have no entries and no registry row of their own, so a
+      // revalidation switch would persist a setting nothing reads and the
+      // Builder never offers (same rationale as `versions` above).
+      if (kind === "component" && e.revalidate !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "'revalidate' is not supported on components",
+          path: ["revalidate"],
         });
       }
       // `status` reserved as a field name only when the lifecycle column is on.

--- a/packages/nextly/src/schemas/dynamic-collections/mysql.ts
+++ b/packages/nextly/src/schemas/dynamic-collections/mysql.ts
@@ -42,6 +42,7 @@ import {
 
 import type { FieldConfig } from "@nextly/collections";
 
+import type { RevalidateConfig } from "../../revalidation/types";
 import { users } from "../users/mysql";
 // Normalized versioning config persisted on the registry `versions` column.
 import type { ResolvedVersionsConfig } from "../versions/types";
@@ -155,6 +156,13 @@ export const dynamicCollectionsMysql = mysqlTable(
      * later stages read more fields without a re-migration. See postgres schema.
      */
     versions: json("versions").$type<ResolvedVersionsConfig>(),
+
+    /**
+     * Cache-revalidation config (`{ tags?, disable? }`), a JSON column like
+     * `versions` so `disable`/extra-`tags` reach the write path. Nullable when
+     * the collection sets no `revalidate` config.
+     */
+    revalidate: json("revalidate").$type<RevalidateConfig>(),
 
     /**
      * Admin UI configuration options.

--- a/packages/nextly/src/schemas/dynamic-collections/postgres.ts
+++ b/packages/nextly/src/schemas/dynamic-collections/postgres.ts
@@ -42,6 +42,7 @@ import {
 
 import type { FieldConfig } from "@nextly/collections";
 
+import type { RevalidateConfig } from "../../revalidation/types";
 import { users } from "../users/postgres";
 // Normalized versioning config persisted on the registry `versions` column.
 import type { ResolvedVersionsConfig } from "../versions/types";
@@ -158,6 +159,13 @@ export const dynamicCollectionsPg = pgTable(
      * re-migration.
      */
     versions: jsonb("versions").$type<ResolvedVersionsConfig>(),
+
+    /**
+     * Cache-revalidation config (`{ tags?, disable? }`), a JSON column like
+     * `versions` so `disable`/extra-`tags` reach the write path. Nullable when
+     * the collection sets no `revalidate` config.
+     */
+    revalidate: jsonb("revalidate").$type<RevalidateConfig>(),
 
     /**
      * Admin UI configuration options.

--- a/packages/nextly/src/schemas/dynamic-collections/sqlite.ts
+++ b/packages/nextly/src/schemas/dynamic-collections/sqlite.ts
@@ -33,6 +33,7 @@ import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
 
 import type { FieldConfig } from "@nextly/collections";
 
+import type { RevalidateConfig } from "../../revalidation/types";
 import { users } from "../users/sqlite";
 // Normalized versioning config persisted on the registry `versions` column.
 import type { ResolvedVersionsConfig } from "../versions/types";
@@ -149,6 +150,15 @@ export const dynamicCollectionsSqlite = sqliteTable(
     versions: text("versions", {
       mode: "json",
     }).$type<ResolvedVersionsConfig>(),
+
+    /**
+     * Cache-revalidation config (`{ tags?, disable? }`), a JSON column like
+     * `versions` so `disable`/extra-`tags` reach the write path. Nullable when
+     * the collection sets no `revalidate` config.
+     */
+    revalidate: text("revalidate", {
+      mode: "json",
+    }).$type<RevalidateConfig>(),
 
     /**
      * Admin UI configuration options.

--- a/packages/nextly/src/schemas/dynamic-collections/types.ts
+++ b/packages/nextly/src/schemas/dynamic-collections/types.ts
@@ -11,6 +11,7 @@
 
 import type { FieldConfig, IndexConfig } from "@nextly/collections";
 
+import type { RevalidateConfig } from "../../revalidation/types";
 import type { CollectionAccessRules } from "../../services/access/types";
 // Registry-facing resolved versioning config shape for the `versions` column.
 import type { ResolvedVersionsConfig } from "../versions/types";
@@ -387,6 +388,13 @@ export interface DynamicCollectionInsert {
    * `resolveVersionsConfig`, persisted on the `versions` column.
    */
   versions?: ResolvedVersionsConfig | null;
+
+  /**
+   * Cache-revalidation config (`{ tags?, disable? }`), or null/undefined when
+   * the collection sets none. Persisted on the `revalidate` column; the write
+   * path reads it back to honor `disable` and merge extra `tags`.
+   */
+  revalidate?: RevalidateConfig | null;
 
   /** Collection-level i18n master switch. Default: false. */
   localized?: boolean;

--- a/packages/nextly/src/schemas/dynamic-singles/mysql.ts
+++ b/packages/nextly/src/schemas/dynamic-singles/mysql.ts
@@ -50,6 +50,7 @@ import {
 } from "drizzle-orm/mysql-core";
 
 import type { FieldConfig } from "../../collections/fields/types";
+import type { RevalidateConfig } from "../../revalidation/types";
 import type { SingleAdminOptions } from "../../singles/config/types";
 // Normalized versioning config persisted on the registry `versions` column.
 import type { ResolvedVersionsConfig } from "../versions/types";
@@ -190,6 +191,13 @@ export const dynamicSinglesMysql = mysqlTable(
      * `ResolvedVersionsConfig` so every consumer reads one canonical shape.
      */
     versions: json("versions").$type<ResolvedVersionsConfig>(),
+
+    /**
+     * Cache-revalidation config (`{ tags?, disable? }`), a JSON column like
+     * `versions` so `disable`/extra-`tags` reach the write path. Nullable when
+     * the single sets no `revalidate` config.
+     */
+    revalidate: json("revalidate").$type<RevalidateConfig>(),
 
     /**
      * Path to the config file (code-first Singles only).

--- a/packages/nextly/src/schemas/dynamic-singles/postgres.ts
+++ b/packages/nextly/src/schemas/dynamic-singles/postgres.ts
@@ -51,6 +51,7 @@ import {
 } from "drizzle-orm/pg-core";
 
 import type { FieldConfig } from "../../collections/fields/types";
+import type { RevalidateConfig } from "../../revalidation/types";
 import type { SingleAdminOptions } from "../../singles/config/types";
 // Normalized versioning config persisted on the registry `versions` column.
 import type { ResolvedVersionsConfig } from "../versions/types";
@@ -192,6 +193,13 @@ export const dynamicSinglesPg = pgTable(
      * re-migration. Mirrors the collections schema.
      */
     versions: jsonb("versions").$type<ResolvedVersionsConfig>(),
+
+    /**
+     * Cache-revalidation config (`{ tags?, disable? }`), a JSON column like
+     * `versions` so `disable`/extra-`tags` reach the write path. Nullable when
+     * the single sets no `revalidate` config.
+     */
+    revalidate: jsonb("revalidate").$type<RevalidateConfig>(),
 
     /**
      * Path to the config file (code-first Singles only).

--- a/packages/nextly/src/schemas/dynamic-singles/sqlite.ts
+++ b/packages/nextly/src/schemas/dynamic-singles/sqlite.ts
@@ -41,6 +41,7 @@
 import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
 
 import type { FieldConfig } from "../../collections/fields/types";
+import type { RevalidateConfig } from "../../revalidation/types";
 import type { SingleAdminOptions } from "../../singles/config/types";
 // Normalized versioning config persisted on the registry `versions` column.
 import type { ResolvedVersionsConfig } from "../versions/types";
@@ -184,6 +185,15 @@ export const dynamicSinglesSqlite = sqliteTable(
     versions: text("versions", {
       mode: "json",
     }).$type<ResolvedVersionsConfig>(),
+
+    /**
+     * Cache-revalidation config (`{ tags?, disable? }`), a JSON column like
+     * `versions` so `disable`/extra-`tags` reach the write path. Nullable when
+     * the single sets no `revalidate` config.
+     */
+    revalidate: text("revalidate", {
+      mode: "json",
+    }).$type<RevalidateConfig>(),
 
     /**
      * Path to the config file (code-first Singles only).

--- a/packages/nextly/src/schemas/dynamic-singles/types.ts
+++ b/packages/nextly/src/schemas/dynamic-singles/types.ts
@@ -20,6 +20,7 @@
  */
 
 import type { FieldConfig } from "../../collections/fields/types";
+import type { RevalidateConfig } from "../../revalidation/types";
 import type { StoredAccessRule } from "../../services/access/types";
 import type { SingleAdminOptions } from "../../singles/config/types";
 // Registry-facing resolved versioning config shape for the `versions` column.
@@ -224,6 +225,13 @@ export interface DynamicSingleInsert {
    * reads it back to decide whether to capture a version snapshot on write.
    */
   versions?: ResolvedVersionsConfig | null;
+
+  /**
+   * Cache-revalidation config (`{ tags?, disable? }`), or null when the single
+   * sets none. Persisted on the `revalidate` column; the write path reads it
+   * back to honor `disable` and merge extra `tags`.
+   */
+  revalidate?: RevalidateConfig | null;
 
   /**
    * Path to the config file (code-first Singles only).

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -334,6 +334,8 @@ export class CollectionsHandler {
     status?: boolean;
     /** i18n: whether the collection is localized (translatable fields + companion table). */
     localized?: boolean;
+    /** Whether writes bust cache tags. Default on; false opts the collection out. */
+    revalidate?: boolean;
     fields: FieldDefinition[];
     createdBy?: string;
   }) {
@@ -415,6 +417,8 @@ export class CollectionsHandler {
       sidebarGroup?: string;
       useAsTitle?: string;
       hidden?: boolean;
+      /** Toggle cache revalidation. Honoured when defined; undefined leaves it unchanged. */
+      revalidate?: boolean;
       fields?: FieldDefinition[];
     }
   ) {


### PR DESCRIPTION
## What & why

F1 (cache-revalidation) shipped its core module (#314), write-path wiring (#316), and localized-slug coverage (#322), but the `revalidate` config lived **only** on code-first configs and was never persisted. The write path read it back as `undefined`, so `disable`/extra-`tags` had no effect, and a Schema-Builder-created collection could neither opt out nor round-trip the setting. This closes that gap (audit "parity discrepancy #1", F1 PR2.5 / left-task 007).

This is the deferred "2.5" half that was built and round-trip-tested in #322, then split out so it could ship together with the additive core-column upgrade safety.

## What's in it

**1. Persist `revalidate` to the registry** (`e5eca4f6`)
- Nullable JSON `revalidate` column on `dynamic_collections` + `dynamic_singles`, all three dialects, reconciled like `versions`.
- Round-trips through every registry write, sync, change-detection, and deserialize path; code-first sync sends `null` on removal so dropping the config clears the column. The write site now honors `disable` (busts nothing) and merges configured `tags`.

**2. Additive core-column upgrade safety** (`f5dddc69`)
- `reconcileCore` (`nextly upgrade`) and boot drift detection (`findCoreSchemaDrift`) are fully generic, so a nullable core column is picked up automatically — no per-column code needed. An existing DB upgraded **without** `nextly migrate` is warned at boot until it reconciles.
- Extended the `upgrade-sim-045` golden test to accept the additive `ADD COLUMN revalidate` on postgres + mysql (sqlite is covered by the destructive-statement scanner), and the drift unit test now lists `revalidate` among the columns to reconcile. Both are load-bearing: without the golden guard, the sim fails `phantom diff: ALTER TABLE "dynamic_collections" ADD COLUMN "revalidate"`.

**3. Schema Builder parity** (`9366d6ed`)
- New **Cache revalidation** switch on the Advanced tab for collections + singles (on by default; off opts the entity out). Components are excluded (no entries/registry row), rejected by the manifest zod like `versions`.
- Threaded through every write path the `versions` switch uses — runtime create/update handlers, standalone schema routes, and the `ui-schema.json` metadata upserts — normalized through a single `resolveBuilderRevalidate` (on → `null`, off → `{ disable: true }`).
- The manifest boolean is inverted from `versions` because revalidation defaults **on**: absent/`true` → on, only explicit `false` → off.

## Scope notes

- **Custom extra `tags`** stay a code-first control (`revalidate: { tags: [...] }`); the Builder switch is on/off only, matching the `versions` precedent.
- **Per-op `disableRevalidate` context flag** (F1 design §6) is intentionally **deferred to PR3 (008)**: it is inert with today's `NoopRevalidator`, and its "auto-set in CLI/migrate/seed/bulk" requirement pairs naturally with the real `NextCacheRevalidator`. The per-collection/single **config** `disable` (acceptance #3, "from either origin") is fully implemented and tested here.

## Testing (load-bearing, proven by breaking)

- Registry round-trip on sqlite + postgres: disabled collection/single busts nothing, configured tags merged (cache-revalidation integration, 20/20 sqlite, 18/18 pg).
- `resolveBuilderRevalidate` unit; `metadata-sql` revalidate literal for on/off × collection/single; ui-schema component-rejection.
- Builder-origin integration: a Builder collection with revalidation **off** busts nothing, **on** busts the same derived tags as code-first (binds the resolver output to the write path).
- Admin: AdvancedTab renders the switch checked-by-default and sets `false` when toggled off; settings-to-manifest carries it; `settings-dirty` compares it.
- Golden upgrade-sim + drift on pg/mysql/sqlite.

**Known baseline (not from this PR):** the `ui-schema.test.ts` "accepts a toggle field with a boolean default" failure and the dispatcher/single-shapes stale-mock status-forwarding failures pre-exist identically on `main`.

One changeset, all 20 lockstep packages, patch.
