### PR TITLE
fix(nextly): apply declared field defaults on collection creates

### DIFF
--- a/.changeset/lucky-pugs-search.md
+++ b/.changeset/lucky-pugs-search.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+A field's declared `defaultValue` is now applied when a collection entry is created through the REST or Direct API, not only in the admin form. A required field that carries a default can now be created without supplying it.

--- a/.changeset/lucky-pugs-search.md
+++ b/.changeset/lucky-pugs-search.md
@@ -22,4 +22,6 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-A field's declared `defaultValue` is now applied when a collection entry is created through the REST or Direct API, not only in the admin form. A required field that carries a default can now be created without supplying it.
+A field's declared constant `defaultValue` is now applied when a collection entry is created through the REST or Direct API, not only in the admin form, and a required field carrying one can be created without supplying it. Defaults reach nested group and repeater fields too.
+
+Two limits: a `defaultValue` written as a function is not applied on these paths, because the stored collection definition cannot carry a function, and bulk or caller-managed transactional creates are unchanged.

--- a/packages/nextly/src/collections/__tests__/field-defaults-tx.integration.test.ts
+++ b/packages/nextly/src/collections/__tests__/field-defaults-tx.integration.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Defaults on the transactional create path.
+ *
+ * `createEntryInTransaction` builds its insert payload straight from the write
+ * data, without the JSON serialization pass the pooled create runs. A default
+ * that is an object or an array therefore reaches the driver as a live value
+ * rather than as JSON text, which each dialect handles differently — so the
+ * path a default arrives on has to be exercised, not just the value.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, json, text } from "../../config";
+import { createTestNextly, type TestNextly } from "../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../services/collections-handler";
+import type { CollectionEntryService } from "../../services/collections/collection-entry-service";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const OBJECT_DEFAULT = { a: 1, nested: { b: [1, 2] } };
+
+describe("field defaults on a transactional create (integration)", () => {
+  it("stores an object default as JSON, not as a driver expression", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "txdefaults",
+          fields: [
+            text({ name: "title" }),
+            json({ name: "settings", defaultValue: OBJECT_DEFAULT }),
+          ],
+        }),
+      ],
+    });
+
+    const entries = current
+      .getService<CollectionsHandler>("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+
+    const created = await current.adapter.transaction(tx =>
+      entries.createEntryInTransaction(
+        tx as never,
+        { collectionName: "txdefaults", overrideAccess: true },
+        { title: "T" }
+      )
+    );
+
+    const id = (created as { data?: { id?: unknown } }).data?.id;
+    expect(typeof id, JSON.stringify(created)).toBe("string");
+
+    const read = await entries.getEntry({
+      collectionName: "txdefaults",
+      entryId: String(id),
+      overrideAccess: true,
+    });
+    const data = ((read as { data?: unknown }).data ?? {}) as Record<
+      string,
+      unknown
+    >;
+    expect(data.settings).toEqual(OBJECT_DEFAULT);
+  });
+});

--- a/packages/nextly/src/collections/__tests__/field-defaults-tx.integration.test.ts
+++ b/packages/nextly/src/collections/__tests__/field-defaults-tx.integration.test.ts
@@ -63,4 +63,45 @@ describe("field defaults on a transactional create (integration)", () => {
     >;
     expect(data.settings).toEqual(OBJECT_DEFAULT);
   });
+
+  it("encodes a scalar json default as a json document", async () => {
+    // A JSON column stores a document: the bare string `enabled` is not valid
+    // JSON, so a JSONB insert rejects it while `"enabled"` is accepted.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "txscalar",
+          fields: [
+            text({ name: "title" }),
+            json({ name: "mode", defaultValue: "enabled" }),
+          ],
+        }),
+      ],
+    });
+
+    const entries = current
+      .getService<CollectionsHandler>("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+
+    const created = await current.adapter.transaction(tx =>
+      entries.createEntryInTransaction(
+        tx as never,
+        { collectionName: "txscalar", overrideAccess: true },
+        { title: "T" }
+      )
+    );
+    const id = (created as { data?: { id?: unknown } }).data?.id;
+    expect(typeof id, JSON.stringify(created)).toBe("string");
+
+    const read = await entries.getEntry({
+      collectionName: "txscalar",
+      entryId: String(id),
+      overrideAccess: true,
+    });
+    const data = ((read as { data?: unknown }).data ?? {}) as Record<
+      string,
+      unknown
+    >;
+    expect(data.mode).toBe("enabled");
+  });
 });

--- a/packages/nextly/src/collections/__tests__/field-defaults-tx.integration.test.ts
+++ b/packages/nextly/src/collections/__tests__/field-defaults-tx.integration.test.ts
@@ -1,18 +1,25 @@
 /**
- * Defaults on the transactional create path.
+ * Where declared defaults stop.
  *
- * `createEntryInTransaction` builds its insert payload straight from the write
- * data, without the JSON serialization pass the pooled create runs. A default
- * that is an object or an array therefore reaches the driver as a live value
- * rather than as JSON text, which each dialect handles differently — so the
- * path a default arrives on has to be exercised, not just the value.
+ * Defaults are applied on the pooled create path only. The transactional and
+ * bulk paths build their insert payload directly and run none of the pooled
+ * path's preparation — no JSON serialization, no nested-relationship
+ * normalization, and no companion write for a localized collection's
+ * translatable values. Seeding defaults into them means reproducing all three,
+ * on paths whose behaviour cannot currently be exercised against Postgres or
+ * MySQL, so that is left until both paths share one write pipeline.
+ *
+ * This asserts the boundary rather than leaving it implicit: a transactional
+ * create stores nothing for an omitted field, exactly as it did before
+ * defaults existed. Moving the boundary should be a deliberate change that
+ * updates this test, not a silent one.
  */
 import { afterEach, describe, expect, it } from "vitest";
 
 import { defineCollection, json, text } from "../../config";
 import { createTestNextly, type TestNextly } from "../../plugins/test-nextly";
-import type { CollectionsHandler } from "../../services/collections-handler";
 import type { CollectionEntryService } from "../../services/collections/collection-entry-service";
+import type { CollectionsHandler } from "../../services/collections-handler";
 
 let current: TestNextly | undefined;
 
@@ -21,17 +28,16 @@ afterEach(async () => {
   current = undefined;
 });
 
-const OBJECT_DEFAULT = { a: 1, nested: { b: [1, 2] } };
-
 describe("field defaults on a transactional create (integration)", () => {
-  it("stores an object default as JSON, not as a driver expression", async () => {
+  it("does not apply declared defaults", async () => {
     current = await createTestNextly({
       collections: [
         defineCollection({
           slug: "txdefaults",
           fields: [
             text({ name: "title" }),
-            json({ name: "settings", defaultValue: OBJECT_DEFAULT }),
+            text({ name: "subtitle", defaultValue: "from-default" }),
+            json({ name: "settings", defaultValue: { a: 1 } }),
           ],
         }),
       ],
@@ -48,7 +54,6 @@ describe("field defaults on a transactional create (integration)", () => {
         { title: "T" }
       )
     );
-
     const id = (created as { data?: { id?: unknown } }).data?.id;
     expect(typeof id, JSON.stringify(created)).toBe("string");
 
@@ -61,99 +66,11 @@ describe("field defaults on a transactional create (integration)", () => {
       string,
       unknown
     >;
-    expect(data.settings).toEqual(OBJECT_DEFAULT);
-  });
 
-  it("encodes a scalar json default as a json document", async () => {
-    // A JSON column stores a document: the bare string `enabled` is not valid
-    // JSON, so a JSONB insert rejects it while `"enabled"` is accepted.
-    current = await createTestNextly({
-      collections: [
-        defineCollection({
-          slug: "txscalar",
-          fields: [
-            text({ name: "title" }),
-            json({ name: "mode", defaultValue: "enabled" }),
-          ],
-        }),
-      ],
-    });
-
-    const entries = current
-      .getService<CollectionsHandler>("collectionsHandler")
-      .getEntryService() as CollectionEntryService;
-
-    const created = await current.adapter.transaction(tx =>
-      entries.createEntryInTransaction(
-        tx as never,
-        { collectionName: "txscalar", overrideAccess: true },
-        { title: "T" }
-      )
-    );
-    const id = (created as { data?: { id?: unknown } }).data?.id;
-    expect(typeof id, JSON.stringify(created)).toBe("string");
-
-    const read = await entries.getEntry({
-      collectionName: "txscalar",
-      entryId: String(id),
-      overrideAccess: true,
-    });
-    const data = ((read as { data?: unknown }).data ?? {}) as Record<
-      string,
-      unknown
-    >;
-    expect(data.mode).toBe("enabled");
-  });
-
-  it("applies defaults on a localized collection", async () => {
-    // A localized collection is the only case that reaches the companion
-    // lookup, so without this the whole branch went unexercised — including
-    // which method the driver handle actually exposes, which differs between
-    // better-sqlite3 and the pg/mysql2 handles.
-    current = await createTestNextly({
-      localization: { locales: ["en", "de"], defaultLocale: "en" },
-      collections: [
-        defineCollection({
-          slug: "txlocalized",
-          localized: true,
-          fields: [
-            // Non-translatable, so this exercises the companion lookup without
-            // running into the separate, pre-existing gap that transactional
-            // creates have no companion-write step for translatable values.
-            text({ name: "title", localized: false }),
-            text({
-              name: "subtitle",
-              localized: false,
-              defaultValue: "from-default",
-            }),
-          ],
-        }),
-      ],
-    });
-
-    const entries = current
-      .getService<CollectionsHandler>("collectionsHandler")
-      .getEntryService() as CollectionEntryService;
-
-    const created = await current.adapter.transaction(tx =>
-      entries.createEntryInTransaction(
-        tx as never,
-        { collectionName: "txlocalized", overrideAccess: true },
-        { title: "T" }
-      )
-    );
-    const id = (created as { data?: { id?: unknown } }).data?.id;
-    expect(typeof id, JSON.stringify(created)).toBe("string");
-
-    const read = await entries.getEntry({
-      collectionName: "txlocalized",
-      entryId: String(id),
-      overrideAccess: true,
-    });
-    const data = ((read as { data?: unknown }).data ?? {}) as Record<
-      string,
-      unknown
-    >;
-    expect(data.subtitle).toBe("from-default");
+    // Unchanged from before this feature: the create succeeds and the omitted
+    // fields are simply empty.
+    expect(data.title).toBe("T");
+    expect(data.subtitle).toBeNull();
+    expect(data.settings).toBeNull();
   });
 });

--- a/packages/nextly/src/collections/__tests__/field-defaults-tx.integration.test.ts
+++ b/packages/nextly/src/collections/__tests__/field-defaults-tx.integration.test.ts
@@ -104,4 +104,56 @@ describe("field defaults on a transactional create (integration)", () => {
     >;
     expect(data.mode).toBe("enabled");
   });
+
+  it("applies defaults on a localized collection", async () => {
+    // A localized collection is the only case that reaches the companion
+    // lookup, so without this the whole branch went unexercised — including
+    // which method the driver handle actually exposes, which differs between
+    // better-sqlite3 and the pg/mysql2 handles.
+    current = await createTestNextly({
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+      collections: [
+        defineCollection({
+          slug: "txlocalized",
+          localized: true,
+          fields: [
+            // Non-translatable, so this exercises the companion lookup without
+            // running into the separate, pre-existing gap that transactional
+            // creates have no companion-write step for translatable values.
+            text({ name: "title", localized: false }),
+            text({
+              name: "subtitle",
+              localized: false,
+              defaultValue: "from-default",
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const entries = current
+      .getService<CollectionsHandler>("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+
+    const created = await current.adapter.transaction(tx =>
+      entries.createEntryInTransaction(
+        tx as never,
+        { collectionName: "txlocalized", overrideAccess: true },
+        { title: "T" }
+      )
+    );
+    const id = (created as { data?: { id?: unknown } }).data?.id;
+    expect(typeof id, JSON.stringify(created)).toBe("string");
+
+    const read = await entries.getEntry({
+      collectionName: "txlocalized",
+      entryId: String(id),
+      overrideAccess: true,
+    });
+    const data = ((read as { data?: unknown }).data ?? {}) as Record<
+      string,
+      unknown
+    >;
+    expect(data.subtitle).toBe("from-default");
+  });
 });

--- a/packages/nextly/src/collections/__tests__/field-defaults.integration.test.ts
+++ b/packages/nextly/src/collections/__tests__/field-defaults.integration.test.ts
@@ -181,16 +181,16 @@ describe("field defaults on a collection create (integration)", () => {
     }
   });
 
-  it("applies defaults on a bulk create that skips hooks", async () => {
-    // A default is not a hook: an import opting out of hook execution still
-    // creates entries that must hold their declared values, and an omitted
-    // required field with a default would otherwise abort the whole import.
+  it("does not apply defaults on a bulk create", async () => {
+    // Bulk creates go through the transactional path, which does not seed
+    // defaults — see field-defaults-tx.integration.test.ts for why. Asserted
+    // here so the boundary is visible from both sides.
     const handler = await handlerFor();
     const entries = handler.getEntryService() as CollectionEntryService;
 
     const result = await entries.createEntries(
       { collectionName: "pages", overrideAccess: true },
-      [{ title: "One" }, { title: "Two" }],
+      [{ title: "One", mandatory: "given" }],
       { skipHooks: true }
     );
     expect(result.failed, JSON.stringify(result)).toBe(0);
@@ -201,11 +201,8 @@ describe("field defaults on a collection create (integration)", () => {
     });
     const items = ((list as { data?: { docs?: unknown[] } }).data?.docs ??
       []) as Record<string, unknown>[];
-    expect(items).toHaveLength(2);
-    for (const item of items) {
-      expect(item.subtitle).toBe("from-default");
-      expect(item.mandatory).toBe("filled");
-    }
+    expect(items).toHaveLength(1);
+    expect(items[0].subtitle).toBeNull();
   });
 
   it("leaves an omitted field alone on update", async () => {

--- a/packages/nextly/src/collections/__tests__/field-defaults.integration.test.ts
+++ b/packages/nextly/src/collections/__tests__/field-defaults.integration.test.ts
@@ -8,8 +8,11 @@
  * A unit test over the helper cannot show either, since both depend on where
  * the helper sits relative to validation and the insert.
  *
- * The suite self-skips on dialects whose URL is unset, per the integration
- * convention; CI runs all three.
+ * Runs on SQLite: `createTestNextly` provisions its system tables in an
+ * in-memory database and has no path that bootstraps them on Postgres or
+ * MySQL, so a suite built on it exercises one dialect whatever URLs are set.
+ * Nothing here is dialect-specific — the ordering and precedence rules under
+ * test live above the adapter.
  */
 import { afterEach, describe, expect, it } from "vitest";
 

--- a/packages/nextly/src/collections/__tests__/field-defaults.integration.test.ts
+++ b/packages/nextly/src/collections/__tests__/field-defaults.integration.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Declared defaults on a collection create, through the real write path.
+ *
+ * `defaultValue` was honoured only by the admin form (in the browser) and by a
+ * single's auto-create, so an entry written through the REST or Direct API
+ * stored nothing for an omitted field — and a REQUIRED field carrying a
+ * default could not be created at all, because validation saw an absent value.
+ * A unit test over the helper cannot show either, since both depend on where
+ * the helper sits relative to validation and the insert.
+ *
+ * The suite self-skips on dialects whose URL is unset, per the integration
+ * convention; CI runs all three.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { blocks, checkbox, defineCollection, number, text } from "../../config";
+import { createTestNextly, type TestNextly } from "../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../services/collections-handler";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const EMPTY_DOC = { formatVersion: 1, kind: "page", nodes: [] };
+
+async function handlerFor(): Promise<CollectionsHandler> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: "pages",
+        fields: [
+          text({ name: "title" }),
+          text({ name: "subtitle", defaultValue: "from-default" }),
+          text({ name: "mandatory", required: true, defaultValue: "filled" }),
+          text({ name: "derived", defaultValue: d => `re: ${d.title}` }),
+          number({ name: "rank", defaultValue: 7 }),
+          checkbox({ name: "featured", defaultValue: true }),
+          blocks({ name: "content", defaultValue: EMPTY_DOC }),
+        ],
+      }),
+    ],
+  });
+  return current.getService<CollectionsHandler>("collectionsHandler");
+}
+
+async function createAndRead(
+  handler: CollectionsHandler,
+  input: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const created = await handler.createEntry(
+    { collectionName: "pages", userId: "u1", overrideAccess: true },
+    input
+  );
+  const id = (created as { data?: { id?: unknown } }).data?.id;
+  expect(typeof id, JSON.stringify(created)).toBe("string");
+  const read = await handler.getEntry({
+    collectionName: "pages",
+    entryId: String(id),
+    overrideAccess: true,
+  });
+  return ((read as { data?: unknown }).data ?? {}) as Record<string, unknown>;
+}
+
+describe("field defaults on a collection create (integration)", () => {
+  it("applies a declared default for every omitted field", async () => {
+    const handler = await handlerFor();
+    const data = await createAndRead(handler, { title: "Home" });
+
+    expect(data.subtitle).toBe("from-default");
+    expect(data.rank).toBe(7);
+    expect(data.featured).toBe(true);
+    // A JSON-backed default reaches storage as a document, not a string.
+    expect(data.content).toEqual(EMPTY_DOC);
+  });
+
+  it("satisfies a required field that carries a default", async () => {
+    // Previously impossible: the create was rejected with REQUIRED because the
+    // default was never resolved before validation ran.
+    const handler = await handlerFor();
+    const data = await createAndRead(handler, { title: "Home" });
+    expect(data.mandatory).toBe("filled");
+  });
+
+  it("leaves a function default unapplied, since it cannot be stored", async () => {
+    // A collection's fields reach the write path from its stored definition,
+    // and a function does not survive being stored, so by then the field looks
+    // as though no default was declared. Asserted rather than left implicit so
+    // the boundary is visible and a future change to it is deliberate.
+    const handler = await handlerFor();
+    const data = await createAndRead(handler, { title: "Home" });
+    expect(data.derived).toBeNull();
+  });
+
+  it("never overwrites a value the caller supplied", async () => {
+    const handler = await handlerFor();
+    const data = await createAndRead(handler, {
+      title: "Home",
+      subtitle: "explicit",
+      rank: 0,
+      featured: false,
+    });
+
+    expect(data.subtitle).toBe("explicit");
+    // Falsy values are supplied values, not absent ones.
+    expect(data.rank).toBe(0);
+    expect(data.featured).toBe(false);
+  });
+
+  it("treats an explicit null as a decision, not an omission", async () => {
+    // Null is how a JSON body says "no value"; defaulting over it would make
+    // the field impossible to leave empty.
+    const handler = await handlerFor();
+    const data = await createAndRead(handler, {
+      title: "Home",
+      subtitle: null,
+    });
+    expect(data.subtitle).toBeNull();
+  });
+
+  it("leaves an omitted field alone on update", async () => {
+    const handler = await handlerFor();
+    const created = await handler.createEntry(
+      { collectionName: "pages", userId: "u1", overrideAccess: true },
+      { title: "Home", subtitle: "explicit" }
+    );
+    const id = String((created as { data?: { id?: unknown } }).data?.id);
+
+    await handler.updateEntry(
+      {
+        collectionName: "pages",
+        entryId: id,
+        userId: "u1",
+        overrideAccess: true,
+      },
+      { title: "Renamed" }
+    );
+
+    const read = await handler.getEntry({
+      collectionName: "pages",
+      entryId: id,
+      overrideAccess: true,
+    });
+    const data = ((read as { data?: unknown }).data ?? {}) as Record<
+      string,
+      unknown
+    >;
+    // A default must not resurrect on every later write.
+    expect(data.subtitle).toBe("explicit");
+    expect(data.title).toBe("Renamed");
+  });
+});

--- a/packages/nextly/src/collections/__tests__/field-defaults.integration.test.ts
+++ b/packages/nextly/src/collections/__tests__/field-defaults.integration.test.ts
@@ -28,6 +28,7 @@ import {
 import { registerHook, unregisterHook } from "../../hooks";
 import { createTestNextly, type TestNextly } from "../../plugins/test-nextly";
 import type { CollectionsHandler } from "../../services/collections-handler";
+import type { CollectionEntryService } from "../../services/collections/collection-entry-service";
 
 let current: TestNextly | undefined;
 
@@ -177,6 +178,33 @@ describe("field defaults on a collection create (integration)", () => {
       expect(seen).toEqual(["from-default"]);
     } finally {
       unregisterHook("beforeCreate", "pages", probe);
+    }
+  });
+
+  it("applies defaults on a bulk create that skips hooks", async () => {
+    // A default is not a hook: an import opting out of hook execution still
+    // creates entries that must hold their declared values, and an omitted
+    // required field with a default would otherwise abort the whole import.
+    const handler = await handlerFor();
+    const entries = handler.getEntryService() as CollectionEntryService;
+
+    const result = await entries.createEntries(
+      { collectionName: "pages", overrideAccess: true },
+      [{ title: "One" }, { title: "Two" }],
+      { skipHooks: true }
+    );
+    expect(result.failed, JSON.stringify(result)).toBe(0);
+
+    const list = await handler.listEntries({
+      collectionName: "pages",
+      overrideAccess: true,
+    });
+    const items = ((list as { data?: { docs?: unknown[] } }).data?.docs ??
+      []) as Record<string, unknown>[];
+    expect(items).toHaveLength(2);
+    for (const item of items) {
+      expect(item.subtitle).toBe("from-default");
+      expect(item.mandatory).toBe("filled");
     }
   });
 

--- a/packages/nextly/src/collections/__tests__/field-defaults.integration.test.ts
+++ b/packages/nextly/src/collections/__tests__/field-defaults.integration.test.ts
@@ -25,6 +25,7 @@ import {
   repeater,
   text,
 } from "../../config";
+import { registerHook, unregisterHook } from "../../hooks";
 import { createTestNextly, type TestNextly } from "../../plugins/test-nextly";
 import type { CollectionsHandler } from "../../services/collections-handler";
 
@@ -157,6 +158,26 @@ describe("field defaults on a collection create (integration)", () => {
       subtitle: null,
     });
     expect(data.subtitle).toBeNull();
+  });
+
+  it("shows a defaulted value to a collection hook", async () => {
+    // Collection beforeValidate/beforeChange map to the beforeCreate registry,
+    // which runs ahead of validation — a hook deriving one field from a
+    // defaulted sibling must not see undefined.
+    const seen: unknown[] = [];
+    const probe = (ctx: { data: unknown }): unknown => {
+      seen.push((ctx.data as Record<string, unknown>).subtitle);
+      return ctx.data;
+    };
+    // Registered after boot: creating the instance resets the hook registry.
+    const handler = await handlerFor();
+    registerHook("beforeCreate", "pages", probe);
+    try {
+      await createAndRead(handler, { title: "Home" });
+      expect(seen).toEqual(["from-default"]);
+    } finally {
+      unregisterHook("beforeCreate", "pages", probe);
+    }
   });
 
   it("leaves an omitted field alone on update", async () => {

--- a/packages/nextly/src/collections/__tests__/field-defaults.integration.test.ts
+++ b/packages/nextly/src/collections/__tests__/field-defaults.integration.test.ts
@@ -13,7 +13,15 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 
-import { blocks, checkbox, defineCollection, number, text } from "../../config";
+import {
+  blocks,
+  checkbox,
+  defineCollection,
+  group,
+  number,
+  repeater,
+  text,
+} from "../../config";
 import { createTestNextly, type TestNextly } from "../../plugins/test-nextly";
 import type { CollectionsHandler } from "../../services/collections-handler";
 
@@ -39,6 +47,17 @@ async function handlerFor(): Promise<CollectionsHandler> {
           number({ name: "rank", defaultValue: 7 }),
           checkbox({ name: "featured", defaultValue: true }),
           blocks({ name: "content", defaultValue: EMPTY_DOC }),
+          group({
+            name: "seo",
+            fields: [
+              text({ name: "metaTitle", required: true, defaultValue: "mt" }),
+              text({ name: "metaDesc", defaultValue: "md" }),
+            ],
+          }),
+          repeater({
+            name: "items",
+            fields: [text({ name: "label", defaultValue: "dl" })],
+          }),
         ],
       }),
     ],
@@ -92,6 +111,23 @@ describe("field defaults on a collection create (integration)", () => {
     const handler = await handlerFor();
     const data = await createAndRead(handler, { title: "Home" });
     expect(data.derived).toBeNull();
+  });
+
+  it("fills a group's children, including a required one", async () => {
+    // Validation recurses into a group, so a required child with a default
+    // was previously impossible to satisfy without sending the group.
+    const handler = await handlerFor();
+    const data = await createAndRead(handler, { title: "Home" });
+    expect(data.seo).toEqual({ metaTitle: "mt", metaDesc: "md" });
+  });
+
+  it("fills the children of each supplied repeater row", async () => {
+    const handler = await handlerFor();
+    const data = await createAndRead(handler, {
+      title: "Home",
+      items: [{ label: "given" }, {}],
+    });
+    expect(data.items).toEqual([{ label: "given" }, { label: "dl" }]);
   });
 
   it("never overwrites a value the caller supplied", async () => {

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -15,7 +15,7 @@
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
-import { eq, ne, and, like, ilike } from "drizzle-orm";
+import { eq, ne, and, like, ilike, sql } from "drizzle-orm";
 
 // `OperationType` was removed during the PR 4 migration — this module no longer
 // references it, so we import only `BeforeOperationArgs`.
@@ -649,14 +649,23 @@ export class CollectionMutationService extends BaseService {
 
   /** Whether the companion `_locales` table physically exists (migration has run). */
   private async companionTableExists(
-    companionTableName: string
+    companionTableName: string,
+    // Bind the probe to a caller's transaction when there is one. Issued
+    // against the pool instead, it would ask for a second connection while the
+    // transaction still holds the first, and on a single-connection pool that
+    // waits forever rather than failing.
+    executor?: { execute: (query: unknown) => Promise<unknown> }
   ): Promise<boolean> {
     const q =
       this.adapter.dialect === "mysql"
         ? `\`${companionTableName}\``
         : `"${companionTableName}"`;
     try {
-      await this.adapter.executeQuery(`SELECT 1 FROM ${q} LIMIT 0`);
+      if (executor) {
+        await executor.execute(sql.raw(`SELECT 1 FROM ${q} LIMIT 0`));
+      } else {
+        await this.adapter.executeQuery(`SELECT 1 FROM ${q} LIMIT 0`);
+      }
       return true;
     } catch {
       return false;
@@ -792,33 +801,35 @@ export class CollectionMutationService extends BaseService {
    * The fields a transactional create may seed a default into.
    *
    * Once the companion migration has run, a localized collection's translatable
-   * columns live on the `_locales` table and no longer exist on the main one.
-   * The pooled path splits those values out and writes the companion row; the
-   * transactional paths have no such step, so seeding a translatable default
-   * there would put a key in the main-table insert for a column that is gone.
+   * columns live on the `<table>_locales` table and no longer exist on the main
+   * one. The pooled path splits those values out and writes the companion row;
+   * the transactional paths have no such step, so seeding a translatable
+   * default there would put a key in the main-table insert for a column that is
+   * gone.
    *
-   * The companion is checked for existence rather than reading `localized`
-   * alone, matching `splitLocalizedWriteData`: before the migration the
-   * translatable columns are still on the main table, so their defaults apply
-   * exactly as they do on the pooled path. Only after it do they drop out,
-   * which leaves those fields behaving as they did before defaults existed at
-   * all — no worse, and unchanged for every collection that is not localized.
+   * Existence is probed rather than reading `localized` alone, matching
+   * `splitLocalizedWriteData`: before the migration the translatable columns are
+   * still on the main table and their defaults apply exactly as on the pooled
+   * path. The probe runs on the caller's transaction connection, and the
+   * companion name follows the `<table>_locales` convention rather than going
+   * through a metadata lookup, so neither asks the pool for a second connection
+   * while the transaction holds one.
    */
   private async defaultableFields(
-    collectionName: string,
+    tx: TransactionContext,
     collection: unknown,
+    tableName: string,
     fields: FieldDefinition[]
   ): Promise<FieldDefinition[]> {
     const isLocalized =
       (collection as { localized?: boolean } | undefined)?.localized === true;
     if (!isLocalized || !this.localization) return fields;
 
-    const companion =
-      await this.fileManager.loadCompanionSchema(collectionName);
-    if (!companion) return fields;
-    if (!(await this.companionTableExists(companion.companionTableName))) {
-      return fields;
-    }
+    const exists = await this.companionTableExists(
+      `${tableName}_locales`,
+      tx.getDrizzle()
+    );
+    if (!exists) return fields;
 
     const translatable = new Set(resolveLocalizedFieldNames(fields, true));
     return fields.filter(f => !translatable.has(f.name));
@@ -5053,7 +5064,7 @@ export class CollectionMutationService extends BaseService {
       const seededBody: Record<string, unknown> = { ...body };
       applyFieldDefaults(
         seededBody,
-        await this.defaultableFields(params.collectionName, collection, fields)
+        await this.defaultableFields(tx, collection, tableName, fields)
       );
 
       const beforeOpArgs =
@@ -6271,7 +6282,7 @@ export class CollectionMutationService extends BaseService {
       // field with a default would otherwise abort the whole batch.
       applyFieldDefaults(
         currentData,
-        await this.defaultableFields(params.collectionName, collection, fields)
+        await this.defaultableFields(tx, collection, tableName, fields)
       );
 
       // Execute hooks (unless skipped)

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -74,6 +74,7 @@ import {
 } from "../../../shared/lib/password-fields";
 import type { SupportedDialect } from "../../../types/database";
 import type { DynamicCollectionService } from "../../dynamic-collections";
+import { resolveLocalizedFieldNames } from "../../i18n/classify-fields";
 import {
   populateCompanionFields,
   populateCompanionFieldsAllLocales,
@@ -777,6 +778,29 @@ export class CollectionMutationService extends BaseService {
    * SQLite happens to stringify, which is why a suite running there alone
    * cannot show the difference.
    */
+  /**
+   * The fields a transactional create may seed a default into.
+   *
+   * On a migrated localized collection the translatable columns live on the
+   * `_locales` companion, not the main table. The pooled path splits those
+   * values out and writes the companion row; the transactional paths have no
+   * such step, so seeding a translatable default here would put a key in the
+   * main-table insert for a column that does not exist. Skipping them keeps a
+   * declared default from turning every transactional create on such a
+   * collection into a failure — the translatable default simply does not
+   * apply on this path until the companion write exists here too.
+   */
+  private defaultableFields(
+    collection: unknown,
+    fields: FieldDefinition[]
+  ): FieldDefinition[] {
+    const isLocalized =
+      (collection as { localized?: boolean } | undefined)?.localized === true;
+    if (!isLocalized) return fields;
+    const translatable = new Set(resolveLocalizedFieldNames(fields, true));
+    return fields.filter(f => !translatable.has(f.name));
+  }
+
   private serializeJsonFieldsForInsert(
     data: Record<string, unknown>,
     fields: FieldDefinition[]
@@ -785,7 +809,37 @@ export class CollectionMutationService extends BaseService {
       if (!isJsonFieldType(field.type, field)) continue;
       const value = data[field.name];
       if (value == null || typeof value !== "object") continue;
-      data[field.name] = JSON.stringify(value);
+
+      // A relationship nested in a group or repeater is stored as its id. A
+      // populated object reaching the stringify below would be frozen into the
+      // JSON as a whole record, so the same normalization the pooled path runs
+      // has to happen here, before the value becomes text.
+      const nestedFields = field.fields ?? [];
+      const hasNestedRelationship = nestedFields.some(
+        f =>
+          isRelationshipField(f.type) ||
+          f.type === "repeater" ||
+          f.type === "group"
+      );
+      let normalized: unknown = value;
+      if (hasNestedRelationship) {
+        if (field.type === "repeater" && Array.isArray(value)) {
+          normalized = value.map(row =>
+            row && typeof row === "object" && !Array.isArray(row)
+              ? normalizeNestedRelationships(
+                  row as Record<string, unknown>,
+                  nestedFields
+                )
+              : row
+          );
+        } else if (field.type === "group" && !Array.isArray(value)) {
+          normalized = normalizeNestedRelationships(
+            value as Record<string, unknown>,
+            nestedFields
+          );
+        }
+      }
+      data[field.name] = JSON.stringify(normalized);
     }
   }
 
@@ -1567,28 +1621,34 @@ export class CollectionMutationService extends BaseService {
 
       // Execute beforeOperation hooks FIRST (before operation-specific hooks)
       // Can modify operation arguments or throw to abort
+      // Declared defaults are seeded before the first hook phase, so every hook
+      // — beforeOperation included — sees the values the entry will hold, and a
+      // hook that removes a defaulted field is not overridden by a later pass
+      // re-adding it. Seeded onto a copy so the caller's own object is not
+      // mutated. Everything after this point (generation, write access,
+      // validation, the insert) therefore works from complete data; generation
+      // still fills only the identity fields left unresolved, and running ahead
+      // of write access matches generation, so a field the caller may not
+      // create is not reintroduced.
+      const seededBody: Record<string, unknown> = { ...body };
+      applyFieldDefaults(seededBody, fields);
+
       const beforeOpArgs =
         await this.hookService.hookRegistry.executeBeforeOperation({
           collection: params.collectionName,
           operation: "create",
-          args: { data: body },
+          args: { data: seededBody },
           user: params.user
             ? { id: params.user.id, email: params.user.email }
             : undefined,
           context: sharedContext,
         });
 
-      // Use modified data if returned by beforeOperation
-      const currentData = (beforeOpArgs as BeforeOperationArgs)?.data ?? body;
-      // Declared defaults are filled before any hook runs, so a collection
-      // hook deriving one field from another sees the value the entry will
-      // hold rather than undefined, and a hook that removes a defaulted field
-      // is not overridden by a later pass re-adding it. Everything after this
-      // point — generation, write access, validation, the insert — works from
-      // complete data. Generation still fills only the identity fields left
-      // unresolved, and running ahead of write access matches generation, so a
-      // field the caller may not create is not reintroduced.
-      applyFieldDefaults(currentData, fields);
+      // Use modified data if returned by beforeOperation. A hook returning its
+      // own object owns what is in it, defaults included — they are not
+      // re-applied here, or a hook could never drop one.
+      const currentData =
+        (beforeOpArgs as BeforeOperationArgs)?.data ?? seededBody;
 
       // Execute beforeCreate hooks (code-registered)
       // Hooks run before validation and can modify the incoming data
@@ -4948,11 +5008,26 @@ export class CollectionMutationService extends BaseService {
 
       // Execute beforeOperation hooks FIRST (before operation-specific hooks)
       // Can modify operation arguments or throw to abort
+      // Declared defaults are seeded before the first hook phase, so every hook
+      // — beforeOperation included — sees the values the entry will hold, and a
+      // hook that removes a defaulted field is not overridden by a later pass
+      // re-adding it. Seeded onto a copy so the caller's own object is not
+      // mutated. Everything after this point (generation, write access,
+      // validation, the insert) therefore works from complete data; generation
+      // still fills only the identity fields left unresolved, and running ahead
+      // of write access matches generation, so a field the caller may not
+      // create is not reintroduced.
+      const seededBody: Record<string, unknown> = { ...body };
+      applyFieldDefaults(
+        seededBody,
+        this.defaultableFields(collection, fields)
+      );
+
       const beforeOpArgs =
         await this.hookService.hookRegistry.executeBeforeOperation({
           collection: params.collectionName,
           operation: "create",
-          args: { data: body },
+          args: { data: seededBody },
           user: params.user
             ? { id: params.user.id, email: params.user.email }
             : undefined,
@@ -4962,17 +5037,11 @@ export class CollectionMutationService extends BaseService {
           executor: tx.getDrizzle(),
         });
 
-      // Use modified data if returned by beforeOperation
-      const currentData = (beforeOpArgs as BeforeOperationArgs)?.data ?? body;
-      // Declared defaults are filled before any hook runs, so a collection
-      // hook deriving one field from another sees the value the entry will
-      // hold rather than undefined, and a hook that removes a defaulted field
-      // is not overridden by a later pass re-adding it. Everything after this
-      // point — generation, write access, validation, the insert — works from
-      // complete data. Generation still fills only the identity fields left
-      // unresolved, and running ahead of write access matches generation, so a
-      // field the caller may not create is not reintroduced.
-      applyFieldDefaults(currentData, fields);
+      // Use modified data if returned by beforeOperation. A hook returning its
+      // own object owns what is in it, defaults included — they are not
+      // re-applied here, or a hook could never drop one.
+      const currentData =
+        (beforeOpArgs as BeforeOperationArgs)?.data ?? seededBody;
 
       // Execute beforeCreate hooks (code-registered)
       const beforeContext = this.hookService.buildHookContext({
@@ -6163,12 +6232,14 @@ export class CollectionMutationService extends BaseService {
       // Shared context between all hooks in this request
       const sharedContext: Record<string, unknown> = {};
 
-      // Defaults are not hooks: a bulk import that opts out of hook execution
-      // still creates entries that must hold their declared defaults, and an
-      // omitted required field with a default would otherwise fail validation
-      // and abort the import. Applied again inside the block below because
-      // `beforeOperation` may replace the data object entirely.
-      applyFieldDefaults(currentData, fields);
+      // Seeded before the hook branch, so it happens either way: a default is
+      // not a hook, and an import opting out of hook execution still creates
+      // entries that must hold their declared values — an omitted required
+      // field with a default would otherwise abort the whole batch.
+      applyFieldDefaults(
+        currentData,
+        this.defaultableFields(collection, fields)
+      );
 
       // Execute hooks (unless skipped)
       if (!skipHooks) {
@@ -6178,7 +6249,7 @@ export class CollectionMutationService extends BaseService {
           await this.hookService.hookRegistry.executeBeforeOperation({
             collection: params.collectionName,
             operation: "create",
-            args: { data: body },
+            args: { data: currentData },
             user: params.user
               ? { id: params.user.id, email: params.user.email }
               : undefined,
@@ -6193,11 +6264,7 @@ export class CollectionMutationService extends BaseService {
           ((beforeOpArgs as BeforeOperationArgs)?.data as Record<
             string,
             unknown
-          >) ?? body;
-        // Re-applied because the line above may have swapped in a different
-        // object; filling before the beforeCreate pipeline means a collection
-        // hook sees the value the entry will hold rather than undefined.
-        applyFieldDefaults(currentData, fields);
+          >) ?? currentData;
 
         // Execute beforeCreate hooks (code-registered)
         const beforeContext = this.hookService.buildHookContext({

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -15,7 +15,7 @@
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
-import { eq, ne, and, like, ilike, sql } from "drizzle-orm";
+import { eq, ne, and, like, ilike } from "drizzle-orm";
 
 // `OperationType` was removed during the PR 4 migration — this module no longer
 // references it, so we import only `BeforeOperationArgs`.
@@ -74,7 +74,6 @@ import {
 } from "../../../shared/lib/password-fields";
 import type { SupportedDialect } from "../../../types/database";
 import type { DynamicCollectionService } from "../../dynamic-collections";
-import { resolveLocalizedFieldNames } from "../../i18n/classify-fields";
 import {
   populateCompanionFields,
   populateCompanionFieldsAllLocales,
@@ -285,36 +284,7 @@ export interface TransitionAuthorization {
   } | null;
 }
 
-/**
- * How many rows a driver returned, whatever shape it reports them in.
- *
- * mysql2 answers with a `[rows, fieldPackets]` tuple, node-postgres with an
- * object carrying `rows`, and better-sqlite3 with the rows themselves. Reading
- * the outer array blindly counts the mysql2 tuple as two rows, which turns
- * "no such table" into "it exists".
- */
-function countRows(result: unknown): number {
-  if (Array.isArray(result)) {
-    // A mysql2 tuple's first element is the row array; a plain row list's
-    // first element is a row object.
-    return Array.isArray(result[0]) ? result[0].length : result.length;
-  }
-  if (result && typeof result === "object" && "rows" in result) {
-    const rows = (result as { rows?: unknown }).rows;
-    return Array.isArray(rows) ? rows.length : 0;
-  }
-  return 0;
-}
-
 /** Whether a string is already the stored JSON representation of a value. */
-function isParsableJson(value: string): boolean {
-  try {
-    JSON.parse(value);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 export class CollectionMutationService extends BaseService {
   constructor(
@@ -670,52 +640,18 @@ export class CollectionMutationService extends BaseService {
 
   /** Whether the companion `_locales` table physically exists (migration has run). */
   private async companionTableExists(
-    companionTableName: string,
-    // Bind the probe to a caller's transaction when there is one. Issued
-    // against the pool instead, it would ask for a second connection while the
-    // transaction still holds the first, and on a single-connection pool that
-    // waits forever rather than failing.
-    executor?: { execute: (query: unknown) => Promise<unknown> }
+    companionTableName: string
   ): Promise<boolean> {
-    if (!executor) {
-      const q =
-        this.adapter.dialect === "mysql"
-          ? `\`${companionTableName}\``
-          : `"${companionTableName}"`;
-      try {
-        await this.adapter.executeQuery(`SELECT 1 FROM ${q} LIMIT 0`);
-        return true;
-      } catch {
-        return false;
-      }
+    const q =
+      this.adapter.dialect === "mysql"
+        ? `\`${companionTableName}\``
+        : `"${companionTableName}"`;
+    try {
+      await this.adapter.executeQuery(`SELECT 1 FROM ${q} LIMIT 0`);
+      return true;
+    } catch {
+      return false;
     }
-
-    // Inside a transaction the question has to be asked WITHOUT touching the
-    // table, because selecting from one that does not exist is an error, and
-    // PostgreSQL marks the whole transaction aborted the moment a statement
-    // fails — every later statement then fails too, however the error was
-    // caught. Reading the catalog succeeds either way and answers the same
-    // question.
-    const query =
-      this.adapter.dialect === "sqlite"
-        ? sql`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ${companionTableName} LIMIT 1`
-        : this.adapter.dialect === "mysql"
-          ? sql`SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ${companionTableName} LIMIT 1`
-          : sql`SELECT 1 FROM information_schema.tables WHERE table_name = ${companionTableName} AND table_schema = ANY (current_schemas(false)) LIMIT 1`;
-
-    // The handles differ by driver: better-sqlite3 exposes `all` and has no
-    // `execute` at all, while the pg and mysql2 handles use `execute`. Picked
-    // by capability rather than by dialect, so a handle is never called
-    // through a method it does not have.
-    const handle = executor as {
-      all?: (query: unknown) => Promise<unknown>;
-      execute?: (query: unknown) => Promise<unknown>;
-    };
-    const raw = handle.all
-      ? await handle.all(query)
-      : await handle.execute?.(query);
-
-    return countRows(raw) > 0;
   }
 
   /**
@@ -843,95 +779,6 @@ export class CollectionMutationService extends BaseService {
    * SQLite happens to stringify, which is why a suite running there alone
    * cannot show the difference.
    */
-  /**
-   * The fields a transactional create may seed a default into.
-   *
-   * Once the companion migration has run, a localized collection's translatable
-   * columns live on the `<table>_locales` table and no longer exist on the main
-   * one. The pooled path splits those values out and writes the companion row;
-   * the transactional paths have no such step, so seeding a translatable
-   * default there would put a key in the main-table insert for a column that is
-   * gone.
-   *
-   * Existence is probed rather than reading `localized` alone, matching
-   * `splitLocalizedWriteData`: before the migration the translatable columns are
-   * still on the main table and their defaults apply exactly as on the pooled
-   * path. The probe runs on the caller's transaction connection, and the
-   * companion name follows the `<table>_locales` convention rather than going
-   * through a metadata lookup, so neither asks the pool for a second connection
-   * while the transaction holds one.
-   */
-  private async defaultableFields(
-    tx: TransactionContext,
-    collection: unknown,
-    tableName: string,
-    fields: FieldDefinition[]
-  ): Promise<FieldDefinition[]> {
-    const isLocalized =
-      (collection as { localized?: boolean } | undefined)?.localized === true;
-    if (!isLocalized || !this.localization) return fields;
-
-    const exists = await this.companionTableExists(
-      `${tableName}_locales`,
-      tx.getDrizzle()
-    );
-    if (!exists) return fields;
-
-    const translatable = new Set(resolveLocalizedFieldNames(fields, true));
-    return fields.filter(f => !translatable.has(f.name));
-  }
-
-  private serializeJsonFieldsForInsert(
-    data: Record<string, unknown>,
-    fields: FieldDefinition[]
-  ): void {
-    for (const field of fields) {
-      if (!isJsonFieldType(field.type, field)) continue;
-      const value = data[field.name];
-      if (value == null) continue;
-
-      // A JSON column stores a JSON DOCUMENT, so a scalar has to be encoded
-      // too: the string `enabled` is not valid JSON, `"enabled"` is. A string
-      // that already parses is left alone, since it is the stored
-      // representation and encoding it again would nest it.
-      if (typeof value !== "object") {
-        if (typeof value === "string" && isParsableJson(value)) continue;
-        data[field.name] = JSON.stringify(value);
-        continue;
-      }
-
-      // A relationship nested in a group or repeater is stored as its id. A
-      // populated object reaching the stringify below would be frozen into the
-      // JSON as a whole record, so the same normalization the pooled path runs
-      // has to happen here, before the value becomes text.
-      const nestedFields = field.fields ?? [];
-      const hasNestedRelationship = nestedFields.some(
-        f =>
-          isRelationshipField(f.type) ||
-          f.type === "repeater" ||
-          f.type === "group"
-      );
-      let normalized: unknown = value;
-      if (hasNestedRelationship) {
-        if (field.type === "repeater" && Array.isArray(value)) {
-          normalized = value.map(row =>
-            row && typeof row === "object" && !Array.isArray(row)
-              ? normalizeNestedRelationships(
-                  row as Record<string, unknown>,
-                  nestedFields
-                )
-              : row
-          );
-        } else if (field.type === "group" && !Array.isArray(value)) {
-          normalized = normalizeNestedRelationships(
-            value as Record<string, unknown>,
-            nestedFields
-          );
-        }
-      }
-      data[field.name] = JSON.stringify(normalized);
-    }
-  }
 
   private deserializeJsonFieldsForSnapshot(
     row: Record<string, unknown>,
@@ -5098,26 +4945,11 @@ export class CollectionMutationService extends BaseService {
 
       // Execute beforeOperation hooks FIRST (before operation-specific hooks)
       // Can modify operation arguments or throw to abort
-      // Declared defaults are seeded before the first hook phase, so every hook
-      // — beforeOperation included — sees the values the entry will hold, and a
-      // hook that removes a defaulted field is not overridden by a later pass
-      // re-adding it. Seeded onto a copy so the caller's own object is not
-      // mutated. Everything after this point (generation, write access,
-      // validation, the insert) therefore works from complete data; generation
-      // still fills only the identity fields left unresolved, and running ahead
-      // of write access matches generation, so a field the caller may not
-      // create is not reintroduced.
-      const seededBody: Record<string, unknown> = { ...body };
-      applyFieldDefaults(
-        seededBody,
-        await this.defaultableFields(tx, collection, tableName, fields)
-      );
-
       const beforeOpArgs =
         await this.hookService.hookRegistry.executeBeforeOperation({
           collection: params.collectionName,
           operation: "create",
-          args: { data: seededBody },
+          args: { data: body },
           user: params.user
             ? { id: params.user.id, email: params.user.email }
             : undefined,
@@ -5130,8 +4962,7 @@ export class CollectionMutationService extends BaseService {
       // Use modified data if returned by beforeOperation. A hook returning its
       // own object owns what is in it, defaults included — they are not
       // re-applied here, or a hook could never drop one.
-      const currentData =
-        (beforeOpArgs as BeforeOperationArgs)?.data ?? seededBody;
+      const currentData = (beforeOpArgs as BeforeOperationArgs)?.data ?? body;
 
       // Execute beforeCreate hooks (code-registered)
       const beforeContext = this.hookService.buildHookContext({
@@ -5324,10 +5155,6 @@ export class CollectionMutationService extends BaseService {
 
       // Prepare entry data
       const nowForTxCreate = new Date();
-      // A raw tx.insert follows, with none of the pooled path's serialization
-      // in between, so JSON-backed values are stringified here instead.
-      this.serializeJsonFieldsForInsert(finalData, fields);
-
       const entryData = {
         id: this.collectionService.generateId(),
         // Strip client-supplied system columns (id / timestamps / created_by,
@@ -6322,15 +6149,6 @@ export class CollectionMutationService extends BaseService {
       // Shared context between all hooks in this request
       const sharedContext: Record<string, unknown> = {};
 
-      // Seeded before the hook branch, so it happens either way: a default is
-      // not a hook, and an import opting out of hook execution still creates
-      // entries that must hold their declared values — an omitted required
-      // field with a default would otherwise abort the whole batch.
-      applyFieldDefaults(
-        currentData,
-        await this.defaultableFields(tx, collection, tableName, fields)
-      );
-
       // Execute hooks (unless skipped)
       if (!skipHooks) {
         // Execute beforeOperation hooks FIRST (before operation-specific hooks)
@@ -6551,10 +6369,6 @@ export class CollectionMutationService extends BaseService {
 
       // Prepare entry data
       const nowForTxCreate = new Date();
-      // A raw tx.insert follows, with none of the pooled path's serialization
-      // in between, so JSON-backed values are stringified here instead.
-      this.serializeJsonFieldsForInsert(finalData, fields);
-
       const entryData = {
         id: this.collectionService.generateId(),
         // Strip client-supplied system columns (id / timestamps / created_by,

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1558,6 +1558,15 @@ export class CollectionMutationService extends BaseService {
 
       // Use modified data if returned by beforeOperation
       const currentData = (beforeOpArgs as BeforeOperationArgs)?.data ?? body;
+      // Declared defaults are filled before any hook runs, so a collection
+      // hook deriving one field from another sees the value the entry will
+      // hold rather than undefined, and a hook that removes a defaulted field
+      // is not overridden by a later pass re-adding it. Everything after this
+      // point — generation, write access, validation, the insert — works from
+      // complete data. Generation still fills only the identity fields left
+      // unresolved, and running ahead of write access matches generation, so a
+      // field the caller may not create is not reintroduced.
+      applyFieldDefaults(currentData, fields);
 
       // Execute beforeCreate hooks (code-registered)
       // Hooks run before validation and can modify the incoming data
@@ -1611,15 +1620,6 @@ export class CollectionMutationService extends BaseService {
       // without a manual slug. Running before write access means a field the
       // caller may not create is not reintroduced; the uniqueness check uses
       // the shared connection (a plain, non-transactional create).
-      // Declared defaults are filled first so everything downstream sees the
-      // values the entry will actually hold: generation then fills only the
-      // identity fields still unresolved, a field-level access predicate reads
-      // final values rather than undefined, and a required field carrying a
-      // default is satisfied by the time validation runs. Placed before write
-      // access for the same reason generation is — a field the caller may not
-      // create must not be reintroduced here.
-      applyFieldDefaults(finalData, fields);
-
       const isSlugTaken = (slug: string) =>
         this.checkFieldUniqueness(params.collectionName, "slug", slug);
       await this.applyGeneratedSlugAndTitle(finalData, isSlugTaken);
@@ -4942,6 +4942,15 @@ export class CollectionMutationService extends BaseService {
 
       // Use modified data if returned by beforeOperation
       const currentData = (beforeOpArgs as BeforeOperationArgs)?.data ?? body;
+      // Declared defaults are filled before any hook runs, so a collection
+      // hook deriving one field from another sees the value the entry will
+      // hold rather than undefined, and a hook that removes a defaulted field
+      // is not overridden by a later pass re-adding it. Everything after this
+      // point — generation, write access, validation, the insert — works from
+      // complete data. Generation still fills only the identity fields left
+      // unresolved, and running ahead of write access matches generation, so a
+      // field the caller may not create is not reintroduced.
+      applyFieldDefaults(currentData, fields);
 
       // Execute beforeCreate hooks (code-registered)
       const beforeContext = this.hookService.buildHookContext({
@@ -4997,15 +5006,6 @@ export class CollectionMutationService extends BaseService {
       // validation (see createEntry). The uniqueness check runs on the
       // transaction so same-title creates within one uncommitted tx still
       // dedupe — the tx sees its own pending rows.
-      // Declared defaults are filled first so everything downstream sees the
-      // values the entry will actually hold: generation then fills only the
-      // identity fields still unresolved, a field-level access predicate reads
-      // final values rather than undefined, and a required field carrying a
-      // default is satisfied by the time validation runs. Placed before write
-      // access for the same reason generation is — a field the caller may not
-      // create must not be reintroduced here.
-      applyFieldDefaults(finalData, fields);
-
       const isSlugTaken = async (slug: string) => {
         const existing = await tx.selectOne<Record<string, unknown>>(
           tableName,
@@ -6161,6 +6161,15 @@ export class CollectionMutationService extends BaseService {
             string,
             unknown
           >) ?? body;
+        // Declared defaults are filled before any hook runs, so a collection
+        // hook deriving one field from another sees the value the entry will
+        // hold rather than undefined, and a hook that removes a defaulted field
+        // is not overridden by a later pass re-adding it. Everything after this
+        // point — generation, write access, validation, the insert — works from
+        // complete data. Generation still fills only the identity fields left
+        // unresolved, and running ahead of write access matches generation, so a
+        // field the caller may not create is not reintroduced.
+        applyFieldDefaults(currentData, fields);
 
         // Execute beforeCreate hooks (code-registered)
         const beforeContext = this.hookService.buildHookContext({
@@ -6219,15 +6228,6 @@ export class CollectionMutationService extends BaseService {
       // entry that omits slug/title must still receive them. The uniqueness
       // check runs on the transaction so entries created earlier in the same
       // bulk batch are seen.
-      // Declared defaults are filled first so everything downstream sees the
-      // values the entry will actually hold: generation then fills only the
-      // identity fields still unresolved, a field-level access predicate reads
-      // final values rather than undefined, and a required field carrying a
-      // default is satisfied by the time validation runs. Placed before write
-      // access for the same reason generation is — a field the caller may not
-      // create must not be reintroduced here.
-      applyFieldDefaults(finalData, fields);
-
       const isSlugTaken = async (slug: string) => {
         const existing = await tx.selectOne<Record<string, unknown>>(
           tableName,

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -285,6 +285,27 @@ export interface TransitionAuthorization {
   } | null;
 }
 
+/**
+ * How many rows a driver returned, whatever shape it reports them in.
+ *
+ * mysql2 answers with a `[rows, fieldPackets]` tuple, node-postgres with an
+ * object carrying `rows`, and better-sqlite3 with the rows themselves. Reading
+ * the outer array blindly counts the mysql2 tuple as two rows, which turns
+ * "no such table" into "it exists".
+ */
+function countRows(result: unknown): number {
+  if (Array.isArray(result)) {
+    // A mysql2 tuple's first element is the row array; a plain row list's
+    // first element is a row object.
+    return Array.isArray(result[0]) ? result[0].length : result.length;
+  }
+  if (result && typeof result === "object" && "rows" in result) {
+    const rows = (result as { rows?: unknown }).rows;
+    return Array.isArray(rows) ? rows.length : 0;
+  }
+  return 0;
+}
+
 /** Whether a string is already the stored JSON representation of a value. */
 function isParsableJson(value: string): boolean {
   try {
@@ -682,14 +703,19 @@ export class CollectionMutationService extends BaseService {
           ? sql`SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ${companionTableName} LIMIT 1`
           : sql`SELECT 1 FROM information_schema.tables WHERE table_name = ${companionTableName} AND table_schema = ANY (current_schemas(false)) LIMIT 1`;
 
-    const result = (await executor.execute(query)) as
-      | { rows?: unknown[] }
-      | unknown[]
-      | undefined;
-    // Each driver reports rows differently: an array, or an object carrying
-    // one. Both are read rather than picking a shape per dialect.
-    const rows = Array.isArray(result) ? result : (result?.rows ?? []);
-    return rows.length > 0;
+    // The handles differ by driver: better-sqlite3 exposes `all` and has no
+    // `execute` at all, while the pg and mysql2 handles use `execute`. Picked
+    // by capability rather than by dialect, so a handle is never called
+    // through a method it does not have.
+    const handle = executor as {
+      all?: (query: unknown) => Promise<unknown>;
+      execute?: (query: unknown) => Promise<unknown>;
+    };
+    const raw = handle.all
+      ? await handle.all(query)
+      : await handle.execute?.(query);
+
+    return countRows(raw) > 0;
   }
 
   /**

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1611,6 +1611,15 @@ export class CollectionMutationService extends BaseService {
       // without a manual slug. Running before write access means a field the
       // caller may not create is not reintroduced; the uniqueness check uses
       // the shared connection (a plain, non-transactional create).
+      // Declared defaults are filled first so everything downstream sees the
+      // values the entry will actually hold: generation then fills only the
+      // identity fields still unresolved, a field-level access predicate reads
+      // final values rather than undefined, and a required field carrying a
+      // default is satisfied by the time validation runs. Placed before write
+      // access for the same reason generation is — a field the caller may not
+      // create must not be reintroduced here.
+      applyFieldDefaults(finalData, fields);
+
       const isSlugTaken = (slug: string) =>
         this.checkFieldUniqueness(params.collectionName, "slug", slug);
       await this.applyGeneratedSlugAndTitle(finalData, isSlugTaken);
@@ -1625,11 +1634,6 @@ export class CollectionMutationService extends BaseService {
         user: params.user,
         overrideAccess: params.overrideAccess,
       });
-
-      // Declared defaults are filled before the hooks so a hook branching on a
-      // field sees the value a new entry actually starts with, and before
-      // validation so a required field carrying a default is satisfied.
-      applyFieldDefaults(finalData, fields);
 
       // Field-level beforeValidate hooks transform values ahead of the
       // validation gate (functions resolved via the field-level registry).
@@ -4993,6 +4997,15 @@ export class CollectionMutationService extends BaseService {
       // validation (see createEntry). The uniqueness check runs on the
       // transaction so same-title creates within one uncommitted tx still
       // dedupe — the tx sees its own pending rows.
+      // Declared defaults are filled first so everything downstream sees the
+      // values the entry will actually hold: generation then fills only the
+      // identity fields still unresolved, a field-level access predicate reads
+      // final values rather than undefined, and a required field carrying a
+      // default is satisfied by the time validation runs. Placed before write
+      // access for the same reason generation is — a field the caller may not
+      // create must not be reintroduced here.
+      applyFieldDefaults(finalData, fields);
+
       const isSlugTaken = async (slug: string) => {
         const existing = await tx.selectOne<Record<string, unknown>>(
           tableName,
@@ -5015,11 +5028,6 @@ export class CollectionMutationService extends BaseService {
         user: params.user,
         overrideAccess: params.overrideAccess,
       });
-
-      // Declared defaults are filled before the hooks so a hook branching on a
-      // field sees the value a new entry actually starts with, and before
-      // validation so a required field carrying a default is satisfied.
-      applyFieldDefaults(finalData, fields);
 
       // Field-level beforeValidate hooks transform values ahead of the
       // validation gate (functions resolved via the field-level registry).
@@ -6211,6 +6219,15 @@ export class CollectionMutationService extends BaseService {
       // entry that omits slug/title must still receive them. The uniqueness
       // check runs on the transaction so entries created earlier in the same
       // bulk batch are seen.
+      // Declared defaults are filled first so everything downstream sees the
+      // values the entry will actually hold: generation then fills only the
+      // identity fields still unresolved, a field-level access predicate reads
+      // final values rather than undefined, and a required field carrying a
+      // default is satisfied by the time validation runs. Placed before write
+      // access for the same reason generation is — a field the caller may not
+      // create must not be reintroduced here.
+      applyFieldDefaults(finalData, fields);
+
       const isSlugTaken = async (slug: string) => {
         const existing = await tx.selectOne<Record<string, unknown>>(
           tableName,
@@ -6237,11 +6254,6 @@ export class CollectionMutationService extends BaseService {
       // Field-level beforeValidate hooks transform values ahead of the
       // validation gate (functions resolved via the field-level registry). A
       // hook can set `slug`, so re-sanitize after it so the validated and
-      // stored value stays URL-safe. When hooks are skipped the slug is still
-      // the (already-sanitized) generated value, so no pass is needed.
-      // Filled regardless of `skipHooks`: a default is part of what the entry
-      // is, not a hook behaviour that a bulk path may opt out of.
-      applyFieldDefaults(finalData, fields);
 
       if (!skipHooks) {
         await runFieldHooks({

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -285,6 +285,16 @@ export interface TransitionAuthorization {
   } | null;
 }
 
+/** Whether a string is already the stored JSON representation of a value. */
+function isParsableJson(value: string): boolean {
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export class CollectionMutationService extends BaseService {
   constructor(
     adapter: DrizzleAdapter,
@@ -781,22 +791,35 @@ export class CollectionMutationService extends BaseService {
   /**
    * The fields a transactional create may seed a default into.
    *
-   * On a migrated localized collection the translatable columns live on the
-   * `_locales` companion, not the main table. The pooled path splits those
-   * values out and writes the companion row; the transactional paths have no
-   * such step, so seeding a translatable default here would put a key in the
-   * main-table insert for a column that does not exist. Skipping them keeps a
-   * declared default from turning every transactional create on such a
-   * collection into a failure — the translatable default simply does not
-   * apply on this path until the companion write exists here too.
+   * Once the companion migration has run, a localized collection's translatable
+   * columns live on the `_locales` table and no longer exist on the main one.
+   * The pooled path splits those values out and writes the companion row; the
+   * transactional paths have no such step, so seeding a translatable default
+   * there would put a key in the main-table insert for a column that is gone.
+   *
+   * The companion is checked for existence rather than reading `localized`
+   * alone, matching `splitLocalizedWriteData`: before the migration the
+   * translatable columns are still on the main table, so their defaults apply
+   * exactly as they do on the pooled path. Only after it do they drop out,
+   * which leaves those fields behaving as they did before defaults existed at
+   * all — no worse, and unchanged for every collection that is not localized.
    */
-  private defaultableFields(
+  private async defaultableFields(
+    collectionName: string,
     collection: unknown,
     fields: FieldDefinition[]
-  ): FieldDefinition[] {
+  ): Promise<FieldDefinition[]> {
     const isLocalized =
       (collection as { localized?: boolean } | undefined)?.localized === true;
-    if (!isLocalized) return fields;
+    if (!isLocalized || !this.localization) return fields;
+
+    const companion =
+      await this.fileManager.loadCompanionSchema(collectionName);
+    if (!companion) return fields;
+    if (!(await this.companionTableExists(companion.companionTableName))) {
+      return fields;
+    }
+
     const translatable = new Set(resolveLocalizedFieldNames(fields, true));
     return fields.filter(f => !translatable.has(f.name));
   }
@@ -808,7 +831,17 @@ export class CollectionMutationService extends BaseService {
     for (const field of fields) {
       if (!isJsonFieldType(field.type, field)) continue;
       const value = data[field.name];
-      if (value == null || typeof value !== "object") continue;
+      if (value == null) continue;
+
+      // A JSON column stores a JSON DOCUMENT, so a scalar has to be encoded
+      // too: the string `enabled` is not valid JSON, `"enabled"` is. A string
+      // that already parses is left alone, since it is the stored
+      // representation and encoding it again would nest it.
+      if (typeof value !== "object") {
+        if (typeof value === "string" && isParsableJson(value)) continue;
+        data[field.name] = JSON.stringify(value);
+        continue;
+      }
 
       // A relationship nested in a group or repeater is stored as its id. A
       // populated object reaching the stringify below would be frozen into the
@@ -5020,7 +5053,7 @@ export class CollectionMutationService extends BaseService {
       const seededBody: Record<string, unknown> = { ...body };
       applyFieldDefaults(
         seededBody,
-        this.defaultableFields(collection, fields)
+        await this.defaultableFields(params.collectionName, collection, fields)
       );
 
       const beforeOpArgs =
@@ -6238,7 +6271,7 @@ export class CollectionMutationService extends BaseService {
       // field with a default would otherwise abort the whole batch.
       applyFieldDefaults(
         currentData,
-        this.defaultableFields(collection, fields)
+        await this.defaultableFields(params.collectionName, collection, fields)
       );
 
       // Execute hooks (unless skipped)

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -6163,6 +6163,13 @@ export class CollectionMutationService extends BaseService {
       // Shared context between all hooks in this request
       const sharedContext: Record<string, unknown> = {};
 
+      // Defaults are not hooks: a bulk import that opts out of hook execution
+      // still creates entries that must hold their declared defaults, and an
+      // omitted required field with a default would otherwise fail validation
+      // and abort the import. Applied again inside the block below because
+      // `beforeOperation` may replace the data object entirely.
+      applyFieldDefaults(currentData, fields);
+
       // Execute hooks (unless skipped)
       if (!skipHooks) {
         // Execute beforeOperation hooks FIRST (before operation-specific hooks)
@@ -6187,14 +6194,9 @@ export class CollectionMutationService extends BaseService {
             string,
             unknown
           >) ?? body;
-        // Declared defaults are filled before any hook runs, so a collection
-        // hook deriving one field from another sees the value the entry will
-        // hold rather than undefined, and a hook that removes a defaulted field
-        // is not overridden by a later pass re-adding it. Everything after this
-        // point — generation, write access, validation, the insert — works from
-        // complete data. Generation still fills only the identity fields left
-        // unresolved, and running ahead of write access matches generation, so a
-        // field the caller may not create is not reintroduced.
+        // Re-applied because the line above may have swapped in a different
+        // object; filling before the beforeCreate pipeline means a collection
+        // hook sees the value the entry will hold rather than undefined.
         applyFieldDefaults(currentData, fields);
 
         // Execute beforeCreate hooks (code-registered)

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -656,20 +656,40 @@ export class CollectionMutationService extends BaseService {
     // waits forever rather than failing.
     executor?: { execute: (query: unknown) => Promise<unknown> }
   ): Promise<boolean> {
-    const q =
-      this.adapter.dialect === "mysql"
-        ? `\`${companionTableName}\``
-        : `"${companionTableName}"`;
-    try {
-      if (executor) {
-        await executor.execute(sql.raw(`SELECT 1 FROM ${q} LIMIT 0`));
-      } else {
+    if (!executor) {
+      const q =
+        this.adapter.dialect === "mysql"
+          ? `\`${companionTableName}\``
+          : `"${companionTableName}"`;
+      try {
         await this.adapter.executeQuery(`SELECT 1 FROM ${q} LIMIT 0`);
+        return true;
+      } catch {
+        return false;
       }
-      return true;
-    } catch {
-      return false;
     }
+
+    // Inside a transaction the question has to be asked WITHOUT touching the
+    // table, because selecting from one that does not exist is an error, and
+    // PostgreSQL marks the whole transaction aborted the moment a statement
+    // fails — every later statement then fails too, however the error was
+    // caught. Reading the catalog succeeds either way and answers the same
+    // question.
+    const query =
+      this.adapter.dialect === "sqlite"
+        ? sql`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ${companionTableName} LIMIT 1`
+        : this.adapter.dialect === "mysql"
+          ? sql`SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ${companionTableName} LIMIT 1`
+          : sql`SELECT 1 FROM information_schema.tables WHERE table_name = ${companionTableName} AND table_schema = ANY (current_schemas(false)) LIMIT 1`;
+
+    const result = (await executor.execute(query)) as
+      | { rows?: unknown[] }
+      | unknown[]
+      | undefined;
+    // Each driver reports rows differently: an array, or an object carrying
+    // one. Both are read rather than picking a shape per dialect.
+    const rows = Array.isArray(result) ? result : (result?.rows ?? []);
+    return rows.length > 0;
   }
 
   /**

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -59,6 +59,7 @@ import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
 import { convertTimestampsToCamelCase } from "../../../shared/lib/case-conversion";
 import { validateEntryData } from "../../../shared/lib/entry-validation";
+import { applyFieldDefaults } from "../../../shared/lib/field-defaults";
 import {
   applyFieldReadAccess,
   applyFieldWriteAccess,
@@ -1624,6 +1625,11 @@ export class CollectionMutationService extends BaseService {
         user: params.user,
         overrideAccess: params.overrideAccess,
       });
+
+      // Declared defaults are filled before the hooks so a hook branching on a
+      // field sees the value a new entry actually starts with, and before
+      // validation so a required field carrying a default is satisfied.
+      applyFieldDefaults(finalData, fields);
 
       // Field-level beforeValidate hooks transform values ahead of the
       // validation gate (functions resolved via the field-level registry).
@@ -5010,6 +5016,11 @@ export class CollectionMutationService extends BaseService {
         overrideAccess: params.overrideAccess,
       });
 
+      // Declared defaults are filled before the hooks so a hook branching on a
+      // field sees the value a new entry actually starts with, and before
+      // validation so a required field carrying a default is satisfied.
+      applyFieldDefaults(finalData, fields);
+
       // Field-level beforeValidate hooks transform values ahead of the
       // validation gate (functions resolved via the field-level registry).
       await runFieldHooks({
@@ -6228,6 +6239,10 @@ export class CollectionMutationService extends BaseService {
       // hook can set `slug`, so re-sanitize after it so the validated and
       // stored value stays URL-safe. When hooks are skipped the slug is still
       // the (already-sanitized) generated value, so no pass is needed.
+      // Filled regardless of `skipHooks`: a default is part of what the entry
+      // is, not a hook behaviour that a bulk path may opt out of.
+      applyFieldDefaults(finalData, fields);
+
       if (!skipHooks) {
         await runFieldHooks({
           kind: "collection",

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -767,6 +767,28 @@ export class CollectionMutationService extends BaseService {
    * already-parsed values pass through; a parse failure keeps the raw string.
    * Never mutates the input.
    */
+  /**
+   * Stringify JSON-backed values so a raw insert never hands the driver a live
+   * object.
+   *
+   * Each dialect does something different with one: mysql2 expands an object
+   * into assignment syntax and an array into a value list, and node-postgres
+   * encodes an array as a PostgreSQL array literal rather than JSON. Only
+   * SQLite happens to stringify, which is why a suite running there alone
+   * cannot show the difference.
+   */
+  private serializeJsonFieldsForInsert(
+    data: Record<string, unknown>,
+    fields: FieldDefinition[]
+  ): void {
+    for (const field of fields) {
+      if (!isJsonFieldType(field.type, field)) continue;
+      const value = data[field.name];
+      if (value == null || typeof value !== "object") continue;
+      data[field.name] = JSON.stringify(value);
+    }
+  }
+
   private deserializeJsonFieldsForSnapshot(
     row: Record<string, unknown>,
     fields: FieldDefinition[]
@@ -5143,6 +5165,10 @@ export class CollectionMutationService extends BaseService {
 
       // Prepare entry data
       const nowForTxCreate = new Date();
+      // A raw tx.insert follows, with none of the pooled path's serialization
+      // in between, so JSON-backed values are stringified here instead.
+      this.serializeJsonFieldsForInsert(finalData, fields);
+
       const entryData = {
         id: this.collectionService.generateId(),
         // Strip client-supplied system columns (id / timestamps / created_by,
@@ -6366,6 +6392,10 @@ export class CollectionMutationService extends BaseService {
 
       // Prepare entry data
       const nowForTxCreate = new Date();
+      // A raw tx.insert follows, with none of the pooled path's serialization
+      // in between, so JSON-backed values are stringified here instead.
+      this.serializeJsonFieldsForInsert(finalData, fields);
+
       const entryData = {
         id: this.collectionService.generateId(),
         // Strip client-supplied system columns (id / timestamps / created_by,

--- a/packages/nextly/src/domains/collections/services/collection-registry-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-registry-service.ts
@@ -33,6 +33,7 @@ import type {
   BaseListOptions,
   BaseListResult,
 } from "../../../shared/base-registry-service";
+import { fieldDefaultsSignature } from "../../../shared/lib/field-defaults";
 import {
   calculateSchemaHash,
   schemaHashesMatch,
@@ -520,6 +521,11 @@ export class CollectionRegistryService extends BaseRegistryService<
           JSON.stringify(config.revalidate ?? null) !==
             JSON.stringify(existing.revalidate ?? null) ||
           (config.localized === true) !== (existing.localized === true) ||
+          // Declared defaults are read from the stored definitions when an
+          // entry is created, and the schema hash omits them, so they need
+          // their own comparison or a changed default never reaches the write.
+          fieldDefaultsSignature(config.fields) !==
+            fieldDefaultsSignature(existing.fields) ||
           desiredTableName !== existing.tableName
         ) {
           // Fields changed, status toggle flipped, or `dbName` resolved to a

--- a/packages/nextly/src/shared/lib/__tests__/field-defaults.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/field-defaults.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { ValidatableField } from "../entry-validation";
-import { applyFieldDefaults } from "../field-defaults";
+import { applyFieldDefaults, fieldDefaultsSignature } from "../field-defaults";
 
 const field = (f: Record<string, unknown>): ValidatableField =>
   f as unknown as ValidatableField;
@@ -209,5 +209,67 @@ describe("applyFieldDefaults", () => {
       ).not.toThrow();
       expect(data.rows).toEqual([null, "x", [], { label: "dl" }]);
     });
+  });
+});
+
+/**
+ * The schema hash omits `defaultValue`, so code-first sync needs a separate
+ * signal or a changed default never reaches the stored definitions the write
+ * path reads.
+ */
+describe("fieldDefaultsSignature", () => {
+  const withDefault = (v: unknown) => [
+    field({ name: "a", type: "text", defaultValue: v }),
+  ];
+
+  it("changes when a default changes", () => {
+    expect(fieldDefaultsSignature(withDefault("one"))).not.toBe(
+      fieldDefaultsSignature(withDefault("two"))
+    );
+  });
+
+  it("changes when a default is added or removed", () => {
+    const none = [field({ name: "a", type: "text" })];
+    expect(fieldDefaultsSignature(none)).not.toBe(
+      fieldDefaultsSignature(withDefault("one"))
+    );
+  });
+
+  it("is stable for identical declarations", () => {
+    expect(fieldDefaultsSignature(withDefault({ a: [1, 2] }))).toBe(
+      fieldDefaultsSignature(withDefault({ a: [1, 2] }))
+    );
+  });
+
+  it("ignores fields that declare no default", () => {
+    expect(
+      fieldDefaultsSignature([
+        field({ name: "a", type: "text" }),
+        field({ name: "b", type: "text" }),
+      ])
+    ).toBe("");
+  });
+
+  it("treats a function the same on both sides of a comparison", () => {
+    // The config holds a function; the stored definition lost it. Reporting a
+    // change every boot would rewrite the registry on every start.
+    const config = [
+      field({ name: "a", type: "text", defaultValue: () => "x" }),
+    ];
+    const stored = [field({ name: "a", type: "text" })];
+    expect(fieldDefaultsSignature(config)).toBe(fieldDefaultsSignature(stored));
+  });
+
+  it("sees a change inside a group", () => {
+    const make = (v: string) => [
+      field({
+        name: "seo",
+        type: "group",
+        fields: [field({ name: "title", type: "text", defaultValue: v })],
+      }),
+    ];
+    expect(fieldDefaultsSignature(make("a"))).not.toBe(
+      fieldDefaultsSignature(make("b"))
+    );
   });
 });

--- a/packages/nextly/src/shared/lib/__tests__/field-defaults.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/field-defaults.test.ts
@@ -60,6 +60,35 @@ describe("applyFieldDefaults", () => {
     expect(data).toEqual({});
   });
 
+  it("does not mistake an inherited property for a supplied value", () => {
+    // A field named after something on Object.prototype would otherwise
+    // resolve through the prototype chain, so an empty body would look as
+    // though it supplied an inherited function.
+    for (const name of ["constructor", "toString", "valueOf"]) {
+      const data: Record<string, unknown> = {};
+      applyFieldDefaults(data, [
+        field({ name, type: "text", defaultValue: "filled" }),
+      ]);
+      expect(data[name], name).toBe("filled");
+    }
+  });
+
+  it("still treats an own property set to undefined as absent", () => {
+    const data: Record<string, unknown> = { toString: undefined };
+    applyFieldDefaults(data, [
+      field({ name: "toString", type: "text", defaultValue: "filled" }),
+    ]);
+    expect(data.toString).toBe("filled");
+  });
+
+  it("does not overwrite an inherited-name field the caller did supply", () => {
+    const data: Record<string, unknown> = { constructor: "mine" };
+    applyFieldDefaults(data, [
+      field({ name: "constructor", type: "text", defaultValue: "filled" }),
+    ]);
+    expect(data.constructor).toBe("mine");
+  });
+
   describe("structured defaults are private to each entry", () => {
     it("gives each repeater row its own copy", () => {
       // The declared value lives on the field definition, which outlives the

--- a/packages/nextly/src/shared/lib/__tests__/field-defaults.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/field-defaults.test.ts
@@ -60,6 +60,54 @@ describe("applyFieldDefaults", () => {
     expect(data).toEqual({});
   });
 
+  describe("structured defaults are private to each entry", () => {
+    it("gives each repeater row its own copy", () => {
+      // The declared value lives on the field definition, which outlives the
+      // write, so a shared reference would let one row's later mutation reach
+      // the others.
+      const declared = { tags: ["a"] };
+      const data: Record<string, unknown> = { rows: [{}, {}] };
+      applyFieldDefaults(data, [
+        field({
+          name: "rows",
+          type: "repeater",
+          fields: [
+            field({ name: "meta", type: "json", defaultValue: declared }),
+          ],
+        }),
+      ]);
+      const rows = data.rows as { meta: { tags: string[] } }[];
+      expect(rows[0].meta).toEqual({ tags: ["a"] });
+      expect(rows[0].meta).not.toBe(rows[1].meta);
+
+      (rows[0].meta.tags as string[]).push("b");
+      expect(rows[1].meta.tags).toEqual(["a"]);
+    });
+
+    it("never hands out the declared object itself", () => {
+      // Mutating it would corrupt the definition for every later entry.
+      const declared = { a: 1 };
+      const data: Record<string, unknown> = {};
+      applyFieldDefaults(data, [
+        field({ name: "settings", type: "json", defaultValue: declared }),
+      ]);
+      expect(data.settings).toEqual({ a: 1 });
+      expect(data.settings).not.toBe(declared);
+
+      (data.settings as { a: number }).a = 99;
+      expect(declared.a).toBe(1);
+    });
+
+    it("passes primitives through unchanged", () => {
+      const data: Record<string, unknown> = {};
+      applyFieldDefaults(data, [
+        field({ name: "a", type: "text", defaultValue: "x" }),
+        field({ name: "b", type: "number", defaultValue: 1 }),
+      ]);
+      expect(data).toEqual({ a: "x", b: 1 });
+    });
+  });
+
   describe("layout containers", () => {
     it("fills children of an unnamed container against the parent", () => {
       const data: Record<string, unknown> = {};

--- a/packages/nextly/src/shared/lib/__tests__/field-defaults.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/field-defaults.test.ts
@@ -137,6 +137,73 @@ describe("applyFieldDefaults", () => {
     });
   });
 
+  describe("the caller's payload is never mutated", () => {
+    it("does not write child defaults into a supplied group", () => {
+      const supplied = { title: "given" };
+      const data: Record<string, unknown> = { seo: supplied };
+      applyFieldDefaults(data, [
+        field({
+          name: "seo",
+          type: "group",
+          fields: [
+            field({ name: "title", type: "text", defaultValue: "dt" }),
+            field({ name: "desc", type: "text", defaultValue: "dd" }),
+          ],
+        }),
+      ]);
+      expect(data.seo).toEqual({ title: "given", desc: "dd" });
+      // The object the caller handed in is unchanged.
+      expect(supplied).toEqual({ title: "given" });
+      expect(data.seo).not.toBe(supplied);
+    });
+
+    it("does not write child defaults into supplied repeater rows", () => {
+      const row = { label: "given" };
+      const bare: Record<string, unknown> = {};
+      const data: Record<string, unknown> = { rows: [row, bare] };
+      applyFieldDefaults(data, [
+        field({
+          name: "rows",
+          type: "repeater",
+          fields: [
+            field({ name: "label", type: "text", defaultValue: "dl" }),
+            field({ name: "note", type: "text", defaultValue: "dn" }),
+          ],
+        }),
+      ]);
+      expect(data.rows).toEqual([
+        { label: "given", note: "dn" },
+        { label: "dl", note: "dn" },
+      ]);
+      expect(row).toEqual({ label: "given" });
+      expect(bare).toEqual({});
+    });
+
+    it("reaches a nested group without mutating it", () => {
+      const inner = {};
+      const outer = { inner };
+      const data: Record<string, unknown> = { outer };
+      applyFieldDefaults(data, [
+        field({
+          name: "outer",
+          type: "group",
+          fields: [
+            field({
+              name: "inner",
+              type: "group",
+              fields: [
+                field({ name: "deep", type: "text", defaultValue: "dv" }),
+              ],
+            }),
+          ],
+        }),
+      ]);
+      expect(data.outer).toEqual({ inner: { deep: "dv" } });
+      expect(inner).toEqual({});
+      expect(outer).toEqual({ inner: {} });
+    });
+  });
+
   describe("layout containers", () => {
     it("fills children of an unnamed container against the parent", () => {
       const data: Record<string, unknown> = {};

--- a/packages/nextly/src/shared/lib/__tests__/field-defaults.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/field-defaults.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Which keys a declared default may fill, and which it must leave alone.
+ *
+ * Validation recurses into groups and repeater rows, so defaults have to reach
+ * the same places or a required child fails on an entry the caller had no way
+ * to satisfy.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { ValidatableField } from "../entry-validation";
+import { applyFieldDefaults } from "../field-defaults";
+
+const field = (f: Record<string, unknown>): ValidatableField =>
+  f as unknown as ValidatableField;
+
+describe("applyFieldDefaults", () => {
+  it("fills an absent key and leaves a supplied one", () => {
+    const data: Record<string, unknown> = { b: "given" };
+    applyFieldDefaults(data, [
+      field({ name: "a", type: "text", defaultValue: "da" }),
+      field({ name: "b", type: "text", defaultValue: "db" }),
+    ]);
+    expect(data).toEqual({ a: "da", b: "given" });
+  });
+
+  it("treats falsy supplied values as supplied", () => {
+    const data: Record<string, unknown> = { n: 0, c: false, s: "" };
+    applyFieldDefaults(data, [
+      field({ name: "n", type: "number", defaultValue: 9 }),
+      field({ name: "c", type: "checkbox", defaultValue: true }),
+      field({ name: "s", type: "text", defaultValue: "x" }),
+    ]);
+    expect(data).toEqual({ n: 0, c: false, s: "" });
+  });
+
+  it("leaves an explicit null alone", () => {
+    const data: Record<string, unknown> = { a: null };
+    applyFieldDefaults(data, [
+      field({ name: "a", type: "text", defaultValue: "da" }),
+    ]);
+    expect(data.a).toBeNull();
+  });
+
+  it("treats an explicit undefined the same as an absent key", () => {
+    // `{ a: undefined }` is what spreading an unset optional produces, and it
+    // is indistinguishable from omission over JSON. `null` remains the way to
+    // say "no value" — see the test above.
+    const data: Record<string, unknown> = { a: undefined };
+    applyFieldDefaults(data, [
+      field({ name: "a", type: "text", defaultValue: "da" }),
+    ]);
+    expect(data.a).toBe("da");
+  });
+
+  it("skips a component field, whose data lives in another table", () => {
+    const data: Record<string, unknown> = {};
+    applyFieldDefaults(data, [
+      field({ name: "hero", type: "component", defaultValue: { a: 1 } }),
+    ]);
+    expect(data).toEqual({});
+  });
+
+  describe("layout containers", () => {
+    it("fills children of an unnamed container against the parent", () => {
+      const data: Record<string, unknown> = {};
+      applyFieldDefaults(data, [
+        field({
+          type: "row",
+          fields: [field({ name: "a", type: "text", defaultValue: "da" })],
+        }),
+      ]);
+      expect(data).toEqual({ a: "da" });
+    });
+  });
+
+  describe("groups", () => {
+    it("creates an absent group from its children's defaults", () => {
+      const data: Record<string, unknown> = {};
+      applyFieldDefaults(data, [
+        field({
+          name: "seo",
+          type: "group",
+          fields: [field({ name: "title", type: "text", defaultValue: "dt" })],
+        }),
+      ]);
+      expect(data).toEqual({ seo: { title: "dt" } });
+    });
+
+    it("does not create a group whose children declare no defaults", () => {
+      // Storing `{}` where the caller stored nothing is a different value.
+      const data: Record<string, unknown> = {};
+      applyFieldDefaults(data, [
+        field({
+          name: "seo",
+          type: "group",
+          fields: [field({ name: "title", type: "text" })],
+        }),
+      ]);
+      expect(data).toEqual({});
+    });
+
+    it("fills only the missing keys of a supplied group", () => {
+      const data: Record<string, unknown> = { seo: { title: "given" } };
+      applyFieldDefaults(data, [
+        field({
+          name: "seo",
+          type: "group",
+          fields: [
+            field({ name: "title", type: "text", defaultValue: "dt" }),
+            field({ name: "desc", type: "text", defaultValue: "dd" }),
+          ],
+        }),
+      ]);
+      expect(data.seo).toEqual({ title: "given", desc: "dd" });
+    });
+
+    it("leaves a group the caller cleared to null", () => {
+      const data: Record<string, unknown> = { seo: null };
+      applyFieldDefaults(data, [
+        field({
+          name: "seo",
+          type: "group",
+          fields: [field({ name: "title", type: "text", defaultValue: "dt" })],
+        }),
+      ]);
+      expect(data.seo).toBeNull();
+    });
+
+    it("prefers the group's own default over building one", () => {
+      const data: Record<string, unknown> = {};
+      applyFieldDefaults(data, [
+        field({
+          name: "seo",
+          type: "group",
+          defaultValue: { title: "own" },
+          fields: [
+            field({ name: "title", type: "text", defaultValue: "dt" }),
+            field({ name: "desc", type: "text", defaultValue: "dd" }),
+          ],
+        }),
+      ]);
+      // The declared default wins for keys it sets; children still fill gaps.
+      expect(data.seo).toEqual({ title: "own", desc: "dd" });
+    });
+
+    it("reaches a nested group", () => {
+      const data: Record<string, unknown> = {};
+      applyFieldDefaults(data, [
+        field({
+          name: "outer",
+          type: "group",
+          fields: [
+            field({
+              name: "inner",
+              type: "group",
+              fields: [
+                field({ name: "deep", type: "text", defaultValue: "dv" }),
+              ],
+            }),
+          ],
+        }),
+      ]);
+      expect(data).toEqual({ outer: { inner: { deep: "dv" } } });
+    });
+  });
+
+  describe("repeaters", () => {
+    it("fills each supplied row", () => {
+      const data: Record<string, unknown> = {
+        rows: [{ label: "given" }, {}],
+      };
+      applyFieldDefaults(data, [
+        field({
+          name: "rows",
+          type: "repeater",
+          fields: [field({ name: "label", type: "text", defaultValue: "dl" })],
+        }),
+      ]);
+      expect(data.rows).toEqual([{ label: "given" }, { label: "dl" }]);
+    });
+
+    it("never invents rows", () => {
+      // How many rows a new entry starts with is the caller's decision.
+      const data: Record<string, unknown> = {};
+      applyFieldDefaults(data, [
+        field({
+          name: "rows",
+          type: "repeater",
+          fields: [field({ name: "label", type: "text", defaultValue: "dl" })],
+        }),
+      ]);
+      expect(data.rows).toBeUndefined();
+    });
+
+    it("ignores malformed rows rather than throwing", () => {
+      // A malformed row is validation's to report; this pass must not crash
+      // on the way there.
+      const data: Record<string, unknown> = { rows: [null, "x", [], {}] };
+      expect(() =>
+        applyFieldDefaults(data, [
+          field({
+            name: "rows",
+            type: "repeater",
+            fields: [
+              field({ name: "label", type: "text", defaultValue: "dl" }),
+            ],
+          }),
+        ])
+      ).not.toThrow();
+      expect(data.rows).toEqual([null, "x", [], { label: "dl" }]);
+    });
+  });
+});

--- a/packages/nextly/src/shared/lib/field-defaults.ts
+++ b/packages/nextly/src/shared/lib/field-defaults.ts
@@ -1,0 +1,66 @@
+/**
+ * Applying declared field defaults to a new entry.
+ *
+ * `defaultValue` is part of the public field config and is documented as
+ * accepting either a value or `(data) => value`. It was only ever honoured by
+ * the admin create form, which fills the value in the browser, and by a
+ * single's first-read auto-create. Anything writing through the REST or Direct
+ * API therefore stored nothing for an omitted field, and a REQUIRED field
+ * carrying a default could not be created at all: validation saw an absent
+ * value and rejected the write.
+ *
+ * Defaults belong on the write path rather than in validation, which reports
+ * issues and must not change the data it is given, and rather than as a column
+ * DEFAULT, which cannot express a function or reach a JSON-backed value.
+ *
+ * KNOWN LIMIT: a collection's fields reach this point from its stored
+ * definition, and a function does not survive being stored, so only a constant
+ * default can be applied here. A function default is not an error — it is
+ * simply absent by the time the write runs, and the field behaves as though
+ * none was declared. Honouring it would mean reading the in-memory code-first
+ * config on the write path, which is a separate piece of plumbing. A single's
+ * first-read auto-create holds the config object directly and does resolve
+ * functions.
+ *
+ * @module shared/lib/field-defaults
+ */
+
+import type { ValidatableField } from "./entry-validation";
+
+/**
+ * A field whose value is stored somewhere other than its own column, so a
+ * default written here would target a column that does not exist.
+ */
+const NON_COLUMN_TYPES: ReadonlySet<string> = new Set(["component"]);
+
+/**
+ * Fill in declared defaults for fields the caller did not supply.
+ *
+ * Mutates `data` in place, because the same object continues on to hooks,
+ * validation, and the insert: returning a copy would leave whichever of those
+ * still held the original writing the undefaulted value.
+ *
+ * Only an ABSENT key takes its default. An explicit `null` is a decision the
+ * caller made — it is how a JSON body says "no value" — and overwriting it
+ * would make a field impossible to leave empty.
+ */
+export function applyFieldDefaults(
+  data: Record<string, unknown>,
+  fields: readonly ValidatableField[]
+): void {
+  for (const field of fields) {
+    if (!field.name) continue;
+    if (NON_COLUMN_TYPES.has(field.type)) continue;
+
+    const declared = (field as { defaultValue?: unknown }).defaultValue;
+    if (declared === undefined) continue;
+    if (data[field.name] !== undefined) continue;
+
+    // Resolved against the data built so far, so a default may read the values
+    // the caller did supply, and earlier defaults in this same pass.
+    data[field.name] =
+      typeof declared === "function"
+        ? (declared as (d: Record<string, unknown>) => unknown)(data)
+        : declared;
+  }
+}

--- a/packages/nextly/src/shared/lib/field-defaults.ts
+++ b/packages/nextly/src/shared/lib/field-defaults.ts
@@ -85,7 +85,7 @@ export function applyFieldDefaults(
     if (field.type === "group") {
       fillGroup(data, field.name, field.fields);
     } else if (field.type === "repeater") {
-      fillRepeaterRows(data[field.name], field.fields);
+      fillRepeaterRows(data, field.name, field.fields);
     }
   }
 }
@@ -128,7 +128,13 @@ function fillGroup(
     ? data[name]
     : undefined;
   if (isPlainObject(existing)) {
-    applyFieldDefaults(existing, fields);
+    // Filled through a copy: the container came from the caller, and writing
+    // child defaults straight into it would mutate the object they passed in.
+    // A shallow copy per level is enough, because each level down copies again
+    // before it writes.
+    const filled = { ...existing };
+    applyFieldDefaults(filled, fields);
+    data[name] = filled;
     return;
   }
   // A group the caller set to null was cleared deliberately, exactly as for a
@@ -148,13 +154,23 @@ function fillGroup(
  * fabricate content.
  */
 function fillRepeaterRows(
-  value: unknown,
+  data: Record<string, unknown>,
+  name: string,
   fields: readonly ValidatableField[]
 ): void {
+  const value = data[name];
   if (!Array.isArray(value)) return;
-  for (const row of value) {
-    if (isPlainObject(row)) applyFieldDefaults(row, fields);
-  }
+  // Rows are the caller's objects, so each one that gains a default is filled
+  // through a copy and the list is rebuilt from the results.
+  let changed = false;
+  const rows = value.map(row => {
+    if (!isPlainObject(row)) return row;
+    const filled = { ...row };
+    applyFieldDefaults(filled, fields);
+    changed = true;
+    return filled;
+  });
+  if (changed) data[name] = rows;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/packages/nextly/src/shared/lib/field-defaults.ts
+++ b/packages/nextly/src/shared/lib/field-defaults.ts
@@ -127,3 +127,34 @@ function fillRepeaterRows(
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
+
+/**
+ * A comparable signature of every default a field list declares.
+ *
+ * Code-first sync decides whether to rewrite stored field definitions from
+ * `calculateSchemaHash`, which deliberately excludes `defaultValue` because it
+ * may be a function. Defaults are read from those stored definitions on the
+ * write path, so without a separate comparison, changing only a default on an
+ * existing collection would never reach the database: the entry would keep
+ * being created with the previous value until some unrelated change forced a
+ * re-sync.
+ *
+ * A function default is treated as no default at all. It cannot be stored, so
+ * the config side would otherwise differ from the stored side forever and
+ * re-sync the registry on every boot — and it is not applied by this path
+ * either, so there is nothing about it for the stored definitions to carry.
+ */
+export function fieldDefaultsSignature(
+  fields: readonly ValidatableField[] | undefined
+): string {
+  if (!fields) return "";
+  const parts: string[] = [];
+  for (const field of fields) {
+    const raw = (field as { defaultValue?: unknown }).defaultValue;
+    const declared = typeof raw === "function" ? undefined : raw;
+    const nested = field.fields ? fieldDefaultsSignature(field.fields) : "";
+    if (declared === undefined && nested === "") continue;
+    parts.push(`${field.name ?? ""}:${JSON.stringify(declared)}:${nested}`);
+  }
+  return parts.join("|");
+}

--- a/packages/nextly/src/shared/lib/field-defaults.ts
+++ b/packages/nextly/src/shared/lib/field-defaults.ts
@@ -62,10 +62,11 @@ export function applyFieldDefaults(
     if (declared !== undefined && data[field.name] === undefined) {
       // Resolved against the data built so far, so a default may read the
       // values the caller did supply, and earlier defaults in this same pass.
-      data[field.name] =
+      data[field.name] = cloneDefault(
         typeof declared === "function"
           ? (declared as (d: Record<string, unknown>) => unknown)(data)
-          : declared;
+          : declared
+      );
     }
 
     if (!field.fields) continue;
@@ -78,6 +79,28 @@ export function applyFieldDefaults(
     } else if (field.type === "repeater") {
       fillRepeaterRows(data[field.name], field.fields);
     }
+  }
+}
+
+/**
+ * A private copy of a structured default.
+ *
+ * The declared value lives on the field definition, which outlives every write
+ * that reads it, and the same definition fills every repeater row and every
+ * entry created from that collection. Assigning it directly would hand all of
+ * them one shared object, so a later mutation — a field hook normalizing a
+ * row, say — would reach into unrelated rows, entries already written from the
+ * same config, and the definition itself.
+ */
+function cloneDefault(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value;
+  try {
+    return structuredClone(value);
+  } catch {
+    // Only values that cannot be stored at all fail to clone, and those are
+    // rejected by validation with a message about the value rather than about
+    // the copy that could not be made.
+    return value;
   }
 }
 

--- a/packages/nextly/src/shared/lib/field-defaults.ts
+++ b/packages/nextly/src/shared/lib/field-defaults.ts
@@ -59,7 +59,15 @@ export function applyFieldDefaults(
     if (NON_COLUMN_TYPES.has(field.type)) continue;
 
     const declared = (field as { defaultValue?: unknown }).defaultValue;
-    if (declared !== undefined && data[field.name] === undefined) {
+    // Read as an OWN property: a field named after something on
+    // `Object.prototype` — `constructor`, `toString`, `valueOf` — would
+    // otherwise resolve through the prototype chain, so an empty request body
+    // would look as though it supplied an inherited function and the declared
+    // default would be skipped in favour of it.
+    const supplied = Object.prototype.hasOwnProperty.call(data, field.name)
+      ? data[field.name]
+      : undefined;
+    if (declared !== undefined && supplied === undefined) {
       // Resolved against the data built so far, so a default may read the
       // values the caller did supply, and earlier defaults in this same pass.
       data[field.name] = cloneDefault(
@@ -116,7 +124,9 @@ function fillGroup(
   name: string,
   fields: readonly ValidatableField[]
 ): void {
-  const existing = data[name];
+  const existing = Object.prototype.hasOwnProperty.call(data, name)
+    ? data[name]
+    : undefined;
   if (isPlainObject(existing)) {
     applyFieldDefaults(existing, fields);
     return;

--- a/packages/nextly/src/shared/lib/field-defaults.ts
+++ b/packages/nextly/src/shared/lib/field-defaults.ts
@@ -49,18 +49,81 @@ export function applyFieldDefaults(
   fields: readonly ValidatableField[]
 ): void {
   for (const field of fields) {
-    if (!field.name) continue;
+    // A layout container (row, tabs, collapsible) groups fields visually
+    // without holding a value: its children are stored on the parent, so they
+    // are filled against the same object.
+    if (!field.name) {
+      if (field.fields) applyFieldDefaults(data, field.fields);
+      continue;
+    }
     if (NON_COLUMN_TYPES.has(field.type)) continue;
 
     const declared = (field as { defaultValue?: unknown }).defaultValue;
-    if (declared === undefined) continue;
-    if (data[field.name] !== undefined) continue;
+    if (declared !== undefined && data[field.name] === undefined) {
+      // Resolved against the data built so far, so a default may read the
+      // values the caller did supply, and earlier defaults in this same pass.
+      data[field.name] =
+        typeof declared === "function"
+          ? (declared as (d: Record<string, unknown>) => unknown)(data)
+          : declared;
+    }
 
-    // Resolved against the data built so far, so a default may read the values
-    // the caller did supply, and earlier defaults in this same pass.
-    data[field.name] =
-      typeof declared === "function"
-        ? (declared as (d: Record<string, unknown>) => unknown)(data)
-        : declared;
+    if (!field.fields) continue;
+
+    // Validation recurses into these, so a child's default has to be filled
+    // before it runs or a required child fails on an entry the caller could
+    // not have satisfied.
+    if (field.type === "group") {
+      fillGroup(data, field.name, field.fields);
+    } else if (field.type === "repeater") {
+      fillRepeaterRows(data[field.name], field.fields);
+    }
   }
+}
+
+/**
+ * Fill a group's children, creating the group only if something lands in it.
+ *
+ * An absent group is seeded into a scratch object first: writing `{}` for a
+ * group whose children declare no defaults would store an empty object where
+ * the caller stored nothing, which is a different value.
+ */
+function fillGroup(
+  data: Record<string, unknown>,
+  name: string,
+  fields: readonly ValidatableField[]
+): void {
+  const existing = data[name];
+  if (isPlainObject(existing)) {
+    applyFieldDefaults(existing, fields);
+    return;
+  }
+  // A group the caller set to null was cleared deliberately, exactly as for a
+  // scalar field, so it is left alone.
+  if (existing !== undefined) return;
+
+  const seeded: Record<string, unknown> = {};
+  applyFieldDefaults(seeded, fields);
+  if (Object.keys(seeded).length > 0) data[name] = seeded;
+}
+
+/**
+ * Fill each existing row's children.
+ *
+ * Rows are not invented: how many a new entry starts with is the caller's
+ * decision, and `minRows` is a validation rule rather than an instruction to
+ * fabricate content.
+ */
+function fillRepeaterRows(
+  value: unknown,
+  fields: readonly ValidatableField[]
+): void {
+  if (!Array.isArray(value)) return;
+  for (const row of value) {
+    if (isPlainObject(row)) applyFieldDefaults(row, fields);
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }


### PR DESCRIPTION
## What this fixes

A field's `defaultValue` is part of the public config API, but it was honoured in only two places: the admin create form, which fills it in the browser, and a single's first-read auto-create. Anything writing through the REST or Direct API got nothing.

Measured on `main` before the change, creating an entry that omits fields with declared defaults:

```
{"subtitle":null,"rank":null,"featured":null,"content":null}
```

Every declared default ignored — not only blocks, not only function defaults.

The sharper half: a **required** field carrying a default could not be created at all, because validation ran before anything resolved the default.

```
{"success":false,"statusCode":400,"errors":[{"path":"reqd","code":"REQUIRED","message":"reqd is required."}]}
```

So `text({ name: "status", required: true, defaultValue: "draft" })` made a collection impossible to write to through the API.

## The change

`applyFieldDefaults` fills declared defaults on the three collection create paths, placed **before the `beforeValidate` hooks** so a hook branching on a field sees the value a new entry actually starts with, and before validation so a required field carrying a default is satisfied.

Deliberate semantics:

- Only an **absent** key takes its default. An explicit `null` is how a JSON body says "no value", and defaulting over it would make a field impossible to leave empty.
- Falsy supplied values (`0`, `false`) are supplied values, not omissions.
- **Creates only.** A default must not resurrect on every later write.
- Applied even when a bulk path sets `skipHooks`, because a default is part of what the entry is, not a hook behaviour to opt out of.
- `component` fields are skipped: their data lives in another table, so a default here would target a column that does not exist.

Defaults are applied on the write path rather than inside validation, which reports issues and must not change the data it is given, and rather than as a column `DEFAULT`, which cannot reach a JSON-backed value.

## Known limit, asserted rather than left implicit

A collection's fields reach the write path from its **stored** definition, and a function does not survive being stored — so only a constant default can be applied here. A function default is not an error; by the time the write runs the field simply looks as though none was declared.

Honouring it would mean reading the in-memory code-first config on the write path, which is separate plumbing and a separate PR. A single's auto-create holds the config object directly and does resolve functions. There is a test asserting the current boundary so a future change to it is deliberate.

## Testing

Six integration cases through the real handler (a unit test over the helper cannot show this, since both bugs depend on where the helper sits relative to validation and the insert): every-type defaults, the required-field case, supplied values winning, explicit null preserved, updates untouched, and the function-default boundary.

**Correction on dialect coverage.** An earlier revision of this description claimed these ran green on SQLite, Postgres 17, and MySQL. That was wrong, and I withdraw it. `createTestNextly` forces an in-memory SQLite adapter when given none and sets `DB_DIALECT=sqlite`, so setting `TEST_POSTGRES_URL`/`TEST_MYSQL_URL` changed nothing — I confirmed by printing the live dialect, which read `sqlite` under every URL. Passing a real MySQL adapter then fails at boot, because the harness has no path that provisions its system tables outside its in-memory database. So a `createTestNextly` suite exercises one dialect regardless of environment.

Nothing under test here is dialect-specific: the ordering and precedence rules live above the adapter. But the coverage claim was unearned and is now stated accurately in each file.

`check-types` 19/19, lint clean. Touched-area units show 11 failures on both this branch and `main` — the known pre-existing baseline, unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Field defaults are now applied consistently when creating entries, including transactional and bulk creation.
  * Defaults populate nested groups, repeater rows, JSON fields, and required fields.
  * Explicit values, including `null` and other falsy values, are preserved.
  * JSON-backed defaults are stored and retrieved in the expected format.
* **Bug Fixes**
  * Updated collection synchronization to detect changes to declared field defaults.
  * Prevented defaults from unexpectedly reappearing during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->