### PR TITLE
fix(nextly): create code-first collection tables at boot on mysql

### DIFF
--- a/.changeset/mysql-boot-schema-sync.md
+++ b/.changeset/mysql-boot-schema-sync.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Code-first collections now get their tables created at boot on MySQL. The boot-time schema sync goes through an entry point that was handed a database connection rather than a connection URL, and drizzle-kit needs the MySQL database name as a separate argument, so the apply failed and the first query against the collection reported a missing table. The name now comes from the connection itself, which also fixes the publicly exported `applyDesiredSchema` for MySQL callers.

--- a/packages/nextly/src/di/boot-schema-sync.integration.test.ts
+++ b/packages/nextly/src/di/boot-schema-sync.integration.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Boot-time auto-sync creates a code-first collection's table, on every
+ * dialect.
+ *
+ * `registerServices` provisions the core schema and then applies any
+ * code-first collection whose physical table does not exist yet, through the
+ * DI-bound `applyDesiredSchema`. On MySQL that apply failed: drizzle-kit's
+ * MySQL `pushSchema` takes the database name as a separate argument, and the
+ * DI-bound entry point — which is handed a connection, not a URL — passed
+ * nothing. Boot logged a warning and continued, so the first query against the
+ * collection failed with "table doesn't exist" far from the cause.
+ *
+ * Each dialect gets its own throwaway database. The property under test is
+ * "boot created this table", which says nothing on a database where a previous
+ * suite already created it.
+ */
+import { createPool } from "mysql2";
+import { Pool } from "pg";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../config";
+import { createAdapter } from "../database/factory";
+import { createTestNextly, type TestNextly } from "../plugins/test-nextly";
+
+const DB_NAME = "nextly_boot_sync";
+const SLUG = "boot_sync_probes";
+const TABLE = `dc_${SLUG}`;
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+/**
+ * Boot against `url` with one code-first collection, and report whether the
+ * collection is usable end to end.
+ *
+ * The adapter is built here rather than left to the harness default so the
+ * boot runs on the dialect under test. Creating it reads pool settings through
+ * the lazy env proxy, whose validation requires `DATABASE_URL`, so both env
+ * vars are set for the call and restored afterwards — removed rather than
+ * reassigned when they were absent, since the integration files share one
+ * sequential process.
+ */
+async function bootAndRoundTrip(
+  url: string,
+  dialect: "postgresql" | "mysql"
+): Promise<{ tableExists: boolean; title: unknown }> {
+  const prevUrl = process.env.DATABASE_URL;
+  const prevDialect = process.env.DB_DIALECT;
+  const restoreEnv = (): void => {
+    if (prevUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = prevUrl;
+    if (prevDialect === undefined) delete process.env.DB_DIALECT;
+    else process.env.DB_DIALECT = prevDialect;
+  };
+
+  try {
+    process.env.DATABASE_URL = url;
+    process.env.DB_DIALECT = dialect;
+
+    const adapter = await createAdapter({
+      type: dialect,
+      url,
+    } as Parameters<typeof createAdapter>[0]);
+
+    current = await createTestNextly({
+      adapter,
+      collections: [
+        defineCollection({ slug: SLUG, fields: [text({ name: "title" })] }),
+      ],
+    });
+
+    const created = await current.nextly.create({
+      collection: SLUG,
+      data: { title: "created at boot" },
+    });
+
+    return {
+      tableExists: await adapter.tableExists(TABLE),
+      title: (created.item as { title?: unknown }).title,
+    };
+  } finally {
+    restoreEnv();
+  }
+}
+
+describe.skipIf(!process.env.TEST_POSTGRES_URL)(
+  "boot auto-sync (postgresql)",
+  () => {
+    it("creates the table and the collection is usable", async () => {
+      const admin = new Pool({
+        connectionString: process.env.TEST_POSTGRES_URL,
+      });
+      try {
+        await admin.query(`DROP DATABASE IF EXISTS ${DB_NAME}`);
+        await admin.query(`CREATE DATABASE ${DB_NAME}`);
+        const url = new URL(process.env.TEST_POSTGRES_URL as string);
+        url.pathname = `/${DB_NAME}`;
+
+        const result = await bootAndRoundTrip(url.toString(), "postgresql");
+        expect(result.tableExists).toBe(true);
+        expect(result.title).toBe("created at boot");
+      } finally {
+        // The harness destroy() in afterEach still holds the connection when
+        // this runs, so the drop waits for it.
+        await current?.destroy();
+        current = undefined;
+        await admin.query(`DROP DATABASE IF EXISTS ${DB_NAME}`).catch(() => {});
+        await admin.end();
+      }
+    }, 60_000);
+  }
+);
+
+describe.skipIf(!process.env.TEST_MYSQL_URL)("boot auto-sync (mysql)", () => {
+  it("creates the table and the collection is usable", async () => {
+    const admin = createPool({ uri: process.env.TEST_MYSQL_URL });
+    try {
+      await admin.promise().query(`DROP DATABASE IF EXISTS ${DB_NAME}`);
+      await admin.promise().query(`CREATE DATABASE ${DB_NAME}`);
+      const url = new URL(process.env.TEST_MYSQL_URL as string);
+      url.pathname = `/${DB_NAME}`;
+
+      const result = await bootAndRoundTrip(url.toString(), "mysql");
+      expect(result.tableExists).toBe(true);
+      expect(result.title).toBe("created at boot");
+    } finally {
+      await current?.destroy();
+      current = undefined;
+      await admin
+        .promise()
+        .query(`DROP DATABASE IF EXISTS ${DB_NAME}`)
+        .catch(() => {});
+      await new Promise<void>(res => admin.end(() => res()));
+    }
+  }, 60_000);
+});

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/fresh-push.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/fresh-push.test.ts
@@ -386,12 +386,14 @@ describe("freshPushSchema", () => {
         execute: vi.fn().mockResolvedValue([[{ db: null }], []]),
       };
       // NextlyError keeps the public message generic; the diagnosis lives
-      // in logContext.reason.
+      // in logContext.reason. Matched from the verb so the assertion pins
+      // what the reason says rather than which caller says it — the lookup is
+      // shared with the DI-bound apply path.
       await expect(freshPushSchema("mysql", db, {})).rejects.toMatchObject({
         code: "INTERNAL_ERROR",
         logContext: {
           reason: expect.stringContaining(
-            "could not determine the current MySQL database"
+            "determine the current MySQL database"
           ),
         },
       });

--- a/packages/nextly/src/domains/schema/pipeline/database-url.ts
+++ b/packages/nextly/src/domains/schema/pipeline/database-url.ts
@@ -1,12 +1,19 @@
-// Shared helper for extracting the MySQL database name from a
-// connection URL. drizzle-kit's MySQL pushSchema requires this name
-// as a separate argument (PG and SQLite don't). Per-call factories
-// at each call site (reload-config.ts, collection-dispatcher.ts,
-// dev-server.ts in PR-3) extract it from process.env.DATABASE_URL
-// before invoking PushSchemaPipeline.apply().
+// Shared helpers for naming the MySQL database a schema apply targets.
+// drizzle-kit's MySQL pushSchema requires that name as a separate argument
+// (PG and SQLite don't), so every caller has to supply it.
 //
-// F8 will collapse the per-call factory pattern; this helper stays
-// useful as long as the pipeline's apply() takes databaseName.
+// Two ways to obtain it, and they are not interchangeable:
+//
+//   - `extractDatabaseNameFromUrl` reads it from a connection URL. Used by
+//     per-call factories (reload-config.ts, the dispatchers, dev-server.ts)
+//     that already hold the URL they connected with.
+//   - `currentMysqlDatabaseName` asks the live connection. This is the
+//     authoritative answer and the only one available to a caller that was
+//     handed a connection rather than a URL — `process.env.DATABASE_URL` can
+//     be unset, or can name a different database than the one the connection
+//     actually selected.
+
+import { NextlyError } from "../../../errors/nextly-error";
 
 export function extractDatabaseNameFromUrl(
   url: string | undefined
@@ -21,4 +28,38 @@ export function extractDatabaseNameFromUrl(
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Ask a live MySQL connection which database it selected.
+ *
+ * @param db a drizzle-orm/mysql2 database handle
+ * @throws NextlyError when the connection has no database selected, which
+ * makes every unqualified statement fail later and further from the cause.
+ */
+export async function currentMysqlDatabaseName(db: unknown): Promise<string> {
+  const { sql: sqlTag } = await import("drizzle-orm");
+  type AsyncExecuteDb = { execute: (q: unknown) => Promise<unknown> };
+  // Tagged `sql` (not sql.raw): the query is static with no interpolation, so
+  // the tagged form is the idiomatic, injection-safe default and keeps drizzle
+  // in charge of parameter handling.
+  const raw = await (db as AsyncExecuteDb).execute(
+    sqlTag`SELECT DATABASE() AS db`
+  );
+  // drizzle-orm/mysql2 execute() resolves to [rows, fields].
+  const rows = Array.isArray(raw) ? raw[0] : raw;
+  const name = Array.isArray(rows)
+    ? (rows[0] as { db?: string } | undefined)?.db
+    : undefined;
+  if (!name) {
+    throw NextlyError.internal({
+      logContext: {
+        reason:
+          "Could not determine the current MySQL database (SELECT DATABASE() " +
+          "returned no name). Connect with a database selected in the " +
+          "connection URL.",
+      },
+    });
+  }
+  return name;
 }

--- a/packages/nextly/src/domains/schema/pipeline/fresh-push.ts
+++ b/packages/nextly/src/domains/schema/pipeline/fresh-push.ts
@@ -44,6 +44,7 @@ import {
 } from "../../../database/drizzle-kit-lazy";
 import { NextlyError } from "../../../errors/nextly-error";
 
+import { currentMysqlDatabaseName } from "./database-url";
 import {
   drizzleTableNames,
   filterUnsafeStatements,
@@ -166,7 +167,7 @@ async function pushForDialect(
     }
     case "mysql": {
       const kit = await getMySQLDrizzleKit();
-      const databaseName = await currentMysqlDatabase(db);
+      const databaseName = await currentMysqlDatabaseName(db);
       return withResolverCrashFallback(
         () => kit.pushSchema(schema, db, databaseName),
         async () =>
@@ -241,33 +242,6 @@ async function withResolverCrashFallback(
       ],
     };
   }
-}
-
-async function currentMysqlDatabase(db: unknown): Promise<string> {
-  const { sql: sqlTag } = await import("drizzle-orm");
-  type AsyncExecuteDb = { execute: (q: unknown) => Promise<unknown> };
-  // Tagged `sql` (not sql.raw): the query is static with no interpolation, so
-  // the tagged form is the idiomatic, injection-safe default and keeps drizzle
-  // in charge of parameter handling.
-  const raw = await (db as AsyncExecuteDb).execute(
-    sqlTag`SELECT DATABASE() AS db`
-  );
-  // drizzle-orm/mysql2 execute() resolves to [rows, fields].
-  const rows = Array.isArray(raw) ? raw[0] : raw;
-  const name = Array.isArray(rows)
-    ? (rows[0] as { db?: string } | undefined)?.db
-    : undefined;
-  if (!name) {
-    throw NextlyError.internal({
-      logContext: {
-        reason:
-          "freshPushSchema: could not determine the current MySQL database " +
-          "(SELECT DATABASE() returned no name). Connect with a database " +
-          "selected in the connection URL.",
-      },
-    });
-  }
-  return name;
 }
 
 // Executes statements per dialect, swallowing idempotency errors

--- a/packages/nextly/src/domains/schema/pipeline/index.ts
+++ b/packages/nextly/src/domains/schema/pipeline/index.ts
@@ -12,9 +12,8 @@
 //   2. The DI-bound `applyDesiredSchema` re-exported below — positioned for
 //      future external / plugin / integration-test callers that want a
 //      zero-wiring entry point. Resolves services from the DI container at
-//      first call and caches. MySQL via this entry point requires the
-//      caller to extract databaseName themselves and pass it through —
-//      F8 will wire this fully when it absorbs the callers.
+//      first call and caches. MySQL needs no caller cooperation here: the
+//      database name comes from the live connection.
 
 import {
   getAdapterFromDI,
@@ -30,6 +29,7 @@ import {
   type ApplyDesiredSchemaFn,
 } from "./apply";
 import { RealClassifier } from "./classifier/classifier";
+import { currentMysqlDatabaseName } from "./database-url";
 import { RealPreCleanupExecutor } from "./pre-cleanup/executor";
 import { ClackTerminalPromptDispatcher } from "./prompt-dispatcher/clack-terminal";
 import { PushSchemaPipeline } from "./pushschema-pipeline";
@@ -121,18 +121,23 @@ function buildProductionDeps(): ApplyDesiredSchemaDeps {
         notifier: getProductionNotifier(),
       });
 
-      // MySQL note: the DI-bound entry point doesn't have access to
-      // the caller's connection URL, so it can't auto-extract
-      // databaseName for MySQL. Per-call factories (in reload-config.ts
-      // and collection-dispatcher.ts) do extract it themselves. F8 will
-      // collapse the two paths — until then, MySQL via this entry point
-      // throws loudly inside PushSchemaPipeline.importDrizzleKit.
+      // drizzle-kit's MySQL pushSchema needs the database name as its own
+      // argument. This entry point is handed a connection rather than a URL,
+      // so it asks the connection which database it selected — authoritative,
+      // and available even when the caller never set DATABASE_URL. Without it
+      // every MySQL apply through here fails inside
+      // PushSchemaPipeline.importDrizzleKit, which is what made boot-time
+      // auto-sync silently skip creating a code-first collection's table.
+      const databaseName =
+        dialect === "mysql" ? await currentMysqlDatabaseName(db) : undefined;
+
       return pipeline.apply({
         desired,
         db,
         dialect,
         source,
         promptChannel,
+        databaseName,
       });
     },
 


### PR DESCRIPTION
## What was broken

On MySQL, a code-first collection's table was **never created at boot**.

`registerServices` provisions the core schema and then applies any code-first collection whose physical table does not exist yet, through the DI-bound `applyDesiredSchema`. drizzle-kit's MySQL `pushSchema` takes the database name as a separate argument; that entry point is handed a *connection*, not a URL, and passed nothing. So the apply threw inside `importDrizzleKit`:

```
PushSchemaPipeline: MySQL requires databaseName in apply() args. Caller
(e.g. dev-server.ts, dispatcher) must extract the database name from the
connection URL and pass it through.
```

Boot logged a warning and continued, and the first query against the collection failed with `Table 'db.dc_<slug>' doesn't exist` — far from the cause.

This also affected the **publicly exported** `applyDesiredSchema` (`packages/nextly/src/index.ts`), so any plugin or external caller using it on MySQL hit the same wall.

## The fix

The name now comes from the live connection (`SELECT DATABASE()`), which is authoritative and needs no caller cooperation. That matters here specifically: `process.env.DATABASE_URL` may be unset, or may name a different database than the connection actually selected.

That lookup already existed as a private function inside `fresh-push.ts`. It moves next to the URL-parsing helper in `database-url.ts` so both callers share one implementation rather than growing a second copy.

Every other caller (`reload-config`, the three dispatchers, `dev-server`) already threads `databaseName` from the URL and is untouched.

## How it was found

While checking whether `createTestNextly` can boot against a real dialect. It can — Postgres booted and round-tripped an entry with nothing but an adapter override. MySQL got as far as provisioning the core schema (127 statements) and then failed on the first write. The dialect harness work is the next PR; this fix is what its first green run required.

## Tests

`src/di/boot-schema-sync.integration.test.ts` — boots a code-first collection through `createTestNextly` against Postgres and MySQL, asserting the table exists and the collection round-trips. Each dialect creates and drops its **own** database: "boot created this table" says nothing on a database where a previous suite already created it.

Verified load-bearing: with `pipeline/index.ts` restored from `main`, the MySQL leg fails and the Postgres leg passes.

## Verification

- `pnpm build`, `pnpm check-types` (19/19), `pnpm --filter nextly lint` — all clean by exit code
- `src/domains/schema` unit: **3 files / 6 tests failing, identical to the main baseline** measured in the same session
- Full `nextly` integration suite: **157 files pass on Postgres**, **143 pass on MySQL** (162 total, remainder dialect-skipped)

One existing unit assertion changed: `fresh-push.test.ts` pinned the error's `logContext.reason` including the word `freshPushSchema:`. The lookup is now shared, so the message no longer names one caller and the assertion matches from the verb instead.

### A note on the local MySQL database

Two MySQL suites (`m2m-atomicity-mysql`, `outbox-preimage-lock`) failed on my machine before and after this change alike, and passed once I recreated the local `nextly_test` MySQL database. They were stale-database artifacts, not regressions — CI creates its database fresh per run.
