### PR TITLE
fix(nextly): skip Single webhook payload assembly on recording opt-out

### DIFF
--- a/.changeset/webhook-single-payload-gate.md
+++ b/.changeset/webhook-single-payload-gate.md
@@ -1,0 +1,24 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+A Single that opts out of webhook recording (`webhooks: false`) no longer assembles its webhook payload on update. Previously the previous/next event documents were built (reading every component subtree) before the opt-out was checked, so a scalar update to an opted-out Single still performed webhook-only component reads and could fail on a missing or stale component table. The opt-out is now resolved before any payload assembly.

--- a/packages/nextly/src/domains/singles/services/__tests__/single-mutation-service.atomicity.integration.test.ts
+++ b/packages/nextly/src/domains/singles/services/__tests__/single-mutation-service.atomicity.integration.test.ts
@@ -34,6 +34,10 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 
+import {
+  resetWebhookRecordingPolicy,
+  setWebhookRecording,
+} from "../../../webhooks/recording-policy";
 import { clearServices } from "../../../../di/register";
 import {
   seedBuilderComponent,
@@ -132,5 +136,39 @@ describe("SingleMutationService component-save atomicity (integration)", () => {
     );
     expect(rows).toHaveLength(1);
     expect(rows[0].headline).toBe("Original headline");
+  });
+
+  it("does not assemble the webhook payload (nor read components) for an opted-out Single", async () => {
+    const { singles } = await seedSettingsWithHero();
+    const adapter = handle!.adapter;
+
+    // Seed an initial value while the component table still exists.
+    const first = await singles.update(
+      "preferences",
+      { headline: "Original headline", seo: { heading: "Original SEO" } },
+      { overrideAccess: true }
+    );
+    expect(first.success).toBe(true);
+
+    // Opt this Single out of recording, then drop the component table. The
+    // webhook payload assembly reads component subtrees (populateComponentData,
+    // strict) even for a scalar-only update, so before the opt-out gate a scalar
+    // write would throw on the missing table. With recording off, that assembly
+    // is skipped and the scalar write must still succeed.
+    setWebhookRecording("single", "preferences", false);
+    await adapter.executeQuery(`DROP TABLE "comp_hero"`);
+
+    const scalar = await singles.update(
+      "preferences",
+      { headline: "Scalar-only change" },
+      { overrideAccess: true }
+    );
+
+    expect(scalar.success).toBe(true);
+    const rows = await adapter.executeQuery<{ headline: string }>(
+      `SELECT headline FROM single_preferences LIMIT 1`
+    );
+    expect(rows[0].headline).toBe("Scalar-only change");
+    resetWebhookRecordingPolicy();
   });
 });

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -1765,36 +1765,48 @@ export class SingleMutationService extends BaseService {
               id: existingDoc.id,
               ...(eventLocale != null ? { locale: eventLocale } : {}),
             };
-            recorded = await recordMutationEvent(tx, {
-              type: "single.updated",
-              resource,
-              data: dataDoc,
-              previous: previousDoc,
-              fields: webhookFields,
-              actor,
-            });
-            // A publish emits BOTH `single.updated` and `single.published` (and
-            // an unpublish both `single.updated` and `single.unpublished`), so a
-            // consumer subscribes to whichever it needs.
-            if (publishedTransition) {
-              await recordMutationEvent(tx, {
-                type: "single.published",
+            // Record only when the same opt-out decision that gated the payload
+            // assembly still holds. `recordMutationEvent` re-derives the policy
+            // internally, but a dev HMR reload can flip `webhooks` mid-write: if
+            // it went false -> true between the check above and here, that
+            // internal re-check would record the DEGRADED opt-out payload built
+            // above (raw row, no previous, unexpanded components). Gating on the
+            // one `recordingEnabled` value read at assembly time keeps the two
+            // checks from diverging — either the full payload is recorded, or
+            // nothing is. (An opt-out that flips true -> false mid-write likewise
+            // records nothing here, which is the safe direction.)
+            if (recordingEnabled) {
+              recorded = await recordMutationEvent(tx, {
+                type: "single.updated",
                 resource,
                 data: dataDoc,
                 previous: previousDoc,
                 fields: webhookFields,
                 actor,
               });
-            }
-            if (unpublishedTransition) {
-              await recordMutationEvent(tx, {
-                type: "single.unpublished",
-                resource,
-                data: dataDoc,
-                previous: previousDoc,
-                fields: webhookFields,
-                actor,
-              });
+              // A publish emits BOTH `single.updated` and `single.published` (and
+              // an unpublish both `single.updated` and `single.unpublished`), so a
+              // consumer subscribes to whichever it needs.
+              if (publishedTransition) {
+                await recordMutationEvent(tx, {
+                  type: "single.published",
+                  resource,
+                  data: dataDoc,
+                  previous: previousDoc,
+                  fields: webhookFields,
+                  actor,
+                });
+              }
+              if (unpublishedTransition) {
+                await recordMutationEvent(tx, {
+                  type: "single.unpublished",
+                  resource,
+                  data: dataDoc,
+                  previous: previousDoc,
+                  fields: webhookFields,
+                  actor,
+                });
+              }
             }
 
             return rows;

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -1346,22 +1346,32 @@ export class SingleMutationService extends BaseService {
             // view; a non-localized single has no locale.
             const payloadLocale = eventLocale ?? defaultViewLocale;
 
-            const previousDoc = preRow
-              ? await this.buildSingleWebhookDoc(
-                  tx,
-                  existingDoc.id,
-                  singleMeta.tableName,
-                  preRow,
-                  fieldConfigs,
-                  companion,
-                  companionPhysicallyExists,
-                  eventLocale != null
-                    ? previousCompanionValues
-                    : defaultViewCompanion,
-                  payloadLocale,
-                  overlayLocaleStatus ? previousLocaleStatus : undefined
-                )
-              : null;
+            // Resolve the opt-out ONCE, before assembling any webhook payload.
+            // Building the previous/next documents calls populateComponentData
+            // (strict) — a per-component read that can throw on a missing/stale
+            // component table — and expands the field tree, all of which only
+            // ever feed recordMutationEvent. That helper short-circuits on the
+            // opt-out, so for a `webhooks: false` Single this assembly is pure
+            // waste and must not be able to fail a scalar content write.
+            const recordingEnabled = isWebhookRecordingEnabled("single", slug);
+
+            const previousDoc =
+              recordingEnabled && preRow
+                ? await this.buildSingleWebhookDoc(
+                    tx,
+                    existingDoc.id,
+                    singleMeta.tableName,
+                    preRow,
+                    fieldConfigs,
+                    companion,
+                    companionPhysicallyExists,
+                    eventLocale != null
+                      ? previousCompanionValues
+                      : defaultViewCompanion,
+                    payloadLocale,
+                    overlayLocaleStatus ? previousLocaleStatus : undefined
+                  )
+                : null;
 
             // Clone per attempt: saveComponentDataInTransaction mutates the data
             // in place (hashing passwords, assigning ids), so a conflict retry
@@ -1685,28 +1695,34 @@ export class SingleMutationService extends BaseService {
             // columns); a shared-field event instead carries the default view
             // (`defaultViewCompanion`), which the shared write left untouched.
             // Components are read on the transaction (read-your-writes).
-            const dataDoc = await this.buildSingleWebhookDoc(
-              tx,
-              existingDoc.id,
-              singleMeta.tableName,
-              rows[0],
-              fieldConfigs,
-              companion,
-              companionPhysicallyExists,
-              eventLocale != null ? dataCompanionValues : defaultViewCompanion,
-              payloadLocale,
-              overlayLocaleStatus ? dataLocaleStatus : undefined
-            );
+            // Assemble the event document only when recording — this is the
+            // populateComponentData(strict) read the opt-out must skip. When off,
+            // recordMutationEvent ignores `data`, so the raw written row stands in.
+            const dataDoc = recordingEnabled
+              ? await this.buildSingleWebhookDoc(
+                  tx,
+                  existingDoc.id,
+                  singleMeta.tableName,
+                  rows[0],
+                  fieldConfigs,
+                  companion,
+                  companionPhysicallyExists,
+                  eventLocale != null
+                    ? dataCompanionValues
+                    : defaultViewCompanion,
+                  payloadLocale,
+                  overlayLocaleStatus ? dataLocaleStatus : undefined
+                )
+              : rows[0];
 
             // The single's field tree with component references expanded, so the
             // secret/hidden strip descends into fields declared inside a
             // component. Resolved on the transaction's connection (components
             // already read on it) to avoid taking a second pooled connection
-            // while this write still holds one. Skipped when the single opted out
-            // of recording: recordMutationEvent short-circuits before it reads
-            // `fields`, so the per-component registry reads would be pure waste and
-            // a scalar write should not be able to fail on them.
-            const webhookFields = isWebhookRecordingEnabled("single", slug)
+            // while this write still holds one. Skipped on the same opt-out: the
+            // per-component registry reads would be pure waste and a scalar write
+            // should not be able to fail on them.
+            const webhookFields = recordingEnabled
               ? await expandComponentFields(
                   fieldConfigs,
                   async componentSlug =>


### PR DESCRIPTION
Follow-up to #336 (codex P2, found post-merge). Third of three split follow-up PRs.

## Problem
For an opted-out (`webhooks: false`) Single with a component field, #336 gated only the field-tree expansion. The previous/next event **documents** are still assembled first — `buildSingleWebhookDoc` calls `populateComponentData` with `strict: true`, a per-component read that can throw on a missing/stale component table. So even a scalar-only update to an opted-out Single performs webhook-only component reads and can fail the content write, despite recording being disabled.

## Fix
Resolve the recording opt-out once, before assembling `previousDoc`/`dataDoc`. When recording is off, both documents are skipped (the raw written row stands in — `recordMutationEvent` short-circuits before it reads `data`/`previous`), along with the field-tree expansion.

## Tests
- New integration test: an opted-out Single with a component field takes a scalar-only update **after its component table is dropped** and still succeeds (before the fix, the webhook assembly read the dropped table and failed the write).
- check-types + lint clean; the existing atomicity suite still passes.