### PR TITLE
fix(admin): expose a retry when the version history refresh fails

### DIFF
--- a/.changeset/admin-version-history-retry.md
+++ b/.changeset/admin-version-history-retry.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Recover a version history that failed to refresh, without reopening the panel.
+
+When the history panel cannot refresh its list (for example after the tab regains focus following a save made elsewhere), it keeps the loaded history on screen but holds back the "Compare with current" and "Load more" actions until it can confirm the latest version. It now shows a short notice with a "Try again" button, so a transient failure can be recovered in place rather than by closing and reopening the panel.

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -329,6 +329,36 @@ export function VersionHistorySheet({
           </SheetDescription>
         </SheetHeader>
 
+        {/* A head revalidation (on open or window focus) can fail after history
+            has already loaded. The rows stay on screen but may be stale, so the
+            freshness gate hides "Compare with current" and disables "Load more"
+            until a refetch succeeds — which, without this, only a reopen or
+            another window focus could trigger. This keeps the gate but gives the
+            recovery a visible control. Suppressed in compare mode (the pair is
+            already chosen, so head staleness no longer affects what is shown) and
+            when there are no rows (the full-panel load error covers that). */}
+        {isRefetchError && comparing === null && versions.length > 0 ? (
+          <div className="px-4 pt-4">
+            <Alert variant="warning" role="status">
+              <div className="flex flex-1 flex-wrap items-center justify-between gap-3">
+                <AlertDescription>
+                  Couldn&apos;t refresh this history. It may be out of date.
+                </AlertDescription>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  // Disabled while a retry is in flight; the same refetch also
+                  // fires from window focus, so this reflects either trigger.
+                  disabled={isRefetching}
+                  onClick={() => void list.refetch()}
+                >
+                  {isRefetching ? "Retrying…" : "Try again"}
+                </Button>
+              </div>
+            </Alert>
+          </div>
+        ) : null}
+
         <div className="flex-1 overflow-y-auto">
           {comparing !== null ? (
             // Keyed by the pair so a different comparison always mounts fresh,

--- a/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
@@ -142,6 +142,92 @@ describe("VersionHistorySheet", () => {
     expect(screen.queryByText(/No versions recorded/)).not.toBeInTheDocument();
   });
 
+  it("offers a retry when a background refresh fails after history has loaded", async () => {
+    // A focus or mount head revalidation can fail with rows already on screen.
+    // They stay (possibly stale), so the freshness gate holds compare + load
+    // more; without this control the only recovery is reopening the panel.
+    const refetch = vi.fn();
+    useVersionsMock.mockReturnValue(
+      listState({
+        data: {
+          pages: [
+            { items: [version(2), version(1)], meta: { hasNext: false } },
+          ],
+        },
+        isError: true,
+        isRefetchError: true,
+        refetch,
+      })
+    );
+
+    renderSheet();
+
+    // The loaded rows are kept, not replaced by the full-panel load error.
+    expect(screen.getByText("Version 2")).toBeInTheDocument();
+    expect(screen.queryByText(/could not be loaded/)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Couldn't refresh this history/)
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /Try again/ }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the retry while a refresh is already in flight", () => {
+    useVersionsMock.mockReturnValue(
+      listState({
+        data: { pages: [{ items: [version(2)], meta: { hasNext: false } }] },
+        isRefetchError: true,
+        isRefetching: true,
+      })
+    );
+
+    renderSheet();
+
+    expect(screen.getByRole("button", { name: /Retrying/ })).toBeDisabled();
+  });
+
+  it("shows the full-panel error, not the stale-history banner, when nothing loaded", () => {
+    // With no rows the failure is a load error, not a stale refresh: the
+    // full-panel message owns that state and the banner must stay out of it.
+    useVersionsMock.mockReturnValue(
+      listState({ isError: true, isRefetchError: true })
+    );
+
+    renderSheet();
+
+    expect(screen.getByText(/could not be loaded/)).toBeInTheDocument();
+    expect(screen.queryByText(/may be out of date/)).not.toBeInTheDocument();
+  });
+
+  it("keeps a retry reachable from a preview when the head refresh fails", async () => {
+    // In preview the freshness gate hides "Compare with current"; the retry has
+    // to remain reachable or the comparison cannot recover without a reopen.
+    const refetch = vi.fn();
+    useVersionsMock.mockReturnValue(
+      listState({
+        data: {
+          pages: [
+            { items: [version(3), version(2)], meta: { hasNext: false } },
+          ],
+        },
+        isError: true,
+        isRefetchError: true,
+        refetch,
+      })
+    );
+    useVersionMock.mockReturnValue(detailState({ data: { snapshot: {} } }));
+
+    renderSheet();
+    await userEvent.click(screen.getByRole("button", { name: /Version 2/ }));
+
+    expect(
+      screen.queryByRole("button", { name: /Compare with current/ })
+    ).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /Try again/ }));
+    expect(refetch).toHaveBeenCalled();
+  });
+
   it("offers more only when another page exists", () => {
     useVersionsMock.mockReturnValue(
       listState({


### PR DESCRIPTION
## What

Adds an in-panel retry when the version history list fails to refresh after it has already loaded.

When the history panel reopens (or the tab regains focus) it revalidates its list against the current head. If that revalidation fails, the panel keeps the loaded rows on screen but holds back "Compare with current" and "Load more" behind its freshness gate, since the head can no longer be trusted (see the guards in `VersionHistorySheet`). Until now nothing offered a way back: the actions only recovered on a full reopen or another window-focus event.

This adds a small notice with a **Try again** button (calls `list.refetch()`) shown between the header and the content whenever a refresh has failed with rows present. The stale-head safety gate is unchanged: the compare/load-more actions stay disabled until a refetch actually succeeds. It renders in both list and preview modes (where the compare actions live), and is suppressed in compare mode and when nothing loaded (the full-panel load error owns that state).

## Why

Follow-up to the versioning diff view (#398). Codex flagged this as a P2 during that review; the founder merged #398 and asked to address it here (task 022, versioning UX polish). Reference: `VersionHistorySheet.tsx` freshness gate + the deferred thread on #398.

## Testing

- `@nextlyhq/admin` versions suite: 175 pass (12 files), including 4 new cases — list-mode recovery + `refetch` wiring, the in-flight disabled state, staying out of the full-load-error state, and reachability from a preview where "Compare with current" is gated off.
- `check-types` and `lint --max-warnings 0` clean.
- Token-driven `warning` Alert; both light and dark.

## Changeset

`admin-version-history-retry.md` (all fixed-group packages, patch).