### PR TITLE
fix(nextly): apply webhook recording opt-outs before schema introspection

### DIFF
--- a/.changeset/webhook-hmr-introspect-optout.md
+++ b/.changeset/webhook-hmr-introspect-optout.md
@@ -1,0 +1,24 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Fixed a dev-mode gap where setting a collection or single to `webhooks: false` did not take effect if the same config reload also hit a schema error (for example a transient database blip during introspection, or a change awaiting confirmation). The recording opt-out is now applied up front, so a newly private entity stops recording immediately even when the rest of the reload is deferred; re-enabling recording still waits for a clean schema sync.

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -1117,5 +1117,33 @@ describe("reloadNextlyConfig", () => {
       expect(isWebhookRecordingEnabled("collection", "posts")).toBe(true);
       resetWebhookRecordingPolicy();
     });
+
+    it("applies a new opt-out even when live introspection throws", async () => {
+      const { isWebhookRecordingEnabled, resetWebhookRecordingPolicy } =
+        await import("../../domains/webhooks/recording-policy");
+      resetWebhookRecordingPolicy();
+      // A live reload sets a nonempty collection to `webhooks: false`, but the
+      // batched `introspectLiveSnapshot` throws (a transient DB blip). The reload
+      // event is already consumed, so if the opt-out were published only after a
+      // successful sync it would never take effect until a restart. Opt-outs are
+      // published BEFORE introspection, so this one stops recording immediately.
+      loadConfigSpy.mockResolvedValue({
+        config: {
+          collections: [
+            { slug: "leads", tableName: "dc_leads", webhooks: false },
+          ],
+        },
+      });
+      introspectSpy.mockRejectedValue(new Error("connection reset"));
+
+      const { reloadNextlyConfig } = await import("../reload-config");
+      await reloadNextlyConfig({ resolver: buildResolver() });
+
+      // Introspection failed, so no schema was applied...
+      expect(pipelineApplySpy).not.toHaveBeenCalled();
+      // ...but the opt-out took effect anyway.
+      expect(isWebhookRecordingEnabled("collection", "leads")).toBe(false);
+      resetWebhookRecordingPolicy();
+    });
   });
 });

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -658,6 +658,16 @@ export async function reloadNextlyConfig(opts?: {
     return;
   }
 
+  // Apply recording OPT-OUTS now, before introspection and the schema apply.
+  // Turning recording off builds no payload and reads no field tree, so an
+  // opt-out is always safe to honor immediately — and every path from here can
+  // still bail early (introspection throwing, an unsafe diff deferring, the
+  // apply failing), each of which consumes the reload event. Publishing opt-outs
+  // up front means a reload that sets `webhooks: false` stops recording even when
+  // one of those later steps aborts; opt-INs (and pruning) still wait for a
+  // successful field-tree sync, applied by the per-scope republishes below.
+  republishRecordingPolicies(newConfig, { collections: false, singles: false });
+
   // Extracted once so the same list is passed to introspectLiveSnapshot
   // AND registered in the live-snapshot cache for the pipeline to reuse.
   const managedTableNames = [

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -423,15 +423,23 @@ function publishScopeRecording(
 
 /**
  * Republish the webhook recording policy from the reloaded config, so a live
- * `webhooks` opt-out/opt-in takes effect without a restart. Called AFTER a sync
- * path completes — never before it — so a reload whose schema apply fails does
- * not leave a recording OPT-IN ahead of the still-old runtime field tree.
+ * `webhooks` opt-out/opt-in takes effect without a restart.
+ *
+ * Called at two points, by design, with different `scopes`:
+ *   - BEFORE introspection with both scopes `false` — publishes only the
+ *     privacy-critical OPT-OUTS (which need no field tree) so they take effect
+ *     even if a later step of this reload (introspection, an unsafe diff, the
+ *     apply) aborts. Opt-INs are suppressed by the false flags.
+ *   - AFTER each scope's metadata sync succeeds with that scope `true` — adds
+ *     the OPT-INS (and removed-slug pruning), which DO read the field tree, so a
+ *     reload whose schema apply fails never leaves a recording opt-in ahead of
+ *     the still-old runtime field tree.
  *
  * Per-scope on purpose: `scopes` names the entity kinds whose metadata sync
  * actually succeeded, so a PARTIAL reload (collections synced, singles/component
  * failed) still activates the committed collections' opt-ins instead of holding
  * them hostage to an unrelated failure. Opt-OUTS ignore the gate entirely (see
- * {@link publishScopeRecording}).
+ * {@link publishScopeRecording}), which is what makes the pre-sync call safe.
  */
 function republishRecordingPolicies(
   newConfig: {


### PR DESCRIPTION
Follow-up to #336 (codex P1, found post-merge).

## Problem
When an HMR reload changes a nonempty collection/single to `webhooks: false` and `introspectLiveSnapshot` throws (a transient DB blip) — or an unsafe diff defers, or the apply fails — the reload returns before any call to `republishRecordingPolicies`. The reload event is already consumed, so the old record-enabled decision stays active and later writes keep persisting and delivering the newly opted-out content until another reload or a restart.

## Fix
Publish the recording **opt-outs** up front, before introspection and the schema apply. Turning recording off builds no payload and reads no field tree, so an opt-out is always safe to honor immediately — and every downstream step can still bail early. Opt-**ins** (and removed-slug pruning) still wait for a successful field-tree sync via the existing per-scope republishes.

## Tests
- New reload-config test: an opt-out set on a reload whose introspection throws still takes effect (pipeline never runs).
- check-types + lint clean; zero new failures vs the 3-failure reload-config baseline (identical on `main`).

One of three follow-up PRs splitting the post-merge codex findings (this one, plus the Single payload-assembly gate and the `SingleResult.committed` retention signal).