### PR TITLE
fix(nextly): carry explicit committed signal through Single results

### DIFF
--- a/.changeset/webhook-single-committed-retention.md
+++ b/.changeset/webhook-single-committed-retention.md
@@ -1,0 +1,24 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Fixed webhook-outbox retention not running after a Single update that opts out of both recording (`webhooks: false`) and cache revalidation (`revalidate: { disable: true }`) when a post-commit hook then fails. The Single write result now carries an explicit committed-write signal, matching the collection path, so the write-path cleanup runs for every durable write on installs without a scheduled webhook drain.

--- a/packages/nextly/src/domains/singles/services/__tests__/single-mutation-service.atomicity.integration.test.ts
+++ b/packages/nextly/src/domains/singles/services/__tests__/single-mutation-service.atomicity.integration.test.ts
@@ -102,6 +102,9 @@ describe("SingleMutationService component-save atomicity (integration)", () => {
       { overrideAccess: true }
     );
     expect(first.success).toBe(true);
+    // A committed write carries the explicit `committed` flag (the write-path
+    // retention signal), set the moment the row is written.
+    expect(first.committed).toBe(true);
 
     // Drop the component's table so the next update's component save fails
     // from inside the same transaction as the scalar update.
@@ -116,6 +119,9 @@ describe("SingleMutationService component-save atomicity (integration)", () => {
     // update() never throws — every error is caught and mapped to a
     // { success: false } result (see single-mutation-service.ts's catch).
     expect(second.success).toBe(false);
+    // The transaction rolled back, so nothing was written — `committed` must be
+    // falsy, otherwise the write-path retention pass would fire for a no-write.
+    expect(second.committed).toBeFalsy();
 
     // Pre-fix, the scalar UPDATE ran on its own operation before the
     // component save, so the headline would have changed here. Post-fix,

--- a/packages/nextly/src/domains/singles/services/single-entry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-entry-service.ts
@@ -141,16 +141,16 @@ export class SingleEntryService extends BaseService {
   ): Promise<SingleResult> {
     const result = await this.mutationService.update(slug, data, options);
     // Cache revalidation AND the opportunistic retention pass both follow the
-    // CONTENT write, not the webhook event: a successful write (even one that
-    // opted out of recording) must still bust its ISR tags, and — since the
-    // write path is the only prune trigger for installs with no webhook drain —
-    // must still offer a retention pass. A committed-but-post-hook-failed write
-    // reports `success:false`; it sets `eventRecorded:true` when it recorded, but
-    // an OPTED-OUT such write records nothing yet still committed content — a
-    // populated `revalidationIntent` is the durable-write signal in that case, so
-    // key off all three or its ISR tag would be left stale.
+    // CONTENT write, not the webhook event: a committed write (even one that opts
+    // out of recording) must still bust its ISR tags, and — since the write path
+    // is the only prune trigger for installs with no webhook drain — must still
+    // offer a retention pass. Keyed off the explicit `committed` flag, set the
+    // moment a row is written independent of the opt-outs, so a Single with BOTH
+    // `webhooks: false` and `revalidate: { disable: true }` whose post-commit hook
+    // then throws (reporting `success:false`, no event, no intent) is still
+    // covered. NOT keyed off `success`, which a no-op also reports.
     if (
-      result.success ||
+      result.committed === true ||
       result.eventRecorded === true ||
       result.revalidationIntent != null
     ) {

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -432,6 +432,10 @@ export class SingleMutationService extends BaseService {
     // return report a committed-but-post-hook-failed write as `eventRecorded`
     // even when `success` is false. Declared out here so every return sees it.
     let eventRecorded = false;
+    // Set once a row is actually written, independent of the recording and
+    // revalidation opt-outs — the durable-write signal the retention pass keys
+    // off, so a Single that opts out of BOTH still triggers write-path cleanup.
+    let committedWrite = false;
     // Whether the outbox event was actually appended: false when the Single
     // opted out of recording (`webhooks: false`), so the post-commit drain is
     // scheduled only for a write that recorded something. The three single.*
@@ -1798,6 +1802,8 @@ export class SingleMutationService extends BaseService {
       // Single, whose committed content must still bust its ISR tag even though
       // it records no outbox event.
       const wroteRow = updatedRows.length > 0;
+      // The row is durable regardless of the recording/revalidation opt-outs.
+      committedWrite = wroteRow;
       // `eventRecorded` additionally requires that recording actually happened:
       // the empty-rows path returns before recording, and an opted-out Single
       // records nothing — either way it owes no delivery/drain.
@@ -1815,9 +1821,10 @@ export class SingleMutationService extends BaseService {
           success: false,
           statusCode: 500,
           message: "Failed to update Single document",
-          // Carries the per-write state; here it is false (nothing was recorded
-          // for an empty write) but is threaded for parity with the other returns.
+          // Carries the per-write state; here both are false (no row written) but
+          // are threaded for parity with the other returns.
           eventRecorded,
+          committed: committedWrite,
         };
       }
 
@@ -1894,6 +1901,7 @@ export class SingleMutationService extends BaseService {
         data: updatedDoc,
         eventRecorded,
         revalidationIntent,
+        committed: committedWrite,
       };
     } catch (error) {
       // A publish-transition refused against the row-locked status aborts the
@@ -1911,6 +1919,7 @@ export class SingleMutationService extends BaseService {
         ...buildSingleErrorResult(error, "Failed to update Single document"),
         eventRecorded,
         revalidationIntent,
+        committed: committedWrite,
       };
     }
   }

--- a/packages/nextly/src/domains/singles/types.ts
+++ b/packages/nextly/src/domains/singles/types.ts
@@ -212,4 +212,14 @@ export interface SingleResult<T = SingleDocument> {
    * disabled for the single.
    */
   revalidationIntent?: RevalidationIntent;
+  /**
+   * Whether this update committed a content write to the database — true once the
+   * row is written (even a write that opts out of BOTH recording and
+   * revalidation, and even one whose post-commit hook then throws), false for a
+   * rejected request or a no-op. The write-path retention pass keys off this so
+   * it runs for every durable write yet skips one that changed nothing, without
+   * conflating `success` (a no-op reports success) with a committed write.
+   * Mirrors `CollectionServiceResult.committed`.
+   */
+  committed?: boolean;
 }


### PR DESCRIPTION
Follow-up to #336 (codex P2, found post-merge). One of three split follow-up PRs.

## Problem
If a `webhooks: false` Single also has `revalidate: { disable: true }`, its transaction can commit and then a post-commit hook (or response step) throws. The result is then `success: false`, `eventRecorded: false`, and no `revalidationIntent` — so the `SingleEntryService.update` wrapper skips both cache revalidation and the retention pass even though content was durably written. On installs without a scheduled webhook drain, the write path is the only prune trigger, so repeated writes of this kind can leave expired outbox rows unpruned.

## Fix
Add a `committed` flag to `SingleResult` (mirroring `CollectionServiceResult.committed` from #336), set the moment the row is written — independent of the recording and revalidation opt-outs — and gate the write-path revalidation + retention on it. `success` is no longer part of the gate (a no-op reports success).

## Tests
- Extended the Single atomicity integration test: a committed update reports `committed: true`; a rolled-back write (component-save failure) reports `committed` falsy.
- check-types + lint clean; zero new failures vs baseline (singles + single-dispatcher-shapes identical to `main`); the new `committed` field breaks no wire-shape test.