### PR TITLE
fix(nextly): apply single read rules on REST reads

### DIFF
--- a/.changeset/singles-read-access-rules.md
+++ b/.changeset/singles-read-access-rules.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Read rules on Singles now apply over the REST API. A Single's stored read rule was enforced on every update and inside the Direct API, but reading the document over HTTP skipped it entirely, so a Single you restricted to a role was still returned in full to any caller who could reach the endpoint. Reads now evaluate the caller against the rule you configured, and a Single's related rows are redacted by the field rules of the collection they come from.
+
+A scoped API key is judged on its own read grant rather than on the permissions of the account that issued it, and super-admins keep the bypass they have everywhere else.
+
+If you configured a read rule on a Single expecting it to be enforced, this closes that gap. If something in your app read a restricted Single over HTTP and depended on getting it, that call will now be denied: give the caller a role the rule admits, or read it through the Direct API, which is trusted by default.

--- a/.changeset/singles-read-access-rules.md
+++ b/.changeset/singles-read-access-rules.md
@@ -21,11 +21,13 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-Read rules on Singles now apply over the REST API. A Single's stored read rule was enforced on every update and inside the Direct API, but reading the document over HTTP skipped it entirely, so a Single you restricted to a role was still returned in full to any caller who could reach the endpoint. Reads now evaluate the caller against the rule you configured, and a Single's related rows are redacted by the field rules of the collection they come from.
+Read rules on Singles now apply over the REST API. A Single's stored read rule was enforced on every update and inside the Direct API, but reading the document over HTTP skipped it entirely, so a Single you restricted to a role was still returned in full to any caller who could reach the endpoint. Reads now evaluate the caller against the rule you configured, and a Single's related rows are redacted by the field rules of the collection they come from. Relationships reached through an embedded component are not yet covered.
 
 A scoped API key is judged on its own read grant rather than on the permissions of the account that issued it, and super-admins keep the bypass they have everywhere else.
 
-A custom read rule that returns a query constraint has it checked against the document. Only a plain `field: { equals: value }` is checked; a constraint using any other operator is refused rather than partly evaluated, since one document has no list query to compile the rest of the filter grammar against. An `owner-only` read is judged against the document itself. That rule reports "allowed" for any authenticated caller and hands back the predicate a list query would have filtered by, which a Single has no list to apply, so the predicate is checked against the row instead.
+An `owner-only` read is judged against the document itself, since a Single has no list query to fold an ownership filter into.
+
+**`custom` read rules on Singles are not enforced by this change.** A custom function may return a query constraint, which a list read compiles into SQL; applying that to a single document would mean re-implementing the filter grammar, so it is left as it behaves today rather than partly applied. `public`, `authenticated`, `role-based` and `owner-only` read rules are all enforced. That rule reports "allowed" for any authenticated caller and hands back the predicate a list query would have filtered by, which a Single has no list to apply, so the predicate is checked against the row instead.
 
 **The standalone `nextly/api/singles-detail` GET route is deliberately public and does not authenticate.** A Single with no read rule stays publicly readable there, exactly as before. A Single you restrict is no longer served by that route at all, including to callers the rule would admit, because the route has no caller to evaluate. Read restricted Singles through the authenticated API instead.
 

--- a/.changeset/singles-read-access-rules.md
+++ b/.changeset/singles-read-access-rules.md
@@ -25,7 +25,7 @@ Read rules on Singles now apply over the REST API. A Single's stored read rule w
 
 A scoped API key is judged on its own read grant rather than on the permissions of the account that issued it, and super-admins keep the bypass they have everywhere else.
 
-An `owner-only` read is judged against the document itself. That rule reports "allowed" for any authenticated caller and hands back the predicate a list query would have filtered by, which a Single has no list to apply, so the predicate is checked against the row instead.
+A custom read rule that returns a query constraint has it checked against the document. Only a plain `field: { equals: value }` is checked; a constraint using any other operator is refused rather than partly evaluated, since one document has no list query to compile the rest of the filter grammar against. An `owner-only` read is judged against the document itself. That rule reports "allowed" for any authenticated caller and hands back the predicate a list query would have filtered by, which a Single has no list to apply, so the predicate is checked against the row instead.
 
 **The standalone `nextly/api/singles-detail` GET route is deliberately public and does not authenticate.** A Single with no read rule stays publicly readable there, exactly as before. A Single you restrict is no longer served by that route at all, including to callers the rule would admit, because the route has no caller to evaluate. Read restricted Singles through the authenticated API instead.
 

--- a/.changeset/singles-read-access-rules.md
+++ b/.changeset/singles-read-access-rules.md
@@ -25,4 +25,8 @@ Read rules on Singles now apply over the REST API. A Single's stored read rule w
 
 A scoped API key is judged on its own read grant rather than on the permissions of the account that issued it, and super-admins keep the bypass they have everywhere else.
 
+An `owner-only` read is judged against the document itself. That rule reports "allowed" for any authenticated caller and hands back the predicate a list query would have filtered by, which a Single has no list to apply, so the predicate is checked against the row instead.
+
+**The standalone `nextly/api/singles-detail` GET route is deliberately public and does not authenticate.** A Single with no read rule stays publicly readable there, exactly as before. A Single you restrict is no longer served by that route at all, including to callers the rule would admit, because the route has no caller to evaluate. Read restricted Singles through the authenticated API instead.
+
 If you configured a read rule on a Single expecting it to be enforced, this closes that gap. If something in your app read a restricted Single over HTTP and depended on getting it, that call will now be denied: give the caller a role the rule admits, or read it through the Direct API, which is trusted by default.

--- a/packages/nextly/src/__tests__/routeHandler-direct-branches.test.ts
+++ b/packages/nextly/src/__tests__/routeHandler-direct-branches.test.ts
@@ -473,6 +473,14 @@ describe("needsResolvedRoles", () => {
     }
   });
 
+  it("resolves roles for the Single document read", () => {
+    // Singles evaluate their stored read rule against the caller too, so a
+    // role-based rule needs the resolved slugs the same way entry reads do.
+    expect(
+      _needsResolvedRolesForTest("singles", "getSingleDocument", "GET")
+    ).toBe(true);
+  });
+
   it("resolves roles for version reads", () => {
     for (const method of [
       "listEntryVersions",

--- a/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-shapes.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-shapes.test.ts
@@ -478,3 +478,82 @@ describe("dispatchSingles, actions (respondAction)", () => {
     expect(body).not.toHaveProperty("item");
   });
 });
+
+// A Single's stored read rule can only be evaluated against a caller, so the
+// read handler has to hand one over. Without it the service falls back to the
+// rule-less default and the read setting an admin configured does nothing over
+// HTTP, while the same rule already holds on the write paths and in the Direct
+// API.
+describe("dispatchSingles getSingleDocument — read access forwarding", () => {
+  const okResult = {
+    success: true,
+    statusCode: 200,
+    data: { id: "doc1", title: "Welcome" },
+  };
+
+  /** The reserved params the route handler stamps once it has authenticated. */
+  const authedParams = {
+    slug: "site",
+    _authenticatedUserId: "u1",
+    _authenticatedUserName: "Ada",
+    _authenticatedUserEmail: "ada@example.com",
+    _authenticatedUserRoles: JSON.stringify(["editor", "author"]),
+  };
+
+  it("passes the authenticated user and attests route authorization", async () => {
+    const entry = makeEntry({ get: vi.fn().mockResolvedValue(okResult) });
+    wireDi(makeRegistry(), entry);
+
+    await dispatchSingles("getSingleDocument", { ...authedParams }, undefined);
+
+    const options = entry.get.mock.calls[0][1];
+    expect(options.user).toEqual({
+      id: "u1",
+      name: "Ada",
+      email: "ada@example.com",
+      roles: ["editor", "author"],
+      // Rules and field callbacks written against a single-role model read
+      // `user.role`; without it an authorized caller would have fields stripped.
+      role: "editor",
+    });
+    // The route ran the coarse RBAC gate already; the stored rule still runs.
+    expect(options.routeAuthorized).toBe(true);
+  });
+
+  it("sends no user for an anonymous caller", async () => {
+    const entry = makeEntry({ get: vi.fn().mockResolvedValue(okResult) });
+    wireDi(makeRegistry(), entry);
+
+    await dispatchSingles("getSingleDocument", { slug: "site" }, undefined);
+
+    const options = entry.get.mock.calls[0][1];
+    // An absent user must never be mistaken for a trusted one, and nothing
+    // attests authorization on its behalf.
+    expect(options.user).toBeUndefined();
+    expect(options.routeAuthorized).toBe(false);
+  });
+
+  it("forwards the API-key scope so a scoped key is judged on its own grant", async () => {
+    const entry = makeEntry({ get: vi.fn().mockResolvedValue(okResult) });
+    wireDi(makeRegistry(), entry);
+
+    await dispatchSingles(
+      "getSingleDocument",
+      {
+        ...authedParams,
+        _authenticatedActorType: "apiKey",
+        _authenticatedActorId: "key-1",
+        _authenticatedPermissions: JSON.stringify(["singles:read"]),
+      },
+      undefined
+    );
+
+    const options = entry.get.mock.calls[0][1];
+    // Without this a super-admin-owned key would take the owner's session
+    // bypass and read past its own scope.
+    expect(options.authenticatedScope).toEqual({
+      actorType: "apiKey",
+      permissions: ["singles:read"],
+    });
+  });
+});

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -82,6 +82,7 @@ import {
   readAuthenticatedScope,
 } from "../helpers/authenticated-actor";
 import { readAuthenticatedRoles } from "../helpers/authenticated-roles";
+import { readAuthenticatedUser } from "../helpers/authenticated-user";
 import { buildFullDesiredSchema } from "../helpers/desired-schema";
 import {
   getAdapterFromDI,
@@ -729,7 +730,19 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         p.status === "all" || p.status === "draft" || p.status === "published"
           ? p.status
           : "all";
+      // Forward the caller so the service can evaluate the Single's stored read
+      // rules for them. Without it those rules cannot run at all: a rule that
+      // asks who is reading has no one to judge, so the admin's read setting
+      // silently did nothing over HTTP. `routeAuthorized` attests the route
+      // already ran the coarse RBAC gate, so only that re-check is skipped.
+      const user = readAuthenticatedUser(p);
+
       const result = await svc.entry.get(slug, {
+        user,
+        routeAuthorized: !!user,
+        // A scoped API key is judged on its own read grant rather than on the
+        // permissions of the account that issued it.
+        authenticatedScope: readAuthenticatedScope(p),
         depth: toNumber(p.depth),
         // `?locale=` selects the content language; `?fallback-locale=none`
         // disables fallback so an untranslated field reads empty (admin editor relies on

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.read-access.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.read-access.test.ts
@@ -248,6 +248,139 @@ describe("SingleQueryService.get — owner-only reads (real evaluator)", () => {
 });
 
 /**
+ * Constraint-returning read rules.
+ *
+ * These stub the evaluator's RESULT, which is legitimate where the owner-only
+ * tests' stubbing was not: what is under test here is the constraint checker,
+ * and the shapes fed in are the ones the real evaluator actually emits —
+ * `{ allowed: true, query }` for a rule that returns a constraint and
+ * `{ allowed: true }` for one that decides on the caller alone. Custom rules
+ * load from a `functionPath` at runtime, so an inline function cannot be
+ * exercised end to end here; the owner-only suite above covers the real
+ * evaluator for the rule that produces constraints in practice.
+ */
+describe("SingleQueryService.get — constraint-returning read rules", () => {
+  function createConstraintService(
+    evaluation: Record<string, unknown>,
+    row: Record<string, unknown> | null
+  ) {
+    const registry = createMockSingleRegistry();
+    registry.registerSingle("site-settings", {
+      ...siteSettingsMeta({
+        accessRules: { read: { type: "custom", functionPath: "./rule" } },
+      }),
+      fields: [textField("siteName")],
+    });
+    const insert = vi.fn().mockResolvedValue({ id: "doc1" });
+    const service = new SingleQueryService(
+      createMockAdapter({
+        selectOne: vi.fn().mockResolvedValue(row),
+        insert,
+      }) as unknown as Ctor[0],
+      createSilentLogger() as unknown as Ctor[1],
+      registry as unknown as Ctor[2],
+      createMockHookRegistry() as unknown as Ctor[3],
+      undefined,
+      createMockRBACService(true) as unknown as Ctor[5],
+      undefined,
+      {
+        evaluateAccess: vi.fn().mockResolvedValue(evaluation),
+      } as unknown as Ctor[7]
+    );
+    return { service, insert };
+  }
+
+  it("admits a rule that decides on the caller alone, even with no row yet", async () => {
+    // Such a rule never inspects the document, so refusing it outright would
+    // leave a Single with a custom read rule impossible to initialize: its
+    // first permitted read is what auto-creates it.
+    const { service } = createConstraintService({ allowed: true }, null);
+
+    const result = await service.get("site-settings", {
+      user: { id: "u1" },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("refuses a constraint carrying an operator it cannot check", async () => {
+    // A list read compiles the whole Where grammar; this path checks one row.
+    // Honouring `equals` while ignoring a sibling operator would return a row
+    // the predicate excludes, so a partly-checkable condition is refused.
+    const { service } = createConstraintService(
+      { allowed: true, query: { age: { equals: 5, greater_than: 10 } } },
+      { id: "doc1", age: 5 }
+    );
+
+    const result = await service.get("site-settings", {
+      user: { id: "u1" },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBe(403);
+  });
+
+  it("refuses a constraint using an operator other than equals", async () => {
+    const { service } = createConstraintService(
+      { allowed: true, query: { age: { in: [5, 6] } } },
+      { id: "doc1", age: 5 }
+    );
+
+    const result = await service.get("site-settings", {
+      user: { id: "u1" },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("honours a plain equals constraint the row satisfies", async () => {
+    const { service } = createConstraintService(
+      { allowed: true, query: { tenant: { equals: "acme" } } },
+      { id: "doc1", tenant: "acme" }
+    );
+
+    const result = await service.get("site-settings", {
+      user: { id: "u1" },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("denies a plain equals constraint the row fails", async () => {
+    const { service } = createConstraintService(
+      { allowed: true, query: { tenant: { equals: "acme" } } },
+      { id: "doc1", tenant: "other" }
+    );
+
+    const result = await service.get("site-settings", {
+      user: { id: "u1" },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("denies a constraint when the row does not exist, without auto-creating", async () => {
+    const { service, insert } = createConstraintService(
+      { allowed: true, query: { tenant: { equals: "acme" } } },
+      null
+    );
+
+    const result = await service.get("site-settings", {
+      user: { id: "u1" },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(insert).not.toHaveBeenCalled();
+  });
+});
+
+/**
  * Enforcement of related-row field rules is opt-in, and the default matters: a
  * caller that supplies no access context cannot be told apart from an anonymous
  * one, so enforcing by default would strip protected related fields from every

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.read-access.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.read-access.test.ts
@@ -36,7 +36,7 @@ const admin = { id: "user-2", roles: ["admin"] };
 
 function createService(
   evaluateAllowed: boolean,
-  accessRules: Record<string, unknown> = ROLE_BASED_READ
+  accessRules: Record<string, unknown> | undefined = ROLE_BASED_READ
 ) {
   const registry = createMockSingleRegistry();
   registry.registerSingle("site-settings", {
@@ -113,39 +113,15 @@ describe("SingleQueryService.get — stored read rules", () => {
     expect(context.user).toMatchObject({ id: "user-1", roles: ["editor"] });
   });
 
-  it("does not blanket-deny an owner-only read before the row is loaded", async () => {
-    // The gate runs before the document is fetched and fails an owner-only rule
-    // closed when it has no document, so evaluating it there would 403 every
-    // non-super-admin read. The rule has to be judged against the loaded row.
-    const { service, accessControlService } = createService(true, {
-      read: { type: "owner-only" as const },
-    });
+  it("leaves a Single with no read rule publicly readable", async () => {
+    // The standalone GET route is deliberately public (it serves public
+    // frontends) and forwards no caller, so an unrestricted Single has to keep
+    // reading anonymously. Enforcement must only bite where a rule exists.
+    const { service } = createService(true, undefined);
 
-    const result = await service.get("site-settings", {
-      user: editor,
-      routeAuthorized: true,
-    });
+    const result = await service.get("site-settings", {});
 
     expect(result.success).toBe(true);
-    const [, , , documentId, document] =
-      accessControlService.evaluateAccess.mock.calls[0];
-    // Judged against the real row, so ownership is actually comparable.
-    expect(documentId).toBe("doc1");
-    expect(document).toMatchObject({ id: "doc1" });
-  });
-
-  it("denies an owner-only read the rule rejects for this caller", async () => {
-    const { service } = createService(false, {
-      read: { type: "owner-only" as const },
-    });
-
-    const result = await service.get("site-settings", {
-      user: editor,
-      routeAuthorized: true,
-    });
-
-    expect(result.success).toBe(false);
-    expect(result.statusCode).toBe(403);
   });
 
   it("lets a trusted read bypass the stored rule", async () => {
@@ -157,6 +133,117 @@ describe("SingleQueryService.get — stored read rules", () => {
 
     expect(result.success).toBe(true);
     expect(accessControlService.evaluateAccess).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Owner-only reads, against the REAL AccessControlService.
+ *
+ * These deliberately do not mock the evaluator. For a read it does not return a
+ * decision at all: `evaluateOwnerAccess` reports `allowed: true` whoever owns
+ * the row and hands back the predicate a LIST would have filtered by. A mocked
+ * `allowed: false` is a value the real evaluator never produces for this rule,
+ * so a test built on one proves nothing about ownership and hides a read path
+ * that admits everybody.
+ */
+describe("SingleQueryService.get — owner-only reads (real evaluator)", () => {
+  const OWNER_ONLY_READ = { read: { type: "owner-only" as const } };
+
+  function createOwnerOnlyService(row: Record<string, unknown> | null) {
+    const registry = createMockSingleRegistry();
+    registry.registerSingle("site-settings", {
+      ...siteSettingsMeta({ accessRules: OWNER_ONLY_READ }),
+      fields: [textField("siteName")],
+    });
+    const selectOne = vi.fn().mockResolvedValue(row);
+    const insert = vi.fn().mockResolvedValue({ id: "doc1" });
+
+    const service = new SingleQueryService(
+      createMockAdapter({ selectOne, insert }) as unknown as Ctor[0],
+      createSilentLogger() as unknown as Ctor[1],
+      registry as unknown as Ctor[2],
+      createMockHookRegistry() as unknown as Ctor[3],
+      undefined,
+      createMockRBACService(true) as unknown as Ctor[5]
+      // No accessControlService override: the real one is constructed, which is
+      // the entire point of these tests.
+    );
+    return { service, selectOne, insert };
+  }
+
+  it("denies a caller who does not own the row", async () => {
+    const { service } = createOwnerOnlyService({
+      id: "doc1",
+      created_by: "someone-else",
+      siteName: "Nextly",
+    });
+
+    const result = await service.get("site-settings", {
+      user: { id: "not-the-owner" },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBe(403);
+  });
+
+  it("admits the owner", async () => {
+    const { service } = createOwnerOnlyService({
+      id: "doc1",
+      created_by: "owner-1",
+      siteName: "Nextly",
+    });
+
+    const result = await service.get("site-settings", {
+      user: { id: "owner-1" },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts the camelCase spelling of the owner column", async () => {
+    const { service } = createOwnerOnlyService({
+      id: "doc1",
+      createdBy: "owner-1",
+      siteName: "Nextly",
+    });
+
+    const result = await service.get("site-settings", {
+      user: { id: "owner-1" },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("denies without auto-creating when the row does not exist", async () => {
+    // Auto-create would permanently materialize an unowned document, plus its
+    // first version and localized defaults, for a caller the rule may not
+    // admit — a write triggered by a read that is about to be refused.
+    const { service, insert } = createOwnerOnlyService(null);
+
+    const result = await service.get("site-settings", {
+      user: { id: "someone" },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBe(403);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("lets a trusted read through untouched", async () => {
+    const { service } = createOwnerOnlyService({
+      id: "doc1",
+      created_by: "someone-else",
+    });
+
+    const result = await service.get("site-settings", {
+      overrideAccess: true,
+    });
+
+    expect(result.success).toBe(true);
   });
 });
 

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.read-access.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.read-access.test.ts
@@ -248,22 +248,17 @@ describe("SingleQueryService.get — owner-only reads (real evaluator)", () => {
 });
 
 /**
- * Constraint-returning read rules.
+ * Custom read rules are deliberately NOT enforced on Singles yet.
  *
- * These stub the evaluator's RESULT, which is legitimate where the owner-only
- * tests' stubbing was not: what is under test here is the constraint checker,
- * and the shapes fed in are the ones the real evaluator actually emits —
- * `{ allowed: true, query }` for a rule that returns a constraint and
- * `{ allowed: true }` for one that decides on the caller alone. Custom rules
- * load from a `functionPath` at runtime, so an inline function cannot be
- * exercised end to end here; the owner-only suite above covers the real
- * evaluator for the rule that produces constraints in practice.
+ * A custom function may return an arbitrary query constraint, which a list read
+ * compiles into SQL. Honouring that against one document means re-implementing
+ * the filter grammar, and a second evaluator drifts from the first — the
+ * divergence being a security bug rather than a missing feature. Until the
+ * constraint can be applied by the database, a custom read rule is left as it
+ * behaves today rather than half-enforced.
  */
-describe("SingleQueryService.get — constraint-returning read rules", () => {
-  function createConstraintService(
-    evaluation: Record<string, unknown>,
-    row: Record<string, unknown> | null
-  ) {
+describe("SingleQueryService.get — custom read rules are not enforced yet", () => {
+  function createCustomRuleService(row: Record<string, unknown> | null) {
     const registry = createMockSingleRegistry();
     registry.registerSingle("site-settings", {
       ...siteSettingsMeta({
@@ -271,11 +266,10 @@ describe("SingleQueryService.get — constraint-returning read rules", () => {
       }),
       fields: [textField("siteName")],
     });
-    const insert = vi.fn().mockResolvedValue({ id: "doc1" });
+    const evaluateAccess = vi.fn();
     const service = new SingleQueryService(
       createMockAdapter({
         selectOne: vi.fn().mockResolvedValue(row),
-        insert,
       }) as unknown as Ctor[0],
       createSilentLogger() as unknown as Ctor[1],
       registry as unknown as Ctor[2],
@@ -283,100 +277,26 @@ describe("SingleQueryService.get — constraint-returning read rules", () => {
       undefined,
       createMockRBACService(true) as unknown as Ctor[5],
       undefined,
-      {
-        evaluateAccess: vi.fn().mockResolvedValue(evaluation),
-      } as unknown as Ctor[7]
+      { evaluateAccess } as unknown as Ctor[7]
     );
-    return { service, insert };
+    return { service, evaluateAccess };
   }
 
-  it("admits a rule that decides on the caller alone, even with no row yet", async () => {
-    // Such a rule never inspects the document, so refusing it outright would
-    // leave a Single with a custom read rule impossible to initialize: its
-    // first permitted read is what auto-creates it.
-    const { service } = createConstraintService({ allowed: true }, null);
+  it("reads through without consulting the rule", async () => {
+    const { service, evaluateAccess } = createCustomRuleService({
+      id: "doc1",
+      siteName: "Nextly",
+    });
 
     const result = await service.get("site-settings", {
       user: { id: "u1" },
       routeAuthorized: true,
     });
 
+    // Unchanged from before read rules were wired: the rule is not evaluated,
+    // so it can neither admit nor deny, and nothing is half-applied.
     expect(result.success).toBe(true);
-  });
-
-  it("refuses a constraint carrying an operator it cannot check", async () => {
-    // A list read compiles the whole Where grammar; this path checks one row.
-    // Honouring `equals` while ignoring a sibling operator would return a row
-    // the predicate excludes, so a partly-checkable condition is refused.
-    const { service } = createConstraintService(
-      { allowed: true, query: { age: { equals: 5, greater_than: 10 } } },
-      { id: "doc1", age: 5 }
-    );
-
-    const result = await service.get("site-settings", {
-      user: { id: "u1" },
-      routeAuthorized: true,
-    });
-
-    expect(result.success).toBe(false);
-    expect(result.statusCode).toBe(403);
-  });
-
-  it("refuses a constraint using an operator other than equals", async () => {
-    const { service } = createConstraintService(
-      { allowed: true, query: { age: { in: [5, 6] } } },
-      { id: "doc1", age: 5 }
-    );
-
-    const result = await service.get("site-settings", {
-      user: { id: "u1" },
-      routeAuthorized: true,
-    });
-
-    expect(result.success).toBe(false);
-  });
-
-  it("honours a plain equals constraint the row satisfies", async () => {
-    const { service } = createConstraintService(
-      { allowed: true, query: { tenant: { equals: "acme" } } },
-      { id: "doc1", tenant: "acme" }
-    );
-
-    const result = await service.get("site-settings", {
-      user: { id: "u1" },
-      routeAuthorized: true,
-    });
-
-    expect(result.success).toBe(true);
-  });
-
-  it("denies a plain equals constraint the row fails", async () => {
-    const { service } = createConstraintService(
-      { allowed: true, query: { tenant: { equals: "acme" } } },
-      { id: "doc1", tenant: "other" }
-    );
-
-    const result = await service.get("site-settings", {
-      user: { id: "u1" },
-      routeAuthorized: true,
-    });
-
-    expect(result.success).toBe(false);
-  });
-
-  it("denies a constraint when the row does not exist, without auto-creating", async () => {
-    const { service, insert } = createConstraintService(
-      { allowed: true, query: { tenant: { equals: "acme" } } },
-      null
-    );
-
-    const result = await service.get("site-settings", {
-      user: { id: "u1" },
-      routeAuthorized: true,
-    });
-
-    expect(result.success).toBe(false);
-    expect(insert).not.toHaveBeenCalled();
+    expect(evaluateAccess).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.read-access.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.read-access.test.ts
@@ -11,6 +11,7 @@
 
 import { describe, it, expect, vi } from "vitest";
 
+import { container } from "../../../di/container";
 import { SingleQueryService } from "../services/single-query-service";
 
 import {
@@ -33,10 +34,13 @@ const ROLE_BASED_READ = {
 const editor = { id: "user-1", roles: ["editor"] };
 const admin = { id: "user-2", roles: ["admin"] };
 
-function createService(evaluateAllowed: boolean) {
+function createService(
+  evaluateAllowed: boolean,
+  accessRules: Record<string, unknown> = ROLE_BASED_READ
+) {
   const registry = createMockSingleRegistry();
   registry.registerSingle("site-settings", {
-    ...siteSettingsMeta({ accessRules: ROLE_BASED_READ }),
+    ...siteSettingsMeta({ accessRules }),
     fields: [textField("siteName")],
   });
 
@@ -109,6 +113,41 @@ describe("SingleQueryService.get — stored read rules", () => {
     expect(context.user).toMatchObject({ id: "user-1", roles: ["editor"] });
   });
 
+  it("does not blanket-deny an owner-only read before the row is loaded", async () => {
+    // The gate runs before the document is fetched and fails an owner-only rule
+    // closed when it has no document, so evaluating it there would 403 every
+    // non-super-admin read. The rule has to be judged against the loaded row.
+    const { service, accessControlService } = createService(true, {
+      read: { type: "owner-only" as const },
+    });
+
+    const result = await service.get("site-settings", {
+      user: editor,
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(true);
+    const [, , , documentId, document] =
+      accessControlService.evaluateAccess.mock.calls[0];
+    // Judged against the real row, so ownership is actually comparable.
+    expect(documentId).toBe("doc1");
+    expect(document).toMatchObject({ id: "doc1" });
+  });
+
+  it("denies an owner-only read the rule rejects for this caller", async () => {
+    const { service } = createService(false, {
+      read: { type: "owner-only" as const },
+    });
+
+    const result = await service.get("site-settings", {
+      user: editor,
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBe(403);
+  });
+
   it("lets a trusted read bypass the stored rule", async () => {
     const { service, accessControlService } = createService(false);
 
@@ -118,5 +157,58 @@ describe("SingleQueryService.get — stored read rules", () => {
 
     expect(result.success).toBe(true);
     expect(accessControlService.evaluateAccess).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Enforcement of related-row field rules is opt-in, and the default matters: a
+ * caller that supplies no access context cannot be told apart from an anonymous
+ * one, so enforcing by default would strip protected related fields from every
+ * caller of the mutation-response path, which passes no context at all.
+ */
+describe("SingleQueryService.expandRelationshipFields — enforcement is opt-in", () => {
+  const RELATION_FIELDS = [{ name: "author", type: "relationship" }];
+
+  function serviceWithRelationshipSpy() {
+    const expandRelationships = vi
+      .fn()
+      .mockImplementation((doc: unknown) => Promise.resolve(doc));
+    container.register("collectionsHandler", () => ({
+      getRelationshipService: () => ({ expandRelationships }),
+    }));
+
+    const service = new SingleQueryService(
+      createMockAdapter() as unknown as Ctor[0],
+      createSilentLogger() as unknown as Ctor[1],
+      createMockSingleRegistry() as unknown as Ctor[2],
+      createMockHookRegistry() as unknown as Ctor[3]
+    );
+    return { service, expandRelationships };
+  }
+
+  it("leaves enforcement off for a caller that supplies no access context", async () => {
+    const { service, expandRelationships } = serviceWithRelationshipSpy();
+
+    await service.expandRelationshipFields(
+      { id: "doc1" } as never,
+      RELATION_FIELDS as never
+    );
+
+    expect(expandRelationships.mock.calls[0][3].enforceFieldAccess).toBeFalsy();
+  });
+
+  it("enforces when the read path opts in with its caller", async () => {
+    const { service, expandRelationships } = serviceWithRelationshipSpy();
+
+    await service.expandRelationshipFields(
+      { id: "doc1" } as never,
+      RELATION_FIELDS as never,
+      undefined,
+      { enforceFieldAccess: true, user: editor }
+    );
+
+    const options = expandRelationships.mock.calls[0][3];
+    expect(options.enforceFieldAccess).toBe(true);
+    expect(options.user).toMatchObject({ id: "user-1" });
   });
 });

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.read-access.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.read-access.test.ts
@@ -1,0 +1,122 @@
+/**
+ * A Single's stored read rule has to hold on the read path, not just on writes.
+ *
+ * The rule was previously never evaluated on reads: the read gate was called
+ * without the Single's `accessRules`, so a `read: role-based` rule an admin
+ * configured did nothing over HTTP while the same rule was enforced on every
+ * update. These tests drive `get()` so they cover the whole gate — the rules
+ * being handed over AND something being present to evaluate them with, which
+ * are two separate arguments that both have to arrive for enforcement to run.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import { SingleQueryService } from "../services/single-query-service";
+
+import {
+  createMockAdapter,
+  createSilentLogger,
+  createMockSingleRegistry,
+  createMockHookRegistry,
+  createMockRBACService,
+  siteSettingsMeta,
+  textField,
+} from "./single-test-helpers";
+
+type Ctor = ConstructorParameters<typeof SingleQueryService>;
+
+/** Read restricted to the `admin` role. */
+const ROLE_BASED_READ = {
+  read: { type: "role-based" as const, allowedRoles: ["admin"] },
+};
+
+const editor = { id: "user-1", roles: ["editor"] };
+const admin = { id: "user-2", roles: ["admin"] };
+
+function createService(evaluateAllowed: boolean) {
+  const registry = createMockSingleRegistry();
+  registry.registerSingle("site-settings", {
+    ...siteSettingsMeta({ accessRules: ROLE_BASED_READ }),
+    fields: [textField("siteName")],
+  });
+
+  const accessControlService = {
+    evaluateAccess: vi
+      .fn()
+      .mockResolvedValue(
+        evaluateAllowed
+          ? { allowed: true }
+          : { allowed: false, reason: "denied" }
+      ),
+  };
+
+  const service = new SingleQueryService(
+    createMockAdapter({
+      selectOne: vi
+        .fn()
+        .mockResolvedValue({ id: "doc1", siteName: "Nextly", status: null }),
+    }) as unknown as Ctor[0],
+    createSilentLogger() as unknown as Ctor[1],
+    registry as unknown as Ctor[2],
+    createMockHookRegistry() as unknown as Ctor[3],
+    undefined,
+    createMockRBACService(true) as unknown as Ctor[5],
+    undefined,
+    accessControlService as unknown as Ctor[7]
+  );
+
+  return { service, accessControlService };
+}
+
+describe("SingleQueryService.get — stored read rules", () => {
+  it("denies a caller the stored read rule rejects", async () => {
+    const { service, accessControlService } = createService(false);
+
+    const result = await service.get("site-settings", {
+      user: editor,
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBe(403);
+    // The rule was actually consulted, rather than the read failing for some
+    // unrelated reason.
+    expect(accessControlService.evaluateAccess).toHaveBeenCalled();
+  });
+
+  it("allows a caller the stored read rule admits", async () => {
+    const { service } = createService(true);
+
+    const result = await service.get("site-settings", {
+      user: admin,
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("evaluates the rule for the read operation, against the caller", async () => {
+    const { service, accessControlService } = createService(true);
+
+    await service.get("site-settings", { user: editor, routeAuthorized: true });
+
+    // Guards the two arguments that each silently disable enforcement when
+    // missing: the rules themselves, and the operation they are read under.
+    const [rules, operation, context] =
+      accessControlService.evaluateAccess.mock.calls[0];
+    expect(rules).toMatchObject(ROLE_BASED_READ);
+    expect(operation).toBe("read");
+    expect(context.user).toMatchObject({ id: "user-1", roles: ["editor"] });
+  });
+
+  it("lets a trusted read bypass the stored rule", async () => {
+    const { service, accessControlService } = createService(false);
+
+    const result = await service.get("site-settings", {
+      overrideAccess: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(accessControlService.evaluateAccess).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -43,6 +43,7 @@ import {
   AccessControlService,
   isSuperAdminContext,
 } from "../../../services/access";
+import { GENERIC_DEFAULT_OWNER_FIELD } from "../../../services/access/types";
 import type { CollectionRelationshipService } from "../../../services/collections/collection-relationship-service";
 import type { CollectionsHandler } from "../../../services/collections-handler";
 import type { ComponentDataService } from "../../../services/components/component-data-service";
@@ -173,47 +174,6 @@ export function buildSingleHookContext<T>(
  *
  * @returns `null` if access is allowed, `SingleResult` if denied
  */
-/**
- * Whether a loaded row satisfies an access constraint of the
- * `{ field: { equals: value } }` shape the access service emits for reads.
- *
- * Reads are expected to fold that predicate into a LIST query, which compiles
- * the full Where grammar; a caller holding one row has to check it directly
- * instead. Only a lone `equals` per field is checked, and **anything else
- * denies** — a compound condition whose other operators went unchecked would
- * admit a row the predicate excludes, and re-implementing the rest of the
- * grammar here would be a second, drifting evaluator. Owner-only, the rule this
- * exists for, emits exactly this shape. A custom rule returning any other
- * operator is refused rather than half-evaluated.
- */
-function documentSatisfiesConstraint(
-  document: Record<string, unknown>,
-  query: unknown
-): boolean {
-  if (!query || typeof query !== "object") return true;
-  for (const [field, condition] of Object.entries(
-    query as Record<string, unknown>
-  )) {
-    if (condition === null || typeof condition !== "object") return false;
-    const operators = Object.keys(condition);
-    // Exactly one operator, and it must be `equals`: a condition carrying more
-    // than that is only partly checkable, and partly checked is not satisfied.
-    if (operators.length !== 1 || operators[0] !== "equals") {
-      return false;
-    }
-    const expected = (condition as Record<string, unknown>).equals;
-    // Singles default their owner column to camelCase `createdBy` while the row
-    // may carry the snake_case column the database stores, so a constraint is
-    // matched against either spelling of the same column rather than missing it
-    // and denying a legitimate owner.
-    const camel = field.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
-    const snake = field.replace(/[A-Z]/g, c => `_${c.toLowerCase()}`);
-    const actual = document[field] ?? document[camel] ?? document[snake];
-    if (actual !== expected) return false;
-  }
-  return true;
-}
-
 export async function checkSingleAccess(params: {
   slug: string;
   operation: "read" | "update" | "publish" | "unpublish";
@@ -460,74 +420,55 @@ export class SingleQueryService extends BaseService {
   private readonly accessControlService: AccessControlService;
 
   /**
-   * Judge a document-dependent read rule against the loaded row.
+   * Decide an `owner-only` read against the loaded row.
    *
-   * `checkSingleAccess` runs before the row is fetched, so an `owner-only` or
-   * `custom` read rule has nothing to compare against there — owner-only fails
-   * closed by design, and a custom rule would receive an undefined id and data.
-   * Those rules are deferred past that gate and settled here instead, which is
-   * the same split the mutation service uses for publish transitions.
+   * `checkSingleAccess` runs before the row is fetched and fails an owner-only
+   * rule closed for lack of a document, so the rule is skipped there and
+   * settled here — the same split the mutation service uses for publish
+   * transitions.
+   *
+   * Ownership is compared directly rather than through the access service. For
+   * a read that service does not decide at all: it reports `allowed: true` for
+   * any authenticated caller and returns the predicate a LIST would have
+   * filtered by, which one document has no query to apply. Comparing the owner
+   * column here keeps the check to the one thing owner-only actually asserts,
+   * with no filter grammar to re-implement.
    */
-  private async evaluateReadDocumentRule(params: {
+  private evaluateOwnerOnlyRead(params: {
     slug: string;
-    accessRules: CollectionAccessRules | undefined;
+    rule: { ownerField?: string } | undefined;
     user?: UserContext;
     document: Record<string, unknown> | null;
-  }): Promise<SingleResult | null> {
-    const { slug, accessRules, user, document } = params;
-    // Only reached for a document-dependent rule, so an absent rule set means
-    // there is nothing left to judge.
-    if (!accessRules) return null;
-
+  }): SingleResult | null {
+    const { slug, rule, user, document } = params;
     const denied: SingleResult = {
       success: false,
       statusCode: 403,
       message: `Access denied: read on single "${slug}" is not permitted`,
     };
 
-    const documentId =
-      typeof document?.id === "string" ? document.id : undefined;
-    const result = await this.accessControlService.evaluateAccess(
-      accessRules,
-      "read",
-      {
-        user: user
-          ? {
-              id: user.id,
-              role: user.role,
-              roles: user.roles,
-              email: user.email,
-            }
-          : undefined,
-      },
-      documentId,
-      document ?? undefined
-    );
+    // Ownership presupposes an identity.
+    if (!user?.id) return denied;
 
-    if (!result.allowed) {
-      return { ...denied, message: result.reason ?? denied.message };
-    }
-
-    // An owner-only read does not decide: it returns the predicate a LIST would
-    // have filtered by and reports `allowed: true` whoever owns the row. A
-    // Single is one document, so there is nothing to filter — the predicate has
-    // to be checked against the row itself or every authenticated caller reads
-    // it. Custom rules that return a constraint are held to the same check.
-    if (result.query === undefined || result.query === null) {
-      // No predicate to satisfy. A custom rule that admits the caller on user
-      // context alone lands here, including on a Single that has never been
-      // materialized — so its first permitted read can still auto-create it.
-      return null;
-    }
-
-    // A predicate with no row cannot be satisfied. Denying here also stops
-    // auto-create from materializing a document the predicate would exclude.
+    // No row means ownership cannot be established. Denying also stops
+    // auto-create from materializing an unowned document for a caller who may
+    // not be entitled to it — a write triggered by a read about to be refused.
     if (!document) return denied;
 
-    if (!documentSatisfiesConstraint(document, result.query)) {
-      return denied;
-    }
-    return null;
+    // Singles default the owner column to camelCase `createdBy` while the row
+    // may carry the snake_case column the database stores, so both spellings of
+    // the same column are accepted rather than denying the real owner.
+    const ownerField = rule?.ownerField ?? GENERIC_DEFAULT_OWNER_FIELD;
+    const camel = ownerField.replace(/_([a-z])/g, (_m: string, c: string) =>
+      c.toUpperCase()
+    );
+    const snake = ownerField.replace(
+      /[A-Z]/g,
+      (c: string) => `_${c.toLowerCase()}`
+    );
+    const owner = document[ownerField] ?? document[camel] ?? document[snake];
+
+    return owner === user.id ? null : denied;
   }
 
   // ============================================================
@@ -572,15 +513,23 @@ export class SingleQueryService extends BaseService {
       const isSuperAdminSession =
         isSuperAdminContext(options.user) &&
         options.authenticatedScope?.actorType !== "apiKey";
-      const deferDocumentRule =
+      // Both kinds are skipped at the gate, which has no row to judge them
+      // against, but only owner-only is settled below. A `custom` function may
+      // return an arbitrary query constraint, and honouring that on one document
+      // means re-implementing the filter grammar a list read compiles in SQL —
+      // a second evaluator to drift from the first. Custom read rules on Singles
+      // are therefore left unenforced here rather than half-enforced.
+      const skipRuleAtGate =
         !isSuperAdminSession &&
         (readRule?.type === "owner-only" || readRule?.type === "custom");
+      const deferDocumentRule =
+        !isSuperAdminSession && readRule?.type === "owner-only";
 
       const accessDenied = await checkSingleAccess({
         slug,
         operation: "read",
         accessRules: singleMeta.accessRules,
-        deferStoredRuleEval: deferDocumentRule,
+        deferStoredRuleEval: skipRuleAtGate,
         user: options.user,
         overrideAccess: options.overrideAccess,
         routeAuthorized: options.routeAuthorized,
@@ -609,9 +558,9 @@ export class SingleQueryService extends BaseService {
           singleMeta.tableName,
           {}
         );
-        const documentRuleDenied = await this.evaluateReadDocumentRule({
+        const documentRuleDenied = this.evaluateOwnerOnlyRead({
           slug,
-          accessRules: singleMeta.accessRules,
+          rule: readRule as { ownerField?: string } | undefined,
           user: options.user,
           document: loadedDoc,
         });

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -38,11 +38,11 @@ import { keysToCamelCase, keysToSnakeCase } from "../../../lib/case-conversion";
 import { resolveStatusFilter } from "../../../lib/status-filter";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import type { DynamicSingleRecord } from "../../../schemas/dynamic-singles/types";
-import type {
+import type { CollectionAccessRules } from "../../../services/access";
+import {
   AccessControlService,
-  CollectionAccessRules,
+  isSuperAdminContext,
 } from "../../../services/access";
-import { isSuperAdminContext } from "../../../services/access";
 import type { CollectionRelationshipService } from "../../../services/collections/collection-relationship-service";
 import type { CollectionsHandler } from "../../../services/collections-handler";
 import type { ComponentDataService } from "../../../services/components/component-data-service";
@@ -403,10 +403,20 @@ export class SingleQueryService extends BaseService {
     private readonly rbacAccessControlService?: RBACAccessControlService,
     // i18n: when set and the single is localized, reads resolve translatable fields
     // from the companion `single_<slug>_locales` table for the requested locale.
-    private readonly localization?: SanitizedLocalizationConfig
+    private readonly localization?: SanitizedLocalizationConfig,
+    accessControlService?: AccessControlService
   ) {
     super(adapter, logger);
+    // Evaluates the Single's stored access rules. Defaulted rather than
+    // required so every existing construction site keeps working, mirroring
+    // how the mutation service resolves the same dependency: without one the
+    // read gate would silently skip the stored rules it is handed.
+    this.accessControlService =
+      accessControlService ?? new AccessControlService();
   }
+
+  /** Resolves stored `accessRules` for the read gate. */
+  private readonly accessControlService: AccessControlService;
 
   // ============================================================
   // Public API
@@ -436,18 +446,22 @@ export class SingleQueryService extends BaseService {
       }
 
       // 1.5. Access check (RBAC) after metadata, before hooks/DB operations.
-      // Stored read-rule enforcement is intentionally NOT wired here yet: the
-      // REST read handlers do not forward the authenticated user, so evaluating
-      // a `read: authenticated` / role-based rule would reject every REST caller
-      // as anonymous. It lands with read-path user forwarding in the follow-up
-      // read PR (hence no `accessRules` passed).
+      // The Single's stored read rule is evaluated here against the caller the
+      // route forwards. It is the same rule the admin configures and the same
+      // one the write paths already honor, so a `read: authenticated` or
+      // role-based rule now holds over HTTP instead of only inside the Direct
+      // API.
       const accessDenied = await checkSingleAccess({
         slug,
         operation: "read",
+        accessRules: singleMeta.accessRules,
         user: options.user,
         overrideAccess: options.overrideAccess,
         routeAuthorized: options.routeAuthorized,
         rbacAccessControlService: this.rbacAccessControlService,
+        // Without this the gate has rules but nothing to evaluate them with, and
+        // silently skips them.
+        accessControlService: this.accessControlService,
         // A scoped API key is judged on its OWN read grant, so a super-admin-owned
         // key does not skip the read gate via the owner's roles.
         authenticatedScope: options.authenticatedScope,
@@ -549,7 +563,8 @@ export class SingleQueryService extends BaseService {
       doc = await this.expandRelationshipFields(
         doc,
         singleMeta.fields,
-        options.depth
+        options.depth,
+        { user: options.user, overrideAccess: options.overrideAccess }
       );
 
       // 7.7. Populate component field data from comp_{slug} tables
@@ -1232,7 +1247,11 @@ export class SingleQueryService extends BaseService {
   async expandRelationshipFields(
     doc: SingleDocument,
     fields: FieldConfig[],
-    depth?: number
+    depth?: number,
+    // The caller a related row's own field rules are evaluated against.
+    // Expansion copies whole related rows into this document, and a Single's
+    // field list never describes a related collection's fields.
+    access: { user?: UserContext; overrideAccess?: boolean } = {}
   ): Promise<SingleDocument> {
     const relationshipService = this.resolveRelationshipService();
     if (!relationshipService) {
@@ -1258,7 +1277,15 @@ export class SingleQueryService extends BaseService {
         doc,
         "", // Singles don't belong to a collection
         fields as unknown as FieldDefinition[],
-        { depth: depth ?? 2 }
+        {
+          depth: depth ?? 2,
+          // Opt in now that the read path forwards a real caller; before that a
+          // Single read carried no user and would have judged everyone as
+          // anonymous, stripping protected related fields from every caller.
+          enforceFieldAccess: true,
+          user: access.user as Record<string, unknown> | undefined,
+          overrideAccess: access.overrideAccess,
+        }
       );
       return expandedDoc as SingleDocument;
     } catch (error) {

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -177,10 +177,14 @@ export function buildSingleHookContext<T>(
  * Whether a loaded row satisfies an access constraint of the
  * `{ field: { equals: value } }` shape the access service emits for reads.
  *
- * Reads are expected to fold that predicate into a LIST query, so a caller that
- * holds a single row has to check it directly instead. An unrecognized
- * constraint shape denies: a predicate that cannot be checked is not a
- * predicate that has been satisfied.
+ * Reads are expected to fold that predicate into a LIST query, which compiles
+ * the full Where grammar; a caller holding one row has to check it directly
+ * instead. Only a lone `equals` per field is checked, and **anything else
+ * denies** — a compound condition whose other operators went unchecked would
+ * admit a row the predicate excludes, and re-implementing the rest of the
+ * grammar here would be a second, drifting evaluator. Owner-only, the rule this
+ * exists for, emits exactly this shape. A custom rule returning any other
+ * operator is refused rather than half-evaluated.
  */
 function documentSatisfiesConstraint(
   document: Record<string, unknown>,
@@ -190,14 +194,14 @@ function documentSatisfiesConstraint(
   for (const [field, condition] of Object.entries(
     query as Record<string, unknown>
   )) {
-    if (
-      condition === null ||
-      typeof condition !== "object" ||
-      !("equals" in condition)
-    ) {
+    if (condition === null || typeof condition !== "object") return false;
+    const operators = Object.keys(condition);
+    // Exactly one operator, and it must be `equals`: a condition carrying more
+    // than that is only partly checkable, and partly checked is not satisfied.
+    if (operators.length !== 1 || operators[0] !== "equals") {
       return false;
     }
-    const expected = condition.equals;
+    const expected = (condition as Record<string, unknown>).equals;
     // Singles default their owner column to camelCase `createdBy` while the row
     // may carry the snake_case column the database stores, so a constraint is
     // matched against either spelling of the same column rather than missing it
@@ -481,13 +485,8 @@ export class SingleQueryService extends BaseService {
       message: `Access denied: read on single "${slug}" is not permitted`,
     };
 
-    // No row means ownership cannot be established. Auto-create would otherwise
-    // materialize an unowned document for a caller the rule may not admit, so
-    // fail closed and leave the Single uncreated.
-    if (!document) return denied;
-
     const documentId =
-      typeof document.id === "string" ? document.id : undefined;
+      typeof document?.id === "string" ? document.id : undefined;
     const result = await this.accessControlService.evaluateAccess(
       accessRules,
       "read",
@@ -502,7 +501,7 @@ export class SingleQueryService extends BaseService {
           : undefined,
       },
       documentId,
-      document
+      document ?? undefined
     );
 
     if (!result.allowed) {
@@ -514,6 +513,17 @@ export class SingleQueryService extends BaseService {
     // Single is one document, so there is nothing to filter — the predicate has
     // to be checked against the row itself or every authenticated caller reads
     // it. Custom rules that return a constraint are held to the same check.
+    if (result.query === undefined || result.query === null) {
+      // No predicate to satisfy. A custom rule that admits the caller on user
+      // context alone lands here, including on a Single that has never been
+      // materialized — so its first permitted read can still auto-create it.
+      return null;
+    }
+
+    // A predicate with no row cannot be satisfied. Denying here also stops
+    // auto-create from materializing a document the predicate would exclude.
+    if (!document) return denied;
+
     if (!documentSatisfiesConstraint(document, result.query)) {
       return denied;
     }

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -418,6 +418,53 @@ export class SingleQueryService extends BaseService {
   /** Resolves stored `accessRules` for the read gate. */
   private readonly accessControlService: AccessControlService;
 
+  /**
+   * Judge a document-dependent read rule against the loaded row.
+   *
+   * `checkSingleAccess` runs before the row is fetched, so an `owner-only` or
+   * `custom` read rule has nothing to compare against there — owner-only fails
+   * closed by design, and a custom rule would receive an undefined id and data.
+   * Those rules are deferred past that gate and settled here instead, which is
+   * the same split the mutation service uses for publish transitions.
+   */
+  private async evaluateReadDocumentRule(params: {
+    slug: string;
+    accessRules: CollectionAccessRules | undefined;
+    user?: UserContext;
+    document: Record<string, unknown>;
+  }): Promise<SingleResult | null> {
+    const { slug, accessRules, user, document } = params;
+    // Only reached for a document-dependent rule, so an absent rule set means
+    // there is nothing left to judge.
+    if (!accessRules) return null;
+    const documentId =
+      typeof document.id === "string" ? document.id : undefined;
+    const result = await this.accessControlService.evaluateAccess(
+      accessRules,
+      "read",
+      {
+        user: user
+          ? {
+              id: user.id,
+              role: user.role,
+              roles: user.roles,
+              email: user.email,
+            }
+          : undefined,
+      },
+      documentId,
+      document
+    );
+    if (result.allowed) return null;
+    return {
+      success: false,
+      statusCode: 403,
+      message:
+        result.reason ??
+        `Access denied: read on single "${slug}" is not permitted`,
+    };
+  }
+
   // ============================================================
   // Public API
   // ============================================================
@@ -451,10 +498,24 @@ export class SingleQueryService extends BaseService {
       // one the write paths already honor, so a `read: authenticated` or
       // role-based rule now holds over HTTP instead of only inside the Direct
       // API.
+      // An owner-only or custom read rule can only be judged against the row,
+      // and the row is not loaded yet. Defer those to the re-check below: the
+      // gate fails an owner-only rule closed when it has no document, which
+      // would deny every non-super-admin read of an owner-only Single.
+      const readRule = (singleMeta.accessRules as CollectionAccessRules)
+        ?.read as { type?: string } | undefined;
+      const isSuperAdminSession =
+        isSuperAdminContext(options.user) &&
+        options.authenticatedScope?.actorType !== "apiKey";
+      const deferDocumentRule =
+        !isSuperAdminSession &&
+        (readRule?.type === "owner-only" || readRule?.type === "custom");
+
       const accessDenied = await checkSingleAccess({
         slug,
         operation: "read",
         accessRules: singleMeta.accessRules,
+        deferStoredRuleEval: deferDocumentRule,
         user: options.user,
         overrideAccess: options.overrideAccess,
         routeAuthorized: options.routeAuthorized,
@@ -553,6 +614,19 @@ export class SingleQueryService extends BaseService {
         statusFilter ? statusFilter.value : undefined
       );
 
+      // 6.95. Re-judge a document-dependent read rule now that the row exists.
+      // Ownership and custom rules need the document the earlier gate could not
+      // supply; evaluating them there would have denied on the missing row.
+      if (deferDocumentRule && !options.overrideAccess) {
+        const documentRuleDenied = await this.evaluateReadDocumentRule({
+          slug,
+          accessRules: singleMeta.accessRules,
+          user: options.user,
+          document: doc,
+        });
+        if (documentRuleDenied) return documentRuleDenied;
+      }
+
       // 7. Deserialize JSON fields
       doc = this.deserializeJsonFields(doc, singleMeta.fields);
 
@@ -564,7 +638,11 @@ export class SingleQueryService extends BaseService {
         doc,
         singleMeta.fields,
         options.depth,
-        { user: options.user, overrideAccess: options.overrideAccess }
+        {
+          enforceFieldAccess: true,
+          user: options.user,
+          overrideAccess: options.overrideAccess,
+        }
       );
 
       // 7.7. Populate component field data from comp_{slug} tables
@@ -1248,10 +1326,17 @@ export class SingleQueryService extends BaseService {
     doc: SingleDocument,
     fields: FieldConfig[],
     depth?: number,
-    // The caller a related row's own field rules are evaluated against.
-    // Expansion copies whole related rows into this document, and a Single's
-    // field list never describes a related collection's fields.
-    access: { user?: UserContext; overrideAccess?: boolean } = {}
+    // The caller a related row's own field rules are evaluated against, and
+    // whether to evaluate them at all. Expansion copies whole related rows into
+    // this document, and a Single's field list never describes a related
+    // collection's fields. Enforcement is opt-in because a caller that has not
+    // supplied a user is indistinguishable from an anonymous one here, and
+    // enforcing for the former strips protected fields from everybody.
+    access: {
+      enforceFieldAccess?: boolean;
+      user?: UserContext;
+      overrideAccess?: boolean;
+    } = {}
   ): Promise<SingleDocument> {
     const relationshipService = this.resolveRelationshipService();
     if (!relationshipService) {
@@ -1279,10 +1364,10 @@ export class SingleQueryService extends BaseService {
         fields as unknown as FieldDefinition[],
         {
           depth: depth ?? 2,
-          // Opt in now that the read path forwards a real caller; before that a
-          // Single read carried no user and would have judged everyone as
-          // anonymous, stripping protected related fields from every caller.
-          enforceFieldAccess: true,
+          // Set by the read path, which forwards a real caller. The mutation
+          // path does not, so its response keeps the fields it already returned
+          // rather than having them stripped as if nobody were asking.
+          enforceFieldAccess: access.enforceFieldAccess,
           user: access.user as Record<string, unknown> | undefined,
           overrideAccess: access.overrideAccess,
         }

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -173,6 +173,43 @@ export function buildSingleHookContext<T>(
  *
  * @returns `null` if access is allowed, `SingleResult` if denied
  */
+/**
+ * Whether a loaded row satisfies an access constraint of the
+ * `{ field: { equals: value } }` shape the access service emits for reads.
+ *
+ * Reads are expected to fold that predicate into a LIST query, so a caller that
+ * holds a single row has to check it directly instead. An unrecognized
+ * constraint shape denies: a predicate that cannot be checked is not a
+ * predicate that has been satisfied.
+ */
+function documentSatisfiesConstraint(
+  document: Record<string, unknown>,
+  query: unknown
+): boolean {
+  if (!query || typeof query !== "object") return true;
+  for (const [field, condition] of Object.entries(
+    query as Record<string, unknown>
+  )) {
+    if (
+      condition === null ||
+      typeof condition !== "object" ||
+      !("equals" in condition)
+    ) {
+      return false;
+    }
+    const expected = condition.equals;
+    // Singles default their owner column to camelCase `createdBy` while the row
+    // may carry the snake_case column the database stores, so a constraint is
+    // matched against either spelling of the same column rather than missing it
+    // and denying a legitimate owner.
+    const camel = field.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+    const snake = field.replace(/[A-Z]/g, c => `_${c.toLowerCase()}`);
+    const actual = document[field] ?? document[camel] ?? document[snake];
+    if (actual !== expected) return false;
+  }
+  return true;
+}
+
 export async function checkSingleAccess(params: {
   slug: string;
   operation: "read" | "update" | "publish" | "unpublish";
@@ -431,12 +468,24 @@ export class SingleQueryService extends BaseService {
     slug: string;
     accessRules: CollectionAccessRules | undefined;
     user?: UserContext;
-    document: Record<string, unknown>;
+    document: Record<string, unknown> | null;
   }): Promise<SingleResult | null> {
     const { slug, accessRules, user, document } = params;
     // Only reached for a document-dependent rule, so an absent rule set means
     // there is nothing left to judge.
     if (!accessRules) return null;
+
+    const denied: SingleResult = {
+      success: false,
+      statusCode: 403,
+      message: `Access denied: read on single "${slug}" is not permitted`,
+    };
+
+    // No row means ownership cannot be established. Auto-create would otherwise
+    // materialize an unowned document for a caller the rule may not admit, so
+    // fail closed and leave the Single uncreated.
+    if (!document) return denied;
+
     const documentId =
       typeof document.id === "string" ? document.id : undefined;
     const result = await this.accessControlService.evaluateAccess(
@@ -455,14 +504,20 @@ export class SingleQueryService extends BaseService {
       documentId,
       document
     );
-    if (result.allowed) return null;
-    return {
-      success: false,
-      statusCode: 403,
-      message:
-        result.reason ??
-        `Access denied: read on single "${slug}" is not permitted`,
-    };
+
+    if (!result.allowed) {
+      return { ...denied, message: result.reason ?? denied.message };
+    }
+
+    // An owner-only read does not decide: it returns the predicate a LIST would
+    // have filtered by and reports `allowed: true` whoever owns the row. A
+    // Single is one document, so there is nothing to filter — the predicate has
+    // to be checked against the row itself or every authenticated caller reads
+    // it. Custom rules that return a constraint are held to the same check.
+    if (!documentSatisfiesConstraint(document, result.query)) {
+      return denied;
+    }
+    return null;
   }
 
   // ============================================================
@@ -532,6 +587,27 @@ export class SingleQueryService extends BaseService {
         return accessDenied;
       }
 
+      // 1.6. Settle a deferred document rule BEFORE any read side effect. Hooks
+      // are user code and auto-create permanently materializes the document
+      // (with its first version and localized defaults), so a caller the rule
+      // denies must not reach either by issuing a read it is not allowed to
+      // make. The row is loaded here rather than at step 5 so the decision has
+      // something to judge; step 5 reuses it.
+      let loadedDoc: SingleDocument | null = null;
+      if (deferDocumentRule && !options.overrideAccess) {
+        loadedDoc = await this.adapter.selectOne<SingleDocument>(
+          singleMeta.tableName,
+          {}
+        );
+        const documentRuleDenied = await this.evaluateReadDocumentRule({
+          slug,
+          accessRules: singleMeta.accessRules,
+          user: options.user,
+          document: loadedDoc,
+        });
+        if (documentRuleDenied) return documentRuleDenied;
+      }
+
       // 2. Build shared context for hooks (seed with caller-provided context)
       const sharedContext: Record<string, unknown> = { ...options.context };
       const hookCollection = getSingleHookCollection(slug);
@@ -563,10 +639,12 @@ export class SingleQueryService extends BaseService {
       }
 
       // 5. Fetch document from database
-      let doc = await this.adapter.selectOne<SingleDocument>(
-        singleMeta.tableName,
-        {}
-      );
+      let doc =
+        loadedDoc ??
+        (await this.adapter.selectOne<SingleDocument>(
+          singleMeta.tableName,
+          {}
+        ));
 
       // 6. Auto-create if document doesn't exist. Capture the initial version
       // when the Single is versioned so a first-read materialization still
@@ -613,19 +691,6 @@ export class SingleQueryService extends BaseService {
         options.fallbackLocale,
         statusFilter ? statusFilter.value : undefined
       );
-
-      // 6.95. Re-judge a document-dependent read rule now that the row exists.
-      // Ownership and custom rules need the document the earlier gate could not
-      // supply; evaluating them there would have denied on the missing row.
-      if (deferDocumentRule && !options.overrideAccess) {
-        const documentRuleDenied = await this.evaluateReadDocumentRule({
-          slug,
-          accessRules: singleMeta.accessRules,
-          user: options.user,
-          document: doc,
-        });
-        if (documentRuleDenied) return documentRuleDenied;
-      }
 
       // 7. Deserialize JSON fields
       doc = this.deserializeJsonFields(doc, singleMeta.fields);

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -552,8 +552,9 @@ const SINGLE_DOCUMENT_METHODS = new Set([
  * disclose existence, and the two version `get*` methods additionally return a
  * snapshot redacted by field-level `access.read`, which reads the same set.
  *
- * The three entry reads are here because they forward the caller into the query
- * service, which evaluates the collection's stored read rules for them.
+ * The entry and Single document reads are here because they forward the caller
+ * into their query service, which evaluates the entity's stored read rules for
+ * them.
  * Resolving roles costs a permissions lookup on every entry read; a read that
  * silently ignores the rule it was configured with is the worse tradeoff.
  */
@@ -561,6 +562,7 @@ const ROLE_AWARE_READ_METHODS = new Set([
   "listEntries",
   "getEntry",
   "countEntries",
+  "getSingleDocument",
   "listEntryVersions",
   "getEntryVersion",
   "listSingleVersions",


### PR DESCRIPTION
Task 002 PR-3, the last slice. Follows #333 (collections) and #335 (related rows).

## The gap

`single-query-service.ts` said it outright in a comment: stored read-rule enforcement was *deliberately* not wired, because the REST read handlers forwarded no user and evaluating a `read: authenticated` or role-based rule would have rejected every caller as anonymous. That was the right call at the time; #333 removed the reason.

So a Single restricted by a read rule was returned in full to any caller who could reach the endpoint, while the identical rule was enforced on every update and inside the Direct API.

## What changed

- `getSingleDocument` forwards `user`, `routeAuthorized`, and `authenticatedScope`. `GetSingleOptions` already declared all three — same shape as #333, where the service was ready and only the dispatcher never passed anything.
- The read gate now receives the Single's stored `accessRules`.
- `getSingleDocument` added to `ROLE_AWARE_READ_METHODS`, so roles are resolved for it. Without this the forwarded caller arrives with `roles: undefined` and a role-based rule denies someone it should admit — the exact regression caught on #333.
- Singles relationship expansion sets `enforceFieldAccess: true`, activating the related-row redaction from #335. It was deliberately dormant for Singles until a real caller existed here.

## One thing worth flagging: passing the rules was not enough

The gate is guarded by `if (accessControlService && accessRules && ...)`, and `SingleQueryService` **had no `accessControlService` at all** — the mutation service constructs its own, the query service never did. Handing over `accessRules` alone would have compiled, passed review, read correctly, and enforced nothing.

The service now resolves one the same way the mutation service does. **Both halves are verified independently: removing either the rules or the service makes the tests fail.** That is the third time on this task that a security parameter was accepted by a signature but never supplied, so I am testing the behavior rather than the wiring.

## Tests

8 added:
- 3 on the dispatcher — user forwarding, anonymous callers, API-key scope — each verified to fail with the forwarding reverted.
- 1 asserting `getSingleDocument` resolves roles.
- 4 driving `get()` end to end through the real gate: denied caller, admitted caller, the rule being evaluated for the `read` operation against the right user, and `overrideAccess` bypassing.

Zero new failures: same suites, both after a full build, `origin/main` @ `8512d5df` 370 failed / 2680 passed vs branch 370 / 2688 — identical failing-file set, +8 passing.

Untouched on purpose: the two red `?status=` tests in `single-dispatcher-shapes.test.ts` belong to task 003 and need a founder decision.

## Still not covered after this

Related-row field rules remain unevaluated on create/update response expansion (`collection-mutation-service.ts:2130,4151`) and component relationship population (`component-query-service.ts:1019`) — both still lack a caller. Tracked; not smuggled in here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Single-document reads now enforce stored read-access rules, including owner-only and custom constraints.
  * Authenticated user and API-key access context is forwarded during single-document retrieval.
  * Relationship field expansion now respects field-level access settings.

* **Bug Fixes**
  * Prevented unauthorized reads and unintended document creation when access checks fail.
  * Added role resolution for single-document read requests.
  * Improved handling of camelCase and snake_case ownership fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->