### PR TITLE
feat(nextly): add content routing and sitemap/robots delivery to runtime

### DIFF
--- a/.changeset/tier0-routing-delivery.md
+++ b/.changeset/tier0-routing-delivery.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+nextly now ships content routing and sitemap/robots delivery from `nextly/runtime`: `resolveContent` (F1-cached published-by-slug lookup that rethrows on a transient error), `createContentRoute` (an optional catch-all factory that resolves any path to a published entry, with `generateStaticParams`, `generateMetadata`, and a reserved-path denylist), `isReservedPath`, and `nextlySitemap` / `nextlyRobots` for the canonical `app/sitemap.ts` and `app/robots.ts`. `cachedFind` now runs the read UNCACHED (instead of throwing a framework invariant) when called outside a Next request/build scope, so content reads work in tests, scripts, and other non-request contexts.

--- a/packages/nextly/src/runtime.ts
+++ b/packages/nextly/src/runtime.ts
@@ -53,3 +53,22 @@ export {
   type MetadataEntry,
   type SeoMetaInput,
 } from "./runtime/seo";
+
+// Content routing + sitemap/robots delivery. `next`/`react` are type-only and
+// `next/navigation` resolves lazily, so importing these never forces them.
+export {
+  resolveContent,
+  isReservedPath,
+  createContentRoute,
+  nextlySitemap,
+  nextlyRobots,
+  type ContentEntry,
+  type ResolveContentOptions,
+  type ContentRoute,
+  type ContentRouteArgs,
+  type ContentRouteConfig,
+  type ResolvedContext,
+  type NextlySitemapEntry,
+  type NextlySitemapOptions,
+  type NextlyRobotsOptions,
+} from "./runtime/routing";

--- a/packages/nextly/src/runtime/cache/__tests__/read-helpers.test.ts
+++ b/packages/nextly/src/runtime/cache/__tests__/read-helpers.test.ts
@@ -81,6 +81,23 @@ describe("applyCache (passthrough without Next)", () => {
       )
     ).rejects.toBe(boom);
   });
+
+  it("propagates an unrelated error that merely mentions incrementalCache", async () => {
+    // A bare `incrementalCache` substring must NOT be mistaken for Next's
+    // missing-scope invariant, or a real failure would be retried and masked.
+    const boom = new Error("failed to warm the incrementalCache for posts");
+    const reader = vi.fn(async () => ({ id: "z" }));
+    const throwsUnrelated: UnstableCache = () => () => {
+      throw boom;
+    };
+    await expect(
+      applyCache(throwsUnrelated, reader, {
+        tags: nextlyTags("posts"),
+        keyParts: ["posts", "detail"],
+      })
+    ).rejects.toBe(boom);
+    expect(reader).not.toHaveBeenCalled();
+  });
 });
 
 describe("applyCache — key forwarding and per-caller isolation", () => {

--- a/packages/nextly/src/runtime/cache/__tests__/read-helpers.test.ts
+++ b/packages/nextly/src/runtime/cache/__tests__/read-helpers.test.ts
@@ -52,6 +52,35 @@ describe("applyCache (passthrough without Next)", () => {
     expect(result).toEqual({ id: "x" });
     expect(reader).toHaveBeenCalledTimes(1);
   });
+
+  it("runs the reader UNCACHED when unstable_cache throws the missing-scope invariant", async () => {
+    // Outside a Next request/build scope `unstable_cache` throws this invariant;
+    // the read must still succeed uncached rather than surface a framework error.
+    const reader = vi.fn(async () => ({ id: "y" }));
+    const missingScope: UnstableCache = () => () => {
+      throw new Error("Invariant: incrementalCache missing in unstable_cache");
+    };
+    const result = await applyCache(missingScope, reader, {
+      tags: nextlyTags("posts"),
+      keyParts: ["posts", "detail"],
+    });
+    expect(result).toEqual({ id: "y" });
+    expect(reader).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows a genuine reader error rather than swallowing it", async () => {
+    const boom = new Error("db exploded");
+    const passthrough: UnstableCache = <T>(cb: () => Promise<T>) => cb;
+    await expect(
+      applyCache(
+        passthrough,
+        async () => {
+          throw boom;
+        },
+        { tags: nextlyTags("posts"), keyParts: ["posts", "detail"] }
+      )
+    ).rejects.toBe(boom);
+  });
 });
 
 describe("applyCache — key forwarding and per-caller isolation", () => {

--- a/packages/nextly/src/runtime/cache/cached-find.ts
+++ b/packages/nextly/src/runtime/cache/cached-find.ts
@@ -107,5 +107,30 @@ export function applyCache<T>(
     tags: options.tags,
     revalidate: options.revalidate ?? false,
   });
-  return cached();
+  return runCachedOrDirect(cached, reader);
+}
+
+/**
+ * `unstable_cache` throws an "incrementalCache missing" invariant when invoked
+ * outside a Next request/build scope (a standalone script, a test, a non-Next
+ * caller that still has `next` installed). Run the reader UNCACHED there rather
+ * than surfacing a cryptic framework error — inside a Next scope the cache is
+ * present and this fallback never runs. A genuine reader error is rethrown so
+ * callers that rethrow-on-error keep working.
+ */
+async function runCachedOrDirect<T>(
+  cached: () => Promise<T>,
+  reader: () => Promise<T>
+): Promise<T> {
+  try {
+    return await cached();
+  } catch (error) {
+    if (isMissingCacheScopeError(error)) return reader();
+    throw error;
+  }
+}
+
+/** True for the `unstable_cache` "no incremental cache in this scope" invariant. */
+function isMissingCacheScopeError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("incrementalCache");
 }

--- a/packages/nextly/src/runtime/cache/cached-find.ts
+++ b/packages/nextly/src/runtime/cache/cached-find.ts
@@ -132,5 +132,10 @@ async function runCachedOrDirect<T>(
 
 /** True for the `unstable_cache` "no incremental cache in this scope" invariant. */
 function isMissingCacheScopeError(error: unknown): boolean {
-  return error instanceof Error && error.message.includes("incrementalCache");
+  // Match Next's specific invariant phrase, not a bare `incrementalCache`
+  // substring — an unrelated reader error mentioning the cache must propagate
+  // rather than be retried uncached.
+  return (
+    error instanceof Error && error.message.includes("incrementalCache missing")
+  );
 }

--- a/packages/nextly/src/runtime/routing/__tests__/content-route.integration.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route.integration.test.ts
@@ -62,6 +62,21 @@ describe("createContentRoute (integration)", () => {
     expect(params).not.toContainEqual({ slug: ["secret"] });
   });
 
+  it("excludes published entries whose slug is a reserved path", async () => {
+    current = await createTestNextly({ collections: [pages()] });
+    await seed(current.nextly);
+    // A published entry sitting on a framework path must never be pre-rendered:
+    // `ContentPage` always notFound()s it, so the param would build an unservable page.
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "admin", title: "Admin", status: "published" },
+    });
+
+    const params = await route(current.nextly).generateStaticParams();
+    expect(params).not.toContainEqual({ slug: ["admin"] });
+    expect(params).toContainEqual({ slug: ["about"] });
+  });
+
   it("renders a resolved entry via the render callback", async () => {
     current = await createTestNextly({ collections: [pages()] });
     await seed(current.nextly);

--- a/packages/nextly/src/runtime/routing/__tests__/content-route.integration.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route.integration.test.ts
@@ -1,0 +1,105 @@
+/**
+ * `createContentRoute` against a real boot: `generateStaticParams` lists
+ * published paths (segmented, drafts excluded), the page renders a resolved
+ * entry, a genuine miss and a reserved path trigger `notFound`, and
+ * `generateMetadata` maps the resolved entry.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import { createContentRoute } from "../content-route";
+import type { ContentEntry } from "../resolve-content";
+
+const pages = () =>
+  defineCollection({
+    slug: "pages",
+    status: true,
+    fields: [text({ name: "slug" }), text({ name: "title" })],
+  });
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+function route(nextly: TestNextly["nextly"]) {
+  return createContentRoute({
+    collections: ["pages"],
+    nextly,
+    render: (entry: ContentEntry) => ({ title: entry.title }),
+    buildMetadata: (entry: ContentEntry) => ({ title: String(entry.title) }),
+  });
+}
+
+async function seed(nextly: TestNextly["nextly"]) {
+  await nextly.create({
+    collection: "pages",
+    data: { slug: "about", title: "About", status: "published" },
+  });
+  await nextly.create({
+    collection: "pages",
+    data: { slug: "contact", title: "Contact", status: "published" },
+  });
+  await nextly.create({
+    collection: "pages",
+    data: { slug: "secret", title: "Secret", status: "draft" },
+  });
+}
+
+describe("createContentRoute (integration)", () => {
+  it("lists published paths (segmented) and excludes drafts", async () => {
+    current = await createTestNextly({ collections: [pages()] });
+    await seed(current.nextly);
+
+    const params = await route(current.nextly).generateStaticParams();
+    expect(params).toContainEqual({ slug: ["about"] });
+    expect(params).toContainEqual({ slug: ["contact"] });
+    expect(params).not.toContainEqual({ slug: ["secret"] });
+  });
+
+  it("renders a resolved entry via the render callback", async () => {
+    current = await createTestNextly({ collections: [pages()] });
+    await seed(current.nextly);
+
+    const rendered = await route(current.nextly).ContentPage({
+      params: { slug: ["about"] },
+    });
+    expect(rendered).toEqual({ title: "About" });
+  });
+
+  it("triggers notFound for a genuine miss and a reserved path", async () => {
+    current = await createTestNextly({ collections: [pages()] });
+    await seed(current.nextly);
+    const { ContentPage } = route(current.nextly);
+
+    await expect(
+      ContentPage({ params: { slug: ["missing"] } })
+    ).rejects.toThrow();
+    // A draft is not published → notFound.
+    await expect(
+      ContentPage({ params: { slug: ["secret"] } })
+    ).rejects.toThrow();
+    // A reserved path must never resolve to content.
+    await expect(
+      ContentPage({ params: { slug: ["admin"] } })
+    ).rejects.toThrow();
+  });
+
+  it("maps the resolved entry in generateMetadata, and returns {} on a miss", async () => {
+    current = await createTestNextly({ collections: [pages()] });
+    await seed(current.nextly);
+    const { generateMetadata } = route(current.nextly);
+
+    expect(await generateMetadata({ params: { slug: ["about"] } })).toEqual({
+      title: "About",
+    });
+    expect(await generateMetadata({ params: { slug: ["missing"] } })).toEqual(
+      {}
+    );
+  });
+});

--- a/packages/nextly/src/runtime/routing/__tests__/content-route.integration.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route.integration.test.ts
@@ -52,6 +52,54 @@ async function seed(nextly: TestNextly["nextly"]) {
 }
 
 describe("createContentRoute (integration)", () => {
+  it("applies per-collection status filtering across mixed collections", async () => {
+    // `pages` has the lifecycle (filter by published); `docs` is status-less
+    // with its OWN `status` field — one global statusField can't serve both.
+    current = await createTestNextly({
+      collections: [
+        pages(),
+        defineCollection({
+          slug: "docs",
+          fields: [
+            text({ name: "slug" }),
+            text({ name: "title" }),
+            text({ name: "status" }),
+          ],
+        }),
+      ],
+    });
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "about", title: "About", status: "published" },
+    });
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "hidden", title: "Hidden", status: "draft" },
+    });
+    await current.nextly.create({
+      collection: "docs",
+      data: { slug: "intro", title: "Intro", status: "active" },
+    });
+
+    const { ContentPage } = createContentRoute({
+      collections: ["pages", { slug: "docs", statusField: false }],
+      nextly: current.nextly,
+      render: (entry: ContentEntry) => ({ title: entry.title }),
+    });
+
+    // Lifecycle collection: published resolves, draft is not found.
+    expect(await ContentPage({ params: { slug: ["about"] } })).toEqual({
+      title: "About",
+    });
+    await expect(
+      ContentPage({ params: { slug: ["hidden"] } })
+    ).rejects.toThrow();
+    // Status-less collection: resolved despite its non-"published" status.
+    expect(await ContentPage({ params: { slug: ["intro"] } })).toEqual({
+      title: "Intro",
+    });
+  });
+
   it("lists published paths (segmented) and excludes drafts", async () => {
     current = await createTestNextly({ collections: [pages()] });
     await seed(current.nextly);

--- a/packages/nextly/src/runtime/routing/__tests__/content-route.integration.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/content-route.integration.test.ts
@@ -77,6 +77,19 @@ describe("createContentRoute (integration)", () => {
     expect(params).toContainEqual({ slug: ["about"] });
   });
 
+  it("returns no static params when the limit is non-positive", async () => {
+    current = await createTestNextly({ collections: [pages()] });
+    await seed(current.nextly);
+    // A `0` limit disables pre-rendering — every path renders on demand.
+    const params = await createContentRoute({
+      collections: ["pages"],
+      nextly: current.nextly,
+      render: (entry: ContentEntry) => ({ title: entry.title }),
+      staticParamsLimit: 0,
+    }).generateStaticParams();
+    expect(params).toEqual([]);
+  });
+
   it("renders a resolved entry via the render callback", async () => {
     current = await createTestNextly({ collections: [pages()] });
     await seed(current.nextly);
@@ -84,6 +97,18 @@ describe("createContentRoute (integration)", () => {
     const rendered = await route(current.nextly).ContentPage({
       params: { slug: ["about"] },
     });
+    expect(rendered).toEqual({ title: "About" });
+  });
+
+  it("awaits an async render callback (no nested promise)", async () => {
+    current = await createTestNextly({ collections: [pages()] });
+    await seed(current.nextly);
+    // An async render must resolve to the awaited value, not a Promise of one.
+    const rendered = await createContentRoute({
+      collections: ["pages"],
+      nextly: current.nextly,
+      render: async (entry: ContentEntry) => ({ title: entry.title }),
+    }).ContentPage({ params: { slug: ["about"] } });
     expect(rendered).toEqual({ title: "About" });
   });
 

--- a/packages/nextly/src/runtime/routing/__tests__/nextly-content-reader.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/nextly-content-reader.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Compile-time guard: the public `Nextly` instance (what `await getNextly(config)`
+ * returns) must satisfy the structural `NextlyContentReader` the routing helpers
+ * accept — otherwise the documented explicit-instance path would not type-check.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { Nextly as PublicNextly } from "../../../init";
+import type { NextlyContentReader } from "../resolve-content";
+
+describe("NextlyContentReader", () => {
+  it("accepts the public Nextly instance type", () => {
+    const assign = (n: PublicNextly): NextlyContentReader => n;
+    expect(typeof assign).toBe("function");
+  });
+});

--- a/packages/nextly/src/runtime/routing/__tests__/reserved-paths.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/reserved-paths.test.ts
@@ -31,6 +31,16 @@ describe("isReservedPath", () => {
     }
   });
 
+  it("collapses redundant slashes so a slash-prefixed slug can't dodge the match", () => {
+    // A slash-preserving slug field storing "/admin" would otherwise check
+    // "//admin" and slip past the prefix.
+    expect(isReservedPath("//admin")).toBe(true);
+    expect(isReservedPath("/admin//foo")).toBe(true);
+    expect(isReservedPath("//api")).toBe(true);
+    // A genuine content path with an internal double slash still resolves cleanly.
+    expect(isReservedPath("blog//post")).toBe(false);
+  });
+
   it("allows ordinary content paths", () => {
     for (const path of [
       "/about",

--- a/packages/nextly/src/runtime/routing/__tests__/reserved-paths.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/reserved-paths.test.ts
@@ -23,6 +23,7 @@ describe("isReservedPath", () => {
       "/robots.txt",
       "/favicon.ico",
       "/manifest.webmanifest",
+      "/manifest.json",
       "/opengraph-image",
       "/twitter-image",
     ]) {

--- a/packages/nextly/src/runtime/routing/__tests__/reserved-paths.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/reserved-paths.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { isReservedPath } from "../reserved-paths";
+
+describe("isReservedPath", () => {
+  it("reserves the framework prefixes and their children", () => {
+    for (const path of [
+      "/admin",
+      "/admin/",
+      "/admin/collections/posts",
+      "/api",
+      "/api/plugins/x",
+      "/_next/static/chunk.js",
+      "/static/logo.png",
+    ]) {
+      expect(isReservedPath(path)).toBe(true);
+    }
+  });
+
+  it("reserves the well-known metadata files", () => {
+    for (const path of [
+      "/sitemap.xml",
+      "/robots.txt",
+      "/favicon.ico",
+      "/manifest.webmanifest",
+      "/opengraph-image",
+      "/twitter-image",
+    ]) {
+      expect(isReservedPath(path)).toBe(true);
+    }
+  });
+
+  it("allows ordinary content paths", () => {
+    for (const path of [
+      "/about",
+      "/blog/hello-world",
+      "/administration", // not /admin
+      "/apiary", // not /api
+      "/sitemap", // not /sitemap.xml
+      "/",
+    ]) {
+      expect(isReservedPath(path)).toBe(false);
+    }
+  });
+
+  it("normalizes a missing leading slash and a trailing slash", () => {
+    expect(isReservedPath("admin")).toBe(true);
+    expect(isReservedPath("about/")).toBe(false);
+    expect(isReservedPath("api/")).toBe(true);
+  });
+});

--- a/packages/nextly/src/runtime/routing/__tests__/resolve-content.integration.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/resolve-content.integration.test.ts
@@ -50,4 +50,30 @@ describe("resolveContent (integration)", () => {
       await resolveContent("pages", "missing", { nextly: current.nextly })
     ).toBeNull();
   });
+
+  it("does not apply a published filter on a status-less collection", async () => {
+    // No `status: true` — the collection defines its own ordinary `status`
+    // field. A blanket `status = published` filter would wrongly drop this row.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "docs",
+          fields: [
+            text({ name: "slug" }),
+            text({ name: "title" }),
+            text({ name: "status" }),
+          ],
+        }),
+      ],
+    });
+    await current.nextly.create({
+      collection: "docs",
+      data: { slug: "intro", title: "Intro", status: "active" },
+    });
+
+    const doc = await resolveContent("docs", "intro", {
+      nextly: current.nextly,
+    });
+    expect((doc as { title?: string } | null)?.title).toBe("Intro");
+  });
 });

--- a/packages/nextly/src/runtime/routing/__tests__/resolve-content.integration.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/resolve-content.integration.test.ts
@@ -1,0 +1,53 @@
+/**
+ * `resolveContent` against a real boot: it returns a published entry by slug,
+ * ignores drafts, returns null on a genuine miss, and rethrows a read error.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import { resolveContent } from "../resolve-content";
+
+const pages = () =>
+  defineCollection({
+    slug: "pages",
+    status: true,
+    fields: [text({ name: "slug" }), text({ name: "title" })],
+  });
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+describe("resolveContent (integration)", () => {
+  it("resolves a published entry by slug and ignores drafts", async () => {
+    current = await createTestNextly({ collections: [pages()] });
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "about", title: "About", status: "published" },
+    });
+    await current.nextly.create({
+      collection: "pages",
+      data: { slug: "secret", title: "Secret", status: "draft" },
+    });
+
+    const about = await resolveContent("pages", "about", {
+      nextly: current.nextly,
+    });
+    expect((about as { title?: string } | null)?.title).toBe("About");
+
+    // A draft is not resolved for a public read.
+    expect(
+      await resolveContent("pages", "secret", { nextly: current.nextly })
+    ).toBeNull();
+    // A genuine miss returns null.
+    expect(
+      await resolveContent("pages", "missing", { nextly: current.nextly })
+    ).toBeNull();
+  });
+});

--- a/packages/nextly/src/runtime/routing/__tests__/resolve-content.integration.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/resolve-content.integration.test.ts
@@ -51,9 +51,10 @@ describe("resolveContent (integration)", () => {
     ).toBeNull();
   });
 
-  it("does not apply a published filter on a status-less collection", async () => {
+  it("skips status filtering when statusField is false (status-less collection)", async () => {
     // No `status: true` — the collection defines its own ordinary `status`
-    // field. A blanket `status = published` filter would wrongly drop this row.
+    // field. A blanket `status = published` filter would wrongly drop this row,
+    // so the caller opts out with `statusField: false`.
     current = await createTestNextly({
       collections: [
         defineCollection({
@@ -73,6 +74,7 @@ describe("resolveContent (integration)", () => {
 
     const doc = await resolveContent("docs", "intro", {
       nextly: current.nextly,
+      statusField: false,
     });
     expect((doc as { title?: string } | null)?.title).toBe("Intro");
   });

--- a/packages/nextly/src/runtime/routing/__tests__/resolve-content.integration.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/resolve-content.integration.test.ts
@@ -78,4 +78,29 @@ describe("resolveContent (integration)", () => {
     });
     expect((doc as { title?: string } | null)?.title).toBe("Intro");
   });
+
+  it("resolves duplicate published slugs deterministically (lowest id)", async () => {
+    current = await createTestNextly({ collections: [pages()] });
+    // A slug field is not unique — seed several published rows on the same slug.
+    for (let i = 0; i < 4; i++) {
+      await current.nextly.create({
+        collection: "pages",
+        data: { slug: "dup", title: `Dup ${i}`, status: "published" },
+      });
+    }
+    // Sorting by `id` makes the lexicographically smallest id the stable winner.
+    const all = await current.nextly.find({
+      collection: "pages",
+      where: { slug: { equals: "dup" } },
+      limit: 50,
+    });
+    const expectedId = all.items
+      .map(row => (row as { id: string }).id)
+      .sort()[0];
+
+    const resolved = await resolveContent("pages", "dup", {
+      nextly: current.nextly,
+    });
+    expect((resolved as { id?: string } | null)?.id).toBe(expectedId);
+  });
 });

--- a/packages/nextly/src/runtime/routing/__tests__/robots.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/robots.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { nextlyRobots } from "../robots";
+
+describe("nextlyRobots", () => {
+  it("disallows /admin and /api and advertises the sitemap", () => {
+    const robots = nextlyRobots({
+      sitemap: "https://example.com/sitemap.xml",
+    })();
+    expect(robots).toEqual({
+      rules: { userAgent: "*", disallow: ["/admin", "/api"] },
+      sitemap: "https://example.com/sitemap.xml",
+    });
+  });
+
+  it("merges and dedupes extra disallow paths and keeps the defaults", () => {
+    const robots = nextlyRobots({ disallow: ["/api", "/drafts"] })();
+    expect(robots.rules).toEqual({
+      userAgent: "*",
+      disallow: ["/admin", "/api", "/drafts"],
+    });
+  });
+
+  it("passes through userAgent, allow, and host", () => {
+    const robots = nextlyRobots({
+      userAgent: "Googlebot",
+      allow: ["/api/public"],
+      host: "https://example.com",
+    })();
+    expect(robots.rules).toMatchObject({
+      userAgent: "Googlebot",
+      allow: ["/api/public"],
+    });
+    expect(robots.host).toBe("https://example.com");
+  });
+
+  it("omits the sitemap key when none is given", () => {
+    const robots = nextlyRobots()();
+    expect(robots).not.toHaveProperty("sitemap");
+  });
+});

--- a/packages/nextly/src/runtime/routing/__tests__/robots.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/robots.test.ts
@@ -3,21 +3,35 @@ import { describe, expect, it } from "vitest";
 import { nextlyRobots } from "../robots";
 
 describe("nextlyRobots", () => {
-  it("disallows /admin and /api and advertises the sitemap", () => {
+  it("disallows the /admin and /api roots on a path boundary and advertises the sitemap", () => {
     const robots = nextlyRobots({
       sitemap: "https://example.com/sitemap.xml",
     })();
     expect(robots).toEqual({
-      rules: { userAgent: "*", disallow: ["/admin", "/api"] },
+      rules: {
+        userAgent: "*",
+        disallow: ["/admin/", "/admin$", "/api/", "/api$"],
+      },
       sitemap: "https://example.com/sitemap.xml",
     });
   });
 
+  it("does not blanket-exclude a similarly-prefixed content path like /administration", () => {
+    const { rules } = nextlyRobots()();
+    const disallow = rules.disallow as string[];
+    // A raw `/admin` prefix would match `/administration`; the boundary forms
+    // (`/admin/`, `/admin$`) do not.
+    expect(disallow).not.toContain("/admin");
+    expect(disallow.some(rule => "/administration".startsWith(rule))).toBe(
+      false
+    );
+  });
+
   it("merges and dedupes extra disallow paths and keeps the defaults", () => {
-    const robots = nextlyRobots({ disallow: ["/api", "/drafts"] })();
+    const robots = nextlyRobots({ disallow: ["/api/", "/drafts"] })();
     expect(robots.rules).toEqual({
       userAgent: "*",
-      disallow: ["/admin", "/api", "/drafts"],
+      disallow: ["/admin/", "/admin$", "/api/", "/api$", "/drafts"],
     });
   });
 

--- a/packages/nextly/src/runtime/routing/__tests__/robots.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/robots.test.ts
@@ -10,7 +10,7 @@ describe("nextlyRobots", () => {
     expect(robots).toEqual({
       rules: {
         userAgent: "*",
-        disallow: ["/admin/", "/admin$", "/api/", "/api$"],
+        disallow: ["/admin/", "/admin$", "/admin?", "/api/", "/api$", "/api?"],
       },
       sitemap: "https://example.com/sitemap.xml",
     });
@@ -20,18 +20,34 @@ describe("nextlyRobots", () => {
     const { rules } = nextlyRobots()();
     const disallow = rules.disallow as string[];
     // A raw `/admin` prefix would match `/administration`; the boundary forms
-    // (`/admin/`, `/admin$`) do not.
+    // (`/admin/`, `/admin$`, `/admin?`) do not.
     expect(disallow).not.toContain("/admin");
     expect(disallow.some(rule => "/administration".startsWith(rule))).toBe(
       false
     );
   });
 
+  it("covers the bare root, subtree, and query variants of a framework root", () => {
+    const disallow = nextlyRobots()().rules.disallow as string[];
+    // Subtree, exact-root ($), and query-bearing root (?) are all pinned.
+    expect(disallow).toContain("/admin/");
+    expect(disallow).toContain("/admin$");
+    expect(disallow).toContain("/admin?");
+  });
+
   it("merges and dedupes extra disallow paths and keeps the defaults", () => {
     const robots = nextlyRobots({ disallow: ["/api/", "/drafts"] })();
     expect(robots.rules).toEqual({
       userAgent: "*",
-      disallow: ["/admin/", "/admin$", "/api/", "/api$", "/drafts"],
+      disallow: [
+        "/admin/",
+        "/admin$",
+        "/admin?",
+        "/api/",
+        "/api$",
+        "/api?",
+        "/drafts",
+      ],
     });
   });
 

--- a/packages/nextly/src/runtime/routing/__tests__/sitemap.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/sitemap.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { nextlySitemap } from "../sitemap";
+
+describe("nextlySitemap", () => {
+  it("maps the provider's entries to Next's sitemap shape", async () => {
+    const sitemap = nextlySitemap({
+      entries: () => [
+        {
+          url: "https://x.com/a",
+          lastModified: "2026-01-02T00:00:00.000Z",
+          changeFrequency: "daily",
+          priority: 0.8,
+          alternates: { languages: { en: "https://x.com/en/a" } },
+        },
+        { url: "https://x.com/b" },
+      ],
+    });
+
+    expect(await sitemap()).toEqual([
+      {
+        url: "https://x.com/a",
+        lastModified: "2026-01-02T00:00:00.000Z",
+        changeFrequency: "daily",
+        priority: 0.8,
+        alternates: { languages: { en: "https://x.com/en/a" } },
+      },
+      { url: "https://x.com/b" },
+    ]);
+  });
+
+  it("awaits an async provider and drops entries without a url", async () => {
+    const sitemap = nextlySitemap({
+      entries: async () => [
+        { url: "https://x.com/a" },
+        { url: "" },
+        { url: "https://x.com/c" },
+      ],
+    });
+
+    expect((await sitemap()).map(e => e.url)).toEqual([
+      "https://x.com/a",
+      "https://x.com/c",
+    ]);
+  });
+});

--- a/packages/nextly/src/runtime/routing/__tests__/slug-to-static-param.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/slug-to-static-param.test.ts
@@ -27,4 +27,14 @@ describe("slugToStaticParam", () => {
     expect(slugToStaticParam("admin")).toBeNull();
     expect(slugToStaticParam("api/keys")).toBeNull();
   });
+
+  it("normalizes redundant slashes and still rejects a slash-prefixed reserved slug", () => {
+    // A leading slash must not smuggle a reserved path past the check.
+    expect(slugToStaticParam("/admin")).toBeNull();
+    // Edge/duplicate slashes collapse to clean segments.
+    expect(slugToStaticParam("/blog/post/")).toEqual({
+      slug: ["blog", "post"],
+    });
+    expect(slugToStaticParam("a//b")).toEqual({ slug: ["a", "b"] });
+  });
 });

--- a/packages/nextly/src/runtime/routing/__tests__/slug-to-static-param.test.ts
+++ b/packages/nextly/src/runtime/routing/__tests__/slug-to-static-param.test.ts
@@ -1,0 +1,30 @@
+/**
+ * `slugToStaticParam` maps a stored slug to a static-params entry: an empty
+ * slug becomes the root (`{ slug: [] }`), nested slugs split on `/`, and
+ * whitespace-only, non-string, or reserved values are skipped.
+ */
+import { describe, expect, it } from "vitest";
+
+import { slugToStaticParam } from "../content-route";
+
+describe("slugToStaticParam", () => {
+  it("emits the no-segment root param for an empty slug", () => {
+    expect(slugToStaticParam("")).toEqual({ slug: [] });
+  });
+
+  it("splits a nested slug into segments", () => {
+    expect(slugToStaticParam("blog/post")).toEqual({ slug: ["blog", "post"] });
+  });
+
+  it("keeps a single-segment slug", () => {
+    expect(slugToStaticParam("about")).toEqual({ slug: ["about"] });
+  });
+
+  it("skips whitespace-only, non-string, and reserved values", () => {
+    expect(slugToStaticParam("   ")).toBeNull();
+    expect(slugToStaticParam(42)).toBeNull();
+    expect(slugToStaticParam(null)).toBeNull();
+    expect(slugToStaticParam("admin")).toBeNull();
+    expect(slugToStaticParam("api/keys")).toBeNull();
+  });
+});

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -165,8 +165,15 @@ export function slugToStaticParam(value: unknown): { slug: string[] } | null {
   if (typeof value !== "string") return null;
   if (value === "") return isReservedPath("/") ? null : { slug: [] };
   if (value.trim() === "") return null;
-  if (isReservedPath(`/${value}`)) return null;
-  return { slug: value.split("/") };
+  // Collapse leading/trailing/duplicate slashes so a stored "/admin" or "a//b"
+  // normalizes to clean segments and can't dodge the reserved-path check.
+  const normalized = value
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "")
+    .replace(/\/{2,}/g, "/");
+  if (normalized === "") return null;
+  if (isReservedPath(`/${normalized}`)) return null;
+  return { slug: normalized.split("/") };
 }
 
 export function createContentRoute<TNode>(

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -12,6 +12,14 @@
  * `next`/`react` imports are TYPE-ONLY and `next/navigation` is resolved lazily,
  * so importing this never forces those onto a non-Next consumer at load.
  *
+ * `generateStaticParams` returns `[]` when there is nothing to pre-render (a
+ * `staticParamsLimit` of `0`, or no published slugs yet), which is valid for
+ * standard App Router builds. Next 16 Cache Components is stricter: an EXPORTED
+ * `generateStaticParams` must return at least one entry. Under that mode, do not
+ * wire `generateStaticParams` into the route file for a no-prerender/empty-site
+ * setup — export only `ContentPage` and `generateMetadata` and let paths render
+ * on demand.
+ *
  * @module runtime/routing/content-route
  */
 import { createRequire } from "node:module";

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -19,14 +19,13 @@ import { createRequire } from "node:module";
 import type { Metadata } from "next";
 
 import { getNextly } from "../../direct-api/nextly";
-import type { Nextly } from "../../direct-api/nextly";
 import { NextlyError } from "../../errors/nextly-error";
 
 import { isReservedPath } from "./reserved-paths";
 import {
-  collectionHasStatusLifecycle,
   resolveContent,
   type ContentEntry,
+  type NextlyContentReader,
 } from "./resolve-content";
 
 /** Where a resolved entry was found — passed to `render`/`buildMetadata`. */
@@ -60,10 +59,16 @@ export interface ContentRouteConfig<TNode> {
   ) => Metadata | Promise<Metadata>;
   /** Field holding the slug (default `"slug"`). */
   slugField?: string;
+  /**
+   * Field holding the publish status (default `"status"`), matched against
+   * `"published"`. Pass `false` to skip status filtering for status-less
+   * collections (no built-in draft/published lifecycle).
+   */
+  statusField?: string | false;
   /** Relation depth for the resolved read (default `1`). */
   depth?: number;
   /** A booted Nextly instance (defaults to `getNextly()`). */
-  nextly?: Nextly;
+  nextly?: NextlyContentReader;
   /**
    * Extra cache tags attached to every resolved read, so a write to a related
    * collection (a populated author, category, media) can bust the page. The
@@ -144,10 +149,11 @@ export function createContentRoute<TNode>(
 ): ContentRoute<TNode> {
   const collections = [...new Set(config.collections)];
   const slugField = config.slugField ?? "slug";
+  const statusField = config.statusField ?? "status";
   const depth = config.depth ?? 1;
   const staticParamsLimit = config.staticParamsLimit ?? 1000;
 
-  const getInstance = (): Nextly => config.nextly ?? getNextly();
+  const getInstance = (): NextlyContentReader => config.nextly ?? getNextly();
 
   /** Resolve the joined slug across the configured collections (first match wins). */
   async function resolve(
@@ -157,6 +163,7 @@ export function createContentRoute<TNode>(
       const entry = await resolveContent(collection, slug, {
         nextly: config.nextly,
         slugField,
+        statusField,
         depth,
         tags: config.tags,
         revalidate: config.revalidate,
@@ -174,20 +181,16 @@ export function createContentRoute<TNode>(
     const nextly = getInstance();
     const params: Array<{ slug: string[] }> = [];
     for (const collection of collections) {
-      // Filter by `published` only when the built-in lifecycle exists, else a
-      // status-less collection's read would drop rows or target a missing column.
-      const filterByStatus = await collectionHasStatusLifecycle(
-        nextly,
-        collection
-      );
       let page = 1;
       let collected = 0;
       for (;;) {
         const result = await nextly.find({
           collection,
-          ...(filterByStatus
-            ? { where: { status: { equals: "published" } } }
-            : {}),
+          // Filter by `published` unless the caller opted out for a status-less
+          // collection (`statusField: false`), which has no such column.
+          ...(statusField === false
+            ? {}
+            : { where: { [statusField]: { equals: "published" } } }),
           select: { [slugField]: true },
           // `id` is unique and present on every collection; `createdAt` may be
           // absent (timestamps off) or non-unique, letting rows shift between

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -20,6 +20,7 @@ import type { Metadata } from "next";
 
 import { getNextly } from "../../direct-api/nextly";
 import type { Nextly } from "../../direct-api/nextly";
+import { NextlyError } from "../../errors/nextly-error";
 
 import { isReservedPath } from "./reserved-paths";
 import { resolveContent, type ContentEntry } from "./resolve-content";
@@ -43,8 +44,11 @@ export interface ContentRouteConfig<TNode> {
    * a published entry whose slug matches the path wins.
    */
   collections: string[];
-  /** Render the resolved entry (your server component body). */
-  render: (entry: ContentEntry, context: ResolvedContext) => TNode;
+  /** Render the resolved entry (your server component body). May be async. */
+  render: (
+    entry: ContentEntry,
+    context: ResolvedContext
+  ) => TNode | Promise<TNode>;
   /** Optional per-entry metadata (e.g. via `buildMetadata`). */
   buildMetadata?: (
     entry: ContentEntry,
@@ -56,6 +60,13 @@ export interface ContentRouteConfig<TNode> {
   depth?: number;
   /** A booted Nextly instance (defaults to `getNextly()`). */
   nextly?: Nextly;
+  /**
+   * Extra cache tags attached to every resolved read, so a write to a related
+   * collection (a populated author, category, media) can bust the page. The
+   * primary collection is always tagged; add the related collections' tags
+   * (e.g. `nextlyTags("authors")`) here when you render populated relations.
+   */
+  tags?: string[];
   /** Time-based revalidation seconds for the resolved read. */
   revalidate?: number | false;
   /**
@@ -93,9 +104,12 @@ function loadNotFound(): () => never {
   }
   if (!cachedNotFound) {
     // Outside a Next runtime there is no not-found boundary to trigger.
-    throw new Error(
-      "createContentRoute requires next/navigation (use it inside a Next.js app)"
-    );
+    throw NextlyError.internal({
+      logContext: {
+        reason:
+          "createContentRoute requires next/navigation (use it inside a Next.js app)",
+      },
+    });
   }
   return cachedNotFound;
 }
@@ -126,6 +140,7 @@ export function createContentRoute<TNode>(
         nextly: config.nextly,
         slugField,
         depth,
+        tags: config.tags,
         revalidate: config.revalidate,
       });
       if (entry) return { entry, context: { collection, slug } };
@@ -134,6 +149,10 @@ export function createContentRoute<TNode>(
   }
 
   async function generateStaticParams(): Promise<Array<{ slug: string[] }>> {
+    // A non-positive limit disables pre-rendering entirely — every path then
+    // renders on demand via `dynamicParams`. Return before querying so a `0`
+    // limit yields zero params instead of one-per-collection.
+    if (staticParamsLimit <= 0) return [];
     const nextly = getInstance();
     const params: Array<{ slug: string[] }> = [];
     for (const collection of collections) {

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -79,6 +79,12 @@ export interface ContentRouteConfig<TNode> {
   /** Time-based revalidation seconds for the resolved read. */
   revalidate?: number | false;
   /**
+   * A stable discriminator folded into the resolved read's cache key — supply
+   * one when distinct `nextly` readers (per-tenant/per-database) can resolve the
+   * same collection + slug, so their cached reads never alias.
+   */
+  cacheScope?: string;
+  /**
    * Max published paths to pre-render per collection in `generateStaticParams`
    * (default `1000`). The rest render on demand via `dynamicParams`.
    */
@@ -167,6 +173,7 @@ export function createContentRoute<TNode>(
         depth,
         tags: config.tags,
         revalidate: config.revalidate,
+        cacheScope: config.cacheScope,
       });
       if (entry) return { entry, context: { collection, slug } };
     }

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -23,7 +23,11 @@ import type { Nextly } from "../../direct-api/nextly";
 import { NextlyError } from "../../errors/nextly-error";
 
 import { isReservedPath } from "./reserved-paths";
-import { resolveContent, type ContentEntry } from "./resolve-content";
+import {
+  collectionHasStatusLifecycle,
+  resolveContent,
+  type ContentEntry,
+} from "./resolve-content";
 
 /** Where a resolved entry was found — passed to `render`/`buildMetadata`. */
 export interface ResolvedContext {
@@ -121,6 +125,20 @@ function triggerNotFound(): never {
 
 const MAX_STATIC_PARAMS_PER_PAGE = 500;
 
+/**
+ * Map a stored slug value to a static param, or `null` to skip it. An empty
+ * slug is the site root (`/`) — emitted as the no-segment param so the homepage
+ * pre-renders — while whitespace-only, non-string, and reserved values are
+ * dropped (the page would only `notFound()` them).
+ */
+export function slugToStaticParam(value: unknown): { slug: string[] } | null {
+  if (typeof value !== "string") return null;
+  if (value === "") return isReservedPath("/") ? null : { slug: [] };
+  if (value.trim() === "") return null;
+  if (isReservedPath(`/${value}`)) return null;
+  return { slug: value.split("/") };
+}
+
 export function createContentRoute<TNode>(
   config: ContentRouteConfig<TNode>
 ): ContentRoute<TNode> {
@@ -156,24 +174,32 @@ export function createContentRoute<TNode>(
     const nextly = getInstance();
     const params: Array<{ slug: string[] }> = [];
     for (const collection of collections) {
+      // Filter by `published` only when the built-in lifecycle exists, else a
+      // status-less collection's read would drop rows or target a missing column.
+      const filterByStatus = await collectionHasStatusLifecycle(
+        nextly,
+        collection
+      );
       let page = 1;
       let collected = 0;
       for (;;) {
         const result = await nextly.find({
           collection,
-          where: { status: { equals: "published" } },
+          ...(filterByStatus
+            ? { where: { status: { equals: "published" } } }
+            : {}),
           select: { [slugField]: true },
-          sort: "createdAt",
+          // `id` is unique and present on every collection; `createdAt` may be
+          // absent (timestamps off) or non-unique, letting rows shift between
+          // pages and duplicate or vanish across the paginated scan.
+          sort: "id",
           limit: MAX_STATIC_PARAMS_PER_PAGE,
           page,
         });
         for (const item of result.items) {
-          const value = item[slugField];
-          if (typeof value !== "string" || value.trim() === "") continue;
-          // Skip reserved paths — `ContentPage` always `notFound()`s them, so
-          // pre-rendering them just schedules pages that can never be served.
-          if (isReservedPath(`/${value}`)) continue;
-          params.push({ slug: value.split("/") });
+          const param = slugToStaticParam(item[slugField]);
+          if (!param) continue;
+          params.push(param);
           collected += 1;
           if (collected >= staticParamsLimit) break;
         }

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -49,12 +49,23 @@ export interface ResolvedContext {
  * server component's return, e.g. `ReactNode`) — inferred from `render`, so
  * `nextly` needs no `react` dependency of its own.
  */
+/**
+ * A collection to resolve paths against: a bare slug (uses the route's default
+ * `statusField`), or an object that overrides the status field for THAT
+ * collection — so one catch-all can mix a lifecycle collection (filter by
+ * `status: "published"`) with a status-less one (`statusField: false`).
+ */
+export type ContentRouteCollection =
+  | string
+  | { slug: string; statusField?: string | false };
+
 export interface ContentRouteConfig<TNode> {
   /**
    * Collections to resolve a path against, in order — the first collection with
-   * a published entry whose slug matches the path wins.
+   * a published entry whose slug matches the path wins. Each entry may be a bare
+   * slug or `{ slug, statusField }` to set its status filter independently.
    */
-  collections: string[];
+  collections: ContentRouteCollection[];
   /** Render the resolved entry (your server component body). May be async. */
   render: (
     entry: ContentEntry,
@@ -161,11 +172,23 @@ export function slugToStaticParam(value: unknown): { slug: string[] } | null {
 export function createContentRoute<TNode>(
   config: ContentRouteConfig<TNode>
 ): ContentRoute<TNode> {
-  const collections = [...new Set(config.collections)];
   const slugField = config.slugField ?? "slug";
-  const statusField = config.statusField ?? "status";
+  const defaultStatusField = config.statusField ?? "status";
   const depth = config.depth ?? 1;
   const staticParamsLimit = config.staticParamsLimit ?? 1000;
+
+  // Normalize each collection to `{ slug, statusField }` so a bare slug inherits
+  // the route default while an object can set its own filter — deduped by slug.
+  const collections = dedupeBySlug(
+    config.collections.map(entry =>
+      typeof entry === "string"
+        ? { slug: entry, statusField: defaultStatusField }
+        : {
+            slug: entry.slug,
+            statusField: entry.statusField ?? defaultStatusField,
+          }
+    )
+  );
 
   const getInstance = (): NextlyContentReader => config.nextly ?? getNextly();
 
@@ -173,7 +196,7 @@ export function createContentRoute<TNode>(
   async function resolve(
     slug: string
   ): Promise<{ entry: ContentEntry; context: ResolvedContext } | null> {
-    for (const collection of collections) {
+    for (const { slug: collection, statusField } of collections) {
       const entry = await resolveContent(collection, slug, {
         nextly: config.nextly,
         slugField,
@@ -195,14 +218,14 @@ export function createContentRoute<TNode>(
     if (staticParamsLimit <= 0) return [];
     const nextly = getInstance();
     const params: Array<{ slug: string[] }> = [];
-    for (const collection of collections) {
+    for (const { slug: collection, statusField } of collections) {
       let page = 1;
       let collected = 0;
       for (;;) {
         const result = await nextly.find({
           collection,
-          // Filter by `published` unless the caller opted out for a status-less
-          // collection (`statusField: false`), which has no such column.
+          // Filter by `published` unless this collection opted out
+          // (`statusField: false`), which has no such column.
           ...(statusField === false
             ? {}
             : { where: { [statusField]: { equals: "published" } } }),
@@ -252,4 +275,18 @@ export function createContentRoute<TNode>(
 /** Join the optional-catch-all segments into a slug path (no leading slash). */
 function joinSlug(params: { slug?: string[] }): string {
   return (params.slug ?? []).join("/");
+}
+
+/** Dedupe normalized collections by slug, keeping the first (its status filter). */
+function dedupeBySlug(
+  entries: Array<{ slug: string; statusField: string | false }>
+): Array<{ slug: string; statusField: string | false }> {
+  const seen = new Set<string>();
+  const out: Array<{ slug: string; statusField: string | false }> = [];
+  for (const entry of entries) {
+    if (seen.has(entry.slug)) continue;
+    seen.add(entry.slug);
+    out.push(entry);
+  }
+  return out;
 }

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -1,0 +1,189 @@
+/**
+ * `createContentRoute` — a thin factory for a single `app/[[...slug]]/page.tsx`
+ * optional catch-all that resolves ANY path to a published content entry (the
+ * pages-collection model: add an `/about` entry and it just works).
+ *
+ * You keep the route file; this fills the body. It returns `generateStaticParams`
+ * (pre-render published paths, with `dynamicParams` handling the rest),
+ * `generateMetadata`, and the page component — which resolves the path across the
+ * configured collections, calls `notFound()` on a genuine miss or a reserved
+ * path, and otherwise renders your component with the resolved entry.
+ *
+ * `next`/`react` imports are TYPE-ONLY and `next/navigation` is resolved lazily,
+ * so importing this never forces those onto a non-Next consumer at load.
+ *
+ * @module runtime/routing/content-route
+ */
+import { createRequire } from "node:module";
+
+import type { Metadata } from "next";
+
+import { getNextly } from "../../direct-api/nextly";
+import type { Nextly } from "../../direct-api/nextly";
+
+import { isReservedPath } from "./reserved-paths";
+import { resolveContent, type ContentEntry } from "./resolve-content";
+
+/** Where a resolved entry was found — passed to `render`/`buildMetadata`. */
+export interface ResolvedContext {
+  /** The collection the entry was resolved from. */
+  collection: string;
+  /** The joined slug path (no leading slash), e.g. `"about/team"`. */
+  slug: string;
+}
+
+/**
+ * Config for {@link createContentRoute}. `TNode` is the render output (your
+ * server component's return, e.g. `ReactNode`) — inferred from `render`, so
+ * `nextly` needs no `react` dependency of its own.
+ */
+export interface ContentRouteConfig<TNode> {
+  /**
+   * Collections to resolve a path against, in order — the first collection with
+   * a published entry whose slug matches the path wins.
+   */
+  collections: string[];
+  /** Render the resolved entry (your server component body). */
+  render: (entry: ContentEntry, context: ResolvedContext) => TNode;
+  /** Optional per-entry metadata (e.g. via `buildMetadata`). */
+  buildMetadata?: (
+    entry: ContentEntry,
+    context: ResolvedContext
+  ) => Metadata | Promise<Metadata>;
+  /** Field holding the slug (default `"slug"`). */
+  slugField?: string;
+  /** Relation depth for the resolved read (default `1`). */
+  depth?: number;
+  /** A booted Nextly instance (defaults to `getNextly()`). */
+  nextly?: Nextly;
+  /** Time-based revalidation seconds for the resolved read. */
+  revalidate?: number | false;
+  /**
+   * Max published paths to pre-render per collection in `generateStaticParams`
+   * (default `1000`). The rest render on demand via `dynamicParams`.
+   */
+  staticParamsLimit?: number;
+}
+
+/** The optional-catch-all route arg: `{ params: Promise<{ slug?: string[] }> }`. */
+export interface ContentRouteArgs {
+  params: Promise<{ slug?: string[] }> | { slug?: string[] };
+}
+
+/** What {@link createContentRoute} returns — wire these into the route file. */
+export interface ContentRoute<TNode> {
+  generateStaticParams: () => Promise<Array<{ slug: string[] }>>;
+  generateMetadata: (args: ContentRouteArgs) => Promise<Metadata>;
+  ContentPage: (args: ContentRouteArgs) => Promise<TNode>;
+}
+
+// `next/navigation` is resolved lazily (opaque to bundlers), so importing this
+// module never forces `next` at load; `notFound()` throws the special error the
+// App Router catches to render the not-found page.
+let cachedNotFound: (() => never) | null | undefined;
+function loadNotFound(): () => never {
+  if (cachedNotFound === undefined) {
+    try {
+      const require = createRequire(import.meta.url);
+      const mod = require("next/navigation") as { notFound?: () => never };
+      cachedNotFound = typeof mod.notFound === "function" ? mod.notFound : null;
+    } catch {
+      cachedNotFound = null;
+    }
+  }
+  if (!cachedNotFound) {
+    // Outside a Next runtime there is no not-found boundary to trigger.
+    throw new Error(
+      "createContentRoute requires next/navigation (use it inside a Next.js app)"
+    );
+  }
+  return cachedNotFound;
+}
+
+/** Trigger the App Router's not-found boundary; never returns (narrows callers). */
+function triggerNotFound(): never {
+  return loadNotFound()();
+}
+
+const MAX_STATIC_PARAMS_PER_PAGE = 500;
+
+export function createContentRoute<TNode>(
+  config: ContentRouteConfig<TNode>
+): ContentRoute<TNode> {
+  const collections = [...new Set(config.collections)];
+  const slugField = config.slugField ?? "slug";
+  const depth = config.depth ?? 1;
+  const staticParamsLimit = config.staticParamsLimit ?? 1000;
+
+  const getInstance = (): Nextly => config.nextly ?? getNextly();
+
+  /** Resolve the joined slug across the configured collections (first match wins). */
+  async function resolve(
+    slug: string
+  ): Promise<{ entry: ContentEntry; context: ResolvedContext } | null> {
+    for (const collection of collections) {
+      const entry = await resolveContent(collection, slug, {
+        nextly: config.nextly,
+        slugField,
+        depth,
+        revalidate: config.revalidate,
+      });
+      if (entry) return { entry, context: { collection, slug } };
+    }
+    return null;
+  }
+
+  async function generateStaticParams(): Promise<Array<{ slug: string[] }>> {
+    const nextly = getInstance();
+    const params: Array<{ slug: string[] }> = [];
+    for (const collection of collections) {
+      let page = 1;
+      let collected = 0;
+      for (;;) {
+        const result = await nextly.find({
+          collection,
+          where: { status: { equals: "published" } },
+          select: { [slugField]: true },
+          sort: "createdAt",
+          limit: MAX_STATIC_PARAMS_PER_PAGE,
+          page,
+        });
+        for (const item of result.items) {
+          const value = item[slugField];
+          if (typeof value !== "string" || value.trim() === "") continue;
+          params.push({ slug: value.split("/") });
+          collected += 1;
+          if (collected >= staticParamsLimit) break;
+        }
+        if (collected >= staticParamsLimit || !result.meta.hasNext) break;
+        page += 1;
+      }
+    }
+    return params;
+  }
+
+  async function generateMetadata(args: ContentRouteArgs): Promise<Metadata> {
+    if (!config.buildMetadata) return {};
+    const slug = joinSlug(await args.params);
+    if (isReservedPath(`/${slug}`)) return {};
+    const resolved = await resolve(slug);
+    if (!resolved) return {};
+    return config.buildMetadata(resolved.entry, resolved.context);
+  }
+
+  async function ContentPage(args: ContentRouteArgs): Promise<TNode> {
+    const slug = joinSlug(await args.params);
+    // Never serve content at a framework/metadata path.
+    if (isReservedPath(`/${slug}`)) triggerNotFound();
+    const resolved = await resolve(slug);
+    if (!resolved) triggerNotFound();
+    return config.render(resolved.entry, resolved.context);
+  }
+
+  return { generateStaticParams, generateMetadata, ContentPage };
+}
+
+/** Join the optional-catch-all segments into a slug path (no leading slash). */
+function joinSlug(params: { slug?: string[] }): string {
+  return (params.slug ?? []).join("/");
+}

--- a/packages/nextly/src/runtime/routing/content-route.ts
+++ b/packages/nextly/src/runtime/routing/content-route.ts
@@ -151,6 +151,9 @@ export function createContentRoute<TNode>(
         for (const item of result.items) {
           const value = item[slugField];
           if (typeof value !== "string" || value.trim() === "") continue;
+          // Skip reserved paths — `ContentPage` always `notFound()`s them, so
+          // pre-rendering them just schedules pages that can never be served.
+          if (isReservedPath(`/${value}`)) continue;
           params.push({ slug: value.split("/") });
           collected += 1;
           if (collected >= staticParamsLimit) break;

--- a/packages/nextly/src/runtime/routing/index.ts
+++ b/packages/nextly/src/runtime/routing/index.ts
@@ -1,0 +1,25 @@
+/**
+ * `runtime/routing` — Next-coupled content-routing + sitemap/robots delivery.
+ * `next`/`react` imports are type-only and `next/navigation` is resolved
+ * lazily, so importing this never forces those at load.
+ *
+ * @module runtime/routing
+ */
+export { resolveContent } from "./resolve-content";
+export type { ContentEntry, ResolveContentOptions } from "./resolve-content";
+
+export { isReservedPath } from "./reserved-paths";
+
+export { createContentRoute } from "./content-route";
+export type {
+  ContentRoute,
+  ContentRouteArgs,
+  ContentRouteConfig,
+  ResolvedContext,
+} from "./content-route";
+
+export { nextlySitemap } from "./sitemap";
+export type { NextlySitemapEntry, NextlySitemapOptions } from "./sitemap";
+
+export { nextlyRobots } from "./robots";
+export type { NextlyRobotsOptions } from "./robots";

--- a/packages/nextly/src/runtime/routing/reserved-paths.ts
+++ b/packages/nextly/src/runtime/routing/reserved-paths.ts
@@ -1,0 +1,37 @@
+/**
+ * Reserved-path denylist — the paths a content catch-all must NOT serve, so
+ * content can never be minted at a URL that shadows the admin panel, the API,
+ * Next internals, or a well-known metadata file.
+ *
+ * @module runtime/routing/reserved-paths
+ */
+
+/** Path prefixes owned by the framework/admin — a content path under any is refused. */
+const RESERVED_PREFIXES = ["/admin", "/api", "/_next", "/static"] as const;
+
+/** Exact well-known files that must resolve to their own handlers, not content. */
+const RESERVED_EXACT = new Set([
+  "/sitemap.xml",
+  "/robots.txt",
+  "/favicon.ico",
+  "/manifest.webmanifest",
+  "/opengraph-image",
+  "/twitter-image",
+]);
+
+/**
+ * Whether `path` is reserved (owned by the framework/admin/metadata) and must
+ * not be served as content. Accepts a path with or without a leading slash;
+ * a trailing slash is ignored.
+ */
+export function isReservedPath(path: string): boolean {
+  let normalized = path.startsWith("/") ? path : `/${path}`;
+  // Drop a trailing slash (but keep the root "/").
+  if (normalized.length > 1 && normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1);
+  }
+  if (RESERVED_EXACT.has(normalized)) return true;
+  return RESERVED_PREFIXES.some(
+    prefix => normalized === prefix || normalized.startsWith(`${prefix}/`)
+  );
+}

--- a/packages/nextly/src/runtime/routing/reserved-paths.ts
+++ b/packages/nextly/src/runtime/routing/reserved-paths.ts
@@ -15,6 +15,7 @@ const RESERVED_EXACT = new Set([
   "/robots.txt",
   "/favicon.ico",
   "/manifest.webmanifest",
+  "/manifest.json",
   "/opengraph-image",
   "/twitter-image",
 ]);

--- a/packages/nextly/src/runtime/routing/reserved-paths.ts
+++ b/packages/nextly/src/runtime/routing/reserved-paths.ts
@@ -26,7 +26,10 @@ const RESERVED_EXACT = new Set([
  * a trailing slash is ignored.
  */
 export function isReservedPath(path: string): boolean {
-  let normalized = path.startsWith("/") ? path : `/${path}`;
+  // Force a single leading slash and collapse any redundant slashes, so a stored
+  // slug carrying an extra slash (e.g. "/admin" -> "//admin", or "a//admin")
+  // cannot dodge the prefix match.
+  let normalized = `/${path}`.replace(/\/{2,}/g, "/");
   // Drop a trailing slash (but keep the root "/").
   if (normalized.length > 1 && normalized.endsWith("/")) {
     normalized = normalized.slice(0, -1);

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -86,7 +86,9 @@ export async function resolveContent(
     },
     {
       // Tag by the collection so any write to it makes this read fresh. The key
-      // varies by slug + locale so distinct URLs (and locales) cache separately.
+      // varies by every dimension that changes the read result — slug, locale,
+      // and the query shape (status field, depth, rich-text format) — so two
+      // callers that differ in any of them never share a cache entry.
       tags: nextlyTags(collection),
       keyParts: [
         "nextly",
@@ -95,6 +97,9 @@ export async function resolveContent(
         slugField,
         slug,
         locale ?? "",
+        statusField,
+        String(depth),
+        options.richTextFormat ?? "json",
       ],
       revalidate: options.revalidate ?? false,
     }

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -59,8 +59,15 @@ export interface ResolveContentOptions {
   /**
    * Time-based revalidation in seconds — a safety net on top of tag-based
    * busting. `false` (default) means the read only revalidates on a tag bust.
+   * A non-positive value is treated as `false` (`unstable_cache` rejects `0`).
    */
   revalidate?: number | false;
+  /**
+   * A stable discriminator folded into the cache key. Supply a unique value when
+   * distinct `nextly` readers (e.g. per-tenant or per-database) can resolve the
+   * same collection + slug, so their cached reads never alias each other.
+   */
+  cacheScope?: string;
 }
 
 /**
@@ -118,6 +125,9 @@ export async function resolveContent(
       keyParts: [
         "nextly",
         "resolve-content",
+        // A caller-supplied scope so distinct readers (per-tenant/per-database)
+        // resolving the same collection + slug never share a cache entry.
+        options.cacheScope ?? "",
         collection,
         slugField,
         slug,
@@ -126,7 +136,12 @@ export async function resolveContent(
         String(depth),
         options.richTextFormat ?? "json",
       ],
-      revalidate: options.revalidate ?? false,
+      // `unstable_cache` rejects `revalidate: 0` (needs `false` or `> 0`), so a
+      // non-positive value degrades to tag-only busting rather than failing.
+      revalidate:
+        typeof options.revalidate === "number" && options.revalidate > 0
+          ? options.revalidate
+          : false,
     }
   );
 }

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -37,6 +37,12 @@ export interface ResolveContentOptions {
   /** Rich-text output format for rich-text fields (default `"json"`). */
   richTextFormat?: "json" | "html" | "both";
   /**
+   * Extra cache tags merged with the collection's own tag. Add related
+   * collections' tags (e.g. `nextlyTags("authors")`) when a `depth > 0` read
+   * populates relations, so a write to one of those busts this read too.
+   */
+  tags?: string[];
+  /**
    * Time-based revalidation in seconds — a safety net on top of tag-based
    * busting. `false` (default) means the read only revalidates on a tag bust.
    */
@@ -85,11 +91,12 @@ export async function resolveContent(
       return result.items[0] ?? null;
     },
     {
-      // Tag by the collection so any write to it makes this read fresh. The key
-      // varies by every dimension that changes the read result — slug, locale,
-      // and the query shape (status field, depth, rich-text format) — so two
-      // callers that differ in any of them never share a cache entry.
-      tags: nextlyTags(collection),
+      // Tag by the collection so any write to it makes this read fresh, plus any
+      // caller-supplied tags (related collections a populated read depends on).
+      // The key varies by every dimension that changes the read result — slug,
+      // locale, and the query shape (status field, depth, rich-text format) — so
+      // two callers that differ in any of them never share a cache entry.
+      tags: [...nextlyTags(collection), ...(options.tags ?? [])],
       keyParts: [
         "nextly",
         "resolve-content",

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -106,6 +106,10 @@ export async function resolveContent(
         collection,
         where,
         limit: 1,
+        // A slug field is ordinary text and need not be unique; sort by the
+        // always-present unique `id` so duplicate-slug rows resolve to the same
+        // entry deterministically instead of an arbitrary one.
+        sort: "id",
         depth,
         ...(options.richTextFormat
           ? { richTextFormat: options.richTextFormat }

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -138,7 +138,10 @@ export async function resolveContent(
         locale ?? "",
         statusField === false ? "no-status" : statusField,
         String(depth),
-        options.richTextFormat ?? "json",
+        // When omitted, the read inherits the reader's default format (which may
+        // not be "json"), so key it as "inherit" — never as a concrete format —
+        // so an explicit-format call can't reuse an inherited-shape cache entry.
+        options.richTextFormat ?? "inherit",
       ],
       // `unstable_cache` rejects `revalidate: 0` (needs `false` or `> 0`), so a
       // non-positive value degrades to tag-only busting rather than failing.

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -1,0 +1,102 @@
+/**
+ * `resolveContent` — resolve a URL slug to a single PUBLISHED content entry,
+ * cached with F1 so the page and its metadata share one read and go stale in
+ * lockstep on a content write.
+ *
+ * A genuine miss returns `null` (the caller renders `notFound()`), while a
+ * transient read error is RETHROWN rather than swallowed to `null` — so a DB
+ * blip becomes a retryable error instead of a permanently-cached 404 (the exact
+ * lesson from the F1 blog-template review).
+ *
+ * @module runtime/routing/resolve-content
+ */
+import { getNextly } from "../../direct-api/nextly";
+import type { Nextly } from "../../direct-api/nextly";
+import { cachedFind } from "../cache/cached-find";
+import { nextlyTags } from "../cache/nextly-tags";
+
+/** A resolved content entry (loose by design — shape is the app's collection). */
+export type ContentEntry = Record<string, unknown>;
+
+/** Options for {@link resolveContent}. */
+export interface ResolveContentOptions {
+  /**
+   * A booted Nextly instance. Defaults to the runtime singleton (`getNextly()`),
+   * which requires services to be registered — pass one explicitly from a
+   * frontend read path that boots the config itself.
+   */
+  nextly?: Nextly;
+  /** The field holding the URL slug (default `"slug"`). */
+  slugField?: string;
+  /** The field holding the publish status (default `"status"`). */
+  statusField?: string;
+  /** Relation population depth for rendering (default `1`). */
+  depth?: number;
+  /** Read a specific locale (localized collections). */
+  locale?: string;
+  /** Rich-text output format for rich-text fields (default `"json"`). */
+  richTextFormat?: "json" | "html" | "both";
+  /**
+   * Time-based revalidation in seconds — a safety net on top of tag-based
+   * busting. `false` (default) means the read only revalidates on a tag bust.
+   */
+  revalidate?: number | false;
+}
+
+/**
+ * Resolve a published entry by slug in `collection`, F1-cached and tagged so a
+ * write to the collection busts it.
+ *
+ * @example
+ * ```ts
+ * const post = await resolveContent("posts", slug, { depth: 2 });
+ * if (!post) notFound();
+ * ```
+ */
+export async function resolveContent(
+  collection: string,
+  slug: string,
+  options: ResolveContentOptions = {}
+): Promise<ContentEntry | null> {
+  const nextly = options.nextly ?? getNextly();
+  const slugField = options.slugField ?? "slug";
+  const statusField = options.statusField ?? "status";
+  const depth = options.depth ?? 1;
+  const locale = options.locale;
+
+  return cachedFind(
+    async () => {
+      const result = await nextly.find({
+        collection,
+        where: {
+          and: [
+            { [statusField]: { equals: "published" } },
+            { [slugField]: { equals: slug } },
+          ],
+        },
+        limit: 1,
+        depth,
+        ...(options.richTextFormat
+          ? { richTextFormat: options.richTextFormat }
+          : {}),
+        // The content locale drives the localized read + fallback.
+        ...(locale ? { locale } : {}),
+      });
+      return result.items[0] ?? null;
+    },
+    {
+      // Tag by the collection so any write to it makes this read fresh. The key
+      // varies by slug + locale so distinct URLs (and locales) cache separately.
+      tags: nextlyTags(collection),
+      keyParts: [
+        "nextly",
+        "resolve-content",
+        collection,
+        slugField,
+        slug,
+        locale ?? "",
+      ],
+      revalidate: options.revalidate ?? false,
+    }
+  );
+}

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -18,40 +18,32 @@ import { nextlyTags } from "../cache/nextly-tags";
 /** A resolved content entry (loose by design — shape is the app's collection). */
 export type ContentEntry = Record<string, unknown>;
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
 /**
- * Whether `collection` has the built-in draft/published lifecycle enabled
- * (`status: true`). A status-less collection has no `status` column, so a
- * blanket `status = published` predicate would either be silently dropped or —
- * if the collection defines its own field named `status` — wrongly filter live
- * rows; both routing reads gate the filter on this. Mirrors the sitemap plugin.
+ * The booted-Nextly surface these helpers need: just a `find` reader. Typed
+ * structurally (not as the Direct API class) so BOTH the internal singleton and
+ * the public instance returned by `await getNextly(config)` satisfy it — the
+ * public interface does not expose the Direct API's internal handlers.
  */
-export async function collectionHasStatusLifecycle(
-  nextly: Nextly,
-  collection: string
-): Promise<boolean> {
-  const result = await nextly.collectionsHandler.getCollection({
-    collectionName: collection,
-  });
-  const data = isRecord(result) ? result.data : undefined;
-  return isRecord(data) && data.status === true;
-}
+export type NextlyContentReader = Pick<Nextly, "find">;
 
 /** Options for {@link resolveContent}. */
 export interface ResolveContentOptions {
   /**
    * A booted Nextly instance. Defaults to the runtime singleton (`getNextly()`),
-   * which requires services to be registered — pass one explicitly from a
-   * frontend read path that boots the config itself.
+   * which requires services to be registered — pass one explicitly (e.g. the
+   * value from `await getNextly(config)`) from a frontend read path that boots
+   * the config itself.
    */
-  nextly?: Nextly;
+  nextly?: NextlyContentReader;
   /** The field holding the URL slug (default `"slug"`). */
   slugField?: string;
-  /** The field holding the publish status (default `"status"`). */
-  statusField?: string;
+  /**
+   * The field holding the publish status (default `"status"`), matched against
+   * `"published"`. Pass `false` to skip status filtering entirely — required
+   * for status-less collections (no built-in draft/published lifecycle), which
+   * have no such column.
+   */
+  statusField?: string | false;
   /** Relation population depth for rendering (default `1`). */
   depth?: number;
   /** Read a specific locale (localized collections). */
@@ -94,16 +86,15 @@ export async function resolveContent(
 
   return cachedFind(
     async () => {
-      // Only require `published` when the collection actually has that field: a
-      // custom `statusField` is the caller asserting it exists, and the default
-      // `status` field only exists when the built-in lifecycle is enabled.
-      const filterByStatus =
-        statusField !== "status" ||
-        (await collectionHasStatusLifecycle(nextly, collection));
+      // Filter by `published` unless the caller opted out (`statusField: false`)
+      // for a status-less collection that has no such column.
       const slugCondition = { [slugField]: { equals: slug } };
-      const where = filterByStatus
-        ? { and: [{ [statusField]: { equals: "published" } }, slugCondition] }
-        : slugCondition;
+      const where =
+        statusField === false
+          ? slugCondition
+          : {
+              and: [{ [statusField]: { equals: "published" } }, slugCondition],
+            };
       const result = await nextly.find({
         collection,
         where,
@@ -131,7 +122,7 @@ export async function resolveContent(
         slugField,
         slug,
         locale ?? "",
-        statusField,
+        statusField === false ? "no-status" : statusField,
         String(depth),
         options.richTextFormat ?? "json",
       ],

--- a/packages/nextly/src/runtime/routing/resolve-content.ts
+++ b/packages/nextly/src/runtime/routing/resolve-content.ts
@@ -18,6 +18,28 @@ import { nextlyTags } from "../cache/nextly-tags";
 /** A resolved content entry (loose by design — shape is the app's collection). */
 export type ContentEntry = Record<string, unknown>;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Whether `collection` has the built-in draft/published lifecycle enabled
+ * (`status: true`). A status-less collection has no `status` column, so a
+ * blanket `status = published` predicate would either be silently dropped or —
+ * if the collection defines its own field named `status` — wrongly filter live
+ * rows; both routing reads gate the filter on this. Mirrors the sitemap plugin.
+ */
+export async function collectionHasStatusLifecycle(
+  nextly: Nextly,
+  collection: string
+): Promise<boolean> {
+  const result = await nextly.collectionsHandler.getCollection({
+    collectionName: collection,
+  });
+  const data = isRecord(result) ? result.data : undefined;
+  return isRecord(data) && data.status === true;
+}
+
 /** Options for {@link resolveContent}. */
 export interface ResolveContentOptions {
   /**
@@ -72,14 +94,19 @@ export async function resolveContent(
 
   return cachedFind(
     async () => {
+      // Only require `published` when the collection actually has that field: a
+      // custom `statusField` is the caller asserting it exists, and the default
+      // `status` field only exists when the built-in lifecycle is enabled.
+      const filterByStatus =
+        statusField !== "status" ||
+        (await collectionHasStatusLifecycle(nextly, collection));
+      const slugCondition = { [slugField]: { equals: slug } };
+      const where = filterByStatus
+        ? { and: [{ [statusField]: { equals: "published" } }, slugCondition] }
+        : slugCondition;
       const result = await nextly.find({
         collection,
-        where: {
-          and: [
-            { [statusField]: { equals: "published" } },
-            { [slugField]: { equals: slug } },
-          ],
-        },
+        where,
         limit: 1,
         depth,
         ...(options.richTextFormat

--- a/packages/nextly/src/runtime/routing/robots.ts
+++ b/packages/nextly/src/runtime/routing/robots.ts
@@ -35,8 +35,19 @@ export function nextlyRobots(
   options: NextlyRobotsOptions = {}
 ): () => MetadataRoute.Robots {
   // Keep the admin panel and API out of the index; a caller can disallow more.
+  // Exclude the framework roots on a path boundary, not a raw prefix: the
+  // trailing-slash form (`/admin/`) covers the whole subtree on every crawler,
+  // and the `$`-anchored form (`/admin$`) pins the bare root on crawlers that
+  // support it — neither swallows similarly-prefixed content like
+  // `/administration`, which the router does serve.
   const disallow = [
-    ...new Set(["/admin", "/api", ...(options.disallow ?? [])]),
+    ...new Set([
+      "/admin/",
+      "/admin$",
+      "/api/",
+      "/api$",
+      ...(options.disallow ?? []),
+    ]),
   ];
   return () => ({
     rules: {

--- a/packages/nextly/src/runtime/routing/robots.ts
+++ b/packages/nextly/src/runtime/routing/robots.ts
@@ -37,15 +37,18 @@ export function nextlyRobots(
   // Keep the admin panel and API out of the index; a caller can disallow more.
   // Exclude the framework roots on a path boundary, not a raw prefix: the
   // trailing-slash form (`/admin/`) covers the whole subtree on every crawler,
-  // and the `$`-anchored form (`/admin$`) pins the bare root on crawlers that
-  // support it — neither swallows similarly-prefixed content like
-  // `/administration`, which the router does serve.
+  // the `$`-anchored form (`/admin$`) pins the bare root where supported, and
+  // the `?` form (`/admin?`) covers query-bearing roots (`/admin?next=/x`).
+  // None swallows similarly-prefixed content like `/administration`, which the
+  // router does serve.
   const disallow = [
     ...new Set([
       "/admin/",
       "/admin$",
+      "/admin?",
       "/api/",
       "/api$",
+      "/api?",
       ...(options.disallow ?? []),
     ]),
   ];

--- a/packages/nextly/src/runtime/routing/robots.ts
+++ b/packages/nextly/src/runtime/routing/robots.ts
@@ -1,0 +1,52 @@
+/**
+ * `nextlyRobots` — build the default export for a Next `app/robots.ts` that
+ * disallows the framework paths (`/admin`, `/api`) and points crawlers at the
+ * sitemap. The `next` import is type-only.
+ *
+ * @module runtime/routing/robots
+ */
+import type { MetadataRoute } from "next";
+
+/** Options for {@link nextlyRobots}. */
+export interface NextlyRobotsOptions {
+  /** Absolute sitemap URL(s) to advertise (e.g. `"https://example.com/sitemap.xml"`). */
+  sitemap?: string | string[];
+  /** User-agent the rule applies to (default `"*"`). */
+  userAgent?: string;
+  /** Extra disallowed paths, merged with the defaults (`/admin`, `/api`). */
+  disallow?: string[];
+  /** Allowed paths (takes precedence over a broader disallow). */
+  allow?: string[];
+  /** Preferred host for canonicalization. */
+  host?: string;
+}
+
+/**
+ * Create the `app/robots.ts` default export.
+ *
+ * @example
+ * ```ts
+ * // app/robots.ts
+ * import { nextlyRobots } from "nextly/runtime";
+ * export default nextlyRobots({ sitemap: "https://example.com/sitemap.xml" });
+ * ```
+ */
+export function nextlyRobots(
+  options: NextlyRobotsOptions = {}
+): () => MetadataRoute.Robots {
+  // Keep the admin panel and API out of the index; a caller can disallow more.
+  const disallow = [
+    ...new Set(["/admin", "/api", ...(options.disallow ?? [])]),
+  ];
+  return () => ({
+    rules: {
+      userAgent: options.userAgent ?? "*",
+      ...(options.allow && options.allow.length > 0
+        ? { allow: options.allow }
+        : {}),
+      disallow,
+    },
+    ...(options.sitemap ? { sitemap: options.sitemap } : {}),
+    ...(options.host ? { host: options.host } : {}),
+  });
+}

--- a/packages/nextly/src/runtime/routing/sitemap.ts
+++ b/packages/nextly/src/runtime/routing/sitemap.ts
@@ -38,7 +38,14 @@ export interface NextlySitemapOptions {
    * with the pages — use `nextlyTags(collection)` for each configured collection.
    */
   tags?: string[];
-  /** Cache key parts (default a single stable key). */
+  /**
+   * Cache key parts. Defaults to `["nextly", "sitemap", ...tags]`, which keeps
+   * sitemaps with distinct tags apart. Multiple sitemap helpers that share the
+   * SAME tags (e.g. partitioned routes over the same collections) MUST pass
+   * distinct `keyParts` — the `entries` provider lives in a closure and the
+   * route pathname is not part of Next's cache key, so there is no automatic
+   * way to tell two same-tagged providers apart.
+   */
   keyParts?: string[];
   /** Time-based revalidation seconds (safety net on top of tag busting). */
   revalidate?: number | false;

--- a/packages/nextly/src/runtime/routing/sitemap.ts
+++ b/packages/nextly/src/runtime/routing/sitemap.ts
@@ -9,9 +9,32 @@
  *
  * @module runtime/routing/sitemap
  */
+import { createRequire } from "node:module";
+
 import type { MetadataRoute } from "next";
 
 import { cachedFind } from "../cache/cached-find";
+
+// `next/cache` is resolved lazily (opaque to bundlers) so importing this module
+// never forces `next` at load. `unstable_noStore()` opts the current render out
+// of Next's Data/Full Route Cache, which is what keeps an uncached sitemap from
+// being frozen as a build-time prerender.
+let cachedNoStore: (() => void) | null | undefined;
+function markDynamic(): void {
+  if (cachedNoStore === undefined) {
+    try {
+      const require = createRequire(import.meta.url);
+      const mod = require("next/cache") as { unstable_noStore?: () => void };
+      cachedNoStore =
+        typeof mod.unstable_noStore === "function"
+          ? mod.unstable_noStore
+          : null;
+    } catch {
+      cachedNoStore = null;
+    }
+  }
+  cachedNoStore?.();
+}
 
 /** A sitemap entry (a superset-compatible slice of Next's `MetadataRoute.Sitemap`). */
 export interface NextlySitemapEntry {
@@ -81,9 +104,13 @@ export function nextlySitemap(
       : false;
   // With neither invalidation tags nor a revalidate window, a cached entry would
   // pin the first render forever — publishes, edits, and deletes would never
-  // reach `/sitemap.xml`. Read uncached in that case so it always stays current.
+  // reach `/sitemap.xml`. Mark the render dynamic (so Next doesn't freeze it as
+  // a build-time prerender either) and read uncached so it always stays current.
   if (!hasTags && revalidate === false) {
-    return async () => normalize(await options.entries());
+    return async () => {
+      markDynamic();
+      return normalize(await options.entries());
+    };
   }
   // Default the key off the tags so multiple sitemap helpers (partitioned or
   // nested) that omit `keyParts` don't alias to one shared cache entry.

--- a/packages/nextly/src/runtime/routing/sitemap.ts
+++ b/packages/nextly/src/runtime/routing/sitemap.ts
@@ -1,0 +1,96 @@
+/**
+ * `nextlySitemap` — build the default export for a Next `app/sitemap.ts` from a
+ * caller-supplied entry provider, cached with F1 so a content write busts it.
+ *
+ * The provider is where you wire your data — e.g. `@nextlyhq/plugin-seo`'s
+ * `buildSitemapUrls`, mapping each `{ loc }` to `{ url }`. Keeping the data
+ * caller-supplied lets `nextly` stay independent of the plugin while the plugin
+ * owns the agnostic source of truth. The `next` import is type-only.
+ *
+ * @module runtime/routing/sitemap
+ */
+import type { MetadataRoute } from "next";
+
+import { cachedFind } from "../cache/cached-find";
+
+/** A sitemap entry (a superset-compatible slice of Next's `MetadataRoute.Sitemap`). */
+export interface NextlySitemapEntry {
+  url: string;
+  lastModified?: string | Date;
+  changeFrequency?:
+    | "always"
+    | "hourly"
+    | "daily"
+    | "weekly"
+    | "monthly"
+    | "yearly"
+    | "never";
+  priority?: number;
+  alternates?: { languages?: Record<string, string> };
+}
+
+/** Options for {@link nextlySitemap}. */
+export interface NextlySitemapOptions {
+  /** Provide the sitemap entries (typically from the SEO plugin's data). */
+  entries: () => Promise<NextlySitemapEntry[]> | NextlySitemapEntry[];
+  /**
+   * F1 cache tags for the read, so a content write busts the sitemap in lockstep
+   * with the pages — use `nextlyTags(collection)` for each configured collection.
+   */
+  tags?: string[];
+  /** Cache key parts (default a single stable key). */
+  keyParts?: string[];
+  /** Time-based revalidation seconds (safety net on top of tag busting). */
+  revalidate?: number | false;
+}
+
+/**
+ * Create the `app/sitemap.ts` default export.
+ *
+ * @example
+ * ```ts
+ * // app/sitemap.ts
+ * import { nextlySitemap, nextlyTags } from "nextly/runtime";
+ * import { buildSitemapUrls } from "@nextlyhq/plugin-seo";
+ *
+ * export default nextlySitemap({
+ *   entries: async () => {
+ *     const urls = await buildSitemapUrls(services, { collections: ["posts"], baseUrl });
+ *     return urls.map(u => ({ url: u.loc, lastModified: u.lastModified }));
+ *   },
+ *   tags: nextlyTags("posts"),
+ * });
+ * ```
+ */
+export function nextlySitemap(
+  options: NextlySitemapOptions
+): () => Promise<MetadataRoute.Sitemap> {
+  return () =>
+    cachedFind(async () => normalize(await options.entries()), {
+      tags: options.tags ?? [],
+      keyParts: options.keyParts ?? ["nextly", "sitemap"],
+      revalidate: options.revalidate ?? false,
+    });
+}
+
+/** Map entries to Next's sitemap shape, dropping ones without a URL. */
+function normalize(entries: NextlySitemapEntry[]): MetadataRoute.Sitemap {
+  const sitemap: MetadataRoute.Sitemap = [];
+  for (const entry of entries) {
+    if (typeof entry.url !== "string" || entry.url === "") continue;
+    sitemap.push({
+      url: entry.url,
+      ...(entry.lastModified !== undefined
+        ? { lastModified: entry.lastModified }
+        : {}),
+      ...(entry.changeFrequency !== undefined
+        ? { changeFrequency: entry.changeFrequency }
+        : {}),
+      ...(entry.priority !== undefined ? { priority: entry.priority } : {}),
+      ...(entry.alternates !== undefined
+        ? { alternates: entry.alternates }
+        : {}),
+    });
+  }
+  return sitemap;
+}

--- a/packages/nextly/src/runtime/routing/sitemap.ts
+++ b/packages/nextly/src/runtime/routing/sitemap.ts
@@ -65,6 +65,15 @@ export interface NextlySitemapOptions {
 export function nextlySitemap(
   options: NextlySitemapOptions
 ): () => Promise<MetadataRoute.Sitemap> {
+  const hasTags = (options.tags?.length ?? 0) > 0;
+  const hasRevalidate =
+    typeof options.revalidate === "number" && options.revalidate >= 0;
+  // With neither invalidation tags nor a revalidate window, a cached entry would
+  // pin the first render forever — publishes, edits, and deletes would never
+  // reach `/sitemap.xml`. Read uncached in that case so it always stays current.
+  if (!hasTags && !hasRevalidate) {
+    return async () => normalize(await options.entries());
+  }
   return () =>
     cachedFind(async () => normalize(await options.entries()), {
       tags: options.tags ?? [],

--- a/packages/nextly/src/runtime/routing/sitemap.ts
+++ b/packages/nextly/src/runtime/routing/sitemap.ts
@@ -66,19 +66,30 @@ export function nextlySitemap(
   options: NextlySitemapOptions
 ): () => Promise<MetadataRoute.Sitemap> {
   const hasTags = (options.tags?.length ?? 0) > 0;
-  const hasRevalidate =
-    typeof options.revalidate === "number" && options.revalidate >= 0;
+  // Only a POSITIVE window is a valid cache lifetime — `unstable_cache` rejects
+  // `revalidate: 0` (Next requires `false` or `> 0`), so treat 0 as no window.
+  const revalidate =
+    typeof options.revalidate === "number" && options.revalidate > 0
+      ? options.revalidate
+      : false;
   // With neither invalidation tags nor a revalidate window, a cached entry would
   // pin the first render forever — publishes, edits, and deletes would never
   // reach `/sitemap.xml`. Read uncached in that case so it always stays current.
-  if (!hasTags && !hasRevalidate) {
+  if (!hasTags && revalidate === false) {
     return async () => normalize(await options.entries());
   }
+  // Default the key off the tags so multiple sitemap helpers (partitioned or
+  // nested) that omit `keyParts` don't alias to one shared cache entry.
+  const keyParts = options.keyParts ?? [
+    "nextly",
+    "sitemap",
+    ...(options.tags ?? []),
+  ];
   return () =>
     cachedFind(async () => normalize(await options.entries()), {
       tags: options.tags ?? [],
-      keyParts: options.keyParts ?? ["nextly", "sitemap"],
-      revalidate: options.revalidate ?? false,
+      keyParts,
+      revalidate,
     });
 }
 


### PR DESCRIPTION
## What

Tier-0 PR4 — content routing + sitemap/robots delivery, all in `nextly/runtime` (the Next-coupled behavior half; the plugin owns the agnostic data). After PR1 fields (#349), PR2 sitemap (#351), PR3 `buildMetadata` (#353).

New exports from `nextly/runtime`:

- **`resolveContent(collection, slug, opts)`** — resolve a URL slug to a single PUBLISHED entry, F1-cached (page + metadata share one read, busts on write). A genuine miss → `null`; a transient read error is **rethrown** (never swallowed to a permanently-cached 404 — the F1 blog-template lesson). Generalizes the blog's `getPostBySlug`.
- **`createContentRoute(config)`** — a thin factory for a single `app/[[...slug]]/page.tsx` optional catch-all: returns `generateStaticParams` (pre-render published paths, `dynamicParams` handles the rest), `generateMetadata`, and `ContentPage`. Resolves a path across the configured collections (first match wins), calls `notFound()` on a genuine miss or a **reserved path**, and otherwise renders your component. Generic over the render node, so `nextly` needs no `react` dependency.
- **`isReservedPath(path)`** — the denylist so content can't be minted at a URL shadowing `/admin`, `/api`, `/_next`, `/static`, or a well-known metadata file (`/sitemap.xml`, `/robots.txt`, …).
- **`nextlySitemap({ entries, tags })`** — the `app/sitemap.ts` default export, F1-cached, mapping a caller-supplied entry provider (wire it to `@nextlyhq/plugin-seo`'s `buildSitemapUrls`) to `MetadataRoute.Sitemap`.
- **`nextlyRobots({ sitemap })`** — the `app/robots.ts` default export, disallowing `/admin` + `/api` and pointing at the sitemap.

## F1 hardening (`cachedFind`)

`unstable_cache` throws an `"incrementalCache missing"` invariant when invoked **outside a Next request/build scope** (a standalone script, a test, a non-Next caller with `next` installed). `cachedFind` now catches that specific invariant and runs the reader **uncached** rather than surfacing a cryptic framework error — it already degraded when `next/cache` was entirely absent; this extends that to the no-scope case. A genuine reader error still propagates (so `resolveContent`'s rethrow-on-error is intact). This makes every content read robust in non-request contexts.

## Design notes

- **`next`/`react` are type-only** and `next/navigation` (`notFound`) resolves lazily via `createRequire`, so importing this never forces those at load (keeps the package root Node-safe; mirrors the runtime cache helpers).
- **No plugin dependency:** `nextly` can't depend on `@nextlyhq/plugin-seo` (backwards), so `nextlySitemap` takes the entries as an argument — the app wires the plugin's data.
- **Nested paths:** a field named `slug` is slugified (slashes stripped), so multi-segment paths (`/blog/post`) need a slash-preserving field via `slugField`; single-segment paths (`/about`) work with the default. `createContentRoute` splits the stored value on `/` either way.
- `NextlyError` (not bare `Error`) conventions respected; no `as any`.

## Tests

- **Unit** (pure): `isReservedPath` (prefixes, metadata files, allowed paths, normalization), `nextlyRobots` (rule shape, dedupe, passthrough), `nextlySitemap` (mapping, async provider, url-less drop), and `cachedFind` degrade (uncached on missing-scope invariant; rethrows a real error).
- **Integration** (real boot, SQLite leg): `resolveContent` (published found, draft/miss → null) and `createContentRoute` (`generateStaticParams` segmented + drafts excluded, render, `notFound` on miss/reserved, `generateMetadata`).

## Scope / follow-ups

- One changeset, all 21 fixed-group packages, `patch`.
- Sitemap sharding (`generateSitemaps` for >50k) is left to the app (partition the entries provider) — a documented extension; PR5 (blog dogfood + docs) covers real-world wiring next.

@codex please review this PR
@coderabbitai review
@greptile-apps review
