### PR TITLE
fix(nextly): retire insecure webhook-notification prebuilt hook

### DIFF
--- a/.changeset/retire-insecure-webhook-hook.md
+++ b/.changeset/retire-insecure-webhook-hook.md
@@ -1,0 +1,40 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Retire the insecure `webhook-notification` prebuilt hook
+
+The `webhook-notification` prebuilt hook (selectable in the Schema Builder's
+Hooks editor) delivered over a bare `fetch` with no SSRF protection, and its
+`secret` produced a base64 of the payload rather than a real HMAC. A signature
+that is not an HMAC gives a false sense of authenticity, so the hook is removed
+rather than left in place.
+
+Use Nextly's signed webhook system instead: add an endpoint under **Webhooks**
+in the admin. It delivers HMAC-signed, SSRF-guarded requests through the
+delivery engine.
+
+Migration: any collection that still has a stored `webhook-notification` hook
+degrades to a no-op after upgrade (the write path skips unknown hook ids and the
+admin hides the missing card), so content keeps saving. Re-create the
+notification as a Webhooks endpoint to restore delivery.

--- a/packages/admin/src/components/features/schema-builder/HooksEditor/utils/prebuiltHooks.ts
+++ b/packages/admin/src/components/features/schema-builder/HooksEditor/utils/prebuiltHooks.ts
@@ -79,25 +79,6 @@ const auditFieldsConfigSchema = z.object({
 });
 
 /**
- * Configuration schema for webhook notification hook.
- */
-const webhookNotificationConfigSchema = z.object({
-  url: z.string().url().describe("Webhook URL"),
-  includeData: z
-    .boolean()
-    .default(true)
-    .describe("Include document data in payload"),
-  operations: z
-    .array(z.enum(["create", "update", "delete"]))
-    .default(["create", "update"])
-    .describe("Operations that trigger the webhook"),
-  secret: z
-    .string()
-    .optional()
-    .describe("Secret key for signature verification"),
-});
-
-/**
  * Configuration schema for unique validation hook.
  */
 const uniqueValidationConfigSchema = z.object({
@@ -132,14 +113,6 @@ export const prebuiltHooks: PrebuiltHookConfig[] = [
     hookType: "beforeChange",
     category: "audit",
     configSchema: auditFieldsConfigSchema,
-  },
-  {
-    id: "webhook-notification",
-    name: "Send Webhook",
-    description: "Send HTTP POST notification to a URL when documents change",
-    hookType: "afterChange",
-    category: "notification",
-    configSchema: webhookNotificationConfigSchema,
   },
   {
     id: "unique-validation",

--- a/packages/nextly/src/hooks/__tests__/prebuilt-registry.test.ts
+++ b/packages/nextly/src/hooks/__tests__/prebuilt-registry.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for the prebuilt-hook registry.
+ *
+ * Guards the retirement of the insecure `webhook-notification` prebuilt hook:
+ * it shipped a bare (unsigned, non-SSRF-guarded) fetch and must not be
+ * selectable. The signed webhook engine (admin Webhooks + delivery service) is
+ * the sanctioned path for outbound notifications.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import type { StoredHookConfig } from "../../schemas/dynamic-collections/types";
+import { prebuiltHooks, getPrebuiltHook } from "../prebuilt";
+import { StoredHookExecutor } from "../stored-hook-executor";
+
+describe("prebuilt hooks registry", () => {
+  it("does not expose the retired webhook-notification hook", () => {
+    expect(getPrebuiltHook("webhook-notification")).toBeUndefined();
+    expect(prebuiltHooks.some(hook => hook.id === "webhook-notification")).toBe(
+      false
+    );
+  });
+
+  it("still exposes the safe prebuilt hooks", () => {
+    const ids = prebuiltHooks.map(hook => hook.id);
+    expect(ids).toEqual(
+      expect.arrayContaining(["auto-slug", "audit-fields", "unique-validation"])
+    );
+  });
+
+  it("skips a stored config that references the retired hook without firing or throwing", async () => {
+    // A collection created before the retirement may still carry a stored
+    // webhook-notification hook. It must degrade to a no-op, not crash the
+    // write path, so existing data keeps saving after upgrade.
+    const storedHooks: StoredHookConfig[] = [
+      {
+        hookId: "webhook-notification",
+        hookType: "afterChange",
+        enabled: true,
+        config: { url: "https://example.com/hook" },
+        order: 0,
+      },
+    ];
+
+    const executor = new StoredHookExecutor();
+    const result = await executor.execute("afterCreate", storedHooks, {
+      collection: "posts",
+      operation: "create",
+      data: { title: "My Post" },
+      context: {},
+    });
+
+    expect(result.skippedHookIds).toContain("webhook-notification");
+    expect(result.executedCount).toBe(0);
+    expect(result.data).toEqual({ title: "My Post" });
+  });
+});

--- a/packages/nextly/src/hooks/prebuilt/index.ts
+++ b/packages/nextly/src/hooks/prebuilt/index.ts
@@ -106,7 +106,7 @@ export interface PrebuiltHookConfig<TConfig = unknown> {
    * Unique identifier for this hook.
    * Used to reference the hook in stored configurations.
    *
-   * @example 'auto-slug', 'audit-fields', 'webhook-notification'
+   * @example 'auto-slug', 'audit-fields', 'unique-validation'
    */
   id: string;
 
@@ -388,153 +388,6 @@ export const auditFields: PrebuiltHookConfig<AuditFieldsConfig> = {
 };
 
 // ============================================================
-// Webhook Notification Hook
-// ============================================================
-
-/**
- * Configuration schema for webhook notification hook.
- */
-const webhookNotificationConfigSchema = z.object({
-  /**
-   * The URL to send the webhook POST request to.
-   */
-  url: z.string().url().describe("Webhook URL"),
-
-  /**
-   * Whether to include the document data in the webhook payload.
-   * @default true
-   */
-  includeData: z
-    .boolean()
-    .default(true)
-    .describe("Include document data in payload"),
-
-  /**
-   * Which operations should trigger the webhook.
-   * @default ['create', 'update']
-   */
-  operations: z
-    .array(z.enum(["create", "update", "delete"]))
-    .default(["create", "update"])
-    .describe("Operations that trigger the webhook"),
-
-  /**
-   * Optional secret key for webhook signature verification.
-   * If provided, adds an X-Webhook-Signature header.
-   */
-  secret: z
-    .string()
-    .optional()
-    .describe("Secret key for signature verification"),
-
-  /**
-   * Custom headers to include in the webhook request.
-   */
-  headers: z
-    .record(z.string(), z.string())
-    .optional()
-    .describe("Custom headers for the request"),
-});
-
-/**
- * Inferred type for webhook notification configuration.
- */
-export type WebhookNotificationConfig = z.infer<
-  typeof webhookNotificationConfigSchema
->;
-
-/**
- * Send Webhook Hook
- *
- * Sends an HTTP POST notification to a URL when documents change.
- * Useful for integrating with external services, Zapier, IFTTT, etc.
- *
- * **Runs on:** afterChange (after create and update)
- *
- * **Error Handling:** Webhook failures are logged but do not block
- * the operation. The primary database operation always succeeds.
- *
- * @example
- * ```typescript
- * // Configuration in Admin UI:
- * {
- *   url: 'https://hooks.example.com/nextly',
- *   includeData: true,
- *   operations: ['create', 'update']
- * }
- *
- * // Webhook payload:
- * {
- *   collection: 'posts',
- *   operation: 'create',
- *   timestamp: '2025-01-01T12:00:00.000Z',
- *   data: { id: '123', title: 'My Post', ... }
- * }
- * ```
- */
-export const webhookNotification: PrebuiltHookConfig<WebhookNotificationConfig> =
-  {
-    id: "webhook-notification",
-    name: "Send Webhook",
-    description: "Send HTTP POST notification to a URL when documents change",
-    hookType: "afterChange",
-    category: "notification",
-    configSchema: webhookNotificationConfigSchema,
-    execute: async (config, context) => {
-      const { url, includeData, operations, secret, headers } = config;
-
-      // Check if this operation should trigger the webhook
-      if (
-        !operations.includes(
-          context.operation as "create" | "update" | "delete"
-        )
-      ) {
-        return;
-      }
-
-      // Build the webhook payload
-      const payload = {
-        collection: context.collection,
-        operation: context.operation,
-        timestamp: new Date().toISOString(),
-        data: includeData ? context.data : undefined,
-      };
-
-      // Build request headers
-      const requestHeaders: Record<string, string> = {
-        "Content-Type": "application/json",
-        ...headers,
-      };
-
-      // Add signature header if secret is provided
-      if (secret) {
-        // Simple HMAC-like signature (in production, use crypto.createHmac)
-        // For now, we use a basic approach that can be enhanced later
-        const payloadString = JSON.stringify(payload);
-        requestHeaders["X-Webhook-Signature"] = `sha256=${Buffer.from(
-          payloadString + secret
-        ).toString("base64")}`;
-      }
-
-      try {
-        await fetch(url, {
-          method: "POST",
-          headers: requestHeaders,
-          body: JSON.stringify(payload),
-        });
-      } catch (error) {
-        // Log error but don't throw - webhooks should not block operations
-        console.error(
-          `[Nextly] Webhook failed for ${context.collection}:`,
-          error instanceof Error ? error.message : String(error)
-        );
-      }
-
-      // afterChange hooks don't return data
-    },
-  };
-
-// ============================================================
 // Unique Validation Hook
 // ============================================================
 
@@ -670,7 +523,6 @@ export const uniqueValidation: PrebuiltHookConfig<UniqueValidationConfig> = {
 export const prebuiltHooks: PrebuiltHookConfig<any>[] = [
   autoSlug,
   auditFields,
-  webhookNotification,
   uniqueValidation,
 ];
 

--- a/packages/nextly/src/schemas/dynamic-collections/types.ts
+++ b/packages/nextly/src/schemas/dynamic-collections/types.ts
@@ -289,7 +289,7 @@ export interface StoredHookConfig {
    * Reference to the pre-built hook ID.
    * Must match an ID in the prebuilt hooks registry.
    *
-   * @example 'auto-slug', 'audit-fields', 'webhook-notification'
+   * @example 'auto-slug', 'audit-fields', 'unique-validation'
    */
   hookId: string;
 
@@ -314,8 +314,8 @@ export interface StoredHookConfig {
    * // For auto-slug hook:
    * config: { sourceField: 'title', targetField: 'slug' }
    *
-   * // For webhook-notification hook:
-   * config: { url: 'https://example.com/webhook', events: ['create', 'update'] }
+   * // For unique-validation hook:
+   * config: { field: 'email', caseInsensitive: true }
    * ```
    */
   config: Record<string, unknown>;


### PR DESCRIPTION
## What

Retires the `webhook-notification` prebuilt hook from the core registry and the admin Schema Builder's Hooks editor. Part of task 031 (webhook cleanup batch), item 1 — reconciling the duplicate/insecure webhook paths.

## Why

The prebuilt hook was insecure and already selectable in the admin:

- **Bare `fetch`, no SSRF protection** — it POSTed to any configured URL directly (`hooks/prebuilt/index.ts`), unlike the signed engine which pins/guards outbound requests.
- **Fake signature** — with a `secret` set it sent `X-Webhook-Signature: sha256=base64(payload + secret)`, which is *not* an HMAC (the code comment admitted "Simple HMAC-like signature ... can be enhanced later"). A non-HMAC signature implies authenticity it does not provide, which is worse than none.

Nextly now ships a first-class, signed, SSRF-guarded webhook system (admin **Webhooks** + delivery engine). The insecure prebuilt hook is redundant with a weaker implementation, so per the founder decision it is removed rather than secured in place.

Note: the form-builder's own webhook handler (`plugin-form-builder/src/handlers/webhooks.ts`) already uses `safeFetch` + real HMAC-SHA256, so it is **not** affected here.

## Changes

- Remove `webhookNotification` (schema, type, hook, registry entry) from `packages/nextly/src/hooks/prebuilt/index.ts`.
- Remove its mirror from `packages/admin/.../HooksEditor/utils/prebuiltHooks.ts`.
- Update three doc `@example`s that referenced the retired hook id.
- Add `prebuilt-registry.test.ts`: the hook is gone from the registry, the safe hooks remain, and a **stored** `webhook-notification` config degrades to a no-op (executor skips unknown ids; the admin card already returns null) so existing content keeps saving after upgrade.

## Migration

Existing collections with a stored `webhook-notification` hook keep working (the hook silently stops firing). Re-create the notification as a **Webhooks** endpoint to restore signed delivery. Documented in the changeset.

## Notes

- The `notification` hook category constant is retained deliberately — `HookSelectorModal` skips empty categories (`hooks.length === 0 -> null`), so there is no empty-category UI, and the category is valid for a future signed notification hook. Removing it would widen the change across the modal's hardcoded category records for no user-visible benefit.

## Verification

- `pnpm --filter nextly check-types` / `lint` — clean.
- `pnpm --filter @nextlyhq/admin check-types` / `lint` — clean.
- New tests pass; no new failures vs the known baseline (the 2 red `hooks-integration` performance/timing tests fail identically on `main`).