### PR TITLE
fix(release): dedupe and cap consolidated release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,13 @@ jobs:
         env:
           TURBO_CACHE_DIR: .turbo
 
+      # Release tooling under `scripts/` sits in no workspace package, so
+      # `turbo run test` never reaches it. Its own suite runs here: a defect in
+      # the release-notes builder only surfaces during a real publish, after the
+      # packages are already on npm. Needs no build, runs in milliseconds.
+      - name: Release script tests
+        run: pnpm test:scripts
+
       # Enforce the design-token theming contract in the admin + plugin packages
       # (no hsl(var(--x)) wrappers, no hardcoded colors, no stray !important).
       # See packages/ui/docs/plugin-ui-authoring.md. Cheap check, fails fast.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,39 +135,16 @@ jobs:
           # first entry's version is the canonical monorepo version.
           VERSION=$(echo "$MANIFEST" | jq -r '.[0].version')
           TAG="v${VERSION}"
-          PKG_COUNT=$(echo "$MANIFEST" | jq -r 'length')
 
-          # Build the release notes by extracting each package's CHANGELOG
-          # section for this version and concatenating them under one
-          # "What's changed" heading.
+          # Build the release notes from the same manifest. Every package in
+          # the train shares a version, so each changeset is written verbatim
+          # into all of their changelogs; the builder prints each entry once,
+          # drops the generated "Updated dependencies" blocks, and caps the
+          # body below GitHub's 125,000-character release limit. Concatenating
+          # the raw sections instead produced a 349k body that the API rejected
+          # with a 422 after the packages were already live on npm.
           NOTES_FILE=$(mktemp)
-          {
-            echo "Released ${PKG_COUNT} packages at \`${VERSION}\` in lockstep."
-            echo
-            echo "## What's changed"
-            echo
-            for pkg in $(echo "$MANIFEST" | jq -r '.[].name'); do
-              pkg_dir="packages/${pkg#@nextlyhq/}"
-              CHANGELOG="${pkg_dir}/CHANGELOG.md"
-              if [[ -f "$CHANGELOG" ]]; then
-                # Extract everything between "## $VERSION" and the next "## "
-                section=$(awk -v ver="## ${VERSION}" '
-                  $0 == ver { found = 1; next }
-                  found && /^## / { exit }
-                  found { print }
-                ' "$CHANGELOG")
-                # Skip packages whose CHANGELOG didn't actually change for
-                # this version (can happen for purely internal-dependency
-                # bumps where changesets writes only "Patch Changes" with
-                # no human-authored entry, still worth listing).
-                if [[ -n "$section" ]]; then
-                  echo "### ${pkg}"
-                  echo
-                  echo "$section"
-                fi
-              fi
-            done
-          } > "$NOTES_FILE"
+          node scripts/release/release-notes.mjs > "$NOTES_FILE"
 
           # Configure git for the bot so we can push the unified tag
           git config user.name "github-actions[bot]"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:coverage": "turbo run test:coverage",
     "test:ui": "turbo run test:ui",
     "test:unit": "turbo run test",
+    "test:scripts": "vitest run --dir scripts",
     "test:integration": "turbo run test:integration",
     "test:integration:postgres15": "TEST_POSTGRES_URL=postgres://postgres:postgres@localhost:5434/nextly_test turbo run test:integration",
     "test:integration:postgres17": "TEST_POSTGRES_URL=postgres://postgres:postgres@localhost:5435/nextly_test turbo run test:integration",
@@ -67,6 +68,7 @@
     "release:preflight": "node scripts/release/preflight.mjs",
     "release:verify": "node scripts/release/verify.mjs",
     "release:manifest": "node scripts/release/manifest.mjs",
+    "release:notes": "node scripts/release/release-notes.mjs",
     "release:publish": "pnpm release:preflight && turbo build --filter='./packages/*' && changeset publish",
     "release:status": "changeset status",
     "release:dry-run": "changeset publish --dry-run"

--- a/scripts/release/release-notes.mjs
+++ b/scripts/release/release-notes.mjs
@@ -1,0 +1,320 @@
+// Builds the body of the consolidated GitHub Release for a lockstep train.
+//
+// Every publishable package shares one version through the Changesets `fixed`
+// group, so a single changeset is written verbatim into every changelog it
+// covers. Concatenating whole changelog sections therefore repeats the same
+// human-authored prose once per package and adds a block of generated
+// "Updated dependencies" bumps on top of it, which is how a release body
+// reached 349k characters against GitHub's 125,000-character ceiling and
+// failed the release step outright.
+//
+// The notes are instead the union of the distinct entries across the train:
+// each changeset appears once, dependency bumps are dropped, and the result is
+// capped below the API limit so long notes are truncated rather than fatal.
+//
+// Usage: node scripts/release/release-notes.mjs [--version <semver>]
+//                                               [--max-length <chars>]
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { getReleaseManifest, REPO_ROOT } from "./lib.mjs";
+
+// GitHub rejects a release body over 125,000 characters with a 422. Sitting on
+// the exact limit leaves no room for the truncation marker itself, so cap lower
+// and let the marker fit inside the remaining margin.
+export const MAX_BODY_LENGTH = 120000;
+
+/** Change-type headings in the order a reader expects to meet them. */
+const HEADING_ORDER = ["Major Changes", "Minor Changes", "Patch Changes"];
+
+/**
+ * The body of one version's section of a changelog: everything between
+ * `## <version>` and the next `## ` heading. Returns an empty string when the
+ * version has no section, which is the normal state for a package that was not
+ * part of that train.
+ */
+export function extractVersionSection(changelog, version) {
+  const wanted = `## ${version}`;
+  const lines = changelog.split("\n");
+  const collected = [];
+  let inside = false;
+
+  for (const line of lines) {
+    if (!inside) {
+      if (line.trim() === wanted) inside = true;
+      continue;
+    }
+    if (line.startsWith("## ")) break;
+    collected.push(line);
+  }
+
+  return collected.join("\n").trim();
+}
+
+/**
+ * Splits a changelog section into its individual entries, each tagged with the
+ * change-type heading it sits under.
+ *
+ * An entry starts at a top-level `- ` bullet and runs until the next one, so
+ * the indented continuation lines of a multi-paragraph changeset stay attached
+ * to it. Nested bullets (the `  - pkg@version` lines a dependency bump writes)
+ * are indented and therefore never start a new entry, which is what keeps a
+ * genuine entry sitting directly after one from being swallowed or split.
+ */
+export function parseChangelogSection(section) {
+  const entries = [];
+  let heading = null;
+  let current = null;
+
+  const flush = () => {
+    if (!current) return;
+    const text = current.lines.join("\n").replace(/\s+$/, "");
+    if (text.length > 0) entries.push({ heading: current.heading, text });
+    current = null;
+  };
+
+  for (const line of section.split("\n")) {
+    const headingMatch = /^#{2,4}\s+(.+?)\s*$/.exec(line);
+    if (headingMatch) {
+      flush();
+      heading = headingMatch[1];
+      continue;
+    }
+
+    if (line.startsWith("- ")) {
+      flush();
+      current = { heading, lines: [line] };
+      continue;
+    }
+
+    if (current) current.lines.push(line);
+  }
+
+  flush();
+  return entries;
+}
+
+/**
+ * Whether an entry is a generated dependency bump rather than authored prose.
+ *
+ * Changesets writes one of these into every package in the fixed group on every
+ * train, listing the sibling versions that moved. In a lockstep repo that is
+ * always "all of them", so the block carries no information and accounts for
+ * most of the volume. The prefix is only honoured at the very start of the
+ * entry so prose that merely mentions updating dependencies is kept.
+ */
+export function isDependencyBumpEntry(text) {
+  return /^-\s+Updated dependencies\b/.test(text);
+}
+
+/** Comparison key that ignores whitespace differences between changelog copies. */
+function dedupeKey(heading, text) {
+  return `${heading ?? ""}\n${text.replace(/\s+/g, " ").trim()}`;
+}
+
+/**
+ * The distinct authored entries across every package in the train, in
+ * first-seen order. Packages sharing a changeset produce byte-identical
+ * entries, so the first copy encountered stands for all of them.
+ */
+export function collectUniqueEntries(packages, version) {
+  const seen = new Set();
+  const entries = [];
+
+  for (const pkg of packages) {
+    const section = extractVersionSection(pkg.changelog ?? "", version);
+    if (!section) continue;
+
+    for (const entry of parseChangelogSection(section)) {
+      if (isDependencyBumpEntry(entry.text)) continue;
+
+      const key = dedupeKey(entry.heading, entry.text);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      entries.push(entry);
+    }
+  }
+
+  return entries;
+}
+
+/** Groups entries under their change-type heading, known headings first. */
+function groupByHeading(entries) {
+  const groups = new Map();
+
+  for (const entry of entries) {
+    const heading = entry.heading ?? "Changes";
+    if (!groups.has(heading)) groups.set(heading, []);
+    groups.get(heading).push(entry.text);
+  }
+
+  return [...groups.entries()].sort((a, b) => {
+    const rankA = HEADING_ORDER.indexOf(a[0]);
+    const rankB = HEADING_ORDER.indexOf(b[0]);
+    if (rankA === rankB) return 0;
+    if (rankA === -1) return 1;
+    if (rankB === -1) return -1;
+    return rankA - rankB;
+  });
+}
+
+/**
+ * Trims a body to `maxLength` at a block boundary, appending `marker` so the
+ * reader knows detail is missing. The final hard slice is a backstop for the
+ * degenerate case where a single block is larger than the whole budget: the
+ * step must never hand GitHub a body it will reject.
+ */
+function fitWithinLimit(blocks, marker, maxLength) {
+  const joined = blocks.join("\n\n");
+  if (joined.length <= maxLength) return joined;
+
+  const separator = "\n\n";
+  const budget = maxLength - marker.length - separator.length;
+  const kept = [];
+  let used = 0;
+
+  for (const block of blocks) {
+    const cost =
+      kept.length === 0 ? block.length : block.length + separator.length;
+    if (used + cost > budget) break;
+    kept.push(block);
+    used += cost;
+  }
+
+  const truncated = [...kept, marker].join(separator);
+  return truncated.length <= maxLength
+    ? truncated
+    : truncated.slice(0, maxLength);
+}
+
+/**
+ * The release body for one lockstep version.
+ *
+ * `packages` are `{ name, changelog }` pairs taken from the release manifest,
+ * not from the publish step's output: a recovery run publishes only the
+ * stragglers, and notes built from that would describe a three-package release.
+ */
+export function buildReleaseNotes({
+  version,
+  packages,
+  repoUrl,
+  maxLength = MAX_BODY_LENGTH,
+}) {
+  const tag = `v${version}`;
+  const tagUrl = `${repoUrl}/tree/${tag}`;
+  const entries = collectUniqueEntries(packages, version);
+
+  const blocks = [
+    `Released ${packages.length} packages at \`${version}\` in lockstep. ` +
+      `Every package below ships at this version.`,
+    "## What's changed",
+  ];
+
+  if (entries.length === 0) {
+    blocks.push(
+      `No changelog entries were recorded for \`${version}\`. ` +
+        `See the \`CHANGELOG.md\` files at [${tag}](${tagUrl}).`
+    );
+  } else {
+    for (const [heading, texts] of groupByHeading(entries)) {
+      blocks.push(`### ${heading}`);
+      blocks.push(...texts);
+    }
+  }
+
+  blocks.push("## Packages");
+  blocks.push(packages.map(pkg => `- \`${pkg.name}\``).join("\n"));
+
+  const marker =
+    `> Notes truncated to stay within GitHub's release body limit. ` +
+    `The complete changelog for every package is in its \`CHANGELOG.md\` at ` +
+    `[${tag}](${tagUrl}).`;
+
+  return fitWithinLimit(blocks, marker, maxLength);
+}
+
+/**
+ * Repository the tag links should point at. Actions supplies
+ * `GITHUB_REPOSITORY`; the Changesets changelog config carries the same value
+ * for local runs, so neither path hardcodes the slug.
+ */
+function resolveRepoUrl() {
+  const fromEnv = process.env.GITHUB_REPOSITORY;
+  if (fromEnv) return `https://github.com/${fromEnv}`;
+
+  const configPath = join(REPO_ROOT, ".changeset", "config.json");
+  if (existsSync(configPath)) {
+    const config = JSON.parse(readFileSync(configPath, "utf8"));
+    const repo = Array.isArray(config.changelog)
+      ? config.changelog[1]?.repo
+      : undefined;
+    if (repo) return `https://github.com/${repo}`;
+  }
+
+  throw new Error(
+    "cannot resolve the repository: set GITHUB_REPOSITORY or add changelog.repo to .changeset/config.json"
+  );
+}
+
+/** Reads a flag's value from argv, or `undefined` when it is absent. */
+function readOption(argv, flag) {
+  const index = argv.indexOf(flag);
+  if (index === -1) return undefined;
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const manifest = getReleaseManifest();
+
+  if (manifest.length === 0) {
+    throw new Error("release manifest is empty: nothing to write notes for");
+  }
+
+  const version = readOption(argv, "--version") ?? manifest[0].version;
+
+  const rawMaxLength = readOption(argv, "--max-length");
+  const maxLength =
+    rawMaxLength === undefined ? MAX_BODY_LENGTH : Number(rawMaxLength);
+  if (!Number.isInteger(maxLength) || maxLength <= 0) {
+    throw new Error(
+      `--max-length must be a positive integer, got ${rawMaxLength}`
+    );
+  }
+
+  const packages = manifest.map(entry => {
+    const changelogPath = join(entry.dir, "CHANGELOG.md");
+    return {
+      name: entry.name,
+      changelog: existsSync(changelogPath)
+        ? readFileSync(changelogPath, "utf8")
+        : "",
+    };
+  });
+
+  process.stdout.write(
+    `${buildReleaseNotes({
+      version,
+      packages,
+      repoUrl: resolveRepoUrl(),
+      maxLength,
+    })}\n`
+  );
+}
+
+// Only run when invoked directly, so the exported helpers stay importable from
+// tests without producing output.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`release notes failed: ${error.message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/release/release-notes.mjs
+++ b/scripts/release/release-notes.mjs
@@ -162,16 +162,28 @@ function groupByHeading(entries) {
 
 /**
  * Trims a body to `maxLength` at a block boundary, appending `marker` so the
- * reader knows detail is missing. The final hard slice is a backstop for the
- * degenerate case where a single block is larger than the whole budget: the
- * step must never hand GitHub a body it will reject.
+ * reader knows detail is missing.
+ *
+ * `tail` is the part of the body that must outlive truncation, so its rendered
+ * size and the separator that attaches it are reserved out of the budget before
+ * a single `block` is measured. Dropping blocks from the end without that
+ * reservation would take the tail with them, since it sits after every block
+ * that can be dropped.
+ *
+ * The final hard slice is a backstop for the degenerate case where the marker
+ * and the tail together already exceed the whole budget: the step must never
+ * hand GitHub a body it will reject, and a bounded slice terminates where
+ * shedding more blocks cannot.
  */
-function fitWithinLimit(blocks, marker, maxLength) {
-  const joined = blocks.join("\n\n");
+function fitWithinLimit(blocks, tail, marker, maxLength) {
+  const separator = "\n\n";
+  const joined = [...blocks, ...tail].join(separator);
   if (joined.length <= maxLength) return joined;
 
-  const separator = "\n\n";
-  const budget = maxLength - marker.length - separator.length;
+  const tailText = tail.join(separator);
+  const reserved =
+    tailText.length === 0 ? 0 : tailText.length + separator.length;
+  const budget = maxLength - reserved - marker.length - separator.length;
   const kept = [];
   let used = 0;
 
@@ -183,7 +195,11 @@ function fitWithinLimit(blocks, marker, maxLength) {
     used += cost;
   }
 
-  const truncated = [...kept, marker].join(separator);
+  const truncated = [
+    ...kept,
+    marker,
+    ...(tailText.length === 0 ? [] : [tailText]),
+  ].join(separator);
   return truncated.length <= maxLength
     ? truncated
     : truncated.slice(0, maxLength);
@@ -224,15 +240,20 @@ export function buildReleaseNotes({
     }
   }
 
-  blocks.push("## Packages");
-  blocks.push(packages.map(pkg => `- \`${pkg.name}\``).join("\n"));
+  // The inventory is the one section a reader cannot rebuild from the entries,
+  // and the intro promises it, so it is held apart from the blocks truncation
+  // may drop and is instead reserved out of the budget.
+  const tail = [
+    "## Packages",
+    packages.map(pkg => `- \`${pkg.name}\``).join("\n"),
+  ];
 
   const marker =
     `> Notes truncated to stay within GitHub's release body limit. ` +
     `The complete changelog for every package is in its \`CHANGELOG.md\` at ` +
     `[${tag}](${tagUrl}).`;
 
-  return fitWithinLimit(blocks, marker, maxLength);
+  return fitWithinLimit(blocks, tail, marker, maxLength);
 }
 
 /**

--- a/scripts/release/release-notes.test.mjs
+++ b/scripts/release/release-notes.test.mjs
@@ -303,6 +303,137 @@ describe("buildReleaseNotes", () => {
     expect(notes.length).toBeLessThanOrEqual(500);
   });
 
+  it("keeps the whole package list when entries are truncated", () => {
+    const bulky = Array.from(
+      { length: 400 },
+      (_, index) =>
+        `- [#${index}](${REPO_URL}/pull/${index}) Thanks [@author](https://github.com/author)! - ${"x".repeat(2000)}`
+    );
+    const packages = lockstepPackages.map(pkg => ({
+      ...pkg,
+      changelog: changelogFor(pkg.name, bulky),
+    }));
+
+    const notes = buildReleaseNotes({
+      version: VERSION,
+      packages,
+      repoUrl: REPO_URL,
+    });
+
+    expect(notes.length).toBeLessThanOrEqual(MAX_BODY_LENGTH);
+    expect(notes).toContain("Notes truncated");
+    expect(notes).toContain("## Packages");
+    for (const pkg of packages) {
+      expect(notes).toContain(`- \`${pkg.name}\``);
+    }
+  });
+
+  it("keeps the package list when one entry is larger than the budget", () => {
+    const packages = lockstepPackages.map(pkg => ({
+      ...pkg,
+      changelog: changelogFor(pkg.name, [`- ${"x".repeat(5000)}`]),
+    }));
+
+    const notes = buildReleaseNotes({
+      version: VERSION,
+      packages,
+      repoUrl: REPO_URL,
+      maxLength: 1000,
+    });
+
+    expect(notes.length).toBeLessThanOrEqual(1000);
+    expect(notes).toContain("Notes truncated");
+    expect(notes).toContain("## Packages");
+    for (const pkg of packages) {
+      expect(notes).toContain(`- \`${pkg.name}\``);
+    }
+    expect(notes).not.toContain("xxxxx");
+  });
+
+  it("puts the truncation marker before the package list", () => {
+    const packages = lockstepPackages.map(pkg => ({
+      ...pkg,
+      changelog: changelogFor(pkg.name, [`- ${"x".repeat(5000)}`]),
+    }));
+
+    const notes = buildReleaseNotes({
+      version: VERSION,
+      packages,
+      repoUrl: REPO_URL,
+      maxLength: 1000,
+    });
+
+    expect(notes.indexOf("Notes truncated")).toBeGreaterThan(-1);
+    expect(notes.indexOf("Notes truncated")).toBeLessThan(
+      notes.indexOf("## Packages")
+    );
+  });
+
+  // The intro tells the reader every package is listed below it. That sentence
+  // and the list have to survive or fall together, at any cap.
+  it("lists every package whenever the intro promises the list", () => {
+    const packages = lockstepPackages.map(pkg => ({
+      ...pkg,
+      changelog: changelogFor(pkg.name, [`- ${"x".repeat(4000)}`]),
+    }));
+
+    for (const maxLength of [200, 400, 700, 1200, 5000, 20000]) {
+      const notes = buildReleaseNotes({
+        version: VERSION,
+        packages,
+        repoUrl: REPO_URL,
+        maxLength,
+      });
+
+      expect(notes.length).toBeLessThanOrEqual(maxLength);
+      if (!notes.includes("Every package below ships at this version.")) {
+        continue;
+      }
+      for (const pkg of packages) {
+        expect(notes).toContain(`- \`${pkg.name}\``);
+      }
+    }
+  });
+
+  // A cap smaller than the inventory itself cannot happen with a real train,
+  // but the builder still has to return a bounded body rather than throw, loop,
+  // or hand GitHub something it will reject.
+  it("returns a bounded body when the package list alone exceeds the cap", () => {
+    const packages = Array.from({ length: 17 }, (_, index) => ({
+      name: `@nextlyhq/package-with-a-long-name-${index}`,
+      changelog: changelogFor(`pkg-${index}`, [MIGRATE_ENTRY]),
+    }));
+
+    for (const maxLength of [1, 40, 120, 300]) {
+      const notes = buildReleaseNotes({
+        version: VERSION,
+        packages,
+        repoUrl: REPO_URL,
+        maxLength,
+      });
+
+      expect(notes.length).toBeGreaterThan(0);
+      expect(notes.length).toBeLessThanOrEqual(maxLength);
+    }
+  });
+
+  it("keeps the package list last in an untruncated release", () => {
+    const notes = buildReleaseNotes({
+      version: VERSION,
+      packages: lockstepPackages,
+      repoUrl: REPO_URL,
+    });
+
+    expect(notes).not.toContain("Notes truncated");
+    expect(notes.indexOf("## What's changed")).toBeLessThan(
+      notes.indexOf("## Packages")
+    );
+    expect(notes.indexOf("design tokens")).toBeLessThan(
+      notes.indexOf("## Packages")
+    );
+    expect(notes.trimEnd().endsWith("- `@nextlyhq/adapter-sqlite`")).toBe(true);
+  });
+
   it("still names the version when no entries were recorded", () => {
     const packages = [{ name: "nextly", changelog: "# nextly\n" }];
 

--- a/scripts/release/release-notes.test.mjs
+++ b/scripts/release/release-notes.test.mjs
@@ -1,0 +1,318 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildReleaseNotes,
+  collectUniqueEntries,
+  extractVersionSection,
+  isDependencyBumpEntry,
+  MAX_BODY_LENGTH,
+  parseChangelogSection,
+} from "./release-notes.mjs";
+
+const VERSION = "0.0.2-alpha.43";
+const REPO_URL = "https://github.com/nextlyhq/nextly";
+
+/** A changeset entry as Changesets renders it, with a multi-paragraph body. */
+const THEMING_ENTRY = `- [#368](${REPO_URL}/pull/368) Thanks [@author](https://github.com/author)! - The admin's design tokens now drive its appearance.
+
+  Font weights work again across the admin.`;
+
+const MIGRATE_ENTRY = `- [#361](${REPO_URL}/pull/361) Thanks [@author](https://github.com/author)! - \`nextly migrate\` can be run more than once.`;
+
+/** The generated sibling-bump block every package in a fixed group receives. */
+const DEPENDENCY_ENTRY = `- Updated dependencies [[\`648c7f4\`](${REPO_URL}/commit/648c7f4), [\`7d5a62d\`](${REPO_URL}/commit/7d5a62d)]:
+  - nextly@${VERSION}
+  - @nextlyhq/ui@${VERSION}`;
+
+function changelog(title, sections) {
+  return `# ${title}\n\n${sections}\n`;
+}
+
+/** A changelog whose current version carries the given entries, plus history. */
+function changelogFor(title, entries) {
+  return changelog(
+    title,
+    [
+      `## ${VERSION}`,
+      "",
+      "### Patch Changes",
+      "",
+      entries.join("\n\n"),
+      "",
+      "## 0.0.2-alpha.42",
+      "",
+      "### Patch Changes",
+      "",
+      "- An older release entry that must not leak into these notes.",
+    ].join("\n")
+  );
+}
+
+describe("extractVersionSection", () => {
+  it("returns only the requested version's body", () => {
+    const section = extractVersionSection(
+      changelogFor("nextly", [MIGRATE_ENTRY]),
+      VERSION
+    );
+
+    expect(section).toContain("can be run more than once");
+    expect(section).not.toContain("must not leak");
+  });
+
+  it("returns an empty string for a version the changelog does not have", () => {
+    expect(
+      extractVersionSection(changelogFor("nextly", [MIGRATE_ENTRY]), "9.9.9")
+    ).toBe("");
+  });
+});
+
+describe("parseChangelogSection", () => {
+  it("keeps indented continuation lines with their entry", () => {
+    const entries = parseChangelogSection(
+      ["### Patch Changes", "", THEMING_ENTRY, "", MIGRATE_ENTRY].join("\n")
+    );
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0].heading).toBe("Patch Changes");
+    expect(entries[0].text).toContain("Font weights work again");
+    expect(entries[1].text).toContain("more than once");
+  });
+
+  it("does not split a dependency bump's nested package bullets", () => {
+    const entries = parseChangelogSection(
+      ["### Patch Changes", "", DEPENDENCY_ENTRY, "", MIGRATE_ENTRY].join("\n")
+    );
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0].text).toContain("- @nextlyhq/ui@");
+    expect(entries[1].text).toContain("more than once");
+  });
+
+  it("tags entries with the change-type heading they sit under", () => {
+    const entries = parseChangelogSection(
+      [
+        "### Minor Changes",
+        "",
+        MIGRATE_ENTRY,
+        "",
+        "### Patch Changes",
+        "",
+        THEMING_ENTRY,
+      ].join("\n")
+    );
+
+    expect(entries.map(entry => entry.heading)).toEqual([
+      "Minor Changes",
+      "Patch Changes",
+    ]);
+  });
+});
+
+describe("isDependencyBumpEntry", () => {
+  it("matches the generated sibling-bump block", () => {
+    expect(isDependencyBumpEntry(DEPENDENCY_ENTRY)).toBe(true);
+  });
+
+  it("keeps prose that merely mentions updating dependencies", () => {
+    expect(
+      isDependencyBumpEntry(
+        "- [#12](https://example.test/12) Thanks [@a](https://example.test)! - Updated dependencies are now installed by the CLI."
+      )
+    ).toBe(false);
+  });
+});
+
+describe("collectUniqueEntries", () => {
+  it("emits a shared changeset once across a fixed group", () => {
+    const packages = [
+      "nextly",
+      "@nextlyhq/ui",
+      "@nextlyhq/admin",
+      "@nextlyhq/tsconfig",
+    ].map(name => ({
+      name,
+      changelog: changelogFor(name, [
+        THEMING_ENTRY,
+        MIGRATE_ENTRY,
+        DEPENDENCY_ENTRY,
+      ]),
+    }));
+
+    const entries = collectUniqueEntries(packages, VERSION);
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0].text).toContain("design tokens");
+    expect(entries[1].text).toContain("more than once");
+  });
+
+  it("takes the union when packages carry different entries", () => {
+    const packages = [
+      { name: "nextly", changelog: changelogFor("nextly", [MIGRATE_ENTRY]) },
+      {
+        name: "@nextlyhq/ui",
+        changelog: changelogFor("@nextlyhq/ui", [THEMING_ENTRY]),
+      },
+      {
+        name: "@nextlyhq/admin",
+        changelog: changelogFor("@nextlyhq/admin", [
+          MIGRATE_ENTRY,
+          THEMING_ENTRY,
+        ]),
+      },
+    ];
+
+    expect(collectUniqueEntries(packages, VERSION)).toHaveLength(2);
+  });
+
+  it("ignores a package with no section for the version", () => {
+    const packages = [
+      { name: "nextly", changelog: changelogFor("nextly", [MIGRATE_ENTRY]) },
+      { name: "@nextlyhq/ui", changelog: "# @nextlyhq/ui\n" },
+    ];
+
+    expect(collectUniqueEntries(packages, VERSION)).toHaveLength(1);
+  });
+});
+
+describe("buildReleaseNotes", () => {
+  const lockstepPackages = [
+    "nextly",
+    "@nextlyhq/ui",
+    "@nextlyhq/admin",
+    "@nextlyhq/adapter-sqlite",
+  ].map(name => ({
+    name,
+    changelog: changelogFor(name, [
+      THEMING_ENTRY,
+      MIGRATE_ENTRY,
+      DEPENDENCY_ENTRY,
+    ]),
+  }));
+
+  it("passes a small release through with every entry intact", () => {
+    const notes = buildReleaseNotes({
+      version: VERSION,
+      packages: lockstepPackages,
+      repoUrl: REPO_URL,
+    });
+
+    expect(notes).toContain(
+      `Released 4 packages at \`${VERSION}\` in lockstep.`
+    );
+    expect(notes).toContain("## What's changed");
+    expect(notes).toContain("### Patch Changes");
+    expect(notes).toContain("design tokens");
+    expect(notes).toContain("more than once");
+    expect(notes).not.toContain("truncated");
+  });
+
+  it("prints each shared entry once rather than once per package", () => {
+    const notes = buildReleaseNotes({
+      version: VERSION,
+      packages: lockstepPackages,
+      repoUrl: REPO_URL,
+    });
+
+    expect(notes.split("design tokens now drive")).toHaveLength(2);
+    expect(notes.split("can be run more than once")).toHaveLength(2);
+  });
+
+  it("drops the generated dependency bumps but lists every package", () => {
+    const notes = buildReleaseNotes({
+      version: VERSION,
+      packages: lockstepPackages,
+      repoUrl: REPO_URL,
+    });
+
+    expect(notes).not.toContain("Updated dependencies");
+    expect(notes).toContain("## Packages");
+    for (const pkg of lockstepPackages) {
+      expect(notes).toContain(`- \`${pkg.name}\``);
+    }
+  });
+
+  it("orders major, then minor, then patch changes", () => {
+    const packages = [
+      {
+        name: "nextly",
+        changelog: changelog(
+          "nextly",
+          [
+            `## ${VERSION}`,
+            "",
+            "### Patch Changes",
+            "",
+            MIGRATE_ENTRY,
+            "",
+            "### Major Changes",
+            "",
+            THEMING_ENTRY,
+          ].join("\n")
+        ),
+      },
+    ];
+
+    const notes = buildReleaseNotes({
+      version: VERSION,
+      packages,
+      repoUrl: REPO_URL,
+    });
+
+    expect(notes.indexOf("### Major Changes")).toBeLessThan(
+      notes.indexOf("### Patch Changes")
+    );
+  });
+
+  it("truncates with a marker instead of exceeding the limit", () => {
+    const bulky = Array.from(
+      { length: 400 },
+      (_, index) =>
+        `- [#${index}](${REPO_URL}/pull/${index}) Thanks [@author](https://github.com/author)! - ${"x".repeat(2000)}`
+    );
+    const packages = [
+      { name: "nextly", changelog: changelogFor("nextly", bulky) },
+    ];
+
+    const notes = buildReleaseNotes({
+      version: VERSION,
+      packages,
+      repoUrl: REPO_URL,
+    });
+
+    expect(notes.length).toBeLessThanOrEqual(MAX_BODY_LENGTH);
+    expect(notes).toContain("Notes truncated");
+    expect(notes).toContain(`[v${VERSION}](${REPO_URL}/tree/v${VERSION})`);
+    expect(notes).toContain("- [#0]");
+  });
+
+  it("stays within the limit when a single entry is larger than the budget", () => {
+    const packages = [
+      {
+        name: "nextly",
+        changelog: changelogFor("nextly", [`- ${"x".repeat(5000)}`]),
+      },
+    ];
+
+    const notes = buildReleaseNotes({
+      version: VERSION,
+      packages,
+      repoUrl: REPO_URL,
+      maxLength: 500,
+    });
+
+    expect(notes.length).toBeLessThanOrEqual(500);
+  });
+
+  it("still names the version when no entries were recorded", () => {
+    const packages = [{ name: "nextly", changelog: "# nextly\n" }];
+
+    const notes = buildReleaseNotes({
+      version: VERSION,
+      packages,
+      repoUrl: REPO_URL,
+    });
+
+    expect(notes).toContain("No changelog entries were recorded");
+    expect(notes).toContain("- `nextly`");
+  });
+});


### PR DESCRIPTION
## The defect

The **Create consolidated GitHub Release** step in `release.yml` has been failing with:

```
HTTP 422: Validation Failed (https://api.github.com/repos/nextlyhq/nextly/releases)
body is too long (maximum is 125000 characters)
```

npm publish and registry verification both succeed, so the packages go live and the tag is pushed — only the GitHub Release is never created. `v0.0.2-alpha.42` and `v0.0.2-alpha.43` are both fully published to npm with tags on origin, but the releases page still showed `v0.0.2-alpha.41` as the newest.

## Root cause

The step looped every package in the manifest and printed that package's whole `CHANGELOG.md` section for the version under a `### <pkg>` heading. All 17 published packages are a single Changesets `fixed[]` group, so every changeset is written verbatim into every one of their changelogs. Each piece of authored prose was therefore repeated up to 17 times, plus 17 generated "Updated dependencies" blocks.

Measured against the real `0.0.2-alpha.43` changelogs: **349,566 characters** for 13 distinct changesets.

## The fix

`scripts/release/release-notes.mjs` builds the body instead:

- **Dedupe.** Entries are parsed out of each package's section and emitted once. Packages sharing a changeset produce byte-identical entries, so the first copy stands for all of them; the result is the union across the train.
- **Drop dependency noise.** The generated `Updated dependencies` blocks are filtered. The prefix is only honoured at the very start of an entry, and nested `  - pkg@version` bullets are indented so they stay attached to their own entry rather than splitting the next one.
- **Hard size guard.** The body is capped at 120,000 characters (margin under GitHub's 125,000) and truncated at an entry boundary with a marker linking to the tag's changelogs. A final slice backstops the degenerate case of a single oversized entry. The step can no longer fail because notes are long.

Everything else in the step is unchanged: the manifest-based package list (not the publish step's output, per the existing recovery-run comment), version/tag derivation, prerelease detection via the hyphen in the semver, the "release already exists → skip" idempotency, and the tag-conflict guard.

## Result on real data

| | body size |
| --- | --- |
| before, `0.0.2-alpha.43` | 349,566 |
| after, `0.0.2-alpha.43` | 20,383 |
| after, `0.0.2-alpha.42` | 18,993 |

All 13 distinct changesets are preserved — verified by diffing the set of authored entries in the old output against the new one (0 missing).

Truncation guard proven separately against synthetic input: a 7.97M-character naive body renders as 119,588 characters ending in the truncation marker.

## Backfill

`v0.0.2-alpha.42` and `v0.0.2-alpha.43` were created from this builder, both marked pre-release. The existing tags were not recreated, moved, or deleted.

- https://github.com/nextlyhq/nextly/releases/tag/v0.0.2-alpha.42
- https://github.com/nextlyhq/nextly/releases/tag/v0.0.2-alpha.43

## Tests

`scripts/release/release-notes.test.mjs`, 17 tests: version-section extraction, entry parsing including multi-paragraph bodies and nested dependency bullets, dependency-noise filtering (including prose that merely mentions updating dependencies), dedupe across a fixed group, union across differing changelogs, heading ordering, a normal small release passing through unchanged, the truncation guard firing with its marker, and the single-oversized-entry backstop.

`scripts/` sits in no workspace package, so `turbo run test` never reached it. Added `pnpm test:scripts` and a CI step — a defect in this builder otherwise only surfaces during a real publish, after the packages are already on npm.

## No changeset

CI/release-tooling only. Per `AGENTS.md`, "Test-only, CI-only, or docs-only PRs get NO changeset."
