### PR TITLE
feat(nextly): add buildMetadata seo bridge to nextly/runtime

### DIFF
--- a/.changeset/tier0-build-metadata.md
+++ b/.changeset/tier0-build-metadata.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+nextly now exports `buildMetadata` from `nextly/runtime`: it maps a content entry's SEO field group (from `@nextlyhq/plugin-seo`) to a Next.js `Metadata` object, so a page's `generateMetadata` becomes a single call instead of a hand-written mapping. It sets the title, description, canonical, OpenGraph, Twitter card, robots (from `noindex`), and hreflang alternates, with per-call fallbacks for blank fields. The `next` dependency is type-only, so importing it never forces `next` at load.

--- a/packages/nextly/src/runtime.ts
+++ b/packages/nextly/src/runtime.ts
@@ -44,3 +44,12 @@ export {
   type NextCacheModule,
   type CachedFindOptions,
 } from "./runtime/cache";
+
+// SEO bridge — map the plugin's `seo` field group to a Next `Metadata` object.
+// The `next` import is type-only, so this never forces `next` at load.
+export {
+  buildMetadata,
+  type BuildMetadataOptions,
+  type MetadataEntry,
+  type SeoMetaInput,
+} from "./runtime/seo";

--- a/packages/nextly/src/runtime/seo/__tests__/build-metadata.test.ts
+++ b/packages/nextly/src/runtime/seo/__tests__/build-metadata.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+
+import { buildMetadata } from "../build-metadata";
+
+describe("buildMetadata", () => {
+  it("maps a fully-populated seo group to Metadata", () => {
+    const meta = buildMetadata({
+      seo: {
+        metaTitle: "Meta Title",
+        metaDescription: "Meta description.",
+        ogImage: { url: "https://cdn.example/og.png" },
+        canonical: "https://example.com/post",
+        noindex: false,
+      },
+    });
+
+    expect(meta.title).toBe("Meta Title");
+    expect(meta.description).toBe("Meta description.");
+    expect(meta.alternates).toEqual({ canonical: "https://example.com/post" });
+    expect(meta.robots).toEqual({ index: true, follow: true });
+    expect(meta.openGraph).toMatchObject({
+      title: "Meta Title",
+      description: "Meta description.",
+      url: "https://example.com/post",
+      images: [{ url: "https://cdn.example/og.png" }],
+    });
+    expect(meta.twitter).toMatchObject({
+      card: "summary_large_image",
+      title: "Meta Title",
+      description: "Meta description.",
+      images: ["https://cdn.example/og.png"],
+    });
+  });
+
+  it("falls back to the provided values when seo fields are blank", () => {
+    const meta = buildMetadata(
+      { seo: { metaTitle: "", metaDescription: "   " } },
+      {
+        fallback: {
+          title: "Post Title",
+          description: "The excerpt.",
+          image: "https://cdn.example/featured.png",
+          canonical: "/blog/hello",
+        },
+      }
+    );
+
+    expect(meta.title).toBe("Post Title");
+    expect(meta.description).toBe("The excerpt.");
+    expect(meta.alternates).toEqual({ canonical: "/blog/hello" });
+    expect(meta.openGraph).toMatchObject({
+      images: [{ url: "https://cdn.example/featured.png" }],
+    });
+  });
+
+  it("prefers the seo field over the fallback", () => {
+    const meta = buildMetadata(
+      { seo: { metaTitle: "SEO Title" } },
+      { fallback: { title: "Entry Title" } }
+    );
+    expect(meta.title).toBe("SEO Title");
+  });
+
+  it("sets robots to noindex/nofollow when noindex is true", () => {
+    const meta = buildMetadata({ seo: { noindex: true } });
+    expect(meta.robots).toEqual({ index: false, follow: false });
+  });
+
+  it("returns minimal, indexable metadata when there is no seo group", () => {
+    const meta = buildMetadata({});
+    expect(meta.title).toBeUndefined();
+    expect(meta.description).toBeUndefined();
+    expect(meta.alternates).toBeUndefined();
+    expect(meta.openGraph).toBeUndefined();
+    expect(meta.twitter).toBeUndefined();
+    expect(meta.robots).toEqual({ index: true, follow: true });
+  });
+
+  it("ignores an unresolved ogImage id and uses the image fallback", () => {
+    const meta = buildMetadata(
+      { seo: { ogImage: "media-id-123" } },
+      { fallback: { image: "https://cdn.example/fallback.png" } }
+    );
+    expect(meta.openGraph).toMatchObject({
+      images: [{ url: "https://cdn.example/fallback.png" }],
+    });
+    expect(meta.twitter).toMatchObject({
+      images: ["https://cdn.example/fallback.png"],
+    });
+  });
+
+  it("omits image-derived fields when there is no image", () => {
+    const meta = buildMetadata({ seo: { metaTitle: "T" } });
+    expect(meta.openGraph).not.toHaveProperty("images");
+    // No image → no large-image twitter card is implied by an image.
+    expect(meta.twitter).not.toHaveProperty("images");
+  });
+
+  it("maps locale alternates to alternates.languages", () => {
+    const meta = buildMetadata(
+      { seo: { canonical: "https://example.com/en/p" } },
+      {
+        languages: {
+          en: "https://example.com/en/p",
+          de: "https://example.com/de/p",
+        },
+      }
+    );
+    expect(meta.alternates).toEqual({
+      canonical: "https://example.com/en/p",
+      languages: {
+        en: "https://example.com/en/p",
+        de: "https://example.com/de/p",
+      },
+    });
+  });
+
+  it("merges caller openGraph and twitter extras on top of the derived fields", () => {
+    const meta = buildMetadata(
+      { seo: { metaTitle: "T", metaDescription: "D" } },
+      {
+        openGraph: {
+          type: "article",
+          publishedTime: "2026-01-02T00:00:00.000Z",
+        },
+        twitter: { creator: "@author" },
+      }
+    );
+    expect(meta.openGraph).toMatchObject({
+      title: "T",
+      description: "D",
+      type: "article",
+      publishedTime: "2026-01-02T00:00:00.000Z",
+    });
+    expect(meta.twitter).toMatchObject({ title: "T", creator: "@author" });
+  });
+
+  it("does not set alternates when neither canonical nor languages are present", () => {
+    const meta = buildMetadata({ seo: { metaTitle: "T" } });
+    expect(meta.alternates).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/runtime/seo/__tests__/build-metadata.test.ts
+++ b/packages/nextly/src/runtime/seo/__tests__/build-metadata.test.ts
@@ -135,6 +135,21 @@ describe("buildMetadata", () => {
     expect(meta.twitter).toMatchObject({ title: "T", creator: "@author" });
   });
 
+  it("rejects a non-http canonical and falls back to a usable one", () => {
+    const meta = buildMetadata(
+      { seo: { canonical: "mailto:hi@example.com" } },
+      { fallback: { canonical: "/blog/hello" } }
+    );
+    expect(meta.alternates).toEqual({ canonical: "/blog/hello" });
+    expect(meta.openGraph).toMatchObject({ url: "/blog/hello" });
+  });
+
+  it("drops an unusable canonical entirely when there is no usable fallback", () => {
+    const meta = buildMetadata({ seo: { canonical: "javascript:alert(1)" } });
+    expect(meta.alternates).toBeUndefined();
+    expect(meta.openGraph).toBeUndefined();
+  });
+
   it("does not set alternates when neither canonical nor languages are present", () => {
     const meta = buildMetadata({ seo: { metaTitle: "T" } });
     expect(meta.alternates).toBeUndefined();

--- a/packages/nextly/src/runtime/seo/build-metadata.ts
+++ b/packages/nextly/src/runtime/seo/build-metadata.ts
@@ -77,6 +77,34 @@ function imageUrl(ogImage: unknown): string | undefined {
 }
 
 /**
+ * A usable `<link rel="canonical">` value: a root-relative path (resolved
+ * against `metadataBase`) or an absolute http(s) URL. `canonical` is a free-text
+ * field, so a non-web value like `mailto:` / `javascript:` must not become the
+ * canonical URL.
+ */
+function isUsableCanonical(value: string): boolean {
+  if (value.startsWith("/")) return true;
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/** The first non-blank, usable canonical among the candidates (trimmed), or undefined. */
+function firstUsableCanonical(
+  ...values: Array<string | null | undefined>
+): string | undefined {
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed !== "" && isUsableCanonical(trimmed)) return trimmed;
+  }
+  return undefined;
+}
+
+/**
  * Map an entry's `seo` group to a Next.js `Metadata` object.
  *
  * @example
@@ -102,7 +130,7 @@ export function buildMetadata(
   const title = firstNonBlank(seo.metaTitle, fallback.title);
   const description = firstNonBlank(seo.metaDescription, fallback.description);
   const image = firstNonBlank(imageUrl(seo.ogImage), fallback.image);
-  const canonical = firstNonBlank(seo.canonical, fallback.canonical);
+  const canonical = firstUsableCanonical(seo.canonical, fallback.canonical);
   // A page is indexable unless it explicitly opts out.
   const noindex = seo.noindex === true;
 

--- a/packages/nextly/src/runtime/seo/build-metadata.ts
+++ b/packages/nextly/src/runtime/seo/build-metadata.ts
@@ -1,0 +1,146 @@
+/**
+ * `buildMetadata` — turn a content entry's `seo` field group into a Next.js
+ * `Metadata` object, so an app's `generateMetadata` is one call instead of a
+ * hand-mapped block per page.
+ *
+ * The `next` import is TYPE-ONLY, so importing this never forces `next` onto a
+ * consumer at runtime — the function returns a plain object typed as `Metadata`.
+ * It reads the field group `@nextlyhq/plugin-seo` contributes (`metaTitle`,
+ * `metaDescription`, `ogImage`, `canonical`, `noindex`) and is defensive: a
+ * missing group or blank field falls back to the value you pass in `options`.
+ *
+ * @module runtime/seo/build-metadata
+ */
+import type { Metadata } from "next";
+
+/** The `seo` field group shape this bridge reads (all fields optional). */
+export interface SeoMetaInput {
+  metaTitle?: string | null;
+  metaDescription?: string | null;
+  /** Populated upload relation (`{ url }`) or an unresolved id — read defensively. */
+  ogImage?: unknown;
+  canonical?: string | null;
+  noindex?: boolean | null;
+}
+
+/** An entry carrying the plugin's `seo` group (plus whatever else it has). */
+export interface MetadataEntry {
+  seo?: SeoMetaInput | null;
+}
+
+/** Options for {@link buildMetadata}. */
+export interface BuildMetadataOptions {
+  /**
+   * Fallbacks used when the matching `seo` field is blank — e.g. the entry's
+   * own title, excerpt, featured image, and route path.
+   */
+  fallback?: {
+    title?: string;
+    description?: string;
+    image?: string;
+    canonical?: string;
+  };
+  /**
+   * Extra OpenGraph fields merged on top of the derived ones — for page-type
+   * specifics the SEO group does not carry (e.g. `type: "article"`,
+   * `publishedTime`, `authors`).
+   */
+  openGraph?: Metadata["openGraph"];
+  /** Extra Twitter-card fields merged on top of the derived ones. */
+  twitter?: Metadata["twitter"];
+  /**
+   * hreflang alternates (locale → absolute or relative URL) for a localized
+   * page, mapped to `alternates.languages`.
+   */
+  languages?: Record<string, string>;
+}
+
+/** True for a plain, indexable object (not null, not an array-hostile value). */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/** The first non-blank string among the candidates, or undefined. */
+function firstNonBlank(
+  ...values: Array<string | null | undefined>
+): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim() !== "") return value;
+  }
+  return undefined;
+}
+
+/** Read a URL from a populated upload relation (`{ url }`); undefined otherwise. */
+function imageUrl(ogImage: unknown): string | undefined {
+  if (isRecord(ogImage) && typeof ogImage.url === "string") return ogImage.url;
+  return undefined;
+}
+
+/**
+ * Map an entry's `seo` group to a Next.js `Metadata` object.
+ *
+ * @example
+ * ```ts
+ * export async function generateMetadata({ params }) {
+ *   const { slug } = await params;
+ *   const post = await getPostBySlug(slug);
+ *   if (!post) return {};
+ *   return buildMetadata(post, {
+ *     fallback: { title: post.title, description: post.excerpt, canonical: `/blog/${slug}` },
+ *     openGraph: { type: "article", publishedTime: post.publishedAt ?? undefined },
+ *   });
+ * }
+ * ```
+ */
+export function buildMetadata(
+  entry: MetadataEntry,
+  options: BuildMetadataOptions = {}
+): Metadata {
+  const seo = entry.seo ?? {};
+  const fallback = options.fallback ?? {};
+
+  const title = firstNonBlank(seo.metaTitle, fallback.title);
+  const description = firstNonBlank(seo.metaDescription, fallback.description);
+  const image = firstNonBlank(imageUrl(seo.ogImage), fallback.image);
+  const canonical = firstNonBlank(seo.canonical, fallback.canonical);
+  // A page is indexable unless it explicitly opts out.
+  const noindex = seo.noindex === true;
+
+  const metadata: Metadata = {};
+  if (title !== undefined) metadata.title = title;
+  if (description !== undefined) metadata.description = description;
+
+  const languages = options.languages;
+  const hasLanguages =
+    languages !== undefined && Object.keys(languages).length > 0;
+  if (canonical !== undefined || hasLanguages) {
+    metadata.alternates = {
+      ...(canonical !== undefined ? { canonical } : {}),
+      ...(hasLanguages ? { languages } : {}),
+    };
+  }
+
+  // OpenGraph — caller extras win, so a page can set `type`/`publishedTime` etc.
+  const openGraph: NonNullable<Metadata["openGraph"]> = {
+    ...(title !== undefined ? { title } : {}),
+    ...(description !== undefined ? { description } : {}),
+    ...(canonical !== undefined ? { url: canonical } : {}),
+    ...(image !== undefined ? { images: [{ url: image }] } : {}),
+    ...options.openGraph,
+  };
+  if (Object.keys(openGraph).length > 0) metadata.openGraph = openGraph;
+
+  // Twitter — a large-image card whenever there is an image; caller extras win.
+  const twitter: NonNullable<Metadata["twitter"]> = {
+    ...(image !== undefined ? { card: "summary_large_image" } : {}),
+    ...(title !== undefined ? { title } : {}),
+    ...(description !== undefined ? { description } : {}),
+    ...(image !== undefined ? { images: [image] } : {}),
+    ...options.twitter,
+  };
+  if (Object.keys(twitter).length > 0) metadata.twitter = twitter;
+
+  metadata.robots = { index: !noindex, follow: !noindex };
+
+  return metadata;
+}

--- a/packages/nextly/src/runtime/seo/index.ts
+++ b/packages/nextly/src/runtime/seo/index.ts
@@ -1,0 +1,13 @@
+/**
+ * `runtime/seo` — Next-coupled SEO bridges that turn the `@nextlyhq/plugin-seo`
+ * field group into Next.js primitives. Type-only `next` imports, so nothing
+ * here forces `next` at load.
+ *
+ * @module runtime/seo
+ */
+export { buildMetadata } from "./build-metadata";
+export type {
+  BuildMetadataOptions,
+  MetadataEntry,
+  SeoMetaInput,
+} from "./build-metadata";

--- a/packages/plugin-seo/README.md
+++ b/packages/plugin-seo/README.md
@@ -4,7 +4,7 @@
 
 First-party SEO plugin for Nextly. It is **opt-in** and **framework-agnostic** (zero `next` dependency), so it is safe in every deployment mode — an integrated site, a headless setup feeding a separate frontend, or an internal admin tool. You add it only to the collections that need SEO.
 
-This package is **framework-agnostic** (zero `next`): it adds SEO fields to your content and serves a sitemap of your published content over plain HTTP, nothing Next-specific, so it is safe in headless and admin-only projects. Turning the SEO fields into `<meta>` tags and wiring a canonical `app/sitemap.ts` / `robots.ts` are your app's job today; first-party Next.js helpers for that are planned as a separate, opt-in package.
+This package is **framework-agnostic** (zero `next`): it adds SEO fields to your content and serves a sitemap of your published content over plain HTTP, nothing Next-specific, so it is safe in headless and admin-only projects. In a Next.js app, turn the SEO fields into `<meta>` tags with `buildMetadata` from `nextly/runtime` (see [Next.js metadata](#nextjs-metadata) below); wiring a canonical `app/sitemap.ts` / `robots.ts` is still your app's job today, and first-party helpers for that are planned.
 
 ## Install
 
@@ -53,6 +53,36 @@ seoPlugin({
   fields: [text({ name: "focusKeyword" })],
 });
 ```
+
+## Next.js metadata
+
+In a Next.js app, `buildMetadata` from `nextly/runtime` turns the `seo` group into a Next `Metadata` object, so a page's `generateMetadata` is one call instead of a hand-written mapping. It sets the title, description, canonical, OpenGraph, Twitter card, and `robots` (from `noindex`), with per-call fallbacks for blank fields:
+
+```ts
+// app/blog/[slug]/page.tsx
+import { buildMetadata } from "nextly/runtime";
+
+export async function generateMetadata({ params }) {
+  const { slug } = await params;
+  const post = await getPostBySlug(slug);
+  if (!post) return {};
+  return buildMetadata(post, {
+    // Used when the matching seo field is blank.
+    fallback: {
+      title: post.title,
+      description: post.excerpt,
+      canonical: `/blog/${slug}`,
+    },
+    // Page-type specifics the seo group does not carry.
+    openGraph: {
+      type: "article",
+      publishedTime: post.publishedAt ?? undefined,
+    },
+  });
+}
+```
+
+Set `metadataBase` once in your root layout so a relative `canonical` resolves to an absolute URL. Pass `languages` (locale → URL) to emit `alternates.languages` (hreflang) for a localized page. `buildMetadata` lives in `nextly/runtime` (Next-only), so it stays out of the agnostic plugin.
 
 ## Sitemap
 


### PR DESCRIPTION
## What

Adds `buildMetadata` to `nextly/runtime` — a small bridge that maps a content entry's `seo` field group (the one `@nextlyhq/plugin-seo` contributes) to a Next.js `Metadata` object, so an app's `generateMetadata` becomes one call instead of a hand-written mapping per page.

This is Tier-0 PR3 (after PR1 SEO fields #349 and PR2 sitemap #351). It's the Next-coupled **behavior** half of the data-vs-behavior split: the plugin owns the agnostic data, this bridge turns it into Next primitives.

```ts
export async function generateMetadata({ params }) {
  const { slug } = await params;
  const post = await getPostBySlug(slug);
  if (!post) return {};
  return buildMetadata(post, {
    fallback: { title: post.title, description: post.excerpt, canonical: `/blog/${slug}` },
    openGraph: { type: "article", publishedTime: post.publishedAt ?? undefined },
  });
}
```

## Mapping

From `entry.seo` (`metaTitle`, `metaDescription`, `ogImage`, `canonical`, `noindex`):
- `title` / `description` — with per-call `fallback` when the field is blank
- `alternates.canonical`
- `openGraph` (`title`, `description`, `url`, `images`) + caller extras merged on top (`type`, `publishedTime`, `authors`, …)
- `twitter` (`summary_large_image` when there's an image) + caller extras
- `robots: { index, follow }` from `noindex` (indexable by default)
- `alternates.languages` (hreflang) from an optional `languages` map

It mirrors the exact block the blog template hand-rolls today (`templates/blog/.../blog/[slug]/page.tsx`), so PR5 can drop it in.

## Design

- **`next` is a type-only import** — `buildMetadata` returns a plain object typed as Next's `Metadata`, so importing it never forces `next` at runtime (keeps the package root Node-safe; consistent with how `nextly/runtime`'s cache helpers resolve `next/cache` lazily).
- **Pure and defensive** — no throw; a missing `seo` group or blank field falls back; an unresolved `ogImage` id (vs a populated `{ url }`) is read safely and falls through to the image fallback.
- **Caller extras win** — `openGraph`/`twitter` options are spread last so a page can add content-type specifics without losing the derived fields.
- Lives in `packages/nextly/src/runtime/seo/`, exported from the `nextly/runtime` barrel. No `as any`, no new runtime deps.

## Tests

10 unit tests (`build-metadata.test.ts`): full mapping, fallbacks, seo-over-fallback precedence, `noindex` → robots, empty-seo minimal output, unresolved-`ogImage` → fallback, no-image omissions, hreflang, caller-extra merging, and no-alternates-when-empty.

## Scope

- One changeset, all 21 fixed-group packages, `patch`.
- `nextly/runtime` already exists as a subpath; this only adds to its barrel.
- **Next in the program:** PR4 (routing helper + canonical `nextlySitemap`/`nextlyRobots` delivery), then PR5 (blog dogfood + docs).

@codex please review this PR
@coderabbitai review
@greptile-apps review
