### PR TITLE
feat(nextly): derive the field group rename plan from the database

### DIFF
--- a/.changeset/field-group-migration-manifest.md
+++ b/.changeset/field-group-migration-manifest.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+More groundwork for the upcoming field group storage migration: the rename plan is now derived from the database rather than from configuration, so a table named through `dbName` is found and left alone rather than renamed over. Nothing calls this yet, so there is no change in behaviour in this release.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/guard.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/guard.test.ts
@@ -213,13 +213,43 @@ describe("field-group storage verdict", () => {
     });
   });
 
-  // A `down` run interrupted at step 4 is not a `up` run interrupted at step 4,
-  // and the verdict is the only thing telling them apart.
+  // A `down` run interrupted at step 4 is not an `up` run interrupted at step 4,
+  // and the verdict is the only thing telling them apart. A rollback also cannot
+  // derive the plan it is reversing, so that plan travels with the verdict.
   it("distinguishes an interrupted down run from an interrupted up run", () => {
-    const down: MigratingState = { ...IN_FLIGHT, direction: "down" };
+    const applied = [
+      { kind: "table" as const, from: "fg_hero", to: "comp_hero" },
+    ];
+    const down: MigratingState = {
+      ...IN_FLIGHT,
+      direction: "down",
+      appliedManifest: applied,
+    };
     expect(
       resolveStorageVerdict({ state: down, probe: probe() })
-    ).toMatchObject({ action: "resume", direction: "down" });
+    ).toMatchObject({
+      action: "resume",
+      direction: "down",
+      appliedManifest: applied,
+    });
+  });
+
+  // An in-flight rollback with no recorded plan cannot be resumed at all:
+  // guessing the reverse from the database would rename names this migration
+  // never created.
+  it("refuses to resume a rollback that recorded no plan", () => {
+    const down: MigratingState = { ...IN_FLIGHT, direction: "down" };
+    const refusal = captureRefusal(() =>
+      resolveStorageVerdict({ state: down, probe: probe() })
+    );
+    expect(refusal.logContext?.reason).toMatch(/recorded no plan to reverse/);
+  });
+
+  // An up run derives its plan from registry rows, so it carries none.
+  it("resumes an up run without a recorded plan", () => {
+    expect(
+      resolveStorageVerdict({ state: IN_FLIGHT, probe: probe() })
+    ).toMatchObject({ action: "resume", direction: "up" });
   });
 
   // An interrupted run is interpretable only by the step list, whatever the

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
@@ -294,6 +294,18 @@ describe("field-group migration manifest", () => {
     ).not.toThrow();
   });
 
+  // Companion ownership is an identity question, so it compares exactly. On
+  // Postgres a quoted COMP_HERO_LOCALES is a different table, and folding would
+  // refuse that installation permanently.
+  it("does not treat a case-different table as a companion alias", () => {
+    expect(() =>
+      buildMigrationManifest([
+        row({ slug: "hero", tableName: "comp_hero", hasCompanion: true }),
+        row({ slug: "other", tableName: "COMP_HERO_LOCALES" }),
+      ])
+    ).not.toThrow();
+  });
+
   // Renaming a table away frees its name, so two rows swapping prefixes is not
   // a conflict.
   it("allows a target whose occupant is itself renamed away", () => {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
+import {
+  buildMigrationManifest,
+  hashManifest,
+  MIGRATION_TARGET,
+  retargetName,
+  type RegistryRow,
+} from "../manifest";
+
+function row(over: Partial<RegistryRow> = {}): RegistryRow {
+  return {
+    slug: "hero",
+    tableName: "comp_hero",
+    localized: false,
+    hasTypeColumn: false,
+    ...over,
+  };
+}
+
+describe("field-group migration manifest", () => {
+  it("moves a prefixed table onto the new prefix", () => {
+    expect(retargetName("comp_hero")).toBe("fg_hero");
+  });
+
+  // A table named through `dbName` was never named after the concept, so there
+  // is no vocabulary in it to retire. Renaming it would change a name its
+  // author chose, for no benefit.
+  it("leaves a custom-named table alone", () => {
+    expect(retargetName("my_seo_block")).toBeNull();
+  });
+
+  it("renames the table and, when localized, its companion", () => {
+    const { entries } = buildMigrationManifest([row({ localized: true })]);
+    expect(entries).toEqual([
+      { kind: "table", from: "comp_hero", to: "fg_hero" },
+      { kind: "companion", from: "comp_hero_locales", to: "fg_hero_locales" },
+      {
+        kind: "registry",
+        from: "dynamic_components",
+        to: "dynamic_field_groups",
+      },
+    ]);
+  });
+
+  // The companion name is built from the table name that was read, so a table
+  // with an unexpected name still has its companion found.
+  it("derives the companion from the read table name", () => {
+    const { entries } = buildMigrationManifest([
+      row({ tableName: "comp_odd_name", localized: true }),
+    ]);
+    expect(entries).toContainEqual({
+      kind: "companion",
+      from: `comp_odd_name${STORAGE_FORMAT.companionSuffix}`,
+      to: `fg_odd_name${STORAGE_FORMAT.companionSuffix}`,
+    });
+  });
+
+  // Only dynamic zones carry the discriminator column.
+  it("renames the type column only where it exists", () => {
+    const without = buildMigrationManifest([row()]);
+    expect(without.entries.some(e => e.kind === "column")).toBe(false);
+
+    const withColumn = buildMigrationManifest([row({ hasTypeColumn: true })]);
+    expect(withColumn.entries).toContainEqual({
+      kind: "column",
+      from: STORAGE_FORMAT.columns.type,
+      to: MIGRATION_TARGET.columnType,
+      table: "fg_hero",
+    });
+  });
+
+  // The column rename runs after its table's, so addressing it by the old name
+  // would fail: by then the old name resolves to nothing.
+  it("addresses the column by its post-rename table", () => {
+    const { entries } = buildMigrationManifest([row({ hasTypeColumn: true })]);
+    const column = entries.find(e => e.kind === "column");
+    const table = entries.findIndex(e => e.kind === "table");
+    const columnAt = entries.findIndex(e => e.kind === "column");
+    expect(column?.table).toBe("fg_hero");
+    expect(columnAt).toBeGreaterThan(table);
+  });
+
+  // A custom-named table is not renamed, so its column keeps being addressed by
+  // the name it already has.
+  it("addresses a custom-named table's column by its unchanged name", () => {
+    const { entries } = buildMigrationManifest([
+      row({ tableName: "my_seo_block", hasTypeColumn: true }),
+    ]);
+    expect(entries).toContainEqual({
+      kind: "column",
+      from: STORAGE_FORMAT.columns.type,
+      to: MIGRATION_TARGET.columnType,
+      table: "my_seo_block",
+    });
+    expect(entries.some(e => e.kind === "table")).toBe(false);
+  });
+
+  // While the registry answers to its old name a resumed run can rebuild this
+  // plan from it. Renaming it first would strand the resume.
+  it("renames the registry last", () => {
+    const { entries } = buildMigrationManifest([
+      row({ tableName: "comp_a", localized: true }),
+      row({ tableName: "comp_b" }),
+    ]);
+    expect(entries[entries.length - 1]).toEqual({
+      kind: "registry",
+      from: STORAGE_FORMAT.registryTable,
+      to: MIGRATION_TARGET.registryTable,
+    });
+    expect(entries.filter(e => e.kind === "registry")).toHaveLength(1);
+  });
+
+  // Step numbers index into this list, so an order that varied between runs
+  // would make a resumed step point at a different object.
+  it("orders the plan the same way regardless of row order", () => {
+    const a = buildMigrationManifest([
+      row({ tableName: "comp_b" }),
+      row({ tableName: "comp_a" }),
+    ]);
+    const b = buildMigrationManifest([
+      row({ tableName: "comp_a" }),
+      row({ tableName: "comp_b" }),
+    ]);
+    expect(a.entries).toEqual(b.entries);
+    expect(a.hash).toBe(b.hash);
+  });
+
+  it("changes the hash when the object map changes", () => {
+    const before = buildMigrationManifest([row()]);
+    const after = buildMigrationManifest([row(), row({ tableName: "comp_x" })]);
+    expect(after.hash).not.toBe(before.hash);
+  });
+
+  // Same objects renamed in a different order is a different plan: a recorded
+  // step position would mean something else under it.
+  it("changes the hash when only the order changes", () => {
+    const a = hashManifest([
+      { kind: "table", from: "comp_a", to: "fg_a" },
+      { kind: "table", from: "comp_b", to: "fg_b" },
+    ]);
+    const b = hashManifest([
+      { kind: "table", from: "comp_b", to: "fg_b" },
+      { kind: "table", from: "comp_a", to: "fg_a" },
+    ]);
+    expect(a).not.toBe(b);
+  });
+
+  it("targets a prefix no longer than the one it replaces", () => {
+    // Guarantees the migration cannot push a name past an identifier limit:
+    // Postgres caps at 63 bytes and MySQL at 64, and every name that fits today
+    // gets shorter rather than longer.
+    expect(MIGRATION_TARGET.tablePrefix.length).toBeLessThanOrEqual(
+      STORAGE_FORMAT.tablePrefix.length
+    );
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
@@ -264,6 +264,25 @@ describe("field-group migration manifest", () => {
     ).not.toThrow();
   });
 
+  // A row naming a system table is malformed. It is left unrenamed, so its
+  // discriminator rename would be issued against the registry itself -- and the
+  // registry's own rename puts that name among the plan's sources, so nothing
+  // else flags the overlap.
+  it.each(["dynamic_components", "dynamic_field_groups"])(
+    "refuses a row whose table is the system registry (%s)",
+    table => {
+      try {
+        buildMigrationManifest([row({ slug: "x", tableName: table })]);
+        expect.fail("expected a refusal");
+      } catch (error) {
+        expect((error as NextlyError).code).toBe("SERVICE_UNAVAILABLE");
+        expect((error as NextlyError).logContext?.reason).toMatch(
+          /names a system table/
+        );
+      }
+    }
+  );
+
   // Renaming a table away frees its name, so two rows swapping prefixes is not
   // a conflict.
   it("allows a target whose occupant is itself renamed away", () => {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
@@ -283,6 +283,17 @@ describe("field-group migration manifest", () => {
     }
   );
 
+  // The system-table check asks whether a row IS the registry, which is an
+  // identity question. Folding it would refuse a legitimate Postgres table
+  // quoted as DYNAMIC_COMPONENTS and block that installation permanently.
+  it("does not refuse a custom table that differs from the registry only in case", () => {
+    expect(() =>
+      buildMigrationManifest([
+        row({ slug: "x", tableName: "DYNAMIC_COMPONENTS" }),
+      ])
+    ).not.toThrow();
+  });
+
   // Renaming a table away frees its name, so two rows swapping prefixes is not
   // a conflict.
   it("allows a target whose occupant is itself renamed away", () => {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
@@ -191,6 +191,33 @@ describe("field-group migration manifest", () => {
     ).toThrowError(NextlyError);
   });
 
+  // A kept row occupies its companion's name as well as its own. `fg_x` staying
+  // put means `fg_x_locales` stays put too, so another row's table cannot be
+  // renamed onto it.
+  it("refuses when a target is taken by a kept row's companion", () => {
+    try {
+      buildMigrationManifest([
+        row({ tableName: "fg_x", hasCompanion: true }),
+        row({ slug: "other", tableName: "comp_x_locales" }),
+      ]);
+      expect.fail("expected a refusal");
+    } catch (error) {
+      expect((error as NextlyError).code).toBe("SERVICE_UNAVAILABLE");
+      expect((error as NextlyError).logContext?.to).toBe("fg_x_locales");
+    }
+  });
+
+  // A kept row without a companion reserves only its own name; the companion
+  // name is free, and refusing there would block a legitimate rename.
+  it("does not reserve a companion name for a row that has none", () => {
+    expect(() =>
+      buildMigrationManifest([
+        row({ tableName: "fg_y", hasCompanion: false }),
+        row({ slug: "other", tableName: "comp_y_locales" }),
+      ])
+    ).not.toThrow();
+  });
+
   // Renaming a table away frees its name, so two rows swapping prefixes is not
   // a conflict.
   it("allows a target whose occupant is itself renamed away", () => {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
@@ -5,6 +5,7 @@ import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
 import {
   buildMigrationManifest,
   hashManifest,
+  invertManifest,
   MIGRATION_TARGET,
   retargetName,
   type RegistryRow,
@@ -193,12 +194,62 @@ describe("field-group migration manifest", () => {
   // A run that crashed after a rename committed but before its marker write
   // must rebuild the plan and find that step already satisfied, rather than
   // reading its own finished work as a conflict.
-  it("treats a completed rename as done, not as a collision", () => {
+  it("marks a completed rename satisfied instead of removing it", () => {
     const { entries } = buildMigrationManifest(
-      [row({ tableName: "fg_hero" })],
-      { existingTables: ["fg_hero", "dynamic_field_groups"] }
+      [row({ tableName: "comp_hero" })],
+      {
+        existingTables: ["fg_hero", "dynamic_field_groups"],
+      }
     );
-    expect(entries).toEqual([]);
+    expect(entries).toEqual([
+      { kind: "table", from: "comp_hero", to: "fg_hero", satisfied: true },
+      {
+        kind: "registry",
+        from: "dynamic_components",
+        to: "dynamic_field_groups",
+        satisfied: true,
+      },
+    ]);
+  });
+
+  // The plan is positionally indexed and hash-identified, so progress must not
+  // change its identity: a resume would otherwise refuse the plan it resumes.
+  it("keeps the same hash once steps have been applied", () => {
+    const rows = [row({ tableName: "comp_a" }), row({ tableName: "comp_b" })];
+    const fresh = buildMigrationManifest(rows, {
+      existingTables: ["comp_a", "comp_b", "dynamic_components"],
+    });
+    const partlyDone = buildMigrationManifest(rows, {
+      existingTables: ["fg_a", "comp_b", "dynamic_components"],
+    });
+    expect(partlyDone.hash).toBe(fresh.hash);
+    expect(partlyDone.entries).toHaveLength(fresh.entries.length);
+    expect(partlyDone.entries[0]?.satisfied).toBe(true);
+    expect(partlyDone.entries[1]?.satisfied).toBeUndefined();
+  });
+
+  // The column names its post-rename table, which is legitimately absent from a
+  // pre-migration catalog. Dropping it would migrate the table and leave its
+  // discriminator behind.
+  it("keeps the column rename for a table this plan is about to create", () => {
+    const { entries } = buildMigrationManifest(
+      [row({ tableName: "comp_hero", hasTypeColumn: true })],
+      { existingTables: ["comp_hero", "dynamic_components"] }
+    );
+    const column = entries.find(e => e.kind === "column");
+    expect(column).toBeDefined();
+    expect(column?.satisfied).toBeUndefined();
+    expect(column?.table).toBe("fg_hero");
+  });
+
+  // Presence is matched exactly: on Postgres a quoted COMP_HERO is a different
+  // table, and folding would hide a genuinely missing source.
+  it("does not let a case-variant table mask a missing source", () => {
+    expect(() =>
+      buildMigrationManifest([row({ tableName: "comp_hero" })], {
+        existingTables: ["COMP_HERO", "dynamic_components"],
+      })
+    ).toThrowError(NextlyError);
   });
 
   // The registry names a table that is gone. Renaming it would fail after the
@@ -221,34 +272,41 @@ describe("field-group migration manifest", () => {
     ).toThrowError(NextlyError);
   });
 
-  // The marker records a direction, so the plan has to be able to express one.
-  it("reverses the mapping for a down migration", () => {
-    const { entries } = buildMigrationManifest(
-      [row({ tableName: "fg_hero", hasCompanion: true })],
-      { direction: "down" }
-    );
-    expect(entries).toEqual([
-      { kind: "table", from: "fg_hero", to: "comp_hero" },
-      { kind: "companion", from: "fg_hero_locales", to: "comp_hero_locales" },
+  // A rollback inverts what was applied. It is never derived from the prefix,
+  // because a prefix rule cannot tell a name this migration created from one an
+  // author chose before it existed.
+  it("inverts an applied plan for rollback, in reverse order", () => {
+    const up = buildMigrationManifest([
+      row({ tableName: "comp_hero", hasCompanion: true, hasTypeColumn: true }),
+    ]);
+    const down = invertManifest(up.entries);
+    expect(down.entries).toEqual([
       {
         kind: "registry",
         from: "dynamic_field_groups",
         to: "dynamic_components",
       },
+      {
+        kind: "column",
+        from: MIGRATION_TARGET.columnType,
+        to: STORAGE_FORMAT.columns.type,
+        // Still the migrated name: the column reverts before its table does.
+        table: "fg_hero",
+      },
+      { kind: "companion", from: "fg_hero_locales", to: "comp_hero_locales" },
+      { kind: "table", from: "fg_hero", to: "comp_hero" },
     ]);
   });
 
-  it("reverses the column mapping too", () => {
-    const { entries } = buildMigrationManifest(
-      [row({ tableName: "fg_hero", hasTypeColumn: true })],
-      { direction: "down" }
-    );
-    expect(entries).toContainEqual({
-      kind: "column",
-      from: MIGRATION_TARGET.columnType,
-      to: STORAGE_FORMAT.columns.type,
-      table: "comp_hero",
-    });
+  // The case this protects: an author whose dbName was already `fg_hero` before
+  // any migration. Up leaves it alone, so nothing about it is in the plan, so a
+  // rollback cannot rename it either.
+  it("never touches a custom name the up plan left alone", () => {
+    const up = buildMigrationManifest([row({ tableName: "fg_hero" })]);
+    const down = invertManifest(up.entries);
+    expect(
+      down.entries.some(e => e.from === "fg_hero" || e.to === "fg_hero")
+    ).toBe(false);
   });
 
   // A plan rebuilt after a partial run must contain only outstanding work, so a

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
@@ -22,15 +22,27 @@ const COLUMN_RENAME = {
 };
 
 describe("field-group migration manifest", () => {
-  it("moves a prefixed table onto the new prefix", () => {
-    expect(retargetName("comp_hero")).toBe("fg_hero");
+  it("moves a canonically named table onto the new prefix", () => {
+    expect(retargetName({ slug: "hero", tableName: "comp_hero" })).toBe(
+      "fg_hero"
+    );
   });
 
   // A table named through `dbName` was never named after the concept, so there
   // is no vocabulary in it to retire. Renaming it would change a name its
   // author chose, for no benefit.
   it("leaves a custom-named table alone", () => {
-    expect(retargetName("my_seo_block")).toBeNull();
+    expect(retargetName({ slug: "seo", tableName: "my_seo_block" })).toBeNull();
+  });
+
+  // Ownership is decided against the canonical name for the slug, not the
+  // prefix. `dbName` was taken verbatim for field groups, so an author could
+  // name a table `comp_archive` under the slug `hero`; a prefix rule reads that
+  // as generated and renames an identifier this migration never created.
+  it("leaves a custom name alone even when it carries the legacy prefix", () => {
+    expect(
+      retargetName({ slug: "hero", tableName: "comp_archive" })
+    ).toBeNull();
   });
 
   it("renames the table, its companion, and its discriminator", () => {
@@ -52,9 +64,9 @@ describe("field-group migration manifest", () => {
   // for some would leave the rest reachable under the wrong name.
   it("renames the discriminator on every field group", () => {
     const { entries } = buildMigrationManifest([
-      row({ tableName: "comp_a" }),
-      row({ tableName: "comp_b" }),
-      row({ tableName: "my_seo_block" }),
+      row({ slug: "a", tableName: "comp_a" }),
+      row({ slug: "b", tableName: "comp_b" }),
+      row({ slug: "seo", tableName: "my_seo_block" }),
     ]);
     const columns = entries.filter(e => e.kind === "column");
     expect(columns).toHaveLength(3);
@@ -66,11 +78,11 @@ describe("field-group migration manifest", () => {
     ]);
   });
 
-  // The companion name is built from the table name that was read, so a table
-  // with an unexpected name still has its companion found.
+  // The companion name is built from the table name that was read, so a slug
+  // whose canonical name was normalized still has its companion found.
   it("derives the companion from the read table name", () => {
     const { entries } = buildMigrationManifest([
-      row({ tableName: "comp_odd_name", hasCompanion: true }),
+      row({ slug: "odd-name", tableName: "comp_odd_name", hasCompanion: true }),
     ]);
     expect(entries).toContainEqual({
       kind: "companion",
@@ -100,8 +112,8 @@ describe("field-group migration manifest", () => {
   // plan from it. Renaming it first would strand the resume.
   it("renames the registry last", () => {
     const { entries } = buildMigrationManifest([
-      row({ tableName: "comp_a", hasCompanion: true }),
-      row({ tableName: "comp_b" }),
+      row({ slug: "a", tableName: "comp_a", hasCompanion: true }),
+      row({ slug: "b", tableName: "comp_b" }),
     ]);
     expect(entries[entries.length - 1]).toEqual({
       kind: "registry",
@@ -115,12 +127,12 @@ describe("field-group migration manifest", () => {
   // would make a resumed step point at a different object.
   it("orders the plan the same way regardless of row order", () => {
     const a = buildMigrationManifest([
-      row({ tableName: "comp_b" }),
-      row({ tableName: "comp_a" }),
+      row({ slug: "b", tableName: "comp_b" }),
+      row({ slug: "a", tableName: "comp_a" }),
     ]);
     const b = buildMigrationManifest([
-      row({ tableName: "comp_a" }),
-      row({ tableName: "comp_b" }),
+      row({ slug: "a", tableName: "comp_a" }),
+      row({ slug: "b", tableName: "comp_b" }),
     ]);
     expect(a.entries).toEqual(b.entries);
     expect(a.hash).toBe(b.hash);
@@ -128,7 +140,10 @@ describe("field-group migration manifest", () => {
 
   it("changes the hash when the object map changes", () => {
     const before = buildMigrationManifest([row()]);
-    const after = buildMigrationManifest([row(), row({ tableName: "comp_x" })]);
+    const after = buildMigrationManifest([
+      row(),
+      row({ slug: "x", tableName: "comp_x" }),
+    ]);
     expect(after.hash).not.toBe(before.hash);
   });
 
@@ -170,8 +185,8 @@ describe("field-group migration manifest", () => {
   it("refuses when a target is taken by a row it leaves alone", () => {
     try {
       buildMigrationManifest([
-        row({ tableName: "comp_hero" }),
-        row({ slug: "other", tableName: "fg_hero" }),
+        row({ slug: "hero", tableName: "comp_hero" }),
+        row({ slug: "hero2", tableName: "fg_hero" }),
       ]);
       expect.fail("expected a refusal");
     } catch (error) {
@@ -185,8 +200,8 @@ describe("field-group migration manifest", () => {
   it("refuses a target conflict that differs only in case", () => {
     expect(() =>
       buildMigrationManifest([
-        row({ tableName: "comp_hero" }),
-        row({ slug: "other", tableName: "FG_HERO" }),
+        row({ slug: "hero", tableName: "comp_hero" }),
+        row({ slug: "hero2", tableName: "FG_HERO" }),
       ])
     ).toThrowError(NextlyError);
   });
@@ -197,8 +212,8 @@ describe("field-group migration manifest", () => {
   it("refuses when a target is taken by a kept row's companion", () => {
     try {
       buildMigrationManifest([
-        row({ tableName: "fg_x", hasCompanion: true }),
-        row({ slug: "other", tableName: "comp_x_locales" }),
+        row({ slug: "x", tableName: "fg_x", hasCompanion: true }),
+        row({ slug: "x_locales", tableName: "comp_x_locales" }),
       ]);
       expect.fail("expected a refusal");
     } catch (error) {
@@ -212,8 +227,8 @@ describe("field-group migration manifest", () => {
   it("does not reserve a companion name for a row that has none", () => {
     expect(() =>
       buildMigrationManifest([
-        row({ tableName: "fg_y", hasCompanion: false }),
-        row({ slug: "other", tableName: "comp_y_locales" }),
+        row({ slug: "y", tableName: "fg_y", hasCompanion: false }),
+        row({ slug: "y_locales", tableName: "comp_y_locales" }),
       ])
     ).not.toThrow();
   });
@@ -223,7 +238,7 @@ describe("field-group migration manifest", () => {
   it("allows a target whose occupant is itself renamed away", () => {
     expect(() =>
       buildMigrationManifest([
-        row({ tableName: "comp_a" }),
+        row({ slug: "a", tableName: "comp_a" }),
         row({ slug: "b", tableName: "comp_b" }),
       ])
     ).not.toThrow();
@@ -258,7 +273,9 @@ describe("field-group migration manifest", () => {
   // The case this protects: an author whose dbName was already `fg_hero` before
   // any migration. Up leaves the table alone, so a rollback cannot rename it.
   it("never renames a custom table the up plan left alone", () => {
-    const up = buildMigrationManifest([row({ tableName: "fg_hero" })]);
+    const up = buildMigrationManifest([
+      row({ slug: "hero", tableName: "fg_hero" }),
+    ]);
     const down = invertManifest(up.entries);
     expect(
       down.entries.some(

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
@@ -267,6 +267,35 @@ describe("field-group migration manifest", () => {
     ).toBe(false);
   });
 
+  // `table_name` is an unconstrained varchar, so a name containing the old
+  // delimiters made two different plans serialize to the same bytes -- and a
+  // resume would then accept a plan whose step positions address other work.
+  it("cannot be made to collide by a name containing delimiters", () => {
+    const one = hashManifest([
+      {
+        kind: "column",
+        table: "a:_component_type>_field_group_type\ncolumn:b",
+        from: "_component_type",
+        to: "_field_group_type",
+      },
+    ]);
+    const two = hashManifest([
+      {
+        kind: "column",
+        table: "a",
+        from: "_component_type",
+        to: "_field_group_type",
+      },
+      {
+        kind: "column",
+        table: "b",
+        from: "_component_type",
+        to: "_field_group_type",
+      },
+    ]);
+    expect(one).not.toBe(two);
+  });
+
   it("targets a prefix no longer than the one it replaces", () => {
     // Guarantees the migration cannot push a name past an identifier limit:
     // Postgres caps at 63 bytes and MySQL at 64, and every name that fits today

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
@@ -233,6 +233,37 @@ describe("field-group migration manifest", () => {
     ).not.toThrow();
   });
 
+  // A companion name is derived, not stored, so it can collide with another
+  // row's stored table name. `comp_hero`'s companion computes to
+  // `comp_hero_locales`, which an author could have chosen as their own table.
+  // The unique constraint on `table_name` does not prevent it, because the
+  // companion is not a registry row. Two rows then claim one physical table.
+  it("refuses when a companion name aliases another row's table", () => {
+    try {
+      buildMigrationManifest([
+        row({ slug: "hero", tableName: "comp_hero", hasCompanion: true }),
+        row({ slug: "archive", tableName: "comp_hero_locales" }),
+      ]);
+      expect.fail("expected a refusal");
+    } catch (error) {
+      expect((error as NextlyError).code).toBe("SERVICE_UNAVAILABLE");
+      expect((error as NextlyError).logContext?.reason).toMatch(
+        /claimed by more than one field group/
+      );
+    }
+  });
+
+  // The check must not fire on the ordinary case. No self-collision is possible
+  // -- a name cannot equal itself plus a suffix -- so a lone row with a
+  // companion has to plan cleanly.
+  it("does not refuse a lone row that has a companion", () => {
+    expect(() =>
+      buildMigrationManifest([
+        row({ slug: "hero", tableName: "comp_hero", hasCompanion: true }),
+      ])
+    ).not.toThrow();
+  });
+
   // Renaming a table away frees its name, so two rows swapping prefixes is not
   // a conflict.
   it("allows a target whose occupant is itself renamed away", () => {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
@@ -8,18 +8,18 @@ import {
   invertManifest,
   MIGRATION_TARGET,
   retargetName,
+  type ManifestEntry,
   type RegistryRow,
 } from "../manifest";
 
 function row(over: Partial<RegistryRow> = {}): RegistryRow {
-  return {
-    slug: "hero",
-    tableName: "comp_hero",
-    hasCompanion: false,
-    hasTypeColumn: false,
-    ...over,
-  };
+  return { slug: "hero", tableName: "comp_hero", hasCompanion: false, ...over };
 }
+
+const COLUMN_RENAME = {
+  from: STORAGE_FORMAT.columns.type,
+  to: MIGRATION_TARGET.columnType,
+};
 
 describe("field-group migration manifest", () => {
   it("moves a prefixed table onto the new prefix", () => {
@@ -33,16 +33,36 @@ describe("field-group migration manifest", () => {
     expect(retargetName("my_seo_block")).toBeNull();
   });
 
-  it("renames the table and, when localized, its companion", () => {
+  it("renames the table, its companion, and its discriminator", () => {
     const { entries } = buildMigrationManifest([row({ hasCompanion: true })]);
     expect(entries).toEqual([
       { kind: "table", from: "comp_hero", to: "fg_hero" },
       { kind: "companion", from: "comp_hero_locales", to: "fg_hero_locales" },
+      { kind: "column", ...COLUMN_RENAME, table: "fg_hero" },
       {
         kind: "registry",
         from: "dynamic_components",
         to: "dynamic_field_groups",
       },
+    ]);
+  });
+
+  // The schema service emits the discriminator unconditionally and so do all
+  // three runtime schemas, so every field-group table has one. Renaming it only
+  // for some would leave the rest reachable under the wrong name.
+  it("renames the discriminator on every field group", () => {
+    const { entries } = buildMigrationManifest([
+      row({ tableName: "comp_a" }),
+      row({ tableName: "comp_b" }),
+      row({ tableName: "my_seo_block" }),
+    ]);
+    const columns = entries.filter(e => e.kind === "column");
+    expect(columns).toHaveLength(3);
+    expect(columns.map(c => c.table)).toEqual([
+      "fg_a",
+      "fg_b",
+      // Not renamed, so its column is addressed by the name it keeps.
+      "my_seo_block",
     ]);
   });
 
@@ -59,44 +79,21 @@ describe("field-group migration manifest", () => {
     });
   });
 
-  // Only dynamic zones carry the discriminator column.
-  it("renames the type column only where it exists", () => {
-    const without = buildMigrationManifest([row()]);
-    expect(without.entries.some(e => e.kind === "column")).toBe(false);
-
-    const withColumn = buildMigrationManifest([row({ hasTypeColumn: true })]);
-    expect(withColumn.entries).toContainEqual({
-      kind: "column",
-      from: STORAGE_FORMAT.columns.type,
-      to: MIGRATION_TARGET.columnType,
-      table: "fg_hero",
-    });
+  // A localized group with no translatable fields has no companion table, and
+  // the create path accepts exactly that. Naming one would make the step fail.
+  it("does not rename a companion that was never created", () => {
+    const { entries } = buildMigrationManifest([row({ hasCompanion: false })]);
+    expect(entries.some(e => e.kind === "companion")).toBe(false);
   });
 
   // The column rename runs after its table's, so addressing it by the old name
   // would fail: by then the old name resolves to nothing.
   it("addresses the column by its post-rename table", () => {
-    const { entries } = buildMigrationManifest([row({ hasTypeColumn: true })]);
-    const column = entries.find(e => e.kind === "column");
-    const table = entries.findIndex(e => e.kind === "table");
+    const { entries } = buildMigrationManifest([row()]);
+    const tableAt = entries.findIndex(e => e.kind === "table");
     const columnAt = entries.findIndex(e => e.kind === "column");
-    expect(column?.table).toBe("fg_hero");
-    expect(columnAt).toBeGreaterThan(table);
-  });
-
-  // A custom-named table is not renamed, so its column keeps being addressed by
-  // the name it already has.
-  it("addresses a custom-named table's column by its unchanged name", () => {
-    const { entries } = buildMigrationManifest([
-      row({ tableName: "my_seo_block", hasTypeColumn: true }),
-    ]);
-    expect(entries).toContainEqual({
-      kind: "column",
-      from: STORAGE_FORMAT.columns.type,
-      to: MIGRATION_TARGET.columnType,
-      table: "my_seo_block",
-    });
-    expect(entries.some(e => e.kind === "table")).toBe(false);
+    expect(entries[columnAt]?.table).toBe("fg_hero");
+    expect(columnAt).toBeGreaterThan(tableAt);
   });
 
   // While the registry answers to its old name a resumed run can rebuild this
@@ -149,31 +146,33 @@ describe("field-group migration manifest", () => {
     expect(a).not.toBe(b);
   });
 
-  // A localized group with no translatable fields has no companion table, and
-  // the create path accepts exactly that. Naming one would make the step fail.
-  it("does not rename a companion that was never created", () => {
-    const { entries } = buildMigrationManifest([row({ hasCompanion: false })]);
-    expect(entries.some(e => e.kind === "companion")).toBe(false);
+  // Progress is not identity. Reconciliation marks applied entries elsewhere,
+  // and the plan must still be recognised by the hash the marker recorded.
+  it("hashes a plan the same whether or not steps have been applied", () => {
+    const plan: ManifestEntry[] = [
+      { kind: "table", from: "comp_a", to: "fg_a" },
+      {
+        kind: "registry",
+        from: "dynamic_components",
+        to: "dynamic_field_groups",
+      },
+    ];
+    const applied: ManifestEntry[] = [
+      { ...plan[0], satisfied: true } as ManifestEntry,
+      plan[1] as ManifestEntry,
+    ];
+    expect(hashManifest(applied)).toBe(hashManifest(plan));
   });
 
   // `table_name` is unique but unconstrained, so a generated `comp_hero` and an
-  // author-named `fg_hero` can both exist today. The second is left alone by
-  // design, so the first would rename onto an occupied name mid-run.
-  it("refuses when a target name is taken by a row it leaves alone", () => {
-    expect(() =>
+  // author-named `fg_hero` can both exist. The second is left alone by design,
+  // so the first would rename onto an occupied name mid-run.
+  it("refuses when a target is taken by a row it leaves alone", () => {
+    try {
       buildMigrationManifest([
         row({ tableName: "comp_hero" }),
         row({ slug: "other", tableName: "fg_hero" }),
-      ])
-    ).toThrowError(NextlyError);
-  });
-
-  it("refuses when a target name is taken by a table outside the registry", () => {
-    try {
-      buildMigrationManifest([row({ tableName: "comp_hero" })], {
-        // A complete catalog: the source, the squatter, and the registry.
-        existingTables: ["comp_hero", "fg_hero", "dynamic_components"],
-      });
+      ]);
       expect.fail("expected a refusal");
     } catch (error) {
       expect((error as NextlyError).code).toBe("SERVICE_UNAVAILABLE");
@@ -181,95 +180,26 @@ describe("field-group migration manifest", () => {
     }
   });
 
-  // Renaming a table away frees its name, so a plan that moves comp_a to fg_a
-  // while something else vacates fg_a is not a collision.
-  it("allows a target whose occupant is itself being renamed away", () => {
-    expect(() =>
-      buildMigrationManifest([row({ tableName: "comp_hero" })], {
-        existingTables: ["comp_hero", "dynamic_components"],
-      })
-    ).not.toThrow();
-  });
-
-  // A run that crashed after a rename committed but before its marker write
-  // must rebuild the plan and find that step already satisfied, rather than
-  // reading its own finished work as a conflict.
-  it("marks a completed rename satisfied instead of removing it", () => {
-    const { entries } = buildMigrationManifest(
-      [row({ tableName: "comp_hero" })],
-      {
-        existingTables: ["fg_hero", "dynamic_field_groups"],
-      }
-    );
-    expect(entries).toEqual([
-      { kind: "table", from: "comp_hero", to: "fg_hero", satisfied: true },
-      {
-        kind: "registry",
-        from: "dynamic_components",
-        to: "dynamic_field_groups",
-        satisfied: true,
-      },
-    ]);
-  });
-
-  // The plan is positionally indexed and hash-identified, so progress must not
-  // change its identity: a resume would otherwise refuse the plan it resumes.
-  it("keeps the same hash once steps have been applied", () => {
-    const rows = [row({ tableName: "comp_a" }), row({ tableName: "comp_b" })];
-    const fresh = buildMigrationManifest(rows, {
-      existingTables: ["comp_a", "comp_b", "dynamic_components"],
-    });
-    const partlyDone = buildMigrationManifest(rows, {
-      existingTables: ["fg_a", "comp_b", "dynamic_components"],
-    });
-    expect(partlyDone.hash).toBe(fresh.hash);
-    expect(partlyDone.entries).toHaveLength(fresh.entries.length);
-    expect(partlyDone.entries[0]?.satisfied).toBe(true);
-    expect(partlyDone.entries[1]?.satisfied).toBeUndefined();
-  });
-
-  // The column names its post-rename table, which is legitimately absent from a
-  // pre-migration catalog. Dropping it would migrate the table and leave its
-  // discriminator behind.
-  it("keeps the column rename for a table this plan is about to create", () => {
-    const { entries } = buildMigrationManifest(
-      [row({ tableName: "comp_hero", hasTypeColumn: true })],
-      { existingTables: ["comp_hero", "dynamic_components"] }
-    );
-    const column = entries.find(e => e.kind === "column");
-    expect(column).toBeDefined();
-    expect(column?.satisfied).toBeUndefined();
-    expect(column?.table).toBe("fg_hero");
-  });
-
-  // Presence is matched exactly: on Postgres a quoted COMP_HERO is a different
-  // table, and folding would hide a genuinely missing source.
-  it("does not let a case-variant table mask a missing source", () => {
-    expect(() =>
-      buildMigrationManifest([row({ tableName: "comp_hero" })], {
-        existingTables: ["COMP_HERO", "dynamic_components"],
-      })
-    ).toThrowError(NextlyError);
-  });
-
-  // The registry names a table that is gone. Renaming it would fail after the
-  // marker had been written, so it is refused before the run starts.
-  it("refuses when the source table is missing entirely", () => {
-    expect(() =>
-      buildMigrationManifest([row({ tableName: "comp_hero" })], {
-        existingTables: ["dynamic_components"],
-      })
-    ).toThrowError(NextlyError);
-  });
-
   // SQLite matches table names case-insensitively, as does MySQL under the
-  // usual settings, so a case-different squatter is still a squatter.
-  it("catches a target collision that differs only in case", () => {
+  // usual settings, so a case-different name still occupies the target.
+  it("refuses a target conflict that differs only in case", () => {
     expect(() =>
-      buildMigrationManifest([row({ tableName: "comp_hero" })], {
-        existingTables: ["comp_hero", "FG_HERO", "dynamic_components"],
-      })
+      buildMigrationManifest([
+        row({ tableName: "comp_hero" }),
+        row({ slug: "other", tableName: "FG_HERO" }),
+      ])
     ).toThrowError(NextlyError);
+  });
+
+  // Renaming a table away frees its name, so two rows swapping prefixes is not
+  // a conflict.
+  it("allows a target whose occupant is itself renamed away", () => {
+    expect(() =>
+      buildMigrationManifest([
+        row({ tableName: "comp_a" }),
+        row({ slug: "b", tableName: "comp_b" }),
+      ])
+    ).not.toThrow();
   });
 
   // A rollback inverts what was applied. It is never derived from the prefix,
@@ -277,7 +207,7 @@ describe("field-group migration manifest", () => {
   // author chose before it existed.
   it("inverts an applied plan for rollback, in reverse order", () => {
     const up = buildMigrationManifest([
-      row({ tableName: "comp_hero", hasCompanion: true, hasTypeColumn: true }),
+      row({ tableName: "comp_hero", hasCompanion: true }),
     ]);
     const down = invertManifest(up.entries);
     expect(down.entries).toEqual([
@@ -299,21 +229,15 @@ describe("field-group migration manifest", () => {
   });
 
   // The case this protects: an author whose dbName was already `fg_hero` before
-  // any migration. Up leaves it alone, so nothing about it is in the plan, so a
-  // rollback cannot rename it either.
-  it("never touches a custom name the up plan left alone", () => {
+  // any migration. Up leaves the table alone, so a rollback cannot rename it.
+  it("never renames a custom table the up plan left alone", () => {
     const up = buildMigrationManifest([row({ tableName: "fg_hero" })]);
     const down = invertManifest(up.entries);
     expect(
-      down.entries.some(e => e.from === "fg_hero" || e.to === "fg_hero")
+      down.entries.some(
+        e => e.kind !== "column" && (e.from === "fg_hero" || e.to === "fg_hero")
+      )
     ).toBe(false);
-  });
-
-  // A plan rebuilt after a partial run must contain only outstanding work, so a
-  // row already carrying a migrated name contributes nothing.
-  it("produces no rename for a row already migrated", () => {
-    const { entries } = buildMigrationManifest([row({ tableName: "fg_hero" })]);
-    expect(entries.filter(e => e.kind !== "registry")).toEqual([]);
   });
 
   it("targets a prefix no longer than the one it replaces", () => {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { NextlyError } from "../../../../errors/nextly-error";
 import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
 import {
   buildMigrationManifest,
@@ -13,7 +14,7 @@ function row(over: Partial<RegistryRow> = {}): RegistryRow {
   return {
     slug: "hero",
     tableName: "comp_hero",
-    localized: false,
+    hasCompanion: false,
     hasTypeColumn: false,
     ...over,
   };
@@ -32,7 +33,7 @@ describe("field-group migration manifest", () => {
   });
 
   it("renames the table and, when localized, its companion", () => {
-    const { entries } = buildMigrationManifest([row({ localized: true })]);
+    const { entries } = buildMigrationManifest([row({ hasCompanion: true })]);
     expect(entries).toEqual([
       { kind: "table", from: "comp_hero", to: "fg_hero" },
       { kind: "companion", from: "comp_hero_locales", to: "fg_hero_locales" },
@@ -48,7 +49,7 @@ describe("field-group migration manifest", () => {
   // with an unexpected name still has its companion found.
   it("derives the companion from the read table name", () => {
     const { entries } = buildMigrationManifest([
-      row({ tableName: "comp_odd_name", localized: true }),
+      row({ tableName: "comp_odd_name", hasCompanion: true }),
     ]);
     expect(entries).toContainEqual({
       kind: "companion",
@@ -101,7 +102,7 @@ describe("field-group migration manifest", () => {
   // plan from it. Renaming it first would strand the resume.
   it("renames the registry last", () => {
     const { entries } = buildMigrationManifest([
-      row({ tableName: "comp_a", localized: true }),
+      row({ tableName: "comp_a", hasCompanion: true }),
       row({ tableName: "comp_b" }),
     ]);
     expect(entries[entries.length - 1]).toEqual({
@@ -145,6 +146,54 @@ describe("field-group migration manifest", () => {
       { kind: "table", from: "comp_a", to: "fg_a" },
     ]);
     expect(a).not.toBe(b);
+  });
+
+  // A localized group with no translatable fields has no companion table, and
+  // the create path accepts exactly that. Naming one would make the step fail.
+  it("does not rename a companion that was never created", () => {
+    const { entries } = buildMigrationManifest([row({ hasCompanion: false })]);
+    expect(entries.some(e => e.kind === "companion")).toBe(false);
+  });
+
+  // `table_name` is unique but unconstrained, so a generated `comp_hero` and an
+  // author-named `fg_hero` can both exist today. The second is left alone by
+  // design, so the first would rename onto an occupied name mid-run.
+  it("refuses when a target name is taken by a row it leaves alone", () => {
+    expect(() =>
+      buildMigrationManifest([
+        row({ tableName: "comp_hero" }),
+        row({ slug: "other", tableName: "fg_hero" }),
+      ])
+    ).toThrowError(NextlyError);
+  });
+
+  it("refuses when a target name is taken by a table outside the registry", () => {
+    try {
+      buildMigrationManifest([row({ tableName: "comp_hero" })], {
+        existingTables: ["fg_hero"],
+      });
+      expect.fail("expected a refusal");
+    } catch (error) {
+      expect((error as NextlyError).code).toBe("SERVICE_UNAVAILABLE");
+      expect((error as NextlyError).logContext?.to).toBe("fg_hero");
+    }
+  });
+
+  // Renaming a table away frees its name, so a plan that moves comp_a to fg_a
+  // while something else vacates fg_a is not a collision.
+  it("allows a target whose occupant is itself being renamed away", () => {
+    expect(() =>
+      buildMigrationManifest([row({ tableName: "comp_hero" })], {
+        existingTables: ["comp_hero"],
+      })
+    ).not.toThrow();
+  });
+
+  // A plan rebuilt after a partial run must contain only outstanding work, so a
+  // row already carrying a migrated name contributes nothing.
+  it("produces no rename for a row already migrated", () => {
+    const { entries } = buildMigrationManifest([row({ tableName: "fg_hero" })]);
+    expect(entries.filter(e => e.kind !== "registry")).toEqual([]);
   });
 
   it("targets a prefix no longer than the one it replaces", () => {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
@@ -170,7 +170,8 @@ describe("field-group migration manifest", () => {
   it("refuses when a target name is taken by a table outside the registry", () => {
     try {
       buildMigrationManifest([row({ tableName: "comp_hero" })], {
-        existingTables: ["fg_hero"],
+        // A complete catalog: the source, the squatter, and the registry.
+        existingTables: ["comp_hero", "fg_hero", "dynamic_components"],
       });
       expect.fail("expected a refusal");
     } catch (error) {
@@ -184,9 +185,70 @@ describe("field-group migration manifest", () => {
   it("allows a target whose occupant is itself being renamed away", () => {
     expect(() =>
       buildMigrationManifest([row({ tableName: "comp_hero" })], {
-        existingTables: ["comp_hero"],
+        existingTables: ["comp_hero", "dynamic_components"],
       })
     ).not.toThrow();
+  });
+
+  // A run that crashed after a rename committed but before its marker write
+  // must rebuild the plan and find that step already satisfied, rather than
+  // reading its own finished work as a conflict.
+  it("treats a completed rename as done, not as a collision", () => {
+    const { entries } = buildMigrationManifest(
+      [row({ tableName: "fg_hero" })],
+      { existingTables: ["fg_hero", "dynamic_field_groups"] }
+    );
+    expect(entries).toEqual([]);
+  });
+
+  // The registry names a table that is gone. Renaming it would fail after the
+  // marker had been written, so it is refused before the run starts.
+  it("refuses when the source table is missing entirely", () => {
+    expect(() =>
+      buildMigrationManifest([row({ tableName: "comp_hero" })], {
+        existingTables: ["dynamic_components"],
+      })
+    ).toThrowError(NextlyError);
+  });
+
+  // SQLite matches table names case-insensitively, as does MySQL under the
+  // usual settings, so a case-different squatter is still a squatter.
+  it("catches a target collision that differs only in case", () => {
+    expect(() =>
+      buildMigrationManifest([row({ tableName: "comp_hero" })], {
+        existingTables: ["comp_hero", "FG_HERO", "dynamic_components"],
+      })
+    ).toThrowError(NextlyError);
+  });
+
+  // The marker records a direction, so the plan has to be able to express one.
+  it("reverses the mapping for a down migration", () => {
+    const { entries } = buildMigrationManifest(
+      [row({ tableName: "fg_hero", hasCompanion: true })],
+      { direction: "down" }
+    );
+    expect(entries).toEqual([
+      { kind: "table", from: "fg_hero", to: "comp_hero" },
+      { kind: "companion", from: "fg_hero_locales", to: "comp_hero_locales" },
+      {
+        kind: "registry",
+        from: "dynamic_field_groups",
+        to: "dynamic_components",
+      },
+    ]);
+  });
+
+  it("reverses the column mapping too", () => {
+    const { entries } = buildMigrationManifest(
+      [row({ tableName: "fg_hero", hasTypeColumn: true })],
+      { direction: "down" }
+    );
+    expect(entries).toContainEqual({
+      kind: "column",
+      from: MIGRATION_TARGET.columnType,
+      to: STORAGE_FORMAT.columns.type,
+      table: "comp_hero",
+    });
   });
 
   // A plan rebuilt after a partial run must contain only outstanding work, so a

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test-d.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test-d.ts
@@ -1,0 +1,55 @@
+import { expectTypeOf } from "vitest";
+
+import type { ManifestEntry } from "../manifest";
+import type { BeginMigrationArgs, SettleArgs } from "../state";
+
+const PLAN = { manifestHash: "h", planHash: "p" };
+const APPLIED: ManifestEntry[] = [
+  { kind: "table", from: "comp_hero", to: "fg_hero" },
+];
+
+// The rules these unions exist to enforce are type-level, so they are asserted
+// type-level. A runtime test cannot show that an unsafe call fails to compile,
+// and a comment claiming a field is required has already proven unenforceable
+// here once.
+
+// A `down` run reverses a recorded plan and cannot derive one, so the plan is
+// not optional for it.
+expectTypeOf<BeginMigrationArgs>().toMatchTypeOf<
+  { direction: "up" } | { direction: "down" }
+>();
+
+expectTypeOf({
+  direction: "down" as const,
+  migrationId: "r",
+  plan: PLAN,
+  appliedManifest: APPLIED,
+}).toMatchTypeOf<BeginMigrationArgs>();
+
+// Without the plan, a down run is not a legal argument shape.
+expectTypeOf({
+  direction: "down" as const,
+  migrationId: "r",
+  plan: PLAN,
+}).not.toMatchTypeOf<BeginMigrationArgs>();
+
+// An up run builds its plan from registry rows, so it carries none in.
+expectTypeOf({
+  direction: "up" as const,
+  migrationId: "r",
+  plan: PLAN,
+}).toMatchTypeOf<BeginMigrationArgs>();
+
+// Settling at the migrated generation is the last moment the plan can be
+// recorded, and a rollback has no other source for it.
+expectTypeOf({
+  generation: "field-groups-v2" as const,
+  appliedManifest: APPLIED,
+}).toMatchTypeOf<SettleArgs>();
+
+expectTypeOf({
+  generation: "field-groups-v2" as const,
+}).not.toMatchTypeOf<SettleArgs>();
+
+// Settling back at legacy ends a reversal; there is nothing left to reverse.
+expectTypeOf({ generation: "legacy" as const }).toMatchTypeOf<SettleArgs>();

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -203,6 +203,52 @@ describe("field-group migration marker", () => {
     });
   });
 
+  // The plan must survive the transition out of `settled` and every step after
+  // it. Writing it only at settlement loses it the moment a rollback starts.
+  it("carries the applied plan through a run and its steps", async () => {
+    const { meta } = createMeta();
+    const applied = [
+      { kind: "table" as const, from: "fg_hero", to: "comp_hero" },
+      {
+        kind: "column" as const,
+        from: "_field_group_type",
+        to: "_component_type",
+        table: "fg_hero",
+      },
+    ];
+    await beginMigration(meta, {
+      direction: "down",
+      migrationId: "run-1",
+      plan: { manifestHash: "hash-1", planHash: "plan-1" },
+      appliedManifest: applied,
+    });
+    await expect(readMigrationState(meta)).resolves.toMatchObject({
+      status: "migrating",
+      appliedManifest: applied,
+    });
+
+    await advanceStep(meta, { migrationId: "run-1", step: 1 });
+    await expect(readMigrationState(meta)).resolves.toMatchObject({
+      status: "migrating",
+      step: 1,
+      appliedManifest: applied,
+    });
+  });
+
+  // A column rename is addressed through its table, so an entry without one
+  // cannot be executed or reversed.
+  it("refuses a recorded column entry that names no table", async () => {
+    const { meta } = createMeta({
+      version: MIGRATION_MARKER_VERSION,
+      status: "settled",
+      generation: "field-groups-v2",
+      appliedManifest: [
+        { kind: "column", from: "_component_type", to: "_field_group_type" },
+      ],
+    });
+    await expect(readMigrationState(meta)).rejects.toThrowError(NextlyError);
+  });
+
   // A rollback reverses a persisted plan, so the plan has to survive
   // settlement. Deriving the reverse is impossible: nothing in the database
   // says which `fg_*` names this migration created.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -261,10 +261,22 @@ describe("field-group migration marker", () => {
       [{ kind: "table" as const, from: "fg_a", to: "comp_a" }],
     ],
     [
+      "a registry entry that renames something else",
+      [{ kind: "registry" as const, from: "x", to: "y" }],
+    ],
+    [
       "a list renaming the registry twice",
       [
-        { kind: "registry" as const, from: "a", to: "b" },
-        { kind: "registry" as const, from: "c", to: "d" },
+        {
+          kind: "registry" as const,
+          from: "dynamic_components",
+          to: "dynamic_field_groups",
+        },
+        {
+          kind: "registry" as const,
+          from: "dynamic_field_groups",
+          to: "dynamic_components",
+        },
       ],
     ],
   ])("refuses a recorded plan that is %s", async (_label, appliedManifest) => {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { NextlyError } from "../../../../errors/nextly-error";
 import type { MetaService } from "../../../meta/services/meta-service";
+import { buildMigrationManifest } from "../manifest";
 import {
   advanceStep,
   MAX_MIGRATION_STEP,
@@ -197,7 +198,14 @@ describe("field-group migration marker", () => {
     });
     await settleMigration(meta, {
       generation: "field-groups-v2",
-      appliedManifest: [{ kind: "table", from: "comp_hero", to: "fg_hero" }],
+      appliedManifest: [
+        { kind: "table", from: "comp_hero", to: "fg_hero" },
+        {
+          kind: "registry",
+          from: "dynamic_components",
+          to: "dynamic_field_groups",
+        },
+      ],
     });
     await expect(readMigrationState(meta)).resolves.toMatchObject({
       status: "settled",
@@ -211,6 +219,11 @@ describe("field-group migration marker", () => {
   it("carries the applied plan through a run and its steps", async () => {
     const { meta } = createMeta();
     const applied = [
+      {
+        kind: "registry" as const,
+        from: "dynamic_field_groups",
+        to: "dynamic_components",
+      },
       { kind: "table" as const, from: "fg_hero", to: "comp_hero" },
       {
         kind: "column" as const,
@@ -238,6 +251,48 @@ describe("field-group migration marker", () => {
     });
   });
 
+  // Every plan renames the registry exactly once, so a recorded plan without
+  // that entry is a fragment. Reversing it would restore the data tables and
+  // leave the registry migrated -- a state no direction can then interpret.
+  it.each([
+    ["an empty list", []],
+    [
+      "a list with no registry rename",
+      [{ kind: "table" as const, from: "fg_a", to: "comp_a" }],
+    ],
+    [
+      "a list renaming the registry twice",
+      [
+        { kind: "registry" as const, from: "a", to: "b" },
+        { kind: "registry" as const, from: "c", to: "d" },
+      ],
+    ],
+  ])("refuses a recorded plan that is %s", async (_label, appliedManifest) => {
+    const { meta } = createMeta({
+      version: MIGRATION_MARKER_VERSION,
+      status: "settled",
+      generation: "field-groups-v2",
+      appliedManifest,
+    });
+    await expect(readMigrationState(meta)).rejects.toThrowError(NextlyError);
+  });
+
+  // A plan built by the manifest always satisfies that invariant, so the
+  // round-trip has to keep working.
+  it("accepts a plan built by the manifest builder", async () => {
+    const { meta } = createMeta();
+    const built = buildMigrationManifest([
+      { slug: "hero", tableName: "comp_hero", hasCompanion: false },
+    ]);
+    await settleMigration(meta, {
+      generation: "field-groups-v2",
+      appliedManifest: built.entries,
+    });
+    await expect(readMigrationState(meta)).resolves.toMatchObject({
+      appliedManifest: built.entries,
+    });
+  });
+
   // The writer holds itself to the reader's rules. Writing a plan the next read
   // refuses would strand a run after its first step had already committed.
   it.each([
@@ -258,7 +313,16 @@ describe("field-group migration marker", () => {
         direction: "down",
         migrationId: "run-1",
         plan: { manifestHash: "h", planHash: "p" },
-        appliedManifest: [entry],
+        // Otherwise valid: the registry entry is present, so the refusal is
+        // attributable to the bad entry rather than to a missing registry.
+        appliedManifest: [
+          {
+            kind: "registry" as const,
+            from: "dynamic_field_groups",
+            to: "dynamic_components",
+          },
+          entry,
+        ],
       })
     ).rejects.toThrowError(NextlyError);
     expect(read()).toBe(ABSENT);
@@ -269,7 +333,14 @@ describe("field-group migration marker", () => {
     await expect(
       settleMigration(meta, {
         generation: "field-groups-v2",
-        appliedManifest: [{ kind: "table", from: "comp_a", to: "" }],
+        appliedManifest: [
+          {
+            kind: "registry",
+            from: "dynamic_components",
+            to: "dynamic_field_groups",
+          },
+          { kind: "table", from: "comp_a", to: "" },
+        ],
       })
     ).rejects.toThrowError(NextlyError);
     expect(read()).toBe(ABSENT);
@@ -283,6 +354,11 @@ describe("field-group migration marker", () => {
       status: "settled",
       generation: "field-groups-v2",
       appliedManifest: [
+        {
+          kind: "registry",
+          from: "dynamic_components",
+          to: "dynamic_field_groups",
+        },
         { kind: "column", from: "_component_type", to: "_field_group_type" },
       ],
     });
@@ -301,6 +377,11 @@ describe("field-group migration marker", () => {
         from: "_component_type",
         to: "_field_group_type",
         table: "fg_hero",
+      },
+      {
+        kind: "registry" as const,
+        from: "dynamic_components",
+        to: "dynamic_field_groups",
       },
     ];
     await settleMigration(meta, {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -238,6 +238,43 @@ describe("field-group migration marker", () => {
     });
   });
 
+  // The writer holds itself to the reader's rules. Writing a plan the next read
+  // refuses would strand a run after its first step had already committed.
+  it.each([
+    ["an empty source", { kind: "table" as const, from: "", to: "fg_a" }],
+    ["an empty target", { kind: "table" as const, from: "comp_a", to: "" }],
+    [
+      "a column with no table",
+      {
+        kind: "column" as const,
+        from: "_component_type",
+        to: "_field_group_type",
+      },
+    ],
+  ])("refuses to begin a rollback with %s in the plan", async (_l, entry) => {
+    const { meta, read } = createMeta();
+    await expect(
+      beginMigration(meta, {
+        direction: "down",
+        migrationId: "run-1",
+        plan: { manifestHash: "h", planHash: "p" },
+        appliedManifest: [entry],
+      })
+    ).rejects.toThrowError(NextlyError);
+    expect(read()).toBe(ABSENT);
+  });
+
+  it("refuses to settle with a plan its own reader would reject", async () => {
+    const { meta, read } = createMeta();
+    await expect(
+      settleMigration(meta, {
+        generation: "field-groups-v2",
+        appliedManifest: [{ kind: "table", from: "comp_a", to: "" }],
+      })
+    ).rejects.toThrowError(NextlyError);
+    expect(read()).toBe(ABSENT);
+  });
+
   // A column rename is addressed through its table, so an entry without one
   // cannot be executed or reversed.
   it("refuses a recorded column entry that names no table", async () => {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -218,17 +218,19 @@ describe("field-group migration marker", () => {
   // it. Writing it only at settlement loses it the moment a rollback starts.
   it("carries the applied plan through a run and its steps", async () => {
     const { meta } = createMeta();
+    // A down run records the plan that was APPLIED, not its inverse: the record
+    // says what happened, and the rollback inverts it when it executes.
     const applied = [
       {
         kind: "registry" as const,
-        from: "dynamic_field_groups",
-        to: "dynamic_components",
+        from: "dynamic_components",
+        to: "dynamic_field_groups",
       },
-      { kind: "table" as const, from: "fg_hero", to: "comp_hero" },
+      { kind: "table" as const, from: "comp_hero", to: "fg_hero" },
       {
         kind: "column" as const,
-        from: "_field_group_type",
-        to: "_component_type",
+        from: "_component_type",
+        to: "_field_group_type",
         table: "fg_hero",
       },
     ];
@@ -263,6 +265,18 @@ describe("field-group migration marker", () => {
     [
       "a registry entry that renames something else",
       [{ kind: "registry" as const, from: "x", to: "y" }],
+    ],
+    [
+      // The inverse of an applied plan is not a record of applied work. Storing
+      // it would let a rollback invert it twice and migrate forward.
+      "a pre-inverted registry entry",
+      [
+        {
+          kind: "registry" as const,
+          from: "dynamic_field_groups",
+          to: "dynamic_components",
+        },
+      ],
     ],
     [
       "a list renaming the registry twice",
@@ -330,8 +344,8 @@ describe("field-group migration marker", () => {
         appliedManifest: [
           {
             kind: "registry" as const,
-            from: "dynamic_field_groups",
-            to: "dynamic_components",
+            from: "dynamic_components",
+            to: "dynamic_field_groups",
           },
           entry,
         ],

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -195,8 +195,11 @@ describe("field-group migration marker", () => {
       migrationId: "run-1",
       plan: { manifestHash: "hash-1", planHash: "plan-1" },
     });
-    await settleMigration(meta, "field-groups-v2");
-    await expect(readMigrationState(meta)).resolves.toEqual({
+    await settleMigration(meta, {
+      generation: "field-groups-v2",
+      appliedManifest: [{ kind: "table", from: "comp_hero", to: "fg_hero" }],
+    });
+    await expect(readMigrationState(meta)).resolves.toMatchObject({
       status: "settled",
       generation: "field-groups-v2",
       recorded: true,
@@ -263,7 +266,10 @@ describe("field-group migration marker", () => {
         table: "fg_hero",
       },
     ];
-    await settleMigration(meta, "field-groups-v2", applied);
+    await settleMigration(meta, {
+      generation: "field-groups-v2",
+      appliedManifest: applied,
+    });
     await expect(readMigrationState(meta)).resolves.toMatchObject({
       status: "settled",
       generation: "field-groups-v2",
@@ -271,9 +277,12 @@ describe("field-group migration marker", () => {
     });
   });
 
-  it("settles without a plan when none was recorded", async () => {
+  // Settling back at `legacy` ends a reversal, so there is nothing left to
+  // reverse and no plan to carry. The v2 case cannot be settled this way: the
+  // type does not allow it.
+  it("settles at legacy without a plan", async () => {
     const { meta } = createMeta();
-    await settleMigration(meta, "legacy");
+    await settleMigration(meta, { generation: "legacy" });
     const state = await readMigrationState(meta);
     expect(state).toMatchObject({ status: "settled", generation: "legacy" });
     expect(

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -203,6 +203,60 @@ describe("field-group migration marker", () => {
     });
   });
 
+  // A rollback reverses a persisted plan, so the plan has to survive
+  // settlement. Deriving the reverse is impossible: nothing in the database
+  // says which `fg_*` names this migration created.
+  it("keeps the applied plan through settlement", async () => {
+    const { meta } = createMeta();
+    const applied = [
+      { kind: "table" as const, from: "comp_hero", to: "fg_hero" },
+      {
+        kind: "column" as const,
+        from: "_component_type",
+        to: "_field_group_type",
+        table: "fg_hero",
+      },
+    ];
+    await settleMigration(meta, "field-groups-v2", applied);
+    await expect(readMigrationState(meta)).resolves.toMatchObject({
+      status: "settled",
+      generation: "field-groups-v2",
+      appliedManifest: applied,
+    });
+  });
+
+  it("settles without a plan when none was recorded", async () => {
+    const { meta } = createMeta();
+    await settleMigration(meta, "legacy");
+    const state = await readMigrationState(meta);
+    expect(state).toMatchObject({ status: "settled", generation: "legacy" });
+    expect(
+      (state as { appliedManifest?: unknown }).appliedManifest
+    ).toBeUndefined();
+  });
+
+  // A rollback acts on this plan, so an unreadable one must refuse rather than
+  // revert some objects and silently leave others migrated.
+  it.each([
+    ["not a list", "nonsense"],
+    ["a non-object entry", [42]],
+    ["an entry with no known kind", [{ kind: "whatever", from: "a", to: "b" }]],
+    ["an entry with no source", [{ kind: "table", to: "b" }]],
+    ["an entry with no target", [{ kind: "table", from: "a" }]],
+    [
+      "an entry with an invalid table",
+      [{ kind: "column", from: "a", to: "b", table: 7 }],
+    ],
+  ])("refuses a recorded plan that is %s", async (_label, appliedManifest) => {
+    const { meta } = createMeta({
+      version: MIGRATION_MARKER_VERSION,
+      status: "settled",
+      generation: "field-groups-v2",
+      appliedManifest,
+    });
+    await expect(readMigrationState(meta)).rejects.toThrowError(NextlyError);
+  });
+
   // A marker that exists but cannot be read must never degrade to "absent":
   // that would restart a run which may already have renamed objects.
   it.each([

--- a/packages/nextly/src/domains/field-groups/migration/guard.ts
+++ b/packages/nextly/src/domains/field-groups/migration/guard.ts
@@ -19,12 +19,9 @@
 
 import { NextlyError } from "../../../errors/nextly-error";
 
+import type { ManifestEntry } from "./manifest";
 import { MAX_MIGRATION_STEP } from "./state";
-import type {
-  MigrationDirection,
-  MigrationPlanIdentity,
-  MigrationState,
-} from "./state";
+import type { MigrationPlanIdentity, MigrationState } from "./state";
 
 /**
  * Whether every object the migrated registry points at is actually there and
@@ -71,9 +68,23 @@ export type StorageVerdict =
   | {
       action: "resume";
       step: number;
-      direction: MigrationDirection;
+      direction: "up";
       migrationId: string;
       plan: MigrationPlanIdentity;
+    }
+  | {
+      /**
+       * Resuming a rollback. The plan being reversed travels with the verdict
+       * because it cannot be derived: nothing in the database says which names
+       * this migration created, so a restarted process has no other source for
+       * the steps it still has to undo.
+       */
+      action: "resume";
+      step: number;
+      direction: "down";
+      migrationId: string;
+      plan: MigrationPlanIdentity;
+      appliedManifest: readonly ManifestEntry[];
     };
 
 /**
@@ -104,10 +115,29 @@ export function resolveStorageVerdict(args: {
     // a state only the step list can interpret. The run's own identity travels
     // with the step so the resumed run picks the right list, keeps the same id,
     // and can refuse a plan that moved underneath it.
+    if (state.direction === "down") {
+      // A rollback reverses a recorded plan. An in-flight `down` marker without
+      // one cannot be resumed at all, and guessing the reverse from the database
+      // would rename names this migration never created.
+      if (state.appliedManifest === undefined) {
+        throw refuse("an interrupted rollback recorded no plan to reverse", {
+          step: state.step,
+          migrationId: state.migrationId,
+        });
+      }
+      return {
+        action: "resume",
+        step: state.step + 1,
+        direction: "down",
+        migrationId: state.migrationId,
+        plan: state.plan,
+        appliedManifest: state.appliedManifest,
+      };
+    }
     return {
       action: "resume",
       step: state.step + 1,
-      direction: state.direction,
+      direction: "up",
       migrationId: state.migrationId,
       plan: state.plan,
     };

--- a/packages/nextly/src/domains/field-groups/migration/manifest.ts
+++ b/packages/nextly/src/domains/field-groups/migration/manifest.ts
@@ -14,6 +14,8 @@ import { createHash } from "node:crypto";
 import { NextlyError } from "../../../errors/nextly-error";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 
+import type { MigrationDirection } from "./state";
+
 /**
  * The names storage moves to.
  *
@@ -26,6 +28,23 @@ export const MIGRATION_TARGET = {
   tablePrefix: "fg_",
   columnType: "_field_group_type",
 } as const;
+
+/** The names this direction moves storage from and to. */
+function vocabulary(direction: MigrationDirection) {
+  const up = direction === "up";
+  return {
+    tableFrom: up ? STORAGE_FORMAT.tablePrefix : MIGRATION_TARGET.tablePrefix,
+    tableTo: up ? MIGRATION_TARGET.tablePrefix : STORAGE_FORMAT.tablePrefix,
+    registryFrom: up
+      ? STORAGE_FORMAT.registryTable
+      : MIGRATION_TARGET.registryTable,
+    registryTo: up
+      ? MIGRATION_TARGET.registryTable
+      : STORAGE_FORMAT.registryTable,
+    columnFrom: up ? STORAGE_FORMAT.columns.type : MIGRATION_TARGET.columnType,
+    columnTo: up ? MIGRATION_TARGET.columnType : STORAGE_FORMAT.columns.type,
+  };
+}
 
 /** A registry row, as far as the migration is concerned. */
 export interface RegistryRow {
@@ -73,11 +92,13 @@ export interface MigrationManifest {
  * `table_name` has to be read rather than derived: it decides not just what the
  * objects are called, but which of them are ours to rename at all.
  */
-export function retargetName(name: string): string | null {
-  if (!name.startsWith(STORAGE_FORMAT.tablePrefix)) return null;
-  return `${MIGRATION_TARGET.tablePrefix}${name.slice(
-    STORAGE_FORMAT.tablePrefix.length
-  )}`;
+export function retargetName(
+  name: string,
+  direction: MigrationDirection = "up"
+): string | null {
+  const { tableFrom, tableTo } = vocabulary(direction);
+  if (!name.startsWith(tableFrom)) return null;
+  return `${tableTo}${name.slice(tableFrom.length)}`;
 }
 
 /**
@@ -97,8 +118,20 @@ export function retargetName(name: string): string | null {
  */
 export function buildMigrationManifest(
   rows: readonly RegistryRow[],
-  options: { existingTables?: readonly string[] } = {}
+  options: {
+    direction?: MigrationDirection;
+    /**
+     * Every table in the database, not only the ones this migration expects.
+     *
+     * Partial input is worse than none: a source missing from an incomplete
+     * list reads as a rename that already happened. Omit it entirely when the
+     * catalog is not available, and only plan-level conflicts are checked.
+     */
+    existingTables?: readonly string[];
+  } = {}
 ): MigrationManifest {
+  const direction = options.direction ?? "up";
+  const v = vocabulary(direction);
   const entries: ManifestEntry[] = [];
 
   // Sorted by the stored table name so the plan is stable across runs. Step
@@ -112,15 +145,15 @@ export function buildMigrationManifest(
     // Idempotent by construction: a row already carrying a migrated name
     // produces no rename, so a plan rebuilt after a partial run contains only
     // the work still outstanding.
-    const target = retargetName(row.tableName);
+    const target = retargetName(row.tableName, direction);
     if (target === null) {
       // Custom-named: nothing to retire. Its column may still need renaming,
       // which is why this continues rather than skipping the row entirely.
       if (row.hasTypeColumn) {
         entries.push({
           kind: "column",
-          from: STORAGE_FORMAT.columns.type,
-          to: MIGRATION_TARGET.columnType,
+          from: v.columnFrom,
+          to: v.columnTo,
           table: row.tableName,
         });
       }
@@ -145,8 +178,8 @@ export function buildMigrationManifest(
       // the table rename, so the old name no longer resolves.
       entries.push({
         kind: "column",
-        from: STORAGE_FORMAT.columns.type,
-        to: MIGRATION_TARGET.columnType,
+        from: v.columnFrom,
+        to: v.columnTo,
         table: target,
       });
     }
@@ -154,13 +187,16 @@ export function buildMigrationManifest(
 
   entries.push({
     kind: "registry",
-    from: STORAGE_FORMAT.registryTable,
-    to: MIGRATION_TARGET.registryTable,
+    from: v.registryFrom,
+    to: v.registryTo,
   });
 
-  assertNoTargetCollision(entries, rows, options.existingTables ?? []);
+  const planned = options.existingTables
+    ? reconcileWithCatalog(entries, options.existingTables)
+    : entries;
+  assertNoTargetConflict(planned, rows);
 
-  return { entries, hash: hashManifest(entries) };
+  return { entries: planned, hash: hashManifest(planned) };
 }
 
 /**
@@ -179,64 +215,128 @@ export function hashManifest(entries: readonly ManifestEntry[]): string {
 }
 
 /**
- * Refuse a plan that would rename onto a name something else already answers to.
+ * Compare identifiers the way the loosest supported database would.
  *
- * `table_name` is unique but unconstrained, so a database can legitimately hold
- * both a generated `comp_hero` and another group whose author named its table
- * `fg_hero`. Nothing today prevents that pair, and the second one is left
- * untouched by design, so the first would rename onto an occupied name and fail
- * partway through the run.
- *
- * Detected before the migration starts rather than discovered during it: a
- * refusal here costs an operator a rename, while the same collision found
- * mid-run leaves storage half-migrated.
+ * SQLite matches table names case-insensitively, and MySQL does too under the
+ * usual `lower_case_table_names` settings. Comparing case-sensitively would let
+ * an existing `FG_HERO` slip past a check for `fg_hero` and fail the rename
+ * after the run had already started. Postgres can genuinely hold both, so this
+ * is stricter than Postgres requires — deliberately, because a refusal before
+ * the run costs an operator a rename while a failure during it leaves storage
+ * half-migrated.
  */
-function assertNoTargetCollision(
+function fold(name: string): string {
+  return name.toLowerCase();
+}
+
+/**
+ * Decide each rename against what the database actually contains.
+ *
+ * Four states, and only one of them is ordinary work:
+ *
+ * | source | target | meaning |
+ * |---|---|---|
+ * | present | absent  | the rename still has to happen |
+ * | absent  | present | this migration already did it; drop the entry |
+ * | present | present | something else owns the target; refuse |
+ * | absent  | absent  | the registry names a table that is gone; refuse |
+ *
+ * The second row is what makes a resume work. A run that crashed after a rename
+ * committed but before its marker write must be able to rebuild the plan and
+ * find that step already satisfied, rather than reading its own finished work
+ * as a conflict.
+ */
+function reconcileWithCatalog(
   entries: readonly ManifestEntry[],
-  rows: readonly RegistryRow[],
   existingTables: readonly string[]
+): ManifestEntry[] {
+  const catalog = new Set(existingTables.map(fold));
+  const kept: ManifestEntry[] = [];
+
+  for (const entry of entries) {
+    if (entry.kind === "column") {
+      // A column belongs to a table; if that table is not there, neither is it.
+      if (entry.table === undefined || catalog.has(fold(entry.table))) {
+        kept.push(entry);
+      }
+      continue;
+    }
+
+    const sourcePresent = catalog.has(fold(entry.from));
+    const targetPresent = catalog.has(fold(entry.to));
+
+    if (sourcePresent && targetPresent) {
+      throw refuseRename(
+        entry,
+        "migration target name is already in use",
+        `${entry.to} already exists while ${entry.from} still does`
+      );
+    }
+    if (!sourcePresent && !targetPresent) {
+      throw refuseRename(
+        entry,
+        "migration source object is missing",
+        `neither ${entry.from} nor ${entry.to} exists`
+      );
+    }
+    if (sourcePresent) kept.push(entry);
+    // Otherwise the target is present and the source is gone: already renamed.
+  }
+
+  return kept;
+}
+
+/**
+ * No two entries may claim the same name, and none may claim a name a registry
+ * row is keeping.
+ *
+ * Checked without needing a catalog, because both facts are properties of the
+ * plan and its inputs. A row whose table is left alone — one named through
+ * `dbName` — still occupies its name, and `table_name` being unique does not
+ * stop `comp_hero` and `fg_hero` coexisting.
+ */
+function assertNoTargetConflict(
+  entries: readonly ManifestEntry[],
+  rows: readonly RegistryRow[]
 ): void {
   const renamedAway = new Set(
-    entries.filter(e => e.kind !== "column").map(e => e.from)
+    entries.filter(e => e.kind !== "column").map(e => fold(e.from))
   );
-
-  // Names that will still be in use once the plan finishes: rows this plan
-  // leaves alone, plus catalog tables it never touches.
-  const survivors = new Set<string>();
-  for (const row of rows) {
-    if (!renamedAway.has(row.tableName)) survivors.add(row.tableName);
-  }
-  for (const table of existingTables) {
-    if (!renamedAway.has(table)) survivors.add(table);
-  }
+  const kept = new Set(
+    rows.map(r => fold(r.tableName)).filter(name => !renamedAway.has(name))
+  );
 
   const claimed = new Map<string, string>();
   for (const entry of entries) {
     if (entry.kind === "column") continue;
+    const key = fold(entry.to);
 
-    if (survivors.has(entry.to)) {
-      throw collision(
-        entry.from,
-        entry.to,
-        "an object that is not being renamed"
+    if (kept.has(key)) {
+      throw refuseRename(
+        entry,
+        "migration target name is already in use",
+        `${entry.to} belongs to a field group this plan leaves unchanged`
       );
     }
-    const previous = claimed.get(entry.to);
+    const previous = claimed.get(key);
     if (previous !== undefined) {
-      throw collision(entry.from, entry.to, `the rename of ${previous}`);
+      throw refuseRename(
+        entry,
+        "two objects would be renamed to the same name",
+        `${previous} also renames to ${entry.to}`
+      );
     }
-    claimed.set(entry.to, entry.from);
+    claimed.set(key, entry.from);
   }
 }
 
-function collision(from: string, to: string, occupant: string): NextlyError {
+function refuseRename(
+  entry: ManifestEntry,
+  reason: string,
+  detail: string
+): NextlyError {
   return NextlyError.serviceUnavailable({
-    logMessage: `field-group migration cannot rename ${from}: ${to} is already taken`,
-    logContext: {
-      reason: "migration target name is already in use",
-      from,
-      to,
-      occupiedBy: occupant,
-    },
+    logMessage: `field-group migration cannot rename ${entry.from}: ${detail}`,
+    logContext: { reason, from: entry.from, to: entry.to, detail },
   });
 }

--- a/packages/nextly/src/domains/field-groups/migration/manifest.ts
+++ b/packages/nextly/src/domains/field-groups/migration/manifest.ts
@@ -1,0 +1,157 @@
+/**
+ * What the storage migration will rename, derived from the database.
+ *
+ * The plan is built from the registry rather than from configuration, because
+ * only the registry knows what the objects are actually called. A field group
+ * whose table was named through `dbName` carries whatever the author chose, and
+ * a name cannot be recomputed from a slug once that has happened.
+ *
+ * @module domains/field-groups/migration/manifest
+ */
+
+import { createHash } from "node:crypto";
+
+import { STORAGE_FORMAT } from "../../../schemas/storage-format";
+
+/**
+ * The names storage moves to.
+ *
+ * `dynamic_field_groups` is parallel to `dynamic_collections` and
+ * `dynamic_singles`. `fg_` is deliberately shorter than the prefix it replaces,
+ * so no name that fits an identifier limit today can overflow one by migrating.
+ */
+export const MIGRATION_TARGET = {
+  registryTable: "dynamic_field_groups",
+  tablePrefix: "fg_",
+  columnType: "_field_group_type",
+} as const;
+
+/** A registry row, as far as the migration is concerned. */
+export interface RegistryRow {
+  slug: string;
+  /** Read from `table_name`. Never recomputed from the slug. */
+  tableName: string;
+  /** Localized groups keep translations in a companion table. */
+  localized: boolean;
+  /** Dynamic zones carry the type discriminator column; fixed groups do not. */
+  hasTypeColumn: boolean;
+}
+
+/** One thing the migration will rename. */
+export interface ManifestEntry {
+  kind: "registry" | "table" | "companion" | "column";
+  from: string;
+  to: string;
+  /** Set for `column`, naming the table the column belongs to. */
+  table?: string;
+}
+
+export interface MigrationManifest {
+  entries: ManifestEntry[];
+  /**
+   * Identifies the object map this plan was built against. Recorded when a run
+   * starts so a resume can refuse a plan that has since moved.
+   */
+  hash: string;
+}
+
+/**
+ * Rename a legacy-prefixed name onto the new prefix, or leave it alone.
+ *
+ * A table only gets renamed when it actually carries the prefix this migration
+ * is retiring. One named through `dbName` was never named after the concept —
+ * `my_seo_block` contains no vocabulary to migrate — and rewriting it would
+ * change a name its author chose, for no benefit. This is the second reason
+ * `table_name` has to be read rather than derived: it decides not just what the
+ * objects are called, but which of them are ours to rename at all.
+ */
+export function retargetName(name: string): string | null {
+  if (!name.startsWith(STORAGE_FORMAT.tablePrefix)) return null;
+  return `${MIGRATION_TARGET.tablePrefix}${name.slice(
+    STORAGE_FORMAT.tablePrefix.length
+  )}`;
+}
+
+/**
+ * Build the ordered rename plan.
+ *
+ * The registry is renamed **last**. While it still answers to its old name a
+ * resumed run can rebuild this plan from it; renaming it first would leave a
+ * resume unable to find the plan it was meant to finish.
+ */
+export function buildMigrationManifest(
+  rows: readonly RegistryRow[]
+): MigrationManifest {
+  const entries: ManifestEntry[] = [];
+
+  // Sorted by the stored table name so the plan is stable across runs. Step
+  // numbers index into this list, so an unstable order would make a resumed
+  // step point at a different object.
+  const ordered = [...rows].sort((a, b) =>
+    a.tableName < b.tableName ? -1 : a.tableName > b.tableName ? 1 : 0
+  );
+
+  for (const row of ordered) {
+    const target = retargetName(row.tableName);
+    if (target === null) {
+      // Custom-named: nothing to retire. Its column may still need renaming,
+      // which is why this continues rather than skipping the row entirely.
+      if (row.hasTypeColumn) {
+        entries.push({
+          kind: "column",
+          from: STORAGE_FORMAT.columns.type,
+          to: MIGRATION_TARGET.columnType,
+          table: row.tableName,
+        });
+      }
+      continue;
+    }
+
+    entries.push({ kind: "table", from: row.tableName, to: target });
+
+    if (row.localized) {
+      // Derived from the table name that was read, not from the slug, so a
+      // custom-named table's companion is still found.
+      const suffix = STORAGE_FORMAT.companionSuffix;
+      entries.push({
+        kind: "companion",
+        from: `${row.tableName}${suffix}`,
+        to: `${target}${suffix}`,
+      });
+    }
+
+    if (row.hasTypeColumn) {
+      // Addressed by its post-rename table name: the column rename runs after
+      // the table rename, so the old name no longer resolves.
+      entries.push({
+        kind: "column",
+        from: STORAGE_FORMAT.columns.type,
+        to: MIGRATION_TARGET.columnType,
+        table: target,
+      });
+    }
+  }
+
+  entries.push({
+    kind: "registry",
+    from: STORAGE_FORMAT.registryTable,
+    to: MIGRATION_TARGET.registryTable,
+  });
+
+  return { entries, hash: hashManifest(entries) };
+}
+
+/**
+ * Hash the plan's object map.
+ *
+ * Covers what will be renamed and in what order, so a schema change between an
+ * interrupted run and its resume is detected. It deliberately does not cover
+ * the step list the running build produces; that is a separate hash, because a
+ * Nextly upgrade can reorder steps while this map is untouched.
+ */
+export function hashManifest(entries: readonly ManifestEntry[]): string {
+  const canonical = entries
+    .map(e => `${e.kind}:${e.table ?? ""}:${e.from}>${e.to}`)
+    .join("\n");
+  return createHash("sha256").update(canonical).digest("hex");
+}

--- a/packages/nextly/src/domains/field-groups/migration/manifest.ts
+++ b/packages/nextly/src/domains/field-groups/migration/manifest.ts
@@ -11,6 +11,7 @@
 
 import { createHash } from "node:crypto";
 
+import { NextlyError } from "../../../errors/nextly-error";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 
 /**
@@ -31,8 +32,15 @@ export interface RegistryRow {
   slug: string;
   /** Read from `table_name`. Never recomputed from the slug. */
   tableName: string;
-  /** Localized groups keep translations in a companion table. */
-  localized: boolean;
+  /**
+   * Whether a companion table is physically present.
+   *
+   * Deliberately not `localized`: a localized group with no translatable
+   * fields has no companion, and the create path accepts exactly that. Reading
+   * this from the catalog rather than inferring it keeps the plan from naming
+   * a table that was never created.
+   */
+  hasCompanion: boolean;
   /** Dynamic zones carry the type discriminator column; fixed groups do not. */
   hasTypeColumn: boolean;
 }
@@ -75,12 +83,21 @@ export function retargetName(name: string): string | null {
 /**
  * Build the ordered rename plan.
  *
- * The registry is renamed **last**. While it still answers to its old name a
- * resumed run can rebuild this plan from it; renaming it first would leave a
- * resume unable to find the plan it was meant to finish.
+ * The registry is renamed **last**, so that for every step but the final one
+ * the plan can still be rebuilt from the legacy registry on resume.
+ *
+ * That ordering is necessary but not sufficient. The final step has the same
+ * commit-before-marker crash window as any other: once the registry rename
+ * commits, a crash before the marker records it leaves a resume that must retry
+ * a step whose source table no longer exists. So callers must read registry
+ * rows from whichever registry is present — legacy first, then the migrated
+ * name — and this function must produce an identical plan from either. It does,
+ * because the rows are the only input and the entries are derived from them
+ * alone; nothing here reads the registry's own name from the database.
  */
 export function buildMigrationManifest(
-  rows: readonly RegistryRow[]
+  rows: readonly RegistryRow[],
+  options: { existingTables?: readonly string[] } = {}
 ): MigrationManifest {
   const entries: ManifestEntry[] = [];
 
@@ -92,6 +109,9 @@ export function buildMigrationManifest(
   );
 
   for (const row of ordered) {
+    // Idempotent by construction: a row already carrying a migrated name
+    // produces no rename, so a plan rebuilt after a partial run contains only
+    // the work still outstanding.
     const target = retargetName(row.tableName);
     if (target === null) {
       // Custom-named: nothing to retire. Its column may still need renaming,
@@ -109,7 +129,7 @@ export function buildMigrationManifest(
 
     entries.push({ kind: "table", from: row.tableName, to: target });
 
-    if (row.localized) {
+    if (row.hasCompanion) {
       // Derived from the table name that was read, not from the slug, so a
       // custom-named table's companion is still found.
       const suffix = STORAGE_FORMAT.companionSuffix;
@@ -138,6 +158,8 @@ export function buildMigrationManifest(
     to: MIGRATION_TARGET.registryTable,
   });
 
+  assertNoTargetCollision(entries, rows, options.existingTables ?? []);
+
   return { entries, hash: hashManifest(entries) };
 }
 
@@ -154,4 +176,67 @@ export function hashManifest(entries: readonly ManifestEntry[]): string {
     .map(e => `${e.kind}:${e.table ?? ""}:${e.from}>${e.to}`)
     .join("\n");
   return createHash("sha256").update(canonical).digest("hex");
+}
+
+/**
+ * Refuse a plan that would rename onto a name something else already answers to.
+ *
+ * `table_name` is unique but unconstrained, so a database can legitimately hold
+ * both a generated `comp_hero` and another group whose author named its table
+ * `fg_hero`. Nothing today prevents that pair, and the second one is left
+ * untouched by design, so the first would rename onto an occupied name and fail
+ * partway through the run.
+ *
+ * Detected before the migration starts rather than discovered during it: a
+ * refusal here costs an operator a rename, while the same collision found
+ * mid-run leaves storage half-migrated.
+ */
+function assertNoTargetCollision(
+  entries: readonly ManifestEntry[],
+  rows: readonly RegistryRow[],
+  existingTables: readonly string[]
+): void {
+  const renamedAway = new Set(
+    entries.filter(e => e.kind !== "column").map(e => e.from)
+  );
+
+  // Names that will still be in use once the plan finishes: rows this plan
+  // leaves alone, plus catalog tables it never touches.
+  const survivors = new Set<string>();
+  for (const row of rows) {
+    if (!renamedAway.has(row.tableName)) survivors.add(row.tableName);
+  }
+  for (const table of existingTables) {
+    if (!renamedAway.has(table)) survivors.add(table);
+  }
+
+  const claimed = new Map<string, string>();
+  for (const entry of entries) {
+    if (entry.kind === "column") continue;
+
+    if (survivors.has(entry.to)) {
+      throw collision(
+        entry.from,
+        entry.to,
+        "an object that is not being renamed"
+      );
+    }
+    const previous = claimed.get(entry.to);
+    if (previous !== undefined) {
+      throw collision(entry.from, entry.to, `the rename of ${previous}`);
+    }
+    claimed.set(entry.to, entry.from);
+  }
+}
+
+function collision(from: string, to: string, occupant: string): NextlyError {
+  return NextlyError.serviceUnavailable({
+    logMessage: `field-group migration cannot rename ${from}: ${to} is already taken`,
+    logContext: {
+      reason: "migration target name is already in use",
+      from,
+      to,
+      occupiedBy: occupant,
+    },
+  });
 }

--- a/packages/nextly/src/domains/field-groups/migration/manifest.ts
+++ b/packages/nextly/src/domains/field-groups/migration/manifest.ts
@@ -267,12 +267,20 @@ function assertNoAliasedCompanion(rows: readonly RegistryRow[]): void {
   // damage is specific: the row is left unrenamed, so its discriminator rename
   // would be issued against the registry itself, and the registry's own rename
   // puts that name among the plan's sources so nothing flags the overlap.
-  const systemTables = new Set([
-    fold(STORAGE_FORMAT.registryTable),
-    fold(MIGRATION_TARGET.registryTable),
+  //
+  // Compared exactly, not folded. This asks whether a row *is* the system table,
+  // which is an identity question, and folding an identity question is
+  // permanently destructive here: on Postgres a legitimate custom table quoted
+  // as `DYNAMIC_COMPONENTS` is a different table, and refusing it would block
+  // that installation's upgrade for good. The case-insensitive variant, where
+  // MySQL really does resolve the two to one table, needs the dialect and so
+  // belongs to catalog reconciliation.
+  const systemTables = new Set<string>([
+    STORAGE_FORMAT.registryTable,
+    MIGRATION_TARGET.registryTable,
   ]);
   for (const row of rows) {
-    if (!systemTables.has(fold(row.tableName))) continue;
+    if (!systemTables.has(row.tableName)) continue;
     throw NextlyError.serviceUnavailable({
       logMessage: `field-group migration cannot plan: ${row.tableName} is a system table, not field group storage`,
       logContext: {

--- a/packages/nextly/src/domains/field-groups/migration/manifest.ts
+++ b/packages/nextly/src/domains/field-groups/migration/manifest.ts
@@ -20,6 +20,8 @@ import { createHash } from "node:crypto";
 
 import { NextlyError } from "../../../errors/nextly-error";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
+import { resolveComponentTableName } from "../../schema/utils/resolve-table-name";
+import { normalizeIdentifier } from "../../singles/services/resolve-single-table-name";
 
 /**
  * The names storage moves to.
@@ -79,20 +81,26 @@ export interface MigrationManifest {
 }
 
 /**
- * Rename a legacy-prefixed name onto the new prefix, or leave it alone.
+ * The name this migration would have generated for a field group, or `null` if
+ * the stored one is not a name it generated.
  *
- * A table only gets renamed when it actually carries the prefix this migration
- * is retiring. One named through `dbName` was never named after the concept —
- * `my_seo_block` contains no vocabulary to migrate — and rewriting it would
- * change a name its author chose, for no benefit. This is the second reason
- * `table_name` has to be read rather than derived: it decides not just what the
- * objects are called, but which of them are ours to rename at all.
+ * Ownership is decided by comparing against the canonical name for the slug,
+ * not by looking at the prefix. `dbName` was historically taken verbatim for
+ * field groups, so an author could name a table `comp_archive` while its slug is
+ * `hero` — a prefix rule reads that as generated and renames it to `fg_archive`,
+ * changing an identifier this migration never created. Only the canonical name
+ * for the slug distinguishes the two.
+ *
+ * `resolveComponentTableName` is the single source of truth for that canonical
+ * name; deriving it here again would let the two drift, which is exactly the
+ * drift that helper was written to end.
  */
-export function retargetName(name: string): string | null {
-  if (!name.startsWith(STORAGE_FORMAT.tablePrefix)) return null;
-  return `${MIGRATION_TARGET.tablePrefix}${name.slice(
-    STORAGE_FORMAT.tablePrefix.length
-  )}`;
+export function retargetName(row: {
+  slug: string;
+  tableName: string;
+}): string | null {
+  if (row.tableName !== resolveComponentTableName(row.slug)) return null;
+  return `${MIGRATION_TARGET.tablePrefix}${normalizeIdentifier(row.slug)}`;
 }
 
 /**
@@ -153,7 +161,7 @@ export function buildMigrationManifest(
     // Idempotent by construction: a row already carrying a migrated name
     // produces no rename, so a plan rebuilt after a partial run contains only
     // the work still outstanding.
-    const target = retargetName(row.tableName);
+    const target = retargetName(row);
 
     if (target !== null) {
       entries.push({ kind: "table", from: row.tableName, to: target });

--- a/packages/nextly/src/domains/field-groups/migration/manifest.ts
+++ b/packages/nextly/src/domains/field-groups/migration/manifest.ts
@@ -148,6 +148,8 @@ export function invertManifest(
 export function buildMigrationManifest(
   rows: readonly RegistryRow[]
 ): MigrationManifest {
+  assertNoAliasedCompanion(rows);
+
   const entries: ManifestEntry[] = [];
 
   // Sorted by the stored table name so the plan is stable across runs. Step
@@ -244,6 +246,43 @@ export function hashManifest(entries: readonly ManifestEntry[]): string {
  */
 function fold(name: string): string {
   return name.toLowerCase();
+}
+
+/**
+ * Refuse when one physical table is claimed by two field groups.
+ *
+ * A companion name is derived from its owner's table name, not stored, so it can
+ * land on a name an author chose for a different group: `comp_hero`'s companion
+ * computes to `comp_hero_locales`, which was a legal `dbName`. The unique
+ * constraint on `table_name` does not prevent it, because the companion is not a
+ * registry row.
+ *
+ * Left unchecked the collision hides rather than fails: the aliased row's stored
+ * name appears among the sources this plan renames, so it reads as intentionally
+ * renamed away, passes every conflict check, and has its table moved out from
+ * under it. Ownership of a table cannot be shared, so this refuses.
+ */
+function assertNoAliasedCompanion(rows: readonly RegistryRow[]): void {
+  const owners = new Map<string, string>();
+  for (const row of rows) owners.set(fold(row.tableName), row.slug);
+
+  for (const row of rows) {
+    if (!row.hasCompanion) continue;
+    // No self-collision is possible: a name cannot equal itself plus a suffix,
+    // so any owner found here is necessarily a different group.
+    const companion = fold(`${row.tableName}${STORAGE_FORMAT.companionSuffix}`);
+    const owner = owners.get(companion);
+    if (owner === undefined) continue;
+    throw NextlyError.serviceUnavailable({
+      logMessage: `field-group migration cannot plan: ${companion} is claimed by more than one field group`,
+      logContext: {
+        reason: "storage name is claimed by more than one field group",
+        table: companion,
+        companionOf: row.slug,
+        storedBy: owner,
+      },
+    });
+  }
 }
 
 /**

--- a/packages/nextly/src/domains/field-groups/migration/manifest.ts
+++ b/packages/nextly/src/domains/field-groups/migration/manifest.ts
@@ -1,10 +1,17 @@
 /**
- * What the storage migration will rename, derived from the database.
+ * What the storage migration will rename, derived from the registry.
  *
- * The plan is built from the registry rather than from configuration, because
- * only the registry knows what the objects are actually called. A field group
+ * The plan is built from registry rows rather than from configuration, because
+ * only the registry knows what the objects are actually called: a field group
  * whose table was named through `dbName` carries whatever the author chose, and
- * a name cannot be recomputed from a slug once that has happened.
+ * that name cannot be recomputed from a slug.
+ *
+ * This module decides the plan and nothing else — which objects, in what order,
+ * under what identity. It deliberately does **not** look at the database. Names
+ * that exist, whether a run is already recorded, and how a given dialect
+ * compares identifiers are all facts the database layer holds, and reconciling
+ * a plan against them belongs there, next to the catalog probe. Keeping that
+ * out means this stays a pure function of its inputs and stays testable as one.
  *
  * @module domains/field-groups/migration/manifest
  */
@@ -27,23 +34,6 @@ export const MIGRATION_TARGET = {
   columnType: "_field_group_type",
 } as const;
 
-/**
- * The names an up migration moves storage from and to.
- *
- * There is no down variant on purpose: a rollback inverts what was applied
- * rather than deriving the reverse from these. See `invertManifest`.
- */
-function vocabulary() {
-  return {
-    tableFrom: STORAGE_FORMAT.tablePrefix,
-    tableTo: MIGRATION_TARGET.tablePrefix,
-    registryFrom: STORAGE_FORMAT.registryTable,
-    registryTo: MIGRATION_TARGET.registryTable,
-    columnFrom: STORAGE_FORMAT.columns.type,
-    columnTo: MIGRATION_TARGET.columnType,
-  };
-}
-
 /** A registry row, as far as the migration is concerned. */
 export interface RegistryRow {
   slug: string;
@@ -52,14 +42,12 @@ export interface RegistryRow {
   /**
    * Whether a companion table is physically present.
    *
-   * Deliberately not `localized`: a localized group with no translatable
-   * fields has no companion, and the create path accepts exactly that. Reading
-   * this from the catalog rather than inferring it keeps the plan from naming
-   * a table that was never created.
+   * Deliberately not `localized`: a localized group with no translatable fields
+   * has no companion, and the create path accepts exactly that. Reading this
+   * from the catalog rather than inferring it keeps the plan from naming a
+   * table that was never created.
    */
   hasCompanion: boolean;
-  /** Dynamic zones carry the type discriminator column; fixed groups do not. */
-  hasTypeColumn: boolean;
 }
 
 /** One thing the migration will rename. */
@@ -72,11 +60,11 @@ export interface ManifestEntry {
   /**
    * This rename is already reflected in the database.
    *
-   * Annotated rather than removed. The plan is indexed by position and
+   * Set by catalog reconciliation, which lives with the probe rather than here.
+   * Annotated rather than removed: the plan is indexed by position and
    * identified by hash, so dropping an entry would renumber every later step
-   * and change the identity the marker recorded — making a resume refuse the
-   * very plan it is resuming. Steps are idempotent, so a satisfied one costs a
-   * verification and nothing more.
+   * and change the identity the marker recorded, making a resume refuse the
+   * very plan it is resuming.
    */
   satisfied?: boolean;
 }
@@ -101,9 +89,10 @@ export interface MigrationManifest {
  * objects are called, but which of them are ours to rename at all.
  */
 export function retargetName(name: string): string | null {
-  const { tableFrom, tableTo } = vocabulary();
-  if (!name.startsWith(tableFrom)) return null;
-  return `${tableTo}${name.slice(tableFrom.length)}`;
+  if (!name.startsWith(STORAGE_FORMAT.tablePrefix)) return null;
+  return `${MIGRATION_TARGET.tablePrefix}${name.slice(
+    STORAGE_FORMAT.tablePrefix.length
+  )}`;
 }
 
 /**
@@ -113,13 +102,13 @@ export function retargetName(name: string): string | null {
  * cannot work: a field group whose author named its table `fg_hero` before any
  * migration existed is left untouched on the way up, and a prefix rule going
  * back down would rename it to `comp_hero` — destroying an author-chosen
- * identifier that this migration never created. Nothing in the database
- * distinguishes a name we made from a name that was always there; only the
- * record of what was applied does.
+ * identifier this migration never created. Nothing in the database
+ * distinguishes a name we made from one that was always there; only the record
+ * of what was applied does.
  *
- * Order is reversed as well as direction. The column rename therefore runs
- * while its table still carries the migrated name, which is why each column
- * entry keeps the table it already names.
+ * Order reverses along with direction, so each column reverts while its table
+ * still carries the migrated name. That is why every column entry keeps the
+ * table it already names.
  */
 export function invertManifest(
   entries: readonly ManifestEntry[]
@@ -142,26 +131,15 @@ export function invertManifest(
  * That ordering is necessary but not sufficient. The final step has the same
  * commit-before-marker crash window as any other: once the registry rename
  * commits, a crash before the marker records it leaves a resume that must retry
- * a step whose source table no longer exists. So callers must read registry
- * rows from whichever registry is present — legacy first, then the migrated
- * name — and this function must produce an identical plan from either. It does,
- * because the rows are the only input and the entries are derived from them
- * alone; nothing here reads the registry's own name from the database.
+ * a step whose source table no longer exists. So callers read registry rows
+ * from whichever registry is present — legacy first, then the migrated name —
+ * and this function produces an identical plan from either, because the rows
+ * are its only input and nothing here reads the registry's own name from the
+ * database.
  */
 export function buildMigrationManifest(
-  rows: readonly RegistryRow[],
-  options: {
-    /**
-     * Every table in the database, not only the ones this migration expects.
-     *
-     * Partial input is worse than none: a source missing from an incomplete
-     * list reads as a rename that already happened. Omit it entirely when the
-     * catalog is not available, and only plan-level conflicts are checked.
-     */
-    existingTables?: readonly string[];
-  } = {}
+  rows: readonly RegistryRow[]
 ): MigrationManifest {
-  const v = vocabulary();
   const entries: ManifestEntry[] = [];
 
   // Sorted by the stored table name so the plan is stable across runs. Step
@@ -176,57 +154,45 @@ export function buildMigrationManifest(
     // produces no rename, so a plan rebuilt after a partial run contains only
     // the work still outstanding.
     const target = retargetName(row.tableName);
-    if (target === null) {
-      // Custom-named: nothing to retire. Its column may still need renaming,
-      // which is why this continues rather than skipping the row entirely.
-      if (row.hasTypeColumn) {
+
+    if (target !== null) {
+      entries.push({ kind: "table", from: row.tableName, to: target });
+
+      if (row.hasCompanion) {
+        // Derived from the table name that was read, not from the slug, so a
+        // custom-named table's companion is still found.
+        const suffix = STORAGE_FORMAT.companionSuffix;
         entries.push({
-          kind: "column",
-          from: v.columnFrom,
-          to: v.columnTo,
-          table: row.tableName,
+          kind: "companion",
+          from: `${row.tableName}${suffix}`,
+          to: `${target}${suffix}`,
         });
       }
-      continue;
     }
 
-    entries.push({ kind: "table", from: row.tableName, to: target });
-
-    if (row.hasCompanion) {
-      // Derived from the table name that was read, not from the slug, so a
-      // custom-named table's companion is still found.
-      const suffix = STORAGE_FORMAT.companionSuffix;
-      entries.push({
-        kind: "companion",
-        from: `${row.tableName}${suffix}`,
-        to: `${target}${suffix}`,
-      });
-    }
-
-    if (row.hasTypeColumn) {
-      // Addressed by its post-rename table name: the column rename runs after
-      // the table rename, so the old name no longer resolves.
-      entries.push({
-        kind: "column",
-        from: v.columnFrom,
-        to: v.columnTo,
-        table: target,
-      });
-    }
+    // Every field-group data table carries the discriminator column: the schema
+    // service emits it unconditionally, and so do all three runtime schemas.
+    // A table left with the legacy column while the rest of its storage moved
+    // would be read against the wrong name, so the column rename is
+    // unconditional too. It is addressed by the table's post-rename name where
+    // there is one, because the column rename runs after the table's.
+    entries.push({
+      kind: "column",
+      from: STORAGE_FORMAT.columns.type,
+      to: MIGRATION_TARGET.columnType,
+      table: target ?? row.tableName,
+    });
   }
 
   entries.push({
     kind: "registry",
-    from: v.registryFrom,
-    to: v.registryTo,
+    from: STORAGE_FORMAT.registryTable,
+    to: MIGRATION_TARGET.registryTable,
   });
 
-  const planned = options.existingTables
-    ? reconcileWithCatalog(entries, options.existingTables)
-    : entries;
-  assertNoTargetConflict(planned, rows);
+  assertNoTargetConflict(entries, rows);
 
-  return { entries: planned, hash: hashManifest(planned) };
+  return { entries, hash: hashManifest(entries) };
 }
 
 /**
@@ -248,92 +214,30 @@ export function hashManifest(entries: readonly ManifestEntry[]): string {
 }
 
 /**
- * Fold a name for *occupancy* comparisons only.
+ * Fold a name for occupancy comparisons.
  *
  * SQLite matches table names case-insensitively and MySQL usually does, so a
- * `FG_HERO` sitting where `fg_hero` is headed would otherwise slip past and
- * fail the rename mid-run. Folding makes that check stricter than Postgres
- * needs, which is the safe direction for detecting a squatter.
+ * name differing only in case still occupies the target. Folding is the safe
+ * direction for that question: it is stricter than Postgres requires, and a
+ * refusal before the run costs an operator one rename while a missed conflict
+ * fails after the marker is written.
  *
- * It is the unsafe direction for deciding whether something *exists*: on
- * Postgres a quoted `COMP_HERO` would make a genuinely missing `comp_hero` look
- * present, and the pre-flight refusal would be skipped for a rename that then
- * fails anyway. Presence is therefore matched exactly, and only occupancy is
- * folded.
+ * It is only sound because this asks whether a name is *taken*. Asking whether
+ * a name *exists* needs the opposite bias, and that question is not asked here
+ * — it belongs to catalog reconciliation, which has the dialect to answer it
+ * properly.
  */
 function fold(name: string): string {
   return name.toLowerCase();
 }
 
 /**
- * Annotate each rename with what the database says about it, or refuse.
- *
- * Presence is judged on exact names; a target being *occupied* is judged
- * loosely, since that is the comparison where being too strict is safe.
- *
- * | source | target | meaning |
- * |---|---|---|
- * | present | free     | outstanding work |
- * | absent  | present  | already applied — marked satisfied, never removed |
- * | present | occupied | something else owns the target; refuse |
- * | absent  | absent   | the registry names a table that is gone; refuse |
- *
- * Entries are annotated rather than filtered: the plan is positionally indexed
- * and hash-identified, so removing one renumbers later steps and changes the
- * identity the marker holds.
- */
-function reconcileWithCatalog(
-  entries: readonly ManifestEntry[],
-  existingTables: readonly string[]
-): ManifestEntry[] {
-  const exact = new Set(existingTables);
-  const loose = new Set(existingTables.map(fold));
-
-  // A table this plan is about to create by renaming counts as present for the
-  // column rename that follows it; the column's table names the post-rename
-  // table, which is legitimately absent from a pre-migration catalog.
-  const willExist = new Set<string>();
-  for (const entry of entries) {
-    if (entry.kind !== "column") willExist.add(entry.to);
-  }
-
-  return entries.map(entry => {
-    if (entry.kind === "column") {
-      const table = entry.table;
-      if (table === undefined) return entry;
-      const present = exact.has(table) || willExist.has(table);
-      // A column on a table that neither exists nor is about to is not work,
-      // and cannot be verified either.
-      return present ? entry : { ...entry, satisfied: true };
-    }
-
-    const sourcePresent = exact.has(entry.from);
-    const targetPresent = exact.has(entry.to);
-    const targetOccupied = loose.has(entry.to);
-
-    if (sourcePresent && targetOccupied) {
-      throw refuseRename(
-        entry,
-        "migration target name is already in use",
-        `${entry.to} already exists while ${entry.from} still does`
-      );
-    }
-    if (sourcePresent) return entry;
-    if (targetPresent) return { ...entry, satisfied: true };
-    throw refuseRename(
-      entry,
-      "migration source object is missing",
-      `neither ${entry.from} nor ${entry.to} exists`
-    );
-  });
-}
-
-/**
  * No two entries may claim the same name, and none may claim a name a registry
  * row is keeping.
  *
- * Both are properties of the plan and its inputs, so this needs no catalog. A
- * row whose table is left alone still occupies its name, and `table_name` being
+ * Both are properties of the plan and its inputs, which is why they are checked
+ * here rather than against the database. A row whose table is left alone — one
+ * named through `dbName` — still occupies its name, and `table_name` being
  * unique does not stop `comp_hero` and `fg_hero` coexisting.
  */
 function assertNoTargetConflict(

--- a/packages/nextly/src/domains/field-groups/migration/manifest.ts
+++ b/packages/nextly/src/domains/field-groups/migration/manifest.ts
@@ -204,12 +204,19 @@ export function buildMigrationManifest(
  * Nextly upgrade can reorder steps while this map is untouched.
  */
 export function hashManifest(entries: readonly ManifestEntry[]): string {
-  // Deliberately excludes `satisfied`: progress is not identity. A plan whose
+  // JSON rather than delimiter-joined text. `table_name` is an unconstrained
+  // varchar, so a name containing the delimiters would let two different plans
+  // serialize identically -- one row called
+  // `a:_component_type>_field_group_type\ncolumn:b` produced the same bytes as
+  // two rows called `a` and `b`. A resume would then accept a plan whose step
+  // positions address different operations.
+  //
+  // `satisfied` is deliberately excluded: progress is not identity. A plan whose
   // steps have partly run is the same plan, and the marker must still recognise
   // it on resume.
-  const canonical = entries
-    .map(e => `${e.kind}:${e.table ?? ""}:${e.from}>${e.to}`)
-    .join("\n");
+  const canonical = JSON.stringify(
+    entries.map(e => [e.kind, e.table ?? null, e.from, e.to])
+  );
   return createHash("sha256").update(canonical).digest("hex");
 }
 

--- a/packages/nextly/src/domains/field-groups/migration/manifest.ts
+++ b/packages/nextly/src/domains/field-groups/migration/manifest.ts
@@ -291,14 +291,21 @@ function assertNoAliasedCompanion(rows: readonly RegistryRow[]): void {
     });
   }
 
+  // Compared exactly, like the system-table check above and unlike the
+  // occupancy check below. This asks whether a derived companion name and a
+  // stored table name are the *same physical table*, which is identity: on
+  // Postgres a quoted `COMP_HERO_LOCALES` is a different table from
+  // `comp_hero_locales`, and folding would refuse that installation for good.
+  // Where MySQL really does resolve both spellings to one table, deciding that
+  // needs the dialect and belongs to catalog reconciliation.
   const owners = new Map<string, string>();
-  for (const row of rows) owners.set(fold(row.tableName), row.slug);
+  for (const row of rows) owners.set(row.tableName, row.slug);
 
   for (const row of rows) {
     if (!row.hasCompanion) continue;
     // No self-collision is possible: a name cannot equal itself plus a suffix,
     // so any owner found here is necessarily a different group.
-    const companion = fold(`${row.tableName}${STORAGE_FORMAT.companionSuffix}`);
+    const companion = `${row.tableName}${STORAGE_FORMAT.companionSuffix}`;
     const owner = owners.get(companion);
     if (owner === undefined) continue;
     throw NextlyError.serviceUnavailable({

--- a/packages/nextly/src/domains/field-groups/migration/manifest.ts
+++ b/packages/nextly/src/domains/field-groups/migration/manifest.ts
@@ -247,9 +247,17 @@ function assertNoTargetConflict(
   const renamedAway = new Set(
     entries.filter(e => e.kind !== "column").map(e => fold(e.from))
   );
-  const kept = new Set(
-    rows.map(r => fold(r.tableName)).filter(name => !renamedAway.has(name))
-  );
+  // A row this plan leaves alone keeps its companion as well as its base table,
+  // so both names stay occupied. Reserving only the base name let another row's
+  // companion be renamed onto a companion that is still there.
+  const kept = new Set<string>();
+  for (const row of rows) {
+    if (renamedAway.has(fold(row.tableName))) continue;
+    kept.add(fold(row.tableName));
+    if (row.hasCompanion) {
+      kept.add(fold(`${row.tableName}${STORAGE_FORMAT.companionSuffix}`));
+    }
+  }
 
   const claimed = new Map<string, string>();
   for (const entry of entries) {

--- a/packages/nextly/src/domains/field-groups/migration/manifest.ts
+++ b/packages/nextly/src/domains/field-groups/migration/manifest.ts
@@ -263,6 +263,26 @@ function fold(name: string): string {
  * under it. Ownership of a table cannot be shared, so this refuses.
  */
 function assertNoAliasedCompanion(rows: readonly RegistryRow[]): void {
+  // A row naming a system table is malformed rather than merely unusual, and the
+  // damage is specific: the row is left unrenamed, so its discriminator rename
+  // would be issued against the registry itself, and the registry's own rename
+  // puts that name among the plan's sources so nothing flags the overlap.
+  const systemTables = new Set([
+    fold(STORAGE_FORMAT.registryTable),
+    fold(MIGRATION_TARGET.registryTable),
+  ]);
+  for (const row of rows) {
+    if (!systemTables.has(fold(row.tableName))) continue;
+    throw NextlyError.serviceUnavailable({
+      logMessage: `field-group migration cannot plan: ${row.tableName} is a system table, not field group storage`,
+      logContext: {
+        reason: "field group row names a system table",
+        table: row.tableName,
+        slug: row.slug,
+      },
+    });
+  }
+
   const owners = new Map<string, string>();
   for (const row of rows) owners.set(fold(row.tableName), row.slug);
 

--- a/packages/nextly/src/domains/field-groups/migration/manifest.ts
+++ b/packages/nextly/src/domains/field-groups/migration/manifest.ts
@@ -14,8 +14,6 @@ import { createHash } from "node:crypto";
 import { NextlyError } from "../../../errors/nextly-error";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 
-import type { MigrationDirection } from "./state";
-
 /**
  * The names storage moves to.
  *
@@ -29,20 +27,20 @@ export const MIGRATION_TARGET = {
   columnType: "_field_group_type",
 } as const;
 
-/** The names this direction moves storage from and to. */
-function vocabulary(direction: MigrationDirection) {
-  const up = direction === "up";
+/**
+ * The names an up migration moves storage from and to.
+ *
+ * There is no down variant on purpose: a rollback inverts what was applied
+ * rather than deriving the reverse from these. See `invertManifest`.
+ */
+function vocabulary() {
   return {
-    tableFrom: up ? STORAGE_FORMAT.tablePrefix : MIGRATION_TARGET.tablePrefix,
-    tableTo: up ? MIGRATION_TARGET.tablePrefix : STORAGE_FORMAT.tablePrefix,
-    registryFrom: up
-      ? STORAGE_FORMAT.registryTable
-      : MIGRATION_TARGET.registryTable,
-    registryTo: up
-      ? MIGRATION_TARGET.registryTable
-      : STORAGE_FORMAT.registryTable,
-    columnFrom: up ? STORAGE_FORMAT.columns.type : MIGRATION_TARGET.columnType,
-    columnTo: up ? MIGRATION_TARGET.columnType : STORAGE_FORMAT.columns.type,
+    tableFrom: STORAGE_FORMAT.tablePrefix,
+    tableTo: MIGRATION_TARGET.tablePrefix,
+    registryFrom: STORAGE_FORMAT.registryTable,
+    registryTo: MIGRATION_TARGET.registryTable,
+    columnFrom: STORAGE_FORMAT.columns.type,
+    columnTo: MIGRATION_TARGET.columnType,
   };
 }
 
@@ -71,6 +69,16 @@ export interface ManifestEntry {
   to: string;
   /** Set for `column`, naming the table the column belongs to. */
   table?: string;
+  /**
+   * This rename is already reflected in the database.
+   *
+   * Annotated rather than removed. The plan is indexed by position and
+   * identified by hash, so dropping an entry would renumber every later step
+   * and change the identity the marker recorded — making a resume refuse the
+   * very plan it is resuming. Steps are idempotent, so a satisfied one costs a
+   * verification and nothing more.
+   */
+  satisfied?: boolean;
 }
 
 export interface MigrationManifest {
@@ -92,13 +100,37 @@ export interface MigrationManifest {
  * `table_name` has to be read rather than derived: it decides not just what the
  * objects are called, but which of them are ours to rename at all.
  */
-export function retargetName(
-  name: string,
-  direction: MigrationDirection = "up"
-): string | null {
-  const { tableFrom, tableTo } = vocabulary(direction);
+export function retargetName(name: string): string | null {
+  const { tableFrom, tableTo } = vocabulary();
   if (!name.startsWith(tableFrom)) return null;
   return `${tableTo}${name.slice(tableFrom.length)}`;
+}
+
+/**
+ * Reverse a plan that was applied, for a rollback.
+ *
+ * A down plan is **inverted, never derived.** Deriving it from the prefix
+ * cannot work: a field group whose author named its table `fg_hero` before any
+ * migration existed is left untouched on the way up, and a prefix rule going
+ * back down would rename it to `comp_hero` — destroying an author-chosen
+ * identifier that this migration never created. Nothing in the database
+ * distinguishes a name we made from a name that was always there; only the
+ * record of what was applied does.
+ *
+ * Order is reversed as well as direction. The column rename therefore runs
+ * while its table still carries the migrated name, which is why each column
+ * entry keeps the table it already names.
+ */
+export function invertManifest(
+  entries: readonly ManifestEntry[]
+): MigrationManifest {
+  const inverted = [...entries].reverse().map(entry => ({
+    kind: entry.kind,
+    from: entry.to,
+    to: entry.from,
+    ...(entry.table === undefined ? {} : { table: entry.table }),
+  }));
+  return { entries: inverted, hash: hashManifest(inverted) };
 }
 
 /**
@@ -119,7 +151,6 @@ export function retargetName(
 export function buildMigrationManifest(
   rows: readonly RegistryRow[],
   options: {
-    direction?: MigrationDirection;
     /**
      * Every table in the database, not only the ones this migration expects.
      *
@@ -130,8 +161,7 @@ export function buildMigrationManifest(
     existingTables?: readonly string[];
   } = {}
 ): MigrationManifest {
-  const direction = options.direction ?? "up";
-  const v = vocabulary(direction);
+  const v = vocabulary();
   const entries: ManifestEntry[] = [];
 
   // Sorted by the stored table name so the plan is stable across runs. Step
@@ -145,7 +175,7 @@ export function buildMigrationManifest(
     // Idempotent by construction: a row already carrying a migrated name
     // produces no rename, so a plan rebuilt after a partial run contains only
     // the work still outstanding.
-    const target = retargetName(row.tableName, direction);
+    const target = retargetName(row.tableName);
     if (target === null) {
       // Custom-named: nothing to retire. Its column may still need renaming,
       // which is why this continues rather than skipping the row entirely.
@@ -208,6 +238,9 @@ export function buildMigrationManifest(
  * Nextly upgrade can reorder steps while this map is untouched.
  */
 export function hashManifest(entries: readonly ManifestEntry[]): string {
+  // Deliberately excludes `satisfied`: progress is not identity. A plan whose
+  // steps have partly run is the same plan, and the marker must still recognise
+  // it on resume.
   const canonical = entries
     .map(e => `${e.kind}:${e.table ?? ""}:${e.from}>${e.to}`)
     .join("\n");
@@ -215,85 +248,93 @@ export function hashManifest(entries: readonly ManifestEntry[]): string {
 }
 
 /**
- * Compare identifiers the way the loosest supported database would.
+ * Fold a name for *occupancy* comparisons only.
  *
- * SQLite matches table names case-insensitively, and MySQL does too under the
- * usual `lower_case_table_names` settings. Comparing case-sensitively would let
- * an existing `FG_HERO` slip past a check for `fg_hero` and fail the rename
- * after the run had already started. Postgres can genuinely hold both, so this
- * is stricter than Postgres requires — deliberately, because a refusal before
- * the run costs an operator a rename while a failure during it leaves storage
- * half-migrated.
+ * SQLite matches table names case-insensitively and MySQL usually does, so a
+ * `FG_HERO` sitting where `fg_hero` is headed would otherwise slip past and
+ * fail the rename mid-run. Folding makes that check stricter than Postgres
+ * needs, which is the safe direction for detecting a squatter.
+ *
+ * It is the unsafe direction for deciding whether something *exists*: on
+ * Postgres a quoted `COMP_HERO` would make a genuinely missing `comp_hero` look
+ * present, and the pre-flight refusal would be skipped for a rename that then
+ * fails anyway. Presence is therefore matched exactly, and only occupancy is
+ * folded.
  */
 function fold(name: string): string {
   return name.toLowerCase();
 }
 
 /**
- * Decide each rename against what the database actually contains.
+ * Annotate each rename with what the database says about it, or refuse.
  *
- * Four states, and only one of them is ordinary work:
+ * Presence is judged on exact names; a target being *occupied* is judged
+ * loosely, since that is the comparison where being too strict is safe.
  *
  * | source | target | meaning |
  * |---|---|---|
- * | present | absent  | the rename still has to happen |
- * | absent  | present | this migration already did it; drop the entry |
- * | present | present | something else owns the target; refuse |
- * | absent  | absent  | the registry names a table that is gone; refuse |
+ * | present | free     | outstanding work |
+ * | absent  | present  | already applied — marked satisfied, never removed |
+ * | present | occupied | something else owns the target; refuse |
+ * | absent  | absent   | the registry names a table that is gone; refuse |
  *
- * The second row is what makes a resume work. A run that crashed after a rename
- * committed but before its marker write must be able to rebuild the plan and
- * find that step already satisfied, rather than reading its own finished work
- * as a conflict.
+ * Entries are annotated rather than filtered: the plan is positionally indexed
+ * and hash-identified, so removing one renumbers later steps and changes the
+ * identity the marker holds.
  */
 function reconcileWithCatalog(
   entries: readonly ManifestEntry[],
   existingTables: readonly string[]
 ): ManifestEntry[] {
-  const catalog = new Set(existingTables.map(fold));
-  const kept: ManifestEntry[] = [];
+  const exact = new Set(existingTables);
+  const loose = new Set(existingTables.map(fold));
 
+  // A table this plan is about to create by renaming counts as present for the
+  // column rename that follows it; the column's table names the post-rename
+  // table, which is legitimately absent from a pre-migration catalog.
+  const willExist = new Set<string>();
   for (const entry of entries) {
+    if (entry.kind !== "column") willExist.add(entry.to);
+  }
+
+  return entries.map(entry => {
     if (entry.kind === "column") {
-      // A column belongs to a table; if that table is not there, neither is it.
-      if (entry.table === undefined || catalog.has(fold(entry.table))) {
-        kept.push(entry);
-      }
-      continue;
+      const table = entry.table;
+      if (table === undefined) return entry;
+      const present = exact.has(table) || willExist.has(table);
+      // A column on a table that neither exists nor is about to is not work,
+      // and cannot be verified either.
+      return present ? entry : { ...entry, satisfied: true };
     }
 
-    const sourcePresent = catalog.has(fold(entry.from));
-    const targetPresent = catalog.has(fold(entry.to));
+    const sourcePresent = exact.has(entry.from);
+    const targetPresent = exact.has(entry.to);
+    const targetOccupied = loose.has(entry.to);
 
-    if (sourcePresent && targetPresent) {
+    if (sourcePresent && targetOccupied) {
       throw refuseRename(
         entry,
         "migration target name is already in use",
         `${entry.to} already exists while ${entry.from} still does`
       );
     }
-    if (!sourcePresent && !targetPresent) {
-      throw refuseRename(
-        entry,
-        "migration source object is missing",
-        `neither ${entry.from} nor ${entry.to} exists`
-      );
-    }
-    if (sourcePresent) kept.push(entry);
-    // Otherwise the target is present and the source is gone: already renamed.
-  }
-
-  return kept;
+    if (sourcePresent) return entry;
+    if (targetPresent) return { ...entry, satisfied: true };
+    throw refuseRename(
+      entry,
+      "migration source object is missing",
+      `neither ${entry.from} nor ${entry.to} exists`
+    );
+  });
 }
 
 /**
  * No two entries may claim the same name, and none may claim a name a registry
  * row is keeping.
  *
- * Checked without needing a catalog, because both facts are properties of the
- * plan and its inputs. A row whose table is left alone — one named through
- * `dbName` — still occupies its name, and `table_name` being unique does not
- * stop `comp_hero` and `fg_hero` coexisting.
+ * Both are properties of the plan and its inputs, so this needs no catalog. A
+ * row whose table is left alone still occupies its name, and `table_name` being
+ * unique does not stop `comp_hero` and `fg_hero` coexisting.
  */
 function assertNoTargetConflict(
   entries: readonly ManifestEntry[],

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -18,6 +18,8 @@
 import { NextlyError } from "../../../errors/nextly-error";
 import type { MetaService } from "../../meta/services/meta-service";
 
+import type { ManifestEntry } from "./manifest";
+
 /** `nextly_meta` key holding the marker. */
 export const FIELD_GROUP_MIGRATION_KEY = "field_groups.storage_migration";
 
@@ -66,6 +68,19 @@ export interface SettledState {
    * unexplained rather than expected.
    */
   recorded: boolean;
+  /**
+   * The plan that produced this generation, kept so a rollback can reverse it.
+   *
+   * A rollback cannot derive the reverse mapping: nothing in the database
+   * distinguishes a `fg_*` name this migration created from one an author chose
+   * before it existed, so renaming by prefix on the way down would destroy the
+   * latter. Only the record of what was applied carries that distinction, which
+   * is why it survives settlement rather than being discarded with the run.
+   *
+   * Absent on a `legacy` generation that no run produced, and on markers written
+   * before a plan was recorded.
+   */
+  appliedManifest?: ManifestEntry[];
 }
 
 /**
@@ -117,6 +132,7 @@ interface StoredMarker {
   step?: number;
   manifestHash?: string;
   planHash?: string;
+  appliedManifest?: unknown;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -170,6 +186,9 @@ export async function readMigrationState(
       status: "settled",
       generation: marker.generation,
       recorded: true,
+      ...(marker.appliedManifest === undefined
+        ? {}
+        : { appliedManifest: parseAppliedManifest(marker.appliedManifest) }),
     };
   }
 
@@ -378,14 +397,63 @@ function planMoved(
  */
 export async function settleMigration(
   meta: MetaService,
-  generation: StorageGeneration
+  generation: StorageGeneration,
+  appliedManifest?: readonly ManifestEntry[]
 ): Promise<void> {
   const marker: StoredMarker = {
     version: MIGRATION_MARKER_VERSION,
     status: "settled",
     generation,
+    // Recorded so a later process can reverse this run. Inverting a persisted
+    // plan is the only safe rollback: the reverse cannot be derived from the
+    // database, which cannot say which names this migration created.
+    ...(appliedManifest === undefined
+      ? {}
+      : { appliedManifest: [...appliedManifest] }),
   };
   await meta.set(FIELD_GROUP_MIGRATION_KEY, marker);
+}
+
+/**
+ * Validate a persisted plan on the way back in.
+ *
+ * A rollback acts on this, so a marker carrying something unreadable must
+ * refuse rather than hand back a partial plan that would revert some objects
+ * and silently leave others migrated.
+ */
+function parseAppliedManifest(value: unknown): ManifestEntry[] {
+  if (!Array.isArray(value)) {
+    throw markerCorrupt("recorded plan is not a list");
+  }
+  return value.map(raw => {
+    if (!isRecord(raw)) {
+      throw markerCorrupt("recorded plan contains a non-object entry");
+    }
+    const { kind, from, to, table } = raw;
+    if (
+      kind !== "registry" &&
+      kind !== "table" &&
+      kind !== "companion" &&
+      kind !== "column"
+    ) {
+      throw markerCorrupt("recorded plan entry has no known kind");
+    }
+    if (typeof from !== "string" || from.length === 0) {
+      throw markerCorrupt("recorded plan entry has no source name");
+    }
+    if (typeof to !== "string" || to.length === 0) {
+      throw markerCorrupt("recorded plan entry has no target name");
+    }
+    if (table !== undefined && typeof table !== "string") {
+      throw markerCorrupt("recorded plan entry has an invalid table");
+    }
+    return {
+      kind,
+      from,
+      to,
+      ...(table === undefined ? {} : { table }),
+    };
+  });
 }
 
 // A marker that exists but cannot be read is refused rather than ignored:

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -251,15 +251,33 @@ export async function readMigrationState(
  * this write resumes at step 1 and re-runs the first step from scratch. Every
  * step is idempotent precisely so that re-run is safe.
  */
+/**
+ * Starting a run, with the plan required exactly where a run cannot do without it.
+ *
+ * A `down` run reverses a recorded plan; it cannot derive one, because nothing in
+ * the database says which names this migration created. An `up` run builds its
+ * plan from registry rows, so it has none to carry in. Expressing that as a union
+ * rather than an optional field with a comment means the unsafe call does not
+ * typecheck — a comment saying "required" while the type says otherwise is the
+ * kind of claim that goes unenforced.
+ */
+export type BeginMigrationArgs =
+  | {
+      direction: "up";
+      migrationId: string;
+      plan: MigrationPlanIdentity;
+      appliedManifest?: undefined;
+    }
+  | {
+      direction: "down";
+      migrationId: string;
+      plan: MigrationPlanIdentity;
+      appliedManifest: readonly ManifestEntry[];
+    };
+
 export async function beginMigration(
   meta: MetaService,
-  args: {
-    direction: MigrationDirection;
-    migrationId: string;
-    plan: MigrationPlanIdentity;
-    /** Required for `down`, which reverses a recorded plan rather than deriving one. */
-    appliedManifest?: readonly ManifestEntry[];
-  }
+  args: BeginMigrationArgs
 ): Promise<void> {
   // The writer holds itself to the reader's invariants. Persisting a marker the
   // next read would reject leaves the database unavailable with no way forward,
@@ -419,11 +437,28 @@ function planMoved(
  * Called only after structural verification passes, so the generation the
  * marker reports is one that has been checked rather than assumed.
  */
+/**
+ * Settling, with the plan required exactly where a rollback will need it.
+ *
+ * Settling at `field-groups-v2` is the only moment the plan that produced it can
+ * still be recorded, and a rollback has no other source for it. Settling back at
+ * `legacy` is the end of a reversal, with nothing left to reverse. Making the
+ * distinction a union stops the v2 case being settled without a plan, which the
+ * previous optional argument allowed and which no comment could prevent.
+ */
+export type SettleArgs =
+  | { generation: "field-groups-v2"; appliedManifest: readonly ManifestEntry[] }
+  | { generation: "legacy" };
+
 export async function settleMigration(
   meta: MetaService,
-  generation: StorageGeneration,
-  appliedManifest?: readonly ManifestEntry[]
+  settled: SettleArgs
 ): Promise<void> {
+  const { generation } = settled;
+  const appliedManifest =
+    settled.generation === "field-groups-v2"
+      ? settled.appliedManifest
+      : undefined;
   const marker: StoredMarker = {
     version: MIGRATION_MARKER_VERSION,
     status: "settled",

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -118,6 +118,15 @@ export interface MigratingState {
   migrationId: string;
   step: number;
   plan: MigrationPlanIdentity;
+  /**
+   * The plan being applied, carried for the whole run.
+   *
+   * A `down` run reverses what an earlier `up` recorded, so the record has to
+   * survive the transition out of `settled` and every step after it. Writing it
+   * only at settlement would lose it the moment a rollback started, leaving a
+   * crashed run with a step position and no plan to index into.
+   */
+  appliedManifest?: ManifestEntry[];
 }
 
 export type MigrationState = SettledState | MigratingState;
@@ -226,6 +235,9 @@ export async function readMigrationState(
       migrationId,
       step,
       plan: { manifestHash, planHash },
+      ...(marker.appliedManifest === undefined
+        ? {}
+        : { appliedManifest: parseAppliedManifest(marker.appliedManifest) }),
     };
   }
 
@@ -245,6 +257,8 @@ export async function beginMigration(
     direction: MigrationDirection;
     migrationId: string;
     plan: MigrationPlanIdentity;
+    /** Required for `down`, which reverses a recorded plan rather than deriving one. */
+    appliedManifest?: readonly ManifestEntry[];
   }
 ): Promise<void> {
   // The writer holds itself to the reader's invariants. Persisting a marker the
@@ -262,6 +276,11 @@ export async function beginMigration(
     step: 0,
     manifestHash: args.plan.manifestHash,
     planHash: args.plan.planHash,
+    // Carried from the settled marker rather than dropped: a rollback has no
+    // other source for the plan it is reversing.
+    ...(args.appliedManifest === undefined
+      ? {}
+      : { appliedManifest: [...args.appliedManifest] }),
   };
   await meta.set(FIELD_GROUP_MIGRATION_KEY, marker);
 }
@@ -336,6 +355,11 @@ export async function advanceStep(
     step: args.step,
     manifestHash: current.plan.manifestHash,
     planHash: current.plan.planHash,
+    // Preserved on every step. Losing it mid-run would leave a crash with a
+    // step position and no plan to index into.
+    ...(current.appliedManifest === undefined
+      ? {}
+      : { appliedManifest: current.appliedManifest }),
   };
   await meta.set(FIELD_GROUP_MIGRATION_KEY, marker);
 }
@@ -444,7 +468,14 @@ function parseAppliedManifest(value: unknown): ManifestEntry[] {
     if (typeof to !== "string" || to.length === 0) {
       throw markerCorrupt("recorded plan entry has no target name");
     }
-    if (table !== undefined && typeof table !== "string") {
+    // A column rename is addressed through its table, so an entry without one
+    // cannot be executed or reversed. Accepting it would hand a rollback a plan
+    // that reverts some objects and silently skips others.
+    if (kind === "column") {
+      if (typeof table !== "string" || table.length === 0) {
+        throw markerCorrupt("recorded column entry names no table");
+      }
+    } else if (table !== undefined && typeof table !== "string") {
       throw markerCorrupt("recorded plan entry has an invalid table");
     }
     return {

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -295,10 +295,12 @@ export async function beginMigration(
     manifestHash: args.plan.manifestHash,
     planHash: args.plan.planHash,
     // Carried from the settled marker rather than dropped: a rollback has no
-    // other source for the plan it is reversing.
+    // other source for the plan it is reversing. Validated through the same
+    // function the read uses, so a write cannot produce a marker its own reader
+    // refuses -- which would strand a run after its first step had committed.
     ...(args.appliedManifest === undefined
       ? {}
-      : { appliedManifest: [...args.appliedManifest] }),
+      : { appliedManifest: parseAppliedManifest(args.appliedManifest) }),
   };
   await meta.set(FIELD_GROUP_MIGRATION_KEY, marker);
 }
@@ -468,7 +470,7 @@ export async function settleMigration(
     // database, which cannot say which names this migration created.
     ...(appliedManifest === undefined
       ? {}
-      : { appliedManifest: [...appliedManifest] }),
+      : { appliedManifest: parseAppliedManifest(appliedManifest) }),
   };
   await meta.set(FIELD_GROUP_MIGRATION_KEY, marker);
 }

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -486,6 +486,18 @@ function parseAppliedManifest(value: unknown): ManifestEntry[] {
   if (!Array.isArray(value)) {
     throw markerCorrupt("recorded plan is not a list");
   }
+  // Every plan renames the registry exactly once, so a recorded plan without
+  // that entry is a fragment rather than a plan. Accepting one would let a
+  // rollback reverse the data tables and leave the registry migrated, which is
+  // a state no direction can then interpret. An empty list fails here too.
+  const registryEntries = value.filter(
+    raw => isRecord(raw) && raw.kind === "registry"
+  ).length;
+  if (registryEntries !== 1) {
+    throw markerCorrupt(
+      `recorded plan renames the registry ${String(registryEntries)} times, not once`
+    );
+  }
   return value.map(raw => {
     if (!isRecord(raw)) {
       throw markerCorrupt("recorded plan contains a non-object entry");

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -16,9 +16,10 @@
  */
 
 import { NextlyError } from "../../../errors/nextly-error";
+import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import type { MetaService } from "../../meta/services/meta-service";
 
-import type { ManifestEntry } from "./manifest";
+import { MIGRATION_TARGET, type ManifestEntry } from "./manifest";
 
 /** `nextly_meta` key holding the marker. */
 export const FIELD_GROUP_MIGRATION_KEY = "field_groups.storage_migration";
@@ -492,10 +493,26 @@ function parseAppliedManifest(value: unknown): ManifestEntry[] {
   // a state no direction can then interpret. An empty list fails here too.
   const registryEntries = value.filter(
     raw => isRecord(raw) && raw.kind === "registry"
-  ).length;
-  if (registryEntries !== 1) {
+  );
+  if (registryEntries.length !== 1) {
     throw markerCorrupt(
-      `recorded plan renames the registry ${String(registryEntries)} times, not once`
+      `recorded plan renames the registry ${String(registryEntries.length)} times, not once`
+    );
+  }
+  // Counting the entry is not enough: it has to be the registry rename. An
+  // entry naming anything else satisfies a count check while leaving a rollback
+  // unable to restore the registry, which is the state this validation exists to
+  // rule out. Only the two canonical directions are legal.
+  const registry = registryEntries[0] as Record<string, unknown>;
+  const legacyToTarget =
+    registry.from === STORAGE_FORMAT.registryTable &&
+    registry.to === MIGRATION_TARGET.registryTable;
+  const targetToLegacy =
+    registry.from === MIGRATION_TARGET.registryTable &&
+    registry.to === STORAGE_FORMAT.registryTable;
+  if (!legacyToTarget && !targetToLegacy) {
+    throw markerCorrupt(
+      "recorded plan's registry entry does not rename the registry table"
     );
   }
   return value.map(raw => {

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -122,6 +122,11 @@ export interface MigratingState {
   /**
    * The plan being applied, carried for the whole run.
    *
+   * Always the plan that was applied to reach migrated storage, never its
+   * inverse. A rollback reverses it at execution time; storing it pre-inverted
+   * would let a resume invert it twice and migrate forward while believing it
+   * was rolling back.
+   *
    * A `down` run reverses what an earlier `up` recorded, so the record has to
    * survive the transition out of `settled` and every step after it. Writing it
    * only at settlement would lose it the moment a rollback started, leaving a
@@ -499,20 +504,22 @@ function parseAppliedManifest(value: unknown): ManifestEntry[] {
       `recorded plan renames the registry ${String(registryEntries.length)} times, not once`
     );
   }
-  // Counting the entry is not enough: it has to be the registry rename. An
-  // entry naming anything else satisfies a count check while leaving a rollback
-  // unable to restore the registry, which is the state this validation exists to
-  // rule out. Only the two canonical directions are legal.
+  // Counting the entry is not enough: it has to be *the* registry rename, in the
+  // one direction a record of applied work can have.
+  //
+  // `appliedManifest` always holds the plan that was applied to reach migrated
+  // storage — legacy to target. It is a record of what happened, not of what is
+  // about to happen, and a rollback inverts it at execution time rather than
+  // storing it pre-inverted. Accepting the inverted form would let a rollback
+  // invert it a second time and generate legacy-to-migrated operations while
+  // claiming to restore legacy.
   const registry = registryEntries[0] as Record<string, unknown>;
-  const legacyToTarget =
-    registry.from === STORAGE_FORMAT.registryTable &&
-    registry.to === MIGRATION_TARGET.registryTable;
-  const targetToLegacy =
-    registry.from === MIGRATION_TARGET.registryTable &&
-    registry.to === STORAGE_FORMAT.registryTable;
-  if (!legacyToTarget && !targetToLegacy) {
+  if (
+    registry.from !== STORAGE_FORMAT.registryTable ||
+    registry.to !== MIGRATION_TARGET.registryTable
+  ) {
     throw markerCorrupt(
-      "recorded plan's registry entry does not rename the registry table"
+      "recorded plan's registry entry is not the applied registry rename"
     );
   }
   return value.map(raw => {


### PR DESCRIPTION
B1-3a of the Components → Field Groups storage migration (task 011). Builds on #399 and #402.

Ships dark: nothing calls this yet, and the changeset says so.

## The decision this PR encodes

**The rename plan is built from the registry, not from configuration.** Only the registry knows what the objects are actually called: a field group whose table was named through `dbName` carries whatever its author chose, and that name cannot be recomputed from a slug.

Reading `dynamic_components.table_name` decides **two** things, and the second one surprised me:

1. Which objects exist.
2. **Which of them are ours to rename at all.** A table that does not carry the retiring `comp_` prefix was never named after the concept — `my_seo_block` contains no vocabulary to migrate — so it keeps its name instead of being renamed over. Its type column is still migrated, since that column *is* ours.

A prefix-derivation rule would pass every test built on modern fixtures and silently rename over exactly the sites that have been around longest.

## Target names

| Current | Target |
|---|---|
| `dynamic_components` | `dynamic_field_groups` |
| `comp_` | `fg_` |
| `_component_type` | `_field_group_type` |

Checked before committing, because a second rename is a second migration on every site:

- **Identifier limits are safe by construction.** `fg_` is *shorter* than `comp_`, so every name that fits Postgres's 63 or MySQL's 64 bytes today gets shorter, never longer. There is a test pinning this property rather than the literal.
- **No `fg_` collision** anywhere in the codebase.
- **The Drizzle binding follows the constant** — the schema files bind via `pgTable(STORAGE_FORMAT.registryTable, …)`, so the ORM tracks the new name automatically.
- A host application owning a target-named table already **refuses** via #399's guard rather than being renamed over.

## Two ordering rules

- **The registry renames last.** While it still answers to its old name, a resumed run can rebuild the plan from it; renaming it first would strand the resume.
- **The plan is ordered by stored table name.** Step numbers index into it, so an order that varied between runs would make a recorded step point at a different object.

## On Drizzle

Checked the current Drizzle docs rather than assuming. Drizzle has **no query-builder API for `RENAME TABLE`/`RENAME COLUMN`** — schema change is drizzle-kit's job, and its own documented answer for DDL it cannot generate is a custom SQL migration. The `sql` template parameterizes *values*, not *identifiers*, so it would not make renames safer; `quoteIdent` inside the repo's existing `generateSQL(op, dialect)` is what does. The following slice therefore emits `Operation` values to that generator and writes no SQL of its own. This module writes none either.

## Testing

88 tests in the migration module (was 76). Four breaks run, all caught, count checked each time:

| Break | Fails |
|---|---|
| derive the target from the slug instead of reading it | 2 |
| rename the registry first | 2 |
| drop the stable ordering | 1 |
| address the column by its pre-rename table | 2 |

`pnpm check-types` 19/19 · `pnpm lint` exit 0 · `pnpm build` 17/17 · full `packages/nextly` run **400 failures = baseline exactly**, name-level diff zero new.

## Next in B1-3

The rename steps themselves (via `generateSQL`), the storage probe satisfying #399's `migratedObjects` contract, and making `db:sync` refuse while the marker says migrating (P0-E — it currently classifies builder-made tables as orphans to drop).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced field-group migration manifest planning for storage table, companion, and type-column rename semantics, including deterministic ordering and rollback inversion.
  * Migration state now persists, validates, and preserves the applied plan for safer rollback/resume; begin/settle inputs are tightened with direction- and generation-specific requirements.
  * Improved resume behavior for interrupted rollbacks, refusing when no applied plan was recorded.

* **Tests**
  * Expanded manifest/plan validation for emitted entry sequences, hashing determinism, collision edge cases, and rollback correctness.
  * Added type-level and runtime coverage for `appliedManifest` requirements, preservation, and malformed-plan rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->