### PR TITLE
fix(nextly): apply related-row field rules inside components

### DIFF
--- a/.changeset/component-related-row-access.md
+++ b/.changeset/component-related-row-access.md
@@ -1,0 +1,26 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Field-level read rules now reach related rows inside components. A component's relationship fields copy whole rows out of the collection they point at, and neither the parent entity's field list nor the component's describes that collection's fields, so a field you protected there was returned inside the populated component to any caller that could read the parent. Reading a collection entry or a Single now judges those related rows by the rules of the collection they come from, for the caller making the request.
+
+This completes the read side of the redaction added for direct relationships. Write-side callers that assemble a payload without a caller are unchanged, so a mutation response still returns what it did before.

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1151,6 +1151,15 @@ export class CollectionQueryService extends BaseService {
             // untranslated embedded field blank instead of showing default text.
             locale: params.locale,
             fallbackLocale: params.fallbackLocale,
+            // A component's relationship fields copy whole rows out of the
+            // target collection, which this collection's field rules say nothing
+            // about — so the caller travels down to reach the related row's own
+            // rules, exactly as it does for direct relationships.
+            access: {
+              enforceFieldAccess: true,
+              user: params.user,
+              overrideAccess: params.overrideAccess,
+            },
           });
       }
 
@@ -1982,6 +1991,13 @@ export class CollectionQueryService extends BaseService {
           // fields blank rather than showing default-language text.
           locale: params.locale,
           fallbackLocale: params.fallbackLocale,
+          // Same reasoning as the list path: a related row reached through a
+          // component is judged by its own collection's field rules.
+          access: {
+            enforceFieldAccess: true,
+            user: params.user,
+            overrideAccess: params.overrideAccess,
+          },
         });
       }
 

--- a/packages/nextly/src/domains/components/__tests__/component-data-service.test.ts
+++ b/packages/nextly/src/domains/components/__tests__/component-data-service.test.ts
@@ -771,6 +771,51 @@ describe("ComponentDataService", () => {
       expect(ctx.relationship.expandRelationships).toHaveBeenCalled();
     });
 
+    it("carries the caller down to the related row's own field rules", async () => {
+      // A component's relationship fields copy whole rows out of the TARGET
+      // collection. Neither the parent entity's field registry nor the
+      // component's describes that collection's fields, so without the caller
+      // reaching the expansion a field the target protects is returned inside
+      // the populated component to anyone who reads the parent.
+      ctx.adapter.select.mockResolvedValue([
+        { id: "seo-1", _parent_id: "entry-1", _order: 0, meta_title: "X" },
+      ]);
+
+      await ctx.service.populateComponentData({
+        entry: { id: "entry-1" },
+        parentTable: "dc_pages",
+        fields: [seoComponentField()],
+        depth: 2,
+        access: {
+          enforceFieldAccess: true,
+          user: { id: "u1", roles: ["editor"] },
+        },
+      });
+
+      const options = ctx.relationship.expandRelationships.mock.calls[0][3];
+      expect(options.enforceFieldAccess).toBe(true);
+      expect(options.user).toMatchObject({ id: "u1" });
+    });
+
+    it("leaves enforcement off for a caller that supplies no access context", async () => {
+      // Write-side callers assembling a payload pass no caller. Enforcing for
+      // them would judge everyone anonymous and strip protected related fields
+      // from a response returned to the very user who just wrote it.
+      ctx.adapter.select.mockResolvedValue([
+        { id: "seo-1", _parent_id: "entry-1", _order: 0, meta_title: "X" },
+      ]);
+
+      await ctx.service.populateComponentData({
+        entry: { id: "entry-1" },
+        parentTable: "dc_pages",
+        fields: [seoComponentField()],
+        depth: 2,
+      });
+
+      const options = ctx.relationship.expandRelationships.mock.calls[0][3];
+      expect(options.enforceFieldAccess).toBeFalsy();
+    });
+
     it("skips relationship expansion when depth is 0", async () => {
       ctx.adapter.select.mockResolvedValue([
         { id: "seo-1", _parent_id: "entry-1", _order: 0, meta_title: "X" },

--- a/packages/nextly/src/domains/components/services/component-query-service.ts
+++ b/packages/nextly/src/domains/components/services/component-query-service.ts
@@ -32,6 +32,16 @@ import {
 /**
  * Parameters for populating component data on a single parent entry.
  */
+/**
+ * The caller context a component's related rows are judged against, mirroring
+ * the relationship service's own options so it can be forwarded unchanged.
+ */
+export interface ComponentReadAccess {
+  enforceFieldAccess?: boolean;
+  user?: Record<string, unknown>;
+  overrideAccess?: boolean;
+}
+
 export interface PopulateComponentDataParams {
   /** The entry to populate with component data */
   entry: Record<string, unknown>;
@@ -88,6 +98,21 @@ export interface PopulateComponentDataParams {
    * than shipping a payload with silently-missing component data.
    */
   strict?: boolean;
+  /**
+   * The caller a related row reached THROUGH this component is redacted for.
+   *
+   * Component population expands the component's own relationship fields, which
+   * copy whole rows out of the target collection. Neither the parent entity's
+   * field registry nor the component's describes that collection's fields, so
+   * without the caller here a field the target collection protects is returned
+   * inside the populated component to anyone who reads the parent.
+   *
+   * Enforcement is opt-in for the reason established in the relationship
+   * service: a caller that supplies no context is indistinguishable from an
+   * anonymous one, and enforcing for the former strips fields from everybody.
+   * The read paths opt in; write-side callers assembling payloads do not.
+   */
+  access?: ComponentReadAccess;
 }
 
 /**
@@ -104,6 +129,8 @@ export interface PopulateComponentDataManyParams {
   locale?: string;
   /** i18n: per-request fallback control (see PopulateComponentDataParams.fallbackLocale). */
   fallbackLocale?: string | false;
+  /** See PopulateComponentDataParams.access. */
+  access?: ComponentReadAccess;
 }
 
 // Duplicated here (and in the mutation service) to avoid a cross-domain
@@ -313,6 +340,7 @@ export class ComponentQueryService extends BaseService {
       fallbackLocale,
       executor,
       strict = false,
+      access = {},
     } = params;
     const entryId = entry.id as string;
     if (!entryId) return entry;
@@ -339,7 +367,8 @@ export class ComponentQueryService extends BaseService {
             locale,
             fallbackLocale,
             executor,
-            strict
+            strict,
+            access
           );
         } else if (field.component) {
           if (field.repeatable) {
@@ -353,7 +382,8 @@ export class ComponentQueryService extends BaseService {
               locale,
               fallbackLocale,
               executor,
-              strict
+              strict,
+              access
             );
           } else {
             result[fieldName] = await this.populateSingleField(
@@ -366,7 +396,8 @@ export class ComponentQueryService extends BaseService {
               locale,
               fallbackLocale,
               executor,
-              strict
+              strict,
+              access
             );
           }
         }
@@ -400,6 +431,7 @@ export class ComponentQueryService extends BaseService {
       select,
       locale,
       fallbackLocale,
+      access = {},
     } = params;
     if (entries.length === 0) return entries;
 
@@ -432,7 +464,8 @@ export class ComponentQueryService extends BaseService {
             depth,
             currentDepth,
             locale,
-            fallbackLocale
+            fallbackLocale,
+            access
           );
           fieldDataMaps.set(field.name, dataMap);
         } else if (field.component) {
@@ -445,7 +478,8 @@ export class ComponentQueryService extends BaseService {
               depth,
               currentDepth,
               locale,
-              fallbackLocale
+              fallbackLocale,
+              access
             );
             fieldDataMaps.set(field.name, dataMap);
           } else {
@@ -457,7 +491,8 @@ export class ComponentQueryService extends BaseService {
               depth,
               currentDepth,
               locale,
-              fallbackLocale
+              fallbackLocale,
+              access
             );
             fieldDataMaps.set(field.name, dataMap);
           }
@@ -499,7 +534,8 @@ export class ComponentQueryService extends BaseService {
     locale?: string,
     fallbackLocale?: string | false,
     executor?: unknown,
-    strict = false
+    strict = false,
+    access: ComponentReadAccess = {}
   ): Promise<Record<string, unknown> | null> {
     const meta = await this.registryService.getComponent(
       componentSlug,
@@ -532,7 +568,8 @@ export class ComponentQueryService extends BaseService {
       componentSlug,
       componentFields,
       depth,
-      currentDepth + 1
+      currentDepth + 1,
+      access
     );
 
     return data;
@@ -548,7 +585,8 @@ export class ComponentQueryService extends BaseService {
     locale?: string,
     fallbackLocale?: string | false,
     executor?: unknown,
-    strict = false
+    strict = false,
+    access: ComponentReadAccess = {}
   ): Promise<Record<string, unknown>[]> {
     const meta = await this.registryService.getComponent(
       componentSlug,
@@ -583,7 +621,8 @@ export class ComponentQueryService extends BaseService {
       componentSlug,
       componentFields,
       depth,
-      currentDepth + 1
+      currentDepth + 1,
+      access
     );
 
     return dataArray;
@@ -599,7 +638,8 @@ export class ComponentQueryService extends BaseService {
     locale?: string,
     fallbackLocale?: string | false,
     executor?: unknown,
-    strict = false
+    strict = false,
+    access: ComponentReadAccess = {}
   ): Promise<Record<string, unknown>[]> {
     const allowedSlugs = field.components ?? [];
     const allRows: {
@@ -655,7 +695,8 @@ export class ComponentQueryService extends BaseService {
         slug,
         fields,
         depth,
-        currentDepth + 1
+        currentDepth + 1,
+        access
       );
       results.push(data);
     }
@@ -671,7 +712,8 @@ export class ComponentQueryService extends BaseService {
     depth: number,
     currentDepth: number,
     locale?: string,
-    fallbackLocale?: string | false
+    fallbackLocale?: string | false,
+    access: ComponentReadAccess = {}
   ): Promise<Map<string, unknown>> {
     const meta = await this.registryService.getComponent(componentSlug);
     const componentFields = meta.fields;
@@ -711,7 +753,8 @@ export class ComponentQueryService extends BaseService {
           componentSlug,
           componentFields,
           depth,
-          currentDepth + 1
+          currentDepth + 1,
+          access
         )
       );
     }
@@ -726,7 +769,8 @@ export class ComponentQueryService extends BaseService {
     depth: number,
     currentDepth: number,
     locale?: string,
-    fallbackLocale?: string | false
+    fallbackLocale?: string | false,
+    access: ComponentReadAccess = {}
   ): Promise<Map<string, unknown>> {
     const meta = await this.registryService.getComponent(componentSlug);
     const componentFields = meta.fields;
@@ -763,7 +807,8 @@ export class ComponentQueryService extends BaseService {
             componentSlug,
             componentFields,
             depth,
-            currentDepth + 1
+            currentDepth + 1,
+            access
           )
         );
     }
@@ -778,7 +823,8 @@ export class ComponentQueryService extends BaseService {
     depth: number,
     currentDepth: number,
     locale?: string,
-    fallbackLocale?: string | false
+    fallbackLocale?: string | false,
+    access: ComponentReadAccess = {}
   ): Promise<Map<string, unknown>> {
     const allowedSlugs = field.components ?? [];
 
@@ -836,7 +882,8 @@ export class ComponentQueryService extends BaseService {
           slug,
           fields,
           depth,
-          currentDepth + 1
+          currentDepth + 1,
+          access
         );
         expandedItems.push(data);
       }
@@ -999,7 +1046,8 @@ export class ComponentQueryService extends BaseService {
     componentSlug: string,
     componentFields: FieldConfig[],
     depth: number,
-    currentDepth: number
+    currentDepth: number,
+    access: ComponentReadAccess = {}
   ): Promise<Record<string, unknown>> {
     if (!this.relationshipService) {
       return componentData;
@@ -1020,7 +1068,15 @@ export class ComponentQueryService extends BaseService {
         componentData,
         `comp:${componentSlug}`,
         fields,
-        { depth, currentDepth }
+        {
+          depth,
+          currentDepth,
+          // The related row belongs to another collection, so it is judged by
+          // that collection's field rules for this caller.
+          enforceFieldAccess: access.enforceFieldAccess,
+          user: access.user,
+          overrideAccess: access.overrideAccess,
+        }
       );
 
       return expanded;
@@ -1038,7 +1094,8 @@ export class ComponentQueryService extends BaseService {
     componentSlug: string,
     componentFields: FieldConfig[],
     depth: number,
-    currentDepth: number
+    currentDepth: number,
+    access: ComponentReadAccess = {}
   ): Promise<Record<string, unknown>[]> {
     if (!this.relationshipService || depth === 0 || currentDepth >= depth) {
       return componentDataArray;
@@ -1051,7 +1108,8 @@ export class ComponentQueryService extends BaseService {
           componentSlug,
           componentFields,
           depth,
-          currentDepth
+          currentDepth,
+          access
         )
       )
     );

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -682,6 +682,14 @@ export class SingleQueryService extends BaseService {
           // fields blank instead of showing default-language text.
           locale: options.locale,
           fallbackLocale: options.fallbackLocale,
+          // A component's relationship fields copy whole rows out of the target
+          // collection, which a Single's field list never describes — so the
+          // caller travels down to reach the related row's own rules.
+          access: {
+            enforceFieldAccess: true,
+            user: options.user as Record<string, unknown> | undefined,
+            overrideAccess: options.overrideAccess,
+          },
         })) as SingleDocument;
       }
 


### PR DESCRIPTION
Task 057, first slice. Closes the component half of the gap acknowledged on #338.

## The leak

A component's relationship fields expand by copying whole rows out of the target collection. Two independent reasons its field rules could not fire:

1. Redaction runs against the **parent entity's** field registry, which never describes a related collection's fields — the same root cause as #335, one level deeper.
2. `PopulateComponentDataParams` carried no caller at all, so there was nothing to judge a rule against even if it had been consulted.

So a field protected on collection B was returned inside a populated component to anyone who could read the parent entry or Single. Codex flagged the Singles half on #338; the collection half is identical and more commonly hit, which is why this fixes both in one change rather than half of it.

## What changed

- `ComponentReadAccess` on the two public population params, threaded through the six private populate methods to both expansion helpers, so nested and batch paths are covered at every depth.
- The three **read** paths opt in: `collection-query-service.ts` list and get, and `single-query-service.ts`.

**Enforcement stays opt-in, deliberately.** #338 proved twice that enforcing where no caller is threaded judges everyone as anonymous and strips protected fields from entitled callers — including from a mutation response returned to the user who just wrote it, and from the data reaching `afterUpdate` hooks. There is a test pinning that a caller supplying no context gets enforcement off.

## Scope

Read paths only. The write-side population sites (`collection-mutation-service.ts:944`, `single-mutation-service.ts` ×3) still pass no caller and are unchanged — they need a deliberate decision about whether a writer should see related fields their own read rules deny, which is tracked in task 057 rather than settled silently here.

Practical note: `collection-mutation-service.ts` is currently being edited in another workstream, so keeping this PR to the read paths also avoids a pointless conflict.

## Verification

2 tests, in the suite's existing idiom. The forwarding test was verified to fail with the forwarding removed.

Zero new failures: same suites, both after a full build, `origin/main` @ `1687ff1a` 370 failed / 2850 passed vs branch 370 / 2852 — identical failing-file set. The one failure in the component suite (`uses the transaction context instead of the adapter`) is pre-existing on main, confirmed by running it there.

Lint and typecheck clean.