### PR TITLE
fix(nextly): make core schema reconciliation idempotent

### DIFF
--- a/.changeset/core-reconcile-idempotency.md
+++ b/.changeset/core-reconcile-idempotency.md
@@ -22,4 +22,4 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-`nextly migrate` can be run more than once against MySQL and PostgreSQL. The core schema comparison read several dialect spellings of the same value as differences — MySQL booleans, its `now()`/`CURRENT_TIMESTAMP` defaults, and PostgreSQL serial sequence defaults — so a second run reported changes to the schema the first run had just written and refused to proceed.
+`nextly migrate` can be run more than once against MySQL and PostgreSQL. The core schema comparison read several dialect spellings of the same value as differences — MySQL booleans, its `now()`/`CURRENT_TIMESTAMP` defaults, and PostgreSQL serial sequence defaults — so a second run reported changes to the schema the first run had just written and refused to proceed. A `nextval()` default over any sequence other than the one its column owns is still reported as a change.

--- a/.changeset/core-reconcile-idempotency.md
+++ b/.changeset/core-reconcile-idempotency.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+`nextly migrate` can be run more than once against MySQL and PostgreSQL. The core schema comparison read several dialect spellings of the same value as differences — MySQL booleans, its `now()`/`CURRENT_TIMESTAMP` defaults, and PostgreSQL serial sequence defaults — so a second run reported changes to the schema the first run had just written and refused to proceed.

--- a/packages/nextly/src/domains/schema/migrate/core-reconcile-idempotency.integration.test.ts
+++ b/packages/nextly/src/domains/schema/migrate/core-reconcile-idempotency.integration.test.ts
@@ -1,0 +1,66 @@
+/**
+ * `reconcileCore` provisions the core schema by diffing the canonical
+ * definition against live introspection, so running it a second time against
+ * its own output must be a no-op.
+ *
+ * It was not, on MySQL. The second run reported a type change for all 23
+ * boolean columns and a default change for every timestamp and boolean, then
+ * refused the apply as destructive — so `nextly migrate` succeeded once and
+ * then failed against the schema it had just written, advising a version
+ * mismatch. The causes were dialect spellings of the same thing: MySQL has no
+ * boolean type (`BOOL`/`BOOLEAN` are `TINYINT(1)`), reports `now()` where the
+ * schema authored `CURRENT_TIMESTAMP`, and stores boolean defaults as 1/0.
+ *
+ * Asserted per dialect because that is where the difference lives; each leg
+ * self-skips when its URL is unset, per the integration convention.
+ */
+import { describe, expect, it } from "vitest";
+
+import { createAdapter } from "../../../database/factory";
+import type { SupportedDialect } from "../../../types/database";
+import { getSchemaEventsDdl } from "../events/schema-events-ddl";
+
+import { reconcileCore } from "./core-reconcile";
+
+type Leg = { dialect: SupportedDialect; url: string | undefined };
+
+const LEGS: Leg[] = [
+  { dialect: "postgresql", url: process.env.TEST_POSTGRES_URL },
+  { dialect: "mysql", url: process.env.TEST_MYSQL_URL },
+];
+
+for (const { dialect, url } of LEGS) {
+  describe.skipIf(!url)(`reconcileCore idempotency (${dialect})`, () => {
+    it("reports no change on a second run", async () => {
+      process.env.DB_DIALECT = dialect;
+      const adapter = await createAdapter({
+        type: dialect,
+        url,
+      } as Parameters<typeof createAdapter>[0]);
+
+      const ensureLedger = async (): Promise<void> => {
+        if (!(await adapter.tableExists("nextly_schema_events"))) {
+          for (const stmt of getSchemaEventsDdl(dialect)) {
+            await adapter.executeQuery(stmt);
+          }
+        }
+      };
+      const run = (): Promise<{ changed: boolean }> =>
+        reconcileCore({
+          db: adapter.getDrizzle(),
+          dialect,
+          logger: { info: () => {}, warn: () => {} },
+          ensureLedger,
+        });
+
+      // First run provisions the schema.
+      await run();
+
+      // Second run sees its own output. Anything other than "unchanged" means
+      // the differ disagrees with what the applier just wrote — and because
+      // the core diff refuses destructive ops, that disagreement is fatal
+      // rather than cosmetic.
+      await expect(run()).resolves.toEqual({ changed: false });
+    });
+  });
+}

--- a/packages/nextly/src/domains/schema/migrate/core-reconcile-idempotency.integration.test.ts
+++ b/packages/nextly/src/domains/schema/migrate/core-reconcile-idempotency.integration.test.ts
@@ -38,26 +38,41 @@ async function secondRunChanged(
   // integration files sequentially in one process.
   const prevUrl = process.env.DATABASE_URL;
   const prevDialect = process.env.DB_DIALECT;
-  process.env.DATABASE_URL = url;
-  process.env.DB_DIALECT = dialect;
+  // A variable that was absent has to be removed again, not assigned back:
+  // `process.env.X = undefined` stores the string "undefined", which the
+  // suites that follow in this same process would read as a configured value.
+  const restoreEnv = (): void => {
+    if (prevUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = prevUrl;
+    if (prevDialect === undefined) delete process.env.DB_DIALECT;
+    else process.env.DB_DIALECT = prevDialect;
+  };
 
-  const adapter = await createAdapter({
-    type: dialect,
-    url,
-  } as Parameters<typeof createAdapter>[0]);
+  // Declared outside the try so a failure while constructing the adapter still
+  // restores the environment, and so cleanup skips a pool that never existed.
+  let adapter: Awaited<ReturnType<typeof createAdapter>> | undefined;
   try {
+    process.env.DATABASE_URL = url;
+    process.env.DB_DIALECT = dialect;
+
+    const connected = await createAdapter({
+      type: dialect,
+      url,
+    } as Parameters<typeof createAdapter>[0]);
+    adapter = connected;
+
     // Mirrors how `nextly migrate` bootstraps the ledger: only when it is not
     // already there. Creating it unconditionally re-runs its CREATE INDEX and
     // fails on the second pass.
     const ensureLedger = async (): Promise<void> => {
-      if (await adapter.tableExists("nextly_schema_events")) return;
+      if (await connected.tableExists("nextly_schema_events")) return;
       for (const stmt of getSchemaEventsDdl(dialect)) {
-        await adapter.executeQuery(stmt);
+        await connected.executeQuery(stmt);
       }
     };
     const run = (): Promise<{ changed: boolean }> =>
       reconcileCore({
-        db: adapter.getDrizzle(),
+        db: connected.getDrizzle(),
         dialect,
         logger: { info: () => {}, warn: () => {} },
         ensureLedger,
@@ -72,9 +87,8 @@ async function secondRunChanged(
   } finally {
     // The pool would otherwise stay open for the rest of the run, which is a
     // single process shared with every other integration file.
-    await adapter.disconnect?.();
-    process.env.DATABASE_URL = prevUrl;
-    process.env.DB_DIALECT = prevDialect;
+    await adapter?.disconnect?.();
+    restoreEnv();
   }
 }
 
@@ -85,16 +99,16 @@ describe.skipIf(!process.env.TEST_POSTGRES_URL)(
       const admin = new Pool({
         connectionString: process.env.TEST_POSTGRES_URL,
       });
-      await admin.query(`DROP DATABASE IF EXISTS ${DB_NAME}`);
-      await admin.query(`CREATE DATABASE ${DB_NAME}`);
-      const url = new URL(process.env.TEST_POSTGRES_URL as string);
-      url.pathname = `/${DB_NAME}`;
-      const pool = new Pool({ connectionString: url.toString() });
+      // Everything after the connection runs inside the try, so a failure
+      // while creating the database still drops it and closes the pool.
       try {
+        await admin.query(`DROP DATABASE IF EXISTS ${DB_NAME}`);
+        await admin.query(`CREATE DATABASE ${DB_NAME}`);
+        const url = new URL(process.env.TEST_POSTGRES_URL as string);
+        url.pathname = `/${DB_NAME}`;
         const changed = await secondRunChanged(url.toString(), "postgresql");
         expect(changed).toBe(false);
       } finally {
-        await pool.end();
         await admin.query(`DROP DATABASE IF EXISTS ${DB_NAME}`).catch(() => {});
         await admin.end();
       }
@@ -107,16 +121,16 @@ describe.skipIf(!process.env.TEST_MYSQL_URL)(
   () => {
     it("reports no change on a second run", async () => {
       const admin = createPool({ uri: process.env.TEST_MYSQL_URL });
-      await admin.promise().query(`DROP DATABASE IF EXISTS ${DB_NAME}`);
-      await admin.promise().query(`CREATE DATABASE ${DB_NAME}`);
-      const url = new URL(process.env.TEST_MYSQL_URL as string);
-      url.pathname = `/${DB_NAME}`;
-      const pool = createPool({ uri: url.toString() });
+      // Everything after the connection runs inside the try, so a failure
+      // while creating the database still drops it and closes the pool.
       try {
+        await admin.promise().query(`DROP DATABASE IF EXISTS ${DB_NAME}`);
+        await admin.promise().query(`CREATE DATABASE ${DB_NAME}`);
+        const url = new URL(process.env.TEST_MYSQL_URL as string);
+        url.pathname = `/${DB_NAME}`;
         const changed = await secondRunChanged(url.toString(), "mysql");
         expect(changed).toBe(false);
       } finally {
-        await new Promise<void>(res => pool.end(() => res()));
         await admin
           .promise()
           .query(`DROP DATABASE IF EXISTS ${DB_NAME}`)

--- a/packages/nextly/src/domains/schema/migrate/core-reconcile-idempotency.integration.test.ts
+++ b/packages/nextly/src/domains/schema/migrate/core-reconcile-idempotency.integration.test.ts
@@ -7,60 +7,122 @@
  * boolean columns and a default change for every timestamp and boolean, then
  * refused the apply as destructive — so `nextly migrate` succeeded once and
  * then failed against the schema it had just written, advising a version
- * mismatch. The causes were dialect spellings of the same thing: MySQL has no
- * boolean type (`BOOL`/`BOOLEAN` are `TINYINT(1)`), reports `now()` where the
- * schema authored `CURRENT_TIMESTAMP`, and stores boolean defaults as 1/0.
+ * mismatch. PostgreSQL had a narrower version of the same problem through
+ * serial columns' sequence defaults.
  *
- * Asserted per dialect because that is where the difference lives; each leg
- * self-skips when its URL is unset, per the integration convention.
+ * Each dialect gets its OWN database, created and dropped here. The property
+ * under test is "the core schema agrees with itself", which only holds for a
+ * database nothing else has touched — the shared integration database is
+ * mutated by the ~160 suites that run alongside this one.
  */
+import { createPool } from "mysql2";
+import { Pool } from "pg";
 import { describe, expect, it } from "vitest";
 
 import { createAdapter } from "../../../database/factory";
-import type { SupportedDialect } from "../../../types/database";
 import { getSchemaEventsDdl } from "../events/schema-events-ddl";
 
 import { reconcileCore } from "./core-reconcile";
 
-type Leg = { dialect: SupportedDialect; url: string | undefined };
+const DB_NAME = "nextly_core_idem";
 
-const LEGS: Leg[] = [
-  { dialect: "postgresql", url: process.env.TEST_POSTGRES_URL },
-  { dialect: "mysql", url: process.env.TEST_MYSQL_URL },
-];
+/** Run reconcileCore twice and return whether the second run saw a change. */
+async function secondRunChanged(
+  url: string,
+  dialect: "postgresql" | "mysql"
+): Promise<boolean> {
+  // The adapter is handed its URL explicitly, but creating it reads pool
+  // settings through the lazy env proxy, whose validation requires
+  // DATABASE_URL. The canonical root scripts set only the TEST_* URL, so this
+  // leg supplies it — and restores both afterwards, since the package runs its
+  // integration files sequentially in one process.
+  const prevUrl = process.env.DATABASE_URL;
+  const prevDialect = process.env.DB_DIALECT;
+  process.env.DATABASE_URL = url;
+  process.env.DB_DIALECT = dialect;
 
-for (const { dialect, url } of LEGS) {
-  describe.skipIf(!url)(`reconcileCore idempotency (${dialect})`, () => {
-    it("reports no change on a second run", async () => {
-      process.env.DB_DIALECT = dialect;
-      const adapter = await createAdapter({
-        type: dialect,
-        url,
-      } as Parameters<typeof createAdapter>[0]);
+  const adapter = await createAdapter({
+    type: dialect,
+    url,
+  } as Parameters<typeof createAdapter>[0]);
+  try {
+    // Mirrors how `nextly migrate` bootstraps the ledger: only when it is not
+    // already there. Creating it unconditionally re-runs its CREATE INDEX and
+    // fails on the second pass.
+    const ensureLedger = async (): Promise<void> => {
+      if (await adapter.tableExists("nextly_schema_events")) return;
+      for (const stmt of getSchemaEventsDdl(dialect)) {
+        await adapter.executeQuery(stmt);
+      }
+    };
+    const run = (): Promise<{ changed: boolean }> =>
+      reconcileCore({
+        db: adapter.getDrizzle(),
+        dialect,
+        logger: { info: () => {}, warn: () => {} },
+        ensureLedger,
+      });
 
-      const ensureLedger = async (): Promise<void> => {
-        if (!(await adapter.tableExists("nextly_schema_events"))) {
-          for (const stmt of getSchemaEventsDdl(dialect)) {
-            await adapter.executeQuery(stmt);
-          }
-        }
-      };
-      const run = (): Promise<{ changed: boolean }> =>
-        reconcileCore({
-          db: adapter.getDrizzle(),
-          dialect,
-          logger: { info: () => {}, warn: () => {} },
-          ensureLedger,
-        });
-
-      // First run provisions the schema.
-      await run();
-
-      // Second run sees its own output. Anything other than "unchanged" means
-      // the differ disagrees with what the applier just wrote — and because
-      // the core diff refuses destructive ops, that disagreement is fatal
-      // rather than cosmetic.
-      await expect(run()).resolves.toEqual({ changed: false });
-    });
-  });
+    await run();
+    // The second run sees the first run's output. Anything other than
+    // "unchanged" means the differ disagrees with what the applier wrote — and
+    // because the core diff refuses destructive ops, that disagreement is
+    // fatal rather than cosmetic.
+    return (await run()).changed;
+  } finally {
+    // The pool would otherwise stay open for the rest of the run, which is a
+    // single process shared with every other integration file.
+    await adapter.disconnect?.();
+    process.env.DATABASE_URL = prevUrl;
+    process.env.DB_DIALECT = prevDialect;
+  }
 }
+
+describe.skipIf(!process.env.TEST_POSTGRES_URL)(
+  "reconcileCore idempotency (postgresql)",
+  () => {
+    it("reports no change on a second run", async () => {
+      const admin = new Pool({
+        connectionString: process.env.TEST_POSTGRES_URL,
+      });
+      await admin.query(`DROP DATABASE IF EXISTS ${DB_NAME}`);
+      await admin.query(`CREATE DATABASE ${DB_NAME}`);
+      const url = new URL(process.env.TEST_POSTGRES_URL as string);
+      url.pathname = `/${DB_NAME}`;
+      const pool = new Pool({ connectionString: url.toString() });
+      try {
+        const changed = await secondRunChanged(url.toString(), "postgresql");
+        expect(changed).toBe(false);
+      } finally {
+        await pool.end();
+        await admin.query(`DROP DATABASE IF EXISTS ${DB_NAME}`).catch(() => {});
+        await admin.end();
+      }
+    });
+  }
+);
+
+describe.skipIf(!process.env.TEST_MYSQL_URL)(
+  "reconcileCore idempotency (mysql)",
+  () => {
+    it("reports no change on a second run", async () => {
+      const admin = createPool({ uri: process.env.TEST_MYSQL_URL });
+      await admin.promise().query(`DROP DATABASE IF EXISTS ${DB_NAME}`);
+      await admin.promise().query(`CREATE DATABASE ${DB_NAME}`);
+      const url = new URL(process.env.TEST_MYSQL_URL as string);
+      url.pathname = `/${DB_NAME}`;
+      const pool = createPool({ uri: url.toString() });
+      try {
+        const changed = await secondRunChanged(url.toString(), "mysql");
+        expect(changed).toBe(false);
+      } finally {
+        await new Promise<void>(res => pool.end(() => res()));
+        await admin
+          .promise()
+          .query(`DROP DATABASE IF EXISTS ${DB_NAME}`)
+          .catch(() => {});
+        await new Promise<void>(res => admin.end(() => res()));
+      }
+    });
+  }
+);

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-default.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-default.test.ts
@@ -267,6 +267,36 @@ describe("normalizeDefault — MySQL equivalences", () => {
     );
   });
 
+  it("ignores whitespace inside the call", () => {
+    // Insignificant to every dialect, but not to the string compare the diff
+    // performs, so a hand-written spacing must reduce to the same token.
+    for (const spelling of [
+      "CURRENT_TIMESTAMP ( 3 )",
+      "current_timestamp(3 )",
+      "current_timestamp (3)",
+    ]) {
+      expect(normalizeDefault(spelling), spelling).toBe(
+        normalizeDefault("now(3)")
+      );
+    }
+    expect(normalizeDefault("now ( 3 )")).toBe(normalizeDefault("now(3)"));
+  });
+
+  it("treats a no-argument call as the bare keyword", () => {
+    // MySQL accepts `CURRENT_TIMESTAMP()`, which denotes exactly what the
+    // bare keyword does.
+    expect(normalizeDefault("CURRENT_TIMESTAMP()")).toBe(
+      normalizeDefault("now()")
+    );
+    expect(normalizeDefault("current_timestamp( )")).toBe("now()");
+  });
+
+  it("leaves a bare `now` alone", () => {
+    // Not callable without parentheses in any supported dialect, so an
+    // expression spelling it that way denotes something else.
+    expect(normalizeDefault("now")).toBe("now");
+  });
+
   it("reads 1 and 0 as booleans on a boolean column", () => {
     // MySQL booleans ARE tinyint(1), so a boolean default comes back as 1/0
     // where the schema authored true/false.

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-default.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-default.test.ts
@@ -233,9 +233,62 @@ describe("normalizeDefault — passthrough behaviour", () => {
     expect(normalizeDefault("some_unknown_expr(1,2)")).toBe(
       "some_unknown_expr(1,2)"
     );
-    // Keywords now normalise to lower case, because the dialects report them
-    // back in whatever case they choose. Non-keyword expressions still pass
-    // through untouched, which is what this case is really guarding.
-    expect(normalizeDefault("CURRENT_TIMESTAMP")).toBe("current_timestamp");
+    // Keywords normalise to lower case, because the dialects report them back
+    // in whatever case they choose. Non-keyword expressions still pass through
+    // untouched, which is what this case is really guarding.
+    expect(normalizeDefault("MyFunc()")).toBe("MyFunc()");
+  });
+});
+
+/**
+ * MySQL reports defaults for the schema this project itself writes in forms
+ * the desired side never spells that way, which made the core reconciler emit
+ * a default change for every timestamp and boolean column — so `nextly
+ * migrate` applied once and then refused to run again against its own output.
+ */
+describe("normalizeDefault — MySQL equivalences", () => {
+  it("treats current_timestamp and now() as the same default", () => {
+    expect(normalizeDefault("CURRENT_TIMESTAMP")).toBe(
+      normalizeDefault("now()")
+    );
+    expect(normalizeDefault("current_timestamp")).toBe("now()");
+  });
+
+  it("carries a precision argument across the collapse", () => {
+    // A DATETIME(3) column authored `CURRENT_TIMESTAMP(3)` reads back from
+    // MySQL as `now(3)`.
+    expect(normalizeDefault("CURRENT_TIMESTAMP(3)")).toBe(
+      normalizeDefault("now(3)")
+    );
+    // Precision is part of the value, so it is not discarded: a column
+    // defaulting to whole seconds is not the same as one keeping millis.
+    expect(normalizeDefault("current_timestamp(3)")).not.toBe(
+      normalizeDefault("now()")
+    );
+  });
+
+  it("reads 1 and 0 as booleans on a boolean column", () => {
+    // MySQL booleans ARE tinyint(1), so a boolean default comes back as 1/0
+    // where the schema authored true/false.
+    expect(normalizeDefault("1", "tinyint(1)")).toBe(
+      normalizeDefault("true", "boolean")
+    );
+    expect(normalizeDefault("0", "tinyint(1)")).toBe(
+      normalizeDefault("false", "boolean")
+    );
+  });
+
+  it("does not read 1 as a boolean on an integer column", () => {
+    // The whole point of passing the type: on an int column `1` is the
+    // number, and collapsing it would hide a real default change.
+    expect(normalizeDefault("1", "int")).not.toBe(
+      normalizeDefault("true", "boolean")
+    );
+    expect(normalizeDefault("1", "int")).toBe("1");
+  });
+
+  it("still normalises a boolean default when no type is supplied", () => {
+    // Without a type the literal is left alone rather than guessed at.
+    expect(normalizeDefault("1")).toBe("1");
   });
 });

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-type.mysql.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-type.mysql.test.ts
@@ -23,6 +23,14 @@ describe("normalizeType — MySQL booleans", () => {
     expect(normalizeType("  TINYINT(1) ")).toBe(normalizeType("boolean"));
   });
 
+  it("is not confused by whitespace inside the width", () => {
+    // Insignificant to the engine but not to a string compare, and the
+    // fallback below would strip the width and leave a plain `tinyint`.
+    for (const t of ["TINYINT ( 1 )", "tinyint( 1 )", "tinyint (1)"]) {
+      expect(normalizeType(t), t).toBe(normalizeType("boolean"));
+    }
+  });
+
   it("keeps a plain tinyint distinct from a boolean", () => {
     // A one-byte integer, not a boolean — MySQL 8 reports it as `tinyint`
     // with no width, which is exactly what distinguishes the two.

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-type.mysql.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/normalize-type.mysql.test.ts
@@ -1,0 +1,45 @@
+/**
+ * MySQL has no boolean type. `BOOL` and `BOOLEAN` are synonyms for
+ * `TINYINT(1)`, and introspection reports all three as `tinyint(1)` — verified
+ * against MySQL 8: a table declared with BOOLEAN, BOOL, and TINYINT(1) columns
+ * reports the identical `COLUMN_TYPE` for each.
+ *
+ * Without collapsing them, the core differ compared the live `tinyint(1)`
+ * against the desired `boolean` and reported a type change for every boolean
+ * column in the schema — so `nextly migrate` succeeded once and then refused
+ * to run again, calling its own output a destructive change.
+ */
+import { describe, expect, it } from "vitest";
+
+import { normalizeType } from "../normalize-type";
+
+describe("normalizeType — MySQL booleans", () => {
+  it("treats tinyint(1) and boolean as the same type", () => {
+    expect(normalizeType("tinyint(1)")).toBe(normalizeType("boolean"));
+    expect(normalizeType("tinyint(1)")).toBe(normalizeType("bool"));
+  });
+
+  it("is not confused by case or surrounding whitespace", () => {
+    expect(normalizeType("  TINYINT(1) ")).toBe(normalizeType("boolean"));
+  });
+
+  it("keeps a plain tinyint distinct from a boolean", () => {
+    // A one-byte integer, not a boolean — MySQL 8 reports it as `tinyint`
+    // with no width, which is exactly what distinguishes the two.
+    expect(normalizeType("tinyint")).not.toBe(normalizeType("boolean"));
+  });
+
+  it("keeps an unsigned tinyint(1) distinct", () => {
+    // Not what the boolean synonym produces, so collapsing it would hide a
+    // real difference rather than a cosmetic one.
+    expect(normalizeType("tinyint(1) unsigned")).not.toBe(
+      normalizeType("boolean")
+    );
+  });
+
+  it("leaves the other integer widths alone", () => {
+    for (const t of ["smallint", "mediumint", "int", "bigint"]) {
+      expect(normalizeType(t), t).not.toBe(normalizeType("boolean"));
+    }
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/pg-sequence-ownership.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/pg-sequence-ownership.integration.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Which `nextval()` defaults the snapshot marks as owned.
+ *
+ * A `serial` column's default is the sequence PostgreSQL creates and gives it;
+ * the diff suppresses that one, because the desired side never spells it. Any
+ * other `nextval()` default was pointed there deliberately and has to keep
+ * being reported — and the two are indistinguishable by expression, since a
+ * serial column can be repointed at a foreign sequence and still read as
+ * `nextval('...'::regclass)`.
+ *
+ * Ownership is therefore read from the server rather than inferred from the
+ * shape of the default, and this suite is what proves the reading is right.
+ */
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { introspectLiveSnapshot } from "../introspect-live";
+import type { ColumnSpec } from "../types";
+
+const SERIAL_TABLE = "nextly_seqown_serial";
+const REPOINTED_TABLE = "nextly_seqown_repointed";
+const CUSTOM_SEQUENCE = "nextly_seqown_custom_seq";
+const TABLES = [SERIAL_TABLE, REPOINTED_TABLE];
+
+describe.skipIf(!process.env.TEST_POSTGRES_URL)(
+  "postgres sequence-default ownership",
+  () => {
+    let pool: Pool;
+    let columns: Map<string, ColumnSpec>;
+
+    beforeAll(async () => {
+      pool = new Pool({ connectionString: process.env.TEST_POSTGRES_URL });
+      await pool.query(`DROP TABLE IF EXISTS "${SERIAL_TABLE}" CASCADE`);
+      await pool.query(`DROP TABLE IF EXISTS "${REPOINTED_TABLE}" CASCADE`);
+      await pool.query(`DROP SEQUENCE IF EXISTS "${CUSTOM_SEQUENCE}" CASCADE`);
+
+      await pool.query(`CREATE SEQUENCE "${CUSTOM_SEQUENCE}"`);
+      // Owns its sequence, and draws from it: what `serial` produces.
+      await pool.query(
+        `CREATE TABLE "${SERIAL_TABLE}" (id serial PRIMARY KEY, n integer)`
+      );
+      // Still owns a sequence, but its default draws from another one. The
+      // expression is identical in shape to the case above.
+      await pool.query(
+        `CREATE TABLE "${REPOINTED_TABLE}" (id serial PRIMARY KEY)`
+      );
+      await pool.query(
+        `ALTER TABLE "${REPOINTED_TABLE}"
+           ALTER COLUMN id SET DEFAULT nextval('${CUSTOM_SEQUENCE}')`
+      );
+
+      const live = await introspectLiveSnapshot(
+        drizzle({ client: pool }),
+        "postgresql",
+        TABLES
+      );
+      columns = new Map(
+        live.tables.flatMap(t => t.columns.map(c => [`${t.name}.${c.name}`, c]))
+      );
+    });
+
+    afterAll(async () => {
+      await pool.query(`DROP TABLE IF EXISTS "${SERIAL_TABLE}" CASCADE`);
+      await pool.query(`DROP TABLE IF EXISTS "${REPOINTED_TABLE}" CASCADE`);
+      await pool
+        .query(`DROP SEQUENCE IF EXISTS "${CUSTOM_SEQUENCE}" CASCADE`)
+        .catch(() => {});
+      await pool.end();
+    });
+
+    it("marks a serial column's own sequence as owned", () => {
+      const id = columns.get(`${SERIAL_TABLE}.id`);
+      expect(id?.default).toMatch(/^nextval\(/);
+      expect(id?.ownedSequenceDefault).toBe(true);
+    });
+
+    it("does not mark a sequence the column does not own", () => {
+      // The reason ownership is read from the server: this default is the
+      // same shape as the one above and must still be reconciled.
+      const id = columns.get(`${REPOINTED_TABLE}.id`);
+      expect(id?.default).toMatch(/^nextval\(/);
+      expect(id?.ownedSequenceDefault).toBeUndefined();
+    });
+
+    it("leaves a column with no default unmarked", () => {
+      const n = columns.get(`${SERIAL_TABLE}.n`);
+      expect(n?.default).toBeUndefined();
+      expect(n?.ownedSequenceDefault).toBeUndefined();
+    });
+  }
+);

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/serial-default.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/serial-default.test.ts
@@ -1,0 +1,76 @@
+/**
+ * A `serial` column's sequence default belongs to the type: PostgreSQL reports
+ * `nextval('<table>_id_seq'::regclass)` while the desired side declares no
+ * default at all. Read literally that is a default being dropped on every
+ * reconcile, so it is suppressed — but only while the column is still declared
+ * serial. A sequence default anywhere else was set deliberately, and removing
+ * it is a real change.
+ */
+import { describe, expect, it } from "vitest";
+
+import { diffSnapshots } from "../diff";
+import type { NextlySchemaSnapshot } from "../types";
+
+const NEXTVAL = "nextval('t_id_seq'::regclass)";
+
+function snapshot(
+  type: string,
+  columnDefault: string | undefined
+): NextlySchemaSnapshot {
+  return {
+    tables: [
+      {
+        name: "t",
+        columns: [
+          { name: "id", type, nullable: false, default: columnDefault },
+        ],
+        indexes: [],
+      },
+    ],
+  } as unknown as NextlySchemaSnapshot;
+}
+
+const defaultOps = (
+  live: NextlySchemaSnapshot,
+  desired: NextlySchemaSnapshot
+): unknown[] =>
+  diffSnapshots(live, desired).filter(
+    op => op.type === "change_column_default"
+  );
+
+describe("serial sequence defaults", () => {
+  it("does not report a change while the column is still serial", () => {
+    // The live side materialises what `serial` implies; the desired side
+    // never spells it.
+    expect(
+      defaultOps(snapshot("int4", NEXTVAL), snapshot("serial", undefined))
+    ).toHaveLength(0);
+  });
+
+  it("covers bigserial and smallserial", () => {
+    for (const [live, desired] of [
+      ["int8", "bigserial"],
+      ["int2", "smallserial"],
+    ]) {
+      expect(
+        defaultOps(snapshot(live, NEXTVAL), snapshot(desired, undefined)),
+        desired
+      ).toHaveLength(0);
+    }
+  });
+
+  it("reports the change when the column is no longer serial", () => {
+    // serial → integer drops the sequence. Suppressing this would leave the
+    // column drawing from it forever, and the type comparison cannot catch it
+    // because `serial` and `integer` share a storage type.
+    expect(
+      defaultOps(snapshot("int4", NEXTVAL), snapshot("integer", undefined))
+    ).toHaveLength(1);
+  });
+
+  it("still reports a sequence default replaced by a real one", () => {
+    expect(
+      defaultOps(snapshot("int4", NEXTVAL), snapshot("serial", "42"))
+    ).toHaveLength(1);
+  });
+});

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/serial-default.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/serial-default.test.ts
@@ -2,32 +2,34 @@
  * A `serial` column's sequence default belongs to the type: PostgreSQL reports
  * `nextval('<table>_id_seq'::regclass)` while the desired side declares no
  * default at all. Read literally that is a default being dropped on every
- * reconcile, so it is suppressed — but only while the column is still declared
- * serial. A sequence default anywhere else was set deliberately, and removing
- * it is a real change.
+ * reconcile, so it is suppressed — but only for the sequence the column owns,
+ * and only while the column is still declared serial. A sequence default
+ * pointed anywhere else was set deliberately, and removing it is a real
+ * change.
  */
 import { describe, expect, it } from "vitest";
 
 import { diffSnapshots } from "../diff";
-import type { NextlySchemaSnapshot } from "../types";
+import type { ColumnSpec, NextlySchemaSnapshot } from "../types";
 
-const NEXTVAL = "nextval('t_id_seq'::regclass)";
+/** What PostgreSQL renders for the sequence a `serial` column owns. */
+const OWNED_NEXTVAL = "nextval('t_id_seq'::regclass)";
+/** A sequence the column does not own, created and pointed at by hand. */
+const CUSTOM_NEXTVAL = "nextval('custom_seq'::regclass)";
 
 function snapshot(
   type: string,
-  columnDefault: string | undefined
+  columnDefault: string | undefined,
+  ownedSequenceDefault?: boolean
 ): NextlySchemaSnapshot {
-  return {
-    tables: [
-      {
-        name: "t",
-        columns: [
-          { name: "id", type, nullable: false, default: columnDefault },
-        ],
-        indexes: [],
-      },
-    ],
-  } as unknown as NextlySchemaSnapshot;
+  const column: ColumnSpec = {
+    name: "id",
+    type,
+    nullable: false,
+    default: columnDefault,
+  };
+  if (ownedSequenceDefault) column.ownedSequenceDefault = true;
+  return { tables: [{ name: "t", columns: [column], indexes: [] }] };
 }
 
 const defaultOps = (
@@ -43,7 +45,10 @@ describe("serial sequence defaults", () => {
     // The live side materialises what `serial` implies; the desired side
     // never spells it.
     expect(
-      defaultOps(snapshot("int4", NEXTVAL), snapshot("serial", undefined))
+      defaultOps(
+        snapshot("int4", OWNED_NEXTVAL, true),
+        snapshot("serial", undefined)
+      )
     ).toHaveLength(0);
   });
 
@@ -53,7 +58,10 @@ describe("serial sequence defaults", () => {
       ["int2", "smallserial"],
     ]) {
       expect(
-        defaultOps(snapshot(live, NEXTVAL), snapshot(desired, undefined)),
+        defaultOps(
+          snapshot(live, OWNED_NEXTVAL, true),
+          snapshot(desired, undefined)
+        ),
         desired
       ).toHaveLength(0);
     }
@@ -64,13 +72,44 @@ describe("serial sequence defaults", () => {
     // column drawing from it forever, and the type comparison cannot catch it
     // because `serial` and `integer` share a storage type.
     expect(
-      defaultOps(snapshot("int4", NEXTVAL), snapshot("integer", undefined))
+      defaultOps(
+        snapshot("int4", OWNED_NEXTVAL, true),
+        snapshot("integer", undefined)
+      )
     ).toHaveLength(1);
   });
 
   it("still reports a sequence default replaced by a real one", () => {
     expect(
-      defaultOps(snapshot("int4", NEXTVAL), snapshot("serial", "42"))
+      defaultOps(
+        snapshot("int4", OWNED_NEXTVAL, true),
+        snapshot("serial", "42")
+      )
+    ).toHaveLength(1);
+  });
+
+  it("reports a default drawing from a sequence the column does not own", () => {
+    // A serial column can be repointed at another sequence. The expression
+    // looks exactly like the implicit one, so only ownership separates them —
+    // and the desired side declaring no default means that repointing is
+    // being undone, which is a change the diff has to emit.
+    expect(
+      defaultOps(
+        snapshot("int4", CUSTOM_NEXTVAL, false),
+        snapshot("serial", undefined)
+      )
+    ).toHaveLength(1);
+  });
+
+  it("reports a sequence default on a snapshot that never recorded ownership", () => {
+    // Snapshots written before ownership was tracked carry no marker. They
+    // read as "not known to be owned", which costs a spurious op rather than
+    // a swallowed one.
+    expect(
+      defaultOps(
+        snapshot("int4", OWNED_NEXTVAL, undefined),
+        snapshot("serial", undefined)
+      )
     ).toHaveLength(1);
   });
 });

--- a/packages/nextly/src/domains/schema/pipeline/diff/diff.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/diff.ts
@@ -44,13 +44,6 @@ import type {
   TableSpec,
 } from "./types";
 
-/**
- * PostgreSQL's rendering of the default a `serial` column carries implicitly.
- * Matched rather than normalised because the two sides are not two spellings
- * of one value: the desired side has no default at all.
- */
-const SEQUENCE_DEFAULT = /^nextval\(/i;
-
 /** The declared types whose sequence default is part of the type itself. */
 const SERIAL_TYPES = new Set(["serial", "bigserial", "smallserial"]);
 
@@ -220,13 +213,17 @@ function diffColumns(
       // reports the materialised `nextval('<table>_id_seq'::regclass)`. Read
       // literally that is a default being removed on every reconcile.
       //
-      // Gated on the DESIRED column still being declared serial. A `nextval`
-      // default on any other column was set deliberately, and dropping it —
-      // by moving to a plain integer, say — is a real change that must still
-      // emit an op, or the column keeps drawing from the sequence forever.
+      // Two conditions, and both are needed. The live default must be over
+      // the sequence the column OWNS (see ColumnSpec.ownedSequenceDefault) —
+      // a `nextval` over any other sequence was pointed there deliberately
+      // and is a real default. And the DESIRED column must still be declared
+      // serial: moving to a plain integer drops the sequence, which the type
+      // comparison cannot catch because serial and integer share a storage
+      // type, so suppressing it would leave the column drawing from the
+      // sequence forever.
       const sequenceDefaultUnchanged =
         curC.default === undefined &&
-        SEQUENCE_DEFAULT.test(prevC.default ?? "") &&
+        prevC.ownedSequenceDefault === true &&
         SERIAL_TYPES.has((curC.type ?? "").trim().toLowerCase());
 
       if (

--- a/packages/nextly/src/domains/schema/pipeline/diff/diff.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/diff.ts
@@ -51,6 +51,9 @@ import type {
  */
 const SEQUENCE_DEFAULT = /^nextval\(/i;
 
+/** The declared types whose sequence default is part of the type itself. */
+const SERIAL_TYPES = new Set(["serial", "bigserial", "smallserial"]);
+
 export function diffSnapshots(
   prev: NextlySchemaSnapshot,
   cur: NextlySchemaSnapshot
@@ -216,9 +219,15 @@ function diffColumns(
       // to the type, so the desired side declares no default while PostgreSQL
       // reports the materialised `nextval('<table>_id_seq'::regclass)`. Read
       // literally that is a default being removed on every reconcile.
-      const prevIsSequenceDefault = SEQUENCE_DEFAULT.test(prevC.default ?? "");
+      //
+      // Gated on the DESIRED column still being declared serial. A `nextval`
+      // default on any other column was set deliberately, and dropping it —
+      // by moving to a plain integer, say — is a real change that must still
+      // emit an op, or the column keeps drawing from the sequence forever.
       const sequenceDefaultUnchanged =
-        prevIsSequenceDefault && curC.default === undefined;
+        curC.default === undefined &&
+        SEQUENCE_DEFAULT.test(prevC.default ?? "") &&
+        SERIAL_TYPES.has((curC.type ?? "").trim().toLowerCase());
 
       if (
         !sequenceDefaultUnchanged &&

--- a/packages/nextly/src/domains/schema/pipeline/diff/diff.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/diff.ts
@@ -44,6 +44,13 @@ import type {
   TableSpec,
 } from "./types";
 
+/**
+ * PostgreSQL's rendering of the default a `serial` column carries implicitly.
+ * Matched rather than normalised because the two sides are not two spellings
+ * of one value: the desired side has no default at all.
+ */
+const SEQUENCE_DEFAULT = /^nextval\(/i;
+
 export function diffSnapshots(
   prev: NextlySchemaSnapshot,
   cur: NextlySchemaSnapshot
@@ -201,7 +208,23 @@ function diffColumns(
       // `'draft'`. See ./normalize-default.ts for the bounded set of
       // equivalences. The emitted op carries the original, un-normalised
       // values so downstream tooling sees what's actually stored.
-      if (normalizeDefault(prevC.default) !== normalizeDefault(curC.default)) {
+      // The column type is passed so a boolean default compares by meaning:
+      // MySQL stores booleans as tinyint(1) and reports 1/0 where the schema
+      // authored true/false.
+      //
+      // A serial column is the other asymmetry: its sequence default belongs
+      // to the type, so the desired side declares no default while PostgreSQL
+      // reports the materialised `nextval('<table>_id_seq'::regclass)`. Read
+      // literally that is a default being removed on every reconcile.
+      const prevIsSequenceDefault = SEQUENCE_DEFAULT.test(prevC.default ?? "");
+      const sequenceDefaultUnchanged =
+        prevIsSequenceDefault && curC.default === undefined;
+
+      if (
+        !sequenceDefaultUnchanged &&
+        normalizeDefault(prevC.default, prevC.type) !==
+          normalizeDefault(curC.default, curC.type)
+      ) {
         defaultChanges.push({
           type: "change_column_default",
           tableName,

--- a/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
@@ -76,6 +76,7 @@ interface PgRow {
   udt_name: string;
   is_nullable: "YES" | "NO";
   column_default: string | null;
+  owned_sequence_default: boolean;
 }
 
 interface MysqlRow {
@@ -142,12 +143,34 @@ export async function introspectLiveSnapshot(
     // or "NO". column_default is the raw expression as written.
     //
     // drizzle-orm/node-postgres returns pg QueryResult { rows, rowCount, ... }.
+    // `owned_sequence_default` answers whether the default is the sequence
+    // this column owns, which is what `serial` materialises and the only
+    // sequence default the diff may treat as no default at all.
+    // `pg_get_serial_sequence` names the owned sequence (NULL when there is
+    // none); the substring pulls the sequence the default actually draws
+    // from. Both sides are cast to regclass so the comparison is by identity
+    // rather than by spelling — the default renders the name relative to the
+    // search path while the function returns it schema-qualified. Anything
+    // that is not exactly a `nextval()` call yields NULL from the substring
+    // and so falls to false, which is the safe direction: a default the diff
+    // does not recognise is reported, never swallowed.
     const result = (await dbTyped.execute(
-      sql`SELECT table_name, column_name, udt_name, is_nullable, column_default
-          FROM information_schema.columns
-          WHERE table_schema = 'public'
-            AND table_name IN (${tableNamesIn})
-          ORDER BY table_name, ordinal_position`
+      sql`SELECT c.table_name, c.column_name, c.udt_name, c.is_nullable,
+                 c.column_default,
+                 COALESCE(
+                   substring(
+                     c.column_default from '^nextval[(]''(.+)''::regclass[)]$'
+                   )::regclass
+                     = pg_get_serial_sequence(
+                         format('%I.%I', c.table_schema, c.table_name),
+                         c.column_name
+                       )::regclass,
+                   false
+                 ) AS owned_sequence_default
+          FROM information_schema.columns c
+          WHERE c.table_schema = 'public'
+            AND c.table_name IN (${tableNamesIn})
+          ORDER BY c.table_name, c.ordinal_position`
     )) as { rows: PgRow[] };
     const snapshot = buildSnapshotFromPgRows(result.rows);
     // Index query: join pg_index/pg_class/pg_attribute. Exclude primary keys
@@ -309,12 +332,16 @@ function buildSnapshotFromPgRows(rows: PgRow[]): NextlySchemaSnapshot {
       cols = [];
       byTable.set(r.table_name, cols);
     }
-    cols.push({
+    const column: ColumnSpec = {
       name: r.column_name,
       type: r.udt_name,
       nullable: r.is_nullable === "YES",
       default: r.column_default ?? undefined,
-    });
+    };
+    // Recorded only when true, so a snapshot carries the marker rather than a
+    // false on every column that has no sequence at all.
+    if (r.owned_sequence_default === true) column.ownedSequenceDefault = true;
+    cols.push(column);
   }
   return {
     tables: [...byTable.entries()].map(

--- a/packages/nextly/src/domains/schema/pipeline/diff/normalize-default.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/normalize-default.ts
@@ -18,10 +18,18 @@
 //     change_column_default op; we'd rather emit a false-positive op than
 //     silently swallow a real one.
 //
-// Scope: PostgreSQL is the only dialect that currently surfaces this
-// mismatch. MySQL/SQLite-specific equivalences can be added here when they
-// emerge; the function signature is dialect-agnostic so callers don't need
-// to know.
+// MySQL surfaces two more, both reported against the schema this project
+// itself writes:
+//   - `now()` and `CURRENT_TIMESTAMP` are synonyms (in PostgreSQL too), so a
+//     timestamp column reported one way and authored the other looked changed.
+//     They collapse into `now()`, the form already canonical here.
+//   - A boolean column stores 1/0, because MySQL booleans ARE `tinyint(1)`,
+//     while the desired side authors `true`/`false`. That collapse is applied
+//     ONLY when the column's type is boolean: for an integer column a default
+//     of `1` means the number one, and treating it as `true` would hide a real
+//     change. Hence the optional column-type argument.
+
+import { normalizeType } from "./normalize-type";
 
 // The list of PG type names that PG appends as a `::<type>` cast suffix to
 // literal defaults. Two-word types (`character varying`, `double precision`,
@@ -64,7 +72,12 @@ const CAST_SUFFIX_RE = new RegExp(
  * Return the canonical form of a column-default expression for diff
  * comparison. `undefined` (no default) is passed through unchanged.
  */
-export function normalizeDefault(expr: string | undefined): string | undefined {
+export function normalizeDefault(
+  expr: string | undefined,
+  // The column's declared type, when the caller has it. Only consulted to
+  // decide whether a bare 1/0 denotes a boolean.
+  columnType?: string
+): string | undefined {
   if (expr === undefined) return undefined;
 
   // Step 1: strip PG's redundant `::<type>` cast suffix when it follows a
@@ -91,6 +104,26 @@ export function normalizeDefault(expr: string | undefined): string | undefined {
   // identifier from `myfunc()` depending on how it was quoted.
   if (KEYWORD_WITH_OPTIONAL_PRECISION.test(normalised.trim())) {
     normalised = normalised.toLowerCase();
+  }
+
+  // Step 5: `current_timestamp` and `now()` denote the same value, and MySQL
+  // reports one where the schema authored the other — including with a
+  // fractional-seconds precision, where a DATETIME(3) column authored
+  // `CURRENT_TIMESTAMP(3)` reads back as `now(3)`. `now()` is the form this
+  // codebase already treats as canonical, so the keyword collapses into it
+  // and any precision is carried across unchanged.
+  normalised = normalised.replace(
+    /^current_timestamp(?:\(\s*(\d+)\s*\))?$/,
+    (_m, precision?: string) => (precision ? `now(${precision})` : "now()")
+  );
+
+  // Step 6: a boolean column's default, whichever spelling the dialect
+  // reports. Gated on the column type because `1` is only "true" where the
+  // column is a boolean — elsewhere it is the number.
+  if (normalizeType(columnType) === "bool") {
+    const b = normalised.trim().toLowerCase();
+    if (b === "1" || b === "true") return "true";
+    if (b === "0" || b === "false") return "false";
   }
 
   return normalised;

--- a/packages/nextly/src/domains/schema/pipeline/diff/normalize-default.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/normalize-default.ts
@@ -111,11 +111,23 @@ export function normalizeDefault(
   // fractional-seconds precision, where a DATETIME(3) column authored
   // `CURRENT_TIMESTAMP(3)` reads back as `now(3)`. `now()` is the form this
   // codebase already treats as canonical, so the keyword collapses into it
-  // and any precision is carried across unchanged.
-  normalised = normalised.replace(
-    /^current_timestamp(?:\(\s*(\d+)\s*\))?$/,
-    (_m, precision?: string) => (precision ? `now(${precision})` : "now()")
-  );
+  // and any precision is carried across unchanged. Whitespace inside the call
+  // is insignificant to every dialect but not to a string compare, so
+  // `CURRENT_TIMESTAMP ( 3 )` has to reduce to the same token as `now(3)`.
+  //
+  // A bare `now` is deliberately left alone: unlike the keywords it is not
+  // callable without parentheses in any supported dialect, so an expression
+  // that spells it that way is something else.
+  const timestampKeyword = normalised.trim().match(TIMESTAMP_KEYWORD);
+  if (timestampKeyword) {
+    const precision = timestampKeyword[2];
+    if (
+      timestampKeyword[1] === "current_timestamp" ||
+      precision !== undefined
+    ) {
+      normalised = precision ? `now(${precision})` : "now()";
+    }
+  }
 
   // Step 6: a boolean column's default, whichever spelling the dialect
   // reports. Gated on the column type because `1` is only "true" where the
@@ -167,13 +179,20 @@ const NILADIC_KEYWORDS = [
   "user",
 ].join("|");
 
-// The built-in keywords, alone or with a fractional-seconds precision, and
-// `now()`. These name the same thing in any case, so both sides of the diff
-// can be reduced to lower case; anything outside this set is left as written.
+// The built-in keywords, alone or called with an optional fractional-seconds
+// precision, and `now(...)`. These name the same thing in any case, so both
+// sides of the diff can be reduced to lower case; anything outside this set is
+// left as written. The precision is optional and may be empty because MySQL
+// accepts `CURRENT_TIMESTAMP()` as a call with no argument.
 const KEYWORD_WITH_OPTIONAL_PRECISION = new RegExp(
-  `^(?:now\\(\\)|(?:${NILADIC_KEYWORDS})(?:\\s*\\(\\s*\\d+\\s*\\))?)$`,
+  `^(?:now\\s*\\(\\s*\\d*\\s*\\)|(?:${NILADIC_KEYWORDS})(?:\\s*\\(\\s*\\d*\\s*\\))?)$`,
   "i"
 );
+
+// The two spellings of "the current timestamp", with the precision they may
+// carry. Applied after the lowercase pass, so it needs no `i` flag; the
+// capture groups are the keyword and the precision digits.
+const TIMESTAMP_KEYWORD = /^(current_timestamp|now)(?:\s*\(\s*(\d*)\s*\))?$/;
 
 const EXPRESSION_SHAPED = new RegExp(
   // Anything parenthesised (`(unixepoch())`), anything that calls (`now()`,

--- a/packages/nextly/src/domains/schema/pipeline/diff/normalize-type.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/normalize-type.ts
@@ -86,10 +86,15 @@ export function normalizeType(type: string | undefined): string | undefined {
 
   const lowered = type.trim().toLowerCase();
   // MySQL reports `BOOLEAN`, `BOOL`, and `TINYINT(1)` all as `tinyint(1)`,
-  // so the width has to be read before it is stripped. Left signed-only on
-  // purpose: `tinyint(1) unsigned` is not what the boolean synonym produces,
-  // and treating it as one would hide a real difference.
-  if (lowered === "tinyint(1)") return "bool";
+  // so the width has to be read before it is stripped. Whitespace around the
+  // width is insignificant and a hand-written `TINYINT ( 1 )` reaches the
+  // desired side as authored, so it is tolerated here — matching it exactly
+  // would leave that spelling to the strip below, which would reduce it to
+  // `tinyint` and report a type change against the very column it describes.
+  // Left signed-only on purpose: `tinyint(1) unsigned` is not what the
+  // boolean synonym produces, and treating it as one would hide a real
+  // difference.
+  if (/^tinyint\s*\(\s*1\s*\)$/.test(lowered)) return "bool";
 
   // Lowercase + strip every `(...)` length/precision modifier (and any
   // whitespace that preceded it), e.g. `varchar(255)` → `varchar`,

--- a/packages/nextly/src/domains/schema/pipeline/diff/normalize-type.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/normalize-type.ts
@@ -21,6 +21,12 @@
 //     `serial`/`bigserial`/`smallserial` collapse to their integer storage
 //     type (the sequence default is a separate, already-handled concern).
 //   - Normalise array notation: PG's `_text` and SQL `text[]` → `<base>[]`.
+//   - Collapse MySQL's `tinyint(1)` to the boolean token. MySQL has no
+//     separate boolean type: `BOOL` and `BOOLEAN` are synonyms for
+//     `TINYINT(1)`, and introspection reports all three identically. This one
+//     is matched BEFORE the length strip below, because the width is the
+//     whole signal — a plain `TINYINT` is a one-byte integer and must stay
+//     distinct from a boolean.
 //   - Anything unrecognised passes through (lowercased, length-stripped). A
 //     real type change (e.g. `varchar` → `text`) is therefore still caught.
 
@@ -77,6 +83,13 @@ const TYPE_ALIASES: Record<string, string> = {
  */
 export function normalizeType(type: string | undefined): string | undefined {
   if (type === undefined) return undefined;
+
+  const lowered = type.trim().toLowerCase();
+  // MySQL reports `BOOLEAN`, `BOOL`, and `TINYINT(1)` all as `tinyint(1)`,
+  // so the width has to be read before it is stripped. Left signed-only on
+  // purpose: `tinyint(1) unsigned` is not what the boolean synonym produces,
+  // and treating it as one would hide a real difference.
+  if (lowered === "tinyint(1)") return "bool";
 
   // Lowercase + strip every `(...)` length/precision modifier (and any
   // whitespace that preceded it), e.g. `varchar(255)` → `varchar`,

--- a/packages/nextly/src/domains/schema/pipeline/diff/types.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/types.ts
@@ -35,6 +35,20 @@ export interface ColumnSpec {
   // costs the nullability exemption the diff grants primary keys — never a
   // wrong op.
   primaryKey?: boolean;
+  // `true` when the live default is a `nextval()` over the sequence this
+  // column OWNS — what PostgreSQL materialises for a `serial` declaration.
+  // Recorded only when true, and only by PostgreSQL introspection: no other
+  // dialect has sequences in a default, and the desired side never spells the
+  // default at all.
+  //
+  // Ownership is the point. A column can hold a `nextval()` default over a
+  // sequence it does not own, either because someone pointed it at one
+  // deliberately or because a `serial` column was later repointed. Those are
+  // real defaults and the diff must keep reporting them; only the implicit
+  // one may be suppressed. Reading the shape of the expression cannot tell
+  // the two apart, which is why this is carried in the snapshot rather than
+  // re-derived in the diff.
+  ownedSequenceDefault?: boolean;
 }
 
 export interface IndexSpec {


### PR DESCRIPTION
## `nextly migrate` failed the second time it was run

Found while building the dialect test harness, and reproduced from a clean database on MySQL 8 and PostgreSQL 17.

`reconcileCore` provisions the core schema by diffing the canonical definition against live introspection. Run it twice and the second run should be a no-op. It was not:

```
1st run → { changed: true }     tables created
2nd run → NEXTLY_CORE_DESTRUCTIVE_REFUSED
          changes column 'users.is_active' type from 'tinyint(1)' to 'boolean'
          … 22 more boolean columns
```

The user-facing message says this "usually means a Nextly version mismatch" and suggests `NEXTLY_ALLOW_CORE_DESTRUCTIVE=1`. In fact Nextly had written that schema itself moments earlier, and was now judging its own output.

## Four dialect spellings read as real differences

**MySQL has no boolean type.** `BOOL` and `BOOLEAN` are synonyms for `TINYINT(1)`; verified on MySQL 8 that a table declared with all three reports the identical `COLUMN_TYPE`:

```
a BOOLEAN     → tinyint(1)
b BOOL        → tinyint(1)
c TINYINT(1)  → tinyint(1)
d TINYINT     → tinyint      ← a real integer, and it stays distinct
```

The collapse is matched **before** the length strip, because the width is the whole signal.

**MySQL boolean defaults** come back as `1`/`0` where the schema authored `true`/`false`. That collapse is gated on the column type — on an integer column `1` is the number one, and equating them would hide a real change. This is why `normalizeDefault` now takes the column type.

**MySQL timestamp defaults** report `now()` where the schema authored `CURRENT_TIMESTAMP`, precision included: a `DATETIME(3)` column authored `CURRENT_TIMESTAMP(3)` reads back as `now(3)`. Precision is carried across rather than dropped, so a column keeping milliseconds is not equated with one that does not.

**PostgreSQL serial columns** report the implicit sequence default as `nextval('<table>_id_seq'::regclass)` while the desired side declares no default at all. That is not two spellings of one value — one side genuinely has nothing — so it is matched explicitly rather than normalised.

## Why it was never caught

There is a `phantom-diff.integration.test.ts` for exactly this class. Its MySQL leg is `it.skipIf(!process.env.TEST_MYSQL_URL)`, so it skips unless that URL is set.

The new `core-reconcile-idempotency.integration.test.ts` asserts the property directly — run, run again, expect `{ changed: false }` — per dialect, since that is where the difference lives.

## Testing

- Idempotency verified from a clean database on **PostgreSQL 17** and **MySQL 8**; both legs fail without this change.
- 5 unit cases for the type collapse, including that a plain `tinyint`, an unsigned `tinyint(1)`, and the other integer widths stay distinct from boolean.
- 5 unit cases for the default equivalences, including that `1` on an integer column is still the number.
- One existing test used `CURRENT_TIMESTAMP` as its example of an *unrecognised* expression. It is now recognised, so the example was changed to a genuinely unknown one; the case still guards what it was written to guard.

`check-types` 19/19, lint clean. Touched-area suites match `main` exactly (3 files / 6 tests failing on both — the known pre-existing baseline).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema comparisons for PostgreSQL `serial`, `bigserial`, and `smallserial` columns to avoid reporting false default changes.
  * Improved MySQL handling for boolean types and defaults, including `tinyint(1)`, `BOOL`, and `BOOLEAN`.
  * Standardized timestamp defaults across supported databases for more accurate schema diffs.

* **Tests**
  * Added coverage for schema reconciliation idempotency across PostgreSQL and MySQL.
  * Expanded tests for default and type normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->