### PR TITLE
fix(nextly): populate relationships pointing at several collections

### DIFF
--- a/.changeset/polymorphic-relationship-expansion.md
+++ b/.changeset/polymorphic-relationship-expansion.md
@@ -1,0 +1,34 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Populate relationships that point at several collections. A field declared with
+a list of targets stores its value as a `{ relationTo, value }` pair, and
+expansion treated that pair as if it were a plain id while resolving the table
+from the field's first declared target. The resulting query bound an object
+where the driver expected a string, failed, and the failure was discarded, so
+the field came back as its raw pair at every depth with nothing logged.
+
+Values are now loaded from the collection each one names, on single reads,
+listings and nested hops alike, and a populated row is redacted by that
+collection's own field rules.

--- a/packages/admin/src/components/features/entries/EntryList/EntryTableCell.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/EntryTableCell.tsx
@@ -104,6 +104,14 @@ function getRelationshipLabel(value: unknown): string {
 
   if (typeof value === "object" && value !== null) {
     const obj = value as Record<string, unknown>;
+    // A relationship naming several collections arrives as
+    // `{ relationTo, value }`, and `value` holds the populated row once the
+    // list was read at a populating depth. The label fields live on that row,
+    // so reading the wrapper alone falls through to the generic badge and
+    // discards a label that was already fetched.
+    if (typeof obj.relationTo === "string" && "value" in obj) {
+      return getRelationshipLabel(obj.value);
+    }
     // Try common title fields in order of preference
     const label = obj.title || obj.name || obj.label || obj.email || obj.id;
     if (label) {

--- a/packages/admin/src/components/features/entries/EntryList/EntryTableCell.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/EntryTableCell.tsx
@@ -107,9 +107,18 @@ function getRelationshipLabel(value: unknown): string {
     // A relationship naming several collections arrives as
     // `{ relationTo, value }`, and `value` holds the populated row once the
     // list was read at a populating depth. The label fields live on that row,
-    // so reading the wrapper alone falls through to the generic badge and
-    // discards a label that was already fetched.
-    if (typeof obj.relationTo === "string" && "value" in obj) {
+    // so reading the wrapper alone discards a label that was already fetched.
+    //
+    // The row is identified first, because a target collection may itself
+    // define fields called `relationTo` and `value` — neither is reserved —
+    // and such a row is shaped exactly like a wrapper. A row carries an id and
+    // a wrapper does not, so unwrapping only what has no id reads the row's
+    // own `value` field as a label for nobody.
+    if (
+      !("id" in obj) &&
+      typeof obj.relationTo === "string" &&
+      "value" in obj
+    ) {
       return getRelationshipLabel(obj.value);
     }
     // Try common title fields in order of preference

--- a/packages/admin/src/components/features/entries/fields/relational/RelationshipInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/relational/RelationshipInput.tsx
@@ -338,13 +338,12 @@ export function RelationshipInput<
       if (hasMany) {
         const currentValues = Array.isArray(value) ? [...value] : [];
 
-        // Check if already selected
-        const isAlreadySelected = currentValues.some(v => {
-          if (typeof v === "string") return v === item.id;
-          if (typeof v === "object" && "id" in v) return v.id === item.id;
-          if (typeof v === "object" && "value" in v) return v.value === item.id;
-          return false;
-        });
+        // Check if already selected. Read the same way removal and quick-edit
+        // read it, or a value whose target was populated compares an object
+        // against an id, matches nothing, and the guard admits a duplicate.
+        const isAlreadySelected = currentValues.some(
+          v => referenceIdOf(v) === item.id
+        );
 
         if (!isAlreadySelected) {
           if (isPolymorphicField) {

--- a/packages/admin/src/components/features/entries/fields/relational/RelationshipInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/relational/RelationshipInput.tsx
@@ -149,6 +149,28 @@ function polymorphicEntryToItem(entry: {
 }
 
 /**
+ * The document id a stored form value refers to, whatever shape it is in.
+ *
+ * A value may be a bare id, a populated row, or a `{ relationTo, value }` pair
+ * whose `value` is either of those — the pair carries the row once the entry
+ * was read at a populating depth. Comparing the raw value against an id
+ * silently matches nothing in that last case, which is how a removal or a
+ * quick-edit update can appear to succeed and change nothing.
+ */
+function referenceIdOf(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (value === null || typeof value !== "object") return undefined;
+  const record = value as { id?: unknown; value?: unknown };
+  if (typeof record.id === "string") return record.id;
+  if (typeof record.value === "string") return record.value;
+  if (record.value !== null && typeof record.value === "object") {
+    const nested = record.value as { id?: unknown };
+    if (typeof nested.id === "string") return nested.id;
+  }
+  return undefined;
+}
+
+/**
  * Converts the form value to an array of selected items for display.
  * Handles all value formats (simple IDs, objects, polymorphic).
  */
@@ -368,23 +390,7 @@ export function RelationshipInput<
     (itemId: string) => {
       if (hasMany) {
         const currentValues = Array.isArray(value) ? (value as unknown[]) : [];
-        const filtered = currentValues.filter(v => {
-          if (typeof v === "string") return v !== itemId;
-          if (typeof v === "object" && v !== null && "id" in v)
-            return (v as { id: string }).id !== itemId;
-          if (typeof v === "object" && v !== null && "value" in v) {
-            // `value` is the target's id, or the target row when the entry was
-            // read at a populating depth. Comparing the row against an id never
-            // matches, which would leave the item in the list after removal.
-            const target = v.value;
-            const id =
-              typeof target === "string"
-                ? target
-                : ((target as { id?: string } | null)?.id ?? undefined);
-            return id !== itemId;
-          }
-          return true;
-        });
+        const filtered = currentValues.filter(v => referenceIdOf(v) !== itemId);
         onChange(filtered);
       } else {
         onChange(null);
@@ -470,7 +476,7 @@ export function RelationshipInput<
         const currentValues = Array.isArray(value) ? [...value] : [];
         const updatedValues = currentValues.map(v => {
           // Match by ID (handle both string and object values)
-          const itemId = typeof v === "string" ? v : v?.id || v?.value;
+          const itemId = referenceIdOf(v);
           if (itemId === editingItem.id) {
             if (isPolymorphicField) {
               return {

--- a/packages/admin/src/components/features/entries/fields/relational/RelationshipInput.tsx
+++ b/packages/admin/src/components/features/entries/fields/relational/RelationshipInput.tsx
@@ -54,10 +54,14 @@ export type MultiRelationshipValue = string[] | null | undefined;
 
 /**
  * Value format for polymorphic relationship (single item).
+ *
+ * `value` is the target's id when nothing was populated, and the target row
+ * itself when the entry was read at a depth that populates relationships — the
+ * edit page asks for one, so both arrive here.
  */
 export interface PolymorphicRelationshipValue {
   relationTo: string;
-  value: string;
+  value: string | { id: string; [key: string]: unknown };
 }
 
 /**
@@ -126,6 +130,25 @@ function getCollections(relationTo: string | string[]): string[] {
 }
 
 /**
+ * Reads a polymorphic entry as the item to display.
+ *
+ * Its `value` is the target's id, or the whole target row when the entry was
+ * read at a populating depth. Passing the row through as the id would put an
+ * object where a string is expected and render it as a React child; taking the
+ * row's own fields also gives the card something to show besides the id.
+ */
+function polymorphicEntryToItem(entry: {
+  relationTo: string;
+  value: string | { id: string; [key: string]: unknown };
+}): RelatedItem {
+  const { relationTo, value } = entry;
+  if (typeof value === "string") {
+    return { id: value, relationTo };
+  }
+  return { ...value, relationTo };
+}
+
+/**
  * Converts the form value to an array of selected items for display.
  * Handles all value formats (simple IDs, objects, polymorphic).
  */
@@ -140,12 +163,9 @@ function valueToSelectedItems(
   // Handle array values (hasMany: true)
   if (Array.isArray(value)) {
     return value.map(item => {
-      // Polymorphic array item: { relationTo: string, value: string }
+      // Polymorphic array item: { relationTo, value: id | populated row }
       if (typeof item === "object" && "value" in item && "relationTo" in item) {
-        return {
-          id: item.value,
-          relationTo: item.relationTo,
-        };
+        return polymorphicEntryToItem(item);
       }
       // Simple string ID
       if (typeof item === "string") {
@@ -160,9 +180,9 @@ function valueToSelectedItems(
     });
   }
 
-  // Handle single polymorphic value: { relationTo: string, value: string }
+  // Handle single polymorphic value: { relationTo, value: id | populated row }
   if (typeof value === "object" && "value" in value && "relationTo" in value) {
-    return [{ id: value.value, relationTo: value.relationTo }];
+    return [polymorphicEntryToItem(value)];
   }
 
   // Handle single object (populated relationship)
@@ -352,8 +372,17 @@ export function RelationshipInput<
           if (typeof v === "string") return v !== itemId;
           if (typeof v === "object" && v !== null && "id" in v)
             return (v as { id: string }).id !== itemId;
-          if (typeof v === "object" && v !== null && "value" in v)
-            return (v as { value: string }).value !== itemId;
+          if (typeof v === "object" && v !== null && "value" in v) {
+            // `value` is the target's id, or the target row when the entry was
+            // read at a populating depth. Comparing the row against an id never
+            // matches, which would leave the item in the list after removal.
+            const target = v.value;
+            const id =
+              typeof target === "string"
+                ? target
+                : ((target as { id?: string } | null)?.id ?? undefined);
+            return id !== itemId;
+          }
           return true;
         });
         onChange(filtered);

--- a/packages/admin/src/lib/field-validation.polymorphic.test.ts
+++ b/packages/admin/src/lib/field-validation.polymorphic.test.ts
@@ -1,0 +1,75 @@
+/**
+ * A multi-target relationship validates in both the shapes it is served in.
+ *
+ * The value is stored as `{ relationTo, value }`, where `value` is the target's
+ * id — or the target row itself once the entry was read at a depth that
+ * populates relationships, which the edit page asks for. The form validates its
+ * own defaults on every submit, so a schema that accepts only the id rejects a
+ * save that touched nothing but some unrelated field.
+ */
+
+import type { FieldConfig } from "nextly/config";
+import { describe, it, expect } from "vitest";
+
+import { generateClientSchema } from "./field-validation";
+
+const polymorphicField = (hasMany: boolean): FieldConfig =>
+  ({
+    type: "relationship",
+    name: "target",
+    relationTo: ["posts", "pages"],
+    ...(hasMany ? { hasMany: true } : {}),
+  }) as unknown as FieldConfig;
+
+const POPULATED_ROW = {
+  id: "11111111-1111-4111-8111-111111111111",
+  title: "A page",
+  slug: "a-page",
+};
+
+describe("generateClientSchema — multi-target relationships", () => {
+  it("accepts a reference that carries the id", () => {
+    const schema = generateClientSchema([polymorphicField(false)]);
+
+    const result = schema.safeParse({
+      target: { relationTo: "pages", value: POPULATED_ROW.id },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a reference whose target was populated", () => {
+    const schema = generateClientSchema([polymorphicField(false)]);
+
+    const result = schema.safeParse({
+      target: { relationTo: "pages", value: POPULATED_ROW },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts populated entries in a list of references", () => {
+    const schema = generateClientSchema([polymorphicField(true)]);
+
+    const result = schema.safeParse({
+      target: [
+        { relationTo: "pages", value: POPULATED_ROW },
+        { relationTo: "posts", value: "22222222-2222-4222-8222-222222222222" },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  // The mirror: widening the shape must not turn the field into "anything
+  // goes", or the schema stops catching a value that could never be stored.
+  it("still rejects a reference whose target is neither an id nor a row", () => {
+    const schema = generateClientSchema([polymorphicField(false)]);
+
+    const result = schema.safeParse({
+      target: { relationTo: "pages", value: { title: "no id here" } },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/admin/src/lib/field-validation.ts
+++ b/packages/admin/src/lib/field-validation.ts
@@ -836,11 +836,16 @@ function convertRelationshipFieldToZod(
   let singleSchema: z.ZodTypeAny;
 
   if (isPolymorphic) {
-    // Polymorphic: { relationTo: string, value: string } or just string ID
+    // Polymorphic: { relationTo, value } or just string ID.
+    //
+    // `value` is the target's id, or the target row itself once the entry was
+    // read at a populating depth — which the edit page asks for. The form
+    // validates its own defaults on every submit, so rejecting the populated
+    // shape here fails a save that only touched some other field.
     singleSchema = z
       .object({
         relationTo: z.string(),
-        value: z.string(),
+        value: z.string().or(z.object({ id: z.string() }).passthrough()),
       })
       .or(z.string()); // Allow ID string for backwards compatibility
   } else {

--- a/packages/nextly/src/domains/collections/__tests__/polymorphic-relationship-expansion.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/polymorphic-relationship-expansion.integration.test.ts
@@ -113,7 +113,10 @@ describe("polymorphic relationship expansion (integration)", () => {
 
     const target = await readTarget(handler, postRefId);
 
-    expect(target).toMatchObject({ title: "A post" });
+    expect(target).toMatchObject({
+      relationTo: "posts",
+      value: { title: "A post" },
+    });
   });
 
   // The mirror, and the reason the case above is not enough on its own:
@@ -126,7 +129,10 @@ describe("polymorphic relationship expansion (integration)", () => {
 
     const target = await readTarget(handler, pageRefId);
 
-    expect(target).toMatchObject({ title: "A page" });
+    expect(target).toMatchObject({
+      relationTo: "pages",
+      value: { title: "A page" },
+    });
   });
 
   // The list path batches its fetches instead of loading one row at a time,
@@ -146,8 +152,14 @@ describe("polymorphic relationship expansion (integration)", () => {
       target?: Record<string, unknown>;
     }[];
     const byName = new Map(rows.map(item => [item.name, item.target]));
-    expect(byName.get("points at a post")).toMatchObject({ title: "A post" });
-    expect(byName.get("points at a page")).toMatchObject({ title: "A page" });
+    expect(byName.get("points at a post")).toMatchObject({
+      relationTo: "posts",
+      value: { title: "A post" },
+    });
+    expect(byName.get("points at a page")).toMatchObject({
+      relationTo: "pages",
+      value: { title: "A page" },
+    });
   });
 
   // Populating spreads the whole related row into the parent, and the row now
@@ -201,8 +213,11 @@ describe("polymorphic relationship expansion (integration)", () => {
     const target = (result.data as { target?: Record<string, unknown> }).target;
     // Expanded, so the rule had something to act on, and the protected field
     // did not survive it.
-    expect(target).toMatchObject({ title: "A page" });
-    expect(target).not.toHaveProperty("hidden");
+    expect(target).toMatchObject({
+      relationTo: "pages",
+      value: { title: "A page" },
+    });
+    expect(target).not.toHaveProperty("value.hidden");
 
     // The mirror: without it, the assertion above would hold just as well for
     // a field that never reaches the response at all, and would keep holding
@@ -215,7 +230,7 @@ describe("polymorphic relationship expansion (integration)", () => {
     });
     expect(
       (trusted.data as { target?: Record<string, unknown> }).target
-    ).toHaveProperty("hidden");
+    ).toHaveProperty("value.hidden");
   });
 
   // Nothing validates the stored slug on the way in, so the value cannot be
@@ -285,7 +300,7 @@ describe("polymorphic relationship expansion (integration)", () => {
     });
     const populated = (read.data as { target?: Record<string, unknown> })
       .target;
-    expect(populated).toMatchObject({ title: "A page" });
+    expect(populated).toMatchObject({ value: { title: "A page" } });
 
     // Saved back exactly as it was served, which is what a client editing one
     // other field does.
@@ -303,7 +318,7 @@ describe("polymorphic relationship expansion (integration)", () => {
     // Still the page, not a post and not empty: the target survived the trip.
     expect(
       (after.data as { target?: Record<string, unknown> }).target
-    ).toMatchObject({ title: "A page" });
+    ).toMatchObject({ relationTo: "pages", value: { title: "A page" } });
   });
 
   it("keeps the pair intact when no expansion was asked for", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/polymorphic-relationship-expansion.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/polymorphic-relationship-expansion.integration.test.ts
@@ -326,6 +326,66 @@ describeEachDialect("polymorphic relationship expansion", dialect => {
     ).toMatchObject({ relationTo: "pages", value: { title: "A page" } });
   });
 
+  // A field's public value is the document id, and a custom validator is
+  // written against that. Saving a document read at depth hands the validator
+  // the populated row instead, so it compares an object to a string — or calls
+  // a string method on it and throws — and rejects an unchanged form.
+  it("shows a validator the id when a populated value is saved back", async () => {
+    const seen: unknown[] = [];
+    current = await createTestNextly({
+      dialect,
+      collections: [
+        defineCollection({ slug: "posts", fields: [text({ name: "title" })] }),
+        defineCollection({ slug: "pages", fields: [text({ name: "title" })] }),
+        defineCollection({
+          slug: "refs",
+          fields: [
+            text({ name: "name" }),
+            relationship({
+              name: "target",
+              relationTo: ["posts", "pages"],
+              validate: (value: unknown) => {
+                seen.push(value);
+                return true;
+              },
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const handler = current.getService<Handler>("collectionsHandler");
+    const page = await handler.createEntry(
+      { collectionName: "pages", overrideAccess: true },
+      { title: "A page" }
+    );
+    const pageId = (page.data as { id: string }).id;
+    const ref = await handler.createEntry(
+      { collectionName: "refs", overrideAccess: true },
+      { name: "r", target: { relationTo: "pages", value: pageId } }
+    );
+
+    const read = await handler.getEntry({
+      collectionName: "refs",
+      entryId: (ref.data as { id: string }).id,
+      depth: 1,
+      overrideAccess: true,
+    });
+
+    seen.length = 0;
+    await handler.updateEntry(
+      {
+        collectionName: "refs",
+        entryId: (ref.data as { id: string }).id,
+        overrideAccess: true,
+      },
+      { name: "renamed", target: (read.data as { target: unknown }).target }
+    );
+
+    // The row travelled in; the validator was shown the reference it stands for.
+    expect(seen).toContainEqual({ relationTo: "pages", value: pageId });
+  });
+
   it("keeps the pair intact when no expansion was asked for", async () => {
     const { handler, postRefId } = await bootPolymorphic(dialect);
 

--- a/packages/nextly/src/domains/collections/__tests__/polymorphic-relationship-expansion.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/polymorphic-relationship-expansion.integration.test.ts
@@ -14,7 +14,7 @@
  * driver rejects the bound parameter.
  */
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, expect, it } from "vitest";
 
 import {
   checkbox,
@@ -22,8 +22,10 @@ import {
   relationship,
   text,
 } from "../../../config";
+import { describeEachDialect } from "../../../plugins/__tests__/helpers/dialect-matrix";
 import {
   createTestNextly,
+  type TestDialect,
   type TestNextly,
 } from "../../../plugins/test-nextly";
 import type { CollectionsHandler } from "../../../services/collections-handler";
@@ -37,12 +39,13 @@ afterEach(async () => {
 type Handler = CollectionsHandler;
 
 /** `refs.target` may point at either collection, so it stores the pair. */
-async function bootPolymorphic(): Promise<{
+async function bootPolymorphic(dialect: TestDialect): Promise<{
   handler: Handler;
   postRefId: string;
   pageRefId: string;
 }> {
   current = await createTestNextly({
+    dialect,
     collections: [
       defineCollection({
         slug: "posts",
@@ -107,9 +110,9 @@ async function readTarget(
   return (result.data as { target?: Record<string, unknown> }).target;
 }
 
-describe("polymorphic relationship expansion (integration)", () => {
+describeEachDialect("polymorphic relationship expansion", dialect => {
   it("expands a value pointing at the first declared target", async () => {
-    const { handler, postRefId } = await bootPolymorphic();
+    const { handler, postRefId } = await bootPolymorphic(dialect);
 
     const target = await readTarget(handler, postRefId);
 
@@ -125,7 +128,7 @@ describe("polymorphic relationship expansion (integration)", () => {
   // to the posts table. Only a value that points at a LATER target proves the
   // collection is read from the value.
   it("expands a value pointing at a later declared target", async () => {
-    const { handler, pageRefId } = await bootPolymorphic();
+    const { handler, pageRefId } = await bootPolymorphic(dialect);
 
     const target = await readTarget(handler, pageRefId);
 
@@ -139,7 +142,7 @@ describe("polymorphic relationship expansion (integration)", () => {
   // and resolves the collection separately from the read above — so it needs
   // its own coverage, including a batch that spans both collections at once.
   it("expands values from several collections in one listing", async () => {
-    const { handler } = await bootPolymorphic();
+    const { handler } = await bootPolymorphic(dialect);
 
     const result = await handler.listEntries({
       collectionName: "refs",
@@ -167,6 +170,7 @@ describe("polymorphic relationship expansion (integration)", () => {
   // evaluated must be that collection's, not the first declared target's.
   it("judges a populated row by its own collection's field rules", async () => {
     current = await createTestNextly({
+      dialect,
       collections: [
         defineCollection({ slug: "posts", fields: [text({ name: "title" })] }),
         defineCollection({
@@ -238,6 +242,7 @@ describe("polymorphic relationship expansion (integration)", () => {
   // written turns any writable relationship into a reader for any table.
   it("refuses to populate from a collection the field never declared", async () => {
     current = await createTestNextly({
+      dialect,
       collections: [
         defineCollection({ slug: "posts", fields: [text({ name: "title" })] }),
         defineCollection({ slug: "pages", fields: [text({ name: "title" })] }),
@@ -290,7 +295,7 @@ describe("polymorphic relationship expansion (integration)", () => {
   // field's first declared target. So reading at depth and saving the document
   // back unchanged has to leave the reference pointing where it did.
   it("survives a read-then-write round trip at depth", async () => {
-    const { handler, pageRefId } = await bootPolymorphic();
+    const { handler, pageRefId } = await bootPolymorphic(dialect);
 
     const read = await handler.getEntry({
       collectionName: "refs",
@@ -322,7 +327,7 @@ describe("polymorphic relationship expansion (integration)", () => {
   });
 
   it("keeps the pair intact when no expansion was asked for", async () => {
-    const { handler, postRefId } = await bootPolymorphic();
+    const { handler, postRefId } = await bootPolymorphic(dialect);
 
     const result = await handler.getEntry({
       collectionName: "refs",

--- a/packages/nextly/src/domains/collections/__tests__/polymorphic-relationship-expansion.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/polymorphic-relationship-expansion.integration.test.ts
@@ -218,6 +218,58 @@ describe("polymorphic relationship expansion (integration)", () => {
     ).toHaveProperty("hidden");
   });
 
+  // Nothing validates the stored slug on the way in, so the value cannot be
+  // trusted to name a collection the field ever declared. Honouring it as
+  // written turns any writable relationship into a reader for any table.
+  it("refuses to populate from a collection the field never declared", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "posts", fields: [text({ name: "title" })] }),
+        defineCollection({ slug: "pages", fields: [text({ name: "title" })] }),
+        defineCollection({
+          slug: "secrets",
+          fields: [text({ name: "title" }), text({ name: "apiKey" })],
+        }),
+        defineCollection({
+          slug: "refs",
+          fields: [
+            text({ name: "name" }),
+            relationship({ name: "target", relationTo: ["posts", "pages"] }),
+          ],
+        }),
+      ],
+    });
+
+    const handler = current.getService<Handler>("collectionsHandler");
+    const secret = await handler.createEntry(
+      { collectionName: "secrets", overrideAccess: true },
+      { title: "Confidential", apiKey: "sk-live-XXXX" }
+    );
+    const ref = await handler.createEntry(
+      { collectionName: "refs", overrideAccess: true },
+      {
+        name: "smuggled",
+        target: {
+          relationTo: "secrets",
+          value: (secret.data as { id: string }).id,
+        },
+      }
+    );
+
+    const result = await handler.getEntry({
+      collectionName: "refs",
+      entryId: (ref.data as { id: string }).id,
+      depth: 1,
+      overrideAccess: true,
+    });
+
+    // Left exactly as stored: not populated, and above all not carrying a row
+    // from a table this field was never pointed at.
+    const target = (result.data as { target?: Record<string, unknown> }).target;
+    expect(target).toMatchObject({ relationTo: "secrets" });
+    expect(target).not.toHaveProperty("apiKey");
+  });
+
   it("keeps the pair intact when no expansion was asked for", async () => {
     const { handler, postRefId } = await bootPolymorphic();
 

--- a/packages/nextly/src/domains/collections/__tests__/polymorphic-relationship-expansion.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/polymorphic-relationship-expansion.integration.test.ts
@@ -270,6 +270,42 @@ describe("polymorphic relationship expansion (integration)", () => {
     expect(target).not.toHaveProperty("apiKey");
   });
 
+  // A populated value is reduced back to a bare id on write unless it still
+  // says which collection it came from, and a bare id resolves against the
+  // field's first declared target. So reading at depth and saving the document
+  // back unchanged has to leave the reference pointing where it did.
+  it("survives a read-then-write round trip at depth", async () => {
+    const { handler, pageRefId } = await bootPolymorphic();
+
+    const read = await handler.getEntry({
+      collectionName: "refs",
+      entryId: pageRefId,
+      depth: 1,
+      overrideAccess: true,
+    });
+    const populated = (read.data as { target?: Record<string, unknown> })
+      .target;
+    expect(populated).toMatchObject({ title: "A page" });
+
+    // Saved back exactly as it was served, which is what a client editing one
+    // other field does.
+    await handler.updateEntry(
+      { collectionName: "refs", entryId: pageRefId, overrideAccess: true },
+      { name: "renamed", target: populated }
+    );
+
+    const after = await handler.getEntry({
+      collectionName: "refs",
+      entryId: pageRefId,
+      depth: 1,
+      overrideAccess: true,
+    });
+    // Still the page, not a post and not empty: the target survived the trip.
+    expect(
+      (after.data as { target?: Record<string, unknown> }).target
+    ).toMatchObject({ title: "A page" });
+  });
+
   it("keeps the pair intact when no expansion was asked for", async () => {
     const { handler, postRefId } = await bootPolymorphic();
 

--- a/packages/nextly/src/domains/collections/__tests__/polymorphic-relationship-expansion.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/polymorphic-relationship-expansion.integration.test.ts
@@ -1,0 +1,236 @@
+/**
+ * A relationship that names several target collections expands like any other.
+ *
+ * A field whose `relationTo` is a list stores its value as a
+ * `{ relationTo, value }` pair rather than a bare id, because the row itself
+ * has to say which collection the id belongs to. Expansion handled neither
+ * half of that shape: it passed the whole pair to the row loader as if it were
+ * an id, and it resolved the target collection from the FIELD's first declared
+ * target instead of from the value. The loader's query then bound an object
+ * where a string was expected, threw, and the failure was swallowed — so the
+ * field came back as its raw pair at every depth, with nothing logged.
+ *
+ * Pinned against a real database because the failure only appears once a
+ * driver rejects the bound parameter.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  checkbox,
+  defineCollection,
+  relationship,
+  text,
+} from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+type Handler = CollectionsHandler;
+
+/** `refs.target` may point at either collection, so it stores the pair. */
+async function bootPolymorphic(): Promise<{
+  handler: Handler;
+  postRefId: string;
+  pageRefId: string;
+}> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: "posts",
+        fields: [text({ name: "title" })],
+      }),
+      defineCollection({
+        slug: "pages",
+        fields: [text({ name: "title" })],
+      }),
+      defineCollection({
+        slug: "refs",
+        fields: [
+          text({ name: "name" }),
+          relationship({ name: "target", relationTo: ["posts", "pages"] }),
+        ],
+      }),
+    ],
+  });
+
+  const handler = current.getService<Handler>("collectionsHandler");
+  const post = await handler.createEntry(
+    { collectionName: "posts", overrideAccess: true },
+    { title: "A post" }
+  );
+  const page = await handler.createEntry(
+    { collectionName: "pages", overrideAccess: true },
+    { title: "A page" }
+  );
+
+  const postRef = await handler.createEntry(
+    { collectionName: "refs", overrideAccess: true },
+    {
+      name: "points at a post",
+      target: { relationTo: "posts", value: (post.data as { id: string }).id },
+    }
+  );
+  const pageRef = await handler.createEntry(
+    { collectionName: "refs", overrideAccess: true },
+    {
+      name: "points at a page",
+      target: { relationTo: "pages", value: (page.data as { id: string }).id },
+    }
+  );
+
+  return {
+    handler,
+    postRefId: (postRef.data as { id: string }).id,
+    pageRefId: (pageRef.data as { id: string }).id,
+  };
+}
+
+async function readTarget(
+  handler: Handler,
+  entryId: string
+): Promise<Record<string, unknown> | undefined> {
+  const result = await handler.getEntry({
+    collectionName: "refs",
+    entryId,
+    depth: 1,
+    overrideAccess: true,
+  });
+  return (result.data as { target?: Record<string, unknown> }).target;
+}
+
+describe("polymorphic relationship expansion (integration)", () => {
+  it("expands a value pointing at the first declared target", async () => {
+    const { handler, postRefId } = await bootPolymorphic();
+
+    const target = await readTarget(handler, postRefId);
+
+    expect(target).toMatchObject({ title: "A post" });
+  });
+
+  // The mirror, and the reason the case above is not enough on its own:
+  // resolving the target collection from the field's first declared entry
+  // would satisfy the "posts" case by accident while sending a "pages" value
+  // to the posts table. Only a value that points at a LATER target proves the
+  // collection is read from the value.
+  it("expands a value pointing at a later declared target", async () => {
+    const { handler, pageRefId } = await bootPolymorphic();
+
+    const target = await readTarget(handler, pageRefId);
+
+    expect(target).toMatchObject({ title: "A page" });
+  });
+
+  // The list path batches its fetches instead of loading one row at a time,
+  // and resolves the collection separately from the read above — so it needs
+  // its own coverage, including a batch that spans both collections at once.
+  it("expands values from several collections in one listing", async () => {
+    const { handler } = await bootPolymorphic();
+
+    const result = await handler.listEntries({
+      collectionName: "refs",
+      depth: 1,
+      overrideAccess: true,
+    });
+
+    const rows = result.data!.docs as {
+      name: string;
+      target?: Record<string, unknown>;
+    }[];
+    const byName = new Map(rows.map(item => [item.name, item.target]));
+    expect(byName.get("points at a post")).toMatchObject({ title: "A post" });
+    expect(byName.get("points at a page")).toMatchObject({ title: "A page" });
+  });
+
+  // Populating spreads the whole related row into the parent, and the row now
+  // arrives from whichever collection the value named — so the rules that get
+  // evaluated must be that collection's, not the first declared target's.
+  it("judges a populated row by its own collection's field rules", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "posts", fields: [text({ name: "title" })] }),
+        defineCollection({
+          slug: "pages",
+          fields: [
+            text({ name: "title" }),
+            checkbox({ name: "hidden", access: { read: () => false } }),
+          ],
+        }),
+        defineCollection({
+          slug: "refs",
+          fields: [
+            text({ name: "name" }),
+            relationship({ name: "target", relationTo: ["posts", "pages"] }),
+          ],
+        }),
+      ],
+    });
+
+    const handler = current.getService<Handler>("collectionsHandler");
+    const page = await handler.createEntry(
+      { collectionName: "pages", overrideAccess: true },
+      { title: "A page", hidden: true }
+    );
+    const ref = await handler.createEntry(
+      { collectionName: "refs", overrideAccess: true },
+      {
+        name: "r",
+        target: {
+          relationTo: "pages",
+          value: (page.data as { id: string }).id,
+        },
+      }
+    );
+
+    const result = await handler.getEntry({
+      collectionName: "refs",
+      entryId: (ref.data as { id: string }).id,
+      depth: 1,
+      user: { id: "reader-1" },
+      routeAuthorized: true,
+    });
+
+    const target = (result.data as { target?: Record<string, unknown> }).target;
+    // Expanded, so the rule had something to act on, and the protected field
+    // did not survive it.
+    expect(target).toMatchObject({ title: "A page" });
+    expect(target).not.toHaveProperty("hidden");
+
+    // The mirror: without it, the assertion above would hold just as well for
+    // a field that never reaches the response at all, and would keep holding
+    // if population broke again.
+    const trusted = await handler.getEntry({
+      collectionName: "refs",
+      entryId: (ref.data as { id: string }).id,
+      depth: 1,
+      overrideAccess: true,
+    });
+    expect(
+      (trusted.data as { target?: Record<string, unknown> }).target
+    ).toHaveProperty("hidden");
+  });
+
+  it("keeps the pair intact when no expansion was asked for", async () => {
+    const { handler, postRefId } = await bootPolymorphic();
+
+    const result = await handler.getEntry({
+      collectionName: "refs",
+      entryId: postRefId,
+      depth: 0,
+      overrideAccess: true,
+    });
+
+    // Depth zero asks for references, so the stored pair is the correct
+    // answer here — expansion must not be the only way the field round-trips.
+    const target = (result.data as { target?: unknown }).target;
+    expect(target).toMatchObject({ relationTo: "posts" });
+  });
+});

--- a/packages/nextly/src/domains/collections/__tests__/write-response-related-access.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/write-response-related-access.integration.test.ts
@@ -1,0 +1,129 @@
+/**
+ * A collection's write response applies the related row's own field rules.
+ *
+ * Creating or updating an entry at a populating depth returns the document with
+ * its relationships expanded. Those rows belong to another collection and carry
+ * that collection's field-level `access.read` rules; the response redaction runs
+ * against the SOURCE collection's schema and so cannot reach inside a populated
+ * row. Without the caller travelling into expansion, the write path answers a
+ * question a GET would refuse: write anything, read the response, see the field.
+ *
+ * The writer supplied a relationship id, not the related row's protected
+ * columns, so "they just wrote it" does not cover them.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  checkbox,
+  defineCollection,
+  relationship,
+  text,
+} from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+async function boot(): Promise<{
+  handler: CollectionsHandler;
+  authorId: string;
+}> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: "authors",
+        fields: [
+          text({ name: "name" }),
+          checkbox({ name: "suspended", access: { read: () => false } }),
+        ],
+      }),
+      defineCollection({
+        slug: "posts",
+        fields: [
+          text({ name: "title" }),
+          relationship({ name: "author", relationTo: "authors" }),
+        ],
+      }),
+    ],
+  });
+
+  const handler = current.getService<CollectionsHandler>("collectionsHandler");
+  const author = await handler.createEntry(
+    { collectionName: "authors", overrideAccess: true },
+    { name: "Ada", suspended: true }
+  );
+  return { handler, authorId: (author.data as { id: string }).id };
+}
+
+describe("collection write response — related-row field access (integration)", () => {
+  it("withholds a related field the creator may not read", async () => {
+    const { handler, authorId } = await boot();
+
+    const result = await handler.createEntry(
+      {
+        collectionName: "posts",
+        user: { id: "writer-1" },
+        routeAuthorized: true,
+        depth: 1,
+      },
+      { title: "Hello", author: authorId }
+    );
+
+    expect(result.success).toBe(true);
+    const author = (result.data as { author?: Record<string, unknown> }).author;
+    // Expanded, so the rule had a row to act on, and the protected field did
+    // not survive it.
+    expect(author).toMatchObject({ name: "Ada" });
+    expect(author).not.toHaveProperty("suspended");
+  });
+
+  it("withholds it on update too", async () => {
+    const { handler, authorId } = await boot();
+
+    const created = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "Hello", author: authorId }
+    );
+
+    const result = await handler.updateEntry(
+      {
+        collectionName: "posts",
+        entryId: (created.data as { id: string }).id,
+        user: { id: "writer-1" },
+        routeAuthorized: true,
+        depth: 1,
+      },
+      { title: "Hello again" }
+    );
+
+    expect(result.success).toBe(true);
+    const author = (result.data as { author?: Record<string, unknown> }).author;
+    expect(author).toMatchObject({ name: "Ada" });
+    expect(author).not.toHaveProperty("suspended");
+  });
+
+  // The mirror, and the reason the cases above are not enough on their own:
+  // enforcing without a caller judges everyone anonymous and strips the field
+  // from entitled callers too, so a passing leak test says nothing about
+  // whether a trusted write still returns the whole row.
+  it("still returns the whole row to a trusted write", async () => {
+    const { handler, authorId } = await boot();
+
+    const result = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true, depth: 1 },
+      { title: "Hello", author: authorId }
+    );
+
+    expect(
+      (result.data as { author?: Record<string, unknown> }).author
+    ).toHaveProperty("suspended");
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -66,7 +66,10 @@ import {
   attachFieldValidators,
   runFieldHooks,
 } from "../../../shared/lib/field-level-registry";
-import { coerceDateFieldsToDate } from "../../../shared/lib/field-transform";
+import {
+  coerceDateFieldsToDate,
+  normalizeRelationshipFields,
+} from "../../../shared/lib/field-transform";
 import {
   hashPasswordFieldValues,
   stripPasswordFieldValues,
@@ -110,7 +113,6 @@ import {
   toCamelCase,
   isJsonFieldType,
   isRelationshipField,
-  normalizeRelationshipValue,
   normalizeNestedRelationships,
   normalizeUploadFields,
   getTableName,
@@ -1940,28 +1942,13 @@ export class CollectionMutationService extends BaseService {
 
       // Normalize relationship field values (extract IDs from objects with display properties)
       // This must happen before many-to-many extraction and JSON serialization
-      fields.forEach(field => {
-        if (isRelationshipField(field.type) && finalData[field.name] != null) {
-          const isPolymorphic =
-            Array.isArray(field.options?.target) ||
-            Array.isArray(field.relationTo);
-          const hasMany =
-            field.hasMany === true ||
-            field.options?.relationType === "manyToMany";
-
-          let normalized = normalizeRelationshipValue(
-            finalData[field.name],
-            isPolymorphic
-          );
-
-          // Single relationships: unwrap arrays to a single value
-          if (!hasMany && Array.isArray(normalized)) {
-            normalized = normalized.length > 0 ? normalized[0] : null;
-          }
-
-          finalData[field.name] = normalized;
-        }
-      });
+      // Walks containers too: a reference left populated inside a group or
+      // repeater is serialized to JSON as the row and never read back as a
+      // reference.
+      normalizeRelationshipFields(
+        finalData,
+        fields as unknown as FieldConfig[]
+      );
 
       // Normalize upload field values (extract IDs from populated media objects)
       normalizeUploadFields(finalData, fields);
@@ -3838,28 +3825,13 @@ export class CollectionMutationService extends BaseService {
 
       // Normalize relationship field values (extract IDs from objects with display properties)
       // This must happen before many-to-many extraction and JSON serialization
-      fields.forEach(field => {
-        if (isRelationshipField(field.type) && finalData[field.name] != null) {
-          const isPolymorphic =
-            Array.isArray(field.options?.target) ||
-            Array.isArray(field.relationTo);
-          const hasMany =
-            field.hasMany === true ||
-            field.options?.relationType === "manyToMany";
-
-          let normalized = normalizeRelationshipValue(
-            finalData[field.name],
-            isPolymorphic
-          );
-
-          // Single relationships: unwrap arrays to a single value
-          if (!hasMany && Array.isArray(normalized)) {
-            normalized = normalized.length > 0 ? normalized[0] : null;
-          }
-
-          finalData[field.name] = normalized;
-        }
-      });
+      // Walks containers too: a reference left populated inside a group or
+      // repeater is serialized to JSON as the row and never read back as a
+      // reference.
+      normalizeRelationshipFields(
+        finalData,
+        fields as unknown as FieldConfig[]
+      );
 
       // Normalize upload field values (extract IDs from populated media objects)
       normalizeUploadFields(finalData, fields);
@@ -5709,28 +5681,13 @@ export class CollectionMutationService extends BaseService {
 
       // Normalize relationship field values (extract IDs from objects with display properties)
       // This must happen before many-to-many extraction and JSON serialization
-      fields.forEach(field => {
-        if (isRelationshipField(field.type) && finalData[field.name] != null) {
-          const isPolymorphic =
-            Array.isArray(field.options?.target) ||
-            Array.isArray(field.relationTo);
-          const hasMany =
-            field.hasMany === true ||
-            field.options?.relationType === "manyToMany";
-
-          let normalized = normalizeRelationshipValue(
-            finalData[field.name],
-            isPolymorphic
-          );
-
-          // Single relationships: unwrap arrays to a single value
-          if (!hasMany && Array.isArray(normalized)) {
-            normalized = normalized.length > 0 ? normalized[0] : null;
-          }
-
-          finalData[field.name] = normalized;
-        }
-      });
+      // Walks containers too: a reference left populated inside a group or
+      // repeater is serialized to JSON as the row and never read back as a
+      // reference.
+      normalizeRelationshipFields(
+        finalData,
+        fields as unknown as FieldConfig[]
+      );
 
       // Normalize upload field values (extract IDs from populated media objects)
       normalizeUploadFields(finalData, fields);
@@ -6249,28 +6206,13 @@ export class CollectionMutationService extends BaseService {
 
       // Normalize relationship field values (extract IDs from objects with display properties)
       // This must happen before many-to-many extraction and JSON serialization
-      fields.forEach(field => {
-        if (isRelationshipField(field.type) && finalData[field.name] != null) {
-          const isPolymorphic =
-            Array.isArray(field.options?.target) ||
-            Array.isArray(field.relationTo);
-          const hasMany =
-            field.hasMany === true ||
-            field.options?.relationType === "manyToMany";
-
-          let normalized = normalizeRelationshipValue(
-            finalData[field.name],
-            isPolymorphic
-          );
-
-          // Single relationships: unwrap arrays to a single value
-          if (!hasMany && Array.isArray(normalized)) {
-            normalized = normalized.length > 0 ? normalized[0] : null;
-          }
-
-          finalData[field.name] = normalized;
-        }
-      });
+      // Walks containers too: a reference left populated inside a group or
+      // repeater is serialized to JSON as the row and never read back as a
+      // reference.
+      normalizeRelationshipFields(
+        finalData,
+        fields as unknown as FieldConfig[]
+      );
 
       // Normalize upload field values (extract IDs from populated media objects)
       normalizeUploadFields(finalData, fields);
@@ -7123,28 +7065,13 @@ export class CollectionMutationService extends BaseService {
 
       // Normalize relationship field values (extract IDs from objects with display properties)
       // This must happen before many-to-many extraction and JSON serialization
-      fields.forEach(field => {
-        if (isRelationshipField(field.type) && finalData[field.name] != null) {
-          const isPolymorphic =
-            Array.isArray(field.options?.target) ||
-            Array.isArray(field.relationTo);
-          const hasMany =
-            field.hasMany === true ||
-            field.options?.relationType === "manyToMany";
-
-          let normalized = normalizeRelationshipValue(
-            finalData[field.name],
-            isPolymorphic
-          );
-
-          // Single relationships: unwrap arrays to a single value
-          if (!hasMany && Array.isArray(normalized)) {
-            normalized = normalized.length > 0 ? normalized[0] : null;
-          }
-
-          finalData[field.name] = normalized;
-        }
-      });
+      // Walks containers too: a reference left populated inside a group or
+      // repeater is serialized to JSON as the row and never read back as a
+      // reference.
+      normalizeRelationshipFields(
+        finalData,
+        fields as unknown as FieldConfig[]
+      );
 
       // Normalize upload field values (extract IDs from populated media objects)
       normalizeUploadFields(finalData, fields);
@@ -7734,28 +7661,13 @@ export class CollectionMutationService extends BaseService {
 
       // Normalize relationship field values (extract IDs from objects with display properties)
       // This must happen before many-to-many extraction and JSON serialization
-      fields.forEach(field => {
-        if (isRelationshipField(field.type) && finalData[field.name] != null) {
-          const isPolymorphic =
-            Array.isArray(field.options?.target) ||
-            Array.isArray(field.relationTo);
-          const hasMany =
-            field.hasMany === true ||
-            field.options?.relationType === "manyToMany";
-
-          let normalized = normalizeRelationshipValue(
-            finalData[field.name],
-            isPolymorphic
-          );
-
-          // Single relationships: unwrap arrays to a single value
-          if (!hasMany && Array.isArray(normalized)) {
-            normalized = normalized.length > 0 ? normalized[0] : null;
-          }
-
-          finalData[field.name] = normalized;
-        }
-      });
+      // Walks containers too: a reference left populated inside a group or
+      // repeater is serialized to JSON as the row and never read back as a
+      // reference.
+      normalizeRelationshipFields(
+        finalData,
+        fields as unknown as FieldConfig[]
+      );
 
       // Normalize upload field values (extract IDs from populated media objects)
       normalizeUploadFields(finalData, fields);

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -2495,7 +2495,18 @@ export class CollectionMutationService extends BaseService {
             entry,
             params.collectionName,
             fields,
-            { depth }
+            {
+              depth,
+              // Related rows carry the TARGET collection's own field rules, and
+              // the response redaction below runs against THIS collection's
+              // schema, so it cannot reach inside a populated row. A writer
+              // supplied a relationship id, not the related row's protected
+              // columns, so a mutation response is a read of that row and is
+              // judged the same way a GET would judge it.
+              enforceFieldAccess: true,
+              user: params.user,
+              overrideAccess: params.overrideAccess,
+            }
           );
         } catch (expansionError) {
           // If expansion fails, return the entry without expanded relationships
@@ -5015,7 +5026,18 @@ export class CollectionMutationService extends BaseService {
             updated,
             params.collectionName,
             fields,
-            { depth }
+            {
+              depth,
+              // Related rows carry the TARGET collection's own field rules, and
+              // the response redaction below runs against THIS collection's
+              // schema, so it cannot reach inside a populated row. A writer
+              // supplied a relationship id, not the related row's protected
+              // columns, so a mutation response is a read of that row and is
+              // judged the same way a GET would judge it.
+              enforceFieldAccess: true,
+              user: params.user,
+              overrideAccess: params.overrideAccess,
+            }
           );
         } catch (expansionError) {
           // If expansion fails, return the entry without expanded relationships

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -58,6 +58,7 @@ import type { FieldGroupDataService } from "../../../services/field-groups/field
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
 import { convertTimestampsToCamelCase } from "../../../shared/lib/case-conversion";
+import { detachData } from "../../../shared/lib/detach";
 import { validateEntryData } from "../../../shared/lib/entry-validation";
 import { applyFieldDefaults } from "../../../shared/lib/field-defaults";
 import {
@@ -755,6 +756,27 @@ export class CollectionMutationService extends BaseService {
     if (args.status === "published" && args.previousStatus !== "published") {
       emitDocumentEvent("published", args.collection, docBase);
     }
+  }
+
+  /**
+   * The document a validator is shown.
+   *
+   * A relationship read at a populating depth comes back as the related row,
+   * and a multi-target one wrapped with the collection it names. A field's
+   * public value is the document id, and a custom validator is written against
+   * that — handed a row it compares an object to a string, or calls a string
+   * method on it and throws.
+   *
+   * Reduced on a detached copy rather than in place, because the submitted
+   * shape is what the hooks between here and storage still expect to see.
+   */
+  private validationView(
+    data: Record<string, unknown>,
+    fields: FieldDefinition[]
+  ): Record<string, unknown> {
+    const view = detachData(data);
+    normalizeRelationshipFields(view, fields as unknown as FieldConfig[]);
+    return view;
   }
 
   /**
@@ -1900,7 +1922,7 @@ export class CollectionMutationService extends BaseService {
           params.locale
         );
         const validationIssues = await validateEntryData(
-          finalData,
+          this.validationView(finalData, fields),
           attachFieldValidators("collection", params.collectionName, fields),
           {
             mode: "create",
@@ -3798,7 +3820,7 @@ export class CollectionMutationService extends BaseService {
           params.locale
         );
         const validationIssues = await validateEntryData(
-          finalData,
+          this.validationView(finalData, fields),
           attachFieldValidators("collection", params.collectionName, fields),
           {
             mode: "update",
@@ -5662,7 +5684,7 @@ export class CollectionMutationService extends BaseService {
 
       {
         const validationIssues = await validateEntryData(
-          finalData,
+          this.validationView(finalData, fields),
           attachFieldValidators("collection", params.collectionName, fields),
           {
             mode: "create",
@@ -6191,7 +6213,7 @@ export class CollectionMutationService extends BaseService {
 
       {
         const validationIssues = await validateEntryData(
-          finalData,
+          this.validationView(finalData, fields),
           attachFieldValidators("collection", params.collectionName, fields),
           {
             mode: "update",
@@ -7046,7 +7068,7 @@ export class CollectionMutationService extends BaseService {
 
       {
         const validationIssues = await validateEntryData(
-          finalData,
+          this.validationView(finalData, fields),
           attachFieldValidators("collection", params.collectionName, fields),
           {
             mode: "create",
@@ -7644,7 +7666,7 @@ export class CollectionMutationService extends BaseService {
 
       {
         const validationIssues = await validateEntryData(
-          finalData,
+          this.validationView(finalData, fields),
           attachFieldValidators("collection", params.collectionName, fields),
           {
             mode: "update",

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -58,7 +58,6 @@ import type { FieldGroupDataService } from "../../../services/field-groups/field
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
 import { convertTimestampsToCamelCase } from "../../../shared/lib/case-conversion";
-import { detachData } from "../../../shared/lib/detach";
 import { validateEntryData } from "../../../shared/lib/entry-validation";
 import { applyFieldDefaults } from "../../../shared/lib/field-defaults";
 import {
@@ -70,6 +69,7 @@ import {
 import {
   coerceDateFieldsToDate,
   normalizeRelationshipFields,
+  relationshipValidationView,
 } from "../../../shared/lib/field-transform";
 import {
   hashPasswordFieldValues,
@@ -774,9 +774,7 @@ export class CollectionMutationService extends BaseService {
     data: Record<string, unknown>,
     fields: FieldDefinition[]
   ): Record<string, unknown> {
-    const view = detachData(data);
-    normalizeRelationshipFields(view, fields as unknown as FieldConfig[]);
-    return view;
+    return relationshipValidationView(data, fields as unknown as FieldConfig[]);
   }
 
   /**

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -180,20 +180,38 @@ function extractRelationshipId(value: unknown): unknown {
 }
 
 /**
+ * The collections a relationship field is allowed to point at.
+ *
+ * A many-to-many field keeps its target under `options.target`, matching how
+ * {@link getTargetCollection} resolves one.
+ */
+function declaredTargets(field: FieldDefinition): string[] {
+  if (field.options?.relationType === "manyToMany" && field.options.target) {
+    return [field.options.target];
+  }
+  if (Array.isArray(field.relationTo)) return field.relationTo;
+  if (typeof field.relationTo === "string") return [field.relationTo];
+  const target = field.options?.target;
+  return typeof target === "string" ? [target] : [];
+}
+
+/**
  * Reads a relationship value that carries its own target collection.
  *
  * A field declaring several targets cannot store a bare id, because the id
  * alone does not say which table it belongs to; it stores a
- * `{ relationTo, value }` pair instead. That stored collection is
- * authoritative — the field's declared list says only which targets are
- * allowed, so resolving against it picks the wrong table for every value that
- * does not point at the first one.
+ * `{ relationTo, value }` pair instead. The stored collection decides which
+ * table the id is read from, so it is only honoured when the field declares
+ * it: nothing validates the slug on the way in, and trusting it as written
+ * would let a writer name any collection and have the row read back out of it,
+ * bypassing that collection's own read rules.
  *
  * Returns null for any other shape, leaving the caller on the single-target
  * path where the field's own target is the right answer.
  */
 function readPolymorphicRef(
-  value: unknown
+  value: unknown,
+  allowedTargets: string[]
 ): { collection: string; id: string } | null {
   // Dialects without a native object column hand the pair back as the JSON
   // text it was stored as. Only a value that actually parses to the pair is
@@ -213,7 +231,30 @@ function readPolymorphicRef(
   }
   const { relationTo, value: id } = candidate as Record<string, unknown>;
   if (typeof relationTo !== "string" || typeof id !== "string") return null;
+  if (!allowedTargets.includes(relationTo)) return null;
   return { collection: relationTo, id };
+}
+
+/**
+ * Whether a value is stored as a `{ relationTo, value }` pair, regardless of
+ * which collection it names. Distinguishes "not a pair" from "a pair naming a
+ * collection this field never declared", so the second can be left alone
+ * rather than treated as an id and sent to the wrong table.
+ */
+function isPolymorphicRefShape(value: unknown): boolean {
+  const candidate =
+    typeof value === "string" && value.startsWith("{")
+      ? parseJsonObject(value)
+      : value;
+  if (
+    candidate === null ||
+    typeof candidate !== "object" ||
+    Array.isArray(candidate)
+  ) {
+    return false;
+  }
+  const { relationTo, value: id } = candidate as Record<string, unknown>;
+  return typeof relationTo === "string" && typeof id === "string";
 }
 
 /** Parses JSON text to an object, or null when it is not one. */
@@ -587,11 +628,15 @@ function readItemArray(value: unknown): unknown[] | null {
  */
 function readRelationshipRef(
   value: unknown,
-  fallbackCollection: string
+  fallbackCollection: string,
+  allowedTargets: string[]
 ): { collection: string; id: string } | null {
   if (value == null) return null;
-  const polymorphic = readPolymorphicRef(value);
+  const polymorphic = readPolymorphicRef(value, allowedTargets);
   if (polymorphic) return polymorphic;
+  // A pair naming an undeclared collection is not an id — reading it as one
+  // would send the whole object to the loader as a bound parameter.
+  if (isPolymorphicRefShape(value)) return null;
   const id = extractRelationshipId(value);
   return typeof id === "string" ? { collection: fallbackCollection, id } : null;
 }
@@ -614,18 +659,30 @@ function relationKey(collection: string, id: string): string {
  * and each may name a different collection, so a single target resolved from
  * the field would send most of them to the wrong table.
  *
- * Indices line up with {@link normalizeToIdArray}, which maps list values
- * one-to-one, so the id and the collection always describe the same entry.
+ * Reads each id against its own item from {@link normalizeToIdArray}, which
+ * maps list values one-to-one, so the id and the collection always describe
+ * the same entry. Entries naming an undeclared collection are dropped, so the
+ * result may be shorter than the stored list; the fetch and the lookup derive
+ * it the same way, so they stay consistent.
  */
 function normalizeToRelationshipRefs(
   value: unknown,
-  fallbackCollection: string
+  fallbackCollection: string,
+  allowedTargets: string[]
 ): { collection: string; id: string }[] {
   const items = readItemArray(value);
-  return normalizeToIdArray(value).map((id, index) => {
-    const ref = items ? readPolymorphicRef(items[index]) : null;
-    return ref ?? { collection: fallbackCollection, id };
-  });
+  return normalizeToIdArray(value)
+    .map((id, index) => {
+      const item = items ? items[index] : undefined;
+      const ref = items ? readPolymorphicRef(item, allowedTargets) : null;
+      if (ref) return ref;
+      // Dropped rather than resolved against the field's own target: the value
+      // names a collection this field never declared, so there is no reference
+      // here to honour.
+      if (items && isPolymorphicRefShape(item)) return null;
+      return { collection: fallbackCollection, id };
+    })
+    .filter((ref): ref is { collection: string; id: string } => ref !== null);
 }
 
 /**
@@ -1044,6 +1101,7 @@ export class CollectionRelationshipService extends BaseService {
       const relationType = field.options?.relationType || "manyToOne";
       const targetCollection = getTargetCollection(field);
       const hasMany = isHasManyRelationship(field);
+      const fieldTargets = declaredTargets(field);
 
       if (!targetCollection) continue;
 
@@ -1068,7 +1126,11 @@ export class CollectionRelationshipService extends BaseService {
         // format. Each carries its own collection when the field declares
         // several targets.
         const allRefs = entries.flatMap(entry =>
-          normalizeToRelationshipRefs(entry[field.name], targetCollection)
+          normalizeToRelationshipRefs(
+            entry[field.name],
+            targetCollection,
+            fieldTargets
+          )
         );
         relationDataMaps[field.name] = await this.batchFetchRefs(
           allRefs,
@@ -1078,7 +1140,9 @@ export class CollectionRelationshipService extends BaseService {
       } else {
         // Batch fetch all referenced IDs for oneToOne/manyToOne/oneToMany
         const relatedRefs = entries
-          .map(e => readRelationshipRef(e[field.name], targetCollection))
+          .map(e =>
+            readRelationshipRef(e[field.name], targetCollection, fieldTargets)
+          )
           .filter(
             (ref): ref is { collection: string; id: string } => ref !== null
           );
@@ -1142,7 +1206,8 @@ export class CollectionRelationshipService extends BaseService {
             // Handle hasMany relationships - expand array of IDs
             const refs = normalizeToRelationshipRefs(
               entry[field.name],
-              fieldTarget
+              fieldTarget,
+              declaredTargets(field)
             );
             expandedEntry[field.name] = refs
               .map(({ collection, id }) =>
@@ -1150,7 +1215,11 @@ export class CollectionRelationshipService extends BaseService {
               )
               .filter(Boolean);
           } else {
-            const ref = readRelationshipRef(entry[field.name], fieldTarget);
+            const ref = readRelationshipRef(
+              entry[field.name],
+              fieldTarget,
+              declaredTargets(field)
+            );
             const row = ref && dataMap.get(relationKey(ref.collection, ref.id));
             if (row) {
               expandedEntry[field.name] = row;
@@ -1654,7 +1723,8 @@ export class CollectionRelationshipService extends BaseService {
           // for the whole field.
           const refs = normalizeToRelationshipRefs(
             entry[field.name],
-            targetCollection
+            targetCollection,
+            declaredTargets(field)
           );
 
           if (refs.length > 0) {
@@ -1724,7 +1794,15 @@ export class CollectionRelationshipService extends BaseService {
           // A multi-target field stores the collection next to the id. Passing
           // the whole pair to the row loader binds an object where the driver
           // expects a string, so the query throws and the value never expands.
-          const polymorphicRef = readPolymorphicRef(storedValue);
+          const polymorphicRef = readPolymorphicRef(
+            storedValue,
+            declaredTargets(field)
+          );
+          // A pair naming a collection the field never declared is left as it
+          // is stored: reading it as an id would send the object to the loader,
+          // and honouring the collection would read a row out of a table this
+          // field was never allowed to reach.
+          if (!polymorphicRef && isPolymorphicRefShape(storedValue)) continue;
           const relatedCollection =
             polymorphicRef?.collection ?? targetCollection;
           const relatedId = polymorphicRef

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -180,6 +180,41 @@ function extractRelationshipId(value: unknown): unknown {
 }
 
 /**
+ * A resolved relationship value: which collection the row is read from, and
+ * whether the stored value named that collection itself.
+ *
+ * `discriminated` decides what the populated row has to carry back, not where
+ * it is read from — a value that named its collection has to keep saying so in
+ * the response, or saving the document back loses it.
+ */
+interface RelationshipRef {
+  collection: string;
+  id: string;
+  discriminated: boolean;
+}
+
+/**
+ * Keeps a populated multi-target value round-trippable.
+ *
+ * The write path reduces a populated object to a bare id unless it still
+ * carries both `relationTo` and `value`, so a document read at depth and saved
+ * back unchanged would lose the collection the reference named and resolve the
+ * id against the field's first declared target instead — silently retargeting
+ * or dropping the relationship.
+ *
+ * Carried beside the row's own columns rather than wrapping it, because that is
+ * the shape the write path already accepts, and applied only to values that
+ * arrived discriminated so an ordinary single-target row is untouched.
+ */
+function withReferenceIdentity(
+  row: Record<string, unknown>,
+  ref: RelationshipRef
+): Record<string, unknown> {
+  if (!ref.discriminated) return row;
+  return { ...row, relationTo: ref.collection, value: ref.id };
+}
+
+/**
  * The collections a relationship field is allowed to point at.
  *
  * A many-to-many field keeps its target under `options.target`, matching how
@@ -212,7 +247,7 @@ function declaredTargets(field: FieldDefinition): string[] {
 function readPolymorphicRef(
   value: unknown,
   allowedTargets: string[]
-): { collection: string; id: string } | null {
+): RelationshipRef | null {
   // Dialects without a native object column hand the pair back as the JSON
   // text it was stored as. Only a value that actually parses to the pair is
   // treated as one: an ordinary id is a bare string, and a Postgres array
@@ -232,7 +267,7 @@ function readPolymorphicRef(
   const { relationTo, value: id } = candidate as Record<string, unknown>;
   if (typeof relationTo !== "string" || typeof id !== "string") return null;
   if (!allowedTargets.includes(relationTo)) return null;
-  return { collection: relationTo, id };
+  return { collection: relationTo, id, discriminated: true };
 }
 
 /**
@@ -630,7 +665,7 @@ function readRelationshipRef(
   value: unknown,
   fallbackCollection: string,
   allowedTargets: string[]
-): { collection: string; id: string } | null {
+): RelationshipRef | null {
   if (value == null) return null;
   const polymorphic = readPolymorphicRef(value, allowedTargets);
   if (polymorphic) return polymorphic;
@@ -638,7 +673,9 @@ function readRelationshipRef(
   // would send the whole object to the loader as a bound parameter.
   if (isPolymorphicRefShape(value)) return null;
   const id = extractRelationshipId(value);
-  return typeof id === "string" ? { collection: fallbackCollection, id } : null;
+  return typeof id === "string"
+    ? { collection: fallbackCollection, id, discriminated: false }
+    : null;
 }
 
 /**
@@ -669,7 +706,7 @@ function normalizeToRelationshipRefs(
   value: unknown,
   fallbackCollection: string,
   allowedTargets: string[]
-): { collection: string; id: string }[] {
+): RelationshipRef[] {
   const items = readItemArray(value);
   return normalizeToIdArray(value)
     .map((id, index) => {
@@ -680,9 +717,9 @@ function normalizeToRelationshipRefs(
       // names a collection this field never declared, so there is no reference
       // here to honour.
       if (items && isPolymorphicRefShape(item)) return null;
-      return { collection: fallbackCollection, id };
+      return { collection: fallbackCollection, id, discriminated: false };
     })
-    .filter((ref): ref is { collection: string; id: string } => ref !== null);
+    .filter((ref): ref is RelationshipRef => ref !== null);
 }
 
 /**
@@ -1143,9 +1180,7 @@ export class CollectionRelationshipService extends BaseService {
           .map(e =>
             readRelationshipRef(e[field.name], targetCollection, fieldTargets)
           )
-          .filter(
-            (ref): ref is { collection: string; id: string } => ref !== null
-          );
+          .filter((ref): ref is RelationshipRef => ref !== null);
 
         relationDataMaps[field.name] = await this.batchFetchRefs(
           relatedRefs,
@@ -1210,9 +1245,12 @@ export class CollectionRelationshipService extends BaseService {
               declaredTargets(field)
             );
             expandedEntry[field.name] = refs
-              .map(({ collection, id }) =>
-                dataMap.get(relationKey(collection, id))
-              )
+              .map(ref => {
+                const row = dataMap.get(relationKey(ref.collection, ref.id));
+                return row && !Array.isArray(row)
+                  ? withReferenceIdentity(row, ref)
+                  : row;
+              })
               .filter(Boolean);
           } else {
             const ref = readRelationshipRef(
@@ -1222,7 +1260,10 @@ export class CollectionRelationshipService extends BaseService {
             );
             const row = ref && dataMap.get(relationKey(ref.collection, ref.id));
             if (row) {
-              expandedEntry[field.name] = row;
+              expandedEntry[field.name] =
+                ref && !Array.isArray(row)
+                  ? withReferenceIdentity(row, ref)
+                  : row;
             }
           }
         }
@@ -1315,7 +1356,7 @@ export class CollectionRelationshipService extends BaseService {
    * @returns Map of {@link relationKey} to expanded entry data
    */
   private async batchFetchRefs(
-    refs: { collection: string; id: string }[],
+    refs: RelationshipRef[],
     field: FieldDefinition,
     access: RelatedRowAccess
   ): Promise<Map<string, Record<string, unknown>>> {
@@ -1745,7 +1786,8 @@ export class CollectionRelationshipService extends BaseService {
 
             // Fetch all related entries
             const expandedRelated = await Promise.all(
-              refs.map(async ({ collection: relatedCollection, id }) => {
+              refs.map(async ref => {
+                const { collection: relatedCollection, id } = ref;
                 const relatedEntry = await this.fetchRelatedEntry(
                   relatedCollection,
                   id,
@@ -1780,7 +1822,7 @@ export class CollectionRelationshipService extends BaseService {
                   }
                 }
 
-                return baseExpanded;
+                return withReferenceIdentity(baseExpanded, ref);
               })
             );
 
@@ -1848,7 +1890,9 @@ export class CollectionRelationshipService extends BaseService {
                 }
               }
 
-              expandedEntry[field.name] = expandedRelated;
+              expandedEntry[field.name] = polymorphicRef
+                ? withReferenceIdentity(expandedRelated, polymorphicRef)
+                : expandedRelated;
             }
           }
         }

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -194,24 +194,27 @@ interface RelationshipRef {
 }
 
 /**
- * Keeps a populated multi-target value round-trippable.
+ * Keeps a populated multi-target value round-trippable, and keeps it out of the
+ * related row's own namespace.
  *
- * The write path reduces a populated object to a bare id unless it still
- * carries both `relationTo` and `value`, so a document read at depth and saved
- * back unchanged would lose the collection the reference named and resolve the
- * id against the field's first declared target instead — silently retargeting
- * or dropping the relationship.
+ * The write path reduces a populated object to a bare id unless it still says
+ * which collection it came from, and a bare id resolves against the field's
+ * first declared target — so a document read at depth and saved back unchanged
+ * would silently retarget or drop the relationship.
  *
- * Carried beside the row's own columns rather than wrapping it, because that is
- * the shape the write path already accepts, and applied only to values that
- * arrived discriminated so an ordinary single-target row is untouched.
+ * The row is nested under `value` rather than carrying the discriminator beside
+ * its own columns: a target collection may legitimately define a field called
+ * `value` or `relationTo` (neither is reserved), and merging would overwrite
+ * that field's real data, including re-adding a key that field-level access
+ * had just removed. Nesting also keeps one shape at every depth — `value` is
+ * the id when nothing was populated, and the row when something was.
  */
 function withReferenceIdentity(
   row: Record<string, unknown>,
   ref: RelationshipRef
 ): Record<string, unknown> {
   if (!ref.discriminated) return row;
-  return { ...row, relationTo: ref.collection, value: ref.id };
+  return { relationTo: ref.collection, value: row };
 }
 
 /**

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -180,6 +180,57 @@ function extractRelationshipId(value: unknown): unknown {
 }
 
 /**
+ * Reads a relationship value that carries its own target collection.
+ *
+ * A field declaring several targets cannot store a bare id, because the id
+ * alone does not say which table it belongs to; it stores a
+ * `{ relationTo, value }` pair instead. That stored collection is
+ * authoritative — the field's declared list says only which targets are
+ * allowed, so resolving against it picks the wrong table for every value that
+ * does not point at the first one.
+ *
+ * Returns null for any other shape, leaving the caller on the single-target
+ * path where the field's own target is the right answer.
+ */
+function readPolymorphicRef(
+  value: unknown
+): { collection: string; id: string } | null {
+  // Dialects without a native object column hand the pair back as the JSON
+  // text it was stored as. Only a value that actually parses to the pair is
+  // treated as one: an ordinary id is a bare string, and a Postgres array
+  // literal opens with the same brace but is not JSON, so both fall through
+  // to the single-target path rather than being mistaken for a reference.
+  const candidate =
+    typeof value === "string" && value.startsWith("{")
+      ? parseJsonObject(value)
+      : value;
+  if (
+    candidate === null ||
+    typeof candidate !== "object" ||
+    Array.isArray(candidate)
+  ) {
+    return null;
+  }
+  const { relationTo, value: id } = candidate as Record<string, unknown>;
+  if (typeof relationTo !== "string" || typeof id !== "string") return null;
+  return { collection: relationTo, id };
+}
+
+/** Parses JSON text to an object, or null when it is not one. */
+function parseJsonObject(text: string): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return parsed !== null &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Strips expanded relationship objects in a data row down to just their IDs.
  * Used when depth=0 to ensure no nested relationships are returned as full objects.
  * Recursively handles nested repeater/group fields.
@@ -508,6 +559,73 @@ function parsePostgresArray(value: unknown): string[] | null {
     return items;
   }
   return null;
+}
+
+/**
+ * Returns the stored values as their original items when the field holds a
+ * list, so a caller can read each one's own target collection. Null for every
+ * other shape, including a Postgres array literal — that format carries bare
+ * ids, which have no collection to read.
+ */
+function readItemArray(value: unknown): unknown[] | null {
+  if (Array.isArray(value)) return value;
+  if (typeof value === "string" && value.startsWith("[")) {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (Array.isArray(parsed)) return parsed;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Reads a single relationship value as the collection and id it refers to.
+ * Falls back to the field's own target for the ordinary single-target case,
+ * where the stored value is just an id.
+ */
+function readRelationshipRef(
+  value: unknown,
+  fallbackCollection: string
+): { collection: string; id: string } | null {
+  if (value == null) return null;
+  const polymorphic = readPolymorphicRef(value);
+  if (polymorphic) return polymorphic;
+  const id = extractRelationshipId(value);
+  return typeof id === "string" ? { collection: fallbackCollection, id } : null;
+}
+
+/**
+ * Identifies a related row by collection AND id, because an id is only unique
+ * within its own collection. A field naming several targets can hold the same
+ * id for two of them, and a lookup keyed on the id alone would hand back
+ * whichever row was fetched last.
+ */
+function relationKey(collection: string, id: string): string {
+  // A NUL separator cannot appear in a slug or an id, so no two distinct
+  // pairs can collapse to the same key.
+  return `${collection}\u0000${id}`;
+}
+
+/**
+ * Pairs every id in a list-valued relationship with the collection it belongs
+ * to. A multi-target field stores one `{ relationTo, value }` pair per entry,
+ * and each may name a different collection, so a single target resolved from
+ * the field would send most of them to the wrong table.
+ *
+ * Indices line up with {@link normalizeToIdArray}, which maps list values
+ * one-to-one, so the id and the collection always describe the same entry.
+ */
+function normalizeToRelationshipRefs(
+  value: unknown,
+  fallbackCollection: string
+): { collection: string; id: string }[] {
+  const items = readItemArray(value);
+  return normalizeToIdArray(value).map((id, index) => {
+    const ref = items ? readPolymorphicRef(items[index]) : null;
+    return ref ?? { collection: fallbackCollection, id };
+  });
 }
 
 /**
@@ -946,42 +1064,30 @@ export class CollectionRelationshipService extends BaseService {
         relationDataMaps[field.name] = dataMap;
       } else if (hasMany) {
         // Handle hasMany relationships (arrays of IDs stored directly)
-        // Collect all IDs from all entries, handling PostgreSQL array format
-        const allRelatedIds: string[] = [];
-        for (const entry of entries) {
-          const ids = normalizeToIdArray(entry[field.name]);
-          allRelatedIds.push(...ids);
-        }
-
-        if (allRelatedIds.length > 0) {
-          const uniqueIds = [...new Set(allRelatedIds)];
-          const dataMap = await this.batchFetchRelatedEntries(
-            targetCollection,
-            uniqueIds,
-            field,
-            access
-          );
-          relationDataMaps[field.name] = dataMap;
-        } else {
-          relationDataMaps[field.name] = new Map();
-        }
+        // Collect all references from all entries, handling PostgreSQL array
+        // format. Each carries its own collection when the field declares
+        // several targets.
+        const allRefs = entries.flatMap(entry =>
+          normalizeToRelationshipRefs(entry[field.name], targetCollection)
+        );
+        relationDataMaps[field.name] = await this.batchFetchRefs(
+          allRefs,
+          field,
+          access
+        );
       } else {
         // Batch fetch all referenced IDs for oneToOne/manyToOne/oneToMany
-        const relatedIds = entries
-          .map(e => e[field.name])
-          .filter(id => id != null) as string[];
-
-        if (relatedIds.length > 0) {
-          const dataMap = await this.batchFetchRelatedEntries(
-            targetCollection,
-            relatedIds,
-            field,
-            access
+        const relatedRefs = entries
+          .map(e => readRelationshipRef(e[field.name], targetCollection))
+          .filter(
+            (ref): ref is { collection: string; id: string } => ref !== null
           );
-          relationDataMaps[field.name] = dataMap;
-        } else {
-          relationDataMaps[field.name] = new Map();
-        }
+
+        relationDataMaps[field.name] = await this.batchFetchRefs(
+          relatedRefs,
+          field,
+          access
+        );
       }
     }
 
@@ -1024,16 +1130,30 @@ export class CollectionRelationshipService extends BaseService {
 
           if (relationType === "manyToMany") {
             expandedEntry[field.name] = dataMap.get(entry.id as string) || [];
-          } else if (hasMany) {
+            continue;
+          }
+
+          // Resolved the same way the fetch above resolved it, so a value that
+          // names its own collection is looked up under that collection.
+          const fieldTarget = getTargetCollection(field);
+          if (!fieldTarget) continue;
+
+          if (hasMany) {
             // Handle hasMany relationships - expand array of IDs
-            const ids = normalizeToIdArray(entry[field.name]);
-            expandedEntry[field.name] = ids
-              .map(id => dataMap.get(id))
+            const refs = normalizeToRelationshipRefs(
+              entry[field.name],
+              fieldTarget
+            );
+            expandedEntry[field.name] = refs
+              .map(({ collection, id }) =>
+                dataMap.get(relationKey(collection, id))
+              )
               .filter(Boolean);
           } else {
-            const relatedId = entry[field.name] as string;
-            if (relatedId && dataMap.has(relatedId)) {
-              expandedEntry[field.name] = dataMap.get(relatedId);
+            const ref = readRelationshipRef(entry[field.name], fieldTarget);
+            const row = ref && dataMap.get(relationKey(ref.collection, ref.id));
+            if (row) {
+              expandedEntry[field.name] = row;
             }
           }
         }
@@ -1109,6 +1229,50 @@ export class CollectionRelationshipService extends BaseService {
         return fullyExpandedEntry;
       })
     );
+  }
+
+  /**
+   * Batch fetch references that may span several collections, one query per
+   * collection. A field declaring several targets holds values from more than
+   * one of them, so a single fetch against the field's first target would miss
+   * every value pointing anywhere else.
+   *
+   * Keys the result by collection and id together, since the caller resolves a
+   * row from the reference it started with and an id alone does not identify
+   * one across collections.
+   *
+   * @param refs - References to load, duplicates allowed
+   * @param field - Field definition, for label resolution
+   * @returns Map of {@link relationKey} to expanded entry data
+   */
+  private async batchFetchRefs(
+    refs: { collection: string; id: string }[],
+    field: FieldDefinition,
+    access: RelatedRowAccess
+  ): Promise<Map<string, Record<string, unknown>>> {
+    const idsByCollection = new Map<string, Set<string>>();
+    for (const { collection, id } of refs) {
+      const ids = idsByCollection.get(collection);
+      if (ids) {
+        ids.add(id);
+      } else {
+        idsByCollection.set(collection, new Set([id]));
+      }
+    }
+
+    const merged = new Map<string, Record<string, unknown>>();
+    for (const [collection, ids] of idsByCollection) {
+      const dataMap = await this.batchFetchRelatedEntries(
+        collection,
+        [...ids],
+        field,
+        access
+      );
+      for (const [id, row] of dataMap) {
+        merged.set(relationKey(collection, id), row);
+      }
+    }
+    return merged;
   }
 
   /**
@@ -1484,25 +1648,43 @@ export class CollectionRelationshipService extends BaseService {
 
           expandedEntry[field.name] = expandedRelated;
         } else if (hasMany) {
-          // Handle hasMany relationships - array of IDs stored directly
-          const ids = normalizeToIdArray(entry[field.name]);
+          // Handle hasMany relationships - array of IDs stored directly.
+          // Each entry carries its own collection when the field declares
+          // several targets, so they are resolved per value rather than once
+          // for the whole field.
+          const refs = normalizeToRelationshipRefs(
+            entry[field.name],
+            targetCollection
+          );
 
-          if (ids.length > 0) {
-            const labelField = await this.getBestLabelField(
-              targetCollection,
-              targetLabelField
-            );
+          if (refs.length > 0) {
+            // Two values in the same field can come from different
+            // collections, and each names its own label field — so the lookup
+            // is per collection, resolved once each rather than once per row.
+            const labelFields = new Map<string, Promise<string>>();
+            const labelFieldFor = (collection: string): Promise<string> => {
+              const cached = labelFields.get(collection);
+              if (cached) return cached;
+              const pending = this.getBestLabelField(
+                collection,
+                targetLabelField
+              );
+              labelFields.set(collection, pending);
+              return pending;
+            };
 
             // Fetch all related entries
             const expandedRelated = await Promise.all(
-              ids.map(async (id: string) => {
+              refs.map(async ({ collection: relatedCollection, id }) => {
                 const relatedEntry = await this.fetchRelatedEntry(
-                  targetCollection,
+                  relatedCollection,
                   id,
                   access
                 );
 
                 if (!relatedEntry) return null;
+
+                const labelField = await labelFieldFor(relatedCollection);
 
                 let baseExpanded: Record<string, unknown> = {
                   id: relatedEntry.id,
@@ -1513,11 +1695,11 @@ export class CollectionRelationshipService extends BaseService {
                 // Recursively expand nested relationships if we have depth remaining
                 if (currentDepth + 1 < effectiveDepth) {
                   const targetFields =
-                    await this.getCollectionFields(targetCollection);
+                    await this.getCollectionFields(relatedCollection);
                   if (targetFields.length > 0) {
                     baseExpanded = await this.expandRelationships(
                       baseExpanded,
-                      targetCollection,
+                      relatedCollection,
                       targetFields,
                       {
                         depth: effectiveDepth,
@@ -1538,18 +1720,27 @@ export class CollectionRelationshipService extends BaseService {
           }
         } else {
           // oneToOne, manyToOne, oneToMany - already have the ID
-          const relatedId = entry[field.name] as string;
+          const storedValue = entry[field.name];
+          // A multi-target field stores the collection next to the id. Passing
+          // the whole pair to the row loader binds an object where the driver
+          // expects a string, so the query throws and the value never expands.
+          const polymorphicRef = readPolymorphicRef(storedValue);
+          const relatedCollection =
+            polymorphicRef?.collection ?? targetCollection;
+          const relatedId = polymorphicRef
+            ? polymorphicRef.id
+            : (storedValue as string);
 
           if (relatedId) {
             const relatedEntry = await this.fetchRelatedEntry(
-              targetCollection,
+              relatedCollection,
               relatedId,
               access
             );
 
             if (relatedEntry) {
               const labelField = await this.getBestLabelField(
-                targetCollection,
+                relatedCollection,
                 targetLabelField
               );
 
@@ -1561,12 +1752,14 @@ export class CollectionRelationshipService extends BaseService {
 
               // Recursively expand nested relationships if we have depth remaining
               if (currentDepth + 1 < effectiveDepth) {
+                // The row came from the collection the value named, so its own
+                // fields are the ones to walk for the next hop.
                 const targetFields =
-                  await this.getCollectionFields(targetCollection);
+                  await this.getCollectionFields(relatedCollection);
                 if (targetFields.length > 0) {
                   expandedRelated = await this.expandRelationships(
                     expandedRelated,
-                    targetCollection,
+                    relatedCollection,
                     targetFields,
                     {
                       depth: effectiveDepth,

--- a/packages/nextly/src/domains/collections/services/collection-utils.ts
+++ b/packages/nextly/src/domains/collections/services/collection-utils.ts
@@ -119,6 +119,21 @@ export function normalizeRelationshipValue(
 }
 
 /**
+ * The id a multi-target reference points at, whichever form it arrives in.
+ *
+ * A read at depth serves the populated row under `value`, so a document saved
+ * back unchanged hands that row here; storing it as-is would put a whole
+ * object in the column. An unpopulated reference already carries the id.
+ */
+function referenceTargetId(value: unknown): unknown {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    const { id } = value as Record<string, unknown>;
+    if (typeof id === "string") return id;
+  }
+  return value;
+}
+
+/**
  * Normalizes a single relationship item.
  */
 export function normalizeRelationshipItem(
@@ -139,7 +154,7 @@ export function normalizeRelationshipItem(
     if (isPolymorphic && "relationTo" in obj && "value" in obj) {
       return {
         relationTo: obj.relationTo,
-        value: obj.value,
+        value: referenceTargetId(obj.value),
       };
     }
 
@@ -151,7 +166,7 @@ export function normalizeRelationshipItem(
     if ("relationTo" in obj && "value" in obj) {
       return {
         relationTo: obj.relationTo,
-        value: obj.value,
+        value: referenceTargetId(obj.value),
       };
     }
   }

--- a/packages/nextly/src/domains/field-groups/services/field-group-mutation-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-mutation-service.ts
@@ -1273,6 +1273,14 @@ export class FieldGroupMutationService extends BaseService {
         ],
       });
     }
+    // Reduced in place, and before validation, because both halves of the write
+    // depend on it. A validator is written against a field's public value, the
+    // document id, and would otherwise be handed the populated row. The
+    // localized split then copies values out of this same object into the
+    // companion payload, which never reaches `serializeComponentRow` — so a
+    // reference left populated here is stored there as a snapshot of the row.
+    normalizeRelationshipFields(instance, componentFields);
+
     const issues = await validateEntryData(instance, componentFields, { mode });
     if (issues.length > 0) {
       throw NextlyError.validation({ errors: issues });

--- a/packages/nextly/src/domains/field-groups/services/field-group-mutation-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-mutation-service.ts
@@ -18,7 +18,10 @@ import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import type { FieldGroupRegistryService } from "../../../services/field-groups/field-group-registry-service";
 import { BaseService } from "../../../shared/base-service";
 import { validateEntryData } from "../../../shared/lib/entry-validation";
-import { coerceDateFieldsToDate } from "../../../shared/lib/field-transform";
+import {
+  coerceDateFieldsToDate,
+  normalizeRelationshipFields,
+} from "../../../shared/lib/field-transform";
 import { hashPasswordFieldValues } from "../../../shared/lib/password-fields";
 import type { Logger } from "../../../shared/types";
 import type { SanitizedLocalizationConfig } from "../../i18n/config/types";
@@ -1290,6 +1293,12 @@ export class FieldGroupMutationService extends BaseService {
     // write path because both `buildInsertRow` and the in-place update
     // sites funnel through here.
     coerceDateFieldsToDate(data, fields);
+
+    // A relationship read at depth comes back populated, and a multi-target one
+    // as `{ relationTo, value: row }`. Serializing that as it arrives would
+    // store a snapshot of the related row in the column, which later reads
+    // would serve in place of reloading the target.
+    normalizeRelationshipFields(data, fields);
 
     const fieldMap = new Map<string, FieldConfig>();
     for (const field of fields) {

--- a/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
@@ -1047,6 +1047,65 @@ describe("Single custom read rules vs the assembled document (integration)", () 
     });
   });
 
+  // A field's public value is the document id, and a custom validator is
+  // written against that. Saving a Single read at depth hands the validator the
+  // populated row instead, so a check like `value.value.startsWith(...)` throws
+  // and blocks an edit to some unrelated field.
+  it("shows a validator the id when a populated single value is saved back", async () => {
+    const seen: unknown[] = [];
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "authors", fields: [text({ name: "name" })] }),
+        defineCollection({ slug: "orgs", fields: [text({ name: "name" })] }),
+      ],
+      singles: [
+        defineSingle({
+          slug: "branding",
+          fields: [
+            text({ name: "siteName" }),
+            relationship({
+              name: "author",
+              relationTo: ["authors", "orgs"],
+              validate: (value: unknown) => {
+                seen.push(value);
+                return true;
+              },
+            }),
+          ],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const author = await handler.createEntry(
+      { collectionName: "authors", overrideAccess: true },
+      { name: "Ada" }
+    );
+    const authorId = (author.data as { id: string }).id;
+    const entry = current.getService<SingleEntryService>("singleEntryService");
+    await entry.update(
+      "branding",
+      {
+        siteName: "Acme",
+        author: { relationTo: "authors", value: authorId },
+      },
+      { overrideAccess: true }
+    );
+
+    const read = await entry.get("branding", {
+      overrideAccess: true,
+      depth: 1,
+    });
+    seen.length = 0;
+    await entry.update(
+      "branding",
+      { siteName: "Acme Two", author: read.data!.author },
+      { overrideAccess: true }
+    );
+
+    expect(seen).toContainEqual({ relationTo: "authors", value: authorId });
+  });
+
   // A container is serialized to JSON wholesale, so a reference left populated
   // inside one is written as the row and never read back as a reference again.
   it("stores a reference for a populated value inside a group", async () => {

--- a/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
@@ -987,6 +987,76 @@ describe("Single custom read rules vs the assembled document (integration)", () 
     });
   });
 
+  // Neither `relationTo` nor `value` is a reserved field name, so a target
+  // collection may define both. A populated row from one then looks exactly
+  // like the wrapper a populated reference is served in, and reading it as one
+  // judges a field value in place of the row — refusing a read that is fine.
+  it("judges a populated row that defines relationTo and value as fields", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "authors",
+          fields: [
+            text({ name: "name" }),
+            text({ name: "relationTo" }),
+            text({ name: "value" }),
+          ],
+        }),
+        defineCollection({ slug: "orgs", fields: [text({ name: "name" })] }),
+      ],
+      singles: [
+        defineSingle({
+          slug: "branding",
+          fields: [
+            text({ name: "siteName" }),
+            relationship({ name: "author", relationTo: ["authors", "orgs"] }),
+          ],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const author = await handler.createEntry(
+      { collectionName: "authors", overrideAccess: true },
+      { name: "A", relationTo: "not a reference", value: "just a string" }
+    );
+    const entry = current.getService<SingleEntryService>("singleEntryService");
+    await entry.update(
+      "branding",
+      {
+        siteName: "Acme",
+        author: {
+          relationTo: "authors",
+          value: (author.data as { id: string }).id,
+        },
+      },
+      { overrideAccess: true }
+    );
+    await current.adapter.update(
+      "dynamic_singles",
+      { access_rules: { read: { type: "custom", functionPath: RULE_PATH } } },
+      { and: [{ column: "slug", op: "=", value: "branding" }] }
+    );
+
+    const result = await entry.get("branding", {
+      user: { id: "always" },
+      routeAuthorized: true,
+      depth: 1,
+    });
+
+    expect(result.success).toBe(true);
+    // The row's own fields survived, rather than one of them being read as the
+    // reference it is named after.
+    expect(result.data!.author).toMatchObject({
+      relationTo: "authors",
+      value: {
+        name: "A",
+        relationTo: "not a reference",
+        value: "just a string",
+      },
+    });
+  });
+
   // Population can fail — a deleted target, a transient error — and the value
   // then stays the reference it was stored as. A rule reading into it would
   // decide on evidence that never arrived, and an absence-tolerant rule reads

--- a/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
@@ -982,8 +982,8 @@ describe("Single custom read rules vs the assembled document (integration)", () 
     // collection the value named, and a bare success assertion would be
     // satisfied by the unexpanded reference just as well.
     expect(result.data!.author).toMatchObject({
-      id: (author.data as { id: string }).id,
-      name: "A",
+      relationTo: "authors",
+      value: { id: (author.data as { id: string }).id, name: "A" },
     });
   });
 

--- a/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
@@ -929,9 +929,9 @@ describe("Single custom read rules vs the assembled document (integration)", () 
   });
 
   it("reads a Single whose relationship points at several collections", async () => {
-    // A polymorphic reference is stored AND served as `{ relationTo, value }` —
-    // it is never populated on this path — so the reference is the outcome and
-    // demanding a row there would refuse every read of such a Single.
+    // A reference naming its own collection is stored as `{ relationTo, value }`
+    // and populated from the collection it names. The read must not be refused
+    // for the shape it arrives in, whether or not the row could be loaded.
     current = await createTestNextly({
       collections: [
         defineCollection({ slug: "authors", fields: [text({ name: "name" })] }),
@@ -978,11 +978,12 @@ describe("Single custom read rules vs the assembled document (integration)", () 
     });
 
     expect(result.success).toBe(true);
-    // The reference IS the outcome here, so pin the shape: expanding or
-    // reshaping it would still satisfy a bare success assertion.
-    expect(result.data!.author).toEqual({
-      relationTo: "authors",
-      value: (author.data as { id: string }).id,
+    // Pin the shape, not just the success: the row has to come from the
+    // collection the value named, and a bare success assertion would be
+    // satisfied by the unexpanded reference just as well.
+    expect(result.data!.author).toMatchObject({
+      id: (author.data as { id: string }).id,
+      name: "A",
     });
   });
 

--- a/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
@@ -987,6 +987,66 @@ describe("Single custom read rules vs the assembled document (integration)", () 
     });
   });
 
+  // A read at depth serves the populated row, and that is what a client sends
+  // back on save. Stored as it arrives it becomes a snapshot: later reads serve
+  // the copy instead of reloading the target, so edits to the target vanish.
+  it("stores a reference, not the row, when a populated value is saved back", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "authors", fields: [text({ name: "name" })] }),
+        defineCollection({ slug: "orgs", fields: [text({ name: "name" })] }),
+      ],
+      singles: [
+        defineSingle({
+          slug: "branding",
+          fields: [
+            text({ name: "siteName" }),
+            relationship({ name: "author", relationTo: ["authors", "orgs"] }),
+          ],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const author = await handler.createEntry(
+      { collectionName: "authors", overrideAccess: true },
+      { name: "Original" }
+    );
+    const authorId = (author.data as { id: string }).id;
+    const entry = current.getService<SingleEntryService>("singleEntryService");
+    await entry.update(
+      "branding",
+      { siteName: "Acme", author: { relationTo: "authors", value: authorId } },
+      { overrideAccess: true }
+    );
+
+    const read = await entry.get("branding", {
+      overrideAccess: true,
+      depth: 1,
+    });
+    // Saved back exactly as served, which is what an unrelated edit does.
+    await entry.update(
+      "branding",
+      { siteName: "Acme Two", author: read.data!.author },
+      { overrideAccess: true }
+    );
+
+    // Change the target: a stored snapshot would keep serving the old name.
+    await handler.updateEntry(
+      { collectionName: "authors", entryId: authorId, overrideAccess: true },
+      { name: "Renamed" }
+    );
+
+    const after = await entry.get("branding", {
+      overrideAccess: true,
+      depth: 1,
+    });
+    expect(after.data!.author).toMatchObject({
+      relationTo: "authors",
+      value: { id: authorId, name: "Renamed" },
+    });
+  });
+
   // Neither `relationTo` nor `value` is a reserved field name, so a target
   // collection may define both. A populated row from one then looks exactly
   // like the wrapper a populated reference is served in, and reading it as one

--- a/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
@@ -987,6 +987,64 @@ describe("Single custom read rules vs the assembled document (integration)", () 
     });
   });
 
+  // Population can fail — a deleted target, a transient error — and the value
+  // then stays the reference it was stored as. A rule reading into it would
+  // decide on evidence that never arrived, and an absence-tolerant rule reads
+  // that absence as permission, so the read is refused instead.
+  it("refuses a judged read when a multi-target reference did not populate", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "authors", fields: [text({ name: "name" })] }),
+        defineCollection({ slug: "orgs", fields: [text({ name: "name" })] }),
+      ],
+      singles: [
+        defineSingle({
+          slug: "branding",
+          fields: [
+            text({ name: "siteName" }),
+            relationship({ name: "author", relationTo: ["authors", "orgs"] }),
+          ],
+        }),
+      ],
+    });
+    const entry = current.getService<SingleEntryService>("singleEntryService");
+    await entry.update(
+      "branding",
+      {
+        siteName: "Acme",
+        // No such row, so nothing can be populated from it.
+        author: {
+          relationTo: "authors",
+          value: "11111111-1111-4111-8111-111111111111",
+        },
+      },
+      { overrideAccess: true }
+    );
+
+    // Read once WITHOUT a stored rule: the check only runs for a judged read,
+    // so an ordinary read of the same document must still be served. Without
+    // this the test would pass just as well if the read were broken outright.
+    const unjudged = await entry.get("branding", {
+      user: { id: "always" },
+      routeAuthorized: true,
+      depth: 1,
+    });
+    expect(unjudged.success).toBe(true);
+
+    await current.adapter.update(
+      "dynamic_singles",
+      { access_rules: { read: { type: "custom", functionPath: RULE_PATH } } },
+      { and: [{ column: "slug", op: "=", value: "branding" }] }
+    );
+
+    const judged = await entry.get("branding", {
+      user: { id: "always" },
+      routeAuthorized: true,
+      depth: 1,
+    });
+    expect(judged.success).toBe(false);
+  });
+
   it("serves a depth-zero read the references it asked for", async () => {
     // `depth: 0` asks for ids and the response gives them, so holding the
     // returned document to "every reference became a document" refuses exactly

--- a/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
@@ -1047,6 +1047,80 @@ describe("Single custom read rules vs the assembled document (integration)", () 
     });
   });
 
+  // A container is serialized to JSON wholesale, so a reference left populated
+  // inside one is written as the row and never read back as a reference again.
+  it("stores a reference for a populated value inside a group", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "authors", fields: [text({ name: "name" })] }),
+        defineCollection({ slug: "orgs", fields: [text({ name: "name" })] }),
+      ],
+      singles: [
+        defineSingle({
+          slug: "branding",
+          fields: [
+            text({ name: "siteName" }),
+            group({
+              name: "meta",
+              fields: [
+                text({ name: "note" }),
+                relationship({
+                  name: "author",
+                  relationTo: ["authors", "orgs"],
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const author = await handler.createEntry(
+      { collectionName: "authors", overrideAccess: true },
+      { name: "Original" }
+    );
+    const authorId = (author.data as { id: string }).id;
+    const entry = current.getService<SingleEntryService>("singleEntryService");
+    await entry.update(
+      "branding",
+      {
+        siteName: "Acme",
+        meta: {
+          note: "n",
+          author: { relationTo: "authors", value: authorId },
+        },
+      },
+      { overrideAccess: true }
+    );
+
+    const read = await entry.get("branding", {
+      overrideAccess: true,
+      depth: 1,
+    });
+    await entry.update(
+      "branding",
+      { siteName: "Acme", meta: read.data!.meta },
+      { overrideAccess: true }
+    );
+
+    await handler.updateEntry(
+      { collectionName: "authors", entryId: authorId, overrideAccess: true },
+      { name: "Renamed" }
+    );
+
+    const after = await entry.get("branding", {
+      overrideAccess: true,
+      depth: 1,
+    });
+    const meta = after.data!.meta as { author?: Record<string, unknown> };
+    // A snapshot stored inside the group would still say "Original".
+    expect(meta.author).toMatchObject({
+      relationTo: "authors",
+      value: { id: authorId, name: "Renamed" },
+    });
+  });
+
   // Neither `relationTo` nor `value` is a reserved field name, so a target
   // collection may define both. A populated row from one then looks exactly
   // like the wrapper a populated reference is served in, and reading it as one

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -55,7 +55,10 @@ import {
   attachFieldValidators,
   runFieldHooks,
 } from "../../../shared/lib/field-level-registry";
-import { coerceDateFieldsToDate } from "../../../shared/lib/field-transform";
+import {
+  coerceDateFieldsToDate,
+  normalizeRelationshipFields,
+} from "../../../shared/lib/field-transform";
 import {
   hashPasswordFieldValues,
   stripPasswordFieldValues,
@@ -817,6 +820,11 @@ export class SingleMutationService extends BaseService {
 
       // 6.5. Normalize upload field values (strip expanded media objects to IDs)
       normalizeUploadFields(currentData, fieldConfigs);
+
+      // 6.5. Relationships come back populated from a read at depth, so reduce
+      // them to the references they stand for rather than storing a snapshot
+      // of the related row.
+      normalizeRelationshipFields(currentData, fieldConfigs);
 
       // 6.6. Coerce date-field strings into `Date` objects so Drizzle can
       // bind them to `timestamp` columns. Without this step the adapter

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -58,6 +58,7 @@ import {
 import {
   coerceDateFieldsToDate,
   normalizeRelationshipFields,
+  relationshipValidationView,
 } from "../../../shared/lib/field-transform";
 import {
   hashPasswordFieldValues,
@@ -656,7 +657,7 @@ export class SingleMutationService extends BaseService {
       // semantics: absent keys stay untouched, provided keys must hold.
       {
         const validationIssues = await validateEntryData(
-          currentData,
+          relationshipValidationView(currentData, fieldConfigs),
           attachFieldValidators("single", slug, fieldConfigs),
           {
             mode: "update",

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -139,24 +139,6 @@ type DefaultDocumentDraft = {
 const DEFAULT_READ_DEPTH = 2;
 
 /**
- * Whether a relationship points at more than one collection.
- *
- * A polymorphic reference is stored — and returned — as `{ relationTo, value }`
- * rather than being populated, so the reference IS the outcome for these
- * fields and there is nothing to verify.
- */
-function isPolymorphicRelation(field: FieldConfig): boolean {
-  const config = field as {
-    relationTo?: unknown;
-    options?: { relationTo?: unknown };
-  };
-  return (
-    Array.isArray(config.relationTo) ||
-    Array.isArray(config.options?.relationTo)
-  );
-}
-
-/**
  * A relationship field's configured population limit, when it declares one.
  * `0` means the reference is meant to stay a reference.
  */
@@ -841,11 +823,6 @@ export class SingleQueryService extends BaseService {
         // populated whatever depth is configured, so the same exemption would
         // skip their only check.
         if (type !== "upload" && relationshipMaxDepth(field) === 0) continue;
-        // Neither is a polymorphic RELATIONSHIP expanded: it is stored and
-        // served as `{ relationTo, value }`, so demanding a row there refuses
-        // every read of a Single that has one. An upload is populated whatever
-        // it points at, so the same exemption would skip its only check.
-        if (type !== "upload" && isPolymorphicRelation(field)) continue;
         if (!referencesExpanded(before, after)) {
           this.logger.error(
             "Refusing a single read: relationship evidence could not be assembled",

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -253,12 +253,16 @@ function isEmptyValue(value: unknown): boolean {
  * shape alone, which would let an unexpanded reference pass for evidence.
  */
 function isExpandedRow(value: unknown): boolean {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    !Array.isArray(value) &&
-    "id" in value
-  );
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  // A reference that names its own collection keeps that shape when it is
+  // populated, with the row under `value` — so the row is what has to be
+  // judged. Unpopulated, `value` is still the bare id and fails the same test.
+  if ("relationTo" in value && "value" in value) {
+    return isExpandedRow((value as Record<string, unknown>).value);
+  }
+  return "id" in value;
 }
 
 /**

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -256,13 +256,18 @@ function isExpandedRow(value: unknown): boolean {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return false;
   }
+  // Tested before the wrapper shape, not after: a row carries an id and a
+  // wrapper never does, while a row from a collection that happens to define
+  // fields called `relationTo` and `value` looks exactly like one. Unwrapping
+  // such a row would judge one of its own field values instead of the row.
+  if ("id" in value) return true;
   // A reference that names its own collection keeps that shape when it is
   // populated, with the row under `value` — so the row is what has to be
   // judged. Unpopulated, `value` is still the bare id and fails the same test.
   if ("relationTo" in value && "value" in value) {
     return isExpandedRow((value as Record<string, unknown>).value);
   }
-  return "id" in value;
+  return false;
 }
 
 /**

--- a/packages/nextly/src/shared/lib/field-transform.ts
+++ b/packages/nextly/src/shared/lib/field-transform.ts
@@ -513,12 +513,17 @@ export function requiresTransformation(fieldType: string): boolean {
 }
 
 /**
- * Normalize relationship field values on write input.
+ * Normalize relationship field values on write input, at any nesting depth.
  *
  * A read at depth serves a relationship as the populated row, and a
- * multi-target one as `{ relationTo, value: row }`. Both come back on save,
- * and stored as they arrive they put a whole row snapshot in the column: later
- * reads then serve that stale copy instead of reloading the target.
+ * multi-target one as `{ relationTo, value: row }`. Both come back on save, and
+ * stored as they arrive they put a whole row snapshot in the column: later
+ * reads then serve that stale copy instead of reloading the target, so an edit
+ * to the target never appears.
+ *
+ * Groups and repeaters are walked rather than skipped. Their contents are
+ * serialized to JSON wholesale, so a reference left populated inside one is
+ * written as the row and never recognised as a reference again.
  *
  * Mutates `data` in place, reducing each value to the reference it stands for.
  */
@@ -527,25 +532,61 @@ export function normalizeRelationshipFields(
   fields: FieldConfig[]
 ): void {
   for (const field of fields) {
-    if (field.type !== "relationship") continue;
     if (!("name" in field) || !field.name) continue;
-    if (data[field.name] == null) continue;
+    const value = data[field.name];
+    if (value == null) continue;
 
-    const config = field as { relationTo?: unknown; hasMany?: boolean };
-    const isPolymorphic = Array.isArray(config.relationTo);
-    let normalized = normalizeRelationshipValue(
-      data[field.name],
-      isPolymorphic
-    );
-
-    // A single relationship holds one value; an array reaching it means the
-    // form sent a list for a field that stores one reference.
-    if (!config.hasMany && Array.isArray(normalized)) {
-      normalized = normalized.length > 0 ? normalized[0] : null;
+    if (field.type === "relationship") {
+      data[field.name] = normalizeRelationshipField(field, value);
+      continue;
     }
 
-    data[field.name] = normalized;
+    const nested = "fields" in field ? (field.fields as FieldConfig[]) : null;
+    if (!nested || nested.length === 0) continue;
+
+    if (field.type === "repeater") {
+      if (!Array.isArray(value)) continue;
+      for (const row of value) {
+        if (row && typeof row === "object" && !Array.isArray(row)) {
+          normalizeRelationshipFields(row as Record<string, unknown>, nested);
+        }
+      }
+    } else if (field.type === "group") {
+      if (typeof value === "object" && !Array.isArray(value)) {
+        normalizeRelationshipFields(value as Record<string, unknown>, nested);
+      }
+    }
   }
+}
+
+/**
+ * Reduce one relationship value to the reference it stands for.
+ *
+ * Reads the target list from either shape a field can carry it in: code-first
+ * fields declare `relationTo`, Builder-authored ones `options.target`.
+ */
+function normalizeRelationshipField(
+  field: FieldConfig,
+  value: unknown
+): unknown {
+  const config = field as {
+    relationTo?: unknown;
+    hasMany?: boolean;
+    options?: { target?: unknown; relationType?: string };
+  };
+  const isPolymorphic =
+    Array.isArray(config.relationTo) || Array.isArray(config.options?.target);
+  const hasMany =
+    config.hasMany === true || config.options?.relationType === "manyToMany";
+
+  const normalized = normalizeRelationshipValue(value, isPolymorphic);
+
+  // A single relationship holds one value; an array reaching it means the form
+  // sent a list for a field that stores one reference.
+  if (!hasMany && Array.isArray(normalized)) {
+    return normalized.length > 0 ? normalized[0] : null;
+  }
+  return normalized;
 }
 
 /**

--- a/packages/nextly/src/shared/lib/field-transform.ts
+++ b/packages/nextly/src/shared/lib/field-transform.ts
@@ -15,6 +15,7 @@ import type {
 import { normalizeRelationshipValue } from "../../domains/collections/services/collection-utils";
 import { NextlyError } from "../../errors";
 
+import { detachData } from "./detach";
 import {
   formatRichTextOutput,
   isRichTextValue,
@@ -557,6 +558,27 @@ export function normalizeRelationshipFields(
       }
     }
   }
+}
+
+/**
+ * The document a validator is shown.
+ *
+ * A relationship read at a populating depth comes back as the related row, and
+ * a multi-target one wrapped with the collection it names. A field's public
+ * value is the document id, and a custom validator is written against that —
+ * handed a row it compares an object to a string, or calls a string method on
+ * it and throws, rejecting a form the user did not otherwise change.
+ *
+ * Reduced on a detached copy rather than in place, because the submitted shape
+ * is what the hooks between validation and storage still expect to see.
+ */
+export function relationshipValidationView(
+  data: Record<string, unknown>,
+  fields: FieldConfig[]
+): Record<string, unknown> {
+  const view = detachData(data);
+  normalizeRelationshipFields(view, fields);
+  return view;
 }
 
 /**

--- a/packages/nextly/src/shared/lib/field-transform.ts
+++ b/packages/nextly/src/shared/lib/field-transform.ts
@@ -12,6 +12,7 @@ import type {
   FieldConfig,
   DataFieldConfig,
 } from "../../collections/fields/types";
+import { normalizeRelationshipValue } from "../../domains/collections/services/collection-utils";
 import { NextlyError } from "../../errors";
 
 import {
@@ -509,6 +510,42 @@ export function requiresTransformation(fieldType: string): boolean {
     fieldType === "upload" ||
     fieldType === "date"
   );
+}
+
+/**
+ * Normalize relationship field values on write input.
+ *
+ * A read at depth serves a relationship as the populated row, and a
+ * multi-target one as `{ relationTo, value: row }`. Both come back on save,
+ * and stored as they arrive they put a whole row snapshot in the column: later
+ * reads then serve that stale copy instead of reloading the target.
+ *
+ * Mutates `data` in place, reducing each value to the reference it stands for.
+ */
+export function normalizeRelationshipFields(
+  data: Record<string, unknown>,
+  fields: FieldConfig[]
+): void {
+  for (const field of fields) {
+    if (field.type !== "relationship") continue;
+    if (!("name" in field) || !field.name) continue;
+    if (data[field.name] == null) continue;
+
+    const config = field as { relationTo?: unknown; hasMany?: boolean };
+    const isPolymorphic = Array.isArray(config.relationTo);
+    let normalized = normalizeRelationshipValue(
+      data[field.name],
+      isPolymorphic
+    );
+
+    // A single relationship holds one value; an array reaching it means the
+    // form sent a list for a field that stores one reference.
+    if (!config.hasMany && Array.isArray(normalized)) {
+      normalized = normalized.length > 0 ? normalized[0] : null;
+    }
+
+    data[field.name] = normalized;
+  }
 }
 
 /**


### PR DESCRIPTION
## What

A relationship field declared with a list of targets (`relationship({ name: 'target', relationTo: ['posts', 'pages'] })`) never populated. It came back as its raw stored pair at every depth, on every read path, with nothing logged.

## Why it happened

Such a field stores `{ relationTo, value }` rather than a bare id, because the id alone does not say which table it belongs to. Expansion handled neither half of that shape:

1. It passed the **whole pair** to the row loader as if it were an id.
2. It resolved the target collection from the **field's first declared entry** instead of from the value.

The loader's query bound an object where the driver expected a string (`RangeError: Too few parameter values were provided`), threw, and the failure was swallowed by a catch that logs and returns null. So the symptom was silence.

The list path failed differently and just as quietly: it extracted the ids correctly but still fetched all of them from the first declared target, so any value pointing elsewhere resolved to nothing.

## What changed

- Values resolve to the collection each one names — single reads, listings, and nested hops.
- A populated row is redacted by **that** collection's own field rules, which is the point of the second bug: previously the wrong collection's rules would have been applied had the fetch ever succeeded.
- Batched lookups are keyed by collection **and** id, since an id is only unique within its collection.
- The stored pair is read whether the dialect returns it as an object or as JSON text. A bare id and a Postgres array literal both deliberately fall through to the single-target path.

## Tests

Five integration tests against a real database, since the failure only appears once a driver rejects the bound parameter:

- expands a value pointing at the first declared target
- **expands a value pointing at a later declared target** — the mirror. Resolving from the field's first entry satisfies the first case by accident; only a later target proves the collection is read from the value.
- expands values from several collections in one listing (the batch path, which resolves separately)
- judges a populated row by its own collection's field rules, **with the trusted-read mirror** so the redaction assertion cannot pass by the field simply being absent
- keeps the pair intact at `depth: 0`

Both halves of the fix were reverted independently and the matching tests confirmed to fail: reverting only the collection resolution fails the mirror and the listing while the first-target case still passes; reverting the stored-shape handling fails all three expansions.

## One behaviour change to flag

`custom-read-constraint.integration.test.ts` had a case pinning these references as *never populated*. That assertion described the swallowed failure, not intent. It now pins the populated row and still covers what it was written for — that the read is **not refused** over the shape the value arrives in. Verified the read still succeeds.

The authorization completeness check in `single-query-service.ts` continues to skip these fields, so this introduces no new refusal path. Whether it should stop skipping them belongs with the loader-strictness work, not here.

## Verification

- Integration: 840 passed, 0 failed.
- Unit: 400 failing before and after, **identical failing-test name sets** (`comm -13`), zero unique to this branch.
- `tsc --noEmit` and eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expansion of relationships that can reference multiple collection types.
  * Preserved collection identity during reads and writes, including nested and depth-limited requests.
  * Corrected batched relationship loading across different collection types.
  * Strengthened access checks when related records are missing, restricted, or use overlapping field names.
  * Improved handling of populated relationship values during data normalization.
  * Enhanced compatibility for relationship operations across supported database drivers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->