### PR TITLE
docs: finish the field group wording in the reference pages

### DIFF
--- a/docs/configuration/field-groups.mdx
+++ b/docs/configuration/field-groups.mdx
@@ -20,7 +20,7 @@ Key characteristics:
 <Tabs items={["Code-first", "Visual Schema Builder"]}>
 <Tab value="Code-first">
 
-Use `defineFieldGroup()` from `nextly` to create components in TypeScript:
+Use `defineFieldGroup()` from `nextly` to create field groups in TypeScript:
 
 ```typescript title="src/field-groups/seo.ts"
 import {
@@ -72,26 +72,26 @@ Only `slug` and `fields` are required.
 
 | Option | Type | Required | Description |
 |---|---|---|---|
-| `slug` | `string` | Yes | Unique identifier across components, collections, and singles. Used as the DB table prefix (`comp_{slug}`). Must be URL-friendly. |
+| `slug` | `string` | Yes | Unique identifier across field groups, collections, and singles. Used as the DB table prefix (`comp_{slug}`). Must be URL-friendly. |
 | `fields` | `FieldConfig[]` | Yes | Array of [field definitions](/docs/configuration/fields). |
 | `label` | `{ singular: string }` | No | Display name in the admin UI. Auto-generated from slug if omitted (e.g. `social-link` → `Social Link`). |
-| `admin.category` | `string` | No | Category that groups components in the sidebar and selector modal (e.g. `"Shared"`, `"Blocks"`). |
-| `admin.icon` | `string` | No | Lucide icon name shown in sidebar and component selector. |
-| `admin.description` | `string` | No | Help text in the component selector modal. |
+| `admin.category` | `string` | No | Category that groups field groups in the sidebar and selector modal (e.g. `"Shared"`, `"Blocks"`). |
+| `admin.icon` | `string` | No | Lucide icon name shown in sidebar and field group selector. |
+| `admin.description` | `string` | No | Help text in the field group selector modal. |
 | `admin.hidden` | `boolean` | No | Hide from admin navigation. Still usable in code and via API. |
-| `admin.imageURL` | `string` | No | Preview image URL shown in the component selector. |
+| `admin.imageURL` | `string` | No | Preview image URL shown in the field group selector. |
 | `description` | `string` | No | General description; falls back to `admin.description`. |
 | `custom` | `Record<string, unknown>` | No | Arbitrary metadata for plugins or custom code. Not persisted. |
 
-> **Components do not have hooks or access control of their own.** They inherit hook execution and access checks from the collection or single they're embedded in.
+> **Field groups do not have hooks or access control of their own.** They inherit hook execution and access checks from the collection or single they're embedded in.
 
 ## Using field groups in collections and singles
 
-Once defined, embed a field group in any collection or single using the `component` field helper. There are three usage modes.
+Once defined, embed a field group in any collection or single using the `fieldGroup()` field helper. There are three usage modes.
 
 ### Single field group (fixed type)
 
-Embed exactly one instance of a specific component type:
+Embed exactly one instance of a specific field group:
 
 ```typescript title="src/collections/pages.ts"
 import { defineCollection, fieldGroup, text, richText } from "nextly";
@@ -108,7 +108,7 @@ export default defineCollection({
 
 ### Dynamic zone (multiple field group types)
 
-Let editors choose from several component types — ideal for flexible page builders:
+Let editors choose from several field group types, which suits flexible page builders:
 
 ```typescript title="src/collections/pages.ts"
 import { defineCollection, fieldGroup, text } from "nextly";
@@ -128,7 +128,7 @@ export default defineCollection({
 
 ### Repeatable single field group
 
-An array of the same component type — for example, a list of feature cards:
+An array of the same field group, for example a list of feature cards:
 
 ```typescript title="src/collections/landing-pages.ts"
 import { defineCollection, fieldGroup, text } from "nextly";
@@ -209,6 +209,6 @@ export default defineFieldGroup({
 
 ## Next steps
 
-- [Fields](/docs/configuration/fields) — all field types available inside components
-- [Collections](/docs/configuration/collections) — where components are most commonly used
-- [Singles](/docs/configuration/singles) — embed components in single-document content
+- [Fields](/docs/configuration/fields) — all field types available inside field groups
+- [Collections](/docs/configuration/collections) — where field groups are most commonly used
+- [Singles](/docs/configuration/singles) — embed field groups in single-document content

--- a/docs/configuration/singles.mdx
+++ b/docs/configuration/singles.mdx
@@ -124,7 +124,7 @@ Only `slug` and `fields` are required.
 | **Type** | `string` |
 | **Required** | Yes |
 
-Unique identifier across all singles **and** collections **and** components. Used as the API endpoint path and database table name (with the `single_` prefix unless `dbName` is set). Must be lowercase and URL-friendly.
+Unique identifier across all singles **and** collections **and** field groups. Used as the API endpoint path and database table name (with the `single_` prefix unless `dbName` is set). Must be lowercase and URL-friendly.
 
 ### `fields`
 

--- a/docs/plugins/api-reference.mdx
+++ b/docs/plugins/api-reference.mdx
@@ -178,7 +178,7 @@ fieldTypes: [
 | Key | What it is |
 |---|---|
 | `data` | The write payload, for rules spanning fields. On update this is the patch, not the merged stored entry. Always the top-level payload, even for a field nested in a repeater row. |
-| `req` | Request context; carries `user` when authenticated. Empty for a field inside a component instance. |
+| `req` | Request context; carries `user` when authenticated. Empty for a field inside a field group instance. |
 | `field` | The instance, so you can read the options your type declares. A detached copy: records, arrays, dates, sets and maps are rebuilt, so editing them changes nothing. Functions and class instances stay shared — treat it as read-only. |
 | `path` | Where this field sits in the write (`"stars"`, `"rows[1].stars"`). |
 | `mode` | `"create"` or `"update"`. |
@@ -207,7 +207,7 @@ Anything you return outside `true | string | PluginFieldIssue[]` is a refusal,
 as is throwing — a validator that forgets to return fails the write rather than
 silently accepting everything.
 
-**Where it runs.** The entry, single, and component write paths. A type offered
+**Where it runs.** The entry, single, and field group write paths. A type offered
 on the `users`, `forms`, or `blocks` surface does **not** run it yet: those
 surfaces validate through their own paths. A disabled plugin keeps its field
 types registered (its collections are retained) but its `validate` does not


### PR DESCRIPTION
Follow-up to #393, which was merged before its copy sweep was complete. Two reviewers (Codex and CodeRabbit) flagged remaining entity wording on the moved page, and both were right.

## What was still wrong

The page had been renamed and its headings fixed, but the **body** still called the entity a component:

- the code-first intro: "create components in TypeScript"
- the options table: `slug` "unique across components", and `admin.category` / `admin.icon` / `admin.description` / `admin.imageURL` all referring to the "component selector"
- the hooks callout: "**Components do not have hooks or access control of their own.**"
- the three usage-mode descriptions
- all three Next-steps links

That left the primary reference internally inconsistent, and worse, it obscured which of the remaining `component` mentions are deliberate.

**Plus an accuracy bug neither reviewer flagged:** the page said to embed a field group "using the `component` field helper". The helper is `fieldGroup()`; `component` is one of its options. Corrected.

**And three entity references outside that page**, found by re-sweeping the tree rather than the cited lines: `singles.mdx` slug-uniqueness ("across all singles and collections and components"), and two in `plugins/api-reference.mdx` ("a field inside a component instance", "the entry, single, and component write paths").

## What is deliberately still called "component"

Now that the prose is clean, everything remaining on the page is intentional and falls into three groups:

- **The stored field type and its options** — `component` fields, `component: "seo"`, `components: ["hero", …]`, and the cross-link to Fields → Component. These are persisted contracts that flip in **B2**.
- **Source paths** — `packages/nextly/src/components/config/...`, which A6 moves.
- **React** — `fumadocs-ui/components/tabs`, `admin.components`, `components.Field|Cell|Filter`, plugin component paths, the Blog template's `src/components/`.

## On the redirect finding

Codex raised `/docs/configuration/components` returning 404 three times across #393. I rebutted it each time and #393 merged without a redirect, so I have not added one here either. The grounds are unchanged: this repo has no docs redirect mechanism to add one to (`docs/` is a plain MDX tree consumed by a separate site; there is no redirects map and no docs-level `next.config`), and the standing directive is no aliases with no public users yet. If you would rather have a stub at the old URL, it is a one-file add and I will do it.

## Verification

`pnpm check-types` across all 19 packages and `pnpm lint` clean. Branched off current `main` (`24df7369`), no conflicts. 3 files, docs only, no changeset.
