### PR TITLE
fix(nextly): generate single-table ddl for the database it runs against

### DIFF
--- a/.changeset/single-table-ddl-dialect.md
+++ b/.changeset/single-table-ddl-dialect.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Singles now get their storage table on MySQL, and on any app configured with only a `DATABASE_URL` rather than an explicit `DB_DIALECT`. The DDL for a Single's table was generated from an optional environment variable that defaults to PostgreSQL instead of from the database the statements were about to run against, and a declared `slug` field was emitted as a type MySQL cannot put a unique index on, so the table was never created and the first read reported it missing.

--- a/packages/nextly/src/cli/commands/dev-server.ts
+++ b/packages/nextly/src/cli/commands/dev-server.ts
@@ -573,11 +573,16 @@ export async function performSinglesAutoSync(
   logger.newline();
   logger.info(`Auto-syncing ${singlesToSync.length} single table(s)...`);
 
-  // Import the schema service for generating migration SQL
+  // Import the schema service for generating migration SQL. The dialect comes
+  // from the adapter that will run the DDL: the service's own default reads
+  // DB_DIALECT, which is optional and falls back to "postgresql".
   const { DynamicCollectionSchemaService } = await import(
     "../../domains/dynamic-collections/services/dynamic-collection-schema-service"
   );
-  const schemaService = new DynamicCollectionSchemaService();
+  const schemaService = new DynamicCollectionSchemaService(
+    undefined,
+    adapter.dialect
+  );
 
   const synced: string[] = [];
   const errors: Array<{ slug: string; error: string }> = [];
@@ -759,7 +764,11 @@ export async function performSinglesReconcile(
   const { DynamicCollectionSchemaService } = await import(
     "../../domains/dynamic-collections/services/dynamic-collection-schema-service"
   );
-  const schemaService = new DynamicCollectionSchemaService();
+  // Same as the auto-sync above: the adapter names the dialect, not DB_DIALECT.
+  const schemaService = new DynamicCollectionSchemaService(
+    undefined,
+    adapter.dialect
+  );
 
   const reconciledSlugs: string[] = [];
 

--- a/packages/nextly/src/collections/__tests__/blocks-field.integration.test.ts
+++ b/packages/nextly/src/collections/__tests__/blocks-field.integration.test.ts
@@ -7,15 +7,19 @@
  * comes back as a string, or with its nesting flattened, would break every
  * renderer downstream while every unit test still passed.
  *
- * The suite self-skips on dialects whose URL is unset, per the integration
- * convention; CI runs all three.
+ * That is the risk it was written for, and until now it did not cover it: the
+ * suite booted the harness with no dialect, which is in-memory SQLite, so the
+ * two dialects whose JSON handling differs were never exercised. It now runs
+ * once per dialect the machine can reach.
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, expect, it } from "vitest";
 
 import { blocks, defineCollection, defineSingle, text } from "../../config";
+import { describeEachDialect } from "../../plugins/__tests__/helpers/dialect-matrix";
 import { createTestNextly, type TestNextly } from "../../plugins/test-nextly";
-import type { CollectionsHandler } from "../../services/collections-handler";
 import type { SingleEntryService } from "../../domains/singles/services/single-entry-service";
+import type { CollectionsHandler } from "../../services/collections-handler";
+import type { TestDialect } from "../../plugins/test-nextly";
 
 let current: TestNextly | undefined;
 
@@ -64,8 +68,9 @@ function dataOf(result: unknown): Record<string, unknown> {
   return (data ?? {}) as Record<string, unknown>;
 }
 
-async function handlerFor(): Promise<CollectionsHandler> {
+async function handlerFor(dialect: TestDialect): Promise<CollectionsHandler> {
   current = await createTestNextly({
+    dialect,
     collections: [
       defineCollection({
         slug: "pages",
@@ -76,9 +81,9 @@ async function handlerFor(): Promise<CollectionsHandler> {
   return current.getService<CollectionsHandler>("collectionsHandler");
 }
 
-describe("blocks field storage (integration)", () => {
+describeEachDialect("blocks field storage", dialect => {
   it("round-trips a nested document unchanged", async () => {
-    const handler = await handlerFor();
+    const handler = await handlerFor(dialect);
 
     const created = await handler.createEntry(
       { collectionName: "pages", userId: "u1", overrideAccess: true },
@@ -97,7 +102,7 @@ describe("blocks field storage (integration)", () => {
   });
 
   it("reads the document back as an object, never a JSON string", async () => {
-    const handler = await handlerFor();
+    const handler = await handlerFor(dialect);
     const created = await handler.createEntry(
       { collectionName: "pages", userId: "u1", overrideAccess: true },
       { title: "Home", content: DOCUMENT }
@@ -118,7 +123,7 @@ describe("blocks field storage (integration)", () => {
   });
 
   it("updates a document in place", async () => {
-    const handler = await handlerFor();
+    const handler = await handlerFor(dialect);
     const created = await handler.createEntry(
       { collectionName: "pages", userId: "u1", overrideAccess: true },
       { title: "Home", content: DOCUMENT }
@@ -144,7 +149,7 @@ describe("blocks field storage (integration)", () => {
   });
 
   it("stores an absent document as null rather than inventing one", async () => {
-    const handler = await handlerFor();
+    const handler = await handlerFor(dialect);
     const created = await handler.createEntry(
       { collectionName: "pages", userId: "u1", overrideAccess: true },
       { title: "No content" }
@@ -162,6 +167,7 @@ describe("blocks field storage (integration)", () => {
     // Singles have their own JSON classifier and their own serialize/
     // deserialize pair, so a collection round-trip proves nothing about them.
     current = await createTestNextly({
+      dialect,
       singles: [
         defineSingle({
           slug: "homepage",
@@ -185,6 +191,7 @@ describe("blocks field storage (integration)", () => {
 
   it("refuses a document the field does not accept", async () => {
     current = await createTestNextly({
+      dialect,
       collections: [
         defineCollection({
           slug: "pages",

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -1956,7 +1956,14 @@ async function reconcileSingleTablesForBoot(
     const { DynamicCollectionSchemaService } = await import(
       "../domains/dynamic-collections/services/dynamic-collection-schema-service"
     );
-    const schemaService = new DynamicCollectionSchemaService();
+    // The dialect comes from the adapter that will run this DDL. Left to its
+    // own default the service reads DB_DIALECT, which is optional and falls
+    // back to "postgresql" — so an app configured with only a MySQL or SQLite
+    // DATABASE_URL would generate a single's table as PostgreSQL.
+    const schemaService = new DynamicCollectionSchemaService(
+      undefined,
+      adapter.getCapabilities().dialect
+    );
     const singleRegistry = container.get<SingleRegistryService>(
       "singleRegistryService"
     );

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -551,7 +551,22 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       // Pass hasStatus so the data table also gets a `status` column
       // when the user opted into Draft/Published — without it the
       // runtime schema would expect a column the DDL never created.
-      const schemaService = new DynamicCollectionSchemaService();
+      // The dialect comes from the adapter that will run this DDL, not from
+      // the service's own DB_DIALECT default — that variable is optional and
+      // falls back to "postgresql", so an app configured with only a MySQL or
+      // SQLite DATABASE_URL would create this table as PostgreSQL.
+      //
+      // Read the same optional way the execution below reads it: with no
+      // adapter registered the statements are generated and never run, so the
+      // service keeps its own default rather than this path demanding a
+      // connection it is not going to use.
+      const createDialect = container.has("adapter")
+        ? container.get<DrizzleAdapter>("adapter").getCapabilities().dialect
+        : undefined;
+      const schemaService = new DynamicCollectionSchemaService(
+        undefined,
+        createDialect
+      );
       const isLocalized = b.localized === true;
       const migrationSQL = schemaService.generateMigrationSQL(
         tableName,
@@ -1023,8 +1038,17 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         updateData.fields = b.fields;
         updateData.schemaHash = calculateSchemaHash(b.fields);
 
-        // Generate and execute ALTER TABLE migration.
-        const schemaService = new DynamicCollectionSchemaService();
+        // Generate and execute ALTER TABLE migration. The dialect comes from
+        // the adapter that will run it, for the same reason as the create
+        // path above: the service's own default is "postgresql". Read
+        // optionally, matching how the execution below reads it.
+        const updateDialect = container.has("adapter")
+          ? container.get<DrizzleAdapter>("adapter").getCapabilities().dialect
+          : undefined;
+        const schemaService = new DynamicCollectionSchemaService(
+          undefined,
+          updateDialect
+        );
         const tableName = existing.tableName;
 
         // Normalize field lists for ALTER TABLE comparison. The physical

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-schema-service.ts
@@ -66,6 +66,26 @@ export class DynamicCollectionSchemaService {
    * @param fields - Field definitions for the table
    * @param options - Optional configuration (reserved for future use)
    */
+  /**
+   * Keep a declared `slug` column indexable.
+   *
+   * Every generated table gets a UNIQUE index on `slug`, and MySQL cannot
+   * index a TEXT column without a prefix length — the system slug column is
+   * `varchar(255)` for exactly that reason. A `slug` the caller declared as a
+   * text field reached this as `text`, so the CREATE INDEX that follows failed
+   * and the whole table was left uncreated. The two now agree.
+   *
+   * Only MySQL, and only the identity column: nothing else here is indexed on
+   * creation, so nothing else needs its declared type narrowed.
+   */
+  private slugSafeType(fieldName: string, mappedType: string): string {
+    if (this.dialect !== "mysql") return mappedType;
+    if (this.toSnakeCase(fieldName) !== "slug") return mappedType;
+    return /^(tiny|medium|long)?(text|blob)$/i.test(mappedType.trim())
+      ? "varchar(255)"
+      : mappedType;
+  }
+
   generateMigrationSQL(
     tableName: string,
     fields: FieldDefinition[],
@@ -123,11 +143,9 @@ export class DynamicCollectionSchemaService {
           return null;
         }
 
-        const type = this.mapFieldTypeToSQL(
-          f.type,
-          f.length,
-          f.options,
-          f.validation
+        const type = this.slugSafeType(
+          f.name,
+          this.mapFieldTypeToSQL(f.type, f.length, f.options, f.validation)
         );
         const nullable = f.required ? "NOT NULL" : "";
 


### PR DESCRIPTION
> Stacked on #366 (the dialect harness). Review that one first; this branch contains only the commit below.

## How this started

Running merged #343's blocks storage suite on real dialects, which is what the harness in #366 was for. The suite's own docblock said:

> The suite self-skips on dialects whose URL is unset, per the integration convention; CI runs all three.

It did not. It booted the harness with no dialect, which is in-memory SQLite, so the two dialects whose JSON handling actually differs were never exercised. Pointing it at Postgres and MySQL failed immediately, and found two separate production bugs.

## Bug 1 — single-table DDL was generated for the wrong database

`DynamicCollectionSchemaService` takes its dialect from `env.DB_DIALECT`, which is declared `z.enum([...]).default("postgresql")` — so it is **always** `"postgresql"` unless explicitly set.

But `DB_DIALECT` is optional by design. The adapter factory documents and implements protocol detection: *"Priority 2: Fallback - detect from DATABASE_URL protocol"*. So an app configured with only `DATABASE_URL=mysql://…` gets a MySQL adapter and **PostgreSQL DDL**.

Six call sites constructed the service with no dialect. Four are reachable with an adapter in hand and are fixed here:

| Site | Path |
|---|---|
| `di/register.ts` | boot-time single-table reconcile |
| `single-dispatcher.ts` ×2 | creating and updating a Single from the admin UI |
| `dev-server.ts` ×2 | `nextly dev` auto-sync and reconcile |

The dialect now comes from the adapter that is about to execute the statements — the same principle as #365, where the MySQL database name came from the live connection rather than an environment variable.

The dispatcher sites read the adapter **optionally**, exactly as the execution below them already does: with no adapter registered the statements are generated and never run, so that path does not start demanding a connection it will not use. (My first attempt made it mandatory and broke a dispatcher shape test — caught before pushing.)

## Bug 2 — MySQL cannot index the slug column that was generated

Every generated table takes a `CREATE UNIQUE INDEX … ON (slug)`. The **system** slug column is already `varchar(255)` on MySQL for exactly that reason. But a **declared** `slug` field went through the generic field mapper and came out as `text`, and MySQL refuses:

```
BLOB/TEXT column 'slug' used in key specification without a key length
```

The table was left uncreated, boot logged a warning and continued, and the first read failed with a missing table. A declared `slug` is now emitted as `varchar(255)` too, so the two branches agree.

## Result

The blocks suite now runs on every dialect the machine can reach and passes on all three — 18 tests. The all-dialect claim that was withdrawn from #343 is now true rather than asserted.

## Verification

- `pnpm build`, `pnpm check-types` (19/19), `pnpm --filter nextly lint` — clean by exit code
- Full `nextly` integration suite: **156 files pass on Postgres**, **143 on MySQL** (fresh database)
- Unit suites over `dynamic-collections`, `dispatcher`, `cli`, `di`: the failing set is **identical** with and without this change, compared by diffing the two `FAIL` lists rather than the counts
- Both new failures were reproduced from a real server before being fixed, and the generated DDL was inspected directly for each dialect
