### PR TITLE
feat(nextly): add the blocks field type

### DIFF
--- a/.changeset/blocks-field-type.md
+++ b/.changeset/blocks-field-type.md
@@ -1,0 +1,24 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Collections and singles can now hold a page built from blocks. Add a field with `blocks({ name: "content" })`, optionally naming which registered blocks it accepts, and the whole page document is stored in one column and typed for you when you generate types.

--- a/.claude/skills/adding-a-field-type/SKILL.md
+++ b/.claude/skills/adding-a-field-type/SKILL.md
@@ -31,24 +31,31 @@ Work through these in order; each layer has tests nearby to extend.
 3. **Type guard**: add it in `collections/fields/guards.ts` via
    `createTypeGuard`, and decide membership in `isDataField` /
    `isRelationalField` / `hasNestedFields`.
-4. **Catalog entry**: add to `FIELD_TYPE_CATALOG` in
+4. **Accepted-type lists (two of them, both hand-maintained)**:
+   - `VALID_FIELD_TYPES` in `packages/nextly/src/shared/base-validator.ts` —
+     the config gate. Miss this and `defineCollection` throws
+     `FIELD_TYPE_INVALID` at boot even though every other layer is wired.
+   - `DynamicFieldType` in
+     `packages/nextly/src/schemas/dynamic-collections/legacy-types.ts` — the
+     shape of a Schema-Builder-stored field definition.
+5. **Catalog entry**: add to `FIELD_TYPE_CATALOG` in
    `collections/fields/catalog.ts` (label, category, hint, Lucide icon NAME
    as a string). Pickers render from the catalog automatically. If the type
    should appear on the user-fields or form surfaces, add it to those
    allow-lists too; if it is surface-only, do NOT add it to the canonical
    union (see the catalog's comment block for why).
-5. **Column mapping (the single source of truth)**: add the per-dialect case
+6. **Column mapping (the single source of truth)**: add the per-dialect case
    in `packages/nextly/src/domains/schema/services/field-column-descriptor.ts`.
    Then verify the descriptor's `kind` is handled by
    `runtime-schema-generator.ts`, `pipeline/diff/build-from-fields.ts`, and
    the DDL emitters in `domains/schema/pipeline/ddl-emitter/`.
-6. **Validation**: add a validator under `collections/fields/validators/` and
+7. **Validation**: add a validator under `collections/fields/validators/` and
    the case in `domains/schema/services/zod-generator.ts` (the per-type
    switch).
-7. **Type generation**: add the TS mapping in
+8. **Type generation**: add the TS mapping in
    `domains/schema/services/type-generator.ts` so `nextly generate:types`
    emits the right property type.
-8. **Admin rendering**:
+9. **Admin rendering**:
    - Edit view: a component under
      `packages/admin/src/components/features/entries/fields/` and its case in
      `FieldRenderer.tsx`.
@@ -57,9 +64,9 @@ Work through these in order; each layer has tests nearby to extend.
    - Builder config: if the type has builder-editable options, extend the
      schema builder's field editor sheet under
      `packages/admin/src/components/features/schema-builder/`.
-9. **Serialization extras** (check, usually small): the collection export
-   service (`domains/collections/services/collection-export-service.ts`) and
-   `domains/schema/services/schema-hash.ts`.
+10. **Serialization extras** (check, usually small): the collection export
+    service (`domains/collections/services/collection-export-service.ts`) and
+    `domains/schema/services/schema-hash.ts`.
 
 ## Verify before opening the PR
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,14 +70,16 @@ jobs:
       # coverage, the #5782 cascade regression, RQB v2 conversions, and the
       # relations registry.
       - name: Drizzle v1 safety suites (unit)
-        # Build the concrete adapters first: this step runs a raw vitest
-        # BEFORE the Build step below, but nextly's database/factory.ts
-        # dynamically imports @nextlyhq/adapter-{postgres,mysql,sqlite}, so
-        # vite fails to resolve their (unbuilt) entry and 4 suites error at
-        # collection with "Failed to resolve entry for package". turbo builds
-        # their shared adapter-drizzle dependency in the same command.
+        # Build nextly's workspace dependencies first: this step runs a raw
+        # vitest BEFORE the Build step below, so any package nextly imports
+        # must already have a dist or vite fails to resolve its entry and the
+        # suites error at collection with "Failed to resolve entry for
+        # package". database/factory.ts dynamically imports
+        # @nextlyhq/adapter-{postgres,mysql,sqlite}, and the schema services
+        # import @nextlyhq/blocks-engine for the blocks field type. turbo
+        # builds their shared dependencies in the same command.
         run: |
-          pnpm turbo build --filter=@nextlyhq/adapter-postgres --filter=@nextlyhq/adapter-mysql --filter=@nextlyhq/adapter-sqlite
+          pnpm turbo build --filter=@nextlyhq/adapter-postgres --filter=@nextlyhq/adapter-mysql --filter=@nextlyhq/adapter-sqlite --filter=@nextlyhq/blocks-engine
           pnpm --filter nextly exec vitest run \
             src/database/__tests__/drizzle-kit-lazy.test.ts \
             src/database/__tests__/drizzle-kit-api-contract.test.ts \

--- a/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
@@ -450,6 +450,14 @@ function getDefaultValues(
           (field as { defaultValue?: unknown }).defaultValue ?? null;
         break;
 
+      case "blocks":
+        // The form control for a blocks field is read-only, so a declared
+        // default that was dropped here could not be restored by hand — and a
+        // required field would fail validation despite having a valid default.
+        defaults[fieldName] =
+          (field as { defaultValue?: unknown }).defaultValue ?? null;
+        break;
+
       case "component": {
         // Component fields: get nested defaults from componentFields
         const componentField = field as {

--- a/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/useEntryForm.ts
@@ -12,7 +12,8 @@
  */
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import type { FieldConfig } from "nextly/config";
+import type { DocumentKind, FieldConfig } from "nextly/config";
+import { emptyBlockDocument } from "nextly/config";
 import { useMemo, useCallback, useEffect } from "react";
 import { useForm, type UseFormReturn } from "react-hook-form";
 import { z } from "zod";
@@ -450,13 +451,24 @@ function getDefaultValues(
           (field as { defaultValue?: unknown }).defaultValue ?? null;
         break;
 
-      case "blocks":
+      case "blocks": {
         // The form control for a blocks field is read-only, so a declared
-        // default that was dropped here could not be restored by hand — and a
-        // required field would fail validation despite having a valid default.
+        // default that was dropped here could not be restored by hand. A
+        // required field with no default gets an empty document rather than
+        // null, or the entry could never be created — and creating it is how
+        // the user reaches the builder to fill it in.
+        const blocksField = field as {
+          defaultValue?: unknown;
+          required?: boolean;
+          blocks?: { kinds?: DocumentKind[] };
+        };
         defaults[fieldName] =
-          (field as { defaultValue?: unknown }).defaultValue ?? null;
+          blocksField.defaultValue ??
+          (blocksField.required
+            ? emptyBlockDocument(blocksField.blocks?.kinds)
+            : null);
         break;
+      }
 
       case "component": {
         // Component fields: get nested defaults from componentFields

--- a/packages/admin/src/components/features/entries/EntryList/EntryTableCell.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/EntryTableCell.tsx
@@ -318,6 +318,38 @@ function RichTextCell({ value }: { value: unknown }) {
 /**
  * Renders a JSON field as a truncated code preview.
  */
+/**
+ * A page document in one line: how many blocks it holds. The document itself
+ * is a nested tree, so stringifying it would fill the column with structure
+ * nobody can read at a glance.
+ */
+function BlocksCell({ value }: { value: unknown }) {
+  const nodes = (value as { nodes?: unknown })?.nodes;
+  const count = countBlocks(Array.isArray(nodes) ? nodes : []);
+  if (count === 0) {
+    return <span className="text-muted-foreground text-sm">Empty</span>;
+  }
+  return (
+    <span className="text-sm">
+      {count} {count === 1 ? "block" : "blocks"}
+    </span>
+  );
+}
+
+/** Every block in the tree, including those nested inside slots. */
+function countBlocks(nodes: readonly unknown[]): number {
+  let total = 0;
+  for (const entry of nodes) {
+    const node = entry as { slots?: Record<string, unknown> };
+    if (!node || typeof node !== "object") continue;
+    total += 1;
+    for (const slot of Object.values(node.slots ?? {})) {
+      if (Array.isArray(slot)) total += countBlocks(slot);
+    }
+  }
+  return total;
+}
+
 function JsonCell({ value }: { value: unknown }) {
   const jsonStr = JSON.stringify(value);
   const maxLength = 40;
@@ -526,6 +558,11 @@ export function EntryTableCell({
     // JSON data
     case "json": {
       return renderContent(<JsonCell value={value} />);
+    }
+
+    // A page built from blocks
+    case "blocks": {
+      return renderContent(<BlocksCell value={value} />);
     }
 
     // Fallback for unknown types

--- a/packages/admin/src/components/features/entries/fields/FieldRenderer.tsx
+++ b/packages/admin/src/components/features/entries/fields/FieldRenderer.tsx
@@ -50,6 +50,7 @@ import { DateInput } from "./selection/DateInput";
 import { MultiSelectInput } from "./selection/MultiSelectInput";
 import { RadioInput } from "./selection/RadioInput";
 import { SelectInput } from "./selection/SelectInput";
+import { BlocksSummary } from "./structured/BlocksSummary";
 import { ComponentInput } from "./structured/ComponentInput";
 import { GroupInput } from "./structured/GroupInput";
 import { JsonInput } from "./structured/JsonInput";
@@ -518,6 +519,11 @@ export function FieldRenderer({
             field={field as JSONFieldConfig}
           />
         );
+
+      case "blocks":
+        // Read-only on the form: a page is edited in the builder, so the form
+        // reports what the field holds rather than offering a second editor.
+        return <BlocksSummary {...commonProps} name={fieldPath} />;
 
       // =========================================
       // Unknown Type

--- a/packages/admin/src/components/features/entries/fields/structured/BlocksSummary.tsx
+++ b/packages/admin/src/components/features/entries/fields/structured/BlocksSummary.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+/**
+ * Blocks Field Summary
+ *
+ * A read-only account of what a blocks field currently holds: how many blocks
+ * the page has and which types it uses.
+ *
+ * Editing happens in the page builder, not in the entry form, so this control
+ * deliberately offers none. It exists so a blocks field on a form reads as a
+ * populated part of the entry rather than an empty box or, worse, the unknown
+ * field-type error the renderer shows for a type it has no case for.
+ *
+ * @module components/entries/fields/structured/BlocksSummary
+ */
+
+import type { BlockDocument, BlockNode } from "nextly/config";
+import { useMemo } from "react";
+import {
+  useWatch,
+  type Control,
+  type FieldValues,
+  type Path,
+} from "react-hook-form";
+
+import { LayoutGrid } from "@admin/components/icons";
+
+export interface BlocksSummaryProps<
+  TFieldValues extends FieldValues = FieldValues,
+> {
+  /** Field path this control reads from. */
+  name: Path<TFieldValues>;
+  /** React Hook Form control the entry form owns. */
+  control: Control<TFieldValues>;
+}
+
+/** Every block type in the tree with how many times it appears, in tree order. */
+function countByType(nodes: readonly BlockNode[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  const visit = (list: readonly BlockNode[]): void => {
+    for (const node of list) {
+      if (!node || typeof node.type !== "string") continue;
+      counts.set(node.type, (counts.get(node.type) ?? 0) + 1);
+      // Children live under named slots, so a container's contents are counted
+      // too rather than the summary reporting only the top level.
+      for (const slot of Object.values(node.slots ?? {})) {
+        if (Array.isArray(slot)) visit(slot);
+      }
+    }
+  };
+  visit(nodes);
+  return counts;
+}
+
+export function BlocksSummary<TFieldValues extends FieldValues = FieldValues>({
+  name,
+  control,
+}: BlocksSummaryProps<TFieldValues>) {
+  const value = useWatch({ control, name }) as BlockDocument | null | undefined;
+
+  const counts = useMemo(() => {
+    const nodes = value?.nodes;
+    return Array.isArray(nodes)
+      ? countByType(nodes)
+      : new Map<string, number>();
+  }, [value]);
+
+  const total = useMemo(
+    () => [...counts.values()].reduce((sum, n) => sum + n, 0),
+    [counts]
+  );
+
+  if (total === 0) {
+    return (
+      <div className="flex items-center gap-2 rounded-none border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+        <LayoutGrid className="size-4 shrink-0" aria-hidden="true" />
+        <span>No blocks yet. Build this page in the page builder.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-none border border-border bg-muted/30 p-4">
+      <div className="flex items-center gap-2 text-sm text-foreground">
+        <LayoutGrid className="size-4 shrink-0" aria-hidden="true" />
+        <span>
+          {total} {total === 1 ? "block" : "blocks"}
+        </span>
+      </div>
+      <ul className="mt-3 flex flex-wrap gap-1.5">
+        {[...counts.entries()].map(([type, count]) => (
+          <li
+            key={type}
+            className="rounded-none border border-border bg-background px-2 py-0.5 font-mono text-xs text-muted-foreground"
+          >
+            {type}
+            {count > 1 ? ` ×${count}` : ""}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/entries/fields/structured/ComponentInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/structured/ComponentInput.tsx
@@ -42,7 +42,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@nextlyhq/ui";
-import type { FieldConfig } from "nextly/config";
+import type { FieldConfig, DocumentKind } from "nextly/config";
+import { emptyBlockDocument } from "nextly/config";
 import { useCallback, useMemo, useState } from "react";
 import {
   useFieldArray,
@@ -229,6 +230,19 @@ function createDefaultComponentValues(
         case "repeater":
           defaultValues[fieldName] = [];
           break;
+        case "blocks": {
+          // The blocks control is read-only, so a required nested field left
+          // null could never be filled in — the instance would be
+          // unsubmittable the moment it is added.
+          const blocksField = subField as {
+            required?: boolean;
+            blocks?: { kinds?: DocumentKind[] };
+          };
+          defaultValues[fieldName] = blocksField.required
+            ? emptyBlockDocument(blocksField.blocks?.kinds)
+            : null;
+          break;
+        }
         case "group":
           if ("fields" in subField) {
             defaultValues[fieldName] = createDefaultComponentValues(

--- a/packages/admin/src/components/features/entries/fields/structured/RepeaterInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/structured/RepeaterInput.tsx
@@ -33,7 +33,12 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@nextlyhq/ui";
-import type { RepeaterFieldConfig, FieldConfig } from "nextly/config";
+import type {
+  RepeaterFieldConfig,
+  FieldConfig,
+  DocumentKind,
+} from "nextly/config";
+import { emptyBlockDocument } from "nextly/config";
 import { useCallback, useState } from "react";
 import {
   useFieldArray,
@@ -152,6 +157,19 @@ function createDefaultRowValues(
         case "repeater":
           defaultValues[fieldName] = [];
           break;
+        case "blocks": {
+          // The blocks control is read-only, so a required nested field left
+          // null could never be filled in — the row would be unsubmittable
+          // the moment it is added.
+          const blocksField = subField as {
+            required?: boolean;
+            blocks?: { kinds?: DocumentKind[] };
+          };
+          defaultValues[fieldName] = blocksField.required
+            ? emptyBlockDocument(blocksField.blocks?.kinds)
+            : null;
+          break;
+        }
         case "group":
           // Recursively create defaults for group fields
           if ("fields" in subField) {

--- a/packages/admin/src/components/features/entries/fields/structured/index.ts
+++ b/packages/admin/src/components/features/entries/fields/structured/index.ts
@@ -25,3 +25,4 @@ export { GroupInput, type GroupInputProps } from "./GroupInput";
 
 // JSON field component
 export { JsonInput, type JsonInputProps } from "./JsonInput";
+export { BlocksSummary } from "./BlocksSummary";

--- a/packages/admin/src/components/features/entries/fields/structured/index.ts
+++ b/packages/admin/src/components/features/entries/fields/structured/index.ts
@@ -25,4 +25,7 @@ export { GroupInput, type GroupInputProps } from "./GroupInput";
 
 // JSON field component
 export { JsonInput, type JsonInputProps } from "./JsonInput";
+// The read-only form renderer for a blocks field. It lives with the other
+// structured-field controls because a page document is structured content, and
+// it is exported here so FieldRenderer resolves it the same way as the rest.
 export { BlocksSummary } from "./BlocksSummary";

--- a/packages/admin/src/components/features/schema-builder/types.ts
+++ b/packages/admin/src/components/features/schema-builder/types.ts
@@ -325,6 +325,12 @@ export interface BuilderField extends FieldConfig {
   /** When true, the Builder shows this field read-only (inspect only). */
   locked?: boolean;
   /**
+   * A blocks field's policy: which registered block names and document kinds
+   * it accepts. Carried through the builder so an edit elsewhere in the schema
+   * cannot rewrite the field without it.
+   */
+  blocks?: { allow?: string[]; kinds?: string[] };
+  /**
    * Field description/help text
    */
   description?: string;

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -22,7 +22,8 @@
  */
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import type { FieldConfig } from "nextly/config";
+import type { DocumentKind, FieldConfig } from "nextly/config";
+import { emptyBlockDocument } from "nextly/config";
 import type React from "react";
 import { useEffect, useMemo, useCallback, useRef } from "react";
 import { useForm } from "react-hook-form";
@@ -268,12 +269,23 @@ function getDefaultValues(
       case "chips":
         defaults[fieldName] = [];
         break;
-      case "blocks":
+      case "blocks": {
         // The form control for a blocks field is read-only, so a declared
-        // default dropped here could not be restored by hand.
+        // default dropped here could not be restored by hand, and a required
+        // field left null could never be satisfied — the single would be
+        // unsavable with no control to fill in.
+        const blocksField = field as {
+          defaultValue?: unknown;
+          required?: boolean;
+          blocks?: { kinds?: DocumentKind[] };
+        };
         defaults[fieldName] =
-          (field as { defaultValue?: unknown }).defaultValue ?? null;
+          blocksField.defaultValue ??
+          (blocksField.required
+            ? emptyBlockDocument(blocksField.blocks?.kinds)
+            : null);
         break;
+      }
       case "group": {
         const groupField = field as { fields: FieldConfig[] };
         defaults[fieldName] = getDefaultValues(groupField.fields);

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -268,6 +268,12 @@ function getDefaultValues(
       case "chips":
         defaults[fieldName] = [];
         break;
+      case "blocks":
+        // The form control for a blocks field is read-only, so a declared
+        // default dropped here could not be restored by hand.
+        defaults[fieldName] =
+          (field as { defaultValue?: unknown }).defaultValue ?? null;
+        break;
       case "group": {
         const groupField = field as { fields: FieldConfig[] };
         defaults[fieldName] = getDefaultValues(groupField.fields);

--- a/packages/admin/src/components/features/versions/value-display/normalize-stored-value.ts
+++ b/packages/admin/src/components/features/versions/value-display/normalize-stored-value.ts
@@ -26,6 +26,9 @@ const JSON_BACKED_TYPES = new Set([
   "json",
   "chips",
   "richText",
+  // A page document is stored as one JSON value, so version history has to
+  // parse it back before rendering, exactly like the other structured types.
+  "blocks",
 ]);
 
 function hasMany(field: FieldConfig): boolean {

--- a/packages/admin/src/lib/blocks-form-defaults.test.ts
+++ b/packages/admin/src/lib/blocks-form-defaults.test.ts
@@ -1,0 +1,27 @@
+import { emptyBlockDocument } from "nextly/config";
+import { describe, expect, it } from "vitest";
+
+/**
+ * A blocks field's form control is read-only: editing happens in the builder.
+ * So whatever the form seeds is what gets submitted, and a required field
+ * seeded with `null` can never be satisfied — the entry or single cannot be
+ * saved, and saving it is how the user reaches the builder in the first place.
+ *
+ * Both form builders (entries and singles) must therefore seed a real document
+ * for a required field. This pins the shape they seed and the reason for it.
+ */
+describe("empty document seeded for a required blocks field", () => {
+  it("is a document the server would accept", () => {
+    const doc = emptyBlockDocument();
+    expect(typeof doc.formatVersion).toBe("number");
+    expect(doc.kind).toBe("page");
+    expect(doc.nodes).toEqual([]);
+  });
+
+  it("uses a kind the field accepts", () => {
+    // Seeding `page` into a template-only field would fail the field's own
+    // policy on submit, which is the failure this seeding exists to avoid.
+    expect(emptyBlockDocument(["template"]).kind).toBe("template");
+    expect(emptyBlockDocument(["pattern", "page"]).kind).toBe("page");
+  });
+});

--- a/packages/admin/src/lib/builder/blocks-policy-roundtrip.test.ts
+++ b/packages/admin/src/lib/builder/blocks-policy-roundtrip.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { convertToFieldDefinition } from "./field-transformers";
+import {
+  convertToBuilderField,
+  convertToFieldDefinition,
+} from "./field-transformers";
 import { mapBuilderFieldToManifest } from "./to-manifest-entity";
 
 import type { BuilderFieldInput } from "./to-manifest-entity";
@@ -30,6 +33,23 @@ describe("blocks policy round-trip through the builder", () => {
 
   it("survives conversion to a manifest field", () => {
     expect(mapBuilderFieldToManifest(FIELD).blocks).toEqual({
+      allow: ["core/*"],
+      kinds: ["page"],
+    });
+  });
+
+  it("survives a full load-then-save cycle", () => {
+    // The builder loads a stored definition into its own state and writes it
+    // back on every save, so the policy has to survive both directions or an
+    // unrelated edit drops it.
+    const stored = {
+      name: "content",
+      type: "blocks",
+      blocks: { allow: ["core/*"], kinds: ["page"] },
+    } as unknown as Parameters<typeof convertToBuilderField>[0];
+    const loaded = convertToBuilderField(stored, 0);
+    expect(loaded.blocks).toEqual({ allow: ["core/*"], kinds: ["page"] });
+    expect(convertToFieldDefinition(loaded).blocks).toEqual({
       allow: ["core/*"],
       kinds: ["page"],
     });

--- a/packages/admin/src/lib/builder/blocks-policy-roundtrip.test.ts
+++ b/packages/admin/src/lib/builder/blocks-policy-roundtrip.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { convertToFieldDefinition } from "./field-transformers";
+import { mapBuilderFieldToManifest } from "./to-manifest-entity";
+
+import type { BuilderFieldInput } from "./to-manifest-entity";
+
+import type { BuilderField } from "@admin/components/features/schema-builder/types";
+
+/**
+ * A blocks field's policy has to survive both builder serializers. Saving any
+ * schema edit rebuilds every field through them, so a dropped policy widens a
+ * restricted field back to accepting everything — without the user touching it.
+ */
+const FIELD = {
+  id: "f1",
+  name: "content",
+  type: "blocks",
+  label: "Content",
+  blocks: { allow: ["core/*"], kinds: ["page"] },
+} as unknown as BuilderField & BuilderFieldInput;
+
+describe("blocks policy round-trip through the builder", () => {
+  it("survives conversion to a field definition", () => {
+    expect(convertToFieldDefinition(FIELD).blocks).toEqual({
+      allow: ["core/*"],
+      kinds: ["page"],
+    });
+  });
+
+  it("survives conversion to a manifest field", () => {
+    expect(mapBuilderFieldToManifest(FIELD).blocks).toEqual({
+      allow: ["core/*"],
+      kinds: ["page"],
+    });
+  });
+
+  it("stays absent when the field declares no policy", () => {
+    const plain = { ...FIELD, blocks: undefined };
+    expect(convertToFieldDefinition(plain).blocks).toBeUndefined();
+    expect(mapBuilderFieldToManifest(plain).blocks).toBeUndefined();
+  });
+});

--- a/packages/admin/src/lib/builder/field-transformers.ts
+++ b/packages/admin/src/lib/builder/field-transformers.ts
@@ -404,6 +404,9 @@ export function convertToBuilderField(
     component: field.component,
     components: field.components ? [...field.components] : undefined,
     repeatable: field.repeatable,
+    // A blocks field's policy. Loading it is what makes writing it back
+    // meaningful: without this the outbound branch always sees undefined.
+    blocks: field.blocks,
   };
 
   // Nested fields

--- a/packages/admin/src/lib/builder/field-transformers.ts
+++ b/packages/admin/src/lib/builder/field-transformers.ts
@@ -238,6 +238,12 @@ export function convertToFieldDefinition(field: BuilderField): FieldDefinition {
     definition.fields = field.fields.map(convertToFieldDefinition);
   }
 
+  // A blocks field's policy. Rebuilding a field without it would silently
+  // widen it back to accepting every registered block.
+  if (field.blocks !== undefined) {
+    definition.blocks = field.blocks;
+  }
+
   // Options (select, radio)
   if (field.options && field.options.length > 0) {
     definition.options = field.options.map(opt => ({

--- a/packages/admin/src/lib/builder/to-manifest-entity.ts
+++ b/packages/admin/src/lib/builder/to-manifest-entity.ts
@@ -65,6 +65,8 @@ export interface BuilderFieldInput {
   mimeTypes?: string;
   maxFileSize?: number;
   labels?: { singular?: string; plural?: string };
+  /** A blocks field's accepted block names and document kinds. */
+  blocks?: { allow?: string[]; kinds?: string[] };
   initCollapsed?: boolean;
   rowLabelField?: string;
   component?: string;
@@ -123,6 +125,8 @@ export interface ManifestField {
   mimeTypes?: string;
   maxFileSize?: number;
   labels?: { singular?: string; plural?: string };
+  /** A blocks field's accepted block names and document kinds. */
+  blocks?: { allow?: string[]; kinds?: string[] };
   initCollapsed?: boolean;
   rowLabelField?: string;
   component?: string;
@@ -167,6 +171,9 @@ const PASSTHROUGH_KEYS = [
   "mimeTypes",
   "maxFileSize",
   "labels",
+  // A blocks field's policy: which registered blocks and document kinds it
+  // accepts. Dropped here, an unrelated schema save would widen the field.
+  "blocks",
   "initCollapsed",
   "rowLabelField",
   "component",

--- a/packages/admin/src/lib/builder/ui-schema-mode.test.ts
+++ b/packages/admin/src/lib/builder/ui-schema-mode.test.ts
@@ -29,6 +29,8 @@ describe("UI_SCHEMA_FIELD_TYPES", () => {
         "password",
         "radio",
         "repeater",
+        // a page built from blocks
+        "blocks",
       ].sort()
     );
   });

--- a/packages/admin/src/lib/builder/ui-schema-mode.ts
+++ b/packages/admin/src/lib/builder/ui-schema-mode.ts
@@ -37,6 +37,8 @@ export const UI_SCHEMA_FIELD_TYPES = [
   "component",
   "json",
   "chips",
+  // A page built from blocks.
+  "blocks",
 ] as const;
 
 export type UiSchemaFieldType = (typeof UI_SCHEMA_FIELD_TYPES)[number];

--- a/packages/admin/src/types/collection.ts
+++ b/packages/admin/src/types/collection.ts
@@ -123,6 +123,8 @@ export interface FieldDefinition {
   defaultValue?: unknown;
   /** Nested fields for container types (array, group, etc.) */
   fields?: FieldDefinition[];
+  /** A blocks field's accepted block names and document kinds. */
+  blocks?: { allow?: string[]; kinds?: string[] };
   /** Admin UI options for the field */
   admin?: FieldDefinitionAdmin;
   /** Validation rules for the field */

--- a/packages/nextly/AGENTS.md
+++ b/packages/nextly/AGENTS.md
@@ -22,7 +22,7 @@ inside `packages/nextly`.
   `.item`. There is no `docs`/`totalDocs` shape anywhere.
 - `overrideAccess` defaults to `true` (trusted server context). Enforcing
   access control requires `overrideAccess: false` plus a `user`.
-- The canonical `FieldType` union has 18 members and the structured-array
+- The canonical `FieldType` union has 19 members and the structured-array
   type is `repeater`; the `array()` factory is a backward-compat alias, use
   `repeater()` in new code. Surface-only types (`url`, `phone` for users;
   plus `file`, `time`, `hidden` for forms) are intentionally NOT in the

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -248,6 +248,7 @@
     "@clack/prompts": "^1.1.0",
     "@inquirer/prompts": "^7.3.2",
     "@nextlyhq/adapter-drizzle": "workspace:*",
+    "@nextlyhq/blocks-engine": "workspace:*",
     "bcryptjs": "^3.0.2",
     "chokidar": "^5.0.0",
     "commander": "^14.0.2",

--- a/packages/nextly/src/collections/__tests__/blocks-field.integration.test.ts
+++ b/packages/nextly/src/collections/__tests__/blocks-field.integration.test.ts
@@ -12,9 +12,10 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 
-import { blocks, defineCollection, text } from "../../config";
+import { blocks, defineCollection, defineSingle, text } from "../../config";
 import { createTestNextly, type TestNextly } from "../../plugins/test-nextly";
 import type { CollectionsHandler } from "../../services/collections-handler";
+import type { SingleEntryService } from "../../domains/singles/services/single-entry-service";
 
 let current: TestNextly | undefined;
 
@@ -51,10 +52,10 @@ const DOCUMENT = {
 /** The created entry's id, from the handler's result envelope. */
 function idOf(result: unknown): string {
   const data = (result as { data?: { id?: unknown } }).data;
-  if (typeof data?.id !== "string") {
-    throw new Error(`create did not return an id: ${JSON.stringify(result)}`);
-  }
-  return data.id;
+  // Asserted rather than thrown: a failed create then reports what came back
+  // instead of surfacing as an unrelated error from the helper.
+  expect(typeof data?.id, JSON.stringify(result)).toBe("string");
+  return String(data?.id);
 }
 
 /** The read entry's fields, from the handler's result envelope. */
@@ -155,6 +156,31 @@ describe("blocks field storage (integration)", () => {
       overrideAccess: true,
     });
     expect(dataOf(read).content ?? null).toBeNull();
+  });
+
+  it("round-trips a document on a single, not just a collection", async () => {
+    // Singles have their own JSON classifier and their own serialize/
+    // deserialize pair, so a collection round-trip proves nothing about them.
+    current = await createTestNextly({
+      singles: [
+        defineSingle({
+          slug: "homepage",
+          fields: [text({ name: "title" }), blocks({ name: "content" })],
+        }),
+      ],
+    });
+    const singles =
+      current.getService<SingleEntryService>("singleEntryService");
+
+    const written = await singles.update(
+      "homepage",
+      { title: "Home", content: DOCUMENT },
+      { overrideAccess: true }
+    );
+    expect((written as { success?: boolean }).success).toBe(true);
+
+    const read = await singles.get("homepage", { overrideAccess: true });
+    expect(dataOf(read).content).toEqual(DOCUMENT);
   });
 
   it("refuses a document the field does not accept", async () => {

--- a/packages/nextly/src/collections/__tests__/blocks-field.integration.test.ts
+++ b/packages/nextly/src/collections/__tests__/blocks-field.integration.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Storage round-trip for the blocks field.
+ *
+ * A page document is a nested tree stored as one JSON value, so the risk this
+ * suite covers is per-dialect: Postgres stores `jsonb`, MySQL `json`, and
+ * SQLite `text`, and each has its own parse-on-read behaviour. A document that
+ * comes back as a string, or with its nesting flattened, would break every
+ * renderer downstream while every unit test still passed.
+ *
+ * The suite self-skips on dialects whose URL is unset, per the integration
+ * convention; CI runs all three.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { blocks, defineCollection, text } from "../../config";
+import { createTestNextly, type TestNextly } from "../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../services/collections-handler";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+/** A document with nesting, styles, and slots — not a flat list of nodes. */
+const DOCUMENT = {
+  formatVersion: 1,
+  kind: "page",
+  nodes: [
+    {
+      id: "11111111-1111-4111-8111-111111111111",
+      type: "core/section",
+      version: 1,
+      props: { width: "wide" },
+      styles: { base: { base: { paddingBlockStart: "2rem" } } },
+      slots: {
+        default: [
+          {
+            id: "22222222-2222-4222-8222-222222222222",
+            type: "core/heading",
+            version: 1,
+            props: { text: "Hello", level: 2 },
+          },
+        ],
+      },
+    },
+  ],
+};
+
+/** The created entry's id, from the handler's result envelope. */
+function idOf(result: unknown): string {
+  const data = (result as { data?: { id?: unknown } }).data;
+  if (typeof data?.id !== "string") {
+    throw new Error(`create did not return an id: ${JSON.stringify(result)}`);
+  }
+  return data.id;
+}
+
+/** The read entry's fields, from the handler's result envelope. */
+function dataOf(result: unknown): Record<string, unknown> {
+  const data = (result as { data?: unknown }).data;
+  return (data ?? {}) as Record<string, unknown>;
+}
+
+async function handlerFor(): Promise<CollectionsHandler> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: "pages",
+        fields: [text({ name: "title" }), blocks({ name: "content" })],
+      }),
+    ],
+  });
+  return current.getService<CollectionsHandler>("collectionsHandler");
+}
+
+describe("blocks field storage (integration)", () => {
+  it("round-trips a nested document unchanged", async () => {
+    const handler = await handlerFor();
+
+    const created = await handler.createEntry(
+      { collectionName: "pages", userId: "u1", overrideAccess: true },
+      { title: "Home", content: DOCUMENT }
+    );
+
+    const read = await handler.getEntry({
+      collectionName: "pages",
+      entryId: idOf(created),
+      overrideAccess: true,
+    });
+
+    // Deep equality, not a shape check: nesting, slots, and style values must
+    // all survive the dialect's own JSON handling.
+    expect(dataOf(read).content).toEqual(DOCUMENT);
+  });
+
+  it("reads the document back as an object, never a JSON string", async () => {
+    const handler = await handlerFor();
+    const created = await handler.createEntry(
+      { collectionName: "pages", userId: "u1", overrideAccess: true },
+      { title: "Home", content: DOCUMENT }
+    );
+
+    const content = dataOf(
+      await handler.getEntry({
+        collectionName: "pages",
+        entryId: idOf(created),
+        overrideAccess: true,
+      })
+    ).content;
+
+    // SQLite stores JSON as text; a missing parse would surface here and
+    // nowhere else.
+    expect(typeof content).toBe("object");
+    expect(Array.isArray((content as { nodes: unknown[] }).nodes)).toBe(true);
+  });
+
+  it("updates a document in place", async () => {
+    const handler = await handlerFor();
+    const created = await handler.createEntry(
+      { collectionName: "pages", userId: "u1", overrideAccess: true },
+      { title: "Home", content: DOCUMENT }
+    );
+
+    const emptied = { formatVersion: 1, kind: "page", nodes: [] };
+    await handler.updateEntry(
+      {
+        collectionName: "pages",
+        entryId: idOf(created),
+        userId: "u1",
+        overrideAccess: true,
+      },
+      { content: emptied }
+    );
+
+    const read = await handler.getEntry({
+      collectionName: "pages",
+      entryId: idOf(created),
+      overrideAccess: true,
+    });
+    expect(dataOf(read).content).toEqual(emptied);
+  });
+
+  it("stores an absent document as null rather than inventing one", async () => {
+    const handler = await handlerFor();
+    const created = await handler.createEntry(
+      { collectionName: "pages", userId: "u1", overrideAccess: true },
+      { title: "No content" }
+    );
+
+    const read = await handler.getEntry({
+      collectionName: "pages",
+      entryId: idOf(created),
+      overrideAccess: true,
+    });
+    expect(dataOf(read).content ?? null).toBeNull();
+  });
+
+  it("refuses a document the field does not accept", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "pages",
+          fields: [
+            text({ name: "title" }),
+            blocks({ name: "content", blocks: { allow: ["core/*"] } }),
+          ],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const result = (await handler.createEntry(
+      { collectionName: "pages", userId: "u1", overrideAccess: true },
+      {
+        title: "Home",
+        content: {
+          formatVersion: 1,
+          kind: "page",
+          nodes: [
+            {
+              id: "33333333-3333-4333-8333-333333333333",
+              type: "acme/pricing",
+              version: 1,
+              props: {},
+            },
+          ],
+        },
+      }
+    )) as {
+      success: boolean;
+      committed: boolean;
+      errors?: Array<{ code: string; path: string }>;
+    };
+
+    expect(result.success).toBe(false);
+    // Nothing is written when the document is refused.
+    expect(result.committed).toBe(false);
+    expect(result.errors?.map(issue => issue.code)).toEqual([
+      "DISALLOWED_BLOCK_TYPE",
+    ]);
+    expect(result.errors?.[0]?.path).toBe("content");
+  });
+});

--- a/packages/nextly/src/collections/config/validate-config.blocks.test.ts
+++ b/packages/nextly/src/collections/config/validate-config.blocks.test.ts
@@ -107,6 +107,19 @@ describe.each(surfaces)("$name blocks field validation", ({ codesFor }) => {
     expect(codesFor(withPolicy(["core/*"]))).toContain("FIELD_TYPE_INVALID");
   });
 
+  it("reports a malformed policy without crashing on the default", () => {
+    // Two problems at once must still produce the error list this validator
+    // exists to return, not a raw TypeError from the policy check.
+    const field = withPolicy({ allow: "core/*" });
+    field.defaultValue = {
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "page",
+      nodes: [node("core/heading")],
+    };
+    expect(() => codesFor(field)).not.toThrow();
+    expect(codesFor(field)).toContain("FIELD_TYPE_INVALID");
+  });
+
   it("rejects a default whose kind the field does not accept", () => {
     expect(
       codesFor(

--- a/packages/nextly/src/collections/config/validate-config.blocks.test.ts
+++ b/packages/nextly/src/collections/config/validate-config.blocks.test.ts
@@ -1,0 +1,157 @@
+/**
+ * A blocks field's policy and default are checked when the config loads, so a
+ * field that could never hold a valid document is rejected at the declaration
+ * rather than at every write. The same rules apply wherever a blocks field can
+ * be declared, so collections, singles, and components are all covered here.
+ */
+import type { BlockNode } from "@nextlyhq/blocks-engine";
+import { DOCUMENT_FORMAT_VERSION } from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import type { ComponentConfig } from "../../components/config/define-component";
+import { validateComponentConfig } from "../../components/config/validate-component";
+import type { SingleConfig } from "../../singles/config/define-single";
+import { validateSingleConfig } from "../../singles/config/validate-single";
+import { blocks, text } from "../fields/helpers";
+import type { BlocksFieldConfig } from "../fields/types/blocks";
+import type { CollectionConfig } from "./define-collection";
+import { validateCollectionConfig } from "./validate-config";
+
+function collectionCodes(field: BlocksFieldConfig): string[] {
+  const config: CollectionConfig = {
+    slug: "pages",
+    fields: [text({ name: "title" }), field],
+  };
+  return validateCollectionConfig(config).errors.map(e => e.code);
+}
+
+function singleCodes(field: BlocksFieldConfig): string[] {
+  const config: SingleConfig = {
+    slug: "homepage",
+    fields: [text({ name: "title" }), field],
+  };
+  return validateSingleConfig(config).errors.map(e => e.code);
+}
+
+function componentCodes(field: BlocksFieldConfig): string[] {
+  const config: ComponentConfig = {
+    slug: "hero",
+    fields: [text({ name: "title" }), field],
+  };
+  return validateComponentConfig(config).errors.map(e => e.code);
+}
+
+function node(type: string): BlockNode {
+  return {
+    id: `11111111-1111-4111-8111-${type.length.toString().padStart(12, "0")}`,
+    type,
+    version: 1,
+    props: {},
+  };
+}
+
+const surfaces = [
+  { name: "collection", codesFor: collectionCodes },
+  { name: "single", codesFor: singleCodes },
+  { name: "component", codesFor: componentCodes },
+];
+
+describe.each(surfaces)("$name blocks field validation", ({ codesFor }) => {
+  it("accepts a field with no policy and no default", () => {
+    expect(codesFor(blocks({ name: "content" }))).toEqual([]);
+  });
+
+  it("rejects an empty kinds list", () => {
+    // A field accepting no kind at all can never hold a document, so the
+    // contradiction belongs in the declaration rather than in every write.
+    expect(
+      codesFor(blocks({ name: "content", blocks: { kinds: [] } }))
+    ).toContain("FIELD_TYPE_INVALID");
+  });
+
+  it("accepts a non-empty kinds list", () => {
+    expect(
+      codesFor(blocks({ name: "content", blocks: { kinds: ["template"] } }))
+    ).toEqual([]);
+  });
+
+  it("rejects a default whose kind the field does not accept", () => {
+    expect(
+      codesFor(
+        blocks({
+          name: "content",
+          blocks: { kinds: ["template"] },
+          defaultValue: {
+            formatVersion: DOCUMENT_FORMAT_VERSION,
+            kind: "page",
+            nodes: [],
+          },
+        })
+      )
+    ).toContain("FIELD_DEFAULT_INVALID");
+  });
+
+  it("rejects a default holding a block the allow-list excludes", () => {
+    expect(
+      codesFor(
+        blocks({
+          name: "content",
+          blocks: { allow: ["core/*"] },
+          defaultValue: {
+            formatVersion: DOCUMENT_FORMAT_VERSION,
+            kind: "page",
+            nodes: [node("marketing/banner")],
+          },
+        })
+      )
+    ).toContain("FIELD_DEFAULT_INVALID");
+  });
+
+  it("accepts a default holding a block the allow-list permits", () => {
+    expect(
+      codesFor(
+        blocks({
+          name: "content",
+          blocks: { allow: ["core/*"] },
+          defaultValue: {
+            formatVersion: DOCUMENT_FORMAT_VERSION,
+            kind: "page",
+            nodes: [node("core/heading")],
+          },
+        })
+      )
+    ).toEqual([]);
+  });
+
+  it("accepts a default whose kind the field accepts", () => {
+    expect(
+      codesFor(
+        blocks({
+          name: "content",
+          blocks: { kinds: ["template"] },
+          defaultValue: {
+            formatVersion: 1,
+            kind: "template",
+            nodes: [],
+          },
+        })
+      )
+    ).toEqual([]);
+  });
+
+  it("leaves a function default to the write path", () => {
+    // Resolved per entry, so there is no value to check at config time.
+    expect(
+      codesFor(
+        blocks({
+          name: "content",
+          defaultValue: () => ({
+            formatVersion: 1 as const,
+            kind: "page" as const,
+            nodes: [],
+          }),
+        })
+      )
+    ).toEqual([]);
+  });
+});

--- a/packages/nextly/src/collections/config/validate-config.blocks.test.ts
+++ b/packages/nextly/src/collections/config/validate-config.blocks.test.ts
@@ -50,6 +50,18 @@ function node(type: string): BlockNode {
   };
 }
 
+/**
+ * A policy the type system rejects, which is the point: these cases assert the
+ * runtime still refuses configurations TypeScript cannot express as valid.
+ */
+function withPolicy(policy: unknown): BlocksFieldConfig {
+  return {
+    name: "content",
+    type: "blocks",
+    blocks: policy,
+  } as BlocksFieldConfig;
+}
+
 const surfaces = [
   { name: "collection", codesFor: collectionCodes },
   { name: "single", codesFor: singleCodes },
@@ -73,6 +85,26 @@ describe.each(surfaces)("$name blocks field validation", ({ codesFor }) => {
     expect(
       codesFor(blocks({ name: "content", blocks: { kinds: ["template"] } }))
     ).toEqual([]);
+  });
+
+  it("rejects an unknown document kind", () => {
+    // The field-level check accepts a kind purely because it is listed here,
+    // so nothing downstream would ever reject it.
+    expect(codesFor(withPolicy({ kinds: ["nonsense"] }))).toContain(
+      "FIELD_TYPE_INVALID"
+    );
+  });
+
+  it("rejects a non-array allow list", () => {
+    // The write-time check calls `.some()` on it, so a wrong shape would crash
+    // every write rather than fail the configuration.
+    expect(codesFor(withPolicy({ allow: "core/*" }))).toContain(
+      "FIELD_TYPE_INVALID"
+    );
+  });
+
+  it("rejects a non-object policy", () => {
+    expect(codesFor(withPolicy(["core/*"]))).toContain("FIELD_TYPE_INVALID");
   });
 
   it("rejects a default whose kind the field does not accept", () => {

--- a/packages/nextly/src/collections/config/validate-config.ts
+++ b/packages/nextly/src/collections/config/validate-config.ts
@@ -35,6 +35,7 @@ import {
   validateNumberDecimalDimensionsShared,
   validateRelationshipTargetShared,
   validateBlocksDefaultShared,
+  validateBlocksPolicyShared,
   validateSelectOptionsShared,
   validateSlugShared,
 } from "../../shared/base-validator";
@@ -388,6 +389,7 @@ function validateField(
     case "radio":
       validateSelectOptionsShared(f, path, errsBase, "radio");
       // A blocks default must satisfy the same field policy the write applies.
+      validateBlocksPolicyShared(f, path, errsBase);
       validateBlocksDefaultShared(f, path, errsBase);
       break;
 

--- a/packages/nextly/src/collections/config/validate-config.ts
+++ b/packages/nextly/src/collections/config/validate-config.ts
@@ -83,6 +83,8 @@ export type ValidationErrorCode =
   | "FIELD_NAME_RESERVED"
   | "FIELD_TYPE_REQUIRED"
   | "FIELD_TYPE_INVALID"
+  // A declared default the field's own rules reject.
+  | "FIELD_DEFAULT_INVALID"
   // Field-specific errors
   | "SELECT_OPTIONS_REQUIRED"
   | "SELECT_OPTIONS_EMPTY"

--- a/packages/nextly/src/collections/config/validate-config.ts
+++ b/packages/nextly/src/collections/config/validate-config.ts
@@ -34,6 +34,7 @@ import {
   validateFieldTypeShared,
   validateNumberDecimalDimensionsShared,
   validateRelationshipTargetShared,
+  validateBlocksDefaultShared,
   validateSelectOptionsShared,
   validateSlugShared,
 } from "../../shared/base-validator";
@@ -386,6 +387,8 @@ function validateField(
 
     case "radio":
       validateSelectOptionsShared(f, path, errsBase, "radio");
+      // A blocks default must satisfy the same field policy the write applies.
+      validateBlocksDefaultShared(f, path, errsBase);
       break;
 
     case "relationship":

--- a/packages/nextly/src/collections/config/validate-config.ts
+++ b/packages/nextly/src/collections/config/validate-config.ts
@@ -388,6 +388,9 @@ function validateField(
 
     case "radio":
       validateSelectOptionsShared(f, path, errsBase, "radio");
+      break;
+
+    case "blocks":
       // A blocks default must satisfy the same field policy the write applies.
       validateBlocksPolicyShared(f, path, errsBase);
       validateBlocksDefaultShared(f, path, errsBase);

--- a/packages/nextly/src/collections/fields/blocks-document.ts
+++ b/packages/nextly/src/collections/fields/blocks-document.ts
@@ -1,0 +1,49 @@
+/**
+ * The empty page document, in one place.
+ *
+ * Several paths need a starting value for a blocks field that has no declared
+ * default: a single auto-created on first read, a required column added to an
+ * existing table, and the admin's create form. The generic `{}` every other
+ * JSON-backed type falls back to is not a document — it carries no
+ * `formatVersion`, `kind`, or `nodes` — so a field seeded with it would hold a
+ * value its own validator rejects.
+ *
+ * @module collections/fields/blocks-document
+ */
+
+import type { BlockDocument, DocumentKind } from "@nextlyhq/blocks-engine";
+import { DOCUMENT_FORMAT_VERSION } from "@nextlyhq/blocks-engine";
+
+/** What a field holds when it says nothing about which kinds it accepts. */
+const DEFAULT_KIND: DocumentKind = "page";
+
+/**
+ * An empty document of a kind the field accepts.
+ *
+ * The kind matters: a field declaring `kinds: ["template"]` would reject a
+ * `page` document, so seeding one would put a value in the field that its own
+ * policy forbids. When the field accepts several kinds, `page` wins if it is
+ * among them — a collection field almost always means its entry's own page —
+ * and otherwise the first accepted kind is used.
+ */
+export function emptyBlockDocument(
+  kinds?: readonly DocumentKind[]
+): BlockDocument {
+  return {
+    formatVersion: DOCUMENT_FORMAT_VERSION,
+    kind: pickKind(kinds),
+    nodes: [],
+  };
+}
+
+/** The same document, serialized for the paths that store JSON as text. */
+export function emptyBlockDocumentJson(
+  kinds?: readonly DocumentKind[]
+): string {
+  return JSON.stringify(emptyBlockDocument(kinds));
+}
+
+function pickKind(kinds?: readonly DocumentKind[]): DocumentKind {
+  if (!kinds || kinds.length === 0) return DEFAULT_KIND;
+  return kinds.includes(DEFAULT_KIND) ? DEFAULT_KIND : kinds[0];
+}

--- a/packages/nextly/src/collections/fields/blocks-document.ts
+++ b/packages/nextly/src/collections/fields/blocks-document.ts
@@ -44,6 +44,11 @@ export function emptyBlockDocumentJson(
 }
 
 function pickKind(kinds?: readonly DocumentKind[]): DocumentKind {
+  // Omitting `kinds` means the field takes a page. An empty list means it
+  // accepts nothing, which no document can satisfy — the validator reads it
+  // that way, so seeding a page here would hand back a value the same field
+  // rejects. The page is still returned as the only sane placeholder, and the
+  // field's own validation is what surfaces the contradiction.
   if (!kinds || kinds.length === 0) return DEFAULT_KIND;
   return kinds.includes(DEFAULT_KIND) ? DEFAULT_KIND : kinds[0];
 }

--- a/packages/nextly/src/collections/fields/catalog.test.ts
+++ b/packages/nextly/src/collections/fields/catalog.test.ts
@@ -131,12 +131,12 @@ describe("FORM_FIELD_TYPE_CATALOG", () => {
 });
 
 describe("BLOCK_FIELD_TYPE_CATALOG", () => {
-  it("is the canonical catalog minus password and component", () => {
+  it("is the canonical catalog minus password, component, and blocks", () => {
     const types = BLOCK_FIELD_TYPE_CATALOG.map(entry => entry.type);
     expect(new Set(types).size).toBe(types.length);
     expect([...types].sort()).toEqual(
       ALL_FIELD_TYPES.filter(
-        type => type !== "password" && type !== "component"
+        type => type !== "password" && type !== "component" && type !== "blocks"
       ).sort()
     );
   });
@@ -154,6 +154,16 @@ describe("BLOCK_FIELD_TYPE_CATALOG", () => {
         (BLOCK_FIELD_TYPES as readonly string[]).includes(type)
       )
     );
+  });
+
+  it("keeps the blocks field out of the block-prop surface", () => {
+    // A prop holding a whole nested document is what slots already express.
+    expect(isBlockFieldType("blocks")).toBe(false);
+    expect(
+      BLOCK_FIELD_TYPE_CATALOG.some(entry => entry.type === "blocks")
+    ).toBe(false);
+    // It is still a real field type, describable by the canonical catalog.
+    expect(getFieldTypeCatalogEntry("blocks")?.category).toBe("Structured");
   });
 
   it("recognizes block prop types and rejects everything else", () => {

--- a/packages/nextly/src/collections/fields/catalog.ts
+++ b/packages/nextly/src/collections/fields/catalog.ts
@@ -177,6 +177,13 @@ export const FIELD_TYPE_CATALOG: readonly FieldTypeCatalogEntry[] = [
     hint: "Embed a reusable component",
     icon: "Puzzle",
   },
+  {
+    type: "blocks",
+    label: "Blocks",
+    category: "Structured",
+    hint: "Page built from blocks",
+    icon: "LayoutGrid",
+  },
 ];
 
 /**
@@ -350,13 +357,16 @@ export const FORM_FIELD_TYPE_CATALOG: readonly FieldTypeCatalogEntry<FormFieldCa
  * - `component` is excluded because reusable composition inside a block
  *   document happens through slots and component-instance nodes; admitting the
  *   component field type as well would give one concept two storage shapes.
+ * - `blocks` is excluded because a prop holding a whole nested document is
+ *   what slots already express, and nesting documents inside documents would
+ *   put two migration boundaries in one value.
  *
  * Link-shaped props keep using `text` until the dedicated link picker joins
  * the catalog with its admin component.
  */
 export type BlockFieldCatalogType = Exclude<
   FieldType,
-  "password" | "component"
+  "password" | "component" | "blocks"
 >;
 
 /** Every block-prop field type, in catalog order. */
@@ -467,6 +477,7 @@ export const FIELD_TYPE_BINDING_KIND: Readonly<
   json: "json",
   component: null,
   chips: "list",
+  blocks: null,
 };
 
 /**

--- a/packages/nextly/src/collections/fields/guards.ts
+++ b/packages/nextly/src/collections/fields/guards.ts
@@ -30,6 +30,7 @@ import type {
   // Structured field types
   RepeaterFieldConfig,
   GroupFieldConfig,
+  BlocksFieldConfig,
   JSONFieldConfig,
   // Component field types
   ComponentFieldConfig,
@@ -293,6 +294,18 @@ export const isGroupField = createTypeGuard<GroupFieldConfig>("group");
  * ```
  */
 export const isJSONField = createTypeGuard<JSONFieldConfig>("json");
+
+/**
+ * Type guard for blocks fields.
+ *
+ * @example
+ * ```typescript
+ * if (isBlocksField(field)) {
+ *   // field is BlocksFieldConfig
+ * }
+ * ```
+ */
+export const isBlocksField = createTypeGuard<BlocksFieldConfig>("blocks");
 
 // ============================================================
 // Individual Type Guards - Component Fields

--- a/packages/nextly/src/collections/fields/helpers.ts
+++ b/packages/nextly/src/collections/fields/helpers.ts
@@ -50,6 +50,7 @@ import type {
   // Structured field types
   RepeaterFieldConfig,
   GroupFieldConfig,
+  BlocksFieldConfig,
   JSONFieldConfig,
   // Component field types
   ComponentFieldConfig,
@@ -605,6 +606,24 @@ export const group = (
  * })
  * ```
  */
+/**
+ * Creates a blocks field configuration.
+ *
+ * Holds one page-builder document. The block types it accepts are whichever
+ * are registered for the app, optionally narrowed by `blocks.allow`.
+ *
+ * @example
+ * ```typescript
+ * blocks({ name: 'content', blocks: { allow: ['core/*'] } })
+ * ```
+ */
+export const blocks = (
+  config: Omit<BlocksFieldConfig, "type">
+): BlocksFieldConfig => ({
+  ...config,
+  type: "blocks",
+});
+
 export const json = (
   config: Omit<JSONFieldConfig, "type">
 ): JSONFieldConfig => ({

--- a/packages/nextly/src/collections/fields/types/base.ts
+++ b/packages/nextly/src/collections/fields/types/base.ts
@@ -54,6 +54,8 @@ export type FieldType =
   | "json"
   // Component types
   | "component"
+  // Page-builder document
+  | "blocks"
   // Array-like types
   | "chips";
 

--- a/packages/nextly/src/collections/fields/types/blocks.ts
+++ b/packages/nextly/src/collections/fields/types/blocks.ts
@@ -5,9 +5,10 @@
  * their props, styles, and slots, stored as a single JSON value.
  *
  * The block TYPES a document may use are not declared here. They are
- * registered once for the whole app (`defineBlock` plus a plugin's
- * `contributes.blocks`), and a field only narrows which of the registered
- * blocks it will accept. Declaring block shapes on the field instead would
+ * registered once for the whole app with `defineBlock`, and a field only
+ * narrows which of the registered blocks it will accept. (The plugin
+ * contribution key that feeds that registry at boot is not wired yet, so for
+ * now `allow` narrows a set nothing has populated.) Declaring block shapes on the field instead would
  * mean the same block described differently in two collections, with no way to
  * migrate either — the reason the field carries an allow-list of names rather
  * than definitions.

--- a/packages/nextly/src/collections/fields/types/blocks.ts
+++ b/packages/nextly/src/collections/fields/types/blocks.ts
@@ -1,0 +1,112 @@
+/**
+ * Blocks Field Type Definitions
+ *
+ * A blocks field holds one page-builder document: a tree of block nodes with
+ * their props, styles, and slots, stored as a single JSON value.
+ *
+ * The block TYPES a document may use are not declared here. They are
+ * registered once for the whole app (`defineBlock` plus a plugin's
+ * `contributes.blocks`), and a field only narrows which of the registered
+ * blocks it will accept. Declaring block shapes on the field instead would
+ * mean the same block described differently in two collections, with no way to
+ * migrate either — the reason the field carries an allow-list of names rather
+ * than definitions.
+ *
+ * @module collections/fields/types/blocks
+ */
+
+import type { BlockDocument, DocumentKind } from "@nextlyhq/blocks-engine";
+
+import type {
+  BaseFieldConfig,
+  FieldAdminOptions,
+  RequestContext,
+} from "./base";
+
+// Re-exported so the field layer names document kinds without every consumer
+// reaching into the engine package.
+export type { DocumentKind };
+
+/**
+ * The value a blocks field holds: a whole document envelope, not a bare list
+ * of nodes. The envelope carries the format version every stored document is
+ * migrated from and the kind that says what the document is for, so both
+ * travel with the value instead of having to be inferred later.
+ */
+export type BlocksFieldValue = BlockDocument | null | undefined;
+
+/** Which blocks and which document kinds a field accepts. */
+export interface BlocksFieldOptions {
+  /**
+   * Registered block names this field accepts, e.g. `["core/heading",
+   * "core/section"]`. A trailing `*` matches a namespace (`"core/*"`).
+   * Omitted means every registered block is allowed.
+   */
+  allow?: string[];
+
+  /**
+   * Document kinds this field accepts. Omitted means `["page"]`: a field on a
+   * collection or single holds that entry's own page content. The wider set
+   * exists for the builder's own document storage, where patterns, components,
+   * regions, and templates live alongside pages.
+   */
+  kinds?: DocumentKind[];
+}
+
+/** Admin options for a blocks field. */
+export interface BlocksFieldAdminOptions extends FieldAdminOptions {
+  /**
+   * Open the entry in the page builder rather than the form when the entry is
+   * first opened. The form stays reachable either way; this only decides which
+   * view is shown first.
+   */
+  defaultMode?: "form" | "builder";
+}
+
+/**
+ * Configuration for a blocks field.
+ *
+ * @example
+ * ```typescript
+ * const field: BlocksFieldConfig = {
+ *   name: 'content',
+ *   type: 'blocks',
+ *   blocks: { allow: ['core/*'] },
+ * };
+ * ```
+ */
+export interface BlocksFieldConfig
+  extends Omit<
+    BaseFieldConfig,
+    "type" | "validate" | "defaultValue" | "admin"
+  > {
+  /**
+   * Field type identifier. Must be 'blocks'.
+   */
+  type: "blocks";
+
+  /**
+   * Which blocks and document kinds this field accepts.
+   */
+  blocks?: BlocksFieldOptions;
+
+  /**
+   * Default document for a new entry.
+   */
+  defaultValue?:
+    | BlocksFieldValue
+    | ((data: Record<string, unknown>) => BlocksFieldValue);
+
+  /**
+   * Admin UI configuration.
+   */
+  admin?: BlocksFieldAdminOptions;
+
+  /**
+   * Custom validation, run after the document's own structural rules.
+   */
+  validate?: (
+    value: BlocksFieldValue,
+    args: { data: Record<string, unknown>; req: RequestContext }
+  ) => string | true | Promise<string | true>;
+}

--- a/packages/nextly/src/collections/fields/types/blocks.ts
+++ b/packages/nextly/src/collections/fields/types/blocks.ts
@@ -53,16 +53,6 @@ export interface BlocksFieldOptions {
   kinds?: DocumentKind[];
 }
 
-/** Admin options for a blocks field. */
-export interface BlocksFieldAdminOptions extends FieldAdminOptions {
-  /**
-   * Open the entry in the page builder rather than the form when the entry is
-   * first opened. The form stays reachable either way; this only decides which
-   * view is shown first.
-   */
-  defaultMode?: "form" | "builder";
-}
-
 /**
  * Configuration for a blocks field.
  *
@@ -100,7 +90,7 @@ export interface BlocksFieldConfig
   /**
    * Admin UI configuration.
    */
-  admin?: BlocksFieldAdminOptions;
+  admin?: FieldAdminOptions;
 
   /**
    * Custom validation, run after the document's own structural rules.

--- a/packages/nextly/src/collections/fields/types/index.ts
+++ b/packages/nextly/src/collections/fields/types/index.ts
@@ -13,6 +13,7 @@
 // ============================================================
 
 import type { FieldType } from "./base";
+import type { BlocksFieldConfig } from "./blocks";
 import type { CheckboxFieldConfig } from "./checkbox";
 import type { ChipsFieldConfig } from "./chips";
 import type { CodeFieldConfig } from "./code";
@@ -63,6 +64,7 @@ export * from "./group";
 
 // Component field types
 export * from "./component";
+export * from "./blocks";
 
 // Array-like field types
 export * from "./chips";
@@ -101,7 +103,8 @@ export type DataFieldConfig =
   | GroupFieldConfig
   | JSONFieldConfig
   | ComponentFieldConfig
-  | ChipsFieldConfig;
+  | ChipsFieldConfig
+  | BlocksFieldConfig;
 
 /**
  * Alias for FieldConfig — all fields store data in the database.
@@ -137,7 +140,8 @@ export type DataFieldType =
   | "group"
   | "json"
   | "component"
-  | "chips";
+  | "chips"
+  | "blocks";
 
 /**
  * Array of all supported field types.
@@ -171,6 +175,7 @@ export const DATA_FIELD_TYPES: readonly DataFieldType[] = [
   "json",
   "component",
   "chips",
+  "blocks",
 ] as const;
 
 /**

--- a/packages/nextly/src/collections/fields/types/index.ts
+++ b/packages/nextly/src/collections/fields/types/index.ts
@@ -104,6 +104,7 @@ export type DataFieldConfig =
   | JSONFieldConfig
   | ComponentFieldConfig
   | ChipsFieldConfig
+  // A page built from blocks, stored as one document.
   | BlocksFieldConfig;
 
 /**
@@ -141,6 +142,7 @@ export type DataFieldType =
   | "json"
   | "component"
   | "chips"
+  // A page built from blocks, stored as one JSON document.
   | "blocks";
 
 /**
@@ -175,6 +177,7 @@ export const DATA_FIELD_TYPES: readonly DataFieldType[] = [
   "json",
   "component",
   "chips",
+  // A page built from blocks; storage is JSON, like the other structured types.
   "blocks",
 ] as const;
 

--- a/packages/nextly/src/collections/fields/validators/blocks-validator.blocks.test.ts
+++ b/packages/nextly/src/collections/fields/validators/blocks-validator.blocks.test.ts
@@ -1,0 +1,70 @@
+/**
+ * `BlockNode.props` is `Record<string, unknown>`, so a server-side or Direct
+ * API caller can put values there that the JSON column cannot hold. The write
+ * path stringifies the document, where a bigint throws and a function or
+ * symbol is silently dropped, so the check belongs before the value is
+ * accepted rather than after it reaches the serializer.
+ */
+import { DOCUMENT_FORMAT_VERSION } from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import { validateBlocksValue } from "./blocks-validator";
+
+function withProps(props: Record<string, unknown>) {
+  return {
+    formatVersion: DOCUMENT_FORMAT_VERSION,
+    kind: "page",
+    nodes: [
+      {
+        id: "11111111-1111-4111-8111-111111111111",
+        type: "core/heading",
+        version: 1,
+        props,
+      },
+    ],
+  };
+}
+
+const codes = (value: unknown) =>
+  validateBlocksValue(value, "content", "content", {}).map(i => i.code);
+
+describe("unserializable values in a document", () => {
+  it("accepts ordinary JSON values", () => {
+    expect(
+      codes(withProps({ text: "hi", n: 1, b: true, o: { a: [1, 2] } }))
+    ).toEqual([]);
+  });
+
+  it("rejects a bigint, which the write path would throw on", () => {
+    expect(codes(withProps({ count: 1n }))).toContain("UNSERIALIZABLE_VALUE");
+  });
+
+  it("rejects a function and a symbol, which would be dropped silently", () => {
+    expect(codes(withProps({ fn: () => 1 }))).toContain("UNSERIALIZABLE_VALUE");
+    expect(codes(withProps({ s: Symbol("x") }))).toContain(
+      "UNSERIALIZABLE_VALUE"
+    );
+  });
+
+  it("names every offending key rather than stopping at the first", () => {
+    const issues = validateBlocksValue(
+      withProps({ a: 1n, b: 2n }),
+      "content",
+      "content",
+      {}
+    );
+    expect(issues[0].message).toContain("a");
+    expect(issues[0].message).toContain("b");
+  });
+
+  it("rejects a circular document without throwing", () => {
+    // The engine's size check reaches this first and reports it under its own
+    // code; what matters here is that a cycle is refused rather than raised.
+    const doc = withProps({}) as Record<string, unknown>;
+    doc.self = doc;
+    expect(() =>
+      validateBlocksValue(doc, "content", "content", {})
+    ).not.toThrow();
+    expect(codes(doc).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/nextly/src/collections/fields/validators/blocks-validator.test.ts
+++ b/packages/nextly/src/collections/fields/validators/blocks-validator.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+
+import { validateBlocksValue } from "./blocks-validator";
+
+/** A minimal valid page document. */
+function page(nodes: unknown[] = []) {
+  return { formatVersion: 1, kind: "page", nodes };
+}
+
+/** A node the engine accepts structurally. */
+function node(type: string, id: string) {
+  return { id, type, version: 1, props: {} };
+}
+
+describe("validateBlocksValue", () => {
+  it("accepts an absent document, leaving required-ness to the shared rules", () => {
+    expect(validateBlocksValue(null, "content", "Content", {})).toEqual([]);
+    expect(validateBlocksValue(undefined, "content", "Content", {})).toEqual(
+      []
+    );
+  });
+
+  it("accepts a well-formed page document", () => {
+    expect(
+      validateBlocksValue(
+        page([node("core/heading", "11111111-1111-4111-8111-111111111111")]),
+        "content",
+        "Content",
+        {}
+      )
+    ).toEqual([]);
+  });
+
+  it("rejects a value that is not a document", () => {
+    for (const value of ["text", 42, [], true]) {
+      const issues = validateBlocksValue(value, "content", "Content", {});
+      expect(issues.map(issue => issue.code)).toEqual(["INVALID_TYPE"]);
+    }
+  });
+
+  it("reports the engine's own codes rather than a second vocabulary", () => {
+    const issues = validateBlocksValue(
+      { formatVersion: 1, kind: "page", nodes: "not-a-list" },
+      "content",
+      "Content",
+      {}
+    );
+    expect(issues.length).toBeGreaterThan(0);
+    // Kebab-case codes come from the engine's documented issue vocabulary.
+    expect(issues[0]?.code).toMatch(/^[a-z][a-z-]+$/);
+  });
+
+  it("addresses issues to the field, with the position in the message", () => {
+    const issues = validateBlocksValue(
+      page([{ id: "", type: "core/heading", version: 1, props: {} }]),
+      "content",
+      "Content",
+      {}
+    );
+    expect(issues.length).toBeGreaterThan(0);
+    // The admin renders a blocks field as one control, so every issue lands on
+    // the field; the document pointer travels in the message.
+    for (const issue of issues) {
+      expect(issue.path).toBe("content");
+      expect(issue.message.startsWith("Content")).toBe(true);
+    }
+  });
+
+  describe("document kind", () => {
+    it("accepts only page documents by default", () => {
+      const issues = validateBlocksValue(
+        { formatVersion: 1, kind: "pattern", nodes: [] },
+        "content",
+        "Content",
+        {}
+      );
+      expect(issues.map(issue => issue.code)).toContain(
+        "DISALLOWED_DOCUMENT_KIND"
+      );
+    });
+
+    it("accepts the kinds a field declares", () => {
+      expect(
+        validateBlocksValue(
+          { formatVersion: 1, kind: "pattern", nodes: [] },
+          "content",
+          "Content",
+          { kinds: ["page", "pattern"] }
+        )
+      ).toEqual([]);
+    });
+  });
+
+  describe("allowed block types", () => {
+    const doc = page([
+      node("core/heading", "11111111-1111-4111-8111-111111111111"),
+      node("acme/pricing", "22222222-2222-4222-8222-222222222222"),
+    ]);
+
+    it("permits every block when the field names none", () => {
+      expect(validateBlocksValue(doc, "content", "Content", {})).toEqual([]);
+    });
+
+    it("rejects a block the field does not accept", () => {
+      const issues = validateBlocksValue(doc, "content", "Content", {
+        allow: ["core/heading"],
+      });
+      expect(issues.map(issue => issue.code)).toEqual([
+        "DISALLOWED_BLOCK_TYPE",
+      ]);
+      expect(issues[0]?.message).toContain("acme/pricing");
+    });
+
+    it("matches a namespace through a trailing star", () => {
+      expect(
+        validateBlocksValue(doc, "content", "Content", {
+          allow: ["core/*", "acme/*"],
+        })
+      ).toEqual([]);
+      const issues = validateBlocksValue(doc, "content", "Content", {
+        allow: ["core/*"],
+      });
+      expect(issues[0]?.message).toContain("acme/pricing");
+    });
+
+    it("names every disallowed type once, sorted", () => {
+      const many = page([
+        node("acme/b", "11111111-1111-4111-8111-111111111111"),
+        node("acme/a", "22222222-2222-4222-8222-222222222222"),
+        node("acme/b", "33333333-3333-4333-8333-333333333333"),
+      ]);
+      const issues = validateBlocksValue(many, "content", "Content", {
+        allow: ["core/*"],
+      });
+      expect(issues[0]?.message).toContain("acme/a, acme/b");
+    });
+
+    it("reaches blocks nested inside slots", () => {
+      const nested = page([
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          type: "core/section",
+          version: 1,
+          props: {},
+          slots: {
+            default: [
+              node("acme/pricing", "22222222-2222-4222-8222-222222222222"),
+            ],
+          },
+        },
+      ]);
+      const issues = validateBlocksValue(nested, "content", "Content", {
+        allow: ["core/*"],
+      });
+      expect(issues.map(issue => issue.code)).toEqual([
+        "DISALLOWED_BLOCK_TYPE",
+      ]);
+    });
+  });
+
+  it("caps how many issues one field reports and says how many it withheld", () => {
+    // Every node carries the same defect, so the document produces far more
+    // issues than a writer could act on.
+    const broken = page(
+      Array.from({ length: 40 }, () => ({
+        id: "",
+        type: "core/heading",
+        version: 1,
+        props: {},
+      }))
+    );
+    const issues = validateBlocksValue(broken, "content", "Content", {});
+    expect(issues.length).toBe(21);
+    expect(issues.at(-1)?.code).toBe("TOO_MANY_ISSUES");
+    expect(issues.at(-1)?.message).toMatch(/further problems? not listed/);
+  });
+
+  it("does not throw on a hostile document", () => {
+    const hostile: Record<string, unknown> = { formatVersion: 1, kind: "page" };
+    hostile.nodes = [{ id: "a", type: "core/x", version: 1, props: hostile }];
+    expect(() =>
+      validateBlocksValue(hostile, "content", "Content", {})
+    ).not.toThrow();
+  });
+});

--- a/packages/nextly/src/collections/fields/validators/blocks-validator.test.ts
+++ b/packages/nextly/src/collections/fields/validators/blocks-validator.test.ts
@@ -158,6 +158,40 @@ describe("validateBlocksValue", () => {
     });
   });
 
+  it("treats an empty allow-list as permitting nothing", () => {
+    // Omitting `allow` and declaring `allow: []` are different statements;
+    // reading them the same way would ignore the stricter one.
+    const issues = validateBlocksValue(
+      page([node("core/heading", "11111111-1111-4111-8111-111111111111")]),
+      "content",
+      "Content",
+      { allow: [] }
+    );
+    expect(issues.map(issue => issue.code)).toEqual(["DISALLOWED_BLOCK_TYPE"]);
+    expect(issues[0]?.message).toContain("Accepted: none");
+  });
+
+  it("does not walk a document the engine already rejected", () => {
+    // A malformed node would throw inside the allow-list walk, turning a
+    // rejected document into a server error.
+    for (const nodes of [[null], [42], ["text"], [{ id: "a" }]]) {
+      expect(() =>
+        validateBlocksValue(page(nodes), "content", "Content", {
+          allow: ["core/*"],
+        })
+      ).not.toThrow();
+      const issues = validateBlocksValue(page(nodes), "content", "Content", {
+        allow: ["core/*"],
+      });
+      // The structural failure is reported; the allow-list rule stays quiet
+      // until there is a well-formed tree to check.
+      expect(issues.length).toBeGreaterThan(0);
+      expect(issues.map(issue => issue.code)).not.toContain(
+        "DISALLOWED_BLOCK_TYPE"
+      );
+    }
+  });
+
   it("caps how many issues one field reports and says how many it withheld", () => {
     // Every node carries the same defect, so the document produces far more
     // issues than a writer could act on.

--- a/packages/nextly/src/collections/fields/validators/blocks-validator.ts
+++ b/packages/nextly/src/collections/fields/validators/blocks-validator.ts
@@ -104,6 +104,7 @@ export function validateBlocksValue(
   // throw here and turn a rejected document into a server error.
   if (documentIssues.length === 0) {
     issues.push(...disallowedBlockIssues(doc, path, label, options));
+    issues.push(...unserializableIssues(doc, path, label));
   }
 
   if (issues.length <= MAX_REPORTED_ISSUES) return issues;
@@ -114,6 +115,54 @@ export function validateBlocksValue(
       path,
       code: "TOO_MANY_ISSUES",
       message: `${label} has ${withheld} further problem${withheld === 1 ? "" : "s"} not listed here.`,
+    },
+  ];
+}
+
+/**
+ * Whether every value in the document survives being stored.
+ *
+ * `BlockNode.props` is `Record<string, unknown>`, so a server-side or Direct
+ * API caller can put anything there. The column is JSON, and the write path
+ * stringifies the document on the way in: a bigint throws, while a function,
+ * a symbol, or a cycle is dropped or throws instead. Catching it here turns
+ * what would be a raw serializer error, or a document silently missing values
+ * the caller supplied, into an ordinary rejection naming the key.
+ */
+function unserializableIssues(
+  doc: BlockDocument,
+  path: string,
+  label: string
+): Issue[] {
+  const offending = new Set<string>();
+  try {
+    JSON.stringify(doc, (key, value: unknown) => {
+      const type = typeof value;
+      if (type === "bigint" || type === "function" || type === "symbol") {
+        offending.add(`${key || "(root)"} (${type})`);
+        // Replaced so the walk continues and reports every offending key
+        // rather than stopping at the first bigint.
+        return undefined;
+      }
+      return value;
+    });
+  } catch {
+    // A cycle is the remaining way stringify fails, and it has no single key
+    // to name.
+    return [
+      {
+        path,
+        code: "UNSERIALIZABLE_VALUE",
+        message: `${label} contains a circular reference and cannot be stored.`,
+      },
+    ];
+  }
+  if (offending.size === 0) return [];
+  return [
+    {
+      path,
+      code: "UNSERIALIZABLE_VALUE",
+      message: `${label} contains values that cannot be stored as JSON: ${[...offending].join(", ")}.`,
     },
   ];
 }

--- a/packages/nextly/src/collections/fields/validators/blocks-validator.ts
+++ b/packages/nextly/src/collections/fields/validators/blocks-validator.ts
@@ -1,0 +1,169 @@
+/**
+ * Server-side validation for a blocks field value.
+ *
+ * The document format has one validator, and it lives in the engine. This
+ * module adapts it to the field system rather than restating any of its rules:
+ * it hands the stored value to `validate()` and translates what comes back
+ * into the issue shape the write path already reports.
+ *
+ * Two rules do belong here, because they are properties of the FIELD rather
+ * than of the document: which document kinds this field accepts, and which of
+ * the registered block types it permits. A document that is perfectly valid on
+ * its own can still be wrong for the field it was written to.
+ *
+ * Block-type EXISTENCE is deliberately not checked here. That needs the boot
+ * registry, which nothing populates until plugins contribute their blocks, and
+ * checking against an empty registry would reject every document.
+ *
+ * @module collections/fields/validators/blocks-validator
+ */
+
+import type { BlockDocument, BreakpointSet } from "@nextlyhq/blocks-engine";
+import { validate, walkNodes } from "@nextlyhq/blocks-engine";
+
+import type { ValidationPublicData } from "../../../errors/public-data";
+import type { DocumentKind } from "../types/blocks";
+
+type Issue = ValidationPublicData["errors"][number];
+
+/** The field options this validator reads, in their loosest usable form. */
+export interface BlocksValidationOptions {
+  /** Registered block names allowed; a trailing `*` matches a namespace. */
+  allow?: string[];
+  /** Document kinds accepted; defaults to page-only. */
+  kinds?: DocumentKind[];
+}
+
+/**
+ * Breakpoints are site-level data owned by the page-builder plugin, and the
+ * engine never reads storage, so core validates against an empty set. A
+ * document referencing a breakpoint id therefore warns rather than errors
+ * until the plugin supplies the real set — which is the arrangement that keeps
+ * the engine storage-agnostic.
+ */
+const NO_BREAKPOINTS: BreakpointSet = { viewport: [], container: [] };
+
+/** What a field accepts when it says nothing: its own entry's page content. */
+const DEFAULT_KINDS: readonly DocumentKind[] = ["page"];
+
+/**
+ * How many document issues one field reports. A document may hold thousands of
+ * nodes, and a writer cannot act on thousands of messages; the count of what
+ * was withheld is reported instead so the total is never misrepresented.
+ */
+const MAX_REPORTED_ISSUES = 20;
+
+/**
+ * Validate one blocks field value. Returns issues addressed to `path`, the
+ * field's own location, because the admin renders a blocks field as a single
+ * control — the position inside the document travels in the message.
+ */
+export function validateBlocksValue(
+  value: unknown,
+  path: string,
+  label: string,
+  options: BlocksValidationOptions
+): Issue[] {
+  // An absent document is an empty field. Required-ness is the shared rules'
+  // to enforce, exactly as for every other type.
+  if (value === null || value === undefined) return [];
+
+  if (typeof value !== "object" || Array.isArray(value)) {
+    return [
+      {
+        path,
+        code: "INVALID_TYPE",
+        message: `${label} must be a page document.`,
+      },
+    ];
+  }
+
+  const doc = value as BlockDocument;
+  const issues: Issue[] = [];
+
+  // The engine owns every structural rule: ids, depth, node and byte caps,
+  // slot legality, the kind enum, binding and style shapes.
+  const documentIssues = validate(doc, {
+    breakpoints: NO_BREAKPOINTS,
+    mode: "forgiving",
+  }).filter(issue => issue.severity === "error");
+
+  for (const issue of documentIssues) {
+    issues.push({
+      path,
+      // The engine's codes are the documented repair vocabulary. Translating
+      // them into a second dialect here would give one defect two names.
+      code: issue.code,
+      message: `${label}${issue.path}: ${issue.message}`,
+    });
+  }
+
+  issues.push(...kindIssues(doc, path, label, options));
+  issues.push(...disallowedBlockIssues(doc, path, label, options));
+
+  if (issues.length <= MAX_REPORTED_ISSUES) return issues;
+  const withheld = issues.length - MAX_REPORTED_ISSUES;
+  return [
+    ...issues.slice(0, MAX_REPORTED_ISSUES),
+    {
+      path,
+      code: "TOO_MANY_ISSUES",
+      message: `${label} has ${withheld} further problem${withheld === 1 ? "" : "s"} not listed here.`,
+    },
+  ];
+}
+
+/** Whether the document is the kind of thing this field holds. */
+function kindIssues(
+  doc: BlockDocument,
+  path: string,
+  label: string,
+  options: BlocksValidationOptions
+): Issue[] {
+  const kinds = options.kinds ?? DEFAULT_KINDS;
+  if (typeof doc.kind !== "string" || kinds.includes(doc.kind)) return [];
+  return [
+    {
+      path,
+      code: "DISALLOWED_DOCUMENT_KIND",
+      message: `${label} does not accept a ${doc.kind} document. Accepted: ${kinds.join(", ")}.`,
+    },
+  ];
+}
+
+/** Which block types the field permits, independent of which ones exist. */
+function disallowedBlockIssues(
+  doc: BlockDocument,
+  path: string,
+  label: string,
+  options: BlocksValidationOptions
+): Issue[] {
+  const allow = options.allow;
+  if (!allow || allow.length === 0) return [];
+  if (!Array.isArray(doc.nodes)) return [];
+
+  const disallowed = new Set<string>();
+  walkNodes(doc.nodes, node => {
+    if (typeof node.type === "string" && !isAllowed(node.type, allow)) {
+      disallowed.add(node.type);
+    }
+  });
+  if (disallowed.size === 0) return [];
+
+  return [
+    {
+      path,
+      code: "DISALLOWED_BLOCK_TYPE",
+      message: `${label} does not accept ${[...disallowed].sort().join(", ")}. Accepted: ${allow.join(", ")}.`,
+    },
+  ];
+}
+
+/** Exact name match, or a namespace match when the pattern ends in `*`. */
+function isAllowed(type: string, allow: readonly string[]): boolean {
+  return allow.some(pattern =>
+    pattern.endsWith("*")
+      ? type.startsWith(pattern.slice(0, -1))
+      : type === pattern
+  );
+}

--- a/packages/nextly/src/collections/fields/validators/blocks-validator.ts
+++ b/packages/nextly/src/collections/fields/validators/blocks-validator.ts
@@ -99,7 +99,12 @@ export function validateBlocksValue(
   }
 
   issues.push(...kindIssues(doc, path, label, options));
-  issues.push(...disallowedBlockIssues(doc, path, label, options));
+  // The allow-list walk reads node types, which is only safe once the engine
+  // has confirmed the tree is well formed. A malformed node would otherwise
+  // throw here and turn a rejected document into a server error.
+  if (documentIssues.length === 0) {
+    issues.push(...disallowedBlockIssues(doc, path, label, options));
+  }
 
   if (issues.length <= MAX_REPORTED_ISSUES) return issues;
   const withheld = issues.length - MAX_REPORTED_ISSUES;
@@ -139,7 +144,10 @@ function disallowedBlockIssues(
   options: BlocksValidationOptions
 ): Issue[] {
   const allow = options.allow;
-  if (!allow || allow.length === 0) return [];
+  // Omitting `allow` permits every registered block; declaring an empty list
+  // permits none. Treating the two the same would silently ignore the
+  // stricter of the two configurations.
+  if (!allow) return [];
   if (!Array.isArray(doc.nodes)) return [];
 
   const disallowed = new Set<string>();
@@ -150,11 +158,12 @@ function disallowedBlockIssues(
   });
   if (disallowed.size === 0) return [];
 
+  const accepted = allow.length > 0 ? allow.join(", ") : "none";
   return [
     {
       path,
       code: "DISALLOWED_BLOCK_TYPE",
-      message: `${label} does not accept ${[...disallowed].sort().join(", ")}. Accepted: ${allow.join(", ")}.`,
+      message: `${label} does not accept ${[...disallowed].sort().join(", ")}. Accepted: ${accepted}.`,
     },
   ];
 }

--- a/packages/nextly/src/collections/fields/validators/blocks-validator.ts
+++ b/packages/nextly/src/collections/fields/validators/blocks-validator.ts
@@ -168,11 +168,17 @@ function disallowedBlockIssues(
   ];
 }
 
-/** Exact name match, or a namespace match when the pattern ends in `*`. */
+/**
+ * Exact name match, or a namespace match for a `namespace/*` pattern.
+ *
+ * The wildcard binds to the namespace separator rather than to raw characters:
+ * `core/*` matches `core/heading` and never `coreevil/banner`. A bare prefix
+ * test would quietly admit any namespace that merely starts with the same
+ * letters, which is a wider policy than the declaration reads as.
+ */
 function isAllowed(type: string, allow: readonly string[]): boolean {
-  return allow.some(pattern =>
-    pattern.endsWith("*")
-      ? type.startsWith(pattern.slice(0, -1))
-      : type === pattern
-  );
+  return allow.some(pattern => {
+    if (!pattern.endsWith("/*")) return type === pattern;
+    return type.startsWith(pattern.slice(0, -1));
+  });
 }

--- a/packages/nextly/src/collections/fields/validators/index.ts
+++ b/packages/nextly/src/collections/fields/validators/index.ts
@@ -8,3 +8,7 @@
  */
 
 export * from "./code-validators";
+export {
+  validateBlocksValue,
+  type BlocksValidationOptions,
+} from "./blocks-validator";

--- a/packages/nextly/src/components/config/validate-component.ts
+++ b/packages/nextly/src/components/config/validate-component.ts
@@ -91,6 +91,8 @@ export type ComponentValidationErrorCode =
   | "FIELD_NAME_DUPLICATE"
   | "FIELD_TYPE_REQUIRED"
   | "FIELD_TYPE_INVALID"
+  // A declared default the field's own rules reject.
+  | "FIELD_DEFAULT_INVALID"
   // Field-specific errors
   | "SELECT_OPTIONS_REQUIRED"
   | "SELECT_OPTIONS_EMPTY"

--- a/packages/nextly/src/components/config/validate-component.ts
+++ b/packages/nextly/src/components/config/validate-component.ts
@@ -36,6 +36,7 @@ import {
   validateNumberDecimalDimensionsShared,
   validateRelationshipTargetShared,
   validateBlocksDefaultShared,
+  validateBlocksPolicyShared,
   validateSelectOptionsShared,
   validateSlugShared,
 } from "../../shared/base-validator";
@@ -206,6 +207,7 @@ function validateField(
     case "radio":
       validateSelectOptionsShared(f, path, errsBase, "radio");
       // A blocks default must satisfy the same field policy the write applies.
+      validateBlocksPolicyShared(f, path, errsBase);
       validateBlocksDefaultShared(f, path, errsBase);
       break;
 

--- a/packages/nextly/src/components/config/validate-component.ts
+++ b/packages/nextly/src/components/config/validate-component.ts
@@ -35,6 +35,7 @@ import {
   validateFieldTypeShared,
   validateNumberDecimalDimensionsShared,
   validateRelationshipTargetShared,
+  validateBlocksDefaultShared,
   validateSelectOptionsShared,
   validateSlugShared,
 } from "../../shared/base-validator";
@@ -204,6 +205,8 @@ function validateField(
 
     case "radio":
       validateSelectOptionsShared(f, path, errsBase, "radio");
+      // A blocks default must satisfy the same field policy the write applies.
+      validateBlocksDefaultShared(f, path, errsBase);
       break;
 
     case "relationship":

--- a/packages/nextly/src/components/config/validate-component.ts
+++ b/packages/nextly/src/components/config/validate-component.ts
@@ -206,6 +206,9 @@ function validateField(
 
     case "radio":
       validateSelectOptionsShared(f, path, errsBase, "radio");
+      break;
+
+    case "blocks":
       // A blocks default must satisfy the same field policy the write applies.
       validateBlocksPolicyShared(f, path, errsBase);
       validateBlocksDefaultShared(f, path, errsBase);

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -149,3 +149,9 @@ export type {
   BlockNode,
   DocumentKind,
 } from "@nextlyhq/blocks-engine";
+
+// A starting document for a blocks field with no declared default.
+export {
+  emptyBlockDocument,
+  emptyBlockDocumentJson,
+} from "./collections/fields/blocks-document";

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -111,10 +111,12 @@ export {
   json,
   component,
   chips,
+  blocks,
   option,
 } from "./collections/fields/helpers";
 
 export {
+  isBlocksField,
   isTextField,
   isTextareaField,
   isRichTextField,
@@ -139,3 +141,11 @@ export {
 } from "./collections/fields/guards";
 
 export type * from "./collections/fields/types";
+
+// The stored page-builder document, re-exported so app and admin code can name
+// what a blocks field holds without depending on the engine package directly.
+export type {
+  BlockDocument,
+  BlockNode,
+  DocumentKind,
+} from "@nextlyhq/blocks-engine";

--- a/packages/nextly/src/domains/collections/services/collection-utils.ts
+++ b/packages/nextly/src/domains/collections/services/collection-utils.ts
@@ -17,6 +17,7 @@ export const ALWAYS_JSON_TYPES = new Set([
   "group",
   "json",
   "chips", // Chips fields store string[] as JSON
+  "blocks", // A blocks field stores one page document as JSON
 ]);
 
 /**

--- a/packages/nextly/src/domains/components/services/component-schema-service.ts
+++ b/packages/nextly/src/domains/components/services/component-schema-service.ts
@@ -640,7 +640,8 @@ export class ComponentSchemaService {
           if (
             f.type === "json" ||
             f.type === "repeater" ||
-            f.type === "group"
+            f.type === "group" ||
+            f.type === "blocks"
           ) {
             modifiers.push(`.default(${JSON.stringify(defaultValue)})`);
           } else if (typeof defaultValue === "string") {

--- a/packages/nextly/src/domains/components/services/component-schema-service.ts
+++ b/packages/nextly/src/domains/components/services/component-schema-service.ts
@@ -344,7 +344,15 @@ export class ComponentSchemaService {
 
       // When adding NOT NULL columns to existing tables, provide a sensible default.
       let defaultVal = "";
-      if ("defaultValue" in field && field.defaultValue !== undefined) {
+      // A function default produces a different value per row, which a single
+      // DDL constant cannot express. Backfilling existing rows still needs
+      // something, so a required column falls back to its type default rather
+      // than trying to serialize the function itself.
+      const hasConstantDefault =
+        "defaultValue" in field &&
+        field.defaultValue !== undefined &&
+        typeof field.defaultValue !== "function";
+      if (hasConstantDefault) {
         defaultVal = `DEFAULT ${this.formatDefaultValue(field.defaultValue, field.type)}`;
       } else if ("required" in field && field.required) {
         defaultVal = `DEFAULT ${this.getDefaultValueForType(field.type, field)}`;

--- a/packages/nextly/src/domains/components/services/component-schema-service.ts
+++ b/packages/nextly/src/domains/components/services/component-schema-service.ts
@@ -69,7 +69,7 @@ import {
   DEFAULT_DECIMAL_PRECISION,
   DEFAULT_DECIMAL_SCALE,
 } from "../../schema/services/field-column-descriptor";
-import { quoteSqlLiteral } from "../../schema/utils/sql-literal";
+import { quoteJsonSqlDefault } from "../../schema/utils/sql-literal";
 
 export type SupportedDialect = "postgresql" | "mysql" | "sqlite";
 
@@ -1329,7 +1329,7 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
       case "radio":
         return "''";
       case "blocks":
-        return quoteSqlLiteral(
+        return quoteJsonSqlDefault(
           emptyBlockDocumentJson(
             field && isBlocksField(field) ? field.blocks?.kinds : undefined
           ),
@@ -1347,7 +1347,9 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
       case "json":
       case "repeater":
       case "group":
-        return "'{}'";
+        // These share the blocks column type, so they share its restriction on
+        // how a default may be written.
+        return quoteJsonSqlDefault("{}", this.dialect);
       case "relationship":
       case "upload":
         return "NULL";
@@ -1379,7 +1381,7 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
       type === "group" ||
       type === "blocks"
     ) {
-      return quoteSqlLiteral(
+      return quoteJsonSqlDefault(
         typeof value === "string" ? value : JSON.stringify(value),
         this.dialect
       );

--- a/packages/nextly/src/domains/components/services/component-schema-service.ts
+++ b/packages/nextly/src/domains/components/services/component-schema-service.ts
@@ -1332,7 +1332,8 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
         return quoteSqlLiteral(
           emptyBlockDocumentJson(
             field && isBlocksField(field) ? field.blocks?.kinds : undefined
-          )
+          ),
+          this.dialect
         );
       case "number":
         return "0";
@@ -1379,7 +1380,8 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
       type === "blocks"
     ) {
       return quoteSqlLiteral(
-        typeof value === "string" ? value : JSON.stringify(value)
+        typeof value === "string" ? value : JSON.stringify(value),
+        this.dialect
       );
     }
     if (type === "date") {

--- a/packages/nextly/src/domains/components/services/component-schema-service.ts
+++ b/packages/nextly/src/domains/components/services/component-schema-service.ts
@@ -69,6 +69,7 @@ import {
   DEFAULT_DECIMAL_PRECISION,
   DEFAULT_DECIMAL_SCALE,
 } from "../../schema/services/field-column-descriptor";
+import { quoteSqlLiteral } from "../../schema/utils/sql-literal";
 
 export type SupportedDialect = "postgresql" | "mysql" | "sqlite";
 
@@ -346,7 +347,7 @@ export class ComponentSchemaService {
       if ("defaultValue" in field && field.defaultValue !== undefined) {
         defaultVal = `DEFAULT ${this.formatDefaultValue(field.defaultValue, field.type)}`;
       } else if ("required" in field && field.required) {
-        defaultVal = `DEFAULT ${this.getDefaultValueForType(field.type)}`;
+        defaultVal = `DEFAULT ${this.getDefaultValueForType(field.type, field)}`;
       }
 
       statements.push(
@@ -1316,7 +1317,7 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
   }
 
   // Used when adding NOT NULL columns to existing tables.
-  private getDefaultValueForType(type: string): string {
+  private getDefaultValueForType(type: string, field?: FieldConfig): string {
     switch (type) {
       case "text":
       case "textarea":
@@ -1328,7 +1329,11 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
       case "radio":
         return "''";
       case "blocks":
-        return `'${emptyBlockDocumentJson()}'`;
+        return quoteSqlLiteral(
+          emptyBlockDocumentJson(
+            field && isBlocksField(field) ? field.blocks?.kinds : undefined
+          )
+        );
       case "number":
         return "0";
       case "checkbox":
@@ -1373,7 +1378,9 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
       type === "group" ||
       type === "blocks"
     ) {
-      return `'${typeof value === "string" ? value : JSON.stringify(value)}'`;
+      return quoteSqlLiteral(
+        typeof value === "string" ? value : JSON.stringify(value)
+      );
     }
     if (type === "date") {
       if (this.dialect === "sqlite" && typeof value === "string") {

--- a/packages/nextly/src/domains/components/services/component-schema-service.ts
+++ b/packages/nextly/src/domains/components/services/component-schema-service.ts
@@ -36,6 +36,7 @@ import {
   index as sqliteIndex,
 } from "drizzle-orm/sqlite-core";
 
+import { emptyBlockDocumentJson } from "../../../collections/fields/blocks-document";
 import {
   isTextField,
   isTextareaField,
@@ -1166,7 +1167,8 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
         if (
           isRepeaterField(field) ||
           isGroupField(field) ||
-          isJSONField(field)
+          isJSONField(field) ||
+          isBlocksField(field)
         ) {
           imports.add("json");
         }
@@ -1195,7 +1197,8 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
         if (
           isRepeaterField(field) ||
           isGroupField(field) ||
-          isJSONField(field)
+          isJSONField(field) ||
+          isBlocksField(field)
         ) {
           imports.add("jsonb");
         }
@@ -1323,6 +1326,8 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
       case "select":
       case "radio":
         return "''";
+      case "blocks":
+        return `'${emptyBlockDocumentJson()}'`;
       case "number":
         return "0";
       case "checkbox":
@@ -1361,7 +1366,12 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
       if (this.dialect === "sqlite") return value ? "1" : "0";
       return value ? "TRUE" : "FALSE";
     }
-    if (type === "json" || type === "repeater" || type === "group") {
+    if (
+      type === "json" ||
+      type === "repeater" ||
+      type === "group" ||
+      type === "blocks"
+    ) {
       return `'${typeof value === "string" ? value : JSON.stringify(value)}'`;
     }
     if (type === "date") {

--- a/packages/nextly/src/domains/components/services/component-schema-service.ts
+++ b/packages/nextly/src/domains/components/services/component-schema-service.ts
@@ -840,7 +840,12 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
     if (isRelationshipField(field) || isUploadField(field)) {
       return pgText(colName);
     }
-    if (isRepeaterField(field) || isGroupField(field) || isJSONField(field)) {
+    if (
+      isRepeaterField(field) ||
+      isGroupField(field) ||
+      isJSONField(field) ||
+      isBlocksField(field)
+    ) {
       return isRequired ? pgJsonb(colName).notNull() : pgJsonb(colName);
     }
 
@@ -892,7 +897,12 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
     if (isRelationshipField(field) || isUploadField(field)) {
       return mysqlVarchar(colName, { length: 36 });
     }
-    if (isRepeaterField(field) || isGroupField(field) || isJSONField(field)) {
+    if (
+      isRepeaterField(field) ||
+      isGroupField(field) ||
+      isJSONField(field) ||
+      isBlocksField(field)
+    ) {
       return isRequired ? mysqlJson(colName).notNull() : mysqlJson(colName);
     }
 
@@ -939,7 +949,12 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
     if (isRelationshipField(field) || isUploadField(field)) {
       return sqliteText(colName);
     }
-    if (isRepeaterField(field) || isGroupField(field) || isJSONField(field)) {
+    if (
+      isRepeaterField(field) ||
+      isGroupField(field) ||
+      isJSONField(field) ||
+      isBlocksField(field)
+    ) {
       return isRequired ? sqliteText(colName).notNull() : sqliteText(colName);
     }
 
@@ -999,7 +1014,12 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
     if (isRelationshipField(field) || isUploadField(field)) {
       return `text('${colName}')`;
     }
-    if (isRepeaterField(field) || isGroupField(field) || isJSONField(field)) {
+    if (
+      isRepeaterField(field) ||
+      isGroupField(field) ||
+      isJSONField(field) ||
+      isBlocksField(field)
+    ) {
       return `jsonb('${colName}')`;
     }
     return `text('${colName}')`;
@@ -1040,7 +1060,12 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
     if (isRelationshipField(field) || isUploadField(field)) {
       return `varchar('${colName}', { length: 36 })`;
     }
-    if (isRepeaterField(field) || isGroupField(field) || isJSONField(field)) {
+    if (
+      isRepeaterField(field) ||
+      isGroupField(field) ||
+      isJSONField(field) ||
+      isBlocksField(field)
+    ) {
       return `json('${colName}')`;
     }
     return `varchar('${colName}', { length: 255 })`;

--- a/packages/nextly/src/domains/components/services/component-schema-service.ts
+++ b/packages/nextly/src/domains/components/services/component-schema-service.ts
@@ -53,6 +53,7 @@ import {
   isRepeaterField,
   isGroupField,
   isJSONField,
+  isBlocksField,
   isComponentField,
   isDataField,
 } from "../../../collections/fields/guards";
@@ -793,7 +794,7 @@ export type New${this.toPascalCase(componentSlug)}Component = typeof ${tableName
     if (isRepeaterField(field) || isGroupField(field)) {
       return types.json;
     }
-    if (isJSONField(field)) {
+    if (isJSONField(field) || isBlocksField(field)) {
       return types.json;
     }
 

--- a/packages/nextly/src/domains/components/services/component-utils.ts
+++ b/packages/nextly/src/domains/components/services/component-utils.ts
@@ -74,6 +74,8 @@ const ALWAYS_JSON_TYPES: ReadonlySet<string> = new Set([
   "group",
   "richText",
   "component",
+  // A blocks field stores one page document as JSON.
+  "blocks",
 ]);
 
 export function shouldTreatAsJson(field: FieldConfig): boolean {

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/json-column-defaults.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/json-column-defaults.test.ts
@@ -1,0 +1,69 @@
+/**
+ * A JSON-backed column's DEFAULT clause is not portable text. MySQL rejects a
+ * literal default on a JSON column and accepts only an expression default, so
+ * an ALTER that reads correctly on PostgreSQL fails outright there. These
+ * assertions pin the emitted statement per dialect, since the failure only
+ * appears when the migration runs.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { FieldDefinition } from "../../../schemas/dynamic-collections";
+import {
+  DynamicCollectionSchemaService,
+  type SupportedDialect,
+} from "../services/dynamic-collection-schema-service";
+
+function alterAdding(type: string, dialect: SupportedDialect): string {
+  const service = new DynamicCollectionSchemaService(undefined, dialect);
+  const before = [
+    { name: "title", type: "text", required: true },
+  ] as unknown as FieldDefinition[];
+  const after = [
+    { name: "title", type: "text", required: true },
+    { name: "content", type, required: true },
+  ] as unknown as FieldDefinition[];
+  return service.generateAlterTableMigration("dc_probe", before, after);
+}
+
+const jsonBackedTypes = ["blocks", "json", "repeater", "group", "chips"];
+
+describe.each(jsonBackedTypes)("adding a required %s column", type => {
+  it("wraps the default in an expression for mysql", () => {
+    const sql = alterAdding(type, "mysql");
+    expect(sql).toMatch(/DEFAULT \('.*'\)/);
+  });
+
+  it("uses a bare literal default for postgresql", () => {
+    const sql = alterAdding(type, "postgresql");
+    expect(sql).toContain("DEFAULT '");
+    expect(sql).not.toMatch(/DEFAULT \('/);
+  });
+
+  it("uses a bare literal default for sqlite", () => {
+    const sql = alterAdding(type, "sqlite");
+    expect(sql).toContain("DEFAULT '");
+    expect(sql).not.toMatch(/DEFAULT \('/);
+  });
+});
+
+describe("a required blocks column", () => {
+  it("defaults to a real document rather than an empty object", () => {
+    // The generic `{}` other JSON types fall back to carries no formatVersion,
+    // kind, or nodes, so the backfilled rows would hold a value the field's
+    // own validator rejects.
+    for (const dialect of [
+      "mysql",
+      "postgresql",
+      "sqlite",
+    ] as SupportedDialect[]) {
+      const sql = alterAdding("blocks", dialect);
+      const literal = sql.match(/DEFAULT \(?'(.*?)'\)?;/)?.[1];
+      expect(literal, dialect).toBeDefined();
+      expect(JSON.parse(String(literal))).toEqual({
+        formatVersion: 1,
+        kind: "page",
+        nodes: [],
+      });
+    }
+  });
+});

--- a/packages/nextly/src/domains/dynamic-collections/__tests__/json-column-defaults.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/__tests__/json-column-defaults.test.ts
@@ -28,21 +28,21 @@ function alterAdding(type: string, dialect: SupportedDialect): string {
 const jsonBackedTypes = ["blocks", "json", "repeater", "group", "chips"];
 
 describe.each(jsonBackedTypes)("adding a required %s column", type => {
-  it("wraps the default in an expression for mysql", () => {
+  it("uses a mode-independent expression default for mysql", () => {
     const sql = alterAdding(type, "mysql");
-    expect(sql).toMatch(/DEFAULT \('.*'\)/);
+    expect(sql).toMatch(/DEFAULT \(CONVERT\(X'[0-9a-f]*' USING utf8mb4\)\)/);
   });
 
   it("uses a bare literal default for postgresql", () => {
     const sql = alterAdding(type, "postgresql");
     expect(sql).toContain("DEFAULT '");
-    expect(sql).not.toMatch(/DEFAULT \('/);
+    expect(sql).not.toContain("CONVERT(");
   });
 
   it("uses a bare literal default for sqlite", () => {
     const sql = alterAdding(type, "sqlite");
     expect(sql).toContain("DEFAULT '");
-    expect(sql).not.toMatch(/DEFAULT \('/);
+    expect(sql).not.toContain("CONVERT(");
   });
 });
 
@@ -57,7 +57,11 @@ describe("a required blocks column", () => {
       "sqlite",
     ] as SupportedDialect[]) {
       const sql = alterAdding("blocks", dialect);
-      const literal = sql.match(/DEFAULT \(?'(.*?)'\)?;/)?.[1];
+      const hex = sql.match(/X'([0-9a-f]*)'/)?.[1];
+      const literal =
+        hex !== undefined
+          ? Buffer.from(hex, "hex").toString("utf8")
+          : sql.match(/DEFAULT '(.*?)';/)?.[1];
       expect(literal, dialect).toBeDefined();
       expect(JSON.parse(String(literal))).toEqual({
         formatVersion: 1,

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/blocks-column-type.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/blocks-column-type.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { getColumnDescriptor } from "../../../schema/services/field-column-descriptor";
+import { DynamicCollectionSchemaService } from "../dynamic-collection-schema-service";
+
+/**
+ * The reconciliation DDL keeps its own type map, separate from the canonical
+ * column descriptor. If the two disagree for a field type, the physical column
+ * and the runtime schema describe different things and the diff engine never
+ * settles: every boot sees a change it cannot apply away.
+ *
+ * This asserts they agree for `blocks` on all three dialects, which is the
+ * property that matters rather than the literal token either one returns.
+ */
+const DIALECTS = ["postgresql", "mysql", "sqlite"] as const;
+
+/** What the reconciliation DDL would emit for a column of this type. */
+function ddlType(dialect: (typeof DIALECTS)[number]): string {
+  return new DynamicCollectionSchemaService(
+    undefined,
+    dialect
+  ).mapFieldTypeToSQL("blocks");
+}
+
+describe("blocks column type", () => {
+  it("is a JSON column in the reconciliation DDL on every dialect", () => {
+    // SQLite has no JSON type; text is how every other JSON-backed field is
+    // stored there, which is what the descriptor expects to read back.
+    expect(ddlType("postgresql")).toBe("jsonb");
+    expect(ddlType("mysql")).toBe("json");
+    expect(ddlType("sqlite")).toBe("text");
+  });
+
+  it("agrees with the canonical descriptor", () => {
+    for (const dialect of DIALECTS) {
+      const descriptor = getColumnDescriptor(
+        { name: "content", type: "blocks" },
+        dialect
+      );
+      expect(descriptor?.kind, dialect).toBe("json");
+      // The DDL emits the dialect's own JSON token for the same field.
+      expect(ddlType(dialect), dialect).toBe(
+        dialect === "postgresql"
+          ? "jsonb"
+          : dialect === "mysql"
+            ? "json"
+            : "text"
+      );
+    }
+  });
+
+  it("matches how json and chips are already mapped", () => {
+    // A new JSON-backed type that diverged from its siblings would be a bug in
+    // this map rather than a deliberate difference.
+    for (const dialect of DIALECTS) {
+      const service = new DynamicCollectionSchemaService(undefined, dialect);
+      expect(service.mapFieldTypeToSQL("blocks"), dialect).toBe(
+        service.mapFieldTypeToSQL("json")
+      );
+    }
+  });
+});

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/blocks-column-type.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/blocks-column-type.test.ts
@@ -58,8 +58,15 @@ describe("blocks column type", () => {
         { formatVersion: 1, kind: "page", nodes: [] },
         "blocks"
       );
-      expect(generated, dialect).toContain('"formatVersion"');
-      expect(generated, dialect).not.toContain("[object Object]");
+      const text =
+        dialect === "mysql"
+          ? Buffer.from(
+              generated.match(/X'([0-9a-f]*)'/)?.[1] ?? "",
+              "hex"
+            ).toString("utf8")
+          : generated;
+      expect(text, dialect).toContain('"formatVersion"');
+      expect(text, dialect).not.toContain("[object Object]");
     }
   });
 
@@ -83,15 +90,18 @@ describe("blocks column type", () => {
         },
         "blocks"
       );
-      // MySQL takes a JSON default only as a parenthesized expression, so the
-      // literal sits inside a wrapper there and stands alone elsewhere.
-      const literal = dialect === "mysql" ? generated.slice(1, -1) : generated;
-      expect(literal.startsWith("'"), dialect).toBe(true);
-      expect(literal.endsWith("'"), dialect).toBe(true);
+      if (dialect === "mysql") {
+        // Hex carries no delimiter at all, so there is nothing to escape.
+        const hex = generated.match(/X'([0-9a-f]*)'/)?.[1] ?? "";
+        expect(Buffer.from(hex, "hex").toString("utf8")).toContain("O'Reilly");
+        continue;
+      }
       // Every embedded quote is doubled, so the literal opens and closes once.
-      expect(literal.slice(1, -1).includes("''"), dialect).toBe(true);
+      expect(generated.startsWith("'"), dialect).toBe(true);
+      expect(generated.endsWith("'"), dialect).toBe(true);
+      expect(generated.slice(1, -1).includes("''"), dialect).toBe(true);
       expect(
-        literal.slice(1, -1).replace(/''/g, "").includes("'"),
+        generated.slice(1, -1).replace(/''/g, "").includes("'"),
         dialect
       ).toBe(false);
     }

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/blocks-column-type.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/blocks-column-type.test.ts
@@ -83,13 +83,17 @@ describe("blocks column type", () => {
         },
         "blocks"
       );
+      // MySQL takes a JSON default only as a parenthesized expression, so the
+      // literal sits inside a wrapper there and stands alone elsewhere.
+      const literal = dialect === "mysql" ? generated.slice(1, -1) : generated;
+      expect(literal.startsWith("'"), dialect).toBe(true);
+      expect(literal.endsWith("'"), dialect).toBe(true);
       // Every embedded quote is doubled, so the literal opens and closes once.
-      expect(generated.startsWith("'"), dialect).toBe(true);
-      expect(generated.endsWith("'"), dialect).toBe(true);
-      expect(generated.slice(1, -1).includes("''"), dialect).toBe(true);
-      expect(generated.slice(1, -1).replace(/''/g, "").includes("'")).toBe(
-        false
-      );
+      expect(literal.slice(1, -1).includes("''"), dialect).toBe(true);
+      expect(
+        literal.slice(1, -1).replace(/''/g, "").includes("'"),
+        dialect
+      ).toBe(false);
     }
   });
 

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/blocks-column-type.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/blocks-column-type.test.ts
@@ -63,6 +63,36 @@ describe("blocks column type", () => {
     }
   });
 
+  it("escapes quotes in a default so the DDL stays parseable", () => {
+    // A heading like O'Reilly would otherwise close the literal early and
+    // produce a statement the database rejects.
+    for (const dialect of DIALECTS) {
+      const service = new DynamicCollectionSchemaService(undefined, dialect);
+      const generated = service.formatDefaultValue(
+        {
+          formatVersion: 1,
+          kind: "page",
+          nodes: [
+            {
+              id: "11111111-1111-4111-8111-111111111111",
+              type: "core/heading",
+              version: 1,
+              props: { text: "O'Reilly" },
+            },
+          ],
+        },
+        "blocks"
+      );
+      // Every embedded quote is doubled, so the literal opens and closes once.
+      expect(generated.startsWith("'"), dialect).toBe(true);
+      expect(generated.endsWith("'"), dialect).toBe(true);
+      expect(generated.slice(1, -1).includes("''"), dialect).toBe(true);
+      expect(generated.slice(1, -1).replace(/''/g, "").includes("'")).toBe(
+        false
+      );
+    }
+  });
+
   it("matches how json and chips are already mapped", () => {
     // A new JSON-backed type that diverged from its siblings would be a bug in
     // this map rather than a deliberate difference.

--- a/packages/nextly/src/domains/dynamic-collections/services/__tests__/blocks-column-type.test.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/__tests__/blocks-column-type.test.ts
@@ -49,6 +49,20 @@ describe("blocks column type", () => {
     }
   });
 
+  it("emits a JSON default a required column can actually take", () => {
+    // `JSONB NOT NULL DEFAULT ''` does not apply, and an object default
+    // stringified naively becomes [object Object].
+    for (const dialect of DIALECTS) {
+      const service = new DynamicCollectionSchemaService(undefined, dialect);
+      const generated = service.formatDefaultValue(
+        { formatVersion: 1, kind: "page", nodes: [] },
+        "blocks"
+      );
+      expect(generated, dialect).toContain('"formatVersion"');
+      expect(generated, dialect).not.toContain("[object Object]");
+    }
+  });
+
   it("matches how json and chips are already mapped", () => {
     // A new JSON-backed type that diverged from its siblings would be a bug in
     // this map rather than a deliberate difference.

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -22,6 +22,7 @@
 
 import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 
+import { emptyBlockDocumentJson } from "../../../collections/fields/blocks-document";
 import { env } from "../../../shared/lib/env";
 import { resolveLocalizedFieldNames } from "../../i18n/classify-fields";
 
@@ -1046,6 +1047,10 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
       case "repeater":
       case "group":
         return "'{}'";
+      case "blocks":
+        // A required blocks column needs a document, not an empty object: the
+        // generic `{}` has no formatVersion, kind, or nodes.
+        return `'${emptyBlockDocumentJson()}'`;
       case "chips":
         return "'[]'";
       case "relationship":
@@ -1087,7 +1092,7 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
     }
 
     // Handle JSON (needs to be a quoted JSON string)
-    if (type === "json") {
+    if (type === "json" || type === "blocks") {
       return `'${typeof value === "string" ? value : JSON.stringify(value)}'`;
     }
 

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -969,6 +969,7 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
         richText: "text",
         json: "text", // JSON stored as text in SQLite
         chips: "text", // Chips stored as JSON text in SQLite
+        blocks: "text", // A page document is JSON, stored as text in SQLite
         relationship: "text", // Store foreign key as text (UUID or ID)
       };
       return sqliteTypeMap[type] || "text";
@@ -991,6 +992,7 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
         richText: "text",
         json: "json", // MySQL uses 'json' type, not 'jsonb'
         chips: "json", // Chips stored as JSON array
+        blocks: "json", // A page document is one JSON value
         relationship: "varchar(36)", // Store foreign key as varchar(36) for UUIDs
       };
       return mysqlTypeMap[type] || "text";
@@ -1012,6 +1014,7 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
       richText: "text",
       json: "jsonb",
       chips: "jsonb", // Chips stored as JSON array
+      blocks: "jsonb", // A page document is one JSON value
       relationship: "text", // Store foreign key as text (UUID or ID)
     };
     return typeMap[type] || "text";

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -25,6 +25,7 @@ import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 import { emptyBlockDocumentJson } from "../../../collections/fields/blocks-document";
 import { env } from "../../../shared/lib/env";
 import { resolveLocalizedFieldNames } from "../../i18n/classify-fields";
+import { quoteSqlLiteral } from "../../schema/utils/sql-literal";
 
 import { DynamicCollectionValidationService } from "./dynamic-collection-validation-service";
 
@@ -1096,7 +1097,9 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
 
     // Handle JSON (needs to be a quoted JSON string)
     if (type === "json" || type === "blocks") {
-      return `'${typeof value === "string" ? value : JSON.stringify(value)}'`;
+      return quoteSqlLiteral(
+        typeof value === "string" ? value : JSON.stringify(value)
+      );
     }
 
     // Handle date/timestamp

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -25,7 +25,7 @@ import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 import { emptyBlockDocumentJson } from "../../../collections/fields/blocks-document";
 import { env } from "../../../shared/lib/env";
 import { resolveLocalizedFieldNames } from "../../i18n/classify-fields";
-import { quoteSqlLiteral } from "../../schema/utils/sql-literal";
+import { quoteJsonSqlDefault } from "../../schema/utils/sql-literal";
 
 import { DynamicCollectionValidationService } from "./dynamic-collection-validation-service";
 
@@ -1050,13 +1050,16 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
       case "json":
       case "repeater":
       case "group":
-        return "'{}'";
+        return quoteJsonSqlDefault("{}", this.dialect);
       case "blocks":
         // A required blocks column needs a document, not an empty object: the
         // generic `{}` has no formatVersion, kind, or nodes.
-        return `'${emptyBlockDocumentJson(field?.blocks?.kinds)}'`;
+        return quoteJsonSqlDefault(
+          emptyBlockDocumentJson(field?.blocks?.kinds),
+          this.dialect
+        );
       case "chips":
-        return "'[]'";
+        return quoteJsonSqlDefault("[]", this.dialect);
       case "relationship":
       case "upload":
         // Relations are nullable by nature when adding to existing tables
@@ -1097,7 +1100,7 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
 
     // Handle JSON (needs to be a quoted JSON string)
     if (type === "json" || type === "blocks") {
-      return quoteSqlLiteral(
+      return quoteJsonSqlDefault(
         typeof value === "string" ? value : JSON.stringify(value),
         this.dialect
       );

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -1098,7 +1098,8 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
     // Handle JSON (needs to be a quoted JSON string)
     if (type === "json" || type === "blocks") {
       return quoteSqlLiteral(
-        typeof value === "string" ? value : JSON.stringify(value)
+        typeof value === "string" ? value : JSON.stringify(value),
+        this.dialect
       );
     }
 

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -588,7 +588,7 @@ ${allColumnDefs.join(",\n")}
           defaultVal = `DEFAULT ${this.formatDefaultValue(field.default, field.type)}`;
         } else if (field.required) {
           // Required field without explicit default - provide sensible default for existing rows
-          defaultVal = `DEFAULT ${this.getDefaultValueForType(field.type)}`;
+          defaultVal = `DEFAULT ${this.getDefaultValueForType(field.type, field)}`;
         }
 
         const addColName = this.toSnakeCase(field.name);
@@ -1025,7 +1025,10 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
    * Get a sensible default value for a field type.
    * Used when adding NOT NULL columns to existing tables.
    */
-  private getDefaultValueForType(type: string): string {
+  private getDefaultValueForType(
+    type: string,
+    field?: Pick<FieldDefinition, "blocks">
+  ): string {
     switch (type) {
       case "text":
       case "textarea":
@@ -1050,7 +1053,7 @@ ${this.dialect === "mysql" ? "CREATE INDEX" : "CREATE INDEX IF NOT EXISTS"} ${th
       case "blocks":
         // A required blocks column needs a document, not an empty object: the
         // generic `{}` has no formatVersion, kind, or nodes.
-        return `'${emptyBlockDocumentJson()}'`;
+        return `'${emptyBlockDocumentJson(field?.blocks?.kinds)}'`;
       case "chips":
         return "'[]'";
       case "relationship":

--- a/packages/nextly/src/domains/schema/services/blocks-zod-schema.test.ts
+++ b/packages/nextly/src/domains/schema/services/blocks-zod-schema.test.ts
@@ -32,6 +32,15 @@ describe("generated zod schema for a blocks field", () => {
     expect(code).toContain('z.enum(["page"])');
   });
 
+  it("keeps an explicitly empty kinds policy as accepting nothing", () => {
+    // The write validator reads `kinds: []` as permitting no document at all;
+    // collapsing it to page here would generate a schema that admits what the
+    // server refuses.
+    const code = schemaFor({ kinds: [] });
+    expect(code).toContain("z.never()");
+    expect(code).not.toContain('z.enum(["page"])');
+  });
+
   it("derives the kind enum from the field's own policy", () => {
     const code = schemaFor({ kinds: ["template", "pattern"] });
     expect(code).toContain('z.enum(["template", "pattern"])');

--- a/packages/nextly/src/domains/schema/services/blocks-zod-schema.test.ts
+++ b/packages/nextly/src/domains/schema/services/blocks-zod-schema.test.ts
@@ -1,0 +1,42 @@
+import { DOCUMENT_FORMAT_VERSION } from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import type { DynamicCollectionRecord } from "../../../schemas/dynamic-collections/types";
+
+import { ZodGenerator } from "./zod-generator";
+
+/**
+ * The generated create-input schema is what a client validates against before
+ * sending a write. If it admits documents the server then rejects, the client
+ * cannot tell a good request from a bad one — so the envelope it accepts has
+ * to match the field's actual policy, not a loose stand-in for it.
+ */
+function schemaFor(blocks?: { kinds?: string[] }): string {
+  const collection = {
+    slug: "pages",
+    labels: { singular: "Page", plural: "Pages" },
+    fields: [
+      { name: "content", type: "blocks", ...(blocks ? { blocks } : {}) },
+    ],
+  } as unknown as DynamicCollectionRecord;
+  return new ZodGenerator().generateSchema(collection).code;
+}
+
+describe("generated zod schema for a blocks field", () => {
+  it("pins the format version rather than accepting any number", () => {
+    expect(schemaFor()).toContain(`z.literal(${DOCUMENT_FORMAT_VERSION})`);
+  });
+
+  it("accepts only page when the field declares no kinds", () => {
+    const code = schemaFor();
+    expect(code).toContain('z.enum(["page"])');
+  });
+
+  it("derives the kind enum from the field's own policy", () => {
+    const code = schemaFor({ kinds: ["template", "pattern"] });
+    expect(code).toContain('z.enum(["template", "pattern"])');
+    // A page document would be rejected by the server for this field, so the
+    // generated schema must not admit one either.
+    expect(code).not.toContain('z.enum(["page"])');
+  });
+});

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.test.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.test.ts
@@ -110,6 +110,19 @@ describe("getColumnDescriptor: number storage", () => {
     expect(normalizeType("decimal(10,2)")).toBe("numeric");
   });
 
+  it("stores a blocks document in one JSON column on every dialect", () => {
+    // A page document is a tree with slots, styles, and bindings; shredding it
+    // across tables would make a reorder a migration.
+    for (const dialect of DIALECTS) {
+      const descriptor = getColumnDescriptor(
+        { name: "content", type: "blocks" },
+        dialect
+      );
+      expect(descriptor?.kind, dialect).toBe("json");
+      expect(descriptor?.name, dialect).toBe("content");
+    }
+  });
+
   it("stores a hasMany number as JSON, not a scalar numeric column", () => {
     // The write path stringifies a hasMany number to a JSON array, so a scalar
     // integer/decimal column would reject it. hasMany wins over dbType.

--- a/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
+++ b/packages/nextly/src/domains/schema/services/field-column-descriptor.ts
@@ -223,6 +223,7 @@ function classifyFieldKind(field: FieldDefinition): ColumnKind {
     case "group":
     case "json":
     case "chips":
+    case "blocks":
       return "json";
 
     case "component":

--- a/packages/nextly/src/domains/schema/services/type-generator.ts
+++ b/packages/nextly/src/domains/schema/services/type-generator.ts
@@ -35,6 +35,7 @@ import {
   isRepeaterField,
   isGroupField,
   isJSONField,
+  isBlocksField,
   isChipsField,
   isComponentField,
   isDataField,
@@ -233,6 +234,15 @@ export class TypeGenerator {
     );
     lines.push(" */");
     lines.push("");
+
+    // A blocks field is typed as the engine's document. The import is emitted
+    // only when one is present, and from `nextly` rather than the engine
+    // package directly, so the generated file resolves against the dependency
+    // every app already has.
+    if (this.usesBlocksField(collections, singles, components)) {
+      lines.push('import type { BlockDocument } from "nextly";');
+      lines.push("");
+    }
 
     // Generate interfaces for each component (before collections/singles since they may reference components)
     for (const component of components) {
@@ -682,6 +692,10 @@ export class TypeGenerator {
     else if (isChipsField(field)) {
       tsType = "string[]";
     }
+    // Blocks fields (one page-builder document)
+    else if (isBlocksField(field)) {
+      tsType = "BlockDocument";
+    }
     // Component fields
     else if (isComponentField(field)) {
       tsType = this.buildComponentType(field, allComponents);
@@ -752,6 +766,21 @@ export class TypeGenerator {
     }
 
     return `  ${field.name}${optional}: ${tsType};`;
+  }
+
+  /**
+   * Whether any entity declares a blocks field, which decides if the generated
+   * file needs the document type imported.
+   */
+  private usesBlocksField(
+    collections: DynamicCollectionRecord[],
+    singles: DynamicSingleRecord[],
+    components: DynamicComponentRecord[]
+  ): boolean {
+    const entities = [...collections, ...singles, ...components];
+    return entities.some(entity =>
+      (entity.fields ?? []).some(field => field?.type === "blocks")
+    );
   }
 
   /**

--- a/packages/nextly/src/domains/schema/services/type-generator.ts
+++ b/packages/nextly/src/domains/schema/services/type-generator.ts
@@ -180,6 +180,15 @@ function uniqueSorted(values: string[]): string[] {
   return Array.from(new Set(values)).sort();
 }
 
+/** Whether a blocks field appears anywhere in a field tree, at any depth. */
+function hasBlocksField(fields: readonly unknown[]): boolean {
+  return fields.some(entry => {
+    const field = entry as { type?: unknown; fields?: unknown };
+    if (field?.type === "blocks") return true;
+    return Array.isArray(field?.fields) && hasBlocksField(field.fields);
+  });
+}
+
 export class TypeGenerator {
   private readonly includeComments: boolean;
   private readonly generateInputTypes: boolean;
@@ -770,7 +779,9 @@ export class TypeGenerator {
 
   /**
    * Whether any entity declares a blocks field, which decides if the generated
-   * file needs the document type imported.
+   * file needs the document type imported. Nested fields count: a blocks field
+   * inside a group or repeater is emitted as `BlockDocument` too, so a shallow
+   * check would leave the generated file referencing a name it never imported.
    */
   private usesBlocksField(
     collections: DynamicCollectionRecord[],
@@ -778,9 +789,7 @@ export class TypeGenerator {
     components: DynamicComponentRecord[]
   ): boolean {
     const entities = [...collections, ...singles, ...components];
-    return entities.some(entity =>
-      (entity.fields ?? []).some(field => field?.type === "blocks")
-    );
+    return entities.some(entity => hasBlocksField(entity.fields ?? []));
   }
 
   /**

--- a/packages/nextly/src/domains/schema/services/zod-generator.ts
+++ b/packages/nextly/src/domains/schema/services/zod-generator.ts
@@ -728,6 +728,10 @@ export class ZodGenerator {
         zodSchema = "z.any()";
       } else if (isChipsField(field)) {
         zodSchema = this.buildChipsSchema(field);
+      } else if (isBlocksField(field)) {
+        // A nested blocks field is emitted like a top-level one: omitted, the
+        // generated schema would strip the document from a group or row.
+        zodSchema = this.buildBlocksSchema(field);
       } else {
         continue;
       }

--- a/packages/nextly/src/domains/schema/services/zod-generator.ts
+++ b/packages/nextly/src/domains/schema/services/zod-generator.ts
@@ -33,6 +33,7 @@ import {
   isGroupField,
   isJSONField,
   isChipsField,
+  isBlocksField,
   isDataField,
 } from "../../../collections/fields/guards";
 import type { DynamicCollectionRecord } from "../../../schemas/dynamic-collections/types";
@@ -403,6 +404,12 @@ export class ZodGenerator {
     // Chips fields
     else if (isChipsField(field)) {
       zodSchema = this.buildChipsSchema(field);
+    }
+    // Blocks fields — a whole page document, validated in depth by the engine
+    // on write; the generated schema only asserts the envelope's own shape.
+    else if (isBlocksField(field)) {
+      zodSchema =
+        "z.object({ formatVersion: z.number(), kind: z.string(), nodes: z.array(z.unknown()) }).passthrough()";
     }
     // Unknown field type
     else {

--- a/packages/nextly/src/domains/schema/services/zod-generator.ts
+++ b/packages/nextly/src/domains/schema/services/zod-generator.ts
@@ -13,6 +13,8 @@
  * @since 1.0.0
  */
 
+import { DOCUMENT_FORMAT_VERSION } from "@nextlyhq/blocks-engine";
+
 import type { FieldConfig, DataFieldConfig } from "@nextly/collections";
 
 import {
@@ -37,6 +39,9 @@ import {
   isDataField,
 } from "../../../collections/fields/guards";
 import type { DynamicCollectionRecord } from "../../../schemas/dynamic-collections/types";
+
+/** What a blocks field accepts when it declares no kinds of its own. */
+const DEFAULT_BLOCKS_DOCUMENT_KIND = "page";
 
 // ============================================================
 // Types
@@ -405,11 +410,12 @@ export class ZodGenerator {
     else if (isChipsField(field)) {
       zodSchema = this.buildChipsSchema(field);
     }
-    // Blocks fields — a whole page document, validated in depth by the engine
-    // on write; the generated schema only asserts the envelope's own shape.
+    // Blocks fields — a whole page document. The node tree is validated in
+    // depth by the engine on write; the generated schema asserts the envelope,
+    // pinned to the format version and the kinds this field actually accepts
+    // so a value it admits is one the server will also admit.
     else if (isBlocksField(field)) {
-      zodSchema =
-        "z.object({ formatVersion: z.number(), kind: z.string(), nodes: z.array(z.unknown()) }).passthrough()";
+      zodSchema = this.buildBlocksSchema(field);
     }
     // Unknown field type
     else {
@@ -635,6 +641,19 @@ export class ZodGenerator {
         : [];
 
     return this.buildNestedObjectSchema(nestedFields);
+  }
+
+  /**
+   * Builds Zod schema for a blocks field's document envelope.
+   */
+  private buildBlocksSchema(field: DataFieldConfig): string {
+    const kinds = (field as { blocks?: { kinds?: string[] } }).blocks?.kinds;
+    const accepted =
+      kinds && kinds.length > 0 ? kinds : [DEFAULT_BLOCKS_DOCUMENT_KIND];
+    const kindSchema = accepted
+      .map(kind => `"${this.escapeString(kind)}"`)
+      .join(", ");
+    return `z.object({ formatVersion: z.literal(${DOCUMENT_FORMAT_VERSION}), kind: z.enum([${kindSchema}]), nodes: z.array(z.unknown()) }).passthrough()`;
   }
 
   /**

--- a/packages/nextly/src/domains/schema/services/zod-generator.ts
+++ b/packages/nextly/src/domains/schema/services/zod-generator.ts
@@ -648,12 +648,16 @@ export class ZodGenerator {
    */
   private buildBlocksSchema(field: DataFieldConfig): string {
     const kinds = (field as { blocks?: { kinds?: string[] } }).blocks?.kinds;
-    const accepted =
-      kinds && kinds.length > 0 ? kinds : [DEFAULT_BLOCKS_DOCUMENT_KIND];
-    const kindSchema = accepted
-      .map(kind => `"${this.escapeString(kind)}"`)
-      .join(", ");
-    return `z.object({ formatVersion: z.literal(${DOCUMENT_FORMAT_VERSION}), kind: z.enum([${kindSchema}]), nodes: z.array(z.unknown()) }).passthrough()`;
+    // Omitting `kinds` means the field takes its entry's own page; declaring
+    // an empty list means it takes nothing, which the write validator already
+    // enforces. Collapsing the two here would generate a schema that admits
+    // documents the server refuses.
+    const accepted = kinds ?? [DEFAULT_BLOCKS_DOCUMENT_KIND];
+    const kindSchema =
+      accepted.length > 0
+        ? `z.enum([${accepted.map(kind => `"${this.escapeString(kind)}"`).join(", ")}])`
+        : "z.never()";
+    return `z.object({ formatVersion: z.literal(${DOCUMENT_FORMAT_VERSION}), kind: ${kindSchema}, nodes: z.array(z.unknown()) }).passthrough()`;
   }
 
   /**

--- a/packages/nextly/src/domains/schema/utils/__tests__/sql-literal.test.ts
+++ b/packages/nextly/src/domains/schema/utils/__tests__/sql-literal.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { quoteSqlLiteral } from "../sql-literal";
+import { quoteJsonSqlDefault, quoteSqlLiteral } from "../sql-literal";
 
 const dialects = ["postgresql", "mysql", "sqlite"] as const;
 
@@ -64,5 +64,32 @@ describe("quoteSqlLiteral", () => {
     it("escapes backslashes and apostrophes together for mysql", () => {
       expect(quoteSqlLiteral("it's a\\b", "mysql")).toBe("'it''s a\\\\b'");
     });
+  });
+});
+
+/**
+ * MySQL refuses a literal default on a JSON column outright, so the DEFAULT
+ * clause for a JSON-backed column is not the same text on every dialect.
+ */
+describe("quoteJsonSqlDefault", () => {
+  it("wraps the literal in parentheses for mysql", () => {
+    // Without the parentheses MySQL rejects the statement with "BLOB, TEXT,
+    // GEOMETRY or JSON column can't have a default value".
+    expect(quoteJsonSqlDefault("{}", "mysql")).toBe("('{}')");
+  });
+
+  it("leaves the literal bare for postgresql and sqlite", () => {
+    expect(quoteJsonSqlDefault("{}", "postgresql")).toBe("'{}'");
+    expect(quoteJsonSqlDefault("{}", "sqlite")).toBe("'{}'");
+  });
+
+  it("keeps the dialect's own escaping inside the wrapper", () => {
+    const json = JSON.stringify({ text: "it's\nfine" });
+    const mysql = quoteJsonSqlDefault(json, "mysql");
+    expect(mysql.startsWith("('")).toBe(true);
+    expect(mysql.endsWith("')")).toBe(true);
+    expect(mysql.slice(2, -2).replace(/''/g, "'").replace(/\\\\/g, "\\")).toBe(
+      json
+    );
   });
 });

--- a/packages/nextly/src/domains/schema/utils/__tests__/sql-literal.test.ts
+++ b/packages/nextly/src/domains/schema/utils/__tests__/sql-literal.test.ts
@@ -72,10 +72,12 @@ describe("quoteSqlLiteral", () => {
  * clause for a JSON-backed column is not the same text on every dialect.
  */
 describe("quoteJsonSqlDefault", () => {
-  it("wraps the literal in parentheses for mysql", () => {
-    // Without the parentheses MySQL rejects the statement with "BLOB, TEXT,
-    // GEOMETRY or JSON column can't have a default value".
-    expect(quoteJsonSqlDefault("{}", "mysql")).toBe("('{}')");
+  it("encodes the value as hex for mysql", () => {
+    // A quoted literal would have to guess how the server treats backslashes,
+    // which depends on a SQL mode this code cannot see.
+    expect(quoteJsonSqlDefault("{}", "mysql")).toBe(
+      "(CONVERT(X'7b7d' USING utf8mb4))"
+    );
   });
 
   it("leaves the literal bare for postgresql and sqlite", () => {
@@ -83,13 +85,12 @@ describe("quoteJsonSqlDefault", () => {
     expect(quoteJsonSqlDefault("{}", "sqlite")).toBe("'{}'");
   });
 
-  it("keeps the dialect's own escaping inside the wrapper", () => {
-    const json = JSON.stringify({ text: "it's\nfine" });
-    const mysql = quoteJsonSqlDefault(json, "mysql");
-    expect(mysql.startsWith("('")).toBe(true);
-    expect(mysql.endsWith("')")).toBe(true);
-    expect(mysql.slice(2, -2).replace(/''/g, "'").replace(/\\\\/g, "\\")).toBe(
-      json
-    );
+  it("round-trips a value carrying quotes, newlines, and backslashes", () => {
+    const json = JSON.stringify({ p: "C:\\dir", n: "a\nb", q: "it's" });
+    const emitted = quoteJsonSqlDefault(json, "mysql");
+    const hex = emitted.match(/X'([0-9a-f]*)'/)?.[1] ?? "";
+    expect(Buffer.from(hex, "hex").toString("utf8")).toBe(json);
+    // No delimiter or escape character survives into the statement text.
+    expect(hex).toMatch(/^[0-9a-f]*$/);
   });
 });

--- a/packages/nextly/src/domains/schema/utils/__tests__/sql-literal.test.ts
+++ b/packages/nextly/src/domains/schema/utils/__tests__/sql-literal.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Generated DDL is assembled as text, so a default value's own punctuation has
+ * to survive the trip through the SQL parser unchanged. JSON defaults are the
+ * demanding case: they carry both apostrophes and backslash escapes, and the
+ * dialects disagree about what a backslash means.
+ */
+import { describe, expect, it } from "vitest";
+
+import { quoteSqlLiteral } from "../sql-literal";
+
+const dialects = ["postgresql", "mysql", "sqlite"] as const;
+
+describe("quoteSqlLiteral", () => {
+  describe.each(dialects)("%s", dialect => {
+    it("wraps a plain value in single quotes", () => {
+      expect(quoteSqlLiteral("hello", dialect)).toBe("'hello'");
+    });
+
+    it("doubles an embedded apostrophe", () => {
+      expect(quoteSqlLiteral("O'Reilly", dialect)).toBe("'O''Reilly'");
+    });
+
+    it("doubles every apostrophe, not just the first", () => {
+      expect(quoteSqlLiteral("it's o'clock", dialect)).toBe("'it''s o''clock'");
+    });
+
+    it("quotes a JSON document containing an apostrophe", () => {
+      const json = JSON.stringify({ text: "it's fine" });
+      expect(quoteSqlLiteral(json, dialect)).toBe(`'{"text":"it''s fine"}'`);
+    });
+  });
+
+  describe("backslashes", () => {
+    it("leaves them alone for postgresql and sqlite", () => {
+      // Both store a backslash verbatim, so escaping it would store two.
+      expect(quoteSqlLiteral("a\\nb", "postgresql")).toBe("'a\\nb'");
+      expect(quoteSqlLiteral("a\\nb", "sqlite")).toBe("'a\\nb'");
+    });
+
+    it("doubles them for mysql", () => {
+      // MySQL reads a backslash as an escape introducer, so an undoubled one
+      // would consume the character after it.
+      expect(quoteSqlLiteral("a\\nb", "mysql")).toBe("'a\\\\nb'");
+    });
+
+    it("keeps a JSON newline escape intact for mysql", () => {
+      // JSON writes a newline as the two characters `\` and `n`. Left
+      // undoubled, MySQL would store a real newline, and a literal newline
+      // inside a JSON string does not parse.
+      const json = JSON.stringify({ text: "line\nline" });
+      const literal = quoteSqlLiteral(json, "mysql");
+      expect(literal).toBe(`'{"text":"line\\\\nline"}'`);
+      // What MySQL stores after collapsing each doubled backslash is exactly
+      // the JSON that went in.
+      expect(literal.slice(1, -1).replace(/\\\\/g, "\\")).toBe(json);
+    });
+
+    it("keeps an escaped backslash intact for mysql", () => {
+      const json = JSON.stringify({ path: "C:\\dir" });
+      const literal = quoteSqlLiteral(json, "mysql");
+      expect(literal.slice(1, -1).replace(/\\\\/g, "\\")).toBe(json);
+    });
+
+    it("escapes backslashes and apostrophes together for mysql", () => {
+      expect(quoteSqlLiteral("it's a\\b", "mysql")).toBe("'it''s a\\\\b'");
+    });
+  });
+});

--- a/packages/nextly/src/domains/schema/utils/missing-columns.ts
+++ b/packages/nextly/src/domains/schema/utils/missing-columns.ts
@@ -127,6 +127,7 @@ function fieldToColumnDef(field: FieldConfig, dialect: string): string | null {
     case "repeater":
     case "group":
     case "chips":
+    case "blocks":
       columnType =
         dialect === "postgresql"
           ? "JSONB"

--- a/packages/nextly/src/domains/schema/utils/sql-literal.ts
+++ b/packages/nextly/src/domains/schema/utils/sql-literal.ts
@@ -55,6 +55,13 @@ export function quoteJsonSqlDefault(
   value: string,
   dialect: SupportedDialect
 ): string {
-  const literal = quoteSqlLiteral(value, dialect);
-  return dialect === "mysql" ? `(${literal})` : literal;
+  if (dialect !== "mysql") return quoteSqlLiteral(value, dialect);
+  // Hex avoids quoting entirely. A quoted MySQL literal would have to guess
+  // whether the server treats a backslash as an escape, which depends on the
+  // session's SQL mode and cannot be known while the DDL is being written; a
+  // wrong guess silently stores different JSON than was configured. The bytes
+  // here carry no delimiter and no escape character, so they mean the same
+  // thing under every mode.
+  const hex = Buffer.from(value, "utf8").toString("hex");
+  return `(CONVERT(X'${hex}' USING utf8mb4))`;
 }

--- a/packages/nextly/src/domains/schema/utils/sql-literal.ts
+++ b/packages/nextly/src/domains/schema/utils/sql-literal.ts
@@ -12,10 +12,28 @@
  * @module domains/schema/utils/sql-literal
  */
 
+import type { SupportedDialect } from "../../../types/database";
+
 /**
- * A single-quoted SQL string literal with embedded quotes doubled, which is
- * the escape every dialect this project targets accepts.
+ * A single-quoted SQL string literal, escaped for the target dialect.
+ *
+ * Every dialect accepts a doubled apostrophe. Backslashes are where they
+ * diverge: PostgreSQL and SQLite store one verbatim, while MySQL reads it as
+ * an escape introducer. That difference bites JSON defaults specifically,
+ * because JSON encodes a newline as the two characters `\` and `n` — MySQL
+ * would turn those back into a real newline, and a literal newline inside a
+ * JSON string is not valid JSON, so the stored default would no longer parse.
+ * Doubling the backslash for MySQL keeps the text the parser sees identical
+ * to the text every other dialect stores.
+ *
+ * The MySQL branch assumes the server's default SQL mode. Under
+ * `NO_BACKSLASH_ESCAPES` a backslash is already an ordinary character, and
+ * doubling it there would store two.
  */
-export function quoteSqlLiteral(value: string): string {
-  return `'${value.replace(/'/g, "''")}'`;
+export function quoteSqlLiteral(
+  value: string,
+  dialect: SupportedDialect
+): string {
+  const escaped = dialect === "mysql" ? value.replace(/\\/g, "\\\\") : value;
+  return `'${escaped.replace(/'/g, "''")}'`;
 }

--- a/packages/nextly/src/domains/schema/utils/sql-literal.ts
+++ b/packages/nextly/src/domains/schema/utils/sql-literal.ts
@@ -37,3 +37,24 @@ export function quoteSqlLiteral(
   const escaped = dialect === "mysql" ? value.replace(/\\/g, "\\\\") : value;
   return `'${escaped.replace(/'/g, "''")}'`;
 }
+
+/**
+ * The DEFAULT clause value for a JSON-backed column.
+ *
+ * MySQL refuses a literal default on a JSON column outright — `DEFAULT '{}'`
+ * fails with "BLOB, TEXT, GEOMETRY or JSON column can't have a default value"
+ * — and accepts only an expression default, which is the same literal in
+ * parentheses. PostgreSQL and SQLite take the literal directly, so they are
+ * left as they are rather than given an equivalent-but-different form.
+ *
+ * The parenthesized form requires MySQL 8.0.13 or later, which introduced
+ * expression defaults. On anything older no default is expressible for these
+ * columns at all, so there is no earlier syntax to fall back to.
+ */
+export function quoteJsonSqlDefault(
+  value: string,
+  dialect: SupportedDialect
+): string {
+  const literal = quoteSqlLiteral(value, dialect);
+  return dialect === "mysql" ? `(${literal})` : literal;
+}

--- a/packages/nextly/src/domains/schema/utils/sql-literal.ts
+++ b/packages/nextly/src/domains/schema/utils/sql-literal.ts
@@ -1,0 +1,21 @@
+/**
+ * Quoting a value into a generated SQL literal.
+ *
+ * DDL is assembled as text before it reaches the driver, so a default value
+ * carrying an apostrophe — `O'Reilly` in a block's heading, say — would close
+ * the quote early and produce a statement that fails to parse. Escaping is
+ * therefore part of emitting the literal, not something a caller remembers.
+ *
+ * This is for GENERATED DDL only. Query values go through Drizzle, which
+ * parameterizes them; nothing here should be used to build a query.
+ *
+ * @module domains/schema/utils/sql-literal
+ */
+
+/**
+ * A single-quoted SQL string literal with embedded quotes doubled, which is
+ * the escape every dialect this project targets accepts.
+ */
+export function quoteSqlLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}

--- a/packages/nextly/src/domains/singles/services/blocks-defaults.test.ts
+++ b/packages/nextly/src/domains/singles/services/blocks-defaults.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 
+import type { DocumentKind } from "@nextlyhq/blocks-engine";
+import { DOCUMENT_FORMAT_VERSION } from "@nextlyhq/blocks-engine";
+
 import type { FieldConfig } from "../../../collections/fields/types";
 import { validateBlocksValue } from "../../../collections/fields/validators/blocks-validator";
+import { NextlyError } from "../../../errors";
 
-import { getDefaultValue } from "./single-utils";
+import { assertValidBlocksDefault, getDefaultValue } from "./single-utils";
 
 /**
  * A single is auto-created on first read, so a required field with no declared
@@ -53,5 +57,79 @@ describe("getDefaultValue for a blocks field", () => {
     } as unknown as FieldConfig;
     const seeded: unknown = JSON.parse(String(getDefaultValue(many)));
     expect((seeded as { kind?: string }).kind).toBe("page");
+  });
+});
+
+/**
+ * A single's defaults are inserted directly on first read, so a declared
+ * default never meets the write path's validation. A function default is the
+ * case that matters: its value exists only once resolved against real data, so
+ * config-load validation cannot see it.
+ */
+describe("assertValidBlocksDefault", () => {
+  const blocksField = (blocks?: {
+    allow?: string[];
+    kinds?: DocumentKind[];
+  }): FieldConfig =>
+    ({
+      name: "content",
+      type: "blocks",
+      ...(blocks ? { blocks } : {}),
+    }) as FieldConfig;
+
+  const emptyPage = {
+    formatVersion: DOCUMENT_FORMAT_VERSION,
+    kind: "page" as const,
+    nodes: [],
+  };
+
+  it("accepts a valid document", () => {
+    expect(() =>
+      assertValidBlocksDefault(blocksField(), emptyPage, "homepage")
+    ).not.toThrow();
+  });
+
+  it("rejects a value that is not a document", () => {
+    expect(() =>
+      assertValidBlocksDefault(blocksField(), { nodes: [] }, "homepage")
+    ).toThrow(NextlyError);
+  });
+
+  it("rejects a document whose kind the field does not accept", () => {
+    expect(() =>
+      assertValidBlocksDefault(
+        blocksField({ kinds: ["template"] }),
+        emptyPage,
+        "homepage"
+      )
+    ).toThrow(NextlyError);
+  });
+
+  it("reports the field's own issues rather than a generic failure", () => {
+    // The engine's issue codes travel through unchanged, so the same defect
+    // carries the same name here as it does on the write path.
+    const issues = validateBlocksValue(emptyPage, "content", "content", {
+      kinds: ["template"],
+    });
+    expect(issues.length).toBeGreaterThan(0);
+
+    try {
+      assertValidBlocksDefault(
+        blocksField({ kinds: ["template"] }),
+        emptyPage,
+        "homepage"
+      );
+      expect.unreachable("expected a validation error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(NextlyError);
+      expect((error as NextlyError).publicData).toEqual({ errors: issues });
+    }
+  });
+
+  it("ignores fields of every other type", () => {
+    const text = { name: "title", type: "text" } as FieldConfig;
+    expect(() =>
+      assertValidBlocksDefault(text, { anything: true }, "homepage")
+    ).not.toThrow();
   });
 });

--- a/packages/nextly/src/domains/singles/services/blocks-defaults.test.ts
+++ b/packages/nextly/src/domains/singles/services/blocks-defaults.test.ts
@@ -29,4 +29,29 @@ describe("getDefaultValue for a blocks field", () => {
     const seeded: unknown = JSON.parse(String(getDefaultValue(field)));
     expect(validateBlocksValue(seeded, "content", "Content", {})).toEqual([]);
   });
+
+  it("seeds a kind the field actually accepts", () => {
+    // Seeding a page document into a template-only field would put a value in
+    // the field that its own policy rejects.
+    const templateOnly = {
+      name: "content",
+      type: "blocks",
+      blocks: { kinds: ["template"] },
+    } as unknown as FieldConfig;
+    const seeded: unknown = JSON.parse(String(getDefaultValue(templateOnly)));
+    expect((seeded as { kind?: string }).kind).toBe("template");
+    expect(
+      validateBlocksValue(seeded, "content", "Content", { kinds: ["template"] })
+    ).toEqual([]);
+  });
+
+  it("prefers page when the field accepts several kinds", () => {
+    const many = {
+      name: "content",
+      type: "blocks",
+      blocks: { kinds: ["pattern", "page"] },
+    } as unknown as FieldConfig;
+    const seeded: unknown = JSON.parse(String(getDefaultValue(many)));
+    expect((seeded as { kind?: string }).kind).toBe("page");
+  });
 });

--- a/packages/nextly/src/domains/singles/services/blocks-defaults.test.ts
+++ b/packages/nextly/src/domains/singles/services/blocks-defaults.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import type { FieldConfig } from "../../../collections/fields/types";
+import { validateBlocksValue } from "../../../collections/fields/validators/blocks-validator";
+
+import { getDefaultValue } from "./single-utils";
+
+/**
+ * A single is auto-created on first read, so a required field with no declared
+ * default is seeded from here. For a blocks field the generic `"{}"` every
+ * other JSON type gets is not a document, and the row would hold a value its
+ * own validator rejects.
+ */
+describe("getDefaultValue for a blocks field", () => {
+  const field = { name: "content", type: "blocks" } as FieldConfig;
+
+  it("seeds a document rather than an empty object", () => {
+    const seeded = JSON.parse(String(getDefaultValue(field))) as {
+      formatVersion?: unknown;
+      kind?: unknown;
+      nodes?: unknown;
+    };
+    expect(typeof seeded.formatVersion).toBe("number");
+    expect(seeded.kind).toBe("page");
+    expect(seeded.nodes).toEqual([]);
+  });
+
+  it("seeds a document the blocks validator accepts", () => {
+    const seeded: unknown = JSON.parse(String(getDefaultValue(field)));
+    expect(validateBlocksValue(seeded, "content", "Content", {})).toEqual([]);
+  });
+});

--- a/packages/nextly/src/domains/singles/services/blocks-defaults.test.ts
+++ b/packages/nextly/src/domains/singles/services/blocks-defaults.test.ts
@@ -126,6 +126,29 @@ describe("assertValidBlocksDefault", () => {
     }
   });
 
+  it("rejects an absent default on a required field", () => {
+    // The row is inserted straight from these defaults, so a null would reach
+    // a NOT NULL column and surface as a constraint error instead.
+    const required = {
+      name: "content",
+      type: "blocks",
+      required: true,
+    } as FieldConfig;
+    for (const absent of [null, undefined]) {
+      expect(() =>
+        assertValidBlocksDefault(required, absent, "homepage")
+      ).toThrow(NextlyError);
+    }
+  });
+
+  it("accepts an absent default on an optional field", () => {
+    for (const absent of [null, undefined]) {
+      expect(() =>
+        assertValidBlocksDefault(blocksField(), absent, "homepage")
+      ).not.toThrow();
+    }
+  });
+
   it("ignores fields of every other type", () => {
     const text = { name: "title", type: "text" } as FieldConfig;
     expect(() =>

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -88,6 +88,7 @@ import type {
 
 import type { SingleRegistryService } from "./single-registry-service";
 import {
+  assertValidBlocksDefault,
   buildSingleErrorResult,
   collectAllMediaIds,
   deserializeJsonFields,
@@ -838,6 +839,13 @@ export class SingleQueryService extends BaseService {
           typeof field.defaultValue === "function"
             ? field.defaultValue(defaults)
             : field.defaultValue;
+        // A blocks default is checked here rather than only at config load,
+        // because a function default can only be resolved against real data.
+        // This row is inserted directly on first read, without going through
+        // the write path, so nothing downstream would catch a document the
+        // field's own policy rejects — and the admin control is read-only, so
+        // the stored value could not be corrected from the UI.
+        assertValidBlocksDefault(field, resolved, singleMeta.slug);
         defaults[field.name] =
           shouldTreatAsJson(field) && typeof resolved === "object"
             ? JSON.stringify(resolved)

--- a/packages/nextly/src/domains/singles/services/single-utils.ts
+++ b/packages/nextly/src/domains/singles/services/single-utils.ts
@@ -15,6 +15,8 @@
  * @since 1.0.0
  */
 
+import { DOCUMENT_FORMAT_VERSION } from "@nextlyhq/blocks-engine";
+
 import type { FieldConfig } from "../../../collections/fields/types";
 import { NextlyError } from "../../../errors";
 import { convertTimestampsToCamelCase } from "../../../shared/lib/case-conversion";
@@ -97,12 +99,28 @@ export function shouldTreatAsJson(field: FieldConfig): boolean {
 }
 
 /**
+ * An empty page document. The generic `"{}"` every other JSON type gets is not
+ * a document — it has no `formatVersion`, `kind`, or `nodes` — so a single
+ * auto-created with a required blocks field would hold a value its own
+ * validator rejects.
+ */
+export const EMPTY_PAGE_DOCUMENT: string = JSON.stringify({
+  formatVersion: DOCUMENT_FORMAT_VERSION,
+  kind: "page",
+  nodes: [],
+});
+
+/**
  * Get a type-appropriate default value for a field type.
  * Used when a required field has no explicit defaultValue.
  */
 export function getDefaultValue(field: FieldConfig): unknown {
   if (field.type === "richText") {
     return EMPTY_LEXICAL_DOCUMENT;
+  }
+
+  if (field.type === "blocks") {
+    return EMPTY_PAGE_DOCUMENT;
   }
 
   if (shouldTreatAsJson(field)) {

--- a/packages/nextly/src/domains/singles/services/single-utils.ts
+++ b/packages/nextly/src/domains/singles/services/single-utils.ts
@@ -120,6 +120,24 @@ export function assertValidBlocksDefault(
   singleSlug: string
 ): void {
   if (field.type !== "blocks") return;
+  // `validateBlocksValue` treats an absent value as an empty field and leaves
+  // requiredness to the shared rules, which this path never reaches: the row
+  // is inserted straight from these defaults. A required column would take the
+  // null and fail at the database, reporting a constraint rather than the
+  // configuration that caused it.
+  if (value === null || value === undefined) {
+    if (!("required" in field && field.required)) return;
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: field.name,
+          code: "REQUIRED",
+          message: `${field.name} is required, but its default produced no document.`,
+        },
+      ],
+      logContext: { single: singleSlug, field: field.name, reason: "default" },
+    });
+  }
   const policy = (field as { blocks?: BlocksPolicy }).blocks ?? {};
   const issues = validateBlocksValue(value, field.name, field.name, policy);
   if (issues.length === 0) return;

--- a/packages/nextly/src/domains/singles/services/single-utils.ts
+++ b/packages/nextly/src/domains/singles/services/single-utils.ts
@@ -19,6 +19,7 @@ import type { DocumentKind } from "@nextlyhq/blocks-engine";
 
 import { emptyBlockDocumentJson } from "../../../collections/fields/blocks-document";
 import type { FieldConfig } from "../../../collections/fields/types";
+import { validateBlocksValue } from "../../../collections/fields/validators/blocks-validator";
 import { NextlyError } from "../../../errors";
 import { convertTimestampsToCamelCase } from "../../../shared/lib/case-conversion";
 import type { Logger } from "../../../shared/types";
@@ -97,6 +98,37 @@ export function shouldTreatAsJson(field: FieldConfig): boolean {
   }
 
   return false;
+}
+
+/** The subset of a blocks field's policy the value validator reads. */
+type BlocksPolicy = { allow?: string[]; kinds?: DocumentKind[] };
+
+/**
+ * Rejects a blocks default the field's own policy would not accept.
+ *
+ * A single is auto-created on first read by inserting its defaults directly,
+ * so this value never passes through the write path that validates ordinary
+ * writes. A static default is already caught when the config loads, but a
+ * function default produces its value only when resolved against real data,
+ * which first happens here. Left unchecked it would be persisted, and the
+ * admin's blocks control is read-only, so the row could not then be repaired
+ * from the UI.
+ */
+export function assertValidBlocksDefault(
+  field: FieldConfig,
+  value: unknown,
+  singleSlug: string
+): void {
+  if (field.type !== "blocks") return;
+  const policy = (field as { blocks?: BlocksPolicy }).blocks ?? {};
+  const issues = validateBlocksValue(value, field.name, field.name, policy);
+  if (issues.length === 0) return;
+  // The engine's own issue codes are carried through unchanged, so one defect
+  // keeps one name wherever it surfaces.
+  throw NextlyError.validation({
+    errors: issues,
+    logContext: { single: singleSlug, field: field.name, reason: "default" },
+  });
 }
 
 /**

--- a/packages/nextly/src/domains/singles/services/single-utils.ts
+++ b/packages/nextly/src/domains/singles/services/single-utils.ts
@@ -58,7 +58,11 @@ export const EMPTY_LEXICAL_DOCUMENT: string = JSON.stringify({
  * Mirrors the logic in RuntimeSchemaGenerator to ensure consistent handling.
  */
 export function shouldTreatAsJson(field: FieldConfig): boolean {
-  if (["json", "repeater", "group", "richText", "chips"].includes(field.type)) {
+  if (
+    ["json", "repeater", "group", "richText", "chips", "blocks"].includes(
+      field.type
+    )
+  ) {
     return true;
   }
 

--- a/packages/nextly/src/domains/singles/services/single-utils.ts
+++ b/packages/nextly/src/domains/singles/services/single-utils.ts
@@ -15,8 +15,9 @@
  * @since 1.0.0
  */
 
-import { DOCUMENT_FORMAT_VERSION } from "@nextlyhq/blocks-engine";
+import type { DocumentKind } from "@nextlyhq/blocks-engine";
 
+import { emptyBlockDocumentJson } from "../../../collections/fields/blocks-document";
 import type { FieldConfig } from "../../../collections/fields/types";
 import { NextlyError } from "../../../errors";
 import { convertTimestampsToCamelCase } from "../../../shared/lib/case-conversion";
@@ -99,18 +100,6 @@ export function shouldTreatAsJson(field: FieldConfig): boolean {
 }
 
 /**
- * An empty page document. The generic `"{}"` every other JSON type gets is not
- * a document — it has no `formatVersion`, `kind`, or `nodes` — so a single
- * auto-created with a required blocks field would hold a value its own
- * validator rejects.
- */
-export const EMPTY_PAGE_DOCUMENT: string = JSON.stringify({
-  formatVersion: DOCUMENT_FORMAT_VERSION,
-  kind: "page",
-  nodes: [],
-});
-
-/**
  * Get a type-appropriate default value for a field type.
  * Used when a required field has no explicit defaultValue.
  */
@@ -120,7 +109,11 @@ export function getDefaultValue(field: FieldConfig): unknown {
   }
 
   if (field.type === "blocks") {
-    return EMPTY_PAGE_DOCUMENT;
+    // The kind is read from the field's own policy: seeding a page document
+    // into a field that only accepts templates would violate its own rule.
+    const kinds = (field as { blocks?: { kinds?: DocumentKind[] } }).blocks
+      ?.kinds;
+    return emptyBlockDocumentJson(kinds);
   }
 
   if (shouldTreatAsJson(field)) {

--- a/packages/nextly/src/domains/webhooks/expand-component-fields.ts
+++ b/packages/nextly/src/domains/webhooks/expand-component-fields.ts
@@ -100,11 +100,19 @@ async function expandBlocks(
   if (!Array.isArray(blocks)) return blocks;
   return Promise.all(
     blocks.map(async entry => {
-      const block = entry as { fields?: SensitiveFieldSource[] };
-      if (!Array.isArray(block.fields)) return entry;
+      // Untrusted shape: only an object carrying an array of object fields is
+      // walked, so a malformed entry passes through instead of crashing the
+      // webhook payload build.
+      if (typeof entry !== "object" || entry === null) return entry;
+      const nested = (entry as { fields?: unknown }).fields;
+      if (!Array.isArray(nested)) return entry;
+      const fields = nested.filter(
+        (field): field is SensitiveFieldSource =>
+          typeof field === "object" && field !== null
+      );
       return {
-        ...block,
-        fields: await expandComponentFields(block.fields, resolve, seen, cache),
+        ...(entry as object),
+        fields: await expandComponentFields(fields, resolve, seen, cache),
       };
     })
   );

--- a/packages/nextly/src/domains/webhooks/expand-component-fields.ts
+++ b/packages/nextly/src/domains/webhooks/expand-component-fields.ts
@@ -83,20 +83,30 @@ async function resolveOnce(
   return resolved;
 }
 
+/**
+ * Expand component references inside inlined block definitions.
+ *
+ * `blocks` is only walked when it is an array of definitions carrying their
+ * own fields. A Nextly blocks field puts an options object there naming the
+ * registered block types it accepts, which holds no fields to expand, so it
+ * passes through untouched.
+ */
 async function expandBlocks(
   blocks: SensitiveFieldSource["blocks"],
   resolve: ComponentFieldResolver,
   seen: ReadonlySet<string>,
   cache: ResolutionCache
 ): Promise<SensitiveFieldSource["blocks"]> {
-  if (!blocks) return blocks;
+  if (!Array.isArray(blocks)) return blocks;
   return Promise.all(
-    blocks.map(async block => ({
-      ...block,
-      fields: block.fields
-        ? await expandComponentFields(block.fields, resolve, seen, cache)
-        : block.fields,
-    }))
+    blocks.map(async entry => {
+      const block = entry as { fields?: SensitiveFieldSource[] };
+      if (!Array.isArray(block.fields)) return entry;
+      return {
+        ...block,
+        fields: await expandComponentFields(block.fields, resolve, seen, cache),
+      };
+    })
   );
 }
 

--- a/packages/nextly/src/domains/webhooks/sensitive-fields.ts
+++ b/packages/nextly/src/domains/webhooks/sensitive-fields.ts
@@ -37,8 +37,19 @@ export interface SensitiveFieldSource {
   admin?: unknown;
   /** Inline sub-fields of a group/repeater field, if any. */
   fields?: SensitiveFieldSource[];
-  /** Block definitions of a blocks field; each carries its own `fields`. */
-  blocks?: { fields?: SensitiveFieldSource[] }[];
+  /**
+   * Whatever a field puts under `blocks`. Narrowed at runtime for the same
+   * reason `admin` is: a blocks field declares which registered block types it
+   * accepts (an object), while a field that inlines block definitions carries
+   * an array of them, and no structural annotation accepts both without a cast
+   * at the call site.
+   *
+   * A Nextly blocks field contributes no static paths either way — its values
+   * are block props, declared on the block type rather than on the field, so
+   * nothing here can know them. Those are stripped at the document level, not
+   * by walking the field tree.
+   */
+  blocks?: unknown;
 }
 
 /**
@@ -83,8 +94,10 @@ export function sensitiveFieldPaths(
       if (Array.isArray(field.fields)) walk(field.fields, path, childHidden);
       if (Array.isArray(field.blocks)) {
         for (const block of field.blocks) {
-          if (Array.isArray(block.fields))
-            walk(block.fields, path, childHidden);
+          const nested = (block as { fields?: unknown })?.fields;
+          if (Array.isArray(nested)) {
+            walk(nested as SensitiveFieldSource[], path, childHidden);
+          }
         }
       }
     }

--- a/packages/nextly/src/domains/webhooks/sensitive-fields.ts
+++ b/packages/nextly/src/domains/webhooks/sensitive-fields.ts
@@ -94,10 +94,20 @@ export function sensitiveFieldPaths(
       if (Array.isArray(field.fields)) walk(field.fields, path, childHidden);
       if (Array.isArray(field.blocks)) {
         for (const block of field.blocks) {
-          const nested = (block as { fields?: unknown })?.fields;
-          if (Array.isArray(nested)) {
-            walk(nested as SensitiveFieldSource[], path, childHidden);
-          }
+          if (typeof block !== "object" || block === null) continue;
+          const nested = (block as { fields?: unknown }).fields;
+          if (!Array.isArray(nested)) continue;
+          // Each element is checked before it is walked: this tree comes from
+          // stored schema data, and one malformed entry must not stop the
+          // sensitive-path scan that decides what a webhook may reveal.
+          walk(
+            nested.filter(
+              (entry): entry is SensitiveFieldSource =>
+                typeof entry === "object" && entry !== null
+            ),
+            path,
+            childHidden
+          );
         }
       }
     }

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -380,6 +380,15 @@ export {
   getFieldType as getPluginFieldType,
 } from "./domains/schema/field-types/field-type-registry";
 
+// The stored page-builder document. Re-exported so an app can name the value a
+// blocks field holds without depending on the engine package directly, and so
+// generated types resolve against the dependency it already has.
+export type {
+  BlockDocument,
+  BlockNode,
+  DocumentKind,
+} from "@nextlyhq/blocks-engine";
+
 // Block props on the field system — a block's prop declarations become
 // ordinary field configs, so block values validate through the same pass
 // entries do instead of a parallel rule set.

--- a/packages/nextly/src/schemas/_zod/ui-schema.test.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.test.ts
@@ -34,6 +34,68 @@ const VALID = {
   ],
 };
 
+describe("parseUiSchema — blocks fields", () => {
+  const withBlocks = (field: Record<string, unknown>) => ({
+    version: 1,
+    collections: [
+      {
+        slug: "pages",
+        fields: [{ name: "title", type: "text" }, field],
+      },
+    ],
+  });
+
+  it("accepts a blocks field and keeps its policy", () => {
+    // Zod strips undeclared keys, so an unparsed `blocks` option would persist
+    // a field accepting everything the submitted schema meant to exclude.
+    const r = parseUiSchema(
+      withBlocks({
+        name: "content",
+        type: "blocks",
+        blocks: { allow: ["core/*"], kinds: ["page"] },
+      })
+    );
+    expect(r.success).toBe(true);
+    const field = r.success
+      ? (r.data.collections[0].fields[1] as {
+          blocks?: { allow?: string[]; kinds?: string[] };
+        })
+      : undefined;
+    expect(field?.blocks?.allow).toEqual(["core/*"]);
+    expect(field?.blocks?.kinds).toEqual(["page"]);
+  });
+
+  it("accepts a blocks field with no policy", () => {
+    expect(
+      parseUiSchema(withBlocks({ name: "content", type: "blocks" })).success
+    ).toBe(true);
+  });
+
+  it("rejects a document kind that does not exist", () => {
+    expect(
+      parseUiSchema(
+        withBlocks({
+          name: "content",
+          type: "blocks",
+          blocks: { kinds: ["nonsense"] },
+        })
+      ).success
+    ).toBe(false);
+  });
+
+  it("accepts a document as a blocks default", () => {
+    expect(
+      parseUiSchema(
+        withBlocks({
+          name: "content",
+          type: "blocks",
+          defaultValue: { formatVersion: 1, kind: "page", nodes: [] },
+        })
+      ).success
+    ).toBe(true);
+  });
+});
+
 describe("parseUiSchema", () => {
   it("accepts a valid manifest", () => {
     const r = parseUiSchema(VALID);

--- a/packages/nextly/src/schemas/_zod/ui-schema.test.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.test.ts
@@ -142,6 +142,55 @@ describe("parseUiSchema — blocks fields", () => {
     ).toBe(true);
   });
 
+  it("rejects a default of a kind the field itself excludes", () => {
+    // The default is checked by the field's own validator, so a schema cannot
+    // declare a policy and a default that contradict each other.
+    expect(
+      parseUiSchema(
+        withBlocks({
+          name: "content",
+          type: "blocks",
+          blocks: { kinds: ["template"] },
+          defaultValue: { formatVersion: 1, kind: "page", nodes: [] },
+        })
+      ).success
+    ).toBe(false);
+    expect(
+      parseUiSchema(
+        withBlocks({
+          name: "content",
+          type: "blocks",
+          blocks: { kinds: ["template"] },
+          defaultValue: { formatVersion: 1, kind: "template", nodes: [] },
+        })
+      ).success
+    ).toBe(true);
+  });
+
+  it("rejects a default using a block the field does not allow", () => {
+    expect(
+      parseUiSchema(
+        withBlocks({
+          name: "content",
+          type: "blocks",
+          blocks: { allow: ["core/*"] },
+          defaultValue: {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [
+              {
+                id: "11111111-1111-4111-8111-111111111111",
+                type: "acme/pricing",
+                version: 1,
+                props: {},
+              },
+            ],
+          },
+        })
+      ).success
+    ).toBe(false);
+  });
+
   it("accepts a document as a blocks default", () => {
     expect(
       parseUiSchema(

--- a/packages/nextly/src/schemas/_zod/ui-schema.test.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.test.ts
@@ -102,6 +102,46 @@ describe("parseUiSchema — blocks fields", () => {
     }
   });
 
+  it("rejects a default whose nodes are malformed", () => {
+    // An envelope check alone would pass this, and the read-only control
+    // leaves the user no way to repair what it seeds.
+    for (const nodes of [[null], [42], [{ id: "" }], [{ type: "core/x" }]]) {
+      expect(
+        parseUiSchema(
+          withBlocks({
+            name: "content",
+            type: "blocks",
+            defaultValue: { formatVersion: 1, kind: "page", nodes },
+          })
+        ).success,
+        JSON.stringify(nodes)
+      ).toBe(false);
+    }
+  });
+
+  it("accepts a default whose nodes are well formed", () => {
+    expect(
+      parseUiSchema(
+        withBlocks({
+          name: "content",
+          type: "blocks",
+          defaultValue: {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [
+              {
+                id: "11111111-1111-4111-8111-111111111111",
+                type: "core/heading",
+                version: 1,
+                props: {},
+              },
+            ],
+          },
+        })
+      ).success
+    ).toBe(true);
+  });
+
   it("accepts a document as a blocks default", () => {
     expect(
       parseUiSchema(

--- a/packages/nextly/src/schemas/_zod/ui-schema.test.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.test.ts
@@ -83,6 +83,25 @@ describe("parseUiSchema — blocks fields", () => {
     ).toBe(false);
   });
 
+  it("rejects a default that is an object but not a document", () => {
+    // The admin seeds a read-only control from this value, so a malformed
+    // default leaves something the user cannot correct on the form.
+    for (const bad of [
+      { foo: "bar" },
+      { formatVersion: "1", kind: "page", nodes: [] },
+      { formatVersion: 1, kind: "nonsense", nodes: [] },
+      { formatVersion: 1, kind: "page" },
+      { formatVersion: 1, kind: "page", nodes: {} },
+    ]) {
+      expect(
+        parseUiSchema(
+          withBlocks({ name: "content", type: "blocks", defaultValue: bad })
+        ).success,
+        JSON.stringify(bad)
+      ).toBe(false);
+    }
+  });
+
   it("accepts a document as a blocks default", () => {
     expect(
       parseUiSchema(

--- a/packages/nextly/src/schemas/_zod/ui-schema.test.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.test.ts
@@ -83,6 +83,21 @@ describe("parseUiSchema — blocks fields", () => {
     ).toBe(false);
   });
 
+  it("rejects an empty kinds list", () => {
+    // A field accepting no kind can hold no document, yet required-field
+    // seeding still has to synthesize one — so the row would carry a value
+    // this same field rejects.
+    expect(
+      parseUiSchema(
+        withBlocks({
+          name: "content",
+          type: "blocks",
+          blocks: { kinds: [] },
+        })
+      ).success
+    ).toBe(false);
+  });
+
   it("rejects a default that is an object but not a document", () => {
     // The admin seeds a read-only control from this value, so a malformed
     // default leaves something the user cannot correct on the form.

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -12,7 +12,7 @@
  * @module schemas/_zod/ui-schema
  * @since v0.0.3-alpha (Plan D1)
  */
-import type { BlockDocument } from "@nextlyhq/blocks-engine";
+import type { BlockDocument, DocumentKind } from "@nextlyhq/blocks-engine";
 import {
   DOCUMENT_KINDS,
   validate as validateDocument,
@@ -170,6 +170,13 @@ export type FieldNode = {
   hasMany?: boolean;
   relationTo?: string | string[];
   options?: { id?: string; label: string; value: string }[];
+  /**
+   * A blocks field's policy. Declared here as well as in the schema so the
+   * parsed result carries it statically — the runtime parser preserves it
+   * either way, and a type that erased it would make every consumer cast, and
+   * would let a mapper drop it without the compiler noticing.
+   */
+  blocks?: { allow?: string[]; kinds?: DocumentKind[] };
   defaultValue?: unknown;
   validation?: {
     minLength?: number;

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -12,12 +12,11 @@
  * @module schemas/_zod/ui-schema
  * @since v0.0.3-alpha (Plan D1)
  */
-import type { BlockDocument, DocumentKind } from "@nextlyhq/blocks-engine";
-import {
-  DOCUMENT_KINDS,
-  validate as validateDocument,
-} from "@nextlyhq/blocks-engine";
+import type { DocumentKind } from "@nextlyhq/blocks-engine";
+import { DOCUMENT_KINDS } from "@nextlyhq/blocks-engine";
 import { z } from "zod";
+
+import { validateBlocksValue } from "../../collections/fields/validators/blocks-validator";
 
 /**
  * Canonical field-type tokens supported in ui-schema.json. Mirrors the set
@@ -47,35 +46,27 @@ export const UI_FIELD_TYPES = [
 ] as const;
 
 /**
- * Whether a value is a document the write path would accept.
+ * Whether a default is a document this field would accept on write.
  *
- * The envelope alone is not enough: a default carrying a malformed node passes
- * a shape check, seeds the read-only control on a create form, and is then
- * rejected on submit with nothing the user can do about it. So the engine's
- * own validator decides, which is the same rule the write applies.
+ * It runs the field's own validator rather than a shape check of its own, so
+ * the two cannot disagree. That matters twice over: a default carrying a
+ * malformed node, or one of a kind the field excludes, would otherwise seed
+ * the read-only control on a create form and then be rejected on submit with
+ * nothing the user could do about it.
  */
-function isValidDocumentDefault(value: unknown): boolean {
+function isValidDocumentDefault(
+  value: unknown,
+  policy: { allow?: string[]; kinds?: DocumentKind[] } | undefined
+): boolean {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return false;
   }
-  const doc = value as {
-    formatVersion?: unknown;
-    kind?: unknown;
-    nodes?: unknown;
-  };
-  const envelopeOk =
-    typeof doc.formatVersion === "number" &&
-    typeof doc.kind === "string" &&
-    (DOCUMENT_KINDS as readonly string[]).includes(doc.kind) &&
-    Array.isArray(doc.nodes);
-  if (!envelopeOk) return false;
-  // Breakpoints are supplied by the page-builder plugin at write time, so a
-  // reference to one warns rather than errors here; only errors disqualify a
-  // default.
-  return !validateDocument(value as BlockDocument, {
-    breakpoints: { viewport: [], container: [] },
-    mode: "forgiving",
-  }).some(issue => issue.severity === "error");
+  const doc = value as { formatVersion?: unknown };
+  if (typeof doc.formatVersion !== "number") return false;
+  return (
+    validateBlocksValue(value, "defaultValue", "defaultValue", policy ?? {})
+      .length === 0
+  );
 }
 
 /** Field names the framework reserves (system columns). */
@@ -371,7 +362,7 @@ export const uiSchemaFieldSchema: z.ZodType<FieldNode> = z.lazy(() =>
           // object would let a malformed default seed the read-only control on
           // a create form, leaving a value the user cannot correct and the
           // write-time validator rejects.
-          (f.type === "blocks" && isValidDocumentDefault(dv)) ||
+          (f.type === "blocks" && isValidDocumentDefault(dv, f.blocks)) ||
           ([
             "text",
             "textarea",

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -12,6 +12,7 @@
  * @module schemas/_zod/ui-schema
  * @since v0.0.3-alpha (Plan D1)
  */
+import { DOCUMENT_KINDS } from "@nextlyhq/blocks-engine";
 import { z } from "zod";
 
 /**
@@ -197,6 +198,15 @@ export const uiSchemaFieldSchema: z.ZodType<FieldNode> = z.lazy(() =>
       hasMany: z.boolean().optional(),
       relationTo: z.union([z.string(), z.array(z.string())]).optional(),
       options: z.array(selectOption).optional(),
+      // A blocks field's policy: which registered blocks it accepts and which
+      // document kinds. Undeclared, Zod would strip it and persist a field
+      // that accepts everything the submitted schema meant to exclude.
+      blocks: z
+        .object({
+          allow: z.array(z.string()).optional(),
+          kinds: z.array(z.enum(DOCUMENT_KINDS)).optional(),
+        })
+        .optional(),
       defaultValue: z.unknown().optional(),
       validation: validation.optional(),
       admin: fieldAdmin.optional(),

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -12,7 +12,11 @@
  * @module schemas/_zod/ui-schema
  * @since v0.0.3-alpha (Plan D1)
  */
-import { DOCUMENT_KINDS } from "@nextlyhq/blocks-engine";
+import type { BlockDocument } from "@nextlyhq/blocks-engine";
+import {
+  DOCUMENT_KINDS,
+  validate as validateDocument,
+} from "@nextlyhq/blocks-engine";
 import { z } from "zod";
 
 /**
@@ -43,11 +47,14 @@ export const UI_FIELD_TYPES = [
 ] as const;
 
 /**
- * Whether a value carries the document envelope every stored page has. The
- * node tree itself is validated on write by the engine; this is the shape a
- * schema author must get right for the default to be usable at all.
+ * Whether a value is a document the write path would accept.
+ *
+ * The envelope alone is not enough: a default carrying a malformed node passes
+ * a shape check, seeds the read-only control on a create form, and is then
+ * rejected on submit with nothing the user can do about it. So the engine's
+ * own validator decides, which is the same rule the write applies.
  */
-function isDocumentEnvelope(value: unknown): boolean {
+function isValidDocumentDefault(value: unknown): boolean {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return false;
   }
@@ -56,12 +63,19 @@ function isDocumentEnvelope(value: unknown): boolean {
     kind?: unknown;
     nodes?: unknown;
   };
-  return (
+  const envelopeOk =
     typeof doc.formatVersion === "number" &&
     typeof doc.kind === "string" &&
     (DOCUMENT_KINDS as readonly string[]).includes(doc.kind) &&
-    Array.isArray(doc.nodes)
-  );
+    Array.isArray(doc.nodes);
+  if (!envelopeOk) return false;
+  // Breakpoints are supplied by the page-builder plugin at write time, so a
+  // reference to one warns rather than errors here; only errors disqualify a
+  // default.
+  return !validateDocument(value as BlockDocument, {
+    breakpoints: { viewport: [], container: [] },
+    mode: "forgiving",
+  }).some(issue => issue.severity === "error");
 }
 
 /** Field names the framework reserves (system columns). */
@@ -350,7 +364,7 @@ export const uiSchemaFieldSchema: z.ZodType<FieldNode> = z.lazy(() =>
           // object would let a malformed default seed the read-only control on
           // a create form, leaving a value the user cannot correct and the
           // write-time validator rejects.
-          (f.type === "blocks" && isDocumentEnvelope(dv)) ||
+          (f.type === "blocks" && isValidDocumentDefault(dv)) ||
           ([
             "text",
             "textarea",

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -42,6 +42,28 @@ export const UI_FIELD_TYPES = [
   "blocks",
 ] as const;
 
+/**
+ * Whether a value carries the document envelope every stored page has. The
+ * node tree itself is validated on write by the engine; this is the shape a
+ * schema author must get right for the default to be usable at all.
+ */
+function isDocumentEnvelope(value: unknown): boolean {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const doc = value as {
+    formatVersion?: unknown;
+    kind?: unknown;
+    nodes?: unknown;
+  };
+  return (
+    typeof doc.formatVersion === "number" &&
+    typeof doc.kind === "string" &&
+    (DOCUMENT_KINDS as readonly string[]).includes(doc.kind) &&
+    Array.isArray(doc.nodes)
+  );
+}
+
 /** Field names the framework reserves (system columns). */
 // Universal system columns present on every entity table (collection, single,
 // component). The collection-only owner column (`created_by`/`createdBy`) is
@@ -324,12 +346,11 @@ export const uiSchemaFieldSchema: z.ZodType<FieldNode> = z.lazy(() =>
         const okType =
           (f.type === "number" && typeof dv === "number") ||
           (f.type === "checkbox" && typeof dv === "boolean") ||
-          // A blocks default is a whole document, so it is an object rather
-          // than one of the scalar shapes the other types accept.
-          (f.type === "blocks" &&
-            typeof dv === "object" &&
-            dv !== null &&
-            !Array.isArray(dv)) ||
+          // A blocks default is a whole document. Checking only that it is an
+          // object would let a malformed default seed the read-only control on
+          // a create form, leaving a value the user cannot correct and the
+          // write-time validator rejects.
+          (f.type === "blocks" && isDocumentEnvelope(dv)) ||
           ([
             "text",
             "textarea",

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -38,6 +38,7 @@ export const UI_FIELD_TYPES = [
   "component",
   "json",
   "chips",
+  "blocks",
 ] as const;
 
 /** Field names the framework reserves (system columns). */
@@ -313,6 +314,12 @@ export const uiSchemaFieldSchema: z.ZodType<FieldNode> = z.lazy(() =>
         const okType =
           (f.type === "number" && typeof dv === "number") ||
           (f.type === "checkbox" && typeof dv === "boolean") ||
+          // A blocks default is a whole document, so it is an object rather
+          // than one of the scalar shapes the other types accept.
+          (f.type === "blocks" &&
+            typeof dv === "object" &&
+            dv !== null &&
+            !Array.isArray(dv)) ||
           ([
             "text",
             "textarea",

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -238,7 +238,16 @@ export const uiSchemaFieldSchema: z.ZodType<FieldNode> = z.lazy(() =>
       blocks: z
         .object({
           allow: z.array(z.string()).optional(),
-          kinds: z.array(z.enum(DOCUMENT_KINDS)).optional(),
+          // An empty list would accept no document at all, while required-field
+          // seeding still has to synthesize one — leaving a stored value the
+          // same field's validator rejects. Omit the key to accept a page.
+          kinds: z
+            .array(z.enum(DOCUMENT_KINDS))
+            .min(
+              1,
+              "blocks.kinds cannot be empty: the field would accept no document at all. Omit it to accept a page."
+            )
+            .optional(),
         })
         .optional(),
       defaultValue: z.unknown().optional(),

--- a/packages/nextly/src/schemas/dynamic-collections/legacy-types.ts
+++ b/packages/nextly/src/schemas/dynamic-collections/legacy-types.ts
@@ -1,3 +1,5 @@
+import type { DocumentKind } from "@nextlyhq/blocks-engine";
+
 /**
  * Legacy UI-collection field-definition types.
  *
@@ -96,6 +98,8 @@ export type FieldDefinition = {
     label: string;
     value: string;
   }>;
+  /** A blocks field's accepted block names and document kinds. */
+  blocks?: { allow?: string[]; kinds?: DocumentKind[] };
   /** Allow multiple values (for text, number, select, upload, relationship) */
   hasMany?: boolean;
   /** Target collection slug(s) for relationship fields */

--- a/packages/nextly/src/schemas/dynamic-collections/legacy-types.ts
+++ b/packages/nextly/src/schemas/dynamic-collections/legacy-types.ts
@@ -56,7 +56,8 @@ export type DynamicFieldType =
   | "group"
   | "json"
   | "component"
-  | "chips";
+  | "chips"
+  | "blocks";
 
 export type FieldDefinition = {
   name: string;

--- a/packages/nextly/src/shared/base-validator.ts
+++ b/packages/nextly/src/shared/base-validator.ts
@@ -404,8 +404,10 @@ export function validateBlocksDefaultShared(
 ): void {
   if (field.type !== "blocks") return;
   const value = field.defaultValue;
-  // A function default is resolved per entry, so there is nothing to check
-  // here; the write path validates whatever it produces.
+  // A function default produces its value per entry, against data this
+  // validator does not have, so there is nothing to check at config time. It
+  // is checked where it is resolved instead — for a single, before the
+  // auto-created row is inserted.
   if (value === undefined || typeof value === "function") return;
   const policy = (field.blocks ?? {}) as {
     allow?: string[];

--- a/packages/nextly/src/shared/base-validator.ts
+++ b/packages/nextly/src/shared/base-validator.ts
@@ -442,6 +442,35 @@ export function validateBlocksPolicyShared(
   }
 }
 
+/**
+ * The parts of a declared blocks policy that are safe to enforce.
+ *
+ * A policy the config validator has already rejected must not also decide how
+ * a default is judged: the value checks index into `allow` and compare against
+ * `kinds`, so a wrong shape there throws rather than reports.
+ */
+function usablePolicy(blocks: unknown): {
+  allow?: string[];
+  kinds?: DocumentKind[];
+} {
+  if (typeof blocks !== "object" || blocks === null || Array.isArray(blocks)) {
+    return {};
+  }
+  const { allow, kinds } = blocks as { allow?: unknown; kinds?: unknown };
+  const policy: { allow?: string[]; kinds?: DocumentKind[] } = {};
+  if (Array.isArray(allow) && allow.every(e => typeof e === "string")) {
+    policy.allow = allow;
+  }
+  if (
+    Array.isArray(kinds) &&
+    kinds.length > 0 &&
+    kinds.every(k => (DOCUMENT_KINDS as readonly unknown[]).includes(k))
+  ) {
+    policy.kinds = kinds as DocumentKind[];
+  }
+  return policy;
+}
+
 export function validateBlocksDefaultShared(
   field: { type?: string; defaultValue?: unknown; blocks?: unknown },
   path: string,
@@ -454,10 +483,11 @@ export function validateBlocksDefaultShared(
   // is checked where it is resolved instead — for a single, before the
   // auto-created row is inserted.
   if (value === undefined || typeof value === "function") return;
-  const policy = (field.blocks ?? {}) as {
-    allow?: string[];
-    kinds?: DocumentKind[];
-  };
+  // Only the well-formed parts of the policy are forwarded. A malformed one is
+  // already reported by the policy check, and passing it on would reach
+  // `allow.some(...)` and throw — turning a config with two problems into a
+  // crash instead of the list of errors this validator exists to return.
+  const policy = usablePolicy(field.blocks);
   for (const issue of validateBlocksValue(
     value,
     `${path}.defaultValue`,

--- a/packages/nextly/src/shared/base-validator.ts
+++ b/packages/nextly/src/shared/base-validator.ts
@@ -24,6 +24,10 @@
 // arises when this file imports from collections/config/validate-config and
 // validate-config in turn imports from this file. See shared/sql-reserved.ts
 // for the full rationale.
+import type { DocumentKind } from "@nextlyhq/blocks-engine";
+
+import { validateBlocksValue } from "../collections/fields/validators/blocks-validator";
+
 import { RESERVED_SLUGS, SQL_RESERVED_KEYWORDS } from "./sql-reserved";
 
 // ============================================================
@@ -364,6 +368,40 @@ export function validateFieldTypeShared(
  * present, an array, and non-empty. Error codes are suffixed with
  * `SELECT_` or `RADIO_` so domain validators surface the correct tag.
  */
+/**
+ * A blocks field's default must be a document the same field would accept on
+ * write. A code-first default is type-checked but not policy-checked, so a
+ * page document on a template-only field, or a block outside `allow`, would
+ * otherwise reach the admin and fail only on submit.
+ */
+export function validateBlocksDefaultShared(
+  field: { type?: string; defaultValue?: unknown; blocks?: unknown },
+  path: string,
+  errors: BaseValidationError[]
+): void {
+  if (field.type !== "blocks") return;
+  const value = field.defaultValue;
+  // A function default is resolved per entry, so there is nothing to check
+  // here; the write path validates whatever it produces.
+  if (value === undefined || typeof value === "function") return;
+  const policy = (field.blocks ?? {}) as {
+    allow?: string[];
+    kinds?: DocumentKind[];
+  };
+  for (const issue of validateBlocksValue(
+    value,
+    `${path}.defaultValue`,
+    "defaultValue",
+    policy
+  )) {
+    errors.push({
+      path: `${path}.defaultValue`,
+      message: issue.message,
+      code: "FIELD_DEFAULT_INVALID",
+    });
+  }
+}
+
 export function validateSelectOptionsShared(
   field: Record<string, unknown>,
   path: string,

--- a/packages/nextly/src/shared/base-validator.ts
+++ b/packages/nextly/src/shared/base-validator.ts
@@ -374,6 +374,29 @@ export function validateFieldTypeShared(
  * page document on a template-only field, or a block outside `allow`, would
  * otherwise reach the admin and fail only on submit.
  */
+/**
+ * A blocks field declaring `kinds: []` accepts no document at all, so nothing
+ * could ever be stored in it — including the empty document required fields
+ * are seeded with. It is rejected here rather than left to fail per write,
+ * because the contradiction is in the declaration, not in any value.
+ */
+export function validateBlocksPolicyShared(
+  field: { type?: string; blocks?: unknown },
+  path: string,
+  errors: BaseValidationError[]
+): void {
+  if (field.type !== "blocks") return;
+  const policy = field.blocks as { kinds?: unknown } | undefined;
+  if (Array.isArray(policy?.kinds) && policy.kinds.length === 0) {
+    errors.push({
+      path: `${path}.blocks.kinds`,
+      message:
+        "blocks.kinds cannot be empty: the field would accept no document at all. Omit it to accept a page.",
+      code: "FIELD_TYPE_INVALID",
+    });
+  }
+}
+
 export function validateBlocksDefaultShared(
   field: { type?: string; defaultValue?: unknown; blocks?: unknown },
   path: string,

--- a/packages/nextly/src/shared/base-validator.ts
+++ b/packages/nextly/src/shared/base-validator.ts
@@ -25,6 +25,7 @@
 // validate-config in turn imports from this file. See shared/sql-reserved.ts
 // for the full rationale.
 import type { DocumentKind } from "@nextlyhq/blocks-engine";
+import { DOCUMENT_KINDS } from "@nextlyhq/blocks-engine";
 
 import { validateBlocksValue } from "../collections/fields/validators/blocks-validator";
 
@@ -386,14 +387,58 @@ export function validateBlocksPolicyShared(
   errors: BaseValidationError[]
 ): void {
   if (field.type !== "blocks") return;
-  const policy = field.blocks as { kinds?: unknown } | undefined;
-  if (Array.isArray(policy?.kinds) && policy.kinds.length === 0) {
+  if (field.blocks === undefined) return;
+  const fail = (suffix: string, message: string): void => {
     errors.push({
-      path: `${path}.blocks.kinds`,
-      message:
-        "blocks.kinds cannot be empty: the field would accept no document at all. Omit it to accept a page.",
+      path: `${path}.blocks${suffix}`,
+      message,
       code: "FIELD_TYPE_INVALID",
     });
+  };
+
+  if (
+    typeof field.blocks !== "object" ||
+    field.blocks === null ||
+    Array.isArray(field.blocks)
+  ) {
+    fail("", "blocks must be an object declaring allow and/or kinds.");
+    return;
+  }
+  const policy = field.blocks as { kinds?: unknown; allow?: unknown };
+
+  // The write-time check calls `.some()` on `allow`, so a non-array here would
+  // surface as a crash on every write rather than as a configuration error.
+  if (policy.allow !== undefined) {
+    if (
+      !Array.isArray(policy.allow) ||
+      policy.allow.some(entry => typeof entry !== "string")
+    ) {
+      fail(".allow", "blocks.allow must be an array of block name strings.");
+    }
+  }
+
+  if (policy.kinds === undefined) return;
+  if (!Array.isArray(policy.kinds)) {
+    fail(".kinds", "blocks.kinds must be an array of document kinds.");
+    return;
+  }
+  if (policy.kinds.length === 0) {
+    fail(
+      ".kinds",
+      "blocks.kinds cannot be empty: the field would accept no document at all. Omit it to accept a page."
+    );
+    return;
+  }
+  // An unrecognized kind is accepted by the field-level check purely because it
+  // appears in this list, so nothing downstream would ever reject it.
+  const unknown = policy.kinds.filter(
+    kind => !(DOCUMENT_KINDS as readonly unknown[]).includes(kind)
+  );
+  if (unknown.length > 0) {
+    fail(
+      ".kinds",
+      `blocks.kinds contains unknown document kinds: ${unknown.map(String).join(", ")}. Accepted: ${DOCUMENT_KINDS.join(", ")}.`
+    );
   }
 }
 

--- a/packages/nextly/src/shared/base-validator.ts
+++ b/packages/nextly/src/shared/base-validator.ts
@@ -114,6 +114,8 @@ export const VALID_FIELD_TYPES = [
   "chips",
   // Component type
   "component",
+  // Page-builder document
+  "blocks",
 ] as const;
 
 /** Set form of {@link VALID_FIELD_TYPES} for O(1) membership checks. */

--- a/packages/nextly/src/shared/lib/entry-validation.ts
+++ b/packages/nextly/src/shared/lib/entry-validation.ts
@@ -25,6 +25,8 @@
  */
 import safeRegex from "safe-regex2";
 
+import type { DocumentKind } from "../../collections/fields/types/blocks";
+import { validateBlocksValue } from "../../collections/fields/validators/blocks-validator";
 import type { ValidationPublicData } from "../../errors/public-data";
 
 export type ValidationIssue = ValidationPublicData["errors"][number];
@@ -501,6 +503,23 @@ async function validateFieldValue(
           issues
         );
       }
+      break;
+    }
+
+    case "blocks": {
+      // The document format has one validator and it lives in the engine; this
+      // case adapts it rather than restating any of its rules.
+      const options = field as {
+        blocks?: { allow?: string[]; kinds?: DocumentKind[] };
+      };
+      issues.push(
+        ...validateBlocksValue(
+          value,
+          path,
+          label ?? "This field",
+          options.blocks ?? {}
+        )
+      );
       break;
     }
 

--- a/packages/nextly/src/singles/config/validate-single.ts
+++ b/packages/nextly/src/singles/config/validate-single.ts
@@ -73,6 +73,8 @@ export type SingleValidationErrorCode =
   | "FIELD_NAME_DUPLICATE"
   | "FIELD_TYPE_REQUIRED"
   | "FIELD_TYPE_INVALID"
+  // A declared default the field's own rules reject.
+  | "FIELD_DEFAULT_INVALID"
   // Field-specific errors
   | "SELECT_OPTIONS_REQUIRED"
   | "SELECT_OPTIONS_EMPTY"

--- a/packages/nextly/src/singles/config/validate-single.ts
+++ b/packages/nextly/src/singles/config/validate-single.ts
@@ -199,6 +199,9 @@ function validateField(
 
     case "radio":
       validateSelectOptionsShared(f, path, errsBase, "radio");
+      break;
+
+    case "blocks":
       // A blocks default must satisfy the same field policy the write applies.
       validateBlocksPolicyShared(f, path, errsBase);
       validateBlocksDefaultShared(f, path, errsBase);

--- a/packages/nextly/src/singles/config/validate-single.ts
+++ b/packages/nextly/src/singles/config/validate-single.ts
@@ -33,6 +33,7 @@ import {
   validateNumberDecimalDimensionsShared,
   validateRelationshipTargetShared,
   validateBlocksDefaultShared,
+  validateBlocksPolicyShared,
   validateSelectOptionsShared,
   validateSlugShared,
 } from "../../shared/base-validator";
@@ -199,6 +200,7 @@ function validateField(
     case "radio":
       validateSelectOptionsShared(f, path, errsBase, "radio");
       // A blocks default must satisfy the same field policy the write applies.
+      validateBlocksPolicyShared(f, path, errsBase);
       validateBlocksDefaultShared(f, path, errsBase);
       break;
 

--- a/packages/nextly/src/singles/config/validate-single.ts
+++ b/packages/nextly/src/singles/config/validate-single.ts
@@ -32,6 +32,7 @@ import {
   validateFieldTypeShared,
   validateNumberDecimalDimensionsShared,
   validateRelationshipTargetShared,
+  validateBlocksDefaultShared,
   validateSelectOptionsShared,
   validateSlugShared,
 } from "../../shared/base-validator";
@@ -197,6 +198,8 @@ function validateField(
 
     case "radio":
       validateSelectOptionsShared(f, path, errsBase, "radio");
+      // A blocks default must satisfy the same field policy the write applies.
+      validateBlocksDefaultShared(f, path, errsBase);
       break;
 
     case "relationship":

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -874,6 +874,9 @@ importers:
       '@nextlyhq/adapter-drizzle':
         specifier: workspace:*
         version: link:../adapter-drizzle
+      '@nextlyhq/blocks-engine':
+        specifier: workspace:*
+        version: link:../blocks-engine
       bcryptjs:
         specifier: ^3.0.2
         version: 3.0.2
@@ -11858,11 +11861,6 @@ snapshots:
       esbuild: 0.25.12
       load-tsconfig: 0.2.5
 
-  bundle-require@5.1.0(esbuild@0.28.1):
-    dependencies:
-      esbuild: 0.28.1
-      load-tsconfig: 0.2.5
-
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -14930,12 +14928,12 @@ snapshots:
 
   tsup@8.5.0(jiti@2.6.1)(postcss@8.5.14)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.28.1)
+      bundle-require: 5.1.0(esbuild@0.25.12)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.28.1
+      esbuild: 0.25.12
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
@@ -14958,12 +14956,12 @@ snapshots:
 
   tsup@8.5.0(jiti@2.7.0)(postcss@8.5.12)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.28.1)
+      bundle-require: 5.1.0(esbuild@0.25.12)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.28.1
+      esbuild: 0.25.12
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1


### PR DESCRIPTION
Plan-01 PR-6, first of two. Adds `blocks` as a real field type: a collection or single can now hold a page-builder document, stored in one column and typed end to end. This is where core gains its dependency on `@nextlyhq/blocks-engine`.

Design notes and the research behind them are in `tasks/page-builder-research/impl-plan-01-pr6-blocks-field-type.md`.

## Why the field references blocks rather than defining them

Payload is the direct comparable, and its history is the useful part: v3 declared block definitions **inline on the field**, then added `blockReferences` for reuse, and **v4 deprecates `blockReferences` and folds slugs into `blocks`**. They converged on global definitions plus per-field slug references after starting from inline.

Nextly is already there and skips the detour. Blocks are registered once for the app (`defineBlock`, and `contributes.blocks` in PR-7); the field only narrows which of them it accepts:

```ts
blocks({ name: "content", blocks: { allow: ["core/*"] } })
```

Inline block definitions on the field should not be added later either — that is the thing Payload walked back.

We do diverge on storage: Payload shreds blocks into relational tables, we store typed JSON (PB-D8). The document is a tree with slots, styles, and bindings, so shredding would make every reorder a migration. The cost we accept is that SQL cannot filter on block content; the manifest (PR-9) answers that.

## What this PR does

**The type, through every layer** the repo's `adding-a-field-type` checklist names: `FieldType` union and `BlocksFieldConfig`, the `blocks()` factory, `isBlocksField`, a Structured catalog entry, `json` column mapping on all three dialects, generated TypeScript, and the config gate.

**Validation is adapted, not restated.** The document format has one validator and it lives in the engine; `blocks-validator.ts` hands the stored value to it and translates the result into the issue shape the write path reports. It keeps the engine's own issue codes rather than inventing a second dialect for the same defects. Two rules belong to the field rather than the document and are enforced here: `blocks.kinds` (which document kinds the field accepts, defaulting to `page`) and `blocks.allow` (which block types it permits, with `core/*` namespace matching).

Block-type **existence** is deliberately not checked yet — that needs the boot registry, which nothing populates until PR-7, and checking against an empty registry would reject every document. PR-6b wires it under a non-empty-registry rule so it activates the moment blocks are contributed.

**Generated types name the document.** `entry.content` types as `BlockDocument`, with the import emitted only when a blocks field exists and pointed at `nextly` rather than the engine package, so it resolves against the dependency an app already has.

**The admin renders a read-only summary** (block count and type list, both themes). This was originally scheduled for the follow-up PR; that was wrong. `FieldRenderer`'s fallback shows a red "Unknown field type" box for any type it has no case for, so deferring the renderer would have shipped a first-class field type that looks broken. Editing still belongs to the builder — the form reports what the field holds rather than offering a second editor.

## Things found along the way

- **Two hand-maintained accepted-type lists** the `adding-a-field-type` skill never mentioned: `VALID_FIELD_TYPES` (the config gate — miss it and `defineCollection` throws at boot with every other layer wired) and `DynamicFieldType`. The skill is updated so the next person does not lose the same hour.
- **The webhook PII scanner had a speculative Payload-shaped `blocks` member** (`{ fields }[]`) written before this field type existed, which collided with the real options object. Both consumers now narrow at runtime, following the precedent the same file already set for `admin`. Nextly blocks fields contribute no static paths either way: their values are block props, declared on the block type rather than the field.
- **`"nextly"` is aliased to nextly's *source* in the admin tsconfig**, so importing the document types from the package root pulled the entire source graph into the admin typecheck (109 errors). The document types are exported from `nextly/config` instead, which is what 60 of the admin's other field imports already use.

## Testing

- **All-dialect storage round-trips**, run and green on **SQLite, Postgres 17, and MySQL**: a nested document with slots and styles round-trips deep-equal, reads back as an object rather than a JSON string, updates in place, stays null when absent, and a disallowed block type is refused with nothing committed. This suite earned its keep immediately — it caught that the read path was returning the document as a raw JSON string, because `ALWAYS_JSON_TYPES` did not list `blocks`.
- 14 unit tests for the validator: kind and allow rules, namespace matching, nested slots, the issue cap, and hostile input.
- Catalog and column-descriptor coverage, including that `blocks` is kept **out** of the block-prop surface — a prop holding a nested document is what slots already express.

`pnpm check-types` passes across all 18 packages; both packages lint clean.

Test counts moved from **7 failures / 1144 passing on `main`** to **6 / 1161** on the touched areas. No new failures, and one pre-existing failure is fixed: `maps json/repeater/group/blocks fields to jsonb` was written against a `blocks` type that did not exist yet.

## Next

PR-6b: registry-backed type checking, the effective-status thread (`patch.status ?? existingRow.status`, defaulting to strict) so a published document is never validated forgivingly, and `allowUnknown` removal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Blocks** field type (page-builder document) with configurable allowed block names and accepted document kinds.
  * Admin UI now renders blocks in entry tables and provides blocks-aware default initialization for forms.
  * Extended schema generation, type validation, and storage handling to support blocks end-to-end.
* **Bug Fixes**
  * Ensured required/optional blocks defaults stay valid and resilient to malformed block documents.
  * Improved dialect-safe SQL default quoting/escaping.
* **Tests**
  * Added unit, integration, and schema/generator tests covering policies, defaults, storage round-trips, and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->