### PR TITLE
feat(nextly): endpoint-gate outbox event recording

### DIFF
--- a/.changeset/endpoint-gated-outbox-recording.md
+++ b/.changeset/endpoint-gated-outbox-recording.md
@@ -1,0 +1,26 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Outbox event recording is now endpoint-gated. A content write records a webhook event only when the install has at least one enabled webhook endpoint, or when the new `webhooks.audit` option is turned on. Installs with no webhooks configured no longer pay an event-table insert and a full-document serialization on every write.
+
+Recording resumes immediately when an endpoint is created in the same process, and within about 30 seconds for one created in another process. A few events may still be recorded just after the last endpoint is removed; retention prunes them.

--- a/packages/nextly/src/cli/utils/config-loader.ts
+++ b/packages/nextly/src/cli/utils/config-loader.ts
@@ -86,6 +86,10 @@ function applyFoldedToBase(
     components: folded.components ?? base.components,
     plugins: transformed.plugins ?? base.plugins,
     storage: transformed.storage ?? base.storage,
+    // Carry a plugin setup transformer's audit decision through, so an audit
+    // plugin that forces recording is not dropped back to the base value on a
+    // reload. Always a resolved boolean on a sanitized config.
+    webhookAuditEnabled: transformed.webhookAuditEnabled,
   };
 }
 

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -58,6 +58,7 @@ import type {
 } from "../domains/singles/services/single-registry-service";
 import { resolveVersionsConfig } from "../domains/versions/resolve-config";
 import type { VersionsService } from "../domains/versions/versions-service";
+import { resetWebhookActivation } from "../domains/webhooks/recording-activation";
 import {
   resetWebhookRecordingPolicy,
   setWebhookRecording,
@@ -2367,6 +2368,10 @@ export async function shutdownServices(): Promise<void> {
     // DB/Builder-backed inherits a prior instance's stale opt-out and silently
     // stops recording.
     resetWebhookRecordingPolicy();
+    // The recording activation (audit flag + endpoint-presence provider) is
+    // process-global too, and its provider closes over this container's
+    // registry; clear it so a later instance never resolves a dead one.
+    resetWebhookActivation();
     globalForReg.__nextly_isRegistered = false;
   }
 }
@@ -2381,6 +2386,9 @@ export function clearServices(): void {
   // Clear the process-global recording policy alongside the container so a
   // re-initialization does not inherit a prior config's opt-outs.
   resetWebhookRecordingPolicy();
+  // Clear the process-global recording activation for the same reason; its
+  // provider closes over this container's registry.
+  resetWebhookActivation();
   globalForReg.__nextly_isRegistered = false;
 }
 

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -269,6 +269,12 @@ export interface NextlyServiceConfig {
    * retention off; absent when this container was built without app config.
    */
   webhookRetention?: ResolvedWebhookRetentionConfig | null;
+
+  /**
+   * Whether the audit seam forces outbox recording regardless of endpoints.
+   * Carried from the sanitized config; absent when built without app config.
+   */
+  webhookAuditEnabled?: boolean;
 }
 
 // ============================================================

--- a/packages/nextly/src/di/registrations/register-webhooks.ts
+++ b/packages/nextly/src/di/registrations/register-webhooks.ts
@@ -59,10 +59,10 @@ export function registerWebhookServices(ctx: RegistrationContext): void {
   // endpoint presence is resolved through the shared registry (its cache carries
   // the CRUD invalidation and TTL), so the gate needs no second cache.
   setWebhookAuditEnabled(ctx.config.webhookAuditEnabled ?? false);
-  setEndpointPresenceProvider(() =>
+  setEndpointPresenceProvider(reader =>
     container
       .get<WebhookEndpointRegistry>("webhookEndpointRegistry")
-      .hasEnabledEndpoints()
+      .hasEnabledEndpoints(reader)
   );
 
   container.registerSingleton<WebhookEndpointService>(

--- a/packages/nextly/src/di/registrations/register-webhooks.ts
+++ b/packages/nextly/src/di/registrations/register-webhooks.ts
@@ -21,6 +21,10 @@ import {
   WebhookEndpointRegistry,
   type WebhookEndpointReader,
 } from "../../domains/webhooks/endpoint-registry";
+import {
+  setEndpointPresenceProvider,
+  setWebhookAuditEnabled,
+} from "../../domains/webhooks/recording-activation";
 import { MetaRetentionGate } from "../../domains/webhooks/retention-gate";
 import { WebhookDeliveryQueryService } from "../../domains/webhooks/services/webhook-delivery-query-service";
 import { WebhookEndpointService } from "../../domains/webhooks/services/webhook-endpoint-service";
@@ -48,6 +52,17 @@ export function registerWebhookServices(ctx: RegistrationContext): void {
         container.get<WebhookEndpointReader>("adapter"),
         { ttlMs: ENDPOINT_REGISTRY_TTL_MS }
       )
+  );
+
+  // Publish the outbox recording gate inputs so the recording choke point can
+  // skip events no endpoint would receive. Audit forces recording regardless;
+  // endpoint presence is resolved through the shared registry (its cache carries
+  // the CRUD invalidation and TTL), so the gate needs no second cache.
+  setWebhookAuditEnabled(ctx.config.webhookAuditEnabled ?? false);
+  setEndpointPresenceProvider(() =>
+    container
+      .get<WebhookEndpointRegistry>("webhookEndpointRegistry")
+      .hasEnabledEndpoints()
   );
 
   container.registerSingleton<WebhookEndpointService>(

--- a/packages/nextly/src/di/registrations/register-webhooks.ts
+++ b/packages/nextly/src/di/registrations/register-webhooks.ts
@@ -22,7 +22,8 @@ import {
   type WebhookEndpointReader,
 } from "../../domains/webhooks/endpoint-registry";
 import {
-  setEndpointPresenceProvider,
+  refreshEndpointPresence,
+  setEndpointPresenceRefresher,
   setWebhookAuditEnabled,
 } from "../../domains/webhooks/recording-activation";
 import { MetaRetentionGate } from "../../domains/webhooks/retention-gate";
@@ -56,14 +57,17 @@ export function registerWebhookServices(ctx: RegistrationContext): void {
 
   // Publish the outbox recording gate inputs so the recording choke point can
   // skip events no endpoint would receive. Audit forces recording regardless;
-  // endpoint presence is resolved through the shared registry (its cache carries
-  // the CRUD invalidation and TTL), so the gate needs no second cache.
+  // endpoint presence is refreshed from the shared registry on a POOLED
+  // connection (never a content transaction) at boot, on endpoint CRUD, and on a
+  // stale background reload. Prime it now, non-awaited so registration is not
+  // blocked on the read; the flag fails open until it lands.
   setWebhookAuditEnabled(ctx.config.webhookAuditEnabled ?? false);
-  setEndpointPresenceProvider(reader =>
+  setEndpointPresenceRefresher(() =>
     container
       .get<WebhookEndpointRegistry>("webhookEndpointRegistry")
-      .hasEnabledEndpoints(reader)
+      .hasEnabledEndpoints()
   );
+  void refreshEndpointPresence();
 
   container.registerSingleton<WebhookEndpointService>(
     "webhookEndpointService",

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
@@ -22,6 +22,7 @@ import { defineCollection, text } from "../../../config";
 import { createAdapter } from "../../../database/factory";
 import { container } from "../../../di/container";
 import type { RBACAccessControlService } from "../../../domains/auth/services/rbac-access-control-service";
+import { setWebhookAuditEnabled } from "../../../domains/webhooks/recording-activation";
 import { NextlyError } from "../../../errors/nextly-error";
 import { registerHook, unregisterHook } from "../../../hooks";
 import type { HookHandler } from "../../../hooks/types";
@@ -52,6 +53,9 @@ const BEFOREOP_SLUG = "poolreentrybeforeop";
 // transaction — the binding this fixture exercises. Its teardown also drops the
 // companion table (see `drop`).
 const LOCALIZED_DELETE_SLUG = "poolreentrylocdel";
+// A write whose outbox recording gate must read endpoint presence on the
+// caller's transaction, not a second pooled connection, when its cache is cold.
+const GATE_SLUG = "poolreentrygate";
 const SLUGS = [
   RBAC_SLUG,
   BULK_CREATE_SLUG,
@@ -64,6 +68,7 @@ const SLUGS = [
   DIRECT_DELETE_SLUG,
   BEFOREOP_SLUG,
   LOCALIZED_DELETE_SLUG,
+  GATE_SLUG,
 ];
 
 type TestAdapter = Awaited<ReturnType<typeof createAdapter>>;
@@ -161,6 +166,44 @@ describePg(
         }
       }
     }
+
+    it("completes a gated write whose cold endpoint lookup binds to the caller's transaction", async () => {
+      const adapter = await connectSingleConnection();
+      let handle: TestNextly | undefined;
+      try {
+        handle = await createTestNextly({
+          adapter,
+          collections: [openCollection(GATE_SLUG)],
+        });
+        // Turn the harness's audit default off so the recording gate actually
+        // consults endpoint presence — the read that must bind to the caller's
+        // transaction. No endpoint is seeded, so the gate loads a cold registry;
+        // that load must run on the transaction's own connection, never a second
+        // pooled one, which would block forever on this `max: 1` pool.
+        setWebhookAuditEnabled(false);
+        const entries = handle
+          .getService<CollectionsHandler>("collectionsHandler")
+          .getEntryService() as CollectionEntryService;
+
+        const result = await withTimeout(
+          handle.adapter.transaction(tx =>
+            entries.createEntriesInTransaction(
+              tx,
+              { collectionName: GATE_SLUG, user: { id: "editor" } },
+              [{ title: "t" }]
+            )
+          ),
+          15_000
+        );
+
+        // The write reached completion instead of deadlocking on a second
+        // connection; with no endpoint and audit off, no event is recorded.
+        expect(result.successful).toBe(1);
+        expect(result.failed).toBe(0);
+      } finally {
+        await handle?.destroy();
+      }
+    }, 30_000);
 
     it("resolves a publish RBAC check on the transaction's own connection", async () => {
       const adapter = await connectSingleConnection();

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
@@ -22,7 +22,10 @@ import { defineCollection, text } from "../../../config";
 import { createAdapter } from "../../../database/factory";
 import { container } from "../../../di/container";
 import type { RBACAccessControlService } from "../../../domains/auth/services/rbac-access-control-service";
-import { setWebhookAuditEnabled } from "../../../domains/webhooks/recording-activation";
+import {
+  refreshEndpointPresence,
+  setWebhookAuditEnabled,
+} from "../../../domains/webhooks/recording-activation";
 import { NextlyError } from "../../../errors/nextly-error";
 import { registerHook, unregisterHook } from "../../../hooks";
 import type { HookHandler } from "../../../hooks/types";
@@ -53,8 +56,9 @@ const BEFOREOP_SLUG = "poolreentrybeforeop";
 // transaction — the binding this fixture exercises. Its teardown also drops the
 // companion table (see `drop`).
 const LOCALIZED_DELETE_SLUG = "poolreentrylocdel";
-// A write whose outbox recording gate must read endpoint presence on the
-// caller's transaction, not a second pooled connection, when its cache is cold.
+// A write whose outbox recording gate reads endpoint presence from a
+// synchronous out-of-band flag, never the database, so it takes no connection
+// inside the write transaction.
 const GATE_SLUG = "poolreentrygate";
 const SLUGS = [
   RBAC_SLUG,
@@ -181,9 +185,19 @@ describePg(
         // A regression that made the gate read endpoints inside the write
         // transaction would deadlock forever on this `max: 1` pool.
         setWebhookAuditEnabled(false);
+        // Prime the presence flag to its real (empty) value so the gate reads a
+        // deterministic `false` rather than the fail-open default while the boot
+        // prime is still in flight.
+        await refreshEndpointPresence();
         const entries = handle
           .getService<CollectionsHandler>("collectionsHandler")
           .getEntryService() as CollectionEntryService;
+
+        // The shared system table persists rows from earlier cases, so measure
+        // the delta this write adds rather than asserting a global empty count.
+        const before = (
+          await handle.adapter.select<{ id: string }>("nextly_events")
+        ).length;
 
         const result = await withTimeout(
           handle.adapter.transaction(tx =>
@@ -200,6 +214,12 @@ describePg(
         // connection; with no endpoint and audit off, no event is recorded.
         expect(result.successful).toBe(1);
         expect(result.failed).toBe(0);
+        // Prove the gate actually closed: a regression that recorded despite no
+        // endpoint would still complete, so assert the outbox gained no row.
+        const after = (
+          await handle.adapter.select<{ id: string }>("nextly_events")
+        ).length;
+        expect(after).toBe(before);
       } finally {
         await handle?.destroy();
       }

--- a/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/publish-enforcement-pool-reentry.integration.test.ts
@@ -167,7 +167,7 @@ describePg(
       }
     }
 
-    it("completes a gated write whose cold endpoint lookup binds to the caller's transaction", async () => {
+    it("completes a gated write without any endpoint read inside the transaction", async () => {
       const adapter = await connectSingleConnection();
       let handle: TestNextly | undefined;
       try {
@@ -175,11 +175,11 @@ describePg(
           adapter,
           collections: [openCollection(GATE_SLUG)],
         });
-        // Turn the harness's audit default off so the recording gate actually
-        // consults endpoint presence — the read that must bind to the caller's
-        // transaction. No endpoint is seeded, so the gate loads a cold registry;
-        // that load must run on the transaction's own connection, never a second
-        // pooled one, which would block forever on this `max: 1` pool.
+        // Turn the harness's audit default off so the recording gate consults
+        // endpoint presence. It reads a synchronous, out-of-band-refreshed flag —
+        // NOT the database — so the write never checks out a second connection.
+        // A regression that made the gate read endpoints inside the write
+        // transaction would deadlock forever on this `max: 1` pool.
         setWebhookAuditEnabled(false);
         const entries = handle
           .getService<CollectionsHandler>("collectionsHandler")

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -94,7 +94,7 @@ import { VersionCaptureService } from "../../versions/version-capture-service";
 import { withVersionConflictRetry } from "../../versions/version-conflict";
 import { expandComponentFields } from "../../webhooks/expand-component-fields";
 import { recordMutationEvent } from "../../webhooks/record-mutation-event";
-import { isWebhookRecordingEnabled } from "../../webhooks/recording-policy";
+import { isOutboxRecordingActive } from "../../webhooks/recording-activation";
 import type { SensitiveFieldSource } from "../../webhooks/sensitive-fields";
 import { statusEventsFor } from "../../webhooks/status-events";
 
@@ -359,7 +359,11 @@ export class CollectionMutationService extends BaseService {
     fields: readonly SensitiveFieldSource[],
     executor?: unknown
   ): Promise<readonly SensitiveFieldSource[]> {
-    if (!isWebhookRecordingEnabled("collection", collectionSlug)) return fields;
+    // Skip the component expansion when this write will not be recorded — the
+    // per-entity opt-out, or no endpoint with audit off. Component expansion
+    // issues a registry read per slug, so gating it here means a gated-off write
+    // pays nothing and cannot fail on a webhook-only read.
+    if (!isOutboxRecordingActive("collection", collectionSlug)) return fields;
     return this.webhookFieldTree(fields, executor);
   }
 

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -94,7 +94,7 @@ import { VersionCaptureService } from "../../versions/version-capture-service";
 import { withVersionConflictRetry } from "../../versions/version-conflict";
 import { expandComponentFields } from "../../webhooks/expand-component-fields";
 import { recordMutationEvent } from "../../webhooks/record-mutation-event";
-import { isOutboxRecordingActive } from "../../webhooks/recording-activation";
+import { isWebhookRecordingEnabled } from "../../webhooks/recording-policy";
 import type { SensitiveFieldSource } from "../../webhooks/sensitive-fields";
 import { statusEventsFor } from "../../webhooks/status-events";
 
@@ -359,11 +359,13 @@ export class CollectionMutationService extends BaseService {
     fields: readonly SensitiveFieldSource[],
     executor?: unknown
   ): Promise<readonly SensitiveFieldSource[]> {
-    // Skip the component expansion when this write will not be recorded — the
-    // per-entity opt-out, or no endpoint with audit off. Component expansion
-    // issues a registry read per slug, so gating it here means a gated-off write
-    // pays nothing and cannot fail on a webhook-only read.
-    if (!isOutboxRecordingActive("collection", collectionSlug)) return fields;
+    // Gate only on the per-entity opt-out, NOT the endpoint/audit flag: that flag
+    // can flip on between this pre-record expansion and the in-transaction
+    // recordMutationEvent, and skipping expansion here while the choke point then
+    // records would ship component-nested secret/hidden values unstripped. The
+    // choke point still gates the actual write, so a gated-off collection records
+    // nothing — only this expansion runs, exactly as before endpoint gating.
+    if (!isWebhookRecordingEnabled("collection", collectionSlug)) return fields;
     return this.webhookFieldTree(fields, executor);
   }
 

--- a/packages/nextly/src/domains/media/services/media-service.ts
+++ b/packages/nextly/src/domains/media/services/media-service.ts
@@ -50,6 +50,7 @@
 // logContext per §13.8; public messages remain generic and end with a period.
 import { actorForWrite, type RequestActor } from "../../../auth/request-actor";
 import type { WebhookFastDrainScheduler } from "../../../domains/webhooks/after-drain";
+import { isUnscopedRecordingActive } from "../../../domains/webhooks/recording-activation";
 import type { WebhookRetentionRunner } from "../../../domains/webhooks/retention-runner";
 import { NextlyError } from "../../../errors";
 import { emitMediaEvent } from "../../../events/domain-events";
@@ -220,7 +221,12 @@ export class MediaService {
    * committed media write into an error. Mirrors the collection write path.
    */
   private async afterWrite(): Promise<void> {
-    this.fastDrainScheduler?.offer();
+    // Only offer the fast drain when a media write would have recorded an event
+    // (an endpoint exists, or audit is on). Media has no per-entity opt-out, so
+    // this sync check equals the recorder's result; without it an install with
+    // no webhooks pays a fresh `nextly_webhooks` query on every media write.
+    // Retention still runs — it prunes prior rows regardless.
+    if (isUnscopedRecordingActive()) this.fastDrainScheduler?.offer();
     await this.retentionRunner?.maybeRun(MediaService.WRITE_PATH_PRUNE_BATCHES);
   }
 

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -89,7 +89,7 @@ import { VersionCaptureService } from "../../versions/version-capture-service";
 import { withVersionConflictRetry } from "../../versions/version-conflict";
 import { expandComponentFields } from "../../webhooks/expand-component-fields";
 import { recordMutationEvent } from "../../webhooks/record-mutation-event";
-import { isWebhookRecordingEnabled } from "../../webhooks/recording-policy";
+import { isOutboxRecordingActive } from "../../webhooks/recording-activation";
 import type { WebhookResource } from "../../webhooks/types";
 import type {
   SingleDocument,
@@ -1346,14 +1346,15 @@ export class SingleMutationService extends BaseService {
             // view; a non-localized single has no locale.
             const payloadLocale = eventLocale ?? defaultViewLocale;
 
-            // Resolve the opt-out ONCE, before assembling any webhook payload.
-            // Building the previous/next documents calls populateComponentData
-            // (strict) — a per-component read that can throw on a missing/stale
-            // component table — and expands the field tree, all of which only
-            // ever feed recordMutationEvent. That helper short-circuits on the
-            // opt-out, so for a `webhooks: false` Single this assembly is pure
-            // waste and must not be able to fail a scalar content write.
-            const recordingEnabled = isWebhookRecordingEnabled("single", slug);
+            // Resolve the FULL recording gate ONCE, before assembling any webhook
+            // payload. Building the previous/next documents calls
+            // populateComponentData (strict) — a per-component read that can throw
+            // on a missing/stale component table — and expands the field tree, all
+            // of which only ever feed recordMutationEvent. The choke point
+            // re-checks the same gate, so for an opted-out Single, or one with no
+            // endpoint and audit off, this assembly is pure waste and must not be
+            // able to fail a scalar content write.
+            const recordingEnabled = isOutboxRecordingActive("single", slug);
 
             const previousDoc =
               recordingEnabled && preRow

--- a/packages/nextly/src/domains/webhooks/__tests__/endpoint-gated-recording.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/endpoint-gated-recording.integration.test.ts
@@ -13,7 +13,10 @@ import {
 } from "../../../plugins/test-nextly";
 import type { CollectionsHandler } from "../../../services/collections-handler";
 import type { WebhookEndpointRegistry } from "../endpoint-registry";
-import { setWebhookAuditEnabled } from "../recording-activation";
+import {
+  refreshEndpointPresence,
+  setWebhookAuditEnabled,
+} from "../recording-activation";
 
 let current: TestNextly | undefined;
 
@@ -51,11 +54,12 @@ async function seedEnabledEndpoint(handle: TestNextly): Promise<void> {
     created_at: new Date("2020-01-01T00:00:00.000Z"),
     updated_at: new Date("2020-01-01T00:00:00.000Z"),
   });
-  // The gate reads the registry's cached list; force a reload so the just-seeded
-  // row is visible, exactly as the CRUD surface does on create.
+  // Invalidate the registry cache and re-derive the recording gate's presence
+  // flag, exactly as the CRUD surface does on create.
   handle
     .getService<WebhookEndpointRegistry>("webhookEndpointRegistry")
     .invalidate();
+  await refreshEndpointPresence();
 }
 
 describe("endpoint-gated outbox recording (integration)", () => {
@@ -66,8 +70,10 @@ describe("endpoint-gated outbox recording (integration)", () => {
       ],
     });
     // The harness defaults audit on so machinery tests are endpoint-independent;
-    // this suite tests the gate, so turn it off.
+    // this suite tests the gate, so turn it off. Prime the presence flag so it
+    // reflects the actual (empty) endpoint set rather than the fail-open default.
     setWebhookAuditEnabled(false);
+    await refreshEndpointPresence();
     await makePost(current);
     expect(await eventCount(current)).toBe(0);
   });
@@ -106,14 +112,15 @@ describe("endpoint-gated outbox recording (integration)", () => {
     await makePost(current);
     expect(await eventCount(current)).toBe(1);
 
-    // Disable the endpoint (SQLite stores booleans as 0/1) and invalidate, as a
-    // disable through the CRUD surface would.
+    // Disable the endpoint (SQLite stores booleans as 0/1), invalidate, and
+    // re-derive the presence flag, as a disable through the CRUD surface would.
     await current.adapter.executeQuery(
       "UPDATE nextly_webhooks SET enabled = 0"
     );
     current
       .getService<WebhookEndpointRegistry>("webhookEndpointRegistry")
       .invalidate();
+    await refreshEndpointPresence();
     await makePost(current);
     expect(await eventCount(current)).toBe(1); // no new row recorded
   });

--- a/packages/nextly/src/domains/webhooks/__tests__/endpoint-gated-recording.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/endpoint-gated-recording.integration.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Endpoint-gated outbox recording, end to end. With no enabled endpoint and the
+ * audit seam off, a content write records nothing; creating an endpoint (or
+ * enabling audit) resumes recording. Proves the perf/privacy contract at the
+ * real write path.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+import type { WebhookEndpointRegistry } from "../endpoint-registry";
+import { setWebhookAuditEnabled } from "../recording-activation";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+async function eventCount(handle: TestNextly): Promise<number> {
+  const rows = await handle.adapter.select<{ id: string }>("nextly_events");
+  return rows.length;
+}
+
+async function makePost(handle: TestNextly): Promise<void> {
+  const handler = handle.getService<CollectionsHandler>("collectionsHandler");
+  await handler.createEntry(
+    { collectionName: "posts", overrideAccess: true },
+    { title: "hi" }
+  );
+}
+
+async function seedEnabledEndpoint(handle: TestNextly): Promise<void> {
+  await handle.adapter.insert("nextly_webhooks", {
+    id: "w1",
+    name: "w1",
+    url: "https://example.com/w1",
+    enabled: true,
+    event_types: ["entry.created"],
+    filter: null,
+    headers: null,
+    secret_hash: [],
+    secret_prefix: "whsec_",
+    field_allowlist: null,
+    created_by: null,
+    created_at: new Date("2020-01-01T00:00:00.000Z"),
+    updated_at: new Date("2020-01-01T00:00:00.000Z"),
+  });
+  // The gate reads the registry's cached list; force a reload so the just-seeded
+  // row is visible, exactly as the CRUD surface does on create.
+  handle
+    .getService<WebhookEndpointRegistry>("webhookEndpointRegistry")
+    .invalidate();
+}
+
+describe("endpoint-gated outbox recording (integration)", () => {
+  it("records nothing when there is no endpoint and audit is off", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "posts", fields: [text({ name: "title" })] }),
+      ],
+    });
+    // The harness defaults audit on so machinery tests are endpoint-independent;
+    // this suite tests the gate, so turn it off.
+    setWebhookAuditEnabled(false);
+    await makePost(current);
+    expect(await eventCount(current)).toBe(0);
+  });
+
+  it("records once an enabled endpoint exists", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "posts", fields: [text({ name: "title" })] }),
+      ],
+    });
+    setWebhookAuditEnabled(false);
+    await seedEnabledEndpoint(current);
+    await makePost(current);
+    expect(await eventCount(current)).toBe(1);
+  });
+
+  it("records with no endpoint when the audit seam is on", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "posts", fields: [text({ name: "title" })] }),
+      ],
+    });
+    setWebhookAuditEnabled(true);
+    await makePost(current);
+    expect(await eventCount(current)).toBe(1);
+  });
+
+  it("stops recording after the last endpoint is disabled", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "posts", fields: [text({ name: "title" })] }),
+      ],
+    });
+    setWebhookAuditEnabled(false);
+    await seedEnabledEndpoint(current);
+    await makePost(current);
+    expect(await eventCount(current)).toBe(1);
+
+    // Disable the endpoint (SQLite stores booleans as 0/1) and invalidate, as a
+    // disable through the CRUD surface would.
+    await current.adapter.executeQuery(
+      "UPDATE nextly_webhooks SET enabled = 0"
+    );
+    current
+      .getService<WebhookEndpointRegistry>("webhookEndpointRegistry")
+      .invalidate();
+    await makePost(current);
+    expect(await eventCount(current)).toBe(1); // no new row recorded
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/endpoint-gated-recording.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/endpoint-gated-recording.integration.test.ts
@@ -15,6 +15,7 @@ import type { CollectionsHandler } from "../../../services/collections-handler";
 import type { WebhookEndpointRegistry } from "../endpoint-registry";
 import {
   refreshEndpointPresence,
+  resetWebhookActivation,
   setWebhookAuditEnabled,
 } from "../recording-activation";
 
@@ -23,6 +24,9 @@ let current: TestNextly | undefined;
 afterEach(async () => {
   await current?.destroy();
   current = undefined;
+  // `destroy()` clears the container but not this process-global; reset it so a
+  // suite's audit/presence state never leaks into the next sequential file.
+  resetWebhookActivation();
 });
 
 async function eventCount(handle: TestNextly): Promise<number> {

--- a/packages/nextly/src/domains/webhooks/__tests__/endpoint-registry.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/endpoint-registry.test.ts
@@ -161,4 +161,18 @@ describe("WebhookEndpointRegistry", () => {
     reader.resolveNext([row("fresh")]);
     expect((await second).map(e => e.id)).toEqual(["fresh"]);
   });
+
+  it("hasEnabledEndpoints reflects whether the enabled set is non-empty", async () => {
+    const reader = new FakeReader();
+    const registry = new WebhookEndpointRegistry(reader);
+
+    const none = registry.hasEnabledEndpoints();
+    reader.resolveNext([]);
+    expect(await none).toBe(false);
+
+    registry.invalidate();
+    const some = registry.hasEnabledEndpoints();
+    reader.resolveNext([row("w1")]);
+    expect(await some).toBe(true);
+  });
 });

--- a/packages/nextly/src/domains/webhooks/__tests__/record-mutation-event.gate.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/record-mutation-event.gate.test.ts
@@ -4,8 +4,9 @@ import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
 
 import { recordMutationEvent } from "../record-mutation-event";
 import {
+  refreshEndpointPresence,
   resetWebhookActivation,
-  setEndpointPresenceProvider,
+  setEndpointPresenceRefresher,
   setWebhookAuditEnabled,
 } from "../recording-activation";
 import {
@@ -62,9 +63,14 @@ describe("recordMutationEvent recording gate", () => {
   });
 });
 
+async function primePresence(present: boolean): Promise<void> {
+  setEndpointPresenceRefresher(() => Promise.resolve(present));
+  await refreshEndpointPresence();
+}
+
 describe("recordMutationEvent endpoint/audit gate", () => {
   it("does not record when there are no endpoints and audit is off", async () => {
-    setEndpointPresenceProvider(() => Promise.resolve(false));
+    await primePresence(false);
     const { tx, insert } = makeTx();
     const recorded = await recordMutationEvent(tx, entryArgs("posts"));
     expect(insert).not.toHaveBeenCalled();
@@ -72,26 +78,23 @@ describe("recordMutationEvent endpoint/audit gate", () => {
   });
 
   it("records when an endpoint is present", async () => {
-    setEndpointPresenceProvider(() => Promise.resolve(true));
+    await primePresence(true);
     const { tx, insert } = makeTx();
     const recorded = await recordMutationEvent(tx, entryArgs("posts"));
     expect(insert).toHaveBeenCalledTimes(1);
     expect(recorded).toBe(true);
   });
 
-  it("records when audit is on even with no endpoints (skips the endpoint check)", async () => {
-    const provider = vi.fn(() => Promise.resolve(false));
-    setEndpointPresenceProvider(provider);
+  it("records when audit is on even with no endpoints", async () => {
+    await primePresence(false);
     setWebhookAuditEnabled(true);
     const { tx, insert } = makeTx();
     const recorded = await recordMutationEvent(tx, entryArgs("posts"));
     expect(insert).toHaveBeenCalledTimes(1);
     expect(recorded).toBe(true);
-    expect(provider).not.toHaveBeenCalled();
   });
 
-  it("records (fail-open) when the endpoint provider throws", async () => {
-    setEndpointPresenceProvider(() => Promise.reject(new Error("db down")));
+  it("records (fail-open) before the presence flag is primed", async () => {
     const { tx, insert } = makeTx();
     const recorded = await recordMutationEvent(tx, entryArgs("posts"));
     expect(insert).toHaveBeenCalledTimes(1);
@@ -99,7 +102,7 @@ describe("recordMutationEvent endpoint/audit gate", () => {
   });
 
   it("the per-entity opt-out still wins over a present endpoint", async () => {
-    setEndpointPresenceProvider(() => Promise.resolve(true));
+    await primePresence(true);
     setWebhookRecording("collection", "submissions", false);
     const { tx, insert } = makeTx();
     const recorded = await recordMutationEvent(tx, entryArgs("submissions"));

--- a/packages/nextly/src/domains/webhooks/__tests__/record-mutation-event.gate.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/record-mutation-event.gate.test.ts
@@ -4,12 +4,18 @@ import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
 
 import { recordMutationEvent } from "../record-mutation-event";
 import {
+  resetWebhookActivation,
+  setEndpointPresenceProvider,
+  setWebhookAuditEnabled,
+} from "../recording-activation";
+import {
   resetWebhookRecordingPolicy,
   setWebhookRecording,
 } from "../recording-policy";
 
 afterEach(() => {
   resetWebhookRecordingPolicy();
+  resetWebhookActivation();
 });
 
 // A minimal tx: only `insert` is exercised (recordEvent appends one outbox row).
@@ -53,5 +59,51 @@ describe("recordMutationEvent recording gate", () => {
       fields: [],
     });
     expect(insert).not.toHaveBeenCalled();
+  });
+});
+
+describe("recordMutationEvent endpoint/audit gate", () => {
+  it("does not record when there are no endpoints and audit is off", async () => {
+    setEndpointPresenceProvider(() => Promise.resolve(false));
+    const { tx, insert } = makeTx();
+    const recorded = await recordMutationEvent(tx, entryArgs("posts"));
+    expect(insert).not.toHaveBeenCalled();
+    expect(recorded).toBe(false);
+  });
+
+  it("records when an endpoint is present", async () => {
+    setEndpointPresenceProvider(() => Promise.resolve(true));
+    const { tx, insert } = makeTx();
+    const recorded = await recordMutationEvent(tx, entryArgs("posts"));
+    expect(insert).toHaveBeenCalledTimes(1);
+    expect(recorded).toBe(true);
+  });
+
+  it("records when audit is on even with no endpoints (skips the endpoint check)", async () => {
+    const provider = vi.fn(() => Promise.resolve(false));
+    setEndpointPresenceProvider(provider);
+    setWebhookAuditEnabled(true);
+    const { tx, insert } = makeTx();
+    const recorded = await recordMutationEvent(tx, entryArgs("posts"));
+    expect(insert).toHaveBeenCalledTimes(1);
+    expect(recorded).toBe(true);
+    expect(provider).not.toHaveBeenCalled();
+  });
+
+  it("records (fail-open) when the endpoint provider throws", async () => {
+    setEndpointPresenceProvider(() => Promise.reject(new Error("db down")));
+    const { tx, insert } = makeTx();
+    const recorded = await recordMutationEvent(tx, entryArgs("posts"));
+    expect(insert).toHaveBeenCalledTimes(1);
+    expect(recorded).toBe(true);
+  });
+
+  it("the per-entity opt-out still wins over a present endpoint", async () => {
+    setEndpointPresenceProvider(() => Promise.resolve(true));
+    setWebhookRecording("collection", "submissions", false);
+    const { tx, insert } = makeTx();
+    const recorded = await recordMutationEvent(tx, entryArgs("submissions"));
+    expect(insert).not.toHaveBeenCalled();
+    expect(recorded).toBe(false);
   });
 });

--- a/packages/nextly/src/domains/webhooks/__tests__/record-mutation-event.gate.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/record-mutation-event.gate.test.ts
@@ -14,6 +14,9 @@ import {
   setWebhookRecording,
 } from "../recording-policy";
 
+// The recording policy and activation are process-global singletons, so each
+// test explicitly primes them and clears them here — otherwise one test's
+// opt-out or presence value would leak into the next.
 afterEach(() => {
   resetWebhookRecordingPolicy();
   resetWebhookActivation();
@@ -63,6 +66,9 @@ describe("recordMutationEvent recording gate", () => {
   });
 });
 
+// Drive the endpoint-presence flag to a known value: wire a refresher that
+// resolves to `present` and await one refresh, so the synchronous
+// `endpointsPresent()` the gate reads reflects it deterministically.
 async function primePresence(present: boolean): Promise<void> {
   setEndpointPresenceRefresher(() => Promise.resolve(present));
   await refreshEndpointPresence();

--- a/packages/nextly/src/domains/webhooks/__tests__/recording-activation.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/recording-activation.test.ts
@@ -87,13 +87,49 @@ describe("endpoint presence flag", () => {
     expect(endpointsPresent()).toBe(true);
   });
 
-  it("keeps the last known value when a refresh throws", async () => {
+  it("keeps a known-positive value when a refresh throws (a blip must not disable delivery)", async () => {
     const refresher = vi.fn().mockResolvedValue(true);
     setEndpointPresenceRefresher(refresher);
     await refreshEndpointPresence();
 
     refresher.mockRejectedValue(new Error("db down"));
     await refreshEndpointPresence();
+    expect(endpointsPresent()).toBe(true);
+  });
+
+  it("drops a cached negative to fail-open when its refresh fails", async () => {
+    const refresher = vi.fn().mockResolvedValue(false);
+    setEndpointPresenceRefresher(refresher);
+    await refreshEndpointPresence();
+    expect(endpointsPresent()).toBe(false);
+
+    // A cross-process endpoint create whose presence re-read fails must not keep
+    // dropping events on a stale `false`; the unknown state fails open.
+    refresher.mockRejectedValue(new Error("db down"));
+    await refreshEndpointPresence();
+    expect(endpointsPresent()).toBe(true);
+  });
+
+  it("coalesces a refresh requested while one is in flight", async () => {
+    const resolvers: Array<(v: boolean) => void> = [];
+    const refresher = vi.fn(
+      () => new Promise<boolean>(res => resolvers.push(res))
+    );
+    setEndpointPresenceRefresher(refresher);
+
+    const first = refreshEndpointPresence();
+    // Requested during the in-flight refresh (e.g. endpoint CRUD): must not be
+    // discarded, so the active refresh runs once more afterward.
+    const second = refreshEndpointPresence();
+    expect(refresher).toHaveBeenCalledTimes(1);
+
+    resolvers[0](false);
+    await flush();
+    expect(refresher).toHaveBeenCalledTimes(2);
+
+    resolvers[1](true);
+    await first;
+    await second;
     expect(endpointsPresent()).toBe(true);
   });
 

--- a/packages/nextly/src/domains/webhooks/__tests__/recording-activation.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/recording-activation.test.ts
@@ -1,19 +1,24 @@
 /**
- * Process-level webhook recording activation: the audit seam, the fail-open
- * endpoint-presence resolver, and the pure gate predicate.
+ * Process-level webhook recording activation: the audit seam and the
+ * synchronously-read, out-of-band-refreshed endpoint-presence flag.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   endpointsPresent,
   isWebhookAuditEnabled,
+  refreshEndpointPresence,
   resetWebhookActivation,
-  setEndpointPresenceProvider,
+  setActivationClock,
+  setEndpointPresenceRefresher,
   setWebhookAuditEnabled,
   shouldRecordEvent,
 } from "../recording-activation";
 
 afterEach(() => resetWebhookActivation());
+
+const flush = (): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, 0));
 
 describe("shouldRecordEvent", () => {
   it("never records when the collection opted out, regardless of endpoints/audit", () => {
@@ -66,19 +71,49 @@ describe("audit flag", () => {
   });
 });
 
-describe("endpointsPresent (fail-open)", () => {
-  it("returns true when no provider is set", async () => {
-    expect(await endpointsPresent()).toBe(true);
+describe("endpoint presence flag", () => {
+  it("fails open before it is primed", () => {
+    expect(endpointsPresent()).toBe(true);
   });
-  it("returns true when the provider throws", async () => {
-    setEndpointPresenceProvider(() => Promise.reject(new Error("db down")));
-    expect(await endpointsPresent()).toBe(true);
+
+  it("reflects the refresher after a refresh", async () => {
+    const refresher = vi.fn().mockResolvedValue(false);
+    setEndpointPresenceRefresher(refresher);
+    await refreshEndpointPresence();
+    expect(endpointsPresent()).toBe(false);
+
+    refresher.mockResolvedValue(true);
+    await refreshEndpointPresence();
+    expect(endpointsPresent()).toBe(true);
   });
-  it("returns the provider's answer when it resolves", async () => {
-    const provider = vi.fn().mockResolvedValue(false);
-    setEndpointPresenceProvider(provider);
-    expect(await endpointsPresent()).toBe(false);
-    provider.mockResolvedValue(true);
-    expect(await endpointsPresent()).toBe(true);
+
+  it("keeps the last known value when a refresh throws", async () => {
+    const refresher = vi.fn().mockResolvedValue(true);
+    setEndpointPresenceRefresher(refresher);
+    await refreshEndpointPresence();
+
+    refresher.mockRejectedValue(new Error("db down"));
+    await refreshEndpointPresence();
+    expect(endpointsPresent()).toBe(true);
+  });
+
+  it("serves the last value synchronously and schedules a background refresh when stale", async () => {
+    let clock = 1000;
+    setActivationClock(() => clock);
+    const refresher = vi.fn().mockResolvedValue(true);
+    setEndpointPresenceRefresher(refresher);
+    await refreshEndpointPresence();
+    expect(refresher).toHaveBeenCalledTimes(1);
+
+    // The endpoint set changed but the flag is now stale (past the TTL).
+    refresher.mockResolvedValue(false);
+    clock = 1000 + 30_001;
+
+    // The stale read returns the last known value with no await, and schedules
+    // a background reload that lands on the next tick.
+    expect(endpointsPresent()).toBe(true);
+    await flush();
+    expect(refresher).toHaveBeenCalledTimes(2);
+    expect(endpointsPresent()).toBe(false);
   });
 });

--- a/packages/nextly/src/domains/webhooks/__tests__/recording-activation.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/recording-activation.test.ts
@@ -110,26 +110,50 @@ describe("endpoint presence flag", () => {
     expect(endpointsPresent()).toBe(true);
   });
 
-  it("coalesces a refresh requested while one is in flight", async () => {
+  it("resolves only after its own serialized refresh completes", async () => {
     const resolvers: Array<(v: boolean) => void> = [];
     const refresher = vi.fn(
       () => new Promise<boolean>(res => resolvers.push(res))
     );
     setEndpointPresenceRefresher(refresher);
 
+    // A CRUD caller must not see its awaited refresh resolve before the read it
+    // requested completes; requests serialize on a shared tail.
     const first = refreshEndpointPresence();
-    // Requested during the in-flight refresh (e.g. endpoint CRUD): must not be
-    // discarded, so the active refresh runs once more afterward.
     const second = refreshEndpointPresence();
-    expect(refresher).toHaveBeenCalledTimes(1);
+    let secondDone = false;
+    void second.then(() => {
+      secondDone = true;
+    });
 
-    resolvers[0](false);
     await flush();
-    expect(refresher).toHaveBeenCalledTimes(2);
-
-    resolvers[1](true);
+    resolvers[0](false); // first refresh completes
     await first;
+    expect(secondDone).toBe(false); // second still awaits its own trailing read
+
+    resolvers[1](true); // second refresh completes
     await second;
+    expect(secondDone).toBe(true);
+    expect(refresher).toHaveBeenCalledTimes(2);
+    expect(endpointsPresent()).toBe(true);
+  });
+
+  it("discards a refresh that resolves after a reset", async () => {
+    let resolveStale: (v: boolean) => void = () => undefined;
+    const refresher = vi.fn(
+      () => new Promise<boolean>(res => (resolveStale = res))
+    );
+    setEndpointPresenceRefresher(refresher);
+
+    const inflight = refreshEndpointPresence();
+    await flush();
+    // A new instance registers (reset) while the prior read is still in flight.
+    resetWebhookActivation();
+    resolveStale(false); // the prior read resolves AFTER the reset
+    await inflight;
+
+    // The stale `false` from the prior instance must not have been committed; the
+    // reset instance is unprimed, so it fails open.
     expect(endpointsPresent()).toBe(true);
   });
 

--- a/packages/nextly/src/domains/webhooks/__tests__/recording-activation.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/recording-activation.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Process-level webhook recording activation: the audit seam, the fail-open
+ * endpoint-presence resolver, and the pure gate predicate.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  endpointsPresent,
+  isWebhookAuditEnabled,
+  resetWebhookActivation,
+  setEndpointPresenceProvider,
+  setWebhookAuditEnabled,
+  shouldRecordEvent,
+} from "../recording-activation";
+
+afterEach(() => resetWebhookActivation());
+
+describe("shouldRecordEvent", () => {
+  it("never records when the collection opted out, regardless of endpoints/audit", () => {
+    expect(
+      shouldRecordEvent({
+        collectionAllows: false,
+        auditEnabled: true,
+        hasEndpoints: true,
+      })
+    ).toBe(false);
+  });
+  it("records when an endpoint exists", () => {
+    expect(
+      shouldRecordEvent({
+        collectionAllows: true,
+        auditEnabled: false,
+        hasEndpoints: true,
+      })
+    ).toBe(true);
+  });
+  it("records when audit is on even with no endpoints", () => {
+    expect(
+      shouldRecordEvent({
+        collectionAllows: true,
+        auditEnabled: true,
+        hasEndpoints: false,
+      })
+    ).toBe(true);
+  });
+  it("skips when allowed but no endpoints and audit off", () => {
+    expect(
+      shouldRecordEvent({
+        collectionAllows: true,
+        auditEnabled: false,
+        hasEndpoints: false,
+      })
+    ).toBe(false);
+  });
+});
+
+describe("audit flag", () => {
+  it("defaults to false", () => {
+    expect(isWebhookAuditEnabled()).toBe(false);
+  });
+  it("is settable and reset clears it", () => {
+    setWebhookAuditEnabled(true);
+    expect(isWebhookAuditEnabled()).toBe(true);
+    resetWebhookActivation();
+    expect(isWebhookAuditEnabled()).toBe(false);
+  });
+});
+
+describe("endpointsPresent (fail-open)", () => {
+  it("returns true when no provider is set", async () => {
+    expect(await endpointsPresent()).toBe(true);
+  });
+  it("returns true when the provider throws", async () => {
+    setEndpointPresenceProvider(() => Promise.reject(new Error("db down")));
+    expect(await endpointsPresent()).toBe(true);
+  });
+  it("returns the provider's answer when it resolves", async () => {
+    const provider = vi.fn().mockResolvedValue(false);
+    setEndpointPresenceProvider(provider);
+    expect(await endpointsPresent()).toBe(false);
+    provider.mockResolvedValue(true);
+    expect(await endpointsPresent()).toBe(true);
+  });
+});

--- a/packages/nextly/src/domains/webhooks/endpoint-registry.ts
+++ b/packages/nextly/src/domains/webhooks/endpoint-registry.ts
@@ -173,6 +173,15 @@ export class WebhookEndpointRegistry {
     return this.getEnabledEndpoints();
   }
 
+  /**
+   * Whether any enabled endpoint exists, from the same cached list the drain
+   * reads (so this shares its invalidation and TTL). Used by the outbox
+   * recording gate to skip writing events no endpoint would receive.
+   */
+  async hasEnabledEndpoints(): Promise<boolean> {
+    return (await this.getEnabledEndpoints()).length > 0;
+  }
+
   private async load(): Promise<WebhookEndpoint[]> {
     const rows = await this.reader.select<Record<string, unknown>>(
       "nextly_webhooks",

--- a/packages/nextly/src/domains/webhooks/endpoint-registry.ts
+++ b/packages/nextly/src/domains/webhooks/endpoint-registry.ts
@@ -10,6 +10,8 @@
  * @module domains/webhooks/endpoint-registry
  */
 
+import type { SelectOptions } from "@nextlyhq/adapter-drizzle/types";
+
 import { normalizeSecretEntries } from "./secret-entries";
 import type {
   FilterSpec,
@@ -40,16 +42,16 @@ function normalizeFilter(raw: unknown): FilterSpec | null {
   };
 }
 
-/** The narrow read surface the registry needs (satisfied by the DB adapter). */
+/**
+ * The narrow read surface the registry needs. Satisfied by the DB adapter and,
+ * crucially, by a `TransactionContext`: the recording gate passes its open
+ * transaction here so a cold endpoint load reads on that transaction's own
+ * connection. Uses the adapter's `SelectOptions` verbatim so both are assignable
+ * (a hand-rolled subset with `op: string` would reject the transaction, whose
+ * `op` is the stricter `WhereOperator`).
+ */
 export interface WebhookEndpointReader {
-  select<T = unknown>(
-    table: string,
-    options?: {
-      where?: {
-        and: Array<{ column: string; op: string; value: unknown }>;
-      };
-    }
-  ): Promise<T[]>;
+  select<T = unknown>(table: string, options?: SelectOptions): Promise<T[]>;
 }
 
 /**
@@ -177,13 +179,34 @@ export class WebhookEndpointRegistry {
    * Whether any enabled endpoint exists, from the same cached list the drain
    * reads (so this shares its invalidation and TTL). Used by the outbox
    * recording gate to skip writing events no endpoint would receive.
+   *
+   * The gate calls this from inside an open write transaction, so `reader` — the
+   * caller's transaction — is used for a cold/expired load instead of the pooled
+   * adapter: reading through the pool while the transaction holds its connection
+   * deadlocks a single-connection pool. A warm cache answers without any read,
+   * so the executor only matters on the load path. This deliberately does not
+   * join the pooled in-flight load: a transaction-bound caller must never await
+   * a pooled read, and an occasional extra count is harmless.
    */
-  async hasEnabledEndpoints(): Promise<boolean> {
-    return (await this.getEnabledEndpoints()).length > 0;
+  async hasEnabledEndpoints(reader?: WebhookEndpointReader): Promise<boolean> {
+    if (this.cache !== null && !this.isExpired()) {
+      return this.cache.length > 0;
+    }
+    const gen = this.generation;
+    const rows = await this.load(reader ?? this.reader);
+    // Commit to the cache only if no invalidation happened while loading, so a
+    // concurrent CRUD change is not overwritten by this in-flight snapshot.
+    if (gen === this.generation) {
+      this.cache = rows;
+      this.cachedAtMs = this.now();
+    }
+    return rows.length > 0;
   }
 
-  private async load(): Promise<WebhookEndpoint[]> {
-    const rows = await this.reader.select<Record<string, unknown>>(
+  private async load(
+    reader: WebhookEndpointReader = this.reader
+  ): Promise<WebhookEndpoint[]> {
+    const rows = await reader.select<Record<string, unknown>>(
       "nextly_webhooks",
       {
         where: {

--- a/packages/nextly/src/domains/webhooks/endpoint-registry.ts
+++ b/packages/nextly/src/domains/webhooks/endpoint-registry.ts
@@ -10,8 +10,6 @@
  * @module domains/webhooks/endpoint-registry
  */
 
-import type { SelectOptions } from "@nextlyhq/adapter-drizzle/types";
-
 import { normalizeSecretEntries } from "./secret-entries";
 import type {
   FilterSpec,
@@ -42,16 +40,16 @@ function normalizeFilter(raw: unknown): FilterSpec | null {
   };
 }
 
-/**
- * The narrow read surface the registry needs. Satisfied by the DB adapter and,
- * crucially, by a `TransactionContext`: the recording gate passes its open
- * transaction here so a cold endpoint load reads on that transaction's own
- * connection. Uses the adapter's `SelectOptions` verbatim so both are assignable
- * (a hand-rolled subset with `op: string` would reject the transaction, whose
- * `op` is the stricter `WhereOperator`).
- */
+/** The narrow read surface the registry needs (satisfied by the DB adapter). */
 export interface WebhookEndpointReader {
-  select<T = unknown>(table: string, options?: SelectOptions): Promise<T[]>;
+  select<T = unknown>(
+    table: string,
+    options?: {
+      where?: {
+        and: Array<{ column: string; op: string; value: unknown }>;
+      };
+    }
+  ): Promise<T[]>;
 }
 
 /**
@@ -177,36 +175,16 @@ export class WebhookEndpointRegistry {
 
   /**
    * Whether any enabled endpoint exists, from the same cached list the drain
-   * reads (so this shares its invalidation and TTL). Used by the outbox
-   * recording gate to skip writing events no endpoint would receive.
-   *
-   * The gate calls this from inside an open write transaction, so `reader` — the
-   * caller's transaction — is used for a cold/expired load instead of the pooled
-   * adapter: reading through the pool while the transaction holds its connection
-   * deadlocks a single-connection pool. A warm cache answers without any read,
-   * so the executor only matters on the load path. This deliberately does not
-   * join the pooled in-flight load: a transaction-bound caller must never await
-   * a pooled read, and an occasional extra count is harmless.
+   * reads (so this shares its invalidation and TTL). The recording gate's
+   * presence flag is refreshed from this on a pooled connection, never inside a
+   * content write transaction.
    */
-  async hasEnabledEndpoints(reader?: WebhookEndpointReader): Promise<boolean> {
-    if (this.cache !== null && !this.isExpired()) {
-      return this.cache.length > 0;
-    }
-    const gen = this.generation;
-    const rows = await this.load(reader ?? this.reader);
-    // Commit to the cache only if no invalidation happened while loading, so a
-    // concurrent CRUD change is not overwritten by this in-flight snapshot.
-    if (gen === this.generation) {
-      this.cache = rows;
-      this.cachedAtMs = this.now();
-    }
-    return rows.length > 0;
+  async hasEnabledEndpoints(): Promise<boolean> {
+    return (await this.getEnabledEndpoints()).length > 0;
   }
 
-  private async load(
-    reader: WebhookEndpointReader = this.reader
-  ): Promise<WebhookEndpoint[]> {
-    const rows = await reader.select<Record<string, unknown>>(
+  private async load(): Promise<WebhookEndpoint[]> {
+    const rows = await this.reader.select<Record<string, unknown>>(
       "nextly_webhooks",
       {
         where: {

--- a/packages/nextly/src/domains/webhooks/record-mutation-event.ts
+++ b/packages/nextly/src/domains/webhooks/record-mutation-event.ts
@@ -96,29 +96,24 @@ export async function recordMutationEvent(
 
   // Endpoint/audit gate: an install with no enabled endpoint and the audit seam
   // off records nothing, so a mutation never pays the outbox INSERT + full
-  // document serialization for an event no subscriber would receive. Audit is
-  // checked first (sync) so an audit-on install never consults the registry.
-  // `endpointsPresent()` reads the registry's cached list (shared with the
-  // drain, so its CRUD invalidation and TTL apply here) and fails open, so this
-  // adds one resolved microtask on the warm path and never aborts the write on
-  // a lookup error. Race contract: a same-process endpoint create invalidates
-  // immediately; an endpoint created in another process is picked up within the
-  // registry TTL; a few events recorded just before the last endpoint is removed
-  // may remain and are pruned by retention.
-  if (!isWebhookAuditEnabled()) {
-    // Pass `tx` so a cold endpoint lookup reads on this transaction's own
-    // connection, never a second pooled one (which deadlocks a 1-connection
-    // pool while this transaction holds its connection).
-    const hasEndpoints = await endpointsPresent(tx);
-    if (
-      !shouldRecordEvent({
-        collectionAllows: true,
-        auditEnabled: false,
-        hasEndpoints,
-      })
-    ) {
-      return false;
-    }
+  // document serialization for an event no subscriber would receive. Both inputs
+  // are read synchronously with NO database access — safe inside this write
+  // transaction, where a read would deadlock a single-connection pool, cache a
+  // stale transaction snapshot, or poison the transaction on failure. Endpoint
+  // presence is a flag refreshed out of band (boot, endpoint CRUD, and a stale-
+  // read background reload), and fails open until primed. Race contract: a same-
+  // process endpoint change refreshes the flag immediately; an endpoint changed
+  // in another process is picked up within the flag TTL; a few events recorded
+  // just before the last endpoint is removed may remain and are pruned by
+  // retention.
+  if (
+    !shouldRecordEvent({
+      collectionAllows: true,
+      auditEnabled: isWebhookAuditEnabled(),
+      hasEndpoints: endpointsPresent(),
+    })
+  ) {
+    return false;
   }
 
   const envelope = buildEnvelope({

--- a/packages/nextly/src/domains/webhooks/record-mutation-event.ts
+++ b/packages/nextly/src/domains/webhooks/record-mutation-event.ts
@@ -106,7 +106,10 @@ export async function recordMutationEvent(
   // registry TTL; a few events recorded just before the last endpoint is removed
   // may remain and are pruned by retention.
   if (!isWebhookAuditEnabled()) {
-    const hasEndpoints = await endpointsPresent();
+    // Pass `tx` so a cold endpoint lookup reads on this transaction's own
+    // connection, never a second pooled one (which deadlocks a 1-connection
+    // pool while this transaction holds its connection).
+    const hasEndpoints = await endpointsPresent(tx);
     if (
       !shouldRecordEvent({
         collectionAllows: true,

--- a/packages/nextly/src/domains/webhooks/record-mutation-event.ts
+++ b/packages/nextly/src/domains/webhooks/record-mutation-event.ts
@@ -18,6 +18,11 @@ import type { RequestActor } from "../../auth/request-actor";
 
 import { buildEnvelope } from "./envelope";
 import { recordEvent } from "./record-event";
+import {
+  endpointsPresent,
+  isWebhookAuditEnabled,
+  shouldRecordEvent,
+} from "./recording-activation";
 import { isWebhookRecordingEnabled } from "./recording-policy";
 import {
   sensitiveFieldPaths,
@@ -87,6 +92,30 @@ export async function recordMutationEvent(
   // here at the single seam so every write path inherits it.
   if (!resourceRecordingEnabled(args.resource)) {
     return false;
+  }
+
+  // Endpoint/audit gate: an install with no enabled endpoint and the audit seam
+  // off records nothing, so a mutation never pays the outbox INSERT + full
+  // document serialization for an event no subscriber would receive. Audit is
+  // checked first (sync) so an audit-on install never consults the registry.
+  // `endpointsPresent()` reads the registry's cached list (shared with the
+  // drain, so its CRUD invalidation and TTL apply here) and fails open, so this
+  // adds one resolved microtask on the warm path and never aborts the write on
+  // a lookup error. Race contract: a same-process endpoint create invalidates
+  // immediately; an endpoint created in another process is picked up within the
+  // registry TTL; a few events recorded just before the last endpoint is removed
+  // may remain and are pruned by retention.
+  if (!isWebhookAuditEnabled()) {
+    const hasEndpoints = await endpointsPresent();
+    if (
+      !shouldRecordEvent({
+        collectionAllows: true,
+        auditEnabled: false,
+        hasEndpoints,
+      })
+    ) {
+      return false;
+    }
   }
 
   const envelope = buildEnvelope({

--- a/packages/nextly/src/domains/webhooks/recording-activation.ts
+++ b/packages/nextly/src/domains/webhooks/recording-activation.ts
@@ -30,6 +30,11 @@
  * @module domains/webhooks/recording-activation
  */
 
+import {
+  isWebhookRecordingEnabled,
+  type WebhookRecordingScope,
+} from "./recording-policy";
+
 /**
  * How long a primed presence value is trusted before a stale read schedules a
  * background reload. Matches the endpoint registry TTL so a cross-process
@@ -47,6 +52,8 @@ interface ActivationState {
   presenceAtMs: number;
   refresher: EndpointPresenceRefresher | null;
   refreshing: boolean;
+  /** A refresh was requested while one was in flight; run once more after it. */
+  refreshPending: boolean;
   now: () => number;
 }
 
@@ -60,6 +67,7 @@ if (!globalForActivation.__nextly_webhookActivation) {
     presenceAtMs: 0,
     refresher: null,
     refreshing: false,
+    refreshPending: false,
     now: () => Date.now(),
   };
 }
@@ -105,15 +113,33 @@ export function setActivationClock(now: () => number): void {
 
 async function runRefresh(): Promise<void> {
   const refresher = state.refresher;
-  if (refresher === null || state.refreshing) return;
+  if (refresher === null) return;
+  // Coalesce: a refresh requested while one is in flight (e.g. endpoint CRUD
+  // during the boot/TTL refresh) must not be discarded, or the in-flight read
+  // could commit a pre-mutation result after the change. Mark it pending so the
+  // active refresh runs once more and picks up the newest state.
+  if (state.refreshing) {
+    state.refreshPending = true;
+    return;
+  }
   state.refreshing = true;
   try {
-    const present = await refresher();
-    state.endpointsPresent = present;
-    state.presenceAtMs = state.now();
+    do {
+      state.refreshPending = false;
+      const present = await refresher();
+      state.endpointsPresent = present;
+      state.presenceAtMs = state.now();
+    } while (state.refreshPending);
   } catch {
-    // Leave the last value in place; a transient read failure must not flip the
-    // flag. If it was never primed it stays `null` (fail open).
+    // A failed read must not pin a stale value. Keep a known-POSITIVE value (a
+    // transient blip should not disable delivery), but drop a negative/unknown
+    // value to `null` so the next read fails open and retries — otherwise a
+    // cross-process endpoint create whose refresh failed would keep dropping
+    // events irreversibly.
+    if (state.endpointsPresent !== true) {
+      state.endpointsPresent = null;
+    }
+    state.refreshPending = false;
   } finally {
     state.refreshing = false;
   }
@@ -150,6 +176,33 @@ export function endpointsPresent(): boolean {
   return present;
 }
 
+/**
+ * Whether a write to this collection/single would be recorded — the full gate,
+ * read synchronously: the per-entity opt-out AND (audit OR endpoint presence).
+ * Write paths call this BEFORE assembling a webhook payload so a gated-off write
+ * skips component expansion and document assembly (and cannot abort the content
+ * write on a webhook-only read). The recording choke point re-checks the same
+ * inputs, so a change between prep and record only costs a discarded payload.
+ */
+export function isOutboxRecordingActive(
+  scope: WebhookRecordingScope,
+  slug: string
+): boolean {
+  return (
+    isWebhookRecordingEnabled(scope, slug) &&
+    (state.auditEnabled || endpointsPresent())
+  );
+}
+
+/**
+ * Whether an UNSCOPED resource (media, user — no per-entity opt-out) would be
+ * recorded: audit OR endpoint presence. For gating post-write webhook work
+ * (e.g. a media fast-drain) on a path that cannot thread the recorder's boolean.
+ */
+export function isUnscopedRecordingActive(): boolean {
+  return state.auditEnabled || endpointsPresent();
+}
+
 /** Clear activation state (boot/test reset). */
 export function resetWebhookActivation(): void {
   state.auditEnabled = false;
@@ -157,5 +210,6 @@ export function resetWebhookActivation(): void {
   state.presenceAtMs = 0;
   state.refresher = null;
   state.refreshing = false;
+  state.refreshPending = false;
   state.now = () => Date.now();
 }

--- a/packages/nextly/src/domains/webhooks/recording-activation.ts
+++ b/packages/nextly/src/domains/webhooks/recording-activation.ts
@@ -51,9 +51,12 @@ interface ActivationState {
   endpointsPresent: boolean | null;
   presenceAtMs: number;
   refresher: EndpointPresenceRefresher | null;
-  refreshing: boolean;
-  /** A refresh was requested while one was in flight; run once more after it. */
-  refreshPending: boolean;
+  /** Tail of the serialized refresh chain; each request runs after the last. */
+  refreshTail: Promise<void>;
+  /** A background (stale-read) refresh is already queued; do not stampede. */
+  backgroundQueued: boolean;
+  /** Bumped on reset so an in-flight refresh from a prior instance is discarded. */
+  generation: number;
   now: () => number;
 }
 
@@ -66,8 +69,9 @@ if (!globalForActivation.__nextly_webhookActivation) {
     endpointsPresent: null,
     presenceAtMs: 0,
     refresher: null,
-    refreshing: false,
-    refreshPending: false,
+    refreshTail: Promise.resolve(),
+    backgroundQueued: false,
+    generation: 0,
     now: () => Date.now(),
   };
 }
@@ -114,23 +118,16 @@ export function setActivationClock(now: () => number): void {
 async function runRefresh(): Promise<void> {
   const refresher = state.refresher;
   if (refresher === null) return;
-  // Coalesce: a refresh requested while one is in flight (e.g. endpoint CRUD
-  // during the boot/TTL refresh) must not be discarded, or the in-flight read
-  // could commit a pre-mutation result after the change. Mark it pending so the
-  // active refresh runs once more and picks up the newest state.
-  if (state.refreshing) {
-    state.refreshPending = true;
-    return;
-  }
-  state.refreshing = true;
+  // Capture the generation so a refresh started before a reset never writes the
+  // new instance's state (its registry closes over a prior container).
+  const gen = state.generation;
   try {
-    do {
-      state.refreshPending = false;
-      const present = await refresher();
-      state.endpointsPresent = present;
-      state.presenceAtMs = state.now();
-    } while (state.refreshPending);
+    const present = await refresher();
+    if (gen !== state.generation) return;
+    state.endpointsPresent = present;
+    state.presenceAtMs = state.now();
   } catch {
+    if (gen !== state.generation) return;
     // A failed read must not pin a stale value. Keep a known-POSITIVE value (a
     // transient blip should not disable delivery), but drop a negative/unknown
     // value to `null` so the next read fails open and retries — otherwise a
@@ -139,19 +136,37 @@ async function runRefresh(): Promise<void> {
     if (state.endpointsPresent !== true) {
       state.endpointsPresent = null;
     }
-    state.refreshPending = false;
-  } finally {
-    state.refreshing = false;
   }
 }
 
 /**
- * Refresh the presence flag now, awaiting the read. Called at boot and after
- * endpoint CRUD — both outside any content transaction — so same-process changes
- * take effect immediately.
+ * Refresh the presence flag now. AWAITS a read that starts AFTER this call, so a
+ * caller that just changed endpoints (boot, endpoint CRUD) sees its change
+ * reflected before the returned promise resolves. Requests are serialized on a
+ * shared tail, so concurrent callers each await their own trailing read rather
+ * than a stale in-flight one.
  */
 export async function refreshEndpointPresence(): Promise<void> {
-  await runRefresh();
+  const run = state.refreshTail.then(runRefresh, runRefresh);
+  // Keep the chain alive even if a run rejects (runRefresh swallows, but guard
+  // the tail regardless) so later refreshes are not blocked by an earlier error.
+  state.refreshTail = run.catch(() => undefined);
+  await run;
+}
+
+/**
+ * Kick a background refresh without awaiting it, coalesced so a burst of stale
+ * reads does not stampede the database. Safe to call from inside a content write
+ * transaction: the refresh runs on a pooled connection and is never awaited by
+ * the caller, so it cannot check out a second connection while the write holds
+ * one.
+ */
+function scheduleBackgroundRefresh(): void {
+  if (state.backgroundQueued) return;
+  state.backgroundQueued = true;
+  void refreshEndpointPresence().finally(() => {
+    state.backgroundQueued = false;
+  });
 }
 
 /**
@@ -166,12 +181,12 @@ export function endpointsPresent(): boolean {
   if (present === null) {
     // Never primed (e.g. webhooks registered but boot prime not yet finished):
     // fail open, and kick a background prime so later writes gate correctly.
-    void runRefresh();
+    scheduleBackgroundRefresh();
     return true;
   }
   if (state.now() - state.presenceAtMs > PRESENCE_TTL_MS) {
     // Serve the last known value now; refresh out of band for the next read.
-    void runRefresh();
+    scheduleBackgroundRefresh();
   }
   return present;
 }
@@ -209,7 +224,11 @@ export function resetWebhookActivation(): void {
   state.endpointsPresent = null;
   state.presenceAtMs = 0;
   state.refresher = null;
-  state.refreshing = false;
-  state.refreshPending = false;
+  // Bump the generation so any refresh started before this reset is discarded
+  // when it resolves, rather than writing a prior instance's endpoint state onto
+  // the reinitialized one.
+  state.generation += 1;
+  state.refreshTail = Promise.resolve();
+  state.backgroundQueued = false;
   state.now = () => Date.now();
 }

--- a/packages/nextly/src/domains/webhooks/recording-activation.ts
+++ b/packages/nextly/src/domains/webhooks/recording-activation.ts
@@ -8,12 +8,19 @@
  * published here at registration and read back at the choke point, mirroring
  * recording-policy.ts.
  *
- * Endpoint presence is resolved through a provider (wired to the shared
- * endpoint registry, which already has CRUD invalidation and a TTL) rather than
- * a second cache. The resolver FAILS OPEN: an unwired or throwing provider
- * returns `true`, because a wrong "no endpoints" would make the choke point
- * drop events permanently — never delivered, never replayable — whereas a wrong
- * "endpoints present" only records a row retention later prunes.
+ * Endpoint presence is a SYNCHRONOUSLY-read cached flag, never a database read
+ * on the write path. The choke point runs inside the content write transaction,
+ * where a read is unsafe: a second pooled connection deadlocks a single-
+ * connection pool, a transaction-snapshot read (MySQL repeatable-read) would
+ * cache a stale value, and a failed read poisons the whole transaction on
+ * Postgres. So the flag is refreshed OUT OF BAND — at boot, on endpoint CRUD,
+ * and by a non-awaited background reload when a read finds it stale — always on
+ * a pooled connection outside any content transaction.
+ *
+ * The flag FAILS OPEN: until it is primed (`null`) the choke point records,
+ * because a wrong "no endpoints" drops events permanently (never delivered,
+ * never replayable) whereas a wrong "endpoints present" only records a row
+ * retention later prunes.
  *
  * Stored on `globalThis` for the same reason as the recording policy: Next.js
  * and Turbopack can evaluate this module in more than one server module graph,
@@ -23,21 +30,24 @@
  * @module domains/webhooks/recording-activation
  */
 
-import type { WebhookEndpointReader } from "./endpoint-registry";
-
 /**
- * Resolves whether any enabled endpoint exists. Receives the caller's executor
- * (the open write transaction) so a cold lookup reads on that transaction's own
- * connection instead of checking out a second pooled one — which would deadlock
- * a single-connection pool while the transaction holds its connection.
+ * How long a primed presence value is trusted before a stale read schedules a
+ * background reload. Matches the endpoint registry TTL so a cross-process
+ * endpoint change self-heals on the same ~30s bound.
  */
-type EndpointPresenceProvider = (
-  reader?: WebhookEndpointReader
-) => Promise<boolean>;
+const PRESENCE_TTL_MS = 30_000;
+
+/** Resolves enabled-endpoint presence on a POOLED connection (never a content tx). */
+type EndpointPresenceRefresher = () => Promise<boolean>;
 
 interface ActivationState {
   auditEnabled: boolean;
-  endpointPresenceProvider: EndpointPresenceProvider | null;
+  /** `null` until primed → fail open. */
+  endpointsPresent: boolean | null;
+  presenceAtMs: number;
+  refresher: EndpointPresenceRefresher | null;
+  refreshing: boolean;
+  now: () => number;
 }
 
 const globalForActivation = globalThis as unknown as {
@@ -46,7 +56,11 @@ const globalForActivation = globalThis as unknown as {
 if (!globalForActivation.__nextly_webhookActivation) {
   globalForActivation.__nextly_webhookActivation = {
     auditEnabled: false,
-    endpointPresenceProvider: null,
+    endpointsPresent: null,
+    presenceAtMs: 0,
+    refresher: null,
+    refreshing: false,
+    now: () => Date.now(),
   };
 }
 const state = globalForActivation.__nextly_webhookActivation;
@@ -74,38 +88,74 @@ export function isWebhookAuditEnabled(): boolean {
 }
 
 /**
- * Wire the endpoint-presence resolver, at registration, to the shared registry.
- * The provider is expected to be cheap (a cached boolean) since it runs on the
- * write path.
+ * Wire the endpoint-presence refresher (at registration) to a POOLED read of the
+ * enabled-endpoint set. Never pass a content transaction: the refresher runs
+ * outside any write transaction.
  */
-export function setEndpointPresenceProvider(
-  provider: EndpointPresenceProvider
+export function setEndpointPresenceRefresher(
+  refresher: EndpointPresenceRefresher
 ): void {
-  state.endpointPresenceProvider = provider;
+  state.refresher = refresher;
+}
+
+/** Overridable clock (tests). */
+export function setActivationClock(now: () => number): void {
+  state.now = now;
+}
+
+async function runRefresh(): Promise<void> {
+  const refresher = state.refresher;
+  if (refresher === null || state.refreshing) return;
+  state.refreshing = true;
+  try {
+    const present = await refresher();
+    state.endpointsPresent = present;
+    state.presenceAtMs = state.now();
+  } catch {
+    // Leave the last value in place; a transient read failure must not flip the
+    // flag. If it was never primed it stays `null` (fail open).
+  } finally {
+    state.refreshing = false;
+  }
 }
 
 /**
- * Whether the install has an enabled endpoint. Pass the caller's transaction as
- * `reader` so a cold lookup reads on its connection (see
- * {@link EndpointPresenceProvider}). FAILS OPEN: no provider (webhooks not
- * registered, or pre-boot) or a throwing provider returns `true`, so a content
- * write is never gated off — and never aborted — on incomplete or failed
- * endpoint knowledge.
+ * Refresh the presence flag now, awaiting the read. Called at boot and after
+ * endpoint CRUD — both outside any content transaction — so same-process changes
+ * take effect immediately.
  */
-export async function endpointsPresent(
-  reader?: WebhookEndpointReader
-): Promise<boolean> {
-  const provider = state.endpointPresenceProvider;
-  if (provider === null) return true;
-  try {
-    return await provider(reader);
-  } catch {
+export async function refreshEndpointPresence(): Promise<void> {
+  await runRefresh();
+}
+
+/**
+ * Whether the install has an enabled endpoint, read synchronously with no
+ * database access — safe to call inside the content write transaction. FAILS
+ * OPEN before the flag is primed. A stale value (older than the TTL) is returned
+ * as-is and triggers a NON-AWAITED background reload, so a cross-process endpoint
+ * change self-heals within the TTL without ever reading on the write path.
+ */
+export function endpointsPresent(): boolean {
+  const present = state.endpointsPresent;
+  if (present === null) {
+    // Never primed (e.g. webhooks registered but boot prime not yet finished):
+    // fail open, and kick a background prime so later writes gate correctly.
+    void runRefresh();
     return true;
   }
+  if (state.now() - state.presenceAtMs > PRESENCE_TTL_MS) {
+    // Serve the last known value now; refresh out of band for the next read.
+    void runRefresh();
+  }
+  return present;
 }
 
 /** Clear activation state (boot/test reset). */
 export function resetWebhookActivation(): void {
   state.auditEnabled = false;
-  state.endpointPresenceProvider = null;
+  state.endpointsPresent = null;
+  state.presenceAtMs = 0;
+  state.refresher = null;
+  state.refreshing = false;
+  state.now = () => Date.now();
 }

--- a/packages/nextly/src/domains/webhooks/recording-activation.ts
+++ b/packages/nextly/src/domains/webhooks/recording-activation.ts
@@ -1,0 +1,95 @@
+/**
+ * Webhook domain — process-level outbox recording activation.
+ *
+ * Whether the outbox records at all (independent of the per-entity opt-out in
+ * recording-policy.ts) turns on two process-wide signals the pure recording
+ * choke point cannot see from an event `resource` alone: whether the install
+ * has any enabled webhook endpoint, and whether the audit seam is on. Both are
+ * published here at registration and read back at the choke point, mirroring
+ * recording-policy.ts.
+ *
+ * Endpoint presence is resolved through a provider (wired to the shared
+ * endpoint registry, which already has CRUD invalidation and a TTL) rather than
+ * a second cache. The resolver FAILS OPEN: an unwired or throwing provider
+ * returns `true`, because a wrong "no endpoints" would make the choke point
+ * drop events permanently — never delivered, never replayable — whereas a wrong
+ * "endpoints present" only records a row retention later prunes.
+ *
+ * Stored on `globalThis` for the same reason as the recording policy: Next.js
+ * and Turbopack can evaluate this module in more than one server module graph,
+ * so a module-local value risks registration writing one instance while the
+ * choke point reads another.
+ *
+ * @module domains/webhooks/recording-activation
+ */
+
+interface ActivationState {
+  auditEnabled: boolean;
+  endpointPresenceProvider: (() => Promise<boolean>) | null;
+}
+
+const globalForActivation = globalThis as unknown as {
+  __nextly_webhookActivation?: ActivationState;
+};
+if (!globalForActivation.__nextly_webhookActivation) {
+  globalForActivation.__nextly_webhookActivation = {
+    auditEnabled: false,
+    endpointPresenceProvider: null,
+  };
+}
+const state = globalForActivation.__nextly_webhookActivation;
+
+/**
+ * The gate predicate. The per-entity opt-out is absolute; otherwise the audit
+ * seam or a present endpoint un-gates recording. Pure and total for its inputs.
+ */
+export function shouldRecordEvent(input: {
+  collectionAllows: boolean;
+  auditEnabled: boolean;
+  hasEndpoints: boolean;
+}): boolean {
+  return input.collectionAllows && (input.auditEnabled || input.hasEndpoints);
+}
+
+/** Publish whether the audit seam records events regardless of endpoints. */
+export function setWebhookAuditEnabled(enabled: boolean): void {
+  state.auditEnabled = enabled;
+}
+
+/** Whether the audit seam is on. Defaults to false. */
+export function isWebhookAuditEnabled(): boolean {
+  return state.auditEnabled;
+}
+
+/**
+ * Wire the endpoint-presence resolver, at registration, to the shared registry.
+ * The provider is expected to be cheap (a cached boolean) since it runs on the
+ * write path.
+ */
+export function setEndpointPresenceProvider(
+  provider: () => Promise<boolean>
+): void {
+  state.endpointPresenceProvider = provider;
+}
+
+/**
+ * Whether the install has an enabled endpoint. FAILS OPEN: no provider (webhooks
+ * not registered, or pre-boot) or a throwing provider returns `true`, so a
+ * content write is never gated off — and never aborted — on incomplete or failed
+ * endpoint knowledge.
+ */
+export async function endpointsPresent(): Promise<boolean> {
+  const provider = state.endpointPresenceProvider;
+  if (provider === null) return true;
+  try {
+    return await provider();
+  } catch {
+    return true;
+  }
+}
+
+/** Clear activation state (boot/test reset). */
+export function resetWebhookActivation(): void {
+  state.auditEnabled = false;
+  state.endpointPresenceProvider = null;
+}

--- a/packages/nextly/src/domains/webhooks/recording-activation.ts
+++ b/packages/nextly/src/domains/webhooks/recording-activation.ts
@@ -23,9 +23,21 @@
  * @module domains/webhooks/recording-activation
  */
 
+import type { WebhookEndpointReader } from "./endpoint-registry";
+
+/**
+ * Resolves whether any enabled endpoint exists. Receives the caller's executor
+ * (the open write transaction) so a cold lookup reads on that transaction's own
+ * connection instead of checking out a second pooled one — which would deadlock
+ * a single-connection pool while the transaction holds its connection.
+ */
+type EndpointPresenceProvider = (
+  reader?: WebhookEndpointReader
+) => Promise<boolean>;
+
 interface ActivationState {
   auditEnabled: boolean;
-  endpointPresenceProvider: (() => Promise<boolean>) | null;
+  endpointPresenceProvider: EndpointPresenceProvider | null;
 }
 
 const globalForActivation = globalThis as unknown as {
@@ -67,22 +79,26 @@ export function isWebhookAuditEnabled(): boolean {
  * write path.
  */
 export function setEndpointPresenceProvider(
-  provider: () => Promise<boolean>
+  provider: EndpointPresenceProvider
 ): void {
   state.endpointPresenceProvider = provider;
 }
 
 /**
- * Whether the install has an enabled endpoint. FAILS OPEN: no provider (webhooks
- * not registered, or pre-boot) or a throwing provider returns `true`, so a
- * content write is never gated off — and never aborted — on incomplete or failed
+ * Whether the install has an enabled endpoint. Pass the caller's transaction as
+ * `reader` so a cold lookup reads on its connection (see
+ * {@link EndpointPresenceProvider}). FAILS OPEN: no provider (webhooks not
+ * registered, or pre-boot) or a throwing provider returns `true`, so a content
+ * write is never gated off — and never aborted — on incomplete or failed
  * endpoint knowledge.
  */
-export async function endpointsPresent(): Promise<boolean> {
+export async function endpointsPresent(
+  reader?: WebhookEndpointReader
+): Promise<boolean> {
   const provider = state.endpointPresenceProvider;
   if (provider === null) return true;
   try {
-    return await provider();
+    return await provider(reader);
   } catch {
     return true;
   }

--- a/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
+++ b/packages/nextly/src/domains/webhooks/services/webhook-endpoint-service.ts
@@ -48,6 +48,7 @@ import {
 } from "../../../utils/validate-external-url";
 import type { DeliverTransport } from "../deliver";
 import type { WebhookEndpointRegistry } from "../endpoint-registry";
+import { refreshEndpointPresence } from "../recording-activation";
 import { decryptWebhookSecret, generateWebhookSecret } from "../secret";
 import {
   liveSecretEntries,
@@ -210,6 +211,18 @@ export class WebhookEndpointService extends BaseService {
   }
 
   /**
+   * Drop the shared endpoint cache and re-derive the recording gate's presence
+   * flag, after an endpoint mutation has committed. Runs on a pooled connection
+   * outside any content transaction, so the recording choke point can keep
+   * reading presence synchronously; awaited so a same-process change takes effect
+   * before the mutation call returns.
+   */
+  private async refreshRecordingGate(): Promise<void> {
+    this.registry?.invalidate();
+    await refreshEndpointPresence();
+  }
+
+  /**
    * Run a database call, turning a driver error into the canonical envelope.
    *
    * Every statement here can fail for reasons the caller should see as a typed
@@ -368,7 +381,7 @@ export class WebhookEndpointService extends BaseService {
     };
 
     await this.query(() => this.db.insert(this.table).values(row));
-    this.registry?.invalidate();
+    await this.refreshRecordingGate();
 
     return { endpoint: this.toSummary(row), secret };
   }
@@ -438,7 +451,7 @@ export class WebhookEndpointService extends BaseService {
     // Invalidated for every field, not only `enabled`: the cached list carries
     // url, event types and headers too, and a stale copy would keep delivering
     // to the old target.
-    this.registry?.invalidate();
+    await this.refreshRecordingGate();
 
     // Done here rather than in `setEnabled` so that disabling through a plain
     // field update cannot skip it. Not wrapped in a transaction with the update
@@ -556,7 +569,7 @@ export class WebhookEndpointService extends BaseService {
         await this.cancelQueuedDeliveries(txDb, id, "webhook deleted");
       })
     );
-    this.registry?.invalidate();
+    await this.refreshRecordingGate();
   }
 
   /**
@@ -715,7 +728,7 @@ export class WebhookEndpointService extends BaseService {
 
     // The delivery path reads secrets from its own row, but the cached registry
     // still lists this endpoint; invalidate so nothing serves a stale copy.
-    this.registry?.invalidate();
+    await this.refreshRecordingGate();
 
     const updated = await this.getEndpoint(id);
     if (!updated) throw this.notFound(id);
@@ -735,7 +748,7 @@ export class WebhookEndpointService extends BaseService {
       );
       return { entries: primaryOnly, result: undefined };
     });
-    this.registry?.invalidate();
+    await this.refreshRecordingGate();
 
     const updated = await this.getEndpoint(id);
     if (!updated) throw this.notFound(id);

--- a/packages/nextly/src/init/build-service-config.ts
+++ b/packages/nextly/src/init/build-service-config.ts
@@ -178,6 +178,16 @@ export function buildServiceConfig(
     ) {
       serviceConfig.webhookRetention = nextlyConfig.webhookRetention;
     }
+
+    // Audit seam — carry the resolved flag through so the webhook registration
+    // can publish it to the recording gate. `undefined` means not carried; the
+    // sanitizer always produces a boolean, so any value here is authoritative.
+    if (
+      serviceConfig.webhookAuditEnabled === undefined &&
+      nextlyConfig?.webhookAuditEnabled !== undefined
+    ) {
+      serviceConfig.webhookAuditEnabled = nextlyConfig.webhookAuditEnabled;
+    }
   }
 
   // Ensure imageProcessor is always provided

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -59,6 +59,7 @@ import { resolveCollectionTableName } from "../domains/schema/utils/resolve-tabl
 // Resolve the versioning config on the HMR sync path so a `versions` change
 // while `next dev` is running persists without a restart (parity with di/register).
 import { resolveVersionsConfig } from "../domains/versions/resolve-config";
+import { setWebhookAuditEnabled } from "../domains/webhooks/recording-activation";
 import {
   pruneRemovedCodeFirstRecording,
   setWebhookRecording,
@@ -494,6 +495,7 @@ export async function reloadNextlyConfig(opts?: {
         collections?: CollectionDef[];
         singles?: SingleDef[];
         components?: ComponentDef[];
+        webhooks?: { audit?: boolean };
       }
     | undefined;
   try {
@@ -508,6 +510,7 @@ export async function reloadNextlyConfig(opts?: {
           collections?: CollectionDef[];
           singles?: SingleDef[];
           components?: ComponentDef[];
+          webhooks?: { audit?: boolean };
         };
       }
     ).config;
@@ -542,6 +545,13 @@ export async function reloadNextlyConfig(opts?: {
     return;
   }
   if (!newConfig) return;
+
+  // Republish the audit seam from the reloaded config, so toggling
+  // `webhooks.audit` in nextly.config.ts takes effect on save without a
+  // restart. It is a single process-global flag that reads no field tree, so —
+  // like a recording opt-out — it is safe to apply immediately, before the
+  // schema diff is synced.
+  setWebhookAuditEnabled(newConfig.webhooks?.audit ?? false);
 
   // databaseAdapter doubles as our DI-readiness probe. We don't need any
   // other service from DI in this path — the new gate gets prior-state

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -495,7 +495,7 @@ export async function reloadNextlyConfig(opts?: {
         collections?: CollectionDef[];
         singles?: SingleDef[];
         components?: ComponentDef[];
-        webhooks?: { audit?: boolean };
+        webhookAuditEnabled?: boolean;
       }
     | undefined;
   try {
@@ -510,7 +510,7 @@ export async function reloadNextlyConfig(opts?: {
           collections?: CollectionDef[];
           singles?: SingleDef[];
           components?: ComponentDef[];
-          webhooks?: { audit?: boolean };
+          webhookAuditEnabled?: boolean;
         };
       }
     ).config;
@@ -547,11 +547,12 @@ export async function reloadNextlyConfig(opts?: {
   if (!newConfig) return;
 
   // Republish the audit seam from the reloaded config, so toggling
-  // `webhooks.audit` in nextly.config.ts takes effect on save without a
-  // restart. It is a single process-global flag that reads no field tree, so —
-  // like a recording opt-out — it is safe to apply immediately, before the
-  // schema diff is synced.
-  setWebhookAuditEnabled(newConfig.webhooks?.audit ?? false);
+  // `webhooks.audit` in nextly.config.ts takes effect on save without a restart.
+  // `loadConfig()` returns a sanitized config, so the flag is the resolved flat
+  // `webhookAuditEnabled`, not the raw `webhooks.audit` block. It is a single
+  // process-global flag that reads no field tree, so — like a recording opt-out
+  // — it is safe to apply immediately, before the schema diff is synced.
+  setWebhookAuditEnabled(newConfig.webhookAuditEnabled ?? false);
 
   // databaseAdapter doubles as our DI-readiness probe. We don't need any
   // other service from DI in this path — the new gate gets prior-state

--- a/packages/nextly/src/plugins/test-nextly.ts
+++ b/packages/nextly/src/plugins/test-nextly.ts
@@ -22,10 +22,7 @@ import { resetEmailProviderRegistry } from "../domains/email/services/email-prov
 import { normalizeLocalization } from "../domains/i18n/config/normalize";
 import type { LocalizationConfig } from "../domains/i18n/config/types";
 import { clearFieldTypes } from "../domains/schema/field-types/field-type-registry";
-import {
-  resetWebhookActivation,
-  setWebhookAuditEnabled,
-} from "../domains/webhooks/recording-activation";
+import { resetWebhookActivation } from "../domains/webhooks/recording-activation";
 import { resetWebhookRecordingPolicy } from "../domains/webhooks/recording-policy";
 import type { EventBus } from "../events/event-bus";
 import { getEventBus, resetEventBus } from "../events/event-bus";
@@ -174,11 +171,12 @@ export async function createTestNextly(
     localization: opts.localization
       ? normalizeLocalization(opts.localization)
       : undefined,
+    // Record every event by default so machinery tests are independent of
+    // webhook endpoint setup; suites that exercise the endpoint gate turn this
+    // off. Passed through the config (not set after) so it is published before
+    // plugin init() runs, and boot-time plugin events are recorded too.
+    webhookAuditEnabled: true,
   });
-
-  // Record every event by default so machinery tests are independent of webhook
-  // endpoint setup; suites that exercise the endpoint gate turn this off.
-  setWebhookAuditEnabled(true);
 
   // Physical tables for code-first + plugin-contributed collections are created
   // non-interactively by the runtime auto-sync during registerServices (the

--- a/packages/nextly/src/plugins/test-nextly.ts
+++ b/packages/nextly/src/plugins/test-nextly.ts
@@ -22,6 +22,10 @@ import { resetEmailProviderRegistry } from "../domains/email/services/email-prov
 import { normalizeLocalization } from "../domains/i18n/config/normalize";
 import type { LocalizationConfig } from "../domains/i18n/config/types";
 import { clearFieldTypes } from "../domains/schema/field-types/field-type-registry";
+import {
+  resetWebhookActivation,
+  setWebhookAuditEnabled,
+} from "../domains/webhooks/recording-activation";
 import { resetWebhookRecordingPolicy } from "../domains/webhooks/recording-policy";
 import type { EventBus } from "../events/event-bus";
 import { getEventBus, resetEventBus } from "../events/event-bus";
@@ -124,6 +128,7 @@ export async function createTestNextly(
   clearFieldTypes();
   resetFilterRegistry();
   resetWebhookRecordingPolicy();
+  resetWebhookActivation();
   resetPluginRouteRegistry();
   resetNextlyInstance();
   // Each boot is a fresh, distinct in-memory database. The schema-snapshot
@@ -170,6 +175,10 @@ export async function createTestNextly(
       ? normalizeLocalization(opts.localization)
       : undefined,
   });
+
+  // Record every event by default so machinery tests are independent of webhook
+  // endpoint setup; suites that exercise the endpoint gate turn this off.
+  setWebhookAuditEnabled(true);
 
   // Physical tables for code-first + plugin-contributed collections are created
   // non-interactively by the runtime auto-sync during registerServices (the

--- a/packages/nextly/src/route-handler/auth-handler.ts
+++ b/packages/nextly/src/route-handler/auth-handler.ts
@@ -108,6 +108,13 @@ export async function ensureServicesInitialized(): Promise<void> {
       // must not be mistaken for absent.
       if (nextlyConfig.webhookRetention !== undefined)
         serviceConfig.webhookRetention = nextlyConfig.webhookRetention;
+      // Webhook audit seam: carry it so a request-path boot publishes the same
+      // recording-gate override an instrumentation boot would. Without it, an
+      // install configured `webhooks: { audit: true }` that cold-boots through
+      // this path would default audit off and drop events while it has no
+      // endpoint.
+      if (nextlyConfig.webhookAuditEnabled !== undefined)
+        serviceConfig.webhookAuditEnabled = nextlyConfig.webhookAuditEnabled;
       if (nextlyConfig.db) {
         const dbConfig = nextlyConfig.db as Record<string, unknown>;
         if (dbConfig.schemasDir) serviceConfig.schemasDir = dbConfig.schemasDir;

--- a/packages/nextly/src/services/media.ts
+++ b/packages/nextly/src/services/media.ts
@@ -99,11 +99,15 @@ export class MediaService extends BaseService {
    * Both absorb their own failures, so this never turns a committed write into
    * an error.
    */
-  private async afterWrite(): Promise<void> {
+  private async afterWrite(recorded: boolean): Promise<void> {
     if (!this.fastDrainScheduler && !this.retentionRunner) {
       return;
     }
-    this.fastDrainScheduler?.offer();
+    // Only schedule the fast drain when an event was actually recorded: an
+    // install with no endpoint and audit off records nothing, so offering the
+    // drain would pay a fresh `nextly_webhooks` query on every media write for
+    // no subscriber. Retention still runs — it prunes prior rows regardless.
+    if (recorded) this.fastDrainScheduler?.offer();
     await this.retentionRunner?.maybeRun(MediaService.WRITE_PATH_PRUNE_BATCHES);
   }
 
@@ -427,6 +431,7 @@ export class MediaService extends BaseService {
         sizes: sizesData == null ? null : JSON.stringify(sizesData),
       }) as Record<string, unknown>;
 
+      let recorded = false;
       await this.adapter.transaction(async tx => {
         await tx.insert("media", insertRow, { returning: [] });
 
@@ -434,7 +439,7 @@ export class MediaService extends BaseService {
         // prior state, so `previous` is null. Media has no field schema, so
         // `fields` is empty (nothing to strip). The uploader is the recorded
         // subject when no transport actor was threaded.
-        await recordMutationEvent(tx, {
+        recorded = await recordMutationEvent(tx, {
           type: "media.uploaded",
           resource: { kind: "media", id: mediaId },
           data: mediaRecord,
@@ -446,7 +451,7 @@ export class MediaService extends BaseService {
 
       // The upload committed a media.uploaded outbox row; drain and prune it
       // (no-op when the unified media service wraps this one and drains itself).
-      await this.afterWrite();
+      await this.afterWrite(recorded);
 
       return {
         success: true,
@@ -707,6 +712,7 @@ export class MediaService extends BaseService {
       // the other's fresh variants.
       let replacedSizes: unknown = null;
       let updatedRow: Media | null;
+      let recorded = false;
       try {
         updatedRow = await this.adapter.transaction<Media | null>(async tx => {
           await tx.lockRow("media", mediaId);
@@ -736,7 +742,7 @@ export class MediaService extends BaseService {
 
           // `previous` is the freshly-read pre-write row; `data` is the new
           // state. Media has no field schema, so `fields` is empty.
-          await recordMutationEvent(tx, {
+          recorded = await recordMutationEvent(tx, {
             type: "media.updated",
             resource: { kind: "media", id: mediaId },
             data: nextRow,
@@ -797,7 +803,7 @@ export class MediaService extends BaseService {
 
       // The update committed a media.updated outbox row; drain and prune it
       // (no-op when the unified media service wraps this one and drains itself).
-      await this.afterWrite();
+      await this.afterWrite(recorded);
 
       return {
         success: true,
@@ -843,6 +849,7 @@ export class MediaService extends BaseService {
       // is detected reliably on every dialect, and the event's `data` carries
       // the latest committed state rather than the pre-transaction read. The
       // transaction returns the deleted row (or null when it was already gone).
+      let recorded = false;
       const deletedRow = await this.adapter.transaction<Media | null>(
         async tx => {
           await tx.lockRow("media", mediaId);
@@ -861,7 +868,7 @@ export class MediaService extends BaseService {
           // The removed row's final state ships as `data`; there is no
           // post-delete state, so `previous` is null (mirroring create). Media
           // has no field schema, so `fields` is empty (nothing to strip).
-          await recordMutationEvent(tx, {
+          recorded = await recordMutationEvent(tx, {
             type: "media.deleted",
             resource: { kind: "media", id: mediaId },
             data: current,
@@ -931,7 +938,7 @@ export class MediaService extends BaseService {
 
       // The delete committed a media.deleted outbox row; drain and prune it
       // (no-op when the unified media service wraps this one and drains itself).
-      await this.afterWrite();
+      await this.afterWrite(recorded);
 
       return {
         success: true,

--- a/packages/nextly/src/shared/types/__tests__/config.test.ts
+++ b/packages/nextly/src/shared/types/__tests__/config.test.ts
@@ -17,3 +17,15 @@ describe("sanitizeConfig — production migration db options", () => {
     expect(c.db.migrateLockTtlSeconds).toBe(120);
   });
 });
+
+describe("sanitizeConfig — webhook audit seam", () => {
+  it("defaults webhookAuditEnabled to false when unset", () => {
+    expect(sanitizeConfig({}).webhookAuditEnabled).toBe(false);
+  });
+
+  it("resolves webhooks.audit true", () => {
+    expect(
+      sanitizeConfig({ webhooks: { audit: true } }).webhookAuditEnabled
+    ).toBe(true);
+  });
+});

--- a/packages/nextly/src/shared/types/config.ts
+++ b/packages/nextly/src/shared/types/config.ts
@@ -656,12 +656,20 @@ export interface WebhookConfig {
   /**
    * How long recorded events and delivery attempts are kept.
    *
-   * Enabled by default. A row is appended to the event ledger on every content
-   * write, whether or not this install uses webhooks at all, so leaving it
-   * unbounded would tax people who never opted in. `false` keeps everything
-   * forever and accepts that growth.
+   * Enabled by default. Events are recorded only when the install has an enabled
+   * endpoint (or the audit seam is on), so an install with no webhooks writes
+   * nothing to bound; when recording is active, this limits how long the rows
+   * are kept. `false` keeps everything forever and accepts that growth.
    */
   retention?: WebhookRetentionConfig | false;
+
+  /**
+   * Force-record every content event to the outbox even when no webhook
+   * endpoint is configured. Off by default: with no endpoints and this off,
+   * writes record nothing. The org-wide audit log turns this on so it captures
+   * events regardless of delivery subscriptions.
+   */
+  audit?: boolean;
 }
 
 /**
@@ -737,6 +745,12 @@ export interface SanitizedNextlyConfig {
    * Always present after sanitization so consumers never re-resolve it.
    */
   webhookRetention: ResolvedWebhookRetentionConfig | null;
+
+  /**
+   * Whether the audit seam forces outbox recording regardless of endpoints.
+   * Always present after sanitization; defaults to false.
+   */
+  webhookAuditEnabled: boolean;
 }
 
 // ============================================================
@@ -908,5 +922,8 @@ export function sanitizeConfig(config: NextlyConfig): SanitizedNextlyConfig {
     // user switched retention off; an absent `webhooks` key resolves to the
     // defaults, since the event ledger fills whether or not webhooks are used.
     webhookRetention: resolveWebhookRetentionConfig(config.webhooks?.retention),
+    // Off unless explicitly enabled; the org-wide audit log flips this to keep
+    // recording events when an install has no delivery endpoints.
+    webhookAuditEnabled: config.webhooks?.audit ?? false,
   };
 }


### PR DESCRIPTION
## What

Outbox event recording (`nextly_events`) is now **endpoint-gated**: a content write records an event only when the install has at least one enabled webhook endpoint, OR the new `webhooks.audit` seam is on. Installs with no webhooks configured stop paying an outbox INSERT + full-document serialization on every write.

Final predicate at the single recording choke point (`recordMutationEvent`):

```
collectionAllows AND (auditEnabled OR hasEndpoints)
```

It composes with the task-001 per-entity opt-out (which stays absolute) rather than adding a second gate.

## How

- **`recording-activation.ts`** (new, `globalThis`-backed like `recording-policy.ts`): the audit flag, a fail-open endpoint-presence resolver, and the pure `shouldRecordEvent` predicate.
- **`WebhookEndpointRegistry.hasEnabledEndpoints()`**: sources "has endpoints" from the existing registry, so the gate inherits its CRUD `invalidate()` **and** 30s TTL self-heal — no second cache.
- **Choke point**: audit checked first (sync); endpoint presence second (cached, async). Wrapped **fail-open** — an unwired or throwing provider records, because a wrong "no endpoints" would drop events permanently, whereas a wrong "records" only writes a row retention prunes. Never aborts the content write.
- **Config seam**: `webhooks.audit?: boolean` → `webhookAuditEnabled` across all four hops (input → sanitize → service-config carry → registration). Off by default; task-052's audit log flips it.
- **Post-commit drain/retention** already gate on `eventRecorded`, so a gated-off write schedules nothing downstream — no changes needed there.

## Race contract (documented at the gate + changeset)

Same-process endpoint create/enable invalidates immediately; a cross-process create is picked up within the registry TTL (~30s); a few events recorded just before the last endpoint is removed may remain and are pruned by retention.

## Test harness note

The test harness now defaults **audit-on** (record everything = pre-005 semantics, zero delivery side-effects with no endpoints), so the 18 existing outbox integration suites stay endpoint-independent. The dedicated gate suite turns audit off and controls endpoints.

## Tests

- Unit: pure predicate truth-table (incl. 001 composition), activation module fail-open, registry `hasEnabledEndpoints`, choke-point gate (no-endpoint/endpoint/audit-on/provider-throws/opt-out-wins).
- Integration (SQLite; PG leg in CI): 0-rows-without-endpoint, records-with-endpoint, audit-on-records, disable-last-stops.
- Regression: 16 webhooks integration suites + 204 unit green; **zero new failures vs baseline** (the 16 pre-existing stale-mock failures across dispatcher/direct-api/reload-config are identical on base `4f392975`).

Task 005 (`tasks/left-tasks/005-endpoint-gated-outbox-recording.md`). Spec + plan in `tasks/2026-07-26-endpoint-gated-outbox-recording-005-*.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional webhook audit setting to configuration.
  * Webhook event recording now activates when auditing is enabled or active webhook endpoints exist.
  * Configuration reloads and endpoint changes now update recording behavior automatically.

* **Bug Fixes**
  * Prevented unnecessary processing when webhook recording is inactive.
  * Preserved audit settings across configuration reloads.
  * Prevented transaction deadlocks in single-connection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->