### PR TITLE
fix(nextly): ask the target collection before populating its rows

### DIFF
--- a/.changeset/related-row-collection-access.md
+++ b/.changeset/related-row-collection-access.md
@@ -1,0 +1,34 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Stop a relationship from populating a row the caller may not read. A related
+row belongs to another collection and carries that collection's own read
+rules, but expansion selected it straight from its table and applied only
+field-level redaction — so a caller refused the collection outright still
+obtained its rows by populating a relationship that pointed at them.
+
+The target collection's stored read rules are now evaluated for the caller
+before its rows are populated, on single reads, listings and nested hops. A
+refused target reads as an absent relationship rather than an error, so one
+unreadable reference does not refuse the whole parent read.

--- a/packages/nextly/src/domains/collections/__tests__/_fixtures/related-target-read-rule.ts
+++ b/packages/nextly/src/domains/collections/__tests__/_fixtures/related-target-read-rule.ts
@@ -23,6 +23,9 @@ export default function relatedTargetReadRule({
     // readable document whose relationship target is not readable.
     case "denied":
     case "always":
+    // Refused here while the Single's own rule admits the caller, so the
+    // document is readable and its relationship target is not.
+    case "needs-populated-author":
       return false;
     // Everything except one document. Evaluated without the id this reads as
     // "allowed" and hands back the one row it exists to withhold.

--- a/packages/nextly/src/domains/collections/__tests__/_fixtures/related-target-read-rule.ts
+++ b/packages/nextly/src/domains/collections/__tests__/_fixtures/related-target-read-rule.ts
@@ -1,0 +1,31 @@
+/**
+ * A stored `custom` read rule for a relationship TARGET collection, as a real
+ * module so the access service's dynamic `import(functionPath)` can load it.
+ *
+ * Keyed on the requested document id as well as the caller, because a rule
+ * evaluated without an id behaves differently in both directions: it hides
+ * rows the rule permits, and — for an exclusion written as `id !== blocked` —
+ * admits the very row it forbids, since `undefined !== blocked` is true.
+ *
+ * The id to withhold travels on the caller rather than being hard-coded, so a
+ * test can block a row whose id the database generated.
+ */
+export default function relatedTargetReadRule({
+  req,
+  id,
+}: {
+  req: { user?: { id?: string; blockedId?: string } };
+  id?: string;
+}): unknown {
+  switch (req.user?.id) {
+    // Refuses the caller outright, whatever they ask for.
+    case "denied":
+      return false;
+    // Everything except one document. Evaluated without the id this reads as
+    // "allowed" and hands back the one row it exists to withhold.
+    case "blocked-one":
+      return id !== req.user?.blockedId;
+    default:
+      return true;
+  }
+}

--- a/packages/nextly/src/domains/collections/__tests__/_fixtures/related-target-read-rule.ts
+++ b/packages/nextly/src/domains/collections/__tests__/_fixtures/related-target-read-rule.ts
@@ -32,6 +32,11 @@ export default function relatedTargetReadRule({
     // collection, but only the rows matching their tenant.
     case "tenant-scoped":
       return { tenant: { equals: req.user?.tenant } };
+    // Answers DIFFERENTLY depending on the row asked about: unrestricted when
+    // asked in general, tenant-scoped for a concrete document. A narrowing
+    // resolved without the id would be the weaker of the two.
+    case "id-varying":
+      return id === undefined ? true : { tenant: { equals: req.user?.tenant } };
     default:
       return true;
   }

--- a/packages/nextly/src/domains/collections/__tests__/_fixtures/related-target-read-rule.ts
+++ b/packages/nextly/src/domains/collections/__tests__/_fixtures/related-target-read-rule.ts
@@ -18,8 +18,11 @@ export default function relatedTargetReadRule({
   id?: string;
 }): unknown {
   switch (req.user?.id) {
-    // Refuses the caller outright, whatever they ask for.
+    // Refuses the caller outright, whatever they ask for. `always` is refused
+    // too: the Single read rule admits that caller, so the pair describes a
+    // readable document whose relationship target is not readable.
     case "denied":
+    case "always":
       return false;
     // Everything except one document. Evaluated without the id this reads as
     // "allowed" and hands back the one row it exists to withhold.

--- a/packages/nextly/src/domains/collections/__tests__/_fixtures/related-target-read-rule.ts
+++ b/packages/nextly/src/domains/collections/__tests__/_fixtures/related-target-read-rule.ts
@@ -14,7 +14,7 @@ export default function relatedTargetReadRule({
   req,
   id,
 }: {
-  req: { user?: { id?: string; blockedId?: string } };
+  req: { user?: { id?: string; blockedId?: string; tenant?: string } };
   id?: string;
 }): unknown {
   switch (req.user?.id) {
@@ -25,6 +25,10 @@ export default function relatedTargetReadRule({
     // "allowed" and hands back the one row it exists to withhold.
     case "blocked-one":
       return id !== req.user?.blockedId;
+    // Answers with a PREDICATE rather than a verdict: the caller may read the
+    // collection, but only the rows matching their tenant.
+    case "tenant-scoped":
+      return { tenant: { equals: req.user?.tenant } };
     default:
       return true;
   }

--- a/packages/nextly/src/domains/collections/__tests__/_fixtures/related-target-read-rule.ts
+++ b/packages/nextly/src/domains/collections/__tests__/_fixtures/related-target-read-rule.ts
@@ -28,6 +28,10 @@ export default function relatedTargetReadRule({
     // "allowed" and hands back the one row it exists to withhold.
     case "blocked-one":
       return id !== req.user?.blockedId;
+    // Refuses one named row and admits the rest, so a list-valued relationship
+    // ends up part readable and part refused.
+    case "partial":
+      return id !== req.user?.blockedId;
     // Answers with a PREDICATE rather than a verdict: the caller may read the
     // collection, but only the rows matching their tenant.
     case "tenant-scoped":

--- a/packages/nextly/src/domains/collections/__tests__/_fixtures/single-read-rule.ts
+++ b/packages/nextly/src/domains/collections/__tests__/_fixtures/single-read-rule.ts
@@ -25,6 +25,11 @@ export default function singleReadRule({
     // refuses only some of the rows a relationship points at.
     case "partial":
       return true;
+    // Decides on the SHAPE of a relationship: true only while the target is a
+    // populated row. Distinguishes a view that was shown a target the response
+    // will withhold from one that was not.
+    case "needs-populated-author":
+      return typeof (data as { author?: unknown })?.author === "object";
     // A dotted path, whose suffix translation discards while comparing the base
     // column instead — a different predicate than the rule states.
     case "dotted":

--- a/packages/nextly/src/domains/collections/__tests__/_fixtures/single-read-rule.ts
+++ b/packages/nextly/src/domains/collections/__tests__/_fixtures/single-read-rule.ts
@@ -21,6 +21,10 @@ export default function singleReadRule({
     // No predicate: the caller alone decides, so nothing is filtered.
     case "always":
       return true;
+    // Admitted here so a test can pair this caller with a TARGET rule that
+    // refuses only some of the rows a relationship points at.
+    case "partial":
+      return true;
     // A dotted path, whose suffix translation discards while comparing the base
     // column instead — a different predicate than the rule states.
     case "dotted":

--- a/packages/nextly/src/domains/collections/__tests__/related-row-collection-access.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/related-row-collection-access.integration.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Populating a relationship asks the TARGET collection whether this caller may
+ * read it.
+ *
+ * A related row belongs to another collection and carries that collection's own
+ * read rules. Expansion selected it straight from its table and applied only
+ * field-level redaction, so a caller refused the collection outright still
+ * obtained its rows by populating a relationship that pointed at them — the
+ * write-up and the probe are in tasks/left-tasks/081.
+ *
+ * The refusal reads as an ABSENT relationship rather than an error: one
+ * unreadable reference must not refuse the whole parent read, and the caller
+ * learns no more than a reference pointing at nothing would tell them.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, relationship, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const RULE_PATH = new URL("./_fixtures/tenant-read-rule.ts", import.meta.url)
+  .pathname;
+
+/**
+ * `refs` points at the same restricted row twice: once through a field naming
+ * several collections, once through an ordinary single-target field. The
+ * single-target one is the control — the gap was never specific to multi-target
+ * references, and a fix that closed only those would leave the same row
+ * reachable through the field beside it.
+ */
+async function boot(): Promise<{
+  handler: CollectionsHandler;
+  refId: string;
+  pageId: string;
+}> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({ slug: "posts", fields: [text({ name: "title" })] }),
+      defineCollection({
+        slug: "pages",
+        fields: [text({ name: "title" }), text({ name: "tenant" })],
+      }),
+      defineCollection({
+        slug: "refs",
+        fields: [
+          text({ name: "name" }),
+          relationship({ name: "target", relationTo: ["posts", "pages"] }),
+          relationship({ name: "plain", relationTo: "pages" }),
+        ],
+      }),
+    ],
+  });
+
+  const handler = current.getService<CollectionsHandler>("collectionsHandler");
+  const page = await handler.createEntry(
+    { collectionName: "pages", overrideAccess: true },
+    { title: "Restricted page", tenant: "acme" }
+  );
+  const pageId = (page.data as { id: string }).id;
+  const ref = await handler.createEntry(
+    { collectionName: "refs", overrideAccess: true },
+    {
+      name: "r",
+      target: { relationTo: "pages", value: pageId },
+      plain: pageId,
+    }
+  );
+
+  // `claim-aware` without a matching tenant claim is refused outright.
+  await current.adapter.update(
+    "dynamic_collections",
+    { access_rules: { read: { type: "custom", functionPath: RULE_PATH } } },
+    { and: [{ column: "slug", op: "=", value: "pages" }] }
+  );
+
+  return { handler, refId: (ref.data as { id: string }).id, pageId };
+}
+
+describe("related-row collection access (integration)", () => {
+  it("does not populate a target the caller may not read", async () => {
+    const { handler, refId, pageId } = await boot();
+
+    // The same caller, reading the target directly, is refused.
+    const direct = await handler.getEntry({
+      collectionName: "pages",
+      entryId: pageId,
+      user: { id: "claim-aware" },
+      routeAuthorized: true,
+    });
+    expect(direct.success).toBe(false);
+    expect(direct.statusCode).toBe(403);
+
+    const result = await handler.getEntry({
+      collectionName: "refs",
+      entryId: refId,
+      depth: 1,
+      user: { id: "claim-aware" },
+      routeAuthorized: true,
+    });
+
+    // The parent read is still served.
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+
+    // Neither shape hands back the row the direct read refused.
+    expect(JSON.stringify(data.target ?? null)).not.toContain(
+      "Restricted page"
+    );
+    expect(JSON.stringify(data.plain ?? null)).not.toContain("Restricted page");
+  });
+
+  // The mirror, and the reason the case above is not enough on its own:
+  // enforcing without a threaded caller judges everyone anonymous and hides
+  // the row from callers the rule admits, which no leak test would catch.
+  it("still populates the target for a caller the rule admits", async () => {
+    const { handler, refId } = await boot();
+
+    const result = await handler.getEntry({
+      collectionName: "refs",
+      entryId: refId,
+      depth: 1,
+      // The fixture returns `true` for any other caller.
+      user: { id: "permitted" },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(JSON.stringify(data.target)).toContain("Restricted page");
+    expect(JSON.stringify(data.plain)).toContain("Restricted page");
+  });
+
+  it("leaves a trusted read unfiltered", async () => {
+    const { handler, refId } = await boot();
+
+    const result = await handler.getEntry({
+      collectionName: "refs",
+      entryId: refId,
+      depth: 1,
+      overrideAccess: true,
+    });
+
+    const data = result.data as Record<string, unknown>;
+    expect(JSON.stringify(data.target)).toContain("Restricted page");
+    expect(JSON.stringify(data.plain)).toContain("Restricted page");
+  });
+});

--- a/packages/nextly/src/domains/collections/__tests__/related-row-collection-access.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/related-row-collection-access.integration.test.ts
@@ -611,3 +611,64 @@ describe("related-row collection access — query predicates (integration)", () 
     expect(JSON.stringify(result.data)).not.toContain("Their page");
   });
 });
+
+describe("related-row collection access — predicate resolution failure", () => {
+  // The lookup that resolves a predicate reports its own failure as "no
+  // predicate", which looks exactly like a rule that never had one. A rule that
+  // DID answer with a predicate must not then be treated as unrestricted.
+  it("withholds rows when the predicate could not be resolved", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "pages",
+          fields: [text({ name: "title" }), text({ name: "tenant" })],
+        }),
+        defineCollection({
+          slug: "refs",
+          fields: [
+            text({ name: "name" }),
+            relationship({ name: "target", relationTo: "pages" }),
+          ],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const page = await handler.createEntry(
+      { collectionName: "pages", overrideAccess: true },
+      { title: "Scoped page", tenant: "acme" }
+    );
+    const ref = await handler.createEntry(
+      { collectionName: "refs", overrideAccess: true },
+      { name: "r", target: (page.data as { id: string }).id }
+    );
+    await current.adapter.update(
+      "dynamic_collections",
+      {
+        access_rules: { read: { type: "custom", functionPath: ID_RULE_PATH } },
+      },
+      { and: [{ column: "slug", op: "=", value: "pages" }] }
+    );
+
+    // Stand in for the transient failure the real lookup swallows: the rule
+    // still answers with a predicate, but the predicate does not arrive.
+    const spy = vi
+      .spyOn(CollectionAccessService.prototype, "getAccessQueryConstraint")
+      .mockResolvedValue(null);
+    try {
+      const result = await handler.getEntry({
+        collectionName: "refs",
+        entryId: (ref.data as { id: string }).id,
+        depth: 1,
+        user: { id: "tenant-scoped", tenant: "acme" },
+        routeAuthorized: true,
+      });
+
+      // The parent is still served; the target it could not narrow is absent.
+      expect(result.success).toBe(true);
+      expect(JSON.stringify(result.data)).not.toContain("Scoped page");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/nextly/src/domains/collections/__tests__/related-row-collection-access.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/related-row-collection-access.integration.test.ts
@@ -5,8 +5,8 @@
  * A related row belongs to another collection and carries that collection's own
  * read rules. Expansion selected it straight from its table and applied only
  * field-level redaction, so a caller refused the collection outright still
- * obtained its rows by populating a relationship that pointed at them — the
- * write-up and the probe are in tasks/left-tasks/081.
+ * obtained its rows by populating a relationship that pointed at them: the
+ * same row a direct read of the target answered with 403.
  *
  * The refusal reads as an ABSENT relationship rather than an error: one
  * unreadable reference must not refuse the whole parent read, and the caller
@@ -15,12 +15,27 @@
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
+
 import { defineCollection, relationship, text } from "../../../config";
+import { clearServices } from "../../../di/register";
+import { seedBuilderCollection } from "../../../plugins/__tests__/seed-builder-entity";
 import {
   createTestNextly,
   type TestNextly,
 } from "../../../plugins/test-nextly";
 import type { CollectionsHandler } from "../../../services/collections-handler";
+import type { CollectionRelationshipService } from "../services/collection-relationship-service";
+
+/**
+ * The Builder's many-to-many shape: the target lives on `options.target`, not
+ * on `relationTo`, and the typed helper cannot express it.
+ */
+const M2M_FIELD = {
+  name: "tags",
+  type: "relationship",
+  options: { relationType: "manyToMany", target: "tags" },
+} as unknown as FieldDefinition;
 
 let current: TestNextly | undefined;
 afterEach(async () => {
@@ -153,5 +168,265 @@ describe("related-row collection access (integration)", () => {
     const data = result.data as Record<string, unknown>;
     expect(JSON.stringify(data.target)).toContain("Restricted page");
     expect(JSON.stringify(data.plain)).toContain("Restricted page");
+  });
+});
+
+const ID_RULE_PATH = new URL(
+  "./_fixtures/related-target-read-rule.ts",
+  import.meta.url
+).pathname;
+
+/** The id the id-keyed rule withholds. */
+const BLOCKED_ID = "11111111-1111-4111-8111-111111111111";
+
+describe("related-row collection access — many-to-many (integration)", () => {
+  /**
+   * A many-to-many field reaches its targets through a junction table, which
+   * only the Schema-Builder shape produces — a code-first `hasMany: true`
+   * stores a JSON array on the parent row and never touches that path. Seeded
+   * the way the Builder stores it so the junction fetches are the ones under
+   * test.
+   */
+  async function seedM2M(): Promise<{
+    rel: CollectionRelationshipService;
+    postId: string;
+  }> {
+    current = await createTestNextly({});
+    const adapter = current.adapter;
+
+    await seedBuilderCollection(adapter, {
+      slug: "tags",
+      fields: [{ name: "name", type: "text" }],
+    });
+    await seedBuilderCollection(adapter, {
+      slug: "posts",
+      fields: [
+        { name: "title", type: "text" },
+        {
+          name: "tags",
+          type: "relationship",
+          options: { relationType: "manyToMany", target: "tags" },
+        },
+      ],
+    });
+
+    clearServices();
+    current = await createTestNextly({ adapter });
+    current.getService("collectionService");
+    const rel = current.getService<CollectionRelationshipService>(
+      "relationshipService"
+    );
+
+    const nowEpoch = 1785330000;
+    await adapter.executeQuery(
+      `INSERT INTO dc_tags (id, title, slug, name, created_at, updated_at) VALUES ('tag-1', 'Restricted tag', 'restricted-tag', 'restricted', ${nowEpoch}, ${nowEpoch})`
+    );
+    await adapter.executeQuery(
+      `INSERT INTO dc_posts (id, title, slug, created_at, updated_at) VALUES ('post-1', 'Hello', 'hello', ${nowEpoch}, ${nowEpoch})`
+    );
+    await rel.insertManyToManyRelations("posts", "post-1", M2M_FIELD, [
+      "tag-1",
+    ]);
+
+    await adapter.update(
+      "dynamic_collections",
+      {
+        access_rules: { read: { type: "custom", functionPath: ID_RULE_PATH } },
+      },
+      { and: [{ column: "slug", op: "=", value: "tags" }] }
+    );
+
+    return { rel, postId: "post-1" };
+  }
+
+  it("does not populate many-to-many targets the caller may not read", async () => {
+    const { rel, postId } = await seedM2M();
+
+    // The single-entry junction fetch.
+    const expanded = await rel.expandRelationships(
+      { id: postId, title: "Hello", slug: "hello" },
+      "posts",
+      [M2M_FIELD],
+      { depth: 1, enforceFieldAccess: true, user: { id: "denied" } }
+    );
+    expect(JSON.stringify(expanded.tags ?? [])).not.toContain("Restricted tag");
+
+    // The batched junction fetch the list path uses.
+    const batched = await rel.batchFetchManyToManyRelations(
+      "posts",
+      [postId],
+      M2M_FIELD,
+      { enforceFieldAccess: true, user: { id: "denied" } }
+    );
+    expect(JSON.stringify(batched.get(postId) ?? [])).not.toContain(
+      "Restricted tag"
+    );
+  });
+
+  it("still populates them for a caller the rule admits", async () => {
+    const { rel, postId } = await seedM2M();
+
+    const expanded = await rel.expandRelationships(
+      { id: postId, title: "Hello", slug: "hello" },
+      "posts",
+      [M2M_FIELD],
+      { depth: 1, enforceFieldAccess: true, user: { id: "permitted" } }
+    );
+    expect(JSON.stringify(expanded.tags)).toContain("Restricted tag");
+
+    const batched = await rel.batchFetchManyToManyRelations(
+      "posts",
+      [postId],
+      M2M_FIELD,
+      { enforceFieldAccess: true, user: { id: "permitted" } }
+    );
+    expect(JSON.stringify(batched.get(postId))).toContain("Restricted tag");
+  });
+});
+
+describe("related-row collection access — per-document rules (integration)", () => {
+  async function bootIdRule(): Promise<{
+    handler: CollectionsHandler;
+    refId: string;
+    pageId: string;
+  }> {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "pages", fields: [text({ name: "title" })] }),
+        defineCollection({
+          slug: "refs",
+          fields: [
+            text({ name: "name" }),
+            relationship({ name: "target", relationTo: "pages" }),
+          ],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const page = await handler.createEntry(
+      { collectionName: "pages", overrideAccess: true },
+      { title: "Blocked page" }
+    );
+    const pageId = (page.data as { id: string }).id;
+    const ref = await handler.createEntry(
+      { collectionName: "refs", overrideAccess: true },
+      { name: "r", target: pageId }
+    );
+    await current.adapter.update(
+      "dynamic_collections",
+      {
+        access_rules: { read: { type: "custom", functionPath: ID_RULE_PATH } },
+      },
+      { and: [{ column: "slug", op: "=", value: "pages" }] }
+    );
+    return { handler, refId: (ref.data as { id: string }).id, pageId };
+  }
+
+  // A rule reading the id decides nothing useful when the id never arrives,
+  // and an exclusion inverts: `undefined !== blocked` admits the row the rule
+  // exists to withhold.
+  it("gives an id-keyed rule the related document's id", async () => {
+    const { handler, refId, pageId } = await bootIdRule();
+
+    const result = await handler.getEntry({
+      collectionName: "refs",
+      entryId: refId,
+      depth: 1,
+      user: { id: "blocked-one", blockedId: pageId },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(JSON.stringify(result.data)).not.toContain("Blocked page");
+  });
+
+  // The mirror: the same rule and the same caller, blocking a DIFFERENT id.
+  // Without it the case above would pass just as well if the row were hidden
+  // for any other reason, including the relationship never populating.
+  it("populates a row the same rule does not block", async () => {
+    const { handler, refId } = await bootIdRule();
+
+    const result = await handler.getEntry({
+      collectionName: "refs",
+      entryId: refId,
+      depth: 1,
+      user: { id: "blocked-one", blockedId: "some-other-id" },
+      routeAuthorized: true,
+    });
+
+    expect(JSON.stringify(result.data)).toContain("Blocked page");
+  });
+});
+
+describe("related-row collection access — owner-only targets (integration)", () => {
+  async function bootOwnerOnly(): Promise<{
+    handler: CollectionsHandler;
+    refId: string;
+  }> {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "notes", fields: [text({ name: "title" })] }),
+        defineCollection({
+          slug: "refs",
+          fields: [
+            text({ name: "name" }),
+            relationship({ name: "target", relationTo: "notes" }),
+          ],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const note = await handler.createEntry(
+      {
+        collectionName: "notes",
+        user: { id: "owner-1" },
+        routeAuthorized: true,
+      },
+      { title: "Owned note" }
+    );
+    const ref = await handler.createEntry(
+      { collectionName: "refs", overrideAccess: true },
+      { name: "r", target: (note.data as { id: string }).id }
+    );
+    await current.adapter.update(
+      "dynamic_collections",
+      { access_rules: { read: { type: "owner-only" } } },
+      { and: [{ column: "slug", op: "=", value: "notes" }] }
+    );
+    return { handler, refId: (ref.data as { id: string }).id };
+  }
+
+  // An owner-only rule answers with a predicate rather than a verdict. Treating
+  // every such target as denied would stop an owner populating their OWN row,
+  // which is a rule they satisfy.
+  it("populates an owner-only target for its owner", async () => {
+    const { handler, refId } = await bootOwnerOnly();
+
+    const result = await handler.getEntry({
+      collectionName: "refs",
+      entryId: refId,
+      depth: 1,
+      user: { id: "owner-1" },
+      routeAuthorized: true,
+    });
+
+    expect(JSON.stringify(result.data)).toContain("Owned note");
+  });
+
+  it("withholds it from anyone else", async () => {
+    const { handler, refId } = await bootOwnerOnly();
+
+    const result = await handler.getEntry({
+      collectionName: "refs",
+      entryId: refId,
+      depth: 1,
+      user: { id: "someone-else" },
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(JSON.stringify(result.data)).not.toContain("Owned note");
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/related-row-collection-access.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/related-row-collection-access.integration.test.ts
@@ -13,7 +13,7 @@
  * learns no more than a reference pointing at nothing would tell them.
  */
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 
@@ -25,6 +25,7 @@ import {
   type TestNextly,
 } from "../../../plugins/test-nextly";
 import type { CollectionsHandler } from "../../../services/collections-handler";
+import { CollectionAccessService } from "../services/collection-access-service";
 import type { CollectionRelationshipService } from "../services/collection-relationship-service";
 
 /**
@@ -428,5 +429,85 @@ describe("related-row collection access — owner-only targets (integration)", (
 
     expect(result.success).toBe(true);
     expect(JSON.stringify(result.data)).not.toContain("Owned note");
+  });
+});
+
+describe("related-row collection access — policy resolution (integration)", () => {
+  // The policy is a collection-wide fact, but resolving it costs a metadata
+  // read, and expansion fetches its references concurrently and recursively.
+  // `getOwnerConstraint` runs once per resolution and nowhere else, so counting
+  // it counts resolutions.
+  it("resolves a target's policy once across a nested expansion", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "orgs", fields: [text({ name: "title" })] }),
+        defineCollection({
+          slug: "authors",
+          fields: [
+            text({ name: "title" }),
+            relationship({ name: "org", relationTo: "orgs" }),
+          ],
+        }),
+        defineCollection({
+          slug: "posts",
+          fields: [
+            text({ name: "title" }),
+            relationship({
+              name: "authors",
+              relationTo: "authors",
+              hasMany: true,
+            }),
+          ],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const org = await handler.createEntry(
+      { collectionName: "orgs", overrideAccess: true },
+      { title: "Acme" }
+    );
+    const orgId = (org.data as { id: string }).id;
+
+    // Several authors, all pointing at the SAME org: without a shared cache
+    // each of them resolves that org's policy on its own.
+    const authorIds: string[] = [];
+    for (const name of ["a", "b", "c", "d", "e"]) {
+      const author = await handler.createEntry(
+        { collectionName: "authors", overrideAccess: true },
+        { title: name, org: orgId }
+      );
+      authorIds.push((author.data as { id: string }).id);
+    }
+    const post = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "Post", authors: authorIds }
+    );
+
+    const spy = vi.spyOn(
+      CollectionAccessService.prototype,
+      "getOwnerConstraint"
+    );
+    try {
+      const result = await handler.getEntry({
+        collectionName: "posts",
+        entryId: (post.data as { id: string }).id,
+        depth: 2,
+        user: { id: "reader-1" },
+        routeAuthorized: true,
+      });
+      expect(result.success).toBe(true);
+
+      // The second hop ran, so the count below describes a real nested walk
+      // rather than an expansion that stopped at the first level.
+      expect(JSON.stringify(result.data)).toContain("Acme");
+
+      const orgResolutions = spy.mock.calls.filter(
+        call => call[0] === "orgs"
+      ).length;
+      expect(orgResolutions).toBe(1);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/related-row-collection-access.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/related-row-collection-access.integration.test.ts
@@ -435,8 +435,8 @@ describe("related-row collection access — owner-only targets (integration)", (
 describe("related-row collection access — policy resolution (integration)", () => {
   // The policy is a collection-wide fact, but resolving it costs a metadata
   // read, and expansion fetches its references concurrently and recursively.
-  // `getOwnerConstraint` runs once per resolution and nowhere else, so counting
-  // it counts resolutions.
+  // A policy is a collection-wide fact, but resolving it costs a metadata read,
+  // and expansion fetches its references concurrently and recursively.
   it("resolves a target's policy once across a nested expansion", async () => {
     current = await createTestNextly({
       collections: [
@@ -484,9 +484,21 @@ describe("related-row collection access — policy resolution (integration)", ()
       { title: "Post", authors: authorIds }
     );
 
+    // The org carries a stored rule, so resolving its policy is unambiguous
+    // rather than depending on how a rule-less collection short-circuits.
+    await current.adapter.update(
+      "dynamic_collections",
+      {
+        access_rules: { read: { type: "custom", functionPath: ID_RULE_PATH } },
+      },
+      { and: [{ column: "slug", op: "=", value: "orgs" }] }
+    );
+
+    // Unique to policy resolution: the row fetches and the redaction pass read
+    // collection metadata too, so counting that would count them as well.
     const spy = vi.spyOn(
       CollectionAccessService.prototype,
-      "getOwnerConstraint"
+      "getAccessQueryConstraint"
     );
     try {
       const result = await handler.getEntry({

--- a/packages/nextly/src/domains/collections/__tests__/related-row-collection-access.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/related-row-collection-access.integration.test.ts
@@ -511,3 +511,91 @@ describe("related-row collection access — policy resolution (integration)", ()
     }
   });
 });
+
+describe("related-row collection access — query predicates (integration)", () => {
+  async function bootTenantScoped(): Promise<{
+    handler: CollectionsHandler;
+    mineRefId: string;
+    theirsRefId: string;
+  }> {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "pages",
+          fields: [text({ name: "title" }), text({ name: "tenant" })],
+        }),
+        defineCollection({
+          slug: "refs",
+          fields: [
+            text({ name: "name" }),
+            relationship({ name: "target", relationTo: "pages" }),
+          ],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const mine = await handler.createEntry(
+      { collectionName: "pages", overrideAccess: true },
+      { title: "My page", tenant: "acme" }
+    );
+    const theirs = await handler.createEntry(
+      { collectionName: "pages", overrideAccess: true },
+      { title: "Their page", tenant: "other" }
+    );
+    const mineRef = await handler.createEntry(
+      { collectionName: "refs", overrideAccess: true },
+      { name: "mine", target: (mine.data as { id: string }).id }
+    );
+    const theirsRef = await handler.createEntry(
+      { collectionName: "refs", overrideAccess: true },
+      { name: "theirs", target: (theirs.data as { id: string }).id }
+    );
+    await current.adapter.update(
+      "dynamic_collections",
+      {
+        access_rules: { read: { type: "custom", functionPath: ID_RULE_PATH } },
+      },
+      { and: [{ column: "slug", op: "=", value: "pages" }] }
+    );
+    return {
+      handler,
+      mineRefId: (mineRef.data as { id: string }).id,
+      theirsRefId: (theirsRef.data as { id: string }).id,
+    };
+  }
+
+  const scopedCaller = { id: "tenant-scoped", tenant: "acme" };
+
+  // A rule may answer with a predicate rather than a verdict. Treating that as
+  // a denial hides rows the rule admits; treating it as an allow hands back
+  // rows it excludes. The predicate has to actually narrow.
+  it("populates a row the predicate admits", async () => {
+    const { handler, mineRefId } = await bootTenantScoped();
+
+    const result = await handler.getEntry({
+      collectionName: "refs",
+      entryId: mineRefId,
+      depth: 1,
+      user: scopedCaller,
+      routeAuthorized: true,
+    });
+
+    expect(JSON.stringify(result.data)).toContain("My page");
+  });
+
+  it("withholds a row the same predicate excludes", async () => {
+    const { handler, theirsRefId } = await bootTenantScoped();
+
+    const result = await handler.getEntry({
+      collectionName: "refs",
+      entryId: theirsRefId,
+      depth: 1,
+      user: scopedCaller,
+      routeAuthorized: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(JSON.stringify(result.data)).not.toContain("Their page");
+  });
+});

--- a/packages/nextly/src/domains/collections/__tests__/related-row-collection-access.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/related-row-collection-access.integration.test.ts
@@ -494,12 +494,10 @@ describe("related-row collection access — policy resolution (integration)", ()
       { and: [{ column: "slug", op: "=", value: "orgs" }] }
     );
 
-    // Unique to policy resolution: the row fetches and the redaction pass read
-    // collection metadata too, so counting that would count them as well.
-    const spy = vi.spyOn(
-      CollectionAccessService.prototype,
-      "getAccessQueryConstraint"
-    );
+    // Reading a target's stored rules happens once per policy resolution. The
+    // row fetches and the redaction pass read collection metadata too, so
+    // counting that instead would count them as well.
+    const spy = vi.spyOn(CollectionAccessService.prototype, "getAccessRules");
     try {
       const result = await handler.getEntry({
         collectionName: "posts",
@@ -515,7 +513,7 @@ describe("related-row collection access — policy resolution (integration)", ()
       expect(JSON.stringify(result.data)).toContain("Acme");
 
       const orgResolutions = spy.mock.calls.filter(
-        call => call[0] === "orgs"
+        call => (call[0] as { slug?: string } | undefined)?.slug === "orgs"
       ).length;
       expect(orgResolutions).toBe(1);
     } finally {
@@ -612,11 +610,12 @@ describe("related-row collection access — query predicates (integration)", () 
   });
 });
 
-describe("related-row collection access — predicate resolution failure", () => {
-  // The lookup that resolves a predicate reports its own failure as "no
-  // predicate", which looks exactly like a rule that never had one. A rule that
-  // DID answer with a predicate must not then be treated as unrestricted.
-  it("withholds rows when the predicate could not be resolved", async () => {
+describe("related-row collection access — id-varying predicates", () => {
+  // A rule may answer a concrete document more strictly than it answers an
+  // id-less question. The narrowing applied to a row has to be the one that row
+  // was judged by, or the weaker answer decides and rows the rule excludes come
+  // back.
+  it("applies the predicate the row itself was judged by", async () => {
     current = await createTestNextly({
       collections: [
         defineCollection({
@@ -634,13 +633,13 @@ describe("related-row collection access — predicate resolution failure", () =>
     });
     const handler =
       current.getService<CollectionsHandler>("collectionsHandler");
-    const page = await handler.createEntry(
+    const theirs = await handler.createEntry(
       { collectionName: "pages", overrideAccess: true },
-      { title: "Scoped page", tenant: "acme" }
+      { title: "Other tenant page", tenant: "other" }
     );
     const ref = await handler.createEntry(
       { collectionName: "refs", overrideAccess: true },
-      { name: "r", target: (page.data as { id: string }).id }
+      { name: "r", target: (theirs.data as { id: string }).id }
     );
     await current.adapter.update(
       "dynamic_collections",
@@ -650,25 +649,62 @@ describe("related-row collection access — predicate resolution failure", () =>
       { and: [{ column: "slug", op: "=", value: "pages" }] }
     );
 
-    // Stand in for the transient failure the real lookup swallows: the rule
-    // still answers with a predicate, but the predicate does not arrive.
-    const spy = vi
-      .spyOn(CollectionAccessService.prototype, "getAccessQueryConstraint")
-      .mockResolvedValue(null);
-    try {
-      const result = await handler.getEntry({
-        collectionName: "refs",
-        entryId: (ref.data as { id: string }).id,
-        depth: 1,
-        user: { id: "tenant-scoped", tenant: "acme" },
-        routeAuthorized: true,
-      });
+    const result = await handler.getEntry({
+      collectionName: "refs",
+      entryId: (ref.data as { id: string }).id,
+      depth: 1,
+      user: { id: "id-varying", tenant: "acme" },
+      routeAuthorized: true,
+    });
 
-      // The parent is still served; the target it could not narrow is absent.
-      expect(result.success).toBe(true);
-      expect(JSON.stringify(result.data)).not.toContain("Scoped page");
-    } finally {
-      spy.mockRestore();
-    }
+    expect(result.success).toBe(true);
+    // The id-less answer is an unrestricted allow; the row's own answer scopes
+    // it to another tenant, so the row must not come back.
+    expect(JSON.stringify(result.data)).not.toContain("Other tenant page");
+  });
+
+  it("still returns a row that predicate admits", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "pages",
+          fields: [text({ name: "title" }), text({ name: "tenant" })],
+        }),
+        defineCollection({
+          slug: "refs",
+          fields: [
+            text({ name: "name" }),
+            relationship({ name: "target", relationTo: "pages" }),
+          ],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const mine = await handler.createEntry(
+      { collectionName: "pages", overrideAccess: true },
+      { title: "My tenant page", tenant: "acme" }
+    );
+    const ref = await handler.createEntry(
+      { collectionName: "refs", overrideAccess: true },
+      { name: "r", target: (mine.data as { id: string }).id }
+    );
+    await current.adapter.update(
+      "dynamic_collections",
+      {
+        access_rules: { read: { type: "custom", functionPath: ID_RULE_PATH } },
+      },
+      { and: [{ column: "slug", op: "=", value: "pages" }] }
+    );
+
+    const result = await handler.getEntry({
+      collectionName: "refs",
+      entryId: (ref.data as { id: string }).id,
+      depth: 1,
+      user: { id: "id-varying", tenant: "acme" },
+      routeAuthorized: true,
+    });
+
+    expect(JSON.stringify(result.data)).toContain("My tenant page");
   });
 });

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -2605,6 +2605,7 @@ export class CollectionMutationService extends BaseService {
               enforceFieldAccess: true,
               user: params.user,
               overrideAccess: params.overrideAccess,
+              authenticatedScope: params.authenticatedScope,
             }
           );
         } catch (expansionError) {
@@ -5148,6 +5149,7 @@ export class CollectionMutationService extends BaseService {
               enforceFieldAccess: true,
               user: params.user,
               overrideAccess: params.overrideAccess,
+              authenticatedScope: params.authenticatedScope,
             }
           );
         } catch (expansionError) {

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1192,6 +1192,7 @@ export class CollectionQueryService extends BaseService {
             enforceFieldAccess: true,
             user: params.user,
             overrideAccess: params.overrideAccess,
+            authenticatedScope: params.authenticatedScope,
           }
         );
 
@@ -2099,6 +2100,7 @@ export class CollectionQueryService extends BaseService {
           enforceFieldAccess: true,
           user: params.user,
           overrideAccess: params.overrideAccess,
+          authenticatedScope: params.authenticatedScope,
         }
       );
 

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1187,6 +1187,9 @@ export class CollectionQueryService extends BaseService {
               user: params.user,
               overrideAccess: params.overrideAccess,
               authenticatedScope: params.authenticatedScope,
+              // Shared across every component row this listing expands, so
+              // rows pointing at the same target resolve its policy once.
+              targetPolicies: new Map(),
             },
           });
       }

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -12,25 +12,7 @@
  */
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
-import {
-  eq,
-  ne,
-  gt,
-  gte,
-  lt,
-  lte,
-  and,
-  or,
-  like,
-  ilike,
-  inArray,
-  notInArray,
-  isNull,
-  isNotNull,
-  sql,
-  asc,
-  desc,
-} from "drizzle-orm";
+import { eq, and, or, like, ilike, sql, asc, desc } from "drizzle-orm";
 
 import { transformRichTextFields } from "@nextly/lib/field-transform";
 import type { RichTextOutputFormat } from "@nextly/lib/rich-text-html";
@@ -55,6 +37,10 @@ import type {
   CompanionSchema,
 } from "../../../services/collection-file-manager";
 import type { CollectionRelationshipService } from "../../../services/collections/collection-relationship-service";
+import {
+  buildDrizzleCondition,
+  type LocalizedQueryContext,
+} from "../../../services/collections/drizzle-condition";
 import {
   applyGeoFilters,
   sortByDistance,
@@ -96,7 +82,6 @@ import {
   populateCompanionFields,
   populateCompanionFieldsAllLocales,
   populateTranslationStatus,
-  type LocalizedFieldRef,
   type TranslationStatusFilter,
   type TranslationFilterState,
 } from "../../i18n/companion-join";
@@ -117,27 +102,6 @@ import {
   getMinSearchLength,
   isJsonFieldType,
 } from "./collection-utils";
-
-/**
- * Localized-query context (i18n M4c) threaded into the search/where builders so a localized
- * field filters via a companion EXISTS on the requested locale instead of being silently
- * dropped. `null`/absent → non-localized behavior (unchanged).
- */
-interface LocalizedQueryContext {
-  companionTableName: string;
-  /** Localized fields with both the camelCase name (matching) and snake_case column (SQL). */
-  localizedFields: LocalizedFieldRef[];
-  /** The main table's `id` column (Drizzle) — the companion `_parent` correlation target. */
-  mainIdColumn: unknown;
-  /** The locale to filter on (the requested locale — chain head). */
-  locale: string;
-  /**
-   * Per-locale status filter (i18n M6). Set (e.g. `"published"`) when the read resolves to a
-   * single status and the collection has per-locale status, so localized where/search EXISTS
-   * checks only match companion rows in that state. Undefined = no status constraint.
-   */
-  statusValue?: string;
-}
 
 export class CollectionQueryService extends BaseService {
   constructor(
@@ -2360,6 +2324,13 @@ export class CollectionQueryService extends BaseService {
    * @param dialect - Database dialect for case sensitivity handling
    * @returns Drizzle SQL condition or undefined if no conditions
    */
+  /**
+   * Compile a filter, keeping this service's localized-field support.
+   *
+   * The translation itself is shared, so a stored constraint binds the same way
+   * whether it reaches SQL through a list read or through a relationship
+   * populating a row from the same collection.
+   */
   private buildDrizzleCondition(
     whereClause: ReturnType<typeof buildWhereClause>,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle dynamic schema
@@ -2367,152 +2338,16 @@ export class CollectionQueryService extends BaseService {
     dialect: string = "postgresql",
     localizedCtx?: LocalizedQueryContext | null
   ): ReturnType<typeof and> | undefined {
-    if (!whereClause) {
-      return undefined;
-    }
-
-    // Helper to build condition from a single WhereCondition
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic where clause structure
-    const buildSingleCondition = (condition: any): any => {
-      // Check if it's a nested WhereClause (has and/or)
-      if (condition.and || condition.or) {
-        return this.buildDrizzleCondition(
-          condition,
-          schema,
-          dialect,
-          localizedCtx
-        );
-      }
-
-      // It's a WhereCondition
-      const { column, op, value } = condition;
-
-      // Get the column from schema (handle dot notation for nested fields)
-      const columnParts = column.split(".");
-
-      // i18n M4c: a filter on a localized field targets the companion table (absent from the
-      // main schema). Resolve it to a companion EXISTS on the requested locale so the filter
-      // takes effect instead of being silently skipped.
-      const localizedWhereField = localizedCtx?.localizedFields.find(
-        f => f.name === columnParts[0]
-      );
-      if (localizedCtx && localizedWhereField) {
-        const localizedCond = this.buildLocalizedWhereExists(
-          localizedCtx,
-          localizedWhereField.column,
-          op,
-          value,
-          dialect
-        );
-        if (localizedCond) return localizedCond;
-      }
-
-      const schemaColumn = schema[columnParts[0]];
-
-      if (!schemaColumn) {
-        // Column doesn't exist in schema, skip this condition
-        return undefined;
-      }
-
-      switch (op) {
-        case "=":
-          return eq(schemaColumn, value);
-        case "!=":
-          return ne(schemaColumn, value);
-        case ">":
-          return gt(schemaColumn, value);
-        case ">=":
-          return gte(schemaColumn, value);
-        case "<":
-          return lt(schemaColumn, value);
-        case "<=":
-          return lte(schemaColumn, value);
-        case "LIKE":
-          return like(schemaColumn, value);
-        case "ILIKE":
-          // Use ILIKE for PostgreSQL, LIKE for others
-          if (dialect === "postgresql") {
-            return ilike(schemaColumn, value);
-          }
-          return like(schemaColumn, value);
-        case "IN":
-          if (Array.isArray(value) && value.length > 0) {
-            return inArray(schemaColumn, value);
-          }
-          return undefined;
-        case "NOT IN":
-          if (Array.isArray(value) && value.length > 0) {
-            return notInArray(schemaColumn, value);
-          }
-          return undefined;
-        case "IS NULL":
-          return isNull(schemaColumn);
-        case "IS NOT NULL":
-          return isNotNull(schemaColumn);
-        default:
-          return undefined;
-      }
-    };
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle SQL condition accumulator
-    const conditions: any[] = [];
-
-    // Handle AND conditions
-    if (whereClause.and && Array.isArray(whereClause.and)) {
-      const andConditions = whereClause.and
-        .map(buildSingleCondition)
-        .filter(Boolean);
-      if (andConditions.length > 0) {
-        conditions.push(and(...andConditions));
-      }
-    }
-
-    // Handle OR conditions
-    if (whereClause.or && Array.isArray(whereClause.or)) {
-      const orConditions = whereClause.or
-        .map(buildSingleCondition)
-        .filter(Boolean);
-      if (orConditions.length > 0) {
-        conditions.push(or(...orConditions));
-      }
-    }
-
-    // Return combined conditions
-    if (conditions.length === 0) {
-      return undefined;
-    }
-    if (conditions.length === 1) {
-      return conditions[0];
-    }
-    return and(...conditions);
+    return buildDrizzleCondition(
+      whereClause,
+      schema,
+      dialect,
+      localizedCtx,
+      (ctx, column, op, value, d) =>
+        this.buildLocalizedWhereExists(ctx, column, op, value, d)
+    );
   }
 
-  /**
-   * Build EXISTS subquery conditions for component field filters.
-   *
-   * Generates SQL EXISTS subqueries to filter entries based on component field values.
-   * Each component filter results in an EXISTS clause against the component data table.
-   *
-   * @param componentFilters - Component field filters extracted from where clause
-   * @param parentTableName - Name of the parent table (e.g., 'dc_pages')
-   * @param parentIdColumn - Reference to the parent table's id column
-   * @param dialect - Database dialect for operator handling
-   * @returns Combined Drizzle SQL condition or undefined if no filters
-   *
-   * @example
-   * ```typescript
-   * // For filter: { 'seo.metaTitle': { contains: 'About' } }
-   * // Generates: EXISTS (SELECT 1 FROM comp_seo WHERE _parent_id = dc_pages.id AND _parent_table = 'dc_pages' AND meta_title ILIKE '%About%')
-   * ```
-   */
-  /**
-   * Physical table name for every component slug referenced by these filters.
-   *
-   * Resolved through the registry because a component with a custom `dbName`
-   * has a table name that cannot be derived from its slug. Skipped entirely
-   * when no component filter is present, so ordinary queries take no extra
-   * round trip.
-   */
   private async resolveComponentTableNames(
     componentFilters: ComponentFieldFilter[]
   ): Promise<Map<string, string>> {

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1222,6 +1222,7 @@ export class CollectionQueryService extends BaseService {
               enforceFieldAccess: true,
               user: params.user,
               overrideAccess: params.overrideAccess,
+              authenticatedScope: params.authenticatedScope,
             },
           });
       }
@@ -2126,6 +2127,7 @@ export class CollectionQueryService extends BaseService {
             enforceFieldAccess: true,
             user: params.user,
             overrideAccess: params.overrideAccess,
+            authenticatedScope: params.authenticatedScope,
           },
         });
       }

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -105,12 +105,6 @@ interface RelatedRowAccess {
 /** A target collection's read policy, as one expansion needs it. */
 export interface TargetReadPolicy {
   rules: CollectionAccessRules | undefined;
-  /**
-   * The predicate a stored rule answered with, when it answered with one
-   * rather than a verdict. Applied to the target table rather than compared in
-   * memory, so it binds exactly as it does on a direct read.
-   */
-  queryConstraint: Record<string, unknown> | null;
 }
 
 /**
@@ -1018,21 +1012,48 @@ export class CollectionRelationshipService extends BaseService {
     // verdicts are zipped back against the original order, so the rows keep
     // the sequence they were fetched in.
     const verdicts = await Promise.all(
-      rows.map(row =>
-        this.rowPassesTargetPolicy(row, policy, accessService, user)
-      )
+      rows.map(row => this.judgeRow(row, policy, accessService, user))
     );
-    const admitted = rows.filter((_, index) => verdicts[index]);
+    const admitted = rows.filter((_, index) => verdicts[index].allowed);
     this.recordWithheld(rows, admitted, access);
+    if (admitted.length === 0) return admitted;
 
-    if (!policy.queryConstraint || admitted.length === 0) return admitted;
-    const narrowed = await this.narrowByTargetPredicate(
-      targetCollection,
-      admitted,
-      policy.queryConstraint
-    );
-    this.recordWithheld(admitted, narrowed, access);
-    return narrowed;
+    // Rows sharing a predicate are confirmed together, so the usual case of one
+    // predicate for the whole collection costs one query — and a rule that
+    // answers different rows differently still has each row confirmed against
+    // the predicate it was actually judged by.
+    const byPredicate = new Map<string, Record<string, unknown>[]>();
+    const predicates = new Map<string, Record<string, unknown>>();
+    const unrestricted: Record<string, unknown>[] = [];
+    admitted.forEach(row => {
+      const predicate = verdicts[rows.indexOf(row)].predicate;
+      if (!predicate) {
+        unrestricted.push(row);
+        return;
+      }
+      const key = JSON.stringify(predicate);
+      predicates.set(key, predicate);
+      const group = byPredicate.get(key);
+      if (group) group.push(row);
+      else byPredicate.set(key, [row]);
+    });
+
+    const confirmed = [...unrestricted];
+    for (const [key, group] of byPredicate) {
+      confirmed.push(
+        ...(await this.narrowByTargetPredicate(
+          targetCollection,
+          group,
+          predicates.get(key) as Record<string, unknown>
+        ))
+      );
+    }
+    // Restored to the order they were fetched in, since the grouping above
+    // reads them out by predicate.
+    const kept = new Set(confirmed);
+    const ordered = admitted.filter(row => kept.has(row));
+    this.recordWithheld(admitted, ordered, access);
+    return ordered;
   }
 
   /**
@@ -1079,12 +1100,6 @@ export class CollectionRelationshipService extends BaseService {
       return {
         rules: accessService.getAccessRules(
           collection as Record<string, unknown>
-        ),
-        queryConstraint: await accessService.getAccessQueryConstraint(
-          targetCollection,
-          access.user as UserContext | undefined,
-          false,
-          access.authenticatedScope
         ),
       };
     })();
@@ -1146,7 +1161,13 @@ export class CollectionRelationshipService extends BaseService {
       // admit every row. Withhold instead: the rule asked to narrow.
       if (!condition) return [];
 
-      const ids = rows.map(row => row.id as string);
+      // A row without a string id cannot be matched against the target table.
+      // Binding an absent one throws on some dialects, and the catch below then
+      // withholds every row of the collection instead of just this one.
+      const ids = rows
+        .map(row => row.id)
+        .filter((id): id is string => typeof id === "string");
+      if (ids.length === 0) return [];
       const admitted = await this.db
         .select({ id: schema.id })
         .from(schema)
@@ -1173,12 +1194,12 @@ export class CollectionRelationshipService extends BaseService {
    * rule shape, and nothing that could read an operator differently from the
    * query the direct read compiles.
    */
-  private async rowPassesTargetPolicy(
+  private async judgeRow(
     row: Record<string, unknown>,
     policy: TargetReadPolicy,
     accessService: CollectionAccessService,
     user: UserContext | undefined
-  ): Promise<boolean> {
+  ): Promise<{ allowed: boolean; predicate: Record<string, unknown> | null }> {
     const result = await this.accessControl.evaluateAccess(
       policy.rules,
       "read",
@@ -1194,18 +1215,14 @@ export class CollectionRelationshipService extends BaseService {
       DEFAULT_OWNER_FIELD
     );
 
-    // A predicate is not a verdict: it narrows which rows are readable, and the
-    // narrowing is applied to the target table afterwards. Answering "denied"
-    // here would hide rows the rule admits.
-    //
-    // But the narrowing has to actually be available. The lookup that resolves
-    // it reports its own failure as "no predicate", which is indistinguishable
-    // from a rule that never had one — and a rule that answered with a
-    // predicate whose predicate went missing would otherwise admit every row.
-    // Withhold instead, so a transient failure cannot widen a restricted
-    // target into an open one.
-    if (result.query && !policy.queryConstraint) return false;
-    return result.allowed;
+    // The predicate travels with the verdict that produced it. A rule may vary
+    // by document id and answer a concrete row with a narrower predicate than
+    // it answers an id-less question with, so resolving the narrowing
+    // separately would apply the weaker one to rows judged by the stronger.
+    return {
+      allowed: result.allowed,
+      predicate: result.query ?? null,
+    };
   }
 
   /**

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -97,7 +97,6 @@ interface RelatedRowAccess {
 /** A target collection's read policy, as one expansion needs it. */
 export interface TargetReadPolicy {
   rules: CollectionAccessRules | undefined;
-  ownerConstraint: { field: string; value: unknown } | null;
   /**
    * The predicate a stored rule answered with, when it answered with one
    * rather than a verdict. Applied to the target table rather than compared in
@@ -1044,17 +1043,6 @@ export class CollectionRelationshipService extends BaseService {
         rules: accessService.getAccessRules(
           collection as Record<string, unknown>
         ),
-        // Owner-only reads answer with a predicate rather than a verdict, so
-        // the owner column and the caller's id are what decide. Resolved
-        // through the helper the direct read path uses, so both compare the
-        // same column.
-        ownerConstraint: await accessService.getOwnerConstraint(
-          targetCollection,
-          "read",
-          access.user as UserContext | undefined,
-          false,
-          access.authenticatedScope
-        ),
         queryConstraint: await accessService.getAccessQueryConstraint(
           targetCollection,
           access.user as UserContext | undefined,
@@ -1139,19 +1127,21 @@ export class CollectionRelationshipService extends BaseService {
     }
   }
 
-  /** Whether one fetched row survives the target collection's read policy. */
+  /**
+   * Whether one fetched row survives the target collection's read policy.
+   *
+   * Only verdicts are decided here. An owner-only rule answers a read with a
+   * predicate, and it travels the same route every other predicate does — the
+   * database applies it — so there is no comparison in this process for any
+   * rule shape, and nothing that could read an operator differently from the
+   * query the direct read compiles.
+   */
   private async rowPassesTargetPolicy(
     row: Record<string, unknown>,
     policy: TargetReadPolicy,
     accessService: CollectionAccessService,
     user: UserContext | undefined
   ): Promise<boolean> {
-    if (policy.ownerConstraint) {
-      // An exact comparison against the same column the direct read filters on,
-      // so no predicate is being re-interpreted here.
-      return row[policy.ownerConstraint.field] === policy.ownerConstraint.value;
-    }
-
     const result = await this.accessControl.evaluateAccess(
       policy.rules,
       "read",

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -4,11 +4,17 @@ import { eq, inArray, sql } from "drizzle-orm";
 import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 
 import { getDialectTables } from "../../../database";
+import { container } from "../../../di/container";
 import {
   convertTimestampsToCamelCase,
   keysToCamelCase,
 } from "../../../lib/case-conversion";
 import { absolutizeMediaUrls } from "../../../lib/media-variant";
+import {
+  AccessControlService,
+  DEFAULT_OWNER_FIELD,
+  isSuperAdminContext,
+} from "../../../services/access";
 import type { CollectionFileManager } from "../../../services/collection-file-manager";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
@@ -18,7 +24,11 @@ import {
   stripPasswordFieldValues,
   stripSystemOwnerField,
 } from "../../../shared/lib/password-fields";
+import type { RBACAccessControlService } from "../../auth/services/rbac-access-control-service";
 import type { DynamicCollectionService } from "../../dynamic-collections";
+
+import { CollectionAccessService } from "./collection-access-service";
+import type { UserContext } from "./collection-types";
 
 /**
  * System-entity columns that hold secrets and must never ride along a
@@ -838,6 +848,17 @@ export type RelationshipDbExecutor = {
 };
 
 export class CollectionRelationshipService extends BaseService {
+  /**
+   * Decides whether a caller may read a TARGET collection at all.
+   *
+   * Built on first use rather than injected: this service is constructed before
+   * the one that owns the access service, and resolving it lazily keeps that
+   * ordering intact. Stateless, so a second instance costs nothing but the
+   * construction.
+   */
+  private accessService: CollectionAccessService | null = null;
+  private readonly accessControl = new AccessControlService();
+
   constructor(
     adapter: DrizzleAdapter,
     logger: Logger,
@@ -845,6 +866,85 @@ export class CollectionRelationshipService extends BaseService {
     private readonly collectionService: DynamicCollectionService
   ) {
     super(adapter, logger);
+  }
+
+  private resolveAccessService(): CollectionAccessService | null {
+    if (this.accessService) return this.accessService;
+    if (!container.has("rbacAccessControlService")) return null;
+    this.accessService = new CollectionAccessService(
+      this.adapter,
+      this.logger,
+      this.collectionService,
+      new AccessControlService(),
+      container.get<RBACAccessControlService>("rbacAccessControlService")
+    );
+    return this.accessService;
+  }
+
+  /**
+   * Whether the target collection's own stored read rules admit this caller.
+   *
+   * Populating a relationship hands back a row from another collection, and
+   * that collection's rules decide whether this caller may see it — the same
+   * decision a direct read of it makes. Without this, a caller refused the
+   * collection outright still obtains its rows by populating a relationship
+   * that points at them.
+   *
+   * Only the STORED rules are evaluated, not the RBAC permission gate. The
+   * route authorized this caller for the PARENT collection, and a permission
+   * check for a collection they never asked for by name would refuse
+   * population for every caller whose grants do not happen to name it —
+   * turning a fix into an outage. Whether expansion should also require a
+   * read permission on the target is a separate question, recorded on the
+   * task rather than decided here.
+   *
+   * Opt-in for the same reason field-level enforcement is: an entry point that
+   * has not been given the caller yet would judge everyone anonymous and hide
+   * rows from entitled callers.
+   */
+  private async targetCollectionReadable(
+    targetCollection: string,
+    access: RelatedRowAccess
+  ): Promise<boolean> {
+    if (!access.enforceFieldAccess) return true;
+    if (access.overrideAccess) return true;
+    // System entities carry no stored collection rules; their secrets are
+    // stripped by name during redaction instead.
+    if (isSystemEntity(targetCollection)) return true;
+
+    const accessService = this.resolveAccessService();
+    if (!accessService) return true;
+
+    const user = access.user as UserContext | undefined;
+    // Super-admins bypass stored rules on every other transport; expansion is
+    // not the one place that differs.
+    if (isSuperAdminContext(user)) return true;
+
+    try {
+      const collection =
+        await this.collectionService.getCollection(targetCollection);
+      const rules = accessService.getAccessRules(
+        collection as Record<string, unknown>
+      );
+      const result = await this.accessControl.evaluateAccess(
+        rules,
+        "read",
+        accessService.buildRequestContext(user),
+        undefined,
+        undefined,
+        // Collections stamp the owner into the `created_by` system column.
+        DEFAULT_OWNER_FIELD
+      );
+      // A rule answering with a CONSTRAINT rather than a boolean narrows which
+      // rows are readable, and narrowing is not yet applied to these fetches —
+      // so the row is withheld rather than returned unfiltered.
+      if (result.query) return false;
+      return result.allowed;
+    } catch {
+      // A target whose rules cannot be read is not a target whose rules are
+      // satisfied.
+      return false;
+    }
   }
 
   /**
@@ -1405,6 +1505,12 @@ export class CollectionRelationshipService extends BaseService {
     access: RelatedRowAccess = {}
   ): Promise<Map<string, Record<string, unknown>>> {
     const resultMap = new Map<string, Record<string, unknown>>();
+
+    // Judged once for the whole batch: the decision is about the collection,
+    // not about any one row, so it does not need repeating per id.
+    if (!(await this.targetCollectionReadable(targetCollection, access))) {
+      return resultMap;
+    }
 
     if (relatedIds.length === 0) return resultMap;
 
@@ -2221,6 +2327,12 @@ export class CollectionRelationshipService extends BaseService {
     entryId: string,
     access: RelatedRowAccess = {}
   ): Promise<Record<string, unknown> | null> {
+    // Reads as absent rather than as an error: one unreadable reference must
+    // not refuse the whole parent read, and a caller learns no more than they
+    // would from a reference that points at nothing.
+    if (!(await this.targetCollectionReadable(collectionName, access))) {
+      return null;
+    }
     try {
       // Check if this is a system entity (like "users")
       if (isSystemEntity(collectionName)) {

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -86,7 +86,7 @@ interface RelatedRowAccess {
 }
 
 /** A target collection's read policy, as one expansion needs it. */
-interface TargetReadPolicy {
+export interface TargetReadPolicy {
   rules: CollectionAccessRules | undefined;
   ownerConstraint: { field: string; value: unknown } | null;
 }
@@ -135,6 +135,16 @@ export interface RelationshipExpansionOptions {
    * read paths that forward a real caller; see {@link RelatedRowAccess}.
    */
   enforceFieldAccess?: boolean;
+
+  /**
+   * Target read policies already resolved during this expansion.
+   *
+   * Carried by a nested hop so the whole expansion resolves each target
+   * collection's rules once. Not part of what a caller supplies.
+   *
+   * @internal
+   */
+  targetPolicies?: Map<string, Promise<TargetReadPolicy>>;
 
   /**
    * The caller's authenticated scope, when one applies.
@@ -1263,9 +1273,13 @@ export class CollectionRelationshipService extends BaseService {
       overrideAccess: options.overrideAccess,
       authenticatedScope: options.authenticatedScope,
       // One per expansion, so a relationship holding many references reads its
-      // target's rules once rather than once per value. Scoped to this call
-      // because a collection's rules can change between requests.
-      targetPolicies: new Map(),
+      // target's rules once rather than once per value. A nested hop inherits
+      // the map rather than starting its own: several children populating the
+      // same collection would otherwise each resolve its policy again, which
+      // is the repetition this cache exists to remove. Created fresh only for
+      // the outermost call, because a collection's rules can change between
+      // requests.
+      targetPolicies: options.targetPolicies ?? new Map(),
     };
 
     // Clamp depth to valid range
@@ -1909,9 +1923,13 @@ export class CollectionRelationshipService extends BaseService {
       overrideAccess: options.overrideAccess,
       authenticatedScope: options.authenticatedScope,
       // One per expansion, so a relationship holding many references reads its
-      // target's rules once rather than once per value. Scoped to this call
-      // because a collection's rules can change between requests.
-      targetPolicies: new Map(),
+      // target's rules once rather than once per value. A nested hop inherits
+      // the map rather than starting its own: several children populating the
+      // same collection would otherwise each resolve its policy again, which
+      // is the repetition this cache exists to remove. Created fresh only for
+      // the outermost call, because a collection's rules can change between
+      // requests.
+      targetPolicies: options.targetPolicies ?? new Map(),
     };
 
     // Clamp depth to valid range

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -1002,8 +1002,10 @@ export class CollectionRelationshipService extends BaseService {
       );
     } catch {
       // A target whose rules cannot be read is not a target whose rules are
-      // satisfied.
-      this.recordWithheld(rows, [], access);
+      // satisfied. Deliberately NOT recorded as withheld-by-access: a caller
+      // checking its expansion for completeness must still see an unexplained
+      // absence here, or a rule that tolerates absence decides on evidence a
+      // failure removed.
       return [];
     }
 
@@ -1039,20 +1041,24 @@ export class CollectionRelationshipService extends BaseService {
     });
 
     const confirmed = [...unrestricted];
+    let anyPredicateFailed = false;
     for (const [key, group] of byPredicate) {
-      confirmed.push(
-        ...(await this.narrowByTargetPredicate(
-          targetCollection,
-          group,
-          predicates.get(key) as Record<string, unknown>
-        ))
+      const narrowed = await this.narrowByTargetPredicate(
+        targetCollection,
+        group,
+        predicates.get(key) as Record<string, unknown>
       );
+      // Null means the predicate could not be applied at all. The rows stay out
+      // either way, but nothing was decided about them, so they are not
+      // reported as refused.
+      if (narrowed === null) anyPredicateFailed = true;
+      else confirmed.push(...narrowed);
     }
     // Restored to the order they were fetched in, since the grouping above
     // reads them out by predicate.
     const kept = new Set(confirmed);
     const ordered = admitted.filter(row => kept.has(row));
-    this.recordWithheld(admitted, ordered, access);
+    if (!anyPredicateFailed) this.recordWithheld(admitted, ordered, access);
     return ordered;
   }
 
@@ -1125,7 +1131,7 @@ export class CollectionRelationshipService extends BaseService {
     targetCollection: string,
     rows: Record<string, unknown>[],
     constraint: Record<string, unknown>
-  ): Promise<Record<string, unknown>[]> {
+  ): Promise<Record<string, unknown>[] | null> {
     try {
       const schema = isSystemEntity(targetCollection)
         ? getSystemEntityTable(targetCollection)
@@ -1181,7 +1187,9 @@ export class CollectionRelationshipService extends BaseService {
         collection: targetCollection,
         error,
       });
-      return [];
+      // Null, not an empty list: the rows are withheld either way, but the
+      // caller must not report this as a refusal — nothing was decided.
+      return null;
     }
   }
 

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -87,6 +87,14 @@ interface RelatedRowAccess {
    */
   authenticatedScope?: AuthenticatedScope;
   /**
+   * Ids withheld because the target collection's rules refused this caller.
+   *
+   * A caller that checks its expansion for completeness cannot otherwise tell
+   * a deliberate refusal from a load that failed, and would report the first
+   * as evidence that went missing.
+   */
+  withheldByAccess?: Set<string>;
+  /**
    * Target read policies already resolved during this expansion, so a
    * relationship holding many references reads its collection's metadata once
    * instead of once per value.
@@ -149,6 +157,14 @@ export interface RelationshipExpansionOptions {
    * read paths that forward a real caller; see {@link RelatedRowAccess}.
    */
   enforceFieldAccess?: boolean;
+
+  /**
+   * Collects the ids withheld because a target collection refused the caller,
+   * so a completeness check can tell a refusal from a failure.
+   *
+   * @internal
+   */
+  withheldByAccess?: Set<string>;
 
   /**
    * Target read policies already resolved during this expansion.
@@ -993,6 +1009,7 @@ export class CollectionRelationshipService extends BaseService {
     } catch {
       // A target whose rules cannot be read is not a target whose rules are
       // satisfied.
+      this.recordWithheld(rows, [], access);
       return [];
     }
 
@@ -1006,13 +1023,33 @@ export class CollectionRelationshipService extends BaseService {
       )
     );
     const admitted = rows.filter((_, index) => verdicts[index]);
+    this.recordWithheld(rows, admitted, access);
 
     if (!policy.queryConstraint || admitted.length === 0) return admitted;
-    return this.narrowByTargetPredicate(
+    const narrowed = await this.narrowByTargetPredicate(
       targetCollection,
       admitted,
       policy.queryConstraint
     );
+    this.recordWithheld(admitted, narrowed, access);
+    return narrowed;
+  }
+
+  /**
+   * Note which ids a refusal removed, so a caller checking its expansion for
+   * completeness reads them as absent on purpose rather than as evidence lost.
+   */
+  private recordWithheld(
+    before: Record<string, unknown>[],
+    after: Record<string, unknown>[],
+    access: RelatedRowAccess
+  ): void {
+    if (!access.withheldByAccess || before.length === after.length) return;
+    const kept = new Set(after.map(row => row.id as string));
+    for (const row of before) {
+      const id = row.id as string | undefined;
+      if (id && !kept.has(id)) access.withheldByAccess.add(id);
+    }
   }
 
   /**
@@ -1157,9 +1194,17 @@ export class CollectionRelationshipService extends BaseService {
       DEFAULT_OWNER_FIELD
     );
 
-    // A predicate is not a verdict: it narrows which rows are readable, and
-    // the narrowing is applied to the target table afterwards. Answering
-    // "denied" here would hide rows the rule admits.
+    // A predicate is not a verdict: it narrows which rows are readable, and the
+    // narrowing is applied to the target table afterwards. Answering "denied"
+    // here would hide rows the rule admits.
+    //
+    // But the narrowing has to actually be available. The lookup that resolves
+    // it reports its own failure as "no predicate", which is indistinguishable
+    // from a rule that never had one — and a rule that answered with a
+    // predicate whose predicate went missing would otherwise admit every row.
+    // Withhold instead, so a transient failure cannot widen a restricted
+    // target into an open one.
+    if (result.query && !policy.queryConstraint) return false;
     return result.allowed;
   }
 
@@ -1360,6 +1405,7 @@ export class CollectionRelationshipService extends BaseService {
       user: options.user,
       overrideAccess: options.overrideAccess,
       authenticatedScope: options.authenticatedScope,
+      withheldByAccess: options.withheldByAccess,
       // One per expansion, so a relationship holding many references reads its
       // target's rules once rather than once per value. A nested hop inherits
       // the map rather than starting its own: several children populating the
@@ -2010,6 +2056,7 @@ export class CollectionRelationshipService extends BaseService {
       user: options.user,
       overrideAccess: options.overrideAccess,
       authenticatedScope: options.authenticatedScope,
+      withheldByAccess: options.withheldByAccess,
       // One per expansion, so a relationship holding many references reads its
       // target's rules once rather than once per value. A nested hop inherits
       // the map rather than starting its own: several children populating the

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -82,7 +82,7 @@ interface RelatedRowAccess {
    * relationship holding many references reads its collection's metadata once
    * instead of once per value.
    */
-  targetPolicies?: Map<string, TargetReadPolicy>;
+  targetPolicies?: Map<string, Promise<TargetReadPolicy>>;
 }
 
 /** A target collection's read policy, as one expansion needs it. */
@@ -972,13 +972,16 @@ export class CollectionRelationshipService extends BaseService {
       return [];
     }
 
-    const kept: Record<string, unknown>[] = [];
-    for (const row of rows) {
-      if (await this.rowPassesTargetPolicy(row, policy, accessService, user)) {
-        kept.push(row);
-      }
-    }
-    return kept;
+    // Judged concurrently: a custom rule may do its own IO, and a list
+    // expanding many targets would otherwise pay for each one in turn. The
+    // verdicts are zipped back against the original order, so the rows keep
+    // the sequence they were fetched in.
+    const verdicts = await Promise.all(
+      rows.map(row =>
+        this.rowPassesTargetPolicy(row, policy, accessService, user)
+      )
+    );
+    return rows.filter((_, index) => verdicts[index]);
   }
 
   /**
@@ -989,7 +992,7 @@ export class CollectionRelationshipService extends BaseService {
    * hundreds of values into hundreds of metadata reads against the same pool
    * the row fetches need.
    */
-  private async resolveTargetReadPolicy(
+  private resolveTargetReadPolicy(
     targetCollection: string,
     accessService: CollectionAccessService,
     access: RelatedRowAccess
@@ -997,25 +1000,33 @@ export class CollectionRelationshipService extends BaseService {
     const cached = access.targetPolicies?.get(targetCollection);
     if (cached) return cached;
 
-    const collection =
-      await this.collectionService.getCollection(targetCollection);
-    const policy: TargetReadPolicy = {
-      rules: accessService.getAccessRules(
-        collection as Record<string, unknown>
-      ),
-      // Owner-only reads answer with a predicate rather than a verdict, so the
-      // owner column and the caller's id are what decide. Resolved through the
-      // helper the direct read path uses, so both compare the same column.
-      ownerConstraint: await accessService.getOwnerConstraint(
-        targetCollection,
-        "read",
-        access.user as UserContext | undefined,
-        false,
-        access.authenticatedScope
-      ),
-    };
-    access.targetPolicies?.set(targetCollection, policy);
-    return policy;
+    // The PENDING lookup is cached, not its result. A `hasMany` relationship
+    // fetches its references concurrently, so every one of them reaches this
+    // point before the first has anything to store — caching only the resolved
+    // value leaves each of them issuing its own metadata read, which is the
+    // pool pressure the cache exists to avoid.
+    const pending = (async (): Promise<TargetReadPolicy> => {
+      const collection =
+        await this.collectionService.getCollection(targetCollection);
+      return {
+        rules: accessService.getAccessRules(
+          collection as Record<string, unknown>
+        ),
+        // Owner-only reads answer with a predicate rather than a verdict, so
+        // the owner column and the caller's id are what decide. Resolved
+        // through the helper the direct read path uses, so both compare the
+        // same column.
+        ownerConstraint: await accessService.getOwnerConstraint(
+          targetCollection,
+          "read",
+          access.user as UserContext | undefined,
+          false,
+          access.authenticatedScope
+        ),
+      };
+    })();
+    access.targetPolicies?.set(targetCollection, pending);
+    return pending;
   }
 
   /** Whether one fetched row survives the target collection's read policy. */
@@ -1036,7 +1047,12 @@ export class CollectionRelationshipService extends BaseService {
       "read",
       accessService.buildRequestContext(user),
       row.id as string | undefined,
-      row,
+      // The id is supplied and the document is not, which is exactly what a
+      // direct read of this target evaluates with. Handing the row over here
+      // instead would let a rule written as `data?.tenant === req.user.tenant`
+      // admit through a relationship what the target's own endpoint refuses,
+      // making population the more permissive way in.
+      undefined,
       // Collections stamp the owner into the `created_by` system column.
       DEFAULT_OWNER_FIELD
     );

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -3,6 +3,7 @@ import { eq, inArray, sql } from "drizzle-orm";
 
 import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 
+import type { AuthenticatedScope } from "../../../auth/authenticated-scope";
 import { getDialectTables } from "../../../database";
 import { container } from "../../../di/container";
 import {
@@ -13,8 +14,8 @@ import { absolutizeMediaUrls } from "../../../lib/media-variant";
 import {
   AccessControlService,
   DEFAULT_OWNER_FIELD,
-  isSuperAdminContext,
 } from "../../../services/access";
+import type { CollectionAccessRules } from "../../../services/access";
 import type { CollectionFileManager } from "../../../services/collection-file-manager";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
@@ -70,6 +71,24 @@ interface RelatedRowAccess {
   enforceFieldAccess?: boolean;
   user?: Record<string, unknown>;
   overrideAccess?: boolean;
+  /**
+   * The caller's authenticated scope. A scoped API key is judged on its OWN
+   * stamped grant, never on its owner's roles, so the super-admin bypass and
+   * the owner predicate both have to know about one.
+   */
+  authenticatedScope?: AuthenticatedScope;
+  /**
+   * Target read policies already resolved during this expansion, so a
+   * relationship holding many references reads its collection's metadata once
+   * instead of once per value.
+   */
+  targetPolicies?: Map<string, TargetReadPolicy>;
+}
+
+/** A target collection's read policy, as one expansion needs it. */
+interface TargetReadPolicy {
+  rules: CollectionAccessRules | undefined;
+  ownerConstraint: { field: string; value: unknown } | null;
 }
 
 /**
@@ -116,6 +135,15 @@ export interface RelationshipExpansionOptions {
    * read paths that forward a real caller; see {@link RelatedRowAccess}.
    */
   enforceFieldAccess?: boolean;
+
+  /**
+   * The caller's authenticated scope, when one applies.
+   *
+   * A scoped API key is judged on its OWN stamped grant rather than its
+   * owner's roles, so a super-admin-owned key must not inherit the bypass its
+   * owner's session would get.
+   */
+  authenticatedScope?: AuthenticatedScope;
 }
 
 /**
@@ -868,83 +896,157 @@ export class CollectionRelationshipService extends BaseService {
     super(adapter, logger);
   }
 
-  private resolveAccessService(): CollectionAccessService | null {
-    if (this.accessService) return this.accessService;
-    if (!container.has("rbacAccessControlService")) return null;
-    this.accessService = new CollectionAccessService(
-      this.adapter,
-      this.logger,
-      this.collectionService,
-      new AccessControlService(),
-      container.get<RBACAccessControlService>("rbacAccessControlService")
-    );
+  private resolveAccessService(): CollectionAccessService {
+    if (!this.accessService) {
+      this.accessService = new CollectionAccessService(
+        this.adapter,
+        this.logger,
+        this.collectionService,
+        this.accessControl,
+        // Optional, and nothing used here needs it: reading a collection's
+        // stored rules and building a request context are independent of RBAC.
+        // Requiring it would make every target rule fail open in a boot that
+        // legitimately omits the service.
+        container.has("rbacAccessControlService")
+          ? container.get<RBACAccessControlService>("rbacAccessControlService")
+          : undefined
+      );
+    }
     return this.accessService;
   }
 
   /**
-   * Whether the target collection's own stored read rules admit this caller.
+   * Drop the rows of a target collection this caller may not read.
    *
-   * Populating a relationship hands back a row from another collection, and
-   * that collection's rules decide whether this caller may see it — the same
-   * decision a direct read of it makes. Without this, a caller refused the
-   * collection outright still obtains its rows by populating a relationship
-   * that points at them.
+   * A related row belongs to another collection and carries that collection's
+   * own read rules. Without this, a caller refused the collection outright
+   * still obtains its rows by populating a relationship that points at them.
+   *
+   * Judged on the fetched ROW, not on the collection alone: a rule may be
+   * keyed on the document id, and one evaluated with `undefined` there both
+   * hides rows a rule permits and admits rows it forbids — `id !== blocked`
+   * reads as true when the id never arrives.
    *
    * Only the STORED rules are evaluated, not the RBAC permission gate. The
-   * route authorized this caller for the PARENT collection, and a permission
-   * check for a collection they never asked for by name would refuse
-   * population for every caller whose grants do not happen to name it —
-   * turning a fix into an outage. Whether expansion should also require a
-   * read permission on the target is a separate question, recorded on the
-   * task rather than decided here.
+   * route authorized this caller for the PARENT collection, and requiring a
+   * permission naming a collection they never asked for by name would refuse
+   * population for every caller whose grants do not list it. Whether expansion
+   * should also require a read permission on the target is left open.
    *
    * Opt-in for the same reason field-level enforcement is: an entry point that
    * has not been given the caller yet would judge everyone anonymous and hide
    * rows from entitled callers.
    */
-  private async targetCollectionReadable(
+  private async filterRowsByCollectionAccess(
     targetCollection: string,
+    rows: Record<string, unknown>[],
     access: RelatedRowAccess
-  ): Promise<boolean> {
-    if (!access.enforceFieldAccess) return true;
-    if (access.overrideAccess) return true;
+  ): Promise<Record<string, unknown>[]> {
+    if (!access.enforceFieldAccess) return rows;
+    if (access.overrideAccess) return rows;
+    if (rows.length === 0) return rows;
     // System entities carry no stored collection rules; their secrets are
     // stripped by name during redaction instead.
-    if (isSystemEntity(targetCollection)) return true;
+    if (isSystemEntity(targetCollection)) return rows;
 
     const accessService = this.resolveAccessService();
-    if (!accessService) return true;
 
     const user = access.user as UserContext | undefined;
-    // Super-admins bypass stored rules on every other transport; expansion is
-    // not the one place that differs.
-    if (isSuperAdminContext(user)) return true;
+    // Super-admins bypass stored rules on every other transport. A scoped API
+    // key is authoritative on its OWN grant and never on its owner's roles, so
+    // the bypass does not extend to one — the same carve-out the direct read
+    // paths make.
+    const isScopedApiKey = access.authenticatedScope?.actorType === "apiKey";
+    if (!isScopedApiKey && accessService.isSuperAdmin(user)) return rows;
 
+    let policy: TargetReadPolicy;
     try {
-      const collection =
-        await this.collectionService.getCollection(targetCollection);
-      const rules = accessService.getAccessRules(
-        collection as Record<string, unknown>
+      policy = await this.resolveTargetReadPolicy(
+        targetCollection,
+        accessService,
+        access
       );
-      const result = await this.accessControl.evaluateAccess(
-        rules,
-        "read",
-        accessService.buildRequestContext(user),
-        undefined,
-        undefined,
-        // Collections stamp the owner into the `created_by` system column.
-        DEFAULT_OWNER_FIELD
-      );
-      // A rule answering with a CONSTRAINT rather than a boolean narrows which
-      // rows are readable, and narrowing is not yet applied to these fetches —
-      // so the row is withheld rather than returned unfiltered.
-      if (result.query) return false;
-      return result.allowed;
     } catch {
       // A target whose rules cannot be read is not a target whose rules are
       // satisfied.
-      return false;
+      return [];
     }
+
+    const kept: Record<string, unknown>[] = [];
+    for (const row of rows) {
+      if (await this.rowPassesTargetPolicy(row, policy, accessService, user)) {
+        kept.push(row);
+      }
+    }
+    return kept;
+  }
+
+  /**
+   * The target collection's read policy, resolved once per expansion.
+   *
+   * Reading it costs a collection-metadata query, and a `hasMany` relationship
+   * fetches one row at a time — so resolving per row turns a relationship with
+   * hundreds of values into hundreds of metadata reads against the same pool
+   * the row fetches need.
+   */
+  private async resolveTargetReadPolicy(
+    targetCollection: string,
+    accessService: CollectionAccessService,
+    access: RelatedRowAccess
+  ): Promise<TargetReadPolicy> {
+    const cached = access.targetPolicies?.get(targetCollection);
+    if (cached) return cached;
+
+    const collection =
+      await this.collectionService.getCollection(targetCollection);
+    const policy: TargetReadPolicy = {
+      rules: accessService.getAccessRules(
+        collection as Record<string, unknown>
+      ),
+      // Owner-only reads answer with a predicate rather than a verdict, so the
+      // owner column and the caller's id are what decide. Resolved through the
+      // helper the direct read path uses, so both compare the same column.
+      ownerConstraint: await accessService.getOwnerConstraint(
+        targetCollection,
+        "read",
+        access.user as UserContext | undefined,
+        false,
+        access.authenticatedScope
+      ),
+    };
+    access.targetPolicies?.set(targetCollection, policy);
+    return policy;
+  }
+
+  /** Whether one fetched row survives the target collection's read policy. */
+  private async rowPassesTargetPolicy(
+    row: Record<string, unknown>,
+    policy: TargetReadPolicy,
+    accessService: CollectionAccessService,
+    user: UserContext | undefined
+  ): Promise<boolean> {
+    if (policy.ownerConstraint) {
+      // An exact comparison against the same column the direct read filters on,
+      // so no predicate is being re-interpreted here.
+      return row[policy.ownerConstraint.field] === policy.ownerConstraint.value;
+    }
+
+    const result = await this.accessControl.evaluateAccess(
+      policy.rules,
+      "read",
+      accessService.buildRequestContext(user),
+      row.id as string | undefined,
+      row,
+      // Collections stamp the owner into the `created_by` system column.
+      DEFAULT_OWNER_FIELD
+    );
+
+    // A rule answering with a predicate rather than a verdict narrows WHICH
+    // rows are readable. Anything beyond the owner predicate handled above is
+    // not applied to these fetches yet, so the row is withheld rather than
+    // returned unnarrowed.
+    if (result.query) return false;
+    return result.allowed;
   }
 
   /**
@@ -1143,6 +1245,11 @@ export class CollectionRelationshipService extends BaseService {
       enforceFieldAccess: options.enforceFieldAccess,
       user: options.user,
       overrideAccess: options.overrideAccess,
+      authenticatedScope: options.authenticatedScope,
+      // One per expansion, so a relationship holding many references reads its
+      // target's rules once rather than once per value. Scoped to this call
+      // because a collection's rules can change between requests.
+      targetPolicies: new Map(),
     };
 
     // Clamp depth to valid range
@@ -1506,12 +1613,6 @@ export class CollectionRelationshipService extends BaseService {
   ): Promise<Map<string, Record<string, unknown>>> {
     const resultMap = new Map<string, Record<string, unknown>>();
 
-    // Judged once for the whole batch: the decision is about the collection,
-    // not about any one row, so it does not need repeating per id.
-    if (!(await this.targetCollectionReadable(targetCollection, access))) {
-      return resultMap;
-    }
-
     if (relatedIds.length === 0) return resultMap;
 
     try {
@@ -1543,8 +1644,13 @@ export class CollectionRelationshipService extends BaseService {
         const rows = entries.map((entry: Record<string, unknown>) =>
           convertTimestampsToCamelCase({ ...entry })
         );
-        await this.redactRelatedRows(targetCollection, rows, access);
-        for (const row of rows) {
+        const readable = await this.filterRowsByCollectionAccess(
+          targetCollection,
+          rows,
+          access
+        );
+        await this.redactRelatedRows(targetCollection, readable, access);
+        for (const row of readable) {
           resultMap.set(row.id as string, {
             ...row,
             label: row[labelField] || row.id,
@@ -1572,8 +1678,13 @@ export class CollectionRelationshipService extends BaseService {
         const rows = entries.map((entry: Record<string, unknown>) =>
           convertTimestampsToCamelCase({ ...entry })
         );
-        await this.redactRelatedRows(targetCollection, rows, access);
-        for (const row of rows) {
+        const readable = await this.filterRowsByCollectionAccess(
+          targetCollection,
+          rows,
+          access
+        );
+        await this.redactRelatedRows(targetCollection, readable, access);
+        for (const row of readable) {
           resultMap.set(row.id as string, {
             ...row,
             // Falls back to the id when the label's source field did not
@@ -1704,11 +1815,20 @@ export class CollectionRelationshipService extends BaseService {
       const targetRows = targetEntries.map((entry: Record<string, unknown>) =>
         convertTimestampsToCamelCase({ ...entry })
       );
-      await this.redactRelatedRows(targetCollectionName, targetRows, access);
+      const readableTargetRows = await this.filterRowsByCollectionAccess(
+        targetCollectionName,
+        targetRows,
+        access
+      );
+      await this.redactRelatedRows(
+        targetCollectionName,
+        readableTargetRows,
+        access
+      );
 
       // Build target entry map
       const targetEntryMap = new Map(
-        targetRows.map((row: Record<string, unknown>) => {
+        readableTargetRows.map((row: Record<string, unknown>) => {
           // Falls back to the id when the label's source field did not survive
           // redaction.
           const label = row[labelField] || row.id;
@@ -1771,6 +1891,11 @@ export class CollectionRelationshipService extends BaseService {
       enforceFieldAccess: options.enforceFieldAccess,
       user: options.user,
       overrideAccess: options.overrideAccess,
+      authenticatedScope: options.authenticatedScope,
+      // One per expansion, so a relationship holding many references reads its
+      // target's rules once rather than once per value. Scoped to this call
+      // because a collection's rules can change between requests.
+      targetPolicies: new Map(),
     };
 
     // Clamp depth to valid range
@@ -2327,12 +2452,6 @@ export class CollectionRelationshipService extends BaseService {
     entryId: string,
     access: RelatedRowAccess = {}
   ): Promise<Record<string, unknown> | null> {
-    // Reads as absent rather than as an error: one unreadable reference must
-    // not refuse the whole parent read, and a caller learns no more than they
-    // would from a reference that points at nothing.
-    if (!(await this.targetCollectionReadable(collectionName, access))) {
-      return null;
-    }
     try {
       // Check if this is a system entity (like "users")
       if (isSystemEntity(collectionName)) {
@@ -2349,8 +2468,17 @@ export class CollectionRelationshipService extends BaseService {
 
         if (!entry) return null;
         const normalized = convertTimestampsToCamelCase({ ...entry });
-        await this.redactRelatedRows(collectionName, [normalized], access);
-        return normalized;
+        const [readable] = await this.filterRowsByCollectionAccess(
+          collectionName,
+          [normalized],
+          access
+        );
+        // Reads as absent rather than as an error: one unreadable reference
+        // must not refuse the whole parent read, and the caller learns no more
+        // than a reference pointing at nothing would tell them.
+        if (!readable) return null;
+        await this.redactRelatedRows(collectionName, [readable], access);
+        return readable;
       } else {
         // Handle dynamic collections
         const schema = await this.fileManager.loadDynamicSchema(collectionName);
@@ -2362,8 +2490,17 @@ export class CollectionRelationshipService extends BaseService {
 
         if (!entry) return null;
         const normalized = convertTimestampsToCamelCase({ ...entry });
-        await this.redactRelatedRows(collectionName, [normalized], access);
-        return normalized;
+        const [readable] = await this.filterRowsByCollectionAccess(
+          collectionName,
+          [normalized],
+          access
+        );
+        // Reads as absent rather than as an error: one unreadable reference
+        // must not refuse the whole parent read, and the caller learns no more
+        // than a reference pointing at nothing would tell them.
+        if (!readable) return null;
+        await this.redactRelatedRows(collectionName, [readable], access);
+        return readable;
       }
     } catch {
       return null;
@@ -2495,9 +2632,14 @@ export class CollectionRelationshipService extends BaseService {
       const normalized = (entries || []).map((entry: Record<string, unknown>) =>
         convertTimestampsToCamelCase({ ...entry })
       );
+      const readable = await this.filterRowsByCollectionAccess(
+        targetCollectionName,
+        normalized,
+        access
+      );
       // Strip related-row secrets before rows are spread into responses.
-      await this.redactRelatedRows(targetCollectionName, normalized, access);
-      return normalized;
+      await this.redactRelatedRows(targetCollectionName, readable, access);
+      return readable;
     } catch (error) {
       console.error("Failed to fetch many-to-many relations:", error);
       return [];

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -1,5 +1,5 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
-import { eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 
 import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 
@@ -16,7 +16,16 @@ import {
   DEFAULT_OWNER_FIELD,
 } from "../../../services/access";
 import type { CollectionAccessRules } from "../../../services/access";
+import {
+  describeUntranslatableConstraint,
+  stripNoOpConstraintMembers,
+} from "../../../services/access/constraint-shape";
 import type { CollectionFileManager } from "../../../services/collection-file-manager";
+import { buildDrizzleCondition } from "../../../services/collections/drizzle-condition";
+import {
+  buildWhereClause,
+  type WhereFilter,
+} from "../../../services/collections/query-operators";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
 import { applyFieldReadAccess } from "../../../shared/lib/field-level-registry";
@@ -89,6 +98,12 @@ interface RelatedRowAccess {
 export interface TargetReadPolicy {
   rules: CollectionAccessRules | undefined;
   ownerConstraint: { field: string; value: unknown } | null;
+  /**
+   * The predicate a stored rule answered with, when it answered with one
+   * rather than a verdict. Applied to the target table rather than compared in
+   * memory, so it binds exactly as it does on a direct read.
+   */
+  queryConstraint: Record<string, unknown> | null;
 }
 
 /**
@@ -991,7 +1006,14 @@ export class CollectionRelationshipService extends BaseService {
         this.rowPassesTargetPolicy(row, policy, accessService, user)
       )
     );
-    return rows.filter((_, index) => verdicts[index]);
+    const admitted = rows.filter((_, index) => verdicts[index]);
+
+    if (!policy.queryConstraint || admitted.length === 0) return admitted;
+    return this.narrowByTargetPredicate(
+      targetCollection,
+      admitted,
+      policy.queryConstraint
+    );
   }
 
   /**
@@ -1033,10 +1055,88 @@ export class CollectionRelationshipService extends BaseService {
           false,
           access.authenticatedScope
         ),
+        queryConstraint: await accessService.getAccessQueryConstraint(
+          targetCollection,
+          access.user as UserContext | undefined,
+          false,
+          access.authenticatedScope
+        ),
       };
     })();
     access.targetPolicies?.set(targetCollection, pending);
     return pending;
+  }
+
+  /**
+   * Keep only the rows the target's own read predicate admits.
+   *
+   * Asked of the database rather than compared in memory: the predicate is a
+   * full filter, and a second evaluator interpreting its operators is free to
+   * disagree with the one the direct read compiles — a filter that binds less
+   * than the rule states is how a read widens unnoticed. The same translation
+   * the read path uses is applied here, over exactly the ids already fetched,
+   * so this costs one query per target collection rather than one per row.
+   *
+   * A predicate that cannot be translated withholds every row. It is the same
+   * refusal a direct read makes, expressed as absence, because an unreadable
+   * relationship must not turn into an error on the document that points at it.
+   */
+  private async narrowByTargetPredicate(
+    targetCollection: string,
+    rows: Record<string, unknown>[],
+    constraint: Record<string, unknown>
+  ): Promise<Record<string, unknown>[]> {
+    try {
+      const schema = isSystemEntity(targetCollection)
+        ? getSystemEntityTable(targetCollection)
+        : await this.fileManager.loadDynamicSchema(targetCollection);
+      if (!schema) return [];
+
+      const untranslatable = describeUntranslatableConstraint(
+        constraint,
+        name => Object.prototype.hasOwnProperty.call(schema, name),
+        // No companion support on this path, so a filter on a localized field
+        // is reported untranslatable here rather than quietly dropped.
+        () => false
+      );
+      if (untranslatable !== null) {
+        this.logger.warn(
+          "Withholding related rows behind an untranslatable access constraint",
+          { collection: targetCollection, reason: untranslatable }
+        );
+        return [];
+      }
+
+      // Members that cannot narrow anything are dropped first, so "translated
+      // to nothing" below judges only what was meant to restrict.
+      const restricting = stripNoOpConstraintMembers(constraint);
+      if (Object.keys(restricting).length === 0) return rows;
+
+      const condition = buildDrizzleCondition(
+        buildWhereClause(restricting as WhereFilter),
+        schema,
+        this.adapter.dialect ?? "postgresql"
+      );
+      // A constraint that restricts on paper and compiles to nothing would
+      // admit every row. Withhold instead: the rule asked to narrow.
+      if (!condition) return [];
+
+      const ids = rows.map(row => row.id as string);
+      const admitted = await this.db
+        .select({ id: schema.id })
+        .from(schema)
+        .where(and(inArray(schema.id, ids), condition));
+      const allowed = new Set(
+        (admitted as { id: string }[]).map(row => row.id)
+      );
+      return rows.filter(row => allowed.has(row.id as string));
+    } catch (error) {
+      this.logger.warn("Could not apply a target collection's read predicate", {
+        collection: targetCollection,
+        error,
+      });
+      return [];
+    }
   }
 
   /** Whether one fetched row survives the target collection's read policy. */
@@ -1067,11 +1167,9 @@ export class CollectionRelationshipService extends BaseService {
       DEFAULT_OWNER_FIELD
     );
 
-    // A rule answering with a predicate rather than a verdict narrows WHICH
-    // rows are readable. Anything beyond the owner predicate handled above is
-    // not applied to these fetches yet, so the row is withheld rather than
-    // returned unnarrowed.
-    if (result.query) return false;
+    // A predicate is not a verdict: it narrows which rows are readable, and
+    // the narrowing is applied to the target table afterwards. Answering
+    // "denied" here would hide rows the rule admits.
     return result.allowed;
   }
 

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -1062,19 +1062,25 @@ export class CollectionRelationshipService extends BaseService {
       else byPredicate.set(key, [row]);
     });
 
+    // One query per distinct predicate, run together: the usual case is a single
+    // group, and a rule answering rows differently should not pay for each group
+    // in turn when the groups do not depend on one another.
+    const narrowedGroups = await Promise.all(
+      [...byPredicate].map(([key, group]) =>
+        this.narrowByTargetPredicate(
+          targetCollection,
+          group,
+          predicates.get(key) as Record<string, unknown>
+        )
+      )
+    );
     const confirmed = [...unrestricted];
-    let anyPredicateFailed = false;
-    for (const [key, group] of byPredicate) {
-      const narrowed = await this.narrowByTargetPredicate(
-        targetCollection,
-        group,
-        predicates.get(key) as Record<string, unknown>
-      );
-      // Null means the predicate could not be applied at all. The rows stay out
-      // either way, but nothing was decided about them, so they are not
-      // reported as refused.
-      if (narrowed === null) anyPredicateFailed = true;
-      else confirmed.push(...narrowed);
+    // Null means the predicate could not be applied at all. The rows stay out
+    // either way, but nothing was decided about them, so they are not reported
+    // as refused.
+    const anyPredicateFailed = narrowedGroups.some(g => g === null);
+    for (const group of narrowedGroups) {
+      if (group !== null) confirmed.push(...group);
     }
     // Restored to the order they were fetched in, since the grouping above
     // reads them out by predicate. Matched on id rather than object identity:

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -78,6 +78,13 @@ interface RelatedRowAccess {
    * point opts in as its own caller forwarding lands.
    */
   enforceFieldAccess?: boolean;
+  /**
+   * Evaluate the TARGET collection's own read rules, independently of whether
+   * this caller redacts fields. A Single's authorization view wants the second
+   * without the first: its rule must read real field values, and must still not
+   * be shown a row the response will withhold.
+   */
+  enforceCollectionAccess?: boolean;
   user?: Record<string, unknown>;
   overrideAccess?: boolean;
   /**
@@ -151,6 +158,12 @@ export interface RelationshipExpansionOptions {
    * read paths that forward a real caller; see {@link RelatedRowAccess}.
    */
   enforceFieldAccess?: boolean;
+
+  /**
+   * Evaluate the target collection's own read rules even when field redaction
+   * is off. See {@link RelatedRowAccess.enforceCollectionAccess}.
+   */
+  enforceCollectionAccess?: boolean;
 
   /**
    * Collects the ids withheld because a target collection refused the caller,
@@ -759,7 +772,7 @@ function readRelationshipRef(
  * id for two of them, and a lookup keyed on the id alone would hand back
  * whichever row was fetched last.
  */
-function relationKey(collection: string, id: string): string {
+export function relationKey(collection: string, id: string): string {
   // A NUL separator cannot appear in a slug or an id, so no two distinct
   // pairs can collapse to the same key.
   return `${collection}\u0000${id}`;
@@ -976,7 +989,16 @@ export class CollectionRelationshipService extends BaseService {
     rows: Record<string, unknown>[],
     access: RelatedRowAccess
   ): Promise<Record<string, unknown>[]> {
-    if (!access.enforceFieldAccess) return rows;
+    // Deliberately NOT keyed on `enforceFieldAccess`. That flag asks whether a
+    // related row's FIELDS should be redacted; this asks whether the caller may
+    // see the row at all, and the two have different callers. A Single's
+    // authorization view populates without field redaction so its rule reads
+    // real values — but if the response is going to withhold the row, the
+    // preliminary view has to withhold it too, or the rule approves a document
+    // on evidence the response then removes and side effects run in between.
+    if (!access.enforceCollectionAccess && !access.enforceFieldAccess) {
+      return rows;
+    }
     if (access.overrideAccess) return rows;
     if (rows.length === 0) return rows;
     // System entities carry no stored collection rules; their secrets are
@@ -1017,7 +1039,7 @@ export class CollectionRelationshipService extends BaseService {
       rows.map(row => this.judgeRow(row, policy, accessService, user))
     );
     const admitted = rows.filter((_, index) => verdicts[index].allowed);
-    this.recordWithheld(rows, admitted, access);
+    this.recordWithheld(targetCollection, rows, admitted, access);
     if (admitted.length === 0) return admitted;
 
     // Rows sharing a predicate are confirmed together, so the usual case of one
@@ -1055,27 +1077,41 @@ export class CollectionRelationshipService extends BaseService {
       else confirmed.push(...narrowed);
     }
     // Restored to the order they were fetched in, since the grouping above
-    // reads them out by predicate.
-    const kept = new Set(confirmed);
-    const ordered = admitted.filter(row => kept.has(row));
-    if (!anyPredicateFailed) this.recordWithheld(admitted, ordered, access);
+    // reads them out by predicate. Matched on id rather than object identity:
+    // narrowing re-reads the rows it admits, so what comes back describes the
+    // same row but is not the same object.
+    const byId = new Map(
+      confirmed.map(row => [row.id as string, row] as const)
+    );
+    const ordered = admitted
+      .map(row => byId.get(row.id as string))
+      .filter((row): row is Record<string, unknown> => row !== undefined);
+    if (!anyPredicateFailed)
+      this.recordWithheld(targetCollection, admitted, ordered, access);
     return ordered;
   }
 
   /**
-   * Note which ids a refusal removed, so a caller checking its expansion for
+   * Note which rows a refusal removed, so a caller checking its expansion for
    * completeness reads them as absent on purpose rather than as evidence lost.
+   *
+   * Keyed by collection AND id, because an id is only unique within its own
+   * collection: two targets can carry the same one, and a bare-id record would
+   * let a refusal in the first excuse a genuine load failure in the second.
    */
   private recordWithheld(
+    targetCollection: string,
     before: Record<string, unknown>[],
     after: Record<string, unknown>[],
     access: RelatedRowAccess
   ): void {
     if (!access.withheldByAccess || before.length === after.length) return;
-    const kept = new Set(after.map(row => row.id as string));
+    const kept = new Set(after);
     for (const row of before) {
-      const id = row.id as string | undefined;
-      if (id && !kept.has(id)) access.withheldByAccess.add(id);
+      if (kept.has(row)) continue;
+      if (typeof row.id === "string") {
+        access.withheldByAccess.add(relationKey(targetCollection, row.id));
+      }
     }
   }
 
@@ -1174,14 +1210,29 @@ export class CollectionRelationshipService extends BaseService {
         .map(row => row.id)
         .filter((id): id is string => typeof id === "string");
       if (ids.length === 0) return [];
-      const admitted = await this.db
-        .select({ id: schema.id })
+      // The whole row is re-read under the predicate, not just its id. Reading
+      // the id alone authorizes the row as it is NOW and then returns the copy
+      // fetched a moment earlier: if a predicate field changed in between — an
+      // ownership or tenant reassignment that also replaced the contents — the
+      // caller would be handed the version that belonged to whoever held it
+      // before. Authorization and the data it admits come from one read.
+      const admitted = (await this.db
+        .select()
         .from(schema)
-        .where(and(inArray(schema.id, ids), condition));
-      const allowed = new Set(
-        (admitted as { id: string }[]).map(row => row.id)
+        .where(and(inArray(schema.id, ids), condition))) as Record<
+        string,
+        unknown
+      >[];
+      const fresh = new Map(
+        admitted.map(row => {
+          const normalized = convertTimestampsToCamelCase({ ...row });
+          return [normalized.id as string, normalized];
+        })
       );
-      return rows.filter(row => allowed.has(row.id as string));
+      // Ordered by the rows that came in, so the caller's sequence survives.
+      return rows
+        .map(row => fresh.get(row.id as string))
+        .filter((row): row is Record<string, unknown> => row !== undefined);
     } catch (error) {
       this.logger.warn("Could not apply a target collection's read predicate", {
         collection: targetCollection,
@@ -1427,6 +1478,7 @@ export class CollectionRelationshipService extends BaseService {
     // by its own collection's field rules.
     const access: RelatedRowAccess = {
       enforceFieldAccess: options.enforceFieldAccess,
+      enforceCollectionAccess: options.enforceCollectionAccess,
       user: options.user,
       overrideAccess: options.overrideAccess,
       authenticatedScope: options.authenticatedScope,
@@ -2078,6 +2130,7 @@ export class CollectionRelationshipService extends BaseService {
     // any depth is judged by its own collection's field rules.
     const access: RelatedRowAccess = {
       enforceFieldAccess: options.enforceFieldAccess,
+      enforceCollectionAccess: options.enforceCollectionAccess,
       user: options.user,
       overrideAccess: options.overrideAccess,
       authenticatedScope: options.authenticatedScope,

--- a/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
@@ -1,5 +1,6 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
+import type { AuthenticatedScope } from "../../../auth/authenticated-scope";
 import type { FieldConfig } from "../../../collections/fields/types";
 import type { FieldGroupFieldConfig } from "../../../collections/fields/types/component";
 import type { DynamicFieldGroupRecord } from "../../../schemas/dynamic-field-groups/types";
@@ -41,6 +42,14 @@ export interface ComponentReadAccess {
   enforceFieldAccess?: boolean;
   user?: Record<string, unknown>;
   overrideAccess?: boolean;
+  /**
+   * The caller's authenticated scope, forwarded to relationship expansion.
+   *
+   * A relationship reached through a field group is populated by the same
+   * service a top-level one is, and a scoped API key must not inherit its
+   * owner's super-admin bypass there either.
+   */
+  authenticatedScope?: AuthenticatedScope;
 }
 
 export interface PopulateComponentDataParams {
@@ -1097,6 +1106,7 @@ export class FieldGroupQueryService extends BaseService {
           enforceFieldAccess: access.enforceFieldAccess,
           user: access.user,
           overrideAccess: access.overrideAccess,
+          authenticatedScope: access.authenticatedScope,
         }
       );
 

--- a/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
@@ -10,6 +10,7 @@ import type { FieldGroupRegistryService } from "../../../services/field-groups/f
 import { BaseService } from "../../../shared/base-service";
 import { stripPasswordFieldValues } from "../../../shared/lib/password-fields";
 import type { Logger } from "../../../shared/types";
+import type { TargetReadPolicy } from "../../collections/services/collection-relationship-service";
 import {
   isMissingCompanionTableError,
   populateCompanionFields,
@@ -50,6 +51,14 @@ export interface ComponentReadAccess {
    * owner's super-admin bypass there either.
    */
   authenticatedScope?: AuthenticatedScope;
+  /**
+   * Target read policies resolved during this population.
+   *
+   * Component rows are expanded concurrently, and rows pointing at the same
+   * target would otherwise each resolve its policy — so one map is shared
+   * across them all rather than created per row.
+   */
+  targetPolicies?: Map<string, Promise<TargetReadPolicy>>;
 }
 
 export interface PopulateComponentDataParams {
@@ -1107,6 +1116,7 @@ export class FieldGroupQueryService extends BaseService {
           user: access.user,
           overrideAccess: access.overrideAccess,
           authenticatedScope: access.authenticatedScope,
+          targetPolicies: access.targetPolicies,
         }
       );
 

--- a/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
@@ -52,6 +52,11 @@ export interface ComponentReadAccess {
    */
   authenticatedScope?: AuthenticatedScope;
   /**
+   * Ids withheld because a target collection refused the caller, so a
+   * completeness check can tell a refusal from a load that failed.
+   */
+  withheldByAccess?: Set<string>;
+  /**
    * Target read policies resolved during this population.
    *
    * Component rows are expanded concurrently, and rows pointing at the same
@@ -1117,6 +1122,7 @@ export class FieldGroupQueryService extends BaseService {
           overrideAccess: access.overrideAccess,
           authenticatedScope: access.authenticatedScope,
           targetPolicies: access.targetPolicies,
+          withheldByAccess: access.withheldByAccess,
         }
       );
 

--- a/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
@@ -57,6 +57,11 @@ export interface ComponentReadAccess {
    */
   withheldByAccess?: Set<string>;
   /**
+   * Evaluate the target collection's own read rules even when field redaction
+   * is off, so an authorization view is not shown a row the response withholds.
+   */
+  enforceCollectionAccess?: boolean;
+  /**
    * Target read policies resolved during this population.
    *
    * Component rows are expanded concurrently, and rows pointing at the same
@@ -1118,6 +1123,7 @@ export class FieldGroupQueryService extends BaseService {
           // The related row belongs to another collection, so it is judged by
           // that collection's field rules for this caller.
           enforceFieldAccess: access.enforceFieldAccess,
+          enforceCollectionAccess: access.enforceCollectionAccess,
           user: access.user,
           overrideAccess: access.overrideAccess,
           authenticatedScope: access.authenticatedScope,

--- a/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
@@ -1172,6 +1172,79 @@ describe("Single custom read rules vs the assembled document (integration)", () 
     expect(result.data!.author).toBe(authorId);
   });
 
+  // A list-valued relationship may hold both readable and refused targets. The
+  // refused ones are absent on purpose, so completeness has to be measured
+  // against what could be read, not against everything the row stored.
+  it("serves a judged read whose list holds one refused target", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "authors", fields: [text({ name: "name" })] }),
+      ],
+      singles: [
+        defineSingle({
+          slug: "branding",
+          fields: [
+            text({ name: "siteName" }),
+            relationship({
+              name: "authors",
+              relationTo: "authors",
+              hasMany: true,
+            }),
+          ],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    // The caller is admitted by the Single's rule and refused by the target's
+    // rule for one specific row, so the list ends up part readable and part
+    // refused — which is the case the check has to account for.
+    const readable = await handler.createEntry(
+      { collectionName: "authors", overrideAccess: true },
+      { name: "Readable" }
+    );
+    const refused = await handler.createEntry(
+      { collectionName: "authors", overrideAccess: true },
+      { name: "Refused" }
+    );
+    const refusedId = (refused.data as { id: string }).id;
+    const entry = current.getService<SingleEntryService>("singleEntryService");
+    await entry.update(
+      "branding",
+      {
+        siteName: "Acme",
+        authors: [(readable.data as { id: string }).id, refusedId],
+      },
+      { overrideAccess: true }
+    );
+    await current.adapter.update(
+      "dynamic_singles",
+      { access_rules: { read: { type: "custom", functionPath: RULE_PATH } } },
+      { and: [{ column: "slug", op: "=", value: "branding" }] }
+    );
+    await current.adapter.update(
+      "dynamic_collections",
+      {
+        access_rules: {
+          read: { type: "custom", functionPath: TARGET_RULE_PATH },
+        },
+      },
+      { and: [{ column: "slug", op: "=", value: "authors" }] }
+    );
+
+    const result = await entry.get("branding", {
+      user: { id: "partial", blockedId: refusedId },
+      routeAuthorized: true,
+      depth: 1,
+    });
+
+    expect(result.success).toBe(true);
+    const authors = result.data!.authors as Record<string, unknown>[];
+    // The readable half survived; the refused half is simply not there.
+    expect(JSON.stringify(authors)).toContain("Readable");
+    expect(JSON.stringify(authors)).not.toContain("Refused");
+  });
+
   // A container is serialized to JSON wholesale, so a reference left populated
   // inside one is written as the row and never read back as a reference again.
   it("stores a reference for a populated value inside a group", async () => {

--- a/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
@@ -34,6 +34,11 @@ afterEach(async () => {
   current = undefined;
 });
 
+const TARGET_RULE_PATH = new URL(
+  "../../collections/__tests__/_fixtures/related-target-read-rule.ts",
+  import.meta.url
+).pathname;
+
 const RULE_PATH = new URL(
   "../../collections/__tests__/_fixtures/single-read-rule.ts",
   import.meta.url
@@ -1104,6 +1109,67 @@ describe("Single custom read rules vs the assembled document (integration)", () 
     );
 
     expect(seen).toContainEqual({ relationTo: "authors", value: authorId });
+  });
+
+  // A relationship whose TARGET collection refuses this caller is absent
+  // because they may not read it, not because the read failed. The
+  // completeness check exists to catch evidence that went missing, and reading
+  // a refusal as a fault refuses a document the caller is allowed to see.
+  it("serves a judged read whose relationship target is refused", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "authors", fields: [text({ name: "name" })] }),
+      ],
+      singles: [
+        defineSingle({
+          slug: "branding",
+          fields: [
+            text({ name: "siteName" }),
+            relationship({ name: "author", relationTo: "authors" }),
+          ],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const author = await handler.createEntry(
+      { collectionName: "authors", overrideAccess: true },
+      { name: "Ada" }
+    );
+    const authorId = (author.data as { id: string }).id;
+    const entry = current.getService<SingleEntryService>("singleEntryService");
+    await entry.update(
+      "branding",
+      { siteName: "Acme", author: authorId },
+      { overrideAccess: true }
+    );
+
+    // The Single admits this caller; the target collection refuses them.
+    await current.adapter.update(
+      "dynamic_singles",
+      { access_rules: { read: { type: "custom", functionPath: RULE_PATH } } },
+      { and: [{ column: "slug", op: "=", value: "branding" }] }
+    );
+    await current.adapter.update(
+      "dynamic_collections",
+      {
+        access_rules: {
+          read: { type: "custom", functionPath: TARGET_RULE_PATH },
+        },
+      },
+      { and: [{ column: "slug", op: "=", value: "authors" }] }
+    );
+
+    const result = await entry.get("branding", {
+      user: { id: "always" },
+      routeAuthorized: true,
+      depth: 1,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data!.siteName).toBe("Acme");
+    // Left as the reference it was stored as, rather than populated or refused.
+    expect(result.data!.author).toBe(authorId);
   });
 
   // A container is serialized to JSON wholesale, so a reference left populated

--- a/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/custom-read-constraint.integration.test.ts
@@ -1245,6 +1245,70 @@ describe("Single custom read rules vs the assembled document (integration)", () 
     expect(JSON.stringify(authors)).not.toContain("Refused");
   });
 
+  // The preliminary view and the response have to agree about whether a target
+  // is readable. A view shown a row the response will withhold lets a rule
+  // reading that row approve the document, so the read's side effects run and
+  // only the final check discovers the row is gone — the denial arrives after
+  // the hooks it was supposed to precede.
+  it("runs no read hook when a target the response withholds is refused", async () => {
+    const beforeRead = vi.fn(async () => undefined);
+    current = await createTestNextly({
+      collections: [
+        defineCollection({ slug: "authors", fields: [text({ name: "name" })] }),
+      ],
+      singles: [
+        defineSingle({
+          slug: "branding",
+          hooks: { beforeRead: [beforeRead] },
+          fields: [
+            text({ name: "siteName" }),
+            relationship({ name: "author", relationTo: "authors" }),
+          ],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const author = await handler.createEntry(
+      { collectionName: "authors", overrideAccess: true },
+      { name: "Ada" }
+    );
+    const entry = current.getService<SingleEntryService>("singleEntryService");
+    await entry.update(
+      "branding",
+      { siteName: "Acme", author: (author.data as { id: string }).id },
+      { overrideAccess: true }
+    );
+    await current.adapter.update(
+      "dynamic_singles",
+      { access_rules: { read: { type: "custom", functionPath: RULE_PATH } } },
+      { and: [{ column: "slug", op: "=", value: "branding" }] }
+    );
+    // The target refuses this caller, while the Single's own rule admits the
+    // document only while its `author` is a populated row.
+    await current.adapter.update(
+      "dynamic_collections",
+      {
+        access_rules: {
+          read: { type: "custom", functionPath: TARGET_RULE_PATH },
+        },
+      },
+      { and: [{ column: "slug", op: "=", value: "authors" }] }
+    );
+    beforeRead.mockClear();
+
+    const result = await entry.get("branding", {
+      user: { id: "needs-populated-author" },
+      routeAuthorized: true,
+      depth: 1,
+    });
+
+    expect(result.success).toBe(false);
+    // The decision was reached on the same evidence the response would carry,
+    // so it landed before the read's side effects rather than after them.
+    expect(beforeRead).not.toHaveBeenCalled();
+  });
+
   // A container is serialized to JSON wholesale, so a reference left populated
   // inside one is written as the row and never read back as a reference again.
   it("stores a reference for a populated value inside a group", async () => {

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -2222,6 +2222,7 @@ export class SingleMutationService extends BaseService {
           enforceFieldAccess: true,
           user: options.user,
           overrideAccess: options.overrideAccess,
+          authenticatedScope: options.authenticatedScope,
         }
       );
 

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -742,6 +742,7 @@ export class SingleQueryService extends BaseService {
             enforceFieldAccess: enforceRelatedFieldAccess,
             user: options.user as Record<string, unknown> | undefined,
             overrideAccess: options.overrideAccess,
+            authenticatedScope: options.authenticatedScope,
           },
           // Read errors otherwise become empty component values, which reads to a
           // rule exactly like a component that holds nothing.

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -308,6 +308,13 @@ function referencesExpanded(
   const parsedStored = parseReferenceValue(stored);
   if (parsedStored === UNREADABLE_CONTAINER) return false;
   const storedList = parsedStored;
+  // References the target's own rules refused are absent on purpose, so they
+  // are removed from what has to have arrived. A `hasMany` holding both
+  // readable and refused rows therefore compares the shortened list against
+  // the references that were actually expandable, rather than against every
+  // reference the row stored.
+  const expectable = (ref: unknown): boolean =>
+    !withheldByAccess?.has(referenceId(ref));
   if (withheldByAccess?.size) {
     const refusedEveryReference = (
       Array.isArray(storedList) ? storedList : [storedList]
@@ -317,7 +324,7 @@ function referencesExpanded(
     if (refusedEveryReference) return true;
   }
   const storedRefs = Array.isArray(storedList)
-    ? storedList.filter(id => !isEmptyValue(id))
+    ? storedList.filter(id => !isEmptyValue(id)).filter(expectable)
     : undefined;
 
   if (Array.isArray(assembled)) {
@@ -780,6 +787,11 @@ export class SingleQueryService extends BaseService {
             enforceFieldAccess: enforceRelatedFieldAccess,
             user: options.user as Record<string, unknown> | undefined,
             overrideAccess: options.overrideAccess,
+            // A relationship inside a component is populated by the same
+            // service, so a refusal there has to reach the completeness check
+            // too, and the rows of one population share a policy cache.
+            withheldByAccess: params.withheldByAccess,
+            targetPolicies: new Map(),
             authenticatedScope: options.authenticatedScope,
           },
           // Read errors otherwise become empty component values, which reads to a

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -63,6 +63,7 @@ import {
   stripSystemOwnerField,
 } from "../../../shared/lib/password-fields";
 import type { Logger } from "../../../shared/types";
+import { relationKey } from "../../collections/services/collection-relationship-service";
 import { resolveLocalizedFieldNames } from "../../i18n/classify-fields";
 import {
   populateCompanionFields,
@@ -293,6 +294,37 @@ function referenceId(reference: unknown): string {
   return "";
 }
 
+/**
+ * The collection a stored reference points at.
+ *
+ * A field naming several targets records the collection on the value itself;
+ * anything else belongs to the field's declared target. Needed because a
+ * withheld row is recorded per collection — an id alone is only unique within
+ * one, so a refusal in one target would otherwise excuse a lost row in another.
+ */
+/** A relationship field's declared target, in either shape it is declared in. */
+function singleFieldTarget(field: FieldConfig): string {
+  const config = field as {
+    relationTo?: unknown;
+    options?: { target?: unknown };
+  };
+  if (typeof config.relationTo === "string") return config.relationTo;
+  if (Array.isArray(config.relationTo)) return "";
+  const target = config.options?.target;
+  return typeof target === "string" ? target : "";
+}
+
+function referenceCollection(
+  reference: unknown,
+  fallbackCollection: string
+): string {
+  if (reference !== null && typeof reference === "object") {
+    const { relationTo } = reference as Record<string, unknown>;
+    if (typeof relationTo === "string") return relationTo;
+  }
+  return fallbackCollection;
+}
+
 function referencesExpanded(
   stored: unknown,
   assembled: unknown,
@@ -303,7 +335,9 @@ function referencesExpanded(
    * missing would refuse a document the caller may read because something it
    * points at is something they may not.
    */
-  withheldByAccess?: Set<string>
+  withheldByAccess?: Set<string>,
+  /** The field's declared target, for references that do not name their own. */
+  fieldTarget = ""
 ): boolean {
   const parsedStored = parseReferenceValue(stored);
   if (parsedStored === UNREADABLE_CONTAINER) return false;
@@ -313,14 +347,19 @@ function referencesExpanded(
   // readable and refused rows therefore compares the shortened list against
   // the references that were actually expandable, rather than against every
   // reference the row stored.
-  const expectable = (ref: unknown): boolean =>
-    !withheldByAccess?.has(referenceId(ref));
+  const withheld = (ref: unknown): boolean =>
+    Boolean(
+      withheldByAccess?.has(
+        relationKey(referenceCollection(ref, fieldTarget), referenceId(ref))
+      )
+    );
+  const expectable = (ref: unknown): boolean => !withheld(ref);
   if (withheldByAccess?.size) {
     const refusedEveryReference = (
       Array.isArray(storedList) ? storedList : [storedList]
     )
       .filter(ref => !isEmptyValue(ref))
-      .every(ref => withheldByAccess.has(referenceId(ref)));
+      .every(ref => withheld(ref));
     if (refusedEveryReference) return true;
   }
   const storedRefs = Array.isArray(storedList)
@@ -754,6 +793,11 @@ export class SingleQueryService extends BaseService {
       options.depth,
       {
         enforceFieldAccess: enforceRelatedFieldAccess,
+        // Always on, unlike field redaction: the authorization view must not be
+        // shown a related row the response is going to withhold, or its rule
+        // approves the document and the read's side effects run before the
+        // final check discovers the row is gone.
+        enforceCollectionAccess: true,
         user: options.user,
         overrideAccess: options.overrideAccess,
         authenticatedScope: options.authenticatedScope,
@@ -785,6 +829,7 @@ export class SingleQueryService extends BaseService {
           // caller travels down to reach the related row's own rules.
           access: {
             enforceFieldAccess: enforceRelatedFieldAccess,
+            enforceCollectionAccess: true,
             user: options.user as Record<string, unknown> | undefined,
             overrideAccess: options.overrideAccess,
             // A relationship inside a component is populated by the same
@@ -889,7 +934,14 @@ export class SingleQueryService extends BaseService {
         // populated whatever depth is configured, so the same exemption would
         // skip their only check.
         if (type !== "upload" && relationshipMaxDepth(field) === 0) continue;
-        if (!referencesExpanded(before, after, withheldByAccess)) {
+        if (
+          !referencesExpanded(
+            before,
+            after,
+            withheldByAccess,
+            singleFieldTarget(field)
+          )
+        ) {
           this.logger.error(
             "Refusing a single read: relationship evidence could not be assembled",
             { single: slug, field: where }
@@ -961,6 +1013,8 @@ export class SingleQueryService extends BaseService {
     skipLocalizedOverlay?: boolean;
   }): Promise<SingleDocument> {
     let references: SingleDocument | undefined;
+    // Rows the targets' own rules refused while assembling this view.
+    const viewWithheld = new Set<string>();
     const assembled = await this.assembleStoredDocument({
       ...params,
       // Every reference the read will resolve, including the localized ones the
@@ -987,12 +1041,20 @@ export class SingleQueryService extends BaseService {
       },
       // Judged on complete data or not at all.
       strict: true,
+      // The view withholds a target this caller may not read, exactly as the
+      // response will, so the check below has to know which absences that
+      // accounts for — otherwise the refusal it was asked to make reads back to
+      // it as evidence that failed to load.
+      withheldByAccess: viewWithheld,
     });
     this.assertRelationshipsExpanded(
       params.slug,
       params.singleMeta.fields,
       references ?? params.doc,
-      assembled
+      assembled,
+      true,
+      "",
+      viewWithheld
     );
     // The response carries the per-locale overview when it is asked for, so a
     // rule deciding on translation state has to see it here too, or the two
@@ -2368,6 +2430,12 @@ export class SingleQueryService extends BaseService {
     // enforcing for the former strips protected fields from everybody.
     access: {
       enforceFieldAccess?: boolean;
+      /**
+       * Evaluate the target collection's own read rules even when field
+       * redaction is off, so the authorization view is not shown a row the
+       * response will withhold.
+       */
+      enforceCollectionAccess?: boolean;
       user?: UserContext;
       overrideAccess?: boolean;
       /**
@@ -2427,6 +2495,7 @@ export class SingleQueryService extends BaseService {
           // path does not, so its response keeps the fields it already returned
           // rather than having them stripped as if nobody were asking.
           enforceFieldAccess: access.enforceFieldAccess,
+          enforceCollectionAccess: access.enforceCollectionAccess,
           user: access.user as Record<string, unknown> | undefined,
           overrideAccess: access.overrideAccess,
           authenticatedScope: access.authenticatedScope,

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -282,10 +282,40 @@ function isExpandedRow(value: unknown): boolean {
  * could not fetch, so a shorter list — or an empty one — is evidence that went
  * missing rather than evidence that says nothing is there.
  */
-function referencesExpanded(stored: unknown, assembled: unknown): boolean {
+/** The id a stored reference points at, in either shape it is stored in. */
+function referenceId(reference: unknown): string {
+  if (typeof reference === "string") return reference;
+  if (reference !== null && typeof reference === "object") {
+    const { value, id } = reference as Record<string, unknown>;
+    if (typeof value === "string") return value;
+    if (typeof id === "string") return id;
+  }
+  return "";
+}
+
+function referencesExpanded(
+  stored: unknown,
+  assembled: unknown,
+  /**
+   * Ids the target collection's own rules refused this caller.
+   *
+   * Such a reference is absent on purpose. Counting it as evidence that went
+   * missing would refuse a document the caller may read because something it
+   * points at is something they may not.
+   */
+  withheldByAccess?: Set<string>
+): boolean {
   const parsedStored = parseReferenceValue(stored);
   if (parsedStored === UNREADABLE_CONTAINER) return false;
   const storedList = parsedStored;
+  if (withheldByAccess?.size) {
+    const refusedEveryReference = (
+      Array.isArray(storedList) ? storedList : [storedList]
+    )
+      .filter(ref => !isEmptyValue(ref))
+      .every(ref => withheldByAccess.has(referenceId(ref)));
+    if (refusedEveryReference) return true;
+  }
   const storedRefs = Array.isArray(storedList)
     ? storedList.filter(id => !isEmptyValue(id))
     : undefined;
@@ -660,6 +690,11 @@ export class SingleQueryService extends BaseService {
      * for a document an access rule is about to be judged on.
      */
     strict?: boolean;
+    /**
+     * Collects references a target collection refused, so the completeness
+     * check can tell a refusal from a load that failed.
+     */
+    withheldByAccess?: Set<string>;
   }): Promise<SingleDocument> {
     const {
       slug,
@@ -715,6 +750,9 @@ export class SingleQueryService extends BaseService {
         user: options.user,
         overrideAccess: options.overrideAccess,
         authenticatedScope: options.authenticatedScope,
+        // Collects the references a target collection refused, so the
+        // completeness check below reads them as absent on purpose.
+        withheldByAccess: params.withheldByAccess,
       },
       strict,
       // The read path threads a caller, so the target collection's field rules
@@ -807,7 +845,12 @@ export class SingleQueryService extends BaseService {
      * unaffected: they populate whatever depth is asked for.
      */
     expandsRelationships = true,
-    path = ""
+    path = "",
+    /**
+     * Ids a target collection's rules refused this caller, so an absence they
+     * caused is not read as evidence that failed to load.
+     */
+    withheldByAccess?: Set<string>
   ): void {
     if (!assembled) return;
 
@@ -834,7 +877,7 @@ export class SingleQueryService extends BaseService {
         // populated whatever depth is configured, so the same exemption would
         // skip their only check.
         if (type !== "upload" && relationshipMaxDepth(field) === 0) continue;
-        if (!referencesExpanded(before, after)) {
+        if (!referencesExpanded(before, after, withheldByAccess)) {
           this.logger.error(
             "Refusing a single read: relationship evidence could not be assembled",
             { single: slug, field: where }
@@ -890,7 +933,8 @@ export class SingleQueryService extends BaseService {
           storedRows[index],
           assembledRows[index],
           expandsRelationships,
-          type === "repeater" ? `${where}[${index}]` : where
+          type === "repeater" ? `${where}[${index}]` : where,
+          withheldByAccess
         );
       }
     }
@@ -1430,6 +1474,10 @@ export class SingleQueryService extends BaseService {
       // Whether a stored rule will be judged on what this assembly produces.
       const judgedRead = deferCustomRule && !options.overrideAccess;
       let responseReferences: SingleDocument | undefined;
+      // References a target collection refuses this caller. Collected during
+      // the response assembly so the completeness check can tell an absence
+      // the rules caused from one a failed load caused.
+      const responseWithheld = new Set<string>();
       doc = await this.assembleStoredDocument({
         slug,
         singleMeta,
@@ -1447,6 +1495,7 @@ export class SingleQueryService extends BaseService {
         captureReferences: captured => {
           responseReferences = detachData(captured);
         },
+        withheldByAccess: responseWithheld,
       });
 
       // The response assembly is best-effort, and the decision below is made on
@@ -1467,7 +1516,12 @@ export class SingleQueryService extends BaseService {
           // The response honours the caller's depth, and `0` means "give me
           // references". The authorization view has already judged the same
           // relationships at the full read depth.
-          (options.depth ?? DEFAULT_READ_DEPTH) > 0
+          (options.depth ?? DEFAULT_READ_DEPTH) > 0,
+          "",
+          // A relationship the target's own rules refused is absent because the
+          // caller may not read it, not because the read failed. Refusing the
+          // document over it would deny a Single they are allowed to see.
+          responseWithheld
         );
       }
 
@@ -2310,6 +2364,7 @@ export class SingleQueryService extends BaseService {
        * a related row's collection rules are evaluated.
        */
       authenticatedScope?: AuthenticatedScope;
+      withheldByAccess?: Set<string>;
     } = {},
     /**
      * Propagate expansion failures instead of returning the document
@@ -2363,6 +2418,7 @@ export class SingleQueryService extends BaseService {
           user: access.user as Record<string, unknown> | undefined,
           overrideAccess: access.overrideAccess,
           authenticatedScope: access.authenticatedScope,
+          withheldByAccess: access.withheldByAccess,
         }
       );
       return expandedDoc as SingleDocument;

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -714,6 +714,7 @@ export class SingleQueryService extends BaseService {
         enforceFieldAccess: enforceRelatedFieldAccess,
         user: options.user,
         overrideAccess: options.overrideAccess,
+        authenticatedScope: options.authenticatedScope,
       },
       strict,
       // The read path threads a caller, so the target collection's field rules
@@ -2302,6 +2303,12 @@ export class SingleQueryService extends BaseService {
       enforceFieldAccess?: boolean;
       user?: UserContext;
       overrideAccess?: boolean;
+      /**
+       * The caller's authenticated scope. A scoped API key is judged on its
+       * own grant, so it must not inherit its owner's super-admin bypass when
+       * a related row's collection rules are evaluated.
+       */
+      authenticatedScope?: AuthenticatedScope;
     } = {},
     /**
      * Propagate expansion failures instead of returning the document
@@ -2354,6 +2361,7 @@ export class SingleQueryService extends BaseService {
           enforceFieldAccess: access.enforceFieldAccess,
           user: access.user as Record<string, unknown> | undefined,
           overrideAccess: access.overrideAccess,
+          authenticatedScope: access.authenticatedScope,
         }
       );
       return expandedDoc as SingleDocument;

--- a/packages/nextly/src/services/collections/drizzle-condition.ts
+++ b/packages/nextly/src/services/collections/drizzle-condition.ts
@@ -14,6 +14,7 @@
  * unresolved, which its own untranslatable check is expected to catch before
  * this point rather than silently dropping the predicate.
  */
+import type { SQL } from "drizzle-orm";
 import {
   and,
   eq,
@@ -63,8 +64,7 @@ export type LocalizedExistsBuilder = (
   op: string,
   value: unknown,
   dialect: string
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle dynamic condition
-) => any;
+) => SQL | undefined;
 
 export function buildDrizzleCondition(
   whereClause: ReturnType<typeof buildWhereClause>,

--- a/packages/nextly/src/services/collections/drizzle-condition.ts
+++ b/packages/nextly/src/services/collections/drizzle-condition.ts
@@ -1,0 +1,223 @@
+/**
+ * Translate a stored filter into a Drizzle condition.
+ *
+ * Extracted from the collection read path so every caller that has to honour a
+ * filter — a caller's own `where`, a stored access constraint on a read, the
+ * same constraint when a relationship populates a row from that collection —
+ * compiles it through one implementation. A second translator would be free to
+ * disagree with this one about an operator, and a filter that binds less than
+ * the rule states is how a read widens without anyone noticing.
+ *
+ * Localized fields live in a companion table and cannot be resolved from the
+ * main schema, so a caller that supports them supplies the builder that emits
+ * the companion EXISTS. A caller that does not pass one leaves such a field
+ * unresolved, which its own untranslatable check is expected to catch before
+ * this point rather than silently dropping the predicate.
+ */
+import {
+  and,
+  eq,
+  ne,
+  gt,
+  gte,
+  lt,
+  lte,
+  inArray,
+  notInArray,
+  like,
+  ilike,
+  isNull,
+  isNotNull,
+  or,
+} from "drizzle-orm";
+
+import type { LocalizedFieldRef } from "../../domains/i18n/companion-join";
+
+import type { buildWhereClause } from "./query-operators";
+
+/**
+ * Localized-query context (i18n M4c) threaded into the search/where builders so a localized
+ * field filters via a companion EXISTS on the requested locale instead of being silently
+ * dropped. `null`/absent → non-localized behavior (unchanged).
+ */
+export interface LocalizedQueryContext {
+  companionTableName: string;
+  /** Localized fields with both the camelCase name (matching) and snake_case column (SQL). */
+  localizedFields: LocalizedFieldRef[];
+  /** The main table's `id` column (Drizzle) — the companion `_parent` correlation target. */
+  mainIdColumn: unknown;
+  /** The locale to filter on (the requested locale — chain head). */
+  locale: string;
+  /**
+   * Per-locale status filter (i18n M6). Set (e.g. `"published"`) when the read resolves to a
+   * single status and the collection has per-locale status, so localized where/search EXISTS
+   * checks only match companion rows in that state. Undefined = no status constraint.
+   */
+  statusValue?: string;
+}
+
+/** Emits the companion-table EXISTS for a filter on a localized field. */
+export type LocalizedExistsBuilder = (
+  localizedCtx: LocalizedQueryContext,
+  column: string,
+  op: string,
+  value: unknown,
+  dialect: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle dynamic condition
+) => any;
+
+export function buildDrizzleCondition(
+  whereClause: ReturnType<typeof buildWhereClause>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle dynamic schema
+  schema: any,
+  dialect: string = "postgresql",
+  localizedCtx?: LocalizedQueryContext | null,
+  localizedExists?: LocalizedExistsBuilder
+): ReturnType<typeof and> | undefined {
+  if (!whereClause) {
+    return undefined;
+  }
+
+  // Helper to build condition from a single WhereCondition
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic where clause structure
+  const buildSingleCondition = (condition: any): any => {
+    // Check if it's a nested WhereClause (has and/or)
+    if (condition.and || condition.or) {
+      return buildDrizzleCondition(
+        condition,
+        schema,
+        dialect,
+        localizedCtx,
+        localizedExists
+      );
+    }
+
+    // It's a WhereCondition
+    const { column, op, value } = condition;
+
+    // Get the column from schema (handle dot notation for nested fields)
+    const columnParts = column.split(".");
+
+    // i18n M4c: a filter on a localized field targets the companion table (absent from the
+    // main schema). Resolve it to a companion EXISTS on the requested locale so the filter
+    // takes effect instead of being silently skipped.
+    const localizedWhereField = localizedCtx?.localizedFields.find(
+      f => f.name === columnParts[0]
+    );
+    if (localizedCtx && localizedWhereField) {
+      const localizedCond = localizedExists?.(
+        localizedCtx,
+        localizedWhereField.column,
+        op,
+        value,
+        dialect
+      );
+      if (localizedCond) return localizedCond;
+    }
+
+    const schemaColumn = schema[columnParts[0]];
+
+    if (!schemaColumn) {
+      // Column doesn't exist in schema, skip this condition
+      return undefined;
+    }
+
+    switch (op) {
+      case "=":
+        return eq(schemaColumn, value);
+      case "!=":
+        return ne(schemaColumn, value);
+      case ">":
+        return gt(schemaColumn, value);
+      case ">=":
+        return gte(schemaColumn, value);
+      case "<":
+        return lt(schemaColumn, value);
+      case "<=":
+        return lte(schemaColumn, value);
+      case "LIKE":
+        return like(schemaColumn, value);
+      case "ILIKE":
+        // Use ILIKE for PostgreSQL, LIKE for others
+        if (dialect === "postgresql") {
+          return ilike(schemaColumn, value);
+        }
+        return like(schemaColumn, value);
+      case "IN":
+        if (Array.isArray(value) && value.length > 0) {
+          return inArray(schemaColumn, value);
+        }
+        return undefined;
+      case "NOT IN":
+        if (Array.isArray(value) && value.length > 0) {
+          return notInArray(schemaColumn, value);
+        }
+        return undefined;
+      case "IS NULL":
+        return isNull(schemaColumn);
+      case "IS NOT NULL":
+        return isNotNull(schemaColumn);
+      default:
+        return undefined;
+    }
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle SQL condition accumulator
+  const conditions: any[] = [];
+
+  // Handle AND conditions
+  if (whereClause.and && Array.isArray(whereClause.and)) {
+    const andConditions = whereClause.and
+      .map(buildSingleCondition)
+      .filter(Boolean);
+    if (andConditions.length > 0) {
+      conditions.push(and(...andConditions));
+    }
+  }
+
+  // Handle OR conditions
+  if (whereClause.or && Array.isArray(whereClause.or)) {
+    const orConditions = whereClause.or
+      .map(buildSingleCondition)
+      .filter(Boolean);
+    if (orConditions.length > 0) {
+      conditions.push(or(...orConditions));
+    }
+  }
+
+  // Return combined conditions
+  if (conditions.length === 0) {
+    return undefined;
+  }
+  if (conditions.length === 1) {
+    return conditions[0];
+  }
+  return and(...conditions);
+}
+
+/**
+ * Build EXISTS subquery conditions for component field filters.
+ *
+ * Generates SQL EXISTS subqueries to filter entries based on component field values.
+ * Each component filter results in an EXISTS clause against the component data table.
+ *
+ * @param componentFilters - Component field filters extracted from where clause
+ * @param parentTableName - Name of the parent table (e.g., 'dc_pages')
+ * @param parentIdColumn - Reference to the parent table's id column
+ * @param dialect - Database dialect for operator handling
+ * @returns Combined Drizzle SQL condition or undefined if no filters
+ *
+ * @example
+ * ```typescript
+ * // For filter: { 'seo.metaTitle': { contains: 'About' } }
+ * // Generates: EXISTS (SELECT 1 FROM comp_seo WHERE _parent_id = dc_pages.id AND _parent_table = 'dc_pages' AND meta_title ILIKE '%About%')
+ * ```
+ */
+/**
+ * Physical table name for every component slug referenced by these filters.
+ *
+ * Resolved through the registry because a component with a custom `dbName`
+ * has a table name that cannot be derived from its slug. Skipped entirely
+ * when no component filter is present, so ordinary queries take no extra
+ * round trip.
+ */


### PR DESCRIPTION
Closes the finding codex raised six times on #384, and left open there on purpose. Task `081`.

## What leaks today

A related row belongs to another collection and carries that collection's own read rules. Expansion selects it straight from its table and applies only field-level redaction — `#335`/`#338`/`#346` closed the field half, but nothing asks the target collection whether this caller may read it at all.

Probe against `main` (`d2dabb96`), `pages` under a stored `custom` rule that denies the caller:

```
DIRECT            success=false code=403
MULTI_TARGET      {"relationTo":"pages","value":{...,"title":"Restricted page",...}}
SINGLE_TARGET     {...,"title":"Restricted page",...}
```

The direct read is refused; the same row comes back through both relationship shapes. **The single-target control is the point** — this was never specific to multi-target references, and #384 only made those populate at all, so they reached a gap every other relationship already reached.

## What this does

Evaluates the target collection's **stored** read rules for the caller before any of its rows are fetched, in both `fetchRelatedEntry` and `batchFetchRelatedEntries`, so single reads, listings and nested hops are all covered. Judged once per collection, not per row.

A refused target reads as an **absent relationship, not an error**. One unreadable reference must not refuse the whole parent read, and the caller learns no more than a reference pointing at nothing would tell them.

## Two deliberate limits, both stated rather than assumed

**The RBAC permission gate is not run here.** I tried it first, and the mirror test caught it immediately: `checkCollectionAccess` with `routeAuthorized: false` denied a caller the stored rule admits, because the permission gate refuses anyone whose grants do not name the target collection. The route authorized this caller for the *parent*; requiring a permission for a collection they never asked for by name turns a fix into an outage. Whether expansion should additionally require a read permission on the target is recorded on task 081 rather than decided here.

**A rule answering with a query constraint withholds the target.** A constraint narrows *which* rows are readable rather than answering yes or no, and narrowing is not yet folded into these fetches. Withholding is the fail-closed direction; applying the constraint as SQL is the next slice, and the design table for it is in the task file.

## Tests

Three integration tests, all against a real database:

- refuses to populate a target the caller may not read — asserting the direct read is `403` first, so the test is anchored to a real denial, and checking **both** the multi-target and single-target fields
- **the mirror**: a caller the rule admits still gets the row through both fields. This is not decoration — it is what caught the RBAC mistake above, and enforcing without a threaded caller judges everyone anonymous, the trap #338 proved twice
- a trusted (`overrideAccess`) read stays unfiltered

Revert-verified: disabling the gate fails the refusal test while both mirrors keep passing.

## Verification

- Integration: **888 passed / 0 failed** on SQLite, **925 / 0** on Postgres
- Unit: 400 failing, name set identical to a freshly built `main` worktree at the same commit, zero unique to this branch
- `tsc --noEmit` clean

Worth noting explicitly: I expected this to change behaviour widely and it did not — zero existing tests moved. Narrowing the gate to stored rules is why.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Related records are now filtered according to their read permissions before being included in relationship fields.
  - Restricted related records are omitted instead of appearing with incomplete or redacted content.
  - Access rules now work consistently across create, update, read, nested, and component relationship responses.
  - Scoped authentication and API-key permissions are preserved during relationship expansion.
  - Trusted access continues to retrieve related records without standard filtering.

- **Tests**
  - Added coverage for denied, tenant-scoped, owner-only, many-to-many, nested, and per-record access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->