### PR TITLE
fix(admin): stop the media card clipping and correct the radius contract

### DIFF
--- a/.changeset/theming-followups.md
+++ b/.changeset/theming-followups.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Media cards keep their metadata inside the tile, four more surfaces stay within their rounded corners, and the corner-radius guide now matches the components.
+
+In the media library's grid view, a card's file size could paint outside the card border while its dimensions were squeezed to nothing. At the six-column layout this left the dimensions reading as a stray "1..", and a long label such as "Invalid size" spilled past the tile edge. The size is now always readable inside the card, and the dimensions appear once the card is wide enough to render both values in full, with a tooltip on the row carrying both at any card width.
+
+Four surfaces painted a full-bleed child square across a rounded parent, which anyone running a nonzero `--radius` could see: the email-template segmented control, the component-row card header, the schema-builder field table header, and the code editor's validation error strip. `CardHeader` also gained the top-corner counterpart of the fix `CardFooter` already carried. All of these are unchanged at the shipped `--radius: 0`.
+
+The slash command menu in rich text fields declared a stacking order that never took effect, so it could be covered by a dialog. It now sits above one.
+
+The corner-radius tier tables in the theme and in the plugin authoring guide described a system the components do not implement, pointing plugin authors at the wrong step for alerts, table wrappers, checkboxes, icon buttons, switches and tabs. Both now agree with the code and with each other, they no longer offer `rounded-xl` and `rounded-2xl` as steps of the radius knob (the published Tailwind preset never exported them, and they do not go square at `--radius: 0`), and they state what `--radius: 0` actually resolves to for each step. A new test pins the contract so the documents and the components cannot drift apart unnoticed.

--- a/packages/admin/src/components/features/content/SortableFieldsTable.tsx
+++ b/packages/admin/src/components/features/content/SortableFieldsTable.tsx
@@ -141,7 +141,10 @@ export function SortableFieldsTable({
   };
 
   return (
-    <div className="border rounded-md">
+    // `overflow-hidden` matches the other table wrappers: the header row is
+    // painted opaque edge to edge, so without clipping it squares off the
+    // wrapper's rounded top corners at any nonzero --radius.
+    <div className="border rounded-md overflow-hidden">
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}

--- a/packages/admin/src/components/features/entries/fields/special/SlashCommandPlugin.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/SlashCommandPlugin.tsx
@@ -265,6 +265,10 @@ const menuContainerStyle: React.CSSProperties = {
   padding: "4px",
   // Elevation from the theme's shadow ramp rather than a fixed black wash.
   boxShadow: "var(--shadow-lg)",
+  // `z-index` only applies to a positioned box. Without this the element is
+  // `position: static`, the value below is discarded, and the menu loses the
+  // hit test to any positioned overlay above it in paint order.
+  position: "relative",
   zIndex: 9999,
 };
 
@@ -352,10 +356,12 @@ export function SlashCommandPlugin({
   const [editor] = useLexicalComposerContext();
   const [queryString, setQueryString] = useState<string | null>(null);
   // The typeahead anchor is appended to whatever `parent` is given, defaulting
-  // to `ownerDocument.body`. Every token the menu styles read is declared on
-  // `.nextly-admin`, so a body-level anchor resolves none of them: the panel
-  // loses its surface, its border and its elevation. Anchoring inside the
-  // admin's scoped portal root keeps the menu within that cascade.
+  // to `ownerDocument.body`. Dark mode is a `dark` class on the admin's own
+  // root element, not on `<html>`, so the `.dark` overrides of the tokens these
+  // styles read never match an element mounted on the body: a body-level menu
+  // renders with the light-mode surface inside a dark admin. Anchoring inside
+  // the admin's scoped portal root, which carries the same class, keeps the
+  // menu on the correct side of that override.
   const portalContainer = usePortalContainer();
 
   // Check for "/" trigger

--- a/packages/admin/src/components/features/entries/fields/structured/ComponentRow.tsx
+++ b/packages/admin/src/components/features/entries/fields/structured/ComponentRow.tsx
@@ -241,7 +241,10 @@ export function ComponentRow<TFieldValues extends FieldValues = FieldValues>({
       ref={setNodeRef}
       style={style}
       className={cn(
-        "transition-shadow",
+        // The collapsible header tints itself edge to edge, so without clipping
+        // that fill paints square across the card's rounded top corners at any
+        // nonzero --radius. Matches the other structured-field cards.
+        "overflow-hidden transition-shadow",
         isDragging && "opacity-50 ring-2 ring-primary shadow-lg z-10"
       )}
     >

--- a/packages/admin/src/components/features/entries/fields/text/CodeInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/text/CodeInput.tsx
@@ -236,7 +236,12 @@ export function CodeInput<TFieldValues extends FieldValues = FieldValues>({
 
       {/* Validation error hint (shown below editor) */}
       {invalid && error?.message && (
-        <div className="border-t border-destructive bg-destructive/5 px-3 py-2 text-xs text-destructive">
+        // The strip sits on the wrapper's bottom edge and fills its full width,
+        // so it takes the wrapper's own computed corner rather than painting
+        // square across it. `inherit` tracks whatever radius the wrapper ends up
+        // with instead of restating a step, and the editor keeps `overflow`
+        // visible so CodeMirror's own popups are not clipped.
+        <div className="rounded-b-[inherit] border-t border-destructive bg-destructive/5 px-3 py-2 text-xs text-destructive">
           {error.message}
         </div>
       )}

--- a/packages/admin/src/components/features/media-library/MediaCard/index.tsx
+++ b/packages/admin/src/components/features/media-library/MediaCard/index.tsx
@@ -225,28 +225,32 @@ export function MediaCard({
 
       {/* Information Bar - Integrated at bottom of aspect-square */}
       <div className="bg-primary/5  border-t border-border p-3 shrink-0">
-        <div className="flex flex-col gap-1.5">
+        {/* A container context on the metadata column, so the row below keys off
+         * the width it actually gets rather than the viewport: the grid's column
+         * count and the sidebar move card width independently of any breakpoint,
+         * and at `lg` the six columns leave the row about 58px wide. */}
+        <div className="@container/meta flex flex-col gap-1.5">
           <p className="text-xs font-bold text-foreground dark:text-muted-foreground truncate leading-none tracking-tight">
             {media.originalFilename || media.filename}
           </p>
-          {/* The six-column grid leaves cards around 84px wide at the `lg`
-           * breakpoint, narrower than a dimensions/size pair can render on one
-           * line. Neither value has a break opportunity, and the card clips its
-           * overflow, so without a shrink policy the text is cut mid-glyph.
-           * Dimensions truncate (the ellipsis reads as "there is more"); the
-           * shorter size holds its width so the value stays whole. `title`
-           * keeps both readable at any card width. */}
-          <div className="flex items-center justify-between gap-2">
-            <span
-              title={dimensionsLabel}
-              className="text-xs font-medium text-muted-foreground dark:text-muted-foreground uppercase tracking-widest min-w-0 truncate"
-            >
+          {/* The pair needs roughly 160px to render whole, which the row only
+           * has on wide cards. Below that the size wins the space: it is the one
+           * value every asset has (audio and documents have no dimensions) and
+           * the one the preview cannot convey, whereas an image's proportions
+           * are already visible in the thumbnail above. Dimensions are therefore
+           * shown only once the row can hold both in full, so the value is never
+           * a partial number, and the row's `title` keeps them readable at every
+           * width — unlike a tooltip on the span itself, which is unreachable
+           * once the span is squeezed to zero. `truncate` on both is the floor
+           * that keeps a long label, `Invalid size` included, inside the card. */}
+          <div
+            title={`${dimensionsLabel} · ${sizeLabel}`}
+            className="flex items-center justify-between gap-2"
+          >
+            <span className="hidden @min-[10rem]/meta:inline text-xs font-medium text-muted-foreground dark:text-muted-foreground uppercase tracking-widest min-w-0 truncate">
               {dimensionsLabel}
             </span>
-            <span
-              title={sizeLabel}
-              className="text-xs font-bold text-muted-foreground dark:text-muted-foreground uppercase tracking-tighter shrink-0"
-            >
+            <span className="text-xs font-bold text-muted-foreground dark:text-muted-foreground uppercase tracking-tighter min-w-0 truncate">
               {sizeLabel}
             </span>
           </div>

--- a/packages/admin/src/components/features/settings/EmailTemplateForm.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm.tsx
@@ -404,7 +404,11 @@ function Segmented<T extends string>({
   onChange: (v: T) => void;
 }) {
   return (
-    <div className="inline-flex items-center rounded-md border border-input">
+    // The end segments paint their active fill to the outline's edge, so at a
+    // nonzero --radius that fill would square off across the rounded corners.
+    // Clipping to the rounded box keeps the fill inside the outline at every
+    // radius, and is inert at --radius: 0.
+    <div className="inline-flex items-center overflow-hidden rounded-md border border-input">
       {options.map(o => (
         <button
           key={o.value}

--- a/packages/ui/docs/plugin-ui-authoring.md
+++ b/packages/ui/docs/plugin-ui-authoring.md
@@ -94,19 +94,33 @@ keeps up with that only if it picks a **tier by element category** rather than w
 length. Hardcoding a corner — `rounded-none` just as much as `rounded-[6px]` or
 `border-radius: 4px` — pins your UI at that value and opts it out of the knob.
 
-| Tier                         | Use for                                                                                          |
-| ---------------------------- | ------------------------------------------------------------------------------------------------ |
-| `rounded-lg` / `--radius-lg` | Containers: cards, dialogs, popovers, panels, table wrappers, alerts, empty states, image frames |
-| `rounded-md` / `--radius-md` | Controls: buttons, inputs, textareas, select triggers, checkboxes, switches                      |
-| `rounded-sm` / `--radius-sm` | Small controls and adornments: menu items, badges, chips, tags, tabs, icon buttons               |
-| `rounded-xl` / `rounded-2xl` | Surfaces that must read as clearly softer than a card. Rare                                      |
-| `rounded-full`               | Circles only — avatars, status dots, spinners, pills                                             |
+The scale is three steps. These are exactly what `@nextlyhq/ui/tailwind-preset` exports, and
+exactly what the shipped components use, so matching a Nextly component means picking the
+tier it picks.
 
-Two consequences worth internalising:
+| Tier                         | Use for                                                                                                                                      |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rounded-lg` / `--radius-lg` | Floating and grouping containers: cards, dialogs, alert dialogs, popovers, tooltips, dropdown / select / command panels, empty-state panels  |
+| `rounded-md` / `--radius-md` | Controls and the inline surfaces among them: buttons, inputs, textareas, select triggers, icon buttons, alerts, table wrappers, image frames |
+| `rounded-sm` / `--radius-sm` | Small controls and adornments: menu and list items, badges, chips, tags, checkboxes, toolbar affordances                                     |
+| `rounded-full`               | Circles and pills, outside the scale — avatars, status dots, spinners, progress tracks, switch tracks and thumbs                             |
+
+Four consequences worth internalising:
 
 - **`rounded-full` is deliberately outside the scale.** It is `9999px`, not a `--radius`
   step. Those elements are round because of their shape, not because of the theme, so a
   retheme must never flatten them.
+- **`rounded-xl` and `rounded-2xl` are not tiers of this knob.** The preset exports only
+  `lg`, `md` and `sm`, so a plugin built against it gets Tailwind's fixed `0.75rem` /
+  `1rem` for those two, detached from `--radius`. Inside the admin's own build they are
+  defined, but as `--radius + 4px` and `--radius + 8px`, so at the shipped `--radius: 0`
+  they resolve to `4px` and `8px` — visibly round inside a square admin. Pick from
+  `sm` / `md` / `lg`.
+- **`--radius: 0` is not "every step is zero".** `--radius-lg` is `0`, but `--radius-sm`
+  and `--radius-md` compute to `-4px` and `-2px`. They _render_ square only because
+  `border-radius` clamps a negative length to `0`. The token keeps its negative value, so
+  reading a step for padding, for an inset, or through `getComputedStyle` gives you `-4px`,
+  not `0`. Clamp it yourself if you consume a step as a length rather than as a corner.
 - **A rounded container must handle full-bleed children.** If a child paints a background
   all the way to the container's edge (a tinted footer, a sticky header, a hover row), give
   the container `overflow-hidden` or give the child a matching corner with
@@ -116,7 +130,10 @@ Two consequences worth internalising:
 If a specific element genuinely must stay square, keep `rounded-none` and leave a comment
 saying why (overlapped-border strips, full-bleed fills inside an already-rounded parent,
 underline tabs). Square with a stated reason is a decision; square without one is an element
-nobody wired to the knob.
+nobody wired to the knob. Tabs are square for exactly that reason — the active state is a
+bottom border that has to run the full width of the trigger — which is why they are not in
+the `rounded-sm` tier above. Sheet is the counter-example: it is anchored to the viewport
+edge and carries no radius class at all.
 
 ---
 

--- a/packages/ui/src/components/card.tsx
+++ b/packages/ui/src/components/card.tsx
@@ -102,7 +102,14 @@ const CardHeader = forwardRef<HTMLDivElement, CardHeaderProps>(
         ref={ref}
         data-slot="card-header"
         className={cn(
-          "flex flex-col p-4",
+          // Mirrors CardFooter: a header that carries its own tint runs the full
+          // width of the card, so at a nonzero --radius it would paint square
+          // across the card's curved top corners. `inherit` takes the parent's
+          // computed radius rather than restating a step. It only helps when the
+          // header is a direct child of the card; a header nested inside another
+          // wrapper inherits that wrapper's radius instead, and such a card needs
+          // `overflow-hidden` to clip the fill.
+          "flex flex-col rounded-t-[inherit] p-4",
           !noBorder && "border-b border-border",
           className
         )}
@@ -190,7 +197,8 @@ const CardFooter = forwardRef<HTMLDivElement, CardFooterProps>(
           // --radius it would paint square across the card's curved bottom
           // corners. `inherit` takes the card's own computed radius rather than
           // restating a step, so a card whose radius is overridden stays
-          // matched, and at --radius: 0 both resolve to 0 and nothing changes.
+          // matched, and it can never disagree with the card at any --radius,
+          // including the shipped 0 where `rounded-lg` is 0.
           "flex items-center px-6 py-4  border-t border-border bg-primary/5 rounded-b-[inherit]",
           className
         )}

--- a/packages/ui/src/styles/__tests__/radius-tier-contract.test.ts
+++ b/packages/ui/src/styles/__tests__/radius-tier-contract.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Pins the corner-radius contract to the code that is supposed to implement it.
+ *
+ * The tier table is documented twice — in `theme.css` next to the token
+ * definitions, and in the plugin authoring guide — and neither is executable, so
+ * a component can change its corner, or a tier list can be edited, without
+ * anything failing. That is how the two ended up describing different systems:
+ * alerts and table wrappers listed as containers when they ship one step
+ * tighter, switches and tabs listed in tiers they deliberately sit outside, and
+ * `rounded-xl` / `rounded-2xl` presented as steps of the knob when the published
+ * preset never exported them.
+ *
+ * These assertions cover the claims a plugin author would act on: which step a
+ * representative component of each tier actually uses, which steps the preset
+ * ships, and that the two documents agree with each other.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const THEME = resolve(HERE, "../theme.css");
+const DOC = resolve(HERE, "../../../docs/plugin-ui-authoring.md");
+const PRESET = resolve(HERE, "../../tailwind-preset.ts");
+const COMPONENTS = resolve(HERE, "../../components");
+
+/** The steps the contract covers. `full` and `none` are outside it by design. */
+const TIERS = ["sm", "md", "lg"] as const;
+
+const RADIUS_CLASS =
+  /\brounded(?:-(?:t|b|l|r|tl|tr|bl|br))?-(?:lg|md|sm|xl|2xl|full|none|\[[^\]]+\])/g;
+
+/** A line that is nothing but a comment documents, it does not style. */
+function isComment(line: string): boolean {
+  const trimmed = line.trim();
+  return (
+    trimmed.startsWith("//") ||
+    trimmed.startsWith("*") ||
+    trimmed.startsWith("/*")
+  );
+}
+
+/** Every radius class a component actually applies, docblocks excluded. */
+function radiusClassesOf(component: string): string[] {
+  const source = readFileSync(
+    resolve(COMPONENTS, `${component}.tsx`),
+    "utf8"
+  ).split("\n");
+  const found = new Set<string>();
+  for (const line of source) {
+    if (isComment(line)) continue;
+    for (const match of line.matchAll(RADIUS_CLASS)) found.add(match[0]);
+  }
+  return [...found].sort();
+}
+
+/**
+ * One representative per documented claim. The expected list is the complete
+ * set the file applies, so a component picking up a new corner fails here rather
+ * than drifting away from the tier it is documented under.
+ */
+const COMPONENT_CLAIMS: { component: string; classes: string[] }[] = [
+  // rounded-lg containers.
+  { component: "popover", classes: ["rounded-lg"] },
+  { component: "tooltip", classes: ["rounded-lg"] },
+  { component: "alert-dialog", classes: ["rounded-lg"] },
+  // Card is lg, plus the two inherit corners its header and footer use to stay
+  // matched with whatever radius the card ends up with.
+  {
+    component: "card",
+    classes: ["rounded-b-[inherit]", "rounded-lg", "rounded-t-[inherit]"],
+  },
+  // rounded-md controls. Alert is here, not in the container tier.
+  { component: "button", classes: ["rounded-md"] },
+  { component: "input", classes: ["rounded-md"] },
+  { component: "textarea", classes: ["rounded-md"] },
+  { component: "alert", classes: ["rounded-md"] },
+  // Dialog: lg panel, md close icon button.
+  { component: "dialog", classes: ["rounded-lg", "rounded-md"] },
+  // rounded-sm adornments. Checkbox is here, not in the control tier.
+  { component: "badge", classes: ["rounded-sm"] },
+  { component: "checkbox", classes: ["rounded-sm"] },
+  { component: "dropdown-menu", classes: ["rounded-lg", "rounded-sm"] },
+  // Deliberately outside the scale, each with a stated reason in the source.
+  { component: "switch", classes: ["rounded-full"] },
+  { component: "avatar", classes: ["rounded-full"] },
+  { component: "tabs", classes: ["rounded-none"] },
+  // Anchored to the viewport edge, so it carries no corner at all.
+  { component: "sheet", classes: [] },
+];
+
+describe("radius tier contract", () => {
+  it.each(COMPONENT_CLAIMS)(
+    "$component applies exactly $classes",
+    ({ component, classes }) => {
+      expect(
+        radiusClassesOf(component),
+        `${component}.tsx no longer matches the tier it is documented under in ` +
+          `theme.css and docs/plugin-ui-authoring.md. Update the component or ` +
+          `both documents, not just one.`
+      ).toEqual(classes);
+    }
+  );
+
+  it("no component reaches for a step the preset does not export", () => {
+    const offenders = COMPONENT_CLAIMS.filter(({ component }) =>
+      radiusClassesOf(component).some(cls => /-(?:xl|2xl)$/.test(cls))
+    ).map(({ component }) => component);
+
+    expect(
+      offenders,
+      `rounded-xl / rounded-2xl are not part of the scale: the preset exports ` +
+        `only lg/md/sm, and both add to --radius instead of subtracting, so they ` +
+        `are 4px and 8px at the shipped --radius: 0.`
+    ).toEqual([]);
+  });
+});
+
+describe("the published preset", () => {
+  const preset = readFileSync(PRESET, "utf8");
+
+  it("exports exactly the documented steps", () => {
+    const block = /borderRadius:\s*\{([^}]*)\}/.exec(preset)?.[1] ?? "";
+    const keys = [...block.matchAll(/^\s*([a-z0-9]+)\s*:/gm)].map(m => m[1]);
+
+    expect(
+      keys.sort(),
+      `A plugin built against the preset can only use the steps it exports. ` +
+        `Adding one here means adding it to the tier tables too.`
+    ).toEqual([...TIERS].sort());
+  });
+
+  it.each(TIERS)("derives %s from the --radius knob", tier => {
+    expect(preset).toMatch(new RegExp(`${tier}:\\s*"[^"]*var\\(--radius\\)`));
+  });
+});
+
+describe("the two tier documents", () => {
+  const theme = readFileSync(THEME, "utf8");
+  const doc = readFileSync(DOC, "utf8");
+
+  it.each(TIERS)("theme.css defines --radius-%s from the knob", tier => {
+    expect(theme).toMatch(
+      new RegExp(`--radius-${tier}:\\s*(?:calc\\()?\\s*var\\(--radius\\)`)
+    );
+  });
+
+  it("neither presents xl or 2xl as a tier to pick from", () => {
+    // They exist as tokens, but the guide must not table them as options: the
+    // preset has no such steps, so a plugin using one silently leaves the scale.
+    const tierTableRows = doc
+      .split("\n")
+      .filter(line => line.startsWith("| `rounded-"));
+
+    expect(tierTableRows.length).toBeGreaterThan(3);
+    expect(tierTableRows.join("\n")).not.toMatch(/rounded-2?xl/);
+  });
+
+  it("both record that the lower steps go negative at --radius: 0", () => {
+    // calc(0px - 4px) is -4px; border-radius clamps it, a padding or a JS read
+    // does not. Anyone documenting the knob has to say so.
+    for (const [name, source] of [
+      ["theme.css", theme],
+      ["plugin-ui-authoring.md", doc],
+    ] as const) {
+      expect(source, `${name} must state the negative-step behaviour`).toMatch(
+        /-4px/
+      );
+    }
+  });
+
+  it.each([
+    // Element category, and the tier heading it must sit under in both files.
+    { element: "alerts", tier: "md" },
+    { element: "table wrappers", tier: "md" },
+    { element: "image frames", tier: "md" },
+    { element: "checkboxes", tier: "sm" },
+    { element: "icon buttons", tier: "md" },
+    { element: "badges", tier: "sm" },
+  ])("both file $element under the $tier tier", ({ element, tier }) => {
+    for (const [name, source, headings] of [
+      ["theme.css", theme, TIERS.map(t => `rounded-${t} (--radius-${t}`)],
+      ["plugin-ui-authoring.md", doc, TIERS.map(t => `| \`rounded-${t}\``)],
+    ] as const) {
+      // The tier a term falls under is the last tier heading before it.
+      const at = source.indexOf(element);
+      expect(at, `${name} no longer mentions "${element}"`).toBeGreaterThan(-1);
+
+      const owning = headings
+        .map((heading, index) => ({ index, at: source.indexOf(heading) }))
+        .filter(entry => entry.at > -1 && entry.at < at)
+        .sort((a, b) => b.at - a.at)[0];
+
+      expect(
+        owning && TIERS[owning.index],
+        `${name} files "${element}" under the wrong tier`
+      ).toBe(tier);
+    }
+  });
+});

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -380,43 +380,58 @@
   /* ============================================
    * BORDER RADIUS (Tailwind v4.1)
    *
-   * Every step derives from the single --radius knob (shadcn pattern), so the
-   * whole admin re-rounds from one declaration and --radius: 0 collapses the
-   * scale back to square corners.
+   * The contract is three steps — sm, md, lg — all derived from the single
+   * --radius knob (shadcn pattern), so the whole admin re-rounds from one
+   * declaration. Those three are also exactly what `tailwind-preset.ts` exports,
+   * so a plugin built against the published preset gets the same scale.
    *
    * That only holds if components pick a TIER BY ELEMENT CATEGORY instead of
    * naming a length. A component that hardcodes a corner value — `rounded-none`
    * as much as `rounded-[6px]` — pins itself at that value and silently opts
-   * out of the knob. The tiers, and what belongs in each:
+   * out of the knob. The tiers, and what the shipped components put in each:
    *
    *   rounded-lg (--radius-lg, the knob itself)
-   *     Containers: cards, dialogs, popovers, dropdown and select panels,
-   *     sheets, table wrappers, alerts, empty states, image frames.
+   *     Floating and grouping containers: cards, dialogs, alert dialogs,
+   *     popovers, tooltips, dropdown / select / command panels, empty-state
+   *     panels.
    *
    *   rounded-md (--radius-md, one step tighter)
-   *     Controls: buttons, inputs, textareas, select triggers, checkboxes,
-   *     switches, and other things you click or type into. A control nested in
-   *     a container reads as inset when its corner is tighter than the surface
-   *     holding it.
+   *     Controls and the inline surfaces that sit among them: buttons, inputs,
+   *     textareas, select triggers, icon buttons, alerts, table wrappers and
+   *     image frames. A control nested in a container reads as inset when its
+   *     corner is tighter than the surface holding it.
    *
    *   rounded-sm (--radius-sm, tighter again)
    *     Small controls and adornments: menu and list items, badges, chips,
-   *     tags, tabs, icon buttons, toolbar affordances — anything already inside
-   *     a control or a dense row.
+   *     tags, checkboxes, toolbar affordances — anything already inside a
+   *     control or a dense row.
    *
-   *   rounded-xl / rounded-2xl
-   *     Reserved for surfaces that must read as clearly softer than a card;
-   *     nothing in the admin needs them today.
+   * Circles sit deliberately outside the scale: avatars, status dots, spinners,
+   * progress tracks and switch tracks and thumbs use `rounded-full`, which is
+   * 9999px and not a --radius step. They are round because of their shape, not
+   * because of the theme, so a retheme must not flatten them.
    *
-   * Circles sit deliberately outside the scale: avatars, status dots, spinners
-   * and pills use `rounded-full`, which is 9999px and not a --radius step. They
-   * are round because of their shape, not because of the theme, so a retheme
-   * must not flatten them.
+   * rounded-xl / rounded-2xl are NOT tiers of this knob. `tailwind-preset.ts`
+   * exports only lg/md/sm, so a plugin using the preset gets Tailwind's fixed
+   * 0.75rem / 1rem for them, detached from --radius; and the definitions below
+   * add to the knob rather than subtracting, so at the shipped --radius: 0 they
+   * resolve to 4px and 8px — visibly round inside a square admin. Nothing in the
+   * repo uses them. Treat them as off-contract and pick from sm/md/lg.
+   *
+   * What --radius: 0 really does: `lg` is 0, and `sm` and `md` compute to -4px
+   * and -2px. They render square only because border-radius clamps a negative
+   * length to 0 at used-value time. The token itself stays negative, so reading
+   * `--radius-sm` for padding, an inset, or through getComputedStyle yields
+   * -4px, not 0. Anything that consumes a step as a length rather than as a
+   * corner must clamp it itself.
    *
    * A site that genuinely must stay square keeps `rounded-none` WITH an inline
    * comment saying why — overlapped-border strips, full-bleed fills inside an
-   * already-rounded parent, underline tabs. Square with a stated reason is a
-   * decision; square without one is an element that was never wired to the knob.
+   * already-rounded parent, underline tabs (which is why Tabs is square, not a
+   * `rounded-sm` adornment). Square with a stated reason is a decision; square
+   * without one is an element that was never wired to the knob. Sheet is the
+   * standing example of the latter: it is anchored to the viewport edge and
+   * carries no radius class at all.
    *
    * Corollary for containers: a rounded box whose child paints a background to
    * its edge must either clip that child (`overflow-hidden`) or give the child


### PR DESCRIPTION
Post-merge follow-ups to the admin theming refactor (#368). Seven items, all verified in the running admin against the built `packages/admin/dist`.

## I-1 — the media card still clipped

The previous fix protected the wrong field: `min-w-0 truncate` went on the dimensions and `shrink-0` on the size, so the variable-length label held its width while the fixed-length one collapsed.

Measured at viewport 1024 (`lg:grid-cols-6`), the narrowest card the grid can produce — 83.7px card, 57.7px row:

| size label | before | after |
| --- | --- | --- |
| `1.5 MB` | dimensions 14.7px of 74.5px needed | dimensions hidden, size 34.9px, row overflow 0 |
| `1023.9 KB` | dimensions 0px, row overflows 4px | dimensions hidden, size 54px, row overflow 0 |
| `Invalid size` | dimensions 0px, row overflows 20px, **7.8px painted past the card edge** | dimensions hidden, size truncates to 57.7px, row overflow 0, 13px inside the edge |
| `999.9 Bytes` | dimensions 0px, row overflows 21px, **8.3px past the card edge** | same as above |

Truncation alone cannot solve 155px of content in 58px of space, so the row now decides what to show. The size wins the narrow case: it is the one value every asset has (audio and documents have no dimensions) and the one the thumbnail cannot convey, whereas an image's proportions are already visible above. A container query on the metadata column reveals the dimensions only once the row can render **both values in full** — keyed on the card's own width rather than a viewport breakpoint, since column count and sidebar move card width independently. The `title` moved to the row, which is always 57.7 × 16px; a span squeezed to 0px has no hit area.

Verified at every viewport from 320 to 1920: `rowOverflow` is 0 everywhere, nothing paints outside the card, and the dimensions are never a partial number.

## I-2 — four more square-child-in-rounded-parent instances

Fixed at `EmailTemplateForm` (segmented control), `ComponentRow` (card header), `SortableFieldsTable` (opaque `thead`) and `CodeInput` (validation error strip). The first three clip to the parent box; the error strip takes `rounded-b-[inherit]` instead, so CodeMirror's own popups are not clipped. `CardHeader` gained the `rounded-t-[inherit]` mirror of `CardFooter`'s fix.

Probed at `--radius: 0` and `--radius: 24px`:

```
--radius: 0px   all ten shapes identical before and after (0px/0px)
--radius: 24px  before: SQUARE-PROTRUSION on all four
                after:  ok on all four
```

**One correction to the brief:** the `CardHeader` mirror does *not* fix `ComponentRow` generically. All four consumers that tint a `CardHeader` nest it inside `<Collapsible>`, so `inherit` resolves against that wrapper's 0px, not the card's:

```
--radius: 24px  CardHeader direct child           parent=24px child=24px  ok
--radius: 24px  CardHeader nested in Collapsible  parent=24px child=0px   SQUARE-PROTRUSION
```

`overflow-hidden` on the card — matching `GroupInput`, `RepeaterInput` and `RepeaterRow` — is the actual fix. The mirror is still worth having for direct-child headers, and its docblock now says where it applies.

## I-3 — the radius tier contract

Every claim was re-derived from source. The two tier tables were wrong about alerts (`rounded-md`), table wrappers (all 9 marked wrappers are `rounded-md`), image frames (`rounded-md`), checkboxes (`rounded-sm`), icon buttons (`rounded-md`), switches (deliberately `rounded-full`), tabs (deliberately `rounded-none`), sheets (no radius class at all) and empty states. `theme.css` also listed items the guide did not. Both now agree with the source and with each other.

**`rounded-xl` / `rounded-2xl`: removed from the documented tiers** rather than added to the preset. They are the only steps that *add* to the knob, so at the shipped `--radius: 0` they resolve to 4px and 8px — a plugin adopting them would render visibly round inside a square admin. A tier that can only break alignment is not a tier, and nothing in the repo uses them. The tokens stay defined; the guide now says they are off-contract and why.

A new test (`radius-tier-contract.test.ts`, 32 assertions) pins the step each representative component uses, the steps the preset exports, and the tier each element category sits under **in both documents** — it already caught a line-wrap that split "image frames" across two lines in `theme.css`.

## M-1 — the slash menu's z-index was inert

`zIndex: 9999` with no `position` computes to `position: static`, so the value is discarded. Hit-tested against a `position: fixed; z-index: 51` overlay (exactly `DialogContent`):

```
before  position=static    topElementAtPoint=overlay  menuWinsHitTest=false
after   position=relative  topElementAtPoint=menu     menuWinsHitTest=true
```

## M-2 — a comment stated the wrong reason

The tokens the menu reads are declared at `:root` / `.dark` in the shipped `packages/admin/dist/index.css` (lines 7362 and 7431), not on `.nextly-admin`. The real mechanism is that `dark` is applied to `div.nextly-admin` (`RootLayout.tsx:121`), not `<html>`, so a body-level portal never matches the dark overrides. Comment corrected.

## M-4 — a false claim about `--radius: 0`

`--radius-sm` computes `calc(0px - 4px)` = `-4px` and `--radius-md` = `-2px`; they render square only because `border-radius` clamps a negative length at used-value time. Anything reading a step for padding or via JS gets a negative length. Stated accurately in both documents and in `card.tsx`.

M-3 is out of scope as instructed.

## Verification

- `@nextlyhq/ui` tests: **242 passed / 0 failed** (12 files, 32 of them new)
- `@nextlyhq/admin` tests: **37 failed / 1271 passed across 8 files** — the known baseline, matched exactly (identical before and after)
- `check-types`, package `lint` on both packages, and `node scripts/lint-design.mjs`: clean
- 11 changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved rounded-corner rendering across tables, cards, segmented controls, code editor validation messages, and card headers.
  * Enhanced slash command menu interaction and overlay behavior.
  * Improved media card metadata layout with responsive wrapping, truncation, and clearer tooltips.
* **Documentation**
  * Clarified corner-radius tiers, supported styles, and behavior at zero radius.
* **Quality**
  * Added automated checks to keep corner-radius styling and documentation consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->