### PR TITLE
feat(plugin-seo): serve a sitemap of published content over http

### DIFF
--- a/.changeset/plugin-seo-sitemap.md
+++ b/.changeset/plugin-seo-sitemap.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+@nextlyhq/plugin-seo now generates a sitemap of your published content and serves it at a public HTTP route (`/api/plugins/@nextlyhq/plugin-seo/sitemap.xml`). It lists one URL per published entry across the collections you configure, reflects publishes and edits on the next request, and leaves out drafts and any page marked `noindex`. Configure the site origin with `baseUrl` and per-entry paths with `urlFor`.

--- a/.changeset/plugin-seo-sitemap.md
+++ b/.changeset/plugin-seo-sitemap.md
@@ -22,4 +22,4 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-@nextlyhq/plugin-seo now generates a sitemap of your published content and serves it at a public HTTP route (`/api/plugins/@nextlyhq/plugin-seo/sitemap.xml`). It lists one URL per published entry across the collections you configure, reflects publishes and edits on the next request, and leaves out drafts and any page marked `noindex`. Configure the site origin with `baseUrl` and per-entry paths with `urlFor`.
+@nextlyhq/plugin-seo now generates a sitemap of your published content and serves it at a public HTTP route under Nextly's dynamic handler (in a scaffolded app, `/admin/api/plugins/@nextlyhq/plugin-seo/sitemap.xml`). It lists one URL per published entry across the collections you configure, reflects publishes and edits on the next request, and leaves out drafts and any page marked `noindex`. Configure the site origin with `baseUrl` and per-entry paths with `urlFor`, or disable the route with `sitemap: false`.

--- a/packages/plugin-seo/README.md
+++ b/packages/plugin-seo/README.md
@@ -58,11 +58,11 @@ seoPlugin({
 
 The plugin serves a sitemap of your **published** entries — one `<url>` per entry across the named collections — at a public HTTP route:
 
-```
+```text
 GET /api/plugins/@nextlyhq/plugin-seo/sitemap.xml
 ```
 
-It reads live content, so a publish or an edit is reflected on the next request. Drafts and any entry with `seo.noindex` set are left out.
+It reads live content, so a publish or an edit is reflected on the next request. Drafts, entries with `seo.noindex` set, and entries with no usable slug are left out. When an entry declares a `seo.canonical` URL, the sitemap advertises that canonical URL instead of the generated one.
 
 The published filter targets Nextly's built-in draft/published lifecycle (`status: true` on the collection). A collection without that lifecycle has no unpublished state, so all of its entries are listed.
 
@@ -79,7 +79,25 @@ seoPlugin({
 });
 ```
 
-A headless frontend can point crawlers at this URL (or proxy it to `/sitemap.xml`). An integrated Next.js app can also read the data through the planned Next helpers to serve the canonical `/sitemap.xml`.
+### Exposing it to crawlers
+
+Plugin routes are always namespaced under `/api/plugins/<name>/`. Search engines scope a sitemap to URLs beneath its own path unless it is submitted through Search Console or referenced in `robots.txt`, so a sitemap at `/api/plugins/...` whose `<loc>` values live at `/<collection>/...` may be ignored. Expose it at the site root instead — for a Next.js app, add a rewrite:
+
+```ts
+// next.config.ts
+export default {
+  async rewrites() {
+    return [
+      {
+        source: "/sitemap.xml",
+        destination: "/api/plugins/@nextlyhq/plugin-seo/sitemap.xml",
+      },
+    ];
+  },
+};
+```
+
+Then reference `https://example.com/sitemap.xml` from `robots.txt` or submit it in Search Console. An integrated Next.js app can also read the data through the planned Next helpers to serve the canonical `/sitemap.xml` directly. A pure-headless frontend can proxy the route to its own root the same way.
 
 ## License
 

--- a/packages/plugin-seo/README.md
+++ b/packages/plugin-seo/README.md
@@ -62,7 +62,7 @@ The plugin serves a sitemap of your **published** entries — one `<url>` per en
 GET /api/plugins/@nextlyhq/plugin-seo/sitemap.xml
 ```
 
-It reads live content, so a publish or an edit is reflected on the next request. Drafts, entries with `seo.noindex` set, and entries with no usable slug are left out. When an entry declares a `seo.canonical` URL, the sitemap advertises that canonical URL instead of the generated one.
+It reads live content, so a publish or an edit is reflected on the next request. Drafts, entries with `seo.noindex` set, and entries with no usable slug are left out. When an entry declares a same-host `seo.canonical` URL, the sitemap advertises that canonical URL instead of the generated one (a canonical on another host drops the entry, since a sitemap only lists URLs on its own host).
 
 The published filter targets Nextly's built-in draft/published lifecycle (`status: true` on the collection). A collection without that lifecycle has no unpublished state, so all of its entries are listed.
 
@@ -78,6 +78,19 @@ seoPlugin({
     collection === "posts" ? `/blog/${entry.slug}` : `/${entry.slug}`,
 });
 ```
+
+> **The sitemap is public and bypasses read access.** The route is unauthenticated and lists entries as the system role, so it enumerates every published entry's URL (and `lastModified`) **regardless of per-collection read access**. Do not enumerate a collection whose entries should stay private (owner-only, role-gated, or internal). Control it with the `sitemap` option:
+>
+> ```ts
+> // Turn the sitemap route off entirely:
+> seoPlugin({ collections: ["pages", "internalDocs"], sitemap: false });
+>
+> // Or advertise only the public subset (the rest still get SEO fields):
+> seoPlugin({
+>   collections: ["pages", "internalDocs"],
+>   sitemap: { collections: ["pages"] },
+> });
+> ```
 
 ### Exposing it to crawlers
 

--- a/packages/plugin-seo/README.md
+++ b/packages/plugin-seo/README.md
@@ -94,7 +94,13 @@ seoPlugin({
 
 ### Exposing it to crawlers
 
-Plugin routes are always namespaced under `/api/plugins/<name>/`. Search engines scope a sitemap to URLs beneath its own path unless it is submitted through Search Console or referenced in `robots.txt`, so a sitemap at `/api/plugins/...` whose `<loc>` values live at `/<collection>/...` may be ignored. Expose it at the site root instead — for a Next.js app, add a rewrite:
+Plugin routes are namespaced under the mount point of Nextly's dynamic handler. In an app scaffolded by `create-nextly-app` that handler lives at `app/admin/api/[[...params]]/route.ts`, so this route is served at:
+
+```text
+/admin/api/plugins/@nextlyhq/plugin-seo/sitemap.xml
+```
+
+Search engines scope a sitemap to URLs beneath its own path unless it is submitted through Search Console or referenced in `robots.txt`, so a sitemap under `/admin/api/...` whose `<loc>` values live at `/<collection>/...` may be ignored. Expose it at the site root instead — for a Next.js app, add a rewrite (point `destination` at wherever your dynamic handler is mounted):
 
 ```ts
 // next.config.ts
@@ -103,7 +109,7 @@ export default {
     return [
       {
         source: "/sitemap.xml",
-        destination: "/api/plugins/@nextlyhq/plugin-seo/sitemap.xml",
+        destination: "/admin/api/plugins/@nextlyhq/plugin-seo/sitemap.xml",
       },
     ];
   },
@@ -111,6 +117,8 @@ export default {
 ```
 
 Then reference `https://example.com/sitemap.xml` from `robots.txt` or submit it in Search Console. An integrated Next.js app can also read the data through the planned Next helpers to serve the canonical `/sitemap.xml` directly. A pure-headless frontend can proxy the route to its own root the same way.
+
+> **Cache or rate-limit the public route.** It is unauthenticated and regenerates the document per request (up to the 50,000-URL / 50 MB caps), and on the `/admin/api` mount Nextly's built-in rate limiter is skipped. Put it behind an edge/CDN cache (sitemaps are crawled infrequently) or a rate limiter at your proxy — or disable it with `sitemap: false` if you don't need it.
 
 ## License
 

--- a/packages/plugin-seo/README.md
+++ b/packages/plugin-seo/README.md
@@ -64,6 +64,8 @@ GET /api/plugins/@nextlyhq/plugin-seo/sitemap.xml
 
 It reads live content, so a publish or an edit is reflected on the next request. Drafts and any entry with `seo.noindex` set are left out.
 
+The published filter targets Nextly's built-in draft/published lifecycle (`status: true` on the collection). A collection without that lifecycle has no unpublished state, so all of its entries are listed.
+
 ```ts
 seoPlugin({
   collections: ["pages", "posts"],

--- a/packages/plugin-seo/README.md
+++ b/packages/plugin-seo/README.md
@@ -4,7 +4,7 @@
 
 First-party SEO plugin for Nextly. It is **opt-in** and **framework-agnostic** (zero `next` dependency), so it is safe in every deployment mode — an integrated site, a headless setup feeding a separate frontend, or an internal admin tool. You add it only to the collections that need SEO.
 
-This package is **data-only** and framework-agnostic: it adds SEO fields to your content, nothing Next-specific, so it is safe in headless and admin-only projects. Turning those fields into `<meta>` tags, a sitemap, or routes is your app's job today; first-party Next.js helpers for that are planned as a separate, opt-in package.
+This package is **framework-agnostic** (zero `next`): it adds SEO fields to your content and serves a sitemap of your published content over plain HTTP, nothing Next-specific, so it is safe in headless and admin-only projects. Turning the SEO fields into `<meta>` tags and wiring a canonical `app/sitemap.ts` / `robots.ts` are your app's job today; first-party Next.js helpers for that are planned as a separate, opt-in package.
 
 ## Install
 
@@ -53,6 +53,31 @@ seoPlugin({
   fields: [text({ name: "focusKeyword" })],
 });
 ```
+
+## Sitemap
+
+The plugin serves a sitemap of your **published** entries — one `<url>` per entry across the named collections — at a public HTTP route:
+
+```
+GET /api/plugins/@nextlyhq/plugin-seo/sitemap.xml
+```
+
+It reads live content, so a publish or an edit is reflected on the next request. Drafts and any entry with `seo.noindex` set are left out.
+
+```ts
+seoPlugin({
+  collections: ["pages", "posts"],
+  // Absolute origin used for <loc>. When omitted, the route uses the request
+  // origin — correct for a single-origin deployment, wrong behind a host-
+  // rewriting proxy, so set it explicitly there.
+  baseUrl: "https://example.com",
+  // Path per entry (leading slash). Defaults to `/<collection>/<slug>`.
+  urlFor: (entry, collection) =>
+    collection === "posts" ? `/blog/${entry.slug}` : `/${entry.slug}`,
+});
+```
+
+A headless frontend can point crawlers at this URL (or proxy it to `/sitemap.xml`). An integrated Next.js app can also read the data through the planned Next helpers to serve the canonical `/sitemap.xml`.
 
 ## License
 

--- a/packages/plugin-seo/README.md
+++ b/packages/plugin-seo/README.md
@@ -56,10 +56,10 @@ seoPlugin({
 
 ## Sitemap
 
-The plugin serves a sitemap of your **published** entries — one `<url>` per entry across the named collections — at a public HTTP route:
+The plugin serves a sitemap of your **published** entries — one `<url>` per entry across the named collections — at a public HTTP route under Nextly's dynamic handler. In an app scaffolded by `create-nextly-app` (handler at `app/admin/api`), that is:
 
 ```text
-GET /api/plugins/@nextlyhq/plugin-seo/sitemap.xml
+GET /admin/api/plugins/@nextlyhq/plugin-seo/sitemap.xml
 ```
 
 It reads live content, so a publish or an edit is reflected on the next request. Drafts, entries with `seo.noindex` set, and entries with no usable slug are left out. When an entry declares a same-host `seo.canonical` URL, the sitemap advertises that canonical URL instead of the generated one (a canonical on another host drops the entry, since a sitemap only lists URLs on its own host).

--- a/packages/plugin-seo/src/__tests__/plugin.test.ts
+++ b/packages/plugin-seo/src/__tests__/plugin.test.ts
@@ -66,6 +66,23 @@ describe("seoPlugin", () => {
     expect(seoGroup(plugin).fields).toBe(custom);
   });
 
+  it("serves the sitemap route by default", () => {
+    const plugin = seoPlugin({ collections: ["pages"] });
+    expect(plugin.contributes?.routes?.[0]).toMatchObject({
+      method: "GET",
+      path: "/sitemap.xml",
+      public: true,
+    });
+  });
+
+  it("omits the sitemap route when sitemap is disabled", () => {
+    const plugin = seoPlugin({ collections: ["pages"], sitemap: false });
+    // No public enumeration route when the sitemap is turned off.
+    expect(plugin.contributes?.routes).toBeUndefined();
+    // The SEO fields are still contributed.
+    expect(plugin.contributes?.extend?.[0]?.target).toEqual(["pages"]);
+  });
+
   it("defaultSeoFields returns the inner seo fields", () => {
     expect(fieldNames(defaultSeoFields())).toEqual([
       "metaTitle",

--- a/packages/plugin-seo/src/__tests__/plugin.test.ts
+++ b/packages/plugin-seo/src/__tests__/plugin.test.ts
@@ -83,6 +83,14 @@ describe("seoPlugin", () => {
     expect(plugin.contributes?.extend?.[0]?.target).toEqual(["pages"]);
   });
 
+  it("rejects a sitemap collection outside the configured collections", () => {
+    // A typo'd / non-extended slug would 500 the public route at request time;
+    // fail fast at construction instead.
+    expect(() =>
+      seoPlugin({ collections: ["pages"], sitemap: { collections: ["posts"] } })
+    ).toThrow(/subset/i);
+  });
+
   it("defaultSeoFields returns the inner seo fields", () => {
     expect(fieldNames(defaultSeoFields())).toEqual([
       "metaTitle",

--- a/packages/plugin-seo/src/__tests__/plugin.test.ts
+++ b/packages/plugin-seo/src/__tests__/plugin.test.ts
@@ -97,6 +97,18 @@ describe("seoPlugin", () => {
     ).toThrow(/absolute http/i);
   });
 
+  it("does not validate baseUrl when the sitemap is disabled", () => {
+    // A disabled route never consumes baseUrl, so an env-specific/invalid value
+    // must not block boot.
+    expect(() =>
+      seoPlugin({
+        collections: ["pages"],
+        sitemap: false,
+        baseUrl: "not-a-url",
+      })
+    ).not.toThrow();
+  });
+
   it("defaultSeoFields returns the inner seo fields", () => {
     expect(fieldNames(defaultSeoFields())).toEqual([
       "metaTitle",

--- a/packages/plugin-seo/src/__tests__/plugin.test.ts
+++ b/packages/plugin-seo/src/__tests__/plugin.test.ts
@@ -91,6 +91,12 @@ describe("seoPlugin", () => {
     ).toThrow(/subset/i);
   });
 
+  it("rejects a baseUrl that is not an absolute http(s) URL", () => {
+    expect(() =>
+      seoPlugin({ collections: ["pages"], baseUrl: "example.com" })
+    ).toThrow(/absolute http/i);
+  });
+
   it("defaultSeoFields returns the inner seo fields", () => {
     expect(fieldNames(defaultSeoFields())).toEqual([
       "metaTitle",

--- a/packages/plugin-seo/src/__tests__/sitemap.integration.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.integration.test.ts
@@ -5,6 +5,7 @@
  * read. Drives the real `contributes.routes` handler through
  * `createDynamicHandlers` — the same path production serves.
  */
+import { definePlugin } from "@nextlyhq/plugin-sdk";
 import {
   createTestNextly,
   type TestNextly,
@@ -14,6 +15,7 @@ import { createDynamicHandlers } from "nextly/runtime";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { seoPlugin } from "../plugin";
+import { buildSitemapUrls, type SitemapServices } from "../sitemap";
 
 // Segments after `/api/`, matching how the catch-all splits the path. The
 // plugin name `@nextlyhq/plugin-seo` is two segments (it contains a slash).
@@ -121,6 +123,88 @@ describe("seo sitemap route (integration)", () => {
     expect((await fetchSitemap()).body).toContain(
       "<loc>https://x.com/pages/later</loc>"
     );
+  });
+
+  it("pages through every published entry against the real service", async () => {
+    // Capture the real `ctx.services` so the pagination loop runs against the
+    // actual managed facade (which pages by `page`, not `offset`). With a page
+    // size of one and three entries, an offset-advancing loop would re-read
+    // page one forever; a page-advancing loop collects all three and stops.
+    let captured: SitemapServices | undefined;
+    const probe = definePlugin({
+      name: "@test/sitemap-probe",
+      version: "0.0.0",
+      nextly: ">=0.0.0",
+      init(ctx) {
+        captured = ctx.services;
+      },
+    });
+
+    current = await createTestNextly({
+      collections: [pages()],
+      plugins: [
+        seoPlugin({ collections: ["pages"], baseUrl: "https://x.com" }),
+        probe,
+      ],
+    });
+
+    for (const slug of ["a", "b", "c"]) {
+      await current.nextly.create({
+        collection: "pages",
+        data: { slug, title: slug.toUpperCase(), status: "published" },
+      });
+    }
+
+    const services = captured;
+    if (!services) throw new Error("probe did not capture ctx.services");
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["pages"],
+      baseUrl: "https://x.com",
+      pageSize: 1,
+    });
+
+    expect(urls.map(u => u.loc).sort()).toEqual([
+      "https://x.com/pages/a",
+      "https://x.com/pages/b",
+      "https://x.com/pages/c",
+    ]);
+  });
+
+  it("lists every entry of a status-less collection (no unpublished state)", async () => {
+    // A collection without `status: true` has no draft/published lifecycle, so
+    // the published filter is a no-op and every (live) entry is listed.
+    const notes = () =>
+      defineCollection({
+        slug: "notes",
+        fields: [text({ name: "slug" }), text({ name: "title" })],
+      });
+
+    current = await createTestNextly({
+      collections: [notes()],
+      plugins: [
+        seoPlugin({ collections: ["notes"], baseUrl: "https://x.com" }),
+      ],
+    });
+
+    await current.nextly.create({
+      collection: "notes",
+      data: { slug: "one", title: "One" },
+    });
+
+    const handlers = createDynamicHandlers();
+    const res = await handlers.GET(
+      new Request(
+        "http://localhost/api/plugins/@nextlyhq/plugin-seo/sitemap.xml"
+      ),
+      {
+        params: Promise.resolve({
+          params: ["plugins", "@nextlyhq", "plugin-seo", "sitemap.xml"],
+        }),
+      }
+    );
+
+    expect(await res.text()).toContain("<loc>https://x.com/notes/one</loc>");
   });
 
   it("derives the origin from the request when baseUrl is not configured", async () => {

--- a/packages/plugin-seo/src/__tests__/sitemap.integration.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.integration.test.ts
@@ -1,9 +1,16 @@
 /**
  * The sitemap route serves published content as XML over the catch-all, proven
  * end-to-end against a real boot: a published entry appears, a draft and a
- * `noindex` entry do not, and publishing a draft makes it appear on the next
- * read. Drives the real `contributes.routes` handler through
- * `createDynamicHandlers` — the same path production serves.
+ * `noindex` entry do not, only the configured subset is enumerated, and the
+ * (uncached) data provider reflects a publish. Drives the real
+ * `contributes.routes` handler through `createDynamicHandlers` — the same path
+ * production serves.
+ *
+ * The route caches its output behind the collection tags (F1). Outside a Next
+ * request scope `revalidateTag` is a no-op, and `unstable_cache` keys by
+ * `keyParts` at process scope, so each test uses a DISTINCT `baseUrl` (part of
+ * the key) to avoid cross-boot cache bleed, and publish-freshness is checked
+ * against the uncached provider rather than the cached route.
  */
 import { definePlugin } from "@nextlyhq/plugin-sdk";
 import {
@@ -21,6 +28,11 @@ import { buildSitemapUrls, type SitemapServices } from "../sitemap";
 // plugin name `@nextlyhq/plugin-seo` is two segments (it contains a slash).
 const SITEMAP_PARAMS = ["plugins", "@nextlyhq", "plugin-seo", "sitemap.xml"];
 
+// A distinct origin per test so the route's F1 cache key (which includes the
+// baseUrl) never collides across boots in the same process.
+let seq = 0;
+const nextBase = (): string => `https://s${(seq += 1)}.example`;
+
 const pages = () =>
   defineCollection({
     slug: "pages",
@@ -37,15 +49,38 @@ afterEach(async () => {
   current = undefined;
 });
 
-async function fetchSitemap(): Promise<{ status: number; body: string }> {
+async function fetchSitemap(
+  host = "localhost"
+): Promise<{ status: number; body: string }> {
   const handlers = createDynamicHandlers();
   const res = await handlers.GET(
-    new Request(
-      "http://localhost/api/plugins/@nextlyhq/plugin-seo/sitemap.xml"
-    ),
+    new Request(`http://${host}/api/plugins/@nextlyhq/plugin-seo/sitemap.xml`),
     { params: Promise.resolve({ params: SITEMAP_PARAMS }) }
   );
   return { status: res.status, body: await res.text() };
+}
+
+/** A probe plugin that captures the real `ctx.services` for provider tests. */
+function captureServices(): {
+  probe: ReturnType<typeof definePlugin>;
+  get(): SitemapServices;
+} {
+  let captured: SitemapServices | undefined;
+  const probe = definePlugin({
+    name: "@test/sitemap-probe",
+    version: "0.0.0",
+    nextly: ">=0.0.0",
+    init(ctx) {
+      captured = ctx.services;
+    },
+  });
+  return {
+    probe,
+    get() {
+      if (!captured) throw new Error("probe did not capture ctx.services");
+      return captured;
+    },
+  };
 }
 
 describe("seo sitemap route (integration)", () => {
@@ -61,11 +96,10 @@ describe("seo sitemap route (integration)", () => {
   });
 
   it("serves published entries as XML and omits drafts + noindex", async () => {
+    const base = nextBase();
     current = await createTestNextly({
       collections: [pages()],
-      plugins: [
-        seoPlugin({ collections: ["pages"], baseUrl: "https://x.com" }),
-      ],
+      plugins: [seoPlugin({ collections: ["pages"], baseUrl: base })],
     });
 
     await current.nextly.create({
@@ -89,18 +123,17 @@ describe("seo sitemap route (integration)", () => {
     const { status, body } = await fetchSitemap();
 
     expect(status).toBe(200);
-    expect(body).toContain("<loc>https://x.com/pages/published</loc>");
+    expect(body).toContain(`<loc>${base}/pages/published</loc>`);
     // A draft is not public, and a noindexed page must not be advertised.
     expect(body).not.toContain("/pages/draft");
     expect(body).not.toContain("/pages/hidden");
   });
 
-  it("reflects a newly published entry on the next read", async () => {
+  it("reflects a newly published entry (uncached data provider)", async () => {
+    const probe = captureServices();
     current = await createTestNextly({
       collections: [pages()],
-      plugins: [
-        seoPlugin({ collections: ["pages"], baseUrl: "https://x.com" }),
-      ],
+      plugins: [seoPlugin({ collections: ["pages"] }), probe.probe],
     });
 
     const created = await current.nextly.create({
@@ -109,8 +142,16 @@ describe("seo sitemap route (integration)", () => {
     });
     const id = (created.item as { id: string }).id;
 
+    const build = () =>
+      buildSitemapUrls(probe.get(), {
+        collections: ["pages"],
+        baseUrl: "https://x.com",
+      });
+
     // Not yet published: absent from the sitemap.
-    expect((await fetchSitemap()).body).not.toContain("/pages/later");
+    expect((await build()).map(u => u.loc)).not.toContain(
+      "https://x.com/pages/later"
+    );
 
     await current.nextly.update({
       collection: "pages",
@@ -118,34 +159,21 @@ describe("seo sitemap route (integration)", () => {
       data: { status: "published" },
     });
 
-    // Published now: present on the next read (the published filter responds to
-    // the transition; F1 busts the tagged read in a Next runtime).
-    expect((await fetchSitemap()).body).toContain(
-      "<loc>https://x.com/pages/later</loc>"
+    // Published now: the published filter responds to the transition.
+    expect((await build()).map(u => u.loc)).toContain(
+      "https://x.com/pages/later"
     );
   });
 
   it("pages through every published entry against the real service", async () => {
-    // Capture the real `ctx.services` so the pagination loop runs against the
-    // actual managed facade (which pages by `page`, not `offset`). With a page
-    // size of one and three entries, an offset-advancing loop would re-read
-    // page one forever; a page-advancing loop collects all three and stops.
-    let captured: SitemapServices | undefined;
-    const probe = definePlugin({
-      name: "@test/sitemap-probe",
-      version: "0.0.0",
-      nextly: ">=0.0.0",
-      init(ctx) {
-        captured = ctx.services;
-      },
-    });
-
+    // Run the pagination loop against the actual managed facade (which pages by
+    // `page`, not `offset`). With a page size of one and three entries, an
+    // offset-advancing loop would re-read page one forever; a page-advancing
+    // loop collects all three and stops.
+    const probe = captureServices();
     current = await createTestNextly({
       collections: [pages()],
-      plugins: [
-        seoPlugin({ collections: ["pages"], baseUrl: "https://x.com" }),
-        probe,
-      ],
+      plugins: [seoPlugin({ collections: ["pages"] }), probe.probe],
     });
 
     for (const slug of ["a", "b", "c"]) {
@@ -155,10 +183,7 @@ describe("seo sitemap route (integration)", () => {
       });
     }
 
-    const services = captured;
-    if (!services) throw new Error("probe did not capture ctx.services");
-
-    const urls = await buildSitemapUrls(services, {
+    const urls = await buildSitemapUrls(probe.get(), {
       collections: ["pages"],
       baseUrl: "https://x.com",
       pageSize: 1,
@@ -173,7 +198,8 @@ describe("seo sitemap route (integration)", () => {
 
   it("lists every entry of a status-less collection (no unpublished state)", async () => {
     // A collection without `status: true` has no draft/published lifecycle, so
-    // the published filter is a no-op and every (live) entry is listed.
+    // the published filter is skipped and every (live) entry is listed.
+    const base = nextBase();
     const notes = () =>
       defineCollection({
         slug: "notes",
@@ -182,9 +208,7 @@ describe("seo sitemap route (integration)", () => {
 
     current = await createTestNextly({
       collections: [notes()],
-      plugins: [
-        seoPlugin({ collections: ["notes"], baseUrl: "https://x.com" }),
-      ],
+      plugins: [seoPlugin({ collections: ["notes"], baseUrl: base })],
     });
 
     await current.nextly.create({
@@ -192,22 +216,49 @@ describe("seo sitemap route (integration)", () => {
       data: { slug: "one", title: "One" },
     });
 
-    const handlers = createDynamicHandlers();
-    const res = await handlers.GET(
-      new Request(
-        "http://localhost/api/plugins/@nextlyhq/plugin-seo/sitemap.xml"
-      ),
-      {
-        params: Promise.resolve({
-          params: ["plugins", "@nextlyhq", "plugin-seo", "sitemap.xml"],
-        }),
-      }
+    expect((await fetchSitemap()).body).toContain(
+      `<loc>${base}/notes/one</loc>`
     );
+  });
 
-    expect(await res.text()).toContain("<loc>https://x.com/notes/one</loc>");
+  it("advertises only the sitemap subset, keeping a private collection out", async () => {
+    const base = nextBase();
+    const posts = () =>
+      defineCollection({
+        slug: "posts",
+        status: true,
+        fields: [text({ name: "slug" }), text({ name: "title" })],
+      });
+
+    current = await createTestNextly({
+      collections: [pages(), posts()],
+      plugins: [
+        // Both collections get SEO fields, but only `posts` is enumerated.
+        seoPlugin({
+          collections: ["pages", "posts"],
+          baseUrl: base,
+          sitemap: { collections: ["posts"] },
+        }),
+      ],
+    });
+
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "secret", title: "S", status: "published" },
+    });
+    await current.nextly.create({
+      collection: "posts",
+      data: { slug: "hello", title: "H", status: "published" },
+    });
+
+    const { body } = await fetchSitemap();
+    expect(body).toContain(`<loc>${base}/posts/hello</loc>`);
+    expect(body).not.toContain("/pages/secret");
   });
 
   it("derives the origin from the request when baseUrl is not configured", async () => {
+    // Distinct host so the origin-derived cache key is unique to this test.
+    const host = `origin-${seq + 1}.test`;
     current = await createTestNextly({
       collections: [pages()],
       plugins: [seoPlugin({ collections: ["pages"] })],
@@ -218,7 +269,7 @@ describe("seo sitemap route (integration)", () => {
       data: { slug: "home", title: "H", status: "published" },
     });
 
-    const { body } = await fetchSitemap();
-    expect(body).toContain("<loc>http://localhost/pages/home</loc>");
+    const { body } = await fetchSitemap(host);
+    expect(body).toContain(`<loc>http://${host}/pages/home</loc>`);
   });
 });

--- a/packages/plugin-seo/src/__tests__/sitemap.integration.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.integration.test.ts
@@ -25,8 +25,8 @@ import { buildSitemapUrls, type SitemapServices } from "../sitemap";
 // plugin name `@nextlyhq/plugin-seo` is two segments (it contains a slash).
 const SITEMAP_PARAMS = ["plugins", "@nextlyhq", "plugin-seo", "sitemap.xml"];
 
-// A distinct origin per test so the route's F1 cache key (which includes the
-// baseUrl) never collides across boots in the same process.
+// A distinct origin per test so each test's assertions stay independent (the
+// route generates fresh per request; the sequence just keeps hosts unique).
 let seq = 0;
 const nextBase = (): string => `https://s${(seq += 1)}.example`;
 

--- a/packages/plugin-seo/src/__tests__/sitemap.integration.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.integration.test.ts
@@ -2,15 +2,12 @@
  * The sitemap route serves published content as XML over the catch-all, proven
  * end-to-end against a real boot: a published entry appears, a draft and a
  * `noindex` entry do not, only the configured subset is enumerated, and the
- * (uncached) data provider reflects a publish. Drives the real
- * `contributes.routes` handler through `createDynamicHandlers` — the same path
- * production serves.
+ * data provider reflects a publish. Drives the real `contributes.routes`
+ * handler through `createDynamicHandlers` — the same path production serves.
  *
- * The route caches its output behind the collection tags (F1). Outside a Next
- * request scope `revalidateTag` is a no-op, and `unstable_cache` keys by
- * `keyParts` at process scope, so each test uses a DISTINCT `baseUrl` (part of
- * the key) to avoid cross-boot cache bleed, and publish-freshness is checked
- * against the uncached provider rather than the cached route.
+ * Each route test uses a DISTINCT `baseUrl` (or request host) so the assertions
+ * stay independent, and publish-freshness is checked against the data provider
+ * directly.
  */
 import { definePlugin } from "@nextlyhq/plugin-sdk";
 import {

--- a/packages/plugin-seo/src/__tests__/sitemap.integration.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.integration.test.ts
@@ -48,13 +48,17 @@ afterEach(async () => {
 
 async function fetchSitemap(
   host = "localhost"
-): Promise<{ status: number; body: string }> {
+): Promise<{ status: number; body: string; cacheControl: string | null }> {
   const handlers = createDynamicHandlers();
   const res = await handlers.GET(
     new Request(`http://${host}/api/plugins/@nextlyhq/plugin-seo/sitemap.xml`),
     { params: Promise.resolve({ params: SITEMAP_PARAMS }) }
   );
-  return { status: res.status, body: await res.text() };
+  return {
+    status: res.status,
+    body: await res.text(),
+    cacheControl: res.headers.get("cache-control"),
+  };
 }
 
 /** A probe plugin that captures the real `ctx.services` for provider tests. */
@@ -117,13 +121,15 @@ describe("seo sitemap route (integration)", () => {
       },
     });
 
-    const { status, body } = await fetchSitemap();
+    const { status, body, cacheControl } = await fetchSitemap();
 
     expect(status).toBe(200);
     expect(body).toContain(`<loc>${base}/pages/published</loc>`);
     // A draft is not public, and a noindexed page must not be advertised.
     expect(body).not.toContain("/pages/draft");
     expect(body).not.toContain("/pages/hidden");
+    // A configured baseUrl yields a stable, cacheable document.
+    expect(cacheControl).not.toBe("no-store");
   });
 
   it("reflects a newly published entry (uncached data provider)", async () => {
@@ -266,7 +272,9 @@ describe("seo sitemap route (integration)", () => {
       data: { slug: "home", title: "H", status: "published" },
     });
 
-    const { body } = await fetchSitemap(host);
+    const { body, cacheControl } = await fetchSitemap(host);
     expect(body).toContain(`<loc>http://${host}/pages/home</loc>`);
+    // A request-derived origin is spoofable, so the response is uncacheable.
+    expect(cacheControl).toBe("no-store");
   });
 });

--- a/packages/plugin-seo/src/__tests__/sitemap.integration.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.integration.test.ts
@@ -1,0 +1,140 @@
+/**
+ * The sitemap route serves published content as XML over the catch-all, proven
+ * end-to-end against a real boot: a published entry appears, a draft and a
+ * `noindex` entry do not, and publishing a draft makes it appear on the next
+ * read. Drives the real `contributes.routes` handler through
+ * `createDynamicHandlers` — the same path production serves.
+ */
+import {
+  createTestNextly,
+  type TestNextly,
+} from "@nextlyhq/plugin-sdk/testing";
+import { defineCollection, text } from "nextly";
+import { createDynamicHandlers } from "nextly/runtime";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { seoPlugin } from "../plugin";
+
+// Segments after `/api/`, matching how the catch-all splits the path. The
+// plugin name `@nextlyhq/plugin-seo` is two segments (it contains a slash).
+const SITEMAP_PARAMS = ["plugins", "@nextlyhq", "plugin-seo", "sitemap.xml"];
+
+const pages = () =>
+  defineCollection({
+    slug: "pages",
+    // Built-in draft/published lifecycle: adds the NOT NULL `status` column the
+    // sitemap filters on (`{ status: { equals: "published" } }`).
+    status: true,
+    fields: [text({ name: "slug" }), text({ name: "title" })],
+  });
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+async function fetchSitemap(): Promise<{ status: number; body: string }> {
+  const handlers = createDynamicHandlers();
+  const res = await handlers.GET(
+    new Request(
+      "http://localhost/api/plugins/@nextlyhq/plugin-seo/sitemap.xml"
+    ),
+    { params: Promise.resolve({ params: SITEMAP_PARAMS }) }
+  );
+  return { status: res.status, body: await res.text() };
+}
+
+describe("seo sitemap route (integration)", () => {
+  it("declares a public GET /sitemap.xml route", () => {
+    const route = seoPlugin({
+      collections: ["pages"],
+    }).contributes?.routes?.[0];
+    expect(route).toMatchObject({
+      method: "GET",
+      path: "/sitemap.xml",
+      public: true,
+    });
+  });
+
+  it("serves published entries as XML and omits drafts + noindex", async () => {
+    current = await createTestNextly({
+      collections: [pages()],
+      plugins: [
+        seoPlugin({ collections: ["pages"], baseUrl: "https://x.com" }),
+      ],
+    });
+
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "published", title: "P", status: "published" },
+    });
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "draft", title: "D", status: "draft" },
+    });
+    await current.nextly.create({
+      collection: "pages",
+      data: {
+        slug: "hidden",
+        title: "H",
+        status: "published",
+        seo: { noindex: true },
+      },
+    });
+
+    const { status, body } = await fetchSitemap();
+
+    expect(status).toBe(200);
+    expect(body).toContain("<loc>https://x.com/pages/published</loc>");
+    // A draft is not public, and a noindexed page must not be advertised.
+    expect(body).not.toContain("/pages/draft");
+    expect(body).not.toContain("/pages/hidden");
+  });
+
+  it("reflects a newly published entry on the next read", async () => {
+    current = await createTestNextly({
+      collections: [pages()],
+      plugins: [
+        seoPlugin({ collections: ["pages"], baseUrl: "https://x.com" }),
+      ],
+    });
+
+    const created = await current.nextly.create({
+      collection: "pages",
+      data: { slug: "later", title: "L", status: "draft" },
+    });
+    const id = (created.item as { id: string }).id;
+
+    // Not yet published: absent from the sitemap.
+    expect((await fetchSitemap()).body).not.toContain("/pages/later");
+
+    await current.nextly.update({
+      collection: "pages",
+      id,
+      data: { status: "published" },
+    });
+
+    // Published now: present on the next read (the published filter responds to
+    // the transition; F1 busts the tagged read in a Next runtime).
+    expect((await fetchSitemap()).body).toContain(
+      "<loc>https://x.com/pages/later</loc>"
+    );
+  });
+
+  it("derives the origin from the request when baseUrl is not configured", async () => {
+    current = await createTestNextly({
+      collections: [pages()],
+      plugins: [seoPlugin({ collections: ["pages"] })],
+    });
+
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "home", title: "H", status: "published" },
+    });
+
+    const { body } = await fetchSitemap();
+    expect(body).toContain("<loc>http://localhost/pages/home</loc>");
+  });
+});

--- a/packages/plugin-seo/src/__tests__/sitemap.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.test.ts
@@ -336,19 +336,63 @@ describe("buildSitemapUrls", () => {
   });
 
   it("bounds the document to the byte limit", async () => {
-    // A tiny maxBytes forces truncation after the first entry.
     const services = stubServices({
       posts: [[{ slug: "a" }, { slug: "b" }, { slug: "c" }]],
+    });
+
+    // Budget just enough for the wrapper plus a single entry.
+    const oneUrlDoc = serializeSitemap([{ loc: "https://x.com/posts/a" }]);
+    const maxBytes = new TextEncoder().encode(oneUrlDoc).length + 2;
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+      maxBytes,
+    });
+
+    expect(urls.map(u => u.loc)).toEqual(["https://x.com/posts/a"]);
+  });
+
+  it("returns empty when even the first entry exceeds the byte cap", async () => {
+    const services = stubServices({ posts: [[{ slug: "a" }]] });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+      maxBytes: 10,
+    });
+
+    // The hard cap wins over emitting a single oversized document.
+    expect(urls).toEqual([]);
+  });
+
+  it("percent-encodes and origin-checks a custom urlFor path", async () => {
+    const services = stubServices({
+      posts: [[{ slug: "a" }, { slug: "evil" }]],
     });
 
     const urls = await buildSitemapUrls(services, {
       collections: ["posts"],
       baseUrl: "https://x.com",
-      maxBytes: 120,
+      urlFor: entry =>
+        // A space needs encoding; an absolute off-origin URL must be dropped.
+        entry.slug === "evil" ? "https://evil.com/x" : "/people/John Doe",
     });
 
-    // Only the first entry fits under the tiny cap (always emit at least one).
-    expect(urls).toHaveLength(1);
+    expect(urls.map(u => u.loc)).toEqual(["https://x.com/people/John%20Doe"]);
+  });
+
+  it("ignores a same-origin canonical that carries credentials", async () => {
+    const services = stubServices({
+      posts: [[{ slug: "a", seo: { canonical: "https://user:pass@x.com/a" } }]],
+    });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+    });
+
+    // Credentials must never reach a public <loc>; fall back to the generated URL.
     expect(urls[0].loc).toBe("https://x.com/posts/a");
   });
 

--- a/packages/plugin-seo/src/__tests__/sitemap.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.test.ts
@@ -320,15 +320,36 @@ describe("buildSitemapUrls", () => {
     expect(query.select).toBeUndefined();
   });
 
-  it("throws on a baseUrl that is not an absolute http(s) URL", async () => {
+  it("throws on a baseUrl that is not an absolute http(s) origin", async () => {
     const services = stubServices({ posts: [[{ slug: "a" }]] });
 
-    await expect(
-      buildSitemapUrls(services, {
-        collections: ["posts"],
-        baseUrl: "example.com",
-      })
-    ).rejects.toThrow(/absolute http/i);
+    for (const bad of [
+      "example.com", // no scheme
+      "https://x.com/cms", // has a path
+      "https://x.com?q=1", // has a query
+      "https://user:pass@x.com", // credentials
+    ]) {
+      await expect(
+        buildSitemapUrls(services, { collections: ["posts"], baseUrl: bad })
+      ).rejects.toThrow(/absolute http/i);
+    }
+  });
+
+  it("bounds the document to the byte limit", async () => {
+    // A tiny maxBytes forces truncation after the first entry.
+    const services = stubServices({
+      posts: [[{ slug: "a" }, { slug: "b" }, { slug: "c" }]],
+    });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+      maxBytes: 120,
+    });
+
+    // Only the first entry fits under the tiny cap (always emit at least one).
+    expect(urls).toHaveLength(1);
+    expect(urls[0].loc).toBe("https://x.com/posts/a");
   });
 
   it("bounds the document to the sitemap URL limit", async () => {

--- a/packages/plugin-seo/src/__tests__/sitemap.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.test.ts
@@ -356,14 +356,61 @@ describe("buildSitemapUrls", () => {
   it("returns empty when even the first entry exceeds the byte cap", async () => {
     const services = stubServices({ posts: [[{ slug: "a" }]] });
 
+    // Budget holds the wrapper but not a single entry.
+    const emptyDoc = serializeSitemap([]);
+    const maxBytes = new TextEncoder().encode(emptyDoc).length + 5;
+
     const urls = await buildSitemapUrls(services, {
       collections: ["posts"],
       baseUrl: "https://x.com",
-      maxBytes: 10,
+      maxBytes,
     });
 
     // The hard cap wins over emitting a single oversized document.
     expect(urls).toEqual([]);
+  });
+
+  it("throws when maxBytes cannot hold the document wrapper", async () => {
+    const services = stubServices({ posts: [[{ slug: "a" }]] });
+
+    await expect(
+      buildSitemapUrls(services, {
+        collections: ["posts"],
+        baseUrl: "https://x.com",
+        maxBytes: 10,
+      })
+    ).rejects.toThrow(/minimum/i);
+  });
+
+  it("drops a location longer than the protocol limit", async () => {
+    const longSlug = "a".repeat(3000);
+    const services = stubServices({
+      posts: [[{ slug: longSlug }, { slug: "ok" }]],
+    });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+    });
+
+    // The 3,000-char loc exceeds 2,048 and is skipped; the short one remains.
+    expect(urls.map(u => u.loc)).toEqual(["https://x.com/posts/ok"]);
+  });
+
+  it("drops a custom urlFor path that carries credentials", async () => {
+    const services = stubServices({
+      posts: [[{ slug: "a" }, { slug: "b" }]],
+    });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+      urlFor: entry =>
+        entry.slug === "a" ? "https://user:pass@x.com/a" : "/b",
+    });
+
+    // Same-origin but credential-bearing → dropped; the clean one remains.
+    expect(urls.map(u => u.loc)).toEqual(["https://x.com/b"]);
   });
 
   it("percent-encodes and origin-checks a custom urlFor path", async () => {

--- a/packages/plugin-seo/src/__tests__/sitemap.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.test.ts
@@ -82,6 +82,40 @@ describe("buildSitemapUrls", () => {
     expect(opts).toEqual({ as: "system" });
   });
 
+  it("pages with a stable unique sort so pages never overlap or skip", async () => {
+    const spy = vi.fn();
+    const services = stubServices({ posts: [[{ slug: "a" }]] }, spy);
+
+    await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+    });
+
+    const [, query] = spy.mock.calls[0];
+    expect(query.sort).toEqual({ field: "id", direction: "asc" });
+  });
+
+  it("advertises a declared canonical URL instead of the generated one", async () => {
+    const services = stubServices({
+      posts: [
+        [
+          { slug: "a", seo: { canonical: "https://canonical.example/a" } },
+          { slug: "b" },
+        ],
+      ],
+    });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+    });
+
+    expect(urls.map(u => u.loc)).toEqual([
+      "https://canonical.example/a",
+      "https://x.com/posts/b",
+    ]);
+  });
+
   it("maps entries to absolute loc + ISO lastModified", async () => {
     const services = stubServices({
       posts: [[{ slug: "a", updatedAt: "2026-01-02T03:04:05.000Z" }]],

--- a/packages/plugin-seo/src/__tests__/sitemap.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildSitemapUrls,
+  defaultUrlForEntry,
+  escapeXml,
+  generateSitemap,
+  serializeSitemap,
+  type SitemapServices,
+} from "../sitemap";
+
+/**
+ * A stub `listEntries` that returns fixed pages keyed by collection, so a test
+ * can assert the query passed AND the pagination loop, without a real boot.
+ */
+function stubServices(
+  pages: Record<string, Array<Record<string, unknown>[]>>,
+  spy?: ReturnType<typeof vi.fn>
+): SitemapServices {
+  return {
+    collections: {
+      async listEntries(slug, query, opts) {
+        spy?.(slug, query, opts);
+        const collectionPages = pages[slug] ?? [];
+        const limit = query.pagination?.limit ?? 1000;
+        const offset = query.pagination?.offset ?? 0;
+        const index = Math.floor(offset / limit);
+        const data = collectionPages[index] ?? [];
+        return {
+          data,
+          pagination: {
+            hasMore: index < collectionPages.length - 1,
+          },
+        };
+      },
+    },
+  };
+}
+
+describe("escapeXml", () => {
+  it("escapes all five XML entities", () => {
+    expect(escapeXml(`a & b < c > d " e ' f`)).toBe(
+      "a &amp; b &lt; c &gt; d &quot; e &apos; f"
+    );
+  });
+});
+
+describe("defaultUrlForEntry", () => {
+  it("builds /<collection>/<slug>", () => {
+    expect(defaultUrlForEntry({ slug: "hello" }, "posts")).toBe("/posts/hello");
+  });
+
+  it("tolerates a missing slug rather than emitting 'undefined'", () => {
+    expect(defaultUrlForEntry({}, "posts")).toBe("/posts/");
+  });
+});
+
+describe("buildSitemapUrls", () => {
+  it("reads only published entries, as system", async () => {
+    const spy = vi.fn();
+    const services = stubServices({ posts: [[{ slug: "a" }]] }, spy);
+
+    await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+    });
+
+    const [, query, opts] = spy.mock.calls[0];
+    expect(query).toMatchObject({
+      where: { status: { equals: "published" } },
+    });
+    expect(opts).toEqual({ as: "system" });
+  });
+
+  it("maps entries to absolute loc + ISO lastModified", async () => {
+    const services = stubServices({
+      posts: [[{ slug: "a", updatedAt: "2026-01-02T03:04:05.000Z" }]],
+    });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+    });
+
+    expect(urls).toEqual([
+      {
+        loc: "https://x.com/posts/a",
+        lastModified: "2026-01-02T03:04:05.000Z",
+      },
+    ]);
+  });
+
+  it("pages through every result rather than truncating at the first page", async () => {
+    // Two pages of two — a first-page-only read would drop c and d.
+    const services = stubServices({
+      posts: [
+        [{ slug: "a" }, { slug: "b" }],
+        [{ slug: "c" }, { slug: "d" }],
+      ],
+    });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+      pageSize: 2,
+    });
+
+    expect(urls.map(u => u.loc)).toEqual([
+      "https://x.com/posts/a",
+      "https://x.com/posts/b",
+      "https://x.com/posts/c",
+      "https://x.com/posts/d",
+    ]);
+  });
+
+  it("excludes entries flagged seo.noindex", async () => {
+    const services = stubServices({
+      posts: [
+        [
+          { slug: "keep" },
+          { slug: "hidden", seo: { noindex: true } },
+          { slug: "shown", seo: { noindex: false } },
+        ],
+      ],
+    });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+    });
+
+    expect(urls.map(u => u.loc)).toEqual([
+      "https://x.com/posts/keep",
+      "https://x.com/posts/shown",
+    ]);
+  });
+
+  it("honors a custom urlFor and multiple collections", async () => {
+    const services = stubServices({
+      posts: [[{ slug: "a" }]],
+      pages: [[{ slug: "about" }]],
+    });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts", "pages"],
+      baseUrl: "https://x.com",
+      urlFor: (entry, collection) =>
+        collection === "posts" ? `/blog/${entry.slug}` : `/${entry.slug}`,
+    });
+
+    expect(urls.map(u => u.loc)).toEqual([
+      "https://x.com/blog/a",
+      "https://x.com/about",
+    ]);
+  });
+
+  it("trims a trailing slash on baseUrl so paths never double up", async () => {
+    const services = stubServices({ posts: [[{ slug: "a" }]] });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com/",
+    });
+
+    expect(urls[0].loc).toBe("https://x.com/posts/a");
+  });
+});
+
+describe("serializeSitemap", () => {
+  it("wraps urls in a urlset and escapes the loc", () => {
+    const xml = serializeSitemap([
+      {
+        loc: "https://x.com/a?x=1&y=2",
+        lastModified: "2026-01-02T00:00:00.000Z",
+      },
+      { loc: "https://x.com/b" },
+    ]);
+
+    expect(xml).toContain(
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+    );
+    // The ampersand in the query string must be escaped or the XML is invalid.
+    expect(xml).toContain(
+      "<loc>https://x.com/a?x=1&amp;y=2</loc><lastmod>2026-01-02T00:00:00.000Z</lastmod>"
+    );
+    // No lastmod element when the entry has no timestamp.
+    expect(xml).toContain("<loc>https://x.com/b</loc></url>");
+  });
+});
+
+describe("generateSitemap", () => {
+  it("composes build + serialize into a document", async () => {
+    const services = stubServices({ posts: [[{ slug: "a" }]] });
+
+    const xml = await generateSitemap(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+    });
+
+    expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+    expect(xml).toContain("<loc>https://x.com/posts/a</loc>");
+  });
+});

--- a/packages/plugin-seo/src/__tests__/sitemap.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.test.ts
@@ -53,6 +53,15 @@ describe("defaultUrlForEntry", () => {
   it("tolerates a missing slug rather than emitting 'undefined'", () => {
     expect(defaultUrlForEntry({}, "posts")).toBe("/posts/");
   });
+
+  it("percent-encodes an unsafe slug into a valid URL segment", () => {
+    expect(defaultUrlForEntry({ slug: "hello world" }, "posts")).toBe(
+      "/posts/hello%20world"
+    );
+    expect(defaultUrlForEntry({ slug: "café" }, "posts")).toBe(
+      "/posts/caf%C3%A9"
+    );
+  });
 });
 
 describe("buildSitemapUrls", () => {

--- a/packages/plugin-seo/src/__tests__/sitemap.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.test.ts
@@ -16,10 +16,16 @@ import {
  */
 function stubServices(
   pages: Record<string, Array<Record<string, unknown>[]>>,
-  spy?: ReturnType<typeof vi.fn>
+  spy?: ReturnType<typeof vi.fn>,
+  // Collections WITHOUT the built-in lifecycle. Anything not listed here is
+  // treated as `status: true`, matching the common content-collection case.
+  statusless: string[] = []
 ): SitemapServices {
   return {
     collections: {
+      async getCollection(slug) {
+        return { status: !statusless.includes(slug) };
+      },
       async listEntries(slug, query, opts) {
         spy?.(slug, query, opts);
         const collectionPages = pages[slug] ?? [];
@@ -114,6 +120,34 @@ describe("buildSitemapUrls", () => {
       "https://canonical.example/a",
       "https://x.com/posts/b",
     ]);
+  });
+
+  it("resolves a relative canonical against baseUrl (loc must be absolute)", async () => {
+    const services = stubServices({
+      posts: [[{ slug: "a", seo: { canonical: "/about" } }]],
+    });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+    });
+
+    expect(urls[0].loc).toBe("https://x.com/about");
+  });
+
+  it("does not filter by status on a status-less collection", async () => {
+    // `notes` has no lifecycle: the read must carry NO status filter, so a
+    // user-defined `status` field is never wrongly filtered.
+    const spy = vi.fn();
+    const services = stubServices({ notes: [[{ slug: "a" }]] }, spy, ["notes"]);
+
+    await buildSitemapUrls(services, {
+      collections: ["notes"],
+      baseUrl: "https://x.com",
+    });
+
+    const [, query] = spy.mock.calls[0];
+    expect(query.where).toBeUndefined();
   });
 
   it("maps entries to absolute loc + ISO lastModified", async () => {

--- a/packages/plugin-seo/src/__tests__/sitemap.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.test.ts
@@ -10,8 +10,9 @@ import {
 } from "../sitemap";
 
 /**
- * A stub `listEntries` that returns fixed pages keyed by collection, so a test
- * can assert the query passed AND the pagination loop, without a real boot.
+ * A stub `listEntries` that returns fixed pages keyed by collection, paging by
+ * the 1-indexed `page` exactly as the real managed facade does, so a test can
+ * assert the query passed AND the pagination loop without a real boot.
  */
 function stubServices(
   pages: Record<string, Array<Record<string, unknown>[]>>,
@@ -22,14 +23,13 @@ function stubServices(
       async listEntries(slug, query, opts) {
         spy?.(slug, query, opts);
         const collectionPages = pages[slug] ?? [];
-        const limit = query.pagination?.limit ?? 1000;
-        const offset = query.pagination?.offset ?? 0;
-        const index = Math.floor(offset / limit);
-        const data = collectionPages[index] ?? [];
+        const page = query.pagination?.page ?? 1;
+        const data = collectionPages[page - 1] ?? [];
         return {
           data,
           pagination: {
-            hasMore: index < collectionPages.length - 1,
+            // More pages remain after this 1-indexed page.
+            hasMore: page < collectionPages.length,
           },
         };
       },
@@ -111,6 +111,42 @@ describe("buildSitemapUrls", () => {
       "https://x.com/posts/c",
       "https://x.com/posts/d",
     ]);
+  });
+
+  it("advances the page number instead of re-reading page one", async () => {
+    // The managed service pages by `page`, not `offset`; advancing anything but
+    // `page` would re-request page one forever while `hasMore` stayed true.
+    const spy = vi.fn();
+    const services = stubServices(
+      { posts: [[{ slug: "a" }], [{ slug: "b" }]] },
+      spy
+    );
+
+    await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+      pageSize: 1,
+    });
+
+    const pages = spy.mock.calls.map(
+      ([, query]: [string, { pagination?: { page?: number } }]) =>
+        query.pagination?.page
+    );
+    expect(pages).toEqual([1, 2]);
+  });
+
+  it("caps the requested page size at the service maximum", async () => {
+    const spy = vi.fn();
+    const services = stubServices({ posts: [[{ slug: "a" }]] }, spy);
+
+    await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+      pageSize: 5000,
+    });
+
+    const [, query] = spy.mock.calls[0];
+    expect(query.pagination?.limit).toBe(500);
   });
 
   it("excludes entries flagged seo.noindex", async () => {

--- a/packages/plugin-seo/src/__tests__/sitemap.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.test.ts
@@ -101,11 +101,11 @@ describe("buildSitemapUrls", () => {
     expect(query.sort).toEqual({ field: "id", direction: "asc" });
   });
 
-  it("advertises a declared canonical URL instead of the generated one", async () => {
+  it("advertises a same-host declared canonical instead of the generated URL", async () => {
     const services = stubServices({
       posts: [
         [
-          { slug: "a", seo: { canonical: "https://canonical.example/a" } },
+          { slug: "a", seo: { canonical: "https://x.com/real-a" } },
           { slug: "b" },
         ],
       ],
@@ -117,9 +117,44 @@ describe("buildSitemapUrls", () => {
     });
 
     expect(urls.map(u => u.loc)).toEqual([
-      "https://canonical.example/a",
+      "https://x.com/real-a",
       "https://x.com/posts/b",
     ]);
+  });
+
+  it("drops an entry whose canonical is on another host", async () => {
+    // A sitemap must only list URLs on its own host, so a cross-host canonical
+    // means the entry belongs in that other host's sitemap — exclude it here.
+    const services = stubServices({
+      posts: [
+        [
+          { slug: "a", seo: { canonical: "https://other.example/a" } },
+          { slug: "b" },
+        ],
+      ],
+    });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+    });
+
+    expect(urls.map(u => u.loc)).toEqual(["https://x.com/posts/b"]);
+  });
+
+  it("honors a urlFor exclusion even when the entry has a canonical", async () => {
+    const services = stubServices({
+      posts: [[{ slug: "drop", seo: { canonical: "https://x.com/keep" } }]],
+    });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+      // urlFor opts the entry out; the canonical must not resurrect it.
+      urlFor: () => null,
+    });
+
+    expect(urls).toEqual([]);
   });
 
   it("resolves a relative canonical against baseUrl (loc must be absolute)", async () => {

--- a/packages/plugin-seo/src/__tests__/sitemap.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.test.ts
@@ -50,8 +50,9 @@ describe("defaultUrlForEntry", () => {
     expect(defaultUrlForEntry({ slug: "hello" }, "posts")).toBe("/posts/hello");
   });
 
-  it("tolerates a missing slug rather than emitting 'undefined'", () => {
-    expect(defaultUrlForEntry({}, "posts")).toBe("/posts/");
+  it("returns null for a missing or blank slug so the caller skips it", () => {
+    expect(defaultUrlForEntry({}, "posts")).toBeNull();
+    expect(defaultUrlForEntry({ slug: "   " }, "posts")).toBeNull();
   });
 
   it("percent-encodes an unsafe slug into a valid URL segment", () => {
@@ -156,6 +157,36 @@ describe("buildSitemapUrls", () => {
 
     const [, query] = spy.mock.calls[0];
     expect(query.pagination?.limit).toBe(500);
+  });
+
+  it("skips entries with no usable slug (default urlFor) rather than emitting duplicates", async () => {
+    const services = stubServices({
+      posts: [[{ slug: "a" }, {}, { slug: "  " }, { slug: "b" }]],
+    });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+    });
+
+    expect(urls.map(u => u.loc)).toEqual([
+      "https://x.com/posts/a",
+      "https://x.com/posts/b",
+    ]);
+  });
+
+  it("lets a custom urlFor exclude an entry by returning null", async () => {
+    const services = stubServices({
+      posts: [[{ slug: "keep" }, { slug: "drop" }]],
+    });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+      urlFor: entry => (entry.slug === "drop" ? null : `/${entry.slug}`),
+    });
+
+    expect(urls.map(u => u.loc)).toEqual(["https://x.com/keep"]);
   });
 
   it("excludes entries flagged seo.noindex", async () => {

--- a/packages/plugin-seo/src/__tests__/sitemap.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.test.ts
@@ -135,6 +135,20 @@ describe("buildSitemapUrls", () => {
     expect(urls[0].loc).toBe("https://x.com/about");
   });
 
+  it("ignores a non-http(s) canonical and falls back to the generated URL", async () => {
+    const services = stubServices({
+      posts: [[{ slug: "a", seo: { canonical: "mailto:hi@example.com" } }]],
+    });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+    });
+
+    // A mailto: is not a crawlable location, so the generated URL wins.
+    expect(urls[0].loc).toBe("https://x.com/posts/a");
+  });
+
   it("does not filter by status on a status-less collection", async () => {
     // `notes` has no lifecycle: the read must carry NO status filter, so a
     // user-defined `status` field is never wrongly filtered.

--- a/packages/plugin-seo/src/__tests__/sitemap.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.test.ts
@@ -142,6 +142,22 @@ describe("buildSitemapUrls", () => {
     expect(urls.map(u => u.loc)).toEqual(["https://x.com/posts/b"]);
   });
 
+  it("treats a scheme mismatch as a different origin and drops the entry", async () => {
+    // Same host but http vs https is a distinct URL to a crawler.
+    const services = stubServices({
+      posts: [
+        [{ slug: "a", seo: { canonical: "http://x.com/a" } }, { slug: "b" }],
+      ],
+    });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+    });
+
+    expect(urls.map(u => u.loc)).toEqual(["https://x.com/posts/b"]);
+  });
+
   it("honors a urlFor exclusion even when the entry has a canonical", async () => {
     const services = stubServices({
       posts: [[{ slug: "drop", seo: { canonical: "https://x.com/keep" } }]],

--- a/packages/plugin-seo/src/__tests__/sitemap.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.test.ts
@@ -5,6 +5,7 @@ import {
   defaultUrlForEntry,
   escapeXml,
   generateSitemap,
+  MAX_SITEMAP_URLS,
   serializeSitemap,
   type SitemapServices,
 } from "../sitemap";
@@ -290,6 +291,66 @@ describe("buildSitemapUrls", () => {
 
     const [, query] = spy.mock.calls[0];
     expect(query.pagination?.limit).toBe(500);
+  });
+
+  it("projects only the sitemap columns for the default urlFor", async () => {
+    const spy = vi.fn();
+    const services = stubServices({ posts: [[{ slug: "a" }]] }, spy);
+
+    await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+    });
+
+    const [, query] = spy.mock.calls[0];
+    expect(query.select).toEqual({ slug: true, seo: true, updatedAt: true });
+  });
+
+  it("fetches full rows (no projection) for a custom urlFor", async () => {
+    const spy = vi.fn();
+    const services = stubServices({ posts: [[{ slug: "a" }]] }, spy);
+
+    await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+      urlFor: entry => `/${entry.slug}`,
+    });
+
+    const [, query] = spy.mock.calls[0];
+    expect(query.select).toBeUndefined();
+  });
+
+  it("throws on a baseUrl that is not an absolute http(s) URL", async () => {
+    const services = stubServices({ posts: [[{ slug: "a" }]] });
+
+    await expect(
+      buildSitemapUrls(services, {
+        collections: ["posts"],
+        baseUrl: "example.com",
+      })
+    ).rejects.toThrow(/absolute http/i);
+  });
+
+  it("bounds the document to the sitemap URL limit", async () => {
+    // One page per 500 rows; produce one more than the limit and confirm the
+    // output stops at the cap (removing the cap would return them all).
+    const overflowPages: Record<string, string>[][] = [];
+    let made = 0;
+    while (made <= MAX_SITEMAP_URLS) {
+      const page = Array.from({ length: 500 }, (_, i) => ({
+        slug: `s${made + i}`,
+      }));
+      overflowPages.push(page);
+      made += 500;
+    }
+    const services = stubServices({ posts: overflowPages });
+
+    const urls = await buildSitemapUrls(services, {
+      collections: ["posts"],
+      baseUrl: "https://x.com",
+    });
+
+    expect(urls).toHaveLength(MAX_SITEMAP_URLS);
   });
 
   it("skips entries with no usable slug (default urlFor) rather than emitting duplicates", async () => {

--- a/packages/plugin-seo/src/__tests__/sitemap.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.test.ts
@@ -6,6 +6,7 @@ import {
   escapeXml,
   generateSitemap,
   MAX_SITEMAP_URLS,
+  resolveBaseOrigin,
   serializeSitemap,
   type SitemapServices,
 } from "../sitemap";
@@ -373,13 +374,17 @@ describe("buildSitemapUrls", () => {
   it("throws when maxBytes cannot hold the document wrapper", async () => {
     const services = stubServices({ posts: [[{ slug: "a" }]] });
 
-    await expect(
-      buildSitemapUrls(services, {
-        collections: ["posts"],
-        baseUrl: "https://x.com",
-        maxBytes: 10,
-      })
-    ).rejects.toThrow(/minimum/i);
+    // A tiny, zero, or negative budget can't hold the wrapper — never silently
+    // fall back to the 50 MB default.
+    for (const maxBytes of [10, 0, -1]) {
+      await expect(
+        buildSitemapUrls(services, {
+          collections: ["posts"],
+          baseUrl: "https://x.com",
+          maxBytes,
+        })
+      ).rejects.toThrow(/minimum/i);
+    }
   });
 
   it("drops a location longer than the protocol limit", async () => {
@@ -545,6 +550,20 @@ describe("buildSitemapUrls", () => {
     });
 
     expect(urls[0].loc).toBe("https://x.com/posts/a");
+  });
+});
+
+describe("resolveBaseOrigin", () => {
+  it("redacts credentials from the error message", () => {
+    let message = "";
+    try {
+      resolveBaseOrigin("https://user:secret@x.com");
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toMatch(/origin/i);
+    expect(message).not.toContain("secret");
+    expect(message).not.toContain("user:");
   });
 });
 

--- a/packages/plugin-seo/src/__tests__/sitemap.test.ts
+++ b/packages/plugin-seo/src/__tests__/sitemap.test.ts
@@ -371,6 +371,18 @@ describe("buildSitemapUrls", () => {
     expect(urls).toEqual([]);
   });
 
+  it("rejects a non-finite maxBytes rather than disabling the cap", async () => {
+    const services = stubServices({ posts: [[{ slug: "a" }]] });
+
+    await expect(
+      buildSitemapUrls(services, {
+        collections: ["posts"],
+        baseUrl: "https://x.com",
+        maxBytes: Number.NaN,
+      })
+    ).rejects.toThrow(/finite/i);
+  });
+
   it("throws when maxBytes cannot hold the document wrapper", async () => {
     const services = stubServices({ posts: [[{ slug: "a" }]] });
 

--- a/packages/plugin-seo/src/index.ts
+++ b/packages/plugin-seo/src/index.ts
@@ -6,3 +6,16 @@
 export { seoPlugin } from "./plugin";
 export type { SeoPluginOptions } from "./plugin";
 export { defaultSeoFields } from "./fields";
+export {
+  buildSitemapUrls,
+  serializeSitemap,
+  generateSitemap,
+  escapeXml,
+  defaultUrlForEntry,
+} from "./sitemap";
+export type {
+  SitemapUrl,
+  SitemapOptions,
+  SitemapServices,
+  UrlForEntry,
+} from "./sitemap";

--- a/packages/plugin-seo/src/plugin.ts
+++ b/packages/plugin-seo/src/plugin.ts
@@ -90,6 +90,23 @@ export function seoPlugin(options: SeoPluginOptions): PluginDefinition {
     fields: options.fields ?? defaultSeoFields(),
   });
 
+  // A configured baseUrl must be an absolute http(s) origin — otherwise every
+  // `<loc>` is invalid. Fail fast at construction rather than at request time.
+  if (options.baseUrl !== undefined) {
+    let validBase = false;
+    try {
+      const parsed = new URL(options.baseUrl);
+      validBase = parsed.protocol === "http:" || parsed.protocol === "https:";
+    } catch {
+      validBase = false;
+    }
+    if (!validBase) {
+      throw new Error(
+        `seoPlugin: baseUrl must be an absolute http(s) URL, got: ${options.baseUrl}`
+      );
+    }
+  }
+
   // Dedupe once: a repeated slug would make the schema-extend fold add `seo`
   // twice (a duplicate-field error), and would list the same URLs twice in the
   // sitemap.

--- a/packages/plugin-seo/src/plugin.ts
+++ b/packages/plugin-seo/src/plugin.ts
@@ -17,6 +17,7 @@ import {
 } from "@nextlyhq/plugin-sdk";
 
 import { defaultSeoFields } from "./fields";
+import { generateSitemap, type UrlForEntry } from "./sitemap";
 
 // Read the version from package.json so the plugin's declared version can never
 // drift from what actually ships (mirrors @nextlyhq/plugin-form-builder).
@@ -39,6 +40,20 @@ export interface SeoPluginOptions {
    * data from one predictable place.
    */
   fields?: FieldConfig[];
+  /**
+   * Absolute site origin used for `<loc>` in the generated sitemap
+   * (e.g. "https://example.com", no trailing slash). When omitted, the sitemap
+   * route derives the origin from the incoming request — correct for a
+   * single-origin deployment, but wrong behind a proxy that rewrites the host,
+   * so set it explicitly there.
+   */
+  baseUrl?: string;
+  /**
+   * Build the URL path for a sitemap entry (leading slash, appended to the
+   * origin). Defaults to `/<collection>/<slug>`. Override it to match your
+   * routing (e.g. posts served at `/blog/:slug`).
+   */
+  urlFor?: UrlForEntry;
 }
 
 /**
@@ -63,6 +78,11 @@ export function seoPlugin(options: SeoPluginOptions): PluginDefinition {
     fields: options.fields ?? defaultSeoFields(),
   });
 
+  // Dedupe once: a repeated slug would make the schema-extend fold add `seo`
+  // twice (a duplicate-field error), and would list the same URLs twice in the
+  // sitemap. The extend targets and the sitemap collections are the same set.
+  const targets = [...new Set(options.collections)];
+
   return definePlugin({
     name: "@nextlyhq/plugin-seo",
     version: PLUGIN_VERSION,
@@ -76,11 +96,31 @@ export function seoPlugin(options: SeoPluginOptions): PluginDefinition {
     category: "seo",
     tags: ["seo", "meta"],
     contributes: {
-      // Add the SEO group to each named collection. Dedupe the targets: a
-      // repeated slug would make the schema-extend fold add `seo` twice and
-      // throw a duplicate-field error.
-      extend: [
-        { target: [...new Set(options.collections)], fields: [seoGroup] },
+      // Add the SEO group to each named collection.
+      extend: [{ target: targets, fields: [seoGroup] }],
+      // Serve a sitemap of published entries over HTTP, mounted at
+      // /api/plugins/@nextlyhq/plugin-seo/sitemap.xml. Public so crawlers and
+      // headless frontends (which have no Next `app/sitemap.ts`) can read it.
+      routes: [
+        {
+          method: "GET",
+          path: "/sitemap.xml",
+          public: true,
+          handler: async (req, ctx) => {
+            // A single-origin deployment can rely on the request origin; a
+            // proxied one must configure `baseUrl` so `<loc>` uses the public
+            // host rather than the internal one.
+            const baseUrl = options.baseUrl ?? new URL(req.url).origin;
+            const xml = await generateSitemap(ctx.services, {
+              collections: targets,
+              baseUrl,
+              urlFor: options.urlFor,
+            });
+            return new Response(xml, {
+              headers: { "content-type": "application/xml; charset=utf-8" },
+            });
+          },
+        },
       ],
     },
   });

--- a/packages/plugin-seo/src/plugin.ts
+++ b/packages/plugin-seo/src/plugin.ts
@@ -94,13 +94,6 @@ export function seoPlugin(options: SeoPluginOptions): PluginDefinition {
     fields: options.fields ?? defaultSeoFields(),
   });
 
-  // A configured baseUrl must be an absolute http(s) ORIGIN — otherwise every
-  // `<loc>` is invalid (or doubles a base path). Validate at construction, using
-  // the same rule the generator applies, so a misconfig fails fast at boot.
-  if (options.baseUrl !== undefined) {
-    resolveBaseOrigin(options.baseUrl);
-  }
-
   // Dedupe once: a repeated slug would make the schema-extend fold add `seo`
   // twice (a duplicate-field error), and would list the same URLs twice in the
   // sitemap.
@@ -111,6 +104,14 @@ export function seoPlugin(options: SeoPluginOptions): PluginDefinition {
   // SEO collections). Kept separate from `targets` so a private collection can
   // carry SEO fields without being enumerated in the public sitemap.
   const sitemapEnabled = options.sitemap !== false;
+
+  // A configured baseUrl must be an absolute http(s) ORIGIN — otherwise every
+  // `<loc>` is invalid (or doubles a base path). Validate at construction (same
+  // rule the generator applies) so a misconfig fails fast — but only when the
+  // sitemap is enabled, since a disabled route never consumes baseUrl.
+  if (sitemapEnabled && options.baseUrl !== undefined) {
+    resolveBaseOrigin(options.baseUrl);
+  }
   const sitemapTargets =
     options.sitemap &&
     typeof options.sitemap === "object" &&

--- a/packages/plugin-seo/src/plugin.ts
+++ b/packages/plugin-seo/src/plugin.ts
@@ -139,15 +139,23 @@ export function seoPlugin(options: SeoPluginOptions): PluginDefinition {
           // A single-origin deployment can rely on the request origin; a
           // proxied one must configure `baseUrl` so `<loc>` uses the public
           // host rather than the internal one.
-          const baseUrl = options.baseUrl ?? new URL(req.url).origin;
+          const configuredBaseUrl = options.baseUrl;
+          const baseUrl = configuredBaseUrl ?? new URL(req.url).origin;
           const xml = await generateSitemap(ctx.services, {
             collections: sitemapTargets,
             baseUrl,
             urlFor: options.urlFor,
           });
-          return new Response(xml, {
-            headers: { "content-type": "application/xml; charset=utf-8" },
-          });
+          const headers: Record<string, string> = {
+            "content-type": "application/xml; charset=utf-8",
+          };
+          if (!configuredBaseUrl) {
+            // The origin came from the (spoofable) request Host — keep an
+            // intermediary from caching a host-derived document and serving it
+            // for a different host. Configure `baseUrl` for a cacheable sitemap.
+            headers["cache-control"] = "no-store";
+          }
+          return new Response(xml, { headers });
         },
       },
     ];

--- a/packages/plugin-seo/src/plugin.ts
+++ b/packages/plugin-seo/src/plugin.ts
@@ -18,7 +18,11 @@ import {
 } from "@nextlyhq/plugin-sdk";
 
 import { defaultSeoFields } from "./fields";
-import { generateSitemap, type UrlForEntry } from "./sitemap";
+import {
+  generateSitemap,
+  resolveBaseOrigin,
+  type UrlForEntry,
+} from "./sitemap";
 
 // Read the version from package.json so the plugin's declared version can never
 // drift from what actually ships (mirrors @nextlyhq/plugin-form-builder).
@@ -90,21 +94,11 @@ export function seoPlugin(options: SeoPluginOptions): PluginDefinition {
     fields: options.fields ?? defaultSeoFields(),
   });
 
-  // A configured baseUrl must be an absolute http(s) origin — otherwise every
-  // `<loc>` is invalid. Fail fast at construction rather than at request time.
+  // A configured baseUrl must be an absolute http(s) ORIGIN — otherwise every
+  // `<loc>` is invalid (or doubles a base path). Validate at construction, using
+  // the same rule the generator applies, so a misconfig fails fast at boot.
   if (options.baseUrl !== undefined) {
-    let validBase = false;
-    try {
-      const parsed = new URL(options.baseUrl);
-      validBase = parsed.protocol === "http:" || parsed.protocol === "https:";
-    } catch {
-      validBase = false;
-    }
-    if (!validBase) {
-      throw new Error(
-        `seoPlugin: baseUrl must be an absolute http(s) URL, got: ${options.baseUrl}`
-      );
-    }
+    resolveBaseOrigin(options.baseUrl);
   }
 
   // Dedupe once: a repeated slug would make the schema-extend fold add `seo`

--- a/packages/plugin-seo/src/plugin.ts
+++ b/packages/plugin-seo/src/plugin.ts
@@ -107,6 +107,17 @@ export function seoPlugin(options: SeoPluginOptions): PluginDefinition {
       ? [...new Set(options.sitemap.collections)]
       : targets;
 
+  // A sitemap subset must be a subset of the SEO collections. A slug outside
+  // them is never extended, so it would only surface at request time as a 500
+  // (metadata lookup on an unknown collection) — fail fast at construction.
+  const unknownSitemap = sitemapTargets.filter(slug => !targets.includes(slug));
+  if (unknownSitemap.length > 0) {
+    throw new Error(
+      `seoPlugin: sitemap.collections must be a subset of collections; ` +
+        `unknown: ${unknownSitemap.join(", ")}`
+    );
+  }
+
   const contributes: PluginContributions = {
     // Add the SEO group to each named collection.
     extend: [{ target: targets, fields: [seoGroup] }],

--- a/packages/plugin-seo/src/plugin.ts
+++ b/packages/plugin-seo/src/plugin.ts
@@ -13,6 +13,7 @@ import {
   definePlugin,
   group,
   type FieldConfig,
+  type PluginContributions,
   type PluginDefinition,
 } from "@nextlyhq/plugin-sdk";
 
@@ -54,6 +55,17 @@ export interface SeoPluginOptions {
    * routing (e.g. posts served at `/blog/:slug`).
    */
   urlFor?: UrlForEntry;
+  /**
+   * Controls the public sitemap route. `true` (the default) serves a sitemap of
+   * the `collections` above. `false` omits the route entirely. Pass
+   * `{ collections: [...] }` to advertise only a subset.
+   *
+   * The sitemap is PUBLIC and lists every published entry's URL as system, so it
+   * bypasses per-collection read access. Exclude any collection whose entries
+   * should not be publicly enumerable (owner-only, role-gated, or internal) by
+   * narrowing this list or disabling the route.
+   */
+  sitemap?: boolean | { collections?: string[] };
 }
 
 /**
@@ -80,8 +92,55 @@ export function seoPlugin(options: SeoPluginOptions): PluginDefinition {
 
   // Dedupe once: a repeated slug would make the schema-extend fold add `seo`
   // twice (a duplicate-field error), and would list the same URLs twice in the
-  // sitemap. The extend targets and the sitemap collections are the same set.
+  // sitemap.
   const targets = [...new Set(options.collections)];
+
+  // The sitemap is on by default; `sitemap: false` disables the route, and
+  // `{ collections }` narrows which collections it advertises (defaulting to the
+  // SEO collections). Kept separate from `targets` so a private collection can
+  // carry SEO fields without being enumerated in the public sitemap.
+  const sitemapEnabled = options.sitemap !== false;
+  const sitemapTargets =
+    options.sitemap &&
+    typeof options.sitemap === "object" &&
+    options.sitemap.collections
+      ? [...new Set(options.sitemap.collections)]
+      : targets;
+
+  const contributes: PluginContributions = {
+    // Add the SEO group to each named collection.
+    extend: [{ target: targets, fields: [seoGroup] }],
+  };
+
+  if (sitemapEnabled) {
+    // Serve a sitemap of published entries over HTTP, mounted at
+    // /api/plugins/@nextlyhq/plugin-seo/sitemap.xml. Public so crawlers and
+    // headless frontends (which have no Next `app/sitemap.ts`) can read it.
+    // The document is generated per request (agnostic, no `next`); ISR caching
+    // of the canonical `/sitemap.xml` belongs to the Next delivery layer, and
+    // headless consumers cache at their edge.
+    contributes.routes = [
+      {
+        method: "GET",
+        path: "/sitemap.xml",
+        public: true,
+        handler: async (req, ctx) => {
+          // A single-origin deployment can rely on the request origin; a
+          // proxied one must configure `baseUrl` so `<loc>` uses the public
+          // host rather than the internal one.
+          const baseUrl = options.baseUrl ?? new URL(req.url).origin;
+          const xml = await generateSitemap(ctx.services, {
+            collections: sitemapTargets,
+            baseUrl,
+            urlFor: options.urlFor,
+          });
+          return new Response(xml, {
+            headers: { "content-type": "application/xml; charset=utf-8" },
+          });
+        },
+      },
+    ];
+  }
 
   return definePlugin({
     name: "@nextlyhq/plugin-seo",
@@ -95,33 +154,6 @@ export function seoPlugin(options: SeoPluginOptions): PluginDefinition {
     license: "MIT",
     category: "seo",
     tags: ["seo", "meta"],
-    contributes: {
-      // Add the SEO group to each named collection.
-      extend: [{ target: targets, fields: [seoGroup] }],
-      // Serve a sitemap of published entries over HTTP, mounted at
-      // /api/plugins/@nextlyhq/plugin-seo/sitemap.xml. Public so crawlers and
-      // headless frontends (which have no Next `app/sitemap.ts`) can read it.
-      routes: [
-        {
-          method: "GET",
-          path: "/sitemap.xml",
-          public: true,
-          handler: async (req, ctx) => {
-            // A single-origin deployment can rely on the request origin; a
-            // proxied one must configure `baseUrl` so `<loc>` uses the public
-            // host rather than the internal one.
-            const baseUrl = options.baseUrl ?? new URL(req.url).origin;
-            const xml = await generateSitemap(ctx.services, {
-              collections: targets,
-              baseUrl,
-              urlFor: options.urlFor,
-            });
-            return new Response(xml, {
-              headers: { "content-type": "application/xml; charset=utf-8" },
-            });
-          },
-        },
-      ],
-    },
+    contributes,
   });
 }

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -78,8 +78,9 @@ export interface SitemapOptions {
   /** Collections whose published entries appear in the sitemap. */
   collections: string[];
   /**
-   * Absolute site origin for `<loc>` (e.g. "https://example.com"). A trailing
-   * slash is trimmed so a leading-slash path never produces a doubled `//`.
+   * Absolute site origin for `<loc>` (e.g. "https://example.com"). Must be an
+   * origin only — no path, query, fragment, or credentials; per-entry paths come
+   * from {@link UrlForEntry}. An invalid value throws.
    */
   baseUrl: string;
   /** Path builder; defaults to `/<collection>/<slug>`. */

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -24,6 +24,16 @@
  */
 export interface SitemapServices {
   collections: {
+    /**
+     * Collection metadata — read only to check the built-in draft/published
+     * lifecycle flag (`status: true`). Typed as `unknown` and narrowed at the
+     * call site (the core `Collection` type does not surface `status`). The
+     * context arg is unused by the read; pass `{}`.
+     */
+    getCollection(
+      slug: string,
+      context: Record<string, never>
+    ): Promise<unknown>;
     listEntries(
       slug: string,
       query: {
@@ -160,6 +170,16 @@ export async function buildSitemapUrls(
   const urls: SitemapUrl[] = [];
 
   for (const collection of options.collections) {
+    // Apply the published filter ONLY to collections with the built-in
+    // lifecycle. A status-less collection has no unpublished state, and it may
+    // even define an ordinary `status` field (e.g. "active"/"closed"), so a
+    // blanket `status = published` filter there would wrongly drop live rows.
+    const meta = await services.collections.getCollection(collection, {});
+    const hasLifecycle = isRecord(meta) && meta.status === true;
+    const where = hasLifecycle
+      ? { status: { equals: "published" } }
+      : undefined;
+
     // 1-indexed: the managed service reads by `page`, not `offset`, so the loop
     // MUST advance `page` — advancing an ignored `offset` would re-read page 1
     // forever while `hasMore` stayed true.
@@ -168,7 +188,7 @@ export async function buildSitemapUrls(
       const result = await services.collections.listEntries(
         collection,
         {
-          where: { status: { equals: "published" } },
+          where,
           depth: 0,
           // Deterministic paging: without an explicit sort the service pages an
           // unordered query, so rows could repeat or vanish between pages. `id`
@@ -186,13 +206,21 @@ export async function buildSitemapUrls(
         if (seo?.noindex === true) continue;
         // Honor a declared canonical: a sitemap should list canonical URLs, so
         // when the entry sets one, advertise THAT rather than the generated URL
-        // it points away from.
+        // it points away from. The `canonical` field is free text, so resolve it
+        // against `baseUrl` (a relative `/about` becomes absolute) and fall back
+        // to the generated URL if it is not a usable URL — a `<loc>` must be a
+        // valid absolute URL.
         const canonical =
           typeof seo?.canonical === "string" ? seo.canonical.trim() : "";
-        let loc: string;
+        let loc: string | null = null;
         if (canonical) {
-          loc = canonical;
-        } else {
+          try {
+            loc = new URL(canonical, baseUrl).href;
+          } catch {
+            loc = null;
+          }
+        }
+        if (loc === null) {
           // A falsy path means the entry has no stable URL (no slug, or a
           // custom urlFor opted it out) — skip it rather than emit a bogus loc.
           const path = urlFor(row, collection);

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -130,6 +130,21 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+/**
+ * Resolve a urlFor path against the origin to a valid absolute URL, percent-
+ * encoding any unsafe characters. Returns `null` when the path is unusable or
+ * escapes the origin (a custom mapper returning an absolute/protocol-relative
+ * value) — such an entry is dropped rather than advertised at a foreign URL.
+ */
+function resolveOnOrigin(path: string, baseOrigin: string): string | null {
+  try {
+    const resolved = new URL(path, baseOrigin);
+    return resolved.origin === baseOrigin ? resolved.href : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Normalize a stored timestamp to ISO-8601, or undefined when unusable. */
 function toLastModified(value: unknown): string | undefined {
   if (value === null || value === undefined || value === "") return undefined;
@@ -306,43 +321,47 @@ export async function buildSitemapUrls(
         // stable URL (no slug, or a custom urlFor opted it out) — skip it.
         const path = urlFor(row, collection);
         if (!path) continue;
-        let loc = `${baseOrigin}${path}`;
+        // Normalize the path through URL so a custom mapper's spaces/non-ASCII
+        // are percent-encoded, and DROP an entry whose path escapes the origin
+        // (an absolute or protocol-relative value a custom urlFor returned).
+        let loc = resolveOnOrigin(path, baseOrigin);
+        if (loc === null) continue;
 
         // A declared canonical overrides the generated URL, but only a same-
-        // origin http(s) one. The `canonical` field is free text: resolve it
-        // against the origin (a relative `/about` becomes absolute); ignore a
-        // non-http scheme (`mailto:`/`javascript:`/`data:`), keeping the
-        // generated URL; and DROP the entry when the canonical is on another
-        // origin, since a sitemap must only list URLs on its own origin.
+        // origin http(s) one with no credentials. The `canonical` field is free
+        // text: resolve it against the origin (a relative `/about` becomes
+        // absolute); ignore a non-http scheme (`mailto:`/`javascript:`/`data:`)
+        // or embedded credentials, keeping the generated URL; and DROP the entry
+        // when the canonical is on another origin.
         const canonical =
           typeof seo?.canonical === "string" ? seo.canonical.trim() : "";
         if (canonical) {
-          let offHost = false;
+          let offOrigin = false;
           try {
             const resolved = new URL(canonical, baseOrigin);
             const isHttp =
               resolved.protocol === "http:" || resolved.protocol === "https:";
-            if (isHttp && resolved.origin === baseOrigin) {
+            const hasCreds =
+              resolved.username !== "" || resolved.password !== "";
+            if (isHttp && resolved.origin === baseOrigin && !hasCreds) {
               loc = resolved.href;
-            } else if (isHttp) {
-              offHost = true;
+            } else if (isHttp && resolved.origin !== baseOrigin) {
+              offOrigin = true;
             }
           } catch {
             // Malformed canonical → keep the generated URL.
           }
-          if (offHost) continue;
+          if (offOrigin) continue;
         }
         const entry: SitemapUrl = {
           loc,
           lastModified: toLastModified(row.updatedAt),
         };
-        // Stop before the serialized size would exceed the byte limit, but
-        // always emit at least one entry so a single oversized URL still yields
-        // a document. `+ 1` accounts for the newline joining entries.
+        // Stop before the serialized size would exceed the byte limit — for the
+        // FIRST entry too, so a single oversized URL never yields an over-limit
+        // document. `+ 1` accounts for the newline joining entries.
         const entryBytes = utf8Bytes(serializeUrlEntry(entry)) + 1;
-        if (urls.length > 0 && byteSize + entryBytes > maxBytes) {
-          return urls;
-        }
+        if (byteSize + entryBytes > maxBytes) return urls;
         byteSize += entryBytes;
         urls.push(entry);
         // Bound the document to the protocol limits so the single `<urlset>`

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -39,6 +39,10 @@ export interface SitemapServices {
       query: {
         where?: Record<string, unknown>;
         depth?: number;
+        // Field projection — narrow the columns fetched to just what the default
+        // mapper reads, so a collection's large content columns are not
+        // transferred on every public request.
+        select?: Record<string, boolean>;
         // A stable, unique sort so consecutive pages don't overlap or skip
         // rows: the managed service adds `ORDER BY` only when `sort` is passed.
         sort?: { field: string; direction: "asc" | "desc" };
@@ -143,6 +147,39 @@ function toLastModified(value: unknown): string | undefined {
 export const MAX_PAGE_SIZE = 500;
 
 /**
+ * The sitemap protocol allows at most 50,000 URLs (and 50 MB uncompressed) per
+ * document. Collection is bounded to this so the single `<urlset>` is always
+ * valid; sharding a larger corpus into a sitemap index belongs to the Next
+ * delivery layer (`generateSitemaps()`).
+ */
+export const MAX_SITEMAP_URLS = 50_000;
+
+/** The columns the default mapper reads — used to project the query. */
+const DEFAULT_SELECT: Record<string, boolean> = {
+  slug: true,
+  seo: true,
+  updatedAt: true,
+};
+
+/** Resolve `baseUrl` to an origin, rejecting anything but an absolute http(s) URL. */
+function resolveBaseOrigin(baseUrl: string): string {
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    throw new Error(
+      `sitemap: baseUrl must be an absolute http(s) URL, got: ${baseUrl}`
+    );
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(
+      `sitemap: baseUrl must be an absolute http(s) URL, got: ${baseUrl}`
+    );
+  }
+  return url.origin;
+}
+
+/**
  * List every configured collection's PUBLISHED entries and map them to sitemap
  * URLs. Reads as system (a sitemap is public derived data), and pages through
  * ALL matches by advancing the 1-indexed `page` — no silent cap — so a large
@@ -161,6 +198,9 @@ export async function buildSitemapUrls(
   services: SitemapServices,
   options: SitemapOptions
 ): Promise<SitemapUrl[]> {
+  // A custom urlFor may read arbitrary fields, so only project the columns when
+  // using the built-in mapper; a custom callback gets full rows.
+  const usingDefaultUrlFor = options.urlFor === undefined;
   const urlFor = options.urlFor ?? defaultUrlForEntry;
   const pageSize =
     options.pageSize && options.pageSize > 0
@@ -170,14 +210,8 @@ export async function buildSitemapUrls(
   const baseUrl = options.baseUrl.replace(/\/+$/, "");
   // The sitemap's own origin (scheme + host + port) — a `<loc>` must live on it,
   // so a canonical on a different origin is dropped rather than mixed in.
-  // Compare origins, not hosts: `http://x.com` and `https://x.com` are distinct
-  // URLs to a crawler.
-  let baseOrigin = "";
-  try {
-    baseOrigin = new URL(baseUrl).origin;
-  } catch {
-    baseOrigin = "";
-  }
+  // Rejects an empty/relative baseUrl up front so `<loc>` is never invalid.
+  const baseOrigin = resolveBaseOrigin(baseUrl);
   const urls: SitemapUrl[] = [];
 
   for (const collection of options.collections) {
@@ -201,6 +235,7 @@ export async function buildSitemapUrls(
         {
           where,
           depth: 0,
+          ...(usingDefaultUrlFor ? { select: DEFAULT_SELECT } : {}),
           // Deterministic paging: without an explicit sort the service pages an
           // unordered query, so rows could repeat or vanish between pages. `id`
           // is unique and stable on every collection.
@@ -248,6 +283,9 @@ export async function buildSitemapUrls(
           if (offHost) continue;
         }
         urls.push({ loc, lastModified: toLastModified(row.updatedAt) });
+        // Bound the document to the protocol limit so the single `<urlset>`
+        // stays valid; a larger corpus needs a sitemap index (delivery layer).
+        if (urls.length >= MAX_SITEMAP_URLS) return urls;
       }
 
       if (!result.pagination.hasMore) break;

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -168,13 +168,15 @@ export async function buildSitemapUrls(
       : MAX_PAGE_SIZE;
   // Trim a trailing slash so `${baseUrl}${"/path"}` never yields `//path`.
   const baseUrl = options.baseUrl.replace(/\/+$/, "");
-  // The sitemap's own host — a `<loc>` must live on it, so a canonical on a
-  // different host is dropped rather than mixed in.
-  let baseHost = "";
+  // The sitemap's own origin (scheme + host + port) — a `<loc>` must live on it,
+  // so a canonical on a different origin is dropped rather than mixed in.
+  // Compare origins, not hosts: `http://x.com` and `https://x.com` are distinct
+  // URLs to a crawler.
+  let baseOrigin = "";
   try {
-    baseHost = new URL(baseUrl).host;
+    baseOrigin = new URL(baseUrl).origin;
   } catch {
-    baseHost = "";
+    baseOrigin = "";
   }
   const urls: SitemapUrl[] = [];
 
@@ -235,7 +237,7 @@ export async function buildSitemapUrls(
             const resolved = new URL(canonical, baseUrl);
             const isHttp =
               resolved.protocol === "http:" || resolved.protocol === "https:";
-            if (isHttp && resolved.host === baseHost) {
+            if (isHttp && resolved.origin === baseOrigin) {
               loc = resolved.href;
             } else if (isHttp) {
               offHost = true;

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -1,0 +1,184 @@
+/**
+ * Sitemap generation for `@nextlyhq/plugin-seo`.
+ *
+ * Framework-agnostic (zero `next`): lists each configured collection's
+ * PUBLISHED entries through the managed service (as system — a sitemap is
+ * public derived data) and renders a sitemaps.org `<urlset>`. Pure given a
+ * services object, so it is unit-testable with a stub and integration-testable
+ * against a real boot.
+ *
+ * Caching lives in the delivery layer, not here: the `<loc>` set is derived
+ * from `status: published` content, which the F1 write path already busts on
+ * every create / update / publish / delete, so a cached read tagged with the
+ * collection tags refreshes on content changes without any bespoke cache.
+ *
+ * @module sitemap
+ */
+/**
+ * The minimal `listEntries` the sitemap builder calls — a structural slice of
+ * the managed collection service (`ctx.services.collections`). Declared
+ * explicitly (rather than `Pick<PluginCollectionService, ...>`) so a test can
+ * satisfy it with a plain stub, while the real, richer service stays assignable
+ * to it. Reads published rows as system; only the fields the sitemap consumes
+ * (`data` + `pagination.hasMore`) are named here.
+ */
+export interface SitemapServices {
+  collections: {
+    listEntries(
+      slug: string,
+      query: {
+        where?: Record<string, unknown>;
+        depth?: number;
+        pagination?: { limit?: number; offset?: number };
+      },
+      opts: { as: "system" }
+    ): Promise<{ data: unknown[]; pagination: { hasMore: boolean } }>;
+  };
+}
+
+/** One resolved sitemap URL. */
+export interface SitemapUrl {
+  /** Absolute location; XML-escaped at serialization time. */
+  loc: string;
+  /** ISO-8601 last-modified timestamp, when the entry carries one. */
+  lastModified?: string;
+}
+
+/**
+ * Build the URL path for an entry (leading slash, appended to the origin).
+ * Defaults to `/<collection>/<slug>`.
+ */
+export type UrlForEntry = (
+  entry: Record<string, unknown>,
+  collection: string
+) => string;
+
+/** Options for {@link buildSitemapUrls} / {@link generateSitemap}. */
+export interface SitemapOptions {
+  /** Collections whose published entries appear in the sitemap. */
+  collections: string[];
+  /**
+   * Absolute site origin for `<loc>` (e.g. "https://example.com"). A trailing
+   * slash is trimmed so a leading-slash path never produces a doubled `//`.
+   */
+  baseUrl: string;
+  /** Path builder; defaults to `/<collection>/<slug>`. */
+  urlFor?: UrlForEntry;
+  /** Page size for the paginated service reads (defaults to 1000). */
+  pageSize?: number;
+}
+
+/** Default path: `/<collection>/<slug>`. */
+export function defaultUrlForEntry(
+  entry: Record<string, unknown>,
+  collection: string
+): string {
+  const slug = typeof entry.slug === "string" ? entry.slug : "";
+  return `/${collection}/${slug}`;
+}
+
+/** XML-escape a text value for safe inclusion in an element body. */
+export function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/** Narrow an unknown row to an indexable object without asserting a type. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/** Normalize a stored timestamp to ISO-8601, or undefined when unusable. */
+function toLastModified(value: unknown): string | undefined {
+  if (value === null || value === undefined || value === "") return undefined;
+  if (
+    typeof value !== "string" &&
+    typeof value !== "number" &&
+    !(value instanceof Date)
+  ) {
+    return undefined;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+const DEFAULT_PAGE_SIZE = 1000;
+
+/**
+ * List every configured collection's PUBLISHED entries and map them to sitemap
+ * URLs. Reads as system (a sitemap is public derived data), and pages through
+ * ALL matches — no silent cap — so a large collection is never truncated to a
+ * first-page slice. Entries flagged `seo.noindex` are excluded: a page told not
+ * to be indexed does not belong in the sitemap.
+ */
+export async function buildSitemapUrls(
+  services: SitemapServices,
+  options: SitemapOptions
+): Promise<SitemapUrl[]> {
+  const urlFor = options.urlFor ?? defaultUrlForEntry;
+  const pageSize =
+    options.pageSize && options.pageSize > 0
+      ? options.pageSize
+      : DEFAULT_PAGE_SIZE;
+  // Trim a trailing slash so `${baseUrl}${"/path"}` never yields `//path`.
+  const baseUrl = options.baseUrl.replace(/\/+$/, "");
+  const urls: SitemapUrl[] = [];
+
+  for (const collection of options.collections) {
+    let offset = 0;
+    // Page until the service reports no more rows, so the whole published set
+    // is emitted rather than a first-page slice.
+    for (;;) {
+      const result = await services.collections.listEntries(
+        collection,
+        {
+          where: { status: { equals: "published" } },
+          depth: 0,
+          pagination: { limit: pageSize, offset },
+        },
+        { as: "system" }
+      );
+
+      for (const row of result.data) {
+        if (!isRecord(row)) continue;
+        const seo = isRecord(row.seo) ? row.seo : undefined;
+        // A noindexed page is intentionally kept out of the sitemap.
+        if (seo?.noindex === true) continue;
+        urls.push({
+          loc: `${baseUrl}${urlFor(row, collection)}`,
+          lastModified: toLastModified(row.updatedAt),
+        });
+      }
+
+      if (!result.pagination.hasMore) break;
+      offset += pageSize;
+    }
+  }
+
+  return urls;
+}
+
+/** Serialize resolved URLs into a sitemaps.org `<urlset>` document. */
+export function serializeSitemap(urls: SitemapUrl[]): string {
+  const body = urls
+    .map(({ loc, lastModified }) => {
+      const lastmod = lastModified
+        ? `<lastmod>${escapeXml(lastModified)}</lastmod>`
+        : "";
+      return `  <url><loc>${escapeXml(loc)}</loc>${lastmod}</url>`;
+    })
+    .join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${body}\n</urlset>`;
+}
+
+/** Build the full sitemap XML for the configured collections. */
+export async function generateSitemap(
+  services: SitemapServices,
+  options: SitemapOptions
+): Promise<string> {
+  return serializeSitemap(await buildSitemapUrls(services, options));
+}

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -39,9 +39,10 @@ export interface SitemapServices {
       query: {
         where?: Record<string, unknown>;
         depth?: number;
-        // Field projection — narrow the columns fetched to just what the default
-        // mapper reads, so a collection's large content columns are not
-        // transferred on every public request.
+        // Field projection passed to the managed service. It trims the returned
+        // rows to what the default mapper reads; note the current service
+        // applies it to the response, not the SQL, so it does not yet avoid
+        // reading the columns at the DB layer (a core enhancement).
         select?: Record<string, boolean>;
         // A stable, unique sort so consecutive pages don't overlap or skip
         // rows: the managed service adds `ORDER BY` only when `sort` is passed.
@@ -189,7 +190,7 @@ export const MAX_SITEMAP_BYTES = 50 * 1024 * 1024;
 /** The sitemap protocol limits a single `<loc>` to 2,048 characters. */
 export const MAX_LOC_LENGTH = 2048;
 
-/** The columns the default mapper reads — used to project the query. */
+/** The columns the default mapper reads — passed as the response projection. */
 const DEFAULT_SELECT: Record<string, boolean> = {
   slug: true,
   seo: true,
@@ -288,7 +289,13 @@ export async function buildSitemapUrls(
   const baseOrigin = resolveBaseOrigin(options.baseUrl);
   // Only `undefined` takes the default; a supplied value (including 0 or a
   // negative) is honored so the wrapper guard below rejects an impossible cap
-  // rather than silently substituting the 50 MB default.
+  // rather than silently substituting the 50 MB default. A non-finite value
+  // (NaN/Infinity) would defeat both guards, so reject it explicitly.
+  if (options.maxBytes !== undefined && !Number.isFinite(options.maxBytes)) {
+    throw new Error(
+      `sitemap: maxBytes must be a finite number, got: ${options.maxBytes}`
+    );
+  }
   const maxBytes =
     options.maxBytes === undefined
       ? MAX_SITEMAP_BYTES

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -216,7 +216,16 @@ export async function buildSitemapUrls(
         let loc: string | null = null;
         if (canonical) {
           try {
-            loc = new URL(canonical, baseUrl).href;
+            const resolved = new URL(canonical, baseUrl);
+            // Only http(s) URLs are crawlable sitemap locations — a syntactically
+            // valid `mailto:` / `javascript:` / `data:` value must not become a
+            // `<loc>`; fall through to the generated URL instead.
+            if (
+              resolved.protocol === "http:" ||
+              resolved.protocol === "https:"
+            ) {
+              loc = resolved.href;
+            }
           } catch {
             loc = null;
           }

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -29,7 +29,9 @@ export interface SitemapServices {
       query: {
         where?: Record<string, unknown>;
         depth?: number;
-        pagination?: { limit?: number; offset?: number };
+        // Paged by 1-indexed `page`: the managed service reads a page from
+        // `page`, not `offset`, so pagination MUST advance `page` to progress.
+        pagination?: { limit?: number; page?: number };
       },
       opts: { as: "system" }
     ): Promise<{ data: unknown[]; pagination: { hasMore: boolean } }>;
@@ -64,7 +66,10 @@ export interface SitemapOptions {
   baseUrl: string;
   /** Path builder; defaults to `/<collection>/<slug>`. */
   urlFor?: UrlForEntry;
-  /** Page size for the paginated service reads (defaults to 1000). */
+  /**
+   * Page size for the paginated service reads. Defaults to and is capped at
+   * {@link MAX_PAGE_SIZE} (the managed service's per-page maximum).
+   */
   pageSize?: number;
 }
 
@@ -106,14 +111,26 @@ function toLastModified(value: unknown): string | undefined {
   return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
 }
 
-const DEFAULT_PAGE_SIZE = 1000;
+/**
+ * The managed service caps a page at 500 rows and drops a larger `limit`, so a
+ * page never exceeds this — the pagination loop relies on the requested size
+ * matching what comes back to know when to stop.
+ */
+export const MAX_PAGE_SIZE = 500;
 
 /**
  * List every configured collection's PUBLISHED entries and map them to sitemap
  * URLs. Reads as system (a sitemap is public derived data), and pages through
- * ALL matches — no silent cap — so a large collection is never truncated to a
- * first-page slice. Entries flagged `seo.noindex` are excluded: a page told not
- * to be indexed does not belong in the sitemap.
+ * ALL matches by advancing the 1-indexed `page` — no silent cap — so a large
+ * collection is never truncated to a first-page slice. Entries flagged
+ * `seo.noindex` are excluded: a page told not to be indexed does not belong in
+ * the sitemap.
+ *
+ * The `status: published` filter applies to collections with the draft/
+ * published lifecycle (`status: true`). A collection without it has no
+ * unpublished state, so the (unknown-field) filter is a no-op there and every
+ * entry — all of which are live — is listed. That mirrors the core's own
+ * status handling (filter only when a status column exists).
  */
 export async function buildSitemapUrls(
   services: SitemapServices,
@@ -122,23 +139,24 @@ export async function buildSitemapUrls(
   const urlFor = options.urlFor ?? defaultUrlForEntry;
   const pageSize =
     options.pageSize && options.pageSize > 0
-      ? options.pageSize
-      : DEFAULT_PAGE_SIZE;
+      ? Math.min(options.pageSize, MAX_PAGE_SIZE)
+      : MAX_PAGE_SIZE;
   // Trim a trailing slash so `${baseUrl}${"/path"}` never yields `//path`.
   const baseUrl = options.baseUrl.replace(/\/+$/, "");
   const urls: SitemapUrl[] = [];
 
   for (const collection of options.collections) {
-    let offset = 0;
-    // Page until the service reports no more rows, so the whole published set
-    // is emitted rather than a first-page slice.
+    // 1-indexed: the managed service reads by `page`, not `offset`, so the loop
+    // MUST advance `page` — advancing an ignored `offset` would re-read page 1
+    // forever while `hasMore` stayed true.
+    let page = 1;
     for (;;) {
       const result = await services.collections.listEntries(
         collection,
         {
           where: { status: { equals: "published" } },
           depth: 0,
-          pagination: { limit: pageSize, offset },
+          pagination: { limit: pageSize, page },
         },
         { as: "system" }
       );
@@ -155,7 +173,7 @@ export async function buildSitemapUrls(
       }
 
       if (!result.pagination.hasMore) break;
-      offset += pageSize;
+      page += 1;
     }
   }
 

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -168,6 +168,14 @@ export async function buildSitemapUrls(
       : MAX_PAGE_SIZE;
   // Trim a trailing slash so `${baseUrl}${"/path"}` never yields `//path`.
   const baseUrl = options.baseUrl.replace(/\/+$/, "");
+  // The sitemap's own host — a `<loc>` must live on it, so a canonical on a
+  // different host is dropped rather than mixed in.
+  let baseHost = "";
+  try {
+    baseHost = new URL(baseUrl).host;
+  } catch {
+    baseHost = "";
+  }
   const urls: SitemapUrl[] = [];
 
   for (const collection of options.collections) {
@@ -205,37 +213,37 @@ export async function buildSitemapUrls(
         const seo = isRecord(row.seo) ? row.seo : undefined;
         // A noindexed page is intentionally kept out of the sitemap.
         if (seo?.noindex === true) continue;
-        // Honor a declared canonical: a sitemap should list canonical URLs, so
-        // when the entry sets one, advertise THAT rather than the generated URL
-        // it points away from. The `canonical` field is free text, so resolve it
-        // against `baseUrl` (a relative `/about` becomes absolute) and fall back
-        // to the generated URL if it is not a usable URL — a `<loc>` must be a
-        // valid absolute URL.
+
+        // Resolve the URL FIRST so `urlFor`'s exclusion contract is honored even
+        // for an entry that also declares a canonical: a falsy path means no
+        // stable URL (no slug, or a custom urlFor opted it out) — skip it.
+        const path = urlFor(row, collection);
+        if (!path) continue;
+        let loc = `${baseUrl}${path}`;
+
+        // A declared canonical overrides the generated URL, but only a same-host
+        // http(s) one. The `canonical` field is free text: resolve it against
+        // `baseUrl` (a relative `/about` becomes absolute); ignore a non-http
+        // scheme (`mailto:`/`javascript:`/`data:`), keeping the generated URL;
+        // and DROP the entry when the canonical is on another host, since a
+        // sitemap must only list URLs on its own host.
         const canonical =
           typeof seo?.canonical === "string" ? seo.canonical.trim() : "";
-        let loc: string | null = null;
         if (canonical) {
+          let offHost = false;
           try {
             const resolved = new URL(canonical, baseUrl);
-            // Only http(s) URLs are crawlable sitemap locations — a syntactically
-            // valid `mailto:` / `javascript:` / `data:` value must not become a
-            // `<loc>`; fall through to the generated URL instead.
-            if (
-              resolved.protocol === "http:" ||
-              resolved.protocol === "https:"
-            ) {
+            const isHttp =
+              resolved.protocol === "http:" || resolved.protocol === "https:";
+            if (isHttp && resolved.host === baseHost) {
               loc = resolved.href;
+            } else if (isHttp) {
+              offHost = true;
             }
           } catch {
-            loc = null;
+            // Malformed canonical → keep the generated URL.
           }
-        }
-        if (loc === null) {
-          // A falsy path means the entry has no stable URL (no slug, or a
-          // custom urlFor opted it out) — skip it rather than emit a bogus loc.
-          const path = urlFor(row, collection);
-          if (!path) continue;
-          loc = `${baseUrl}${path}`;
+          if (offHost) continue;
         }
         urls.push({ loc, lastModified: toLastModified(row.updatedAt) });
       }

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -79,7 +79,11 @@ export function defaultUrlForEntry(
   collection: string
 ): string {
   const slug = typeof entry.slug === "string" ? entry.slug : "";
-  return `/${collection}/${slug}`;
+  // Percent-encode the slug so a value with spaces or non-ASCII characters is
+  // still a valid URL path segment (`<loc>` must be a valid URL, and XML
+  // escaping alone does not make ` ` or `é` URL-safe). The collection segment
+  // is a fixed, already-safe config slug.
+  return `/${collection}/${encodeURIComponent(slug)}`;
 }
 
 /** XML-escape a text value for safe inclusion in an element body. */

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -29,6 +29,9 @@ export interface SitemapServices {
       query: {
         where?: Record<string, unknown>;
         depth?: number;
+        // A stable, unique sort so consecutive pages don't overlap or skip
+        // rows: the managed service adds `ORDER BY` only when `sort` is passed.
+        sort?: { field: string; direction: "asc" | "desc" };
         // Paged by 1-indexed `page`: the managed service reads a page from
         // `page`, not `offset`, so pagination MUST advance `page` to progress.
         pagination?: { limit?: number; page?: number };
@@ -167,6 +170,10 @@ export async function buildSitemapUrls(
         {
           where: { status: { equals: "published" } },
           depth: 0,
+          // Deterministic paging: without an explicit sort the service pages an
+          // unordered query, so rows could repeat or vanish between pages. `id`
+          // is unique and stable on every collection.
+          sort: { field: "id", direction: "asc" },
           pagination: { limit: pageSize, page },
         },
         { as: "system" }
@@ -177,14 +184,22 @@ export async function buildSitemapUrls(
         const seo = isRecord(row.seo) ? row.seo : undefined;
         // A noindexed page is intentionally kept out of the sitemap.
         if (seo?.noindex === true) continue;
-        // A falsy path means the entry has no stable URL (no slug, or a custom
-        // urlFor opted it out) — skip it rather than advertise a bogus loc.
-        const path = urlFor(row, collection);
-        if (!path) continue;
-        urls.push({
-          loc: `${baseUrl}${path}`,
-          lastModified: toLastModified(row.updatedAt),
-        });
+        // Honor a declared canonical: a sitemap should list canonical URLs, so
+        // when the entry sets one, advertise THAT rather than the generated URL
+        // it points away from.
+        const canonical =
+          typeof seo?.canonical === "string" ? seo.canonical.trim() : "";
+        let loc: string;
+        if (canonical) {
+          loc = canonical;
+        } else {
+          // A falsy path means the entry has no stable URL (no slug, or a
+          // custom urlFor opted it out) — skip it rather than emit a bogus loc.
+          const path = urlFor(row, collection);
+          if (!path) continue;
+          loc = `${baseUrl}${path}`;
+        }
+        urls.push({ loc, lastModified: toLastModified(row.updatedAt) });
       }
 
       if (!result.pagination.hasMore) break;

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -140,7 +140,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function resolveOnOrigin(path: string, baseOrigin: string): string | null {
   try {
     const resolved = new URL(path, baseOrigin);
-    return resolved.origin === baseOrigin ? resolved.href : null;
+    if (resolved.origin !== baseOrigin) return null;
+    // Never publish credentials a custom mapper embedded (origin excludes them).
+    if (resolved.username !== "" || resolved.password !== "") return null;
+    return resolved.href;
   } catch {
     return null;
   }
@@ -182,6 +185,9 @@ export const MAX_SITEMAP_URLS = 50_000;
  * first).
  */
 export const MAX_SITEMAP_BYTES = 50 * 1024 * 1024;
+
+/** The sitemap protocol limits a single `<loc>` to 2,048 characters. */
+export const MAX_LOC_LENGTH = 2048;
 
 /** The columns the default mapper reads — used to project the query. */
 const DEFAULT_SELECT: Record<string, boolean> = {
@@ -275,6 +281,14 @@ export async function buildSitemapUrls(
     options.maxBytes && options.maxBytes > 0
       ? Math.min(options.maxBytes, MAX_SITEMAP_BYTES)
       : MAX_SITEMAP_BYTES;
+  // Even an empty document is the wrapper, so a budget below it can never be
+  // met — reject it rather than emit an over-cap wrapper-only document.
+  if (maxBytes < WRAPPER_BYTES) {
+    throw new Error(
+      `sitemap: maxBytes (${maxBytes}) is smaller than the minimum ` +
+        `document size (${WRAPPER_BYTES} bytes).`
+    );
+  }
   const urls: SitemapUrl[] = [];
   // Running serialized size (the wrapper plus each `<url>` line and its join),
   // so the document is bounded by BOTH the URL count and the byte limit.
@@ -354,6 +368,9 @@ export async function buildSitemapUrls(
           }
           if (offOrigin) continue;
         }
+        // A `<loc>` over the protocol's 2,048-char limit is an invalid record —
+        // drop it rather than emit a non-compliant entry.
+        if (loc.length > MAX_LOC_LENGTH) continue;
         const entry: SitemapUrl = {
           loc,
           lastModified: toLastModified(row.updatedAt),

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -48,12 +48,13 @@ export interface SitemapUrl {
 
 /**
  * Build the URL path for an entry (leading slash, appended to the origin).
- * Defaults to `/<collection>/<slug>`.
+ * Defaults to `/<collection>/<slug>`. Return `null`/`undefined` to EXCLUDE the
+ * entry from the sitemap (e.g. it has no stable public URL).
  */
 export type UrlForEntry = (
   entry: Record<string, unknown>,
   collection: string
-) => string;
+) => string | null | undefined;
 
 /** Options for {@link buildSitemapUrls} / {@link generateSitemap}. */
 export interface SitemapOptions {
@@ -73,12 +74,18 @@ export interface SitemapOptions {
   pageSize?: number;
 }
 
-/** Default path: `/<collection>/<slug>`. */
+/**
+ * Default path: `/<collection>/<slug>`. Returns `null` when the entry has no
+ * usable `slug` so the caller SKIPS it — without a slug there is no stable URL,
+ * and emitting `/<collection>/` for every slugless row would advertise
+ * duplicate, meaningless listing URLs.
+ */
 export function defaultUrlForEntry(
   entry: Record<string, unknown>,
   collection: string
-): string {
-  const slug = typeof entry.slug === "string" ? entry.slug : "";
+): string | null {
+  const slug = typeof entry.slug === "string" ? entry.slug.trim() : "";
+  if (!slug) return null;
   // Percent-encode the slug so a value with spaces or non-ASCII characters is
   // still a valid URL path segment (`<loc>` must be a valid URL, and XML
   // escaping alone does not make ` ` or `é` URL-safe). The collection segment
@@ -170,8 +177,12 @@ export async function buildSitemapUrls(
         const seo = isRecord(row.seo) ? row.seo : undefined;
         // A noindexed page is intentionally kept out of the sitemap.
         if (seo?.noindex === true) continue;
+        // A falsy path means the entry has no stable URL (no slug, or a custom
+        // urlFor opted it out) — skip it rather than advertise a bogus loc.
+        const path = urlFor(row, collection);
+        if (!path) continue;
         urls.push({
-          loc: `${baseUrl}${urlFor(row, collection)}`,
+          loc: `${baseUrl}${path}`,
           lastModified: toLastModified(row.updatedAt),
         });
       }

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -150,11 +150,12 @@ export const MAX_PAGE_SIZE = 500;
  * `seo.noindex` are excluded: a page told not to be indexed does not belong in
  * the sitemap.
  *
- * The `status: published` filter applies to collections with the draft/
- * published lifecycle (`status: true`). A collection without it has no
- * unpublished state, so the (unknown-field) filter is a no-op there and every
- * entry — all of which are live — is listed. That mirrors the core's own
- * status handling (filter only when a status column exists).
+ * The `status: published` filter is applied ONLY to collections with the
+ * built-in draft/published lifecycle (`status: true`, read via
+ * `getCollection`). A status-less collection has no unpublished state, so every
+ * entry — all of which are live — is listed; the filter is skipped there rather
+ * than applied to a same-named ordinary field. That mirrors the core's own
+ * status handling (filter only when the lifecycle column exists).
  */
 export async function buildSitemapUrls(
   services: SitemapServices,

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -223,10 +223,19 @@ const WRAPPER_BYTES = utf8Bytes(XML_HEADER) + utf8Bytes(XML_FOOTER);
  */
 export function resolveBaseOrigin(baseUrl: string): string {
   const invalid = (): never => {
+    // Redact any credentials before surfacing the value — this runs at
+    // construction and the message can land in startup/deploy logs.
+    let shown: string;
+    try {
+      const u = new URL(baseUrl);
+      shown = `${u.protocol}//${u.host}${u.pathname}${u.search}${u.hash}`;
+    } catch {
+      shown = "<invalid>";
+    }
     throw new Error(
       `sitemap: baseUrl must be an absolute http(s) origin with no path, ` +
         `query, fragment, or credentials (put per-entry paths in urlFor), ` +
-        `got: ${baseUrl}`
+        `got: ${shown}`
     );
   };
   let url: URL;
@@ -277,10 +286,13 @@ export async function buildSitemapUrls(
   // it, and a canonical on a different origin is dropped rather than mixed in.
   // Rejects a non-origin/relative baseUrl up front so `<loc>` is never invalid.
   const baseOrigin = resolveBaseOrigin(options.baseUrl);
+  // Only `undefined` takes the default; a supplied value (including 0 or a
+  // negative) is honored so the wrapper guard below rejects an impossible cap
+  // rather than silently substituting the 50 MB default.
   const maxBytes =
-    options.maxBytes && options.maxBytes > 0
-      ? Math.min(options.maxBytes, MAX_SITEMAP_BYTES)
-      : MAX_SITEMAP_BYTES;
+    options.maxBytes === undefined
+      ? MAX_SITEMAP_BYTES
+      : Math.min(options.maxBytes, MAX_SITEMAP_BYTES);
   // Even an empty document is the wrapper, so a budget below it can never be
   // met — reject it rather than emit an over-cap wrapper-only document.
   if (maxBytes < WRAPPER_BYTES) {

--- a/packages/plugin-seo/src/sitemap.ts
+++ b/packages/plugin-seo/src/sitemap.ts
@@ -89,6 +89,11 @@ export interface SitemapOptions {
    * {@link MAX_PAGE_SIZE} (the managed service's per-page maximum).
    */
   pageSize?: number;
+  /**
+   * Advanced: cap the serialized document size in bytes. Defaults to and is
+   * capped at {@link MAX_SITEMAP_BYTES} (the 50 MB protocol limit).
+   */
+  maxBytes?: number;
 }
 
 /**
@@ -154,6 +159,14 @@ export const MAX_PAGE_SIZE = 500;
  */
 export const MAX_SITEMAP_URLS = 50_000;
 
+/**
+ * The sitemap protocol also limits an uncompressed document to 50 MB, so
+ * collection stops before the serialized size would cross this even if the URL
+ * count is under {@link MAX_SITEMAP_URLS} (long locations can hit the byte cap
+ * first).
+ */
+export const MAX_SITEMAP_BYTES = 50 * 1024 * 1024;
+
 /** The columns the default mapper reads — used to project the query. */
 const DEFAULT_SELECT: Record<string, boolean> = {
   slug: true,
@@ -161,21 +174,53 @@ const DEFAULT_SELECT: Record<string, boolean> = {
   updatedAt: true,
 };
 
-/** Resolve `baseUrl` to an origin, rejecting anything but an absolute http(s) URL. */
-function resolveBaseOrigin(baseUrl: string): string {
+const XML_HEADER =
+  `<?xml version="1.0" encoding="UTF-8"?>\n` +
+  `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n`;
+const XML_FOOTER = `\n</urlset>`;
+
+/** Serialize one resolved URL into its `<url>` line (shared by size accounting). */
+function serializeUrlEntry({ loc, lastModified }: SitemapUrl): string {
+  const lastmod = lastModified
+    ? `<lastmod>${escapeXml(lastModified)}</lastmod>`
+    : "";
+  return `  <url><loc>${escapeXml(loc)}</loc>${lastmod}</url>`;
+}
+
+// UTF-8 byte length via the web-standard TextEncoder (no Node `Buffer`), so the
+// size cap works in any runtime the agnostic plugin runs in.
+const utf8Encoder = new TextEncoder();
+const utf8Bytes = (value: string): number => utf8Encoder.encode(value).length;
+const WRAPPER_BYTES = utf8Bytes(XML_HEADER) + utf8Bytes(XML_FOOTER);
+
+/**
+ * Resolve `baseUrl` to an origin, requiring an absolute http(s) origin with no
+ * path, query, fragment, or credentials — per-entry paths belong in `urlFor`.
+ * Rejecting a path avoids a doubled base like `https://x.com/cms/pages/a`, and
+ * rejecting credentials avoids leaking them into a public `<loc>`.
+ */
+export function resolveBaseOrigin(baseUrl: string): string {
+  const invalid = (): never => {
+    throw new Error(
+      `sitemap: baseUrl must be an absolute http(s) origin with no path, ` +
+        `query, fragment, or credentials (put per-entry paths in urlFor), ` +
+        `got: ${baseUrl}`
+    );
+  };
   let url: URL;
   try {
     url = new URL(baseUrl);
   } catch {
-    throw new Error(
-      `sitemap: baseUrl must be an absolute http(s) URL, got: ${baseUrl}`
-    );
+    return invalid();
   }
-  if (url.protocol !== "http:" && url.protocol !== "https:") {
-    throw new Error(
-      `sitemap: baseUrl must be an absolute http(s) URL, got: ${baseUrl}`
-    );
-  }
+  const isHttp = url.protocol === "http:" || url.protocol === "https:";
+  const isOriginOnly =
+    (url.pathname === "" || url.pathname === "/") &&
+    !url.search &&
+    !url.hash &&
+    !url.username &&
+    !url.password;
+  if (!isHttp || !isOriginOnly) return invalid();
   return url.origin;
 }
 
@@ -206,13 +251,18 @@ export async function buildSitemapUrls(
     options.pageSize && options.pageSize > 0
       ? Math.min(options.pageSize, MAX_PAGE_SIZE)
       : MAX_PAGE_SIZE;
-  // Trim a trailing slash so `${baseUrl}${"/path"}` never yields `//path`.
-  const baseUrl = options.baseUrl.replace(/\/+$/, "");
-  // The sitemap's own origin (scheme + host + port) — a `<loc>` must live on it,
-  // so a canonical on a different origin is dropped rather than mixed in.
-  // Rejects an empty/relative baseUrl up front so `<loc>` is never invalid.
-  const baseOrigin = resolveBaseOrigin(baseUrl);
+  // The sitemap's own origin (scheme + host + port). Every `<loc>` is built from
+  // it, and a canonical on a different origin is dropped rather than mixed in.
+  // Rejects a non-origin/relative baseUrl up front so `<loc>` is never invalid.
+  const baseOrigin = resolveBaseOrigin(options.baseUrl);
+  const maxBytes =
+    options.maxBytes && options.maxBytes > 0
+      ? Math.min(options.maxBytes, MAX_SITEMAP_BYTES)
+      : MAX_SITEMAP_BYTES;
   const urls: SitemapUrl[] = [];
+  // Running serialized size (the wrapper plus each `<url>` line and its join),
+  // so the document is bounded by BOTH the URL count and the byte limit.
+  let byteSize = WRAPPER_BYTES;
 
   for (const collection of options.collections) {
     // Apply the published filter ONLY to collections with the built-in
@@ -256,20 +306,20 @@ export async function buildSitemapUrls(
         // stable URL (no slug, or a custom urlFor opted it out) — skip it.
         const path = urlFor(row, collection);
         if (!path) continue;
-        let loc = `${baseUrl}${path}`;
+        let loc = `${baseOrigin}${path}`;
 
-        // A declared canonical overrides the generated URL, but only a same-host
-        // http(s) one. The `canonical` field is free text: resolve it against
-        // `baseUrl` (a relative `/about` becomes absolute); ignore a non-http
-        // scheme (`mailto:`/`javascript:`/`data:`), keeping the generated URL;
-        // and DROP the entry when the canonical is on another host, since a
-        // sitemap must only list URLs on its own host.
+        // A declared canonical overrides the generated URL, but only a same-
+        // origin http(s) one. The `canonical` field is free text: resolve it
+        // against the origin (a relative `/about` becomes absolute); ignore a
+        // non-http scheme (`mailto:`/`javascript:`/`data:`), keeping the
+        // generated URL; and DROP the entry when the canonical is on another
+        // origin, since a sitemap must only list URLs on its own origin.
         const canonical =
           typeof seo?.canonical === "string" ? seo.canonical.trim() : "";
         if (canonical) {
           let offHost = false;
           try {
-            const resolved = new URL(canonical, baseUrl);
+            const resolved = new URL(canonical, baseOrigin);
             const isHttp =
               resolved.protocol === "http:" || resolved.protocol === "https:";
             if (isHttp && resolved.origin === baseOrigin) {
@@ -282,8 +332,20 @@ export async function buildSitemapUrls(
           }
           if (offHost) continue;
         }
-        urls.push({ loc, lastModified: toLastModified(row.updatedAt) });
-        // Bound the document to the protocol limit so the single `<urlset>`
+        const entry: SitemapUrl = {
+          loc,
+          lastModified: toLastModified(row.updatedAt),
+        };
+        // Stop before the serialized size would exceed the byte limit, but
+        // always emit at least one entry so a single oversized URL still yields
+        // a document. `+ 1` accounts for the newline joining entries.
+        const entryBytes = utf8Bytes(serializeUrlEntry(entry)) + 1;
+        if (urls.length > 0 && byteSize + entryBytes > maxBytes) {
+          return urls;
+        }
+        byteSize += entryBytes;
+        urls.push(entry);
+        // Bound the document to the protocol limits so the single `<urlset>`
         // stays valid; a larger corpus needs a sitemap index (delivery layer).
         if (urls.length >= MAX_SITEMAP_URLS) return urls;
       }
@@ -298,15 +360,8 @@ export async function buildSitemapUrls(
 
 /** Serialize resolved URLs into a sitemaps.org `<urlset>` document. */
 export function serializeSitemap(urls: SitemapUrl[]): string {
-  const body = urls
-    .map(({ loc, lastModified }) => {
-      const lastmod = lastModified
-        ? `<lastmod>${escapeXml(lastModified)}</lastmod>`
-        : "";
-      return `  <url><loc>${escapeXml(loc)}</loc>${lastmod}</url>`;
-    })
-    .join("\n");
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${body}\n</urlset>`;
+  const body = urls.map(serializeUrlEntry).join("\n");
+  return `${XML_HEADER}${body}${XML_FOOTER}`;
 }
 
 /** Build the full sitemap XML for the configured collections. */


### PR DESCRIPTION
## What

Adds a **sitemap** to `@nextlyhq/plugin-seo`: a framework-agnostic (zero `next`) data provider + XML serializer, exposed over a public HTTP route.

```
GET /api/plugins/@nextlyhq/plugin-seo/sitemap.xml
```

It lists one `<url>` per **published** entry across the collections the plugin is configured for, reflects publishes/edits on the next request, and leaves out drafts and any entry with `seo.noindex` set.

This is the second step of the Tier-0 routing/SEO program (the SEO field group shipped in #349). It keeps the plugin **data-only and agnostic** — the plugin owns the sitemap DATA and a headless HTTP path; the canonical Next `app/sitemap.ts` delivery + its F1 caching land in a later Next-bridge PR.

## Why this shape

- **Agnostic, opt-in.** No `next`/`react`. A headless frontend (which has no `app/sitemap.ts`) can point crawlers at the HTTP route or proxy it to `/sitemap.xml`; an admin-only/API-only deployment that never configures the plugin pays nothing.
- **No bespoke cache, no event subscription.** The sitemap is derived from `status: published` content. The core write path already computes a revalidation intent carrying the collection tag on every create/update/**publish**/delete (`collection-mutation-service` → `buildEntryRevalidationIntent` → `flush`), so once the canonical delivery wraps this data in `cachedFind` (next PR) it busts in lockstep with the page — no in-memory cache and no `ctx.events` subscription needed here.
- **No silent truncation.** The provider pages through the whole published set by offset until the service reports no more rows, rather than capping at a first page.
- **`noindex` respected.** A page told not to be indexed is not advertised in the sitemap.

## API

`seoPlugin` gains two optional options (additive, non-breaking):

- `baseUrl?: string` — absolute origin for `<loc>`. When omitted the route uses the request origin (correct for a single-origin deploy; set it explicitly behind a host-rewriting proxy).
- `urlFor?: (entry, collection) => string` — per-entry path, default `/<collection>/<slug>`.

New public exports: `buildSitemapUrls`, `serializeSitemap`, `generateSitemap`, `escapeXml`, `defaultUrlForEntry`, and the `SitemapUrl` / `SitemapOptions` / `SitemapServices` / `UrlForEntry` types.

## Tests (proven by breaking)

- **Unit** (`sitemap.test.ts`): XML entity escaping; default + custom `urlFor`; published-only + `as: system` query; full pagination across pages (a first-page-only read would drop later entries); `noindex` exclusion; trailing-slash trim; serializer `<urlset>` shape + escaped `<loc>`.
- **Integration** (`sitemap.integration.test.ts`): drives the real route through `createDynamicHandlers` (the same path production serves) against a real boot — a published entry appears; a draft and a `noindex` entry are absent; publishing a draft makes it appear on the next read; the request-origin fallback works.

## Scope / boundaries

- No SDK surface change: uses `definePlugin`, field factories (from #349), `contributes.routes`, and the already-`@public` managed data-access types. The plugin imports only from `@nextlyhq/plugin-sdk` (+ `nextly`/`nextly/runtime` in tests).
- One changeset, all 21 fixed-group packages, `patch`.
- `@nextlyhq/plugin-seo` still needs its npm name bootstrap before it can publish (founder action; does not block this PR).

@codex please review this PR
@coderabbitai review
@greptile-apps review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a framework-agnostic, live-generated XML sitemap at `/sitemap.xml` with per-request canonical/origin resolution and `lastmod` when available.
  - Sitemap can be disabled or limited by collection selection; supports custom URL building and omits drafts, `noindex` entries, and invalid/unresolvable URLs.
  - Enforces sitemap size limits and returns `cache-control: no-store` when `baseUrl` isn’t explicitly configured; exports sitemap helper utilities.

- **Documentation**
  - Updated the plugin README with detailed sitemap inclusion, canonical/origin rules, and exposure guidance for serving `/sitemap.xml` from the site root.

- **Tests**
  - Added unit and integration tests covering routing, pagination, filtering, canonical logic, URL validation, and XML formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->