### PR TITLE
fix(nextly): honour a Single's declared hooks and field defaults

### DIFF
--- a/.changeset/single-hooks-and-defaults.md
+++ b/.changeset/single-hooks-and-defaults.md
@@ -1,0 +1,37 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Honour a Single's declared hooks and field defaults
+
+Two documented parts of the `defineSingle()` config silently did nothing:
+
+- **Hooks** — `hooks: { beforeRead, afterRead, beforeChange, afterChange }` were
+  never registered, so none of them ran. They now register (via the scaffolded
+  init helper, alongside collection hooks) and execute on the single read and
+  update paths. `beforeRead` remains side-effect-only, matching collections.
+- **Field defaults** — a `defaultValue` on a Single's field never applied; the
+  first read auto-created the row with `null` in every defaulted column, because
+  a function `defaultValue` cannot survive serialization to `dynamic_singles`.
+  Defaults are now resolved from the live code-first config, so a scalar or
+  structured (group/repeater) default lands on the auto-created document.

--- a/packages/nextly/src/cli/commands/init.ts
+++ b/packages/nextly/src/cli/commands/init.ts
@@ -296,7 +296,12 @@ function generateNextlyHelperTemplate(): string {
  * \`\`\`
  */
 
-import { getNextly, registerCollectionHooks, type Nextly } from "nextly";
+import {
+  getNextly,
+  registerCollectionHooks,
+  registerSingleHooks,
+  type Nextly,
+} from "nextly";
 import nextlyConfig from "../../nextly.config";
 
 // Track initialization state
@@ -351,6 +356,14 @@ export async function initializeNextly(): Promise<void> {
       const result = registerCollectionHooks(nextlyConfig.collections);
       console.log(
         \`[Nextly] Registered \${result.totalHooks} hooks for \${result.collections.length} collections\`
+      );
+    }
+
+    // Register code-first single hooks with the global registry
+    if (nextlyConfig.singles && nextlyConfig.singles.length > 0) {
+      const result = registerSingleHooks(nextlyConfig.singles);
+      console.log(
+        \`[Nextly] Registered \${result.totalHooks} hooks for \${result.singles.length} singles\`
       );
     }
 

--- a/packages/nextly/src/cli/commands/init.ts
+++ b/packages/nextly/src/cli/commands/init.ts
@@ -296,12 +296,7 @@ function generateNextlyHelperTemplate(): string {
  * \`\`\`
  */
 
-import {
-  getNextly,
-  registerCollectionHooks,
-  registerSingleHooks,
-  type Nextly,
-} from "nextly";
+import { getNextly, registerCollectionHooks, type Nextly } from "nextly";
 import nextlyConfig from "../../nextly.config";
 
 // Track initialization state
@@ -356,14 +351,6 @@ export async function initializeNextly(): Promise<void> {
       const result = registerCollectionHooks(nextlyConfig.collections);
       console.log(
         \`[Nextly] Registered \${result.totalHooks} hooks for \${result.collections.length} collections\`
-      );
-    }
-
-    // Register code-first single hooks with the global registry
-    if (nextlyConfig.singles && nextlyConfig.singles.length > 0) {
-      const result = registerSingleHooks(nextlyConfig.singles);
-      console.log(
-        \`[Nextly] Registered \${result.totalHooks} hooks for \${result.singles.length} singles\`
       );
     }
 

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -824,10 +824,18 @@ export async function registerServices(
     // plugin registered under the same `single:<slug>` namespace untouched (a
     // clear-then-register would wipe those).
     if (transformedConfig.singles && transformedConfig.singles.length > 0) {
-      const singleHooks = registerSingleHooks(
-        transformedConfig.singles,
-        hookRegistry
+      // A disabled plugin's contributions stay in `transformedConfig` so the
+      // schema is deterministic, but the plugin lifecycle's behavior-skip
+      // contract means its runtime hooks must NOT run. Skip singles a disabled
+      // plugin contributed; app and enabled-plugin singles register normally.
+      const disabledSingleSlugs = collectPluginContributedSlugs(
+        resolvedPlugins.filter(plugin => plugin.enabled === false),
+        "singles"
       );
+      const hookedSingles = transformedConfig.singles.filter(
+        single => !disabledSingleSlugs.has(single.slug)
+      );
+      const singleHooks = registerSingleHooks(hookedSingles, hookRegistry);
       resolvedLogger.info?.(
         `Registered ${singleHooks.totalHooks} hook(s) for ${singleHooks.singles.length} single(s)`
       );
@@ -1938,6 +1946,15 @@ async function syncCodeFirstSingles(
     logger.info?.(
       `Singles registered: ${singleSyncResult.created.length} created, ${singleSyncResult.updated.length} updated, ${singleSyncResult.unchanged.length} unchanged`
     );
+    // Expose the live code-first snapshot (for function/structured defaults)
+    // only for singles that synced: a failed slug's serialized metadata did not
+    // advance, so it is kept off the snapshot and falls back to those fields.
+    const failedSingleSlugs = new Set(
+      singleSyncResult.errors.map(entry => entry.slug)
+    );
+    singleRegistry.setCodeFirstSingles(transformedConfig.singles, {
+      keepPriorFor: failedSingleSlugs,
+    });
   } catch (error) {
     logger.warn?.(
       `Singles sync failed: ${error instanceof Error ? error.message : String(error)}`

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -72,7 +72,7 @@ import { getEventBus } from "../events/event-bus";
 import { registerActivityLogHooks } from "../hooks/activity-log-hooks";
 import type { HookRegistry } from "../hooks/hook-registry";
 import { getHookRegistry } from "../hooks/hook-registry";
-import { reregisterSingleHooks } from "../hooks/register-single-hooks";
+import { registerSingleHooks } from "../hooks/register-single-hooks";
 import { createSanitizationHook } from "../hooks/sanitization-hooks";
 import type { PluginPermission, PluginRole } from "../plugins/contributions";
 import { getCoreVersion } from "../plugins/core-version";
@@ -819,10 +819,12 @@ export async function registerServices(
 
     // Register hooks declared on code-first Singles so they run on the read and
     // update paths for every consumer (Direct API, REST, tests), not only apps
-    // that use the scaffolded init helper. reregister is clear-then-register, so
-    // a re-boot or config reload never double-registers into the global registry.
+    // that use the scaffolded init helper. `registerServices` runs once per
+    // process, so a plain append never double-registers; it also leaves hooks a
+    // plugin registered under the same `single:<slug>` namespace untouched (a
+    // clear-then-register would wipe those).
     if (transformedConfig.singles && transformedConfig.singles.length > 0) {
-      const singleHooks = reregisterSingleHooks(
+      const singleHooks = registerSingleHooks(
         transformedConfig.singles,
         hookRegistry
       );

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -72,6 +72,7 @@ import { getEventBus } from "../events/event-bus";
 import { registerActivityLogHooks } from "../hooks/activity-log-hooks";
 import type { HookRegistry } from "../hooks/hook-registry";
 import { getHookRegistry } from "../hooks/hook-registry";
+import { reregisterSingleHooks } from "../hooks/register-single-hooks";
 import { createSanitizationHook } from "../hooks/sanitization-hooks";
 import type { PluginPermission, PluginRole } from "../plugins/contributions";
 import { getCoreVersion } from "../plugins/core-version";
@@ -815,6 +816,20 @@ export async function registerServices(
 
     registerActivityLogHooks(hookRegistry);
     resolvedLogger.info?.("Activity log hooks registered");
+
+    // Register hooks declared on code-first Singles so they run on the read and
+    // update paths for every consumer (Direct API, REST, tests), not only apps
+    // that use the scaffolded init helper. reregister is clear-then-register, so
+    // a re-boot or config reload never double-registers into the global registry.
+    if (transformedConfig.singles && transformedConfig.singles.length > 0) {
+      const singleHooks = reregisterSingleHooks(
+        transformedConfig.singles,
+        hookRegistry
+      );
+      resolvedLogger.info?.(
+        `Registered ${singleHooks.totalHooks} hook(s) for ${singleHooks.singles.length} single(s)`
+      );
+    }
   }
 
   // now Payload-style: an auth-gated POST route in the project's app

--- a/packages/nextly/src/di/registrations/register-singles.ts
+++ b/packages/nextly/src/di/registrations/register-singles.ts
@@ -30,14 +30,11 @@ export function registerSingleServices(ctx: RegistrationContext): void {
   container.registerSingleton<SingleRegistryService>(
     "singleRegistryService",
     () => {
-      // Pass the live code-first single configs so field `defaultValue`
-      // functions (which do not survive serialization to `dynamic_singles`)
-      // remain available when a first read auto-creates the row.
-      const singleRegistryService = new SingleRegistryService(
-        adapter,
-        logger,
-        ctx.config.singles
-      );
+      // The live code-first snapshot (for field `defaultValue` functions that do
+      // not survive serialization) is set AFTER the boot metadata sync via
+      // setCodeFirstSingles, not here — so a single whose sync fails never
+      // exposes new fields paired with stale serialized metadata.
+      const singleRegistryService = new SingleRegistryService(adapter, logger);
 
       if (container.has("permissionSeedService")) {
         singleRegistryService.setPermissionSeedService(

--- a/packages/nextly/src/di/registrations/register-singles.ts
+++ b/packages/nextly/src/di/registrations/register-singles.ts
@@ -30,7 +30,14 @@ export function registerSingleServices(ctx: RegistrationContext): void {
   container.registerSingleton<SingleRegistryService>(
     "singleRegistryService",
     () => {
-      const singleRegistryService = new SingleRegistryService(adapter, logger);
+      // Pass the live code-first single configs so field `defaultValue`
+      // functions (which do not survive serialization to `dynamic_singles`)
+      // remain available when a first read auto-creates the row.
+      const singleRegistryService = new SingleRegistryService(
+        adapter,
+        logger,
+        ctx.config.singles
+      );
 
       if (container.has("permissionSeedService")) {
         singleRegistryService.setPermissionSeedService(

--- a/packages/nextly/src/domains/singles/__tests__/single-config-honored.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-config-honored.integration.test.ts
@@ -10,11 +10,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { checkbox, defineSingle, group, text } from "../../../config";
-import {
-  getHookRegistry,
-  resetHookRegistry,
-} from "../../../hooks/hook-registry";
-import { registerSingleHooks } from "../../../hooks/register-single-hooks";
+import { resetHookRegistry } from "../../../hooks/hook-registry";
 import {
   createTestNextly,
   type TestNextly,
@@ -56,10 +52,10 @@ describe("single config honored — hooks + defaults (integration)", () => {
       ],
     });
 
+    // Single hooks register automatically during framework boot
+    // (registerServices), so no manual registration is needed — a Direct-API
+    // consumer gets them the same way.
     current = await createTestNextly({ singles: [branding] });
-    // Register the single's hooks the way a scaffolded app's init helper does;
-    // the services read them from the global registry `createTestNextly` wires.
-    registerSingleHooks([branding], getHookRegistry());
 
     const service =
       current.getService<SingleEntryService>("singleEntryService");

--- a/packages/nextly/src/domains/singles/__tests__/single-config-honored.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-config-honored.integration.test.ts
@@ -60,20 +60,20 @@ describe("single config honored — hooks + defaults (integration)", () => {
     const service =
       current.getService<SingleEntryService>("singleEntryService");
 
-    // First read auto-creates the row: its declared defaults apply (061) and the
-    // read hooks run (060).
+    // First read auto-creates the row: its declared defaults apply and the read
+    // hooks run.
     const read = await service.get("branding", { overrideAccess: true });
 
     expect(read.success).toBe(true);
-    // 061: function default resolved, structured default deserialized (not a
-    // stringified function).
+    // The function default is resolved and the structured default is
+    // deserialized (not a stringified function).
     expect(read.data?.siteName).toBe("Acme");
     expect(read.data?.settings).toEqual({ private: true });
-    // 060: read hooks fired.
+    // The read hooks fired.
     expect(beforeRead).toHaveBeenCalled();
     expect(afterRead).toHaveBeenCalled();
 
-    // An update runs the change hooks (060), mapped to the update lifecycle.
+    // An update runs the change hooks, mapped to the update lifecycle.
     const updated = await service.update(
       "branding",
       { siteName: "Beta" },

--- a/packages/nextly/src/domains/singles/__tests__/single-config-honored.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-config-honored.integration.test.ts
@@ -1,0 +1,90 @@
+/**
+ * A Single's declared configuration must actually take effect end to end:
+ * - its `hooks` run on the read and update paths (they were never registered), and
+ * - its field `defaultValue`s apply on the first-read auto-create (a function
+ *   default was lost when field metadata is serialized to `dynamic_singles`).
+ *
+ * Both were documented config that silently did nothing; this pins them on a
+ * real database through the full service wiring.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { checkbox, defineSingle, group, text } from "../../../config";
+import {
+  getHookRegistry,
+  resetHookRegistry,
+} from "../../../hooks/hook-registry";
+import { registerSingleHooks } from "../../../hooks/register-single-hooks";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { SingleEntryService } from "../services/single-entry-service";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+  // Single hooks register into the global registry; clear it between tests.
+  resetHookRegistry();
+});
+
+describe("single config honored — hooks + defaults (integration)", () => {
+  it("runs declared hooks and applies function/structured defaults on first read", async () => {
+    const beforeRead = vi.fn(async () => undefined);
+    const afterRead = vi.fn(async (ctx: { data: unknown }) => ctx.data);
+    const beforeChange = vi.fn(async (ctx: { data: unknown }) => ctx.data);
+    const afterChange = vi.fn(async (ctx: { data: unknown }) => ctx.data);
+
+    const branding = defineSingle({
+      slug: "branding",
+      status: true,
+      hooks: {
+        beforeRead: [beforeRead],
+        afterRead: [afterRead],
+        beforeChange: [beforeChange],
+        afterChange: [afterChange],
+      },
+      fields: [
+        text({ name: "siteName", defaultValue: () => "Acme" }),
+        group({
+          name: "settings",
+          fields: [checkbox({ name: "private" })],
+          defaultValue: () => ({ private: true }),
+        }),
+      ],
+    });
+
+    current = await createTestNextly({ singles: [branding] });
+    // Register the single's hooks the way a scaffolded app's init helper does;
+    // the services read them from the global registry `createTestNextly` wires.
+    registerSingleHooks([branding], getHookRegistry());
+
+    const service =
+      current.getService<SingleEntryService>("singleEntryService");
+
+    // First read auto-creates the row: its declared defaults apply (061) and the
+    // read hooks run (060).
+    const read = await service.get("branding", { overrideAccess: true });
+
+    expect(read.success).toBe(true);
+    // 061: function default resolved, structured default deserialized (not a
+    // stringified function).
+    expect(read.data?.siteName).toBe("Acme");
+    expect(read.data?.settings).toEqual({ private: true });
+    // 060: read hooks fired.
+    expect(beforeRead).toHaveBeenCalled();
+    expect(afterRead).toHaveBeenCalled();
+
+    // An update runs the change hooks (060), mapped to the update lifecycle.
+    const updated = await service.update(
+      "branding",
+      { siteName: "Beta" },
+      { overrideAccess: true }
+    );
+    expect(updated.success).toBe(true);
+    expect(beforeChange).toHaveBeenCalled();
+    expect(afterChange).toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
@@ -233,4 +233,70 @@ describe("SingleQueryService.buildDefaultDocument", () => {
     expect(localizedDefaults).toEqual({});
     expect(insertValues).toMatchObject({ region: "us" });
   });
+
+  // A `defaultValue` function does not survive serialization to
+  // `dynamic_singles.fields`, so the resolution must read it from the live
+  // code-first config the registry exposes via `getCodeFirstFields`.
+  it("resolves a defaultValue from the code-first config when the serialized meta lacks it", () => {
+    const registry = createMockSingleRegistry();
+    const service = new SingleQueryService(
+      createMockAdapter() as unknown as Ctor[0],
+      createSilentLogger() as unknown as Ctor[1],
+      registry as unknown as Ctor[2],
+      createMockHookRegistry() as unknown as Ctor[3]
+    );
+
+    // Serialized meta: the function/structured defaults are gone.
+    const meta = siteSettingsMeta({
+      status: true,
+      fields: [
+        { name: "siteName", type: "text" },
+        {
+          name: "settings",
+          type: "group",
+          fields: [{ name: "private", type: "checkbox" }],
+        },
+      ],
+    });
+
+    // Live code-first fields still carry them.
+    registry.getCodeFirstFields.mockReturnValue([
+      { name: "siteName", type: "text", defaultValue: () => "Acme" },
+      {
+        name: "settings",
+        type: "group",
+        fields: [{ name: "private", type: "checkbox" }],
+        defaultValue: () => ({ private: true }),
+      },
+    ]);
+
+    const { insertValues } = service.buildDefaultDocument(
+      meta as unknown as SingleMeta
+    );
+
+    // The function default is resolved to its value (insertValues is keyed by
+    // DB column name, so `siteName` -> `site_name`)...
+    expect(insertValues).toMatchObject({ site_name: "Acme" });
+    // ...and a structured default is JSON-encoded for its json-backed column,
+    // parsing back to the real object rather than a stringified function.
+    expect(typeof insertValues.settings).toBe("string");
+    expect(JSON.parse(insertValues.settings as string)).toEqual({
+      private: true,
+    });
+  });
+
+  it("keeps the serialized-meta default for a UI-created single (no code-first fields)", () => {
+    // getCodeFirstFields returns undefined by default in the mock, mirroring a
+    // UI-created single; the serialized primitive default still applies.
+    const service = createQueryService();
+    const meta = siteSettingsMeta({
+      fields: [{ name: "region", type: "text", defaultValue: "us" }],
+    });
+
+    const { insertValues } = service.buildDefaultDocument(
+      meta as unknown as SingleMeta
+    );
+
+    expect(insertValues).toMatchObject({ region: "us" });
+  });
 });

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
@@ -330,6 +330,31 @@ describe("SingleQueryService.buildDefaultDocument", () => {
     expect(insertValues).toMatchObject({ tier: "pro" });
   });
 
+  it("JSON-encodes a primitive default for a json-backed column", () => {
+    // A json column stores text (SQLite especially), so a primitive default like
+    // `() => true` must be encoded to "true"; a raw boolean cannot be bound.
+    const registry = createMockSingleRegistry();
+    const service = new SingleQueryService(
+      createMockAdapter() as unknown as Ctor[0],
+      createSilentLogger() as unknown as Ctor[1],
+      registry as unknown as Ctor[2],
+      createMockHookRegistry() as unknown as Ctor[3]
+    );
+
+    const meta = siteSettingsMeta({
+      fields: [{ name: "flags", type: "json" }],
+    });
+    registry.getCodeFirstFields.mockReturnValue([
+      { name: "flags", type: "json", defaultValue: () => true },
+    ]);
+
+    const { insertValues } = service.buildDefaultDocument(
+      meta as unknown as SingleMeta
+    );
+
+    expect(insertValues.flags).toBe("true");
+  });
+
   it("keeps the serialized-meta default for a UI-created single (no code-first fields)", () => {
     // getCodeFirstFields returns undefined by default in the mock, mirroring a
     // UI-created single; the serialized primitive default still applies.

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
@@ -285,6 +285,51 @@ describe("SingleQueryService.buildDefaultDocument", () => {
     });
   });
 
+  it("passes logical (not JSON-stringified) prior values to a dependent default function", () => {
+    const registry = createMockSingleRegistry();
+    const service = new SingleQueryService(
+      createMockAdapter() as unknown as Ctor[0],
+      createSilentLogger() as unknown as Ctor[1],
+      registry as unknown as Ctor[2],
+      createMockHookRegistry() as unknown as Ctor[3]
+    );
+
+    const meta = siteSettingsMeta({
+      status: true,
+      fields: [
+        {
+          name: "settings",
+          type: "group",
+          fields: [{ name: "private", type: "checkbox" }],
+        },
+        { name: "tier", type: "text" },
+      ],
+    });
+
+    // `tier`'s default reads the earlier group value: it must see the object,
+    // not the JSON string stored for `settings`'s json-backed column.
+    registry.getCodeFirstFields.mockReturnValue([
+      {
+        name: "settings",
+        type: "group",
+        fields: [{ name: "private", type: "checkbox" }],
+        defaultValue: () => ({ private: true }),
+      },
+      {
+        name: "tier",
+        type: "text",
+        defaultValue: (data: { settings?: { private?: boolean } }) =>
+          data.settings?.private ? "pro" : "free",
+      },
+    ]);
+
+    const { insertValues } = service.buildDefaultDocument(
+      meta as unknown as SingleMeta
+    );
+
+    expect(insertValues).toMatchObject({ tier: "pro" });
+  });
+
   it("keeps the serialized-meta default for a UI-created single (no code-first fields)", () => {
     // getCodeFirstFields returns undefined by default in the mock, mirroring a
     // UI-created single; the serialized primitive default still applies.

--- a/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-query-service.default-document.test.ts
@@ -369,4 +369,68 @@ describe("SingleQueryService.buildDefaultDocument", () => {
 
     expect(insertValues).toMatchObject({ region: "us" });
   });
+
+  it("rejects a password field that declares a defaultValue", () => {
+    // This path inserts the resolved value directly, bypassing the write path's
+    // password hashing, so a password default would persist in plaintext; it
+    // must be refused rather than stored.
+    const registry = createMockSingleRegistry();
+    const service = new SingleQueryService(
+      createMockAdapter() as unknown as Ctor[0],
+      createSilentLogger() as unknown as Ctor[1],
+      registry as unknown as Ctor[2],
+      createMockHookRegistry() as unknown as Ctor[3]
+    );
+    const meta = siteSettingsMeta({
+      fields: [{ name: "secret", type: "password" }],
+    });
+    registry.getCodeFirstFields.mockReturnValue([
+      { name: "secret", type: "password", defaultValue: () => "hunter2" },
+    ]);
+
+    let caught: unknown;
+    try {
+      service.buildDefaultDocument(meta as unknown as SingleMeta);
+    } catch (error) {
+      caught = error;
+    }
+    // A validation error naming the password field, not the plaintext value in
+    // the row that would otherwise be inserted.
+    const publicData = (
+      caught as { publicData?: { errors?: Array<{ code?: string }> } }
+    )?.publicData;
+    expect(publicData?.errors?.[0]?.code).toBe("PASSWORD_DEFAULT_UNSUPPORTED");
+  });
+
+  it("coerces a string date default to a Date for the timestamp column", () => {
+    // A timestamp column needs a Date; the ordinary write path coerces, and the
+    // direct insert must too, or SQLite stores the string in an integer column.
+    const registry = createMockSingleRegistry();
+    const service = new SingleQueryService(
+      createMockAdapter() as unknown as Ctor[0],
+      createSilentLogger() as unknown as Ctor[1],
+      registry as unknown as Ctor[2],
+      createMockHookRegistry() as unknown as Ctor[3]
+    );
+    const meta = siteSettingsMeta({
+      fields: [{ name: "launchAt", type: "date" }],
+    });
+    registry.getCodeFirstFields.mockReturnValue([
+      {
+        name: "launchAt",
+        type: "date",
+        defaultValue: () => "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const { insertValues } = service.buildDefaultDocument(
+      meta as unknown as SingleMeta
+    );
+
+    // insertValues is keyed by DB column name (launchAt -> launch_at).
+    expect(insertValues.launch_at).toBeInstanceOf(Date);
+    expect((insertValues.launch_at as Date).toISOString()).toBe(
+      "2026-01-01T00:00:00.000Z"
+    );
+  });
 });

--- a/packages/nextly/src/domains/singles/__tests__/single-registry-service.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-registry-service.test.ts
@@ -800,4 +800,45 @@ describe("SingleRegistryService", () => {
       expect(tx.insert).not.toHaveBeenCalled();
     });
   });
+
+  describe("code-first default snapshot", () => {
+    // The live snapshot backs function/structured default resolution on
+    // auto-create; a removed single must be evicted so its stale defaults can't
+    // run against its still-readable registry row.
+    const single = (slug: string) =>
+      ({
+        slug,
+        fields: [{ name: "n", type: "text", defaultValue: () => slug }],
+      }) as unknown as Parameters<
+        typeof ctx.service.setCodeFirstSingles
+      >[0][number];
+
+    it("pruneCodeFirstSingles keeps present slugs and drops absent ones", () => {
+      ctx.service.setCodeFirstSingles([single("a"), single("b"), single("c")]);
+
+      ctx.service.pruneCodeFirstSingles(new Set(["a", "c"]));
+
+      expect(ctx.service.getCodeFirstFields("a")).toBeDefined();
+      expect(ctx.service.getCodeFirstFields("c")).toBeDefined();
+      // The removed single falls back to serialized metadata (undefined here).
+      expect(ctx.service.getCodeFirstFields("b")).toBeUndefined();
+    });
+
+    it("pruneCodeFirstSingles with an empty set clears the whole snapshot", () => {
+      ctx.service.setCodeFirstSingles([single("a")]);
+
+      ctx.service.pruneCodeFirstSingles(new Set());
+
+      expect(ctx.service.getCodeFirstFields("a")).toBeUndefined();
+    });
+
+    it("pruneCodeFirstSingles is a no-op when no snapshot was ever set", () => {
+      // No setCodeFirstSingles call — the snapshot is undefined; pruning must
+      // not throw or synthesize an empty snapshot.
+      expect(() =>
+        ctx.service.pruneCodeFirstSingles(new Set(["a"]))
+      ).not.toThrow();
+      expect(ctx.service.getCodeFirstFields("a")).toBeUndefined();
+    });
+  });
 });

--- a/packages/nextly/src/domains/singles/__tests__/single-test-helpers.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-test-helpers.ts
@@ -124,6 +124,10 @@ export function createMockSingleRegistry(): MockRecord {
     getSingleBySlug: vi.fn().mockImplementation(async (slug: string) => {
       return singles.get(slug) ?? null;
     }),
+    // The live code-first field source used to resolve `defaultValue`s that do
+    // not survive serialization. Undefined by default (UI-created behavior);
+    // tests that exercise function defaults override the return value.
+    getCodeFirstFields: vi.fn().mockReturnValue(undefined),
   };
 }
 

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -1340,6 +1340,23 @@ export class SingleQueryService extends BaseService {
     // string instead of the object.
     const logicalDefaults: Record<string, unknown> = { ...defaults };
 
+    // The logical form of a DB-ready default value: a json-backed field's type
+    // default (e.g. `getDefaultValue` returning "{}"/"[]") is a string for the
+    // insert, but a later dependent default must see the decoded object/array.
+    const toLogical = (
+      field: Parameters<typeof shouldTreatAsJson>[0],
+      dbValue: unknown
+    ): unknown => {
+      if (shouldTreatAsJson(field) && typeof dbValue === "string") {
+        try {
+          return JSON.parse(dbValue);
+        } catch {
+          return dbValue;
+        }
+      }
+      return dbValue;
+    };
+
     for (const field of singleMeta.fields) {
       if (!("name" in field) || !field.name) continue;
 
@@ -1398,7 +1415,7 @@ export class SingleQueryService extends BaseService {
         }
         if ("required" in field && field.required) {
           defaults[field.name] = getDefaultValue(field);
-          logicalDefaults[field.name] = defaults[field.name];
+          logicalDefaults[field.name] = toLogical(field, defaults[field.name]);
         } else {
           delete defaults[field.name];
           delete logicalDefaults[field.name];
@@ -1408,7 +1425,7 @@ export class SingleQueryService extends BaseService {
 
       if ("required" in field && field.required) {
         defaults[field.name] = getDefaultValue(field);
-        logicalDefaults[field.name] = defaults[field.name];
+        logicalDefaults[field.name] = toLogical(field, defaults[field.name]);
       }
     }
 

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -1317,29 +1317,52 @@ export class SingleQueryService extends BaseService {
         : []
     );
 
+    // A field's `defaultValue` (a function, or a structured value) does not
+    // survive serialization to `dynamic_singles.fields`, so it is absent from
+    // `singleMeta.fields`. Resolve defaults from the live code-first config when
+    // the Single has one; UI-created singles have none and keep the serialized
+    // fields (which can only carry primitive defaults). Keyed by field name.
+    const codeFirstFields = this.singleRegistryService.getCodeFirstFields(
+      singleMeta.slug
+    );
+    const codeFirstFieldByName = codeFirstFields
+      ? new Map(
+          codeFirstFields
+            .filter(field => "name" in field && field.name)
+            .map(field => [(field as { name: string }).name, field])
+        )
+      : undefined;
+
     for (const field of singleMeta.fields) {
       if (!("name" in field) || !field.name) continue;
+
+      // Prefer the live code-first field for the declared default: the
+      // serialized `field` has lost any `defaultValue` function/structured value.
+      const defaultSource = codeFirstFieldByName?.get(field.name) ?? field;
 
       // Resolve the field's default (explicit defaultValue, else a required
       // field's type-default) once, regardless of whether it is localized — a
       // localized field's default must reach the companion just the same.
-      if ("defaultValue" in field && field.defaultValue !== undefined) {
+      if (
+        "defaultValue" in defaultSource &&
+        defaultSource.defaultValue !== undefined
+      ) {
         // `defaultValue` may be a function `(data) => value`; evaluate it against
         // the document built so far so the stored default is a real value, not a
         // function object. A raw function would be bound as an SQL parameter for
         // the companion/main upsert and fail or persist its stringified form —
         // localized fields now flow through this block, so it must be resolved.
         const resolved =
-          typeof field.defaultValue === "function"
-            ? field.defaultValue(defaults)
-            : field.defaultValue;
+          typeof defaultSource.defaultValue === "function"
+            ? defaultSource.defaultValue(defaults)
+            : defaultSource.defaultValue;
         // A blocks default is checked here rather than only at config load,
         // because a function default can only be resolved against real data.
         // This row is inserted directly on first read, without going through
         // the write path, so nothing downstream would catch a document the
         // field's own policy rejects — and the admin control is read-only, so
         // the stored value could not be corrected from the UI.
-        assertValidBlocksDefault(field, resolved, singleMeta.slug);
+        assertValidBlocksDefault(defaultSource, resolved, singleMeta.slug);
         defaults[field.name] =
           shouldTreatAsJson(field) && typeof resolved === "object"
             ? JSON.stringify(resolved)

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -55,6 +55,7 @@ import {
   applyFieldReadAccess,
   runFieldHooks,
 } from "../../../shared/lib/field-level-registry";
+import { coerceDateFieldsToDate } from "../../../shared/lib/field-transform";
 import {
   hasPasswordField,
   stripPasswordFieldValues,
@@ -91,6 +92,7 @@ import type {
 
 import type { SingleRegistryService } from "./single-registry-service";
 import {
+  assertNoPasswordDefault,
   assertValidBlocksDefault,
   buildSingleErrorResult,
   collectAllMediaIds,
@@ -1388,6 +1390,10 @@ export class SingleQueryService extends BaseService {
         // field's own policy rejects — and the admin control is read-only, so
         // the stored value could not be corrected from the UI.
         assertValidBlocksDefault(defaultSource, resolved, singleMeta.slug);
+        // Same direct-insert reasoning for passwords: this path never runs
+        // `hashPasswordFieldValues`, so a resolved password default would persist
+        // in plaintext. Refuse it (a password must be set explicitly to be hashed).
+        assertNoPasswordDefault(field, singleMeta.slug);
         // Clone before exposing: a live STATIC structured default is the object
         // stored on the config, so handing that reference to later dependent
         // defaults (which may sort/mutate it) would corrupt the config itself.
@@ -1436,6 +1442,13 @@ export class SingleQueryService extends BaseService {
         logicalDefaults[field.name] = toLogical(field, defaults[field.name]);
       }
     }
+
+    // A date default resolves to a string (e.g. `() => new Date().toISOString()`),
+    // but a timestamp column needs a `Date` — the ordinary write path coerces via
+    // `coerceDateFieldsToDate`, and this direct-insert path must do the same or
+    // SQLite stores the string in an integer column and reads back an invalid
+    // date. Idempotent: an existing `Date` passes through untouched.
+    coerceDateFieldsToDate(defaults, singleMeta.fields);
 
     // A field can be translatable/required yet emit NO storage column — a
     // component or other layout-only ("skip") field type. Its default has nowhere

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -50,6 +50,7 @@ import type { ComponentDataService } from "../../../services/components/componen
 import { BaseService } from "../../../shared/base-service";
 import { convertTimestampsToCamelCase } from "../../../shared/lib/case-conversion";
 import { detachData } from "../../../shared/lib/detach";
+import { cloneDefault } from "../../../shared/lib/field-defaults";
 import {
   applyFieldReadAccess,
   runFieldHooks,
@@ -1387,13 +1388,20 @@ export class SingleQueryService extends BaseService {
         // field's own policy rejects — and the admin control is read-only, so
         // the stored value could not be corrected from the UI.
         assertValidBlocksDefault(defaultSource, resolved, singleMeta.slug);
-        // Keep the object on the logical view for later dependent defaults, but
-        // JSON-encode it for the DB insert when the column is json-backed.
-        logicalDefaults[field.name] = resolved;
+        // Clone before exposing: a live STATIC structured default is the object
+        // stored on the config, so handing that reference to later dependent
+        // defaults (which may sort/mutate it) would corrupt the config itself.
+        const cloned = cloneDefault(resolved);
+        // Keep the value on the logical view for later dependent defaults, and
+        // JSON-encode it for the DB insert when the column is json-backed. Encode
+        // EVERY defined value, not only objects: a json-backed column stores text
+        // (SQLite especially), so a primitive default like `() => true` must be
+        // "true", not a raw boolean that better-sqlite3 cannot bind.
+        logicalDefaults[field.name] = cloned;
         defaults[field.name] =
-          shouldTreatAsJson(field) && typeof resolved === "object"
-            ? JSON.stringify(resolved)
-            : resolved;
+          shouldTreatAsJson(field) && cloned !== undefined
+            ? JSON.stringify(cloned)
+            : cloned;
         continue;
       }
 

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -1333,6 +1333,13 @@ export class SingleQueryService extends BaseService {
         )
       : undefined;
 
+    // A logical view of the document as it is built, holding structured values as
+    // real objects. Function defaults receive THIS, not `defaults`: `defaults`
+    // stores json-backed values as JSON strings for the DB insert, so a dependent
+    // default reading an earlier group/repeater/JSON field would otherwise see a
+    // string instead of the object.
+    const logicalDefaults: Record<string, unknown> = { ...defaults };
+
     for (const field of singleMeta.fields) {
       if (!("name" in field) || !field.name) continue;
 
@@ -1354,7 +1361,7 @@ export class SingleQueryService extends BaseService {
         // localized fields now flow through this block, so it must be resolved.
         const resolved =
           typeof defaultSource.defaultValue === "function"
-            ? defaultSource.defaultValue(defaults)
+            ? defaultSource.defaultValue(logicalDefaults)
             : defaultSource.defaultValue;
         // A blocks default is checked here rather than only at config load,
         // because a function default can only be resolved against real data.
@@ -1363,6 +1370,9 @@ export class SingleQueryService extends BaseService {
         // field's own policy rejects — and the admin control is read-only, so
         // the stored value could not be corrected from the UI.
         assertValidBlocksDefault(defaultSource, resolved, singleMeta.slug);
+        // Keep the object on the logical view for later dependent defaults, but
+        // JSON-encode it for the DB insert when the column is json-backed.
+        logicalDefaults[field.name] = resolved;
         defaults[field.name] =
           shouldTreatAsJson(field) && typeof resolved === "object"
             ? JSON.stringify(resolved)
@@ -1388,14 +1398,17 @@ export class SingleQueryService extends BaseService {
         }
         if ("required" in field && field.required) {
           defaults[field.name] = getDefaultValue(field);
+          logicalDefaults[field.name] = defaults[field.name];
         } else {
           delete defaults[field.name];
+          delete logicalDefaults[field.name];
         }
         continue;
       }
 
       if ("required" in field && field.required) {
         defaults[field.name] = getDefaultValue(field);
+        logicalDefaults[field.name] = defaults[field.name];
       }
     }
 

--- a/packages/nextly/src/domains/singles/services/single-registry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-registry-service.ts
@@ -215,6 +215,23 @@ export class SingleRegistryService extends BaseRegistryService<
   }
 
   /**
+   * Drop snapshot entries whose slug is not in `presentSlugs`, leaving the
+   * surviving entries untouched. Used on a config reload to evict a removed
+   * Single's live defaults BEFORE any later `setCodeFirstSingles` call — so a
+   * reload that aborts (introspection failure, deferred schema, apply failure)
+   * after a Single was removed cannot leave its stale function defaults runnable
+   * against the removed-but-still-readable registry row. Remove-only: it never
+   * updates a surviving entry, so it cannot pair new live fields with stale
+   * serialized metadata the way an eager replace could.
+   */
+  pruneCodeFirstSingles(presentSlugs: ReadonlySet<string>): void {
+    if (!this.codeFirstSingles) return;
+    this.codeFirstSingles = this.codeFirstSingles.filter(single =>
+      presentSlugs.has(single.slug)
+    );
+  }
+
+  /**
    * The live code-first field definitions for a Single (with `defaultValue`
    * functions intact), or undefined for a UI-created Single. Callers resolving
    * declared defaults use these instead of the serialized `dynamic_singles.fields`.

--- a/packages/nextly/src/domains/singles/services/single-registry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-registry-service.ts
@@ -47,6 +47,7 @@ import {
   type BaseListResult,
 } from "../../../shared/base-registry-service";
 import type { Logger } from "../../../shared/types";
+import type { SingleConfig } from "../../../singles/config/types";
 import {
   calculateSchemaHash,
   schemaHashesMatch,
@@ -170,8 +171,31 @@ export class SingleRegistryService extends BaseRegistryService<
   /** Optional PermissionSeedService for auto-permission management. */
   private permissionSeedService?: PermissionSeedService;
 
-  constructor(adapter: DrizzleAdapter, logger: Logger) {
+  /**
+   * Live code-first Single configs, kept for their field `defaultValue`s. A
+   * `defaultValue` is a function, which is dropped when field metadata is
+   * JSON-serialized to `dynamic_singles.fields`, so the default resolution on a
+   * first-read auto-create reads defaults from here instead of the serialized
+   * (function-less) registry row. Undefined for UI-created Singles.
+   */
+  private readonly codeFirstSingles?: SingleConfig[];
+
+  constructor(
+    adapter: DrizzleAdapter,
+    logger: Logger,
+    codeFirstSingles?: SingleConfig[]
+  ) {
     super(adapter, logger);
+    this.codeFirstSingles = codeFirstSingles;
+  }
+
+  /**
+   * The live code-first field definitions for a Single (with `defaultValue`
+   * functions intact), or undefined for a UI-created Single. Callers resolving
+   * declared defaults use these instead of the serialized `dynamic_singles.fields`.
+   */
+  getCodeFirstFields(slug: string): SingleConfig["fields"] | undefined {
+    return this.codeFirstSingles?.find(single => single.slug === slug)?.fields;
   }
 
   protected getSearchColumns(): string[] {

--- a/packages/nextly/src/domains/singles/services/single-registry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-registry-service.ts
@@ -176,27 +176,42 @@ export class SingleRegistryService extends BaseRegistryService<
    * `defaultValue` is a function, which is dropped when field metadata is
    * JSON-serialized to `dynamic_singles.fields`, so the default resolution on a
    * first-read auto-create reads defaults from here instead of the serialized
-   * (function-less) registry row. Undefined for UI-created Singles, and refreshed
-   * on config reload (HMR) via {@link setCodeFirstSingles}.
+   * (function-less) registry row. Undefined for UI-created Singles. Set only
+   * AFTER a successful metadata sync (boot and HMR reload) via
+   * {@link setCodeFirstSingles}, never eagerly — otherwise new live fields could
+   * pair with stale serialized metadata for a single whose sync failed.
    */
   private codeFirstSingles?: SingleConfig[];
 
-  constructor(
-    adapter: DrizzleAdapter,
-    logger: Logger,
-    codeFirstSingles?: SingleConfig[]
-  ) {
+  constructor(adapter: DrizzleAdapter, logger: Logger) {
     super(adapter, logger);
-    this.codeFirstSingles = codeFirstSingles;
   }
 
   /**
-   * Replace the live code-first config snapshot. Called after a config reload
-   * (HMR) syncs Single metadata, so a newly added Single or a changed function
-   * default resolves against the current config rather than the boot-time one.
+   * Update the live code-first config snapshot after a metadata sync. Pass
+   * `keepPriorFor` (the slugs whose sync FAILED) to retain their previous
+   * snapshot entry instead of the new config: a failed single's serialized
+   * metadata did not advance, so exposing its new fields would mis-encode a
+   * default against the old type. A failed single with no prior entry is
+   * dropped (it falls back to the serialized fields).
    */
-  setCodeFirstSingles(codeFirstSingles: SingleConfig[]): void {
-    this.codeFirstSingles = codeFirstSingles;
+  setCodeFirstSingles(
+    singles: SingleConfig[],
+    options?: { keepPriorFor?: ReadonlySet<string> }
+  ): void {
+    const keepPrior = options?.keepPriorFor;
+    if (!keepPrior || keepPrior.size === 0) {
+      this.codeFirstSingles = singles;
+      return;
+    }
+    const priorBySlug = new Map(
+      (this.codeFirstSingles ?? []).map(single => [single.slug, single])
+    );
+    this.codeFirstSingles = singles
+      .map(single =>
+        keepPrior.has(single.slug) ? priorBySlug.get(single.slug) : single
+      )
+      .filter((single): single is SingleConfig => single !== undefined);
   }
 
   /**

--- a/packages/nextly/src/domains/singles/services/single-registry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-registry-service.ts
@@ -176,9 +176,10 @@ export class SingleRegistryService extends BaseRegistryService<
    * `defaultValue` is a function, which is dropped when field metadata is
    * JSON-serialized to `dynamic_singles.fields`, so the default resolution on a
    * first-read auto-create reads defaults from here instead of the serialized
-   * (function-less) registry row. Undefined for UI-created Singles.
+   * (function-less) registry row. Undefined for UI-created Singles, and refreshed
+   * on config reload (HMR) via {@link setCodeFirstSingles}.
    */
-  private readonly codeFirstSingles?: SingleConfig[];
+  private codeFirstSingles?: SingleConfig[];
 
   constructor(
     adapter: DrizzleAdapter,
@@ -186,6 +187,15 @@ export class SingleRegistryService extends BaseRegistryService<
     codeFirstSingles?: SingleConfig[]
   ) {
     super(adapter, logger);
+    this.codeFirstSingles = codeFirstSingles;
+  }
+
+  /**
+   * Replace the live code-first config snapshot. Called after a config reload
+   * (HMR) syncs Single metadata, so a newly added Single or a changed function
+   * default resolves against the current config rather than the boot-time one.
+   */
+  setCodeFirstSingles(codeFirstSingles: SingleConfig[]): void {
     this.codeFirstSingles = codeFirstSingles;
   }
 

--- a/packages/nextly/src/domains/singles/services/single-utils.ts
+++ b/packages/nextly/src/domains/singles/services/single-utils.ts
@@ -150,6 +150,38 @@ export function assertValidBlocksDefault(
 }
 
 /**
+ * Reject a `defaultValue` declared on a password field.
+ *
+ * A single's defaults are inserted straight onto the auto-created row, bypassing
+ * the write path that runs `hashPasswordFieldValues`. A resolved password
+ * default would therefore be persisted in PLAINTEXT, so it is refused here
+ * rather than silently stored. (A fixed/seeded default password is itself a
+ * security anti-pattern; a password must be set explicitly through the write
+ * path so it is hashed.) Checked on the same direct-insert path as
+ * {@link assertValidBlocksDefault}.
+ */
+export function assertNoPasswordDefault(
+  field: { name?: string; type?: string },
+  singleSlug: string
+): void {
+  if (field.type !== "password") return;
+  throw NextlyError.validation({
+    errors: [
+      {
+        path: field.name ?? "",
+        code: "PASSWORD_DEFAULT_UNSUPPORTED",
+        message: `A password field cannot declare a defaultValue; set "${field.name ?? "password"}" explicitly so it is hashed.`,
+      },
+    ],
+    logContext: {
+      single: singleSlug,
+      field: field.name,
+      reason: "password-default",
+    },
+  });
+}
+
+/**
  * Get a type-appropriate default value for a field type.
  * Used when a required field has no explicit defaultValue.
  */

--- a/packages/nextly/src/domains/webhooks/__tests__/recording-provenance.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/recording-provenance.test.ts
@@ -91,6 +91,8 @@ describe("collectPluginContributedSlugs", () => {
   });
 
   it("ignores entries without a slug and tolerates missing plugins", () => {
+    // A slugless or empty-slug entry contributes nothing, and an undefined
+    // plugin list yields an empty set rather than throwing.
     const plugins = [
       { name: "x", contributes: { collections: [{}, { slug: "" }] } },
     ];

--- a/packages/nextly/src/domains/webhooks/__tests__/recording-provenance.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/recording-provenance.test.ts
@@ -76,6 +76,8 @@ describe("collectPluginContributedSlugs", () => {
   });
 
   it("leaves a slug the renameMap does not mention untouched", () => {
+    // A renameMap entry for an unrelated slug must not alter the contributed
+    // slug it does not name.
     const plugins = [
       {
         name: "forms",

--- a/packages/nextly/src/domains/webhooks/__tests__/recording-provenance.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/recording-provenance.test.ts
@@ -41,7 +41,7 @@ describe("collectPluginContributedSlugs", () => {
     ).toBe(true);
   });
 
-  it("resolves a renamed slug through the plugin renameMap", () => {
+  it("resolves a renamed CONTRIBUTES slug through the plugin renameMap", () => {
     // The schema fold rewrites the contributed entry to the renamed slug, so
     // the effective slug (not the declared one) must be reported — otherwise a
     // renamed plugin's opt-out is mistagged `code` and pruned, and a disabled
@@ -58,7 +58,11 @@ describe("collectPluginContributedSlugs", () => {
     expect(singles.has("settings")).toBe(false);
   });
 
-  it("applies the renameMap to the legacy plugin.<kind> shape too", () => {
+  it("does NOT rename a legacy plugin.<kind> entry (the fold leaves it declared)", () => {
+    // The schema fold only renames `contributes`; a legacy top-level entry
+    // reaches the config through the plugin's own setup merge under its
+    // declared slug, so provenance must key on the declared slug — renaming it
+    // would mistag the folded collection as code-owned.
     const plugins = [
       {
         name: "legacy",
@@ -67,8 +71,8 @@ describe("collectPluginContributedSlugs", () => {
       },
     ];
     const collections = collectPluginContributedSlugs(plugins, "collections");
-    expect(collections.has("contacts")).toBe(true);
-    expect(collections.has("leads")).toBe(false);
+    expect(collections.has("leads")).toBe(true);
+    expect(collections.has("contacts")).toBe(false);
   });
 
   it("leaves a slug the renameMap does not mention untouched", () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/recording-provenance.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/recording-provenance.test.ts
@@ -41,6 +41,49 @@ describe("collectPluginContributedSlugs", () => {
     ).toBe(true);
   });
 
+  it("resolves a renamed slug through the plugin renameMap", () => {
+    // The schema fold rewrites the contributed entry to the renamed slug, so
+    // the effective slug (not the declared one) must be reported — otherwise a
+    // renamed plugin's opt-out is mistagged `code` and pruned, and a disabled
+    // plugin's renamed single slips the hook-skip filter.
+    const plugins = [
+      {
+        name: "settings",
+        contributes: { singles: [{ slug: "settings" }] },
+        renameMap: { settings: "site-settings" },
+      },
+    ];
+    const singles = collectPluginContributedSlugs(plugins, "singles");
+    expect(singles.has("site-settings")).toBe(true);
+    expect(singles.has("settings")).toBe(false);
+  });
+
+  it("applies the renameMap to the legacy plugin.<kind> shape too", () => {
+    const plugins = [
+      {
+        name: "legacy",
+        collections: [{ slug: "leads" }],
+        renameMap: { leads: "contacts" },
+      },
+    ];
+    const collections = collectPluginContributedSlugs(plugins, "collections");
+    expect(collections.has("contacts")).toBe(true);
+    expect(collections.has("leads")).toBe(false);
+  });
+
+  it("leaves a slug the renameMap does not mention untouched", () => {
+    const plugins = [
+      {
+        name: "forms",
+        contributes: { collections: [{ slug: "submissions" }] },
+        renameMap: { other: "renamed" },
+      },
+    ];
+    expect(
+      collectPluginContributedSlugs(plugins, "collections").has("submissions")
+    ).toBe(true);
+  });
+
   it("ignores entries without a slug and tolerates missing plugins", () => {
     const plugins = [
       { name: "x", contributes: { collections: [{}, { slug: "" }] } },

--- a/packages/nextly/src/domains/webhooks/recording-provenance.ts
+++ b/packages/nextly/src/domains/webhooks/recording-provenance.ts
@@ -37,13 +37,20 @@ interface PluginLike {
 /**
  * The set of EFFECTIVE slugs of `kind` contributed by any plugin in `plugins`,
  * reading both the declarative `contributes.<kind>` and the legacy
- * `plugin.<kind>` (mirrors how the admin-meta fold reads them). Each declared
- * slug is resolved through the plugin's `renameMap`, because the schema fold
- * (`applyPluginSchemaContributionsDeferred`) has already rewritten the config
- * entry to the renamed slug — every consumer compares this set against the
- * post-fold `config.<kind>` slug. Used to tag recording provenance so a
- * plugin's opt-out is never pruned by a code-first reconcile, and to skip a
- * disabled plugin's runtime hooks.
+ * `plugin.<kind>` (mirrors how the admin-meta fold reads them). Every consumer
+ * compares this set against the post-fold `config.<kind>` slug, so each source
+ * is resolved to the slug that actually lands in the config:
+ *
+ * - `contributes.<kind>` entries are folded by
+ *   `applyPluginSchemaContributionsDeferred`, which applies the plugin's
+ *   `renameMap`, so they are recorded under the RENAMED slug.
+ * - legacy `plugin.<kind>` entries are NOT renamed by that fold (only
+ *   `contributes` is); they reach the config through the plugin's own
+ *   `setup()`/manual merge under their DECLARED slug, so they are recorded
+ *   as-declared.
+ *
+ * Used to tag recording provenance so a plugin's opt-out is never pruned by a
+ * code-first reconcile, and to skip a disabled plugin's runtime hooks.
  */
 export function collectPluginContributedSlugs(
   plugins: readonly unknown[] | undefined,
@@ -53,12 +60,15 @@ export function collectPluginContributedSlugs(
   for (const raw of plugins ?? []) {
     const plugin = raw as PluginLike;
     const renameMap = plugin.renameMap ?? {};
-    const declared = plugin.contributes?.[kind] ?? [];
-    const legacy = plugin[kind] ?? [];
-    for (const entity of [...declared, ...legacy]) {
-      // Resolve the declared slug to its renamed form (identity when the
-      // plugin declares no rename for it), matching the folded config entry.
+    // `contributes` entries are rewritten to their renamed form by the schema
+    // fold (identity when the plugin declares no rename for the slug).
+    for (const entity of plugin.contributes?.[kind] ?? []) {
       if (entity?.slug) slugs.add(renameMap[entity.slug] ?? entity.slug);
+    }
+    // Legacy top-level entries keep their declared slug: the fold never renames
+    // them, so the config carries the declared slug regardless of `renameMap`.
+    for (const entity of plugin[kind] ?? []) {
+      if (entity?.slug) slugs.add(entity.slug);
     }
   }
   return slugs;

--- a/packages/nextly/src/domains/webhooks/recording-provenance.ts
+++ b/packages/nextly/src/domains/webhooks/recording-provenance.ts
@@ -28,13 +28,22 @@ interface PluginLike {
     collections?: readonly SluggedEntity[];
     singles?: readonly SluggedEntity[];
   };
+  // A plugin may rename its contributed slugs; the schema fold rewrites the
+  // config entry to the renamed slug, so provenance must key on that same
+  // effective slug (see `collectPluginContributedSlugs`).
+  renameMap?: Record<string, string>;
 }
 
 /**
- * The set of slugs of `kind` contributed by any plugin in `plugins`, reading
- * both the declarative `contributes.<kind>` and the legacy `plugin.<kind>`
- * (mirrors how the admin-meta fold reads them). Used to tag recording
- * provenance so a plugin's opt-out is never pruned by a code-first reconcile.
+ * The set of EFFECTIVE slugs of `kind` contributed by any plugin in `plugins`,
+ * reading both the declarative `contributes.<kind>` and the legacy
+ * `plugin.<kind>` (mirrors how the admin-meta fold reads them). Each declared
+ * slug is resolved through the plugin's `renameMap`, because the schema fold
+ * (`applyPluginSchemaContributionsDeferred`) has already rewritten the config
+ * entry to the renamed slug — every consumer compares this set against the
+ * post-fold `config.<kind>` slug. Used to tag recording provenance so a
+ * plugin's opt-out is never pruned by a code-first reconcile, and to skip a
+ * disabled plugin's runtime hooks.
  */
 export function collectPluginContributedSlugs(
   plugins: readonly unknown[] | undefined,
@@ -43,10 +52,13 @@ export function collectPluginContributedSlugs(
   const slugs = new Set<string>();
   for (const raw of plugins ?? []) {
     const plugin = raw as PluginLike;
+    const renameMap = plugin.renameMap ?? {};
     const declared = plugin.contributes?.[kind] ?? [];
     const legacy = plugin[kind] ?? [];
     for (const entity of [...declared, ...legacy]) {
-      if (entity?.slug) slugs.add(entity.slug);
+      // Resolve the declared slug to its renamed form (identity when the
+      // plugin declares no rename for it), matching the folded config entry.
+      if (entity?.slug) slugs.add(renameMap[entity.slug] ?? entity.slug);
     }
   }
   return slugs;

--- a/packages/nextly/src/hooks/__tests__/register-single-hooks.test.ts
+++ b/packages/nextly/src/hooks/__tests__/register-single-hooks.test.ts
@@ -1,0 +1,60 @@
+/**
+ * `registerSingleHooks` must bridge a code-first Single's declared hook phases to
+ * the HookRegistry under the `single:<slug>` namespace the single services read,
+ * mapping the update-only lifecycle correctly (a Single has no create/delete).
+ */
+
+import { describe, it, expect } from "vitest";
+
+import type { SingleConfig } from "../../singles/config/types";
+import { HookRegistry } from "../hook-registry";
+import { registerSingleHooks } from "../register-single-hooks";
+
+const noop = async () => undefined;
+
+describe("registerSingleHooks", () => {
+  it("registers each phase under single:<slug> with the update-only mapping", () => {
+    const registry = new HookRegistry();
+    const singles = [
+      {
+        slug: "branding",
+        fields: [],
+        hooks: {
+          beforeRead: [noop],
+          afterRead: [noop],
+          beforeChange: [noop],
+          afterChange: [noop],
+        },
+      },
+    ] as unknown as SingleConfig[];
+
+    const result = registerSingleHooks(singles, registry);
+
+    const ns = "single:branding";
+    expect(registry.getHookCount("beforeRead", ns)).toBe(1);
+    expect(registry.getHookCount("afterRead", ns)).toBe(1);
+    // beforeChange/afterChange map to the update registry types only — a Single
+    // is auto-created and update-only, so no create hooks are registered.
+    expect(registry.getHookCount("beforeUpdate", ns)).toBe(1);
+    expect(registry.getHookCount("afterUpdate", ns)).toBe(1);
+    expect(registry.getHookCount("beforeCreate", ns)).toBe(0);
+    expect(registry.getHookCount("afterCreate", ns)).toBe(0);
+
+    expect(result.totalHooks).toBe(4);
+    expect(result.singles).toEqual(["branding"]);
+  });
+
+  it("registers every handler in a phase and skips singles without hooks", () => {
+    const registry = new HookRegistry();
+    const singles = [
+      { slug: "with-hooks", fields: [], hooks: { afterRead: [noop, noop] } },
+      { slug: "plain", fields: [] },
+    ] as unknown as SingleConfig[];
+
+    const result = registerSingleHooks(singles, registry);
+
+    expect(registry.getHookCount("afterRead", "single:with-hooks")).toBe(2);
+    expect(result.singles).toEqual(["with-hooks"]);
+    expect(result.totalHooks).toBe(2);
+  });
+});

--- a/packages/nextly/src/hooks/__tests__/register-single-hooks.test.ts
+++ b/packages/nextly/src/hooks/__tests__/register-single-hooks.test.ts
@@ -57,4 +57,68 @@ describe("registerSingleHooks", () => {
     expect(result.singles).toEqual(["with-hooks"]);
     expect(result.totalHooks).toBe(2);
   });
+
+  it("discards an afterChange handler's return so it cannot rewrite the response", async () => {
+    // afterChange is side-effect-only for Singles, but it maps to the shared
+    // afterUpdate type whose runner applies a returned value; the registered
+    // handler must therefore leave the stored document unchanged.
+    const registry = new HookRegistry();
+    const singles = [
+      {
+        slug: "branding",
+        fields: [],
+        hooks: {
+          afterChange: [
+            async ({ data }: { data: Record<string, unknown> }) => ({
+              ...data,
+              injected: true,
+            }),
+          ],
+        },
+      },
+    ] as unknown as SingleConfig[];
+
+    registerSingleHooks(singles, registry);
+
+    const stored = { title: "Site" };
+    const result = await registry.execute("afterUpdate", {
+      collection: "single:branding",
+      operation: "update",
+      data: stored,
+    });
+
+    // The handler ran but its returned `injected` field was discarded.
+    expect(result).toEqual({ title: "Site" });
+    expect(result).not.toHaveProperty("injected");
+  });
+
+  it("keeps a beforeChange handler's return so it can transform the write data", async () => {
+    // beforeChange legitimately transforms the data before the write, so its
+    // return must survive (only afterChange is side-effect-only).
+    const registry = new HookRegistry();
+    const singles = [
+      {
+        slug: "branding",
+        fields: [],
+        hooks: {
+          beforeChange: [
+            async ({ data }: { data: Record<string, unknown> }) => ({
+              ...data,
+              normalized: true,
+            }),
+          ],
+        },
+      },
+    ] as unknown as SingleConfig[];
+
+    registerSingleHooks(singles, registry);
+
+    const result = await registry.execute("beforeUpdate", {
+      collection: "single:branding",
+      operation: "update",
+      data: { title: "Site" },
+    });
+
+    expect(result).toMatchObject({ title: "Site", normalized: true });
+  });
 });

--- a/packages/nextly/src/hooks/index.ts
+++ b/packages/nextly/src/hooks/index.ts
@@ -14,5 +14,6 @@ export * from "./context-builder";
 export * from "./prebuilt";
 export * from "./stored-hook-executor";
 export * from "./register-collection-hooks";
+export * from "./register-single-hooks";
 export * from "./sanitization-hooks";
 export * from "./activity-log-hooks";

--- a/packages/nextly/src/hooks/register-single-hooks.ts
+++ b/packages/nextly/src/hooks/register-single-hooks.ts
@@ -1,0 +1,150 @@
+/**
+ * Register Single Hooks
+ *
+ * Bridges the declarative `hooks` block of a code-first `defineSingle()` config
+ * to the runtime HookRegistry, the twin of {@link registerCollectionHooks} for
+ * Singles. Without this the four documented Single hook phases never run: the
+ * single services look hooks up under the `single:<slug>` namespace and always
+ * find nothing registered.
+ *
+ * A Single has no create or delete path (it is auto-created and update-only), so
+ * `beforeChange`/`afterChange` map to the update registry types only, and there
+ * are no validate/delete phases.
+ *
+ * @module hooks/register-single-hooks
+ */
+
+import type { SingleConfig, SingleHooks } from "../singles/config/types";
+
+import { getHookRegistry, type HookRegistry } from "./hook-registry";
+import type { HookType, HookHandler } from "./types";
+
+/** Result of registering single hooks. */
+export interface RegisterSingleHooksResult {
+  /** Single slugs that had hooks registered. */
+  singles: string[];
+  /** Total number of hooks registered. */
+  totalHooks: number;
+  /** Breakdown of hooks registered per single. */
+  details: {
+    single: string;
+    hooks: { type: string; count: number }[];
+  }[];
+}
+
+/**
+ * The registry "collection" key a Single's hooks register under. Must match
+ * `getSingleHookCollection` in the single query/mutation services, which look
+ * hooks up under this same `single:<slug>` namespace. Inlined here rather than
+ * imported to keep the hooks module free of a dependency on the singles domain.
+ */
+function singleHookNamespace(slug: string): string {
+  return `single:${slug}`;
+}
+
+/**
+ * Map Single hook phases to HookRegistry hook types. A Single is update-only, so
+ * `beforeChange`/`afterChange` register only the update variants (never create).
+ */
+const HOOK_TYPE_MAPPINGS: Record<keyof SingleHooks, HookType[]> = {
+  beforeRead: ["beforeRead"],
+  afterRead: ["afterRead"],
+  beforeChange: ["beforeUpdate"],
+  afterChange: ["afterUpdate"],
+};
+
+/**
+ * Register hooks declared on code-first Single configs with the global
+ * HookRegistry, so the single read/update paths execute them. Call during app
+ * initialization, mirroring {@link registerCollectionHooks}.
+ *
+ * @param singles - Single configurations from `defineSingle()`
+ * @param registry - Optional HookRegistry (defaults to the global registry)
+ * @returns Registration statistics
+ */
+export function registerSingleHooks(
+  singles: SingleConfig[],
+  registry: HookRegistry = getHookRegistry()
+): RegisterSingleHooksResult {
+  const result: RegisterSingleHooksResult = {
+    singles: [],
+    totalHooks: 0,
+    details: [],
+  };
+
+  for (const single of singles) {
+    if (!single.hooks) {
+      continue;
+    }
+
+    const singleDetails = {
+      single: single.slug,
+      hooks: [] as { type: string; count: number }[],
+    };
+    let singleHookCount = 0;
+
+    for (const [hookKey, handlers] of Object.entries(single.hooks)) {
+      if (!handlers || !Array.isArray(handlers) || handlers.length === 0) {
+        continue;
+      }
+
+      const hookTypes = HOOK_TYPE_MAPPINGS[hookKey as keyof SingleHooks];
+      if (!hookTypes) {
+        continue;
+      }
+
+      for (const hookType of hookTypes) {
+        for (const handler of handlers) {
+          registry.register(
+            hookType,
+            singleHookNamespace(single.slug),
+            handler as HookHandler
+          );
+          singleHookCount++;
+        }
+      }
+
+      singleDetails.hooks.push({ type: hookKey, count: handlers.length });
+    }
+
+    if (singleHookCount > 0) {
+      result.singles.push(single.slug);
+      result.totalHooks += singleHookCount;
+      result.details.push(singleDetails);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Clear all hooks registered for a Single. The registry keys Single hooks under
+ * the `single:<slug>` namespace, so clearing uses that same key.
+ *
+ * @param slug - The single slug to clear hooks for
+ * @param registry - Optional HookRegistry (defaults to the global registry)
+ */
+export function clearSingleHooks(
+  slug: string,
+  registry: HookRegistry = getHookRegistry()
+): void {
+  registry.clearCollection(singleHookNamespace(slug));
+}
+
+/**
+ * Re-register hooks for Singles: clear the existing ones, then register again.
+ * Useful for hot-reload in development.
+ *
+ * @param singles - Single configurations
+ * @param registry - Optional HookRegistry (defaults to the global registry)
+ * @returns Registration statistics
+ */
+export function reregisterSingleHooks(
+  singles: SingleConfig[],
+  registry: HookRegistry = getHookRegistry()
+): RegisterSingleHooksResult {
+  for (const single of singles) {
+    registry.clearCollection(singleHookNamespace(single.slug));
+  }
+  return registerSingleHooks(singles, registry);
+}

--- a/packages/nextly/src/hooks/register-single-hooks.ts
+++ b/packages/nextly/src/hooks/register-single-hooks.ts
@@ -54,6 +54,21 @@ const HOOK_TYPE_MAPPINGS: Record<keyof SingleHooks, HookType[]> = {
 };
 
 /**
+ * `afterChange` is documented as side-effect-only for Singles (cache
+ * invalidation, notifications), but it maps to the shared `afterUpdate` registry
+ * type whose runner in `SingleMutationService` assigns any returned value to the
+ * response after the write has committed. Wrap the handler so its return is
+ * discarded, keeping the API response equal to the stored Single. `beforeChange`
+ * (transforms write data) and `afterRead` (transforms the response) legitimately
+ * return values, so only `afterChange` is wrapped.
+ */
+function discardReturnValue(handler: HookHandler): HookHandler {
+  return async context => {
+    await handler(context);
+  };
+}
+
+/**
  * Register hooks declared on code-first Single configs with the global
  * HookRegistry, so the single read/update paths execute them. Call during app
  * initialization, mirroring {@link registerCollectionHooks}.
@@ -93,12 +108,18 @@ export function registerSingleHooks(
         continue;
       }
 
+      // Discard the return of a side-effect-only phase so a handler that returns
+      // data cannot rewrite the stored Single in the response.
+      const isSideEffectOnly = hookKey === "afterChange";
       for (const hookType of hookTypes) {
         for (const handler of handlers) {
+          const registered = isSideEffectOnly
+            ? discardReturnValue(handler as HookHandler)
+            : (handler as HookHandler);
           registry.register(
             hookType,
             singleHookNamespace(single.slug),
-            handler as HookHandler
+            registered
           );
           singleHookCount++;
         }

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -90,6 +90,13 @@ export {
   type RegisterCollectionHooksResult,
 } from "./hooks/register-collection-hooks";
 
+export {
+  registerSingleHooks,
+  clearSingleHooks,
+  reregisterSingleHooks,
+  type RegisterSingleHooksResult,
+} from "./hooks/register-single-hooks";
+
 // ============================================================
 // INITIALIZATION API
 // ============================================================

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -118,6 +118,7 @@ describe("reloadNextlyConfig", () => {
     const updateCollectionMigrationStatusSpy = vi
       .fn()
       .mockResolvedValue(undefined);
+    const setCodeFirstSinglesSpy = vi.fn();
     const services: Record<string, unknown> = {
       logger: { warn: warnSpy, info: vi.fn(), error: errorSpy },
       // The DI key is "adapter" (renamed from "databaseAdapter" — see the
@@ -144,6 +145,7 @@ describe("reloadNextlyConfig", () => {
       singleRegistryService: {
         syncCodeFirstSingles: vi.fn().mockResolvedValue({}),
         getAllSingles: vi.fn().mockResolvedValue(opts?.allSingles ?? []),
+        setCodeFirstSingles: setCodeFirstSinglesSpy,
       },
       componentRegistryService: {
         syncCodeFirstComponents: syncCodeFirstComponentsSpy,
@@ -158,6 +160,7 @@ describe("reloadNextlyConfig", () => {
       syncCodeFirstComponentsSpy,
       registerDynamicSchemaSpy,
       updateCollectionMigrationStatusSpy,
+      setCodeFirstSinglesSpy,
     });
   }
 
@@ -1023,7 +1026,8 @@ describe("reloadNextlyConfig", () => {
       });
 
       const { reloadNextlyConfig } = await import("../reload-config");
-      await reloadNextlyConfig({ resolver: buildResolver() });
+      const resolver = buildResolver();
+      await reloadNextlyConfig({ resolver });
 
       // The removed code-first entities revert to the default (record)...
       expect(isWebhookRecordingEnabled("collection", "leads")).toBe(true);
@@ -1032,6 +1036,9 @@ describe("reloadNextlyConfig", () => {
       expect(isWebhookRecordingEnabled("collection", "form-submissions")).toBe(
         false
       );
+      // The live default source is also cleared on the empty-target path so a
+      // removed single's function defaults can't run from a stale snapshot.
+      expect(resolver.setCodeFirstSinglesSpy).toHaveBeenCalledWith([]);
       resetWebhookRecordingPolicy();
     });
 

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -119,6 +119,7 @@ describe("reloadNextlyConfig", () => {
       .fn()
       .mockResolvedValue(undefined);
     const setCodeFirstSinglesSpy = vi.fn();
+    const pruneCodeFirstSinglesSpy = vi.fn();
     const services: Record<string, unknown> = {
       logger: { warn: warnSpy, info: vi.fn(), error: errorSpy },
       // The DI key is "adapter" (renamed from "databaseAdapter" — see the
@@ -146,6 +147,7 @@ describe("reloadNextlyConfig", () => {
         syncCodeFirstSingles: vi.fn().mockResolvedValue({}),
         getAllSingles: vi.fn().mockResolvedValue(opts?.allSingles ?? []),
         setCodeFirstSingles: setCodeFirstSinglesSpy,
+        pruneCodeFirstSingles: pruneCodeFirstSinglesSpy,
       },
       componentRegistryService: {
         syncCodeFirstComponents: syncCodeFirstComponentsSpy,
@@ -161,6 +163,7 @@ describe("reloadNextlyConfig", () => {
       registerDynamicSchemaSpy,
       updateCollectionMigrationStatusSpy,
       setCodeFirstSinglesSpy,
+      pruneCodeFirstSinglesSpy,
     });
   }
 
@@ -1036,9 +1039,9 @@ describe("reloadNextlyConfig", () => {
       expect(isWebhookRecordingEnabled("collection", "form-submissions")).toBe(
         false
       );
-      // The live default source is also cleared on the empty-target path so a
+      // The live default snapshot is pruned to the (now empty) present set so a
       // removed single's function defaults can't run from a stale snapshot.
-      expect(resolver.setCodeFirstSinglesSpy).toHaveBeenCalledWith([]);
+      expect(resolver.pruneCodeFirstSinglesSpy).toHaveBeenCalledWith(new Set());
       resetWebhookRecordingPolicy();
     });
 

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -169,6 +169,10 @@ interface SingleRegistrySurface {
     singles: unknown[],
     options?: { keepPriorFor?: ReadonlySet<string> }
   ): void;
+  // Drop removed singles from the live default snapshot BEFORE any reload path
+  // can abort, so a removed-but-readable single can't auto-create from stale
+  // function defaults. Optional for partial resolver fakes.
+  pruneCodeFirstSingles?(presentSlugs: ReadonlySet<string>): void;
   updateMigrationStatus(slug: string, status: string): Promise<unknown>;
   // See CollectionRegistrySurface.getAllCollections — same orphan-drop guard,
   // for UI-created singles. Optional for partial resolver fakes.
@@ -197,22 +201,31 @@ function failedSingleSlugs(syncResult: unknown): Set<string> {
 }
 
 /**
- * Drop the single registry's live default source. Used on the empty-target
- * reload path where the last managed single was removed: its registry row and
- * table stay readable, so an unclear snapshot would still run the removed
- * single's function/structured defaults on a later auto-create read. Non-fatal:
- * the snapshot also clears on the next successful reload or on restart.
+ * Evict removed singles from the live default snapshot, keyed on the slugs the
+ * new config still declares. Runs EARLY on every reload — before the empty-
+ * target return, the metadata-only branch, the DDL apply, and every abort path
+ * (introspection failure, deferred/failed schema apply) — so a removed single's
+ * registry row (which stays readable) can never auto-create from stale function
+ * defaults even when a later `setCodeFirstSingles` never runs. Remove-only, so
+ * it never pairs a surviving single's new fields with stale serialized metadata.
+ * Non-fatal: a missing registry just leaves the snapshot for the next reload.
  */
-async function clearSingleDefaultSource(
-  resolve: ServiceResolver
+async function pruneRemovedSingleDefaults(
+  resolve: ServiceResolver,
+  presentSingles: SingleDef[]
 ): Promise<void> {
   try {
     const singleReg = (await resolve(
       "singleRegistryService"
     )) as SingleRegistrySurface;
-    singleReg.setCodeFirstSingles?.([]);
+    const presentSlugs = new Set(
+      presentSingles
+        .map(single => single.slug)
+        .filter((slug): slug is string => typeof slug === "string")
+    );
+    singleReg.pruneCodeFirstSingles?.(presentSlugs);
   } catch {
-    // DI not initialised or the registry is absent — nothing to clear.
+    // DI not initialised or the registry is absent — nothing to prune.
   }
 }
 
@@ -638,6 +651,13 @@ export async function reloadNextlyConfig(opts?: {
   }
   if (!adapter) return;
 
+  // Evict removed singles from the live default snapshot up front, before any
+  // return/abort below, so a single dropped from the config can never
+  // auto-create from its stale function defaults even if this reload later
+  // aborts (introspection failure, deferred/failed apply) before the
+  // metadata-sync `setCodeFirstSingles` runs.
+  await pruneRemovedSingleDefaults(resolve, newConfig.singles ?? []);
+
   // dialect is an abstract readonly property on DrizzleAdapter, not a
   // method (a previous iteration mistakenly called .getDialect() which
   // would crash at runtime).
@@ -728,10 +748,8 @@ export async function reloadNextlyConfig(opts?: {
     // plugin decisions are preserved). No metadata to sync here, so this is the
     // only reconciliation the empty-target path needs.
     republishRecordingPolicies(newConfig, { collections: true, singles: true });
-    // The removed Single's row/table also stay readable, so clear the live
-    // default source too — otherwise a later auto-create read would still run
-    // the removed single's function/structured defaults from the stale snapshot.
-    await clearSingleDefaultSource(resolve);
+    // The live default snapshot was already pruned to the (now empty) present
+    // set above, so a removed single's stale defaults are gone by here.
     return;
   }
 

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -196,6 +196,26 @@ function failedSingleSlugs(syncResult: unknown): Set<string> {
   return slugs;
 }
 
+/**
+ * Drop the single registry's live default source. Used on the empty-target
+ * reload path where the last managed single was removed: its registry row and
+ * table stay readable, so an unclear snapshot would still run the removed
+ * single's function/structured defaults on a later auto-create read. Non-fatal:
+ * the snapshot also clears on the next successful reload or on restart.
+ */
+async function clearSingleDefaultSource(
+  resolve: ServiceResolver
+): Promise<void> {
+  try {
+    const singleReg = (await resolve(
+      "singleRegistryService"
+    )) as SingleRegistrySurface;
+    singleReg.setCodeFirstSingles?.([]);
+  } catch {
+    // DI not initialised or the registry is absent — nothing to clear.
+  }
+}
+
 interface ComponentRegistrySurface {
   syncCodeFirstComponents(configs: unknown[]): Promise<unknown>;
   // See CollectionRegistrySurface.getAllCollections — same orphan-drop guard,
@@ -708,6 +728,10 @@ export async function reloadNextlyConfig(opts?: {
     // plugin decisions are preserved). No metadata to sync here, so this is the
     // only reconciliation the empty-target path needs.
     republishRecordingPolicies(newConfig, { collections: true, singles: true });
+    // The removed Single's row/table also stay readable, so clear the live
+    // default source too — otherwise a later auto-create read would still run
+    // the removed single's function/structured defaults from the stale snapshot.
+    await clearSingleDefaultSource(resolve);
     return;
   }
 

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -162,9 +162,13 @@ interface CollectionRegistrySurface {
 interface SingleRegistrySurface {
   syncCodeFirstSingles(configs: unknown[]): Promise<unknown>;
   // Refresh the live code-first config snapshot the default resolver reads, so
-  // an HMR-added single or changed function default is honoured. Optional for
-  // partial resolver fakes.
-  setCodeFirstSingles?(singles: unknown[]): void;
+  // an HMR-added single or changed function default is honoured. `keepPriorFor`
+  // holds the slugs whose sync failed, so their prior snapshot is retained.
+  // Optional for partial resolver fakes.
+  setCodeFirstSingles?(
+    singles: unknown[],
+    options?: { keepPriorFor?: ReadonlySet<string> }
+  ): void;
   updateMigrationStatus(slug: string, status: string): Promise<unknown>;
   // See CollectionRegistrySurface.getAllCollections — same orphan-drop guard,
   // for UI-created singles. Optional for partial resolver fakes.
@@ -177,6 +181,21 @@ interface SingleRegistrySurface {
     }>
   >;
 }
+/**
+ * The slugs whose single sync failed. `syncCodeFirstSingles` resolves with an
+ * `errors[]` (per-single failures) rather than rejecting, so a partial failure
+ * is read from there; those slugs keep their prior default snapshot.
+ */
+function failedSingleSlugs(syncResult: unknown): Set<string> {
+  const errs = (syncResult as { errors?: Array<{ slug?: string }> } | undefined)
+    ?.errors;
+  const slugs = new Set<string>();
+  if (Array.isArray(errs)) {
+    for (const entry of errs) if (entry?.slug) slugs.add(entry.slug);
+  }
+  return slugs;
+}
+
 interface ComponentRegistrySurface {
   syncCodeFirstComponents(configs: unknown[]): Promise<unknown>;
   // See CollectionRegistrySurface.getAllCollections — same orphan-drop guard,
@@ -343,17 +362,18 @@ async function syncCodeFirstMetadataOnly(
       "singleRegistryService"
     )) as SingleRegistrySurface;
     const payload = buildSingleSyncPayload(newConfig.singles ?? []);
-    let singleSyncFailed = false;
+    let failedSlugs = new Set<string>();
     if (payload.length > 0) {
-      const syncResult = await singleReg.syncCodeFirstSingles(payload);
-      // Inspect the resolved errors[] (sync does not reject on a per-single
-      // failure) so a single with stale metadata is not paired with new fields.
-      const errs = (syncResult as { errors?: unknown[] } | undefined)?.errors;
-      singleSyncFailed = Array.isArray(errs) && errs.length > 0;
+      failedSlugs = failedSingleSlugs(
+        await singleReg.syncCodeFirstSingles(payload)
+      );
     }
-    // Refresh the live default source only after a successful metadata sync.
-    if (!singleSyncFailed)
-      singleReg.setCodeFirstSingles?.(newConfig.singles ?? []);
+    // Refresh the live default source after the sync: successful singles adopt
+    // the new config; a single whose sync failed keeps its prior snapshot so its
+    // new fields never pair with stale serialized metadata.
+    singleReg.setCodeFirstSingles?.(newConfig.singles ?? [], {
+      keepPriorFor: failedSlugs,
+    });
   } catch (err) {
     singles = false;
     logger?.warn(
@@ -1143,17 +1163,14 @@ export async function reloadNextlyConfig(opts?: {
       const codeFirstSingleConfigs = buildSingleSyncPayload(
         newConfig.singles ?? []
       );
-      let singleSyncFailed = false;
+      let failedSlugs = new Set<string>();
       if (codeFirstSingleConfigs.length > 0) {
-        const syncResult = await singleReg.syncCodeFirstSingles(
-          codeFirstSingleConfigs
+        // syncCodeFirstSingles resolves with an errors[] rather than rejecting;
+        // a per-single failure means its serialized metadata is stale, so that
+        // slug keeps its prior default snapshot below rather than the new fields.
+        failedSlugs = failedSingleSlugs(
+          await singleReg.syncCodeFirstSingles(codeFirstSingleConfigs)
         );
-        // syncCodeFirstSingles resolves with an errors[] rather than rejecting,
-        // so inspect it: a per-single failure means its serialized metadata is
-        // stale, and pairing that with the refreshed live fields below would
-        // encode a new default against the old field type.
-        const errs = (syncResult as { errors?: unknown[] } | undefined)?.errors;
-        singleSyncFailed = Array.isArray(errs) && errs.length > 0;
 
         // registerSingle defaults migration_status to 'pending'. The
         // pipeline above just created any missing physical tables, so
@@ -1170,12 +1187,12 @@ export async function reloadNextlyConfig(opts?: {
           }
         }
       }
-      // Refresh the live default source (with function defaults intact) only
-      // after a successful metadata sync, so new live fields never pair with
-      // stale serialized metadata for a single whose registry update failed.
-      if (!singleSyncFailed) {
-        singleReg.setCodeFirstSingles?.(newConfig.singles ?? []);
-      }
+      // Refresh the live default source after the sync: successful singles adopt
+      // the new config; a single whose sync failed keeps its prior snapshot so
+      // its new fields never pair with stale serialized metadata.
+      singleReg.setCodeFirstSingles?.(newConfig.singles ?? [], {
+        keepPriorFor: failedSlugs,
+      });
     } catch {
       // Non-fatal: same reasoning as collection metadata sync above.
       singleSynced = false;

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -161,6 +161,10 @@ interface CollectionRegistrySurface {
 }
 interface SingleRegistrySurface {
   syncCodeFirstSingles(configs: unknown[]): Promise<unknown>;
+  // Refresh the live code-first config snapshot the default resolver reads, so
+  // an HMR-added single or changed function default is honoured. Optional for
+  // partial resolver fakes.
+  setCodeFirstSingles?(singles: unknown[]): void;
   updateMigrationStatus(slug: string, status: string): Promise<unknown>;
   // See CollectionRegistrySurface.getAllCollections — same orphan-drop guard,
   // for UI-created singles. Optional for partial resolver fakes.
@@ -338,6 +342,9 @@ async function syncCodeFirstMetadataOnly(
     const singleReg = (await resolve(
       "singleRegistryService"
     )) as SingleRegistrySurface;
+    // Refresh the live default source (with function defaults intact) alongside
+    // the metadata sync, so a reloaded single's declared defaults stay current.
+    singleReg.setCodeFirstSingles?.(newConfig.singles ?? []);
     const payload = buildSingleSyncPayload(newConfig.singles ?? []);
     if (payload.length > 0) await singleReg.syncCodeFirstSingles(payload);
   } catch (err) {
@@ -1129,6 +1136,9 @@ export async function reloadNextlyConfig(opts?: {
       const codeFirstSingleConfigs = buildSingleSyncPayload(
         newConfig.singles ?? []
       );
+      // Refresh the live default source (with function defaults intact) so a
+      // reloaded single's declared defaults resolve against the current config.
+      singleReg.setCodeFirstSingles?.(newConfig.singles ?? []);
       if (codeFirstSingleConfigs.length > 0) {
         await singleReg.syncCodeFirstSingles(codeFirstSingleConfigs);
 

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -342,11 +342,18 @@ async function syncCodeFirstMetadataOnly(
     const singleReg = (await resolve(
       "singleRegistryService"
     )) as SingleRegistrySurface;
-    // Refresh the live default source (with function defaults intact) alongside
-    // the metadata sync, so a reloaded single's declared defaults stay current.
-    singleReg.setCodeFirstSingles?.(newConfig.singles ?? []);
     const payload = buildSingleSyncPayload(newConfig.singles ?? []);
-    if (payload.length > 0) await singleReg.syncCodeFirstSingles(payload);
+    let singleSyncFailed = false;
+    if (payload.length > 0) {
+      const syncResult = await singleReg.syncCodeFirstSingles(payload);
+      // Inspect the resolved errors[] (sync does not reject on a per-single
+      // failure) so a single with stale metadata is not paired with new fields.
+      const errs = (syncResult as { errors?: unknown[] } | undefined)?.errors;
+      singleSyncFailed = Array.isArray(errs) && errs.length > 0;
+    }
+    // Refresh the live default source only after a successful metadata sync.
+    if (!singleSyncFailed)
+      singleReg.setCodeFirstSingles?.(newConfig.singles ?? []);
   } catch (err) {
     singles = false;
     logger?.warn(
@@ -1136,11 +1143,17 @@ export async function reloadNextlyConfig(opts?: {
       const codeFirstSingleConfigs = buildSingleSyncPayload(
         newConfig.singles ?? []
       );
-      // Refresh the live default source (with function defaults intact) so a
-      // reloaded single's declared defaults resolve against the current config.
-      singleReg.setCodeFirstSingles?.(newConfig.singles ?? []);
+      let singleSyncFailed = false;
       if (codeFirstSingleConfigs.length > 0) {
-        await singleReg.syncCodeFirstSingles(codeFirstSingleConfigs);
+        const syncResult = await singleReg.syncCodeFirstSingles(
+          codeFirstSingleConfigs
+        );
+        // syncCodeFirstSingles resolves with an errors[] rather than rejecting,
+        // so inspect it: a per-single failure means its serialized metadata is
+        // stale, and pairing that with the refreshed live fields below would
+        // encode a new default against the old field type.
+        const errs = (syncResult as { errors?: unknown[] } | undefined)?.errors;
+        singleSyncFailed = Array.isArray(errs) && errs.length > 0;
 
         // registerSingle defaults migration_status to 'pending'. The
         // pipeline above just created any missing physical tables, so
@@ -1156,6 +1169,12 @@ export async function reloadNextlyConfig(opts?: {
             }
           }
         }
+      }
+      // Refresh the live default source (with function defaults intact) only
+      // after a successful metadata sync, so new live fields never pair with
+      // stale serialized metadata for a single whose registry update failed.
+      if (!singleSyncFailed) {
+        singleReg.setCodeFirstSingles?.(newConfig.singles ?? []);
       }
     } catch {
       // Non-fatal: same reasoning as collection metadata sync above.

--- a/packages/nextly/src/shared/lib/field-defaults.ts
+++ b/packages/nextly/src/shared/lib/field-defaults.ts
@@ -100,7 +100,7 @@ export function applyFieldDefaults(
  * row, say — would reach into unrelated rows, entries already written from the
  * same config, and the definition itself.
  */
-function cloneDefault(value: unknown): unknown {
+export function cloneDefault(value: unknown): unknown {
   if (value === null || typeof value !== "object") return value;
   try {
     return structuredClone(value);


### PR DESCRIPTION
Two P1 bugs (060 + 061), both **documented `defineSingle()` config that silently did nothing**, in one PR. Both were found by the #354 session while writing regression tests and handed off as separate tasks. One commit per bug + an end-to-end integration test.

## 060 — Single hooks never run (`291c2d65`)
`defineSingle({ hooks: { beforeRead, afterRead, beforeChange, afterChange } })` is documented, but nothing ever registered Single hooks: the services look them up under the `single:<slug>` namespace and always found nothing.
- Added `registerSingleHooks` — the twin of `registerCollectionHooks`, with the update-only lifecycle mapping (`beforeChange`/`afterChange` → `beforeUpdate`/`afterUpdate`; a Single has no create/delete).
- Wired it into the scaffolded `nextly init` helper alongside collection hooks (parity — that is how collection hooks register today).
- `beforeRead` stays **side-effect-only**: verified collections also discard the `beforeRead` return, so no read-path change.

## 061 — Single field defaults never apply (`8f934d62`)
A `defaultValue` on a Single field never applied; the first read auto-created the row with `null` in every defaulted column. Root cause: `defaultValue` is a **function**, dropped when field metadata is JSON-serialized to `dynamic_singles.fields`, so `buildDefaultDocument`'s (correct) function-vs-static resolution never saw one.
- `SingleRegistryService` now receives the live code-first configs and exposes `getCodeFirstFields(slug)`.
- `buildDefaultDocument` resolves declared defaults from those live fields, falling back to the serialized fields for UI-created singles (which can only carry primitive defaults). No serialization change; only code-first singles can declare a function default.

## Tests
- Unit: `registerSingleHooks` phase→type mapping + namespace; `buildDefaultDocument` resolving a function + structured default from the code-first source (and the UI-single fallback).
- Integration (`8943a07f`): a code-first Single with hooks + a scalar and a **structured (group)** function default — first read applies both defaults (structured one deserialized) and runs the read hooks; an update runs the change hooks.

## Notes
- **Discovered gap (follow-up, not fixed here):** neither collection nor single hooks register at framework boot — only via the scaffolded init helper — so a Direct-API-only app runs neither. That is a broader change (touches collection behaviour + double-registration) and out of scope for these two bug fixes; filing separately.
- Rebased onto latest `main` (includes #354, which also touched `single-query-service.ts`); the changes are in different sections and merged cleanly.
- `nextly` check-types + lint clean. Singles unit suite (169) green; the 4 pre-existing dispatcher baseline reds are unrelated (untouched files). One lockstep changeset (21 pkgs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lifecycle hooks for code-defined Singles across read and change events (with correct before/after mappings and execution semantics), plus registration utilities to register/clear/reregister hooks.
  * Preserved code-first Single defaults during configuration reloads and refresh flows.
* **Bug Fixes**
  * Improved Single default-value resolution, including function-based and structured defaults, dependent defaults, and correct JSON/string encoding for JSON-backed columns.
  * Webhook provenance now respects plugin slug renames for schema-contributed entities.
* **Tests**
  * Expanded integration and unit coverage for Single hook execution, default resolution/serialization, auto-create behavior, and reload scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->