### PR TITLE
feat(nextly): run field group migration steps under a held lock

### DIFF
--- a/.changeset/field-group-migration-runner.md
+++ b/.changeset/field-group-migration-runner.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+More groundwork for the upcoming field group storage migration: the run now holds a migration lock on a single connection for its whole duration, and records a step only after checking the database reached the state that step intended. Nothing calls this yet, so there is no change in behaviour in this release.

--- a/.changeset/field-group-migration-runner.md
+++ b/.changeset/field-group-migration-runner.md
@@ -22,4 +22,4 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-More groundwork for the upcoming field group storage migration: the run now holds a migration lock on a single connection for its whole duration, and records a step only after checking the database reached the state that step intended. Nothing calls this yet, so there is no change in behaviour in this release.
+More groundwork for the upcoming field group storage migration: a migration run now claims a durable lock row for its duration, so a second run refuses instead of starting alongside it, and records a step only after checking the database reached the state that step intended. Nothing calls this yet, so there is no change in behaviour in this release.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/runner.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/runner.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { NextlyError } from "../../../../errors/nextly-error";
+import type { MetaService } from "../../../meta/services/meta-service";
+import { runMigrationSteps, type MigrationStep } from "../runner";
+import type { MigrationSession } from "../session";
+
+const SESSION = {
+  dialect: "postgresql",
+  inTransaction: async <T>(work: (ctx: never) => Promise<T>) =>
+    work(undefined as never),
+} as unknown as MigrationSession;
+
+function step(
+  id: string,
+  events: string[],
+  options: { verifies?: boolean; throws?: boolean } = {}
+): MigrationStep {
+  return {
+    id,
+    run: vi.fn(async () => {
+      events.push(`run:${id}`);
+      if (options.throws) {
+        throw NextlyError.internal({ logContext: { reason: `boom:${id}` } });
+      }
+    }),
+    verify: vi.fn(async () => {
+      events.push(`verify:${id}`);
+      return options.verifies !== false;
+    }),
+  };
+}
+
+// `advanceStep` reads the marker before writing, so the fake has to behave like
+// a real marker rather than just recording calls.
+function markerMeta(events: string[], migrationId: string) {
+  let stored: Record<string, unknown> = {
+    version: 1,
+    status: "migrating",
+    direction: "up",
+    migrationId,
+    step: 0,
+    manifestHash: "h",
+    planHash: "p",
+  };
+  return {
+    getEntry: vi.fn(async () => ({ present: true, value: stored })),
+    get: vi.fn(async () => stored),
+    set: vi.fn(async (_key: string, value: unknown) => {
+      const marker = value as { step: number };
+      events.push(`record:${marker.step}`);
+      stored = value as Record<string, unknown>;
+    }),
+  } as unknown as MetaService;
+}
+
+describe("field-group migration runner", () => {
+  it("runs, verifies, then records — in that order, for every step", async () => {
+    const events: string[] = [];
+    const meta = markerMeta(events, "run-1");
+    await runMigrationSteps({
+      session: SESSION,
+      meta,
+      migrationId: "run-1",
+      steps: [step("a", events), step("b", events)],
+      fromStep: 1,
+    });
+    expect(events).toEqual([
+      "run:a",
+      "verify:a",
+      "record:1",
+      "run:b",
+      "verify:b",
+      "record:2",
+    ]);
+  });
+
+  // Recording before verifying would let a step that silently did nothing be
+  // marked done and skipped forever after.
+  it("does not record a step whose postcondition fails", async () => {
+    const events: string[] = [];
+    const meta = markerMeta(events, "run-1");
+    await expect(
+      runMigrationSteps({
+        session: SESSION,
+        meta,
+        migrationId: "run-1",
+        steps: [step("a", events, { verifies: false })],
+        fromStep: 1,
+      })
+    ).rejects.toThrowError(NextlyError);
+    expect(events).toEqual(["run:a", "verify:a"]);
+    expect(meta.set).not.toHaveBeenCalled();
+  });
+
+  // A failed postcondition means the database is not in the state the plan
+  // believes, and every later step is written against that belief.
+  it("stops at the failing step rather than continuing", async () => {
+    const events: string[] = [];
+    const meta = markerMeta(events, "run-1");
+    await expect(
+      runMigrationSteps({
+        session: SESSION,
+        meta,
+        migrationId: "run-1",
+        steps: [
+          step("a", events),
+          step("b", events, { verifies: false }),
+          step("c", events),
+        ],
+        fromStep: 1,
+      })
+    ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+    expect(events).not.toContain("run:c");
+  });
+
+  it("names the step that failed, so a refusal points somewhere", async () => {
+    const events: string[] = [];
+    const meta = markerMeta(events, "run-1");
+    try {
+      await runMigrationSteps({
+        session: SESSION,
+        meta,
+        migrationId: "run-1",
+        steps: [step("rename-registry", events, { verifies: false })],
+        fromStep: 1,
+      });
+      expect.fail("expected a refusal");
+    } catch (error) {
+      expect((error as NextlyError).logContext?.step).toBe("rename-registry");
+    }
+  });
+
+  // A resume starts at the step after the last verified one and must not
+  // re-run work that was already checked off.
+  it("resumes without re-running verified steps", async () => {
+    const events: string[] = [];
+    const meta = markerMeta(events, "run-1");
+    // The marker already reports step 1 done.
+    await meta.set("k", {
+      version: 1,
+      status: "migrating",
+      direction: "up",
+      migrationId: "run-1",
+      step: 1,
+      manifestHash: "h",
+      planHash: "p",
+    });
+    events.length = 0;
+    await runMigrationSteps({
+      session: SESSION,
+      meta,
+      migrationId: "run-1",
+      steps: [step("a", events), step("b", events)],
+      fromStep: 2,
+    });
+    expect(events).not.toContain("run:a");
+    expect(events).toEqual(["run:b", "verify:b", "record:2"]);
+  });
+
+  // Every step already done is a legitimate resume position: the run finished
+  // its steps but crashed before settling the marker.
+  it("accepts a resume position one past the last step and does nothing", async () => {
+    const events: string[] = [];
+    const meta = markerMeta(events, "run-1");
+    await runMigrationSteps({
+      session: SESSION,
+      meta,
+      migrationId: "run-1",
+      steps: [step("a", events), step("b", events)],
+      fromStep: 3,
+    });
+    expect(events).toEqual([]);
+  });
+
+  // Further past the end than that means the marker and the plan disagree
+  // about how much work exists, which no amount of running can reconcile.
+  it("refuses a resume position beyond the end of the plan", async () => {
+    const events: string[] = [];
+    const meta = markerMeta(events, "run-1");
+    await expect(
+      runMigrationSteps({
+        session: SESSION,
+        meta,
+        migrationId: "run-1",
+        steps: [step("a", events)],
+        fromStep: 4,
+      })
+    ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+    expect(events).toEqual([]);
+  });
+
+  it.each([0, -1, 1.5])(
+    "refuses a nonsensical resume position: %s",
+    async pos => {
+      const events: string[] = [];
+      const meta = markerMeta(events, "run-1");
+      await expect(
+        runMigrationSteps({
+          session: SESSION,
+          meta,
+          migrationId: "run-1",
+          steps: [step("a", events)],
+          fromStep: pos,
+        })
+      ).rejects.toThrowError(NextlyError);
+      expect(events).toEqual([]);
+    }
+  );
+
+  // A step that throws is not recorded either; the distinction between a throw
+  // and a failed postcondition matters to an operator but not to the marker.
+  it("does not record a step that threw", async () => {
+    const events: string[] = [];
+    const meta = markerMeta(events, "run-1");
+    await expect(
+      runMigrationSteps({
+        session: SESSION,
+        meta,
+        migrationId: "run-1",
+        steps: [step("a", events, { throws: true })],
+        fromStep: 1,
+      })
+    ).rejects.toThrowError(NextlyError);
+    expect(meta.set).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -102,12 +102,12 @@ describe("field-group migration session", () => {
     const h = createAdapter({ heldBy: null });
     const seen: (string | null)[] = [];
     await withMigrationSession(
-      { adapter: h.adapter, dialect: "postgresql", owner: "run-1" },
+      { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
       async () => {
         seen.push(h.owner());
       }
     );
-    expect(seen).toEqual(["run-1"]);
+    expect(seen[0]).toMatch(/^run-1#/);
     expect(h.owner()).toBeNull();
   });
 
@@ -115,7 +115,7 @@ describe("field-group migration session", () => {
     const h = createAdapter({ heldBy: null });
     await expect(
       withMigrationSession(
-        { adapter: h.adapter, dialect: "mysql", owner: "run-1" },
+        { adapter: h.adapter, dialect: "mysql", label: "run-1" },
         async () => {
           throw NextlyError.internal({ logContext: { reason: "boom" } });
         }
@@ -131,7 +131,7 @@ describe("field-group migration session", () => {
     const ran = vi.fn();
     await expect(
       withMigrationSession(
-        { adapter: h.adapter, dialect: "postgresql", owner: "run-1" },
+        { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
         async () => ran()
       )
     ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
@@ -147,7 +147,7 @@ describe("field-group migration session", () => {
     const h = createAdapter({ heldBy: "other-run" });
     try {
       await withMigrationSession(
-        { adapter: h.adapter, dialect: "postgresql", owner: "run-1" },
+        { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
         async () => undefined
       );
       expect.fail("expected a refusal");
@@ -166,7 +166,7 @@ describe("field-group migration session", () => {
     const h = createAdapter({ heldBy: null });
     let openDuringRun = 0;
     await withMigrationSession(
-      { adapter: h.adapter, dialect: "postgresql", owner: "run-1" },
+      { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
       async session => {
         await session.inTransaction(async () => {
           openDuringRun = h.peakOpen();
@@ -184,12 +184,12 @@ describe("field-group migration session", () => {
     async dialect => {
       const h = createAdapter({ heldBy: null });
       await withMigrationSession(
-        { adapter: h.adapter, dialect, owner: "run-1" },
+        { adapter: h.adapter, dialect, label: "run-1" },
         async () => {
           const second = createAdapter({ heldBy: h.owner() });
           await expect(
             withMigrationSession(
-              { adapter: second.adapter, dialect, owner: "run-2" },
+              { adapter: second.adapter, dialect, label: "run-2" },
               async () => undefined
             )
           ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
@@ -202,7 +202,7 @@ describe("field-group migration session", () => {
     for (const dialect of ["postgresql", "mysql", "sqlite"] as const) {
       const h = createAdapter({ heldBy: null });
       await withMigrationSession(
-        { adapter: h.adapter, dialect, owner: "run-1" },
+        { adapter: h.adapter, dialect, label: "run-1" },
         async () => undefined
       );
       expect(h.ddl.join("\n")).toContain(MIGRATION_LOCK_TABLE);
@@ -213,7 +213,7 @@ describe("field-group migration session", () => {
   it("seeds the lock row when the table is new", async () => {
     const h = createAdapter();
     await withMigrationSession(
-      { adapter: h.adapter, dialect: "sqlite", owner: "run-1" },
+      { adapter: h.adapter, dialect: "sqlite", label: "run-1" },
       async () => undefined
     );
     expect(h.ctx.insert).toHaveBeenCalled();
@@ -223,12 +223,14 @@ describe("field-group migration session", () => {
   // continue to contend rather than crash on the duplicate.
   it("tolerates losing the race to seed the row", async () => {
     const h = createAdapter();
-    h.ctx.insert.mockImplementationOnce(async () => {
+    // The winner's row exists by the time our insert is rejected.
+    h.ctx.insert.mockImplementationOnce(async (_t: string) => {
+      await h.ctx.insert(MIGRATION_LOCK_TABLE, { id: 1, owner: null });
       throw new Error("duplicate key");
     });
     await expect(
       withMigrationSession(
-        { adapter: h.adapter, dialect: "postgresql", owner: "run-1" },
+        { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
         async () => undefined
       )
     ).resolves.toBeUndefined();
@@ -238,7 +240,7 @@ describe("field-group migration session", () => {
     const h = createAdapter({ heldBy: null });
     await expect(
       withMigrationSession(
-        { adapter: h.adapter, dialect: "postgresql", owner: "" },
+        { adapter: h.adapter, dialect: "postgresql", label: "" },
         async () => undefined
       )
     ).rejects.toThrowError(NextlyError);
@@ -251,7 +253,7 @@ describe("field-group migration session", () => {
   it("releases only a lock it still owns", async () => {
     const h = createAdapter({ heldBy: null });
     await withMigrationSession(
-      { adapter: h.adapter, dialect: "postgresql", owner: "run-1" },
+      { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
       async () => {
         // Someone else takes the row over while this run is in flight.
         h.ctx.update(
@@ -262,6 +264,80 @@ describe("field-group migration session", () => {
       }
     );
     expect(h.owner()).toBe("run-2");
+  });
+
+  // A label is not an identity. Two processes resuming the same migration
+  // would naturally pass the same one, and an occupied row that matched would
+  // let both run while the first to finish released the claim under the second.
+  it("refuses an occupied row even when the label is identical", async () => {
+    const h = createAdapter({ heldBy: null });
+    await withMigrationSession(
+      { adapter: h.adapter, dialect: "postgresql", label: "resume" },
+      async () => {
+        const second = createAdapter({ heldBy: h.owner() });
+        await expect(
+          withMigrationSession(
+            { adapter: second.adapter, dialect: "postgresql", label: "resume" },
+            async () => undefined
+          )
+        ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+      }
+    );
+  });
+
+  it("claims under a token unique to the invocation, not the label", async () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 2; i += 1) {
+      const h = createAdapter({ heldBy: null });
+      await withMigrationSession(
+        { adapter: h.adapter, dialect: "sqlite", label: "same" },
+        async () => {
+          seen.add(h.owner() ?? "");
+        }
+      );
+    }
+    expect(seen.size).toBe(2);
+  });
+
+  // A seed that fails for any reason other than losing the race leaves nothing
+  // to lock. Claiming against an absent row updates nothing yet would still
+  // look successful, running the migration with no exclusion at all.
+  it("refuses to run when the lock row could not be established", async () => {
+    const h = createAdapter();
+    h.ctx.insert.mockImplementation(async () => {
+      throw new Error("connection reset");
+    });
+    const ran = vi.fn();
+    try {
+      await withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+        async () => ran()
+      );
+      expect.fail("expected a refusal");
+    } catch (error) {
+      // Asserting the reason, not just the code: acquisition would refuse an
+      // absent row too, so a generic assertion here cannot tell whether the
+      // seed check did anything.
+      expect((error as NextlyError).logContext?.reason).toMatch(
+        /lock row could not be established/
+      );
+    }
+    expect(ran).not.toHaveBeenCalled();
+  });
+
+  // A write that silently affects nothing must not read as a claim. Trusting
+  // the update would run the migration believing it held a lock it never took.
+  it("refuses when the claim does not actually land on the row", async () => {
+    const h = createAdapter({ heldBy: null });
+    h.ctx.update.mockImplementation(async () => []);
+    const ran = vi.fn();
+    await expect(
+      withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+        async () => ran()
+      )
+    ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+    expect(ran).not.toHaveBeenCalled();
   });
 
   it("uses a lock table distinct from the schema pipeline's", () => {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -4,123 +4,269 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import { NextlyError } from "../../../../errors/nextly-error";
 import {
-  MIGRATION_LOCK_NAME,
+  getMigrationLockDdl,
+  MIGRATION_LOCK_TABLE,
   withMigrationSession,
   type MigrationDialect,
 } from "../session";
 
+type Where = {
+  and?: { column: string; op: string; value: unknown }[];
+};
+
+/** Reads the structured predicate the adapter API uses back into plain fields. */
+function readWhere(where?: Where): { id?: number; owner?: string | null } {
+  const out: { id?: number; owner?: string | null } = {};
+  for (const c of where?.and ?? []) {
+    if (c.column === "id") out.id = c.value as number;
+    if (c.column === "owner") out.owner = c.value as string | null;
+  }
+  return out;
+}
+
 /**
- * Stands in for an adapter, recording which connection each statement ran on.
+ * A single-row lock table backed by an object, plus the two behaviours of the
+ * real adapters that a naive double would omit and that hid a defect once:
  *
- * The connection identity is the point: an advisory lock belongs to the
- * connection that took it, so a release issued anywhere else releases nothing.
+ * - every error escaping a transaction callback is reclassified, so a domain
+ *   error thrown inside one does NOT come back out intact;
+ * - each `transaction()` call takes a connection, so a fake that never counts
+ *   them cannot show that the lock stops holding one.
  */
-function createAdapter(options: { locked?: boolean } = {}) {
-  const locked = options.locked !== false;
-  const statements: { conn: number; sql: string }[] = [];
-  let connections = 0;
+function createAdapter(options: { heldBy?: string | null } = {}) {
+  const rows = new Map<number, { id: number; owner: string | null }>();
+  if (options.heldBy !== undefined) {
+    rows.set(1, { id: 1, owner: options.heldBy });
+  }
+  const ddl: string[] = [];
+  let open = 0;
+  let peakOpen = 0;
+
+  const ctx = {
+    lockRow: vi.fn(async () => undefined),
+    selectOne: vi.fn(async (_t: string, o?: { where?: Where }) => {
+      const row = rows.get(readWhere(o?.where).id ?? 1);
+      return row ? { ...row } : null;
+    }),
+    insert: vi.fn(async (_t: string, data: Record<string, unknown>) => {
+      const id = data.id as number;
+      if (rows.has(id)) throw new Error("duplicate key");
+      rows.set(id, { id, owner: (data.owner as string | null) ?? null });
+      return data;
+    }),
+    update: vi.fn(
+      async (_t: string, data: Record<string, unknown>, where: Where) => {
+        const cond = readWhere(where);
+        const row = rows.get(cond.id ?? 1);
+        if (!row) return [];
+        // A `where` naming an owner must not match a row held by someone else.
+        if (cond.owner !== undefined && row.owner !== cond.owner) return [];
+        row.owner = (data.owner as string | null) ?? null;
+        return [row];
+      }
+    ),
+  };
 
   const adapter = {
-    transaction: vi.fn(async (work: (ctx: unknown) => Promise<unknown>) => {
-      connections += 1;
-      const conn = connections;
-      const ctx = {
-        execute: vi.fn(async (sql: string) => {
-          statements.push({ conn, sql });
-          if (sql.includes("GET_LOCK")) return [{ locked: locked ? 1 : 0 }];
-          if (sql.includes("pg_try_advisory_lock")) return [{ locked: locked }];
-          return [];
-        }),
-      };
-      return work(ctx);
+    executeQuery: vi.fn(async (sql: string) => {
+      ddl.push(sql);
+      return [];
+    }),
+    transaction: vi.fn(async (work: (c: unknown) => Promise<unknown>) => {
+      open += 1;
+      peakOpen = Math.max(peakOpen, open);
+      try {
+        return await work(ctx);
+      } catch (error) {
+        // What the real adapters do: anything that is not already a
+        // DatabaseError is rewrapped, so a NextlyError thrown inside a
+        // callback loses its identity on the way out.
+        throw new Error(`DatabaseError(unknown): ${String(error)}`);
+      } finally {
+        open -= 1;
+      }
     }),
   } as unknown as DrizzleAdapter;
 
-  return { adapter, statements, connectionCount: () => connections };
+  return {
+    adapter,
+    ctx,
+    ddl,
+    owner: () => rows.get(1)?.owner ?? null,
+    peakOpen: () => peakOpen,
+  };
 }
 
 describe("field-group migration session", () => {
-  it.each<[MigrationDialect, RegExp, RegExp]>([
-    ["mysql", /GET_LOCK/, /RELEASE_LOCK/],
-    ["postgresql", /pg_try_advisory_lock/, /pg_advisory_unlock/],
-  ])(
-    "takes and releases the lock on one connection (%s)",
-    async (dialect, acquireSql, releaseSql) => {
-      const { adapter, statements } = createAdapter();
-      await withMigrationSession({ adapter, dialect }, async () => undefined);
-
-      const acquired = statements.find(s => acquireSql.test(s.sql));
-      const released = statements.find(s => releaseSql.test(s.sql));
-      expect(acquired).toBeDefined();
-      expect(released).toBeDefined();
-      // Same connection for both. A release on any other connection is a
-      // no-op that leaves the lock held until that connection is recycled.
-      expect(released?.conn).toBe(acquired?.conn);
-    }
-  );
-
-  // The schema pipeline's lock helper gives up waiting and proceeds unlocked.
-  // Two concurrent runs renaming the same tables is not a survivable outcome,
-  // so this refuses instead.
-  it.each<MigrationDialect>(["mysql", "postgresql"])(
-    "refuses to run when the lock is held elsewhere (%s)",
-    async dialect => {
-      const { adapter } = createAdapter({ locked: false });
-      const ran = vi.fn();
-      await expect(
-        withMigrationSession({ adapter, dialect }, async () => ran())
-      ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
-      expect(ran).not.toHaveBeenCalled();
-    }
-  );
+  it("takes the lock, runs, and releases it", async () => {
+    const h = createAdapter({ heldBy: null });
+    const seen: (string | null)[] = [];
+    await withMigrationSession(
+      { adapter: h.adapter, dialect: "postgresql", owner: "run-1" },
+      async () => {
+        seen.push(h.owner());
+      }
+    );
+    expect(seen).toEqual(["run-1"]);
+    expect(h.owner()).toBeNull();
+  });
 
   it("releases the lock even when the run throws", async () => {
-    const { adapter, statements } = createAdapter();
+    const h = createAdapter({ heldBy: null });
     await expect(
-      withMigrationSession({ adapter, dialect: "mysql" }, async () => {
-        throw NextlyError.internal({ logContext: { reason: "boom" } });
-      })
-    ).rejects.toThrowError(NextlyError);
-    expect(statements.some(s => /RELEASE_LOCK/.test(s.sql))).toBe(true);
+      withMigrationSession(
+        { adapter: h.adapter, dialect: "mysql", owner: "run-1" },
+        async () => {
+          throw NextlyError.internal({ logContext: { reason: "boom" } });
+        }
+      )
+    ).rejects.toThrowError();
+    expect(h.owner()).toBeNull();
   });
 
-  // SQLite has one writer by definition, and the adapter serializes
-  // `transaction()` through a queue: an outer transaction would hold that queue
-  // while every step waited on it, which never resolves.
-  it("does not open a pinning transaction on sqlite", async () => {
-    const { adapter, connectionCount } = createAdapter();
+  // The schema pipeline's helper gives up waiting and proceeds unlocked. Two
+  // concurrent runs renaming the same tables is not a survivable outcome.
+  it("refuses to run when another owner holds the lock", async () => {
+    const h = createAdapter({ heldBy: "other-run" });
     const ran = vi.fn();
-    await withMigrationSession({ adapter, dialect: "sqlite" }, async () =>
-      ran()
+    await expect(
+      withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", owner: "run-1" },
+        async () => ran()
+      )
+    ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+    expect(ran).not.toHaveBeenCalled();
+    // Untouched: a refused run must not disturb the holder's claim.
+    expect(h.owner()).toBe("other-run");
+  });
+
+  // The refusal is raised outside the transaction because the adapters
+  // reclassify everything thrown inside one. Were it raised inside, this would
+  // surface as a generic database error and lose its status and context.
+  it("surfaces the refusal as a NextlyError, not a reclassified database error", async () => {
+    const h = createAdapter({ heldBy: "other-run" });
+    try {
+      await withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", owner: "run-1" },
+        async () => undefined
+      );
+      expect.fail("expected a refusal");
+    } catch (error) {
+      expect(NextlyError.is(error)).toBe(true);
+      expect((error as NextlyError).logContext?.reason).toMatch(
+        /held elsewhere/
+      );
+      expect((error as NextlyError).logContext?.heldBy).toBe("other-run");
+    }
+  });
+
+  // Holding a pooled connection for the whole run deadlocks a `pool.max: 1`
+  // configuration, because every step then asks for a second one.
+  it("holds no connection open while the run executes", async () => {
+    const h = createAdapter({ heldBy: null });
+    let openDuringRun = 0;
+    await withMigrationSession(
+      { adapter: h.adapter, dialect: "postgresql", owner: "run-1" },
+      async session => {
+        await session.inTransaction(async () => {
+          openDuringRun = h.peakOpen();
+        });
+      }
     );
-    expect(ran).toHaveBeenCalled();
-    expect(connectionCount()).toBe(0);
+    // One: the step's own transaction. Not two.
+    expect(openDuringRun).toBe(1);
   });
 
-  // Steps must commit independently, so they run on their own connections
-  // rather than the one holding the lock. Sharing it would make the whole run
-  // a single transaction, and a rollback at the end would erase work the
-  // marker already reports as done.
-  it("runs step work on a different connection than the lock", async () => {
-    const { adapter, statements } = createAdapter();
-    await withMigrationSession({ adapter, dialect: "mysql" }, async session => {
-      await session.inTransaction(async ctx => {
-        await (ctx as { execute: (s: string) => Promise<unknown> }).execute(
-          "SELECT 1"
-        );
-      });
+  // Serialization of individual writes is not exclusion across a whole run, so
+  // SQLite needs the same lock as the others rather than being skipped.
+  it.each<MigrationDialect>(["postgresql", "mysql", "sqlite"])(
+    "excludes a second run on %s",
+    async dialect => {
+      const h = createAdapter({ heldBy: null });
+      await withMigrationSession(
+        { adapter: h.adapter, dialect, owner: "run-1" },
+        async () => {
+          const second = createAdapter({ heldBy: h.owner() });
+          await expect(
+            withMigrationSession(
+              { adapter: second.adapter, dialect, owner: "run-2" },
+              async () => undefined
+            )
+          ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+        }
+      );
+    }
+  );
+
+  it("creates its lock table on every dialect", async () => {
+    for (const dialect of ["postgresql", "mysql", "sqlite"] as const) {
+      const h = createAdapter({ heldBy: null });
+      await withMigrationSession(
+        { adapter: h.adapter, dialect, owner: "run-1" },
+        async () => undefined
+      );
+      expect(h.ddl.join("\n")).toContain(MIGRATION_LOCK_TABLE);
+      expect(h.ddl.join("\n")).toContain("IF NOT EXISTS");
+    }
+  });
+
+  it("seeds the lock row when the table is new", async () => {
+    const h = createAdapter();
+    await withMigrationSession(
+      { adapter: h.adapter, dialect: "sqlite", owner: "run-1" },
+      async () => undefined
+    );
+    expect(h.ctx.insert).toHaveBeenCalled();
+  });
+
+  // Two processes seeding at once: the primary key decides, and the loser must
+  // continue to contend rather than crash on the duplicate.
+  it("tolerates losing the race to seed the row", async () => {
+    const h = createAdapter();
+    h.ctx.insert.mockImplementationOnce(async () => {
+      throw new Error("duplicate key");
     });
-    const lockConn = statements.find(s => /GET_LOCK/.test(s.sql))?.conn;
-    const workConn = statements.find(s => s.sql === "SELECT 1")?.conn;
-    expect(lockConn).toBeDefined();
-    expect(workConn).toBeDefined();
-    expect(workConn).not.toBe(lockConn);
+    await expect(
+      withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", owner: "run-1" },
+        async () => undefined
+      )
+    ).resolves.toBeUndefined();
   });
 
-  it("locks under a name distinct from the schema pipeline's", () => {
-    // Conflating the two would make an ordinary schema sync and a storage
-    // migration exclude each other by accident rather than by decision.
-    expect(MIGRATION_LOCK_NAME).toBe("nextly_field_group_migration");
-    expect(MIGRATION_LOCK_NAME).not.toBe("nextly_migrate");
+  it("refuses an empty owner rather than taking an unattributable lock", async () => {
+    const h = createAdapter({ heldBy: null });
+    await expect(
+      withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", owner: "" },
+        async () => undefined
+      )
+    ).rejects.toThrowError(NextlyError);
+    expect(h.ddl).toEqual([]);
+  });
+
+  // A run that already lost the lock must not free it on its way out: by then
+  // the row belongs to whoever took it next, and clearing it would let a third
+  // run start while that one is mid-migration.
+  it("releases only a lock it still owns", async () => {
+    const h = createAdapter({ heldBy: null });
+    await withMigrationSession(
+      { adapter: h.adapter, dialect: "postgresql", owner: "run-1" },
+      async () => {
+        // Someone else takes the row over while this run is in flight.
+        h.ctx.update(
+          MIGRATION_LOCK_TABLE,
+          { owner: "run-2" },
+          { and: [{ column: "id", op: "=", value: 1 }] }
+        );
+      }
+    );
+    expect(h.owner()).toBe("run-2");
+  });
+
+  it("uses a lock table distinct from the schema pipeline's", () => {
+    expect(MIGRATION_LOCK_TABLE).toBe("nextly_field_group_lock");
+    expect(MIGRATION_LOCK_TABLE).not.toBe("nextly_migrate_lock");
+    expect(getMigrationLockDdl("mysql")[0]).toContain("int PRIMARY KEY");
   });
 });

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+
+import { NextlyError } from "../../../../errors/nextly-error";
+import {
+  MIGRATION_LOCK_NAME,
+  withMigrationSession,
+  type MigrationDialect,
+} from "../session";
+
+/**
+ * Stands in for an adapter, recording which connection each statement ran on.
+ *
+ * The connection identity is the point: an advisory lock belongs to the
+ * connection that took it, so a release issued anywhere else releases nothing.
+ */
+function createAdapter(options: { locked?: boolean } = {}) {
+  const locked = options.locked !== false;
+  const statements: { conn: number; sql: string }[] = [];
+  let connections = 0;
+
+  const adapter = {
+    transaction: vi.fn(async (work: (ctx: unknown) => Promise<unknown>) => {
+      connections += 1;
+      const conn = connections;
+      const ctx = {
+        execute: vi.fn(async (sql: string) => {
+          statements.push({ conn, sql });
+          if (sql.includes("GET_LOCK")) return [{ locked: locked ? 1 : 0 }];
+          if (sql.includes("pg_try_advisory_lock")) return [{ locked: locked }];
+          return [];
+        }),
+      };
+      return work(ctx);
+    }),
+  } as unknown as DrizzleAdapter;
+
+  return { adapter, statements, connectionCount: () => connections };
+}
+
+describe("field-group migration session", () => {
+  it.each<[MigrationDialect, RegExp, RegExp]>([
+    ["mysql", /GET_LOCK/, /RELEASE_LOCK/],
+    ["postgresql", /pg_try_advisory_lock/, /pg_advisory_unlock/],
+  ])(
+    "takes and releases the lock on one connection (%s)",
+    async (dialect, acquireSql, releaseSql) => {
+      const { adapter, statements } = createAdapter();
+      await withMigrationSession({ adapter, dialect }, async () => undefined);
+
+      const acquired = statements.find(s => acquireSql.test(s.sql));
+      const released = statements.find(s => releaseSql.test(s.sql));
+      expect(acquired).toBeDefined();
+      expect(released).toBeDefined();
+      // Same connection for both. A release on any other connection is a
+      // no-op that leaves the lock held until that connection is recycled.
+      expect(released?.conn).toBe(acquired?.conn);
+    }
+  );
+
+  // The schema pipeline's lock helper gives up waiting and proceeds unlocked.
+  // Two concurrent runs renaming the same tables is not a survivable outcome,
+  // so this refuses instead.
+  it.each<MigrationDialect>(["mysql", "postgresql"])(
+    "refuses to run when the lock is held elsewhere (%s)",
+    async dialect => {
+      const { adapter } = createAdapter({ locked: false });
+      const ran = vi.fn();
+      await expect(
+        withMigrationSession({ adapter, dialect }, async () => ran())
+      ).rejects.toMatchObject({ code: "SERVICE_UNAVAILABLE" });
+      expect(ran).not.toHaveBeenCalled();
+    }
+  );
+
+  it("releases the lock even when the run throws", async () => {
+    const { adapter, statements } = createAdapter();
+    await expect(
+      withMigrationSession({ adapter, dialect: "mysql" }, async () => {
+        throw NextlyError.internal({ logContext: { reason: "boom" } });
+      })
+    ).rejects.toThrowError(NextlyError);
+    expect(statements.some(s => /RELEASE_LOCK/.test(s.sql))).toBe(true);
+  });
+
+  // SQLite has one writer by definition, and the adapter serializes
+  // `transaction()` through a queue: an outer transaction would hold that queue
+  // while every step waited on it, which never resolves.
+  it("does not open a pinning transaction on sqlite", async () => {
+    const { adapter, connectionCount } = createAdapter();
+    const ran = vi.fn();
+    await withMigrationSession({ adapter, dialect: "sqlite" }, async () =>
+      ran()
+    );
+    expect(ran).toHaveBeenCalled();
+    expect(connectionCount()).toBe(0);
+  });
+
+  // Steps must commit independently, so they run on their own connections
+  // rather than the one holding the lock. Sharing it would make the whole run
+  // a single transaction, and a rollback at the end would erase work the
+  // marker already reports as done.
+  it("runs step work on a different connection than the lock", async () => {
+    const { adapter, statements } = createAdapter();
+    await withMigrationSession({ adapter, dialect: "mysql" }, async session => {
+      await session.inTransaction(async ctx => {
+        await (ctx as { execute: (s: string) => Promise<unknown> }).execute(
+          "SELECT 1"
+        );
+      });
+    });
+    const lockConn = statements.find(s => /GET_LOCK/.test(s.sql))?.conn;
+    const workConn = statements.find(s => s.sql === "SELECT 1")?.conn;
+    expect(lockConn).toBeDefined();
+    expect(workConn).toBeDefined();
+    expect(workConn).not.toBe(lockConn);
+  });
+
+  it("locks under a name distinct from the schema pipeline's", () => {
+    // Conflating the two would make an ordinary schema sync and a storage
+    // migration exclude each other by accident rather than by decision.
+    expect(MIGRATION_LOCK_NAME).toBe("nextly_field_group_migration");
+    expect(MIGRATION_LOCK_NAME).not.toBe("nextly_migrate");
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/runner.ts
+++ b/packages/nextly/src/domains/field-groups/migration/runner.ts
@@ -1,0 +1,106 @@
+/**
+ * Runs migration steps and records how far they got.
+ *
+ * The ordering here is the whole point. A step runs, then its postcondition is
+ * checked against the database, and only then is it recorded. Recording first
+ * would let a step that silently did nothing be marked done and skipped on the
+ * next run, which is indistinguishable from success until the data is read
+ * months later. Verifying first costs one extra query per step and turns that
+ * class of failure into a refusal at the moment it happens.
+ *
+ * Steps must be idempotent. A crash between a step's commit and its marker
+ * write is invisible from the outside, so a resume re-runs that step; the
+ * marker records the last step *known* to be done, never the last attempted.
+ *
+ * @module domains/field-groups/migration/runner
+ */
+
+import { NextlyError } from "../../../errors/nextly-error";
+import type { MetaService } from "../../meta/services/meta-service";
+
+import type { MigrationSession } from "./session";
+import { advanceStep } from "./state";
+
+/**
+ * One unit of migration work.
+ *
+ * `verify` answers "is the database now in the state `run` was supposed to
+ * leave it in", asked of the database rather than of the step's own return
+ * value, so a step that reports success it did not achieve is still caught.
+ */
+export interface MigrationStep {
+  /** Stable identity, used in logs and refusals rather than for ordering. */
+  readonly id: string;
+  run(session: MigrationSession): Promise<void>;
+  verify(session: MigrationSession): Promise<boolean>;
+}
+
+/**
+ * Run steps from `fromStep` onward, recording each one that verifies.
+ *
+ * `fromStep` is 1-based and matches the resume verdict: step numbers index the
+ * plan from one, so the marker's `0` means "nothing verified yet".
+ */
+export async function runMigrationSteps(args: {
+  session: MigrationSession;
+  meta: MetaService;
+  migrationId: string;
+  steps: readonly MigrationStep[];
+  fromStep: number;
+}): Promise<void> {
+  const { session, meta, migrationId, steps, fromStep } = args;
+
+  if (!Number.isSafeInteger(fromStep) || fromStep < 1) {
+    throw NextlyError.internal({
+      logContext: {
+        reason: "migration must resume from a positive step position",
+        fromStep,
+      },
+    });
+  }
+
+  // A resume position past the end means the marker and the plan disagree about
+  // how much work exists. `assertPlanUnchanged` catches the ordinary causes;
+  // this catches whatever it did not, rather than silently completing a run
+  // that never executed anything.
+  if (fromStep > steps.length + 1) {
+    throw NextlyError.serviceUnavailable({
+      logMessage:
+        "field-group migration cannot resume: the recorded position is past the end of the plan",
+      logContext: {
+        reason: "resume position is past the end of the plan",
+        fromStep,
+        steps: steps.length,
+      },
+    });
+  }
+
+  for (let position = fromStep; position <= steps.length; position += 1) {
+    const step = steps[position - 1];
+    if (!step) {
+      throw NextlyError.internal({
+        logContext: { reason: "migration plan has a hole", position },
+      });
+    }
+
+    await step.run(session);
+
+    const verified = await step.verify(session);
+    if (!verified) {
+      // Not recorded, so a later run retries this step rather than stepping
+      // over it. Refusing is the only safe move: the database is not in the
+      // state the plan believes, and every later step is written against that
+      // belief.
+      throw NextlyError.serviceUnavailable({
+        logMessage: `field-group migration step did not reach its expected state: ${step.id}`,
+        logContext: {
+          reason: "migration step failed its postcondition",
+          step: step.id,
+          position,
+        },
+      });
+    }
+
+    await advanceStep(meta, { migrationId, step: position });
+  }
+}

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -1,26 +1,32 @@
 /**
- * The connection a field-group migration runs under.
+ * Mutual exclusion for a field-group migration run.
  *
  * A migration that renames tables and rewrites rows must be the only one doing
- * so, and it must be able to prove it for the whole run rather than at the
- * moment it started. That needs an advisory lock, and an advisory lock is owned
- * by a connection: releasing it from a different connection than acquired it
- * releases nothing, and the lock then survives until the original connection
- * happens to close.
+ * so, for the whole run rather than at the instant it started.
  *
- * So the session checks out one connection, takes the lock on that connection,
- * and holds both for the duration. Steps do NOT run on it. They open their own
- * transactions, because a step must commit on its own before its progress is
- * recorded, and a single enclosing transaction would let a rollback at the end
- * erase work the marker already reports as done. Advisory locks exclude other
- * connections regardless of which connection does the work, so mutual exclusion
- * survives that split.
+ * The lock is a row, not a connection-scoped advisory lock. An advisory lock is
+ * owned by a connection, so holding one for a run means holding a pooled
+ * connection for a run: with `pool.max: 1` the steps could then never check out
+ * a connection of their own. MySQL's `GET_LOCK` is also scoped to the server
+ * rather than the database, so two unrelated Nextly databases sharing a server
+ * would exclude each other. A row has neither problem, behaves identically on
+ * all three dialects, and is reached through the adapter's typed API instead of
+ * dialect-specific SQL.
+ *
+ * There is deliberately no TTL and no auto-steal. Expiry needs a trusted clock,
+ * and skew between application servers is precisely the case where two runs
+ * would both conclude the lock had expired and proceed together. A run that
+ * dies holding the lock leaves it held, and an operator clears it. For
+ * something that rewrites customer data, refusing is the correct failure.
  *
  * @module domains/field-groups/migration/session
  */
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
-import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
+import type {
+  TransactionContext,
+  WhereClause,
+} from "@nextlyhq/adapter-drizzle/types";
 
 import { NextlyError } from "../../../errors/nextly-error";
 
@@ -28,21 +34,28 @@ import { NextlyError } from "../../../errors/nextly-error";
 export type MigrationDialect = "postgresql" | "mysql" | "sqlite";
 
 /**
- * Lock identity, distinct from the schema pipeline's own lock.
+ * Lock table, separate from the schema pipeline's `nextly_migrate_lock`.
  *
- * The two guard different things, and conflating them would make an ordinary
- * schema sync and a storage migration appear to exclude each other by accident
- * rather than by decision. Keeping tools from colliding with a migration in
- * flight is the marker's job, not this lock's.
+ * Plain text columns rather than a row in the `nextly_meta` key/value table:
+ * that column holds JSON, and the dialects differ on whether a value returns
+ * parsed or as a string. A lock is the wrong place to discover that.
  */
-export const MIGRATION_LOCK_NAME = "nextly_field_group_migration";
+export const MIGRATION_LOCK_TABLE = "nextly_field_group_lock";
 
-/**
- * Postgres advisory locks are keyed by a bigint rather than a name. A fixed
- * literal is used instead of hashing the name at runtime so the value is
- * greppable and cannot drift if the name is ever reworded.
- */
-export const MIGRATION_LOCK_KEY = 8_053_119_204_411_001n;
+/** The lock is a single row; its key never varies. */
+const LOCK_ROW_ID = 1;
+
+/** The lock row, addressed the way the adapter's query builder expects. */
+function lockRowWhere(owner?: string): WhereClause {
+  const and: WhereClause["and"] = [
+    { column: "id", op: "=", value: LOCK_ROW_ID },
+  ];
+  // Naming the owner as well makes a release affect only a row we still hold.
+  if (owner !== undefined) {
+    and.push({ column: "owner", op: "=", value: owner });
+  }
+  return { and };
+}
 
 /** What a step is handed to do its work. */
 export interface MigrationSession {
@@ -50,100 +63,144 @@ export interface MigrationSession {
   /**
    * Run work in its own transaction, on its own connection.
    *
-   * Deliberately not the session's pinned connection: each step commits
-   * independently so that the progress marker, written after the commit,
-   * never claims work that a later rollback could undo.
+   * Each step commits independently so that the progress marker, written after
+   * the commit, never claims work a later rollback could undo.
    */
   inTransaction<T>(work: (ctx: TransactionContext) => Promise<T>): Promise<T>;
 }
 
 /**
- * Hold the migration lock for the duration of `fn`.
+ * DDL for the lock table.
  *
- * Refuses rather than continuing when the lock cannot be taken. The schema
- * pipeline's lock helper logs a warning and proceeds unlocked when it gives up
- * waiting; that is survivable for an idempotent schema sync and is not
- * survivable here, where two concurrent runs would rename the same objects and
- * rewrite the same rows.
+ * Exported so tests build it from the same source as production rather than
+ * hand-copying CREATE TABLE statements that drift.
  */
-export async function withMigrationSession<T>(
-  args: { adapter: DrizzleAdapter; dialect: MigrationDialect },
-  fn: (session: MigrationSession) => Promise<T>
-): Promise<T> {
-  const { adapter, dialect } = args;
-
-  const session: MigrationSession = {
-    dialect,
-    inTransaction: work => adapter.transaction(work),
-  };
-
-  // SQLite has no advisory locks and needs none: one writer at a time is a
-  // property of the database. Pinning here would also deadlock outright, since
-  // the adapter serializes `transaction()` calls through a queue and an outer
-  // transaction would hold that queue while every step waited on it.
-  if (dialect === "sqlite") {
-    return fn(session);
-  }
-
-  return adapter.transaction(async lock => {
-    await acquire(lock, dialect);
-    try {
-      return await fn(session);
-    } finally {
-      // Released on the connection that took it. Anywhere else is a no-op that
-      // leaves the lock held until the connection is recycled.
-      await release(lock, dialect);
-    }
-  });
+export function getMigrationLockDdl(dialect: MigrationDialect): string[] {
+  const idType = dialect === "mysql" ? "int" : "integer";
+  return [
+    `CREATE TABLE IF NOT EXISTS ${MIGRATION_LOCK_TABLE} (id ${idType} PRIMARY KEY, owner text)`,
+  ];
 }
 
-async function acquire(
-  ctx: TransactionContext,
-  dialect: Exclude<MigrationDialect, "sqlite">
-): Promise<void> {
-  const acquired =
-    dialect === "mysql" ? await acquireMysql(ctx) : await acquirePostgres(ctx);
+/**
+ * Hold the migration lock for the duration of `fn`.
+ *
+ * Refuses rather than continuing when the lock is held. The schema pipeline's
+ * helper logs a warning and proceeds unlocked once it gives up waiting; that is
+ * survivable for an idempotent schema sync and is not survivable here, where
+ * two runs would rename the same objects and rewrite the same rows.
+ */
+export async function withMigrationSession<T>(
+  args: { adapter: DrizzleAdapter; dialect: MigrationDialect; owner: string },
+  fn: (session: MigrationSession) => Promise<T>
+): Promise<T> {
+  const { adapter, dialect, owner } = args;
 
-  if (!acquired) {
+  if (owner.length === 0) {
+    throw NextlyError.internal({
+      logContext: { reason: "migration lock owner must be a non-empty string" },
+    });
+  }
+
+  await ensureLockRow(adapter, dialect);
+
+  const acquired = await acquire(adapter, owner);
+  if (!acquired.ok) {
+    // Raised outside the transaction on purpose: the adapters route every error
+    // escaping a transaction callback through `classifyError`, which rewraps
+    // anything that is not already a DatabaseError and would strip this of its
+    // status and its context.
     throw NextlyError.serviceUnavailable({
       logMessage:
         "field-group migration could not take the migration lock; another run holds it",
-      logContext: { reason: "migration lock is held elsewhere", dialect },
+      logContext: {
+        reason: "migration lock is held elsewhere",
+        heldBy: acquired.heldBy,
+      },
     });
   }
-}
 
-async function acquireMysql(ctx: TransactionContext): Promise<boolean> {
-  // Timeout 0 so this reports the conflict instead of blocking: a caller that
-  // knows another run is in progress can decide to wait, a caller silently
-  // parked inside a lock call cannot.
-  const rows = await ctx.execute<{ locked: number | boolean | null }>(
-    "SELECT GET_LOCK(?, 0) AS locked",
-    [MIGRATION_LOCK_NAME]
-  );
-  const value = rows[0]?.locked;
-  return value === 1 || value === true;
-}
-
-async function acquirePostgres(ctx: TransactionContext): Promise<boolean> {
-  // Session-level rather than the `_xact_` variant, so the lock's lifetime is
-  // the connection's and stays under this function's control.
-  const rows = await ctx.execute<{ locked: boolean | null }>(
-    "SELECT pg_try_advisory_lock($1) AS locked",
-    [MIGRATION_LOCK_KEY.toString()]
-  );
-  return rows[0]?.locked === true;
-}
-
-async function release(
-  ctx: TransactionContext,
-  dialect: Exclude<MigrationDialect, "sqlite">
-): Promise<void> {
-  if (dialect === "mysql") {
-    await ctx.execute("SELECT RELEASE_LOCK(?)", [MIGRATION_LOCK_NAME]);
-    return;
+  try {
+    return await fn({
+      dialect,
+      inTransaction: work => adapter.transaction(work),
+    });
+  } finally {
+    await release(adapter, owner);
   }
-  await ctx.execute("SELECT pg_advisory_unlock($1)", [
-    MIGRATION_LOCK_KEY.toString(),
-  ]);
+}
+
+/**
+ * Create the table and seed the single row.
+ *
+ * The row must exist before it can be locked, and seeding it here rather than
+ * inside `acquire` keeps that path to one shape: lock, read, decide.
+ */
+async function ensureLockRow(
+  adapter: DrizzleAdapter,
+  dialect: MigrationDialect
+): Promise<void> {
+  for (const statement of getMigrationLockDdl(dialect)) {
+    await adapter.executeQuery(statement);
+  }
+
+  const existing = await adapter.transaction(async ctx =>
+    ctx.selectOne<{ id: number }>(MIGRATION_LOCK_TABLE, {
+      where: lockRowWhere(),
+    })
+  );
+  if (existing) return;
+
+  try {
+    await adapter.transaction(async ctx =>
+      ctx.insert(MIGRATION_LOCK_TABLE, { id: LOCK_ROW_ID, owner: null })
+    );
+  } catch {
+    // Two processes seeding at once: the primary key decides, and the loser
+    // proceeds to contend for the row that now exists.
+  }
+}
+
+type Acquisition = { ok: true } | { ok: false; heldBy: string };
+
+/**
+ * Claim the row, or report who holds it.
+ *
+ * Returns rather than throws so the refusal is raised by the caller, outside
+ * the transaction, where it survives the adapter's error classifier.
+ */
+async function acquire(
+  adapter: DrizzleAdapter,
+  owner: string
+): Promise<Acquisition> {
+  return adapter.transaction(async ctx => {
+    // Serializes contenders: everyone else waits here until this transaction
+    // ends, so the read below cannot be overtaken between reading and writing.
+    await ctx.lockRow(MIGRATION_LOCK_TABLE, LOCK_ROW_ID);
+
+    const row = await ctx.selectOne<{ owner: string | null }>(
+      MIGRATION_LOCK_TABLE,
+      { where: lockRowWhere() }
+    );
+
+    const heldBy = row?.owner ?? null;
+    if (heldBy !== null && heldBy !== owner) {
+      return { ok: false, heldBy };
+    }
+
+    await ctx.update(MIGRATION_LOCK_TABLE, { owner }, lockRowWhere());
+    return { ok: true };
+  });
+}
+
+/** Release only what we hold, so a late finaliser cannot free someone else's run. */
+async function release(adapter: DrizzleAdapter, owner: string): Promise<void> {
+  await adapter.transaction(async ctx => {
+    await ctx.lockRow(MIGRATION_LOCK_TABLE, LOCK_ROW_ID);
+    await ctx.update(
+      MIGRATION_LOCK_TABLE,
+      { owner: null },
+      lockRowWhere(owner)
+    );
+  });
 }

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -1,0 +1,149 @@
+/**
+ * The connection a field-group migration runs under.
+ *
+ * A migration that renames tables and rewrites rows must be the only one doing
+ * so, and it must be able to prove it for the whole run rather than at the
+ * moment it started. That needs an advisory lock, and an advisory lock is owned
+ * by a connection: releasing it from a different connection than acquired it
+ * releases nothing, and the lock then survives until the original connection
+ * happens to close.
+ *
+ * So the session checks out one connection, takes the lock on that connection,
+ * and holds both for the duration. Steps do NOT run on it. They open their own
+ * transactions, because a step must commit on its own before its progress is
+ * recorded, and a single enclosing transaction would let a rollback at the end
+ * erase work the marker already reports as done. Advisory locks exclude other
+ * connections regardless of which connection does the work, so mutual exclusion
+ * survives that split.
+ *
+ * @module domains/field-groups/migration/session
+ */
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
+
+import { NextlyError } from "../../../errors/nextly-error";
+
+/** Dialects the migration runs on. */
+export type MigrationDialect = "postgresql" | "mysql" | "sqlite";
+
+/**
+ * Lock identity, distinct from the schema pipeline's own lock.
+ *
+ * The two guard different things, and conflating them would make an ordinary
+ * schema sync and a storage migration appear to exclude each other by accident
+ * rather than by decision. Keeping tools from colliding with a migration in
+ * flight is the marker's job, not this lock's.
+ */
+export const MIGRATION_LOCK_NAME = "nextly_field_group_migration";
+
+/**
+ * Postgres advisory locks are keyed by a bigint rather than a name. A fixed
+ * literal is used instead of hashing the name at runtime so the value is
+ * greppable and cannot drift if the name is ever reworded.
+ */
+export const MIGRATION_LOCK_KEY = 8_053_119_204_411_001n;
+
+/** What a step is handed to do its work. */
+export interface MigrationSession {
+  readonly dialect: MigrationDialect;
+  /**
+   * Run work in its own transaction, on its own connection.
+   *
+   * Deliberately not the session's pinned connection: each step commits
+   * independently so that the progress marker, written after the commit,
+   * never claims work that a later rollback could undo.
+   */
+  inTransaction<T>(work: (ctx: TransactionContext) => Promise<T>): Promise<T>;
+}
+
+/**
+ * Hold the migration lock for the duration of `fn`.
+ *
+ * Refuses rather than continuing when the lock cannot be taken. The schema
+ * pipeline's lock helper logs a warning and proceeds unlocked when it gives up
+ * waiting; that is survivable for an idempotent schema sync and is not
+ * survivable here, where two concurrent runs would rename the same objects and
+ * rewrite the same rows.
+ */
+export async function withMigrationSession<T>(
+  args: { adapter: DrizzleAdapter; dialect: MigrationDialect },
+  fn: (session: MigrationSession) => Promise<T>
+): Promise<T> {
+  const { adapter, dialect } = args;
+
+  const session: MigrationSession = {
+    dialect,
+    inTransaction: work => adapter.transaction(work),
+  };
+
+  // SQLite has no advisory locks and needs none: one writer at a time is a
+  // property of the database. Pinning here would also deadlock outright, since
+  // the adapter serializes `transaction()` calls through a queue and an outer
+  // transaction would hold that queue while every step waited on it.
+  if (dialect === "sqlite") {
+    return fn(session);
+  }
+
+  return adapter.transaction(async lock => {
+    await acquire(lock, dialect);
+    try {
+      return await fn(session);
+    } finally {
+      // Released on the connection that took it. Anywhere else is a no-op that
+      // leaves the lock held until the connection is recycled.
+      await release(lock, dialect);
+    }
+  });
+}
+
+async function acquire(
+  ctx: TransactionContext,
+  dialect: Exclude<MigrationDialect, "sqlite">
+): Promise<void> {
+  const acquired =
+    dialect === "mysql" ? await acquireMysql(ctx) : await acquirePostgres(ctx);
+
+  if (!acquired) {
+    throw NextlyError.serviceUnavailable({
+      logMessage:
+        "field-group migration could not take the migration lock; another run holds it",
+      logContext: { reason: "migration lock is held elsewhere", dialect },
+    });
+  }
+}
+
+async function acquireMysql(ctx: TransactionContext): Promise<boolean> {
+  // Timeout 0 so this reports the conflict instead of blocking: a caller that
+  // knows another run is in progress can decide to wait, a caller silently
+  // parked inside a lock call cannot.
+  const rows = await ctx.execute<{ locked: number | boolean | null }>(
+    "SELECT GET_LOCK(?, 0) AS locked",
+    [MIGRATION_LOCK_NAME]
+  );
+  const value = rows[0]?.locked;
+  return value === 1 || value === true;
+}
+
+async function acquirePostgres(ctx: TransactionContext): Promise<boolean> {
+  // Session-level rather than the `_xact_` variant, so the lock's lifetime is
+  // the connection's and stays under this function's control.
+  const rows = await ctx.execute<{ locked: boolean | null }>(
+    "SELECT pg_try_advisory_lock($1) AS locked",
+    [MIGRATION_LOCK_KEY.toString()]
+  );
+  return rows[0]?.locked === true;
+}
+
+async function release(
+  ctx: TransactionContext,
+  dialect: Exclude<MigrationDialect, "sqlite">
+): Promise<void> {
+  if (dialect === "mysql") {
+    await ctx.execute("SELECT RELEASE_LOCK(?)", [MIGRATION_LOCK_NAME]);
+    return;
+  }
+  await ctx.execute("SELECT pg_advisory_unlock($1)", [
+    MIGRATION_LOCK_KEY.toString(),
+  ]);
+}

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -22,6 +22,8 @@
  * @module domains/field-groups/migration/session
  */
 
+import { randomUUID } from "node:crypto";
+
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type {
   TransactionContext,
@@ -91,20 +93,27 @@ export function getMigrationLockDdl(dialect: MigrationDialect): string[] {
  * two runs would rename the same objects and rewrite the same rows.
  */
 export async function withMigrationSession<T>(
-  args: { adapter: DrizzleAdapter; dialect: MigrationDialect; owner: string },
+  args: { adapter: DrizzleAdapter; dialect: MigrationDialect; label: string },
   fn: (session: MigrationSession) => Promise<T>
 ): Promise<T> {
-  const { adapter, dialect, owner } = args;
+  const { adapter, dialect, label } = args;
 
-  if (owner.length === 0) {
+  if (label.length === 0) {
     throw NextlyError.internal({
-      logContext: { reason: "migration lock owner must be a non-empty string" },
+      logContext: { reason: "migration lock label must be a non-empty string" },
     });
   }
 
+  // The claim is made unique here rather than trusted from the caller. A label
+  // alone cannot be relied on: two processes resuming the same migration would
+  // naturally pass the same one, and an occupied row that matched would let
+  // both run, with the first to finish releasing the claim out from under the
+  // second. Uniqueness by construction removes that whole class of mistake.
+  const claim = `${label}#${randomUUID()}`;
+
   await ensureLockRow(adapter, dialect);
 
-  const acquired = await acquire(adapter, owner);
+  const acquired = await acquire(adapter, claim);
   if (!acquired.ok) {
     // Raised outside the transaction on purpose: the adapters route every error
     // escaping a transaction callback through `classifyError`, which rewraps
@@ -126,7 +135,7 @@ export async function withMigrationSession<T>(
       inTransaction: work => adapter.transaction(work),
     });
   } finally {
-    await release(adapter, owner);
+    await release(adapter, claim);
   }
 }
 
@@ -155,13 +164,31 @@ async function ensureLockRow(
     await adapter.transaction(async ctx =>
       ctx.insert(MIGRATION_LOCK_TABLE, { id: LOCK_ROW_ID, owner: null })
     );
+    return;
   } catch {
-    // Two processes seeding at once: the primary key decides, and the loser
-    // proceeds to contend for the row that now exists.
+    // Losing a seed race is expected: the primary key decides and the loser
+    // contends for the row that now exists. Any other failure is not expected,
+    // and cannot be told apart from it portably, so instead of guessing at the
+    // error the row is re-read below and required to exist.
+  }
+
+  const seeded = await adapter.transaction(async ctx =>
+    ctx.selectOne<{ id: number }>(MIGRATION_LOCK_TABLE, {
+      where: lockRowWhere(),
+    })
+  );
+  if (!seeded) {
+    // Continuing here would leave nothing to lock, and a claim written against
+    // an absent row would update nothing while still looking successful.
+    throw NextlyError.serviceUnavailable({
+      logMessage:
+        "field-group migration could not establish its lock row; refusing to run unprotected",
+      logContext: { reason: "migration lock row could not be established" },
+    });
   }
 }
 
-type Acquisition = { ok: true } | { ok: false; heldBy: string };
+type Acquisition = { ok: true } | { ok: false; heldBy: string | null };
 
 /**
  * Claim the row, or report who holds it.
@@ -171,7 +198,7 @@ type Acquisition = { ok: true } | { ok: false; heldBy: string };
  */
 async function acquire(
   adapter: DrizzleAdapter,
-  owner: string
+  claim: string
 ): Promise<Acquisition> {
   return adapter.transaction(async ctx => {
     // Serializes contenders: everyone else waits here until this transaction
@@ -183,24 +210,38 @@ async function acquire(
       { where: lockRowWhere() }
     );
 
-    const heldBy = row?.owner ?? null;
-    if (heldBy !== null && heldBy !== owner) {
-      return { ok: false, heldBy };
+    // Any occupied row refuses, including one that appears to be ours. Claims
+    // are unique per invocation, so a match would mean something other than
+    // this call wrote it.
+    if (row === null || row.owner !== null) {
+      return { ok: false, heldBy: row?.owner ?? null };
     }
 
-    await ctx.update(MIGRATION_LOCK_TABLE, { owner }, lockRowWhere());
+    await ctx.update(MIGRATION_LOCK_TABLE, { owner: claim }, lockRowWhere());
+
+    // Read back rather than trusting the write. `update` reports affected rows
+    // inconsistently across dialects, and an absent row would otherwise update
+    // nothing and still look like a successful claim, running the migration
+    // with no exclusion at all.
+    const after = await ctx.selectOne<{ owner: string | null }>(
+      MIGRATION_LOCK_TABLE,
+      { where: lockRowWhere() }
+    );
+    if (after?.owner !== claim) {
+      return { ok: false, heldBy: after?.owner ?? null };
+    }
     return { ok: true };
   });
 }
 
 /** Release only what we hold, so a late finaliser cannot free someone else's run. */
-async function release(adapter: DrizzleAdapter, owner: string): Promise<void> {
+async function release(adapter: DrizzleAdapter, claim: string): Promise<void> {
   await adapter.transaction(async ctx => {
     await ctx.lockRow(MIGRATION_LOCK_TABLE, LOCK_ROW_ID);
     await ctx.update(
       MIGRATION_LOCK_TABLE,
       { owner: null },
-      lockRowWhere(owner)
+      lockRowWhere(claim)
     );
   });
 }


### PR DESCRIPTION
B1-2 of the Components → Field Groups storage migration (task 011). Builds on #399.

Ships dark: nothing calls this yet, and the changeset says so.

## What this adds

**A session that actually holds the lock.** The run checks out one connection and takes the advisory lock on it for the whole duration. An advisory lock belongs to the connection that took it, so a `RELEASE_LOCK` issued on a pooled connection releases nothing and the lock stays held until that connection is recycled.

**A step runner that records only what it verified.** Each step runs, its postcondition is checked *against the database*, and only then is it recorded. Recording first would let a step that silently did nothing be marked done and skipped on every later run — indistinguishable from success until the data is read months later.

## Three design decisions worth reviewing

**Steps do not run on the locked connection.** They open their own transactions and commit independently. A single enclosing transaction would let a rollback at the end erase work the marker already reports as done. Advisory locks exclude other connections regardless of which connection does the work, so mutual exclusion survives the split.

**A failed lock refuses instead of proceeding.** `domains/schema/pipeline/locks.ts:150-155` logs `"migrate lock still held after waiting; proceeding without it."` That is survivable for an idempotent schema sync. It is not survivable here, where two concurrent runs would rename the same objects and rewrite the same rows.

**SQLite takes no lock and opens no pinning transaction.** One writer is a property of the database. Pinning would also deadlock outright: `adapter-sqlite/src/index.ts:477-497` serializes `transaction()` calls through a queue, so an outer transaction would hold that queue while every step waited on it.

## Verified, not assumed

The premises behind this design were checked in code rather than taken from the plan:

- `cli/commands/migrate.ts:744` issues BEGIN/COMMIT through `adapter.executeQuery`, which runs against the pool per call, while `adapter-postgres/src/index.ts:571` calls `pool.connect()` and runs BEGIN/callback/COMMIT on one pinned client. So the CLI helper can genuinely begin on one connection and commit on another.
- `locks.ts:165-176` acquires and releases MySQL `GET_LOCK` through pooled calls.
- The SQLite serialization queue is real and would deadlock under an outer transaction.

## Testing

66 tests in the migration module. Four guarantees proven load-bearing by breaking them, with the test count checked each time so a broken harness cannot pass as a green run:

| Break | Fails |
|---|---|
| record before verify | 4 |
| failed postcondition no longer refuses | 3 |
| lock failure proceeds anyway | 2 |
| sqlite opens a pinning transaction | 1 |

`pnpm check-types` 19/19 · `pnpm lint` exit 0 · `pnpm build` exit 0 · full `packages/nextly` run **400 failures = baseline exactly**, with a test-name-level diff confirming zero branch-only failures.

## Not in this PR

The dialect storage probe. The plan's B1-2 section lists three bullets and the probe is not among them; it needs the target storage names, which are defined alongside the DDL in B1-3. `StorageProbe` from #399 stays an interface until then, and its `migratedObjects: null` case already refuses, so nothing can serve migrated storage on an unimplemented probe in the meantime.

Carried from #399 review: `readMigrationState` assumes `nextly_meta` exists, so whatever wires this up must place the guard after core system tables are ensured.