### PR TITLE
feat(nextly): record field group storage migration state

### DIFF
--- a/.changeset/field-group-migration-state.md
+++ b/.changeset/field-group-migration-state.md
@@ -22,4 +22,4 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-Record field group storage migration progress durably, so an interrupted upgrade resumes from where it stopped instead of restarting against a half-renamed database.
+Internal groundwork for the upcoming field group storage migration: durable progress tracking, and a startup guard that refuses to serve a database whose storage state cannot be accounted for. Nothing calls this yet, so there is no change in behaviour in this release.

--- a/.changeset/field-group-migration-state.md
+++ b/.changeset/field-group-migration-state.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Record field group storage migration progress durably, so an interrupted upgrade resumes from where it stopped instead of restarting against a half-renamed database.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/guard.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/guard.test.ts
@@ -14,15 +14,26 @@ const IN_FLIGHT: MigratingState = {
   direction: "up",
   migrationId: "run-1",
   step: 4,
-  manifestHash: "hash-1",
+  plan: { manifestHash: "hash-1", planHash: "plan-1" },
 };
 
 function probe(over: Partial<StorageProbe> = {}): StorageProbe {
   return {
     targetRegistryPresent: false,
     legacyRegistryPresent: true,
+    migratedObjects: null,
     ...over,
   };
+}
+
+/** A probe over a database whose migrated objects all checked out. */
+function verifiedProbe(over: Partial<StorageProbe> = {}): StorageProbe {
+  return probe({
+    targetRegistryPresent: true,
+    legacyRegistryPresent: false,
+    migratedObjects: { complete: true },
+    ...over,
+  });
 }
 
 /**
@@ -51,15 +62,42 @@ describe("field-group storage verdict", () => {
     });
   });
 
-  it("uses migrated storage once the marker and the registry agree", () => {
+  it("uses migrated storage once the marker, registry and objects all agree", () => {
     const verdict = resolveStorageVerdict({
       state: MIGRATED,
-      probe: probe({
-        targetRegistryPresent: true,
-        legacyRegistryPresent: false,
-      }),
+      probe: verifiedProbe(),
     });
     expect(verdict).toEqual({ action: "use-field-groups-v2" });
+  });
+
+  // The registry existing proves only that the registry exists. Serving on that
+  // alone would read content out of data tables nobody checked for.
+  it("refuses migrated storage that was never structurally verified", () => {
+    const refusal = captureRefusal(() =>
+      resolveStorageVerdict({
+        state: MIGRATED,
+        probe: verifiedProbe({ migratedObjects: null }),
+      })
+    );
+    expect(refusal.logContext?.reason).toMatch(/not structurally verified/);
+  });
+
+  // A partial restore leaves the registry pointing at tables that are gone. The
+  // read path turns a missing data table into an empty result, so without this
+  // the site comes up serving blank content and reporting no error at all.
+  it("refuses when objects the registry references are missing", () => {
+    const refusal = captureRefusal(() =>
+      resolveStorageVerdict({
+        state: MIGRATED,
+        probe: verifiedProbe({
+          migratedObjects: { complete: false, missing: ["fg_hero"] },
+        }),
+      })
+    );
+    expect(refusal.logContext?.reason).toMatch(/missing or unmigrated/);
+    // Naming what is missing is the point: an operator needs to know which
+    // objects to restore, not merely that something is wrong.
+    expect(refusal.logContext?.missing).toEqual(["fg_hero"]);
   });
 
   // The host application shares this database. A table wearing our target name
@@ -91,22 +129,39 @@ describe("field-group storage verdict", () => {
   // step is wasteful, and skipping one leaves an object unrenamed.
   it("resumes at the step after the last verified one", () => {
     expect(resolveStorageVerdict({ state: IN_FLIGHT, probe: probe() })).toEqual(
-      { action: "resume", step: 5, manifestHash: "hash-1" }
+      {
+        action: "resume",
+        step: 5,
+        direction: "up",
+        migrationId: "run-1",
+        plan: { manifestHash: "hash-1", planHash: "plan-1" },
+      }
     );
   });
 
-  // A step number only means something against the plan it was checked off
-  // under, so the resumed run is handed that plan's hash to compare against
-  // rather than being left to look it up.
-  it("carries the interrupted run's manifest hash into the resume", () => {
+  // Everything a resume needs travels with the verdict. Without the direction
+  // it could run the wrong step list; without the id `advanceStep` rejects it;
+  // without the plan it cannot tell whether the step still means what it meant.
+  it("carries the interrupted run's full identity into the resume", () => {
     const verdict = resolveStorageVerdict({
       state: IN_FLIGHT,
       probe: probe(),
     });
     expect(verdict).toMatchObject({
       action: "resume",
-      manifestHash: IN_FLIGHT.manifestHash,
+      direction: IN_FLIGHT.direction,
+      migrationId: IN_FLIGHT.migrationId,
+      plan: IN_FLIGHT.plan,
     });
+  });
+
+  // A `down` run interrupted at step 4 is not a `up` run interrupted at step 4,
+  // and the verdict is the only thing telling them apart.
+  it("distinguishes an interrupted down run from an interrupted up run", () => {
+    const down: MigratingState = { ...IN_FLIGHT, direction: "down" };
+    expect(
+      resolveStorageVerdict({ state: down, probe: probe() })
+    ).toMatchObject({ action: "resume", direction: "down" });
   });
 
   // An interrupted run is interpretable only by the step list, whatever the
@@ -118,7 +173,7 @@ describe("field-group storage verdict", () => {
           state: IN_FLIGHT,
           probe: probe({ targetRegistryPresent: target }),
         })
-      ).toEqual({ action: "resume", step: 5, manifestHash: "hash-1" });
+      ).toMatchObject({ action: "resume", step: 5 });
     }
   });
 

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/guard.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/guard.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import { NextlyError } from "../../../../errors/nextly-error";
 import { resolveStorageVerdict, type StorageProbe } from "../guard";
-import type { MigrationState } from "../state";
+import type { MigratingState, MigrationState } from "../state";
 
 const LEGACY: MigrationState = { status: "settled", generation: "legacy" };
 const MIGRATED: MigrationState = {
   status: "settled",
   generation: "field-groups-v2",
 };
-const IN_FLIGHT: MigrationState = {
+const IN_FLIGHT: MigratingState = {
   status: "migrating",
   direction: "up",
   migrationId: "run-1",
@@ -23,6 +23,21 @@ function probe(over: Partial<StorageProbe> = {}): StorageProbe {
     legacyRegistryPresent: true,
     ...over,
   };
+}
+
+/**
+ * Run something expected to refuse, and hand back the refusal to assert on.
+ * Anything else -- returning, or throwing a different kind of error -- fails
+ * the test where it happened rather than further down an assertion chain.
+ */
+function captureRefusal(run: () => unknown): NextlyError {
+  try {
+    run();
+  } catch (error) {
+    if (NextlyError.is(error)) return error;
+    expect.fail(`expected a NextlyError, received ${String(error)}`);
+  }
+  expect.fail("expected a refusal, but the call returned normally");
 }
 
 // The guard is the only thing standing between a half-migrated database and a
@@ -51,47 +66,47 @@ describe("field-group storage verdict", () => {
   // that we have no record of creating is theirs until proven otherwise, and
   // renaming over it would destroy data Nextly does not own.
   it("refuses when a migrated-name object exists with no migration recorded", () => {
-    expect(() =>
+    // The narrative lives in logContext, not in the public message: the
+    // envelope stays generic so a refusal never leaks storage internals.
+    const refusal = captureRefusal(() =>
       resolveStorageVerdict({
         state: LEGACY,
         probe: probe({ targetRegistryPresent: true }),
       })
-    ).toThrowError(NextlyError);
-    // The narrative lives in logContext, not in the public message: the
-    // envelope stays generic so a refusal never leaks storage internals.
-    try {
-      resolveStorageVerdict({
-        state: LEGACY,
-        probe: probe({ targetRegistryPresent: true }),
-      });
-      throw new Error("expected a refusal");
-    } catch (error) {
-      expect((error as NextlyError).logContext?.reason).toMatch(
-        /no migration recorded it/
-      );
-    }
+    );
+    expect(refusal.logContext?.reason).toMatch(/no migration recorded it/);
   });
 
   // A newer marker over an older database: a restore from backup that did not
   // also restore the marker. Serving would write post-migration names while
   // reading a legacy registry.
   it("refuses when the marker claims migrated but the registry is absent", () => {
-    try {
-      resolveStorageVerdict({ state: MIGRATED, probe: probe() });
-      throw new Error("expected a refusal");
-    } catch (error) {
-      expect((error as NextlyError).logContext?.reason).toMatch(
-        /migrated registry is absent/
-      );
-    }
+    const refusal = captureRefusal(() =>
+      resolveStorageVerdict({ state: MIGRATED, probe: probe() })
+    );
+    expect(refusal.logContext?.reason).toMatch(/migrated registry is absent/);
   });
 
   // Resume from the step AFTER the last verified one; re-running a verified
   // step is wasteful, and skipping one leaves an object unrenamed.
   it("resumes at the step after the last verified one", () => {
     expect(resolveStorageVerdict({ state: IN_FLIGHT, probe: probe() })).toEqual(
-      { action: "resume", step: 5 }
+      { action: "resume", step: 5, manifestHash: "hash-1" }
     );
+  });
+
+  // A step number only means something against the plan it was checked off
+  // under, so the resumed run is handed that plan's hash to compare against
+  // rather than being left to look it up.
+  it("carries the interrupted run's manifest hash into the resume", () => {
+    const verdict = resolveStorageVerdict({
+      state: IN_FLIGHT,
+      probe: probe(),
+    });
+    expect(verdict).toMatchObject({
+      action: "resume",
+      manifestHash: IN_FLIGHT.manifestHash,
+    });
   });
 
   // An interrupted run is interpretable only by the step list, whatever the
@@ -103,20 +118,17 @@ describe("field-group storage verdict", () => {
           state: IN_FLIGHT,
           probe: probe({ targetRegistryPresent: target }),
         })
-      ).toEqual({ action: "resume", step: 5 });
+      ).toEqual({ action: "resume", step: 5, manifestHash: "hash-1" });
     }
   });
 
   it("reports refusals as retryable-unavailable, not as a client error", () => {
-    try {
+    const refusal = captureRefusal(() =>
       resolveStorageVerdict({
         state: LEGACY,
         probe: probe({ targetRegistryPresent: true }),
-      });
-      throw new Error("expected a refusal");
-    } catch (error) {
-      expect(NextlyError.is(error)).toBe(true);
-      expect((error as NextlyError).code).toBe("SERVICE_UNAVAILABLE");
-    }
+      })
+    );
+    expect(refusal.code).toBe("SERVICE_UNAVAILABLE");
   });
 });

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/guard.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/guard.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../../../errors/nextly-error";
+import { resolveStorageVerdict, type StorageProbe } from "../guard";
+import type { MigrationState } from "../state";
+
+const LEGACY: MigrationState = { status: "settled", generation: "legacy" };
+const MIGRATED: MigrationState = {
+  status: "settled",
+  generation: "field-groups-v2",
+};
+const IN_FLIGHT: MigrationState = {
+  status: "migrating",
+  direction: "up",
+  migrationId: "run-1",
+  step: 4,
+  manifestHash: "hash-1",
+};
+
+function probe(over: Partial<StorageProbe> = {}): StorageProbe {
+  return {
+    targetRegistryPresent: false,
+    legacyRegistryPresent: true,
+    ...over,
+  };
+}
+
+// The guard is the only thing standing between a half-migrated database and a
+// process that would read or rewrite it. Each case below is a state the pair of
+// (marker, probe) can be found in; the ones with no safe interpretation must
+// refuse rather than pick a side.
+describe("field-group storage verdict", () => {
+  it("uses legacy storage on an untouched database", () => {
+    expect(resolveStorageVerdict({ state: LEGACY, probe: probe() })).toEqual({
+      action: "use-legacy",
+    });
+  });
+
+  it("uses migrated storage once the marker and the registry agree", () => {
+    const verdict = resolveStorageVerdict({
+      state: MIGRATED,
+      probe: probe({
+        targetRegistryPresent: true,
+        legacyRegistryPresent: false,
+      }),
+    });
+    expect(verdict).toEqual({ action: "use-field-groups-v2" });
+  });
+
+  // The host application shares this database. A table wearing our target name
+  // that we have no record of creating is theirs until proven otherwise, and
+  // renaming over it would destroy data Nextly does not own.
+  it("refuses when a migrated-name object exists with no migration recorded", () => {
+    expect(() =>
+      resolveStorageVerdict({
+        state: LEGACY,
+        probe: probe({ targetRegistryPresent: true }),
+      })
+    ).toThrowError(NextlyError);
+    // The narrative lives in logContext, not in the public message: the
+    // envelope stays generic so a refusal never leaks storage internals.
+    try {
+      resolveStorageVerdict({
+        state: LEGACY,
+        probe: probe({ targetRegistryPresent: true }),
+      });
+      throw new Error("expected a refusal");
+    } catch (error) {
+      expect((error as NextlyError).logContext?.reason).toMatch(
+        /no migration recorded it/
+      );
+    }
+  });
+
+  // A newer marker over an older database: a restore from backup that did not
+  // also restore the marker. Serving would write post-migration names while
+  // reading a legacy registry.
+  it("refuses when the marker claims migrated but the registry is absent", () => {
+    try {
+      resolveStorageVerdict({ state: MIGRATED, probe: probe() });
+      throw new Error("expected a refusal");
+    } catch (error) {
+      expect((error as NextlyError).logContext?.reason).toMatch(
+        /migrated registry is absent/
+      );
+    }
+  });
+
+  // Resume from the step AFTER the last verified one; re-running a verified
+  // step is wasteful, and skipping one leaves an object unrenamed.
+  it("resumes at the step after the last verified one", () => {
+    expect(resolveStorageVerdict({ state: IN_FLIGHT, probe: probe() })).toEqual(
+      { action: "resume", step: 5 }
+    );
+  });
+
+  // An interrupted run is interpretable only by the step list, whatever the
+  // objects currently look like. The probe must not override the marker here.
+  it("resumes regardless of what the probe finds", () => {
+    for (const target of [true, false]) {
+      expect(
+        resolveStorageVerdict({
+          state: IN_FLIGHT,
+          probe: probe({ targetRegistryPresent: target }),
+        })
+      ).toEqual({ action: "resume", step: 5 });
+    }
+  });
+
+  it("reports refusals as retryable-unavailable, not as a client error", () => {
+    try {
+      resolveStorageVerdict({
+        state: LEGACY,
+        probe: probe({ targetRegistryPresent: true }),
+      });
+      throw new Error("expected a refusal");
+    } catch (error) {
+      expect(NextlyError.is(error)).toBe(true);
+      expect((error as NextlyError).code).toBe("SERVICE_UNAVAILABLE");
+    }
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/guard.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/guard.test.ts
@@ -70,6 +70,19 @@ describe("field-group storage verdict", () => {
     expect(verdict).toEqual({ action: "use-field-groups-v2" });
   });
 
+  // A completed migration renames the legacy registry rather than copying it,
+  // so finding both is a state the pair cannot explain: two tables claim to be
+  // the registry, and a later rollback would rename onto an occupied name.
+  it("refuses when both registries are present after a completed migration", () => {
+    const refusal = captureRefusal(() =>
+      resolveStorageVerdict({
+        state: MIGRATED,
+        probe: verifiedProbe({ legacyRegistryPresent: true }),
+      })
+    );
+    expect(refusal.logContext?.reason).toMatch(/both the legacy and migrated/);
+  });
+
   // The registry existing proves only that the registry exists. Serving on that
   // alone would read content out of data tables nobody checked for.
   it("refuses migrated storage that was never structurally verified", () => {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/guard.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/guard.test.ts
@@ -2,12 +2,25 @@ import { describe, expect, it } from "vitest";
 
 import { NextlyError } from "../../../../errors/nextly-error";
 import { resolveStorageVerdict, type StorageProbe } from "../guard";
+import { MAX_MIGRATION_STEP } from "../state";
 import type { MigratingState, MigrationState } from "../state";
 
-const LEGACY: MigrationState = { status: "settled", generation: "legacy" };
+// An untouched database: no marker was ever written.
+const FRESH: MigrationState = {
+  status: "settled",
+  generation: "legacy",
+  recorded: false,
+};
+// A marker that explicitly settled back at legacy, i.e. after a rollback.
+const ROLLED_BACK: MigrationState = {
+  status: "settled",
+  generation: "legacy",
+  recorded: true,
+};
 const MIGRATED: MigrationState = {
   status: "settled",
   generation: "field-groups-v2",
+  recorded: true,
 };
 const IN_FLIGHT: MigratingState = {
   status: "migrating",
@@ -57,7 +70,7 @@ function captureRefusal(run: () => unknown): NextlyError {
 // refuse rather than pick a side.
 describe("field-group storage verdict", () => {
   it("uses legacy storage on an untouched database", () => {
-    expect(resolveStorageVerdict({ state: LEGACY, probe: probe() })).toEqual({
+    expect(resolveStorageVerdict({ state: FRESH, probe: probe() })).toEqual({
       action: "use-legacy",
     });
   });
@@ -121,11 +134,43 @@ describe("field-group storage verdict", () => {
     // envelope stays generic so a refusal never leaks storage internals.
     const refusal = captureRefusal(() =>
       resolveStorageVerdict({
-        state: LEGACY,
+        state: FRESH,
         probe: probe({ targetRegistryPresent: true }),
       })
     );
     expect(refusal.logContext?.reason).toMatch(/no migration recorded it/);
+  });
+
+  // An untouched database has no registry yet and creating one is ordinary
+  // first-run behaviour, so absence here is expected rather than suspicious.
+  it("allows a fresh database with no registry at all", () => {
+    expect(
+      resolveStorageVerdict({
+        state: FRESH,
+        probe: probe({ legacyRegistryPresent: false }),
+      })
+    ).toEqual({ action: "use-legacy" });
+  });
+
+  // A marker that explicitly settled at legacy was written after a run that
+  // left a registry behind, so its absence is unexplained. This is the mirror
+  // of the migrated case: same shape of evidence, same refusal.
+  it("refuses when a recorded legacy marker has no legacy registry", () => {
+    const refusal = captureRefusal(() =>
+      resolveStorageVerdict({
+        state: ROLLED_BACK,
+        probe: probe({ legacyRegistryPresent: false }),
+      })
+    );
+    expect(refusal.logContext?.reason).toMatch(/legacy registry is absent/);
+  });
+
+  // The distinction only matters when the registry is missing; with one present
+  // a rolled-back database is served exactly like a fresh one.
+  it("serves a rolled-back database whose legacy registry survived", () => {
+    expect(
+      resolveStorageVerdict({ state: ROLLED_BACK, probe: probe() })
+    ).toEqual({ action: "use-legacy" });
   });
 
   // A newer marker over an older database: a restore from backup that did not
@@ -190,10 +235,33 @@ describe("field-group storage verdict", () => {
     }
   });
 
+  // `advanceStep` will not record a position past the bound, so a resume from
+  // the last recordable step could never check off the work it did. Better to
+  // say so than to hand back a verdict that runs and then cannot be saved.
+  it("refuses to resume from a position it could never advance past", () => {
+    const stuck: MigratingState = { ...IN_FLIGHT, step: MAX_MIGRATION_STEP };
+    const refusal = captureRefusal(() =>
+      resolveStorageVerdict({ state: stuck, probe: probe() })
+    );
+    expect(refusal.logContext?.reason).toMatch(/cannot advance past/);
+  });
+
+  // One below the bound still resumes: the derived step is exactly the highest
+  // recordable one, so the read, resume and write bounds line up.
+  it("still resumes from the last position whose successor can be recorded", () => {
+    const nearly: MigratingState = {
+      ...IN_FLIGHT,
+      step: MAX_MIGRATION_STEP - 1,
+    };
+    expect(
+      resolveStorageVerdict({ state: nearly, probe: probe() })
+    ).toMatchObject({ action: "resume", step: MAX_MIGRATION_STEP });
+  });
+
   it("reports refusals as retryable-unavailable, not as a client error", () => {
     const refusal = captureRefusal(() =>
       resolveStorageVerdict({
-        state: LEGACY,
+        state: FRESH,
         probe: probe({ targetRegistryPresent: true }),
       })
     );

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -46,6 +46,7 @@ describe("field-group migration marker", () => {
     await expect(readMigrationState(meta)).resolves.toEqual({
       status: "settled",
       generation: "legacy",
+      recorded: false,
     });
   });
 
@@ -78,6 +79,31 @@ describe("field-group migration marker", () => {
     await expect(readMigrationState(meta)).resolves.toMatchObject({
       plan: { manifestHash: "hash-1", planHash: "plan-1" },
     });
+  });
+
+  // The writer holds itself to the reader's invariants. Writing an empty
+  // identifier would succeed and then be rejected by the very next read,
+  // turning a successful begin into an unavailable database.
+  it.each([
+    ["migrationId", { migrationId: "", manifestHash: "h", planHash: "p" }],
+    ["manifestHash", { migrationId: "r", manifestHash: "", planHash: "p" }],
+    ["planHash", { migrationId: "r", manifestHash: "h", planHash: "" }],
+  ])("refuses to begin a run with an empty %s", async (_label, fields) => {
+    const { meta, read } = createMeta();
+    await expect(
+      beginMigration(meta, {
+        direction: "up",
+        migrationId: fields.migrationId,
+        plan: {
+          manifestHash: fields.manifestHash,
+          planHash: fields.planHash,
+        },
+      })
+    ).rejects.toThrowError(NextlyError);
+    // Nothing may reach storage: a marker written here is exactly the
+    // unreadable state the check exists to prevent.
+    expect(read()).toBe(ABSENT);
+    expect(meta.set).not.toHaveBeenCalled();
   });
 
   // The first write must land before any statement runs, because MySQL commits
@@ -173,6 +199,7 @@ describe("field-group migration marker", () => {
     await expect(readMigrationState(meta)).resolves.toEqual({
       status: "settled",
       generation: "field-groups-v2",
+      recorded: true,
     });
   });
 
@@ -298,6 +325,7 @@ describe("field-group migration marker", () => {
     await expect(readMigrationState(meta)).resolves.toEqual({
       status: "settled",
       generation: "legacy",
+      recorded: false,
     });
   });
 });

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -206,6 +206,21 @@ describe("field-group migration marker", () => {
       },
     ],
     [
+      // At 2^53 `step + 1 === step`, so a resume would recompute the same
+      // position forever. A number that cannot be incremented is not a
+      // position, whatever `Number.isInteger` says about it.
+      "in-flight with a step beyond the safe integer range",
+      {
+        version: 1,
+        status: "migrating",
+        direction: "up",
+        migrationId: "r",
+        step: Number.MAX_SAFE_INTEGER + 1,
+        manifestHash: "h",
+        planHash: "p",
+      },
+    ],
+    [
       "in-flight without a plan hash",
       {
         version: 1,

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { NextlyError } from "../../../../errors/nextly-error";
+import type { MetaService } from "../../../meta/services/meta-service";
+import {
+  advanceStep,
+  beginMigration,
+  FIELD_GROUP_MIGRATION_KEY,
+  MIGRATION_MARKER_VERSION,
+  readMigrationState,
+  settleMigration,
+} from "../state";
+
+/**
+ * Stands in for `nextly_meta`. The real service round-trips JSON through a
+ * column, so the fake stores the value it was handed and returns it verbatim.
+ */
+function createMeta(initial?: unknown): {
+  meta: MetaService;
+  read: () => unknown;
+} {
+  let stored = initial;
+  const meta = {
+    get: vi.fn(async () => (stored === undefined ? null : stored)),
+    set: vi.fn(async (_key: string, value: unknown) => {
+      stored = value;
+    }),
+  } as unknown as MetaService;
+  return { meta, read: () => stored };
+}
+
+describe("field-group migration marker", () => {
+  it("reads an absent marker as untouched legacy storage", async () => {
+    const { meta } = createMeta();
+    await expect(readMigrationState(meta)).resolves.toEqual({
+      status: "settled",
+      generation: "legacy",
+    });
+  });
+
+  it("round-trips an in-flight run", async () => {
+    const { meta } = createMeta();
+    await beginMigration(meta, {
+      direction: "up",
+      migrationId: "run-1",
+      manifestHash: "hash-1",
+    });
+    await expect(readMigrationState(meta)).resolves.toEqual({
+      status: "migrating",
+      direction: "up",
+      migrationId: "run-1",
+      step: 0,
+      manifestHash: "hash-1",
+    });
+  });
+
+  // The first write must land before any statement runs, because MySQL commits
+  // DDL implicitly and a crash after the first rename would otherwise leave
+  // renamed objects with nothing recording them.
+  it("starts at step 0 so a crash before step 1 re-runs it", async () => {
+    const { meta, read } = createMeta();
+    await beginMigration(meta, {
+      direction: "up",
+      migrationId: "run-1",
+      manifestHash: "hash-1",
+    });
+    expect(read()).toMatchObject({ status: "migrating", step: 0 });
+    expect(meta.set).toHaveBeenCalledWith(
+      FIELD_GROUP_MIGRATION_KEY,
+      expect.objectContaining({ version: MIGRATION_MARKER_VERSION })
+    );
+  });
+
+  it("advances one step at a time", async () => {
+    const { meta } = createMeta();
+    await beginMigration(meta, {
+      direction: "up",
+      migrationId: "run-1",
+      manifestHash: "hash-1",
+    });
+    await advanceStep(meta, { migrationId: "run-1", step: 1 });
+    await advanceStep(meta, { migrationId: "run-1", step: 2 });
+    await expect(readMigrationState(meta)).resolves.toMatchObject({ step: 2 });
+  });
+
+  // Skipping a step would record work that never ran; going backwards would
+  // re-run a verified step under a stale assumption. Both mean the caller has
+  // lost its place and should re-read rather than assert.
+  it("refuses to skip or rewind", async () => {
+    const { meta } = createMeta();
+    await beginMigration(meta, {
+      direction: "up",
+      migrationId: "run-1",
+      manifestHash: "hash-1",
+    });
+    await expect(
+      advanceStep(meta, { migrationId: "run-1", step: 2 })
+    ).rejects.toThrowError(NextlyError);
+    await advanceStep(meta, { migrationId: "run-1", step: 1 });
+    await expect(
+      advanceStep(meta, { migrationId: "run-1", step: 1 })
+    ).rejects.toThrowError(NextlyError);
+  });
+
+  it("refuses a step belonging to a different run", async () => {
+    const { meta } = createMeta();
+    await beginMigration(meta, {
+      direction: "up",
+      migrationId: "run-1",
+      manifestHash: "hash-1",
+    });
+    await expect(
+      advanceStep(meta, { migrationId: "run-2", step: 1 })
+    ).rejects.toThrowError(NextlyError);
+  });
+
+  it("settles at a generation once verification has passed", async () => {
+    const { meta } = createMeta();
+    await beginMigration(meta, {
+      direction: "up",
+      migrationId: "run-1",
+      manifestHash: "hash-1",
+    });
+    await settleMigration(meta, "field-groups-v2");
+    await expect(readMigrationState(meta)).resolves.toEqual({
+      status: "settled",
+      generation: "field-groups-v2",
+    });
+  });
+
+  // A marker that exists but cannot be read must never degrade to "absent":
+  // that would restart a run which may already have renamed objects.
+  it.each([
+    ["not an object", "nonsense"],
+    [
+      "unknown version",
+      { version: 99, status: "settled", generation: "legacy" },
+    ],
+    ["unknown generation", { version: 1, status: "settled", generation: "?" }],
+    ["unknown status", { version: 1, status: "elsewhere" }],
+    [
+      "in-flight without a direction",
+      {
+        version: 1,
+        status: "migrating",
+        migrationId: "r",
+        step: 0,
+        manifestHash: "h",
+      },
+    ],
+    [
+      "in-flight without an id",
+      {
+        version: 1,
+        status: "migrating",
+        direction: "up",
+        step: 0,
+        manifestHash: "h",
+      },
+    ],
+    [
+      "in-flight with a fractional step",
+      {
+        version: 1,
+        status: "migrating",
+        direction: "up",
+        migrationId: "r",
+        step: 1.5,
+        manifestHash: "h",
+      },
+    ],
+    [
+      "in-flight without a manifest hash",
+      {
+        version: 1,
+        status: "migrating",
+        direction: "up",
+        migrationId: "r",
+        step: 0,
+      },
+    ],
+  ])("refuses a corrupt marker: %s", async (_label, stored) => {
+    const { meta } = createMeta(stored);
+    await expect(readMigrationState(meta)).rejects.toThrowError(NextlyError);
+  });
+
+  it("reports a corrupt marker as unavailable rather than absent", async () => {
+    const { meta } = createMeta("nonsense");
+    await expect(readMigrationState(meta)).rejects.toMatchObject({
+      code: "SERVICE_UNAVAILABLE",
+    });
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -4,6 +4,7 @@ import { NextlyError } from "../../../../errors/nextly-error";
 import type { MetaService } from "../../../meta/services/meta-service";
 import {
   advanceStep,
+  assertManifestUnchanged,
   beginMigration,
   FIELD_GROUP_MIGRATION_KEY,
   MIGRATION_MARKER_VERSION,
@@ -11,17 +12,26 @@ import {
   settleMigration,
 } from "../state";
 
+/** Absence is a distinct state from "stored, but holding nothing readable". */
+const ABSENT = Symbol("absent");
+
 /**
  * Stands in for `nextly_meta`. The real service round-trips JSON through a
  * column, so the fake stores the value it was handed and returns it verbatim.
+ *
+ * `getEntry` is what the marker reads through, because it is the only accessor
+ * that separates an absent row from a present row carrying `null`.
  */
-function createMeta(initial?: unknown): {
+function createMeta(initial: unknown = ABSENT): {
   meta: MetaService;
   read: () => unknown;
 } {
   let stored = initial;
   const meta = {
-    get: vi.fn(async () => (stored === undefined ? null : stored)),
+    getEntry: vi.fn(async () =>
+      stored === ABSENT ? { present: false } : { present: true, value: stored }
+    ),
+    get: vi.fn(async () => (stored === ABSENT ? null : stored)),
     set: vi.fn(async (_key: string, value: unknown) => {
       stored = value;
     }),
@@ -189,5 +199,49 @@ describe("field-group migration marker", () => {
     await expect(readMigrationState(meta)).rejects.toMatchObject({
       code: "SERVICE_UNAVAILABLE",
     });
+  });
+
+  // A row whose value is SQL NULL, and a row holding the JSON literal `null`,
+  // both decode to `null`. Neither is an absent marker: we wrote a row, so a
+  // run started, and reading it as "untouched" would restart a migration that
+  // may already have renamed objects.
+  it("refuses a marker row that exists but carries no value", async () => {
+    const { meta } = createMeta(null);
+    await expect(readMigrationState(meta)).rejects.toThrowError(NextlyError);
+    await expect(readMigrationState(meta)).rejects.toMatchObject({
+      code: "SERVICE_UNAVAILABLE",
+    });
+  });
+
+  it("still reads a genuinely absent row as untouched legacy storage", async () => {
+    const { meta } = createMeta();
+    await expect(readMigrationState(meta)).resolves.toEqual({
+      status: "settled",
+      generation: "legacy",
+    });
+  });
+});
+
+// Step numbers index into a plan. Resuming step N against a plan that no longer
+// describes the same objects would rename or verify the wrong ones, and there
+// is no way to reconcile the two, so the mismatch is refused outright.
+describe("field-group migration manifest guard", () => {
+  it("allows a resume whose plan is unchanged", () => {
+    expect(() =>
+      assertManifestUnchanged({ recorded: "hash-1", current: "hash-1" })
+    ).not.toThrow();
+  });
+
+  it("refuses a resume whose plan changed", () => {
+    try {
+      assertManifestUnchanged({ recorded: "hash-1", current: "hash-2" });
+      expect.fail("expected a refusal");
+    } catch (error) {
+      expect(NextlyError.is(error)).toBe(true);
+      expect((error as NextlyError).code).toBe("SERVICE_UNAVAILABLE");
+      expect((error as NextlyError).logContext?.reason).toMatch(
+        /manifest changed/
+      );
+    }
   });
 });

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -4,7 +4,7 @@ import { NextlyError } from "../../../../errors/nextly-error";
 import type { MetaService } from "../../../meta/services/meta-service";
 import {
   advanceStep,
-  assertManifestUnchanged,
+  assertPlanUnchanged,
   beginMigration,
   FIELD_GROUP_MIGRATION_KEY,
   MIGRATION_MARKER_VERSION,
@@ -53,14 +53,29 @@ describe("field-group migration marker", () => {
     await beginMigration(meta, {
       direction: "up",
       migrationId: "run-1",
-      manifestHash: "hash-1",
+      plan: { manifestHash: "hash-1", planHash: "plan-1" },
     });
     await expect(readMigrationState(meta)).resolves.toEqual({
       status: "migrating",
       direction: "up",
       migrationId: "run-1",
       step: 0,
-      manifestHash: "hash-1",
+      plan: { manifestHash: "hash-1", planHash: "plan-1" },
+    });
+  });
+
+  // Both halves of the plan identity survive a step being checked off; losing
+  // either would leave a later resume unable to tell whether it still applies.
+  it("preserves the plan identity across steps", async () => {
+    const { meta } = createMeta();
+    await beginMigration(meta, {
+      direction: "up",
+      migrationId: "run-1",
+      plan: { manifestHash: "hash-1", planHash: "plan-1" },
+    });
+    await advanceStep(meta, { migrationId: "run-1", step: 1 });
+    await expect(readMigrationState(meta)).resolves.toMatchObject({
+      plan: { manifestHash: "hash-1", planHash: "plan-1" },
     });
   });
 
@@ -72,7 +87,7 @@ describe("field-group migration marker", () => {
     await beginMigration(meta, {
       direction: "up",
       migrationId: "run-1",
-      manifestHash: "hash-1",
+      plan: { manifestHash: "hash-1", planHash: "plan-1" },
     });
     expect(read()).toMatchObject({ status: "migrating", step: 0 });
     expect(meta.set).toHaveBeenCalledWith(
@@ -86,7 +101,7 @@ describe("field-group migration marker", () => {
     await beginMigration(meta, {
       direction: "up",
       migrationId: "run-1",
-      manifestHash: "hash-1",
+      plan: { manifestHash: "hash-1", planHash: "plan-1" },
     });
     await advanceStep(meta, { migrationId: "run-1", step: 1 });
     await advanceStep(meta, { migrationId: "run-1", step: 2 });
@@ -101,7 +116,7 @@ describe("field-group migration marker", () => {
     await beginMigration(meta, {
       direction: "up",
       migrationId: "run-1",
-      manifestHash: "hash-1",
+      plan: { manifestHash: "hash-1", planHash: "plan-1" },
     });
     await expect(
       advanceStep(meta, { migrationId: "run-1", step: 2 })
@@ -117,7 +132,7 @@ describe("field-group migration marker", () => {
     await beginMigration(meta, {
       direction: "up",
       migrationId: "run-1",
-      manifestHash: "hash-1",
+      plan: { manifestHash: "hash-1", planHash: "plan-1" },
     });
     await expect(
       advanceStep(meta, { migrationId: "run-2", step: 1 })
@@ -129,7 +144,7 @@ describe("field-group migration marker", () => {
     await beginMigration(meta, {
       direction: "up",
       migrationId: "run-1",
-      manifestHash: "hash-1",
+      plan: { manifestHash: "hash-1", planHash: "plan-1" },
     });
     await settleMigration(meta, "field-groups-v2");
     await expect(readMigrationState(meta)).resolves.toEqual({
@@ -187,6 +202,18 @@ describe("field-group migration marker", () => {
         direction: "up",
         migrationId: "r",
         step: 0,
+        planHash: "p",
+      },
+    ],
+    [
+      "in-flight without a plan hash",
+      {
+        version: 1,
+        status: "migrating",
+        direction: "up",
+        migrationId: "r",
+        step: 0,
+        manifestHash: "h",
       },
     ],
   ])("refuses a corrupt marker: %s", async (_label, stored) => {
@@ -222,26 +249,55 @@ describe("field-group migration marker", () => {
   });
 });
 
-// Step numbers index into a plan. Resuming step N against a plan that no longer
-// describes the same objects would rename or verify the wrong ones, and there
-// is no way to reconcile the two, so the mismatch is refused outright.
-describe("field-group migration manifest guard", () => {
+// Step numbers index into a plan. Resuming step N against a plan that is no
+// longer the same plan would rename or verify the wrong thing, and there is no
+// way to reconcile the two, so any mismatch is refused outright.
+describe("field-group migration plan guard", () => {
+  const PLAN = { manifestHash: "hash-1", planHash: "plan-1" };
+
+  function refusalFrom(current: {
+    manifestHash: string;
+    planHash: string;
+  }): NextlyError {
+    try {
+      assertPlanUnchanged({ recorded: PLAN, current });
+    } catch (error) {
+      if (NextlyError.is(error)) return error;
+      expect.fail(`expected a NextlyError, received ${String(error)}`);
+    }
+    expect.fail("expected a refusal, but the call returned normally");
+  }
+
   it("allows a resume whose plan is unchanged", () => {
     expect(() =>
-      assertManifestUnchanged({ recorded: "hash-1", current: "hash-1" })
+      assertPlanUnchanged({ recorded: PLAN, current: { ...PLAN } })
     ).not.toThrow();
   });
 
-  it("refuses a resume whose plan changed", () => {
-    try {
-      assertManifestUnchanged({ recorded: "hash-1", current: "hash-2" });
-      expect.fail("expected a refusal");
-    } catch (error) {
-      expect(NextlyError.is(error)).toBe(true);
-      expect((error as NextlyError).code).toBe("SERVICE_UNAVAILABLE");
-      expect((error as NextlyError).logContext?.reason).toMatch(
-        /manifest changed/
-      );
-    }
+  // The application's schema moved: step N now names different objects.
+  it("refuses a resume whose object map changed", () => {
+    const refusal = refusalFrom({ ...PLAN, manifestHash: "hash-2" });
+    expect(refusal.code).toBe("SERVICE_UNAVAILABLE");
+    expect(refusal.logContext?.reason).toMatch(/object map changed/);
+  });
+
+  // Nextly itself was upgraded and its steps were added, removed or reordered.
+  // The database's own objects are untouched, so the manifest hash still
+  // matches; only the plan hash catches this, and without it a resume would
+  // continue at a step number that now means a different operation.
+  it("refuses a resume whose step list changed under an unchanged object map", () => {
+    const refusal = refusalFrom({ ...PLAN, planHash: "plan-2" });
+    expect(refusal.code).toBe("SERVICE_UNAVAILABLE");
+    expect(refusal.logContext?.reason).toMatch(/step list changed/);
+  });
+
+  // The two causes are reported separately because they send an operator to
+  // different places: their own schema history, or the Nextly upgrade.
+  it("names which half of the plan moved", () => {
+    expect(
+      refusalFrom({ ...PLAN, manifestHash: "hash-2" }).logContext?.reason
+    ).not.toEqual(
+      refusalFrom({ ...PLAN, planHash: "plan-2" }).logContext?.reason
+    );
   });
 });

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -4,6 +4,7 @@ import { NextlyError } from "../../../../errors/nextly-error";
 import type { MetaService } from "../../../meta/services/meta-service";
 import {
   advanceStep,
+  MAX_MIGRATION_STEP,
   assertPlanUnchanged,
   beginMigration,
   FIELD_GROUP_MIGRATION_KEY,
@@ -127,6 +128,28 @@ describe("field-group migration marker", () => {
     ).rejects.toThrowError(NextlyError);
   });
 
+  // The bound is enforced on the way in as well as on the way out. Recording a
+  // position the next read would reject as corrupt is worse than refusing to
+  // advance, because it leaves the marker with no way forward at all.
+  it("refuses to record a step past the highest readable position", async () => {
+    const { meta, read } = createMeta({
+      version: MIGRATION_MARKER_VERSION,
+      status: "migrating",
+      direction: "up",
+      migrationId: "run-1",
+      step: MAX_MIGRATION_STEP,
+      manifestHash: "hash-1",
+      planHash: "plan-1",
+    });
+    const before = read();
+    await expect(
+      advanceStep(meta, { migrationId: "run-1", step: MAX_MIGRATION_STEP + 1 })
+    ).rejects.toThrowError(NextlyError);
+    // The refusal must leave the marker exactly as it was; a partial write here
+    // is the corruption the bound exists to prevent.
+    expect(read()).toEqual(before);
+  });
+
   it("refuses a step belonging to a different run", async () => {
     const { meta } = createMeta();
     await beginMigration(meta, {
@@ -216,6 +239,21 @@ describe("field-group migration marker", () => {
         direction: "up",
         migrationId: "r",
         step: Number.MAX_SAFE_INTEGER + 1,
+        manifestHash: "h",
+        planHash: "p",
+      },
+    ],
+    [
+      // The ceiling itself is refused too. Accepting it would hand a resume the
+      // step above, which increments to itself, gets recorded, and is then
+      // rejected by the next read -- a marker with no way forward.
+      "in-flight at the safe integer ceiling",
+      {
+        version: 1,
+        status: "migrating",
+        direction: "up",
+        migrationId: "r",
+        step: Number.MAX_SAFE_INTEGER,
         manifestHash: "h",
         planHash: "p",
       },

--- a/packages/nextly/src/domains/field-groups/migration/guard.ts
+++ b/packages/nextly/src/domains/field-groups/migration/guard.ts
@@ -1,0 +1,96 @@
+/**
+ * Decides whether the field-group storage is safe to use.
+ *
+ * Two facts are combined: the durable marker, and whether objects carrying the
+ * post-migration names are actually present. Neither alone is sufficient.
+ *
+ * The marker alone cannot tell us that a run which claims to be finished really
+ * renamed anything. Object presence alone cannot tell us who created what: an
+ * `fg_*` table may belong to the host application, and Nextly shares a database
+ * with the app it runs inside. Only the pair is conclusive, and every
+ * combination the pair cannot explain is refused rather than guessed at.
+ *
+ * This runs before the registry loads. The registry tolerates a missing data
+ * table by design, so a check placed after it would inspect a world that had
+ * already silently absorbed the very inconsistency being looked for.
+ *
+ * @module domains/field-groups/migration/guard
+ */
+
+import { NextlyError } from "../../../errors/nextly-error";
+
+import type { MigrationState } from "./state";
+
+/** What the caller found in the database. Gathering it is dialect-specific. */
+export interface StorageProbe {
+  /** A registry table carrying the post-migration name exists. */
+  targetRegistryPresent: boolean;
+  /** A registry table carrying the pre-migration name exists. */
+  legacyRegistryPresent: boolean;
+}
+
+/** What the caller should do next. */
+export type StorageVerdict =
+  | { action: "use-legacy" }
+  | { action: "use-field-groups-v2" }
+  | { action: "resume"; step: number };
+
+/**
+ * Resolve state plus probe into an instruction, or throw.
+ *
+ * Every throw here is a deliberate refusal. None of these situations is
+ * recoverable by guessing, and guessing wrong rewrites or drops customer data.
+ */
+export function resolveStorageVerdict(args: {
+  state: MigrationState;
+  probe: StorageProbe;
+}): StorageVerdict {
+  const { state, probe } = args;
+
+  if (state.status === "migrating") {
+    // A run died in flight. Resuming is the only safe move: the objects are in
+    // a state only the step list can interpret.
+    return { action: "resume", step: state.step + 1 };
+  }
+
+  if (state.generation === "field-groups-v2") {
+    if (!probe.targetRegistryPresent) {
+      // The marker claims the migration finished but the renamed registry is
+      // gone. Something restored an older database under a newer marker, or
+      // dropped the table. Serving would read the legacy registry while the
+      // runtime writes post-migration names.
+      throw refuse(
+        "marker reports a completed migration but the migrated registry is absent",
+        { generation: state.generation, probe }
+      );
+    }
+    return { action: "use-field-groups-v2" };
+  }
+
+  // generation === "legacy"
+  if (probe.targetRegistryPresent) {
+    // An object carrying our post-migration name exists with no record of us
+    // creating it. It belongs to the host application, or to a migration run
+    // whose marker was lost. Either way the migration cannot claim the name,
+    // and proceeding would rename over data we do not own.
+    throw refuse(
+      "an object using the migrated storage name exists but no migration recorded it",
+      { generation: state.generation, probe }
+    );
+  }
+
+  return { action: "use-legacy" };
+}
+
+/**
+ * Refusals are 503 rather than a programmer-error code: the database is in a
+ * shape a human has to look at, and the process must not serve until they have.
+ * Details go to `logContext` so operators get the full picture while the public
+ * message stays generic.
+ */
+function refuse(reason: string, context: Record<string, unknown>): NextlyError {
+  return NextlyError.serviceUnavailable({
+    logMessage: `field-group storage refused to start: ${reason}`,
+    logContext: { reason, ...context },
+  });
+}

--- a/packages/nextly/src/domains/field-groups/migration/guard.ts
+++ b/packages/nextly/src/domains/field-groups/migration/guard.ts
@@ -29,11 +29,19 @@ export interface StorageProbe {
   legacyRegistryPresent: boolean;
 }
 
-/** What the caller should do next. */
+/**
+ * What the caller should do next.
+ *
+ * The resume verdict carries the manifest hash the interrupted run was planned
+ * against rather than leaving it in the marker for the caller to look up. A
+ * resumed step is only meaningful against that same plan, so the value the
+ * caller must check is handed to it alongside the step it would otherwise run
+ * blind. See `assertManifestUnchanged`.
+ */
 export type StorageVerdict =
   | { action: "use-legacy" }
   | { action: "use-field-groups-v2" }
-  | { action: "resume"; step: number };
+  | { action: "resume"; step: number; manifestHash: string };
 
 /**
  * Resolve state plus probe into an instruction, or throw.
@@ -49,8 +57,13 @@ export function resolveStorageVerdict(args: {
 
   if (state.status === "migrating") {
     // A run died in flight. Resuming is the only safe move: the objects are in
-    // a state only the step list can interpret.
-    return { action: "resume", step: state.step + 1 };
+    // a state only the step list can interpret. The recorded manifest hash
+    // travels with the step so the resumed run can refuse a changed plan.
+    return {
+      action: "resume",
+      step: state.step + 1,
+      manifestHash: state.manifestHash,
+    };
   }
 
   if (state.generation === "field-groups-v2") {

--- a/packages/nextly/src/domains/field-groups/migration/guard.ts
+++ b/packages/nextly/src/domains/field-groups/migration/guard.ts
@@ -112,6 +112,17 @@ export function resolveStorageVerdict(args: {
         { generation: state.generation, probe }
       );
     }
+    if (probe.legacyRegistryPresent) {
+      // A completed migration renames the legacy registry; it does not leave a
+      // copy behind. Both being present means something reintroduced the old
+      // one, so there are two tables claiming to be the registry and no way to
+      // tell which the runtime should believe. It also strands rollback, whose
+      // rename would collide with the table already sitting at the legacy name.
+      throw refuse(
+        "both the legacy and migrated registries are present after a completed migration",
+        { generation: state.generation, probe }
+      );
+    }
     // The registry existing proves only that the registry exists. The objects
     // it points at are what content is actually read from, and the read path
     // treats a missing data table as an empty result rather than an error, so

--- a/packages/nextly/src/domains/field-groups/migration/guard.ts
+++ b/packages/nextly/src/domains/field-groups/migration/guard.ts
@@ -19,6 +19,7 @@
 
 import { NextlyError } from "../../../errors/nextly-error";
 
+import { MAX_MIGRATION_STEP } from "./state";
 import type {
   MigrationDirection,
   MigrationPlanIdentity,
@@ -88,6 +89,17 @@ export function resolveStorageVerdict(args: {
   const { state, probe } = args;
 
   if (state.status === "migrating") {
+    if (state.step >= MAX_MIGRATION_STEP) {
+      // The next position could not be recorded even if its step ran, so a
+      // resume from here can never make progress. Refusing belongs at this
+      // point rather than in the read: the read must keep accepting every step
+      // the writer is allowed to store, or a legitimately recorded marker
+      // becomes unreadable, which is the same dead end from the other side.
+      throw refuse(
+        "the interrupted run stopped at a position it cannot advance past",
+        { step: state.step, max: MAX_MIGRATION_STEP }
+      );
+    }
     // A run died in flight. Resuming is the only safe move: the objects are in
     // a state only the step list can interpret. The run's own identity travels
     // with the step so the resumed run picks the right list, keeps the same id,
@@ -154,6 +166,18 @@ export function resolveStorageVerdict(args: {
     // and proceeding would rename over data we do not own.
     throw refuse(
       "an object using the migrated storage name exists but no migration recorded it",
+      { generation: state.generation, probe }
+    );
+  }
+
+  if (state.recorded && !probe.legacyRegistryPresent) {
+    // A marker that explicitly records legacy storage was written after a run
+    // that left a legacy registry behind, so its absence is unexplained. This
+    // is the mirror of the migrated case, and refusing keeps the two symmetric.
+    // An untouched database is excluded on purpose: it has no marker and no
+    // registry yet, and creating one is ordinary first-run behaviour.
+    throw refuse(
+      "marker records legacy storage but the legacy registry is absent",
       { generation: state.generation, probe }
     );
   }

--- a/packages/nextly/src/domains/field-groups/migration/guard.ts
+++ b/packages/nextly/src/domains/field-groups/migration/guard.ts
@@ -19,7 +19,22 @@
 
 import { NextlyError } from "../../../errors/nextly-error";
 
-import type { MigrationState } from "./state";
+import type {
+  MigrationDirection,
+  MigrationPlanIdentity,
+  MigrationState,
+} from "./state";
+
+/**
+ * Whether every object the migrated registry points at is actually there and
+ * actually migrated.
+ *
+ * `missing` names what was not found, so a refusal tells an operator which
+ * objects to restore rather than only that something is wrong.
+ */
+export type MigratedObjectsVerification =
+  | { complete: true }
+  | { complete: false; missing: string[] };
 
 /** What the caller found in the database. Gathering it is dialect-specific. */
 export interface StorageProbe {
@@ -27,21 +42,38 @@ export interface StorageProbe {
   targetRegistryPresent: boolean;
   /** A registry table carrying the pre-migration name exists. */
   legacyRegistryPresent: boolean;
+  /**
+   * The result of checking the objects the migrated registry references, not
+   * just the registry itself.
+   *
+   * `null` means no such check was performed. That is never sufficient to serve
+   * migrated storage: the registry existing says nothing about whether the data
+   * tables it points at survived, and the read path treats a missing data table
+   * as an empty result rather than an error.
+   */
+  migratedObjects: MigratedObjectsVerification | null;
 }
 
 /**
  * What the caller should do next.
  *
- * The resume verdict carries the manifest hash the interrupted run was planned
- * against rather than leaving it in the marker for the caller to look up. A
- * resumed step is only meaningful against that same plan, so the value the
- * caller must check is handed to it alongside the step it would otherwise run
- * blind. See `assertManifestUnchanged`.
+ * The resume verdict carries everything a resume needs rather than leaving it
+ * in the marker to be looked up separately: `direction` selects which step list
+ * the step number indexes into, `migrationId` is the identity `advanceStep`
+ * checks against, and `plan` is what the rebuilt plan must match. A consumer
+ * that follows this type cannot resume in the wrong direction, mint an id that
+ * will be rejected, or skip the plan comparison. See `assertPlanUnchanged`.
  */
 export type StorageVerdict =
   | { action: "use-legacy" }
   | { action: "use-field-groups-v2" }
-  | { action: "resume"; step: number; manifestHash: string };
+  | {
+      action: "resume";
+      step: number;
+      direction: MigrationDirection;
+      migrationId: string;
+      plan: MigrationPlanIdentity;
+    };
 
 /**
  * Resolve state plus probe into an instruction, or throw.
@@ -57,12 +89,15 @@ export function resolveStorageVerdict(args: {
 
   if (state.status === "migrating") {
     // A run died in flight. Resuming is the only safe move: the objects are in
-    // a state only the step list can interpret. The recorded manifest hash
-    // travels with the step so the resumed run can refuse a changed plan.
+    // a state only the step list can interpret. The run's own identity travels
+    // with the step so the resumed run picks the right list, keeps the same id,
+    // and can refuse a plan that moved underneath it.
     return {
       action: "resume",
       step: state.step + 1,
-      manifestHash: state.manifestHash,
+      direction: state.direction,
+      migrationId: state.migrationId,
+      plan: state.plan,
     };
   }
 
@@ -75,6 +110,26 @@ export function resolveStorageVerdict(args: {
       throw refuse(
         "marker reports a completed migration but the migrated registry is absent",
         { generation: state.generation, probe }
+      );
+    }
+    // The registry existing proves only that the registry exists. The objects
+    // it points at are what content is actually read from, and the read path
+    // treats a missing data table as an empty result rather than an error, so
+    // an unverified or incomplete rename would serve blank content instead of
+    // failing. Nothing short of a full structural check earns a v2 verdict.
+    if (probe.migratedObjects === null) {
+      throw refuse(
+        "migrated storage was not structurally verified before use",
+        { generation: state.generation, probe }
+      );
+    }
+    if (!probe.migratedObjects.complete) {
+      throw refuse(
+        "objects the migrated registry references are missing or unmigrated",
+        {
+          generation: state.generation,
+          missing: probe.migratedObjects.missing,
+        }
       );
     }
     return { action: "use-field-groups-v2" };

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -24,6 +24,21 @@ export const FIELD_GROUP_MIGRATION_KEY = "field_groups.storage_migration";
 /** Marker payload version, so a later migration can evolve this shape. */
 export const MIGRATION_MARKER_VERSION = 1;
 
+/**
+ * Highest step the marker will hold, one below the safe-integer ceiling.
+ *
+ * The bound is enforced identically on read and on write, which is what makes
+ * it useful: every accepted step can be incremented exactly, and every step
+ * written can be read back afterwards. Allowing the ceiling itself would let a
+ * resume hand out `MAX_SAFE_INTEGER + 1`, which increments to itself, be
+ * recorded, and then be rejected as corrupt by the very next read — leaving the
+ * migration permanently unavailable with no way forward.
+ *
+ * A real plan has a handful of steps, so this is a corruption bound rather than
+ * a capacity one.
+ */
+export const MAX_MIGRATION_STEP = Number.MAX_SAFE_INTEGER - 1;
+
 /** Which way a run is travelling. `down` reverses a completed or partial `up`. */
 export type MigrationDirection = "up" | "down";
 
@@ -152,9 +167,16 @@ export async function readMigrationState(
     }
     // Safe rather than merely integral: at 2^53 and above `step + 1 === step`,
     // so a resume would compute the same position forever instead of advancing.
-    // A marker holding a number that cannot be incremented is corrupt, not
-    // resumable.
-    if (typeof step !== "number" || !Number.isSafeInteger(step) || step < 0) {
+    // Bounded one below that ceiling as well, so the step a resume derives from
+    // this one is itself recordable. A marker holding a number that cannot be
+    // incremented, or incremented into a value that cannot be stored, is
+    // corrupt rather than resumable.
+    if (
+      typeof step !== "number" ||
+      !Number.isSafeInteger(step) ||
+      step < 0 ||
+      step > MAX_MIGRATION_STEP
+    ) {
       throw markerCorrupt("in-flight marker carries no valid step");
     }
     if (typeof manifestHash !== "string" || manifestHash.length === 0) {
@@ -236,6 +258,18 @@ export async function advanceStep(
         reason: "migration steps must advance by exactly one",
         from: current.step,
         to: args.step,
+      },
+    });
+  }
+  // Refuse to record a position that could not be read back. Writing past the
+  // bound would settle the marker into a shape the next read rejects as
+  // corrupt, which is a worse outcome than declining to advance.
+  if (args.step > MAX_MIGRATION_STEP) {
+    throw NextlyError.internal({
+      logContext: {
+        reason: "migration step exceeds the highest recordable position",
+        step: args.step,
+        max: MAX_MIGRATION_STEP,
       },
     });
   }

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -42,18 +42,40 @@ export interface SettledState {
 }
 
 /**
+ * What a run was planned against.
+ *
+ * A step is recorded as a number, and a number only indexes into a plan. Two
+ * independent things can change that plan out from under an interrupted run,
+ * and either one makes the recorded step mean something different:
+ *
+ * - `manifestHash` covers the object map: which tables, columns and stored keys
+ *   this database's field groups resolve to. It moves when the application's
+ *   schema changes.
+ * - `planHash` covers the ordered step list the running build produces. It
+ *   moves when Nextly itself is upgraded and steps are added, removed or
+ *   reordered, which can happen while the application's schema is untouched.
+ *
+ * Neither subsumes the other, so both are recorded and both are compared.
+ */
+export interface MigrationPlanIdentity {
+  manifestHash: string;
+  planHash: string;
+}
+
+/**
  * A run is in flight, or died in flight.
  *
  * `step` is the last step whose postcondition verified, so a resume starts at
- * `step + 1`. `manifestHash` pins the object map the run was planned against;
- * resuming against a different map is refused rather than reconciled.
+ * `step + 1`. `direction` and `migrationId` are recorded because a resume needs
+ * both: the direction selects the step list, and `advanceStep` refuses an id it
+ * does not recognise.
  */
 export interface MigratingState {
   status: "migrating";
   direction: MigrationDirection;
   migrationId: string;
   step: number;
-  manifestHash: string;
+  plan: MigrationPlanIdentity;
 }
 
 export type MigrationState = SettledState | MigratingState;
@@ -67,6 +89,7 @@ interface StoredMarker {
   migrationId?: string;
   step?: number;
   manifestHash?: string;
+  planHash?: string;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -120,7 +143,7 @@ export async function readMigrationState(
   }
 
   if (marker.status === "migrating") {
-    const { direction, migrationId, step, manifestHash } = marker;
+    const { direction, migrationId, step, manifestHash, planHash } = marker;
     if (direction !== "up" && direction !== "down") {
       throw markerCorrupt("in-flight marker carries no known direction");
     }
@@ -133,7 +156,16 @@ export async function readMigrationState(
     if (typeof manifestHash !== "string" || manifestHash.length === 0) {
       throw markerCorrupt("in-flight marker carries no manifest hash");
     }
-    return { status: "migrating", direction, migrationId, step, manifestHash };
+    if (typeof planHash !== "string" || planHash.length === 0) {
+      throw markerCorrupt("in-flight marker carries no plan hash");
+    }
+    return {
+      status: "migrating",
+      direction,
+      migrationId,
+      step,
+      plan: { manifestHash, planHash },
+    };
   }
 
   throw markerCorrupt(`unknown marker status ${String(marker.status)}`);
@@ -151,7 +183,7 @@ export async function beginMigration(
   args: {
     direction: MigrationDirection;
     migrationId: string;
-    manifestHash: string;
+    plan: MigrationPlanIdentity;
   }
 ): Promise<void> {
   const marker: StoredMarker = {
@@ -160,7 +192,8 @@ export async function beginMigration(
     direction: args.direction,
     migrationId: args.migrationId,
     step: 0,
-    manifestHash: args.manifestHash,
+    manifestHash: args.plan.manifestHash,
+    planHash: args.plan.planHash,
   };
   await meta.set(FIELD_GROUP_MIGRATION_KEY, marker);
 }
@@ -209,37 +242,58 @@ export async function advanceStep(
     direction: current.direction,
     migrationId: current.migrationId,
     step: args.step,
-    manifestHash: current.manifestHash,
+    manifestHash: current.plan.manifestHash,
+    planHash: current.plan.planHash,
   };
   await meta.set(FIELD_GROUP_MIGRATION_KEY, marker);
 }
 
 /**
- * Refuse to resume a run whose plan no longer describes the same objects.
+ * Refuse to resume a run whose plan is no longer the plan that was interrupted.
  *
  * Steps are identified by position, and a position only means something
- * relative to the manifest it was planned against. If the object map changed
- * between the interrupted run and this one — a deployment, an edited schema, a
- * field group added or removed — then step N now names different objects than
- * the step N that was checked off, and continuing would rename or verify the
- * wrong ones. There is no safe reconciliation, so this refuses.
+ * relative to the plan it was checked off under. Two different changes can
+ * invalidate it, and they are reported separately because they point an
+ * operator at different causes:
  *
- * Callers must invoke this once they have rebuilt the plan and can supply its
- * hash, which is necessarily after the resume decision itself is made.
+ * - The object map moved: the application's schema changed between the
+ *   interrupted run and this one, so step N now names different objects.
+ * - The step list moved: Nextly was upgraded and its steps were added, removed
+ *   or reordered, so step N is a different operation even though the database's
+ *   own objects are untouched.
+ *
+ * Neither is reconcilable, so both refuse. Callers invoke this once they have
+ * rebuilt the plan and can supply its identity, which is necessarily after the
+ * resume decision itself is made.
  */
-export function assertManifestUnchanged(args: {
-  recorded: string;
-  current: string;
+export function assertPlanUnchanged(args: {
+  recorded: MigrationPlanIdentity;
+  current: MigrationPlanIdentity;
 }): void {
-  if (args.recorded === args.current) return;
-  throw NextlyError.serviceUnavailable({
-    logMessage:
-      "field-group migration cannot resume: the plan changed since the interrupted run",
-    logContext: {
-      reason: "migration manifest changed since the interrupted run",
-      recorded: args.recorded,
-      current: args.current,
-    },
+  if (args.recorded.manifestHash !== args.current.manifestHash) {
+    throw planMoved(
+      "migration object map changed since the interrupted run",
+      args.recorded.manifestHash,
+      args.current.manifestHash
+    );
+  }
+  if (args.recorded.planHash !== args.current.planHash) {
+    throw planMoved(
+      "migration step list changed since the interrupted run",
+      args.recorded.planHash,
+      args.current.planHash
+    );
+  }
+}
+
+function planMoved(
+  reason: string,
+  recorded: string,
+  current: string
+): NextlyError {
+  return NextlyError.serviceUnavailable({
+    logMessage: `field-group migration cannot resume: ${reason}`,
+    logContext: { reason, recorded, current },
   });
 }
 

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -1,0 +1,235 @@
+/**
+ * Durable state for the field-group storage migration.
+ *
+ * The migration renames tables, columns and stored JSON keys on a live
+ * database. Knowing where a previous run stopped cannot be inferred from what
+ * objects happen to exist: a half-renamed database and a database that never
+ * started look similar from the outside, and an object carrying the target name
+ * may belong to the host application rather than to us. So the run records its
+ * own progress in `nextly_meta` and every decision is made from that record.
+ *
+ * The marker is written before the first statement rather than after, because
+ * MySQL commits DDL implicitly: a crash between the first rename and a
+ * post-hoc marker write would leave renamed objects with no record of them.
+ *
+ * @module domains/field-groups/migration/state
+ */
+
+import { NextlyError } from "../../../errors/nextly-error";
+import type { MetaService } from "../../meta/services/meta-service";
+
+/** `nextly_meta` key holding the marker. */
+export const FIELD_GROUP_MIGRATION_KEY = "field_groups.storage_migration";
+
+/** Marker payload version, so a later migration can evolve this shape. */
+export const MIGRATION_MARKER_VERSION = 1;
+
+/** Which way a run is travelling. `down` reverses a completed or partial `up`. */
+export type MigrationDirection = "up" | "down";
+
+/**
+ * Storage generation.
+ *
+ * `legacy` is also what an untouched database reports: absent and legacy are
+ * the same starting position, so a first run needs no special case.
+ */
+export type StorageGeneration = "legacy" | "field-groups-v2";
+
+/** No run in progress; storage is at one generation or the other. */
+export interface SettledState {
+  status: "settled";
+  generation: StorageGeneration;
+}
+
+/**
+ * A run is in flight, or died in flight.
+ *
+ * `step` is the last step whose postcondition verified, so a resume starts at
+ * `step + 1`. `manifestHash` pins the object map the run was planned against;
+ * resuming against a different map is refused rather than reconciled.
+ */
+export interface MigratingState {
+  status: "migrating";
+  direction: MigrationDirection;
+  migrationId: string;
+  step: number;
+  manifestHash: string;
+}
+
+export type MigrationState = SettledState | MigratingState;
+
+/** Stored shape. Kept separate from the public union so reads can validate it. */
+interface StoredMarker {
+  version: number;
+  status: "settled" | "migrating";
+  generation?: StorageGeneration;
+  direction?: MigrationDirection;
+  migrationId?: string;
+  step?: number;
+  manifestHash?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Read the marker.
+ *
+ * An absent marker is `settled/legacy`. A marker that is present but malformed
+ * is NOT treated as absent: that would silently restart a migration that may
+ * have already renamed objects, so it throws instead.
+ */
+export async function readMigrationState(
+  meta: MetaService
+): Promise<MigrationState> {
+  const raw = await meta.get<unknown>(FIELD_GROUP_MIGRATION_KEY);
+  if (raw === null || raw === undefined) {
+    return { status: "settled", generation: "legacy" };
+  }
+
+  if (!isRecord(raw)) {
+    throw markerCorrupt("marker is not an object");
+  }
+
+  const marker = raw as unknown as StoredMarker;
+
+  if (marker.version !== MIGRATION_MARKER_VERSION) {
+    throw markerCorrupt(
+      `marker version ${String(marker.version)} is not supported by this build`
+    );
+  }
+
+  if (marker.status === "settled") {
+    if (
+      marker.generation !== "legacy" &&
+      marker.generation !== "field-groups-v2"
+    ) {
+      throw markerCorrupt("settled marker carries no known generation");
+    }
+    return { status: "settled", generation: marker.generation };
+  }
+
+  if (marker.status === "migrating") {
+    const { direction, migrationId, step, manifestHash } = marker;
+    if (direction !== "up" && direction !== "down") {
+      throw markerCorrupt("in-flight marker carries no known direction");
+    }
+    if (typeof migrationId !== "string" || migrationId.length === 0) {
+      throw markerCorrupt("in-flight marker carries no migration id");
+    }
+    if (typeof step !== "number" || !Number.isInteger(step) || step < 0) {
+      throw markerCorrupt("in-flight marker carries no valid step");
+    }
+    if (typeof manifestHash !== "string" || manifestHash.length === 0) {
+      throw markerCorrupt("in-flight marker carries no manifest hash");
+    }
+    return { status: "migrating", direction, migrationId, step, manifestHash };
+  }
+
+  throw markerCorrupt(`unknown marker status ${String(marker.status)}`);
+}
+
+/**
+ * Record that a run is starting. Must be called before the first statement.
+ *
+ * `step: 0` means "planned, nothing verified yet", so a crash immediately after
+ * this write resumes at step 1 and re-runs the first step from scratch. Every
+ * step is idempotent precisely so that re-run is safe.
+ */
+export async function beginMigration(
+  meta: MetaService,
+  args: {
+    direction: MigrationDirection;
+    migrationId: string;
+    manifestHash: string;
+  }
+): Promise<void> {
+  const marker: StoredMarker = {
+    version: MIGRATION_MARKER_VERSION,
+    status: "migrating",
+    direction: args.direction,
+    migrationId: args.migrationId,
+    step: 0,
+    manifestHash: args.manifestHash,
+  };
+  await meta.set(FIELD_GROUP_MIGRATION_KEY, marker);
+}
+
+/**
+ * Check off a step whose postcondition has verified.
+ *
+ * Refuses to move backwards or skip: a caller that has lost track of its
+ * position should re-read the marker rather than assert a new one.
+ */
+export async function advanceStep(
+  meta: MetaService,
+  args: { migrationId: string; step: number }
+): Promise<void> {
+  const current = await readMigrationState(meta);
+  if (current.status !== "migrating") {
+    throw NextlyError.internal({
+      logContext: {
+        reason: "advanceStep called with no migration in flight",
+        step: args.step,
+      },
+    });
+  }
+  if (current.migrationId !== args.migrationId) {
+    throw NextlyError.internal({
+      logContext: {
+        reason: "advanceStep called for a different migration run",
+        expected: current.migrationId,
+        received: args.migrationId,
+      },
+    });
+  }
+  if (args.step !== current.step + 1) {
+    throw NextlyError.internal({
+      logContext: {
+        reason: "migration steps must advance by exactly one",
+        from: current.step,
+        to: args.step,
+      },
+    });
+  }
+
+  const marker: StoredMarker = {
+    version: MIGRATION_MARKER_VERSION,
+    status: "migrating",
+    direction: current.direction,
+    migrationId: current.migrationId,
+    step: args.step,
+    manifestHash: current.manifestHash,
+  };
+  await meta.set(FIELD_GROUP_MIGRATION_KEY, marker);
+}
+
+/**
+ * Settle the marker at a generation.
+ *
+ * Called only after structural verification passes, so the generation the
+ * marker reports is one that has been checked rather than assumed.
+ */
+export async function settleMigration(
+  meta: MetaService,
+  generation: StorageGeneration
+): Promise<void> {
+  const marker: StoredMarker = {
+    version: MIGRATION_MARKER_VERSION,
+    status: "settled",
+    generation,
+  };
+  await meta.set(FIELD_GROUP_MIGRATION_KEY, marker);
+}
+
+// A marker that exists but cannot be read is refused rather than ignored:
+// treating it as absent would restart a run that may already have renamed
+// objects. Serving is unsafe until an operator looks, hence 503 rather than a
+// programmer-error code.
+function markerCorrupt(reason: string): NextlyError {
+  return NextlyError.serviceUnavailable({
+    logMessage: `field-group migration marker is unreadable: ${reason}`,
+    logContext: { key: FIELD_GROUP_MIGRATION_KEY, reason },
+  });
+}

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -79,20 +79,29 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * An absent marker is `settled/legacy`. A marker that is present but malformed
  * is NOT treated as absent: that would silently restart a migration that may
  * have already renamed objects, so it throws instead.
+ *
+ * Absence is decided by whether the row exists, never by whether its value
+ * decodes to `null`. A row holding SQL NULL or the JSON literal `null` is a
+ * marker we wrote and can no longer read, which is the corrupt case, not the
+ * untouched one.
  */
 export async function readMigrationState(
   meta: MetaService
 ): Promise<MigrationState> {
-  const raw = await meta.get<unknown>(FIELD_GROUP_MIGRATION_KEY);
-  if (raw === null || raw === undefined) {
+  const entry = await meta.getEntry<unknown>(FIELD_GROUP_MIGRATION_KEY);
+  if (!entry.present) {
     return { status: "settled", generation: "legacy" };
   }
 
-  if (!isRecord(raw)) {
+  if (entry.value === null || entry.value === undefined) {
+    throw markerCorrupt("marker row exists but carries no value");
+  }
+
+  if (!isRecord(entry.value)) {
     throw markerCorrupt("marker is not an object");
   }
 
-  const marker = raw as unknown as StoredMarker;
+  const marker = entry.value as unknown as StoredMarker;
 
   if (marker.version !== MIGRATION_MARKER_VERSION) {
     throw markerCorrupt(
@@ -203,6 +212,35 @@ export async function advanceStep(
     manifestHash: current.manifestHash,
   };
   await meta.set(FIELD_GROUP_MIGRATION_KEY, marker);
+}
+
+/**
+ * Refuse to resume a run whose plan no longer describes the same objects.
+ *
+ * Steps are identified by position, and a position only means something
+ * relative to the manifest it was planned against. If the object map changed
+ * between the interrupted run and this one — a deployment, an edited schema, a
+ * field group added or removed — then step N now names different objects than
+ * the step N that was checked off, and continuing would rename or verify the
+ * wrong ones. There is no safe reconciliation, so this refuses.
+ *
+ * Callers must invoke this once they have rebuilt the plan and can supply its
+ * hash, which is necessarily after the resume decision itself is made.
+ */
+export function assertManifestUnchanged(args: {
+  recorded: string;
+  current: string;
+}): void {
+  if (args.recorded === args.current) return;
+  throw NextlyError.serviceUnavailable({
+    logMessage:
+      "field-group migration cannot resume: the plan changed since the interrupted run",
+    logContext: {
+      reason: "migration manifest changed since the interrupted run",
+      recorded: args.recorded,
+      current: args.current,
+    },
+  });
 }
 
 /**

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -150,7 +150,11 @@ export async function readMigrationState(
     if (typeof migrationId !== "string" || migrationId.length === 0) {
       throw markerCorrupt("in-flight marker carries no migration id");
     }
-    if (typeof step !== "number" || !Number.isInteger(step) || step < 0) {
+    // Safe rather than merely integral: at 2^53 and above `step + 1 === step`,
+    // so a resume would compute the same position forever instead of advancing.
+    // A marker holding a number that cannot be incremented is corrupt, not
+    // resumable.
+    if (typeof step !== "number" || !Number.isSafeInteger(step) || step < 0) {
       throw markerCorrupt("in-flight marker carries no valid step");
     }
     if (typeof manifestHash !== "string" || manifestHash.length === 0) {

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -45,8 +45,9 @@ export type MigrationDirection = "up" | "down";
 /**
  * Storage generation.
  *
- * `legacy` is also what an untouched database reports: absent and legacy are
- * the same starting position, so a first run needs no special case.
+ * `legacy` is also what an untouched database reports, so a first run needs no
+ * special case for the generation itself. The two are not interchangeable
+ * though, and `SettledState.recorded` keeps them apart.
  */
 export type StorageGeneration = "legacy" | "field-groups-v2";
 
@@ -54,6 +55,17 @@ export type StorageGeneration = "legacy" | "field-groups-v2";
 export interface SettledState {
   status: "settled";
   generation: StorageGeneration;
+  /**
+   * Whether a marker actually said this, or it is the default an untouched
+   * database reports.
+   *
+   * Both read as `legacy`, but they are not the same claim, and one decision
+   * turns on the difference: an untouched database legitimately has no registry
+   * yet, whereas a marker that explicitly records legacy storage was written
+   * after a run that left one behind, so a missing registry there is
+   * unexplained rather than expected.
+   */
+  recorded: boolean;
 }
 
 /**
@@ -128,7 +140,7 @@ export async function readMigrationState(
 ): Promise<MigrationState> {
   const entry = await meta.getEntry<unknown>(FIELD_GROUP_MIGRATION_KEY);
   if (!entry.present) {
-    return { status: "settled", generation: "legacy" };
+    return { status: "settled", generation: "legacy", recorded: false };
   }
 
   if (entry.value === null || entry.value === undefined) {
@@ -154,7 +166,11 @@ export async function readMigrationState(
     ) {
       throw markerCorrupt("settled marker carries no known generation");
     }
-    return { status: "settled", generation: marker.generation };
+    return {
+      status: "settled",
+      generation: marker.generation,
+      recorded: true,
+    };
   }
 
   if (marker.status === "migrating") {
@@ -212,6 +228,13 @@ export async function beginMigration(
     plan: MigrationPlanIdentity;
   }
 ): Promise<void> {
+  // The writer holds itself to the reader's invariants. Persisting a marker the
+  // next read would reject leaves the database unavailable with no way forward,
+  // and an empty identifier is the easiest way to do that by accident.
+  requireIdentifier(args.migrationId, "migrationId");
+  requireIdentifier(args.plan.manifestHash, "manifestHash");
+  requireIdentifier(args.plan.planHash, "planHash");
+
   const marker: StoredMarker = {
     version: MIGRATION_MARKER_VERSION,
     status: "migrating",
@@ -222,6 +245,18 @@ export async function beginMigration(
     planHash: args.plan.planHash,
   };
   await meta.set(FIELD_GROUP_MIGRATION_KEY, marker);
+}
+
+// Mirrors the non-empty check `readMigrationState` applies, so the two cannot
+// drift into a writer that produces markers its own reader refuses.
+function requireIdentifier(value: string, field: string): void {
+  if (typeof value === "string" && value.length > 0) return;
+  throw NextlyError.internal({
+    logContext: {
+      reason: "migration marker identifier must be a non-empty string",
+      field,
+    },
+  });
 }
 
 /**

--- a/packages/nextly/src/domains/meta/services/meta-service.ts
+++ b/packages/nextly/src/domains/meta/services/meta-service.ts
@@ -8,6 +8,17 @@ import { BaseService } from "../../../shared/base-service";
 import type { Logger } from "../../../shared/types";
 
 /**
+ * A key's stored value plus whether the key exists.
+ *
+ * `value` is nullable on a present key because the row's value column may be
+ * SQL NULL or may hold the JSON literal `null`; neither is distinguishable
+ * from the other once decoded, but both are distinguishable from absence.
+ */
+export type MetaEntry<T = unknown> =
+  | { present: true; value: T | null }
+  | { present: false };
+
+/**
  * MetaService — small KV API over the `nextly_meta` table.
  *
  * Used for runtime flags that don't belong in collection schemas
@@ -41,21 +52,38 @@ export class MetaService extends BaseService {
     return this.adapter.getDrizzle();
   }
 
-  async get<T = unknown>(key: string): Promise<T | null> {
+  /**
+   * Read a key together with whether a row for it exists at all.
+   *
+   * `get` collapses three different situations onto `null`: no row, a row whose
+   * value column is SQL NULL, and a row holding the JSON literal `null`.
+   * Callers for which "absent" and "present but carrying nothing readable" mean
+   * different things must use this instead, because for them the difference
+   * decides whether it is safe to proceed.
+   */
+  async getEntry<T = unknown>(key: string): Promise<MetaEntry<T>> {
     const rows = await this.drizzle
       .select()
       .from(this.table)
       .where(eq(this.table.key, key))
       .limit(1);
-    if (rows.length === 0) return null;
+    if (rows.length === 0) return { present: false };
     const raw = rows[0].value as string | null;
-    if (raw === null || raw === undefined) return null;
+    if (raw === null || raw === undefined)
+      return { present: true, value: null };
     try {
-      return JSON.parse(raw) as T;
+      return { present: true, value: JSON.parse(raw) as T };
     } catch {
       // Stored as a non-JSON string somehow — return as-is
-      return raw as T;
+      return { present: true, value: raw as T };
     }
+  }
+
+  // Delegates so there is one query and one decoding path; an absent row and a
+  // row carrying no value both read as `null`, as callers of `get` expect.
+  async get<T = unknown>(key: string): Promise<T | null> {
+    const entry = await this.getEntry<T>(key);
+    return entry.present ? entry.value : null;
   }
 
   async set(key: string, value: unknown): Promise<void> {


### PR DESCRIPTION
First slice of B1, the field-group storage migration. **B1 ships dark**: nothing calls this code, because the runtime still speaks the legacy storage format. It activates in B2.

This slice contains **no DDL and touches no data**. It only decides.

## Why a durable marker rather than looking at the database

Where a previous run stopped cannot be inferred from what objects exist. A half-renamed database and one that never started look similar from the outside, and an object wearing the post-migration name may belong to the **host application** — Nextly shares a database with the app it runs inside. So the run records its own progress in `nextly_meta`, and every decision is made from that record plus a probe, never from either alone.

The marker is written **before** the first statement, not after: MySQL commits DDL implicitly, so a crash between the first rename and a post-hoc write would leave renamed objects with nothing recording them.

## `state.ts` — the marker

`settled/{legacy,field-groups-v2}` or `migrating/{direction,migrationId,step,manifestHash}`, payload-versioned so a later migration can evolve the shape.

- **Absent === legacy**, so a first run needs no special case.
- **A malformed marker throws; it never degrades to "absent."** This is the most important line in the file — degrading would silently restart a run that may already have renamed objects.
- `beginMigration` writes `step: 0` (planned, nothing verified), so a crash before step 1 re-runs step 1 rather than skipping it.
- `advanceStep` refuses to skip, rewind, or accept a different `migrationId`. A caller that has lost its place must re-read, not assert.

## `guard.ts` — the decision

Verdicts: `use-legacy`, `use-field-groups-v2`, `resume(step)`. Two refusals, both deliberate:

- **A target-named object with no migration recorded** → the host-app collision. Renaming over it would destroy data Nextly does not own.
- **Marker says migrated but the registry is absent** → an older database restored under a newer marker; serving would write post-migration names while reading a legacy registry.

Refusals are `SERVICE_UNAVAILABLE`: the database is in a shape a human has to look at, and the process must not serve until they have. The narrative goes to `logContext`, so operators get the full picture while the public message stays generic.

## Prior art this is built on

I surveyed the schema/migration audits before writing it, and four findings shaped the design:

- **Task 077** is the worked example of the failure this prevents: companion migrations emit bare `CREATE TABLE`, ship snapshot-less, and **fail hard mid-run after earlier files in the same invocation already applied**. Partial application with no resume path.
- **Task 062** validates where the guard goes. `FieldGroupQueryService.getExistingInstances` tolerates a missing `comp_*` table by design (the security consequence was re-audited and largely disproven, so this is not a re-raise). That tolerance is exactly why the guard must run **before** the registry load — a check after it would inspect a world that had already absorbed the inconsistency.
- **P0-E** (`db:sync` classifies builder-made tables as orphans to DROP) means a later slice must make `db:sync` refuse while the marker says `migrating`. Noted for B1-3.
- **Index loss on SQLite** means structural verification must assert indexes by name, not just tables. Noted for B1-3.

## Verification

- 23 tests, **proven load-bearing by breaking**: removing the collision refusal fails 2; an off-by-one in the resume step fails 2 more. Restored, 23/23.
- Zero branch-only failures across the full `packages/nextly` suite.
- `check-types` 19/19. **Lint checked by exit code** (0), not by grepping for "error" — a prior program lost time to a grep hiding a real import-order failure.

## Not in this slice

The storage probe is an interface, not an implementation: gathering it is dialect-specific and belongs with the execution harness in B1-2, alongside the pinned-connection runner and the MySQL `GET_LOCK` hardening.
