### PR TITLE
feat(create-nextly-app): blog template tag-based ISR and alpha-channel pinning

### DIFF
--- a/.changeset/f1-blog-template-isr.md
+++ b/.changeset/f1-blog-template-isr.md
@@ -1,0 +1,24 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+The scaffolded blog template now uses tag-based ISR: publishing or editing content in the admin refreshes the affected pages on the next request, with no rebuild and no 60-second timer. Content-template scaffolds (blog) also install `nextly` and `@nextlyhq/*` from the `alpha` dist-tag so they always get the `nextly/runtime` cache helpers the pages use.

--- a/packages/create-nextly-app/src/__tests__/blog-template-isr.test.ts
+++ b/packages/create-nextly-app/src/__tests__/blog-template-isr.test.ts
@@ -57,6 +57,16 @@ describe("blog template — tag-based ISR", () => {
     }
   );
 
+  it("post reads that embed relations carry the related collection tags", () => {
+    // Depth>=1 post reads populate author / category / tag records, so a write
+    // to any of those collections must refresh the post pages showing it — not
+    // only nextly:posts. Guards against a regression back to posts-tag-only.
+    const src = read("src/lib/queries/posts.ts");
+    expect(src).toContain('nextlyTags("categories")');
+    expect(src).toContain('nextlyTags("tags")');
+    expect(src).toContain('nextlyTags("users")');
+  });
+
   const SINGLE_QUERIES = [
     "src/lib/queries/site-settings.ts",
     "src/lib/queries/navigation.ts",

--- a/packages/create-nextly-app/src/__tests__/blog-template-isr.test.ts
+++ b/packages/create-nextly-app/src/__tests__/blog-template-isr.test.ts
@@ -65,6 +65,17 @@ describe("blog template — tag-based ISR", () => {
     expect(src).toContain('nextlyTags("categories")');
     expect(src).toContain('nextlyTags("tags")');
     expect(src).toContain('nextlyTags("users")');
+    // Posts embed media via featuredImage / seo.ogImage (depth>=1).
+    expect(src).toContain('nextlyTags("media")');
+  });
+
+  it("registers the Next cache adapter via instrumentation for serverless writes", () => {
+    // A serverless seed function never loads the admin catch-all route, so
+    // instrumentation.ts must register the adapter or its writes silently use
+    // the no-op revalidator and never bust the timerless singleton caches.
+    const src = read("src/instrumentation.ts");
+    expect(src).toContain("export async function register(");
+    expect(src).toContain("registerNextCacheRevalidator");
   });
 
   it("by-slug detail lookups rethrow transient errors instead of caching a 404", () => {

--- a/packages/create-nextly-app/src/__tests__/blog-template-isr.test.ts
+++ b/packages/create-nextly-app/src/__tests__/blog-template-isr.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Smoke test for the blog template's tag-based ISR wiring.
+ *
+ * The blog template (repo-root /templates/blog) is downloaded at scaffold time
+ * and never built in this workspace, so there is no compile step to catch a
+ * regression here. These static assertions guard the F1 conversion: the query
+ * layer must cache reads through `nextly/runtime`, and the detail pages must
+ * keep build-time `generateStaticParams` while carrying no time-based
+ * `revalidate` (freshness comes from tag busting instead).
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+// /packages/create-nextly-app/src/__tests__ -> repo root -> /templates/blog
+const here = path.dirname(fileURLToPath(import.meta.url));
+const BLOG = path.resolve(here, "../../../../templates/blog");
+
+function read(rel: string): string {
+  return readFileSync(path.join(BLOG, rel), "utf-8");
+}
+
+const DETAIL_PAGES = [
+  "src/app/(frontend)/blog/[slug]/page.tsx",
+  "src/app/(frontend)/authors/[slug]/page.tsx",
+  "src/app/(frontend)/tags/[slug]/page.tsx",
+  "src/app/(frontend)/categories/[slug]/page.tsx",
+] as const;
+
+describe("blog template — tag-based ISR", () => {
+  it.each(DETAIL_PAGES)(
+    "%s pre-renders slugs but has no time-based revalidate",
+    page => {
+      const src = read(page);
+      expect(src).toContain("generateStaticParams");
+      expect(src).not.toMatch(/export\s+const\s+revalidate\s*=/);
+    }
+  );
+
+  const COLLECTION_QUERIES = [
+    "src/lib/queries/posts.ts",
+    "src/lib/queries/categories.ts",
+    "src/lib/queries/tags.ts",
+    "src/lib/queries/authors.ts",
+  ] as const;
+
+  it.each(COLLECTION_QUERIES)(
+    "%s caches reads via nextly/runtime cachedFind + nextlyTags",
+    file => {
+      const src = read(file);
+      expect(src).toContain('from "nextly/runtime"');
+      expect(src).toContain("cachedFind(");
+      expect(src).toContain("nextlyTags(");
+    }
+  );
+
+  const SINGLE_QUERIES = [
+    "src/lib/queries/site-settings.ts",
+    "src/lib/queries/navigation.ts",
+    "src/lib/queries/homepage.ts",
+  ] as const;
+
+  it.each(SINGLE_QUERIES)(
+    "%s caches the single via cachedFind + nextlySingleTags",
+    file => {
+      const src = read(file);
+      expect(src).toContain('from "nextly/runtime"');
+      expect(src).toContain("cachedFind(");
+      expect(src).toContain("nextlySingleTags(");
+    }
+  );
+
+  it("README documents tag-based revalidation, not a fixed ISR window", () => {
+    const readme = read("README.md");
+    expect(readme).toContain("tag-based revalidation");
+    expect(readme).not.toContain("revalidate every 60 seconds");
+  });
+});

--- a/packages/create-nextly-app/src/__tests__/blog-template-isr.test.ts
+++ b/packages/create-nextly-app/src/__tests__/blog-template-isr.test.ts
@@ -67,6 +67,31 @@ describe("blog template — tag-based ISR", () => {
     expect(src).toContain('nextlyTags("users")');
   });
 
+  it("by-slug detail lookups rethrow transient errors instead of caching a 404", () => {
+    // Returning null on a fetch error lets the page bake a permanent, tagless
+    // notFound(); these lookups must rethrow so a transient failure stays a
+    // retryable error. A genuine miss still returns null (cached with a tag).
+    for (const file of [
+      "src/lib/queries/posts.ts",
+      "src/lib/queries/categories.ts",
+      "src/lib/queries/tags.ts",
+      "src/lib/queries/authors.ts",
+    ]) {
+      expect(read(file)).toContain("throw error;");
+    }
+  });
+
+  it("taxonomy count helpers do not cache a swallowed zero count", () => {
+    // A per-item count catch returning 0 would be cached under the read's tag;
+    // the count helpers must let a count failure reject the whole read instead.
+    for (const file of [
+      "src/lib/queries/categories.ts",
+      "src/lib/queries/tags.ts",
+    ]) {
+      expect(read(file)).not.toContain("postCount: 0");
+    }
+  });
+
   const SINGLE_QUERIES = [
     "src/lib/queries/site-settings.ts",
     "src/lib/queries/navigation.ts",

--- a/packages/create-nextly-app/src/__tests__/template-channel.test.ts
+++ b/packages/create-nextly-app/src/__tests__/template-channel.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for the content-template npm dist-tag channel.
+ *
+ * Content templates (blog) render CMS content through `nextly/runtime` cache
+ * helpers, which ship on the active `alpha` channel; the conservative `latest`
+ * tag can lag behind it during the alpha. So a blog scaffold must pin nextly +
+ * @nextlyhq/* to `alpha`, while blank/plugin stay on `latest`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DatabaseConfig } from "../types";
+import { generatePackageJson, templateNextlyChannel } from "../utils/template";
+
+const pgDatabase: DatabaseConfig = {
+  type: "postgresql",
+  adapter: "@nextlyhq/adapter-postgres",
+  databaseDriver: "pg",
+  connectionUrl: "postgresql://localhost/test",
+  envExample: "postgresql://localhost/test",
+};
+
+// Distinct versions per dist-tag so we can assert which channel a scaffold
+// resolved from. Every registry dist-tags request returns both tags.
+const LATEST = "0.0.2-alpha.37";
+const ALPHA = "0.0.2-alpha.42";
+
+describe("templateNextlyChannel", () => {
+  it("routes content templates to alpha and everything else to latest", () => {
+    expect(templateNextlyChannel("blog")).toBe("alpha");
+    expect(templateNextlyChannel("blank")).toBe("latest");
+    expect(templateNextlyChannel("plugin")).toBe("latest");
+  });
+});
+
+describe("content-template dist-tag pinning", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ latest: LATEST, alpha: ALPHA }),
+      }))
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("pins the blog scaffold's nextly + @nextlyhq/* to the alpha channel", async () => {
+    const pkg = JSON.parse(
+      await generatePackageJson("blog-app", pgDatabase, false, "blog")
+    );
+    expect(pkg.dependencies["nextly"]).toBe(`^${ALPHA}`);
+    expect(pkg.dependencies["@nextlyhq/admin"]).toBe(`^${ALPHA}`);
+    expect(pkg.dependencies["@nextlyhq/adapter-drizzle"]).toBe(`^${ALPHA}`);
+  });
+
+  it("pins the blank scaffold's nextly to the latest channel", async () => {
+    const pkg = JSON.parse(
+      await generatePackageJson("blank-app", pgDatabase, false, "blank")
+    );
+    expect(pkg.dependencies["nextly"]).toBe(`^${LATEST}`);
+    expect(pkg.dependencies["@nextlyhq/admin"]).toBe(`^${LATEST}`);
+  });
+});

--- a/packages/create-nextly-app/src/__tests__/template-channel.test.ts
+++ b/packages/create-nextly-app/src/__tests__/template-channel.test.ts
@@ -65,3 +65,41 @@ describe("content-template dist-tag pinning", () => {
     expect(pkg.dependencies["@nextlyhq/admin"]).toBe(`^${LATEST}`);
   });
 });
+
+// Reset modules per test so the per-channel version cache never masks the
+// failure path (a cached alpha version would hide a regression here).
+describe("alpha pin survives a registry lookup failure", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps a blog scaffold on the alpha tag when the registry request fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, json: async () => ({}) }))
+    );
+    const { generatePackageJson: gen } = await import("../utils/template");
+    const pkg = JSON.parse(await gen("blog-app", pgDatabase, false, "blog"));
+    // The dist-tag name is itself a valid npm spec; a content template must
+    // never silently drop to `latest` (which lacks the runtime helpers).
+    expect(pkg.dependencies["nextly"]).toBe("alpha");
+    expect(pkg.dependencies["@nextlyhq/admin"]).toBe("alpha");
+  });
+
+  it("keeps a blog scaffold on the alpha tag when the alpha tag is absent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ latest: LATEST }),
+      }))
+    );
+    const { generatePackageJson: gen } = await import("../utils/template");
+    const pkg = JSON.parse(await gen("blog-app", pgDatabase, false, "blog"));
+    expect(pkg.dependencies["nextly"]).toBe("alpha");
+  });
+});

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -251,9 +251,10 @@ const resolvedNextlyVersions = new Map<NextlyDistTag, Record<string, string>>();
 
 /**
  * Fetch a package's version for the given dist-tag from the npm registry.
- * Falls back to the `latest` tag when the package has no entry for `channel`,
- * and returns the `"latest"` string on failure (network error, timeout, not
- * published yet).
+ * On any failure (non-OK response, timeout, missing tag, thrown error) it
+ * returns the requested dist-tag NAME itself (e.g. "alpha") — a valid npm
+ * install spec — so a content template pinned to `alpha` never silently drops
+ * to `latest`, which lacks the runtime helpers its pages import.
  */
 async function fetchLatestVersion(
   pkg: string,
@@ -264,12 +265,12 @@ async function fetchLatestVersion(
       `https://registry.npmjs.org/-/package/${encodeURIComponent(pkg)}/dist-tags`,
       { signal: AbortSignal.timeout(5000) }
     );
-    if (!res.ok) return "latest";
+    if (!res.ok) return channel;
     const data = (await res.json()) as Record<string, string>;
-    const version = data[channel] ?? data.latest;
-    return version ? `^${version}` : "latest";
+    const version = data[channel];
+    return version ? `^${version}` : channel;
   } catch {
-    return "latest";
+    return channel;
   }
 }
 

--- a/packages/create-nextly-app/src/utils/template.ts
+++ b/packages/create-nextly-app/src/utils/template.ts
@@ -21,6 +21,29 @@ export function projectUsesFormBuilder(projectType: ProjectType): boolean {
   return PROJECT_TYPES_WITH_FORM_BUILDER.has(projectType);
 }
 
+/** The npm dist-tag a scaffold installs `nextly` + `@nextlyhq/*` from. */
+export type NextlyDistTag = "latest" | "alpha";
+
+/**
+ * Templates that render CMS content through `nextly/runtime` cache helpers
+ * (`cachedFind` / `nextlyTags`) install `nextly` + `@nextlyhq/*` from the
+ * `alpha` dist-tag rather than `latest`. Those helpers ship on the active
+ * alpha channel, and during the alpha the conservative `latest` tag can lag
+ * behind it — a content scaffold pinned to `latest` would then install a
+ * `nextly` missing the helpers its pages import, and fail to build. Non-content
+ * scaffolds (blank, plugin) stay on `latest`.
+ */
+const CONTENT_TEMPLATE_TYPES: ReadonlySet<ProjectType> = new Set(["blog"]);
+
+/**
+ * The npm dist-tag a scaffold of `projectType` installs `nextly` + `@nextlyhq/*`
+ * from: content templates track `alpha` (see {@link CONTENT_TEMPLATE_TYPES}),
+ * everything else tracks `latest`.
+ */
+export function templateNextlyChannel(projectType: ProjectType): NextlyDistTag {
+  return CONTENT_TEMPLATE_TYPES.has(projectType) ? "alpha" : "latest";
+}
+
 // ============================================================
 // Text File Extensions (for placeholder replacement)
 // ============================================================
@@ -223,14 +246,19 @@ const NEXTLY_PACKAGES = [
   "@nextlyhq/plugin-sdk",
 ];
 
-/** Cache so we only fetch once per CLI run. */
-let resolvedNextlyVersions: Record<string, string> | null = null;
+/** Cache so we only fetch once per channel per CLI run. */
+const resolvedNextlyVersions = new Map<NextlyDistTag, Record<string, string>>();
 
 /**
- * Fetch the latest version of a package from the npm registry.
- * Returns `"latest"` on failure (network error, timeout, not published yet).
+ * Fetch a package's version for the given dist-tag from the npm registry.
+ * Falls back to the `latest` tag when the package has no entry for `channel`,
+ * and returns the `"latest"` string on failure (network error, timeout, not
+ * published yet).
  */
-async function fetchLatestVersion(pkg: string): Promise<string> {
+async function fetchLatestVersion(
+  pkg: string,
+  channel: NextlyDistTag = "latest"
+): Promise<string> {
   try {
     const res = await fetch(
       `https://registry.npmjs.org/-/package/${encodeURIComponent(pkg)}/dist-tags`,
@@ -238,26 +266,31 @@ async function fetchLatestVersion(pkg: string): Promise<string> {
     );
     if (!res.ok) return "latest";
     const data = (await res.json()) as Record<string, string>;
-    return data.latest ? `^${data.latest}` : "latest";
+    const version = data[channel] ?? data.latest;
+    return version ? `^${version}` : "latest";
   } catch {
     return "latest";
   }
 }
 
 /**
- * Resolve all @nextlyhq/* package versions in parallel.
- * Results are cached for the lifetime of the CLI process.
+ * Resolve all @nextlyhq/* package versions in parallel for the given dist-tag
+ * channel. Results are cached per channel for the lifetime of the CLI process.
  */
-export async function resolveNextlyVersions(): Promise<Record<string, string>> {
-  if (resolvedNextlyVersions) return resolvedNextlyVersions;
+export async function resolveNextlyVersions(
+  channel: NextlyDistTag = "latest"
+): Promise<Record<string, string>> {
+  const cached = resolvedNextlyVersions.get(channel);
+  if (cached) return cached;
 
   const entries = await Promise.all(
     NEXTLY_PACKAGES.map(
-      async pkg => [pkg, await fetchLatestVersion(pkg)] as const
+      async pkg => [pkg, await fetchLatestVersion(pkg, channel)] as const
     )
   );
-  resolvedNextlyVersions = Object.fromEntries(entries);
-  return resolvedNextlyVersions;
+  const versions = Object.fromEntries(entries);
+  resolvedNextlyVersions.set(channel, versions);
+  return versions;
 }
 
 /** Cache for runtime-resolved package versions (next, eslint-config-next). */
@@ -328,7 +361,12 @@ export async function generatePackageJson(
   dependencies["lucide-react"] = "^0.544.0";
 
   if (!useYalc) {
-    const versions = await resolveNextlyVersions();
+    // Content templates (blog) track the `alpha` dist-tag so they always get a
+    // nextly that has the `nextly/runtime` cache helpers their pages import;
+    // other scaffolds track `latest`.
+    const versions = await resolveNextlyVersions(
+      templateNextlyChannel(projectType)
+    );
     dependencies["nextly"] = versions["nextly"];
     dependencies["@nextlyhq/admin"] = versions["@nextlyhq/admin"];
     dependencies["@nextlyhq/ui"] = versions["@nextlyhq/ui"] || "latest";

--- a/templates/blog/README.md
+++ b/templates/blog/README.md
@@ -137,13 +137,13 @@ Pages pre-render at build time via `generateStaticParams`, then stay fresh throu
 
 ### What a write refreshes
 
-| Change in /admin                                      | Pages that refresh on next visit                                                                                                                                                   |
-| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Publish / edit / delete a post                        | Homepage, `/blog` (+ pagination), the post's `/blog/[slug]`, and every author / category / tag listing it appears in                                                               |
-| Rename a post's slug                                  | The new `/blog/[slug]` renders; the old URL 404s (its page regenerated and no published post matches)                                                                              |
-| Edit a category / tag                                 | Its listing page and any post detail that shows it                                                                                                                                 |
-| Edit an author's profile                              | Post pages by that author refresh immediately; the author's own name / bio / avatar refresh within a short safety-net window (the `users` collection does not emit cache tags yet) |
-| Edit the Site settings / Navigation / Homepage single | Every page that reads that global                                                                                                                                                  |
+| Change in /admin                                      | Pages that refresh on next visit                                                                                                                                                                                      |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Publish / edit / delete a post                        | Homepage, `/blog` (+ pagination), the post's `/blog/[slug]`, and every author / category / tag listing it appears in                                                                                                  |
+| Rename a post's slug                                  | The new `/blog/[slug]` renders; the old URL 404s (its page regenerated and no published post matches)                                                                                                                 |
+| Edit a category / tag                                 | Its listing page and any post detail that shows it                                                                                                                                                                    |
+| Edit an author's profile                              | The `users` collection emits no cache tags, so the author's name / bio / avatar refresh within the safety-net window — on `/authors/[slug]` and wherever the author appears in post lists / details — never instantly |
+| Edit the Site settings / Navigation / Homepage single | Every page that reads that global                                                                                                                                                                                     |
 
 ### Opting a write out of revalidation
 

--- a/templates/blog/README.md
+++ b/templates/blog/README.md
@@ -128,14 +128,30 @@ Create new files in `src/app/(frontend)/` following the Next.js App Router conve
 
 ## Performance
 
-Dynamic pages pre-render at build time via `generateStaticParams` and revalidate every 60 seconds (ISR):
+Pages pre-render at build time via `generateStaticParams`, then stay fresh through **tag-based revalidation** — no time-based `revalidate`, no rebuilds:
 
-- Every published post
-- Every author
-- Every category
-- Every tag
+- Every published post, author, category, and tag is pre-rendered at build.
+- Every read in `src/lib/queries/` is wrapped in Nextly's `cachedFind` and tagged with `nextlyTags(...)` / `nextlySingleTags(...)`.
+- When you publish, edit, or delete content in `/admin`, the write busts the matching tag and the affected pages regenerate on the **next** request. The admin route registers the Next cache adapter for you (via `createDynamicHandlers`), so this works out of the box — no `instrumentation.ts` to wire up.
+- Slugs published after the last build render on first request (`dynamicParams`).
 
-New content renders on-demand and caches until the next ISR tick. Adjust the window by editing `export const revalidate = 60` in the relevant page. Lower for fresher content at higher DB cost; higher for the opposite.
+### What a write refreshes
+
+| Change in /admin                                      | Pages that refresh on next visit                                                                                                                                                   |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Publish / edit / delete a post                        | Homepage, `/blog` (+ pagination), the post's `/blog/[slug]`, and every author / category / tag listing it appears in                                                               |
+| Rename a post's slug                                  | The new `/blog/[slug]` renders; the old URL 404s (its page regenerated and no published post matches)                                                                              |
+| Edit a category / tag                                 | Its listing page and any post detail that shows it                                                                                                                                 |
+| Edit an author's profile                              | Post pages by that author refresh immediately; the author's own name / bio / avatar refresh within a short safety-net window (the `users` collection does not emit cache tags yet) |
+| Edit the Site settings / Navigation / Homepage single | Every page that reads that global                                                                                                                                                  |
+
+### Opting a write out of revalidation
+
+A bulk import or seed script can skip the cache bust by passing `disableRevalidate: true` to a Direct API write — `nextly.create({ collection: "posts", data, disableRevalidate: true })`. The write still happens; it just doesn't bust tags, which is handy when you would rather revalidate once at the end of a batch.
+
+### Time-based safety net
+
+Tag busting is exact, so posts, categories, tags, and the singles need no timer. The exception is **authors**: the `users` collection does not emit cache tags yet, so `src/lib/queries/authors.ts` ships a time-based backstop (`AUTHOR_REVALIDATE_SECONDS`, one hour) that makes a profile edit appear within that window — lower it for fresher author pages. To add a backstop to any other read, pass `revalidate: <seconds>` to its `cachedFind` call.
 
 Images use `next/image` with a `sizes` attribute so phones don't download desktop-sized files. The `unoptimized` prop is set on avatar images since they can come from arbitrary remote URLs that aren't in `next.config.images.remotePatterns`.
 
@@ -163,7 +179,7 @@ export default async function BlogPage() {
 }
 ```
 
-The Direct API runs in Server Components with zero HTTP overhead. Relationships populate via the `depth` parameter. Per-request caching (React `cache()`) avoids duplicate fetches when multiple components need the same data; see `src/lib/queries/` for the cached helpers.
+The Direct API runs in Server Components with zero HTTP overhead. Relationships populate via the `depth` parameter. React `cache()` deduplicates fetches within a single request; cross-request freshness is tag-based via `cachedFind` (see [Performance](#performance) above). See `src/lib/queries/` for the cached helpers.
 
 ## Search
 

--- a/templates/blog/README.md
+++ b/templates/blog/README.md
@@ -132,7 +132,7 @@ Pages pre-render at build time via `generateStaticParams`, then stay fresh throu
 
 - Every published post, author, category, and tag is pre-rendered at build.
 - Every read in `src/lib/queries/` is wrapped in Nextly's `cachedFind` and tagged with `nextlyTags(...)` / `nextlySingleTags(...)`.
-- When you publish, edit, or delete content in `/admin`, the write busts the matching tag and the affected pages regenerate on the **next** request. The admin route registers the Next cache adapter for you (via `createDynamicHandlers`), so this works out of the box — no `instrumentation.ts` to wire up.
+- When you publish, edit, or delete content in `/admin`, the write busts the matching tag and the affected pages regenerate on the **next** request. `src/instrumentation.ts` registers the Next cache adapter when any server process boots, so every write path busts tags — the admin API, the seed endpoint, and Server Actions — including in split serverless deployments where those run as separate functions.
 - Slugs published after the last build render on first request (`dynamicParams`).
 
 ### What a write refreshes
@@ -151,7 +151,7 @@ A bulk import or seed script can skip the cache bust by passing `disableRevalida
 
 ### Time-based safety net
 
-Tag busting is exact, so posts, categories, tags, and the singles need no timer. The exception is **authors**: the `users` collection does not emit cache tags yet, so `src/lib/queries/authors.ts` ships a time-based backstop (`AUTHOR_REVALIDATE_SECONDS`, one hour) that makes a profile edit appear within that window — lower it for fresher author pages. To add a backstop to any other read, pass `revalidate: <seconds>` to its `cachedFind` call.
+Tag busting is exact, so post, category, tag, and single edits need no timer. The exceptions are the system collections that do not emit cache tags yet — `users` (authors) and `media`. So the author page (`src/lib/queries/authors.ts`) and the post reads that embed author or image records (`src/lib/queries/posts.ts`) ship a one-hour backstop (`AUTHOR_REVALIDATE_SECONDS` / `RELATION_REVALIDATE_SECONDS`) so an author-profile or image-metadata edit appears within that window — lower it for fresher pages. To add a backstop to any other read, pass `revalidate: <seconds>` to its `cachedFind` call.
 
 Images use `next/image` with a `sizes` attribute so phones don't download desktop-sized files. The `unoptimized` prop is set on avatar images since they can come from arbitrary remote URLs that aren't in `next.config.images.remotePatterns`.
 

--- a/templates/blog/src/app/(frontend)/authors/[slug]/page.tsx
+++ b/templates/blog/src/app/(frontend)/authors/[slug]/page.tsx
@@ -25,12 +25,14 @@ import {
 } from "@/lib/queries";
 import { absoluteUrl } from "@/lib/site-url";
 
+// Pre-render known author pages at build time. Freshness afterward is
+// tag-based: the query helpers tag their reads (src/lib/queries), so an
+// author or post change busts the tag and this page regenerates on the next
+// request — no time-based `revalidate`. New authors render on demand.
 export async function generateStaticParams() {
   const slugs = await getAllAuthorSlugs();
   return slugs.map(slug => ({ slug }));
 }
-
-export const revalidate = 60;
 
 export async function generateMetadata({
   params,

--- a/templates/blog/src/app/(frontend)/blog/[slug]/page.tsx
+++ b/templates/blog/src/app/(frontend)/blog/[slug]/page.tsx
@@ -43,13 +43,17 @@ import {
 } from "@/lib/queries";
 import { absoluteUrl } from "@/lib/site-url";
 
+// Pre-render every published post at build time. Freshness afterward is
+// tag-based: the post query helpers tag their reads (src/lib/queries), so
+// publishing, editing, or deleting a post busts the tag and this page
+// regenerates on the next request — no time-based `revalidate`. A rename
+// busts the collection tag too, so the old slug's page 404s once it moves.
 export async function generateStaticParams() {
   const slugs = await getAllPostSlugs();
   return slugs.map(slug => ({ slug }));
 }
 
-/** Revalidate each post page every 60 seconds (ISR). */
-export const revalidate = 60;
+// Slugs published after the last build render on first request.
 export const dynamicParams = true;
 
 export async function generateMetadata({

--- a/templates/blog/src/app/(frontend)/categories/[slug]/page.tsx
+++ b/templates/blog/src/app/(frontend)/categories/[slug]/page.tsx
@@ -20,12 +20,14 @@ import {
 } from "@/lib/queries";
 import { absoluteUrl } from "@/lib/site-url";
 
+// Pre-render known category pages at build time. Freshness afterward is
+// tag-based: the query helpers tag their reads (src/lib/queries), so a
+// category or post change busts the tag and this page regenerates on the
+// next request — no time-based `revalidate`. New categories render on demand.
 export async function generateStaticParams() {
   const slugs = await getAllCategorySlugs();
   return slugs.map(slug => ({ slug }));
 }
-
-export const revalidate = 60;
 
 export async function generateMetadata({
   params,

--- a/templates/blog/src/app/(frontend)/tags/[slug]/page.tsx
+++ b/templates/blog/src/app/(frontend)/tags/[slug]/page.tsx
@@ -17,12 +17,14 @@ import { PostGrid } from "@/components/PostGrid";
 import { getAllTagSlugs, getPostsByTag, getTagBySlug } from "@/lib/queries";
 import { absoluteUrl } from "@/lib/site-url";
 
+// Pre-render known tag pages at build time. Freshness afterward is
+// tag-based: the query helpers tag their reads (src/lib/queries), so a tag
+// or post change busts the tag and this page regenerates on the next
+// request — no time-based `revalidate`. New tags render on demand.
 export async function generateStaticParams() {
   const slugs = await getAllTagSlugs();
   return slugs.map(slug => ({ slug }));
 }
-
-export const revalidate = 60;
 
 export async function generateMetadata({
   params,

--- a/templates/blog/src/instrumentation.ts
+++ b/templates/blog/src/instrumentation.ts
@@ -1,0 +1,25 @@
+/**
+ * Registers Nextly's Next.js cache adapter as soon as any server instance
+ * boots. Next.js runs `register()` once per server process at startup — in
+ * every serverless function, not just the one serving the admin catch-all
+ * route — so any function that performs a Direct API write (the initial content
+ * seed at `/admin/api/seed`, a Server Action, a custom route) flushes cache
+ * tags instead of silently using the no-op revalidator.
+ *
+ * Without this, a write from an isolated serverless function would not bust the
+ * tag-based caches. That is most damaging for the timerless singleton pages
+ * (site settings, navigation, homepage): `next build` runs against the freshly
+ * migrated, empty database and caches their defaults, and a later seed that
+ * populates them from a separate function would leave those pages stuck on the
+ * build-time defaults forever.
+ *
+ * Guarded to the Node.js runtime: the adapter resolves `next/cache` via
+ * `createRequire`, which is unavailable on the edge runtime (where Nextly does
+ * not run anyway).
+ */
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { registerNextCacheRevalidator } = await import("nextly/runtime");
+    registerNextCacheRevalidator();
+  }
+}

--- a/templates/blog/src/lib/queries/authors.ts
+++ b/templates/blog/src/lib/queries/authors.ts
@@ -11,14 +11,33 @@
  *
  * We keep the `getAuthorBySlug` / `getAllAuthorSlugs` names to match
  * the frontend mental model and the `/authors/[slug]` URL.
+ *
+ * Caching: reads are wrapped in `cachedFind`. Authors are the built-in
+ * `users` collection, whose writes do not emit revalidation tags today — so
+ * unlike posts/categories/tags, an edit to an author's profile cannot bust a
+ * tag. These reads therefore carry a time-based safety net
+ * (`AUTHOR_REVALIDATE_SECONDS`) so a profile change becomes visible within
+ * that window; the `nextlyTags("users")` tag is kept so busting kicks in
+ * automatically should user writes gain tag emission later. The cached value
+ * is the public `Author` projection / slug list only — email, password, and
+ * role fields are stripped before caching.
  */
 
 // Pass nextlyConfig (loaded via the -config path alias) so
 // getNextly() bootstraps with this project's collections list.
 import { getNextly } from "nextly";
+import { cachedFind, nextlyTags } from "nextly/runtime";
 import nextlyConfig from "@nextly-config";
 
 import type { Author } from "./types";
+
+/**
+ * Time-based revalidation for author reads (seconds). Author profiles change
+ * rarely and the `users` collection does not emit revalidation tags today, so
+ * this window is how a profile edit eventually becomes visible. Lower it for
+ * fresher author pages at a higher DB cost.
+ */
+const AUTHOR_REVALIDATE_SECONDS = 3600;
 
 /**
  * Shape the user doc into the public Author projection. We never return
@@ -36,16 +55,25 @@ function toAuthor(doc: Record<string, unknown>): Author {
 
 export async function getAuthorBySlug(slug: string): Promise<Author | null> {
   try {
-    // nextly.users.find() doesn't support a `where` filter - it only exposes
-    // full-text `search`. For a slug (which must be exact) we list users
-    // and filter client-side. Author counts on a blog template are small
-    // (typically <50) so the full page fetch is cheap.
-    const nextly = await getNextly({ config: nextlyConfig });
-    const result = await nextly.users.find({ limit: 1000 });
-    const match = (result.items as unknown as Record<string, unknown>[]).find(
-      d => (d.slug as string | undefined) === slug
+    return await cachedFind(
+      async () => {
+        // nextly.users.find() doesn't support a `where` filter - it only exposes
+        // full-text `search`. For a slug (which must be exact) we list users
+        // and filter client-side. Author counts on a blog template are small
+        // (typically <50) so the full page fetch is cheap.
+        const nextly = await getNextly({ config: nextlyConfig });
+        const result = await nextly.users.find({ limit: 1000 });
+        const match = (
+          result.items as unknown as Record<string, unknown>[]
+        ).find(d => (d.slug as string | undefined) === slug);
+        return match ? toAuthor(match) : null;
+      },
+      {
+        tags: nextlyTags("users"),
+        keyParts: ["users", "author", "detail", slug],
+        revalidate: AUTHOR_REVALIDATE_SECONDS,
+      }
     );
-    return match ? toAuthor(match) : null;
   } catch (error) {
     console.error(`Error fetching author by slug ${slug}:`, error);
     return null;
@@ -54,11 +82,20 @@ export async function getAuthorBySlug(slug: string): Promise<Author | null> {
 
 export async function getAllAuthorSlugs(): Promise<string[]> {
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
-    const result = await nextly.users.find({ limit: 1000 });
-    return (result.items as unknown as Record<string, unknown>[])
-      .map(d => d.slug as string | undefined)
-      .filter((s): s is string => typeof s === "string" && s.length > 0);
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const result = await nextly.users.find({ limit: 1000 });
+        return (result.items as unknown as Record<string, unknown>[])
+          .map(d => d.slug as string | undefined)
+          .filter((s): s is string => typeof s === "string" && s.length > 0);
+      },
+      {
+        tags: nextlyTags("users"),
+        keyParts: ["users", "author", "slugs"],
+        revalidate: AUTHOR_REVALIDATE_SECONDS,
+      }
+    );
   } catch (error) {
     console.error("Error fetching all author slugs:", error);
     return [];

--- a/templates/blog/src/lib/queries/authors.ts
+++ b/templates/blog/src/lib/queries/authors.ts
@@ -75,8 +75,11 @@ export async function getAuthorBySlug(slug: string): Promise<Author | null> {
       }
     );
   } catch (error) {
+    // Rethrow, don't return null: a genuine miss returns null above, but
+    // swallowing a transient error into null would bake a timerless
+    // notFound() on /authors/[slug] — a permanent 404 for a real author.
     console.error(`Error fetching author by slug ${slug}:`, error);
-    return null;
+    throw error;
   }
 }
 

--- a/templates/blog/src/lib/queries/categories.ts
+++ b/templates/blog/src/lib/queries/categories.ts
@@ -36,8 +36,11 @@ export async function getCategoryBySlug(
       }
     );
   } catch (error) {
+    // Rethrow, don't return null: a genuine miss returns null above (cached
+    // with the categories tag, recoverable), but swallowing a transient error
+    // into null would bake a tagless, timerless notFound() — a permanent 404.
     console.error(`Error fetching category by slug ${slug}:`, error);
-    return null;
+    throw error;
   }
 }
 
@@ -113,29 +116,24 @@ export async function getAllCategoriesWithCounts(): Promise<
         return await Promise.all(
           cats.items.map(async cat => {
             const catId = String(cat.id);
-            try {
-              const posts = await nextly.find({
-                collection: "posts",
-                where: {
-                  and: [
-                    { status: { equals: "published" } },
-                    { categories: { contains: catId } },
-                  ],
-                },
-                limit: 0,
-                depth: 0,
-              });
-              return {
-                item: cat as Category,
-                postCount: posts.meta.total,
-              };
-            } catch {
-              // If count fails, return category with 0 posts
-              return {
-                item: cat as Category,
-                postCount: 0,
-              };
-            }
+            // No inner catch: a count failure must reject the whole read so the
+            // outer fallback runs uncached, instead of caching a wrong zero
+            // count until the next category/post write busts the tag.
+            const posts = await nextly.find({
+              collection: "posts",
+              where: {
+                and: [
+                  { status: { equals: "published" } },
+                  { categories: { contains: catId } },
+                ],
+              },
+              limit: 0,
+              depth: 0,
+            });
+            return {
+              item: cat as Category,
+              postCount: posts.meta.total,
+            };
           })
         );
       },

--- a/templates/blog/src/lib/queries/categories.ts
+++ b/templates/blog/src/lib/queries/categories.ts
@@ -1,10 +1,16 @@
 /**
  * Category query helpers.
+ *
+ * Caching: reads are wrapped in `cachedFind` and tagged with
+ * `nextlyTags("categories")` so a category write busts them. The
+ * post-count helper also carries `nextlyTags("posts")` because its numbers
+ * change when a post is published or removed from a category.
  */
 
 // Pass nextlyConfig (loaded via the -config path alias) so
 // getNextly() bootstraps with this project's collections list.
 import { getNextly } from "nextly";
+import { cachedFind, nextlyTags } from "nextly/runtime";
 import nextlyConfig from "@nextly-config";
 
 import type { Category, TaxonomyWithCount } from "./types";
@@ -13,14 +19,22 @@ export async function getCategoryBySlug(
   slug: string
 ): Promise<Category | null> {
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
-    const result = await nextly.find({
-      collection: "categories",
-      where: { slug: { equals: slug } },
-      limit: 1,
-      depth: 0,
-    });
-    return result.items[0] ? (result.items[0] as Category) : null;
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const result = await nextly.find({
+          collection: "categories",
+          where: { slug: { equals: slug } },
+          limit: 1,
+          depth: 0,
+        });
+        return result.items[0] ? (result.items[0] as Category) : null;
+      },
+      {
+        tags: nextlyTags("categories"),
+        keyParts: ["categories", "detail", slug],
+      }
+    );
   } catch (error) {
     console.error(`Error fetching category by slug ${slug}:`, error);
     return null;
@@ -34,13 +48,18 @@ export async function getCategoryBySlug(
  */
 export async function getAllCategories(): Promise<Category[]> {
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
-    const result = await nextly.find({
-      collection: "categories",
-      limit: 1000,
-      depth: 0,
-    });
-    return result.items.map(d => d as unknown as Category);
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const result = await nextly.find({
+          collection: "categories",
+          limit: 1000,
+          depth: 0,
+        });
+        return result.items.map(d => d as unknown as Category);
+      },
+      { tags: nextlyTags("categories"), keyParts: ["categories", "all"] }
+    );
   } catch (error) {
     console.error("Error fetching all categories:", error);
     return [];
@@ -49,13 +68,18 @@ export async function getAllCategories(): Promise<Category[]> {
 
 export async function getAllCategorySlugs(): Promise<string[]> {
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
-    const result = await nextly.find({
-      collection: "categories",
-      limit: 1000,
-      depth: 0,
-    });
-    return result.items.map(d => d.slug as string);
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const result = await nextly.find({
+          collection: "categories",
+          limit: 1000,
+          depth: 0,
+        });
+        return result.items.map(d => d.slug as string);
+      },
+      { tags: nextlyTags("categories"), keyParts: ["categories", "slugs"] }
+    );
   } catch (error) {
     console.error("Error fetching all category slugs:", error);
     return [];
@@ -70,44 +94,55 @@ export async function getAllCategorySlugs(): Promise<string[]> {
  * Runs one count query per category. Acceptable for a small-to-medium
  * blog; if you have hundreds of categories, consider a single SQL query
  * with GROUP BY and drop this helper.
+ *
+ * Carries both the categories and posts tags: a post publish/unpublish
+ * changes these counts, so it must bust this cache too.
  */
 export async function getAllCategoriesWithCounts(): Promise<
   TaxonomyWithCount<Category>[]
 > {
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
-    const cats = await nextly.find({
-      collection: "categories",
-      limit: 1000,
-      depth: 0,
-    });
-    return await Promise.all(
-      cats.items.map(async cat => {
-        const catId = String(cat.id);
-        try {
-          const posts = await nextly.find({
-            collection: "posts",
-            where: {
-              and: [
-                { status: { equals: "published" } },
-                { categories: { contains: catId } },
-              ],
-            },
-            limit: 0,
-            depth: 0,
-          });
-          return {
-            item: cat as Category,
-            postCount: posts.meta.total,
-          };
-        } catch {
-          // If count fails, return category with 0 posts
-          return {
-            item: cat as Category,
-            postCount: 0,
-          };
-        }
-      })
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const cats = await nextly.find({
+          collection: "categories",
+          limit: 1000,
+          depth: 0,
+        });
+        return await Promise.all(
+          cats.items.map(async cat => {
+            const catId = String(cat.id);
+            try {
+              const posts = await nextly.find({
+                collection: "posts",
+                where: {
+                  and: [
+                    { status: { equals: "published" } },
+                    { categories: { contains: catId } },
+                  ],
+                },
+                limit: 0,
+                depth: 0,
+              });
+              return {
+                item: cat as Category,
+                postCount: posts.meta.total,
+              };
+            } catch {
+              // If count fails, return category with 0 posts
+              return {
+                item: cat as Category,
+                postCount: 0,
+              };
+            }
+          })
+        );
+      },
+      {
+        tags: [...nextlyTags("categories"), ...nextlyTags("posts")],
+        keyParts: ["categories", "with-counts"],
+      }
     );
   } catch (error) {
     console.error("Error fetching categories with counts:", error);

--- a/templates/blog/src/lib/queries/homepage.ts
+++ b/templates/blog/src/lib/queries/homepage.ts
@@ -5,8 +5,10 @@
  * toggles. Falls back to sensible defaults if the single hasn't been
  * populated yet.
  *
- * Cached via React's `cache()` so multiple components on the same
- * request share a single DB fetch.
+ * Wrapped in React's `cache()` so multiple components on the same request
+ * share a single DB fetch, and in `cachedFind` so the result persists
+ * across requests until an edit to the homepage single busts
+ * `nextlySingleTags("homepage")`.
  */
 
 import { cache } from "react";
@@ -14,6 +16,7 @@ import { cache } from "react";
 // Pass nextlyConfig (loaded via the -config path alias) so
 // getNextly() bootstraps with this project's collections list.
 import { getNextly } from "nextly";
+import { cachedFind, nextlySingleTags } from "nextly/runtime";
 import nextlyConfig from "@nextly-config";
 
 export interface Homepage {
@@ -46,27 +49,34 @@ const DEFAULTS: Homepage = {
 
 export const getHomepage = cache(async (): Promise<Homepage> => {
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
-    const hp = await nextly.findSingle({ slug: "homepage", depth: 0 });
-    if (!hp) return DEFAULTS;
-    return {
-      heroTitle: (hp.heroTitle as string) || DEFAULTS.heroTitle,
-      heroSubtitle: (hp.heroSubtitle as string) || DEFAULTS.heroSubtitle,
-      showFeaturedPost: hp.showFeaturedPost !== false,
-      featuredSectionTitle:
-        (hp.featuredSectionTitle as string) || DEFAULTS.featuredSectionTitle,
-      showLatestPosts: hp.showLatestPosts !== false,
-      latestSectionTitle:
-        (hp.latestSectionTitle as string) || DEFAULTS.latestSectionTitle,
-      latestPostsCount:
-        (hp.latestPostsCount as number) || DEFAULTS.latestPostsCount,
-      showCategoryStrip: hp.showCategoryStrip !== false,
-      showNewsletterCta: hp.showNewsletterCta !== false,
-      newsletterHeading:
-        (hp.newsletterHeading as string) || DEFAULTS.newsletterHeading,
-      newsletterSubheading:
-        (hp.newsletterSubheading as string) || DEFAULTS.newsletterSubheading,
-    };
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const hp = await nextly.findSingle({ slug: "homepage", depth: 0 });
+        if (!hp) return DEFAULTS;
+        return {
+          heroTitle: (hp.heroTitle as string) || DEFAULTS.heroTitle,
+          heroSubtitle: (hp.heroSubtitle as string) || DEFAULTS.heroSubtitle,
+          showFeaturedPost: hp.showFeaturedPost !== false,
+          featuredSectionTitle:
+            (hp.featuredSectionTitle as string) ||
+            DEFAULTS.featuredSectionTitle,
+          showLatestPosts: hp.showLatestPosts !== false,
+          latestSectionTitle:
+            (hp.latestSectionTitle as string) || DEFAULTS.latestSectionTitle,
+          latestPostsCount:
+            (hp.latestPostsCount as number) || DEFAULTS.latestPostsCount,
+          showCategoryStrip: hp.showCategoryStrip !== false,
+          showNewsletterCta: hp.showNewsletterCta !== false,
+          newsletterHeading:
+            (hp.newsletterHeading as string) || DEFAULTS.newsletterHeading,
+          newsletterSubheading:
+            (hp.newsletterSubheading as string) ||
+            DEFAULTS.newsletterSubheading,
+        };
+      },
+      { tags: nextlySingleTags("homepage"), keyParts: ["single", "homepage"] }
+    );
   } catch (err) {
     if (process.env.NODE_ENV !== "production") {
       console.warn(

--- a/templates/blog/src/lib/queries/navigation.ts
+++ b/templates/blog/src/lib/queries/navigation.ts
@@ -5,8 +5,10 @@
  * to sensible defaults if the single hasn't been populated yet (first
  * run before seed, fresh install, or a deleted single).
  *
- * Cached via React's `cache()` so multiple components on the same
- * request share a single DB fetch.
+ * Wrapped in React's `cache()` so multiple components on the same request
+ * share a single DB fetch, and in `cachedFind` so the result persists
+ * across requests until an edit to the navigation single busts
+ * `nextlySingleTags("navigation")`.
  */
 
 import { cache } from "react";
@@ -14,6 +16,7 @@ import { cache } from "react";
 // Pass nextlyConfig (loaded via the -config path alias) so
 // getNextly() bootstraps with this project's collections list.
 import { getNextly } from "nextly";
+import { cachedFind, nextlySingleTags } from "nextly/runtime";
 import nextlyConfig from "@nextly-config";
 
 export interface NavLink {
@@ -47,18 +50,26 @@ const DEFAULTS: Navigation = {
 
 export const getNavigation = cache(async (): Promise<Navigation> => {
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
-    const nav = await nextly.findSingle({ slug: "navigation", depth: 0 });
-    if (!nav) return DEFAULTS;
-    return {
-      headerLinks:
-        (nav.headerLinks as NavLink[] | undefined) ?? DEFAULTS.headerLinks,
-      footerReadLinks:
-        (nav.footerReadLinks as NavLink[] | undefined) ??
-        DEFAULTS.footerReadLinks,
-      showThemeToggle: nav.showThemeToggle !== false,
-      showSearchIcon: nav.showSearchIcon !== false,
-    };
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const nav = await nextly.findSingle({ slug: "navigation", depth: 0 });
+        if (!nav) return DEFAULTS;
+        return {
+          headerLinks:
+            (nav.headerLinks as NavLink[] | undefined) ?? DEFAULTS.headerLinks,
+          footerReadLinks:
+            (nav.footerReadLinks as NavLink[] | undefined) ??
+            DEFAULTS.footerReadLinks,
+          showThemeToggle: nav.showThemeToggle !== false,
+          showSearchIcon: nav.showSearchIcon !== false,
+        };
+      },
+      {
+        tags: nextlySingleTags("navigation"),
+        keyParts: ["single", "navigation"],
+      }
+    );
   } catch (err) {
     if (process.env.NODE_ENV !== "production") {
       console.warn(

--- a/templates/blog/src/lib/queries/posts.ts
+++ b/templates/blog/src/lib/queries/posts.ts
@@ -10,13 +10,21 @@
  * when nothing matches; pages should call `notFound()` from `next/navigation`
  * to render the 404 page.
  *
- * Caching: every read is wrapped in `cachedFind` and tagged with
- * `nextlyTags("posts")`. Publishing, editing, or deleting a post busts that
- * tag on write (the admin route registers the Next cache adapter for you),
- * so these pages regenerate on the next request with no rebuild and no
- * time-based `revalidate`. All reads are public (published content, no
- * per-caller filter), so a stable cache key shared by every visitor is
+ * Caching: every read is wrapped in `cachedFind`. Publishing, editing, or
+ * deleting a post busts `nextly:posts` on write (the admin route registers the
+ * Next cache adapter for you), so these pages regenerate on the next request
+ * with no rebuild and no fixed timer. All reads are public (published content,
+ * no per-caller filter), so a stable cache key shared by every visitor is
  * correct; the varying arguments (slug, page, limit, ...) go in `keyParts`.
+ *
+ * Depth>=1 reads embed related author / category / tag records, so an edit to
+ * one of those must also refresh the post pages showing it. Those reads use
+ * `POST_WITH_RELATIONS_TAGS`: category and tag writes bust their own collection
+ * tags immediately, and because the `users` collection (authors) does not emit
+ * cache tags yet, those reads also carry a time-based safety net
+ * (`RELATION_REVALIDATE_SECONDS`) so an author profile edit becomes visible
+ * within that window. Depth=0 reads select only post columns and stay tagged
+ * with `nextly:posts` alone.
  */
 
 // Pass nextlyConfig (loaded via the @nextly-config path alias) so
@@ -32,6 +40,28 @@ import { getCategoryBySlug } from "./categories";
 import { getTagBySlug } from "./tags";
 
 const PUBLISHED = { status: { equals: "published" } };
+
+/**
+ * Tags for a read that populates related records (depth>=1). Carries the post,
+ * category, tag, and user collection tags so an edit to any embedded relation
+ * busts these pages. Categories and tags emit their tags on write; the `users`
+ * tag is inert today (see `RELATION_REVALIDATE_SECONDS`) but future-proofs the
+ * read for when user writes gain tag emission.
+ */
+const POST_WITH_RELATIONS_TAGS = [
+  ...nextlyTags("posts"),
+  ...nextlyTags("categories"),
+  ...nextlyTags("tags"),
+  ...nextlyTags("users"),
+];
+
+/**
+ * Time-based safety net (seconds) for reads that embed author (user) fields.
+ * The `users` collection does not emit revalidation tags today, so this window
+ * is how an author's updated name / bio / avatar becomes visible inside posts.
+ * Lower it for fresher relation data at a higher DB cost.
+ */
+const RELATION_REVALIDATE_SECONDS = 3600;
 
 /**
  * Nextly's `find()` returns loosely-typed documents (Record<string, unknown>).
@@ -67,8 +97,9 @@ export async function getLatestPosts(limit = 3): Promise<Post[]> {
         return coercePosts(result.items);
       },
       {
-        tags: nextlyTags("posts"),
+        tags: POST_WITH_RELATIONS_TAGS,
         keyParts: ["posts", "latest", String(limit)],
+        revalidate: RELATION_REVALIDATE_SECONDS,
       }
     );
   } catch (error) {
@@ -99,7 +130,11 @@ export async function getFeaturedPost(): Promise<Post | null> {
         });
         return result.items[0] ? coercePost(result.items[0]) : null;
       },
-      { tags: nextlyTags("posts"), keyParts: ["posts", "featured"] }
+      {
+        tags: POST_WITH_RELATIONS_TAGS,
+        keyParts: ["posts", "featured"],
+        revalidate: RELATION_REVALIDATE_SECONDS,
+      }
     );
   } catch (error) {
     console.error("Error fetching featured post:", error);
@@ -158,8 +193,9 @@ export async function getPosts({
         };
       },
       {
-        tags: nextlyTags("posts"),
+        tags: POST_WITH_RELATIONS_TAGS,
         keyParts: ["posts", "list", String(page), String(limit)],
+        revalidate: RELATION_REVALIDATE_SECONDS,
       }
     );
   } catch (error) {
@@ -175,7 +211,7 @@ export async function getPosts({
  * separate helper with a token-based auth check.
  * Returns null when the slug doesn't match or the post is not published.
  *
- * Tagged with the collection tag (not an entry-id tag): the id isn't known
+ * Tagged with the collection tags (not an entry-id tag): the id isn't known
  * until the read resolves, and a slug rename busts `nextly:posts` anyway, so
  * the old slug's page regenerates and 404s once the post moves.
  */
@@ -195,7 +231,11 @@ export async function getPostBySlug(slug: string): Promise<Post | null> {
         });
         return result.items[0] ? coercePost(result.items[0]) : null;
       },
-      { tags: nextlyTags("posts"), keyParts: ["posts", "detail", slug] }
+      {
+        tags: POST_WITH_RELATIONS_TAGS,
+        keyParts: ["posts", "detail", slug],
+        revalidate: RELATION_REVALIDATE_SECONDS,
+      }
     );
   } catch (error) {
     console.error(`Error fetching post by slug ${slug}:`, error);
@@ -301,8 +341,9 @@ export async function getPostsByAuthor(
         };
       },
       {
-        tags: nextlyTags("posts"),
+        tags: POST_WITH_RELATIONS_TAGS,
         keyParts: ["posts", "by-author", authorId, String(page), String(limit)],
+        revalidate: RELATION_REVALIDATE_SECONDS,
       }
     );
   } catch (error) {
@@ -358,7 +399,7 @@ export async function getPostsByCategory(
         };
       },
       {
-        tags: nextlyTags("posts"),
+        tags: POST_WITH_RELATIONS_TAGS,
         keyParts: [
           "posts",
           "by-category",
@@ -366,6 +407,7 @@ export async function getPostsByCategory(
           String(page),
           String(limit),
         ],
+        revalidate: RELATION_REVALIDATE_SECONDS,
       }
     );
   } catch (error) {
@@ -413,8 +455,9 @@ export async function getPostsByTag(
         };
       },
       {
-        tags: nextlyTags("posts"),
+        tags: POST_WITH_RELATIONS_TAGS,
         keyParts: ["posts", "by-tag", tagSlug, String(page), String(limit)],
+        revalidate: RELATION_REVALIDATE_SECONDS,
       }
     );
   } catch (error) {
@@ -541,8 +584,9 @@ export async function getRelatedPosts(
           return coercePosts(result.items);
         },
         {
-          tags: nextlyTags("posts"),
+          tags: POST_WITH_RELATIONS_TAGS,
           keyParts: ["posts", "related", currentSlug, keySuffix, String(limit)],
+          revalidate: RELATION_REVALIDATE_SECONDS,
         }
       );
 

--- a/templates/blog/src/lib/queries/posts.ts
+++ b/templates/blog/src/lib/queries/posts.ts
@@ -238,8 +238,13 @@ export async function getPostBySlug(slug: string): Promise<Post | null> {
       }
     );
   } catch (error) {
+    // Rethrow rather than return null: a genuine miss (no published post)
+    // already returns null above and caches a tagged 404 that a later publish
+    // busts, but swallowing a transient DB error into null would make the page
+    // bake a notFound() that carries no tags and no timer — a permanent 404 for
+    // a real post. Letting it throw yields an uncached, retryable error instead.
     console.error(`Error fetching post by slug ${slug}:`, error);
-    return null;
+    throw error;
   }
 }
 

--- a/templates/blog/src/lib/queries/posts.ts
+++ b/templates/blog/src/lib/queries/posts.ts
@@ -9,6 +9,14 @@
  * Helpers that look up a single entity return `null` (not a thrown error)
  * when nothing matches; pages should call `notFound()` from `next/navigation`
  * to render the 404 page.
+ *
+ * Caching: every read is wrapped in `cachedFind` and tagged with
+ * `nextlyTags("posts")`. Publishing, editing, or deleting a post busts that
+ * tag on write (the admin route registers the Next cache adapter for you),
+ * so these pages regenerate on the next request with no rebuild and no
+ * time-based `revalidate`. All reads are public (published content, no
+ * per-caller filter), so a stable cache key shared by every visitor is
+ * correct; the varying arguments (slug, page, limit, ...) go in `keyParts`.
  */
 
 // Pass nextlyConfig (loaded via the @nextly-config path alias) so
@@ -16,6 +24,7 @@
 // Without this, the global singleton initializes empty and
 // find('posts') throws "Schema not in registry".
 import { getNextly } from "nextly";
+import { cachedFind, nextlyTags } from "nextly/runtime";
 import nextlyConfig from "@nextly-config";
 
 import type { Post } from "./types";
@@ -45,15 +54,23 @@ function coercePosts(docs: unknown[]): Post[] {
  */
 export async function getLatestPosts(limit = 3): Promise<Post[]> {
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
-    const result = await nextly.find({
-      collection: "posts",
-      where: PUBLISHED,
-      sort: "-publishedAt",
-      limit,
-      depth: 2,
-    });
-    return coercePosts(result.items);
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const result = await nextly.find({
+          collection: "posts",
+          where: PUBLISHED,
+          sort: "-publishedAt",
+          limit,
+          depth: 2,
+        });
+        return coercePosts(result.items);
+      },
+      {
+        tags: nextlyTags("posts"),
+        keyParts: ["posts", "latest", String(limit)],
+      }
+    );
   } catch (error) {
     console.error("Error fetching latest posts:", error);
     return [];
@@ -68,17 +85,22 @@ export async function getLatestPosts(limit = 3): Promise<Post[]> {
  */
 export async function getFeaturedPost(): Promise<Post | null> {
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
-    const result = await nextly.find({
-      collection: "posts",
-      where: {
-        and: [PUBLISHED, { featured: { equals: true } }],
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const result = await nextly.find({
+          collection: "posts",
+          where: {
+            and: [PUBLISHED, { featured: { equals: true } }],
+          },
+          sort: "-publishedAt",
+          limit: 1,
+          depth: 2,
+        });
+        return result.items[0] ? coercePost(result.items[0]) : null;
       },
-      sort: "-publishedAt",
-      limit: 1,
-      depth: 2,
-    });
-    return result.items[0] ? coercePost(result.items[0]) : null;
+      { tags: nextlyTags("posts"), keyParts: ["posts", "featured"] }
+    );
   } catch (error) {
     console.error("Error fetching featured post:", error);
     return null;
@@ -115,23 +137,31 @@ export async function getPosts({
   limit = 9,
 }: PostListOptions = {}): Promise<PostListResult> {
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
-    const result = await nextly.find({
-      collection: "posts",
-      where: PUBLISHED,
-      sort: "-publishedAt",
-      page,
-      limit,
-      depth: 2,
-    });
-    return {
-      items: coercePosts(result.items),
-      meta: {
-        total: result.meta.total,
-        totalPages: result.meta.totalPages,
-        page,
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const result = await nextly.find({
+          collection: "posts",
+          where: PUBLISHED,
+          sort: "-publishedAt",
+          page,
+          limit,
+          depth: 2,
+        });
+        return {
+          items: coercePosts(result.items),
+          meta: {
+            total: result.meta.total,
+            totalPages: result.meta.totalPages,
+            page,
+          },
+        };
       },
-    };
+      {
+        tags: nextlyTags("posts"),
+        keyParts: ["posts", "list", String(page), String(limit)],
+      }
+    );
   } catch (error) {
     console.error("Error fetching posts:", error);
     return { items: [], meta: { total: 0, totalPages: 0, page: 1 } };
@@ -144,20 +174,29 @@ export async function getPosts({
  * Only returns published posts — a draft preview system would need a
  * separate helper with a token-based auth check.
  * Returns null when the slug doesn't match or the post is not published.
+ *
+ * Tagged with the collection tag (not an entry-id tag): the id isn't known
+ * until the read resolves, and a slug rename busts `nextly:posts` anyway, so
+ * the old slug's page regenerates and 404s once the post moves.
  */
 export async function getPostBySlug(slug: string): Promise<Post | null> {
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
-    const result = await nextly.find({
-      collection: "posts",
-      where: {
-        and: [PUBLISHED, { slug: { equals: slug } }],
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const result = await nextly.find({
+          collection: "posts",
+          where: {
+            and: [PUBLISHED, { slug: { equals: slug } }],
+          },
+          limit: 1,
+          depth: 2,
+          richTextFormat: "html",
+        });
+        return result.items[0] ? coercePost(result.items[0]) : null;
       },
-      limit: 1,
-      depth: 2,
-      richTextFormat: "html",
-    });
-    return result.items[0] ? coercePost(result.items[0]) : null;
+      { tags: nextlyTags("posts"), keyParts: ["posts", "detail", slug] }
+    );
   } catch (error) {
     console.error(`Error fetching post by slug ${slug}:`, error);
     return null;
@@ -171,14 +210,19 @@ export async function getPostBySlug(slug: string): Promise<Post | null> {
  */
 export async function getAllPostSlugs(): Promise<string[]> {
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
-    const result = await nextly.find({
-      collection: "posts",
-      where: PUBLISHED,
-      limit: 1000,
-      depth: 0,
-    });
-    return result.items.map(d => d.slug as string);
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const result = await nextly.find({
+          collection: "posts",
+          where: PUBLISHED,
+          limit: 1000,
+          depth: 0,
+        });
+        return result.items.map(d => d.slug as string);
+      },
+      { tags: nextlyTags("posts"), keyParts: ["posts", "slugs"] }
+    );
   } catch (error) {
     console.error("Error fetching all post slugs:", error);
     return [];
@@ -200,20 +244,25 @@ export interface ArchiveEntry {
  */
 export async function getAllPublishedForArchive(): Promise<ArchiveEntry[]> {
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
-    const result = await nextly.find({
-      collection: "posts",
-      where: PUBLISHED,
-      sort: "-publishedAt",
-      limit: 1000,
-      depth: 0,
-    });
-    return result.items.map(d => ({
-      id: d.id as string,
-      title: d.title as string,
-      slug: d.slug as string,
-      publishedAt: (d.publishedAt as string | null) ?? null,
-    }));
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const result = await nextly.find({
+          collection: "posts",
+          where: PUBLISHED,
+          sort: "-publishedAt",
+          limit: 1000,
+          depth: 0,
+        });
+        return result.items.map(d => ({
+          id: d.id as string,
+          title: d.title as string,
+          slug: d.slug as string,
+          publishedAt: (d.publishedAt as string | null) ?? null,
+        }));
+      },
+      { tags: nextlyTags("posts"), keyParts: ["posts", "archive"] }
+    );
   } catch (error) {
     console.error("Error fetching archive posts:", error);
     return [];
@@ -229,25 +278,33 @@ export async function getPostsByAuthor(
 ): Promise<PostListResult> {
   const { page = 1, limit = 20 } = opts;
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
-    const result = await nextly.find({
-      collection: "posts",
-      where: {
-        and: [PUBLISHED, { author: { equals: authorId } }],
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const result = await nextly.find({
+          collection: "posts",
+          where: {
+            and: [PUBLISHED, { author: { equals: authorId } }],
+          },
+          sort: "-publishedAt",
+          page,
+          limit,
+          depth: 2,
+        });
+        return {
+          items: coercePosts(result.items),
+          meta: {
+            total: result.meta.total,
+            totalPages: result.meta.totalPages,
+            page,
+          },
+        };
       },
-      sort: "-publishedAt",
-      page,
-      limit,
-      depth: 2,
-    });
-    return {
-      items: coercePosts(result.items),
-      meta: {
-        total: result.meta.total,
-        totalPages: result.meta.totalPages,
-        page,
-      },
-    };
+      {
+        tags: nextlyTags("posts"),
+        keyParts: ["posts", "by-author", authorId, String(page), String(limit)],
+      }
+    );
   } catch (error) {
     console.error(`Error fetching posts by author ${authorId}:`, error);
     return { items: [], meta: { total: 0, totalPages: 0, page: 1 } };
@@ -261,6 +318,9 @@ export async function getPostsByAuthor(
  * in a TEXT column (e.g. `["uuid1","uuid2"]`). The `contains` operator
  * translates to `LIKE '%value%'` which correctly matches the category
  * ID within the serialized JSON string.
+ *
+ * The slug→id lookup (`getCategoryBySlug`, itself cached) resolves before
+ * the cached posts read so the two caches never nest.
  */
 export async function getPostsByCategory(
   categorySlug: string,
@@ -268,7 +328,6 @@ export async function getPostsByCategory(
 ): Promise<PostListResult> {
   const { page = 1, limit = 9 } = opts;
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
     const category = await getCategoryBySlug(categorySlug);
     if (!category) {
       return { items: [], meta: { total: 0, totalPages: 0, page: 1 } };
@@ -276,24 +335,39 @@ export async function getPostsByCategory(
 
     const categoryId = String(category.id);
 
-    const result = await nextly.find({
-      collection: "posts",
-      where: {
-        and: [PUBLISHED, { categories: { contains: categoryId } }],
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const result = await nextly.find({
+          collection: "posts",
+          where: {
+            and: [PUBLISHED, { categories: { contains: categoryId } }],
+          },
+          sort: "-publishedAt",
+          page,
+          limit,
+          depth: 2,
+        });
+        return {
+          items: coercePosts(result.items),
+          meta: {
+            total: result.meta.total,
+            totalPages: result.meta.totalPages,
+            page,
+          },
+        };
       },
-      sort: "-publishedAt",
-      page,
-      limit,
-      depth: 2,
-    });
-    return {
-      items: coercePosts(result.items),
-      meta: {
-        total: result.meta.total,
-        totalPages: result.meta.totalPages,
-        page,
-      },
-    };
+      {
+        tags: nextlyTags("posts"),
+        keyParts: [
+          "posts",
+          "by-category",
+          categorySlug,
+          String(page),
+          String(limit),
+        ],
+      }
+    );
   } catch (error) {
     console.error(`Error fetching posts for category ${categorySlug}:`, error);
     return { items: [], meta: { total: 0, totalPages: 0, page: 1 } };
@@ -309,7 +383,6 @@ export async function getPostsByTag(
 ): Promise<PostListResult> {
   const { page = 1, limit = 9 } = opts;
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
     const tag = await getTagBySlug(tagSlug);
     if (!tag) {
       return { items: [], meta: { total: 0, totalPages: 0, page: 1 } };
@@ -317,24 +390,33 @@ export async function getPostsByTag(
 
     const tagId = String(tag.id);
 
-    const result = await nextly.find({
-      collection: "posts",
-      where: {
-        and: [PUBLISHED, { tags: { contains: tagId } }],
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const result = await nextly.find({
+          collection: "posts",
+          where: {
+            and: [PUBLISHED, { tags: { contains: tagId } }],
+          },
+          sort: "-publishedAt",
+          page,
+          limit,
+          depth: 2,
+        });
+        return {
+          items: coercePosts(result.items),
+          meta: {
+            total: result.meta.total,
+            totalPages: result.meta.totalPages,
+            page,
+          },
+        };
       },
-      sort: "-publishedAt",
-      page,
-      limit,
-      depth: 2,
-    });
-    return {
-      items: coercePosts(result.items),
-      meta: {
-        total: result.meta.total,
-        totalPages: result.meta.totalPages,
-        page,
-      },
-    };
+      {
+        tags: nextlyTags("posts"),
+        keyParts: ["posts", "by-tag", tagSlug, String(page), String(limit)],
+      }
+    );
   } catch (error) {
     console.error(`Error fetching posts for tag ${tagSlug}:`, error);
     return { items: [], meta: { total: 0, totalPages: 0, page: 1 } };
@@ -358,44 +440,58 @@ export async function getAdjacentPosts(
 }> {
   try {
     if (!currentPublishedAt) return { previous: null, next: null };
-    const nextly = await getNextly({ config: nextlyConfig });
 
-    const [prev, next] = await Promise.all([
-      nextly.find({
-        collection: "posts",
-        where: {
-          and: [
-            PUBLISHED,
-            { publishedAt: { less_than: currentPublishedAt } },
-            { slug: { not_equals: currentSlug } },
-          ],
-        },
-        sort: "-publishedAt",
-        limit: 1,
-        depth: 0,
-      }),
-      nextly.find({
-        collection: "posts",
-        where: {
-          and: [
-            PUBLISHED,
-            { publishedAt: { greater_than: currentPublishedAt } },
-            { slug: { not_equals: currentSlug } },
-          ],
-        },
-        sort: "publishedAt",
-        limit: 1,
-        depth: 0,
-      }),
-    ]);
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
 
-    const pick = (doc?: Record<string, unknown>) =>
-      doc ? { title: doc.title as string, slug: doc.slug as string } : null;
+        const [prev, next] = await Promise.all([
+          nextly.find({
+            collection: "posts",
+            where: {
+              and: [
+                PUBLISHED,
+                { publishedAt: { less_than: currentPublishedAt } },
+                { slug: { not_equals: currentSlug } },
+              ],
+            },
+            sort: "-publishedAt",
+            limit: 1,
+            depth: 0,
+          }),
+          nextly.find({
+            collection: "posts",
+            where: {
+              and: [
+                PUBLISHED,
+                { publishedAt: { greater_than: currentPublishedAt } },
+                { slug: { not_equals: currentSlug } },
+              ],
+            },
+            sort: "publishedAt",
+            limit: 1,
+            depth: 0,
+          }),
+        ]);
 
-    return {
-      previous: pick(prev.items[0]),
-      next: pick(next.items[0]),
-    };
+        const pick = (doc?: Record<string, unknown>) =>
+          doc ? { title: doc.title as string, slug: doc.slug as string } : null;
+
+        return {
+          previous: pick(prev.items[0]),
+          next: pick(next.items[0]),
+        };
+      },
+      {
+        tags: nextlyTags("posts"),
+        keyParts: [
+          "posts",
+          "adjacent",
+          currentSlug,
+          String(currentPublishedAt),
+        ],
+      }
+    );
   } catch (err) {
     console.error("[blog] getAdjacentPosts error:", err);
     return { previous: null, next: null };
@@ -416,6 +512,9 @@ export interface RelatedPostsOptions {
  * the first layer that returns results. If none match, returns [] so
  * the caller can hide the "Related Posts" section rather than show
  * unrelated newest posts (which would be misleading labelling).
+ *
+ * Each layer's posts read is cached under its own key; the slug→id
+ * lookups resolve before the cached read so the caches never nest.
  */
 export async function getRelatedPosts(
   currentSlug: string,
@@ -423,42 +522,53 @@ export async function getRelatedPosts(
 ): Promise<Post[]> {
   try {
     const { tagSlugs = [], categorySlugs = [], authorId, limit = 2 } = opts;
-    const nextly = await getNextly({ config: nextlyConfig });
 
     const excludeCurrent = { slug: { not_equals: currentSlug } };
 
-    const tryQuery = async (where: Record<string, unknown>) => {
-      const result = await nextly.find({
-        collection: "posts",
-        where: {
-          and: [PUBLISHED, excludeCurrent, where],
+    const tryQuery = (keySuffix: string, where: Record<string, unknown>) =>
+      cachedFind(
+        async () => {
+          const nextly = await getNextly({ config: nextlyConfig });
+          const result = await nextly.find({
+            collection: "posts",
+            where: {
+              and: [PUBLISHED, excludeCurrent, where],
+            },
+            sort: "-publishedAt",
+            limit,
+            depth: 2,
+          });
+          return coercePosts(result.items);
         },
-        sort: "-publishedAt",
-        limit,
-        depth: 2,
-      });
-      return coercePosts(result.items);
-    };
+        {
+          tags: nextlyTags("posts"),
+          keyParts: ["posts", "related", currentSlug, keySuffix, String(limit)],
+        }
+      );
 
     // Resolve slugs to IDs then use `contains` on the JSON-encoded TEXT column
     if (tagSlugs.length > 0) {
       const tag = await getTagBySlug(tagSlugs[0]);
       if (tag) {
-        const docs = await tryQuery({ tags: { contains: String(tag.id) } });
+        const docs = await tryQuery(`tag:${tag.id}`, {
+          tags: { contains: String(tag.id) },
+        });
         if (docs.length > 0) return docs;
       }
     }
     if (categorySlugs.length > 0) {
       const cat = await getCategoryBySlug(categorySlugs[0]);
       if (cat) {
-        const docs = await tryQuery({
+        const docs = await tryQuery(`category:${cat.id}`, {
           categories: { contains: String(cat.id) },
         });
         if (docs.length > 0) return docs;
       }
     }
     if (authorId) {
-      const docs = await tryQuery({ author: { equals: authorId } });
+      const docs = await tryQuery(`author:${authorId}`, {
+        author: { equals: authorId },
+      });
       if (docs.length > 0) return docs;
     }
 

--- a/templates/blog/src/lib/queries/posts.ts
+++ b/templates/blog/src/lib/queries/posts.ts
@@ -43,23 +43,26 @@ const PUBLISHED = { status: { equals: "published" } };
 
 /**
  * Tags for a read that populates related records (depth>=1). Carries the post,
- * category, tag, and user collection tags so an edit to any embedded relation
- * busts these pages. Categories and tags emit their tags on write; the `users`
- * tag is inert today (see `RELATION_REVALIDATE_SECONDS`) but future-proofs the
- * read for when user writes gain tag emission.
+ * category, tag, user, and media collection tags so an edit to any embedded
+ * relation busts these pages. Categories and tags emit their tags on write; the
+ * `users` and `media` tags are inert today (those system collections do not
+ * emit cache tags — see `RELATION_REVALIDATE_SECONDS`) but future-proof the
+ * read for when they do.
  */
 const POST_WITH_RELATIONS_TAGS = [
   ...nextlyTags("posts"),
   ...nextlyTags("categories"),
   ...nextlyTags("tags"),
   ...nextlyTags("users"),
+  ...nextlyTags("media"),
 ];
 
 /**
- * Time-based safety net (seconds) for reads that embed author (user) fields.
- * The `users` collection does not emit revalidation tags today, so this window
- * is how an author's updated name / bio / avatar becomes visible inside posts.
- * Lower it for fresher relation data at a higher DB cost.
+ * Time-based safety net (seconds) for reads that embed author (user) or media
+ * fields. The `users` and `media` system collections do not emit revalidation
+ * tags today, so this window is how an author's updated name / bio / avatar, or
+ * an edited featured / OG image's alt text or crop, becomes visible inside
+ * posts. Lower it for fresher relation data at a higher DB cost.
  */
 const RELATION_REVALIDATE_SECONDS = 3600;
 

--- a/templates/blog/src/lib/queries/site-settings.ts
+++ b/templates/blog/src/lib/queries/site-settings.ts
@@ -2,9 +2,12 @@
  * Site settings query helper.
  *
  * Wrapped in React's `cache()` so every Server Component on the same
- * request gets a single deduplicated fetch. Falls back to sensible
- * defaults when the settings single hasn't been initialized yet (first
- * run before seed, or fresh project without the single populated).
+ * request gets a single deduplicated fetch, and in `cachedFind` so the
+ * result persists across requests until an edit to the site-settings
+ * single busts `nextlySingleTags("site-settings")`. Falls back to sensible
+ * defaults when the single hasn't been initialized yet (first run before
+ * seed, or fresh project without the single populated); once the single is
+ * created the tag bust refreshes this automatically.
  */
 
 import { cache } from "react";
@@ -12,6 +15,7 @@ import { cache } from "react";
 // Pass nextlyConfig (loaded via the -config path alias) so
 // getNextly() bootstraps with this project's collections list.
 import { getNextly } from "nextly";
+import { cachedFind, nextlySingleTags } from "nextly/runtime";
 import nextlyConfig from "@nextly-config";
 
 import type { SiteSettings } from "./types";
@@ -26,20 +30,28 @@ const DEFAULTS: SiteSettings = {
 
 export const getSiteSettings = cache(async (): Promise<SiteSettings> => {
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
-    const settings = await nextly.findSingle({
-      slug: "site-settings",
-      depth: 1,
-    });
-    if (!settings) return DEFAULTS;
-    return {
-      siteName: (settings.siteName as string) || DEFAULTS.siteName,
-      tagline: (settings.tagline as string) || DEFAULTS.tagline,
-      siteDescription:
-        (settings.siteDescription as string) || DEFAULTS.siteDescription,
-      logo: (settings.logo as SiteSettings["logo"]) ?? null,
-      social: (settings.social as SiteSettings["social"]) ?? null,
-    };
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const settings = await nextly.findSingle({
+          slug: "site-settings",
+          depth: 1,
+        });
+        if (!settings) return DEFAULTS;
+        return {
+          siteName: (settings.siteName as string) || DEFAULTS.siteName,
+          tagline: (settings.tagline as string) || DEFAULTS.tagline,
+          siteDescription:
+            (settings.siteDescription as string) || DEFAULTS.siteDescription,
+          logo: (settings.logo as SiteSettings["logo"]) ?? null,
+          social: (settings.social as SiteSettings["social"]) ?? null,
+        };
+      },
+      {
+        tags: nextlySingleTags("site-settings"),
+        keyParts: ["single", "site-settings"],
+      }
+    );
   } catch (err) {
     // Settings single may not exist yet on first run — defaults keep
     // the pages renderable instead of crashing. Log in dev so real

--- a/templates/blog/src/lib/queries/tags.ts
+++ b/templates/blog/src/lib/queries/tags.ts
@@ -1,25 +1,36 @@
 /**
  * Tag query helpers. Mirrors the categories helpers — tags use the
  * same collection shape and the same hasMany relationship storage.
+ *
+ * Caching: reads are wrapped in `cachedFind` and tagged with
+ * `nextlyTags("tags")` so a tag write busts them. The post-count helper
+ * also carries `nextlyTags("posts")` because its numbers change when a
+ * post is published or removed from a tag.
  */
 
 // Pass nextlyConfig (loaded via the -config path alias) so
 // getNextly() bootstraps with this project's collections list.
 import { getNextly } from "nextly";
+import { cachedFind, nextlyTags } from "nextly/runtime";
 import nextlyConfig from "@nextly-config";
 
 import type { Tag, TaxonomyWithCount } from "./types";
 
 export async function getTagBySlug(slug: string): Promise<Tag | null> {
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
-    const result = await nextly.find({
-      collection: "tags",
-      where: { slug: { equals: slug } },
-      limit: 1,
-      depth: 0,
-    });
-    return result.items[0] ? (result.items[0] as Tag) : null;
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const result = await nextly.find({
+          collection: "tags",
+          where: { slug: { equals: slug } },
+          limit: 1,
+          depth: 0,
+        });
+        return result.items[0] ? (result.items[0] as Tag) : null;
+      },
+      { tags: nextlyTags("tags"), keyParts: ["tags", "detail", slug] }
+    );
   } catch (error) {
     console.error(`Error fetching tag by slug ${slug}:`, error);
     return null;
@@ -28,13 +39,18 @@ export async function getTagBySlug(slug: string): Promise<Tag | null> {
 
 export async function getAllTagSlugs(): Promise<string[]> {
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
-    const result = await nextly.find({
-      collection: "tags",
-      limit: 1000,
-      depth: 0,
-    });
-    return result.items.map(d => d.slug as string);
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const result = await nextly.find({
+          collection: "tags",
+          limit: 1000,
+          depth: 0,
+        });
+        return result.items.map(d => d.slug as string);
+      },
+      { tags: nextlyTags("tags"), keyParts: ["tags", "slugs"] }
+    );
   } catch (error) {
     console.error("Error fetching all tag slugs:", error);
     return [];
@@ -45,39 +61,47 @@ export async function getAllTagsWithCounts(): Promise<
   TaxonomyWithCount<Tag>[]
 > {
   try {
-    const nextly = await getNextly({ config: nextlyConfig });
-    const all = await nextly.find({
-      collection: "tags",
-      limit: 1000,
-      depth: 0,
-    });
-    return await Promise.all(
-      all.items.map(async tag => {
-        const tagId = String(tag.id);
-        try {
-          const posts = await nextly.find({
-            collection: "posts",
-            where: {
-              and: [
-                { status: { equals: "published" } },
-                { tags: { contains: tagId } },
-              ],
-            },
-            limit: 0,
-            depth: 0,
-          });
-          return {
-            item: tag as Tag,
-            postCount: posts.meta.total,
-          };
-        } catch {
-          // If count fails, return tag with 0 posts
-          return {
-            item: tag as Tag,
-            postCount: 0,
-          };
-        }
-      })
+    return await cachedFind(
+      async () => {
+        const nextly = await getNextly({ config: nextlyConfig });
+        const all = await nextly.find({
+          collection: "tags",
+          limit: 1000,
+          depth: 0,
+        });
+        return await Promise.all(
+          all.items.map(async tag => {
+            const tagId = String(tag.id);
+            try {
+              const posts = await nextly.find({
+                collection: "posts",
+                where: {
+                  and: [
+                    { status: { equals: "published" } },
+                    { tags: { contains: tagId } },
+                  ],
+                },
+                limit: 0,
+                depth: 0,
+              });
+              return {
+                item: tag as Tag,
+                postCount: posts.meta.total,
+              };
+            } catch {
+              // If count fails, return tag with 0 posts
+              return {
+                item: tag as Tag,
+                postCount: 0,
+              };
+            }
+          })
+        );
+      },
+      {
+        tags: [...nextlyTags("tags"), ...nextlyTags("posts")],
+        keyParts: ["tags", "with-counts"],
+      }
     );
   } catch (error) {
     console.error("Error fetching tags with counts:", error);

--- a/templates/blog/src/lib/queries/tags.ts
+++ b/templates/blog/src/lib/queries/tags.ts
@@ -32,8 +32,11 @@ export async function getTagBySlug(slug: string): Promise<Tag | null> {
       { tags: nextlyTags("tags"), keyParts: ["tags", "detail", slug] }
     );
   } catch (error) {
+    // Rethrow, don't return null: a genuine miss returns null above (cached
+    // with the tags tag, recoverable), but swallowing a transient error into
+    // null would bake a tagless, timerless notFound() — a permanent 404.
     console.error(`Error fetching tag by slug ${slug}:`, error);
-    return null;
+    throw error;
   }
 }
 
@@ -72,29 +75,24 @@ export async function getAllTagsWithCounts(): Promise<
         return await Promise.all(
           all.items.map(async tag => {
             const tagId = String(tag.id);
-            try {
-              const posts = await nextly.find({
-                collection: "posts",
-                where: {
-                  and: [
-                    { status: { equals: "published" } },
-                    { tags: { contains: tagId } },
-                  ],
-                },
-                limit: 0,
-                depth: 0,
-              });
-              return {
-                item: tag as Tag,
-                postCount: posts.meta.total,
-              };
-            } catch {
-              // If count fails, return tag with 0 posts
-              return {
-                item: tag as Tag,
-                postCount: 0,
-              };
-            }
+            // No inner catch: a count failure must reject the whole read so the
+            // outer fallback runs uncached, instead of caching a wrong zero
+            // count until the next tag/post write busts the tag.
+            const posts = await nextly.find({
+              collection: "posts",
+              where: {
+                and: [
+                  { status: { equals: "published" } },
+                  { tags: { contains: tagId } },
+                ],
+              },
+              limit: 0,
+              depth: 0,
+            });
+            return {
+              item: tag as Tag,
+              postCount: posts.meta.total,
+            };
           })
         );
       },


### PR DESCRIPTION
## F1 PR4 (task 009) — blog template tag-based ISR + scaffold channel pinning

Last link of the F1 cache-revalidation program. Converts the scaffolded **blog** template from time-based ISR to tag-based revalidation using 008's `nextly/runtime` helpers, and fixes scaffold version pinning so blog projects actually get those helpers.

### Part A — blog template → tag-based ISR (`templates/blog`)

- Every read in `src/lib/queries/*` is wrapped in `cachedFind` and tagged with `nextlyTags(...)` / `nextlySingleTags(...)`. Caching is centralized in the query layer, so pages, sitemap, feeds, and OG images all get it (DRY). Existing try/catch fallbacks stay **outside** `cachedFind` (a throw is never cached; a success caches the real value).
- Removed `export const revalidate = 60` from the 4 detail pages (`blog|authors|tags|categories/[slug]`); kept `generateStaticParams` + `dynamicParams`. Build-time SSG + on-demand tag ISR is the intended combo.
- **Old slug → 404 (documented):** the write path (#316) busts `nextly:posts` on any post write incl. a rename; the detail read carries the collection tag, so the old URL regenerates and `getPostBySlug` returns null → `notFound()`. No template-side old-path code.
- **Registration is automatic:** `createDynamicHandlers()` (the base admin route every template ships) already calls `registerNextCacheRevalidator()`, so admin-driven writes revalidate with no `instrumentation.ts`.
- **Authors are the exception, handled honestly:** revalidation flushing lives only in the collection/single entry services; the `users` collection (authors) emits no cache tags today. So `getPostsByAuthor` refreshes immediately (`nextly:posts`), but `getAuthorBySlug` (name/bio/avatar) carries a documented time-based safety net (`AUTHOR_REVALIDATE_SECONDS`, 1h) while keeping the `nextly:users` tag for the day user writes gain tag emission. README behavior matrix says so plainly.
- README "Performance" section rewritten: tag-based model, per-write refresh matrix, `disableRevalidate` for bulk/seed, and the safety-net note.

### Part B — content-template scaffolds pin the `alpha` channel (`create-nextly-app`, published → changeset)

`create-nextly-app` scaffolds install `nextly@^latest`, but `latest` is deliberately conservative (currently `alpha.37`) and lags the active `alpha` channel where 008's `/runtime` cache helpers ship. A blog scaffold on `latest` would install a `nextly` missing `cachedFind`/`nextlyTags` and fail to build. Fix: content templates (blog) resolve `nextly` + `@nextlyhq/*` from the **`alpha`** dist-tag; blank/plugin stay on `latest`. New `templateNextlyChannel(projectType)`; per-channel version cache.

### ⚠️ Release ordering (please read before merging)

The blog template is served from **GitHub `main`** (codeload), not npm, so this change goes live for scaffolds the moment it merges — but a blog scaffold only *builds* once a `nextly` containing 008's `/runtime` helpers is on the **`alpha`** dist-tag. Those helpers merged to main (#339) but publish with the next Version PR (~`alpha.42`). The alpha-channel pin makes blog scaffolds **self-heal** the instant `alpha.42` publishes — no further code change. Recommend merging this in coordination with that release (or accept that `-t blog` scaffolds need `alpha.42` before they build).

### Verification

- `pnpm --filter create-nextly-app test` → **128 pass** (12 files), incl. 2 new: `template-channel.test.ts` (blog→alpha, blank→latest) and `blog-template-isr.test.ts` (static smoke: no `revalidate` in detail pages; query layer uses `cachedFind`+tag helpers; `generateStaticParams` retained).
- `check-types` clean; `pnpm build` 16/16; prettier/eslint clean (`templates/**` is eslint-ignored by config).
- Full scaffold+`next build` of the converted template is deferred to post-`alpha.42` (it can't build against npm `latest` until then). The exact `cachedFind`/`nextlyTags` usage is already proven to compile+run in a real Next app by 008's `apps/playground` conversion, which builds in CI.

The blog template is downloaded from GitHub (not an npm artifact); the changeset covers only the published `create-nextly-app` change.

Please review; I won't self-merge.
