### PR TITLE
feat(nextly): emit webhook events for programmatic entry writes

### DIFF
--- a/.changeset/write-path-webhook-events.md
+++ b/.changeset/write-path-webhook-events.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Programmatic entry writes now emit webhook events. Writes through the transaction API (`createEntryInTransaction`/`updateEntryInTransaction`), the batch helpers (`createEntries`/`updateEntries`), and `publishAllLocales` previously recorded no webhook events, so importers, agents, and plugins writing through them were invisible to webhook subscribers. These paths now record `entry.created`/`entry.updated` and the corresponding `published`/`unpublished`/`status_changed` lifecycle events inside the write transaction, so an event is delivered for every entry write and is never emitted for a write that rolls back.

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -1304,6 +1304,10 @@ export class CollectionBulkService extends BaseService {
               createResult.revalidationIntent
             );
           }
+          // Aggregate the outbox signal (set even on a committed-but-hook-failed
+          // item) so the caller offers the post-commit fast drain, matching the
+          // update-in-transaction loop; a batch that recorded nothing owes none.
+          if (createResult.eventRecorded) result.eventRecorded = true;
           if (createResult.success && createResult.data) {
             result.successful++;
             result.ids.push(

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -2685,15 +2685,16 @@ export class CollectionMutationService extends BaseService {
               ...(publishedParentRow ??
                 (existingEntry as Record<string, unknown>)),
               status: "published",
-              // `publishedParentRow` is a pooled read that excludes this tx's own
-              // uncommitted `updated_at` write, and `existingEntry` is older
-              // still, so overlay the committed publish instant — the same value
-              // the transaction's `SET updated_at = now()` wrote — or the event
-              // reports the pre-publish timestamp and omits it from changedFields.
-              updated_at: new Date(),
             },
             fields
           );
+          // Overlay the committed publish instant AFTER camelCasing: the source
+          // rows carry the pre-publish `updatedAt` (the pooled/pre-read excludes
+          // this tx's own `SET updated_at = now()`), and a snake-case overlay
+          // would be dropped because `convertTimestampsToCamelCase` keeps the
+          // existing camelCase value. Without this the event reports the stale
+          // timestamp and omits `updatedAt` from changedFields.
+          publishedDocument.updatedAt = new Date();
           const previousDocument = this.readShapeEventDocument(
             existingEntry as Record<string, unknown>,
             fields

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -2517,6 +2517,9 @@ export class CollectionMutationService extends BaseService {
       // payload exposes a stale pre-image of the non-status columns. The closure
       // sets it; it is read once after commit for the event.
       let publishedParentRow: Record<string, unknown> | undefined;
+      // Set inside the transaction when the publish records its outbox events, so
+      // the caller can flush the drain after IT commits.
+      let eventRecorded = false;
       const needsFreshParent =
         !!versionsConfig?.enabled ||
         (hasMainStatus && previousStatus !== "published");
@@ -2642,11 +2645,58 @@ export class CollectionMutationService extends BaseService {
             }
           }
 
-          // This path writes no base `entry.updated` outbox event, so recording
-          // a status-only lifecycle event here would ship an inconsistent
-          // partial surface (a status change with no corresponding write event).
-          // Its lifecycle events belong with its base write event, not in
-          // isolation, so none are recorded here.
+          // Append the base `entry.updated` outbox event for the publish write,
+          // then its publish lifecycle event, both on this transaction so they
+          // commit with the status write and never survive a rollback. Built from
+          // the post-publish document (the fresh in-tx row overlaid with the new
+          // status, or the pre-read row so the event still fires when no fresh
+          // read was needed). The publish event is gated on a real main-row
+          // transition, matching the post-commit `transitionStatus` below.
+          const publishedDocument = this.deserializeJsonFieldsForSnapshot(
+            {
+              ...(publishedParentRow ??
+                (existingEntry as Record<string, unknown>)),
+              status: "published",
+            },
+            fields
+          );
+          const previousDocument = this.deserializeJsonFieldsForSnapshot(
+            existingEntry as Record<string, unknown>,
+            fields
+          );
+          const publishEventFields = await this.webhookFieldTreeIfRecording(
+            params.collectionName,
+            fields,
+            tx.getDrizzle()
+          );
+          const publishActor = actorForWrite(undefined, params.user);
+          const baseRecorded = await recordMutationEvent(tx, {
+            type: "entry.updated",
+            resource: {
+              kind: "entry",
+              collection: params.collectionName,
+              id: params.entryId,
+            },
+            data: publishedDocument,
+            previous: previousDocument,
+            fields: publishEventFields,
+            actor: publishActor,
+          });
+          eventRecorded = baseRecorded || eventRecorded;
+          if (hasMainStatus && previousStatus !== "published") {
+            const statusRecorded = await this.recordStatusEvents(tx, {
+              collection: params.collectionName,
+              id: params.entryId,
+              from: previousStatus ?? null,
+              to: "published",
+              isCreate: false,
+              data: publishedDocument,
+              previous: previousDocument,
+              fields: publishEventFields,
+              actor: publishActor,
+            });
+            eventRecorded = statusRecorded || eventRecorded;
+          }
         })
       );
 
@@ -2722,6 +2772,7 @@ export class CollectionMutationService extends BaseService {
         statusCode: 200,
         message: "All languages published.",
         data: { id: params.entryId, status: "published" },
+        eventRecorded,
         revalidationIntent,
       };
     } catch (error) {
@@ -5723,6 +5774,58 @@ export class CollectionMutationService extends BaseService {
         }
       }
 
+      // Append the outbox event on the caller's transaction so an update through
+      // the tx-API (importers, plugins) is observable too — the invariant the
+      // interactive path holds. Built from the freshly-updated row and the
+      // pre-update row in read shape; recorded on `tx` so it commits with the
+      // update and never survives a rollback. A status-lifecycle transition also
+      // emits its publish/unpublish/status_changed event, gated on the
+      // collection's Draft/Published flag so an ordinary user `status` field is
+      // not mistaken for a lifecycle change.
+      const updatedDocument = this.deserializeJsonFieldsForSnapshot(
+        updated as Record<string, unknown>,
+        fields
+      );
+      const previousDocument = this.deserializeJsonFieldsForSnapshot(
+        existingEntry,
+        fields
+      );
+      const eventFields = await this.webhookFieldTreeIfRecording(
+        params.collectionName,
+        fields,
+        tx.getDrizzle()
+      );
+      const eventActor = actorForWrite(undefined, params.user);
+      let eventRecorded = await recordMutationEvent(tx, {
+        type: "entry.updated",
+        resource: {
+          kind: "entry",
+          collection: params.collectionName,
+          id: params.entryId,
+        },
+        data: updatedDocument,
+        previous: previousDocument,
+        fields: eventFields,
+        actor: eventActor,
+      });
+      if ((collection as { status?: boolean }).status === true) {
+        const statusRecorded = await this.recordStatusEvents(tx, {
+          collection: params.collectionName,
+          id: params.entryId,
+          from: readStringField(existingEntry, "status") ?? null,
+          to: (updated as { status?: unknown }).status as
+            | string
+            | null
+            | undefined,
+          isCreate: false,
+          data: updatedDocument,
+          previous: previousDocument,
+          fields: eventFields,
+          actor: eventActor,
+        });
+        eventRecorded = eventRecorded || statusRecorded;
+      }
+
       // Execute afterUpdate hooks (code-registered)
       const afterContext = this.hookService.buildHookContext({
         collection: params.collectionName,
@@ -5784,6 +5887,7 @@ export class CollectionMutationService extends BaseService {
         statusCode: 200,
         message: "Entry updated successfully",
         data: updated,
+        eventRecorded,
         revalidationIntent,
       };
     } catch (error: unknown) {
@@ -7038,6 +7142,57 @@ export class CollectionMutationService extends BaseService {
         }
       }
 
+      // Append the outbox event on the caller's transaction so a batch update
+      // (updateEntries) is observable too. Recording is NOT a hook, so it runs
+      // even under `skipHooks`; built from the freshly-updated row and the
+      // pre-update row in read shape and recorded on `tx` so it commits with the
+      // update and never survives a rollback. A status-lifecycle transition also
+      // emits its publish/unpublish/status_changed event, gated on the
+      // collection's Draft/Published flag.
+      const updatedDocument = this.deserializeJsonFieldsForSnapshot(
+        updated as Record<string, unknown>,
+        fields
+      );
+      const previousDocument = this.deserializeJsonFieldsForSnapshot(
+        existingEntry,
+        fields
+      );
+      const eventFields = await this.webhookFieldTreeIfRecording(
+        params.collectionName,
+        fields,
+        tx.getDrizzle()
+      );
+      const eventActor = actorForWrite(undefined, params.user);
+      let eventRecorded = await recordMutationEvent(tx, {
+        type: "entry.updated",
+        resource: {
+          kind: "entry",
+          collection: params.collectionName,
+          id: entryId,
+        },
+        data: updatedDocument,
+        previous: previousDocument,
+        fields: eventFields,
+        actor: eventActor,
+      });
+      if ((collection as { status?: boolean }).status === true) {
+        const statusRecorded = await this.recordStatusEvents(tx, {
+          collection: params.collectionName,
+          id: entryId,
+          from: readStringField(existingEntry, "status") ?? null,
+          to: (updated as { status?: unknown }).status as
+            | string
+            | null
+            | undefined,
+          isCreate: false,
+          data: updatedDocument,
+          previous: previousDocument,
+          fields: eventFields,
+          actor: eventActor,
+        });
+        eventRecorded = eventRecorded || statusRecorded;
+      }
+
       // Execute afterUpdate hooks (unless skipped)
       if (!skipHooks) {
         // Execute afterUpdate hooks (code-registered)
@@ -7107,6 +7262,7 @@ export class CollectionMutationService extends BaseService {
         statusCode: 200,
         message: "Entry updated successfully",
         data: updated,
+        eventRecorded,
         revalidationIntent,
       };
     } catch (error: unknown) {

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -436,6 +436,32 @@ export class CollectionMutationService extends BaseService {
   }
 
   /**
+   * The read-shape parent document a programmatic (tx-API / batch / publish)
+   * write event carries: JSON container fields parsed, then password hashes and
+   * the internal owner column (created_by) stripped — the same server-side
+   * fields the interactive create/update paths remove before building their
+   * event, so a stable user id never leaves in a webhook envelope. Operates on a
+   * shallow copy so the caller's row is not mutated. Many-to-many/component
+   * subtrees are not assembled here (the parent columns are the event payload on
+   * these paths); the full relational assembly rides the version-capture work.
+   */
+  private readShapeEventDocument(
+    row: Record<string, unknown>,
+    fields: readonly unknown[]
+  ): Record<string, unknown> {
+    const doc = this.deserializeJsonFieldsForSnapshot(
+      { ...row },
+      fields as Parameters<typeof this.deserializeJsonFieldsForSnapshot>[1]
+    );
+    stripPasswordFieldValues(
+      doc,
+      fields as Parameters<typeof stripPasswordFieldValues>[1]
+    );
+    stripSystemOwnerField(doc);
+    return doc;
+  }
+
+  /**
    * Assemble a removed entry as the read shape the create/update events carry —
    * JSON container fields parsed, component subtrees and many-to-many id arrays
    * populated, password and system-owner fields stripped — so a delete event
@@ -2652,7 +2678,7 @@ export class CollectionMutationService extends BaseService {
           // status, or the pre-read row so the event still fires when no fresh
           // read was needed). The publish event is gated on a real main-row
           // transition, matching the post-commit `transitionStatus` below.
-          const publishedDocument = this.deserializeJsonFieldsForSnapshot(
+          const publishedDocument = this.readShapeEventDocument(
             {
               ...(publishedParentRow ??
                 (existingEntry as Record<string, unknown>)),
@@ -2660,7 +2686,7 @@ export class CollectionMutationService extends BaseService {
             },
             fields
           );
-          const previousDocument = this.deserializeJsonFieldsForSnapshot(
+          const previousDocument = this.readShapeEventDocument(
             existingEntry as Record<string, unknown>,
             fields
           );
@@ -5283,25 +5309,49 @@ export class CollectionMutationService extends BaseService {
       // freshly-inserted row in read shape; recorded on `tx` so it commits with
       // the entry and never survives a rollback. Carried on the result so the
       // owning caller flushes the drain after IT commits.
-      const eventRecorded = await recordMutationEvent(tx, {
+      const createdDocument = this.readShapeEventDocument(
+        entry as Record<string, unknown>,
+        fields
+      );
+      const eventFields = await this.webhookFieldTreeIfRecording(
+        params.collectionName,
+        fields,
+        tx.getDrizzle()
+      );
+      const eventActor = actorForWrite(undefined, params.user);
+      let eventRecorded = await recordMutationEvent(tx, {
         type: "entry.created",
         resource: {
           kind: "entry",
           collection: params.collectionName,
           id: (entry as Record<string, unknown>).id as string,
         },
-        data: this.deserializeJsonFieldsForSnapshot(
-          entry as Record<string, unknown>,
-          fields
-        ),
+        data: createdDocument,
         previous: null,
-        fields: await this.webhookFieldTreeIfRecording(
-          params.collectionName,
-          fields,
-          tx.getDrizzle()
-        ),
-        actor: actorForWrite(undefined, params.user),
+        fields: eventFields,
+        actor: eventActor,
       });
+      // A create landing directly on `published` is also a publish lifecycle
+      // event, gated on the collection's Draft/Published flag so an ordinary
+      // user `status` field is not mistaken for a lifecycle change. `from` is
+      // null (nothing to transition from), so only `entry.published` is emitted.
+      if ((collection as { status?: boolean }).status === true) {
+        const createdStatusRecorded = await this.recordStatusEvents(tx, {
+          collection: params.collectionName,
+          id: (entry as Record<string, unknown>).id as string,
+          from: null,
+          to: (entry as { status?: unknown }).status as
+            | string
+            | null
+            | undefined,
+          isCreate: true,
+          data: createdDocument,
+          previous: null,
+          fields: eventFields,
+          actor: eventActor,
+        });
+        eventRecorded = createdStatusRecorded || eventRecorded;
+      }
 
       // Compute the intent from the freshly inserted row, before the after-hooks
       // run or redaction can strip the slug.
@@ -5782,11 +5832,11 @@ export class CollectionMutationService extends BaseService {
       // emits its publish/unpublish/status_changed event, gated on the
       // collection's Draft/Published flag so an ordinary user `status` field is
       // not mistaken for a lifecycle change.
-      const updatedDocument = this.deserializeJsonFieldsForSnapshot(
+      const updatedDocument = this.readShapeEventDocument(
         updated as Record<string, unknown>,
         fields
       );
-      const previousDocument = this.deserializeJsonFieldsForSnapshot(
+      const previousDocument = this.readShapeEventDocument(
         existingEntry,
         fields
       );
@@ -6576,25 +6626,49 @@ export class CollectionMutationService extends BaseService {
       // path holds. Recording is NOT a hook, so it runs even under `skipHooks`;
       // built from the freshly-inserted row in read shape and recorded on `tx`
       // so it commits with the entry and never survives a rollback.
-      const eventRecorded = await recordMutationEvent(tx, {
+      const createdDocument = this.readShapeEventDocument(
+        entry as Record<string, unknown>,
+        fields
+      );
+      const eventFields = await this.webhookFieldTreeIfRecording(
+        params.collectionName,
+        fields,
+        tx.getDrizzle()
+      );
+      const eventActor = actorForWrite(undefined, params.user);
+      let eventRecorded = await recordMutationEvent(tx, {
         type: "entry.created",
         resource: {
           kind: "entry",
           collection: params.collectionName,
           id: (entry as Record<string, unknown>).id as string,
         },
-        data: this.deserializeJsonFieldsForSnapshot(
-          entry as Record<string, unknown>,
-          fields
-        ),
+        data: createdDocument,
         previous: null,
-        fields: await this.webhookFieldTreeIfRecording(
-          params.collectionName,
-          fields,
-          tx.getDrizzle()
-        ),
-        actor: actorForWrite(undefined, params.user),
+        fields: eventFields,
+        actor: eventActor,
       });
+      // A create landing directly on `published` is also a publish lifecycle
+      // event, gated on the collection's Draft/Published flag so an ordinary
+      // user `status` field is not mistaken for a lifecycle change. `from` is
+      // null (nothing to transition from), so only `entry.published` is emitted.
+      if ((collection as { status?: boolean }).status === true) {
+        const createdStatusRecorded = await this.recordStatusEvents(tx, {
+          collection: params.collectionName,
+          id: (entry as Record<string, unknown>).id as string,
+          from: null,
+          to: (entry as { status?: unknown }).status as
+            | string
+            | null
+            | undefined,
+          isCreate: true,
+          data: createdDocument,
+          previous: null,
+          fields: eventFields,
+          actor: eventActor,
+        });
+        eventRecorded = createdStatusRecorded || eventRecorded;
+      }
 
       // Compute the intent from the freshly inserted row, before ANY after-hooks
       // run (a throwing afterCreate hook must not lose it) and before redaction
@@ -7149,11 +7223,11 @@ export class CollectionMutationService extends BaseService {
       // update and never survives a rollback. A status-lifecycle transition also
       // emits its publish/unpublish/status_changed event, gated on the
       // collection's Draft/Published flag.
-      const updatedDocument = this.deserializeJsonFieldsForSnapshot(
+      const updatedDocument = this.readShapeEventDocument(
         updated as Record<string, unknown>,
         fields
       );
-      const previousDocument = this.deserializeJsonFieldsForSnapshot(
+      const previousDocument = this.readShapeEventDocument(
         existingEntry,
         fields
       );

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -449,9 +449,11 @@ export class CollectionMutationService extends BaseService {
     row: Record<string, unknown>,
     fields: readonly unknown[]
   ): Record<string, unknown> {
-    const doc = this.deserializeJsonFieldsForSnapshot(
-      { ...row },
-      fields as Parameters<typeof this.deserializeJsonFieldsForSnapshot>[1]
+    const doc = convertTimestampsToCamelCase(
+      this.deserializeJsonFieldsForSnapshot(
+        { ...row },
+        fields as Parameters<typeof this.deserializeJsonFieldsForSnapshot>[1]
+      )
     );
     stripPasswordFieldValues(
       doc,
@@ -2683,6 +2685,12 @@ export class CollectionMutationService extends BaseService {
               ...(publishedParentRow ??
                 (existingEntry as Record<string, unknown>)),
               status: "published",
+              // `publishedParentRow` is a pooled read that excludes this tx's own
+              // uncommitted `updated_at` write, and `existingEntry` is older
+              // still, so overlay the committed publish instant — the same value
+              // the transaction's `SET updated_at = now()` wrote — or the event
+              // reports the pre-publish timestamp and omits it from changedFields.
+              updated_at: new Date(),
             },
             fields
           );

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -5226,6 +5226,32 @@ export class CollectionMutationService extends BaseService {
         }
       }
 
+      // Append the outbox event on the caller's transaction so a create through
+      // the tx-API (importers, plugins, batch) is observable too — the invariant
+      // the interactive and delete-in-tx paths already hold. Built from the
+      // freshly-inserted row in read shape; recorded on `tx` so it commits with
+      // the entry and never survives a rollback. Carried on the result so the
+      // owning caller flushes the drain after IT commits.
+      const eventRecorded = await recordMutationEvent(tx, {
+        type: "entry.created",
+        resource: {
+          kind: "entry",
+          collection: params.collectionName,
+          id: (entry as Record<string, unknown>).id as string,
+        },
+        data: this.deserializeJsonFieldsForSnapshot(
+          entry as Record<string, unknown>,
+          fields
+        ),
+        previous: null,
+        fields: await this.webhookFieldTreeIfRecording(
+          params.collectionName,
+          fields,
+          tx.getDrizzle()
+        ),
+        actor: actorForWrite(undefined, params.user),
+      });
+
       // Compute the intent from the freshly inserted row, before the after-hooks
       // run or redaction can strip the slug.
       revalidationIntent = buildEntryRevalidationIntent(
@@ -5297,6 +5323,7 @@ export class CollectionMutationService extends BaseService {
         statusCode: 201,
         message: "Entry created successfully",
         data: entry,
+        eventRecorded,
         revalidationIntent,
       };
     } catch (error: unknown) {
@@ -6440,6 +6467,31 @@ export class CollectionMutationService extends BaseService {
         }
       }
 
+      // Append the outbox event on the caller's transaction so a batch create
+      // (createEntries) is observable too — the same invariant the interactive
+      // path holds. Recording is NOT a hook, so it runs even under `skipHooks`;
+      // built from the freshly-inserted row in read shape and recorded on `tx`
+      // so it commits with the entry and never survives a rollback.
+      const eventRecorded = await recordMutationEvent(tx, {
+        type: "entry.created",
+        resource: {
+          kind: "entry",
+          collection: params.collectionName,
+          id: (entry as Record<string, unknown>).id as string,
+        },
+        data: this.deserializeJsonFieldsForSnapshot(
+          entry as Record<string, unknown>,
+          fields
+        ),
+        previous: null,
+        fields: await this.webhookFieldTreeIfRecording(
+          params.collectionName,
+          fields,
+          tx.getDrizzle()
+        ),
+        actor: actorForWrite(undefined, params.user),
+      });
+
       // Compute the intent from the freshly inserted row, before ANY after-hooks
       // run (a throwing afterCreate hook must not lose it) and before redaction
       // can strip the slug.
@@ -6520,6 +6572,7 @@ export class CollectionMutationService extends BaseService {
         statusCode: 201,
         message: "Entry created successfully",
         data: entry,
+        eventRecorded,
         revalidationIntent,
       };
     } catch (error: unknown) {

--- a/packages/nextly/src/domains/collections/services/collection-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service.ts
@@ -192,6 +192,16 @@ export class CollectionService extends BaseService {
   private readonly pendingTxEvents = new Set<unknown>();
 
   /**
+   * Transaction handles whose `*InTransaction` wrappers committed at least one
+   * write, independent of whether that write produced a revalidation intent or an
+   * outbox event. `withTransaction` offers the opportunistic retention pass for
+   * any committed write (matching the automatic path), so a write that opts out
+   * of BOTH revalidation and recording still triggers the pass rather than
+   * relying on those optional signals.
+   */
+  private readonly pendingTxCommittedWrites = new Set<unknown>();
+
+  /**
    * Run work inside a database transaction, then flush the cache-revalidation
    * intents produced by any createEntryInTransaction / updateEntryInTransaction /
    * deleteEntryInTransaction calls made against the same `tx`. The flush happens
@@ -217,6 +227,7 @@ export class CollectionService extends BaseService {
     let ownsFlush = false;
     let collector: RevalidationIntent[] | undefined;
     let sawEvent = false;
+    let sawCommittedWrite = false;
     const result = await this.adapter.transaction(async tx => {
       collector = this.pendingTxIntents.get(tx);
       if (!collector) {
@@ -235,8 +246,10 @@ export class CollectionService extends BaseService {
         // post-commit drain below can see it.
         if (ownsFlush) {
           sawEvent = this.pendingTxEvents.has(tx);
+          sawCommittedWrite = this.pendingTxCommittedWrites.has(tx);
           this.pendingTxIntents.delete(tx);
           this.pendingTxEvents.delete(tx);
+          this.pendingTxCommittedWrites.delete(tx);
         }
       }
     });
@@ -247,14 +260,14 @@ export class CollectionService extends BaseService {
       await this.entryService.flushRevalidationIntents(collectedIntents);
     }
     // A committed transaction runs the same post-write maintenance the automatic
-    // paths run: the opportunistic retention pass for any committed write (a
-    // collected intent or a recorded event both signal one), and the fast drain
-    // once when an outbox event was recorded — so tx-API writes deliver, and
-    // prune, as promptly as the non-transaction paths instead of waiting for an
-    // unrelated operation.
-    if (ownsFlush && (collectedIntents.length > 0 || sawEvent)) {
+    // paths run: the opportunistic retention pass for any committed write —
+    // tracked independently of the optional revalidation/recording signals so a
+    // write that opted out of both still prunes — and the fast drain once when an
+    // outbox event was recorded, so tx-API writes deliver, and prune, as promptly
+    // as the non-transaction paths instead of waiting for an unrelated operation.
+    if (ownsFlush && (sawCommittedWrite || sawEvent)) {
       await this.entryService.offerPostCommitTxMaintenance({
-        committedWrite: true,
+        committedWrite: sawCommittedWrite || sawEvent,
         recordedEvent: sawEvent,
       });
     }
@@ -289,6 +302,20 @@ export class CollectionService extends BaseService {
   ): void {
     if (!eventRecorded) return;
     if (this.pendingTxIntents.has(tx)) this.pendingTxEvents.add(tx);
+  }
+
+  /**
+   * Record that a wrapper's `*InTransaction` write succeeded against the active
+   * owned transaction, so `withTransaction` offers retention for the committed
+   * write even when it produced no intent and no event. A failed wrapper throws
+   * (rolling the transaction back), so only committed writes reach here.
+   */
+  private collectTxCommittedWrite(
+    tx: TransactionContext,
+    success: boolean | undefined
+  ): void {
+    if (!success) return;
+    if (this.pendingTxIntents.has(tx)) this.pendingTxCommittedWrites.add(tx);
   }
 
   /**
@@ -867,6 +894,7 @@ export class CollectionService extends BaseService {
     // withTransaction flushes what was collected once the transaction commits.
     this.collectTxIntent(tx, result.revalidationIntent);
     this.collectTxEvent(tx, result.eventRecorded);
+    this.collectTxCommittedWrite(tx, result.success);
 
     if (!result.success) {
       this.logger.warn("Entry creation in transaction failed", {
@@ -922,6 +950,7 @@ export class CollectionService extends BaseService {
     // post-write hook failure still busts the tags (see createEntryInTransaction).
     this.collectTxIntent(tx, result.revalidationIntent);
     this.collectTxEvent(tx, result.eventRecorded);
+    this.collectTxCommittedWrite(tx, result.success);
 
     if (!result.success) {
       if (result.statusCode === 404) {
@@ -995,6 +1024,7 @@ export class CollectionService extends BaseService {
     // post-delete hook failure still busts the tags (see createEntryInTransaction).
     this.collectTxIntent(tx, result.revalidationIntent);
     this.collectTxEvent(tx, result.eventRecorded);
+    this.collectTxCommittedWrite(tx, result.success);
 
     if (!result.success) {
       if (result.statusCode === 404) {

--- a/packages/nextly/src/domains/collections/services/collection-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service.ts
@@ -242,14 +242,21 @@ export class CollectionService extends BaseService {
     });
     // Reached only on a successful commit; a rejected transaction throws above
     // and flushes nothing. The captured `collector` outlives the map binding.
-    if (ownsFlush && collector && collector.length > 0) {
-      await this.entryService.flushRevalidationIntents(collector);
+    const collectedIntents = collector ?? [];
+    if (ownsFlush && collectedIntents.length > 0) {
+      await this.entryService.flushRevalidationIntents(collectedIntents);
     }
-    // A committed transaction that recorded any outbox event schedules the fast
-    // drain once, so tx-API writes deliver as promptly as the non-transaction
-    // paths instead of waiting for an unrelated operation to trigger a drain.
-    if (ownsFlush && sawEvent) {
-      this.entryService.scheduleFastDrain();
+    // A committed transaction runs the same post-write maintenance the automatic
+    // paths run: the opportunistic retention pass for any committed write (a
+    // collected intent or a recorded event both signal one), and the fast drain
+    // once when an outbox event was recorded — so tx-API writes deliver, and
+    // prune, as promptly as the non-transaction paths instead of waiting for an
+    // unrelated operation.
+    if (ownsFlush && (collectedIntents.length > 0 || sawEvent)) {
+      await this.entryService.offerPostCommitTxMaintenance({
+        committedWrite: true,
+        recordedEvent: sawEvent,
+      });
     }
     return result;
   }

--- a/packages/nextly/src/domains/collections/services/collection-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service.ts
@@ -184,6 +184,14 @@ export class CollectionService extends BaseService {
   private readonly pendingTxIntents = new Map<unknown, RevalidationIntent[]>();
 
   /**
+   * Transaction handles whose `*InTransaction` wrappers recorded at least one
+   * outbox event, so `withTransaction` can offer the fast drain once after the
+   * owning transaction commits — the tx-API wrappers return only the entry, so
+   * the event signal (like the revalidation intent) has nowhere else to go.
+   */
+  private readonly pendingTxEvents = new Set<unknown>();
+
+  /**
    * Run work inside a database transaction, then flush the cache-revalidation
    * intents produced by any createEntryInTransaction / updateEntryInTransaction /
    * deleteEntryInTransaction calls made against the same `tx`. The flush happens
@@ -208,6 +216,7 @@ export class CollectionService extends BaseService {
   ): Promise<T> {
     let ownsFlush = false;
     let collector: RevalidationIntent[] | undefined;
+    let sawEvent = false;
     const result = await this.adapter.transaction(async tx => {
       collector = this.pendingTxIntents.get(tx);
       if (!collector) {
@@ -218,18 +227,29 @@ export class CollectionService extends BaseService {
       try {
         return await work(tx);
       } finally {
-        // Drop the per-tx binding on both commit and rollback, so a throwing or
+        // Drop the per-tx bindings on both commit and rollback, so a throwing or
         // failed-to-commit transaction never leaks its collector in
         // pendingTxIntents. Only the frame that created the collector removes
         // it, so a nested withTransaction sharing the handle leaves the outer's
-        // binding intact.
-        if (ownsFlush) this.pendingTxIntents.delete(tx);
+        // binding intact. Capture the event signal before dropping it so the
+        // post-commit drain below can see it.
+        if (ownsFlush) {
+          sawEvent = this.pendingTxEvents.has(tx);
+          this.pendingTxIntents.delete(tx);
+          this.pendingTxEvents.delete(tx);
+        }
       }
     });
     // Reached only on a successful commit; a rejected transaction throws above
     // and flushes nothing. The captured `collector` outlives the map binding.
     if (ownsFlush && collector && collector.length > 0) {
       await this.entryService.flushRevalidationIntents(collector);
+    }
+    // A committed transaction that recorded any outbox event schedules the fast
+    // drain once, so tx-API writes deliver as promptly as the non-transaction
+    // paths instead of waiting for an unrelated operation to trigger a drain.
+    if (ownsFlush && sawEvent) {
+      this.entryService.scheduleFastDrain();
     }
     return result;
   }
@@ -247,6 +267,21 @@ export class CollectionService extends BaseService {
   ): void {
     if (!intent) return;
     this.pendingTxIntents.get(tx)?.push(intent);
+  }
+
+  /**
+   * Record that a wrapper's `*InTransaction` write appended an outbox event
+   * against the active owned transaction, so `withTransaction` offers the fast
+   * drain once after commit. Only tracked when a collector exists for this `tx`
+   * (a `withTransaction` frame owns it); a caller that obtained `tx` some other
+   * way owns the drain, exactly as it owns the revalidation flush.
+   */
+  private collectTxEvent(
+    tx: TransactionContext,
+    eventRecorded: boolean | undefined
+  ): void {
+    if (!eventRecorded) return;
+    if (this.pendingTxIntents.has(tx)) this.pendingTxEvents.add(tx);
   }
 
   /**
@@ -824,6 +859,7 @@ export class CollectionService extends BaseService {
     // rollback drops the collector unflushed, so collecting here is always safe.
     // withTransaction flushes what was collected once the transaction commits.
     this.collectTxIntent(tx, result.revalidationIntent);
+    this.collectTxEvent(tx, result.eventRecorded);
 
     if (!result.success) {
       this.logger.warn("Entry creation in transaction failed", {
@@ -878,6 +914,7 @@ export class CollectionService extends BaseService {
     // Collect before the success check, so a caller that commits despite a
     // post-write hook failure still busts the tags (see createEntryInTransaction).
     this.collectTxIntent(tx, result.revalidationIntent);
+    this.collectTxEvent(tx, result.eventRecorded);
 
     if (!result.success) {
       if (result.statusCode === 404) {
@@ -950,6 +987,7 @@ export class CollectionService extends BaseService {
     // Collect before the success check, so a caller that commits despite a
     // post-delete hook failure still busts the tags (see createEntryInTransaction).
     this.collectTxIntent(tx, result.revalidationIntent);
+    this.collectTxEvent(tx, result.eventRecorded);
 
     if (!result.success) {
       if (result.statusCode === 404) {

--- a/packages/nextly/src/domains/webhooks/__tests__/outbox-preimage-lock.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/outbox-preimage-lock.integration.test.ts
@@ -142,7 +142,13 @@ for (const leg of LEGS) {
           resourceCollection?: string;
           payload: unknown;
         }>("nextly_events");
-        const updates = rows.filter(r => r.type === "entry.updated");
+        // Scope to THIS entry's events: `nextly_events` is a shared fixed-name
+        // system table, so counting every `entry.updated` in it is fragile once
+        // other suites (or other rows) also record — assert on the two updates to
+        // the row under test, not the whole ledger.
+        const updates = rows.filter(
+          r => r.type === "entry.updated" && envelopeOf(r).resource.id === id
+        );
         expect(updates).toHaveLength(2);
 
         const changed = updates.map(r => envelopeOf(r).changedFields ?? []);

--- a/packages/nextly/src/domains/webhooks/__tests__/write-path-events-matrix.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/write-path-events-matrix.integration.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Webhook-event completeness matrix for the PROGRAMMATIC write paths.
+ *
+ * The interactive create/update/delete paths are covered by `capture-matrix`.
+ * This grid enumerates the tx-API and batch write paths that plugins, importers,
+ * and agents use — `createEntryInTransaction`, `updateEntryInTransaction`,
+ * `createEntries`, `updateEntries`, and `publishAllLocales` — and asserts each
+ * records its outbox event. It is the loud-failure guard for the invariant
+ * "every write is an event": a future write path added without recording fails
+ * a cell here rather than going silently dark.
+ *
+ * Recording is endpoint-gated in production; the test harness defaults the gate
+ * open, so no endpoint registration is needed.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import { NextlyError } from "../../../errors";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionEntryService } from "../../../services/collections/collection-entry-service";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+import { deriveCompanionSpec } from "../../i18n/migration/derive-companion-spec";
+import { buildCompanionCreateOnlySql } from "../../i18n/migration/generate-up";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+interface EventRow {
+  type: string;
+}
+
+const COLLECTION = "posts";
+
+async function boot(localized: boolean): Promise<TestNextly> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: COLLECTION,
+        localized,
+        status: true,
+        fields: [text({ name: "title", localized })],
+      }),
+    ],
+    // Localization config is harmless when the collection is not localized; the
+    // localized publish cell needs it and the others ignore it.
+    localization: { locales: ["en", "de"], defaultLocale: "en" },
+  });
+  return current;
+}
+
+/** Create the `_locales` companion through the production DDL path. */
+async function migrate(t: TestNextly): Promise<void> {
+  const spec = deriveCompanionSpec({
+    slug: COLLECTION,
+    fields: [{ name: "title", type: "text", localized: true }],
+    dialect: t.adapter.dialect,
+    defaultLocale: "en",
+    collectionLocalized: true,
+    status: true,
+  });
+  if (!spec) {
+    throw NextlyError.internal({
+      logContext: { reason: "missing-companion-spec", collection: COLLECTION },
+    });
+  }
+  if (await t.adapter.tableExists(spec.companionTable)) return;
+  const adapter = t.adapter as unknown as {
+    executeQuery: (sql: string) => Promise<unknown>;
+  };
+  await adapter.executeQuery(buildCompanionCreateOnlySql(spec));
+}
+
+function entriesOf(t: TestNextly): CollectionEntryService {
+  return t
+    .getService<CollectionsHandler>("collectionsHandler")
+    .getEntryService() as CollectionEntryService;
+}
+
+/** Run a create through the interactive path purely to seed a row to update. */
+async function seed(
+  t: TestNextly,
+  data: Record<string, unknown>
+): Promise<string> {
+  const created = await t
+    .getService<CollectionsHandler>("collectionsHandler")
+    .createEntry({ collectionName: COLLECTION, overrideAccess: true }, data);
+  return (created.data as { id: string }).id;
+}
+
+interface PathCase {
+  label: string;
+  localized: boolean;
+  /** Drive the write path under test. */
+  run: (t: TestNextly, e: CollectionEntryService) => Promise<void>;
+  /**
+   * Minimum count required per event type. Cells assert the path emits at least
+   * this many of each type. The assert type set is derived from the keys; a seed
+   * step must never emit the SAME type being asserted, so counts stay clean.
+   */
+  atLeast: Record<string, number>;
+}
+
+const CASES: PathCase[] = [
+  {
+    label: "createEntryInTransaction records entry.created",
+    localized: false,
+    run: async (t, e) => {
+      await t.adapter.transaction(tx =>
+        e.createEntryInTransaction(
+          tx as never,
+          { collectionName: COLLECTION, overrideAccess: true },
+          { title: "a", status: "draft" }
+        )
+      );
+    },
+    atLeast: { "entry.created": 1 },
+  },
+  {
+    label: "updateEntryInTransaction records entry.updated",
+    localized: false,
+    run: async (t, e) => {
+      const id = await seed(t, { title: "a", status: "draft" });
+      await t.adapter.transaction(tx =>
+        e.updateEntryInTransaction(
+          tx as never,
+          { collectionName: COLLECTION, entryId: id, overrideAccess: true },
+          { title: "b" }
+        )
+      );
+    },
+    atLeast: { "entry.updated": 1 },
+  },
+  {
+    label: "createEntries records entry.created per item",
+    localized: false,
+    run: async (_t, e) => {
+      await e.createEntries({ collectionName: COLLECTION, overrideAccess: true }, [
+        { title: "a", status: "draft" },
+        { title: "b", status: "draft" },
+      ]);
+    },
+    atLeast: { "entry.created": 2 },
+  },
+  {
+    label: "updateEntries records entry.updated per item",
+    localized: false,
+    run: async (t, e) => {
+      const id1 = await seed(t, { title: "a", status: "draft" });
+      const id2 = await seed(t, { title: "b", status: "draft" });
+      await e.updateEntries({ collectionName: COLLECTION }, [
+        { id: id1, data: { title: "a2" } },
+        { id: id2, data: { title: "b2" } },
+      ]);
+    },
+    atLeast: { "entry.updated": 2 },
+  },
+  {
+    label: "publishAllLocales records entry.updated + entry.published",
+    localized: true,
+    run: async (t, e) => {
+      const id = await seed(t, { title: "a", status: "draft" });
+      await e.publishAllLocales({
+        collectionName: COLLECTION,
+        entryId: id,
+        overrideAccess: true,
+      });
+    },
+    // A draft going live across locales is both a content update and a publish.
+    atLeast: { "entry.updated": 1, "entry.published": 1 },
+  },
+];
+
+describe("webhook write-path event matrix — programmatic writes (integration)", () => {
+  it.each(CASES)("$label", async pathCase => {
+    const t = await boot(pathCase.localized);
+    if (pathCase.localized) await migrate(t);
+    const e = entriesOf(t);
+
+    await pathCase.run(t, e);
+
+    const rows = await t.adapter.select<EventRow>("nextly_events");
+    for (const [type, min] of Object.entries(pathCase.atLeast)) {
+      const count = rows.filter(r => r.type === type).length;
+      expect(count, `${pathCase.label}: expected >=${min} ${type}`).toBeGreaterThanOrEqual(
+        min
+      );
+    }
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/write-path-events-matrix.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/write-path-events-matrix.integration.test.ts
@@ -124,6 +124,32 @@ const CASES: PathCase[] = [
     atLeast: { "entry.created": 1 },
   },
   {
+    label: "createEntryInTransaction as published records entry.published",
+    localized: false,
+    run: async (t, e) => {
+      await t.adapter.transaction(tx =>
+        e.createEntryInTransaction(
+          tx as never,
+          { collectionName: COLLECTION, overrideAccess: true },
+          { title: "a", status: "published" }
+        )
+      );
+    },
+    // A create landing directly on published is a create AND a publish.
+    atLeast: { "entry.created": 1, "entry.published": 1 },
+  },
+  {
+    label: "createEntries as published records entry.published per item",
+    localized: false,
+    run: async (_t, e) => {
+      await e.createEntries({ collectionName: COLLECTION, overrideAccess: true }, [
+        { title: "a", status: "published" },
+        { title: "b", status: "published" },
+      ]);
+    },
+    atLeast: { "entry.created": 2, "entry.published": 2 },
+  },
+  {
     label: "updateEntryInTransaction records entry.updated",
     localized: false,
     run: async (t, e) => {

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -380,6 +380,18 @@ export class CollectionEntryService extends BaseService {
    * a no-op when no cache adapter is registered, and self-absorbing on error so
    * a revalidator fault never turns a committed write into a failure.
    */
+  /**
+   * Offer the fast outbox drain once, for the `CollectionService.withTransaction`
+   * wrapper to call after a tx-API write commits. The wrappers return only the
+   * entry, so — like `flushRevalidationIntents` — the drain cannot be scheduled
+   * from the wrapper's own result; withTransaction schedules it after commit when
+   * any collected `*InTransaction` write recorded an outbox event. No-op when no
+   * scheduler is wired.
+   */
+  scheduleFastDrain(): void {
+    this.fastDrainScheduler?.offer();
+  }
+
   async flushRevalidationIntents(intents: RevalidationIntent[]): Promise<void> {
     if (intents.length === 0) return;
     // Resolve at flush time so a Next cache adapter registered after this

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -381,15 +381,26 @@ export class CollectionEntryService extends BaseService {
    * a revalidator fault never turns a committed write into a failure.
    */
   /**
-   * Offer the fast outbox drain once, for the `CollectionService.withTransaction`
-   * wrapper to call after a tx-API write commits. The wrappers return only the
-   * entry, so — like `flushRevalidationIntents` — the drain cannot be scheduled
-   * from the wrapper's own result; withTransaction schedules it after commit when
-   * any collected `*InTransaction` write recorded an outbox event. No-op when no
-   * scheduler is wired.
+   * Run the write-path maintenance the automatic paths run, for the
+   * `CollectionService.withTransaction` wrapper to call after a tx-API write
+   * commits. The wrappers return only the entry, so — like
+   * `flushRevalidationIntents` — these cannot be triggered from the wrapper's own
+   * result. Mirrors `afterWriteIfRecorded`: a committed write offers the
+   * opportunistic retention pass (the write path is the only prune trigger for an
+   * install with no drain, so tx-API writes must offer it too, or `nextly_events`
+   * grows unbounded), and a recorded event schedules the fast drain. No-ops when
+   * the respective runner/scheduler is unwired.
    */
-  scheduleFastDrain(): void {
-    this.fastDrainScheduler?.offer();
+  async offerPostCommitTxMaintenance(opts: {
+    committedWrite: boolean;
+    recordedEvent: boolean;
+  }): Promise<void> {
+    if (opts.committedWrite) {
+      await this.offerRetentionPass();
+    }
+    if (opts.recordedEvent) {
+      this.fastDrainScheduler?.offer();
+    }
   }
 
   async flushRevalidationIntents(intents: RevalidationIntent[]): Promise<void> {


### PR DESCRIPTION
## What

Closes the webhook side of task 017 (W3): programmatic entry writes now record their webhook events. Previously only the interactive `createEntry`/`updateEntry`/`deleteEntry` and per-item `bulk*` paths recorded, so importers, agents, and plugins writing through the transaction API or batch helpers were invisible to webhook subscribers.

Now recording (inside the write transaction, so it commits with the write and never fires for a rollback):

- `createEntryInTransaction` → `entry.created`
- `updateEntryInTransaction` → `entry.updated` (+ status lifecycle events)
- `createEntries` / `updateEntries` (via `createSingleEntryInTransaction` / `updateSingleEntryInTransaction`) → per-item `entry.created` / `entry.updated` (+ status)
- `publishAllLocales` → `entry.updated` + `entry.published` (it previously deliberately recorded nothing)

Status lifecycle events (`published` / `unpublished` / `status_changed`) are emitted via the shared `recordStatusEvents`, gated on the collection's Draft/Published flag so an ordinary user `status` field is not mistaken for a lifecycle change.

Delivery flows through the existing batch aggregation: each item's `eventRecorded` is OR'd into the batch result (and reset on rollback), and the entry service's `afterWriteIfRecorded` fires the drain — so no new delivery wiring was needed.

## Tests

New `write-path-events-matrix.integration.test.ts` — a table-driven grid over every programmatic write path × records-event, so a future write path added without recording fails loudly rather than going dark. Written failing first (TDD), then made green.

Verified on **all three dialects** (SQLite, Postgres 17, MySQL). No regressions in the webhooks suite (191 passed) or the collection batch/tx/publish suites (90 passed). Typecheck clean.

## Approach

Deep-audit + duplication map first (design doc in `tasks/left-tasks/context/017-018-write-path-unification-design.md`). The lite tx/batch paths were dark for events; recording attaches at each path's post-write choke point (after the DB write + m2m, in the caller's transaction), building the event payload from the freshly-written row in read shape via the same `deserializeJsonFieldsForSnapshot` the interactive path uses.

## Scoped follow-ups (deliberately not in this PR)

- **Version capture** on the same paths — task 018 (PR-C), attaches at the same choke points.
- **`updateEntry` raw-SQL → Drizzle `tx.update()` unify** — deferred to the structural `writeCore` collapse (PR-D); it touches the working full-update path and is orthogonal to "every write records an event".
- **`publishAllLocales` per-locale companion status tagging** — the deeper localized refinement from task 004; this PR emits the main-row `entry.updated` + `published`.
- **Actor threading** — the tx-API params carry no `actor`; the write's `user` is used until the dispatcher threads the actor (task 004 note).