### PR TITLE
feat(nextly): check the field group rename plan against the live catalog

### DIFF
--- a/.changeset/field-group-migration-reconcile.md
+++ b/.changeset/field-group-migration-reconcile.md
@@ -22,6 +22,6 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-Fixed component data teardown resolving table names case-insensitively on every database. On PostgreSQL, and on MySQL with `lower_case_table_names=0`, two names differing only in case are two different tables, so a registered component whose stored name differed in case from a real table could have that other table's rows deleted. Whether two spellings mean one table is now read from the server rather than assumed.
+Fixed component data teardown resolving table names case-insensitively on every database. On PostgreSQL, and on MySQL with `lower_case_table_names=0`, two names differing only in case are two different tables, so a registered component whose stored name differed in case from a real table could have that other table's rows deleted. Whether two spellings mean one table is now read from the server rather than assumed, including that SQLite folds ASCII case only, so `Ä` and `ä` stay distinct tables there.
 
 Also more groundwork for the upcoming field group storage migration: the rename plan is now checked against what the database actually contains before anything runs, so a name already in use, a registry row whose storage or companion table is missing, or a half-applied rename that recorded progress cannot account for all refuse up front instead of failing partway through. That part is not called by anything yet.

--- a/.changeset/field-group-migration-reconcile.md
+++ b/.changeset/field-group-migration-reconcile.md
@@ -22,4 +22,6 @@
 "@nextlyhq/tsconfig": patch
 ---
 
-More groundwork for the upcoming field group storage migration: the rename plan is now checked against what the database actually contains before anything runs, so a name already in use or a registry row whose storage is missing refuses up front instead of failing partway through. Nothing calls this yet, so there is no change in behaviour in this release.
+Fixed component data teardown resolving table names case-insensitively on every database. On PostgreSQL, and on MySQL with `lower_case_table_names=0`, two names differing only in case are two different tables, so a registered component whose stored name differed in case from a real table could have that other table's rows deleted. Whether two spellings mean one table is now read from the server rather than assumed.
+
+Also more groundwork for the upcoming field group storage migration: the rename plan is now checked against what the database actually contains before anything runs, so a name already in use, a registry row whose storage or companion table is missing, or a half-applied rename that recorded progress cannot account for all refuse up front instead of failing partway through. That part is not called by anything yet.

--- a/.changeset/field-group-migration-reconcile.md
+++ b/.changeset/field-group-migration-reconcile.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+More groundwork for the upcoming field group storage migration: the rename plan is now checked against what the database actually contains before anything runs, so a name already in use or a registry row whose storage is missing refuses up front instead of failing partway through. Nothing calls this yet, so there is no change in behaviour in this release.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/reconcile.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/reconcile.test.ts
@@ -5,6 +5,7 @@ import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
 import { identifierCaseRules } from "../../../schema/utils/resolve-catalog-name";
 import {
   buildMigrationManifest,
+  invertManifest,
   MIGRATION_TARGET,
   type RegistryRow,
 } from "../manifest";
@@ -647,5 +648,51 @@ describe("column metadata keyed in another case", () => {
         identifierCase: FOLDING,
       })
     ).not.toThrow();
+  });
+});
+
+describe("reconciling a rollback", () => {
+  const rows = [row()];
+  // The applied plan, reversed: registry first, then the column while its table
+  // still carries the migrated name, then the table itself.
+  const down = invertManifest(buildMigrationManifest(rows).entries).entries;
+  const COLUMN_POSITION = 2;
+
+  function reconcile(columnOnTable: string[]) {
+    // The table revert has committed, so the table is back to `comp_hero`, and
+    // the column entry still names `fg_hero`.
+    const tables = ["dynamic_components", "comp_hero"];
+    return reconcilePlan({
+      entries: down,
+      rows,
+      tables,
+      columns: columnsFor(tables, { comp_hero: columnOnTable }),
+      run: { recorded: true, direction: "down", step: down.length },
+      direction: "down",
+      identifierCase: PRESERVING,
+    });
+  }
+
+  it("inverts into the order the rollback runs", () => {
+    expect(down.map(e => e.kind)).toEqual(["registry", "column", "table"]);
+    expect(down[COLUMN_POSITION - 1]?.table).toBe("fg_hero");
+  });
+
+  // The column entry names the pre-revert table, so once the table revert has
+  // applied that name is gone and the columns have to be found under the name
+  // the revert produced. Without that, the step reads as satisfied and a
+  // rollback that never reverted the discriminator settles legacy storage
+  // carrying `_field_group_type`.
+  it("refuses a rollback that left the migrated discriminator in place", () => {
+    const refusal = capture(() => reconcile([TARGET_COLUMN]));
+    expect(refusal.logContext?.reason).toMatch(
+      /column rename the marker records as verified/
+    );
+    expect(refusal.logContext?.table).toBe("comp_hero");
+  });
+
+  it("accepts a rollback that reverted the discriminator", () => {
+    const out = reconcile([LEGACY_COLUMN]);
+    expect(out[COLUMN_POSITION - 1]?.satisfied).toBe(true);
   });
 });

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/reconcile.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/reconcile.test.ts
@@ -574,3 +574,78 @@ describe("probing a settled generation", () => {
     ).toEqual({ complete: true });
   });
 });
+
+describe("two rows resolving to one physical object", () => {
+  // The plan compares names exactly because it has no dialect, so this alias is
+  // invisible to it: `comp_hero`'s derived companion and a custom row named
+  // `COMP_HERO_LOCALES` are one table only on a folding server. Left unchecked the
+  // plan renames the shared table as the first row's companion and the second
+  // row's loss surfaces only after earlier renames have committed.
+  const rows = [
+    row({ slug: "hero", tableName: "comp_hero", hasCompanion: true }),
+    row({ slug: "seo", tableName: "COMP_HERO_LOCALES" }),
+  ];
+
+  function reconcile(
+    identifierCase: typeof PRESERVING,
+    tables: readonly string[]
+  ) {
+    return reconcilePlan({
+      entries: buildMigrationManifest(rows).entries,
+      rows,
+      tables,
+      columns: columnsFor(tables),
+      run: { recorded: false },
+      direction: "up",
+      identifierCase,
+    });
+  }
+
+  // One physical table, which both rows resolve to because the server folds.
+  it("refuses the alias on a folding server", () => {
+    const refusal = capture(() =>
+      reconcile(FOLDING, [
+        "dynamic_components",
+        "comp_hero",
+        "COMP_HERO_LOCALES",
+      ])
+    );
+    expect(refusal.logContext?.reason).toMatch(/claimed by two field groups/);
+    expect(refusal.logContext?.table).toBe("COMP_HERO_LOCALES");
+  });
+
+  // Two physical tables. A case-preserving server keeps them apart, so each row
+  // claims its own and the same registry is legitimate — the alias check must not
+  // fire on spelling alone.
+  it("accepts both rows where the server keeps the names apart", () => {
+    expect(() =>
+      reconcile(PRESERVING, [
+        "dynamic_components",
+        "comp_hero",
+        "comp_hero_locales",
+        "COMP_HERO_LOCALES",
+      ])
+    ).not.toThrow();
+  });
+});
+
+describe("column metadata keyed in another case", () => {
+  // Callers resolve a table before asking for its columns, so lookups arrive with
+  // the catalog's spelling. Keying the column index by the caller's spelling
+  // instead would miss on a folding server and refuse storage that is present.
+  it("finds a table's columns when the catalog reports another case", () => {
+    const rows = [row()];
+    expect(() =>
+      reconcilePlan({
+        entries: buildMigrationManifest(rows).entries,
+        rows,
+        tables: ["DYNAMIC_COMPONENTS", "COMP_HERO"],
+        // Keyed as Nextly stored them, not as the catalog reports them.
+        columns: columnsFor(["dynamic_components", "comp_hero"]),
+        run: { recorded: false },
+        direction: "up",
+        identifierCase: FOLDING,
+      })
+    ).not.toThrow();
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/reconcile.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/reconcile.test.ts
@@ -696,3 +696,43 @@ describe("reconciling a rollback", () => {
     expect(out[COLUMN_POSITION - 1]?.satisfied).toBe(true);
   });
 });
+
+describe("ownership on a settled marker", () => {
+  // Two custom-named rows that are one table on a folding server. A settled
+  // marker is not exempt from ownership: reporting this complete would let the
+  // verdict authorise both field groups against the same storage.
+  const rows = [
+    row({ slug: "alpha", tableName: "SHARED" }),
+    row({ slug: "beta", tableName: "shared" }),
+  ];
+
+  function probe(identifierCase: typeof PRESERVING, tables: readonly string[]) {
+    return probeStorage({
+      rows,
+      tables,
+      columns: columnsFor(tables, {
+        SHARED: [TARGET_COLUMN],
+        shared: [TARGET_COLUMN],
+      }),
+      identifierCase,
+      generation: "field-groups-v2",
+    });
+  }
+
+  it("refuses two rows resolving to one table", () => {
+    const refusal = capture(() =>
+      probe(FOLDING, ["dynamic_field_groups", "SHARED"])
+    );
+    expect(refusal.logContext?.reason).toMatch(/claimed by two field groups/);
+    expect(refusal.logContext?.table).toBe("SHARED");
+  });
+
+  // Where the server keeps the spellings apart they are two tables, and each row
+  // owns its own, so the same registry is complete.
+  it("accepts them where the server keeps the names apart", () => {
+    expect(
+      probe(PRESERVING, ["dynamic_field_groups", "SHARED", "shared"])
+        .migratedObjects
+    ).toEqual({ complete: true });
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/reconcile.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/reconcile.test.ts
@@ -1,17 +1,42 @@
 import { describe, expect, it } from "vitest";
 
 import { NextlyError } from "../../../../errors/nextly-error";
-import { buildMigrationManifest, type RegistryRow } from "../manifest";
-import { probeStorage, reconcilePlan } from "../reconcile";
+import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
+import { identifierCaseRules } from "../../../schema/utils/resolve-catalog-name";
+import {
+  buildMigrationManifest,
+  MIGRATION_TARGET,
+  type RegistryRow,
+} from "../manifest";
+import { probeStorage, reconcilePlan, type TableColumns } from "../reconcile";
 
 function row(over: Partial<RegistryRow> = {}): RegistryRow {
   return { slug: "hero", tableName: "comp_hero", hasCompanion: false, ...over };
 }
 
+const LEGACY_COLUMN = STORAGE_FORMAT.columns.type;
+const TARGET_COLUMN = MIGRATION_TARGET.columnType;
+
+/** Postgres: every identifier is quoted, so case is significant. */
+const PRESERVING = identifierCaseRules({ dialect: "postgresql" });
+/** SQLite, and MySQL under lower_case_table_names=1. */
+const FOLDING = identifierCaseRules({ dialect: "sqlite" });
+
 /** A pre-migration catalog: the legacy registry plus the row's own table. */
 const BEFORE = ["dynamic_components", "comp_hero"];
 /** After the run: everything renamed. */
 const AFTER = ["dynamic_field_groups", "fg_hero"];
+
+/** Give every named table the legacy discriminator unless told otherwise. */
+function columnsFor(
+  tables: readonly string[],
+  overrides: Record<string, string[]> = {}
+): TableColumns[] {
+  return tables.map(table => ({
+    table,
+    columns: overrides[table] ?? [LEGACY_COLUMN],
+  }));
+}
 
 function capture(run: () => unknown): NextlyError {
   try {
@@ -27,13 +52,22 @@ describe("field-group migration reconciliation", () => {
   const rows = [row()];
   const plan = buildMigrationManifest(rows).entries;
 
-  it("leaves outstanding work unmarked on an untouched database", () => {
-    const out = reconcilePlan({
+  /** The common case: a plan reconciled before anything has run. */
+  function untouched(over: Partial<Parameters<typeof reconcilePlan>[0]> = {}) {
+    return reconcilePlan({
       entries: plan,
       rows,
       tables: BEFORE,
+      columns: columnsFor(BEFORE),
       run: { recorded: false },
+      direction: "up",
+      identifierCase: PRESERVING,
+      ...over,
     });
+  }
+
+  it("leaves outstanding work unmarked on an untouched database", () => {
+    const out = untouched();
     expect(out).toHaveLength(plan.length);
     expect(out.every(e => e.satisfied === undefined)).toBe(true);
   });
@@ -41,62 +75,49 @@ describe("field-group migration reconciliation", () => {
   // The plan is indexed by position and identified by hash, so progress must not
   // change its length or its order.
   it("annotates applied work instead of removing it", () => {
-    // After the run the registry has been rewritten too, so a rebuilt plan reads
-    // rows that already carry migrated names.
-    const migrated = [row({ tableName: "fg_hero" })];
-    const rebuilt = buildMigrationManifest(migrated).entries;
-    const out = reconcilePlan({
-      entries: rebuilt,
-      rows: migrated,
-      tables: AFTER,
-      run: { recorded: true },
-    });
-    expect(out).toHaveLength(rebuilt.length);
-    expect(out.map(e => e.kind)).toEqual(rebuilt.map(e => e.kind));
-    expect(out.filter(e => e.satisfied).length).toBeGreaterThan(0);
-  });
-
-  // Source gone and target present means completed work only when a run is on
-  // record. With none, the target belongs to something else and adopting it
-  // would treat a stranger's table as migrated field-group storage.
-  it("refuses an occupied target when no run is recorded", () => {
-    const refusal = capture(() =>
-      reconcilePlan({
-        entries: plan,
-        rows,
-        // The row's own storage is intact; something else is sitting on the
-        // registry's target name with no run on record to explain it.
-        tables: [
-          ...BEFORE.filter(t => t !== "dynamic_components"),
-          "dynamic_field_groups",
-        ],
-        run: { recorded: false },
-      })
-    );
-    expect(refusal.logContext?.reason).toMatch(/no migration recorded it/);
-  });
-
-  // The same pair with a run on record is this migration's own finished work.
-  it("accepts an occupied target when a run is recorded", () => {
     const out = reconcilePlan({
       entries: plan,
       rows,
-      tables: [
-        ...BEFORE.filter(t => t !== "dynamic_components"),
-        "dynamic_field_groups",
-      ],
-      run: { recorded: true },
+      tables: AFTER,
+      columns: columnsFor(AFTER, { fg_hero: [TARGET_COLUMN] }),
+      run: { recorded: true, direction: "up", step: plan.length },
+      direction: "up",
+      identifierCase: PRESERVING,
+    });
+    expect(out).toHaveLength(plan.length);
+    expect(out.map(e => e.kind)).toEqual(plan.map(e => e.kind));
+    expect(out.every(e => e.satisfied === true)).toBe(true);
+  });
+
+  // Source gone and target present means completed work only when recorded
+  // progress reached it. Otherwise the target belongs to something else and
+  // adopting it would treat a stranger's table as migrated field-group storage.
+  it("refuses an occupied target when no run is recorded", () => {
+    const tables = ["comp_hero", "dynamic_field_groups"];
+    const refusal = capture(() =>
+      untouched({ tables, columns: columnsFor(tables) })
+    );
+    expect(refusal.logContext?.reason).toMatch(/no recorded progress/);
+  });
+
+  it("accepts an occupied target when recorded progress reaches it", () => {
+    const tables = ["comp_hero", "dynamic_field_groups"];
+    const out = untouched({
+      tables,
+      columns: columnsFor(tables),
+      // The registry is the last entry, so progress must have reached it.
+      run: { recorded: true, direction: "up", step: plan.length - 1 },
     });
     expect(out.find(e => e.kind === "registry")?.satisfied).toBe(true);
   });
 
   it("refuses when source and target both exist", () => {
+    const tables = [...BEFORE, ...AFTER];
     const refusal = capture(() =>
-      reconcilePlan({
-        entries: plan,
-        rows,
-        tables: [...BEFORE, ...AFTER],
-        run: { recorded: true },
+      untouched({
+        tables,
+        columns: columnsFor(tables),
+        run: { recorded: true, direction: "up", step: plan.length },
       })
     );
     expect(refusal.logContext?.reason).toMatch(/already in use/);
@@ -111,9 +132,11 @@ describe("field-group migration reconciliation", () => {
       reconcilePlan({
         entries: buildMigrationManifest(withCustom).entries,
         rows: withCustom,
-        // `my_seo_block` is absent.
         tables: BEFORE,
+        columns: columnsFor(BEFORE),
         run: { recorded: false },
+        direction: "up",
+        identifierCase: PRESERVING,
       })
     );
     expect(refusal.logContext?.reason).toMatch(
@@ -122,73 +145,312 @@ describe("field-group migration reconciliation", () => {
     expect(refusal.logContext?.missing).toEqual(["my_seo_block"]);
   });
 
-  // MySQL under `lower_case_table_names` reports a verbatim name folded, so an
-  // exact-only lookup would call a table that exists missing.
-  it("resolves a stored name the catalog reports in a different case", () => {
-    const mixed = [row({ slug: "hero", tableName: "comp_hero" })];
+  // A custom-named row is retargeted by nothing, so the plan holds no companion
+  // entry for it either: without checking it here, a dropped companion is found
+  // only after other objects have already been renamed.
+  it("refuses when a row this plan leaves alone has no companion", () => {
+    const withCustom = [
+      row(),
+      row({ slug: "seo", tableName: "my_seo_block", hasCompanion: true }),
+    ];
+    const tables = [...BEFORE, "my_seo_block"];
+    const refusal = capture(() =>
+      reconcilePlan({
+        entries: buildMigrationManifest(withCustom).entries,
+        rows: withCustom,
+        tables,
+        columns: columnsFor(tables),
+        run: { recorded: false },
+        direction: "up",
+        identifierCase: PRESERVING,
+      })
+    );
+    expect(refusal.logContext?.missing).toEqual([
+      `my_seo_block${STORAGE_FORMAT.companionSuffix}`,
+    ]);
+  });
+
+  it("accepts a left-alone row whose companion is present", () => {
+    const withCustom = [
+      row(),
+      row({ slug: "seo", tableName: "my_seo_block", hasCompanion: true }),
+    ];
+    const tables = [
+      ...BEFORE,
+      "my_seo_block",
+      `my_seo_block${STORAGE_FORMAT.companionSuffix}`,
+    ];
     expect(() =>
       reconcilePlan({
-        entries: buildMigrationManifest(mixed).entries,
-        rows: mixed,
-        tables: ["DYNAMIC_COMPONENTS", "COMP_HERO"],
+        entries: buildMigrationManifest(withCustom).entries,
+        rows: withCustom,
+        tables,
+        columns: columnsFor(tables),
         run: { recorded: false },
+        direction: "up",
+        identifierCase: PRESERVING,
       })
     ).not.toThrow();
   });
 
-  // The column names its post-rename table, absent from a pre-migration catalog,
-  // so it must survive on the strength of the rename that creates it.
-  it("keeps a column rename for a table the plan is about to create", () => {
-    const out = reconcilePlan({
-      entries: plan,
-      rows,
-      tables: BEFORE,
-      run: { recorded: false },
+  // MySQL under `lower_case_table_names=1` reports a verbatim name folded, so an
+  // exact-only lookup would call a table that exists missing.
+  it("resolves a stored name the catalog reports in a different case", () => {
+    const tables = ["DYNAMIC_COMPONENTS", "COMP_HERO"];
+    expect(() =>
+      untouched({
+        tables,
+        columns: columnsFor(tables),
+        identifierCase: FOLDING,
+      })
+    ).not.toThrow();
+  });
+
+  // The same catalog on a case-preserving server names different tables, so the
+  // row's storage is genuinely absent and the near-miss is reported.
+  it("refuses a case-different catalog where case is significant", () => {
+    const tables = ["DYNAMIC_COMPONENTS", "COMP_HERO"];
+    const refusal = capture(() =>
+      untouched({ tables, columns: columnsFor(tables) })
+    );
+    expect(refusal.logContext?.reason).toMatch(
+      /name storage that does not exist/
+    );
+    expect(refusal.logContext?.caseVariants).toEqual({
+      comp_hero: "COMP_HERO",
     });
-    const column = out.find(e => e.kind === "column");
+  });
+
+  // The column names its post-rename table, absent from a pre-migration catalog,
+  // so it is inspected on the table it has not yet moved off.
+  it("keeps a column rename for a table the plan is about to create", () => {
+    const column = untouched().find(e => e.kind === "column");
     expect(column).toBeDefined();
     expect(column?.satisfied).toBeUndefined();
+  });
+
+  // A table rename that commits before its marker write leaves the table present
+  // both before and after the step, so only its columns distinguish outstanding
+  // work from work already done.
+  it("resumes across a committed table rename the marker did not record", () => {
+    const tables = ["dynamic_components", "fg_hero"];
+    const out = untouched({
+      tables,
+      columns: columnsFor(tables),
+      run: { recorded: true, direction: "up", step: 0 },
+    });
+    expect(out[0]).toMatchObject({ kind: "table", satisfied: true });
+    expect(out[1]?.kind).toBe("column");
+    expect(out[1]?.satisfied).toBeUndefined();
+    expect(out[2]?.kind).toBe("registry");
+    expect(out[2]?.satisfied).toBeUndefined();
+  });
+
+  // Without inspecting columns the resume retries a rename whose source column
+  // is already gone, and the retry fails.
+  it("marks a column rename the marker did not record as done", () => {
+    const tables = ["dynamic_components", "fg_hero"];
+    const out = untouched({
+      tables,
+      columns: columnsFor(tables, { fg_hero: [TARGET_COLUMN] }),
+      run: { recorded: true, direction: "up", step: 1 },
+    });
+    expect(out[1]).toMatchObject({ kind: "column", satisfied: true });
+  });
+
+  it("refuses a migrated column no recorded progress accounts for", () => {
+    const tables = ["dynamic_components", "comp_hero"];
+    const refusal = capture(() =>
+      untouched({
+        tables,
+        columns: columnsFor(tables, { comp_hero: [TARGET_COLUMN] }),
+      })
+    );
+    expect(refusal.logContext?.reason).toMatch(
+      /no recorded progress accounts for it/
+    );
+  });
+
+  it("refuses when a table carries both discriminator spellings", () => {
+    const refusal = capture(() =>
+      untouched({
+        columns: columnsFor(BEFORE, {
+          comp_hero: [LEGACY_COLUMN, TARGET_COLUMN],
+        }),
+      })
+    );
+    expect(refusal.logContext?.reason).toMatch(/both discriminator columns/);
+  });
+
+  // Every field-group data table carries the discriminator, so a table holding
+  // neither spelling is not storage this migration can reason about.
+  it("refuses when a table carries neither discriminator spelling", () => {
+    const refusal = capture(() =>
+      untouched({ columns: columnsFor(BEFORE, { comp_hero: ["title"] }) })
+    );
+    expect(refusal.logContext?.reason).toMatch(/no discriminator column/);
+  });
+
+  it("refuses when a table that exists was given no columns", () => {
+    const refusal = capture(() => untouched({ columns: [] }));
+    expect(refusal.logContext?.reason).toMatch(/given no columns/);
+  });
+
+  // MySQL compares column names case-insensitively on every server, so the
+  // discriminator must be found whatever case the catalog reports.
+  it("resolves the discriminator under the column rules", () => {
+    expect(() =>
+      untouched({
+        columns: columnsFor(BEFORE, {
+          comp_hero: [LEGACY_COLUMN.toUpperCase()],
+        }),
+        identifierCase: FOLDING,
+      })
+    ).not.toThrow();
+  });
+
+  // A down plan is the inverse of an up one, so scoring one against the other's
+  // progress would mark real work as done and skip it.
+  it("refuses a plan reconciled against a run going the other way", () => {
+    const refusal = capture(() =>
+      untouched({ run: { recorded: true, direction: "down", step: 1 } })
+    );
+    expect(refusal.logContext?.reason).toMatch(/the other way/);
+  });
+});
+
+describe("recorded progress beyond the crash window", () => {
+  const rows = [
+    row({ slug: "alpha", tableName: "comp_alpha" }),
+    row({ slug: "beta", tableName: "comp_beta" }),
+  ];
+  const plan = buildMigrationManifest(rows).entries;
+  // Ordered by stored table name, so beta's rename sits at position 3.
+  const BETA_POSITION = 3;
+  const tables = ["dynamic_components", "comp_alpha", "fg_beta"];
+
+  function reconcile(step: number) {
+    return reconcilePlan({
+      entries: plan,
+      rows,
+      tables,
+      columns: columnsFor(tables),
+      run: { recorded: true, direction: "up", step },
+      direction: "up",
+      identifierCase: PRESERVING,
+    });
+  }
+
+  // A marker recording step 1 says nothing about step 3. Treating any run record
+  // as blanket permission adopts a table this run never created.
+  it("refuses a target beyond the recorded step and its crash window", () => {
+    const refusal = capture(() => reconcile(1));
+    expect(refusal.logContext?.reason).toMatch(/no recorded progress/);
+    expect(refusal.logContext?.position).toBe(BETA_POSITION);
+  });
+
+  it("accepts the same target once progress reaches its crash window", () => {
+    const out = reconcile(BETA_POSITION - 1);
+    expect(out[BETA_POSITION - 1]).toMatchObject({
+      kind: "table",
+      satisfied: true,
+    });
   });
 });
 
 describe("field-group storage probe", () => {
-  it("reports complete when every referenced object is present", () => {
-    const rows = [row({ hasCompanion: true })];
-    const probe = probeStorage({
-      rows,
-      tables: ["dynamic_components", "comp_hero", "comp_hero_locales"],
+  function probe(over: Partial<Parameters<typeof probeStorage>[0]> = {}) {
+    return probeStorage({
+      rows: [row()],
+      tables: BEFORE,
+      columns: columnsFor(BEFORE),
+      identifierCase: PRESERVING,
+      typeColumn: LEGACY_COLUMN,
+      ...over,
     });
-    expect(probe.migratedObjects).toEqual({ complete: true });
-    expect(probe.legacyRegistryPresent).toBe(true);
-    expect(probe.targetRegistryPresent).toBe(false);
+  }
+
+  it("reports complete when every referenced object is present", () => {
+    const tables = ["dynamic_components", "comp_hero", "comp_hero_locales"];
+    const result = probe({
+      rows: [row({ hasCompanion: true })],
+      tables,
+      columns: columnsFor(tables),
+    });
+    expect(result.migratedObjects).toEqual({ complete: true });
+    expect(result.legacyRegistryPresent).toBe(true);
+    expect(result.targetRegistryPresent).toBe(false);
   });
 
   // The read path turns a missing data table into an empty result, so an
   // incomplete rename would serve blank content rather than fail. Naming what is
   // missing is the point: an operator needs to know what to restore.
   it("names every object it could not find", () => {
-    const rows = [row({ hasCompanion: true })];
-    const probe = probeStorage({ rows, tables: ["dynamic_components"] });
-    expect(probe.migratedObjects).toEqual({
+    const tables = ["dynamic_components"];
+    expect(
+      probe({
+        rows: [row({ hasCompanion: true })],
+        tables,
+        columns: columnsFor(tables),
+      }).migratedObjects
+    ).toEqual({
       complete: false,
       missing: ["comp_hero", "comp_hero_locales"],
     });
   });
 
   it("does not look for a companion a row does not have", () => {
-    const probe = probeStorage({
-      rows: [row({ hasCompanion: false })],
-      tables: ["dynamic_components", "comp_hero"],
-    });
-    expect(probe.migratedObjects).toEqual({ complete: true });
+    expect(probe().migratedObjects).toEqual({ complete: true });
   });
 
   it("reports each registry independently", () => {
-    const probe = probeStorage({
+    const result = probe({
       rows: [],
       tables: ["dynamic_field_groups"],
+      columns: [],
     });
-    expect(probe.targetRegistryPresent).toBe(true);
-    expect(probe.legacyRegistryPresent).toBe(false);
+    expect(result.targetRegistryPresent).toBe(true);
+    expect(result.legacyRegistryPresent).toBe(false);
+  });
+
+  // A table present under its migrated name while still carrying the old column
+  // is not migrated storage, and reading it addresses a column that is not there.
+  it("reports a table whose discriminator was not migrated", () => {
+    expect(
+      probe({
+        rows: [row({ tableName: "fg_hero" })],
+        tables: AFTER,
+        columns: columnsFor(AFTER),
+        typeColumn: TARGET_COLUMN,
+      }).migratedObjects
+    ).toEqual({
+      complete: false,
+      missing: [`fg_hero.${TARGET_COLUMN}`],
+    });
+  });
+
+  it("accepts a table whose discriminator was migrated", () => {
+    expect(
+      probe({
+        rows: [row({ tableName: "fg_hero" })],
+        tables: AFTER,
+        columns: columnsFor(AFTER, { fg_hero: [TARGET_COLUMN] }),
+        typeColumn: TARGET_COLUMN,
+      }).migratedObjects
+    ).toEqual({ complete: true });
+  });
+
+  // Companions hold translations of individual fields and never the type, so
+  // requiring the discriminator on them would report every localized group
+  // incomplete.
+  it("does not require the discriminator on a companion", () => {
+    const tables = ["dynamic_components", "comp_hero", "comp_hero_locales"];
+    expect(
+      probe({
+        rows: [row({ hasCompanion: true })],
+        tables,
+        columns: columnsFor(tables, { comp_hero_locales: ["title"] }),
+      }).migratedObjects
+    ).toEqual({ complete: true });
   });
 });

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/reconcile.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/reconcile.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../../../errors/nextly-error";
+import { buildMigrationManifest, type RegistryRow } from "../manifest";
+import { probeStorage, reconcilePlan } from "../reconcile";
+
+function row(over: Partial<RegistryRow> = {}): RegistryRow {
+  return { slug: "hero", tableName: "comp_hero", hasCompanion: false, ...over };
+}
+
+/** A pre-migration catalog: the legacy registry plus the row's own table. */
+const BEFORE = ["dynamic_components", "comp_hero"];
+/** After the run: everything renamed. */
+const AFTER = ["dynamic_field_groups", "fg_hero"];
+
+function capture(run: () => unknown): NextlyError {
+  try {
+    run();
+  } catch (error) {
+    if (NextlyError.is(error)) return error;
+    expect.fail(`expected a NextlyError, received ${String(error)}`);
+  }
+  expect.fail("expected a refusal, but the call returned normally");
+}
+
+describe("field-group migration reconciliation", () => {
+  const rows = [row()];
+  const plan = buildMigrationManifest(rows).entries;
+
+  it("leaves outstanding work unmarked on an untouched database", () => {
+    const out = reconcilePlan({
+      entries: plan,
+      rows,
+      tables: BEFORE,
+      run: { recorded: false },
+    });
+    expect(out).toHaveLength(plan.length);
+    expect(out.every(e => e.satisfied === undefined)).toBe(true);
+  });
+
+  // The plan is indexed by position and identified by hash, so progress must not
+  // change its length or its order.
+  it("annotates applied work instead of removing it", () => {
+    // After the run the registry has been rewritten too, so a rebuilt plan reads
+    // rows that already carry migrated names.
+    const migrated = [row({ tableName: "fg_hero" })];
+    const rebuilt = buildMigrationManifest(migrated).entries;
+    const out = reconcilePlan({
+      entries: rebuilt,
+      rows: migrated,
+      tables: AFTER,
+      run: { recorded: true },
+    });
+    expect(out).toHaveLength(rebuilt.length);
+    expect(out.map(e => e.kind)).toEqual(rebuilt.map(e => e.kind));
+    expect(out.filter(e => e.satisfied).length).toBeGreaterThan(0);
+  });
+
+  // Source gone and target present means completed work only when a run is on
+  // record. With none, the target belongs to something else and adopting it
+  // would treat a stranger's table as migrated field-group storage.
+  it("refuses an occupied target when no run is recorded", () => {
+    const refusal = capture(() =>
+      reconcilePlan({
+        entries: plan,
+        rows,
+        // The row's own storage is intact; something else is sitting on the
+        // registry's target name with no run on record to explain it.
+        tables: [
+          ...BEFORE.filter(t => t !== "dynamic_components"),
+          "dynamic_field_groups",
+        ],
+        run: { recorded: false },
+      })
+    );
+    expect(refusal.logContext?.reason).toMatch(/no migration recorded it/);
+  });
+
+  // The same pair with a run on record is this migration's own finished work.
+  it("accepts an occupied target when a run is recorded", () => {
+    const out = reconcilePlan({
+      entries: plan,
+      rows,
+      tables: [
+        ...BEFORE.filter(t => t !== "dynamic_components"),
+        "dynamic_field_groups",
+      ],
+      run: { recorded: true },
+    });
+    expect(out.find(e => e.kind === "registry")?.satisfied).toBe(true);
+  });
+
+  it("refuses when source and target both exist", () => {
+    const refusal = capture(() =>
+      reconcilePlan({
+        entries: plan,
+        rows,
+        tables: [...BEFORE, ...AFTER],
+        run: { recorded: true },
+      })
+    );
+    expect(refusal.logContext?.reason).toMatch(/already in use/);
+  });
+
+  // A custom-named row produces no rename entry, so an entry-driven check cannot
+  // see it. Its table can still be missing, and the legacy read path tolerates
+  // that by returning an empty result.
+  it("refuses when a row this plan leaves alone has no storage", () => {
+    const withCustom = [row(), row({ slug: "seo", tableName: "my_seo_block" })];
+    const refusal = capture(() =>
+      reconcilePlan({
+        entries: buildMigrationManifest(withCustom).entries,
+        rows: withCustom,
+        // `my_seo_block` is absent.
+        tables: BEFORE,
+        run: { recorded: false },
+      })
+    );
+    expect(refusal.logContext?.reason).toMatch(
+      /name storage that does not exist/
+    );
+    expect(refusal.logContext?.missing).toEqual(["my_seo_block"]);
+  });
+
+  // MySQL under `lower_case_table_names` reports a verbatim name folded, so an
+  // exact-only lookup would call a table that exists missing.
+  it("resolves a stored name the catalog reports in a different case", () => {
+    const mixed = [row({ slug: "hero", tableName: "comp_hero" })];
+    expect(() =>
+      reconcilePlan({
+        entries: buildMigrationManifest(mixed).entries,
+        rows: mixed,
+        tables: ["DYNAMIC_COMPONENTS", "COMP_HERO"],
+        run: { recorded: false },
+      })
+    ).not.toThrow();
+  });
+
+  // The column names its post-rename table, absent from a pre-migration catalog,
+  // so it must survive on the strength of the rename that creates it.
+  it("keeps a column rename for a table the plan is about to create", () => {
+    const out = reconcilePlan({
+      entries: plan,
+      rows,
+      tables: BEFORE,
+      run: { recorded: false },
+    });
+    const column = out.find(e => e.kind === "column");
+    expect(column).toBeDefined();
+    expect(column?.satisfied).toBeUndefined();
+  });
+});
+
+describe("field-group storage probe", () => {
+  it("reports complete when every referenced object is present", () => {
+    const rows = [row({ hasCompanion: true })];
+    const probe = probeStorage({
+      rows,
+      tables: ["dynamic_components", "comp_hero", "comp_hero_locales"],
+    });
+    expect(probe.migratedObjects).toEqual({ complete: true });
+    expect(probe.legacyRegistryPresent).toBe(true);
+    expect(probe.targetRegistryPresent).toBe(false);
+  });
+
+  // The read path turns a missing data table into an empty result, so an
+  // incomplete rename would serve blank content rather than fail. Naming what is
+  // missing is the point: an operator needs to know what to restore.
+  it("names every object it could not find", () => {
+    const rows = [row({ hasCompanion: true })];
+    const probe = probeStorage({ rows, tables: ["dynamic_components"] });
+    expect(probe.migratedObjects).toEqual({
+      complete: false,
+      missing: ["comp_hero", "comp_hero_locales"],
+    });
+  });
+
+  it("does not look for a companion a row does not have", () => {
+    const probe = probeStorage({
+      rows: [row({ hasCompanion: false })],
+      tables: ["dynamic_components", "comp_hero"],
+    });
+    expect(probe.migratedObjects).toEqual({ complete: true });
+  });
+
+  it("reports each registry independently", () => {
+    const probe = probeStorage({
+      rows: [],
+      tables: ["dynamic_field_groups"],
+    });
+    expect(probe.targetRegistryPresent).toBe(true);
+    expect(probe.legacyRegistryPresent).toBe(false);
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/reconcile.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/reconcile.test.ts
@@ -101,11 +101,12 @@ describe("field-group migration reconciliation", () => {
   });
 
   it("accepts an occupied target when recorded progress reaches it", () => {
-    const tables = ["comp_hero", "dynamic_field_groups"];
+    // A world consistent with that progress: the table and column steps really
+    // did run, so only the registry rename sits in the crash window.
+    const tables = ["fg_hero", "dynamic_field_groups"];
     const out = untouched({
       tables,
-      columns: columnsFor(tables),
-      // The registry is the last entry, so progress must have reached it.
+      columns: columnsFor(tables, { fg_hero: [TARGET_COLUMN] }),
       run: { recorded: true, direction: "up", step: plan.length - 1 },
     });
     expect(out.find(e => e.kind === "registry")?.satisfied).toBe(true);
@@ -325,16 +326,22 @@ describe("recorded progress beyond the crash window", () => {
     row({ slug: "beta", tableName: "comp_beta" }),
   ];
   const plan = buildMigrationManifest(rows).entries;
-  // Ordered by stored table name, so beta's rename sits at position 3.
+  // Ordered by stored table name: 1 = alpha's table, 2 = alpha's column,
+  // 3 = beta's table, 4 = beta's column, 5 = the registry.
   const BETA_POSITION = 3;
-  const tables = ["dynamic_components", "comp_alpha", "fg_beta"];
 
-  function reconcile(step: number) {
+  /**
+   * Alpha is fully renamed and `fg_beta` exists, which is the ambiguity: it is
+   * this run's work only if recorded progress reached beta's position.
+   * `alphaColumn` keeps the world consistent with whichever step is claimed.
+   */
+  function reconcile(step: number, alphaColumn: string) {
+    const tables = ["dynamic_components", "fg_alpha", "fg_beta"];
     return reconcilePlan({
       entries: plan,
       rows,
       tables,
-      columns: columnsFor(tables),
+      columns: columnsFor(tables, { fg_alpha: [alphaColumn] }),
       run: { recorded: true, direction: "up", step },
       direction: "up",
       identifierCase: PRESERVING,
@@ -344,13 +351,13 @@ describe("recorded progress beyond the crash window", () => {
   // A marker recording step 1 says nothing about step 3. Treating any run record
   // as blanket permission adopts a table this run never created.
   it("refuses a target beyond the recorded step and its crash window", () => {
-    const refusal = capture(() => reconcile(1));
+    const refusal = capture(() => reconcile(1, LEGACY_COLUMN));
     expect(refusal.logContext?.reason).toMatch(/no recorded progress/);
     expect(refusal.logContext?.position).toBe(BETA_POSITION);
   });
 
   it("accepts the same target once progress reaches its crash window", () => {
-    const out = reconcile(BETA_POSITION - 1);
+    const out = reconcile(BETA_POSITION - 1, TARGET_COLUMN);
     expect(out[BETA_POSITION - 1]).toMatchObject({
       kind: "table",
       satisfied: true,
@@ -365,7 +372,7 @@ describe("field-group storage probe", () => {
       tables: BEFORE,
       columns: columnsFor(BEFORE),
       identifierCase: PRESERVING,
-      typeColumn: LEGACY_COLUMN,
+      generation: "legacy",
       ...over,
     });
   }
@@ -421,7 +428,7 @@ describe("field-group storage probe", () => {
         rows: [row({ tableName: "fg_hero" })],
         tables: AFTER,
         columns: columnsFor(AFTER),
-        typeColumn: TARGET_COLUMN,
+        generation: "field-groups-v2",
       }).migratedObjects
     ).toEqual({
       complete: false,
@@ -435,7 +442,7 @@ describe("field-group storage probe", () => {
         rows: [row({ tableName: "fg_hero" })],
         tables: AFTER,
         columns: columnsFor(AFTER, { fg_hero: [TARGET_COLUMN] }),
-        typeColumn: TARGET_COLUMN,
+        generation: "field-groups-v2",
       }).migratedObjects
     ).toEqual({ complete: true });
   });
@@ -450,6 +457,119 @@ describe("field-group storage probe", () => {
         rows: [row({ hasCompanion: true })],
         tables,
         columns: columnsFor(tables, { comp_hero_locales: ["title"] }),
+      }).migratedObjects
+    ).toEqual({ complete: true });
+  });
+});
+
+describe("marker and catalog contradicting each other", () => {
+  const rows = [row()];
+  const plan = buildMigrationManifest(rows).entries;
+
+  // The guard resumes at `step + 1`, so a position at or below the recorded step
+  // never runs again. Reporting it as outstanding is a claim nothing acts on: the
+  // rename would be skipped silently and every later step would run against a
+  // schema the plan believes has already moved.
+  it("refuses a rename the marker records as verified but that never happened", () => {
+    const refusal = capture(() =>
+      reconcilePlan({
+        entries: plan,
+        rows,
+        tables: BEFORE,
+        columns: columnsFor(BEFORE),
+        // Step 1 is the table rename, and `comp_hero` is still there.
+        run: { recorded: true, direction: "up", step: 1 },
+        direction: "up",
+        identifierCase: PRESERVING,
+      })
+    );
+    expect(refusal.logContext?.reason).toMatch(
+      /records as verified has not been applied/
+    );
+    expect(refusal.logContext?.position).toBe(1);
+  });
+
+  // Same contradiction one level down: the table moved, the column did not, and
+  // the marker claims the column step verified.
+  it("refuses a column rename the marker records as verified but that never happened", () => {
+    const tables = ["dynamic_components", "fg_hero"];
+    const refusal = capture(() =>
+      reconcilePlan({
+        entries: plan,
+        rows,
+        tables,
+        columns: columnsFor(tables),
+        // Step 2 is the column rename; `fg_hero` still carries the legacy column.
+        run: { recorded: true, direction: "up", step: 2 },
+        direction: "up",
+        identifierCase: PRESERVING,
+      })
+    );
+    expect(refusal.logContext?.reason).toMatch(
+      /column rename the marker records as verified/
+    );
+  });
+
+  // The crash window is the boundary and must stay accepting: at `step + 1` the
+  // statement may simply not have committed, and the runner re-runs it.
+  it("accepts an unapplied rename sitting in the crash window", () => {
+    expect(() =>
+      reconcilePlan({
+        entries: plan,
+        rows,
+        tables: BEFORE,
+        columns: columnsFor(BEFORE),
+        run: { recorded: true, direction: "up", step: 0 },
+        direction: "up",
+        identifierCase: PRESERVING,
+      })
+    ).not.toThrow();
+  });
+});
+
+describe("probing a settled generation", () => {
+  // A completed marker plus a row still naming its legacy table means the rename
+  // never happened. Accepting either name would report that complete and let
+  // `resolveStorageVerdict` authorise v2 storage that does not exist.
+  it("requires the migrated name when probing field-groups-v2", () => {
+    const tables = ["dynamic_field_groups", "comp_hero"];
+    expect(
+      probeStorage({
+        rows: [row()],
+        tables,
+        columns: columnsFor(tables, { comp_hero: [TARGET_COLUMN] }),
+        identifierCase: PRESERVING,
+        generation: "field-groups-v2",
+      }).migratedObjects
+    ).toEqual({ complete: false, missing: ["fg_hero"] });
+  });
+
+  // The legacy probe is the mirror image: the migrated name must not satisfy it.
+  it("requires the stored name when probing legacy", () => {
+    const tables = ["dynamic_components", "fg_hero"];
+    expect(
+      probeStorage({
+        rows: [row()],
+        tables,
+        columns: columnsFor(tables),
+        identifierCase: PRESERVING,
+        generation: "legacy",
+      }).migratedObjects
+    ).toEqual({ complete: false, missing: ["comp_hero"] });
+  });
+
+  // A custom-named row is already at its final name, so it satisfies a v2 probe
+  // as it stands rather than being reported missing forever.
+  it("accepts a custom-named row under its own name when probing v2", () => {
+    const custom = [row({ slug: "seo", tableName: "my_seo_block" })];
+    const tables = ["dynamic_field_groups", "my_seo_block"];
+    expect(
+      probeStorage({
+        rows: custom,
+        tables,
+        columns: columnsFor(tables, { my_seo_block: [TARGET_COLUMN] }),
+        identifierCase: PRESERVING,
+        generation: "field-groups-v2",
       }).migratedObjects
     ).toEqual({ complete: true });
   });

--- a/packages/nextly/src/domains/field-groups/migration/reconcile.ts
+++ b/packages/nextly/src/domains/field-groups/migration/reconcile.ts
@@ -161,6 +161,11 @@ export function probeStorage(args: {
   const catalog = indexCatalog(args.tables, identifierCase.tables);
   const columns = indexColumns(args.columns, catalog, identifierCase);
   const missing: string[] = [];
+  // A settled marker is not exempt from ownership: a registry restored or
+  // repaired with two rows that resolve to one table would otherwise be reported
+  // complete, and the verdict would authorise both field groups against the same
+  // storage.
+  const claim = createClaimLedger();
 
   for (const row of args.rows) {
     for (const object of expectedStorage(row, generation)) {
@@ -169,6 +174,7 @@ export function probeStorage(args: {
         missing.push(object.names[0]);
         continue;
       }
+      claim(found, claimantOf(row, object));
       // Only the base table carries the discriminator; companions hold
       // translations of individual fields and never the type.
       if (!object.isBase) continue;
@@ -269,6 +275,36 @@ function namesFor(
   return [row.tableName, ...(target === null ? [] : [target])];
 }
 
+/**
+ * Records which registry row owns each physical object, and refuses a second
+ * claim on one.
+ *
+ * Shared by the pre-run check and the settled-marker probe because they ask the
+ * same question and an answer that differs between them is a hole: ownership
+ * cannot be shared, whichever path notices. Claims are keyed by the **resolved**
+ * catalog name, the only level at which two spellings are known to be one
+ * object — the plan compares exactly, having no dialect.
+ */
+function createClaimLedger(): (found: string, claimant: string) => void {
+  const claims = new Map<string, string>();
+  return (found, claimant) => {
+    const previous = claims.get(found);
+    if (previous !== undefined) {
+      throw refuse("one physical object is claimed by two field groups", {
+        table: found,
+        claimedBy: previous,
+        alsoClaimedBy: claimant,
+      });
+    }
+    claims.set(found, claimant);
+  };
+}
+
+/** How a refusal names the owner of an expected object. */
+function claimantOf(row: RegistryRow, object: ExpectedObject): string {
+  return `${row.slug}${object.isBase ? "" : " companion"}`;
+}
+
 function resolveAny(
   catalog: CatalogIndex,
   names: readonly string[]
@@ -322,13 +358,7 @@ function assertEveryRowHasStorage(
 ): void {
   const missing: string[] = [];
   const caseVariants: Record<string, string> = {};
-  // Which row already claimed each physical object. Claims are tracked by the
-  // *resolved* catalog name, which is the only level where two spellings are
-  // known to be one object: the plan compares names exactly because it has no
-  // dialect, so on a folding server a row named `COMP_HERO_LOCALES` and another
-  // row's derived `comp_hero_locales` companion pass every check the plan can
-  // make while addressing the same table.
-  const claims = new Map<string, string>();
+  const claim = createClaimLedger();
 
   for (const row of rows) {
     for (const object of expectedStorage(row, "either")) {
@@ -342,17 +372,7 @@ function assertEveryRowHasStorage(
         if (variant !== undefined) caseVariants[object.names[0]] = variant;
         continue;
       }
-
-      const claimant = `${row.slug}${object.isBase ? "" : " companion"}`;
-      const previous = claims.get(found);
-      if (previous !== undefined) {
-        throw refuse("one physical object is claimed by two field groups", {
-          table: found,
-          claimedBy: previous,
-          alsoClaimedBy: claimant,
-        });
-      }
-      claims.set(found, claimant);
+      claim(found, claimantOf(row, object));
     }
   }
 

--- a/packages/nextly/src/domains/field-groups/migration/reconcile.ts
+++ b/packages/nextly/src/domains/field-groups/migration/reconcile.ts
@@ -2,9 +2,10 @@
  * Decides a rename plan against what the database actually contains.
  *
  * The plan itself is a pure function of registry rows and knows nothing about
- * the database. Reconciling it needs three things the plan deliberately does not
- * have: the catalog, the dialect's rules for deciding whether two spellings are
- * one table, and whether a migration run is already recorded. Those live here.
+ * the database. Reconciling it needs four things the plan deliberately does not
+ * have: the catalog, the server's rules for deciding whether two spellings are
+ * one object, the columns those objects carry, and how far a run has already
+ * got. Those live here.
  *
  * Nothing is removed from a plan. Progress is annotated, because the plan is
  * indexed by position and identified by hash: dropping an entry renumbers every
@@ -17,58 +18,106 @@
 import { NextlyError } from "../../../errors/nextly-error";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import {
+  findCaseVariant,
   indexCatalog,
   resolveCatalogName,
   type CatalogIndex,
+  type IdentifierCaseRules,
 } from "../../schema/utils/resolve-catalog-name";
 
 import type { MigratedObjectsVerification, StorageProbe } from "./guard";
 import {
   MIGRATION_TARGET,
+  retargetName,
   type ManifestEntry,
   type RegistryRow,
 } from "./manifest";
+import type { MigrationDirection } from "./state";
+
+/** The columns one table carries, as the database reported them. */
+export interface TableColumns {
+  readonly table: string;
+  readonly columns: readonly string[];
+}
 
 /**
- * Whether a migration run is on record.
+ * How far a run has been recorded, which is what gives a half-applied database
+ * its meaning.
  *
- * This is the fact that gives a half-applied database its meaning. A target that
- * exists while its source is gone is *completed work* if a run is recorded, and
- * *someone else's table* if none is — and the two call for opposite responses,
- * so the state is passed in rather than guessed from the objects.
+ * A target that exists while its source is gone is *completed work* only if the
+ * run that did it got that far. Presence of a run record is not enough on its
+ * own: a marker recording step 1 says nothing about step 7, so treating any
+ * record as blanket permission would adopt an unrelated object that happened to
+ * be sitting on step 7's target name.
+ *
+ * `step` is the last position whose postcondition verified, matching the marker,
+ * so positions up to `step + 1` are explicable — `step + 1` being the crash
+ * window the runner deliberately supports, where a statement committed but its
+ * marker write did not.
  */
-export type RunRecord = { recorded: true } | { recorded: false };
+export type RunRecord =
+  | { recorded: false }
+  | { recorded: true; direction: MigrationDirection; step: number };
 
 /**
  * Reconcile a plan against the catalog.
  *
- * Refuses rather than proceeding whenever the pair of facts has no single
- * reading. Every refusal here costs an operator a look; the alternative is a run
- * that fails after its marker is written, leaving storage half-migrated.
+ * Refuses rather than proceeding whenever the facts have no single reading.
+ * Every refusal here costs an operator a look; the alternative is a run that
+ * fails after its marker is written, leaving storage half-migrated.
+ *
+ * `direction` is the direction of the plan being handed in. It is checked
+ * against the recorded run because the two must agree: a `down` plan is the
+ * inverse of an `up` one, so scoring an `up` plan's positions against a `down`
+ * run's progress would mark real work as already done and skip it.
  */
 export function reconcilePlan(args: {
   entries: readonly ManifestEntry[];
   rows: readonly RegistryRow[];
   tables: readonly string[];
+  columns: readonly TableColumns[];
   run: RunRecord;
+  direction: MigrationDirection;
+  identifierCase: IdentifierCaseRules;
 }): ManifestEntry[] {
-  const { entries, rows, run } = args;
-  const catalog = indexCatalog(args.tables);
+  const { entries, rows, run, direction, identifierCase } = args;
+
+  if (run.recorded && run.direction !== direction) {
+    throw NextlyError.internal({
+      logContext: {
+        reason: "reconciled a plan against a run going the other way",
+        planDirection: direction,
+        runDirection: run.direction,
+      },
+    });
+  }
+
+  const catalog = indexCatalog(args.tables, identifierCase.tables);
+  const columns = indexColumns(args.columns, identifierCase);
 
   assertEveryRowHasStorage(rows, catalog);
 
-  // Names this plan will bring into existence count as present for the entries
-  // that follow them: a column names its post-rename table, which is legitimately
-  // absent from a pre-migration catalog.
-  const willExist = new Set<string>();
+  // A column entry names its table's post-rename name, so before that rename
+  // runs the table is still under the name it came from. Mapping each target
+  // back to its source is what lets a column be inspected either side of the
+  // rename that moves its table.
+  const sourceOf = new Map<string, string>();
   for (const entry of entries) {
-    if (entry.kind !== "column") willExist.add(entry.to);
+    if (entry.kind !== "column") sourceOf.set(entry.to, entry.from);
   }
 
-  return entries.map(entry => {
-    if (entry.kind === "column")
-      return reconcileColumn(entry, catalog, willExist);
-    return reconcileRename(entry, catalog, run);
+  return entries.map((entry, index) => {
+    const position = index + 1;
+    if (entry.kind === "column") {
+      return reconcileColumn(entry, {
+        catalog,
+        columns,
+        sourceOf,
+        position,
+        run,
+      });
+    }
+    return reconcileRename(entry, catalog, position, run);
   });
 }
 
@@ -78,22 +127,42 @@ export function reconcilePlan(args: {
  * `migratedObjects` is what stops the guard trusting registry presence alone:
  * the read path turns a missing data table into an empty result, so an
  * incomplete rename would serve blank content rather than fail.
+ *
+ * `typeColumn` is the discriminator the generation being probed must carry —
+ * the legacy spelling when probing legacy storage, the migrated one when probing
+ * migrated storage. It is checked because a table present under its migrated
+ * name while still holding the old column is *not* migrated storage, and reading
+ * it addresses a column that is not there.
  */
 export function probeStorage(args: {
   rows: readonly RegistryRow[];
   tables: readonly string[];
+  columns: readonly TableColumns[];
+  identifierCase: IdentifierCaseRules;
+  typeColumn: string;
 }): StorageProbe {
-  const catalog = indexCatalog(args.tables);
+  const { identifierCase, typeColumn } = args;
+  const catalog = indexCatalog(args.tables, identifierCase.tables);
+  const columns = indexColumns(args.columns, identifierCase);
   const missing: string[] = [];
 
   for (const row of args.rows) {
-    if (resolveCatalogName(catalog, row.tableName) === undefined) {
-      missing.push(row.tableName);
-    }
-    if (!row.hasCompanion) continue;
-    const companion = `${row.tableName}${STORAGE_FORMAT.companionSuffix}`;
-    if (resolveCatalogName(catalog, companion) === undefined) {
-      missing.push(companion);
+    for (const object of expectedStorage(row)) {
+      const found = resolveAny(catalog, object.names);
+      if (found === undefined) {
+        missing.push(object.names[0]);
+        continue;
+      }
+      // Only the base table carries the discriminator; companions hold
+      // translations of individual fields and never the type.
+      if (!object.isBase) continue;
+      const tableColumns = columns.get(found);
+      if (
+        tableColumns === undefined ||
+        resolveCatalogName(tableColumns, typeColumn) === undefined
+      ) {
+        missing.push(`${found}.${typeColumn}`);
+      }
     }
   }
 
@@ -109,11 +178,85 @@ export function probeStorage(args: {
   };
 }
 
+/** One physical object a registry row requires, and the names it may go by. */
+interface ExpectedObject {
+  /** Acceptable names, stored name first. */
+  readonly names: string[];
+  /** The row's own table, as opposed to its companion. */
+  readonly isBase: boolean;
+}
+
+/**
+ * Every object a registry row requires to exist.
+ *
+ * The single definition of that question. Two callers ask it — the up-front
+ * check and the probe — and when they each answered it separately the up-front
+ * one omitted companions, so a row whose companion had been dropped passed the
+ * check that runs *before* any rename and failed only the probe that runs after.
+ *
+ * A companion is included whenever one is physically present per the registry,
+ * including for a row this plan leaves alone: `buildMigrationManifest` emits a
+ * companion rename only for rows it retargets, so nothing else in the plan ever
+ * names a custom-named row's companion.
+ *
+ * Both the stored name and the migrated name are acceptable because during a run
+ * exactly one of them is real, and which one depends on whether this row's
+ * rename has already committed. Accepting either is not a loophole for an
+ * unexplained target: `reconcileRename` still refuses a target that no recorded
+ * progress accounts for, and does it with a message that names the conflict.
+ */
+function expectedStorage(row: RegistryRow): ExpectedObject[] {
+  const target = retargetName(row);
+  const suffix = STORAGE_FORMAT.companionSuffix;
+
+  const base = [row.tableName, ...(target === null ? [] : [target])];
+  const objects: ExpectedObject[] = [{ names: base, isBase: true }];
+  if (row.hasCompanion) {
+    objects.push({
+      names: base.map(name => `${name}${suffix}`),
+      isBase: false,
+    });
+  }
+  return objects;
+}
+
+function resolveAny(
+  catalog: CatalogIndex,
+  names: readonly string[]
+): string | undefined {
+  for (const name of names) {
+    const found = resolveCatalogName(catalog, name);
+    if (found !== undefined) return found;
+  }
+  return undefined;
+}
+
+/**
+ * Index each table's columns under the server's column rules.
+ *
+ * Keyed by the catalog's own spelling of the table name, resolved through the
+ * table rules, so a lookup that found a table can find its columns under the
+ * same name.
+ */
+function indexColumns(
+  tables: readonly TableColumns[],
+  identifierCase: IdentifierCaseRules
+): Map<string, CatalogIndex> {
+  const byTable = new Map<string, CatalogIndex>();
+  for (const entry of tables) {
+    byTable.set(
+      entry.table,
+      indexCatalog(entry.columns, identifierCase.columns)
+    );
+  }
+  return byTable;
+}
+
 /**
  * Every registry row must have storage, including rows this plan leaves alone.
  *
  * A custom-named row produces no rename entry, so an entry-driven check cannot
- * see it. Its table can still be missing — the legacy read path tolerates that
+ * see it. Its storage can still be missing — the legacy read path tolerates that
  * by returning an empty result — and the migration would then rename around a
  * row whose data is already gone.
  */
@@ -121,30 +264,127 @@ function assertEveryRowHasStorage(
   rows: readonly RegistryRow[],
   catalog: CatalogIndex
 ): void {
-  const missing = rows
-    .filter(row => resolveCatalogName(catalog, row.tableName) === undefined)
-    .map(row => row.tableName);
+  const missing: string[] = [];
+  const caseVariants: Record<string, string> = {};
+
+  for (const row of rows) {
+    for (const object of expectedStorage(row)) {
+      if (resolveAny(catalog, object.names) !== undefined) continue;
+      missing.push(object.names[0]);
+      // A name present under a different case is a different object on this
+      // server, and saying so turns "a table is missing" into a row an operator
+      // can correct.
+      const variant = findCaseVariant(catalog, object.names[0]);
+      if (variant !== undefined) caseVariants[object.names[0]] = variant;
+    }
+  }
+
   if (missing.length === 0) return;
-  throw refuse("registry rows name storage that does not exist", { missing });
+  throw refuse("registry rows name storage that does not exist", {
+    missing,
+    ...(Object.keys(caseVariants).length > 0 ? { caseVariants } : {}),
+  });
 }
 
+/**
+ * Whether recorded progress explains this position already being applied.
+ *
+ * Positions at or below the recorded step verified. The one after it is the
+ * crash window the runner supports, where a statement committed before its
+ * marker write. Anything beyond that has not been attempted, so an applied-looking
+ * object there was not put in place by this run.
+ */
+function acceptsApplied(position: number, run: RunRecord): boolean {
+  return run.recorded && position <= run.step + 1;
+}
+
+/**
+ * Decide a column rename against the columns the table actually has.
+ *
+ * The table's presence says nothing about the column: a rename that commits
+ * before its marker write leaves the table in place both before and after, so
+ * without looking at the columns a resume cannot tell outstanding work from work
+ * already done and would retry a rename whose source column is gone.
+ */
 function reconcileColumn(
   entry: ManifestEntry,
-  catalog: CatalogIndex,
-  willExist: ReadonlySet<string>
+  context: {
+    catalog: CatalogIndex;
+    columns: Map<string, CatalogIndex>;
+    sourceOf: Map<string, string>;
+    position: number;
+    run: RunRecord;
+  }
 ): ManifestEntry {
+  const { catalog, columns, sourceOf, position, run } = context;
   const table = entry.table;
   if (table === undefined) return entry;
-  const present =
-    resolveCatalogName(catalog, table) !== undefined || willExist.has(table);
-  // A column on a table that neither exists nor is coming is not work, and
-  // cannot be verified either.
-  return present ? entry : { ...entry, satisfied: true };
+
+  // Either side of its table's rename: the post-rename name if that has already
+  // happened, otherwise the name the table is still under.
+  const source = sourceOf.get(table);
+  const current =
+    resolveCatalogName(catalog, table) ??
+    (source === undefined ? undefined : resolveCatalogName(catalog, source));
+
+  // Neither the table nor its predecessor exists. There is no work to do and
+  // nothing to verify, and the missing storage is reported by the row check
+  // rather than here, where the table is not the subject.
+  if (current === undefined) return { ...entry, satisfied: true };
+
+  const tableColumns = columns.get(current);
+  if (tableColumns === undefined) {
+    throw NextlyError.internal({
+      logContext: {
+        reason: "reconciliation was given no columns for a table that exists",
+        table: current,
+      },
+    });
+  }
+
+  const hasFrom = resolveCatalogName(tableColumns, entry.from) !== undefined;
+  const hasTo = resolveCatalogName(tableColumns, entry.to) !== undefined;
+
+  if (hasFrom && hasTo) {
+    throw refuse("both discriminator columns exist on one table", {
+      table: current,
+      from: entry.from,
+      to: entry.to,
+    });
+  }
+
+  if (hasFrom) return entry;
+
+  if (hasTo) {
+    if (!acceptsApplied(position, run)) {
+      throw refuse(
+        "a column carries the migrated name but no recorded progress accounts for it",
+        {
+          table: current,
+          from: entry.from,
+          to: entry.to,
+          position,
+          recordedStep: run.recorded ? run.step : null,
+        }
+      );
+    }
+    return { ...entry, satisfied: true };
+  }
+
+  // Every field-group data table carries the discriminator: the schema service
+  // emits it unconditionally. A table holding neither spelling is not field-group
+  // storage this migration can reason about.
+  throw refuse("field group table has no discriminator column", {
+    table: current,
+    from: entry.from,
+    to: entry.to,
+  });
 }
 
 function reconcileRename(
   entry: ManifestEntry,
   catalog: CatalogIndex,
+  position: number,
   run: RunRecord
 ): ManifestEntry {
   const source = resolveCatalogName(catalog, entry.from);
@@ -161,14 +401,20 @@ function reconcileRename(
   if (source !== undefined) return entry;
 
   if (target !== undefined) {
-    // Source gone, target present. Only a recorded run makes this our own
-    // finished work; with no run on record it is a table belonging to something
-    // else, sitting on the name this migration wants, and adopting it would
-    // treat a stranger's table as migrated field-group storage.
-    if (!run.recorded) {
+    // Source gone, target present. Only progress that reached this position
+    // makes it our own finished work; otherwise it is an object belonging to
+    // something else, sitting on the name this migration wants, and adopting it
+    // would treat a stranger's table as migrated field-group storage.
+    if (!acceptsApplied(position, run)) {
       throw refuse(
-        "an object using the migrated storage name exists but no migration recorded it",
-        { from: entry.from, to: entry.to, occupiedBy: target }
+        "an object using the migrated storage name exists but no recorded progress accounts for it",
+        {
+          from: entry.from,
+          to: entry.to,
+          occupiedBy: target,
+          position,
+          recordedStep: run.recorded ? run.step : null,
+        }
       );
     }
     return { ...entry, satisfied: true };

--- a/packages/nextly/src/domains/field-groups/migration/reconcile.ts
+++ b/packages/nextly/src/domains/field-groups/migration/reconcile.ts
@@ -32,7 +32,7 @@ import {
   type ManifestEntry,
   type RegistryRow,
 } from "./manifest";
-import type { MigrationDirection } from "./state";
+import type { MigrationDirection, StorageGeneration } from "./state";
 
 /** The columns one table carries, as the database reported them. */
 export interface TableColumns {
@@ -139,15 +139,21 @@ export function probeStorage(args: {
   tables: readonly string[];
   columns: readonly TableColumns[];
   identifierCase: IdentifierCaseRules;
-  typeColumn: string;
+  generation: StorageGeneration;
 }): StorageProbe {
-  const { identifierCase, typeColumn } = args;
+  const { identifierCase, generation } = args;
+  // Derived from the generation rather than passed alongside it, so the column
+  // required and the names required cannot disagree.
+  const typeColumn =
+    generation === "field-groups-v2"
+      ? MIGRATION_TARGET.columnType
+      : STORAGE_FORMAT.columns.type;
   const catalog = indexCatalog(args.tables, identifierCase.tables);
   const columns = indexColumns(args.columns, identifierCase);
   const missing: string[] = [];
 
   for (const row of args.rows) {
-    for (const object of expectedStorage(row)) {
+    for (const object of expectedStorage(row, generation)) {
       const found = resolveAny(catalog, object.names);
       if (found === undefined) {
         missing.push(object.names[0]);
@@ -187,6 +193,17 @@ interface ExpectedObject {
 }
 
 /**
+ * Which physical names count as satisfying a row.
+ *
+ * `either` is for reconciling a run in flight, where a row is under its stored
+ * name until its rename commits and under the migrated name afterwards. The two
+ * generation values are for *verifying a settled marker*, where only one name is
+ * acceptable — accepting both there would report a migration complete that never
+ * renamed anything.
+ */
+type StorageNaming = "either" | StorageGeneration;
+
+/**
  * Every object a registry row requires to exist.
  *
  * The single definition of that question. Two callers ask it — the up-front
@@ -205,11 +222,14 @@ interface ExpectedObject {
  * unexplained target: `reconcileRename` still refuses a target that no recorded
  * progress accounts for, and does it with a message that names the conflict.
  */
-function expectedStorage(row: RegistryRow): ExpectedObject[] {
+function expectedStorage(
+  row: RegistryRow,
+  naming: StorageNaming
+): ExpectedObject[] {
   const target = retargetName(row);
   const suffix = STORAGE_FORMAT.companionSuffix;
 
-  const base = [row.tableName, ...(target === null ? [] : [target])];
+  const base = namesFor(row, target, naming);
   const objects: ExpectedObject[] = [{ names: base, isBase: true }];
   if (row.hasCompanion) {
     objects.push({
@@ -218,6 +238,25 @@ function expectedStorage(row: RegistryRow): ExpectedObject[] {
     });
   }
   return objects;
+}
+
+/**
+ * The base names acceptable for a row under a given naming mode.
+ *
+ * For `field-groups-v2` the retargeted name is **required**: a settled marker
+ * plus a row still naming its legacy table means the rename never happened, and
+ * accepting the legacy name there would authorise migrated storage that does not
+ * exist. A row with no retarget — a custom name this migration leaves alone — is
+ * already at its final name, so that name is the required one.
+ */
+function namesFor(
+  row: RegistryRow,
+  target: string | null,
+  naming: StorageNaming
+): string[] {
+  if (naming === "legacy") return [row.tableName];
+  if (naming === "field-groups-v2") return [target ?? row.tableName];
+  return [row.tableName, ...(target === null ? [] : [target])];
 }
 
 function resolveAny(
@@ -268,7 +307,7 @@ function assertEveryRowHasStorage(
   const caseVariants: Record<string, string> = {};
 
   for (const row of rows) {
-    for (const object of expectedStorage(row)) {
+    for (const object of expectedStorage(row, "either")) {
       if (resolveAny(catalog, object.names) !== undefined) continue;
       missing.push(object.names[0]);
       // A name present under a different case is a different object on this
@@ -296,6 +335,19 @@ function assertEveryRowHasStorage(
  */
 function acceptsApplied(position: number, run: RunRecord): boolean {
   return run.recorded && position <= run.step + 1;
+}
+
+/**
+ * Whether the marker claims this position's postcondition already verified.
+ *
+ * Stricter than `acceptsApplied` by exactly the crash window: a position at or
+ * below the recorded step was verified and **will never run again**, because the
+ * guard resumes at `step + 1`. So finding its source still in place is not
+ * outstanding work — nothing will pick it up — it is the marker and the database
+ * contradicting each other.
+ */
+function recordedAsDone(position: number, run: RunRecord): boolean {
+  return run.recorded && position <= run.step;
 }
 
 /**
@@ -353,7 +405,21 @@ function reconcileColumn(
     });
   }
 
-  if (hasFrom) return entry;
+  if (hasFrom) {
+    if (recordedAsDone(position, run)) {
+      throw refuse(
+        "a column rename the marker records as verified has not been applied",
+        {
+          table: current,
+          from: entry.from,
+          to: entry.to,
+          position,
+          recordedStep: run.recorded ? run.step : null,
+        }
+      );
+    }
+    return entry;
+  }
 
   if (hasTo) {
     if (!acceptsApplied(position, run)) {
@@ -398,7 +464,20 @@ function reconcileRename(
     });
   }
 
-  if (source !== undefined) return entry;
+  if (source !== undefined) {
+    if (recordedAsDone(position, run)) {
+      throw refuse(
+        "a rename the marker records as verified has not been applied",
+        {
+          from: entry.from,
+          to: entry.to,
+          position,
+          recordedStep: run.recorded ? run.step : null,
+        }
+      );
+    }
+    return entry;
+  }
 
   if (target !== undefined) {
     // Source gone, target present. Only progress that reached this position

--- a/packages/nextly/src/domains/field-groups/migration/reconcile.ts
+++ b/packages/nextly/src/domains/field-groups/migration/reconcile.ts
@@ -93,7 +93,7 @@ export function reconcilePlan(args: {
   }
 
   const catalog = indexCatalog(args.tables, identifierCase.tables);
-  const columns = indexColumns(args.columns, identifierCase);
+  const columns = indexColumns(args.columns, catalog, identifierCase);
 
   assertEveryRowHasStorage(rows, catalog);
 
@@ -149,7 +149,7 @@ export function probeStorage(args: {
       ? MIGRATION_TARGET.columnType
       : STORAGE_FORMAT.columns.type;
   const catalog = indexCatalog(args.tables, identifierCase.tables);
-  const columns = indexColumns(args.columns, identifierCase);
+  const columns = indexColumns(args.columns, catalog, identifierCase);
   const missing: string[] = [];
 
   for (const row of args.rows) {
@@ -206,10 +206,10 @@ type StorageNaming = "either" | StorageGeneration;
 /**
  * Every object a registry row requires to exist.
  *
- * The single definition of that question. Two callers ask it — the up-front
- * check and the probe — and when they each answered it separately the up-front
- * one omitted companions, so a row whose companion had been dropped passed the
- * check that runs *before* any rename and failed only the probe that runs after.
+ * The single definition of that question, shared by the up-front check and the
+ * probe so the two cannot diverge: a check that ran before any rename while
+ * omitting companions would pass a row whose companion is already gone, and the
+ * loss would surface only after other objects had moved.
  *
  * A companion is included whenever one is physically present per the registry,
  * including for a row this plan leaves alone: `buildMigrationManifest` emits a
@@ -279,14 +279,21 @@ function resolveAny(
  */
 function indexColumns(
   tables: readonly TableColumns[],
+  catalog: CatalogIndex,
   identifierCase: IdentifierCaseRules
 ): Map<string, CatalogIndex> {
   const byTable = new Map<string, CatalogIndex>();
   for (const entry of tables) {
-    byTable.set(
-      entry.table,
-      indexCatalog(entry.columns, identifierCase.columns)
-    );
+    // Keyed by the catalog's spelling, because that is the spelling every lookup
+    // here arrives with: callers resolve a table before asking for its columns.
+    // Keying by the caller's spelling instead would miss on any server that
+    // reports a name in a different case, and reconciliation would then refuse
+    // storage that is present.
+    const table = resolveCatalogName(catalog, entry.table);
+    // Columns for a table the catalog does not list describe nothing that can be
+    // renamed or verified.
+    if (table === undefined) continue;
+    byTable.set(table, indexCatalog(entry.columns, identifierCase.columns));
   }
   return byTable;
 }
@@ -305,16 +312,37 @@ function assertEveryRowHasStorage(
 ): void {
   const missing: string[] = [];
   const caseVariants: Record<string, string> = {};
+  // Which row already claimed each physical object. Claims are tracked by the
+  // *resolved* catalog name, which is the only level where two spellings are
+  // known to be one object: the plan compares names exactly because it has no
+  // dialect, so on a folding server a row named `COMP_HERO_LOCALES` and another
+  // row's derived `comp_hero_locales` companion pass every check the plan can
+  // make while addressing the same table.
+  const claims = new Map<string, string>();
 
   for (const row of rows) {
     for (const object of expectedStorage(row, "either")) {
-      if (resolveAny(catalog, object.names) !== undefined) continue;
-      missing.push(object.names[0]);
-      // A name present under a different case is a different object on this
-      // server, and saying so turns "a table is missing" into a row an operator
-      // can correct.
-      const variant = findCaseVariant(catalog, object.names[0]);
-      if (variant !== undefined) caseVariants[object.names[0]] = variant;
+      const found = resolveAny(catalog, object.names);
+      if (found === undefined) {
+        missing.push(object.names[0]);
+        // A name present under a different case is a different object on this
+        // server, and saying so turns "a table is missing" into a row an operator
+        // can correct.
+        const variant = findCaseVariant(catalog, object.names[0]);
+        if (variant !== undefined) caseVariants[object.names[0]] = variant;
+        continue;
+      }
+
+      const claimant = `${row.slug}${object.isBase ? "" : " companion"}`;
+      const previous = claims.get(found);
+      if (previous !== undefined) {
+        throw refuse("one physical object is claimed by two field groups", {
+          table: found,
+          claimedBy: previous,
+          alsoClaimedBy: claimant,
+        });
+      }
+      claims.set(found, claimant);
     }
   }
 

--- a/packages/nextly/src/domains/field-groups/migration/reconcile.ts
+++ b/packages/nextly/src/domains/field-groups/migration/reconcile.ts
@@ -97,13 +97,23 @@ export function reconcilePlan(args: {
 
   assertEveryRowHasStorage(rows, catalog);
 
-  // A column entry names its table's post-rename name, so before that rename
-  // runs the table is still under the name it came from. Mapping each target
-  // back to its source is what lets a column be inspected either side of the
-  // rename that moves its table.
-  const sourceOf = new Map<string, string>();
+  // A column entry names one fixed spelling of its table, but the table itself
+  // moves during the run, so the columns have to be findable under either name.
+  // Which of the two is the "other" one depends on direction: going up a column
+  // names the post-rename table and the other name is where it came from, while
+  // a rollback keeps that same spelling as the name the table starts under, so
+  // the other name is where the revert takes it. Recording both directions makes
+  // the lookup independent of which way the run is going.
+  const otherNames = new Map<string, string[]>();
+  const linkNames = (name: string, other: string): void => {
+    const existing = otherNames.get(name);
+    if (existing === undefined) otherNames.set(name, [other]);
+    else existing.push(other);
+  };
   for (const entry of entries) {
-    if (entry.kind !== "column") sourceOf.set(entry.to, entry.from);
+    if (entry.kind === "column") continue;
+    linkNames(entry.to, entry.from);
+    linkNames(entry.from, entry.to);
   }
 
   return entries.map((entry, index) => {
@@ -112,7 +122,7 @@ export function reconcilePlan(args: {
       return reconcileColumn(entry, {
         catalog,
         columns,
-        sourceOf,
+        otherNames,
         position,
         run,
       });
@@ -391,21 +401,20 @@ function reconcileColumn(
   context: {
     catalog: CatalogIndex;
     columns: Map<string, CatalogIndex>;
-    sourceOf: Map<string, string>;
+    otherNames: Map<string, string[]>;
     position: number;
     run: RunRecord;
   }
 ): ManifestEntry {
-  const { catalog, columns, sourceOf, position, run } = context;
+  const { catalog, columns, otherNames, position, run } = context;
   const table = entry.table;
   if (table === undefined) return entry;
 
-  // Either side of its table's rename: the post-rename name if that has already
-  // happened, otherwise the name the table is still under.
-  const source = sourceOf.get(table);
+  // Either side of its table's rename: the name the entry carries if the table
+  // is still under it, otherwise whichever name the plan moves it to or from.
   const current =
     resolveCatalogName(catalog, table) ??
-    (source === undefined ? undefined : resolveCatalogName(catalog, source));
+    resolveAny(catalog, otherNames.get(table) ?? []);
 
   // Neither the table nor its predecessor exists. There is no work to do and
   // nothing to verify, and the missing storage is reported by the row check

--- a/packages/nextly/src/domains/field-groups/migration/reconcile.ts
+++ b/packages/nextly/src/domains/field-groups/migration/reconcile.ts
@@ -1,0 +1,193 @@
+/**
+ * Decides a rename plan against what the database actually contains.
+ *
+ * The plan itself is a pure function of registry rows and knows nothing about
+ * the database. Reconciling it needs three things the plan deliberately does not
+ * have: the catalog, the dialect's rules for deciding whether two spellings are
+ * one table, and whether a migration run is already recorded. Those live here.
+ *
+ * Nothing is removed from a plan. Progress is annotated, because the plan is
+ * indexed by position and identified by hash: dropping an entry renumbers every
+ * later step and changes the identity the marker recorded, so a resume would
+ * refuse the plan it is resuming.
+ *
+ * @module domains/field-groups/migration/reconcile
+ */
+
+import { NextlyError } from "../../../errors/nextly-error";
+import { STORAGE_FORMAT } from "../../../schemas/storage-format";
+import {
+  indexCatalog,
+  resolveCatalogName,
+  type CatalogIndex,
+} from "../../schema/utils/resolve-catalog-name";
+
+import type { MigratedObjectsVerification, StorageProbe } from "./guard";
+import {
+  MIGRATION_TARGET,
+  type ManifestEntry,
+  type RegistryRow,
+} from "./manifest";
+
+/**
+ * Whether a migration run is on record.
+ *
+ * This is the fact that gives a half-applied database its meaning. A target that
+ * exists while its source is gone is *completed work* if a run is recorded, and
+ * *someone else's table* if none is — and the two call for opposite responses,
+ * so the state is passed in rather than guessed from the objects.
+ */
+export type RunRecord = { recorded: true } | { recorded: false };
+
+/**
+ * Reconcile a plan against the catalog.
+ *
+ * Refuses rather than proceeding whenever the pair of facts has no single
+ * reading. Every refusal here costs an operator a look; the alternative is a run
+ * that fails after its marker is written, leaving storage half-migrated.
+ */
+export function reconcilePlan(args: {
+  entries: readonly ManifestEntry[];
+  rows: readonly RegistryRow[];
+  tables: readonly string[];
+  run: RunRecord;
+}): ManifestEntry[] {
+  const { entries, rows, run } = args;
+  const catalog = indexCatalog(args.tables);
+
+  assertEveryRowHasStorage(rows, catalog);
+
+  // Names this plan will bring into existence count as present for the entries
+  // that follow them: a column names its post-rename table, which is legitimately
+  // absent from a pre-migration catalog.
+  const willExist = new Set<string>();
+  for (const entry of entries) {
+    if (entry.kind !== "column") willExist.add(entry.to);
+  }
+
+  return entries.map(entry => {
+    if (entry.kind === "column")
+      return reconcileColumn(entry, catalog, willExist);
+    return reconcileRename(entry, catalog, run);
+  });
+}
+
+/**
+ * Build the probe the storage guard consumes.
+ *
+ * `migratedObjects` is what stops the guard trusting registry presence alone:
+ * the read path turns a missing data table into an empty result, so an
+ * incomplete rename would serve blank content rather than fail.
+ */
+export function probeStorage(args: {
+  rows: readonly RegistryRow[];
+  tables: readonly string[];
+}): StorageProbe {
+  const catalog = indexCatalog(args.tables);
+  const missing: string[] = [];
+
+  for (const row of args.rows) {
+    if (resolveCatalogName(catalog, row.tableName) === undefined) {
+      missing.push(row.tableName);
+    }
+    if (!row.hasCompanion) continue;
+    const companion = `${row.tableName}${STORAGE_FORMAT.companionSuffix}`;
+    if (resolveCatalogName(catalog, companion) === undefined) {
+      missing.push(companion);
+    }
+  }
+
+  const migratedObjects: MigratedObjectsVerification =
+    missing.length === 0 ? { complete: true } : { complete: false, missing };
+
+  return {
+    targetRegistryPresent:
+      resolveCatalogName(catalog, MIGRATION_TARGET.registryTable) !== undefined,
+    legacyRegistryPresent:
+      resolveCatalogName(catalog, STORAGE_FORMAT.registryTable) !== undefined,
+    migratedObjects,
+  };
+}
+
+/**
+ * Every registry row must have storage, including rows this plan leaves alone.
+ *
+ * A custom-named row produces no rename entry, so an entry-driven check cannot
+ * see it. Its table can still be missing — the legacy read path tolerates that
+ * by returning an empty result — and the migration would then rename around a
+ * row whose data is already gone.
+ */
+function assertEveryRowHasStorage(
+  rows: readonly RegistryRow[],
+  catalog: CatalogIndex
+): void {
+  const missing = rows
+    .filter(row => resolveCatalogName(catalog, row.tableName) === undefined)
+    .map(row => row.tableName);
+  if (missing.length === 0) return;
+  throw refuse("registry rows name storage that does not exist", { missing });
+}
+
+function reconcileColumn(
+  entry: ManifestEntry,
+  catalog: CatalogIndex,
+  willExist: ReadonlySet<string>
+): ManifestEntry {
+  const table = entry.table;
+  if (table === undefined) return entry;
+  const present =
+    resolveCatalogName(catalog, table) !== undefined || willExist.has(table);
+  // A column on a table that neither exists nor is coming is not work, and
+  // cannot be verified either.
+  return present ? entry : { ...entry, satisfied: true };
+}
+
+function reconcileRename(
+  entry: ManifestEntry,
+  catalog: CatalogIndex,
+  run: RunRecord
+): ManifestEntry {
+  const source = resolveCatalogName(catalog, entry.from);
+  const target = resolveCatalogName(catalog, entry.to);
+
+  if (source !== undefined && target !== undefined) {
+    throw refuse("migration target name is already in use", {
+      from: entry.from,
+      to: entry.to,
+      occupiedBy: target,
+    });
+  }
+
+  if (source !== undefined) return entry;
+
+  if (target !== undefined) {
+    // Source gone, target present. Only a recorded run makes this our own
+    // finished work; with no run on record it is a table belonging to something
+    // else, sitting on the name this migration wants, and adopting it would
+    // treat a stranger's table as migrated field-group storage.
+    if (!run.recorded) {
+      throw refuse(
+        "an object using the migrated storage name exists but no migration recorded it",
+        { from: entry.from, to: entry.to, occupiedBy: target }
+      );
+    }
+    return { ...entry, satisfied: true };
+  }
+
+  throw refuse("migration source object is missing", {
+    from: entry.from,
+    to: entry.to,
+  });
+}
+
+/**
+ * Refusals are 503: the database is in a shape a human has to look at, and the
+ * process must not serve or migrate until they have. Detail goes to `logContext`
+ * so operators get the full picture while the public message stays generic.
+ */
+function refuse(reason: string, context: Record<string, unknown>): NextlyError {
+  return NextlyError.serviceUnavailable({
+    logMessage: `field-group migration refused to proceed: ${reason}`,
+    logContext: { reason, ...context },
+  });
+}

--- a/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.test.ts
@@ -361,6 +361,44 @@ describe("teardownEntityComponentData catalog case folding", () => {
   // exact match while resolving its rows case-insensitively would skip registry
   // discovery entirely here, leaving every custom-named component out of the
   // sweep and its rows orphaned once the parent is deleted.
+  // A malformed row pointing back at the registry resolves to whatever spelling
+  // the catalog reports, so excluding only the exact constant would let the
+  // registry be probed as an instance table — where a missing `_parent_table`
+  // column breaks the delete and a permissive adapter could damage metadata.
+  it("never treats the registry as component storage, whatever its case", async () => {
+    const deleted: string[] = [];
+    const adapter = {
+      dialect: "mysql" as const,
+      listTables: vi
+        .fn()
+        .mockResolvedValue(["DYNAMIC_COMPONENTS", "comp_hero"]),
+      tableExists: vi.fn().mockResolvedValue(false),
+      delete: vi.fn(async (table: string) => {
+        deleted.push(table);
+        return 1;
+      }),
+      executeQuery: vi.fn().mockResolvedValue([{ n: 0 }]),
+      getDrizzle: vi.fn(() => ({
+        execute: vi.fn(async () => [[{ lower_case_table_names: 1 }], []]),
+      })),
+      select: vi.fn(async (table: string) => {
+        if (table.toLowerCase() === "dynamic_components") {
+          // The malformed row: it points at the registry itself.
+          return [{ slug: "broken", table_name: "dynamic_components" }];
+        }
+        return [{ id: `${table}-1` }];
+      }),
+    };
+
+    const result = await teardownEntityComponentData({
+      adapter: adapter as never,
+      parentTable: "dc_posts",
+    });
+
+    expect(result.tablesTouched).not.toContain("DYNAMIC_COMPONENTS");
+    expect(deleted).not.toContain("DYNAMIC_COMPONENTS");
+  });
+
   it("discovers the registry when the catalog reports it in another case", async () => {
     const deleted: string[] = [];
     const adapter = {

--- a/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.test.ts
@@ -296,10 +296,14 @@ describe("teardownEntityComponentData registry read failures", () => {
 });
 
 describe("teardownEntityComponentData catalog case folding", () => {
-  it("matches a registered name against a differently-cased catalog entry", async () => {
-    // MySQL with lower_case_table_names reports the folded name.
-    const deleted: string[] = [];
-    const adapter = {
+  /**
+   * A MySQL server that reports `lowerCaseTableNames` for the variable query and
+   * a zero count for every other one. Whether the stored `SEO_META` and the
+   * catalog's `seo_meta` are one table is decided by that setting, so the mock
+   * has to answer it rather than leaving the code to assume.
+   */
+  function mysqlAdapter(lowerCaseTableNames: number, deleted: string[]) {
+    return {
       dialect: "mysql" as const,
       listTables: vi.fn().mockResolvedValue(["seo_meta", "dynamic_components"]),
       tableExists: vi.fn().mockResolvedValue(false),
@@ -307,7 +311,11 @@ describe("teardownEntityComponentData catalog case folding", () => {
         deleted.push(table);
         return 1;
       }),
-      executeQuery: vi.fn().mockResolvedValue([{ n: 0 }]),
+      executeQuery: vi.fn(async (sql: string) =>
+        sql.includes("lower_case_table_names")
+          ? [{ lower_case_table_names: lowerCaseTableNames }]
+          : [{ n: 0 }]
+      ),
       select: vi.fn(async (table: string) => {
         if (table === "dynamic_components") {
           return [{ slug: "seo", table_name: "SEO_META" }];
@@ -315,14 +323,33 @@ describe("teardownEntityComponentData catalog case folding", () => {
         return [{ id: `${table}-1` }];
       }),
     };
+  }
 
+  it("matches a registered name against a differently-cased catalog entry", async () => {
+    // lower_case_table_names=1 lowercases names on creation, so the catalog's
+    // `seo_meta` is the table the registry recorded as `SEO_META`.
+    const deleted: string[] = [];
     const result = await teardownEntityComponentData({
-      adapter: adapter as never,
+      adapter: mysqlAdapter(1, deleted) as never,
       parentTable: "dc_posts",
     });
 
     expect(result.tablesTouched).toContain("seo_meta");
     expect(deleted).toContain("seo_meta");
+  });
+
+  // The same catalog on a case-sensitive server: `seo_meta` is a different table
+  // from the registered `SEO_META`, and deleting its rows would delete another
+  // table's data.
+  it("leaves a differently-cased table alone on a case-sensitive server", async () => {
+    const deleted: string[] = [];
+    const result = await teardownEntityComponentData({
+      adapter: mysqlAdapter(0, deleted) as never,
+      parentTable: "dc_posts",
+    });
+
+    expect(result.tablesTouched).not.toContain("seo_meta");
+    expect(deleted).not.toContain("seo_meta");
   });
 });
 

--- a/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.test.ts
@@ -356,6 +356,41 @@ describe("teardownEntityComponentData catalog case folding", () => {
     expect(result.tablesTouched).not.toContain("seo_meta");
     expect(deleted).not.toContain("seo_meta");
   });
+
+  // The registry is found by the same rules as the tables it names. Gating on an
+  // exact match while resolving its rows case-insensitively would skip registry
+  // discovery entirely here, leaving every custom-named component out of the
+  // sweep and its rows orphaned once the parent is deleted.
+  it("discovers the registry when the catalog reports it in another case", async () => {
+    const deleted: string[] = [];
+    const adapter = {
+      dialect: "mysql" as const,
+      listTables: vi.fn().mockResolvedValue(["seo_meta", "DYNAMIC_COMPONENTS"]),
+      tableExists: vi.fn().mockResolvedValue(false),
+      delete: vi.fn(async (table: string) => {
+        deleted.push(table);
+        return 1;
+      }),
+      executeQuery: vi.fn().mockResolvedValue([{ n: 0 }]),
+      getDrizzle: vi.fn(() => ({
+        execute: vi.fn(async () => [[{ lower_case_table_names: 1 }], []]),
+      })),
+      select: vi.fn(async (table: string) => {
+        if (table.toLowerCase() === "dynamic_components") {
+          return [{ slug: "seo", table_name: "SEO_META" }];
+        }
+        return [{ id: `${table}-1` }];
+      }),
+    };
+
+    const result = await teardownEntityComponentData({
+      adapter: adapter as never,
+      parentTable: "dc_posts",
+    });
+
+    expect(result.tablesTouched).toContain("seo_meta");
+    expect(deleted).toContain("seo_meta");
+  });
 });
 
 describe("teardownEntityComponentData case-distinct catalogs", () => {

--- a/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.test.ts
@@ -382,7 +382,7 @@ describe("teardownEntityComponentData catalog case folding", () => {
         execute: vi.fn(async () => [[{ lower_case_table_names: 1 }], []]),
       })),
       select: vi.fn(async (table: string) => {
-        if (table.toLowerCase() === "dynamic_components") {
+        if (table === "dynamic_components") {
           // The malformed row: it points at the registry itself.
           return [{ slug: "broken", table_name: "dynamic_components" }];
         }
@@ -414,7 +414,7 @@ describe("teardownEntityComponentData catalog case folding", () => {
         execute: vi.fn(async () => [[{ lower_case_table_names: 1 }], []]),
       })),
       select: vi.fn(async (table: string) => {
-        if (table.toLowerCase() === "dynamic_components") {
+        if (table === "dynamic_components") {
           return [{ slug: "seo", table_name: "SEO_META" }];
         }
         return [{ id: `${table}-1` }];

--- a/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.test.ts
@@ -311,11 +311,16 @@ describe("teardownEntityComponentData catalog case folding", () => {
         deleted.push(table);
         return 1;
       }),
-      executeQuery: vi.fn(async (sql: string) =>
-        sql.includes("lower_case_table_names")
-          ? [{ lower_case_table_names: lowerCaseTableNames }]
-          : [{ n: 0 }]
-      ),
+      executeQuery: vi.fn().mockResolvedValue([{ n: 0 }]),
+      // The variable read goes through Drizzle's `sql` template, so the mock
+      // answers on the Drizzle handle and returns the mysql2 `[rows, fields]`
+      // shape the real driver produces.
+      getDrizzle: vi.fn(() => ({
+        execute: vi.fn(async () => [
+          [{ lower_case_table_names: lowerCaseTableNames }],
+          [],
+        ]),
+      })),
       select: vi.fn(async (table: string) => {
         if (table === "dynamic_components") {
           return [{ slug: "seo", table_name: "SEO_META" }];

--- a/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.ts
+++ b/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.ts
@@ -35,6 +35,7 @@ import { NextlyError } from "../../../errors";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import { q } from "../../i18n/migration/ddl-types";
 import { isCompanionTable } from "../../schema/pipeline/managed-tables";
+import { readIdentifierCaseRules } from "../../schema/utils/read-identifier-case";
 import {
   indexCatalog,
   resolveCatalogName,
@@ -225,9 +226,14 @@ async function listRegisteredComponentTables(
     {}
   );
 
-  // Exact-first, then case-insensitive. The reasoning, and the reason both halves
-  // are needed, lives with the shared resolver.
-  const catalog = indexCatalog(discovered);
+  // Exact-first, then case-insensitive only where the server folds. Deleting
+  // rows from a table resolved by folding a name the server treats as distinct
+  // would delete another table's rows, so the comparison rules come from the
+  // server rather than being assumed. The reasoning lives with the resolver.
+  const catalog = indexCatalog(
+    discovered,
+    (await readIdentifierCaseRules(adapter)).tables
+  );
   return (
     rows
       .map(row => row.table_name ?? row.tableName)

--- a/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.ts
+++ b/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.ts
@@ -249,6 +249,12 @@ async function listRegisteredComponentTables(
       // unmaterialized component would block all of them.
       .map(name => resolveCatalogName(catalog, name))
       .filter((name): name is string => name !== undefined)
+      // The registry is metadata, never component storage. A malformed row
+      // pointing back at it resolves to whatever spelling the catalog reports,
+      // so excluding it here — where that spelling is known — is what keeps it
+      // out; a caller comparing against the constant alone would miss a
+      // case-different spelling and probe the registry as an instance table.
+      .filter(name => name !== registryTable)
   );
 }
 

--- a/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.ts
+++ b/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.ts
@@ -35,6 +35,10 @@ import { NextlyError } from "../../../errors";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import { q } from "../../i18n/migration/ddl-types";
 import { isCompanionTable } from "../../schema/pipeline/managed-tables";
+import {
+  indexCatalog,
+  resolveCatalogName,
+} from "../../schema/utils/resolve-catalog-name";
 
 /** Bound on how deep component nesting is followed; mirrors MAX_FIELD_GROUP_NESTING_DEPTH. */
 const DEFAULT_MAX_DEPTH = 10;
@@ -221,24 +225,9 @@ async function listRegisteredComponentTables(
     {}
   );
 
-  // Resolved exactly first, then case-insensitively. MySQL with
-  // `lower_case_table_names` reports a verbatim `SEO_META` as `seo_meta`, so an
-  // exact-only match would discard the registered table and orphan its rows.
-  // Folding unconditionally is equally wrong: PostgreSQL, and MySQL with
-  // `lower_case_table_names=0`, can hold `SEO_META` and `seo_meta` as distinct
-  // quoted tables, and collapsing them would sweep only one. Preferring the
-  // exact hit keeps those distinct, while the fallback still finds a folded
-  // catalog entry — and either way the resolved value is the name the catalog
-  // reported, which is what later statements must address.
-  const catalog = new Set(discovered);
-  const foldedCatalog = new Map<string, string>();
-  for (const name of discovered) {
-    const key = name.toLowerCase();
-    // First writer wins so an ambiguous fold cannot silently retarget a table.
-    if (!foldedCatalog.has(key)) foldedCatalog.set(key, name);
-  }
-  const resolveCatalogName = (name: string): string | undefined =>
-    catalog.has(name) ? name : foldedCatalog.get(name.toLowerCase());
+  // Exact-first, then case-insensitive. The reasoning, and the reason both halves
+  // are needed, lives with the shared resolver.
+  const catalog = indexCatalog(discovered);
   return (
     rows
       .map(row => row.table_name ?? row.tableName)
@@ -247,7 +236,7 @@ async function listRegisteredComponentTables(
       // whose migration is pending or failed. Probing one raises a missing-table
       // error, and because this sweep precedes every entity delete, a single
       // unmaterialized component would block all of them.
-      .map(name => resolveCatalogName(name))
+      .map(name => resolveCatalogName(catalog, name))
       .filter((name): name is string => name !== undefined)
   );
 }

--- a/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.ts
+++ b/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.ts
@@ -211,7 +211,22 @@ async function listRegisteredComponentTables(
   adapter: TeardownComponentDataAdapter,
   discovered: string[]
 ): Promise<string[]> {
-  if (!discovered.includes(REGISTRY_TABLE)) return [];
+  // Exact-first, then case-insensitive only where the server folds. Deleting
+  // rows from a table resolved by folding a name the server treats as distinct
+  // would delete another table's rows, so the comparison rules come from the
+  // server rather than being assumed. The reasoning lives with the resolver.
+  //
+  // Built before the registry itself is looked up, so the registry is found by
+  // the same rules as the tables it names. Gating on an exact match while
+  // resolving its rows case-insensitively would skip registry discovery on a
+  // server that reports the registry in another case, and every custom-named
+  // component would then be left out of the sweep.
+  const catalog = indexCatalog(
+    discovered,
+    (await readIdentifierCaseRules(adapter)).tables
+  );
+  const registryTable = resolveCatalogName(catalog, REGISTRY_TABLE);
+  if (registryTable === undefined) return [];
 
   // Consulted only when the ORM can address it. An executor with no schema
   // registered for the registry — a hand-built adapter carrying just its own
@@ -220,21 +235,10 @@ async function listRegisteredComponentTables(
   // stays complete for everything such an executor can reach. Probing rather
   // than catching keeps genuine read failures propagating instead of being
   // mistaken for "nothing registered".
-  if (!(await isResolvable(adapter, REGISTRY_TABLE))) return [];
+  if (!(await isResolvable(adapter, registryTable))) return [];
 
-  const rows = await adapter.select<Record<string, unknown>>(
-    REGISTRY_TABLE,
-    {}
-  );
+  const rows = await adapter.select<Record<string, unknown>>(registryTable, {});
 
-  // Exact-first, then case-insensitive only where the server folds. Deleting
-  // rows from a table resolved by folding a name the server treats as distinct
-  // would delete another table's rows, so the comparison rules come from the
-  // server rather than being assumed. The reasoning lives with the resolver.
-  const catalog = indexCatalog(
-    discovered,
-    (await readIdentifierCaseRules(adapter)).tables
-  );
   return (
     rows
       .map(row => row.table_name ?? row.tableName)

--- a/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.ts
+++ b/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.ts
@@ -225,9 +225,21 @@ async function listRegisteredComponentTables(
     discovered,
     (await readIdentifierCaseRules(adapter)).tables
   );
+  // Two different questions, deliberately answered with two different names.
+  //
+  // *Which catalog entry is the registry* is physical identity, so it is resolved
+  // through the server's comparison rules and the answer is the spelling the
+  // catalog reports. That spelling is what the metadata exclusion below needs.
   const registryTable = resolveCatalogName(catalog, REGISTRY_TABLE);
   if (registryTable === undefined) return [];
 
+  // *How to address the registry through the ORM* is a different question with a
+  // different answer: the schema registry keys static schemas by the name the
+  // Drizzle table declares and looks them up exactly, so it only ever knows the
+  // canonical name. Addressing it by the catalog's spelling would be reported as
+  // unregistered on a folding server, and this function would return nothing —
+  // silently dropping every custom-named component from the sweep.
+  //
   // Consulted only when the ORM can address it. An executor with no schema
   // registered for the registry — a hand-built adapter carrying just its own
   // tables — has no schema for any component table either, so it could not
@@ -235,9 +247,12 @@ async function listRegisteredComponentTables(
   // stays complete for everything such an executor can reach. Probing rather
   // than catching keeps genuine read failures propagating instead of being
   // mistaken for "nothing registered".
-  if (!(await isResolvable(adapter, registryTable))) return [];
+  if (!(await isResolvable(adapter, REGISTRY_TABLE))) return [];
 
-  const rows = await adapter.select<Record<string, unknown>>(registryTable, {});
+  const rows = await adapter.select<Record<string, unknown>>(
+    REGISTRY_TABLE,
+    {}
+  );
 
   return (
     rows

--- a/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.ts
+++ b/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.ts
@@ -62,6 +62,7 @@ export interface TeardownComponentDataAdapter {
   ): Promise<T[]>;
   delete(table: string, where: WhereClause): Promise<number>;
   executeQuery<T = unknown>(sql: string, params?: unknown[]): Promise<T[]>;
+  getDrizzle<T = unknown>(): T;
   tableExists(tableName: string): Promise<boolean>;
   listTables(): Promise<string[]>;
 }

--- a/packages/nextly/src/domains/schema/utils/__tests__/read-identifier-case.test.ts
+++ b/packages/nextly/src/domains/schema/utils/__tests__/read-identifier-case.test.ts
@@ -3,49 +3,74 @@ import { describe, expect, it, vi } from "vitest";
 
 import { NextlyError } from "../../../../errors/nextly-error";
 import { readIdentifierCaseRules } from "../read-identifier-case";
+import type { IdentifierCase } from "../resolve-catalog-name";
 
-function adapter(dialect: SupportedDialect, rows: unknown[] = []) {
+/**
+ * `result` stands in for whatever the driver hands back from `db.execute`. The
+ * mysql2 driver returns a `[rows, fields]` tuple; others return rows directly,
+ * and both shapes are exercised below.
+ */
+function adapter(dialect: SupportedDialect, result: unknown = []) {
+  const execute = vi.fn().mockResolvedValue(result);
   return {
     dialect,
-    executeQuery: vi.fn().mockResolvedValue(rows),
+    getDrizzle: vi.fn(() => ({ execute })),
+    execute,
   };
 }
 
+const TUPLE = (value: unknown) => [[{ lower_case_table_names: value }], []];
+
 describe("readIdentifierCaseRules", () => {
   // Both are decided by dialect alone, so they must not cost a round trip.
-  it.each<[SupportedDialect, "preserve" | "fold"]>([
+  it.each<[SupportedDialect, IdentifierCase]>([
     ["postgresql", "preserve"],
-    ["sqlite", "fold"],
+    ["sqlite", "fold-ascii"],
   ])("decides %s without querying the server", async (dialect, expected) => {
     const db = adapter(dialect);
     expect((await readIdentifierCaseRules(db)).tables).toBe(expected);
-    expect(db.executeQuery).not.toHaveBeenCalled();
+    expect(db.getDrizzle).not.toHaveBeenCalled();
   });
 
   it("reads lower_case_table_names on mysql", async () => {
-    const db = adapter("mysql", [{ lower_case_table_names: 1 }]);
+    const db = adapter("mysql", TUPLE(1));
     expect(await readIdentifierCaseRules(db)).toEqual({
-      tables: "fold",
-      columns: "fold",
+      tables: "fold-unicode",
+      columns: "fold-unicode",
     });
-    expect(db.executeQuery).toHaveBeenCalledTimes(1);
+    expect(db.execute).toHaveBeenCalledTimes(1);
   });
 
   // The setting is the whole reason for the query: 0 is the case-sensitive
   // packaging, where folding a lookup would report a dropped table as present.
   it("treats mysql lower_case_table_names=0 as case-sensitive for tables", async () => {
-    const db = adapter("mysql", [{ lower_case_table_names: 0 }]);
+    const db = adapter("mysql", TUPLE(0));
     expect((await readIdentifierCaseRules(db)).tables).toBe("preserve");
   });
 
-  // Drivers differ on the column key they hand back.
-  it("accepts the camelCase key a driver may return", async () => {
-    const db = adapter("mysql", [{ lowerCaseTableNames: "1" }]);
-    expect((await readIdentifierCaseRules(db)).tables).toBe("fold");
+  // MySQL compares column names case-insensitively whatever that setting says.
+  it("keeps mysql columns folded even when tables are case-sensitive", async () => {
+    const db = adapter("mysql", TUPLE(0));
+    expect((await readIdentifierCaseRules(db)).columns).toBe("fold-unicode");
   });
 
-  it("refuses when the server returns no row", async () => {
-    const db = adapter("mysql", []);
+  // A driver that returns rows directly rather than a `[rows, fields]` tuple.
+  it("accepts a flat row list", async () => {
+    const db = adapter("mysql", [{ lower_case_table_names: 1 }]);
+    expect((await readIdentifierCaseRules(db)).tables).toBe("fold-unicode");
+  });
+
+  it("accepts a numeric string and the camelCase key a driver may return", async () => {
+    const db = adapter("mysql", [[{ lowerCaseTableNames: "2" }], []]);
+    expect((await readIdentifierCaseRules(db)).tables).toBe("fold-unicode");
+  });
+
+  it.each([
+    ["no rows", [[], []]],
+    ["an empty result", []],
+    ["a non-array result", { rows: [] }],
+  ])("refuses when the server returns %s", async (_label, result) => {
+    const db = adapter("mysql", result);
     await expect(readIdentifierCaseRules(db)).rejects.toSatisfy(
       error =>
         NextlyError.is(error) &&
@@ -54,7 +79,7 @@ describe("readIdentifierCaseRules", () => {
   });
 
   it("refuses when the value cannot be read", async () => {
-    const db = adapter("mysql", [{ lower_case_table_names: "unknown" }]);
+    const db = adapter("mysql", TUPLE("unknown"));
     await expect(readIdentifierCaseRules(db)).rejects.toSatisfy(
       error =>
         NextlyError.is(error) &&

--- a/packages/nextly/src/domains/schema/utils/__tests__/read-identifier-case.test.ts
+++ b/packages/nextly/src/domains/schema/utils/__tests__/read-identifier-case.test.ts
@@ -1,0 +1,64 @@
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+import { describe, expect, it, vi } from "vitest";
+
+import { NextlyError } from "../../../../errors/nextly-error";
+import { readIdentifierCaseRules } from "../read-identifier-case";
+
+function adapter(dialect: SupportedDialect, rows: unknown[] = []) {
+  return {
+    dialect,
+    executeQuery: vi.fn().mockResolvedValue(rows),
+  };
+}
+
+describe("readIdentifierCaseRules", () => {
+  // Both are decided by dialect alone, so they must not cost a round trip.
+  it.each<[SupportedDialect, "preserve" | "fold"]>([
+    ["postgresql", "preserve"],
+    ["sqlite", "fold"],
+  ])("decides %s without querying the server", async (dialect, expected) => {
+    const db = adapter(dialect);
+    expect((await readIdentifierCaseRules(db)).tables).toBe(expected);
+    expect(db.executeQuery).not.toHaveBeenCalled();
+  });
+
+  it("reads lower_case_table_names on mysql", async () => {
+    const db = adapter("mysql", [{ lower_case_table_names: 1 }]);
+    expect(await readIdentifierCaseRules(db)).toEqual({
+      tables: "fold",
+      columns: "fold",
+    });
+    expect(db.executeQuery).toHaveBeenCalledTimes(1);
+  });
+
+  // The setting is the whole reason for the query: 0 is the case-sensitive
+  // packaging, where folding a lookup would report a dropped table as present.
+  it("treats mysql lower_case_table_names=0 as case-sensitive for tables", async () => {
+    const db = adapter("mysql", [{ lower_case_table_names: 0 }]);
+    expect((await readIdentifierCaseRules(db)).tables).toBe("preserve");
+  });
+
+  // Drivers differ on the column key they hand back.
+  it("accepts the camelCase key a driver may return", async () => {
+    const db = adapter("mysql", [{ lowerCaseTableNames: "1" }]);
+    expect((await readIdentifierCaseRules(db)).tables).toBe("fold");
+  });
+
+  it("refuses when the server returns no row", async () => {
+    const db = adapter("mysql", []);
+    await expect(readIdentifierCaseRules(db)).rejects.toSatisfy(
+      error =>
+        NextlyError.is(error) &&
+        /returned no rows/.test(String(error.logContext?.reason))
+    );
+  });
+
+  it("refuses when the value cannot be read", async () => {
+    const db = adapter("mysql", [{ lower_case_table_names: "unknown" }]);
+    await expect(readIdentifierCaseRules(db)).rejects.toSatisfy(
+      error =>
+        NextlyError.is(error) &&
+        /not a non-negative integer/.test(String(error.logContext?.reason))
+    );
+  });
+});

--- a/packages/nextly/src/domains/schema/utils/__tests__/read-identifier-case.test.ts
+++ b/packages/nextly/src/domains/schema/utils/__tests__/read-identifier-case.test.ts
@@ -78,12 +78,24 @@ describe("readIdentifierCaseRules", () => {
     );
   });
 
-  it("refuses when the value cannot be read", async () => {
+  it.each([["unknown"], [""], [3]])(
+    "refuses when the value cannot be read (%p)",
+    async value => {
+      const db = adapter("mysql", TUPLE(value));
+      await expect(readIdentifierCaseRules(db)).rejects.toSatisfy(
+        error =>
+          NextlyError.is(error) &&
+          /not 0, 1 or 2/.test(String(error.logContext?.reason))
+      );
+    }
+  );
+
+  it("refuses when the value is a non-numeric string", async () => {
     const db = adapter("mysql", TUPLE("unknown"));
     await expect(readIdentifierCaseRules(db)).rejects.toSatisfy(
       error =>
         NextlyError.is(error) &&
-        /not a non-negative integer/.test(String(error.logContext?.reason))
+        /not 0, 1 or 2/.test(String(error.logContext?.reason))
     );
   });
 });

--- a/packages/nextly/src/domains/schema/utils/__tests__/resolve-catalog-name.test.ts
+++ b/packages/nextly/src/domains/schema/utils/__tests__/resolve-catalog-name.test.ts
@@ -19,18 +19,20 @@ describe("identifierCaseRules", () => {
     });
   });
 
-  it("folds both on sqlite, where names match case-insensitively", () => {
+  // SQLite understands upper/lower case for ASCII only, so its fold must not be
+  // Unicode-aware.
+  it("folds ASCII only on sqlite", () => {
     expect(identifierCaseRules({ dialect: "sqlite" })).toEqual({
-      tables: "fold",
-      columns: "fold",
+      tables: "fold-ascii",
+      columns: "fold-ascii",
     });
   });
 
   // MySQL's table behaviour is server configuration; only 0 is case-sensitive.
   it.each([
     [0, "preserve"],
-    [1, "fold"],
-    [2, "fold"],
+    [1, "fold-unicode"],
+    [2, "fold-unicode"],
   ])(
     "reads mysql lower_case_table_names=%i as %s for tables",
     (setting, expected) => {
@@ -51,14 +53,14 @@ describe("identifierCaseRules", () => {
       expect(
         identifierCaseRules({ dialect: "mysql", lowerCaseTableNames: setting })
           .columns
-      ).toBe("fold");
+      ).toBe("fold-unicode");
     }
   );
 });
 
 describe("resolveCatalogName", () => {
   it("returns the exact name when the catalog reports it verbatim", () => {
-    const catalog = indexCatalog(["comp_hero"], "fold");
+    const catalog = indexCatalog(["comp_hero"], "fold-ascii");
     expect(resolveCatalogName(catalog, "comp_hero")).toBe("comp_hero");
   });
 
@@ -71,7 +73,7 @@ describe("resolveCatalogName", () => {
   // as `seo_meta`, so an exact-only lookup would call a table that exists
   // missing and orphan its rows.
   it("falls back to a case-different entry where the server folds", () => {
-    const catalog = indexCatalog(["seo_meta"], "fold");
+    const catalog = indexCatalog(["seo_meta"], "fold-unicode");
     expect(resolveCatalogName(catalog, "SEO_META")).toBe("seo_meta");
   });
 
@@ -95,26 +97,28 @@ describe("resolveCatalogName", () => {
   // With an ambiguous fold and no exact hit, the lookup must be stable rather
   // than alternating between two real tables.
   it("resolves an ambiguous fold to the first catalog entry, consistently", () => {
-    const catalog = indexCatalog(["SEO_META", "seo_META"], "fold");
+    const catalog = indexCatalog(["SEO_META", "seo_META"], "fold-ascii");
     const first = resolveCatalogName(catalog, "Seo_Meta");
     expect(first).toBe("SEO_META");
     expect(resolveCatalogName(catalog, "Seo_Meta")).toBe(first);
   });
 
   it("returns undefined when nothing matches either way", () => {
-    const catalog = indexCatalog(["comp_hero"], "fold");
+    const catalog = indexCatalog(["comp_hero"], "fold-ascii");
     expect(resolveCatalogName(catalog, "comp_other")).toBeUndefined();
   });
 
   // The resolved value is what later statements must address, so it is always
   // the catalog's spelling and never the caller's.
   it("returns the catalog's spelling, not the requested one", () => {
-    const catalog = indexCatalog(["Comp_Hero"], "fold");
+    const catalog = indexCatalog(["Comp_Hero"], "fold-ascii");
     expect(resolveCatalogName(catalog, "comp_hero")).toBe("Comp_Hero");
   });
 
   it("handles an empty catalog", () => {
-    expect(resolveCatalogName(indexCatalog([], "fold"), "x")).toBeUndefined();
+    expect(
+      resolveCatalogName(indexCatalog([], "fold-ascii"), "x")
+    ).toBeUndefined();
   });
 });
 
@@ -167,4 +171,30 @@ describe("parseLowerCaseTableNames", () => {
       expect.fail("expected a refusal");
     }
   );
+});
+
+describe("dialect-specific fold width", () => {
+  // SQLite keeps `Ä` and `ä` as separate tables and cannot query one through the
+  // other's spelling, so a Unicode fold here would resolve a registry row to an
+  // unrelated table — and in teardown that means deleting its rows.
+  it("does not merge non-ASCII case under an ASCII fold", () => {
+    const catalog = indexCatalog(["comp_\u00e4rea"], "fold-ascii");
+    expect(resolveCatalogName(catalog, "comp_\u00c4rea")).toBeUndefined();
+  });
+
+  // MySQL lowercases names using the system character set, so the same pair must
+  // resolve there or a legitimate upgrade is refused.
+  it("merges non-ASCII case under a Unicode fold", () => {
+    const catalog = indexCatalog(["comp_\u00e4rea"], "fold-unicode");
+    expect(resolveCatalogName(catalog, "comp_\u00c4rea")).toBe(
+      "comp_\u00e4rea"
+    );
+  });
+
+  // ASCII folding still has to work, or the SQLite fix would break the ordinary
+  // case it exists to serve.
+  it("still folds ASCII case under an ASCII fold", () => {
+    const catalog = indexCatalog(["comp_hero"], "fold-ascii");
+    expect(resolveCatalogName(catalog, "COMP_HERO")).toBe("comp_hero");
+  });
 });

--- a/packages/nextly/src/domains/schema/utils/__tests__/resolve-catalog-name.test.ts
+++ b/packages/nextly/src/domains/schema/utils/__tests__/resolve-catalog-name.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { indexCatalog, resolveCatalogName } from "../resolve-catalog-name";
+
+describe("resolveCatalogName", () => {
+  it("returns the exact name when the catalog reports it verbatim", () => {
+    const catalog = indexCatalog(["comp_hero"]);
+    expect(resolveCatalogName(catalog, "comp_hero")).toBe("comp_hero");
+  });
+
+  // MySQL under `lower_case_table_names` reports a verbatim `SEO_META` as
+  // `seo_meta`, so an exact-only lookup would call a table that exists missing
+  // and orphan its rows.
+  it("falls back to a case-different catalog entry", () => {
+    const catalog = indexCatalog(["seo_meta"]);
+    expect(resolveCatalogName(catalog, "SEO_META")).toBe("seo_meta");
+  });
+
+  // Postgres, and MySQL with `lower_case_table_names=0`, hold both as distinct
+  // quoted tables. Folding first would collapse them and let an operation touch
+  // the wrong one, so an exact hit has to win.
+  it("prefers the exact match when both spellings exist", () => {
+    const catalog = indexCatalog(["SEO_META", "seo_meta"]);
+    expect(resolveCatalogName(catalog, "seo_meta")).toBe("seo_meta");
+    expect(resolveCatalogName(catalog, "SEO_META")).toBe("SEO_META");
+  });
+
+  // With an ambiguous fold and no exact hit, the lookup must be stable rather
+  // than alternating between two real tables.
+  it("resolves an ambiguous fold to the first catalog entry, consistently", () => {
+    const catalog = indexCatalog(["SEO_META", "seo_META"]);
+    const first = resolveCatalogName(catalog, "Seo_Meta");
+    expect(first).toBe("SEO_META");
+    expect(resolveCatalogName(catalog, "Seo_Meta")).toBe(first);
+  });
+
+  it("returns undefined when nothing matches either way", () => {
+    const catalog = indexCatalog(["comp_hero"]);
+    expect(resolveCatalogName(catalog, "comp_other")).toBeUndefined();
+  });
+
+  // The resolved value is what later statements must address, so it is always
+  // the catalog's spelling and never the caller's.
+  it("returns the catalog's spelling, not the requested one", () => {
+    const catalog = indexCatalog(["Comp_Hero"]);
+    expect(resolveCatalogName(catalog, "comp_hero")).toBe("Comp_Hero");
+  });
+
+  it("handles an empty catalog", () => {
+    expect(resolveCatalogName(indexCatalog([]), "anything")).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/domains/schema/utils/__tests__/resolve-catalog-name.test.ts
+++ b/packages/nextly/src/domains/schema/utils/__tests__/resolve-catalog-name.test.ts
@@ -152,25 +152,41 @@ describe("parseLowerCaseTableNames", () => {
     expect(parseLowerCaseTableNames("2")).toBe(2);
   });
 
+  it("accepts the case-insensitive-comparison setting", () => {
+    expect(parseLowerCaseTableNames(0)).toBe(0);
+  });
+
   // Refusing rather than defaulting is the point: both defaults are wrong on
   // some server, so a guess here silently picks one.
-  it.each([[null], [undefined], ["abc"], [1.5], [-1], [{}]])(
-    "refuses an unreadable value (%p)",
-    value => {
-      try {
-        parseLowerCaseTableNames(value);
-      } catch (error) {
-        expect(NextlyError.is(error)).toBe(true);
-        if (NextlyError.is(error)) {
-          expect(error.logContext?.reason).toMatch(
-            /not a non-negative integer/
-          );
-        }
-        return;
+  //
+  // The blank cases are the sharp ones. `Number("")` and `Number("  ")` are both
+  // `0`, so a server that answers with nothing would otherwise be read as the
+  // case-sensitive setting — a definite answer invented from an absent one.
+  // Values outside 0/1/2 are refused for the same reason: sorting an
+  // unrecognised setting into one behaviour or the other is a guess.
+  it.each([
+    [null],
+    [undefined],
+    [""],
+    ["  "],
+    ["abc"],
+    [3],
+    ["3"],
+    [1.5],
+    [-1],
+    [{}],
+  ])("refuses an unreadable value (%p)", value => {
+    try {
+      parseLowerCaseTableNames(value);
+    } catch (error) {
+      expect(NextlyError.is(error)).toBe(true);
+      if (NextlyError.is(error)) {
+        expect(error.logContext?.reason).toMatch(/not 0, 1 or 2/);
       }
-      expect.fail("expected a refusal");
+      return;
     }
-  );
+    expect.fail("expected a refusal");
+  });
 });
 
 describe("dialect-specific fold width", () => {
@@ -196,5 +212,23 @@ describe("dialect-specific fold width", () => {
   it("still folds ASCII case under an ASCII fold", () => {
     const catalog = indexCatalog(["comp_hero"], "fold-ascii");
     expect(resolveCatalogName(catalog, "COMP_HERO")).toBe("comp_hero");
+  });
+});
+
+describe("simple versus full case mapping", () => {
+  // A server maps one character to one character. JavaScript's full Unicode
+  // mapping turns `İ` into `i` plus a combining dot, so keying on it would look
+  // for `i̇tem` while the catalog reports `item`, and a custom table would be
+  // read as missing.
+  it("folds a character whose full lowercase mapping expands", () => {
+    const catalog = indexCatalog(["item"], "fold-unicode");
+    expect(resolveCatalogName(catalog, "\u0130TEM")).toBe("item");
+  });
+
+  // The same character under ASCII rules is left alone, because a server that
+  // folds ASCII only does not touch it.
+  it("leaves an expanding character alone under an ASCII fold", () => {
+    const catalog = indexCatalog(["item"], "fold-ascii");
+    expect(resolveCatalogName(catalog, "\u0130TEM")).toBeUndefined();
   });
 });

--- a/packages/nextly/src/domains/schema/utils/__tests__/resolve-catalog-name.test.ts
+++ b/packages/nextly/src/domains/schema/utils/__tests__/resolve-catalog-name.test.ts
@@ -1,26 +1,93 @@
 import { describe, expect, it } from "vitest";
 
-import { indexCatalog, resolveCatalogName } from "../resolve-catalog-name";
+import { NextlyError } from "../../../../errors/nextly-error";
+import {
+  findCaseVariant,
+  identifierCaseRules,
+  indexCatalog,
+  parseLowerCaseTableNames,
+  resolveCatalogName,
+} from "../resolve-catalog-name";
+
+describe("identifierCaseRules", () => {
+  // Every identifier Nextly emits is quoted, so Postgres stores exactly what it
+  // was given and never folds. Folding a lookup would merge two real tables.
+  it("preserves case on postgres, for tables and columns alike", () => {
+    expect(identifierCaseRules({ dialect: "postgresql" })).toEqual({
+      tables: "preserve",
+      columns: "preserve",
+    });
+  });
+
+  it("folds both on sqlite, where names match case-insensitively", () => {
+    expect(identifierCaseRules({ dialect: "sqlite" })).toEqual({
+      tables: "fold",
+      columns: "fold",
+    });
+  });
+
+  // MySQL's table behaviour is server configuration; only 0 is case-sensitive.
+  it.each([
+    [0, "preserve"],
+    [1, "fold"],
+    [2, "fold"],
+  ])(
+    "reads mysql lower_case_table_names=%i as %s for tables",
+    (setting, expected) => {
+      expect(
+        identifierCaseRules({
+          dialect: "mysql",
+          lowerCaseTableNames: setting,
+        }).tables
+      ).toBe(expected);
+    }
+  );
+
+  // MySQL compares column names case-insensitively on every server, whatever
+  // lower_case_table_names says, so the two rules cannot be one value.
+  it.each([0, 1, 2])(
+    "folds mysql columns regardless of lower_case_table_names=%i",
+    setting => {
+      expect(
+        identifierCaseRules({ dialect: "mysql", lowerCaseTableNames: setting })
+          .columns
+      ).toBe("fold");
+    }
+  );
+});
 
 describe("resolveCatalogName", () => {
   it("returns the exact name when the catalog reports it verbatim", () => {
-    const catalog = indexCatalog(["comp_hero"]);
+    const catalog = indexCatalog(["comp_hero"], "fold");
     expect(resolveCatalogName(catalog, "comp_hero")).toBe("comp_hero");
   });
 
-  // MySQL under `lower_case_table_names` reports a verbatim `SEO_META` as
-  // `seo_meta`, so an exact-only lookup would call a table that exists missing
-  // and orphan its rows.
-  it("falls back to a case-different catalog entry", () => {
-    const catalog = indexCatalog(["seo_meta"]);
+  it("finds an exact match on a case-preserving server too", () => {
+    const catalog = indexCatalog(["comp_hero"], "preserve");
+    expect(resolveCatalogName(catalog, "comp_hero")).toBe("comp_hero");
+  });
+
+  // MySQL under `lower_case_table_names=1` reports a table created as `SEO_META`
+  // as `seo_meta`, so an exact-only lookup would call a table that exists
+  // missing and orphan its rows.
+  it("falls back to a case-different entry where the server folds", () => {
+    const catalog = indexCatalog(["seo_meta"], "fold");
     expect(resolveCatalogName(catalog, "SEO_META")).toBe("seo_meta");
   });
 
-  // Postgres, and MySQL with `lower_case_table_names=0`, hold both as distinct
-  // quoted tables. Folding first would collapse them and let an operation touch
-  // the wrong one, so an exact hit has to win.
+  // The defect this guards: on Postgres, and MySQL with
+  // lower_case_table_names=0, `SEO_META` and `seo_meta` are different tables, so
+  // folding reports a missing table as present and the caller then addresses one
+  // that is not there.
+  it("does not fall back to a case-different entry where case is significant", () => {
+    const catalog = indexCatalog(["seo_meta"], "preserve");
+    expect(resolveCatalogName(catalog, "SEO_META")).toBeUndefined();
+  });
+
+  // A case-preserving server can hold both. Folding first would collapse them
+  // and let an operation touch the wrong one, so an exact hit has to win.
   it("prefers the exact match when both spellings exist", () => {
-    const catalog = indexCatalog(["SEO_META", "seo_meta"]);
+    const catalog = indexCatalog(["SEO_META", "seo_meta"], "preserve");
     expect(resolveCatalogName(catalog, "seo_meta")).toBe("seo_meta");
     expect(resolveCatalogName(catalog, "SEO_META")).toBe("SEO_META");
   });
@@ -28,25 +95,76 @@ describe("resolveCatalogName", () => {
   // With an ambiguous fold and no exact hit, the lookup must be stable rather
   // than alternating between two real tables.
   it("resolves an ambiguous fold to the first catalog entry, consistently", () => {
-    const catalog = indexCatalog(["SEO_META", "seo_META"]);
+    const catalog = indexCatalog(["SEO_META", "seo_META"], "fold");
     const first = resolveCatalogName(catalog, "Seo_Meta");
     expect(first).toBe("SEO_META");
     expect(resolveCatalogName(catalog, "Seo_Meta")).toBe(first);
   });
 
   it("returns undefined when nothing matches either way", () => {
-    const catalog = indexCatalog(["comp_hero"]);
+    const catalog = indexCatalog(["comp_hero"], "fold");
     expect(resolveCatalogName(catalog, "comp_other")).toBeUndefined();
   });
 
   // The resolved value is what later statements must address, so it is always
   // the catalog's spelling and never the caller's.
   it("returns the catalog's spelling, not the requested one", () => {
-    const catalog = indexCatalog(["Comp_Hero"]);
+    const catalog = indexCatalog(["Comp_Hero"], "fold");
     expect(resolveCatalogName(catalog, "comp_hero")).toBe("Comp_Hero");
   });
 
   it("handles an empty catalog", () => {
-    expect(resolveCatalogName(indexCatalog([]), "anything")).toBeUndefined();
+    expect(resolveCatalogName(indexCatalog([], "fold"), "x")).toBeUndefined();
   });
+});
+
+describe("findCaseVariant", () => {
+  // A refusal that names the near-miss is the difference between an operator
+  // hunting a dropped table and correcting one registry row.
+  it("names an entry differing only by case", () => {
+    const catalog = indexCatalog(["COMP_HERO"], "preserve");
+    expect(findCaseVariant(catalog, "comp_hero")).toBe("COMP_HERO");
+  });
+
+  it("reports nothing when the name resolved exactly", () => {
+    const catalog = indexCatalog(["comp_hero"], "preserve");
+    expect(findCaseVariant(catalog, "comp_hero")).toBeUndefined();
+  });
+
+  it("reports nothing when there is no similar entry", () => {
+    const catalog = indexCatalog(["comp_other"], "preserve");
+    expect(findCaseVariant(catalog, "comp_hero")).toBeUndefined();
+  });
+});
+
+describe("parseLowerCaseTableNames", () => {
+  it("accepts a number", () => {
+    expect(parseLowerCaseTableNames(1)).toBe(1);
+  });
+
+  // Drivers disagree about whether a server variable comes back as a number or
+  // a string.
+  it("accepts a numeric string", () => {
+    expect(parseLowerCaseTableNames("2")).toBe(2);
+  });
+
+  // Refusing rather than defaulting is the point: both defaults are wrong on
+  // some server, so a guess here silently picks one.
+  it.each([[null], [undefined], ["abc"], [1.5], [-1], [{}]])(
+    "refuses an unreadable value (%p)",
+    value => {
+      try {
+        parseLowerCaseTableNames(value);
+      } catch (error) {
+        expect(NextlyError.is(error)).toBe(true);
+        if (NextlyError.is(error)) {
+          expect(error.logContext?.reason).toMatch(
+            /not a non-negative integer/
+          );
+        }
+        return;
+      }
+      expect.fail("expected a refusal");
+    }
+  );
 });

--- a/packages/nextly/src/domains/schema/utils/read-identifier-case.ts
+++ b/packages/nextly/src/domains/schema/utils/read-identifier-case.ts
@@ -9,6 +9,7 @@
  */
 
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+import { sql, type SQL } from "drizzle-orm";
 
 import { NextlyError } from "../../../errors/nextly-error";
 
@@ -18,10 +19,21 @@ import {
   type IdentifierCaseRules,
 } from "./resolve-catalog-name";
 
+/**
+ * The slice of a Drizzle database this helper uses.
+ *
+ * Declared rather than imported because the concrete type is dialect-specific
+ * and `getDrizzle` is generic over it; naming only `execute` keeps this typed
+ * without reaching for `any`.
+ */
+interface RawSqlExecutor {
+  execute(query: SQL): Promise<unknown>;
+}
+
 /** Minimal adapter surface this helper needs. */
 export interface IdentifierCaseAdapter {
   dialect: SupportedDialect;
-  executeQuery<T = unknown>(sql: string, params?: unknown[]): Promise<T[]>;
+  getDrizzle<T = unknown>(): T;
 }
 
 /**
@@ -34,9 +46,9 @@ export interface IdentifierCaseAdapter {
  * present, and assuming case-sensitive matching refuses an upgrade that is
  * legitimate on the most common Linux packaging.
  *
- * Read through `executeQuery` because this is a server variable, not data.
- * Drizzle's query builder addresses tables and columns; it has no surface for
- * session variables, and there are no user-supplied values here to parameterise.
+ * Issued through Drizzle's `sql` template rather than as a raw string, which is
+ * the sanctioned way to express something the query builder has no surface for —
+ * a session variable is not a table, so there is nothing to select from.
  */
 export async function readIdentifierCaseRules(
   adapter: IdentifierCaseAdapter
@@ -45,11 +57,13 @@ export async function readIdentifierCaseRules(
     return identifierCaseRules({ dialect: adapter.dialect });
   }
 
-  const rows = await adapter.executeQuery<Record<string, unknown>>(
-    "SELECT @@lower_case_table_names AS lower_case_table_names"
+  const db = adapter.getDrizzle<RawSqlExecutor>();
+  const result = await db.execute(
+    sql`select @@lower_case_table_names as lower_case_table_names`
   );
-  const first = rows[0];
-  if (first === undefined) {
+
+  const row = firstRow(result);
+  if (row === undefined) {
     throw NextlyError.serviceUnavailable({
       logMessage:
         "cannot determine how this MySQL server compares table names: the server returned no value",
@@ -60,7 +74,23 @@ export async function readIdentifierCaseRules(
   return identifierCaseRules({
     dialect: "mysql",
     lowerCaseTableNames: parseLowerCaseTableNames(
-      first.lower_case_table_names ?? first.lowerCaseTableNames
+      row.lower_case_table_names ?? row.lowerCaseTableNames
     ),
   });
+}
+
+/**
+ * The first record out of a Drizzle `execute` result.
+ *
+ * The shape is driver-specific: the mysql2 driver returns a
+ * `[rows, fields]` tuple, while others return the rows directly. The two are
+ * told apart by whether the first element is itself an array, which is the only
+ * distinction that does not depend on trusting one driver's shape.
+ */
+function firstRow(result: unknown): Record<string, unknown> | undefined {
+  if (!Array.isArray(result)) return undefined;
+  const rows = Array.isArray(result[0]) ? result[0] : result;
+  const first: unknown = rows[0];
+  if (typeof first !== "object" || first === null) return undefined;
+  return first as Record<string, unknown>;
 }

--- a/packages/nextly/src/domains/schema/utils/read-identifier-case.ts
+++ b/packages/nextly/src/domains/schema/utils/read-identifier-case.ts
@@ -1,0 +1,66 @@
+/**
+ * Asks a live server how it compares identifier names.
+ *
+ * Separated from `identifierCaseRules` so the mapping from server to rules stays
+ * a pure function that can be tested for every dialect without a database, while
+ * the one dialect that needs a round trip pays for it in a single place.
+ *
+ * @module domains/schema/utils/read-identifier-case
+ */
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+import { NextlyError } from "../../../errors/nextly-error";
+
+import {
+  identifierCaseRules,
+  parseLowerCaseTableNames,
+  type IdentifierCaseRules,
+} from "./resolve-catalog-name";
+
+/** Minimal adapter surface this helper needs. */
+export interface IdentifierCaseAdapter {
+  dialect: SupportedDialect;
+  executeQuery<T = unknown>(sql: string, params?: unknown[]): Promise<T[]>;
+}
+
+/**
+ * Read the server's identifier-comparison rules.
+ *
+ * Postgres and SQLite are decided by dialect alone, so they cost nothing. MySQL
+ * needs `lower_case_table_names`, which is server configuration rather than
+ * anything the dialect or the connection string states, and there is no safe
+ * static answer: assuming case-insensitive matching makes a dropped table look
+ * present, and assuming case-sensitive matching refuses an upgrade that is
+ * legitimate on the most common Linux packaging.
+ *
+ * Read through `executeQuery` because this is a server variable, not data.
+ * Drizzle's query builder addresses tables and columns; it has no surface for
+ * session variables, and there are no user-supplied values here to parameterise.
+ */
+export async function readIdentifierCaseRules(
+  adapter: IdentifierCaseAdapter
+): Promise<IdentifierCaseRules> {
+  if (adapter.dialect !== "mysql") {
+    return identifierCaseRules({ dialect: adapter.dialect });
+  }
+
+  const rows = await adapter.executeQuery<Record<string, unknown>>(
+    "SELECT @@lower_case_table_names AS lower_case_table_names"
+  );
+  const first = rows[0];
+  if (first === undefined) {
+    throw NextlyError.serviceUnavailable({
+      logMessage:
+        "cannot determine how this MySQL server compares table names: the server returned no value",
+      logContext: { reason: "lower_case_table_names query returned no rows" },
+    });
+  }
+
+  return identifierCaseRules({
+    dialect: "mysql",
+    lowerCaseTableNames: parseLowerCaseTableNames(
+      first.lower_case_table_names ?? first.lowerCaseTableNames
+    ),
+  });
+}

--- a/packages/nextly/src/domains/schema/utils/resolve-catalog-name.ts
+++ b/packages/nextly/src/domains/schema/utils/resolve-catalog-name.ts
@@ -1,11 +1,10 @@
 /**
  * Resolves a name Nextly stored to the name the database actually reports.
  *
- * Two callers need this and both get it wrong in a different direction if they
- * guess. Extracted here so there is one implementation rather than a copy per
- * call site, for the same reason `resolveCollectionTableName` was consolidated:
- * independent versions of a naming rule drift, and the drift is invisible until
- * it reaches a database that exercises the difference.
+ * Every caller that maps a stored name onto a live object routes through here, so
+ * one rule governs the question. Independent versions of a naming rule drift, and
+ * the drift stays invisible until it reaches a database whose comparison
+ * behaviour exercises the difference.
  *
  * Whether two spellings name one object is **not** a property of the name. It is
  * a property of the server, so it is an input here rather than a constant, and
@@ -45,10 +44,24 @@ export type IdentifierCase = "preserve" | "fold-ascii" | "fold-unicode";
  * the two folding modes are the whole domain.
  */
 function foldName(name: string, mode: "fold-ascii" | "fold-unicode"): string {
-  if (mode === "fold-unicode") return name.toLowerCase();
-  // Deliberately not `toLowerCase()`, which maps `Ä` to `ä` and would merge two
-  // names SQLite keeps apart.
-  return name.replace(/[A-Z]/g, character => character.toLowerCase());
+  // ASCII rules fold `A`-`Z` and nothing else. `toLowerCase()` would also map
+  // `Ä` to `ä`, merging two names SQLite keeps apart.
+  if (mode === "fold-ascii") {
+    return name.replace(/[A-Z]/g, character => character.toLowerCase());
+  }
+
+  // A server's case table maps one character to one character. JavaScript
+  // applies Unicode's *full* mapping, which for `İ` (U+0130) produces `i` plus a
+  // combining dot where a server produces `i` alone — so a folded lookup would
+  // key `İTEM` as `i̇tem` while the catalog reports `item`. Taking the first code
+  // point of the mapping is the simple mapping for every character whose full
+  // mapping expands, so the two agree.
+  let folded = "";
+  for (const character of name) {
+    const lowered = character.toLowerCase();
+    folded += [...lowered][0] ?? character;
+  }
+  return folded;
 }
 
 /**
@@ -212,16 +225,28 @@ export function findCaseVariant(
  * because both defaults are wrong on some server. Refusing keeps the guess out.
  */
 export function parseLowerCaseTableNames(value: unknown): number {
-  const parsed = typeof value === "string" ? Number(value) : value;
-  if (typeof parsed !== "number" || !Number.isInteger(parsed) || parsed < 0) {
+  const parsed = typeof value === "string" ? parseSetting(value) : value;
+  // Constrained to the values MySQL defines rather than to "any non-negative
+  // integer". `Number("")` is `0`, so a blank value would otherwise read as the
+  // case-sensitive setting, and an unrecognised number would be sorted into one
+  // behaviour or the other — both are guesses about how the server compares
+  // names, which is the one thing this must not do.
+  if (parsed !== 0 && parsed !== 1 && parsed !== 2) {
     throw NextlyError.serviceUnavailable({
       logMessage:
         "cannot determine how this MySQL server compares table names: lower_case_table_names is unreadable",
       logContext: {
-        reason: "lower_case_table_names is not a non-negative integer",
+        reason: "lower_case_table_names is not 0, 1 or 2",
         value,
       },
     });
   }
   return parsed;
+}
+
+/** `undefined` for anything that is not a plain integer literal. */
+function parseSetting(value: string): number | undefined {
+  if (value.trim() === "") return undefined;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) ? parsed : undefined;
 }

--- a/packages/nextly/src/domains/schema/utils/resolve-catalog-name.ts
+++ b/packages/nextly/src/domains/schema/utils/resolve-catalog-name.ts
@@ -1,0 +1,64 @@
+/**
+ * Resolves a name Nextly stored to the name the database actually reports.
+ *
+ * Two callers need this and both get it wrong in a different direction if they
+ * guess. Extracted here so there is one implementation rather than a copy per
+ * call site, for the same reason `resolveCollectionTableName` was consolidated:
+ * independent versions of a naming rule drift, and the drift is invisible until
+ * it reaches a database that exercises the difference.
+ *
+ * @module domains/schema/utils/resolve-catalog-name
+ */
+
+/**
+ * A catalog listing, prepared once for repeated lookups.
+ *
+ * Built from `adapter.listTables()`. Holding both an exact set and a folded
+ * index is what lets a lookup prefer an exact hit and still find a
+ * case-different one.
+ */
+export interface CatalogIndex {
+  /** Names exactly as the database reported them. */
+  readonly exact: ReadonlySet<string>;
+  /** Lower-cased name to the first catalog entry that folded to it. */
+  readonly folded: ReadonlyMap<string, string>;
+}
+
+/** Index a catalog listing for lookup. */
+export function indexCatalog(tables: readonly string[]): CatalogIndex {
+  const exact = new Set(tables);
+  const folded = new Map<string, string>();
+  for (const name of tables) {
+    const key = name.toLowerCase();
+    // First writer wins, so an ambiguous fold cannot silently retarget a table:
+    // if a database holds both `SEO_META` and `seo_meta`, a folded lookup keeps
+    // pointing at whichever the catalog listed first rather than alternating.
+    if (!folded.has(key)) folded.set(key, name);
+  }
+  return { exact, folded };
+}
+
+/**
+ * Resolve a stored name to the catalog's spelling of it, or `undefined`.
+ *
+ * Exact match first, then case-insensitive. Both halves are necessary and
+ * neither is sufficient:
+ *
+ * - MySQL with `lower_case_table_names` reports a verbatim `SEO_META` as
+ *   `seo_meta`, so an exact-only lookup discards a table that genuinely exists.
+ * - Postgres, and MySQL with `lower_case_table_names=0`, hold `SEO_META` and
+ *   `seo_meta` as distinct quoted tables, so folding unconditionally collapses
+ *   two tables into one and lets an operation touch the wrong one.
+ *
+ * Preferring the exact hit keeps those distinct while the fallback still finds a
+ * folded entry. The value returned is always the name the catalog reported,
+ * because that is the spelling later statements have to address — not the
+ * spelling Nextly happened to store.
+ */
+export function resolveCatalogName(
+  catalog: CatalogIndex,
+  storedName: string
+): string | undefined {
+  if (catalog.exact.has(storedName)) return storedName;
+  return catalog.folded.get(storedName.toLowerCase());
+}

--- a/packages/nextly/src/domains/schema/utils/resolve-catalog-name.ts
+++ b/packages/nextly/src/domains/schema/utils/resolve-catalog-name.ts
@@ -7,58 +7,183 @@
  * independent versions of a naming rule drift, and the drift is invisible until
  * it reaches a database that exercises the difference.
  *
+ * Whether two spellings name one object is **not** a property of the name. It is
+ * a property of the server, so it is an input here rather than a constant, and
+ * `identifierCaseRules` is the only place that maps a server to it.
+ *
  * @module domains/schema/utils/resolve-catalog-name
  */
+
+import { NextlyError } from "../../../errors/nextly-error";
+
+/**
+ * How a server decides whether two spellings name the same object.
+ *
+ * - `preserve` — case is significant. `SEO_META` and `seo_meta` are two
+ *   different objects, and a stored name absent from the catalog is genuinely
+ *   absent no matter what else the catalog holds.
+ * - `fold` — case is not significant. The two spellings are one object, so a
+ *   stored name is found under whatever case the catalog reports it in.
+ */
+export type IdentifierCase = "preserve" | "fold";
+
+/**
+ * A server's rules, which differ between tables and columns on MySQL.
+ *
+ * Kept as two fields rather than one because collapsing them is wrong on the
+ * dialect that matters most here: MySQL compares column names case-insensitively
+ * on every server, while its table names follow `lower_case_table_names`. A
+ * single value would have to be wrong for one of the two.
+ */
+export interface IdentifierCaseRules {
+  readonly tables: IdentifierCase;
+  readonly columns: IdentifierCase;
+}
+
+/**
+ * The server whose rules are being described.
+ *
+ * MySQL requires `lowerCaseTableNames` because its table-name behaviour is
+ * server configuration, not a dialect property, and no static default is safe:
+ * assuming `fold` makes a missing table look present on a case-sensitive server,
+ * and assuming `preserve` refuses a legitimate upgrade on a folding one. Making
+ * it a required field means a caller cannot reach that guess by omission.
+ */
+export type IdentifierCaseServer =
+  | { dialect: "postgresql" }
+  | { dialect: "sqlite" }
+  | { dialect: "mysql"; lowerCaseTableNames: number };
+
+/**
+ * Map a server to its identifier-comparison rules.
+ *
+ * - **Postgres** preserves both. Every identifier Nextly emits is quoted
+ *   (`quoteIdent`), so the server stores exactly the name it was given and never
+ *   folds it. Comparing folded here would merge two genuinely distinct tables.
+ * - **SQLite** folds both: table and column names match case-insensitively, so
+ *   two names differing only in case cannot coexist and folding is exact.
+ * - **MySQL** folds columns always. Its tables follow `lower_case_table_names`:
+ *   `0` stores and compares case-sensitively, `1` lowercases names on creation,
+ *   and `2` stores them as given but compares case-insensitively. Only `0`
+ *   preserves. Under `1` the catalog reports a lowercased name for a table
+ *   created with capitals, which is exactly the case a folded lookup must find.
+ */
+export function identifierCaseRules(
+  server: IdentifierCaseServer
+): IdentifierCaseRules {
+  if (server.dialect === "postgresql") {
+    return { tables: "preserve", columns: "preserve" };
+  }
+  if (server.dialect === "sqlite") {
+    return { tables: "fold", columns: "fold" };
+  }
+  return {
+    tables: server.lowerCaseTableNames === 0 ? "preserve" : "fold",
+    columns: "fold",
+  };
+}
 
 /**
  * A catalog listing, prepared once for repeated lookups.
  *
- * Built from `adapter.listTables()`. Holding both an exact set and a folded
- * index is what lets a lookup prefer an exact hit and still find a
- * case-different one.
+ * Built from `adapter.listTables()` for tables, or a table's column names for
+ * columns. The folded index is kept even when the server preserves case: it is
+ * not used to resolve then, but it is what lets a refusal say "the name you
+ * stored is absent and one differing only in case is present", which is the
+ * difference between an operator fixing a row and an operator guessing.
  */
 export interface CatalogIndex {
   /** Names exactly as the database reported them. */
   readonly exact: ReadonlySet<string>;
   /** Lower-cased name to the first catalog entry that folded to it. */
   readonly folded: ReadonlyMap<string, string>;
+  /** How this catalog's server compares the names it reported. */
+  readonly identifierCase: IdentifierCase;
 }
 
-/** Index a catalog listing for lookup. */
-export function indexCatalog(tables: readonly string[]): CatalogIndex {
-  const exact = new Set(tables);
+/** Index a catalog listing for lookup under a server's comparison rules. */
+export function indexCatalog(
+  names: readonly string[],
+  identifierCase: IdentifierCase
+): CatalogIndex {
+  const exact = new Set(names);
   const folded = new Map<string, string>();
-  for (const name of tables) {
+  for (const name of names) {
     const key = name.toLowerCase();
-    // First writer wins, so an ambiguous fold cannot silently retarget a table:
-    // if a database holds both `SEO_META` and `seo_meta`, a folded lookup keeps
-    // pointing at whichever the catalog listed first rather than alternating.
+    // First writer wins, so an ambiguous fold cannot silently retarget an
+    // object: if a case-preserving server holds both `SEO_META` and `seo_meta`,
+    // a folded lookup keeps pointing at whichever the catalog listed first
+    // rather than alternating between two real objects.
     if (!folded.has(key)) folded.set(key, name);
   }
-  return { exact, folded };
+  return { exact, folded, identifierCase };
 }
 
 /**
  * Resolve a stored name to the catalog's spelling of it, or `undefined`.
  *
- * Exact match first, then case-insensitive. Both halves are necessary and
- * neither is sufficient:
+ * An exact hit always wins, on every server. The folded fallback runs only where
+ * the server folds, because there and only there do the two spellings name one
+ * object:
  *
- * - MySQL with `lower_case_table_names` reports a verbatim `SEO_META` as
- *   `seo_meta`, so an exact-only lookup discards a table that genuinely exists.
- * - Postgres, and MySQL with `lower_case_table_names=0`, hold `SEO_META` and
- *   `seo_meta` as distinct quoted tables, so folding unconditionally collapses
- *   two tables into one and lets an operation touch the wrong one.
+ * - On a **folding** server the fallback is necessary. MySQL under
+ *   `lower_case_table_names=1` reports a table created as `SEO_META` as
+ *   `seo_meta`, so an exact-only lookup would call a table that exists missing
+ *   and orphan its rows.
+ * - On a **preserving** server the fallback is unsound. Postgres, and MySQL with
+ *   `lower_case_table_names=0`, hold `SEO_META` and `seo_meta` as distinct
+ *   objects, so folding would report a missing object as present and let the
+ *   caller address one that is not there — or, worse, a different application's.
  *
- * Preferring the exact hit keeps those distinct while the fallback still finds a
- * folded entry. The value returned is always the name the catalog reported,
- * because that is the spelling later statements have to address — not the
- * spelling Nextly happened to store.
+ * The value returned is always the name the catalog reported, because that is
+ * the spelling later statements have to address, not the spelling Nextly
+ * happened to store.
  */
 export function resolveCatalogName(
   catalog: CatalogIndex,
   storedName: string
 ): string | undefined {
   if (catalog.exact.has(storedName)) return storedName;
+  if (catalog.identifierCase === "preserve") return undefined;
   return catalog.folded.get(storedName.toLowerCase());
+}
+
+/**
+ * The catalog entry differing from `storedName` only by case, if there is one
+ * and it is not the resolved answer.
+ *
+ * Only ever non-empty on a case-preserving server, where such an entry is a
+ * *different* object. It exists for refusal messages: "`comp_hero` is missing"
+ * sends an operator looking for a dropped table, while "`comp_hero` is missing
+ * and `COMP_HERO` is present" names the actual problem.
+ */
+export function findCaseVariant(
+  catalog: CatalogIndex,
+  storedName: string
+): string | undefined {
+  if (catalog.exact.has(storedName)) return undefined;
+  const variant = catalog.folded.get(storedName.toLowerCase());
+  return variant === storedName ? undefined : variant;
+}
+
+/**
+ * Read a MySQL server's `lower_case_table_names` from a raw value.
+ *
+ * Drivers disagree about the type of a server variable — some return the number,
+ * some the string — and an unparseable value must not fall back to a default,
+ * because both defaults are wrong on some server. Refusing keeps the guess out.
+ */
+export function parseLowerCaseTableNames(value: unknown): number {
+  const parsed = typeof value === "string" ? Number(value) : value;
+  if (typeof parsed !== "number" || !Number.isInteger(parsed) || parsed < 0) {
+    throw NextlyError.serviceUnavailable({
+      logMessage:
+        "cannot determine how this MySQL server compares table names: lower_case_table_names is unreadable",
+      logContext: {
+        reason: "lower_case_table_names is not a non-negative integer",
+        value,
+      },
+    });
+  }
+  return parsed;
 }

--- a/packages/nextly/src/domains/schema/utils/resolve-catalog-name.ts
+++ b/packages/nextly/src/domains/schema/utils/resolve-catalog-name.ts
@@ -22,10 +22,34 @@ import { NextlyError } from "../../../errors/nextly-error";
  * - `preserve` — case is significant. `SEO_META` and `seo_meta` are two
  *   different objects, and a stored name absent from the catalog is genuinely
  *   absent no matter what else the catalog holds.
- * - `fold` — case is not significant. The two spellings are one object, so a
- *   stored name is found under whatever case the catalog reports it in.
+ * - `fold-ascii` — case is not significant, but **only for `A`–`Z`**. This is
+ *   SQLite, which documents that it understands upper and lower case for ASCII
+ *   characters only: `Ä` and `ä` are two distinct tables there, and neither can
+ *   be queried through the other's spelling.
+ * - `fold-unicode` — case is not significant across the character set. This is
+ *   MySQL, which lowercases names using the system character set rather than
+ *   ASCII rules.
+ *
+ * The two folds are separate because collapsing them is wrong in both
+ * directions: Unicode-folding on SQLite merges two real tables, and
+ * ASCII-folding on MySQL fails to find a table the server itself lowercased.
+ * Nextly's own identifiers are ASCII (`normalizeIdentifier` strips everything
+ * else), so the distinction only bites on a name an author chose.
  */
-export type IdentifierCase = "preserve" | "fold";
+export type IdentifierCase = "preserve" | "fold-ascii" | "fold-unicode";
+
+/**
+ * Fold a name for lookup, under the server's rules.
+ *
+ * `preserve` never reaches here — a preserving server has no folded lookup — so
+ * the two folding modes are the whole domain.
+ */
+function foldName(name: string, mode: "fold-ascii" | "fold-unicode"): string {
+  if (mode === "fold-unicode") return name.toLowerCase();
+  // Deliberately not `toLowerCase()`, which maps `Ä` to `ä` and would merge two
+  // names SQLite keeps apart.
+  return name.replace(/[A-Z]/g, character => character.toLowerCase());
+}
 
 /**
  * A server's rules, which differ between tables and columns on MySQL.
@@ -60,8 +84,9 @@ export type IdentifierCaseServer =
  * - **Postgres** preserves both. Every identifier Nextly emits is quoted
  *   (`quoteIdent`), so the server stores exactly the name it was given and never
  *   folds it. Comparing folded here would merge two genuinely distinct tables.
- * - **SQLite** folds both: table and column names match case-insensitively, so
- *   two names differing only in case cannot coexist and folding is exact.
+ * - **SQLite** folds both, but **ASCII-only**: it understands upper and lower
+ *   case for `A`–`Z` and nothing else, so `Ä` and `ä` are two distinct tables
+ *   there and a Unicode fold would merge them.
  * - **MySQL** folds columns always. Its tables follow `lower_case_table_names`:
  *   `0` stores and compares case-sensitively, `1` lowercases names on creation,
  *   and `2` stores them as given but compares case-insensitively. Only `0`
@@ -75,11 +100,11 @@ export function identifierCaseRules(
     return { tables: "preserve", columns: "preserve" };
   }
   if (server.dialect === "sqlite") {
-    return { tables: "fold", columns: "fold" };
+    return { tables: "fold-ascii", columns: "fold-ascii" };
   }
   return {
-    tables: server.lowerCaseTableNames === 0 ? "preserve" : "fold",
-    columns: "fold",
+    tables: server.lowerCaseTableNames === 0 ? "preserve" : "fold-unicode",
+    columns: "fold-unicode",
   };
 }
 
@@ -109,7 +134,13 @@ export function indexCatalog(
   const exact = new Set(names);
   const folded = new Map<string, string>();
   for (const name of names) {
-    const key = name.toLowerCase();
+    // A preserving server has no folded lookup, so the index it would feed is
+    // never consulted for resolution; ASCII rules are used to build it anyway so
+    // `findCaseVariant` can still name a near-miss in a refusal.
+    const key = foldName(
+      name,
+      identifierCase === "preserve" ? "fold-ascii" : identifierCase
+    );
     // First writer wins, so an ambiguous fold cannot silently retarget an
     // object: if a case-preserving server holds both `SEO_META` and `seo_meta`,
     // a folded lookup keeps pointing at whichever the catalog listed first
@@ -145,7 +176,7 @@ export function resolveCatalogName(
 ): string | undefined {
   if (catalog.exact.has(storedName)) return storedName;
   if (catalog.identifierCase === "preserve") return undefined;
-  return catalog.folded.get(storedName.toLowerCase());
+  return catalog.folded.get(foldName(storedName, catalog.identifierCase));
 }
 
 /**
@@ -162,7 +193,14 @@ export function findCaseVariant(
   storedName: string
 ): string | undefined {
   if (catalog.exact.has(storedName)) return undefined;
-  const variant = catalog.folded.get(storedName.toLowerCase());
+  const variant = catalog.folded.get(
+    foldName(
+      storedName,
+      catalog.identifierCase === "preserve"
+        ? "fold-ascii"
+        : catalog.identifierCase
+    )
+  );
   return variant === storedName ? undefined : variant;
 }
 


### PR DESCRIPTION
B1-3b of the Components → Field Groups storage migration (task 011). Builds on #399, #402, #404.

Ships dark: nothing calls this yet, and the changeset says so.

## What this is

#404 deliberately left `manifest.ts` a pure function of registry rows — no catalog, no dialect. This adds the layer that has those inputs: reconciliation and the storage probe.

It discharges the four obligations recorded in §11 of the implementation plan when that boundary moved.

## The three decisions worth reviewing

**A recorded run is what gives a half-applied database its meaning.** Source gone + target present is *completed work* if a run is on record, and *someone else's table* if none is. Those call for opposite responses, so the run state is an input rather than something inferred from the objects. With no run recorded, that pair refuses — adopting the target would treat a stranger's storage as migrated field-group data.

**Rows the plan leaves unchanged are validated too.** A custom-named row produces no rename entry, so an entry-driven check structurally cannot see it. Its table can still be missing, and the legacy read path tolerates that by returning an empty result rather than erroring — so a stale row survives indefinitely and would otherwise reach the migration.

**Nothing is removed from a plan.** Progress is annotated. The plan is positionally indexed and hash-identified, so dropping an entry renumbers later steps and changes the identity the marker recorded — a resume would refuse the plan it is resuming.

## The resolver was a closure, so "reuse it" meant extract it

`teardown-entity-field-group-data.ts` had the correct exact-then-folded logic inline, with the reasoning documented. It is now `schema/utils/resolve-catalog-name.ts`, and **the original call site was moved onto it** rather than left as a second copy — the same consolidation `resolveCollectionTableName` already did for three drifting sites.

Both halves are necessary and neither is sufficient, and both are now pinned:

| Break | Fails |
|---|---|
| exact-only lookup | `falls back to a case-different catalog entry` — MySQL under `lower_case_table_names` reports a verbatim name folded |
| fold-only lookup | `prefers the exact match when both spellings exist` — Postgres holds `SEO_META` and `seo_meta` as distinct tables |
| last-writer-wins on ambiguous folds | `resolves an ambiguous fold to the first catalog entry, consistently` |

The fold-only break initially **passed**, which showed that half was uncovered; the resolver got its own test file as a result.

## A gap this surfaced in the plan itself

Writing the consumer exposed something #404 does not contain: **renaming `comp_hero` to `fg_hero` leaves `dynamic_components.table_name` still saying `comp_hero`.** The manifest renames the registry table, data tables, companions and the discriminator column — but nothing rewrites the pointer *values* the rows hold, so after a completed run every row would address a table that no longer exists.

It surfaced as a test I could not write honestly: reconciling a post-migration catalog against pre-migration rows refuses, correctly. Written up as §12 of the plan, assigned to B1-3c, where the rename and the pointer update belong together as one step with a `verify` that checks both.

## Testing

181 tests in the touched areas (was 138). Six breaks, all caught, each isolating its own rule.

`pnpm check-types` 19/19 · `pnpm lint` exit 0 · `pnpm build` 17/17 · full `packages/nextly` run **400 failures = baseline exactly**, name-level diff zero new. One pre-existing baseline failure in the refactored file's suite (`deleteComponentDataInTransaction uses the transaction context instead of the adapter`) was confirmed present in the baseline before I started.

## Not in this PR

Rename step execution via `generateSQL`, the registry-pointer update from §12, the P0-E `db:sync` refusal, and SQLite index verification by name. Those all execute or verify DDL and need column/index introspection that does not exist on the adapter yet — a different unit of work and a different review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added field-group migration reconciliation and storage validation to safely resume completed steps or refuse contradictory database states.
  - Added database identifier-casing detection and robust catalog name resolution across PostgreSQL, SQLite, and MySQL.

- **Bug Fixes**
  - Improved field-group teardown behavior on MySQL so the correct tables are targeted using server-specific casing and registry handling.

- **Tests**
  - Expanded Vitest coverage for migration recovery edge cases and for identifier-casing/cat​alog-name utilities across multiple driver result shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->