### PR TITLE
refactor(nextly): serve field groups under the fieldGroups namespace

### DIFF
--- a/.changeset/field-groups-direct-api.md
+++ b/.changeset/field-groups-direct-api.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+The Direct API namespace `nextly.components.*` is now `nextly.fieldGroups.*`, and the dashboard, plugin admin metadata, and plugin introspection responses report field groups under a `fieldGroups` key. Reading the old namespace now reports the rename instead of failing as an undefined property.

--- a/docs/api-reference/direct-api.mdx
+++ b/docs/api-reference/direct-api.mdx
@@ -551,7 +551,7 @@ The Direct API also exposes typed namespaces for users, media, forms, components
 | `nextly.users` | User records | `find`, `findOne`, `findByID`, `create`, `update`, `delete` |
 | `nextly.media` | Media library | `upload`, `find`, `findByID`, `update`, `delete`, `bulkDelete`, `folders.list`, `folders.create` |
 | `nextly.forms` | Form-builder forms | `find`, `findBySlug`, `submit`, `submissions` |
-| `nextly.components` | Reusable component definitions | `find`, `findBySlug`, `create`, `update`, `delete` |
+| `nextly.fieldGroups` | Reusable field group definitions | `find`, `findBySlug`, `create`, `update`, `delete` |
 | `nextly.emailProviders` | Provider CRUD | `find`, `findByID`, `create`, `update`, `delete`, `setDefault`, `test` |
 | `nextly.emailTemplates` | Template CRUD + preview + layout | `find`, `findByID`, `findBySlug`, `create`, `update`, `delete`, `preview`, `getLayout`, `updateLayout` |
 | `nextly.userFields` | Custom user field definitions | `find`, `findByID`, `create`, `update`, `delete`, `reorder` |

--- a/docs/api-reference/direct-api.mdx
+++ b/docs/api-reference/direct-api.mdx
@@ -544,7 +544,7 @@ await nextly.verifyEmail({ token: "verification-token" });
 
 ## Other namespaces
 
-The Direct API also exposes typed namespaces for users, media, forms, components, email providers + templates, RBAC, API keys, and access checks. They follow the same `find` / `findByID` / `create` / `update` / `delete` shape and use the canonical `ListResult<T>` and `MutationResult<T>` envelopes:
+The Direct API also exposes typed namespaces for users, media, forms, field groups, email providers + templates, RBAC, API keys, and access checks. They follow the same `find` / `findByID` / `create` / `update` / `delete` shape and use the canonical `ListResult<T>` and `MutationResult<T>` envelopes:
 
 | Namespace | Purpose | Key methods |
 |---|---|---|

--- a/packages/admin/src/components/features/dashboard/ProjectStatsGrid.tsx
+++ b/packages/admin/src/components/features/dashboard/ProjectStatsGrid.tsx
@@ -80,8 +80,8 @@ export const ProjectStatsGrid: React.FC = () => {
           href: ROUTES.BUILDER_COLLECTIONS,
         },
         {
-          title: "Plugins",
-          value: data.components,
+          title: "Field Groups",
+          value: data.fieldGroups,
           icon: <Puzzle className="h-5 w-5" />,
           href: ROUTES.BUILDER_COMPONENTS,
         },

--- a/packages/admin/src/pages/dashboard/plugins/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/plugins/[slug].tsx
@@ -272,10 +272,10 @@ function Contributions({ plugin }: { plugin: PluginMetadata }) {
       items: (plugin.singles ?? []).map(slug => ({ primary: slug })),
     },
     {
-      key: "components",
-      label: "Components",
+      key: "fieldGroups",
+      label: "Field Groups",
       icon: Package,
-      items: (plugin.components ?? []).map(slug => ({ primary: slug })),
+      items: (plugin.fieldGroups ?? []).map(slug => ({ primary: slug })),
     },
     {
       key: "menu",

--- a/packages/admin/src/types/branding.ts
+++ b/packages/admin/src/types/branding.ts
@@ -72,8 +72,8 @@ export interface PluginMetadata {
   collections: string[];
   /** Slugs of contributed singles, for the detail page's contributions view. */
   singles?: string[];
-  /** Slugs of contributed components, for the detail page's contributions view. */
-  components?: string[];
+  /** Slugs of contributed field groups, for the detail page's contributions view. */
+  fieldGroups?: string[];
   /** Declared custom permissions (identity + display fields only; enabled plugins). */
   permissions?: Array<{
     action: string;

--- a/packages/admin/src/types/dashboard/stats.ts
+++ b/packages/admin/src/types/dashboard/stats.ts
@@ -45,7 +45,7 @@ export interface DashboardStats {
   users: number;
   roles: number;
   permissions: number;
-  components: number;
+  fieldGroups: number;
   singles: number;
   apiKeys: number;
 }

--- a/packages/nextly/src/api/dashboard.test.ts
+++ b/packages/nextly/src/api/dashboard.test.ts
@@ -70,7 +70,7 @@ describe("getDashboardStats", () => {
       users: 1,
       roles: 2,
       permissions: 10,
-      components: 0,
+      fieldGroups: 0,
       singles: 0,
       apiKeys: 0,
     };
@@ -118,9 +118,7 @@ describe("getDashboardRecentEntries", () => {
 describe("getDashboardActivity", () => {
   it("emits respondData with cursor-shaped { activities, total, hasMore }", async () => {
     const result = {
-      activities: [
-        { id: "a1", action: "create", collection: "posts" },
-      ],
+      activities: [{ id: "a1", action: "create", collection: "posts" }],
       total: 1,
       hasMore: false,
     };

--- a/packages/nextly/src/api/field-groups-detail.ts
+++ b/packages/nextly/src/api/field-groups-detail.ts
@@ -133,7 +133,7 @@ export const PATCH = withErrorHandler(
       source: "ui",
     });
 
-    return respondMutation("Component updated.", updated);
+    return respondMutation("Field group updated.", updated);
   }
 );
 

--- a/packages/nextly/src/api/field-groups.ts
+++ b/packages/nextly/src/api/field-groups.ts
@@ -149,7 +149,7 @@ export const GET = withErrorHandler(async (request: Request) => {
  * - admin: Optional admin UI configuration (category, icon, hidden, description, imageURL)
  *
  * Response Codes:
- * - 201 Created: Component created successfully
+ * - 201 Created: Field group created successfully
  * - 400 Bad Request: Invalid input
  * - 401 Unauthorized: Authentication required
  * - 409 Conflict: Component with slug already exists
@@ -208,5 +208,5 @@ export const POST = withErrorHandler(async (request: Request) => {
     schemaHash,
   });
 
-  return respondMutation("Component created.", component, { status: 201 });
+  return respondMutation("Field group created.", component, { status: 201 });
 });

--- a/packages/nextly/src/cli/commands/plugins.test.ts
+++ b/packages/nextly/src/cli/commands/plugins.test.ts
@@ -13,7 +13,7 @@ function info(overrides: Partial<PluginInfo> = {}): PluginInfo {
     optionalDependsOn: [],
     collections: ["forms", "form-submissions"],
     singles: [],
-    components: [],
+    fieldGroups: [],
     permissions: ["export-submissions"],
     events: ["form-builder.submitted"],
     routeCount: 1,

--- a/packages/nextly/src/cli/commands/plugins.ts
+++ b/packages/nextly/src/cli/commands/plugins.ts
@@ -93,7 +93,7 @@ export function renderPluginInfo(
 
   list("collections", info.collections);
   list("singles", info.singles);
-  list("components", info.components);
+  list("field groups", info.fieldGroups);
   list("permissions", info.permissions);
   list("events", info.events);
 

--- a/packages/nextly/src/direct-api/__tests__/field-groups-table-name.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/field-groups-table-name.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createComponentsNamespace } from "../namespaces/components";
+import { createFieldGroupsNamespace } from "../namespaces/field-groups";
 
-// components.create() derives the physical table name through the canonical
+// fieldGroups.create() derives the physical table name through the canonical
 // resolver: the slug is normalized (dashes and other separators become
 // underscores) before the comp_ prefix. An unnormalized name here would
 // diverge from the table the schema layer actually creates.
-describe("components.create derives its table name", () => {
+describe("fieldGroups.create derives its table name", () => {
   function createCtx() {
     const registerComponent = vi.fn().mockResolvedValue({
       id: "comp-1",
@@ -26,8 +26,8 @@ describe("components.create derives its table name", () => {
 
   it("normalizes the slug into the derived table name", async () => {
     const { ctx, registerComponent } = createCtx();
-    const namespace = createComponentsNamespace(
-      ctx as unknown as Parameters<typeof createComponentsNamespace>[0]
+    const namespace = createFieldGroupsNamespace(
+      ctx as unknown as Parameters<typeof createFieldGroupsNamespace>[0]
     );
 
     await namespace.create({

--- a/packages/nextly/src/direct-api/__tests__/legacy-field-groups-namespace.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/legacy-field-groups-namespace.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../errors/nextly-error";
+import { Nextly, nextly } from "../nextly";
+
+// The namespace was renamed rather than aliased, so an untyped caller upgrading
+// from `nextly.components` must be told what to rename instead of hitting a
+// TypeError on an undefined property. Both entry points are covered because a
+// caller can reach field groups through either one.
+describe("the pre-rename field groups namespace", () => {
+  it("rejects instance access with the rename instruction", () => {
+    const instance = new Nextly();
+
+    expect(
+      () => (instance as unknown as { components: unknown }).components
+    ).toThrowError(NextlyError);
+    expect(
+      () => (instance as unknown as { components: unknown }).components
+    ).toThrowError(/'nextly\.components' is now 'nextly\.fieldGroups'/);
+  });
+
+  it("rejects facade access with the rename instruction", () => {
+    expect(
+      () => (nextly as unknown as { components: unknown }).components
+    ).toThrowError(/'nextly\.components' is now 'nextly\.fieldGroups'/);
+  });
+
+  it("serves field groups under the current name", () => {
+    const instance = new Nextly();
+
+    expect(typeof instance.fieldGroups.find).toBe("function");
+    expect(typeof nextly.fieldGroups.find).toBe("function");
+  });
+
+  // The accessor is non-enumerable so that merely copying either surface does
+  // not trigger it; a throwing enumerable property would break every spread.
+  it("stays invisible to enumeration and copying", () => {
+    const instance = new Nextly();
+
+    expect(Object.keys(nextly)).not.toContain("components");
+    expect(() => ({ ...nextly })).not.toThrow();
+    expect(() => ({ ...instance })).not.toThrow();
+    expect(() => JSON.stringify(nextly)).not.toThrow();
+  });
+});

--- a/packages/nextly/src/direct-api/__tests__/legacy-field-groups-namespace.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/legacy-field-groups-namespace.test.ts
@@ -19,6 +19,22 @@ describe("the pre-rename field groups namespace", () => {
     ).toThrowError(/'nextly\.components' is now 'nextly\.fieldGroups'/);
   });
 
+  // Built through the canonical factory, so the status comes from the shared
+  // code mapping rather than an inline number that could drift from it.
+  it("reports the canonical invalid-input code and status", () => {
+    const instance = new Nextly();
+    let caught: unknown;
+    try {
+      void (instance as unknown as { components: unknown }).components;
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(NextlyError);
+    expect((caught as NextlyError).code).toBe("INVALID_INPUT");
+    expect((caught as NextlyError).statusCode).toBe(400);
+  });
+
   it("rejects facade access with the rename instruction", () => {
     expect(
       () => (nextly as unknown as { components: unknown }).components

--- a/packages/nextly/src/direct-api/__tests__/legacy-field-groups-namespace.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/legacy-field-groups-namespace.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { NextlyError } from "../../errors/nextly-error";
+import { installLegacyFieldGroupsNamespaceGuard } from "../legacy-field-groups-namespace";
 import { Nextly, nextly } from "../nextly";
 
 // The namespace was renamed rather than aliased, so an untyped caller upgrading
@@ -46,6 +47,23 @@ describe("the pre-rename field groups namespace", () => {
 
     expect(typeof instance.fieldGroups.find).toBe("function");
     expect(typeof nextly.fieldGroups.find).toBe("function");
+  });
+
+  // `getNextly()` from `init.ts` returns a plain object literal rather than a
+  // `Nextly`, so it is guarded by direct installation instead of inheriting the
+  // prototype accessor. That target shape is exercised here: an own accessor on
+  // a plain object behaves differently under spread than a prototype one.
+  it("guards a plain object without making it uncopyable", () => {
+    const instance: Record<string, unknown> = { fieldGroups: { find() {} } };
+    installLegacyFieldGroupsNamespaceGuard(instance);
+
+    expect(() => instance.components).toThrowError(
+      /'nextly\.components' is now 'nextly\.fieldGroups'/
+    );
+    expect(Object.keys(instance)).not.toContain("components");
+    expect(() => ({ ...instance })).not.toThrow();
+    expect(() => JSON.stringify(instance)).not.toThrow();
+    expect(instance.fieldGroups).toBeDefined();
   });
 
   // The accessor is non-enumerable so that merely copying either surface does

--- a/packages/nextly/src/direct-api/legacy-field-groups-namespace.ts
+++ b/packages/nextly/src/direct-api/legacy-field-groups-namespace.ts
@@ -1,0 +1,47 @@
+/**
+ * Guard against Direct API callers still reaching for the pre-rename namespace.
+ *
+ * `nextly.components` became `nextly.fieldGroups`, and the old name was renamed
+ * rather than aliased. TypeScript catches the old spelling in typed callers, but
+ * the Direct API is also reached from `.js`/`.mjs` app code, from plugins
+ * compiled against an older version, and through dynamic property access that
+ * the compiler never sees. On those paths the property would simply read as
+ * `undefined`, so the first call would surface as
+ * `TypeError: Cannot read properties of undefined (reading 'find')` — a message
+ * that names neither the namespace nor the rename.
+ *
+ * Installing a throwing accessor keeps the failure loud, which is the same
+ * choice the config surface made, while replacing that TypeError with the one
+ * instruction a caller needs.
+ *
+ * @module direct-api/legacy-field-groups-namespace
+ */
+
+import { NextlyError } from "../errors/nextly-error";
+
+/**
+ * Install a `components` accessor that rejects the pre-rename namespace.
+ *
+ * Defined as non-enumerable so it stays invisible to spreads, `Object.keys`,
+ * and `JSON.stringify` — reading it through any of those would otherwise throw
+ * on objects that merely get copied.
+ *
+ * @param target - The Direct API surface to guard (a `Nextly` prototype or the
+ *   `nextly` facade object).
+ */
+export function installLegacyFieldGroupsNamespaceGuard(target: object): void {
+  Object.defineProperty(target, "components", {
+    get(): never {
+      throw new NextlyError({
+        code: "INVALID_INPUT",
+        publicMessage:
+          "'nextly.components' is now 'nextly.fieldGroups'. Rename the call: " +
+          "the old namespace is no longer served.",
+        statusCode: 400,
+        logContext: { reason: "legacy-field-groups-namespace" },
+      });
+    },
+    enumerable: false,
+    configurable: true,
+  });
+}

--- a/packages/nextly/src/direct-api/legacy-field-groups-namespace.ts
+++ b/packages/nextly/src/direct-api/legacy-field-groups-namespace.ts
@@ -32,12 +32,10 @@ import { NextlyError } from "../errors/nextly-error";
 export function installLegacyFieldGroupsNamespaceGuard(target: object): void {
   Object.defineProperty(target, "components", {
     get(): never {
-      throw new NextlyError({
-        code: "INVALID_INPUT",
-        publicMessage:
+      throw NextlyError.invalidInput({
+        message:
           "'nextly.components' is now 'nextly.fieldGroups'. Rename the call: " +
           "the old namespace is no longer served.",
-        statusCode: 400,
         logContext: { reason: "legacy-field-groups-namespace" },
       });
     },

--- a/packages/nextly/src/direct-api/namespaces/field-groups.ts
+++ b/packages/nextly/src/direct-api/namespaces/field-groups.ts
@@ -1,8 +1,8 @@
 /**
- * Direct API Components Namespace
+ * Direct API Field Groups Namespace
  *
- * Factory for the `nextly.components.*` sub-namespace. Manages component
- * *definitions* (metadata + field schemas). Component *instance* data is
+ * Factory for the `nextly.fieldGroups.*` sub-namespace. Manages field group
+ * *definitions* (metadata + field schemas). Field group *instance* data is
  * automatically populated when reading collection/single entries.
  *
  * @packageDocumentation
@@ -13,48 +13,48 @@ import { assertValidFieldGroupConfig } from "../../components/config/validate-fi
 import { resolveComponentTableName } from "../../domains/schema/utils/resolve-table-name";
 import { NextlyError } from "../../errors/nextly-error";
 import type {
-  ComponentDefinition,
-  CreateComponentArgs,
-  DeleteComponentArgs,
-  FindComponentBySlugArgs,
-  FindComponentsArgs,
+  FieldGroupDefinition,
+  CreateFieldGroupArgs,
+  DeleteFieldGroupArgs,
+  FindFieldGroupBySlugArgs,
+  FindFieldGroupsArgs,
   ListResult,
   MutationResult,
-  UpdateComponentArgs,
+  UpdateFieldGroupArgs,
 } from "../types/index";
 
 import type { NextlyContext } from "./context";
-import { isNotFoundError, mapComponentRecord, mergeConfig } from "./helpers";
+import { isNotFoundError, mapFieldGroupRecord, mergeConfig } from "./helpers";
 
 /**
- * Components namespace API, bound to a Nextly context.
+ * Field groups namespace API, bound to a Nextly context.
  *
  * (`ListResult<T>`, `MutationResult<T>`).
  */
-export interface ComponentsNamespace {
-  find(args?: FindComponentsArgs): Promise<ListResult<ComponentDefinition>>;
+export interface FieldGroupsNamespace {
+  find(args?: FindFieldGroupsArgs): Promise<ListResult<FieldGroupDefinition>>;
   findBySlug(
-    args: FindComponentBySlugArgs
-  ): Promise<ComponentDefinition | null>;
+    args: FindFieldGroupBySlugArgs
+  ): Promise<FieldGroupDefinition | null>;
   create(
-    args: CreateComponentArgs
-  ): Promise<MutationResult<ComponentDefinition>>;
+    args: CreateFieldGroupArgs
+  ): Promise<MutationResult<FieldGroupDefinition>>;
   update(
-    args: UpdateComponentArgs
-  ): Promise<MutationResult<ComponentDefinition>>;
-  delete(args: DeleteComponentArgs): Promise<MutationResult<{ slug: string }>>;
+    args: UpdateFieldGroupArgs
+  ): Promise<MutationResult<FieldGroupDefinition>>;
+  delete(args: DeleteFieldGroupArgs): Promise<MutationResult<{ slug: string }>>;
 }
 
 /**
- * Build the `components` namespace for a `Nextly` instance.
+ * Build the `fieldGroups` namespace for a `Nextly` instance.
  */
-export function createComponentsNamespace(
+export function createFieldGroupsNamespace(
   ctx: NextlyContext
-): ComponentsNamespace {
+): FieldGroupsNamespace {
   return {
     async find(
-      args: FindComponentsArgs = {}
-    ): Promise<ListResult<ComponentDefinition>> {
+      args: FindFieldGroupsArgs = {}
+    ): Promise<ListResult<FieldGroupDefinition>> {
       const result = await ctx.componentRegistryService.listComponents({
         source: args.source,
         migrationStatus: args.migrationStatus,
@@ -74,7 +74,7 @@ export function createComponentsNamespace(
       const totalPages = Math.max(1, Math.ceil(total / effectiveLimit));
       const page = Math.floor(offset / effectiveLimit) + 1;
       return {
-        items: result.data.map(mapComponentRecord),
+        items: result.data.map(mapFieldGroupRecord),
         meta: {
           total,
           page,
@@ -87,14 +87,14 @@ export function createComponentsNamespace(
     },
 
     async findBySlug(
-      args: FindComponentBySlugArgs
-    ): Promise<ComponentDefinition | null> {
+      args: FindFieldGroupBySlugArgs
+    ): Promise<FieldGroupDefinition | null> {
       const config = mergeConfig(ctx.defaultConfig, args);
 
       if (!args.slug) {
         throw new NextlyError({
           code: "INVALID_INPUT",
-          publicMessage: "'slug' is required for components.findBySlug()",
+          publicMessage: "'slug' is required for fieldGroups.findBySlug()",
           statusCode: 400,
         });
       }
@@ -113,7 +113,7 @@ export function createComponentsNamespace(
           });
         }
 
-        return mapComponentRecord(component);
+        return mapFieldGroupRecord(component);
       } catch (error) {
         if (error instanceof NextlyError) {
           throw error;
@@ -126,12 +126,12 @@ export function createComponentsNamespace(
     },
 
     async create(
-      args: CreateComponentArgs
-    ): Promise<MutationResult<ComponentDefinition>> {
+      args: CreateFieldGroupArgs
+    ): Promise<MutationResult<FieldGroupDefinition>> {
       if (!args.slug) {
         throw new NextlyError({
           code: "INVALID_INPUT",
-          publicMessage: "'slug' is required for components.create()",
+          publicMessage: "'slug' is required for fieldGroups.create()",
           statusCode: 400,
         });
       }
@@ -139,7 +139,7 @@ export function createComponentsNamespace(
       if (!args.label) {
         throw new NextlyError({
           code: "INVALID_INPUT",
-          publicMessage: "'label' is required for components.create()",
+          publicMessage: "'label' is required for fieldGroups.create()",
           statusCode: 400,
         });
       }
@@ -147,7 +147,7 @@ export function createComponentsNamespace(
       if (!args.fields || !Array.isArray(args.fields)) {
         throw new NextlyError({
           code: "INVALID_INPUT",
-          publicMessage: "'fields' array is required for components.create()",
+          publicMessage: "'fields' array is required for fieldGroups.create()",
           statusCode: 400,
         });
       }
@@ -189,18 +189,18 @@ export function createComponentsNamespace(
       });
 
       return {
-        message: "Component created.",
-        item: mapComponentRecord(component),
+        message: "Field group created.",
+        item: mapFieldGroupRecord(component),
       };
     },
 
     async update(
-      args: UpdateComponentArgs
-    ): Promise<MutationResult<ComponentDefinition>> {
+      args: UpdateFieldGroupArgs
+    ): Promise<MutationResult<FieldGroupDefinition>> {
       if (!args.slug) {
         throw new NextlyError({
           code: "INVALID_INPUT",
-          publicMessage: "'slug' is required for components.update()",
+          publicMessage: "'slug' is required for fieldGroups.update()",
           statusCode: 400,
         });
       }
@@ -208,7 +208,7 @@ export function createComponentsNamespace(
       if (!args.data || typeof args.data !== "object") {
         throw new NextlyError({
           code: "INVALID_INPUT",
-          publicMessage: "'data' object is required for components.update()",
+          publicMessage: "'data' object is required for fieldGroups.update()",
           statusCode: 400,
         });
       }
@@ -243,18 +243,18 @@ export function createComponentsNamespace(
       );
 
       return {
-        message: "Component updated.",
-        item: mapComponentRecord(component),
+        message: "Field group updated.",
+        item: mapFieldGroupRecord(component),
       };
     },
 
     async delete(
-      args: DeleteComponentArgs
+      args: DeleteFieldGroupArgs
     ): Promise<MutationResult<{ slug: string }>> {
       if (!args.slug) {
         throw new NextlyError({
           code: "INVALID_INPUT",
-          publicMessage: "'slug' is required for components.delete()",
+          publicMessage: "'slug' is required for fieldGroups.delete()",
           statusCode: 400,
         });
       }
@@ -263,7 +263,7 @@ export function createComponentsNamespace(
       // the deleted slug rather than `id` because components are addressed
       // by slug throughout this namespace.
       return {
-        message: "Component deleted.",
+        message: "Field group deleted.",
         item: { slug: args.slug },
       };
     },

--- a/packages/nextly/src/direct-api/namespaces/helpers.ts
+++ b/packages/nextly/src/direct-api/namespaces/helpers.ts
@@ -12,8 +12,8 @@
 import { NextlyError } from "../../errors/nextly-error";
 import type { RequestContext } from "../../shared/types/index";
 import type {
-  ComponentDefinition,
   DirectAPIConfig,
+  FieldGroupDefinition,
   ListResult,
   Permission,
   Role,
@@ -269,9 +269,9 @@ export function mapPermission(perm: RawPermissionRecord): Permission {
 }
 
 /**
- * Shape of a raw component record as returned by the component registry service.
+ * Shape of a raw field group record as returned by the registry service.
  */
-export interface RawComponentRecord {
+export interface RawFieldGroupRecord {
   id: string;
   slug: string;
   label: string;
@@ -292,11 +292,11 @@ export interface RawComponentRecord {
 }
 
 /**
- * Normalize a raw component record into the public `ComponentDefinition` type.
+ * Normalize a raw field group record into the public `FieldGroupDefinition` type.
  */
-export function mapComponentRecord(
-  record: RawComponentRecord
-): ComponentDefinition {
+export function mapFieldGroupRecord(
+  record: RawFieldGroupRecord
+): FieldGroupDefinition {
   return {
     id: record.id,
     slug: record.slug,
@@ -307,14 +307,14 @@ export function mapComponentRecord(
       string,
       unknown
     >[],
-    admin: record.admin as ComponentDefinition["admin"],
+    admin: record.admin as FieldGroupDefinition["admin"],
     source: record.source as "code" | "ui",
     locked: record.locked,
     configPath: record.configPath ?? undefined,
     schemaHash: record.schemaHash,
     schemaVersion: record.schemaVersion,
     migrationStatus:
-      record.migrationStatus as ComponentDefinition["migrationStatus"],
+      record.migrationStatus as FieldGroupDefinition["migrationStatus"],
     lastMigrationId: record.lastMigrationId ?? undefined,
     createdBy: record.createdBy ?? undefined,
     createdAt: record.createdAt,

--- a/packages/nextly/src/direct-api/namespaces/index.ts
+++ b/packages/nextly/src/direct-api/namespaces/index.ts
@@ -21,9 +21,9 @@ export {
 } from "./media";
 export { createFormsNamespace, type FormsNamespace } from "./forms";
 export {
-  createComponentsNamespace,
-  type ComponentsNamespace,
-} from "./components";
+  createFieldGroupsNamespace,
+  type FieldGroupsNamespace,
+} from "./field-groups";
 export {
   createEmailNamespace,
   createEmailProvidersNamespace,

--- a/packages/nextly/src/direct-api/nextly.ts
+++ b/packages/nextly/src/direct-api/nextly.ts
@@ -72,13 +72,14 @@ import { UserAccountService } from "../services/users/user-account-service";
 import type { UserFieldDefinitionService } from "../services/users/user-field-definition-service";
 import type { UserService } from "../services/users/user-service";
 
+import { installLegacyFieldGroupsNamespaceGuard } from "./legacy-field-groups-namespace";
 import * as authNs from "./namespaces/auth";
 import * as collectionsNs from "./namespaces/collections";
 import type { NextlyContext } from "./namespaces/context";
 import {
   createAccessNamespace,
   createApiKeysNamespace,
-  createComponentsNamespace,
+  createFieldGroupsNamespace,
   createEmailNamespace,
   createEmailProvidersNamespace,
   createEmailTemplatesNamespace,
@@ -90,7 +91,7 @@ import {
   createUsersNamespace,
   type AccessNamespace,
   type ApiKeysNamespace,
-  type ComponentsNamespace,
+  type FieldGroupsNamespace,
   type EmailNamespace,
   type EmailProvidersNamespace,
   type EmailTemplatesNamespace,
@@ -137,7 +138,7 @@ import type {
   CheckAccessArgs,
   CheckApiKeyArgs,
   CreateApiKeyArgs,
-  CreateComponentArgs,
+  CreateFieldGroupArgs,
   CreateEmailProviderArgs,
   CreateEmailTemplateArgs,
   CreateFolderArgs,
@@ -145,7 +146,7 @@ import type {
   CreateRoleArgs,
   CreateUserArgs,
   CreateUserFieldArgs,
-  DeleteComponentArgs,
+  DeleteFieldGroupArgs,
   DeleteEmailProviderArgs,
   DeleteEmailTemplateArgs,
   DeleteMediaArgs,
@@ -154,8 +155,8 @@ import type {
   DeleteUserArgs,
   DeleteUserFieldArgs,
   FindApiKeyByIDArgs,
-  FindComponentBySlugArgs,
-  FindComponentsArgs,
+  FindFieldGroupBySlugArgs,
+  FindFieldGroupsArgs,
   FindEmailProviderByIDArgs,
   FindEmailProvidersArgs,
   FindEmailTemplateByIDArgs,
@@ -189,7 +190,7 @@ import type {
   SubmitFormArgs,
   TestEmailProviderArgs,
   UpdateApiKeyArgs,
-  UpdateComponentArgs,
+  UpdateFieldGroupArgs,
   UpdateEmailProviderArgs,
   UpdateEmailTemplateArgs,
   UpdateMediaArgs,
@@ -238,7 +239,7 @@ export class Nextly implements NextlyContext {
   public readonly users: UsersNamespace;
   public readonly media: MediaNamespace;
   public readonly forms: FormsNamespace;
-  public readonly components: ComponentsNamespace;
+  public readonly fieldGroups: FieldGroupsNamespace;
   public readonly email: EmailNamespace;
   public readonly emailProviders: EmailProvidersNamespace;
   public readonly emailTemplates: EmailTemplatesNamespace;
@@ -262,7 +263,7 @@ export class Nextly implements NextlyContext {
     this.users = createUsersNamespace(this);
     this.media = createMediaNamespace(this);
     this.forms = createFormsNamespace(this);
-    this.components = createComponentsNamespace(this);
+    this.fieldGroups = createFieldGroupsNamespace(this);
     this.email = createEmailNamespace(this);
     this.emailProviders = createEmailProvidersNamespace(this);
     this.emailTemplates = createEmailTemplatesNamespace(this);
@@ -774,13 +775,16 @@ export const nextly = {
       getNextly().forms.submissions(args),
   },
 
-  components: {
-    find: (args?: FindComponentsArgs) => getNextly().components.find(args),
-    findBySlug: (args: FindComponentBySlugArgs) =>
-      getNextly().components.findBySlug(args),
-    create: (args: CreateComponentArgs) => getNextly().components.create(args),
-    update: (args: UpdateComponentArgs) => getNextly().components.update(args),
-    delete: (args: DeleteComponentArgs) => getNextly().components.delete(args),
+  fieldGroups: {
+    find: (args?: FindFieldGroupsArgs) => getNextly().fieldGroups.find(args),
+    findBySlug: (args: FindFieldGroupBySlugArgs) =>
+      getNextly().fieldGroups.findBySlug(args),
+    create: (args: CreateFieldGroupArgs) =>
+      getNextly().fieldGroups.create(args),
+    update: (args: UpdateFieldGroupArgs) =>
+      getNextly().fieldGroups.update(args),
+    delete: (args: DeleteFieldGroupArgs) =>
+      getNextly().fieldGroups.delete(args),
   },
 
   email: {
@@ -870,3 +874,9 @@ export const nextly = {
       getNextly().access.checkApiKey(args),
   },
 };
+
+// Both Direct API entry points answer for the pre-rename namespace: callers
+// reach field groups either through an instance or through the `nextly` facade,
+// and an untyped caller upgrading from `components` can arrive at either one.
+installLegacyFieldGroupsNamespaceGuard(Nextly.prototype);
+installLegacyFieldGroupsNamespaceGuard(nextly);

--- a/packages/nextly/src/direct-api/types/field-group-slug.test-d.ts
+++ b/packages/nextly/src/direct-api/types/field-group-slug.test-d.ts
@@ -3,7 +3,7 @@ import type {
   DataFromFieldGroupSlugFrom,
   FieldGroupSlug,
   FieldGroupSlugFrom,
-} from "./components";
+} from "./field-groups";
 
 // Compile-time half of the generated-Config contract. These assertions live in
 // a `.test-d.ts` rather than a `.test.ts` because tsconfig excludes the latter:

--- a/packages/nextly/src/direct-api/types/field-groups-public-surface.test-d.ts
+++ b/packages/nextly/src/direct-api/types/field-groups-public-surface.test-d.ts
@@ -1,0 +1,48 @@
+// Imported from the package root on purpose: these are the argument and result
+// types of a public namespace, so a caller must be able to name them without
+// reaching into an internal path. Importing them from "../types/index" instead
+// would still compile while the root export was missing, asserting nothing.
+import type {
+  CreateFieldGroupArgs,
+  DeleteFieldGroupArgs,
+  FieldGroupDefinition,
+  FindFieldGroupBySlugArgs,
+  FindFieldGroupsArgs,
+  UpdateFieldGroupArgs,
+} from "../../index";
+import type { Nextly as InitNextly } from "../../init/nextly-instance";
+
+// Compile-time contract for the public field-group surface. These assertions
+// live in a `.test-d.ts` rather than a `.test.ts` because tsconfig excludes the
+// latter: type-level assertions placed in a normal test file are transpiled away
+// by the runner and checked by nothing.
+
+/** `Exact<A, B>` is `false` when the two types differ in either direction. */
+type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+declare function assertType<T extends true>(proof: T): void;
+
+// Each root export must resolve to a real object type. A missing re-export
+// makes the import above an error; `any` would make these assertions pass
+// vacuously, so each is pinned to a known member instead.
+assertType<Exact<FieldGroupDefinition["slug"], string>>(true);
+assertType<Exact<FindFieldGroupBySlugArgs["slug"], string>>(true);
+assertType<Exact<CreateFieldGroupArgs["slug"], string>>(true);
+assertType<Exact<UpdateFieldGroupArgs["slug"], string>>(true);
+assertType<Exact<DeleteFieldGroupArgs["slug"], string>>(true);
+assertType<Exact<FindFieldGroupsArgs["search"], string | undefined>>(true);
+
+// The instance returned by the async `getNextly()` must expose the namespace
+// too. It is a separately declared surface from the `Nextly` class, so the
+// namespace being reachable on one says nothing about the other.
+type InitFieldGroups = InitNextly["fieldGroups"];
+
+assertType<
+  Exact<
+    Awaited<ReturnType<InitFieldGroups["findBySlug"]>>,
+    FieldGroupDefinition | null
+  >
+>(true);
+assertType<
+  Exact<Parameters<InitFieldGroups["create"]>[0], CreateFieldGroupArgs>
+>(true);

--- a/packages/nextly/src/direct-api/types/field-groups.ts
+++ b/packages/nextly/src/direct-api/types/field-groups.ts
@@ -286,23 +286,3 @@ export interface DeleteFieldGroupArgs extends DirectAPIConfig {
   /** Field group slug (required) */
   slug: string;
 }
-
-/**
- * Result of listing field group definitions.
- *
- * `ListResult<FieldGroupDefinition>` (`{ items, meta }`). This legacy
- * shape is retained only for transitional consumer code and is removed
- */
-export interface FieldGroupListResult {
-  /** Field group definitions */
-  docs: FieldGroupDefinition[];
-
-  /** Total count of matching field groups */
-  totalDocs: number;
-
-  /** Number of results returned */
-  limit: number;
-
-  /** Number of results skipped */
-  offset: number;
-}

--- a/packages/nextly/src/direct-api/types/field-groups.ts
+++ b/packages/nextly/src/direct-api/types/field-groups.ts
@@ -1,8 +1,8 @@
 /**
- * Direct API Components Type Definitions
+ * Direct API Field Groups Type Definitions
  *
- * Type-safe component slug resolution and argument types for the
- * `nextly.components.*` namespace.
+ * Type-safe field group slug resolution and argument types for the
+ * `nextly.fieldGroups.*` namespace.
  *
  * @packageDocumentation
  */
@@ -52,17 +52,17 @@ export type DataFromFieldGroupSlug<TSlug extends string> =
   DataFromFieldGroupSlugFrom<GeneratedTypes, TSlug>;
 
 /**
- * Component definition data returned by the Direct API.
+ * Field group definition data returned by the Direct API.
  *
- * This is the metadata about a component definition, not the instance data.
+ * This is the metadata about a field group definition, not the instance data.
  * Instance data is automatically populated when reading collection/single entries
- * that have component fields.
+ * that have field group fields.
  */
-export interface ComponentDefinition {
+export interface FieldGroupDefinition {
   /** Unique identifier */
   id: string;
 
-  /** Component slug */
+  /** Field group slug */
   slug: string;
 
   /** Display label */
@@ -79,7 +79,7 @@ export interface ComponentDefinition {
 
   /** Admin UI configuration */
   admin?: {
-    /** Category for organizing components */
+    /** Category for organizing field groups */
     category?: string;
     /** Icon identifier */
     icon?: string;
@@ -91,10 +91,10 @@ export interface ComponentDefinition {
     imageURL?: string;
   };
 
-  /** Source of the component definition */
+  /** Source of the field group definition */
   source: "code" | "ui";
 
-  /** Whether the component is locked (code-first components are locked) */
+  /** Whether the field group is locked (code-first field groups are locked) */
   locked: boolean;
 
   /** Path to config file (code-first only) */
@@ -112,7 +112,7 @@ export interface ComponentDefinition {
   /** Last applied migration ID */
   lastMigrationId?: string;
 
-  /** ID of user who created this component */
+  /** ID of user who created this field group */
   createdBy?: string;
 
   /** Creation timestamp */
@@ -123,29 +123,29 @@ export interface ComponentDefinition {
 }
 
 /**
- * Arguments for finding component definitions.
+ * Arguments for finding field group definitions.
  *
  * @example
  * ```typescript
- * // List all components
- * const components = await nextly.components.find();
+ * // List all field groups
+ * const fieldGroups = await nextly.fieldGroups.find();
  *
  * // List with filters
- * const uiComponents = await nextly.components.find({
+ * const uiFieldGroups = await nextly.fieldGroups.find({
  *   source: 'ui',
  *   search: 'hero',
  *   limit: 10,
  * });
  * ```
  */
-export interface FindComponentsArgs extends DirectAPIConfig {
+export interface FindFieldGroupsArgs extends DirectAPIConfig {
   /** Filter by source type */
   source?: "code" | "ui";
 
   /** Filter by migration status */
   migrationStatus?: "synced" | "pending" | "generated" | "applied" | "failed";
 
-  /** Include only locked or unlocked components */
+  /** Include only locked or unlocked field groups */
   locked?: boolean;
 
   /** Search query for filtering by slug or label */
@@ -159,31 +159,31 @@ export interface FindComponentsArgs extends DirectAPIConfig {
 }
 
 /**
- * Arguments for finding a component definition by slug.
+ * Arguments for finding a field group definition by slug.
  *
  * @example
  * ```typescript
- * const component = await nextly.components.findBySlug({ slug: 'seo' });
- * if (component) {
- *   console.log('Fields:', component.fields);
+ * const fieldGroup = await nextly.fieldGroups.findBySlug({ slug: 'seo' });
+ * if (fieldGroup) {
+ *   console.log('Fields:', fieldGroup.fields);
  * }
  * ```
  */
-export interface FindComponentBySlugArgs extends DirectAPIConfig {
-  /** Component slug (required) */
+export interface FindFieldGroupBySlugArgs extends DirectAPIConfig {
+  /** Field group slug (required) */
   slug: string;
 }
 
 /**
- * Arguments for creating a component definition.
+ * Arguments for creating a field group definition.
  *
- * Only UI-created components can be created via the Direct API.
- * Code-first components are synced automatically (HMR listener or
+ * Only UI-created field groups can be created via the Direct API.
+ * Code-first field groups are synced automatically (HMR listener or
  * `nextly db:sync`).
  *
  * @example
  * ```typescript
- * const component = await nextly.components.create({
+ * const fieldGroup = await nextly.fieldGroups.create({
  *   slug: 'testimonial',
  *   label: 'Testimonial',
  *   fields: [
@@ -198,8 +198,8 @@ export interface FindComponentBySlugArgs extends DirectAPIConfig {
  * });
  * ```
  */
-export interface CreateComponentArgs extends DirectAPIConfig {
-  /** Component slug (required) */
+export interface CreateFieldGroupArgs extends DirectAPIConfig {
+  /** Field group slug (required) */
   slug: string;
 
   /** Display label (required) */
@@ -213,7 +213,7 @@ export interface CreateComponentArgs extends DirectAPIConfig {
 
   /** Admin UI configuration */
   admin?: {
-    /** Category for organizing components */
+    /** Category for organizing field groups */
     category?: string;
     /** Icon identifier */
     icon?: string;
@@ -227,13 +227,13 @@ export interface CreateComponentArgs extends DirectAPIConfig {
 }
 
 /**
- * Arguments for updating a component definition.
+ * Arguments for updating a field group definition.
  *
- * Code-first (locked) components cannot be updated via the Direct API.
+ * Code-first (locked) field groups cannot be updated via the Direct API.
  *
  * @example
  * ```typescript
- * const updated = await nextly.components.update({
+ * const updated = await nextly.fieldGroups.update({
  *   slug: 'testimonial',
  *   data: {
  *     label: 'Customer Testimonial',
@@ -242,8 +242,8 @@ export interface CreateComponentArgs extends DirectAPIConfig {
  * });
  * ```
  */
-export interface UpdateComponentArgs extends DirectAPIConfig {
-  /** Component slug (required) */
+export interface UpdateFieldGroupArgs extends DirectAPIConfig {
+  /** Field group slug (required) */
   slug: string;
 
   /** Update data */
@@ -269,35 +269,35 @@ export interface UpdateComponentArgs extends DirectAPIConfig {
 }
 
 /**
- * Arguments for deleting a component definition.
+ * Arguments for deleting a field group definition.
  *
  * Deletion will fail if:
- * - The component is locked (code-first)
- * - Any collection, single, or other component references this component
+ * - The field group is locked (code-first)
+ * - Any collection, single, or other field group references this field group
  *
  * @example
  * ```typescript
- * const result = await nextly.components.delete({ slug: 'testimonial' });
- * console.log(result.message);    // e.g. "Component deleted successfully"
+ * const result = await nextly.fieldGroups.delete({ slug: 'testimonial' });
+ * console.log(result.message);    // e.g. "Field group deleted."
  * console.log(result.item.slug);  // "testimonial"
  * ```
  */
-export interface DeleteComponentArgs extends DirectAPIConfig {
-  /** Component slug (required) */
+export interface DeleteFieldGroupArgs extends DirectAPIConfig {
+  /** Field group slug (required) */
   slug: string;
 }
 
 /**
- * Result of listing component definitions.
+ * Result of listing field group definitions.
  *
- * `ListResult<ComponentDefinition>` (`{ items, meta }`). This legacy
+ * `ListResult<FieldGroupDefinition>` (`{ items, meta }`). This legacy
  * shape is retained only for transitional consumer code and is removed
  */
-export interface ComponentListResult {
-  /** Component definitions */
-  docs: ComponentDefinition[];
+export interface FieldGroupListResult {
+  /** Field group definitions */
+  docs: FieldGroupDefinition[];
 
-  /** Total count of matching components */
+  /** Total count of matching field groups */
   totalDocs: number;
 
   /** Number of results returned */

--- a/packages/nextly/src/direct-api/types/index.ts
+++ b/packages/nextly/src/direct-api/types/index.ts
@@ -111,7 +111,6 @@ export type {
   CreateFieldGroupArgs,
   UpdateFieldGroupArgs,
   DeleteFieldGroupArgs,
-  FieldGroupListResult,
 } from "./field-groups";
 
 export type {

--- a/packages/nextly/src/direct-api/types/index.ts
+++ b/packages/nextly/src/direct-api/types/index.ts
@@ -102,18 +102,17 @@ export type {
 export type {
   // Slug and data types resolve against the `Config.fieldGroups` map that
   // `TypeGenerator` emits, so callers narrow to the same field-group slugs the
-  // generated file declares. The remaining names below still carry the older
-  // vocabulary and move with the Direct API namespace.
+  // generated file declares.
   FieldGroupSlug,
   DataFromFieldGroupSlug,
-  ComponentDefinition,
-  FindComponentsArgs,
-  FindComponentBySlugArgs,
-  CreateComponentArgs,
-  UpdateComponentArgs,
-  DeleteComponentArgs,
-  ComponentListResult,
-} from "./components";
+  FieldGroupDefinition,
+  FindFieldGroupsArgs,
+  FindFieldGroupBySlugArgs,
+  CreateFieldGroupArgs,
+  UpdateFieldGroupArgs,
+  DeleteFieldGroupArgs,
+  FieldGroupListResult,
+} from "./field-groups";
 
 export type {
   FindEmailProvidersArgs,

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -138,6 +138,18 @@ export type {
   DataFromFieldGroupSlug,
 } from "./direct-api/types";
 
+// Direct API types - the `nextly.fieldGroups.*` namespace. Exported from the
+// root because they are the argument and result types of a public namespace:
+// without them a caller cannot annotate a variable holding what it returns.
+export type {
+  FieldGroupDefinition,
+  FindFieldGroupsArgs,
+  FindFieldGroupBySlugArgs,
+  CreateFieldGroupArgs,
+  UpdateFieldGroupArgs,
+  DeleteFieldGroupArgs,
+} from "./direct-api/types";
+
 // Direct API types - core operation argument types
 export type {
   DirectAPIConfig,

--- a/packages/nextly/src/init.ts
+++ b/packages/nextly/src/init.ts
@@ -41,6 +41,7 @@ import {
   registerServices,
   shutdownServices,
 } from "./di/register";
+import { installLegacyFieldGroupsNamespaceGuard } from "./direct-api/legacy-field-groups-namespace";
 import { getNextly as getDirectAPI } from "./direct-api/nextly";
 import { resolveCollectionTableName } from "./domains/schema/utils/resolve-table-name";
 import { NextlyError } from "./errors/nextly-error";
@@ -346,6 +347,12 @@ export async function getNextly(options: GetNextlyOptions): Promise<Nextly> {
         },
       };
 
+      // This instance is a plain object rather than a `Nextly`, so it does not
+      // inherit the class guard: without this, reaching for the pre-rename
+      // namespace here would produce the bare TypeError the guard exists to
+      // replace, on the very entry point the docs recommend.
+      installLegacyFieldGroupsNamespaceGuard(instance);
+
       globalForInit.__nextly_cachedInstance = instance;
 
       // F1 PR 2: open the HMR WebSocket lazily after first init succeeds.
@@ -447,6 +454,7 @@ export async function getCachedNextly(): Promise<Nextly> {
         globalForInit.__nextly_cachedInstance = null;
       },
     };
+    installLegacyFieldGroupsNamespaceGuard(instance);
     globalForInit.__nextly_cachedInstance = instance;
     return instance;
   }

--- a/packages/nextly/src/init.ts
+++ b/packages/nextly/src/init.ts
@@ -314,6 +314,9 @@ export async function getNextly(options: GetNextlyOptions): Promise<Nextly> {
         // Forms API namespace (Direct API style)
         forms: directAPI.forms,
 
+        // Field groups namespace (Direct API style)
+        fieldGroups: directAPI.fieldGroups,
+
         // Email & User Field namespaces
         emailProviders: directAPI.emailProviders,
         emailTemplates: directAPI.emailTemplates,
@@ -425,6 +428,7 @@ export async function getCachedNextly(): Promise<Nextly> {
       users: directAPI.users,
       media: directAPI.media,
       forms: directAPI.forms,
+      fieldGroups: directAPI.fieldGroups,
       emailProviders: directAPI.emailProviders,
       emailTemplates: directAPI.emailTemplates,
       userFields: directAPI.userFields,

--- a/packages/nextly/src/init/nextly-instance.ts
+++ b/packages/nextly/src/init/nextly-instance.ts
@@ -14,6 +14,7 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import type { ServiceMap } from "../di/register";
+import type { FieldGroupsNamespace } from "../direct-api/namespaces/index";
 import type {
   AuthResult,
   BulkDeleteArgs,
@@ -622,6 +623,23 @@ export interface Nextly {
       args: FormSubmissionsArgs
     ) => Promise<ListResult<Record<string, unknown>>>;
   };
+
+  /**
+   * Field groups namespace - reusable field structures shared by collections
+   * and singles.
+   *
+   * Typed as the namespace the Direct API actually builds, so this surface
+   * cannot drift from the implementation the instance delegates to.
+   *
+   * @example
+   * ```typescript
+   * const nextly = await getNextly(config);
+   *
+   * const fieldGroups = await nextly.fieldGroups.find();
+   * const seo = await nextly.fieldGroups.findBySlug({ slug: 'seo' });
+   * ```
+   */
+  fieldGroups: FieldGroupsNamespace;
 
   /**
    * Media service - direct access to MediaService for advanced operations.

--- a/packages/nextly/src/plugins/admin-meta.test.ts
+++ b/packages/nextly/src/plugins/admin-meta.test.ts
@@ -498,7 +498,7 @@ describe("buildPluginAdminMeta", () => {
     expect(disabled[0].routes).toBeUndefined();
   });
 
-  it("lists contributed singles and components slugs alongside collections", () => {
+  it("lists contributed singles and field group slugs alongside collections", () => {
     const meta = buildPluginAdminMeta(
       asPlugins([
         {
@@ -514,6 +514,6 @@ describe("buildPluginAdminMeta", () => {
     );
     expect(meta[0].collections).toEqual(["forms"]);
     expect(meta[0].singles).toEqual(["form-settings"]);
-    expect(meta[0].components).toEqual(["form-block"]);
+    expect(meta[0].fieldGroups).toEqual(["form-block"]);
   });
 });

--- a/packages/nextly/src/plugins/admin-meta.ts
+++ b/packages/nextly/src/plugins/admin-meta.ts
@@ -62,8 +62,8 @@ export interface PluginAdminMeta {
   collections: string[];
   /** Slugs of contributed singles, for the detail page's contributions view. */
   singles?: string[];
-  /** Slugs of contributed components, for the detail page's contributions view. */
-  components?: string[];
+  /** Slugs of contributed field groups, for the detail page's contributions view. */
+  fieldGroups?: string[];
   /**
    * Declared custom permissions (identity + display fields only) — present
    * only for enabled plugins, like the rest of the behavioral surface.
@@ -182,12 +182,12 @@ export function buildPluginAdminMeta(
       collections: pluginCollectionSlugs(plugin),
     };
 
-    // Contributed singles/components slugs, so the detail page can list
+    // Contributed singles/field-group slugs, so the detail page can list
     // everything the plugin adds without loading the plugin itself.
     const singles = plugin.contributes?.singles?.map(s => s.slug) ?? [];
     if (singles.length > 0) meta.singles = singles;
-    const components = plugin.contributes?.fieldGroups?.map(c => c.slug) ?? [];
-    if (components.length > 0) meta.components = components;
+    const fieldGroups = plugin.contributes?.fieldGroups?.map(c => c.slug) ?? [];
+    if (fieldGroups.length > 0) meta.fieldGroups = fieldGroups;
 
     // Behavioral admin UI only for enabled plugins.
     const admin = plugin.contributes?.admin;

--- a/packages/nextly/src/plugins/plugin-introspection.test.ts
+++ b/packages/nextly/src/plugins/plugin-introspection.test.ts
@@ -72,7 +72,7 @@ describe("collectPluginInfo", () => {
     expect(fb.dependsOn).toEqual(["@acme/base"]);
     expect(fb.collections).toEqual(["forms", "form-submissions"]);
     expect(fb.singles).toEqual(["form-settings"]);
-    expect(fb.components).toEqual(["field-group"]);
+    expect(fb.fieldGroups).toEqual(["field-group"]);
     expect(fb.permissions).toEqual(["export-submissions"]);
     expect(fb.events).toEqual(["form-builder.submitted"]);
     expect(fb.routeCount).toBe(1);

--- a/packages/nextly/src/plugins/plugin-introspection.ts
+++ b/packages/nextly/src/plugins/plugin-introspection.ts
@@ -5,7 +5,7 @@
  * derived WITHOUT running the plugin (`init` is never called). Reuses the same
  * folds the runtime/CLI boot uses, so introspection matches reality:
  *   - {@link resolvePlugins} for canonical (topo) order + version validation;
- *   - {@link pluginCollectionSlugs} / `contributes.singles|components` for schema;
+ *   - {@link pluginCollectionSlugs} / `contributes.singles|fieldGroups` for schema;
  *   - {@link collectCustomPermissions} for custom permission slugs (per owner);
  *   - {@link collectPluginRoutes} for route counts (enabled-only, D49);
  *   - {@link buildPluginAdminMeta} for admin menu/page/settings counts.
@@ -37,7 +37,7 @@ export interface PluginInfo {
   /** Owned collection slugs (resolved, post-rename). */
   collections: string[];
   singles: string[];
-  components: string[];
+  fieldGroups: string[];
   /** Custom permission slugs declared by this plugin (CRUD is auto-seeded, not listed). */
   permissions: string[];
   /** Custom event names this plugin declares it may emit. */
@@ -99,7 +99,7 @@ export function collectPluginInfo(
       optionalDependsOn: Object.keys(plugin.optionalDependsOn ?? {}),
       collections: pluginCollectionSlugs(plugin),
       singles: (contributes?.singles ?? []).map(s => s.slug),
-      components: (contributes?.fieldGroups ?? []).map(c => c.slug),
+      fieldGroups: (contributes?.fieldGroups ?? []).map(c => c.slug),
       permissions: (permissionsByOwner.get(plugin.name) ?? []).sort(),
       events: (contributes?.events ?? []).map(e => e.name),
       routeCount: routeCountByPlugin.get(plugin.name) ?? 0,

--- a/packages/nextly/src/services/dashboard/dashboard-service.ts
+++ b/packages/nextly/src/services/dashboard/dashboard-service.ts
@@ -47,7 +47,7 @@ export interface DashboardStatsResponse {
   users: number;
   roles: number;
   permissions: number;
-  components: number;
+  fieldGroups: number;
   singles: number;
   apiKeys: number;
 }
@@ -137,7 +137,7 @@ export class DashboardService extends BaseService {
       users: userCount,
       roles: roleCount,
       permissions: permissionCount,
-      components: componentCount,
+      fieldGroups: componentCount,
       singles: singles.length,
       apiKeys: apiKeyCount,
     };
@@ -212,7 +212,11 @@ export class DashboardService extends BaseService {
           label: "Content Types",
           value: dashStats.content.contentTypes,
         },
-        { key: "components", label: "Components", value: dashStats.components },
+        {
+          key: "fieldGroups",
+          label: "Field Groups",
+          value: dashStats.fieldGroups,
+        },
         { key: "singles", label: "Singles", value: dashStats.singles },
         { key: "users", label: "Users", value: dashStats.users },
         { key: "apiKeys", label: "API Keys", value: dashStats.apiKeys },


### PR DESCRIPTION
Continues the Components → Field Groups rename (task 011). A0.1, A1, A2 and A3a are merged; this is A3b, the Direct API namespace and the response wire keys.

## What changed

**Direct API namespace.** `nextly.components.*` is now `nextly.fieldGroups.*`, on both the `Nextly` class and the `nextly` facade. The seven argument/result types move with it (`ComponentDefinition` → `FieldGroupDefinition`, `FindComponentsArgs` → `FindFieldGroupsArgs`, and so on), along with `ComponentsNamespace`, the namespace factory, and the two record helpers. Both modules are `git mv`d to `field-groups.ts` so the filenames match what they export.

`FieldGroupSlug` / `DataFromFieldGroupSlug` were already renamed in A2 and are untouched here.

**Response wire keys.** The dashboard stats payload, plugin admin metadata, and plugin introspection all reported field groups under a `components` key. All three now use `fieldGroups`, and **every reader moves in this PR** — the admin's `DashboardStats` and `PluginAdminMeta` types, `ProjectStatsGrid`, the plugin detail page, and the `nextly plugins` CLI renderer.

**A loud failure instead of a cryptic one.** The namespace was renamed rather than aliased, per the spec's no-alias rule. But an untyped caller — `.js`/`.mjs` app code, a plugin compiled against an older version, dynamic property access — would have read `nextly.components` as `undefined` and failed with `TypeError: Cannot read properties of undefined (reading 'find')`, which names neither the namespace nor the rename. A throwing accessor now reports the rename directly. It is non-enumerable, so spreads, `Object.keys`, and `JSON.stringify` do not trip it.

**Two fixes found along the way.** The dashboard tile rendered the field-group count under the title **"Plugins"** (with an href to the components builder) — a pre-existing mislabel that renaming the key exposed. And the REST layer, renamed in A3a, still returned `"Component created."` / `"Component updated."`; those now match the Direct API.

## Verification

- Full `packages/nextly` and `packages/admin` suites diffed against clean `main` **at test-name level**: **zero branch-only failures** (baselines 405 / 37).
- `pnpm check-types` across all 19 workspace packages — this caught two misses a grep sweep did not: the CLI reader of the introspection key, and the `.test-d.ts` import of the moved module.
- `pnpm lint` clean, `pnpm build` clean.
- The new guard test is **load-bearing, proven by breaking it twice**: removing the guard installation fails the two rejection cases; making the accessor enumerable fails the copy-safety case. Restored, all four pass.
- Existing assertions on the old wire key (`admin-meta.test.ts`, `plugin-introspection.test.ts`, `dashboard.test.ts`, `plugins.test.ts`) were updated rather than deleted.

26 files, deliberately kept under the 100-file limit so CodeRabbit and Greptile actually review it.

## Not in this PR

A4 owns the admin's own vocabulary: routes, query keys, `useComponents` / `componentApi`, `BuilderKind`, the page directory, and the remaining copy strings. `ROUTES.BUILDER_COMPONENTS` is therefore still spelled that way here.
