### PR TITLE
fix(nextly): classify polymorphic relationships as json-backed

### DIFF
--- a/.changeset/polymorphic-relationship-json.md
+++ b/.changeset/polymorphic-relationship-json.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+A single polymorphic relationship (one whose `relationTo` lists several collections) is now recognised as a JSON-backed field on the write path, matching how upload fields with the same shape are already treated. Its value reached the driver unserialized before, so writing one could fail.

--- a/packages/nextly/src/domains/collections/services/__tests__/json-field-classification.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/json-field-classification.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Which fields the write path treats as JSON-backed.
+ *
+ * The answer has to match how the column descriptor actually stores the value:
+ * a field classified as plain is handed to the driver as-is, so a value the
+ * column holds as JSON reaches it as a live object and the insert fails.
+ */
+import { describe, expect, it } from "vitest";
+
+import { isJsonFieldType } from "../collection-utils";
+
+describe("isJsonFieldType — relationships", () => {
+  it("treats a single relationship to one collection as plain", () => {
+    // Stored as the target's id, so there is nothing to serialize.
+    expect(isJsonFieldType("relationship", { relationTo: "posts" })).toBe(
+      false
+    );
+  });
+
+  it("treats a hasMany relationship as JSON", () => {
+    expect(
+      isJsonFieldType("relationship", { hasMany: true, relationTo: "posts" })
+    ).toBe(true);
+  });
+
+  it("treats a single POLYMORPHIC relationship as JSON", () => {
+    // Stored as `{relationTo, value}` rather than a bare id, so it needs the
+    // same serialization a hasMany relationship gets.
+    expect(
+      isJsonFieldType("relationship", { relationTo: ["posts", "pages"] })
+    ).toBe(true);
+  });
+
+  it("matches how upload already classifies the same shapes", () => {
+    // The two field types store polymorphic targets identically, so a rule
+    // that applied to one and not the other was an inconsistency.
+    for (const field of [
+      { relationTo: "media" },
+      { hasMany: true, relationTo: "media" },
+      { relationTo: ["media", "files"] },
+    ]) {
+      expect(
+        isJsonFieldType("relationship", field),
+        JSON.stringify(field)
+      ).toBe(isJsonFieldType("upload", field));
+    }
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -284,8 +284,6 @@ export interface TransitionAuthorization {
   } | null;
 }
 
-/** Whether a string is already the stored JSON representation of a value. */
-
 export class CollectionMutationService extends BaseService {
   constructor(
     adapter: DrizzleAdapter,
@@ -775,17 +773,6 @@ export class CollectionMutationService extends BaseService {
    * already-parsed values pass through; a parse failure keeps the raw string.
    * Never mutates the input.
    */
-  /**
-   * Stringify JSON-backed values so a raw insert never hands the driver a live
-   * object.
-   *
-   * Each dialect does something different with one: mysql2 expands an object
-   * into assignment syntax and an array into a value list, and node-postgres
-   * encodes an array as a PostgreSQL array literal rather than JSON. Only
-   * SQLite happens to stringify, which is why a suite running there alone
-   * cannot show the difference.
-   */
-
   private deserializeJsonFieldsForSnapshot(
     row: Record<string, unknown>,
     fields: FieldDefinition[]

--- a/packages/nextly/src/domains/collections/services/collection-utils.ts
+++ b/packages/nextly/src/domains/collections/services/collection-utils.ts
@@ -63,11 +63,19 @@ export function isJsonFieldType(
   if (
     (fieldType === "select" ||
       fieldType === "text" ||
-      fieldType === "number" ||
-      fieldType === "relationship") &&
+      fieldType === "number") &&
     field?.hasMany
   ) {
     return true;
+  }
+
+  // A relationship is JSON-backed when it holds many values OR when it is
+  // polymorphic, because a polymorphic target is stored as `{relationTo,
+  // value}` rather than a plain id — the same rule `upload` below already
+  // applies. Testing only `hasMany` left a single polymorphic relationship
+  // written to its JSON column as a live object.
+  if (fieldType === "relationship") {
+    return !!(field?.hasMany || Array.isArray(field?.relationTo));
   }
 
   if (fieldType === "upload") {


### PR DESCRIPTION
Follow-up to #350, from review comments that arrived as it merged.

## Polymorphic relationships were not classified as JSON-backed

`isJsonFieldType` returned true for a relationship only when `hasMany` was set. But a polymorphic relationship — one whose `relationTo` lists several collections — stores `{relationTo, value}` rather than a bare id, whether or not it holds many. So a single polymorphic relationship was handed to the driver as a live object.

The inconsistency is visible in the same function: `upload` already tested `Array.isArray(field?.relationTo)` for exactly this reason. `relationship` now applies the same rule, and a test asserts the two field types classify identical shapes identically, so they cannot drift apart again.

This is pre-existing rather than introduced by #350, but #350 made it easier to reach, since a declared default can now put such a value on the write path without the caller doing anything.

## Comment residue from narrowing #350

Two comments were left behind when the transactional serializer was removed:

- An orphan block describing `isParsableJson`, a helper that no longer exists.
- The serializer's own doc, which came to sit directly on `deserializeJsonFieldsForSnapshot` — describing stringifying values for an insert, the opposite of what that method does, and shadowing its accurate doc immediately above.

Both removed. The second is the one that mattered: tooling would have shown maintainers the wrong description, with dialect guidance for an operation that is no longer there.

## Testing

Four unit cases covering single, hasMany, and polymorphic relationships plus the upload-parity assertion. Verified as real regression coverage — reverting the classification change fails two of them.

`check-types` clean, lint clean, touched-area units unchanged against the pre-existing baseline.
