### PR TITLE
feat(nextly): next cache adapter, read-side tagging helpers, and per-op disableRevalidate

### DIFF
--- a/.changeset/f1-next-adapter-read-helpers.md
+++ b/.changeset/f1-next-adapter-read-helpers.md
@@ -1,0 +1,24 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Content pages can now use tag-based ISR: cache a read with `cachedFind` and tag it with `nextlyTags` from `nextly/runtime`, and every content change (create, update, publish, unpublish, delete, or slug rename) busts exactly those tags so the page regenerates on the next visit — no rebuild, no `force-dynamic`. Revalidation turns on automatically wherever you mount the admin route (`createDynamicHandlers`). A per-operation `disableRevalidate` flag lets a bulk import, seed, or CLI write skip it. See the new "ISR and caching" guide, including the rule for keying a per-user read so it cannot leak across callers.

--- a/apps/playground/src/app/(site)/blog/[slug]/page.tsx
+++ b/apps/playground/src/app/(site)/blog/[slug]/page.tsx
@@ -19,14 +19,30 @@ type NextlyInstance = Awaited<ReturnType<typeof getNextly>>;
 function makeDataProvider(nx: NextlyInstance): DataProvider {
   return {
     find: async args => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Direct API arg shapes vary by slug
-      const result = await nx.find(args as any);
+      // A page-builder layout can Query-Loop any collection, not just posts.
+      // Cache each provider read and tag it with ITS collection, so those tags
+      // attach to this page and a write to the queried collection revalidates it
+      // — otherwise the loop would stay stale once the route is no longer
+      // force-dynamic. Public reads (no per-caller filter), so a stable key is
+      // fine.
+      const collection = args.collection;
+      const result = await cachedFind(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Direct API arg shapes vary by slug
+        () => nx.find(args as any),
+        {
+          tags: nextlyTags(collection),
+          keyParts: ["pb-find", JSON.stringify(args)],
+        }
+      );
       return {
         items: result.items ?? [],
       };
     },
     findOne: async ({ collection, id }) => {
-      const doc = await nx.findByID({ collection, id });
+      const doc = await cachedFind(() => nx.findByID({ collection, id }), {
+        tags: nextlyTags(collection, id),
+        keyParts: ["pb-find-one", collection, id],
+      });
       return doc ?? null;
     },
     resolveMedia: async () => null,

--- a/apps/playground/src/app/(site)/blog/[slug]/page.tsx
+++ b/apps/playground/src/app/(site)/blog/[slug]/page.tsx
@@ -47,11 +47,11 @@ export default async function BlogPost({
 }) {
   const { slug } = await params;
   const nx = await getNextly({ config: nextlyConfig });
-  // ISR via F1: cache the published-post read and tag it with the collection
-  // tag, so publishing or editing a post busts the cache and this page
-  // regenerates on the next visit — no rebuild, no `force-dynamic`. The read
-  // filters by `status: published` only (not by caller), so it is public and
-  // safe to cache under a stable, slug-keyed entry shared by every reader.
+  // Cache the published-post read and tag it with the collection tag, so
+  // publishing or editing a post busts the cache and this page regenerates on
+  // the next visit — no rebuild, no `force-dynamic`. The read filters by
+  // `status: published` only (not by caller), so it is public and safe to cache
+  // under a stable, slug-keyed entry shared by every reader.
   const post = await cachedFind<PostData | null>(
     async () => {
       const { items } = await nx.find({

--- a/apps/playground/src/app/(site)/blog/[slug]/page.tsx
+++ b/apps/playground/src/app/(site)/blog/[slug]/page.tsx
@@ -10,12 +10,9 @@ import {
 } from "@nextlyhq/plugin-page-builder/render";
 import { notFound } from "next/navigation";
 import { getNextly } from "nextly";
+import { cachedFind, nextlyTags } from "nextly/runtime";
 
 import nextlyConfig from "../../../../../nextly.config";
-
-// DB-backed page: render per-request; never prerendered at build (the build
-// environment has no database).
-export const dynamic = "force-dynamic";
 
 type NextlyInstance = Awaited<ReturnType<typeof getNextly>>;
 
@@ -25,13 +22,12 @@ function makeDataProvider(nx: NextlyInstance): DataProvider {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Direct API arg shapes vary by slug
       const result = await nx.find(args as any);
       return {
-        items: (result.items ?? []) as unknown as Record<string, unknown>[],
+        items: result.items ?? [],
       };
     },
     findOne: async ({ collection, id }) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- slug is a generated union
-      const doc = await nx.findByID({ collection, id } as any);
-      return (doc ?? null) as Record<string, unknown> | null;
+      const doc = await nx.findByID({ collection, id });
+      return doc ?? null;
     },
     resolveMedia: async () => null,
   };
@@ -51,12 +47,22 @@ export default async function BlogPost({
 }) {
   const { slug } = await params;
   const nx = await getNextly({ config: nextlyConfig });
-  const { items } = await nx.find({
-    collection: "posts",
-    where: { slug: { equals: slug }, status: { equals: "published" } },
-    limit: 1,
-  });
-  const post = items[0] as PostData | undefined;
+  // ISR via F1: cache the published-post read and tag it with the collection
+  // tag, so publishing or editing a post busts the cache and this page
+  // regenerates on the next visit — no rebuild, no `force-dynamic`. The read
+  // filters by `status: published` only (not by caller), so it is public and
+  // safe to cache under a stable, slug-keyed entry shared by every reader.
+  const post = await cachedFind<PostData | null>(
+    async () => {
+      const { items } = await nx.find({
+        collection: "posts",
+        where: { slug: { equals: slug }, status: { equals: "published" } },
+        limit: 1,
+      });
+      return items[0] ?? null;
+    },
+    { tags: nextlyTags("posts"), keyParts: ["posts", "detail", slug] }
+  );
   if (!post) notFound();
 
   // Page-builder mode → render the visual layout.

--- a/docs/guides/isr-caching.mdx
+++ b/docs/guides/isr-caching.mdx
@@ -48,11 +48,24 @@ export const { GET, POST, PATCH, DELETE } = createDynamicHandlers();
 ```
 
 If you write content through the Direct API (`nextly.create(...)`) from a Server
-Action, a custom route, or a background worker, register from
-`instrumentation.ts` as above — relying on the admin route alone leaves those
-contexts on the no-op revalidator, and their writes would not refresh cached
-pages. A write in a context with no adapter registered is a silent no-op for
-revalidation (never an error), so it is safe but stale.
+Action, a custom route, or the admin API, register from `instrumentation.ts` as
+above — relying on the admin route alone leaves those contexts on the no-op
+revalidator, and their writes would not refresh cached pages. A write in a
+context with no adapter registered is a silent no-op for revalidation (never an
+error), so it is safe but stale.
+
+### Writes must run inside a request
+
+Automatic revalidation fires for a write that runs **inside a Next.js request or
+render** — a Route Handler, a Server Action, or the admin API. That is where
+`revalidateTag` is valid, and it covers how content is normally edited.
+
+A write from **outside** a request — a cron job, a CLI, or a background worker
+with no request in flight — cannot call `revalidateTag` (there is no cache scope
+to invalidate), so the adapter safely skips it (the write still succeeds). Those
+callers should either run the write in a Route Handler / Server Action, or
+invalidate the cache themselves. This mirrors how on-demand ISR works in Next.js
+generally: revalidation is request-scoped.
 
 ## Tag a read
 
@@ -100,8 +113,16 @@ Builds the tags a read should carry:
 - `nextlyTags("posts", id)` — adds the entry-id tag; for a detail page, so a
   change to that one entry invalidates it. Tags by the **immutable id**, so a
   slug rename or a status change still invalidates.
-- `nextlyTags("posts", id, locale)` — adds the per-locale tag, so publishing one
-  locale busts only that locale's page.
+- `nextlyTags("posts", id, locale)` — adds the per-locale id tag.
+
+A detail read intentionally carries the collection tag too, so it also refreshes
+when the collection changes around it. Because a match on **any** tag
+invalidates the entry, that broadens invalidation: any change in the collection
+(or any locale of the entry) refreshes the read, rather than only that one
+locale's page. That is safe — a stale read is never served, only re-fetched more
+often. If you need strictly per-entry or per-locale granularity on a
+high-traffic route, tag with the entry/locale tag alone rather than this helper's
+broad, safe default.
 
 For a singleton (global) use `nextlySingleTags("header")`.
 

--- a/docs/guides/isr-caching.mdx
+++ b/docs/guides/isr-caching.mdx
@@ -1,0 +1,135 @@
+---
+title: ISR and caching
+description: Cache your content pages and revalidate them the moment content changes. Tag reads with nextlyTags/cachedFind and Nextly busts them on every write.
+---
+
+Nextly turns every content change into a cache invalidation. Tag a page's data
+with the collection/entry it reads, and a create, update, publish, unpublish,
+delete, or slug change busts exactly those tags — the page regenerates on the
+next visit, with no rebuild and no `force-dynamic`.
+
+This is [Next.js Incremental Static Regeneration](https://nextjs.org/docs/app/guides/incremental-static-regeneration)
+driven by your content, not a timer.
+
+## How it works
+
+1. A read tags its cached data with the `nextly:*` tags for the collection (and,
+   for a detail page, the entry id).
+2. A write computes the same tags and, after it commits, calls Next's
+   `revalidateTag` for each — so any page tagged with them is invalidated.
+
+The write side is automatic once the admin route is wired (see below). You only
+add the read-side tags.
+
+## Enable it
+
+Cache revalidation turns on wherever you mount the admin route handler:
+
+```ts
+// app/admin/[[...params]]/route.ts
+import { createDynamicHandlers } from "nextly/runtime";
+
+export const { GET, POST, PATCH, DELETE } = createDynamicHandlers();
+```
+
+If your app writes content through the Direct API but never mounts that handler,
+enable it explicitly once at startup:
+
+```ts
+import { registerNextCacheRevalidator } from "nextly/runtime";
+
+registerNextCacheRevalidator();
+```
+
+## Tag a read
+
+Use `cachedFind` to cache a data read and `nextlyTags` to tag it:
+
+```tsx
+// app/(site)/blog/[slug]/page.tsx
+import { getNextly } from "nextly";
+import { cachedFind, nextlyTags } from "nextly/runtime";
+
+export default async function Post({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const nx = await getNextly();
+
+  const post = await cachedFind(
+    async () => {
+      const { items } = await nx.find({
+        collection: "posts",
+        where: { slug: { equals: slug }, status: { equals: "published" } },
+        limit: 1,
+      });
+      return items[0] ?? null;
+    },
+    { tags: nextlyTags("posts"), keyParts: ["posts", "detail", slug] }
+  );
+
+  if (!post) return null;
+  return <article>{/* ... */}</article>;
+}
+```
+
+Publishing or editing any post now busts `nextly:posts` and this page
+regenerates. For a listing page, tag it the same way — `nextlyTags("posts")` —
+and it revalidates on any change in the collection.
+
+### `nextlyTags(collection, id?, locale?)`
+
+Builds the tags a read should carry:
+
+- `nextlyTags("posts")` — the collection tag; for lists, indexes, sitemaps.
+- `nextlyTags("posts", id)` — adds the entry-id tag; for a detail page, so a
+  change to that one entry invalidates it. Tags by the **immutable id**, so a
+  slug rename or a status change still invalidates.
+- `nextlyTags("posts", id, locale)` — adds the per-locale tag, so publishing one
+  locale busts only that locale's page.
+
+For a singleton (global) use `nextlySingleTags("header")`.
+
+## Security: caching a per-user read
+
+`cachedFind`'s `keyParts` decide which requests share a cache entry. **Include
+anything the result varies by** — and for a read that applies per-caller access
+rules (owner-only scoping, role-based visibility, an API key's narrowed scope),
+that means the caller's identity:
+
+```tsx
+// Per-user list — the caller's id is in the key, so it never leaks.
+const mine = await cachedFind(() => nx.find({ collection: "orders", user }), {
+  tags: nextlyTags("orders"),
+  keyParts: ["orders", "list", user.id], // <-- caller identity
+});
+```
+
+If you cache an owner-filtered read under a stable key that omits the caller, two
+different users share one cache entry and one is served the other's rows — a
+cross-tenant data leak, not a stale-cache annoyance. For genuinely public content
+(the same for every reader, like a published blog post) a stable key is correct
+and gives the full caching benefit.
+
+## Opt a write out of revalidation
+
+A bulk import, seed, or CLI write that owns its own cache strategy can skip the
+per-row revalidation with `disableRevalidate`:
+
+```ts
+await nx.create({ collection: "posts", data, disableRevalidate: true });
+```
+
+The write still records its outbox event (webhooks and retention are
+unaffected); it just does not bust any cache tags.
+
+## Notes
+
+- Works across the supported Next range (`^14 || ^15 || ^16`) on the stable
+  `revalidateTag` / `unstable_cache` primitives.
+- `cachedFind` runs the reader directly (no caching) outside a Next runtime, so
+  the same code works in tests and non-Next callers.
+- Add `revalidate: <seconds>` to `cachedFind` for a time-based safety net on top
+  of tag-based busting.

--- a/docs/guides/isr-caching.mdx
+++ b/docs/guides/isr-caching.mdx
@@ -23,7 +23,22 @@ add the read-side tags.
 
 ## Enable it
 
-Cache revalidation turns on wherever you mount the admin route handler:
+Register the adapter once per server process. The most reliable place is Next's
+[`instrumentation.ts`](https://nextjs.org/docs/app/api-reference/file-conventions/instrumentation),
+whose `register()` runs at startup, before any route, Server Action, or
+serverless worker handles a request — so **every** write context busts tags,
+not just the ones that happen to have loaded the admin route:
+
+```ts
+// instrumentation.ts (project root, next to your app/ directory)
+export async function register() {
+  const { registerNextCacheRevalidator } = await import("nextly/runtime");
+  registerNextCacheRevalidator();
+}
+```
+
+Mounting the admin route handler also registers it, which is enough if every
+content write goes through the admin API in the same process:
 
 ```ts
 // app/admin/[[...params]]/route.ts
@@ -32,14 +47,12 @@ import { createDynamicHandlers } from "nextly/runtime";
 export const { GET, POST, PATCH, DELETE } = createDynamicHandlers();
 ```
 
-If your app writes content through the Direct API but never mounts that handler,
-enable it explicitly once at startup:
-
-```ts
-import { registerNextCacheRevalidator } from "nextly/runtime";
-
-registerNextCacheRevalidator();
-```
+If you write content through the Direct API (`nextly.create(...)`) from a Server
+Action, a custom route, or a background worker, register from
+`instrumentation.ts` as above — relying on the admin route alone leaves those
+contexts on the no-op revalidator, and their writes would not refresh cached
+pages. A write in a context with no adapter registered is a silent no-op for
+revalidation (never an error), so it is safe but stale.
 
 ## Tag a read
 

--- a/docs/guides/meta.json
+++ b/docs/guides/meta.json
@@ -6,6 +6,7 @@
     "authentication",
     "media-storage",
     "email",
-    "draft-published-status"
+    "draft-published-status",
+    "isr-caching"
   ]
 }

--- a/packages/nextly/src/di/registrations/register-collections.ts
+++ b/packages/nextly/src/di/registrations/register-collections.ts
@@ -188,10 +188,14 @@ export function registerCollectionServices(ctx: RegistrationContext): void {
         ? container.get<WebhookFastDrainScheduler>("webhookFastDrainScheduler")
         : undefined,
       // Cache revalidator that flushes each write's revalidation intents
-      // post-commit (a no-op unless a Next cache adapter registered one).
-      container.has("cacheRevalidator")
-        ? container.get<CacheRevalidator>("cacheRevalidator")
-        : undefined
+      // post-commit. Resolved lazily at flush time (not captured here) because
+      // this service is constructed during boot, before a Next cache adapter
+      // registers — an eager capture would memoize the no-op and ignore the
+      // real adapter that registers later, at request time.
+      () =>
+        container.has("cacheRevalidator")
+          ? container.get<CacheRevalidator>("cacheRevalidator")
+          : undefined
     );
 
     return new CollectionService(

--- a/packages/nextly/src/di/registrations/register-revalidation.ts
+++ b/packages/nextly/src/di/registrations/register-revalidation.ts
@@ -6,19 +6,21 @@
  * to null-check the sink; a framework adapter (the Next cache adapter) replaces
  * this registration with an implementation that calls `revalidateTag`.
  */
-import { NoopRevalidator } from "../../revalidation/noop-revalidator";
+import { createDefaultRevalidator } from "../../revalidation/default-revalidator";
 import type { CacheRevalidator } from "../../revalidation/types";
 import { container } from "../container";
 
 import type { RegistrationContext } from "./types";
 
 export function registerRevalidationServices(_ctx: RegistrationContext): void {
-  // Only register the no-op default when nothing else has claimed the slot, so a
+  // Only register the default when nothing else has claimed the slot, so a
   // framework adapter registered earlier (or a test's fake) is never clobbered.
+  // `createDefaultRevalidator` returns the framework adapter when one installed
+  // its factory (a Next app), else the no-op — so a reboot after clearServices()
+  // re-seeds the adapter instead of silently falling back to the no-op.
   if (!container.has("cacheRevalidator")) {
-    container.registerSingleton<CacheRevalidator>(
-      "cacheRevalidator",
-      () => new NoopRevalidator()
+    container.registerSingleton<CacheRevalidator>("cacheRevalidator", () =>
+      createDefaultRevalidator()
     );
   }
 }

--- a/packages/nextly/src/di/registrations/register-singles.ts
+++ b/packages/nextly/src/di/registrations/register-singles.ts
@@ -81,11 +81,14 @@ export function registerSingleServices(ctx: RegistrationContext): void {
       container.has("webhookFastDrainScheduler")
         ? container.get<WebhookFastDrainScheduler>("webhookFastDrainScheduler")
         : undefined,
-      // Cache revalidator that flushes each single write's intent post-commit
-      // (a no-op unless a Next cache adapter registered one).
-      container.has("cacheRevalidator")
-        ? container.get<CacheRevalidator>("cacheRevalidator")
-        : undefined
+      // Cache revalidator that flushes each single write's intent post-commit.
+      // Resolved lazily at flush time (not captured here) because this service
+      // is constructed during boot, before a Next cache adapter registers — an
+      // eager capture would memoize the no-op and ignore the real adapter.
+      () =>
+        container.has("cacheRevalidator")
+          ? container.get<CacheRevalidator>("cacheRevalidator")
+          : undefined
     );
   });
 }

--- a/packages/nextly/src/direct-api/namespaces/collections.ts
+++ b/packages/nextly/src/direct-api/namespaces/collections.ts
@@ -169,6 +169,7 @@ export async function create<TSlug extends CollectionSlug>(
       // language's companion row, not the default locale's.
       locale: config.locale,
       context: config.context,
+      disableRevalidate: config.disableRevalidate,
     },
     args.data
   );
@@ -216,6 +217,7 @@ export async function update<TSlug extends CollectionSlug>(
         // language's companion row, not the default locale's.
         locale: config.locale,
         context: config.context,
+        disableRevalidate: config.disableRevalidate,
       },
       args.data
     );
@@ -241,6 +243,7 @@ export async function update<TSlug extends CollectionSlug>(
           ? { id: config.user.id, role: config.user.role }
           : undefined,
         context: config.context,
+        disableRevalidate: config.disableRevalidate,
       },
       { limit: 1 }
     );
@@ -316,6 +319,7 @@ export async function deleteEntry<
         ? { id: config.user.id, role: config.user.role }
         : undefined,
       context: config.context,
+      disableRevalidate: config.disableRevalidate,
     });
 
     if (!result.success) {
@@ -338,6 +342,7 @@ export async function deleteEntry<
           ? { id: config.user.id, role: config.user.role }
           : undefined,
         context: config.context,
+        disableRevalidate: config.disableRevalidate,
       },
       { limit: 1000 }
     );
@@ -449,6 +454,7 @@ export async function duplicate<TSlug extends CollectionSlug>(
       ? { id: config.user.id, role: config.user.role }
       : undefined,
     context: config.context,
+    disableRevalidate: config.disableRevalidate,
   });
 
   if (!result.success) {

--- a/packages/nextly/src/direct-api/namespaces/collections.ts
+++ b/packages/nextly/src/direct-api/namespaces/collections.ts
@@ -420,6 +420,7 @@ export async function bulkDelete(
       ? { id: config.user.id, role: config.user.role }
       : undefined,
     context: config.context,
+    disableRevalidate: config.disableRevalidate,
   });
 
   // Project to the public shape so internal post-commit signals (eventRecorded,

--- a/packages/nextly/src/direct-api/namespaces/singles.ts
+++ b/packages/nextly/src/direct-api/namespaces/singles.ts
@@ -83,6 +83,7 @@ export async function updateSingle<TSlug extends SingleSlug>(
       : undefined,
     overrideAccess: config.overrideAccess,
     context: config.context,
+    disableRevalidate: config.disableRevalidate,
   });
 
   if (!result.success) {

--- a/packages/nextly/src/direct-api/types/collections.ts
+++ b/packages/nextly/src/direct-api/types/collections.ts
@@ -366,6 +366,14 @@ export interface BulkDeleteArgs<TSlug extends CollectionSlug = CollectionSlug>
 
   /** Array of document IDs to delete (required) */
   ids: string[];
+
+  /**
+   * Skip cache revalidation for this bulk delete (the outbox drain still runs).
+   * Set by a CLI, seed, or bulk-import caller that owns its cache strategy.
+   *
+   * @default false
+   */
+  disableRevalidate?: boolean;
 }
 
 /**

--- a/packages/nextly/src/direct-api/types/collections.ts
+++ b/packages/nextly/src/direct-api/types/collections.ts
@@ -198,6 +198,15 @@ export interface CreateArgs<TSlug extends CollectionSlug = CollectionSlug>
    * @default false
    */
   disableVerificationEmail?: boolean;
+
+  /**
+   * Skip cache revalidation for this write (the outbox drain still runs, so
+   * webhooks are unaffected). Set by a CLI, seed, or bulk-import caller that
+   * owns its own cache strategy and does not want a revalidation per row.
+   *
+   * @default false
+   */
+  disableRevalidate?: boolean;
 }
 
 /**
@@ -261,6 +270,14 @@ export interface UpdateArgs<TSlug extends CollectionSlug = CollectionSlug>
    * @default false
    */
   overwriteExistingFiles?: boolean;
+
+  /**
+   * Skip cache revalidation for this write (the outbox drain still runs). Set by
+   * a CLI, seed, or bulk-import caller that owns its own cache strategy.
+   *
+   * @default false
+   */
+  disableRevalidate?: boolean;
 }
 
 /**
@@ -301,6 +318,14 @@ export interface DeleteArgs<TSlug extends CollectionSlug = CollectionSlug>
    * Either `id` or `where` must be provided.
    */
   where?: WhereFilter;
+
+  /**
+   * Skip cache revalidation for this delete (the outbox drain still runs). Set
+   * by a CLI, seed, or bulk-import caller that owns its own cache strategy.
+   *
+   * @default false
+   */
+  disableRevalidate?: boolean;
 }
 
 /**
@@ -369,6 +394,14 @@ export interface DuplicateArgs<TSlug extends CollectionSlug = CollectionSlug>
    * These values override the copied data.
    */
   overrides?: Record<string, unknown>;
+
+  /**
+   * Skip cache revalidation for this duplicate (the outbox drain still runs).
+   * Set by a CLI, seed, or bulk-import caller that owns its cache strategy.
+   *
+   * @default false
+   */
+  disableRevalidate?: boolean;
 }
 
 /**

--- a/packages/nextly/src/direct-api/types/singles.ts
+++ b/packages/nextly/src/direct-api/types/singles.ts
@@ -66,6 +66,14 @@ export interface UpdateSingleArgs<TSlug extends SingleSlug = SingleSlug>
    * @default false
    */
   draft?: boolean;
+
+  /**
+   * Skip cache revalidation for this write (the outbox drain still runs). Set by
+   * a CLI, seed, or bulk-import caller that owns its own cache strategy.
+   *
+   * @default false
+   */
+  disableRevalidate?: boolean;
 }
 
 /**

--- a/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
@@ -499,6 +499,24 @@ describe("cache revalidation — write path (sqlite)", () => {
     expect(spy.flushed).toHaveLength(0);
   });
 
+  it("forwards disableRevalidate through the public handler surface", async () => {
+    // The Direct API (`nx.create`) reaches the write path through this handler,
+    // so the flag has to survive the handler's field-by-field param rebuild —
+    // without this forwarding the documented opt-out would silently revalidate.
+    await boot([openCollection("hskip")]);
+    const handler =
+      handle!.getService<CollectionsHandler>("collectionsHandler");
+    await handler.createEntry(
+      {
+        collectionName: "hskip",
+        overrideAccess: true,
+        disableRevalidate: true,
+      },
+      { title: "T", slug: "h" }
+    );
+    expect(spy.flushed).toHaveLength(0);
+  });
+
   it("flushes nothing when a single write sets disableRevalidate", async () => {
     const adapter = await memoryAdapter();
     handle = await createTestNextly({

--- a/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
@@ -430,6 +430,28 @@ describe("cache revalidation — write path (sqlite)", () => {
     expect(spy.tags).toContain("nextly:builderon:slug:on");
   });
 
+  it("resolves a cache adapter registered AFTER construction (lazy, codex-194)", async () => {
+    // The Next cache adapter registers at request time, well after boot. A write
+    // must resolve the revalidator at flush time, not capture the boot-time
+    // default at construction — otherwise a boot path that touches the entry
+    // service memoizes the no-op and ignores the adapter that registers later.
+    const entries = await boot([openCollection("late")]);
+    // Register a second revalidator AFTER the service was constructed; it must
+    // win. With an eager capture, `spy` (registered pre-boot) would receive the
+    // flush and `lateSpy` would get nothing — this fails there and passes here.
+    const lateSpy = new RecordingRevalidator();
+    container.registerSingleton<CacheRevalidator>(
+      "cacheRevalidator",
+      () => lateSpy
+    );
+    await entries.createEntry(
+      { collectionName: "late", overrideAccess: true },
+      { title: "T", slug: "z" }
+    );
+    expect(lateSpy.tags).toContain("nextly:late:slug:z");
+    expect(spy.flushed).toHaveLength(0);
+  });
+
   it("flushes nothing when a write records no event (update of a missing entry)", async () => {
     const entries = await boot([openCollection("nope")]);
     const result = await entries.updateEntry(

--- a/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
@@ -488,6 +488,39 @@ describe("cache revalidation — write path (sqlite)", () => {
     expect(spy.tags).toContain("nextly:single:header");
   });
 
+  it("flushes nothing when a collection write sets disableRevalidate", async () => {
+    // The per-operation escape hatch: a caller that owns its cache strategy (a
+    // CLI / seed / bulk-import write) skips revalidation for that write.
+    const entries = await boot([openCollection("skip")]);
+    await entries.createEntry(
+      { collectionName: "skip", overrideAccess: true, disableRevalidate: true },
+      { title: "T", slug: "s" }
+    );
+    expect(spy.flushed).toHaveLength(0);
+  });
+
+  it("flushes nothing when a single write sets disableRevalidate", async () => {
+    const adapter = await memoryAdapter();
+    handle = await createTestNextly({
+      adapter,
+      singles: [
+        defineSingle({
+          slug: "footer",
+          access: { read: () => true, update: () => true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const singleEntry =
+      handle.getService<SingleEntryService>("singleEntryService");
+    await singleEntry.update(
+      "footer",
+      { title: "Site" },
+      { overrideAccess: true, disableRevalidate: true }
+    );
+    expect(spy.flushed).toHaveLength(0);
+  });
+
   it("flushes nothing when the single's revalidate config is disabled", async () => {
     // Singles persist + read `revalidate` through their own registry
     // deserialize path, so verify a disabled single busts nothing.

--- a/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
@@ -517,6 +517,28 @@ describe("cache revalidation — write path (sqlite)", () => {
     expect(spy.flushed).toHaveLength(0);
   });
 
+  it("forwards disableRevalidate through the public bulkDelete surface", async () => {
+    // `nx.bulkDelete` reaches the write path through this handler method, which
+    // rebuilds its params field by field — so the flag has to be forwarded here
+    // too, or the documented opt-out silently revalidates every deleted row.
+    const entries = await boot([openCollection("bskip")]);
+    const created = await entries.createEntry(
+      { collectionName: "bskip", overrideAccess: true },
+      { title: "T", slug: "b" }
+    );
+    const id = (created.data as { id: string }).id;
+    spy.flushed.length = 0; // ignore the create's flush
+    const handler =
+      handle!.getService<CollectionsHandler>("collectionsHandler");
+    await handler.bulkDeleteEntries({
+      collectionName: "bskip",
+      ids: [id],
+      overrideAccess: true,
+      disableRevalidate: true,
+    });
+    expect(spy.flushed).toHaveLength(0);
+  });
+
   it("flushes nothing when a single write sets disableRevalidate", async () => {
     const adapter = await memoryAdapter();
     handle = await createTestNextly({

--- a/packages/nextly/src/domains/singles/services/single-entry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-entry-service.ts
@@ -152,7 +152,11 @@ export class SingleEntryService extends BaseService {
     // `success:false` with `eventRecorded:true`, so key off either — otherwise a
     // committed event would miss its fast-drain and retention pass.
     if (result.success || result.eventRecorded === true) {
-      await this.flushRevalidation(result);
+      // The per-operation escape hatch skips cache revalidation (a CLI / seed /
+      // bulk-import write); the outbox drain still runs so webhooks are intact.
+      if (options?.disableRevalidate !== true) {
+        await this.flushRevalidation(result);
+      }
       await this.afterWrite();
     }
     return result;

--- a/packages/nextly/src/domains/singles/services/single-entry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-entry-service.ts
@@ -80,10 +80,15 @@ export class SingleEntryService extends BaseService {
      */
     private readonly fastDrainScheduler?: WebhookFastDrainScheduler,
     /**
-     * Flushes a single write's cache-revalidation intent post-commit. Shared
-     * with the collection write path; a no-op when no cache adapter is present.
+     * Resolves the cache revalidator that flushes a single write's revalidation
+     * intent post-commit. Shared with the collection write path. A resolver (not
+     * the instance) so it is read at flush time: this service is constructed
+     * during boot, before a Next cache adapter registers, and an eager capture
+     * would memoize the no-op default. Returns undefined when no adapter present.
      */
-    private readonly cacheRevalidator?: CacheRevalidator
+    private readonly resolveCacheRevalidator?: () =>
+      | CacheRevalidator
+      | undefined
   ) {
     super(adapter, logger);
 
@@ -160,9 +165,13 @@ export class SingleEntryService extends BaseService {
    * revalidation never turns a committed write into an error.
    */
   private async flushRevalidation(result: SingleResult): Promise<void> {
-    if (!this.cacheRevalidator || !result.revalidationIntent) return;
+    if (!result.revalidationIntent) return;
+    // Resolve at flush time so a Next cache adapter registered after this
+    // service was constructed (at request time, well after boot) is honored.
+    const revalidator = this.resolveCacheRevalidator?.();
+    if (!revalidator) return;
     try {
-      await this.cacheRevalidator.flush([result.revalidationIntent]);
+      await revalidator.flush([result.revalidationIntent]);
     } catch (error) {
       this.logger.error("Cache revalidation failed after a write", { error });
     }

--- a/packages/nextly/src/domains/singles/types.ts
+++ b/packages/nextly/src/domains/singles/types.ts
@@ -158,6 +158,12 @@ export interface UpdateSingleOptions {
    * the key owner's RBAC.
    */
   authenticatedScope?: AuthenticatedScope;
+
+  /**
+   * Skip cache revalidation for this write (the outbox drain still runs). Set by
+   * callers that own their cache strategy — a CLI, seed, or bulk-import write.
+   */
+  disableRevalidate?: boolean;
 }
 
 /**

--- a/packages/nextly/src/revalidation/default-revalidator.ts
+++ b/packages/nextly/src/revalidation/default-revalidator.ts
@@ -3,20 +3,27 @@
  * service boot.
  *
  * A framework adapter (the Next cache adapter) installs its factory here once,
- * at module startup. Because this lives in module scope — not the DI container —
- * it survives `clearServices()` / `shutdownServices()`, which clear only the
- * container. So when services reboot in the same process (HMR, a test harness),
- * the reboot re-seeds the adapter rather than falling back to the no-op default.
- * The adapter's own registration hook (`instrumentation.ts` /
- * `createDynamicHandlers`) runs only once at startup and would not re-run on a
- * reboot, which is why the container alone cannot carry it.
+ * at module startup. Because this lives outside the DI container, it survives
+ * `clearServices()` / `shutdownServices()`, which clear only the container — so
+ * when services reboot in the same process (HMR, a test harness), the reboot
+ * re-seeds the adapter rather than falling back to the no-op default. The
+ * adapter's own registration hook (`instrumentation.ts` / `createDynamicHandlers`)
+ * runs only once at startup and would not re-run on a reboot, which is why the
+ * container alone cannot carry it.
+ *
+ * Stored on `globalThis` (like the DI container itself) so it survives ESM
+ * module duplication in Next.js/Turbopack, which can instantiate the same module
+ * in separate server layers — a module-local variable would be `null` in the
+ * copy that later reboots services.
  *
  * @module revalidation/default-revalidator
  */
 import { NoopRevalidator } from "./noop-revalidator";
 import type { CacheRevalidator } from "./types";
 
-let installedFactory: (() => CacheRevalidator) | null = null;
+const globalForRevalidator = globalThis as unknown as {
+  __nextly_default_revalidator_factory?: (() => CacheRevalidator) | null;
+};
 
 /**
  * Install the factory used to build the default revalidator (or pass `null` to
@@ -26,7 +33,7 @@ let installedFactory: (() => CacheRevalidator) | null = null;
 export function setDefaultRevalidatorFactory(
   factory: (() => CacheRevalidator) | null
 ): void {
-  installedFactory = factory;
+  globalForRevalidator.__nextly_default_revalidator_factory = factory;
 }
 
 /**
@@ -34,5 +41,6 @@ export function setDefaultRevalidatorFactory(
  * installed adapter when one is present, otherwise the no-op.
  */
 export function createDefaultRevalidator(): CacheRevalidator {
-  return installedFactory ? installedFactory() : new NoopRevalidator();
+  const factory = globalForRevalidator.__nextly_default_revalidator_factory;
+  return factory ? factory() : new NoopRevalidator();
 }

--- a/packages/nextly/src/revalidation/default-revalidator.ts
+++ b/packages/nextly/src/revalidation/default-revalidator.ts
@@ -1,0 +1,38 @@
+/**
+ * The factory the DI layer uses to seed the default `cacheRevalidator` on every
+ * service boot.
+ *
+ * A framework adapter (the Next cache adapter) installs its factory here once,
+ * at module startup. Because this lives in module scope — not the DI container —
+ * it survives `clearServices()` / `shutdownServices()`, which clear only the
+ * container. So when services reboot in the same process (HMR, a test harness),
+ * the reboot re-seeds the adapter rather than falling back to the no-op default.
+ * The adapter's own registration hook (`instrumentation.ts` /
+ * `createDynamicHandlers`) runs only once at startup and would not re-run on a
+ * reboot, which is why the container alone cannot carry it.
+ *
+ * @module revalidation/default-revalidator
+ */
+import { NoopRevalidator } from "./noop-revalidator";
+import type { CacheRevalidator } from "./types";
+
+let installedFactory: (() => CacheRevalidator) | null = null;
+
+/**
+ * Install the factory used to build the default revalidator (or pass `null` to
+ * clear it and fall back to the no-op). Called by the Next adapter's
+ * registration one-liner.
+ */
+export function setDefaultRevalidatorFactory(
+  factory: (() => CacheRevalidator) | null
+): void {
+  installedFactory = factory;
+}
+
+/**
+ * Build the default revalidator for a freshly (re)booted container: the
+ * installed adapter when one is present, otherwise the no-op.
+ */
+export function createDefaultRevalidator(): CacheRevalidator {
+  return installedFactory ? installedFactory() : new NoopRevalidator();
+}

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -98,6 +98,7 @@ import {
   getHandlerConfig,
 } from "./route-handler";
 import { handleDevSchemaRequest } from "./route-handler/dev-schema-handler";
+import { registerNextCacheRevalidator } from "./runtime/cache/register";
 import type { CollectionsHandler } from "./services/collections-handler";
 import type { GeneralSettingsService } from "./services/general-settings/general-settings-service";
 import {
@@ -1396,6 +1397,12 @@ export function createDynamicHandlers(options?: {
   if (options?.config) {
     setHandlerConfig(options.config);
   }
+
+  // Enable Next cache-tag revalidation: every content write now busts the tags
+  // a read carries (see `nextly/runtime` `nextlyTags` / `cachedFind`). Runs here
+  // because this is the app's Next entry point; idempotent and safe to omit for
+  // a non-Next runtime (the write path just no-ops the flush).
+  registerNextCacheRevalidator();
 
   // --- Security middleware (created once at init time, not per-request) ---
   const securityConfig = options?.config?.security;

--- a/packages/nextly/src/runtime.ts
+++ b/packages/nextly/src/runtime.ts
@@ -31,3 +31,16 @@ export {
   getCollectionsHandler,
   getCollectionsService,
 } from "./routeHandler";
+
+// F1 cache revalidation — the Next adapter + read-side tagging helpers. Safe to
+// import here: this subpath is already Next-coupled. The write-side adapter
+// resolves `next/cache` lazily, so importing these never forces `next` at load.
+export {
+  NextCacheRevalidator,
+  registerNextCacheRevalidator,
+  nextlyTags,
+  nextlySingleTags,
+  cachedFind,
+  type NextCacheModule,
+  type CachedFindOptions,
+} from "./runtime/cache";

--- a/packages/nextly/src/runtime/cache/__tests__/next-cache-revalidator.test.ts
+++ b/packages/nextly/src/runtime/cache/__tests__/next-cache-revalidator.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The Next cache adapter maps intents to `next/cache` calls with a fake module
+ * (no real Next runtime), no-ops when the module is absent, and never throws.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { RevalidationIntent } from "../../../revalidation/types";
+import {
+  NextCacheRevalidator,
+  type NextCacheModule,
+} from "../next-cache-revalidator";
+
+function fakeNextCache() {
+  return {
+    revalidateTag: vi.fn<(tag: string) => void>(),
+    revalidatePath: vi.fn<(path: string, type?: "page" | "layout") => void>(),
+  } satisfies NextCacheModule;
+}
+
+describe("NextCacheRevalidator", () => {
+  it("busts every tag in every intent via revalidateTag", () => {
+    const next = fakeNextCache();
+    const revalidator = new NextCacheRevalidator(() => next);
+    const intents: RevalidationIntent[] = [
+      { tags: ["nextly:posts", "nextly:posts:id:1"] },
+      { tags: ["nextly:single:header"] },
+    ];
+
+    revalidator.flush(intents);
+
+    expect(next.revalidateTag).toHaveBeenCalledTimes(3);
+    expect(next.revalidateTag).toHaveBeenCalledWith("nextly:posts");
+    expect(next.revalidateTag).toHaveBeenCalledWith("nextly:posts:id:1");
+    expect(next.revalidateTag).toHaveBeenCalledWith("nextly:single:header");
+  });
+
+  it("revalidates path targets with their type", () => {
+    const next = fakeNextCache();
+    const revalidator = new NextCacheRevalidator(() => next);
+
+    revalidator.flush([
+      {
+        tags: ["nextly:posts:id:1"],
+        paths: [{ path: "/blog/[slug]", type: "page" }, { path: "/blog/old" }],
+      },
+    ]);
+
+    expect(next.revalidatePath).toHaveBeenCalledWith("/blog/[slug]", "page");
+    expect(next.revalidatePath).toHaveBeenCalledWith("/blog/old", undefined);
+  });
+
+  it("no-ops when next/cache is unavailable", () => {
+    const revalidator = new NextCacheRevalidator(() => null);
+    // Must not throw when there is no Next cache to talk to.
+    expect(() => revalidator.flush([{ tags: ["nextly:posts"] }])).not.toThrow();
+  });
+
+  it("swallows a throwing next/cache so a committed write never errors", () => {
+    const next = fakeNextCache();
+    // revalidateTag throws outside a request scope (a CLI/background write).
+    next.revalidateTag.mockImplementation(() => {
+      throw new Error("static generation store missing");
+    });
+    const revalidator = new NextCacheRevalidator(() => next);
+
+    expect(() => revalidator.flush([{ tags: ["a", "b"] }])).not.toThrow();
+    // One throwing tag does not stop the rest.
+    expect(next.revalidateTag).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/nextly/src/runtime/cache/__tests__/next-cache-revalidator.test.ts
+++ b/packages/nextly/src/runtime/cache/__tests__/next-cache-revalidator.test.ts
@@ -12,7 +12,7 @@ import {
 
 function fakeNextCache() {
   return {
-    revalidateTag: vi.fn<(tag: string) => void>(),
+    revalidateTag: vi.fn<(tag: string, profile?: string) => void>(),
     revalidatePath: vi.fn<(path: string, type?: "page" | "layout") => void>(),
   } satisfies NextCacheModule;
 }
@@ -29,9 +29,14 @@ describe("NextCacheRevalidator", () => {
     revalidator.flush(intents);
 
     expect(next.revalidateTag).toHaveBeenCalledTimes(3);
-    expect(next.revalidateTag).toHaveBeenCalledWith("nextly:posts");
-    expect(next.revalidateTag).toHaveBeenCalledWith("nextly:posts:id:1");
-    expect(next.revalidateTag).toHaveBeenCalledWith("nextly:single:header");
+    // The "max" cache-life profile silences the Next 16 single-arg deprecation
+    // warning and is ignored on Next 14/15.
+    expect(next.revalidateTag).toHaveBeenCalledWith("nextly:posts", "max");
+    expect(next.revalidateTag).toHaveBeenCalledWith("nextly:posts:id:1", "max");
+    expect(next.revalidateTag).toHaveBeenCalledWith(
+      "nextly:single:header",
+      "max"
+    );
   });
 
   it("revalidates path targets with their type", () => {

--- a/packages/nextly/src/runtime/cache/__tests__/next-cache-revalidator.test.ts
+++ b/packages/nextly/src/runtime/cache/__tests__/next-cache-revalidator.test.ts
@@ -12,7 +12,8 @@ import {
 
 function fakeNextCache() {
   return {
-    revalidateTag: vi.fn<(tag: string, profile?: string) => void>(),
+    revalidateTag:
+      vi.fn<(tag: string, profile?: string | { expire?: number }) => void>(),
     revalidatePath: vi.fn<(path: string, type?: "page" | "layout") => void>(),
   } satisfies NextCacheModule;
 }
@@ -29,13 +30,18 @@ describe("NextCacheRevalidator", () => {
     revalidator.flush(intents);
 
     expect(next.revalidateTag).toHaveBeenCalledTimes(3);
-    // The "max" cache-life profile silences the Next 16 single-arg deprecation
-    // warning and is ignored on Next 14/15.
-    expect(next.revalidateTag).toHaveBeenCalledWith("nextly:posts", "max");
-    expect(next.revalidateTag).toHaveBeenCalledWith("nextly:posts:id:1", "max");
+    // The { expire: 0 } profile expires immediately (an unpublish/delete stops
+    // being served on the next request) and silences the Next 16 single-arg
+    // deprecation warning; ignored on Next 14/15.
+    const immediate = { expire: 0 };
+    expect(next.revalidateTag).toHaveBeenCalledWith("nextly:posts", immediate);
+    expect(next.revalidateTag).toHaveBeenCalledWith(
+      "nextly:posts:id:1",
+      immediate
+    );
     expect(next.revalidateTag).toHaveBeenCalledWith(
       "nextly:single:header",
-      "max"
+      immediate
     );
   });
 

--- a/packages/nextly/src/runtime/cache/__tests__/read-helpers.test.ts
+++ b/packages/nextly/src/runtime/cache/__tests__/read-helpers.test.ts
@@ -63,12 +63,16 @@ describe("applyCache — key forwarding and per-caller isolation", () => {
   } {
     const store = new Map<string, unknown>();
     const calls: { keyParts: string[]; tags?: string[] }[] = [];
-    const fn: UnstableCache = (cb, keyParts, options) => {
+    const fn: UnstableCache = <T>(
+      cb: () => Promise<T>,
+      keyParts: string[],
+      options: { tags?: string[]; revalidate?: number | false }
+    ) => {
       calls.push({ keyParts, tags: options.tags });
-      return async () => {
+      return async (): Promise<T> => {
         const key = JSON.stringify(keyParts);
         if (!store.has(key)) store.set(key, await cb());
-        return store.get(key);
+        return store.get(key) as T;
       };
     };
     return { fn, calls };

--- a/packages/nextly/src/runtime/cache/__tests__/read-helpers.test.ts
+++ b/packages/nextly/src/runtime/cache/__tests__/read-helpers.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Read-side helpers: `nextlyTags` builds the same `nextly:*` scheme the write
+ * side busts, and `cachedFind`/`applyCache` cache a read under a caller-scoped
+ * key. Includes the two-user owner-only leak guard the F1 read-path design
+ * requires: distinct callers must not share a cache entry.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { applyCache, type UnstableCache } from "../cached-find";
+import { nextlySingleTags, nextlyTags } from "../nextly-tags";
+
+describe("nextlyTags", () => {
+  it("returns the collection tag for a listing read", () => {
+    expect(nextlyTags("posts")).toEqual(["nextly:posts"]);
+  });
+
+  it("adds the id tag for an entry detail read (tagged by immutable id)", () => {
+    expect(nextlyTags("posts", "42")).toEqual([
+      "nextly:posts",
+      "nextly:posts:id:42",
+    ]);
+  });
+
+  it("adds the per-locale id tag when a locale is given", () => {
+    expect(nextlyTags("posts", "42", "en")).toEqual([
+      "nextly:posts",
+      "nextly:posts:id:42",
+      "nextly:posts:id:42:en",
+    ]);
+  });
+
+  it("ignores a blank id / locale", () => {
+    expect(nextlyTags("posts", "   ")).toEqual(["nextly:posts"]);
+    expect(nextlyTags("posts", "42", "  ")).toEqual([
+      "nextly:posts",
+      "nextly:posts:id:42",
+    ]);
+  });
+
+  it("builds the single tag", () => {
+    expect(nextlySingleTags("header")).toEqual(["nextly:single:header"]);
+  });
+});
+
+describe("applyCache (passthrough without Next)", () => {
+  it("runs the reader directly and returns its result when no cache is present", async () => {
+    const reader = vi.fn(async () => ({ id: "x" }));
+    const result = await applyCache(null, reader, {
+      tags: nextlyTags("posts"),
+      keyParts: ["posts", "list"],
+    });
+    expect(result).toEqual({ id: "x" });
+    expect(reader).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("applyCache — key forwarding and per-caller isolation", () => {
+  // A fake unstable_cache that memoises by keyParts, so the test can observe
+  // exactly how cache identity is derived (the real thing needs a Next runtime).
+  function memoizingUnstableCache(): {
+    fn: UnstableCache;
+    calls: { keyParts: string[]; tags?: string[] }[];
+  } {
+    const store = new Map<string, unknown>();
+    const calls: { keyParts: string[]; tags?: string[] }[] = [];
+    const fn: UnstableCache = (cb, keyParts, options) => {
+      calls.push({ keyParts, tags: options.tags });
+      return async () => {
+        const key = JSON.stringify(keyParts);
+        if (!store.has(key)) store.set(key, await cb());
+        return store.get(key);
+      };
+    };
+    return { fn, calls };
+  }
+
+  it("forwards keyParts and tags to unstable_cache", async () => {
+    const cache = memoizingUnstableCache();
+    await applyCache(cache.fn, async () => 1, {
+      tags: ["nextly:posts"],
+      keyParts: ["posts", "list", "user-a"],
+      revalidate: 60,
+    });
+    expect(cache.calls[0]).toEqual({
+      keyParts: ["posts", "list", "user-a"],
+      tags: ["nextly:posts"],
+    });
+  });
+
+  it("isolates two callers whose keyParts include their own id", async () => {
+    const cache = memoizingUnstableCache();
+    const opts = (userId: string) => ({
+      tags: nextlyTags("orders"),
+      keyParts: ["orders", "list", userId],
+    });
+
+    const a = await applyCache(cache.fn, async () => "a-rows", opts("user-a"));
+    const b = await applyCache(cache.fn, async () => "b-rows", opts("user-b"));
+
+    // Different keys → each caller sees only their own rows.
+    expect(a).toBe("a-rows");
+    expect(b).toBe("b-rows");
+  });
+
+  it("SHARES a cache entry when the caller is omitted — the leak the key guards against", async () => {
+    const cache = memoizingUnstableCache();
+    // Both callers use a stable key with no user id: the classic footgun.
+    const sharedKey = {
+      tags: nextlyTags("orders"),
+      keyParts: ["orders", "list"],
+    };
+
+    const a = await applyCache(cache.fn, async () => "a-rows", sharedKey);
+    const b = await applyCache(cache.fn, async () => "b-rows", sharedKey);
+
+    // User B is served User A's cached rows — proving why an owner-scoped read
+    // MUST put the caller's identity in keyParts.
+    expect(a).toBe("a-rows");
+    expect(b).toBe("a-rows");
+  });
+});

--- a/packages/nextly/src/runtime/cache/__tests__/register.test.ts
+++ b/packages/nextly/src/runtime/cache/__tests__/register.test.ts
@@ -1,19 +1,34 @@
 /**
  * `registerNextCacheRevalidator` installs the Next adapter as the active
- * `cacheRevalidator`, and must keep working across a container reinitialisation:
- * a module-level "already registered" flag would go stale after the container is
- * cleared and re-seeded with the no-op default, silently leaving revalidation
- * off.
+ * `cacheRevalidator`, and — crucially — keeps it installed across a container
+ * clear + reboot in the same process. Its instrumentation / handler hook runs
+ * only once at startup, so the registration has to persist through
+ * `clearServices()` on its own; otherwise `registerServices()` re-seeds the
+ * no-op default and writes silently stop invalidating caches.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { container } from "../../../di/container";
+import { registerRevalidationServices } from "../../../di/registrations/register-revalidation";
+import type { RegistrationContext } from "../../../di/registrations/types";
+import { setDefaultRevalidatorFactory } from "../../../revalidation/default-revalidator";
 import { NoopRevalidator } from "../../../revalidation/noop-revalidator";
 import type { CacheRevalidator } from "../../../revalidation/types";
 import { NextCacheRevalidator } from "../next-cache-revalidator";
 import { registerNextCacheRevalidator } from "../register";
 
+// registerRevalidationServices ignores its context (it only touches the
+// container), so a bare stub is all the reboot simulation needs.
+const ctx = {} as RegistrationContext;
+
 describe("registerNextCacheRevalidator", () => {
+  afterEach(() => {
+    // The installed factory is module-scoped, so reset it (and the container)
+    // to keep this suite from leaking a Next adapter default into others.
+    setDefaultRevalidatorFactory(null);
+    container.clear();
+  });
+
   it("installs the Next adapter as the active revalidator", () => {
     registerNextCacheRevalidator();
     expect(container.get<CacheRevalidator>("cacheRevalidator")).toBeInstanceOf(
@@ -21,23 +36,27 @@ describe("registerNextCacheRevalidator", () => {
     );
   });
 
-  it("re-installs after the container is re-seeded with the no-op default", () => {
+  it("survives a container clear + reboot without being re-called", () => {
     registerNextCacheRevalidator();
-    // Simulate a clearServices() + boot cycle: the default no-op is registered
-    // again over a fresh container.
-    container.register<CacheRevalidator>(
-      "cacheRevalidator",
-      () => new NoopRevalidator()
-    );
-    expect(container.get<CacheRevalidator>("cacheRevalidator")).toBeInstanceOf(
-      NoopRevalidator
-    );
 
-    // A stale "already registered" flag would make this a no-op and leave the
-    // no-op default in place; driving off the container re-installs the adapter.
-    registerNextCacheRevalidator();
+    // Simulate clearServices()/shutdownServices() followed by a fresh
+    // registerServices() — WITHOUT calling registerNextCacheRevalidator again
+    // (its startup hook does not re-run on a reboot).
+    container.clear();
+    registerRevalidationServices(ctx);
+
+    // The factory persisted in module scope, so the reboot re-seeds the adapter
+    // instead of the no-op default.
     expect(container.get<CacheRevalidator>("cacheRevalidator")).toBeInstanceOf(
       NextCacheRevalidator
+    );
+  });
+
+  it("falls back to the no-op when no adapter installed its factory", () => {
+    // A bare boot with no Next adapter registered uses the no-op.
+    registerRevalidationServices(ctx);
+    expect(container.get<CacheRevalidator>("cacheRevalidator")).toBeInstanceOf(
+      NoopRevalidator
     );
   });
 });

--- a/packages/nextly/src/runtime/cache/__tests__/register.test.ts
+++ b/packages/nextly/src/runtime/cache/__tests__/register.test.ts
@@ -1,0 +1,43 @@
+/**
+ * `registerNextCacheRevalidator` installs the Next adapter as the active
+ * `cacheRevalidator`, and must keep working across a container reinitialisation:
+ * a module-level "already registered" flag would go stale after the container is
+ * cleared and re-seeded with the no-op default, silently leaving revalidation
+ * off.
+ */
+import { describe, expect, it } from "vitest";
+
+import { container } from "../../../di/container";
+import { NoopRevalidator } from "../../../revalidation/noop-revalidator";
+import type { CacheRevalidator } from "../../../revalidation/types";
+import { NextCacheRevalidator } from "../next-cache-revalidator";
+import { registerNextCacheRevalidator } from "../register";
+
+describe("registerNextCacheRevalidator", () => {
+  it("installs the Next adapter as the active revalidator", () => {
+    registerNextCacheRevalidator();
+    expect(container.get<CacheRevalidator>("cacheRevalidator")).toBeInstanceOf(
+      NextCacheRevalidator
+    );
+  });
+
+  it("re-installs after the container is re-seeded with the no-op default", () => {
+    registerNextCacheRevalidator();
+    // Simulate a clearServices() + boot cycle: the default no-op is registered
+    // again over a fresh container.
+    container.register<CacheRevalidator>(
+      "cacheRevalidator",
+      () => new NoopRevalidator()
+    );
+    expect(container.get<CacheRevalidator>("cacheRevalidator")).toBeInstanceOf(
+      NoopRevalidator
+    );
+
+    // A stale "already registered" flag would make this a no-op and leave the
+    // no-op default in place; driving off the container re-installs the adapter.
+    registerNextCacheRevalidator();
+    expect(container.get<CacheRevalidator>("cacheRevalidator")).toBeInstanceOf(
+      NextCacheRevalidator
+    );
+  });
+});

--- a/packages/nextly/src/runtime/cache/cached-find.ts
+++ b/packages/nextly/src/runtime/cache/cached-find.ts
@@ -70,9 +70,10 @@ export interface CachedFindOptions {
  * under `keyParts` + `tags`.
  *
  * @example
- * // Public entry detail — cached and busted when the post changes.
+ * // Public entry detail — cached and busted when any post changes. Tag with the
+ * // collection tag; a slug-routed read has no entry id until the fetch resolves.
  * const post = await cachedFind(() => nextly.findBySlug("posts", slug), {
- *   tags: nextlyTags("posts", post.id),
+ *   tags: nextlyTags("posts"),
  *   keyParts: ["posts", slug],
  * });
  *

--- a/packages/nextly/src/runtime/cache/cached-find.ts
+++ b/packages/nextly/src/runtime/cache/cached-find.ts
@@ -1,0 +1,110 @@
+/**
+ * `cachedFind` — cache a content read and tag it so an on-write bust makes it
+ * fresh. A thin wrapper over Next's `unstable_cache`, the tagging mechanism
+ * supported across the whole `next` peer range (`^14 || ^15 || ^16`). Outside a
+ * Next runtime (or when `next/cache` is unavailable) it runs the reader directly
+ * so the same code works in tests and non-Next callers.
+ *
+ * `next/cache` is resolved lazily via `createRequire` (Node's CommonJS resolver,
+ * opaque to bundlers) — the same pattern the write-side adapter uses.
+ *
+ * @module runtime/cache/cached-find
+ */
+import { createRequire } from "node:module";
+
+/** The subset of `unstable_cache` this helper uses. */
+export type UnstableCache = <T>(
+  cb: () => Promise<T>,
+  keyParts: string[],
+  options: { tags?: string[]; revalidate?: number | false }
+) => () => Promise<T>;
+
+let cachedUnstableCache: UnstableCache | null | undefined;
+
+function loadUnstableCache(): UnstableCache | null {
+  if (cachedUnstableCache !== undefined) return cachedUnstableCache;
+  try {
+    const require = createRequire(import.meta.url);
+    const mod = require("next/cache") as { unstable_cache?: UnstableCache };
+    cachedUnstableCache =
+      typeof mod.unstable_cache === "function" ? mod.unstable_cache : null;
+  } catch {
+    cachedUnstableCache = null;
+  }
+  return cachedUnstableCache;
+}
+
+/** Options for {@link cachedFind}. */
+export interface CachedFindOptions {
+  /**
+   * The cache tags this read carries — use {@link nextlyTags} so a write's bust
+   * invalidates it. A change matching any tag makes the next request re-run the
+   * reader.
+   */
+  tags: string[];
+  /**
+   * The parts that make this cache entry unique, e.g. `["posts", slug]`. Beyond
+   * the query itself, **include anything the result varies by**.
+   *
+   * SECURITY: if the read applies per-caller access rules (owner-only scoping,
+   * role-based visibility, an API-key's narrowed scope), the caller's identity
+   * MUST be in `keyParts` (their user id, role set, or key scope). Two different
+   * users share one cache entry when their `keyParts` match, so caching an
+   * owner-filtered list under a stable key would serve one user's rows to
+   * another — a cross-tenant leak, not a stale-cache annoyance. For genuinely
+   * public content (the same for every reader) a stable key is correct and gives
+   * the full ISR benefit.
+   */
+  keyParts: string[];
+  /**
+   * Optional time-based revalidation in seconds (a safety net on top of
+   * tag-based busting). `false` (the default) means the entry only ever
+   * revalidates on a tag bust.
+   */
+  revalidate?: number | false;
+}
+
+/**
+ * Run `reader` behind Next's tagged cache. On a cache hit the reader is skipped;
+ * on a miss (or after a bust of any of `tags`) it runs and the result is cached
+ * under `keyParts` + `tags`.
+ *
+ * @example
+ * // Public entry detail — cached and busted when the post changes.
+ * const post = await cachedFind(() => nextly.findBySlug("posts", slug), {
+ *   tags: nextlyTags("posts", post.id),
+ *   keyParts: ["posts", slug],
+ * });
+ *
+ * @example
+ * // Per-user list — the caller's id is in the key so it never leaks.
+ * const mine = await cachedFind(() => nextly.find("orders", { user }), {
+ *   tags: nextlyTags("orders"),
+ *   keyParts: ["orders", "list", user.id],
+ * });
+ */
+export function cachedFind<T>(
+  reader: () => Promise<T>,
+  options: CachedFindOptions
+): Promise<T> {
+  return applyCache(loadUnstableCache(), reader, options);
+}
+
+/**
+ * The pure caching step, separated from module resolution so it is testable with
+ * a fake `unstable_cache`. Runs `reader` behind `unstableCache` keyed by
+ * `keyParts` and tagged with `tags`; when `unstableCache` is null (no Next
+ * runtime), runs the reader directly. Not part of the public API.
+ */
+export function applyCache<T>(
+  unstableCache: UnstableCache | null,
+  reader: () => Promise<T>,
+  options: CachedFindOptions
+): Promise<T> {
+  if (!unstableCache) return reader();
+  const cached = unstableCache(reader, options.keyParts, {
+    tags: options.tags,
+    revalidate: options.revalidate ?? false,
+  });
+  return cached();
+}

--- a/packages/nextly/src/runtime/cache/index.ts
+++ b/packages/nextly/src/runtime/cache/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Next.js cache integration for F1 revalidation: the write-side adapter that
+ * busts tags, the one-liner that registers it, and the read-side helpers that
+ * tag content reads so a bust makes them fresh.
+ *
+ * @module runtime/cache
+ */
+export { NextCacheRevalidator } from "./next-cache-revalidator";
+export type { NextCacheModule } from "./next-cache-revalidator";
+export { registerNextCacheRevalidator } from "./register";
+export { nextlyTags, nextlySingleTags } from "./nextly-tags";
+export { cachedFind } from "./cached-find";
+export type { CachedFindOptions } from "./cached-find";

--- a/packages/nextly/src/runtime/cache/next-cache-revalidator.ts
+++ b/packages/nextly/src/runtime/cache/next-cache-revalidator.ts
@@ -1,0 +1,92 @@
+/**
+ * The Next.js cache adapter for the framework-neutral {@link CacheRevalidator}
+ * port. Maps a write's revalidation intents to `revalidateTag` / `revalidatePath`
+ * from `next/cache`.
+ *
+ * `next/cache` is resolved lazily through `createRequire` (Node's CommonJS
+ * resolver, opaque to bundlers — the same pattern as `actions/upload-media.ts`
+ * and `domains/webhooks/after-drain.ts`) so the package root stays Node-safe and
+ * importing this module never forces `next` onto a consumer. The adapter no-ops
+ * when `next/cache` is unavailable (a non-Next runtime, the CLI) and never
+ * throws — a revalidation failure must not turn a committed write into an error.
+ *
+ * `revalidateTag(tag)` is called single-arg, the form supported across the whole
+ * `next` peer range (`^14 || ^15 || ^16`). The Next 16 `{ profile: "max" }`
+ * second argument (stale-while-revalidate) is an optional future enhancement.
+ *
+ * @module runtime/cache/next-cache-revalidator
+ */
+import { createRequire } from "node:module";
+
+import type {
+  CacheRevalidator,
+  RevalidationIntent,
+} from "../../revalidation/types";
+
+/** The subset of `next/cache` this adapter uses. */
+export interface NextCacheModule {
+  revalidateTag: (tag: string) => void;
+  revalidatePath: (path: string, type?: "page" | "layout") => void;
+}
+
+// Resolution is attempted once and memoised (including the null "unavailable"
+// result) so a non-Next runtime does not pay the failed require on every write.
+let cached: NextCacheModule | null | undefined;
+
+function loadNextCache(): NextCacheModule | null {
+  if (cached !== undefined) return cached;
+  try {
+    const require = createRequire(import.meta.url);
+    const mod = require("next/cache") as Partial<NextCacheModule>;
+    cached =
+      typeof mod.revalidateTag === "function" &&
+      typeof mod.revalidatePath === "function"
+        ? (mod as NextCacheModule)
+        : null;
+  } catch {
+    // `next` not installed, or not resolvable in this runtime.
+    cached = null;
+  }
+  return cached;
+}
+
+/**
+ * Maps {@link RevalidationIntent}s to `next/cache` calls. Register it as the
+ * `cacheRevalidator` so the write path flushes tag/path invalidations through
+ * Next's ISR cache.
+ */
+export class NextCacheRevalidator implements CacheRevalidator {
+  /**
+   * @param loader Resolves the `next/cache` module. Defaults to the lazy
+   *   `createRequire` loader; injectable so a test can supply a fake module
+   *   without a real Next runtime.
+   */
+  constructor(
+    private readonly loader: () => NextCacheModule | null = loadNextCache
+  ) {}
+
+  flush(intents: RevalidationIntent[]): void {
+    const next = this.loader();
+    // No Next cache in this runtime: nothing to bust.
+    if (!next) return;
+    for (const intent of intents) {
+      for (const tag of intent.tags) {
+        try {
+          next.revalidateTag(tag);
+        } catch {
+          // `revalidateTag` throws when called outside a request/render scope
+          // (e.g. a CLI or background write). Swallow per-call so one failure
+          // never stops the rest, and a committed write is never turned into an
+          // error.
+        }
+      }
+      for (const target of intent.paths ?? []) {
+        try {
+          next.revalidatePath(target.path, target.type);
+        } catch {
+          // Same rationale as the tag loop above.
+        }
+      }
+    }
+  }
+}

--- a/packages/nextly/src/runtime/cache/next-cache-revalidator.ts
+++ b/packages/nextly/src/runtime/cache/next-cache-revalidator.ts
@@ -10,9 +10,12 @@
  * when `next/cache` is unavailable (a non-Next runtime, the CLI) and never
  * throws — a revalidation failure must not turn a committed write into an error.
  *
- * `revalidateTag(tag)` is called single-arg, the form supported across the whole
- * `next` peer range (`^14 || ^15 || ^16`). The Next 16 `{ profile: "max" }`
- * second argument (stale-while-revalidate) is an optional future enhancement.
+ * `revalidateTag` is called with the `"max"` cache-life profile
+ * (stale-while-revalidate). On Next 16 the single-argument form is deprecated
+ * and logs a warning on every call (noisy under bulk writes); passing `"max"`
+ * silences it and is the recommended form. On Next 14/15 `revalidateTag` takes
+ * only the tag, so the extra argument is ignored — the same call is safe across
+ * the whole `next` peer range (`^14 || ^15 || ^16`).
  *
  * @module runtime/cache/next-cache-revalidator
  */
@@ -23,9 +26,16 @@ import type {
   RevalidationIntent,
 } from "../../revalidation/types";
 
+/**
+ * The `cacheLife` profile passed to `revalidateTag` on Next 16 so it does not
+ * warn about the deprecated single-argument form. `"max"` marks tagged data
+ * stale and serves it stale-while-revalidate; ignored on Next 14/15.
+ */
+const REVALIDATE_PROFILE = "max";
+
 /** The subset of `next/cache` this adapter uses. */
 export interface NextCacheModule {
-  revalidateTag: (tag: string) => void;
+  revalidateTag: (tag: string, profile?: string) => void;
   revalidatePath: (path: string, type?: "page" | "layout") => void;
 }
 
@@ -72,7 +82,7 @@ export class NextCacheRevalidator implements CacheRevalidator {
     for (const intent of intents) {
       for (const tag of intent.tags) {
         try {
-          next.revalidateTag(tag);
+          next.revalidateTag(tag, REVALIDATE_PROFILE);
         } catch {
           // `revalidateTag` throws when called outside a request/render scope
           // (e.g. a CLI or background write). Swallow per-call so one failure

--- a/packages/nextly/src/runtime/cache/next-cache-revalidator.ts
+++ b/packages/nextly/src/runtime/cache/next-cache-revalidator.ts
@@ -10,12 +10,14 @@
  * when `next/cache` is unavailable (a non-Next runtime, the CLI) and never
  * throws — a revalidation failure must not turn a committed write into an error.
  *
- * `revalidateTag` is called with the `"max"` cache-life profile
- * (stale-while-revalidate). On Next 16 the single-argument form is deprecated
- * and logs a warning on every call (noisy under bulk writes); passing `"max"`
- * silences it and is the recommended form. On Next 14/15 `revalidateTag` takes
- * only the tag, so the extra argument is ignored — the same call is safe across
- * the whole `next` peer range (`^14 || ^15 || ^16`).
+ * `revalidateTag` is called with an explicit `{ expire: 0 }` cache-life profile:
+ * a content write must invalidate the cached read immediately — an unpublished
+ * or deleted document has to stop being served on the very next request, not
+ * after a stale-while-revalidate pass. `{ expire: 0 }` is the immediate-expiry
+ * form, and passing it also silences the Next 16 deprecation warning the bare
+ * single-argument call now logs on every tag. On Next 14/15 `revalidateTag`
+ * reads only the tag, so the extra argument is ignored — the same call is safe
+ * across the whole `next` peer range (`^14 || ^15 || ^16`).
  *
  * @module runtime/cache/next-cache-revalidator
  */
@@ -26,16 +28,19 @@ import type {
   RevalidationIntent,
 } from "../../revalidation/types";
 
+/** A Next `cacheLife`-style profile: `{ expire: 0 }` means expire immediately. */
+type CacheLifeProfile = string | { expire?: number };
+
 /**
- * The `cacheLife` profile passed to `revalidateTag` on Next 16 so it does not
- * warn about the deprecated single-argument form. `"max"` marks tagged data
- * stale and serves it stale-while-revalidate; ignored on Next 14/15.
+ * The profile passed to `revalidateTag`: expire the tag immediately so the next
+ * request after a write gets fresh (or 404) content, not a stale copy. Ignored
+ * on Next 14/15, where `revalidateTag` reads only the tag.
  */
-const REVALIDATE_PROFILE = "max";
+const REVALIDATE_PROFILE: CacheLifeProfile = { expire: 0 };
 
 /** The subset of `next/cache` this adapter uses. */
 export interface NextCacheModule {
-  revalidateTag: (tag: string, profile?: string) => void;
+  revalidateTag: (tag: string, profile?: CacheLifeProfile) => void;
   revalidatePath: (path: string, type?: "page" | "layout") => void;
 }
 

--- a/packages/nextly/src/runtime/cache/nextly-tags.ts
+++ b/packages/nextly/src/runtime/cache/nextly-tags.ts
@@ -1,0 +1,52 @@
+/**
+ * Read-side tag builder. A cached read attaches the tags a write later busts, so
+ * both sides go through the same `nextly:*` scheme (`revalidation/compute-tags`):
+ * a change to an entry busts `nextly:{collection}:id:{id}`, which invalidates any
+ * read tagged with it.
+ *
+ * @module runtime/cache/nextly-tags
+ */
+import {
+  collectionTag,
+  entryIdLocaleTag,
+  entryIdTag,
+  singleTag,
+} from "../../revalidation/compute-tags";
+
+/**
+ * The tags a content read should carry so an on-write bust invalidates it.
+ *
+ * - `nextlyTags("posts")` → the collection tag: for a listing / index / sitemap
+ *   read, invalidated by any change in the collection.
+ * - `nextlyTags("posts", id)` → the collection tag + the entry-id tag: for an
+ *   entry detail read, invalidated when that entry changes in any locale (tag by
+ *   the immutable id, not the slug, so a rename still invalidates).
+ * - `nextlyTags("posts", id, locale)` → adds the per-locale id tag, so a
+ *   publish-one-locale busts only that locale's read.
+ *
+ * Tag reads by the entry's immutable id (available after the fetch resolves),
+ * not its slug: the write busts the id tag on every change, so the read stays
+ * invalidatable across slug and status changes.
+ */
+export function nextlyTags(
+  collection: string,
+  id?: string,
+  locale?: string
+): string[] {
+  const tags = [collectionTag(collection)];
+  if (id !== undefined && id.trim().length > 0) {
+    tags.push(entryIdTag(collection, id));
+    if (locale !== undefined && locale.trim().length > 0) {
+      tags.push(entryIdLocaleTag(collection, id, locale));
+    }
+  }
+  return tags;
+}
+
+/**
+ * The tag a singleton / global read should carry, so a write to that single
+ * invalidates every page that consumed it.
+ */
+export function nextlySingleTags(slug: string): string[] {
+  return [singleTag(slug)];
+}

--- a/packages/nextly/src/runtime/cache/nextly-tags.ts
+++ b/packages/nextly/src/runtime/cache/nextly-tags.ts
@@ -21,12 +21,20 @@ import {
  * - `nextlyTags("posts", id)` → the collection tag + the entry-id tag: for an
  *   entry detail read, invalidated when that entry changes in any locale (tag by
  *   the immutable id, not the slug, so a rename still invalidates).
- * - `nextlyTags("posts", id, locale)` → adds the per-locale id tag, so a
- *   publish-one-locale busts only that locale's read.
+ * - `nextlyTags("posts", id, locale)` → also adds the per-locale id tag.
  *
  * Tag reads by the entry's immutable id (available after the fetch resolves),
  * not its slug: the write busts the id tag on every change, so the read stays
  * invalidatable across slug and status changes.
+ *
+ * A detail read intentionally carries the collection tag too, so it also
+ * refreshes when the collection changes around it (a new sibling, a reorder).
+ * Because a match on ANY tag invalidates the entry, that broadens invalidation:
+ * a change to one entry (which busts `nextly:{collection}`) refreshes every
+ * detail read in the collection. That is safe — a stale read is never served,
+ * only re-fetched more often. A high-traffic site that wants strictly per-entry
+ * (or per-locale) granularity should tag with the entry/locale tag alone rather
+ * than this helper's broad, safe default.
  */
 export function nextlyTags(
   collection: string,

--- a/packages/nextly/src/runtime/cache/register.ts
+++ b/packages/nextly/src/runtime/cache/register.ts
@@ -11,11 +11,14 @@ import type { CacheRevalidator } from "../../revalidation/types";
 
 import { NextCacheRevalidator } from "./next-cache-revalidator";
 
-let registered = false;
-
 /**
  * Register {@link NextCacheRevalidator} as the active `cacheRevalidator`,
- * replacing the no-op default. Idempotent.
+ * replacing the no-op default. Safe to call any number of times.
+ *
+ * Registration is driven off the container, not a module-level flag: a flag
+ * would go stale after `clearServices()` / `shutdownServices()` clears the
+ * container, leaving the no-op default in place after a reinitialisation. Each
+ * call simply (re)installs the factory, so a fresh container is always covered.
  *
  * Uses a plain factory (not a memoised singleton) so the registration wins even
  * if the no-op default was already resolved once during boot — the write path
@@ -24,10 +27,8 @@ let registered = false;
  * module scope), so a fresh instance per resolve costs nothing.
  */
 export function registerNextCacheRevalidator(): void {
-  if (registered) return;
   container.register<CacheRevalidator>(
     "cacheRevalidator",
     () => new NextCacheRevalidator()
   );
-  registered = true;
 }

--- a/packages/nextly/src/runtime/cache/register.ts
+++ b/packages/nextly/src/runtime/cache/register.ts
@@ -1,0 +1,33 @@
+/**
+ * Registers the Next.js cache adapter as the `cacheRevalidator` the write path
+ * flushes to. Call once when your app boots inside Next (the admin route wiring
+ * does this for you — see `createDynamicHandlers`); after that, every content
+ * write busts the Next cache tags a read carries.
+ *
+ * @module runtime/cache/register
+ */
+import { container } from "../../di/container";
+import type { CacheRevalidator } from "../../revalidation/types";
+
+import { NextCacheRevalidator } from "./next-cache-revalidator";
+
+let registered = false;
+
+/**
+ * Register {@link NextCacheRevalidator} as the active `cacheRevalidator`,
+ * replacing the no-op default. Idempotent.
+ *
+ * Uses a plain factory (not a memoised singleton) so the registration wins even
+ * if the no-op default was already resolved once during boot — the write path
+ * resolves the revalidator lazily at flush time, so a later registration is
+ * honored. The adapter is stateless (its `next/cache` resolution is memoised at
+ * module scope), so a fresh instance per resolve costs nothing.
+ */
+export function registerNextCacheRevalidator(): void {
+  if (registered) return;
+  container.register<CacheRevalidator>(
+    "cacheRevalidator",
+    () => new NextCacheRevalidator()
+  );
+  registered = true;
+}

--- a/packages/nextly/src/runtime/cache/register.ts
+++ b/packages/nextly/src/runtime/cache/register.ts
@@ -7,28 +7,31 @@
  * @module runtime/cache/register
  */
 import { container } from "../../di/container";
+import { setDefaultRevalidatorFactory } from "../../revalidation/default-revalidator";
 import type { CacheRevalidator } from "../../revalidation/types";
 
 import { NextCacheRevalidator } from "./next-cache-revalidator";
+
+const nextRevalidatorFactory = (): CacheRevalidator =>
+  new NextCacheRevalidator();
 
 /**
  * Register {@link NextCacheRevalidator} as the active `cacheRevalidator`,
  * replacing the no-op default. Safe to call any number of times.
  *
- * Registration is driven off the container, not a module-level flag: a flag
- * would go stale after `clearServices()` / `shutdownServices()` clears the
- * container, leaving the no-op default in place after a reinitialisation. Each
- * call simply (re)installs the factory, so a fresh container is always covered.
- *
- * Uses a plain factory (not a memoised singleton) so the registration wins even
- * if the no-op default was already resolved once during boot — the write path
+ * Installs the factory as the DI layer's default revalidator (so every service
+ * boot — including a reboot after `clearServices()` / `shutdownServices()` in
+ * the same process — re-seeds the adapter rather than the no-op), and also
+ * (re)installs it on the current container so it takes effect immediately even
+ * if the no-op default was already resolved once during boot. The write path
  * resolves the revalidator lazily at flush time, so a later registration is
  * honored. The adapter is stateless (its `next/cache` resolution is memoised at
  * module scope), so a fresh instance per resolve costs nothing.
  */
 export function registerNextCacheRevalidator(): void {
+  setDefaultRevalidatorFactory(nextRevalidatorFactory);
   container.register<CacheRevalidator>(
     "cacheRevalidator",
-    () => new NextCacheRevalidator()
+    nextRevalidatorFactory
   );
 }

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -828,12 +828,15 @@ export class CollectionsHandler {
      * API key's OWN delete grant, not the key owner's.
      */
     authenticatedScope?: AuthenticatedScope;
+    /** Skip cache revalidation for this bulk delete (the outbox drain still runs). */
+    disableRevalidate?: boolean;
   }) {
     return this.entryService.bulkDeleteEntries({
       ...this.resolveUserParam(params),
       // Named explicitly so the API-key scope survives the field-by-field
       // rebuild rather than only via resolveUserParam's rest.
       authenticatedScope: params.authenticatedScope,
+      disableRevalidate: params.disableRevalidate,
     });
   }
 
@@ -872,12 +875,15 @@ export class CollectionsHandler {
      * per-id publish/unpublish transition is judged on the key's OWN grants.
      */
     authenticatedScope?: AuthenticatedScope;
+    /** Skip cache revalidation for this bulk update (the outbox drain still runs). */
+    disableRevalidate?: boolean;
   }) {
     return this.entryService.bulkUpdateEntries({
       ...this.resolveUserParam(params),
       // Named explicitly (like updateEntry) so the API-key scope survives the
       // field-by-field rebuild rather than only via resolveUserParam's rest.
       authenticatedScope: params.authenticatedScope,
+      disableRevalidate: params.disableRevalidate,
     });
   }
 

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -173,9 +173,12 @@ export class CollectionsHandler {
       ? container.get<WebhookFastDrainScheduler>("webhookFastDrainScheduler")
       : undefined;
 
-    const cacheRevalidator = container.has("cacheRevalidator")
-      ? container.get<CacheRevalidator>("cacheRevalidator")
-      : undefined;
+    // Resolved lazily at flush time (not captured here) so a Next cache adapter
+    // registered after this handler was constructed at boot is still honored.
+    const resolveCacheRevalidator = () =>
+      container.has("cacheRevalidator")
+        ? container.get<CacheRevalidator>("cacheRevalidator")
+        : undefined;
 
     // Late-inject relationshipService if componentDataService was created before it was available
     if (componentDataService) {
@@ -205,7 +208,7 @@ export class CollectionsHandler {
       this.localization,
       retentionRunner,
       fastDrainScheduler,
-      cacheRevalidator
+      resolveCacheRevalidator
     );
   }
 

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -539,6 +539,8 @@ export class CollectionsHandler {
        * publish transition gate (create-as-published) judges the key's OWN grants.
        */
       authenticatedScope?: AuthenticatedScope;
+      /** Skip cache revalidation for this write (the outbox drain still runs). */
+      disableRevalidate?: boolean;
     },
     body: Record<string, unknown>
   ) {
@@ -550,6 +552,7 @@ export class CollectionsHandler {
         // Named explicitly (like updateEntry) so the API-key scope survives the
         // field-by-field rebuild rather than only via resolveUserParam's rest.
         authenticatedScope: params.authenticatedScope,
+        disableRevalidate: params.disableRevalidate,
       },
       body,
       params.depth
@@ -694,6 +697,8 @@ export class CollectionsHandler {
        * publish/unpublish transition gate judges the key's OWN grants.
        */
       authenticatedScope?: AuthenticatedScope;
+      /** Skip cache revalidation for this write (the outbox drain still runs). */
+      disableRevalidate?: boolean;
     },
     body: Record<string, unknown>
   ) {
@@ -702,6 +707,7 @@ export class CollectionsHandler {
         ...this.resolveUserParam(params),
         locale: params.locale,
         actor: params.actor,
+        disableRevalidate: params.disableRevalidate,
         // Named explicitly rather than left to the spread above, because this
         // facade rebuilds the params object field by field: anything not named
         // here survives only by passing through `resolveUserParam`'s rest, and
@@ -776,12 +782,15 @@ export class CollectionsHandler {
      * delete grant, so the session super-admin bypass does not apply to it.
      */
     authenticatedScope?: AuthenticatedScope;
+    /** Skip cache revalidation for this delete (the outbox drain still runs). */
+    disableRevalidate?: boolean;
   }) {
     return this.entryService.deleteEntry({
       ...this.resolveUserParam(params),
       // Named explicitly so the API-key scope survives the field-by-field
       // rebuild rather than only via resolveUserParam's rest.
       authenticatedScope: params.authenticatedScope,
+      disableRevalidate: params.disableRevalidate,
     });
   }
 
@@ -904,6 +913,8 @@ export class CollectionsHandler {
        * each per-row transition on a scoped API key's OWN grants.
        */
       authenticatedScope?: AuthenticatedScope;
+      /** Skip cache revalidation for this bulk update (the outbox drain still runs). */
+      disableRevalidate?: boolean;
     },
     options?: { limit?: number }
   ) {
@@ -916,6 +927,7 @@ export class CollectionsHandler {
         // Named explicitly so the API-key scope survives the field-by-field
         // rebuild rather than only via resolveUserParam's rest.
         authenticatedScope: params.authenticatedScope,
+        disableRevalidate: params.disableRevalidate,
       },
       options
     );
@@ -951,6 +963,8 @@ export class CollectionsHandler {
       routeAuthorized?: boolean;
       /** Arbitrary data passed to hooks via context */
       context?: Record<string, unknown>;
+      /** Skip cache revalidation for this bulk delete (the outbox drain still runs). */
+      disableRevalidate?: boolean;
     },
     options?: { limit?: number }
   ) {
@@ -995,12 +1009,15 @@ export class CollectionsHandler {
      * API key copying a published source is judged on the key's OWN grant.
      */
     authenticatedScope?: AuthenticatedScope;
+    /** Skip cache revalidation for this duplicate (the outbox drain still runs). */
+    disableRevalidate?: boolean;
   }) {
     return this.entryService.duplicateEntry({
       ...this.resolveUserParam(params),
       // Named explicitly so the API-key scope survives the field-by-field
       // rebuild rather than only via resolveUserParam's rest.
       authenticatedScope: params.authenticatedScope,
+      disableRevalidate: params.disableRevalidate,
     });
   }
 

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -107,11 +107,16 @@ export class CollectionEntryService extends BaseService {
      */
     private readonly fastDrainScheduler?: WebhookFastDrainScheduler,
     /**
-     * Flushes a write's cache-revalidation intent post-commit. Wired at the same
-     * seam as `fastDrainScheduler` because every event-appending write runs
-     * through this service. Defaults to a no-op when no cache adapter is present.
+     * Resolves the cache revalidator that flushes a write's revalidation intent
+     * post-commit. Wired at the same seam as `fastDrainScheduler` because every
+     * event-appending write runs through this service. A resolver (not the
+     * instance) so it is read at flush time: this service is constructed during
+     * boot, before a Next cache adapter registers, and an eager capture would
+     * memoize the no-op default. Returns undefined when no adapter is present.
      */
-    private readonly cacheRevalidator?: CacheRevalidator
+    private readonly resolveCacheRevalidator?: () =>
+      | CacheRevalidator
+      | undefined
   ) {
     super(adapter, logger);
 
@@ -340,11 +345,15 @@ export class CollectionEntryService extends BaseService {
    * a revalidator fault never turns a committed write into a failure.
    */
   async flushRevalidationIntents(intents: RevalidationIntent[]): Promise<void> {
-    if (!this.cacheRevalidator || intents.length === 0) return;
+    if (intents.length === 0) return;
+    // Resolve at flush time so a Next cache adapter registered after this
+    // service was constructed (at request time, well after boot) is honored.
+    const revalidator = this.resolveCacheRevalidator?.();
+    if (!revalidator) return;
     try {
       // Await so a Promise-returning revalidator finishes here; `revalidateTag`
       // is synchronous, so this adds no latency for the common case.
-      await this.cacheRevalidator.flush(intents);
+      await revalidator.flush(intents);
     } catch (error) {
       this.logger.error("Cache revalidation failed after a write", { error });
     }

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -294,14 +294,19 @@ export class CollectionEntryService extends BaseService {
     result:
       | CollectionServiceResult<unknown>
       | BulkOperationResult<unknown>
-      | BatchOperationResult
+      | BatchOperationResult,
+    disableRevalidate = false
   ): Promise<void> {
     // Revalidation flushes whenever a committed write produced intents. It is
     // NOT tied to the outbox-event gate below: an intent is only ever set after
     // a write commits, so its presence is the "content changed" signal, and a
     // publish-all-locales or a batch create (which record no outbox event) still
-    // bust their tags.
-    await this.flushRevalidation(result);
+    // bust their tags. The per-operation `disableRevalidate` escape hatch skips
+    // it (a CLI / seed / bulk-import write that owns its own cache strategy);
+    // the outbox drain still runs, so webhooks and retention are unaffected.
+    if (!disableRevalidate) {
+      await this.flushRevalidation(result);
+    }
 
     const recorded =
       "success" in result
@@ -362,6 +367,12 @@ export class CollectionEntryService extends BaseService {
   async createEntry(
     params: {
       collectionName: string;
+      /**
+       * Skip cache revalidation for this write (the outbox drain still runs).
+       * Set by callers that own their cache strategy — a CLI, seed, or
+       * bulk-import write — so it does not fan out a revalidation per row.
+       */
+      disableRevalidate?: boolean;
       user?: UserContext;
       /** Who performed the write, recorded on the outbox event. */
       actor?: RequestActor;
@@ -379,7 +390,7 @@ export class CollectionEntryService extends BaseService {
     depth?: number
   ) {
     const result = await this.mutationService.createEntry(params, body, depth);
-    await this.afterWriteIfRecorded(result);
+    await this.afterWriteIfRecorded(result, params.disableRevalidate);
     return result;
   }
 
@@ -404,6 +415,12 @@ export class CollectionEntryService extends BaseService {
   async updateEntry(
     params: {
       collectionName: string;
+      /**
+       * Skip cache revalidation for this write (the outbox drain still runs).
+       * Set by callers that own their cache strategy — a CLI, seed, or
+       * bulk-import write — so it does not fan out a revalidation per row.
+       */
+      disableRevalidate?: boolean;
       entryId: string;
       user?: UserContext;
       /** Who performed the write, recorded on the outbox event. */
@@ -427,13 +444,19 @@ export class CollectionEntryService extends BaseService {
     depth?: number
   ) {
     const result = await this.mutationService.updateEntry(params, body, depth);
-    await this.afterWriteIfRecorded(result);
+    await this.afterWriteIfRecorded(result, params.disableRevalidate);
     return result;
   }
 
   /** i18n M7: publish every language of an entry at once (spec §10). */
   async publishAllLocales(params: {
     collectionName: string;
+    /**
+     * Skip cache revalidation for this write (the outbox drain still runs).
+     * Set by callers that own their cache strategy — a CLI, seed, or
+     * bulk-import write — so it does not fan out a revalidation per row.
+     */
+    disableRevalidate?: boolean;
     entryId: string;
     user?: UserContext;
     overrideAccess?: boolean;
@@ -446,12 +469,18 @@ export class CollectionEntryService extends BaseService {
     authenticatedScope?: AuthenticatedScope;
   }) {
     const result = await this.mutationService.publishAllLocales(params);
-    await this.afterWriteIfRecorded(result);
+    await this.afterWriteIfRecorded(result, params.disableRevalidate);
     return result;
   }
 
   async deleteEntry(params: {
     collectionName: string;
+    /**
+     * Skip cache revalidation for this write (the outbox drain still runs).
+     * Set by callers that own their cache strategy — a CLI, seed, or
+     * bulk-import write — so it does not fan out a revalidation per row.
+     */
+    disableRevalidate?: boolean;
     entryId: string;
     user?: UserContext;
     /** Who performed the delete, recorded on the outbox event. */
@@ -463,7 +492,7 @@ export class CollectionEntryService extends BaseService {
     authenticatedScope?: AuthenticatedScope;
   }) {
     const result = await this.mutationService.deleteEntry(params);
-    await this.afterWriteIfRecorded(result);
+    await this.afterWriteIfRecorded(result, params.disableRevalidate);
     return result;
   }
 
@@ -498,6 +527,12 @@ export class CollectionEntryService extends BaseService {
 
   async duplicateEntry(params: {
     collectionName: string;
+    /**
+     * Skip cache revalidation for this write (the outbox drain still runs).
+     * Set by callers that own their cache strategy — a CLI, seed, or
+     * bulk-import write — so it does not fan out a revalidation per row.
+     */
+    disableRevalidate?: boolean;
     entryId: string;
     user?: UserContext;
     overrides?: Record<string, unknown>;
@@ -509,7 +544,7 @@ export class CollectionEntryService extends BaseService {
     authenticatedScope?: AuthenticatedScope;
   }) {
     const result = await this.bulkService.duplicateEntry(params);
-    await this.afterWriteIfRecorded(result);
+    await this.afterWriteIfRecorded(result, params.disableRevalidate);
     return result;
   }
 
@@ -517,6 +552,12 @@ export class CollectionEntryService extends BaseService {
   // the post-mutation values) and minimal {id} records on delete.
   async bulkDeleteEntries(params: {
     collectionName: string;
+    /**
+     * Skip cache revalidation for this write (the outbox drain still runs).
+     * Set by callers that own their cache strategy — a CLI, seed, or
+     * bulk-import write — so it does not fan out a revalidation per row.
+     */
+    disableRevalidate?: boolean;
     ids: string[];
     user?: UserContext;
     /** Who performed the delete, recorded on each entry's outbox event. */
@@ -528,12 +569,18 @@ export class CollectionEntryService extends BaseService {
     authenticatedScope?: AuthenticatedScope;
   }): Promise<BulkOperationResult<{ id: string }>> {
     const result = await this.bulkService.bulkDeleteEntries(params);
-    await this.afterWriteIfRecorded(result);
+    await this.afterWriteIfRecorded(result, params.disableRevalidate);
     return result;
   }
 
   async bulkUpdateEntries(params: {
     collectionName: string;
+    /**
+     * Skip cache revalidation for this write (the outbox drain still runs).
+     * Set by callers that own their cache strategy — a CLI, seed, or
+     * bulk-import write — so it does not fan out a revalidation per row.
+     */
+    disableRevalidate?: boolean;
     ids: string[];
     data: Record<string, unknown>;
     user?: UserContext;
@@ -546,13 +593,19 @@ export class CollectionEntryService extends BaseService {
     authenticatedScope?: AuthenticatedScope;
   }): Promise<BulkOperationResult<Record<string, unknown>>> {
     const result = await this.bulkService.bulkUpdateEntries(params);
-    await this.afterWriteIfRecorded(result);
+    await this.afterWriteIfRecorded(result, params.disableRevalidate);
     return result;
   }
 
   async bulkUpdateByQuery(
     params: {
       collectionName: string;
+      /**
+       * Skip cache revalidation for this write (the outbox drain still runs).
+       * Set by callers that own their cache strategy — a CLI, seed, or
+       * bulk-import write — so it does not fan out a revalidation per row.
+       */
+      disableRevalidate?: boolean;
       where: WhereFilter;
       data: Record<string, unknown>;
       user?: UserContext;
@@ -568,13 +621,19 @@ export class CollectionEntryService extends BaseService {
     options?: BulkOperationOptions & { limit?: number }
   ): Promise<BulkOperationResult<Record<string, unknown>>> {
     const result = await this.bulkService.bulkUpdateByQuery(params, options);
-    await this.afterWriteIfRecorded(result);
+    await this.afterWriteIfRecorded(result, params.disableRevalidate);
     return result;
   }
 
   async bulkDeleteByQuery(
     params: {
       collectionName: string;
+      /**
+       * Skip cache revalidation for this write (the outbox drain still runs).
+       * Set by callers that own their cache strategy — a CLI, seed, or
+       * bulk-import write — so it does not fan out a revalidation per row.
+       */
+      disableRevalidate?: boolean;
       where: WhereFilter;
       user?: UserContext;
       /** Who performed the delete, recorded on each entry's outbox event. */
@@ -588,13 +647,19 @@ export class CollectionEntryService extends BaseService {
     options?: { limit?: number }
   ): Promise<BulkOperationResult<{ id: string }>> {
     const result = await this.bulkService.bulkDeleteByQuery(params, options);
-    await this.afterWriteIfRecorded(result);
+    await this.afterWriteIfRecorded(result, params.disableRevalidate);
     return result;
   }
 
   async createEntries(
     params: {
       collectionName: string;
+      /**
+       * Skip cache revalidation for this write (the outbox drain still runs).
+       * Set by callers that own their cache strategy — a CLI, seed, or
+       * bulk-import write — so it does not fan out a revalidation per row.
+       */
+      disableRevalidate?: boolean;
       user?: UserContext;
       overrideAccess?: boolean;
       authenticatedScope?: AuthenticatedScope;
@@ -607,7 +672,7 @@ export class CollectionEntryService extends BaseService {
       entries,
       options
     );
-    await this.afterWriteIfRecorded(result);
+    await this.afterWriteIfRecorded(result, params.disableRevalidate);
     return result;
   }
 
@@ -632,6 +697,12 @@ export class CollectionEntryService extends BaseService {
   async updateEntries(
     params: {
       collectionName: string;
+      /**
+       * Skip cache revalidation for this write (the outbox drain still runs).
+       * Set by callers that own their cache strategy — a CLI, seed, or
+       * bulk-import write — so it does not fan out a revalidation per row.
+       */
+      disableRevalidate?: boolean;
       user?: UserContext;
       authenticatedScope?: AuthenticatedScope;
     },
@@ -643,7 +714,7 @@ export class CollectionEntryService extends BaseService {
       entries,
       options
     );
-    await this.afterWriteIfRecorded(result);
+    await this.afterWriteIfRecorded(result, params.disableRevalidate);
     return result;
   }
 
@@ -668,6 +739,12 @@ export class CollectionEntryService extends BaseService {
   async deleteEntries(
     params: {
       collectionName: string;
+      /**
+       * Skip cache revalidation for this write (the outbox drain still runs).
+       * Set by callers that own their cache strategy — a CLI, seed, or
+       * bulk-import write — so it does not fan out a revalidation per row.
+       */
+      disableRevalidate?: boolean;
       user?: UserContext;
       /** Who performed the delete, recorded on each entry's outbox event. */
       actor?: RequestActor;
@@ -676,7 +753,7 @@ export class CollectionEntryService extends BaseService {
     options?: BulkOperationOptions
   ): Promise<BatchOperationResult> {
     const result = await this.bulkService.deleteEntries(params, ids, options);
-    await this.afterWriteIfRecorded(result);
+    await this.afterWriteIfRecorded(result, params.disableRevalidate);
     return result;
   }
 


### PR DESCRIPTION
## What & why

F1's core (#314) computes cache-revalidation intents and the write path (#316) flushes them, but nothing translated those intents into actual Next.js cache operations, and app code had no way to *tag* its reads. This PR delivers the Next-coupled half of F1: the write-side adapter, the read-side helpers, a per-op escape hatch, and a dogfooded ISR route. This is the PR that makes tag-based ISR real for users (left-task 008 / F1 PR3).

Design: `tasks/2026-07-24-f1-cache-revalidation-design.md` §3/§5/§9. Next cache APIs verified against context7 (`/vercel/next.js`) — baseline is single-arg `revalidateTag` + `revalidatePath` + `unstable_cache`, correct across the whole `^14 || ^15 || ^16` peer range.

## What's in it (5 commits)

1. **`e13f8789` — resolve the revalidator at flush time (codex-194).** The entry services captured `cacheRevalidator` at construction, but they're built during boot, *before* any Next adapter registers (that happens at request time). The eager capture memoised the no-op and ignored the real adapter, so writes never busted tags. Now a resolver is passed and read at flush time. Load-bearing test: a revalidator registered *after* construction still receives the flush (fails under the old eager capture).

2. **`03fb3716` — the Next adapter + read-side helpers.**
   - `NextCacheRevalidator` maps tag intents → `revalidateTag`, path intents → `revalidatePath`. Resolves `next/cache` lazily via `createRequire` (same pattern as `upload-media.ts` / `after-drain.ts`), so the package **root stays Node-safe** (build check passes) and it no-ops — never throws — outside a Next runtime.
   - `registerNextCacheRevalidator()` wires it as the active revalidator and is called by `createDynamicHandlers`, so mounting the admin route enables it. A plain factory (not a memoised singleton) so it wins even if the no-op was already resolved.
   - `nextlyTags(collection, id?, locale?)` builds the same `nextly:*` scheme the write side busts; `cachedFind(fn, { tags, keyParts, revalidate? })` wraps `unstable_cache`.

3. **`e8b01c94` — per-operation `disableRevalidate` escape hatch** (F1 design §6) on the 12 collection write methods + single update: a CLI / seed / bulk-import write skips its revalidation flush while the outbox drain still runs (webhooks unaffected).

4. **`7a0d1447` — dogfood + docs.** Convert `(site)/blog/[slug]` from `force-dynamic` to `cachedFind` + `nextlyTags`; add the "ISR and caching" guide.

## Per-user caching (the #333 hazard) — resolved by design

REST reads now vary by caller (owner-only scoping folded into the SQL predicate, #333). `cachedFind`'s `keyParts` is **required**, and the JSDoc + guide mandate including the caller's identity (user id / role set / api-key scope) for any read that applies per-caller rules — matching Next's own `unstable_cache` convention. The suite includes the required **two-user owner-only test**: distinct callers with the caller in `keyParts` stay isolated, and a shared key demonstrates the leak the rule guards against. The dogfood route reads `status: published` only (public), so it caches under a stable slug key.

## Testing (load-bearing, proven by breaking)

- Adapter unit tests with a fake `next/cache` (tags → `revalidateTag`, paths → `revalidatePath` with type, no-op when absent, swallows a throwing module).
- `nextlyTags` scheme + `applyCache` key-forwarding + the two-user isolation/leak tests.
- Integration on sqlite + PG (23/23): lazy-resolution, `disableRevalidate` (collection + single) busts nothing, existing bust behavior intact.
- `pnpm --filter nextly build` confirms the root entry stays Node-safe.

**Known baseline (not from this PR):** the mock-heavy `collection-hooks`/`collection-mutation` contract tests fail on `main` too (verified — my entry-service diff is only the revalidator seam + the `disableRevalidate` gate; those tests pass `undefined` for the revalidator).

## Out of scope
Blog template full conversion (009); Next 16 `'use cache'`/`updateTag` enhancements (feature-detectable later); CDN purge fan-out (cloud, a second adapter behind the same port).

One changeset, all 20 lockstep packages, patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ISR-style caching for blog content, improving page load performance while keeping published content refreshed.
  * Added cache-tag helpers and automatic invalidation for content updates.
  * Added an option to skip cache revalidation for individual writes when needed.
* **Documentation**
  * Added a guide covering cache setup, tagging, invalidation, localization, security, and operational considerations.
* **Bug Fixes**
  * Improved cache integration when caching becomes available after application startup.
  * Cache invalidation failures no longer interrupt subsequent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->