### PR TITLE
fix(nextly): resolve target fields for code-first collections when expanding

### DIFF
--- a/.changeset/nested-relationship-expansion.md
+++ b/.changeset/nested-relationship-expansion.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Relationships nested one level deeper now expand for collections you defined in code, not only for those created in the Schema Builder.
+
+`?depth=2` promises to populate a related document's own relationships, and it did so only for Builder-created collections. Resolving a target collection's fields read one of the two shapes those collections are stored in, so a code-first target resolved to nothing, the recursion guard failed, and the second hop was skipped silently at any depth — you got a bare id where a document was promised.
+
+Two consequences, both now closed. A `depth: 2` read returns what it says it returns. And an access rule reading across two hops — `data.author?.organization?.suspended !== true` — was enforced on a Builder collection while being quietly unenforced on a code-first one, so the same rule over the same data gave different answers depending on how the collection happened to be defined.
+
+Worth knowing if you use code-first collections with chained relationships: reads at depth 2 or more will now issue the queries that second hop requires, where previously they stopped early. Depth still bounds the walk, and a field's own `maxDepth` still overrides it.

--- a/packages/nextly/src/domains/collections/__tests__/nested-relationship-expansion.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-relationship-expansion.integration.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Relationship expansion reaches a second hop for every collection, not only
+ * for those the Schema Builder created.
+ *
+ * `expandRelationships` recurses while depth remains, but it only does so when
+ * it can resolve the target collection's fields. That resolution read
+ * `schemaDefinition.fields` alone, which a Builder-created collection carries
+ * and a code-first one does not — its fields sit at the top level of the stored
+ * row. So a code-first collection resolved to no fields, the recursion guard
+ * failed, and the second hop was silently skipped at any depth.
+ *
+ * Two things rode on that, which is why this is pinned against a real database:
+ * a `?depth=2` read returned a bare id where it promised a document, and an
+ * access rule reading across two hops was enforced for one kind of collection
+ * and quietly unenforced for the other.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, relationship, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+type Handler = CollectionsHandler;
+
+/** posts -> author -> org, all declared in code. */
+async function bootChain(): Promise<{ handler: Handler; postId: string }> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: "orgs",
+        fields: [text({ name: "name" })],
+      }),
+      defineCollection({
+        slug: "authors",
+        fields: [
+          text({ name: "name" }),
+          relationship({ name: "org", relationTo: "orgs" }),
+        ],
+      }),
+      defineCollection({
+        slug: "posts",
+        fields: [
+          text({ name: "title" }),
+          relationship({ name: "author", relationTo: "authors" }),
+        ],
+      }),
+    ],
+  });
+
+  const handler = current.getService<Handler>("collectionsHandler");
+  const org = await handler.createEntry(
+    { collectionName: "orgs", overrideAccess: true },
+    { name: "Acme" }
+  );
+  const author = await handler.createEntry(
+    { collectionName: "authors", overrideAccess: true },
+    { name: "Ada", org: (org.data as { id: string }).id }
+  );
+  const post = await handler.createEntry(
+    { collectionName: "posts", overrideAccess: true },
+    { title: "Hello", author: (author.data as { id: string }).id }
+  );
+  return { handler, postId: (post.data as { id: string }).id };
+}
+
+describe("nested relationship expansion (integration)", () => {
+  it("expands the second hop of a code-first chain", async () => {
+    const { handler, postId } = await bootChain();
+
+    const result = await handler.getEntry({
+      collectionName: "posts",
+      entryId: postId,
+      depth: 2,
+      overrideAccess: true,
+    });
+
+    const author = (result.data as { author?: Record<string, unknown> }).author;
+    expect(author).toMatchObject({ name: "Ada" });
+    // The hop that was silently skipped: `org` came back as its id.
+    expect(author?.org).toMatchObject({ name: "Acme" });
+  });
+
+  it("still stops where the requested depth stops", async () => {
+    // The mirror. Recursion is bounded by depth, and restoring it must not make
+    // expansion unbounded — a `depth: 1` read asks for one hop and gets one.
+    const { handler, postId } = await bootChain();
+
+    const result = await handler.getEntry({
+      collectionName: "posts",
+      entryId: postId,
+      depth: 1,
+      overrideAccess: true,
+    });
+
+    const author = (result.data as { author?: Record<string, unknown> }).author;
+    expect(author).toMatchObject({ name: "Ada" });
+    expect(typeof author?.org).toBe("string");
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -1747,11 +1747,19 @@ export class CollectionRelationshipService extends BaseService {
 
       const collection =
         await this.collectionService.getCollection(collectionName);
-      return ((
-        (collection as Record<string, unknown>).schemaDefinition as
-          | Record<string, unknown>
-          | undefined
-      )?.fields || []) as FieldDefinition[];
+      // Both shapes, the same way `getRedactionFields` reads them: a
+      // Builder-created collection carries `schemaDefinition`, while
+      // `getCollection` returns the raw row for a code-first one and its fields
+      // sit at the top level. Reading only the first resolved a code-first
+      // target to nothing, and the caller's `targetFields.length > 0` guard
+      // then skipped the nested hop entirely — silently, at any depth.
+      const fields =
+        (
+          (collection as Record<string, unknown>).schemaDefinition as
+            | Record<string, unknown>
+            | undefined
+        )?.fields ?? (collection as Record<string, unknown>).fields;
+      return Array.isArray(fields) ? (fields as FieldDefinition[]) : [];
     } catch {
       return [];
     }


### PR DESCRIPTION
Task 063. Found while checking a codex finding on #369 — and it corrects a claim I made there.

## What is wrong

`expandRelationships` recurses into a related row while depth remains, but only once it can resolve the target collection's fields:

```ts
// collection-relationship-service.ts:1513 (and the scalar branch below it)
if (currentDepth + 1 < effectiveDepth) {
  const targetFields = await this.getCollectionFields(targetCollection);
  if (targetFields.length > 0) { /* recurse */ }
}
```

`getCollectionFields` read `schemaDefinition.fields` alone. A Builder-created collection carries that shape; `getCollection` returns the raw row for a code-first one, whose fields sit at the top level. So a code-first target resolved to `[]`, the guard failed, and **the second hop was skipped silently at any depth**.

`getRedactionFields`, in the same file, already reads both shapes and documents exactly this trap:

> "`getCollection` returns the raw row, whose fields live at the top level, so a `schemaDefinition`-only lookup silently resolves to nothing and skips stripping."

This brings the two into line.

## Why it matters twice

A `?depth=2` read returned a bare id where it promised a document — a plain functional bug for anyone using code-first collections with chained relationships.

And an access rule reading across two hops (`data.author?.organization?.suspended !== true`) was **enforced on a Builder collection and silently unenforced on a code-first one**. Same rule, same data, different answer depending on how the collection happened to be defined, with nothing surfacing the difference.

## Correcting the record

On #369 I told the reviewer that expansion is single-hop, based on a probe where `author.org` stayed an id at depth 3 and 5. The probe was real; the inference was wrong. The recursion exists — my test collections were code-first, which is precisely the shape that never reaches it. I've corrected that on the thread, and it is why the second-hop findings deferred there are now tractable.

## Verification

Two integration tests, both against a real database: a code-first `posts → author → org` chain expands the second hop at `depth: 2`, and the mirror — `depth: 1` still stops after one hop, so restoring the recursion does not make expansion unbounded.

Both were confirmed to fail before the fix, with the first reproducing the exact symptom (`org` returned as its id). Baselines measured against `main` after a full build: unit 400 failed both before and after with **zero failing tests unique to this branch** (name-set comparison, not counts); integration 707 → 708 passed, the only baseline failure being this PR's own new test.

## Note for review

This turns on query work that previously did not happen: reads at depth ≥ 2 against code-first collections will now issue the queries the second hop requires. That is the documented meaning of `depth`, and Builder collections have always done it — but it is a real change in query volume for those reads, so it is called out in the changeset rather than buried.
