### PR TITLE
fix(nextly): apply read constraints through the full filter translation

### DIFF
--- a/.changeset/read-constraint-full-predicate.md
+++ b/.changeset/read-constraint-full-predicate.md
@@ -25,4 +25,6 @@ Read rules that narrow by a filter are now applied in full. A stored read rule c
 
 Filters now go through the same translation your own `where` clauses use, so every field and every supported operator binds. Owner-only rules are unaffected: a single non-empty owner id was the one shape the old path handled correctly, which is why this went unnoticed.
 
-A filter is applied only if **all** of it can be applied. If any part cannot be — an operator that needs a different query path, or a field that is not on the table — the read is refused rather than run under a weaker filter that binds some parts and drops others. The refusal is reported as forbidden, and the matching count refuses identically.
+A filter is applied only if **all** of it can be applied, and access filters are held to a narrower shape than the `where` clauses you write yourself. A filter may name columns on the collection (or its localized fields) and compare them with any supported operator, including the shorthand `{ field: value }` form. Logical `and`/`or` groups, dotted paths like `author.name`, and empty `in`/`not_in` lists are refused rather than approximated, because each of those translates to something narrower than the rule states — or, in the dotted case, to a comparison against a different column.
+
+A refused filter is reported as forbidden, and the matching count refuses identically. If you need a shape that is currently refused, the read fails closed instead of quietly returning more than the rule allows.

--- a/.changeset/read-constraint-full-predicate.md
+++ b/.changeset/read-constraint-full-predicate.md
@@ -1,0 +1,28 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Read rules that narrow by a filter are now applied in full. A stored read rule can return a filter describing which rows the caller may see, and only part of it was being applied: the first field's `equals` value. A rule naming two fields filtered by one of them, a rule using any other operator applied nothing at all, and a rule whose value was legitimately falsy — `0`, `false`, an empty string — also applied nothing. In each of those cases the read returned rows the rule was written to exclude, and the matching count reported them too.
+
+Filters now go through the same translation your own `where` clauses use, so every field and every supported operator binds. Owner-only rules are unaffected: a single non-empty owner id was the one shape the old path handled correctly, which is why this went unnoticed.
+
+If a rule returns a filter that cannot be translated, the read is now refused rather than returning everything.

--- a/.changeset/read-constraint-full-predicate.md
+++ b/.changeset/read-constraint-full-predicate.md
@@ -25,4 +25,4 @@ Read rules that narrow by a filter are now applied in full. A stored read rule c
 
 Filters now go through the same translation your own `where` clauses use, so every field and every supported operator binds. Owner-only rules are unaffected: a single non-empty owner id was the one shape the old path handled correctly, which is why this went unnoticed.
 
-If a rule returns a filter that cannot be translated, the read is now refused rather than returning everything.
+A filter is applied only if **all** of it can be applied. If any part cannot be — an operator that needs a different query path, or a field that is not on the table — the read is refused rather than run under a weaker filter that binds some parts and drops others. The refusal is reported as forbidden, and the matching count refuses identically.

--- a/packages/nextly/src/domains/collections/__tests__/_fixtures/tenant-read-rule.ts
+++ b/packages/nextly/src/domains/collections/__tests__/_fixtures/tenant-read-rule.ts
@@ -1,0 +1,31 @@
+/**
+ * A stored `custom` read rule, as a real module so the access service's dynamic
+ * `import(functionPath)` can load it.
+ *
+ * Returns a query CONSTRAINT rather than a boolean, which is the shape that
+ * exposed the bug these tests guard: the constraint used to be reduced to the
+ * first field's `equals` value, so a second field went unapplied and a falsy or
+ * non-`equals` value applied nothing at all.
+ *
+ * The shape returned is chosen per-caller so one fixture covers every case the
+ * tests need.
+ */
+export default function tenantReadRule({
+  req,
+}: {
+  req: { user?: { id?: string } };
+}): unknown {
+  switch (req.user?.id) {
+    // Two fields: both have to bind, or rows from the other region come back.
+    case "multi-field":
+      return { tenant: { equals: "acme" }, region: { equals: "eu" } };
+    // A falsy value: `equals: 0` is a legitimate predicate ("free items").
+    case "falsy-value":
+      return { price: { equals: 0 } };
+    // An operator other than `equals`.
+    case "in-operator":
+      return { region: { in: ["eu", "uk"] } };
+    default:
+      return true;
+  }
+}

--- a/packages/nextly/src/domains/collections/__tests__/_fixtures/tenant-read-rule.ts
+++ b/packages/nextly/src/domains/collections/__tests__/_fixtures/tenant-read-rule.ts
@@ -59,6 +59,9 @@ export default function tenantReadRule({
     // Shorthand equality: a primitive translates to `field = value`.
     case "shorthand":
       return { region: "eu" };
+    // A null shorthand value, which translation skips outright.
+    case "null-shorthand":
+      return { tenant: null, region: "eu" };
     // A logical group. Refused rather than approximated: a branch that
     // translates to nothing is dropped and its siblings decide alone.
     case "or-group":

--- a/packages/nextly/src/domains/collections/__tests__/_fixtures/tenant-read-rule.ts
+++ b/packages/nextly/src/domains/collections/__tests__/_fixtures/tenant-read-rule.ts
@@ -45,6 +45,18 @@ export default function tenantReadRule({
     // An inherited property name rather than a real operator.
     case "inherited-operator":
       return { tenant: { equals: "acme" }, region: { toString: "x" } };
+    // An inherited property name used as a FIELD. A plain lookup resolves it to
+    // a function, which reads as a present column.
+    case "inherited-field":
+      return { tenant: { equals: "acme" }, toString: { not_equals: "x" } };
+    // An empty alternatives group, as a rule building branches dynamically can
+    // produce. It should authorize nothing.
+    case "empty-or":
+      return { tenant: { equals: "acme" }, or: [] };
+    // A scalar `in`, which the translator normalizes to a one-element list, so
+    // it is a valid rule and must NOT be refused.
+    case "scalar-in":
+      return { region: { in: "eu" } };
     default:
       return true;
   }

--- a/packages/nextly/src/domains/collections/__tests__/_fixtures/tenant-read-rule.ts
+++ b/packages/nextly/src/domains/collections/__tests__/_fixtures/tenant-read-rule.ts
@@ -37,6 +37,14 @@ export default function tenantReadRule({
     // `buildDrizzleCondition` skips while keeping the sibling.
     case "partial-unknown-field":
       return { tenant: { equals: "acme" }, nosuchcolumn: { equals: "x" } };
+    // An empty IN list — what a rule returns when the caller has no permitted
+    // ids. It should match nothing; dropped, it leaves the sibling matching
+    // everything the sibling allows.
+    case "empty-in":
+      return { tenant: { equals: "acme" }, region: { in: [] } };
+    // An inherited property name rather than a real operator.
+    case "inherited-operator":
+      return { tenant: { equals: "acme" }, region: { toString: "x" } };
     default:
       return true;
   }

--- a/packages/nextly/src/domains/collections/__tests__/_fixtures/tenant-read-rule.ts
+++ b/packages/nextly/src/domains/collections/__tests__/_fixtures/tenant-read-rule.ts
@@ -25,6 +25,18 @@ export default function tenantReadRule({
     // An operator other than `equals`.
     case "in-operator":
       return { region: { in: ["eu", "uk"] } };
+    // A valid predicate beside one the translators cannot handle. Geo operators
+    // reach SQL through a separate extractor, so `buildWhereClause` drops them
+    // and keeps the sibling — leaving a weaker predicate that looks translated.
+    case "partial-geo":
+      return {
+        tenant: { equals: "acme" },
+        location: { within: { lat: 0, lng: 0, radius: 1 } },
+      };
+    // A valid predicate beside a field that is not on the table at all, which
+    // `buildDrizzleCondition` skips while keeping the sibling.
+    case "partial-unknown-field":
+      return { tenant: { equals: "acme" }, nosuchcolumn: { equals: "x" } };
     default:
       return true;
   }

--- a/packages/nextly/src/domains/collections/__tests__/_fixtures/tenant-read-rule.ts
+++ b/packages/nextly/src/domains/collections/__tests__/_fixtures/tenant-read-rule.ts
@@ -49,10 +49,23 @@ export default function tenantReadRule({
     // a function, which reads as a present column.
     case "inherited-field":
       return { tenant: { equals: "acme" }, toString: { not_equals: "x" } };
-    // An empty alternatives group, as a rule building branches dynamically can
-    // produce. It should authorize nothing.
-    case "empty-or":
-      return { tenant: { equals: "acme" }, or: [] };
+    // An empty field name, which translation drops.
+    case "empty-field-name":
+      return { tenant: { equals: "acme" }, "": { equals: "x" } };
+    // A dotted path. Translation discards the suffix and compares the base
+    // column, applying a different predicate than the rule states.
+    case "dotted-field":
+      return { tenant: { equals: "acme" }, "region.name": { equals: "eu" } };
+    // Shorthand equality: a primitive translates to `field = value`.
+    case "shorthand":
+      return { region: "eu" };
+    // A logical group. Refused rather than approximated: a branch that
+    // translates to nothing is dropped and its siblings decide alone.
+    case "or-group":
+      return { tenant: { equals: "acme" }, or: [{ region: { equals: "eu" } }] };
+    // A branch that translates to nothing inside a non-empty group.
+    case "or-empty-branch":
+      return { tenant: { equals: "acme" }, or: [{}] };
     // A scalar `in`, which the translator normalizes to a one-element list, so
     // it is a valid rule and must NOT be refused.
     case "scalar-in":

--- a/packages/nextly/src/domains/collections/__tests__/collection-query.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-query.test.ts
@@ -460,6 +460,40 @@ describe("CollectionEntryService — Query Contracts", () => {
       );
     });
 
+    it("applies a stored read constraint through the full filter translation", async () => {
+      // The constraint is a filter predicate, not a single equality. Reading one
+      // `equals` off its first key silently returns rows the rule excludes: a
+      // second field goes unapplied, and an operator like `in` leaves the read
+      // completely unfiltered.
+      const buildSpy = vi.spyOn(
+        CollectionQueryService.prototype,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- private seam
+        "buildDrizzleCondition" as any
+      );
+      mockAccessControlService.evaluateAccess.mockResolvedValue({
+        allowed: true,
+        query: { tenant: { equals: "acme" }, tier: { in: ["gold", "silver"] } },
+      });
+      mockCollectionService.getCollection.mockResolvedValue({
+        accessRules: { read: { type: "owner-only" } },
+      });
+      selectData.rows = [];
+
+      await service.listEntries({
+        collectionName: "posts",
+        user: { id: "u1", roles: ["editor"] },
+        routeAuthorized: true,
+      });
+
+      // Both fields reach the translator, including the non-equals operator.
+      const translated = buildSpy.mock.calls
+        .map(call => JSON.stringify(call[0]))
+        .join("|");
+      expect(translated).toContain("tenant");
+      expect(translated).toContain("tier");
+      buildSpy.mockRestore();
+    });
+
     it("should count under the same caller and route attestation the rows were listed under", async () => {
       selectData.rows = [];
       const countSpy = vi.spyOn(

--- a/packages/nextly/src/domains/collections/__tests__/collection-query.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-query.test.ts
@@ -460,40 +460,6 @@ describe("CollectionEntryService — Query Contracts", () => {
       );
     });
 
-    it("applies a stored read constraint through the full filter translation", async () => {
-      // The constraint is a filter predicate, not a single equality. Reading one
-      // `equals` off its first key silently returns rows the rule excludes: a
-      // second field goes unapplied, and an operator like `in` leaves the read
-      // completely unfiltered.
-      const buildSpy = vi.spyOn(
-        CollectionQueryService.prototype,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- private seam
-        "buildDrizzleCondition" as any
-      );
-      mockAccessControlService.evaluateAccess.mockResolvedValue({
-        allowed: true,
-        query: { tenant: { equals: "acme" }, tier: { in: ["gold", "silver"] } },
-      });
-      mockCollectionService.getCollection.mockResolvedValue({
-        accessRules: { read: { type: "owner-only" } },
-      });
-      selectData.rows = [];
-
-      await service.listEntries({
-        collectionName: "posts",
-        user: { id: "u1", roles: ["editor"] },
-        routeAuthorized: true,
-      });
-
-      // Both fields reach the translator, including the non-equals operator.
-      const translated = buildSpy.mock.calls
-        .map(call => JSON.stringify(call[0]))
-        .join("|");
-      expect(translated).toContain("tenant");
-      expect(translated).toContain("tier");
-      buildSpy.mockRestore();
-    });
-
     it("should count under the same caller and route attestation the rows were listed under", async () => {
       selectData.rows = [];
       const countSpy = vi.spyOn(

--- a/packages/nextly/src/domains/collections/__tests__/read-constraint-predicate.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/read-constraint-predicate.integration.test.ts
@@ -222,6 +222,7 @@ describe("stored read constraints are applied in full (integration)", () => {
     ["or-empty-branch", "a group whose branch translates to nothing"],
     ["empty-field-name", "an empty field name"],
     ["dotted-field", "a dotted path whose suffix translation discards"],
+    ["null-shorthand", "a null value that translation skips outright"],
   ])("refuses %s (%s)", async userId => {
     // Each of these translates to something NARROWER than the rule states, or
     // to a different predicate entirely. Refusing beats approximating: the

--- a/packages/nextly/src/domains/collections/__tests__/read-constraint-predicate.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/read-constraint-predicate.integration.test.ts
@@ -173,6 +173,37 @@ describe("stored read constraints are applied in full (integration)", () => {
     expect(counted.statusCode).toBe(403);
   });
 
+  it("refuses an empty IN list rather than dropping it", async () => {
+    // A rule computing "the ids you may see" can legitimately come back empty,
+    // which must match no rows. Dropped, the sibling predicate runs alone and
+    // returns everything it allows.
+    const handler = await bootWithStoredRule();
+
+    const result = await handler.listEntries({
+      collectionName: "docs",
+      user: { id: "empty-in" },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBe(403);
+  });
+
+  it("refuses an inherited property posing as an operator", async () => {
+    // `toString` answers true to an `in`-keyword operator check while mapping to
+    // nothing, so it would be dropped and its sibling would still run.
+    const handler = await bootWithStoredRule();
+
+    const result = await handler.listEntries({
+      collectionName: "docs",
+      user: { id: "inherited-operator" },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBe(403);
+  });
+
   it("counts the same rows it lists", async () => {
     const handler = await bootWithStoredRule();
 

--- a/packages/nextly/src/domains/collections/__tests__/read-constraint-predicate.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/read-constraint-predicate.integration.test.ts
@@ -127,6 +127,52 @@ describe("stored read constraints are applied in full (integration)", () => {
     ]);
   });
 
+  it("refuses a constraint whose members are only partly translatable", async () => {
+    // A geo predicate beside a normal one: the translators drop the geo member
+    // and keep `tenant`, so the read would run under a weaker predicate than the
+    // rule requires and return rows outside the permitted area. Non-empty is not
+    // the same as complete, so the constraint is refused instead.
+    const handler = await bootWithStoredRule();
+
+    const result = await handler.listEntries({
+      collectionName: "docs",
+      user: { id: "partial-geo" },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(false);
+    // An authorization decision, not a server fault.
+    expect(result.statusCode).toBe(403);
+  });
+
+  it("refuses a constraint naming a column the table does not have", async () => {
+    const handler = await bootWithStoredRule();
+
+    const result = await handler.listEntries({
+      collectionName: "docs",
+      user: { id: "partial-unknown-field" },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBe(403);
+  });
+
+  it("refuses the matching count too", async () => {
+    const handler = await bootWithStoredRule();
+
+    const counted = await handler.countEntries({
+      collectionName: "docs",
+      user: { id: "partial-geo" },
+      routeAuthorized: true,
+    });
+
+    // A count that succeeded where the list refused would disclose the size of
+    // a result set the caller may not read.
+    expect(counted.success).toBe(false);
+    expect(counted.statusCode).toBe(403);
+  });
+
   it("counts the same rows it lists", async () => {
     const handler = await bootWithStoredRule();
 

--- a/packages/nextly/src/domains/collections/__tests__/read-constraint-predicate.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/read-constraint-predicate.integration.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Proves a stored read rule's query constraint is applied IN FULL, against a
+ * real (in-memory SQLite) database.
+ *
+ * A read rule can return a filter predicate rather than a yes/no. That
+ * predicate used to be reduced to the first field's `equals` value:
+ *
+ *   const field = Object.keys(constraint)[0];
+ *   const value = (constraint[field] as { equals?: unknown })?.equals;
+ *   if (field && value) push(eq(schema[field], value));
+ *
+ * Three ways that returns rows the rule excludes, all of them over-permissive:
+ * a second field is never applied; any operator other than `equals` leaves
+ * `value` undefined so NOTHING is applied; and a legitimately falsy `equals`
+ * (`0`, `false`, `""`) fails the truthiness guard, so nothing is applied there
+ * either. Owner-only escaped all three by accident — one field, one non-empty
+ * string id — which is why it went unnoticed.
+ *
+ * These run against a real schema on purpose. The unit harness fakes columns
+ * with `Symbol`s, which Drizzle cannot build a condition from, so it can only
+ * ever exercise the fail-closed branch.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, number, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const RULE_PATH = new URL("./_fixtures/tenant-read-rule.ts", import.meta.url)
+  .pathname;
+
+type Row = { title: string };
+
+/**
+ * Boot a collection, attach the stored `custom` read rule, and seed rows.
+ *
+ * The rule is written onto the collection row rather than declared in
+ * `defineCollection`, because `getAccessRules()` reads the STORED shape
+ * (`accessRules`) while the code-first surface exposes `access` (functions).
+ * A Builder-created collection carries it exactly this way.
+ */
+async function bootWithStoredRule(): Promise<CollectionsHandler> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: "docs",
+        fields: [
+          text({ name: "title" }),
+          text({ name: "tenant" }),
+          text({ name: "region" }),
+          number({ name: "price" }),
+        ],
+      }),
+    ],
+  });
+
+  await current.adapter.update(
+    "dynamic_collections",
+    { access_rules: { read: { type: "custom", functionPath: RULE_PATH } } },
+    { and: [{ column: "slug", op: "=", value: "docs" }] }
+  );
+
+  const handler = current.getService<CollectionsHandler>("collectionsHandler");
+
+  const seed = [
+    { title: "acme-eu-free", tenant: "acme", region: "eu", price: 0 },
+    { title: "acme-us-paid", tenant: "acme", region: "us", price: 10 },
+    { title: "other-eu-paid", tenant: "other", region: "eu", price: 10 },
+  ];
+  for (const data of seed) {
+    await handler.createEntry(
+      { collectionName: "docs", overrideAccess: true },
+      data
+    );
+  }
+  return handler;
+}
+
+async function titlesFor(
+  handler: CollectionsHandler,
+  userId: string
+): Promise<string[]> {
+  const result = await handler.listEntries({
+    collectionName: "docs",
+    user: { id: userId },
+    routeAuthorized: true,
+  });
+  expect(result.success).toBe(true);
+  return (result.data!.docs as Row[]).map(r => r.title).sort();
+}
+
+describe("stored read constraints are applied in full (integration)", () => {
+  it("binds every field of a multi-field constraint", async () => {
+    const handler = await bootWithStoredRule();
+
+    // Only the acme+eu row satisfies both fields. Applying `tenant` alone would
+    // also return acme-us-paid.
+    expect(await titlesFor(handler, "multi-field")).toEqual(["acme-eu-free"]);
+  });
+
+  it("applies a constraint whose value is falsy", async () => {
+    const handler = await bootWithStoredRule();
+
+    // `price: { equals: 0 }` is a real predicate. Skipping it on truthiness
+    // returned the paid rows too.
+    expect(await titlesFor(handler, "falsy-value")).toEqual(["acme-eu-free"]);
+  });
+
+  it("applies a constraint using an operator other than equals", async () => {
+    const handler = await bootWithStoredRule();
+
+    // `region: { in: [...] }` has no `equals`, so the old path applied no
+    // predicate at all and returned every row including the us one.
+    expect(await titlesFor(handler, "in-operator")).toEqual([
+      "acme-eu-free",
+      "other-eu-paid",
+    ]);
+  });
+
+  it("counts the same rows it lists", async () => {
+    const handler = await bootWithStoredRule();
+
+    // The count path carried an identical extraction, so a total could describe
+    // rows the list correctly withheld.
+    const listed = await titlesFor(handler, "multi-field");
+    const counted = await handler.countEntries({
+      collectionName: "docs",
+      user: { id: "multi-field" },
+      routeAuthorized: true,
+    });
+
+    expect(counted.success).toBe(true);
+    expect(counted.data!.totalDocs).toBe(listed.length);
+  });
+});

--- a/packages/nextly/src/domains/collections/__tests__/read-constraint-predicate.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/read-constraint-predicate.integration.test.ts
@@ -217,17 +217,37 @@ describe("stored read constraints are applied in full (integration)", () => {
     expect(result.statusCode).toBe(403);
   });
 
-  it("refuses an empty alternatives group", async () => {
+  it.each([
+    ["or-group", "a logical group"],
+    ["or-empty-branch", "a group whose branch translates to nothing"],
+    ["empty-field-name", "an empty field name"],
+    ["dotted-field", "a dotted path whose suffix translation discards"],
+  ])("refuses %s (%s)", async userId => {
+    // Each of these translates to something NARROWER than the rule states, or
+    // to a different predicate entirely. Refusing beats approximating: the
+    // shapes an access constraint may take are deliberately narrower than the
+    // ones a caller's own filter may take.
     const handler = await bootWithStoredRule();
 
     const result = await handler.listEntries({
       collectionName: "docs",
-      user: { id: "empty-or" },
+      user: { id: userId },
       routeAuthorized: true,
     });
 
     expect(result.success).toBe(false);
     expect(result.statusCode).toBe(403);
+  });
+
+  it("accepts shorthand equality", async () => {
+    // A primitive value translates to `field = value`, so it is exact and must
+    // not be refused.
+    const handler = await bootWithStoredRule();
+
+    expect(await titlesFor(handler, "shorthand")).toEqual([
+      "acme-eu-free",
+      "other-eu-paid",
+    ]);
   });
 
   it("accepts a scalar IN, which the translator normalizes", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/read-constraint-predicate.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/read-constraint-predicate.integration.test.ts
@@ -204,6 +204,43 @@ describe("stored read constraints are applied in full (integration)", () => {
     expect(result.statusCode).toBe(403);
   });
 
+  it("refuses an inherited property used as a field name", async () => {
+    const handler = await bootWithStoredRule();
+
+    const result = await handler.listEntries({
+      collectionName: "docs",
+      user: { id: "inherited-field" },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBe(403);
+  });
+
+  it("refuses an empty alternatives group", async () => {
+    const handler = await bootWithStoredRule();
+
+    const result = await handler.listEntries({
+      collectionName: "docs",
+      user: { id: "empty-or" },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBe(403);
+  });
+
+  it("accepts a scalar IN, which the translator normalizes", async () => {
+    // Refusing this would break a valid rule: `buildCondition` wraps a non-array
+    // `in` value in a one-element list, so the member does translate.
+    const handler = await bootWithStoredRule();
+
+    expect(await titlesFor(handler, "scalar-in")).toEqual([
+      "acme-eu-free",
+      "other-eu-paid",
+    ]);
+  });
+
   it("counts the same rows it lists", async () => {
     const handler = await bootWithStoredRule();
 

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -134,20 +134,15 @@ interface LocalizedQueryContext {
   statusValue?: string;
 }
 
-/**
- * The operators `buildWhereClause` can map, as an explicit set.
- *
- * `isValidOperator` tests with the `in` keyword, which also answers true for
- * inherited names like `toString` or `constructor`. Such a member passes
- * validation, is then dropped as unmappable, and leaves its siblings running —
- * a narrower predicate than the rule states.
- */
 let mappableOperators: ReadonlySet<string> | undefined;
 
 /**
- * Built on first use rather than at module load: this module participates in an
- * import cycle, so reading the operator list eagerly can run before that module
- * has initialized and throw while the graph is still being wired.
+ * Whether an operator name is one `buildWhereClause` maps.
+ *
+ * Built on first use, not at module load: this module sits in an import cycle,
+ * so reading the operator list eagerly can run before that module initializes.
+ * Checked against an explicit set rather than the `in` keyword, which also
+ * answers true for inherited names like `toString`.
  */
 function isMappableOperator(operator: string): boolean {
   mappableOperators ??= new Set<string>(getSupportedOperators());
@@ -155,79 +150,76 @@ function isMappableOperator(operator: string): boolean {
 }
 
 /**
- * Whether an operator's VALUE survives translation.
+ * Why an access constraint cannot be applied, or null when it can.
  *
- * `buildWhereClause` skips an `undefined` value, and an empty `IN` list is
- * dropped downstream rather than matching nothing. Either way the member
- * vanishes while its siblings remain, so a rule that should match no rows
- * instead matches every row its other predicates allow.
+ * An access constraint is a security predicate, so it is held to a NARROWER
+ * shape than a caller's own `where` clause. The translators are built for caller
+ * filters, where dropping a member they cannot handle is acceptable; for a rule
+ * that decides who sees what, a dropped member means the read runs under a
+ * weaker predicate than the rule states and returns rows it excludes.
+ *
+ * Rather than enumerate everything translation can drop — a list that has proven
+ * incomplete — only a shape whose translation is exact is accepted:
+ *
+ * - a flat map of field to predicate, no logical groups
+ * - fields that are OWN columns on the main table, or localized fields the
+ *   companion context resolves; no dotted paths, whose suffix translation
+ *   discards and compares the base column instead
+ * - a primitive value (shorthand equality), or operators from the mapped set
+ *   with values that survive translation
+ *
+ * Anything else is refused with its reason rather than partly applied. A rule
+ * needing a richer shape is a feature, not something to approximate here.
  */
-function isTranslatableOperatorValue(
-  operator: string,
-  value: unknown
-): boolean {
-  if (value === undefined) return false;
-  if (operator === "in" || operator === "not_in") {
-    // A scalar is normalized to a one-element list downstream, so it translates.
-    // An EMPTY list does not: it is dropped, and a rule that should match no
-    // rows instead leaves its siblings matching everything they allow.
-    return Array.isArray(value) ? value.length > 0 : true;
-  }
-  return true;
-}
-
-/**
- * Confirm every member of an access constraint can be translated into SQL.
- *
- * The translators drop a member they cannot handle and keep the rest, so a
- * constraint can produce a non-empty condition that binds less than it states —
- * returning rows the rule excludes. Completeness is therefore established here,
- * before translating, rather than inferred from a non-empty result.
- *
- * A field is translatable when it is a column on the main table, or a localized
- * field the companion context can resolve. Returns the first untranslatable
- * member, or null when the whole constraint can be applied.
- */
-function findUntranslatableConstraintMember(
+function describeUntranslatableConstraint(
   constraint: Record<string, unknown>,
   schema: Record<string, unknown>,
   localizedCtx?: LocalizedQueryContext | null
 ): string | null {
-  for (const [key, value] of Object.entries(constraint)) {
-    if (key === "and" || key === "or") {
-      // An empty group is dropped rather than matching nothing, which would let
-      // the siblings beside it run as the whole predicate.
-      if (!Array.isArray(value) || value.length === 0) return key;
-      for (const branch of value) {
-        if (branch === null || typeof branch !== "object") return key;
-        const nested = findUntranslatableConstraintMember(
-          branch as Record<string, unknown>,
-          schema,
-          localizedCtx
-        );
-        if (nested) return nested;
-      }
+  const entries = Object.entries(constraint);
+  if (entries.length === 0) return "constraint is empty";
+
+  for (const [field, predicate] of entries) {
+    if (field === "and" || field === "or") {
+      return `logical group "${field}" is not supported in an access constraint`;
+    }
+    if (!field) return "field name is empty";
+    if (field.includes(".")) {
+      // Translation drops the suffix and compares the base column, which is a
+      // different predicate than the rule states.
+      return `dotted field "${field}" is not supported in an access constraint`;
+    }
+
+    const isOwnColumn = Object.prototype.hasOwnProperty.call(schema, field);
+    const isLocalized = Boolean(
+      localizedCtx?.localizedFields.some(f => f.name === field)
+    );
+    if (!isOwnColumn && !isLocalized) return `unknown field "${field}"`;
+
+    // Shorthand equality: a primitive translates to `field = value`.
+    if (predicate === null || typeof predicate !== "object") {
+      if (predicate === undefined) return `field "${field}" has no value`;
       continue;
     }
 
-    const fieldName = key.split(".")[0];
-    const isLocalized = Boolean(
-      localizedCtx?.localizedFields.some(f => f.name === fieldName)
-    );
-    // An own column only: a plain lookup resolves inherited names like
-    // `toString` to a function, which passes as present and is then read as a
-    // column, leaving the siblings as the effective predicate.
-    const isOwnColumn = Object.prototype.hasOwnProperty.call(schema, fieldName);
-    if (!isOwnColumn && !isLocalized) return key;
-
-    if (value === null || typeof value !== "object") return key;
-    const operators = Object.keys(value);
-    if (operators.length === 0) return key;
+    const operators = Object.keys(predicate);
+    if (operators.length === 0) return `field "${field}" has no operator`;
     for (const operator of operators) {
-      if (!isMappableOperator(operator)) return `${key}.${operator}`;
-      const operatorValue = (value as Record<string, unknown>)[operator];
-      if (!isTranslatableOperatorValue(operator, operatorValue)) {
-        return `${key}.${operator}`;
+      if (!isMappableOperator(operator)) {
+        return `operator "${operator}" on "${field}" is not supported`;
+      }
+      const value = (predicate as Record<string, unknown>)[operator];
+      if (value === undefined) {
+        return `operator "${operator}" on "${field}" has no value`;
+      }
+      // An empty list is dropped rather than matching nothing, so a rule that
+      // should authorize no rows would leave its siblings deciding alone.
+      if (
+        (operator === "in" || operator === "not_in") &&
+        Array.isArray(value) &&
+        value.length === 0
+      ) {
+        return `operator "${operator}" on "${field}" has an empty list`;
       }
     }
   }
@@ -1030,17 +1022,19 @@ export class CollectionQueryService extends BaseService {
       if (accessConstraint) {
         // Refuse before translating: a partially translatable constraint yields a
         // non-empty condition that binds less than the rule requires.
-        const untranslatable = findUntranslatableConstraintMember(
+        const untranslatable = describeUntranslatableConstraint(
           accessConstraint,
           schema,
           localizedCtx
         );
-        if (untranslatable) {
+        // Explicitly against null: a reason can be any string, and an empty one
+        // would read as success.
+        if (untranslatable !== null) {
           throw NextlyError.forbidden({
             logContext: {
               collection: params.collectionName,
               reason: "untranslatable-access-constraint",
-              member: untranslatable,
+              reason_detail: untranslatable,
             },
           });
         }
@@ -1826,17 +1820,19 @@ export class CollectionQueryService extends BaseService {
       if (accessConstraint) {
         // Refuse before translating: a partially translatable constraint yields a
         // non-empty condition that binds less than the rule requires.
-        const untranslatable = findUntranslatableConstraintMember(
+        const untranslatable = describeUntranslatableConstraint(
           accessConstraint,
           schema,
           localizedCtx
         );
-        if (untranslatable) {
+        // Explicitly against null: a reason can be any string, and an empty one
+        // would read as success.
+        if (untranslatable !== null) {
           throw NextlyError.forbidden({
             logContext: {
               collection: params.collectionName,
               reason: "untranslatable-access-constraint",
-              member: untranslatable,
+              reason_detail: untranslatable,
             },
           });
         }

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -38,6 +38,7 @@ import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 
 import type { AuthenticatedScope } from "../../../auth/authenticated-scope";
 import type { FieldConfig } from "../../../collections/fields/types";
+import { NextlyError } from "../../../errors/nextly-error";
 import { getFilterRegistry, FilterSeams } from "../../../filters";
 import { toSnakeCase } from "../../../lib/case-conversion";
 import {
@@ -762,16 +763,10 @@ export class CollectionQueryService extends BaseService {
           params.authenticatedScope
         );
 
-      // Apply access constraint if present
-      if (accessConstraint) {
-        const accessField = Object.keys(accessConstraint)[0];
-        const accessValue = (
-          accessConstraint[accessField] as { equals?: unknown }
-        )?.equals;
-        if (accessField && accessValue) {
-          whereConditions.push(eq(schema[accessField], accessValue));
-        }
-      }
+      // The constraint is applied further down, through the same translation
+      // the caller's own `where` uses: it is a full filter predicate, not a
+      // single equality, and reducing it here would narrow less than the rule
+      // asks for.
 
       // Apply Draft/Published auto-filter. The helper returns null when the
       // collection has no status column, the caller is trusted with no
@@ -923,6 +918,32 @@ export class CollectionQueryService extends BaseService {
 
         if (whereCondition) {
           whereConditions.push(whereCondition);
+        }
+      }
+
+      // Apply the stored read rule's query constraint through the same
+      // translation the caller's `where` uses. It is a full filter predicate:
+      // an owner-only read emits one field, but a custom rule can return any
+      // supported operator across several fields, and reading a single `equals`
+      // off the first key silently returns rows the rule excludes.
+      if (accessConstraint) {
+        const accessCondition = this.buildDrizzleCondition(
+          buildWhereClause(accessConstraint as WhereFilter),
+          schema,
+          dialect,
+          localizedCtx
+        );
+        if (accessCondition) {
+          whereConditions.push(accessCondition);
+        } else {
+          // A constraint that translates to nothing would widen the read to
+          // every row. Fail closed instead: the rule asked to narrow.
+          throw NextlyError.forbidden({
+            logContext: {
+              collection: params.collectionName,
+              reason: "untranslatable-access-constraint",
+            },
+          });
         }
       }
 
@@ -1521,16 +1542,10 @@ export class CollectionQueryService extends BaseService {
           params.authenticatedScope
         );
 
-      // Apply access constraint if present
-      if (accessConstraint) {
-        const accessField = Object.keys(accessConstraint)[0];
-        const accessValue = (
-          accessConstraint[accessField] as { equals?: unknown }
-        )?.equals;
-        if (accessField && accessValue) {
-          whereConditions.push(eq(schema[accessField], accessValue));
-        }
-      }
+      // The constraint is applied further down, through the same translation
+      // the caller's own `where` uses: it is a full filter predicate, not a
+      // single equality, and reducing it here would narrow less than the rule
+      // asks for.
 
       // Apply Draft/Published auto-filter. The helper returns null when the
       // collection has no status column, the caller is trusted with no
@@ -1675,6 +1690,32 @@ export class CollectionQueryService extends BaseService {
           if (whereCondition) {
             whereConditions.push(whereCondition);
           }
+        }
+      }
+
+      // Apply the stored read rule's query constraint through the same
+      // translation the caller's `where` uses. It is a full filter predicate:
+      // an owner-only read emits one field, but a custom rule can return any
+      // supported operator across several fields, and reading a single `equals`
+      // off the first key silently returns rows the rule excludes.
+      if (accessConstraint) {
+        const accessCondition = this.buildDrizzleCondition(
+          buildWhereClause(accessConstraint as WhereFilter),
+          schema,
+          this.adapter?.dialect || "postgresql",
+          localizedCtx
+        );
+        if (accessCondition) {
+          whereConditions.push(accessCondition);
+        } else {
+          // A constraint that translates to nothing would widen the read to
+          // every row. Fail closed instead: the rule asked to narrow.
+          throw NextlyError.forbidden({
+            logContext: {
+              collection: params.collectionName,
+              reason: "untranslatable-access-constraint",
+            },
+          });
         }
       }
 

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -56,6 +56,7 @@ import {
 } from "../../../services/collections/geo-utils";
 import {
   buildWhereClause,
+  isValidOperator,
   extractGeoFilters,
   extractComponentFieldConditions,
 } from "../../../services/collections/query-operators";
@@ -131,6 +132,54 @@ interface LocalizedQueryContext {
    * checks only match companion rows in that state. Undefined = no status constraint.
    */
   statusValue?: string;
+}
+
+/**
+ * Confirm every member of an access constraint can be translated into SQL.
+ *
+ * The translators drop what they cannot handle and keep the rest: an operator
+ * outside `OPERATOR_MAP` (the geo operators, which reach SQL through a separate
+ * extractor) is skipped by `buildWhereClause`, and a field absent from the
+ * schema is skipped by `buildDrizzleCondition`. Either way a sibling predicate
+ * survives, the result is non-empty, and the read runs under a WEAKER predicate
+ * than the rule asked for — the same partial-application bug this whole path
+ * exists to remove, one level up.
+ *
+ * So completeness is established before translating rather than inferred from a
+ * non-empty result. Returns the first untranslatable member, or null when the
+ * whole constraint can be applied.
+ */
+function findUntranslatableConstraintMember(
+  constraint: Record<string, unknown>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle dynamic schema
+  schema: any
+): string | null {
+  for (const [key, value] of Object.entries(constraint)) {
+    if (key === "and" || key === "or") {
+      if (!Array.isArray(value)) return key;
+      for (const branch of value) {
+        if (branch === null || typeof branch !== "object") return key;
+        const nested = findUntranslatableConstraintMember(
+          branch as Record<string, unknown>,
+          schema
+        );
+        if (nested) return nested;
+      }
+      continue;
+    }
+
+    // A field predicate. The column has to exist on the main table: a localized
+    // or otherwise absent column is silently skipped downstream.
+    if (!schema[key.split(".")[0]]) return key;
+
+    if (value === null || typeof value !== "object") return key;
+    const operators = Object.keys(value);
+    if (operators.length === 0) return key;
+    for (const operator of operators) {
+      if (!isValidOperator(operator)) return `${key}.${operator}`;
+    }
+  }
+  return null;
 }
 
 export class CollectionQueryService extends BaseService {
@@ -927,6 +976,21 @@ export class CollectionQueryService extends BaseService {
       // supported operator across several fields, and reading a single `equals`
       // off the first key silently returns rows the rule excludes.
       if (accessConstraint) {
+        // Refuse before translating: a partially translatable constraint yields a
+        // non-empty condition that binds less than the rule requires.
+        const untranslatable = findUntranslatableConstraintMember(
+          accessConstraint,
+          schema
+        );
+        if (untranslatable) {
+          throw NextlyError.forbidden({
+            logContext: {
+              collection: params.collectionName,
+              reason: "untranslatable-access-constraint",
+              member: untranslatable,
+            },
+          });
+        }
         const accessCondition = this.buildDrizzleCondition(
           buildWhereClause(accessConstraint as WhereFilter),
           schema,
@@ -1395,9 +1459,18 @@ export class CollectionQueryService extends BaseService {
         error instanceof Error ? error.message : "Failed to fetch entries";
       const isNotFound =
         message.includes("not found") || message.includes("does not exist");
+      // A NextlyError already carries the right status (a refused access
+      // constraint is a 403); flattening it to 500 would report an authorization
+      // decision as a server fault.
+      const statusCode =
+        error instanceof NextlyError
+          ? error.statusCode
+          : isNotFound
+            ? 404
+            : 500;
       return {
         success: false,
-        statusCode: isNotFound ? 404 : 500,
+        statusCode,
         message,
         data: null,
       };
@@ -1699,6 +1772,21 @@ export class CollectionQueryService extends BaseService {
       // supported operator across several fields, and reading a single `equals`
       // off the first key silently returns rows the rule excludes.
       if (accessConstraint) {
+        // Refuse before translating: a partially translatable constraint yields a
+        // non-empty condition that binds less than the rule requires.
+        const untranslatable = findUntranslatableConstraintMember(
+          accessConstraint,
+          schema
+        );
+        if (untranslatable) {
+          throw NextlyError.forbidden({
+            logContext: {
+              collection: params.collectionName,
+              reason: "untranslatable-access-constraint",
+              member: untranslatable,
+            },
+          });
+        }
         const accessCondition = this.buildDrizzleCondition(
           buildWhereClause(accessConstraint as WhereFilter),
           schema,
@@ -1750,7 +1838,9 @@ export class CollectionQueryService extends BaseService {
       });
       return {
         success: false,
-        statusCode: 500,
+        // Mirrors listEntries: a refused access constraint is a 403, not a
+        // server fault, and the count must report it the same way.
+        statusCode: error instanceof NextlyError ? error.statusCode : 500,
         message,
         data: null,
       };

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -196,11 +196,12 @@ function describeUntranslatableConstraint(
     );
     if (!isOwnColumn && !isLocalized) return `unknown field "${field}"`;
 
-    // Shorthand equality: a primitive translates to `field = value`.
-    if (predicate === null || typeof predicate !== "object") {
-      if (predicate === undefined) return `field "${field}" has no value`;
-      continue;
-    }
+    // Shorthand equality: a primitive translates to `field = value`. `null` and
+    // `undefined` do not — translation skips both, dropping the member while its
+    // siblings stay and decide alone.
+    if (predicate === null) return `field "${field}" is null`;
+    if (predicate === undefined) return `field "${field}" has no value`;
+    if (typeof predicate !== "object") continue;
 
     const operators = Object.keys(predicate);
     if (operators.length === 0) return `field "${field}" has no operator`;
@@ -1030,6 +1031,13 @@ export class CollectionQueryService extends BaseService {
         // Explicitly against null: a reason can be any string, and an empty one
         // would read as success.
         if (untranslatable !== null) {
+          // Logged here rather than left on the error: the surrounding catch
+          // flattens this into a result envelope, so the reason would otherwise
+          // never reach operator logs and every refusal would look alike.
+          this.logger.warn("Refused an untranslatable access constraint", {
+            collection: params.collectionName,
+            reason: untranslatable,
+          });
           throw NextlyError.forbidden({
             logContext: {
               collection: params.collectionName,
@@ -1828,6 +1836,13 @@ export class CollectionQueryService extends BaseService {
         // Explicitly against null: a reason can be any string, and an empty one
         // would read as success.
         if (untranslatable !== null) {
+          // Logged here rather than left on the error: the surrounding catch
+          // flattens this into a result envelope, so the reason would otherwise
+          // never reach operator logs and every refusal would look alike.
+          this.logger.warn("Refused an untranslatable access constraint", {
+            collection: params.collectionName,
+            reason: untranslatable,
+          });
           throw NextlyError.forbidden({
             logContext: {
               collection: params.collectionName,

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -168,7 +168,10 @@ function isTranslatableOperatorValue(
 ): boolean {
   if (value === undefined) return false;
   if (operator === "in" || operator === "not_in") {
-    return Array.isArray(value) && value.length > 0;
+    // A scalar is normalized to a one-element list downstream, so it translates.
+    // An EMPTY list does not: it is dropped, and a rule that should match no
+    // rows instead leaves its siblings matching everything they allow.
+    return Array.isArray(value) ? value.length > 0 : true;
   }
   return true;
 }
@@ -192,7 +195,9 @@ function findUntranslatableConstraintMember(
 ): string | null {
   for (const [key, value] of Object.entries(constraint)) {
     if (key === "and" || key === "or") {
-      if (!Array.isArray(value)) return key;
+      // An empty group is dropped rather than matching nothing, which would let
+      // the siblings beside it run as the whole predicate.
+      if (!Array.isArray(value) || value.length === 0) return key;
       for (const branch of value) {
         if (branch === null || typeof branch !== "object") return key;
         const nested = findUntranslatableConstraintMember(
@@ -209,7 +214,11 @@ function findUntranslatableConstraintMember(
     const isLocalized = Boolean(
       localizedCtx?.localizedFields.some(f => f.name === fieldName)
     );
-    if (!schema[fieldName] && !isLocalized) return key;
+    // An own column only: a plain lookup resolves inherited names like
+    // `toString` to a function, which passes as present and is then read as a
+    // column, leaving the siblings as the effective predicate.
+    const isOwnColumn = Object.prototype.hasOwnProperty.call(schema, fieldName);
+    if (!isOwnColumn && !isLocalized) return key;
 
     if (value === null || typeof value !== "object") return key;
     const operators = Object.keys(value);

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -56,7 +56,7 @@ import {
 } from "../../../services/collections/geo-utils";
 import {
   buildWhereClause,
-  isValidOperator,
+  getSupportedOperators,
   extractGeoFilters,
   extractComponentFieldConditions,
 } from "../../../services/collections/query-operators";
@@ -135,24 +135,60 @@ interface LocalizedQueryContext {
 }
 
 /**
+ * The operators `buildWhereClause` can map, as an explicit set.
+ *
+ * `isValidOperator` tests with the `in` keyword, which also answers true for
+ * inherited names like `toString` or `constructor`. Such a member passes
+ * validation, is then dropped as unmappable, and leaves its siblings running —
+ * a narrower predicate than the rule states.
+ */
+let mappableOperators: ReadonlySet<string> | undefined;
+
+/**
+ * Built on first use rather than at module load: this module participates in an
+ * import cycle, so reading the operator list eagerly can run before that module
+ * has initialized and throw while the graph is still being wired.
+ */
+function isMappableOperator(operator: string): boolean {
+  mappableOperators ??= new Set<string>(getSupportedOperators());
+  return mappableOperators.has(operator);
+}
+
+/**
+ * Whether an operator's VALUE survives translation.
+ *
+ * `buildWhereClause` skips an `undefined` value, and an empty `IN` list is
+ * dropped downstream rather than matching nothing. Either way the member
+ * vanishes while its siblings remain, so a rule that should match no rows
+ * instead matches every row its other predicates allow.
+ */
+function isTranslatableOperatorValue(
+  operator: string,
+  value: unknown
+): boolean {
+  if (value === undefined) return false;
+  if (operator === "in" || operator === "not_in") {
+    return Array.isArray(value) && value.length > 0;
+  }
+  return true;
+}
+
+/**
  * Confirm every member of an access constraint can be translated into SQL.
  *
- * The translators drop what they cannot handle and keep the rest: an operator
- * outside `OPERATOR_MAP` (the geo operators, which reach SQL through a separate
- * extractor) is skipped by `buildWhereClause`, and a field absent from the
- * schema is skipped by `buildDrizzleCondition`. Either way a sibling predicate
- * survives, the result is non-empty, and the read runs under a WEAKER predicate
- * than the rule asked for — the same partial-application bug this whole path
- * exists to remove, one level up.
+ * The translators drop a member they cannot handle and keep the rest, so a
+ * constraint can produce a non-empty condition that binds less than it states —
+ * returning rows the rule excludes. Completeness is therefore established here,
+ * before translating, rather than inferred from a non-empty result.
  *
- * So completeness is established before translating rather than inferred from a
- * non-empty result. Returns the first untranslatable member, or null when the
- * whole constraint can be applied.
+ * A field is translatable when it is a column on the main table, or a localized
+ * field the companion context can resolve. Returns the first untranslatable
+ * member, or null when the whole constraint can be applied.
  */
 function findUntranslatableConstraintMember(
   constraint: Record<string, unknown>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle dynamic schema
-  schema: any
+  schema: Record<string, unknown>,
+  localizedCtx?: LocalizedQueryContext | null
 ): string | null {
   for (const [key, value] of Object.entries(constraint)) {
     if (key === "and" || key === "or") {
@@ -161,22 +197,29 @@ function findUntranslatableConstraintMember(
         if (branch === null || typeof branch !== "object") return key;
         const nested = findUntranslatableConstraintMember(
           branch as Record<string, unknown>,
-          schema
+          schema,
+          localizedCtx
         );
         if (nested) return nested;
       }
       continue;
     }
 
-    // A field predicate. The column has to exist on the main table: a localized
-    // or otherwise absent column is silently skipped downstream.
-    if (!schema[key.split(".")[0]]) return key;
+    const fieldName = key.split(".")[0];
+    const isLocalized = Boolean(
+      localizedCtx?.localizedFields.some(f => f.name === fieldName)
+    );
+    if (!schema[fieldName] && !isLocalized) return key;
 
     if (value === null || typeof value !== "object") return key;
     const operators = Object.keys(value);
     if (operators.length === 0) return key;
     for (const operator of operators) {
-      if (!isValidOperator(operator)) return `${key}.${operator}`;
+      if (!isMappableOperator(operator)) return `${key}.${operator}`;
+      const operatorValue = (value as Record<string, unknown>)[operator];
+      if (!isTranslatableOperatorValue(operator, operatorValue)) {
+        return `${key}.${operator}`;
+      }
     }
   }
   return null;
@@ -980,7 +1023,8 @@ export class CollectionQueryService extends BaseService {
         // non-empty condition that binds less than the rule requires.
         const untranslatable = findUntranslatableConstraintMember(
           accessConstraint,
-          schema
+          schema,
+          localizedCtx
         );
         if (untranslatable) {
           throw NextlyError.forbidden({
@@ -1462,12 +1506,11 @@ export class CollectionQueryService extends BaseService {
       // A NextlyError already carries the right status (a refused access
       // constraint is a 403); flattening it to 500 would report an authorization
       // decision as a server fault.
-      const statusCode =
-        error instanceof NextlyError
-          ? error.statusCode
-          : isNotFound
-            ? 404
-            : 500;
+      const statusCode = NextlyError.is(error)
+        ? error.statusCode
+        : isNotFound
+          ? 404
+          : 500;
       return {
         success: false,
         statusCode,
@@ -1776,7 +1819,8 @@ export class CollectionQueryService extends BaseService {
         // non-empty condition that binds less than the rule requires.
         const untranslatable = findUntranslatableConstraintMember(
           accessConstraint,
-          schema
+          schema,
+          localizedCtx
         );
         if (untranslatable) {
           throw NextlyError.forbidden({
@@ -1840,7 +1884,7 @@ export class CollectionQueryService extends BaseService {
         success: false,
         // Mirrors listEntries: a refused access constraint is a 403, not a
         // server fault, and the count must report it the same way.
-        statusCode: error instanceof NextlyError ? error.statusCode : 500,
+        statusCode: NextlyError.is(error) ? error.statusCode : 500,
         message,
         data: null,
       };


### PR DESCRIPTION
Task 058, PR-1 (collections). Found while re-auditing 058, which was scoped as a Singles-only gap.

## This is a shipped over-permissive leak, not the gap the task described

A stored read rule can return a **filter** describing which rows a caller may see. Both `listEntries` and `countEntries` reduced that filter to the first field's `equals` value:

```js
const accessField = Object.keys(accessConstraint)[0];
const accessValue = (accessConstraint[accessField] as { equals?: unknown })?.equals;
if (accessField && accessValue) whereConditions.push(eq(schema[accessField], accessValue));
```

Three failure modes, all returning **more** than the rule allows. Confirmed against `origin/main` with real rows, not reasoned about:

| Rule returns | main returns | should return |
|---|---|---|
| `{tenant:{equals:"acme"}, region:{equals:"eu"}}` | `acme-eu-free`, **`acme-us-paid`** | `acme-eu-free` |
| `{price:{equals:0}}` | **all 3 rows** | `acme-eu-free` |
| `{region:{in:["eu","uk"]}}` | **all 3 rows** | `acme-eu-free`, `other-eu-paid` |

The last two are the serious ones: no predicate is pushed at all, so the read is completely unfiltered. A falsy `equals` (`0`, `false`, `""`) fails the truthiness guard exactly like a missing one.

**Why it went unnoticed:** owner-only — the only rule most installs use — emits a single field with a non-empty string id, the one shape the old path handled correctly. And the count path carried an identical extraction, so totals leaked the same way.

I should also say plainly: I added the API-key scope parameter to this exact call in #333 and did not notice the extraction below it was lossy.

## The fix

Route the filter through `buildWhereClause` + `buildDrizzleCondition` — the translation the caller's own `where` already uses — so every field and operator binds. Applied at the unconditional point in both paths; the count path's where-block is nested, so applying it there would have skipped the constraint whenever no user `where` was supplied.

A filter that translates to nothing now **refuses the read** rather than returning every row.

## Tests: integration, not unit, deliberately

The unit harness fakes columns with `Symbol`s, which Drizzle cannot build a condition from — so it can only ever reach the fail-closed branch, and a mock-based test here would assert that one function called another. I checked separately that `buildWhereClause` already handles falsy `equals` and `in` correctly, so the bug was purely in the extraction.

These run against a real SQLite schema and assert **which rows come back**. All four pass on this branch; **three fail against `main`** with the values in the table above. The fourth (count agrees with list) passes both ways by construction and guards the count path against regressing separately.

## Scope

Collections only. Singles are PR-2 — that removes the "custom read rules are not enforced" caveat from #338's changeset, and it now has a working test pattern to copy.

Zero new failures: same suites, both after a full build, `origin/main` 370 failed / 2852 passed vs branch 370 / 2852 — identical failing-file set. Lint and typecheck clean.
