### PR TITLE
feat(nextly): default REST reads to published-only, reject invalid ?status=

### DIFF
--- a/.changeset/rest-status-default-published.md
+++ b/.changeset/rest-status-default-published.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+REST reads now default to published-only. A list, get, or count request to a Draft/Published collection or single with no `?status=` returns only published entries; pass `?status=all` or `?status=draft` to include drafts (subject to your read access rules). Previously these reads defaulted to returning every status, which could expose drafts to any caller.
+
+An invalid `?status=` value (for example a typo like `?status=pubished`) is now rejected with a 400 instead of being silently treated as "all", so a malformed filter can never widen a read. Trusted server-side Direct API calls are unchanged (they still see every status). The admin panel already requests every status, so editors continue to see their drafts.

--- a/docs/api-reference/rest-api.mdx
+++ b/docs/api-reference/rest-api.mdx
@@ -594,6 +594,24 @@ curl http://localhost:3000/api/api-keys -b "__nextly_access_token=..."
 
 These parameters are accepted by every list endpoint that delegates to the collection / single dispatcher.
 
+### status
+
+For Draft/Published collections and singles, `?status=` controls which lifecycle states a read returns.
+
+| Value | Returns |
+|---|---|
+| _(omitted)_ | Published only — the safe default. Drafts are never returned unless you ask. |
+| `published` | Published only (explicit). |
+| `draft` | Drafts only. |
+| `all` | Every entry regardless of status. |
+
+```
+?status=all
+?status=draft
+```
+
+An **unrecognized** value (a typo like `?status=pubished`) is rejected with `400 VALIDATION_ERROR` rather than silently returning everything, so a bad filter can never widen a read. Trusted server-side calls through the Direct API (which bypass access checks) see every status by default; over HTTP the default is always published-only. The admin panel requests `?status=all` explicitly so editors still see their drafts.
+
 ### where
 
 Filter rows using bracket notation:

--- a/packages/admin/src/components/features/entries/EntryList/EntryList.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/EntryList.tsx
@@ -306,6 +306,10 @@ export function EntryList({ collectionSlug }: EntryListProps) {
       limit,
       sort,
       search: search || undefined,
+      // The REST default is published-only; the management list must see drafts
+      // too, so request `all` as the base. The status dropdown narrows to
+      // draft/published via `where` on top of this.
+      status: "all",
       where: whereFilter,
       translationStatus: wantsTranslationStatus || undefined,
     },

--- a/packages/admin/src/components/features/entries/fields/relational/RelationshipSearch.tsx
+++ b/packages/admin/src/components/features/entries/fields/relational/RelationshipSearch.tsx
@@ -145,6 +145,9 @@ export function RelationshipSearch({
       search: debouncedSearch,
       limit,
       page: currentPage,
+      // Editors relate to draft content too, so the picker must not be limited
+      // to the REST published-only default — request all statuses.
+      status: "all",
     },
     enabled: !!selectedCollection,
   });

--- a/packages/admin/src/services/entryApi.ts
+++ b/packages/admin/src/services/entryApi.ts
@@ -38,6 +38,12 @@ export interface FindParams {
   search?: string;
   /** Query filters using Nextly where syntax */
   where?: Record<string, unknown>;
+  /**
+   * Status filter (`?status=`). The REST default is published-only, so the
+   * management list must pass `"all"` explicitly to include drafts. Omitted →
+   * the server's published-only default.
+   */
+  status?: "all" | "draft" | "published";
   /** Depth for relationship population (0-10) */
   depth?: number;
   /** Fields to select (reduces response size) */
@@ -251,6 +257,13 @@ export const buildFindQuery = (params: FindParams): string => {
   // Depth for relationship population
   if (params.depth !== undefined) {
     query.set("depth", String(params.depth));
+  }
+
+  // Status filter. The REST default is published-only; the management list
+  // sends `all` so editors still see drafts (the status dropdown narrows via
+  // `where` on top of this).
+  if (params.status !== undefined) {
+    query.set("status", params.status);
   }
 
   // Where clause (Nextly query syntax)

--- a/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-shapes.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-shapes.test.ts
@@ -238,20 +238,22 @@ describe("dispatchCollections listEntries / countEntries — status forwarding",
     );
   });
 
-  it("listEntries drops unknown status values (passes undefined)", async () => {
+  it("listEntries rejects an unknown status value with 400 and never queries", async () => {
     const listEntries = vi.fn().mockResolvedValue(fakeListResult);
     const container = makeContainer({ listEntries });
 
-    await dispatchCollections(
-      container,
-      "listEntries",
-      { collectionName: "posts", status: "lol-injection" },
-      undefined
-    );
+    // An invalid status is rejected rather than silently widened to "all"
+    // (which would leak drafts): the handler throws before touching the service.
+    await expect(
+      dispatchCollections(
+        container,
+        "listEntries",
+        { collectionName: "posts", status: "lol-injection" },
+        undefined
+      )
+    ).rejects.toMatchObject({ statusCode: 400 });
 
-    expect(listEntries).toHaveBeenCalledWith(
-      expect.objectContaining({ status: undefined })
-    );
+    expect(listEntries).not.toHaveBeenCalled();
   });
 
   it("listEntries omits status when ?status= is absent (preserves default)", async () => {
@@ -292,20 +294,20 @@ describe("dispatchCollections listEntries / countEntries — status forwarding",
     );
   });
 
-  it("countEntries drops unknown status values", async () => {
+  it("countEntries rejects an unknown status value with 400 and never queries", async () => {
     const countEntries = vi.fn().mockResolvedValue(fakeCountResult);
     const container = makeContainer({ countEntries });
 
-    await dispatchCollections(
-      container,
-      "countEntries",
-      { collectionName: "posts", status: "garbage" },
-      undefined
-    );
+    await expect(
+      dispatchCollections(
+        container,
+        "countEntries",
+        { collectionName: "posts", status: "garbage" },
+        undefined
+      )
+    ).rejects.toMatchObject({ statusCode: 400 });
 
-    expect(countEntries).toHaveBeenCalledWith(
-      expect.objectContaining({ status: undefined })
-    );
+    expect(countEntries).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-shapes.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/single-dispatcher-shapes.test.ts
@@ -261,7 +261,7 @@ describe("dispatchSingles getSingleDocument — status forwarding (Task 7 PR-5)"
     );
   });
 
-  it("drops unknown status values (passes undefined)", async () => {
+  it("rejects an unknown status value with 400 and never reads", async () => {
     const entryGet = vi.fn().mockResolvedValue({
       success: true,
       statusCode: 200,
@@ -269,16 +269,17 @@ describe("dispatchSingles getSingleDocument — status forwarding (Task 7 PR-5)"
     });
     wireDi(makeRegistry(), makeEntry({ get: entryGet }));
 
-    await dispatchSingles(
-      "getSingleDocument",
-      { slug: "site", status: "lol-injection" },
-      undefined
-    );
+    // An invalid status is rejected rather than silently widened to "all"
+    // (which would leak a draft Single): the handler throws before reading.
+    await expect(
+      dispatchSingles(
+        "getSingleDocument",
+        { slug: "site", status: "lol-injection" },
+        undefined
+      )
+    ).rejects.toMatchObject({ statusCode: 400 });
 
-    expect(entryGet).toHaveBeenCalledWith(
-      "site",
-      expect.objectContaining({ status: undefined })
-    );
+    expect(entryGet).not.toHaveBeenCalled();
   });
 
   it("omits status when ?status= is absent (preserves default published-only filter)", async () => {

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -96,6 +96,7 @@ import {
   isTruthyParam,
   parseRichTextFormat,
   parseSelectParam,
+  parseStatusParam,
   parseWhereParam,
   requireBody,
   requireParam,
@@ -947,17 +948,14 @@ const COLLECTIONS_METHODS: Record<
 
       const rawLimit = p.limit;
 
-      // Why: forward the `?status=` URL param so trusted callers (the admin)
-      // HTTP API default returns every entry regardless of status; pass
-      // `?status=published` or `?status=draft` to filter. Same allowlist as
-      // getEntry — any value outside it falls back to "all". The status
-      // dropdown in the entry table layers a `where: {status: {equals: ...}}`
-      // on top of this; that still works because where-narrowing happens
-      // after the default filter.
-      const status =
-        p.status === "all" || p.status === "draft" || p.status === "published"
-          ? p.status
-          : "all";
+      // Forward the `?status=` URL param. Absent → undefined so the query
+      // service applies its published-only default (an untrusted list read must
+      // not leak drafts); pass `?status=all|draft|published` to widen. An
+      // invalid value is rejected with 400 rather than silently widened. The
+      // status dropdown in the entry table layers a `where: {status: {equals}}`
+      // on top of this, which still works because where-narrowing happens after
+      // the default filter.
+      const status = parseStatusParam(p.status);
 
       // Forward the caller so the service evaluates the collection's stored
       // read rules for them: role-based rules, and owner-only scoping folded
@@ -1014,12 +1012,11 @@ const COLLECTIONS_METHODS: Record<
     // `{ totalDocs }` internally; we translate at the boundary.
     execute: async (svc, p) => {
       requireParam(p, "collectionName");
-      // Match listEntries: count every entry regardless of status by
-      // default; pass `?status=published` (or `draft`) to filter.
-      const status =
-        p.status === "all" || p.status === "draft" || p.status === "published"
-          ? p.status
-          : "all";
+      // Match listEntries: absent → undefined so the service applies its
+      // published-only default; pass `?status=all|draft|published` to widen,
+      // invalid → 400. A count must obey the same filter as the list or the
+      // total would not match the rows returned.
+      const status = parseStatusParam(p.status);
       // The same caller context listEntries forwards. A count that ignored the
       // read rules while the list obeyed them would report totals for rows the
       // caller cannot see, which both leaks how much data exists and breaks
@@ -1092,12 +1089,10 @@ const COLLECTIONS_METHODS: Record<
       if (!p.collectionName || !p.entryId) {
         throw new Error("collectionName and entryId parameters are required");
       }
-      // HTTP API returns the entry regardless of status by default; pass
-      // `?status=published` (or `draft`) to filter. Matches listEntries.
-      const status =
-        p.status === "all" || p.status === "draft" || p.status === "published"
-          ? p.status
-          : "all";
+      // Absent → undefined so the service applies its published-only default;
+      // pass `?status=all|draft|published` to widen, invalid → 400. Matches
+      // listEntries.
+      const status = parseStatusParam(p.status);
       // Same caller context as listEntries. Fetching one document by id is the
       // path where a missing user matters most: without it an owner-only rule
       // could not deny a direct read of someone else's entry.

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -99,6 +99,7 @@ import {
 } from "../helpers/service-envelope";
 import {
   parseRichTextFormat,
+  parseStatusParam,
   requireParam,
   toNumber,
 } from "../helpers/validation";
@@ -721,15 +722,11 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
     execute: async (svc, p) => {
       const slug = requireParam(p, "slug", "Single slug");
       const richTextFormat = parseRichTextFormat(p.richTextFormat);
-      // HTTP API default returns every document regardless of status; pass
-      // `?status=published` or `?status=draft` to filter. The route requires
-      // auth (see isPublicEndpoint), so this only affects callers who
-      // already have read permission. Anything outside the allowlist falls
-      // back to "all" instead of being silently dropped.
-      const status =
-        p.status === "all" || p.status === "draft" || p.status === "published"
-          ? p.status
-          : "all";
+      // Absent → undefined so the service applies its published-only default
+      // (an untrusted read must not leak a draft Single); pass
+      // `?status=all|draft|published` to widen. An invalid value is rejected
+      // with 400 rather than silently widened.
+      const status = parseStatusParam(p.status);
       // Forward the caller so the service can evaluate the Single's stored read
       // rules for them. Without it those rules cannot run at all: a rule that
       // asks who is reading has no one to judge, so the admin's read setting

--- a/packages/nextly/src/dispatcher/helpers/__tests__/parse-status-param.test.ts
+++ b/packages/nextly/src/dispatcher/helpers/__tests__/parse-status-param.test.ts
@@ -1,0 +1,40 @@
+/**
+ * `?status=` parsing contract: absent resolves to `undefined` (the query
+ * service then applies its published-only default), recognized values pass
+ * through, and an unrecognized value is REJECTED with a 400 rather than
+ * silently widened — so a typo can never change what a read returns.
+ */
+import { describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../../errors";
+import { parseStatusParam } from "../validation";
+
+describe("parseStatusParam", () => {
+  it("returns undefined when the param is absent (service applies its default)", () => {
+    expect(parseStatusParam(undefined)).toBeUndefined();
+    expect(parseStatusParam(null)).toBeUndefined();
+    expect(parseStatusParam("")).toBeUndefined();
+  });
+
+  it("passes recognized values through", () => {
+    expect(parseStatusParam("all")).toBe("all");
+    expect(parseStatusParam("draft")).toBe("draft");
+    expect(parseStatusParam("published")).toBe("published");
+  });
+
+  it("rejects an unrecognized value with a 400 validation error", () => {
+    let thrown: unknown;
+    try {
+      parseStatusParam("lol-injection");
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(NextlyError);
+    expect((thrown as NextlyError).statusCode).toBe(400);
+  });
+
+  it("rejects a near-miss typo rather than silently defaulting", () => {
+    expect(() => parseStatusParam("pubished")).toThrow(NextlyError);
+    expect(() => parseStatusParam("PUBLISHED")).toThrow(NextlyError);
+  });
+});

--- a/packages/nextly/src/dispatcher/helpers/validation.ts
+++ b/packages/nextly/src/dispatcher/helpers/validation.ts
@@ -8,7 +8,9 @@
  * logic.
  */
 
+import { NextlyError } from "../../errors";
 import type { RichTextOutputFormat } from "../../lib/rich-text-html";
+import type { StatusOption } from "../../lib/status-filter";
 import type { WhereFilter } from "../../services/collections/query-operators";
 import type { Params } from "../types";
 
@@ -193,6 +195,40 @@ export const parseRichTextFormat = (
     return normalized;
   }
   return undefined;
+};
+
+/**
+ * Parse the `?status=` read filter. Absent (or empty) resolves to `undefined`,
+ * so the query service applies its published-only default for untrusted callers
+ * (a trusted `overrideAccess` call still sees every status). A recognized value
+ * passes through. An UNRECOGNIZED value is REJECTED with a 400 rather than
+ * silently widened to "all" or narrowed to the default — silent widening on bad
+ * input is a draft-leak, and a typo must never quietly change what a read
+ * returns.
+ */
+export const parseStatusParam = (
+  statusParam?: unknown
+): StatusOption | undefined => {
+  if (statusParam === undefined || statusParam === null || statusParam === "") {
+    return undefined;
+  }
+  if (
+    statusParam === "all" ||
+    statusParam === "draft" ||
+    statusParam === "published"
+  ) {
+    return statusParam;
+  }
+  throw NextlyError.validation({
+    errors: [
+      {
+        path: "status",
+        code: "INVALID_VALUE",
+        message: 'Invalid status filter. Use "all", "draft", or "published".',
+      },
+    ],
+    logContext: { param: "status", value: statusParam },
+  });
 };
 
 /**


### PR DESCRIPTION
## What

Settles the `?status=` REST read contract (task 003, founder decision **Option A + reject-invalid-400**).

Before this PR the collection/single dispatcher coerced a **missing or invalid** `?status=` to `"all"`, and `resolveStatusFilter` treats explicit `"all"` as "no filter" — so **every** REST list/get/count read returned drafts by default, to any caller including anonymous. Five contract tests were left red to force this decision.

## Contract (decided)

- **Absent `?status=` → published-only** for every HTTP caller. Drafts only when you pass `?status=all|draft|published`. Trusted Direct API (`overrideAccess`) still sees every status.
- **Invalid `?status=` (e.g. a typo) → `400 VALIDATION_ERROR`**, never silently widened to `all`. Silent widening on bad input was the worse half of the bug.

## How

- New shared `parseStatusParam` (`dispatcher/helpers/validation.ts`): absent → `undefined` (the query service applies its published-only default), valid → passthrough, invalid → `NextlyError.validation` (400). Unit-tested.
- Wired at all four read sites: collection list / get / count + single get.
- Admin (`entryApi` + `EntryList` + `RelationshipSearch`) now sends `?status=all` explicitly, so editors and relationship pickers still see drafts. The status dropdown still narrows via `where` on top.
- The five baseline red tests reconciled to the decided contract (absent → `undefined`/published default; invalid → 400, service never queried).
- REST docs get a `?status=` section; changeset flags the behavior change.

## Scope note

Explicit-`?status=draft|all` **authorization** gating for untrusted callers is deferred to Stage B (task 035). This PR settles the DEFAULT + invalid-input contract only.

## Tests

- `parse-status-param.test.ts` (new): absent/valid/invalid + 400.
- `collection-dispatcher-shapes` + `single-dispatcher-shapes`: 7 previously-red status tests now green (absent → undefined; invalid → rejects 400, service not called).
- Admin `entryApi` + `entryFilters` suites green.
- check-types + lint clean (nextly + admin). Zero new failures: the 4 remaining dispatcher-dir reds (`updateComponent`, `gates-on-live`, `newSchemaVersion`, `bare-preview`) are pre-existing baseline, red on `main` and untouched here.

Task 003 (`003-status-param-default-decision.md`); decision recorded there + in the baseline doc.