### PR TITLE
feat: locale-filtered version history, restore lineage, and builder retention

### DIFF
--- a/.changeset/versions-history-locale-lineage-retention.md
+++ b/.changeset/versions-history-locale-lineage-retention.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Polish version history for localized and restored content, and give the Schema Builder control over retention:
+
+- **Filter version history by locale.** The history panel now shows a language badge on each version and a locale filter (defaulting to all locales), so a localized document's history is legible instead of interleaved. The filter is added to both list surfaces (the REST route and the dispatcher) and hides automatically for non-localized documents.
+- **Show restore lineage.** A version created by restoring an earlier one now displays a "Restored from vN" chip on its row and in its preview, so a rollback is visible at a glance.
+- **Set version retention in the Schema Builder.** The versioning toggle's Advanced tab gains a retention control — keep all history, keep the default (50), or keep the last N per document — reaching parity with code-first `versions.maxPerDoc`. The value persists through the builder's create/update endpoints and the committable `ui-schema.json` manifest.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -390,6 +390,7 @@ export function EntryForm({
                   historyEnabled={historyEnabledFrom(collection)}
                   locale={locale}
                   onLocaleChange={onLocaleChange}
+                  localized={collection.localized === true}
                   toolbarSlot={
                     <EntryFormToolbarSlots
                       context="collection"

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -70,6 +70,10 @@ export interface EntrySystemHeaderProps {
   /** Called when the user switches the active content language (i18n M7). When omitted, the
    *  language switcher is not rendered. */
   onLocaleChange?: (locale: string) => void;
+  /** Whether the entity is localized. Forwarded to the version-history panel as
+   *  the authoritative signal for its locale filter (shared writes can produce
+   *  null-locale versions, so the rows alone are not conclusive). */
+  localized?: boolean;
 
   /** Save Draft handler — routed through useEntryForm.handleSubmit('save-draft').
    *  Used in create mode and when editing a draft entry. */
@@ -175,6 +179,7 @@ export function EntrySystemHeader({
   isRailCollapsed = false,
   onToggleRail,
   toolbarSlot,
+  localized,
 }: EntrySystemHeaderProps) {
   const form = useFormContext();
   const entryLocale = useEntryLocale();
@@ -529,6 +534,8 @@ export function EntrySystemHeader({
                 }
           }
           fields={historyFields}
+          // Authoritative localized signal for the panel's locale filter.
+          entityLocalized={localized}
           // Restore reuses the ordinary edit permission, so a caller who may
           // only read history is not offered a write that would be refused.
           canRestore={canUpdateDocument}

--- a/packages/admin/src/components/features/schema-builder/BuilderSettingsModal.tsx
+++ b/packages/admin/src/components/features/schema-builder/BuilderSettingsModal.tsx
@@ -50,6 +50,10 @@ export type BuilderSettingsValues = {
   status?: boolean;
   i18n?: boolean;
   versions?: boolean;
+  // Version retention, meaningful only when `versions` is on. Undefined = the
+  // default (keep 50); false = keep unlimited history; a number = keep that many
+  // durable versions per document (0 = keep only protected versions).
+  versionsMaxPerDoc?: number | false;
   // Cache revalidation. Undefined means on (the default): writes bust the
   // standard tags. False opts the entity out entirely.
   revalidate?: boolean;

--- a/packages/admin/src/components/features/schema-builder/builder-settings-modal/AdvancedTab.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-settings-modal/AdvancedTab.tsx
@@ -163,22 +163,20 @@ function RetentionField({
 
   const onCount = (text: string) => {
     setCustomText(text);
-    // A blank field commits the default rather than leaving the previous number
-    // persisted if the user saves before typing a replacement; the mode stays
-    // "custom" (explicit state) so the input remains visible meanwhile.
-    if (text === "") {
-      onChange(undefined);
-      return;
-    }
+    // Only a valid non-negative integer is committed; a blank or invalid entry
+    // (mid-edit "", "-1", "20.5") leaves the last valid cap in place. Committing
+    // a fallback here would let clearing-then-typing-invalid silently drop a cap
+    // above the default down to the default and enable unintended pruning. To
+    // choose the default or unlimited, the user picks that mode in the select.
     const n = Number(text);
-    if (Number.isInteger(n) && n >= 0) onChange(n);
+    if (text !== "" && Number.isInteger(n) && n >= 0) onChange(n);
   };
 
   const onBlur = () => {
     // Snap the visible text back to the committed value once editing ends, so a
-    // save can never persist a cap different from what is shown: an invalid
-    // entry (e.g. "20.5" or "-1") is not committed, and the modal's Save is not
-    // a form submit, so the input's min/step never reject it on their own.
+    // save can never persist a cap different from what is shown: an invalid or
+    // blank entry is not committed, and the modal's Save is not a form submit,
+    // so the input's min/step never reject it on their own.
     setCustomText(typeof value === "number" ? String(value) : "50");
   };
 

--- a/packages/admin/src/components/features/schema-builder/builder-settings-modal/AdvancedTab.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-settings-modal/AdvancedTab.tsx
@@ -174,6 +174,14 @@ function RetentionField({
     if (Number.isInteger(n) && n >= 0) onChange(n);
   };
 
+  const onBlur = () => {
+    // Snap the visible text back to the committed value once editing ends, so a
+    // save can never persist a cap different from what is shown: an invalid
+    // entry (e.g. "20.5" or "-1") is not committed, and the modal's Save is not
+    // a form submit, so the input's min/step never reject it on their own.
+    setCustomText(typeof value === "number" ? String(value) : "50");
+  };
+
   return (
     <div className="ml-9 space-y-2">
       <Label htmlFor="versions-retention" className="text-xs font-medium">
@@ -201,6 +209,7 @@ function RetentionField({
             inputMode="numeric"
             value={customText}
             onChange={e => onCount(e.target.value)}
+            onBlur={onBlur}
             className="h-8 text-sm"
             aria-label="Versions to keep per document"
           />

--- a/packages/admin/src/components/features/schema-builder/builder-settings-modal/AdvancedTab.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-settings-modal/AdvancedTab.tsx
@@ -135,8 +135,12 @@ function RetentionField({
   value: number | false | undefined;
   onChange: (v: number | false | undefined) => void;
 }) {
-  const mode: "all" | "default" | "custom" =
-    value === false ? "all" : typeof value === "number" ? "custom" : "default";
+  // Mode is explicit state, not derived from `value`: a blank custom field
+  // commits the default (undefined), and deriving the mode from that would snap
+  // the select back to "Keep default" and hide the input the user is typing in.
+  const [mode, setMode] = useState<"all" | "default" | "custom">(
+    value === false ? "all" : typeof value === "number" ? "custom" : "default"
+  );
 
   const [customText, setCustomText] = useState(
     typeof value === "number" ? String(value) : "50"
@@ -148,6 +152,7 @@ function RetentionField({
   }, [value]);
 
   const onMode = (next: "all" | "default" | "custom") => {
+    setMode(next);
     if (next === "all") onChange(false);
     else if (next === "default") onChange(undefined);
     else {
@@ -158,8 +163,13 @@ function RetentionField({
 
   const onCount = (text: string) => {
     setCustomText(text);
-    // Empty is allowed while typing; the value is only committed once it parses.
-    if (text === "") return;
+    // A blank field commits the default rather than leaving the previous number
+    // persisted if the user saves before typing a replacement; the mode stays
+    // "custom" (explicit state) so the input remains visible meanwhile.
+    if (text === "") {
+      onChange(undefined);
+      return;
+    }
     const n = Number(text);
     if (Number.isInteger(n) && n >= 0) onChange(n);
   };

--- a/packages/admin/src/components/features/schema-builder/builder-settings-modal/AdvancedTab.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-settings-modal/AdvancedTab.tsx
@@ -5,7 +5,16 @@
 // with a neutral "Coming Soon" chip. Show system fields switch mirrors
 // Group + Order from the Advanced tab; server-side admin.group / admin.order
 // still work for code-first config.
-import { Input, Label, Switch } from "@nextlyhq/ui";
+import {
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch,
+} from "@nextlyhq/ui";
 import { useEffect, useState } from "react";
 
 import type { AdvancedField } from "../builder-config";
@@ -60,13 +69,23 @@ export function AdvancedTab({ fields, values, onChange }: Props) {
       )}
 
       {fields.includes("versions") && (
-        <SwitchRow
-          ariaLabel="Version history"
-          label="Version history"
-          help="Record every save so earlier versions can be previewed and restored. Turning it off keeps the versions already recorded but stops new ones; it does not add drafts."
-          checked={values.versions ?? false}
-          onChange={v => set("versions", v)}
-        />
+        <div className="space-y-3">
+          <SwitchRow
+            ariaLabel="Version history"
+            label="Version history"
+            help="Record every save so earlier versions can be previewed and restored. Turning it off keeps the versions already recorded but stops new ones; it does not add drafts."
+            checked={values.versions ?? false}
+            onChange={v => set("versions", v)}
+          />
+          {/* Retention, shown only when history is on: how many durable versions
+              to keep per document. */}
+          {values.versions === true && (
+            <RetentionField
+              value={values.versionsMaxPerDoc}
+              onChange={v => set("versionsMaxPerDoc", v)}
+            />
+          )}
+        </div>
       )}
 
       {fields.includes("revalidate") && (
@@ -96,6 +115,91 @@ export function AdvancedTab({ fields, values, onChange }: Props) {
       )}
 
       {fields.includes("showSystemFields") && <ShowSystemFieldsSwitch />}
+    </div>
+  );
+}
+
+/**
+ * Version retention control. The stored value is a tri-state — `false`
+ * (unlimited), a number (keep that many), or undefined (the default, 50) — so
+ * the mode is a named select and the count only appears for "Keep last N".
+ *
+ * A local text mirror lets the number field be emptied mid-edit without the
+ * mode snapping back; a blank field commits as the default 50 rather than an
+ * invalid count.
+ */
+function RetentionField({
+  value,
+  onChange,
+}: {
+  value: number | false | undefined;
+  onChange: (v: number | false | undefined) => void;
+}) {
+  const mode: "all" | "default" | "custom" =
+    value === false ? "all" : typeof value === "number" ? "custom" : "default";
+
+  const [customText, setCustomText] = useState(
+    typeof value === "number" ? String(value) : "50"
+  );
+  // Keep the field in sync when a concrete count arrives from outside, e.g.
+  // loading an existing schema into the dialog.
+  useEffect(() => {
+    if (typeof value === "number") setCustomText(String(value));
+  }, [value]);
+
+  const onMode = (next: "all" | "default" | "custom") => {
+    if (next === "all") onChange(false);
+    else if (next === "default") onChange(undefined);
+    else {
+      const n = customText === "" ? 50 : Number(customText);
+      onChange(Number.isInteger(n) && n >= 0 ? n : 50);
+    }
+  };
+
+  const onCount = (text: string) => {
+    setCustomText(text);
+    // Empty is allowed while typing; the value is only committed once it parses.
+    if (text === "") return;
+    const n = Number(text);
+    if (Number.isInteger(n) && n >= 0) onChange(n);
+  };
+
+  return (
+    <div className="ml-9 space-y-2">
+      <Label htmlFor="versions-retention" className="text-xs font-medium">
+        Retention
+      </Label>
+      <Select
+        value={mode}
+        onValueChange={(next: "all" | "default" | "custom") => onMode(next)}
+      >
+        <SelectTrigger id="versions-retention" className="h-8 text-sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="default">Keep default (50)</SelectItem>
+          <SelectItem value="all">Keep all history</SelectItem>
+          <SelectItem value="custom">Keep last N…</SelectItem>
+        </SelectContent>
+      </Select>
+      {mode === "custom" && (
+        <div className="space-y-1">
+          <Input
+            type="number"
+            min={0}
+            step={1}
+            inputMode="numeric"
+            value={customText}
+            onChange={e => onCount(e.target.value)}
+            className="h-8 text-sm"
+            aria-label="Versions to keep per document"
+          />
+          <p className="text-xs text-muted-foreground">
+            Older versions are pruned beyond this count. 0 keeps only protected
+            versions (the current one and the latest published).
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/admin/src/components/features/schema-builder/builder-settings-modal/__tests__/AdvancedTab.test.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-settings-modal/__tests__/AdvancedTab.test.tsx
@@ -118,9 +118,9 @@ describe("AdvancedTab -- version history", () => {
     ).toHaveValue(20);
   });
 
-  it("commits the default when a custom retention count is cleared", async () => {
-    // Clearing the field must not leave the previous number persisted on save;
-    // it commits undefined (the default) while the input stays visible.
+  it("keeps the prior cap when the field is cleared and restores it on blur", async () => {
+    // Clearing mid-edit must not drop the committed cap (to the default or 0);
+    // it stays until a valid replacement is typed, and blur restores the field.
     const user = userEvent.setup();
     const onChange = vi.fn();
     render(
@@ -134,10 +134,15 @@ describe("AdvancedTab -- version history", () => {
       name: /versions to keep per document/i,
     });
     await user.clear(input);
-    const last = onChange.mock.lastCall?.[0] as BuilderSettingsValues;
-    expect(last.versionsMaxPerDoc).toBeUndefined();
-    // The field is still on screen so a replacement can be typed.
-    expect(input).toBeInTheDocument();
+    await user.tab(); // blur
+
+    // Clearing never committed a change away from the prior cap...
+    const committed = onChange.mock.calls.map(
+      c => (c[0] as BuilderSettingsValues).versionsMaxPerDoc
+    );
+    expect(committed).not.toContain(undefined);
+    // ...and the field is restored to the committed value, still on screen.
+    expect(input).toHaveValue(20);
   });
 
   it("keeps the saved cap and restores the field when invalid text is entered", async () => {

--- a/packages/admin/src/components/features/schema-builder/builder-settings-modal/__tests__/AdvancedTab.test.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-settings-modal/__tests__/AdvancedTab.test.tsx
@@ -104,6 +104,50 @@ describe("AdvancedTab -- version history", () => {
     render(<Controlled fields={["versions"]} />);
     expect(screen.getByText(/does not add drafts/i)).toBeInTheDocument();
   });
+
+  it("shows the retention count only for a custom cap", () => {
+    // A stored number is the "keep last N" mode, so the count field is visible.
+    render(
+      <Controlled
+        fields={["versions"]}
+        initial={{ versions: true, versionsMaxPerDoc: 20 }}
+      />
+    );
+    expect(
+      screen.getByRole("spinbutton", { name: /versions to keep per document/i })
+    ).toHaveValue(20);
+  });
+
+  it("commits the default when a custom retention count is cleared", async () => {
+    // Clearing the field must not leave the previous number persisted on save;
+    // it commits undefined (the default) while the input stays visible.
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Controlled
+        fields={["versions"]}
+        initial={{ versions: true, versionsMaxPerDoc: 20 }}
+        onChange={onChange}
+      />
+    );
+    const input = screen.getByRole("spinbutton", {
+      name: /versions to keep per document/i,
+    });
+    await user.clear(input);
+    const last = onChange.mock.lastCall?.[0] as BuilderSettingsValues;
+    expect(last.versionsMaxPerDoc).toBeUndefined();
+    // The field is still on screen so a replacement can be typed.
+    expect(input).toBeInTheDocument();
+  });
+
+  it("does not show a retention count when versioning is off", () => {
+    render(<Controlled fields={["versions"]} initial={{ versions: false }} />);
+    expect(
+      screen.queryByRole("spinbutton", {
+        name: /versions to keep per document/i,
+      })
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe("AdvancedTab -- cache revalidation", () => {

--- a/packages/admin/src/components/features/schema-builder/builder-settings-modal/__tests__/AdvancedTab.test.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-settings-modal/__tests__/AdvancedTab.test.tsx
@@ -140,6 +140,35 @@ describe("AdvancedTab -- version history", () => {
     expect(input).toBeInTheDocument();
   });
 
+  it("keeps the saved cap and restores the field when invalid text is entered", async () => {
+    // An invalid entry (fractional/negative) is never committed, and on blur the
+    // field snaps back to the committed value so a save can't persist a cap
+    // different from what is shown.
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Controlled
+        fields={["versions"]}
+        initial={{ versions: true, versionsMaxPerDoc: 20 }}
+        onChange={onChange}
+      />
+    );
+    const input = screen.getByRole("spinbutton", {
+      name: /versions to keep per document/i,
+    });
+    await user.clear(input);
+    await user.type(input, "20.5");
+    await user.tab(); // blur
+
+    const last = onChange.mock.lastCall?.[0] as
+      | BuilderSettingsValues
+      | undefined;
+    // The invalid value was never committed, so the cap is still the last valid
+    // one (or unchanged), and the field shows that value, not "20.5".
+    expect(last?.versionsMaxPerDoc).not.toBe(20.5);
+    expect(input).toHaveValue(20);
+  });
+
   it("does not show a retention count when versioning is off", () => {
     render(<Controlled fields={["versions"]} initial={{ versions: false }} />);
     expect(

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -614,6 +614,7 @@ export function SingleForm({
                    single isn't localized / localization isn't configured. */
                 locale={locale}
                 onLocaleChange={onLocaleChange}
+                localized={schema.localized === true}
                 toolbarSlot={
                   <EntryFormToolbarSlots
                     context="single"

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -63,6 +63,13 @@ export interface VersionHistorySheetProps {
    * about whether this change is publicly visible.
    */
   liveStatus?: string | null;
+  /**
+   * Whether the document's entity is localized. This is the authoritative
+   * signal for the locale filter: a localized document can record shared-field
+   * writes with a null locale, so the loaded rows alone cannot prove one way or
+   * the other. Absent, the panel falls back to inferring it from the rows.
+   */
+  entityLocalized?: boolean;
 }
 
 function ListSkeleton() {
@@ -88,6 +95,7 @@ export function VersionHistorySheet({
   fields,
   canRestore = false,
   liveStatus = null,
+  entityLocalized,
 }: VersionHistorySheetProps) {
   const [selected, setSelected] = useState<number | null>(null);
   // The version pair being compared (older -> newer), or null when not
@@ -193,19 +201,16 @@ export function VersionHistorySheet({
 
   const versions = list.data?.pages.flatMap(page => page.items) ?? [];
 
-  // Whether THIS document is localized, not just whether the app is. A localized
-  // entity stamps a locale on every version and a non-localized one never does,
-  // so the presence of any locale in its own history is the reliable per-entity
-  // signal — `useLocalization().enabled` alone would show the filter on a
-  // non-localized document in an app that has other localized ones, where
-  // picking a locale could only ever match its NULL-locale versions (nothing).
-  //
-  // An active filter also proves the document is localized (it could not have
-  // been set otherwise), so the signal survives filtering to a locale that has
-  // no versions yet — where the filtered result is empty and would otherwise
-  // hide the very control needed to clear or change that filter.
+  // Whether THIS document is localized, not just whether the app is. The
+  // authoritative signal is the entity's own localization flag: a localized
+  // document can record shared-field writes with a null locale, so a loaded page
+  // that happens to hold only such rows (or only one locale) cannot prove it
+  // either way. When the flag is not supplied, fall back to inferring it — any
+  // locale present in the history, or an active filter (which could not have
+  // been set on a non-localized document).
   const isLocalizedDocument =
-    localeFilter !== undefined || versions.some(v => v.locale !== null);
+    entityLocalized ??
+    (localeFilter !== undefined || versions.some(v => v.locale !== null));
 
   // Compare targets for the version being previewed. A comparison must stay
   // within one locale (the server rejects a cross-locale pair), so both the

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -193,6 +193,14 @@ export function VersionHistorySheet({
 
   const versions = list.data?.pages.flatMap(page => page.items) ?? [];
 
+  // Whether THIS document is localized, not just whether the app is. A localized
+  // entity stamps a locale on every version and a non-localized one never does,
+  // so the presence of any locale in its own history is the reliable per-entity
+  // signal — `useLocalization().enabled` alone would show the filter on a
+  // non-localized document in an app that has other localized ones, where
+  // picking a locale could only ever match its NULL-locale versions (nothing).
+  const isLocalizedDocument = versions.some(v => v.locale !== null);
+
   // Compare targets for the version being previewed. A comparison must stay
   // within one locale (the server rejects a cross-locale pair), so both the
   // "current" and "previous" targets are drawn only from versions sharing the
@@ -338,9 +346,10 @@ export function VersionHistorySheet({
                   : `Version ${selected}`}
             </SheetTitle>
             {/* Locale filter, only while browsing the list (a chosen version or
-                a compare pair is already locale-fixed). Renders nothing for a
-                non-localized document. */}
-            {comparing === null && selected === null && (
+                a compare pair is already locale-fixed) and only for a document
+                whose own history carries locales — so it never appears on a
+                non-localized document in an otherwise localized app. */}
+            {comparing === null && selected === null && isLocalizedDocument && (
               <VersionLocaleFilter
                 value={localeFilter}
                 onChange={locale => {

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -35,6 +35,7 @@ import type { VersionScope } from "@admin/services/versionApi";
 import { VersionDiffView } from "./diff/VersionDiffView";
 import { RestoreConfirmDialog } from "./RestoreConfirmDialog";
 import { VersionLabelDialog } from "./VersionLabelDialog";
+import { VersionLocaleFilter } from "./VersionLocaleFilter";
 import { VersionPreview } from "./VersionPreview";
 import { VersionRow } from "./VersionRow";
 
@@ -99,6 +100,11 @@ export function VersionHistorySheet({
   // The version being renamed, which is not necessarily the one being previewed
   // — an editor can name a row without opening it.
   const [renaming, setRenaming] = useState<number | null>(null);
+  // Active locale filter for the listing, or undefined for every locale. Only
+  // meaningful for a localized document; the filter control hides otherwise.
+  const [localeFilter, setLocaleFilter] = useState<string | undefined>(
+    undefined
+  );
 
   // Reopening the panel should start at the list. Without this the previously
   // previewed version would still be showing, which reads as a stale panel.
@@ -111,6 +117,9 @@ export function VersionHistorySheet({
       // does not close it. Left set, it would stay on screen over a dismissed
       // panel, or reappear the moment the panel was reopened.
       setRenaming(null);
+      // Start every open showing all locales rather than a filter left from a
+      // previous document.
+      setLocaleFilter(undefined);
     }
   }, [open]);
 
@@ -135,9 +144,12 @@ export function VersionHistorySheet({
     setComparing(null);
     setConfirmingRestore(false);
     setRenaming(null);
+    // A different document may not have the previously filtered locale at all,
+    // so the filter resets with the rest of the panel's per-document state.
+    setLocaleFilter(undefined);
   }
 
-  const list = useVersions({ scope, enabled: open });
+  const list = useVersions({ scope, enabled: open, locale: localeFilter });
   // Destructured so the boundary-fetch effect can depend on the paging members
   // by identity rather than on the whole query object, which changes each render.
   // `isRefetching` is a whole-list revalidation (not a page fetch), during which
@@ -317,13 +329,30 @@ export function VersionHistorySheet({
         className="w-[480px] sm:max-w-[480px] p-0 flex flex-col"
       >
         <SheetHeader className="p-4 border-b border-border">
-          <SheetTitle>
-            {comparing !== null
-              ? `Compare ${comparing.from} → ${comparing.to}`
-              : selected === null
-                ? "Version history"
-                : `Version ${selected}`}
-          </SheetTitle>
+          <div className="flex items-center justify-between gap-2">
+            <SheetTitle>
+              {comparing !== null
+                ? `Compare ${comparing.from} → ${comparing.to}`
+                : selected === null
+                  ? "Version history"
+                  : `Version ${selected}`}
+            </SheetTitle>
+            {/* Locale filter, only while browsing the list (a chosen version or
+                a compare pair is already locale-fixed). Renders nothing for a
+                non-localized document. */}
+            {comparing === null && selected === null && (
+              <VersionLocaleFilter
+                value={localeFilter}
+                onChange={locale => {
+                  // Changing the visible locale set can drop the previewed or
+                  // compared version out of view, so clear both modes.
+                  setLocaleFilter(locale);
+                  setSelected(null);
+                  setComparing(null);
+                }}
+              />
+            )}
+          </div>
           <SheetDescription className="sr-only">
             Past versions of this document, newest first.
           </SheetDescription>
@@ -379,6 +408,7 @@ export function VersionHistorySheet({
               error={detail.error}
               onRetry={() => void detail.refetch()}
               locale={detail.data?.locale ?? null}
+              sourceVersionNo={detail.data?.sourceVersionNo ?? null}
             />
           ) : list.isLoading ? (
             <ListSkeleton />

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -199,7 +199,13 @@ export function VersionHistorySheet({
   // signal — `useLocalization().enabled` alone would show the filter on a
   // non-localized document in an app that has other localized ones, where
   // picking a locale could only ever match its NULL-locale versions (nothing).
-  const isLocalizedDocument = versions.some(v => v.locale !== null);
+  //
+  // An active filter also proves the document is localized (it could not have
+  // been set otherwise), so the signal survives filtering to a locale that has
+  // no versions yet — where the filtered result is empty and would otherwise
+  // hide the very control needed to clear or change that filter.
+  const isLocalizedDocument =
+    localeFilter !== undefined || versions.some(v => v.locale !== null);
 
   // Compare targets for the version being previewed. A comparison must stay
   // within one locale (the server rejects a cross-locale pair), so both the

--- a/packages/admin/src/components/features/versions/VersionLocaleFilter.tsx
+++ b/packages/admin/src/components/features/versions/VersionLocaleFilter.tsx
@@ -1,0 +1,93 @@
+/**
+ * Locale filter for the version-history panel.
+ *
+ * A localized document captures a version per locale, so the history can be
+ * scoped to one language or left showing every locale ("All locales", the
+ * default). Reuses the app's localization config and the shared dropdown
+ * primitives so it matches the entry-header language switcher, and renders
+ * nothing when the app is not localized — so non-localized documents are
+ * visually unchanged.
+ *
+ * @module components/features/versions/VersionLocaleFilter
+ */
+
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@nextlyhq/ui";
+import { Check, Globe } from "lucide-react";
+import type React from "react";
+
+import { useLocalization } from "@admin/hooks/useLocalization";
+
+export interface VersionLocaleFilterProps {
+  /** The active locale filter, or undefined for "All locales". */
+  value?: string;
+  /** Called with the newly-selected locale, or undefined to clear the filter. */
+  onChange: (locale: string | undefined) => void;
+}
+
+export function VersionLocaleFilter({
+  value,
+  onChange,
+}: VersionLocaleFilterProps): React.ReactElement | null {
+  const { enabled, locales, defaultLocale, getLocale } = useLocalization();
+
+  // A single-locale (or non-localized) history has nothing to filter.
+  if (!enabled) return null;
+
+  const activeMeta = value ? getLocale(value) : undefined;
+  const activeLabel = activeMeta?.label ?? value ?? "All locales";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="gap-1.5"
+          aria-label="Filter history by language"
+        >
+          <Globe className="h-3.5 w-3.5" />
+          <span>{activeLabel}</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => onChange(undefined)} className="gap-2">
+          {value === undefined ? (
+            <Check className="h-3.5 w-3.5" />
+          ) : (
+            <span className="w-3.5" />
+          )}
+          All locales
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {locales.map(locale => (
+          <DropdownMenuItem
+            key={locale.code}
+            onClick={() => onChange(locale.code)}
+            className="justify-between gap-4"
+            {...(locale.rtl ? { dir: "rtl" as const } : {})}
+          >
+            <span className="flex items-center gap-2">
+              {locale.code === value ? (
+                <Check className="h-3.5 w-3.5" />
+              ) : (
+                <span className="w-3.5" />
+              )}
+              {locale.label}
+            </span>
+            {locale.code === defaultLocale && (
+              <span className="text-xs text-muted-foreground">default</span>
+            )}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/admin/src/components/features/versions/VersionPreview.tsx
+++ b/packages/admin/src/components/features/versions/VersionPreview.tsx
@@ -14,6 +14,7 @@ import { FieldValueDisplay } from "@admin/components/features/versions/value-dis
 import {
   Alert,
   AlertDescription,
+  Badge,
   Button,
   Skeleton,
 } from "@admin/components/ui";
@@ -27,6 +28,8 @@ export interface VersionPreviewProps {
   onRetry?: () => void;
   /** The locale this version was captured in, when the document is localized. */
   locale?: string | null;
+  /** The version this one was restored from, when it is a restore; else null. */
+  sourceVersionNo?: number | null;
 }
 
 function PreviewSkeleton() {
@@ -53,6 +56,7 @@ export function VersionPreview({
   error = null,
   onRetry,
   locale = null,
+  sourceVersionNo = null,
 }: VersionPreviewProps) {
   if (isLoading) return <PreviewSkeleton />;
 
@@ -80,7 +84,7 @@ export function VersionPreview({
 
   return (
     <div className="flex flex-col">
-      <div className="px-4 py-2 bg-primary/5 border-b border-border">
+      <div className="px-4 py-2 bg-primary/5 border-b border-border flex flex-wrap items-center gap-2">
         <p className="text-sm text-foreground">
           Viewing version {versionNo}
           {/* A localized document captures a version per locale, so the banner
@@ -88,6 +92,11 @@ export function VersionPreview({
           {locale ? ` (${locale})` : ""}. This is a past state of the document,
           not what is live.
         </p>
+        {/* Lineage, mirroring the row chip: a restored version names the one it
+            was made from. */}
+        {sourceVersionNo !== null && (
+          <Badge variant="default">Restored from v{sourceVersionNo}</Badge>
+        )}
       </div>
 
       <div className="p-4 flex flex-col gap-4">

--- a/packages/admin/src/components/features/versions/VersionRow.tsx
+++ b/packages/admin/src/components/features/versions/VersionRow.tsx
@@ -11,6 +11,7 @@ import { Pencil } from "lucide-react";
 
 import { formatRelativeTime } from "@admin/components/features/notifications/relative-time";
 import { Badge } from "@admin/components/ui";
+import { useLocalization } from "@admin/hooks/useLocalization";
 import { formatDateTime } from "@admin/lib/dates/format";
 import { cn } from "@admin/lib/utils";
 import type { VersionMeta } from "@admin/services/versionApi";
@@ -34,6 +35,15 @@ export function VersionRow({
   // so it is shown but not offered as something to open — or to name.
   const selectable = typeof version.versionNo === "number";
 
+  // A localized document captures a version per locale, so each row names the
+  // language it holds. Only shown when the app is localized and this version
+  // carries a locale; its human label (falling back to the code) is the title.
+  const { enabled: localized, getLocale } = useLocalization();
+  const localeCode = version.locale;
+  const localeLabel =
+    localeCode !== null ? (getLocale(localeCode)?.label ?? localeCode) : null;
+  const showLocale = localized && localeCode !== null;
+
   // What the row is called. `version.label` is the editor's own name for it;
   // the number is the fallback, and stays visible either way so two versions
   // sharing a name are still tellable apart.
@@ -44,6 +54,20 @@ export function VersionRow({
   // Attribution is absent for a system write rather than missing, so it reads
   // as "nobody signed this" instead of looking like a failed lookup.
   const author = version.author?.name ?? "Unknown author";
+
+  // A restore records the version it was made from, so this row can show its
+  // lineage. Absent (null) for an ordinary edit, in which case nothing shows.
+  const restoredFrom = version.sourceVersionNo;
+
+  // The accessible name mirrors what the row shows: name/ordinal, status, the
+  // language, the restore lineage when present, then the author.
+  const ariaLabel =
+    (named
+      ? `${title}, ${ordinal}, ${version.status}`
+      : `${title}, ${version.status}`) +
+    (showLocale ? `, ${localeLabel}` : "") +
+    (restoredFrom !== null ? `, restored from version ${restoredFrom}` : "") +
+    `, by ${author}`;
 
   const canRename = selectable && onRename !== undefined;
 
@@ -65,11 +89,7 @@ export function VersionRow({
         // visually: two versions may share a name, and a screen-reader user
         // would otherwise have no way to tell them apart that a sighted user
         // does.
-        aria-label={
-          named
-            ? `${title}, ${ordinal}, ${version.status}, by ${author}`
-            : `${title}, ${version.status}, by ${author}`
-        }
+        aria-label={ariaLabel}
         aria-current={active ? "true" : undefined}
         className={cn(
           "flex-1 min-w-0 text-left px-4 py-3",
@@ -91,6 +111,24 @@ export function VersionRow({
           <Badge variant="outline" className="shrink-0">
             {version.status}
           </Badge>
+          {/* Language: names which translation this version holds, so an editor
+              scanning a mixed-locale history can tell them apart. */}
+          {showLocale && (
+            <Badge
+              variant="outline"
+              className="shrink-0 uppercase"
+              title={localeLabel ?? undefined}
+            >
+              {localeCode}
+            </Badge>
+          )}
+          {/* Lineage: a restored version names the one it was made from, so an
+              editor can see at a glance that this entry came from a rollback. */}
+          {restoredFrom !== null && (
+            <Badge variant="default" className="shrink-0">
+              Restored from v{restoredFrom}
+            </Badge>
+          )}
           <span
             className="ml-auto text-xs text-muted-foreground shrink-0"
             // The relative label is scannable; the exact time is what an editor

--- a/packages/admin/src/hooks/queries/useVersions.ts
+++ b/packages/admin/src/hooks/queries/useVersions.ts
@@ -68,8 +68,15 @@ function isAddressable(scope: VersionScope): boolean {
 export const versionKeys = {
   all: () => ["versions"] as const,
   lists: () => [...versionKeys.all(), "list"] as const,
-  list: (scope: VersionScope) =>
-    [...versionKeys.lists(), ...scopeKey(scope)] as const,
+  // The optional locale is appended, so a locale-filtered list is its own cache
+  // entry while `list(scope)` (no locale) stays the prefix every mutation
+  // invalidates — that prefix match still clears every locale variant.
+  list: (scope: VersionScope, locale?: string) =>
+    [
+      ...versionKeys.lists(),
+      ...scopeKey(scope),
+      ...(locale !== undefined ? [locale] : []),
+    ] as const,
   details: () => [...versionKeys.all(), "detail"] as const,
   detail: (scope: VersionScope, versionNo: number) =>
     [...versionKeys.details(), ...scopeKey(scope), versionNo] as const,
@@ -100,6 +107,8 @@ export const versionKeys = {
 export interface UseVersionsOptions {
   scope: VersionScope;
   enabled?: boolean;
+  /** Scope the listing to one locale's versions. Absent lists every locale. */
+  locale?: string;
 }
 
 /**
@@ -114,13 +123,18 @@ export interface UseVersionsOptions {
  * list, so returning to the panel must revalidate the head or it would label a
  * stale version as current.
  */
-export function useVersions({ scope, enabled = true }: UseVersionsOptions) {
+export function useVersions({
+  scope,
+  enabled = true,
+  locale,
+}: UseVersionsOptions) {
   return useInfiniteQuery<VersionListResponse, Error>({
-    queryKey: versionKeys.list(scope),
+    queryKey: versionKeys.list(scope, locale),
     queryFn: ({ pageParam }) =>
       versionApi.list(scope, {
         limit: PAGE_SIZE,
         ...(typeof pageParam === "number" ? { cursor: pageParam } : {}),
+        ...(locale !== undefined ? { locale } : {}),
       }),
     initialPageParam: undefined,
     getNextPageParam: lastPage => {

--- a/packages/admin/src/lib/builder/__tests__/settings-dirty.test.ts
+++ b/packages/admin/src/lib/builder/__tests__/settings-dirty.test.ts
@@ -41,6 +41,7 @@ describe("settingsAreDirty", () => {
     status: { ...base, status: false },
     i18n: { ...base, i18n: true },
     versions: { ...base, versions: true },
+    versionsMaxPerDoc: { ...base, versionsMaxPerDoc: 10 },
     revalidate: { ...base, revalidate: false },
     webhooks: { ...base, webhooks: false },
   };

--- a/packages/admin/src/lib/builder/settings-dirty.ts
+++ b/packages/admin/src/lib/builder/settings-dirty.ts
@@ -18,6 +18,7 @@ const COMPARED_KEYS = [
   "status",
   "i18n",
   "versions",
+  "versionsMaxPerDoc",
   "revalidate",
   "webhooks",
 ] as const;

--- a/packages/admin/src/lib/builder/to-manifest-entity.ts
+++ b/packages/admin/src/lib/builder/to-manifest-entity.ts
@@ -91,6 +91,9 @@ export interface BuilderSettingsInput {
   localized?: boolean;
   /** Whether every save is recorded as a restorable version. */
   versions?: boolean;
+  /** Durable versions kept per document. `false` = unlimited, a number = keep
+   *  that many, undefined = the default (50). Ignored when `versions` is off. */
+  versionsMaxPerDoc?: number | false;
   /** Whether writes bust cache tags. Defaults on; false opts out. */
   revalidate?: boolean;
   /** Whether writes are recorded to the webhook outbox. Defaults on; false opts out. */
@@ -154,6 +157,9 @@ export interface ManifestEntity {
   localized?: boolean;
   /** Whether every save is recorded as a restorable version. */
   versions?: boolean;
+  /** Durable versions kept per document. `false` = unlimited, a number = keep
+   *  that many, undefined = the default (50). Ignored when `versions` is off. */
+  versionsMaxPerDoc?: number | false;
   /** Whether writes bust cache tags. Defaults on; false opts out. */
   revalidate?: boolean;
   /** Whether writes are recorded to the webhook outbox. Defaults on; false opts out. */
@@ -234,6 +240,7 @@ export function applyCommonSettings(
     status,
     localized,
     versions,
+    versionsMaxPerDoc,
     revalidate,
     webhooks,
   } = settings;
@@ -247,6 +254,9 @@ export function applyCommonSettings(
   if (status !== undefined) entity.status = status;
   if (localized !== undefined) entity.localized = localized;
   if (versions !== undefined) entity.versions = versions;
+  if (versionsMaxPerDoc !== undefined) {
+    entity.versionsMaxPerDoc = versionsMaxPerDoc;
+  }
   if (revalidate !== undefined) entity.revalidate = revalidate;
   if (webhooks !== undefined) entity.webhooks = webhooks;
 }

--- a/packages/admin/src/pages/dashboard/collections/builder/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/collections/builder/[slug].tsx
@@ -207,6 +207,14 @@ export default function CollectionBuilderEditPage({
       versions:
         (collection as { versions?: { enabled?: boolean } | null }).versions
           ?.enabled === true,
+      // Retention: the stored resolved config always carries the effective
+      // count (`false` = unlimited), so the select reflects the true setting. A
+      // config left at the framework default reads back as its concrete number.
+      versionsMaxPerDoc: (
+        collection as {
+          versions?: { maxPerDoc?: number | false } | null;
+        }
+      ).versions?.maxPerDoc,
       // Cache revalidation is on unless the stored config disables it, so the
       // switch reflects on for both null (default) and an absent-disable config.
       revalidate: collection.revalidate?.disable !== true,
@@ -331,6 +339,8 @@ export default function CollectionBuilderEditPage({
                   status: settings.status === true,
                   localized: settings.i18n === true,
                   versions: settings.versions === true,
+                  // Retention forwarded with the switch; the server resolves it.
+                  versionsMaxPerDoc: settings.versionsMaxPerDoc,
                   // Cache revalidation: on unless explicitly turned off; the
                   // server normalizes the boolean into the stored config.
                   revalidate: settings.revalidate !== false,
@@ -422,6 +432,8 @@ export default function CollectionBuilderEditPage({
             // Version history: the server normalizes this into the resolved
             // config the registry column holds.
             versions: settings.versions === true,
+            // Retention forwarded with the switch; resolved into the config.
+            versionsMaxPerDoc: settings.versionsMaxPerDoc,
             // Cache revalidation: on unless explicitly turned off.
             revalidate: settings.revalidate !== false,
             // Webhook recording: on unless explicitly turned off.

--- a/packages/admin/src/pages/dashboard/collections/builder/index.tsx
+++ b/packages/admin/src/pages/dashboard/collections/builder/index.tsx
@@ -62,6 +62,9 @@ export default function CollectionBuilderPage(): React.ReactElement | null {
         localized: values.i18n === true,
         // Version history opt-in at create; the server resolves the boolean.
         versions: values.versions === true,
+        // Retention: how many durable versions to keep (false = unlimited,
+        // undefined = the default 50). The server resolves it with the switch.
+        versionsMaxPerDoc: values.versionsMaxPerDoc,
         // Cache revalidation opt-out at create; on by default, so only an
         // explicit false is forwarded as off. The server resolves the boolean.
         revalidate: values.revalidate !== false,
@@ -96,6 +99,8 @@ export default function CollectionBuilderPage(): React.ReactElement | null {
                     localized: values.i18n === true,
                     // and with version history.
                     versions: values.versions === true,
+                    // and with its retention setting.
+                    versionsMaxPerDoc: values.versionsMaxPerDoc,
                     // and with cache revalidation (on unless explicitly off).
                     revalidate: values.revalidate !== false,
                     // and with webhook recording (on unless explicitly off).

--- a/packages/admin/src/pages/dashboard/singles/builder/[slug].tsx
+++ b/packages/admin/src/pages/dashboard/singles/builder/[slug].tsx
@@ -168,6 +168,11 @@ export default function SingleBuilderEditPage({
       versions:
         (single as { versions?: { enabled?: boolean } | null }).versions
           ?.enabled === true,
+      // Retention: the stored resolved config carries the effective count
+      // (`false` = unlimited), so the select reflects the true setting.
+      versionsMaxPerDoc: (
+        single as { versions?: { maxPerDoc?: number | false } | null }
+      ).versions?.maxPerDoc,
       // Cache revalidation is on unless the stored config disables it (mirrors
       // the collection builder).
       revalidate: single.revalidate?.disable !== true,
@@ -262,6 +267,8 @@ export default function SingleBuilderEditPage({
                   status: settings.status === true,
                   localized: settings.i18n === true,
                   versions: settings.versions === true,
+                  // Retention forwarded with the switch; the server resolves it.
+                  versionsMaxPerDoc: settings.versionsMaxPerDoc,
                   // Cache revalidation: on unless explicitly turned off.
                   revalidate: settings.revalidate !== false,
                   // Webhook recording: on unless explicitly turned off.
@@ -347,6 +354,8 @@ export default function SingleBuilderEditPage({
             // Version history: the server normalizes this into the resolved
             // config the registry column holds.
             versions: settings.versions === true,
+            // Retention forwarded with the switch; resolved into the config.
+            versionsMaxPerDoc: settings.versionsMaxPerDoc,
             // Cache revalidation: on unless explicitly turned off.
             revalidate: settings.revalidate !== false,
             // Webhook recording: on unless explicitly turned off.

--- a/packages/admin/src/pages/dashboard/singles/builder/index.tsx
+++ b/packages/admin/src/pages/dashboard/singles/builder/index.tsx
@@ -65,6 +65,11 @@ export default function SingleBuilderPage(): React.ReactElement | null {
         ...(values.i18n === true ? { localized: true } : {}),
         // Version history opt-in at create; the server resolves the boolean.
         ...(values.versions === true ? { versions: true } : {}),
+        // Retention: only forwarded when set (else the server default 50
+        // applies); false = unlimited, a number = keep that many.
+        ...(values.versionsMaxPerDoc !== undefined
+          ? { versionsMaxPerDoc: values.versionsMaxPerDoc }
+          : {}),
         // Cache revalidation is on by default, so only forward an explicit
         // opt-out; omitting the key leaves the server default (on).
         ...(values.revalidate === false ? { revalidate: false } : {}),
@@ -92,6 +97,8 @@ export default function SingleBuilderPage(): React.ReactElement | null {
                     localized: values.i18n === true,
                     // and version history.
                     versions: values.versions === true,
+                    // and its retention setting.
+                    versionsMaxPerDoc: values.versionsMaxPerDoc,
                     // and cache revalidation (on unless explicitly off).
                     revalidate: values.revalidate !== false,
                     // and webhook recording (on unless explicitly off).

--- a/packages/admin/src/services/versionApi.ts
+++ b/packages/admin/src/services/versionApi.ts
@@ -86,6 +86,8 @@ export interface ListVersionsParams {
    * not an opaque token.
    */
   cursor?: number;
+  /** Scope the listing to one locale's versions. Absent lists every locale. */
+  locale?: string;
 }
 
 /** Base path for a scope's history. */
@@ -123,6 +125,8 @@ export const versionApi = {
     // so an absent one must stay absent rather than become "undefined".
     if (params.cursor !== undefined)
       search.set("cursor", String(params.cursor));
+    // Only sent when a locale filter is active; absent lists every locale.
+    if (params.locale !== undefined) search.set("locale", params.locale);
 
     const query = search.toString();
     return protectedApi.get<VersionListResponse>(

--- a/packages/admin/src/types/collection.ts
+++ b/packages/admin/src/types/collection.ts
@@ -350,6 +350,9 @@ export interface CreateCollectionPayload {
   localized?: boolean;
   /** Whether every save is recorded as a restorable version. Default false. */
   versions?: boolean;
+  /** Durable versions kept per document. `false` = unlimited, a number = keep
+   *  that many, undefined = the default (50). Ignored when `versions` is off. */
+  versionsMaxPerDoc?: number | false;
   /** Whether writes bust cache tags. Default true; false opts the collection out. */
   revalidate?: boolean;
   /** Whether writes are recorded to the webhook outbox. Default true; false
@@ -377,6 +380,9 @@ export interface UpdateCollectionPayload {
   status?: boolean;
   /** Toggle version history. Every save is recorded as a restorable version. */
   versions?: boolean;
+  /** Durable versions kept per document. `false` = unlimited, a number = keep
+   *  that many, undefined = the default (50). Ignored when `versions` is off. */
+  versionsMaxPerDoc?: number | false;
   /** Toggle cache revalidation. Default true; false opts the collection out. */
   revalidate?: boolean;
   /** Toggle webhook recording. Default true; false keeps the collection's

--- a/packages/admin/src/types/entities.ts
+++ b/packages/admin/src/types/entities.ts
@@ -304,7 +304,7 @@ export interface ApiSingle {
    * shape, so reads carry the object while writes send a boolean — see
    * `UpdateSinglePayload`.
    */
-  versions?: { enabled?: boolean } | null;
+  versions?: { enabled?: boolean; maxPerDoc?: number | false } | null;
 
   /**
    * Resolved cache-revalidation config, or null/absent when revalidation is on
@@ -345,6 +345,9 @@ export type UpdateSinglePayload = Omit<
   "versions" | "revalidate" | "webhooks"
 > & {
   versions?: boolean;
+  /** Durable versions kept per document. `false` = unlimited, a number = keep
+   *  that many, undefined = the default (50). Ignored when `versions` is off. */
+  versionsMaxPerDoc?: number | false;
   revalidate?: boolean;
   webhooks?: boolean;
 };

--- a/packages/nextly/src/api/collections-schema-detail.ts
+++ b/packages/nextly/src/api/collections-schema-detail.ts
@@ -216,6 +216,21 @@ export const PATCH = withErrorHandler(
     // resolver — it aliases to a versioned config for back-compat, which would
     // stop the toggle from turning versioning off on a Draft/Published
     // collection.
+    // Retention without the on/off switch is ambiguous — the resolver needs to
+    // know whether history is enabled — so a retention-only patch is rejected
+    // rather than silently ignored. The switch and its retention always travel
+    // together from the Builder.
+    if (body.versionsMaxPerDoc !== undefined && body.versions === undefined) {
+      throw NextlyError.validation({
+        errors: [
+          {
+            path: "versionsMaxPerDoc",
+            code: "MISSING_DEPENDENCY",
+            message: "versionsMaxPerDoc requires versions to be set.",
+          },
+        ],
+      });
+    }
     if (body.versions !== undefined) {
       updateData.versions = resolveBuilderVersions(
         body.versions === true,

--- a/packages/nextly/src/api/collections-schema-detail.ts
+++ b/packages/nextly/src/api/collections-schema-detail.ts
@@ -25,7 +25,10 @@ import type { FieldConfig } from "@nextly/collections";
 
 import { getService } from "../di";
 import { calculateSchemaHash } from "../domains/schema/services/schema-hash";
-import { resolveBuilderVersions } from "../domains/versions/builder-versions";
+import {
+  coerceBuilderMaxPerDoc,
+  resolveBuilderVersions,
+} from "../domains/versions/builder-versions";
 import { resolveBuilderWebhooks } from "../domains/webhooks/builder-webhooks";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
@@ -214,7 +217,10 @@ export const PATCH = withErrorHandler(
     // stop the toggle from turning versioning off on a Draft/Published
     // collection.
     if (body.versions !== undefined) {
-      updateData.versions = resolveBuilderVersions(body.versions === true);
+      updateData.versions = resolveBuilderVersions(
+        body.versions === true,
+        coerceBuilderMaxPerDoc(body.versionsMaxPerDoc)
+      );
     }
 
     // Cache-revalidation toggle, normalized to the resolved config the write

--- a/packages/nextly/src/api/collections-schema.ts
+++ b/packages/nextly/src/api/collections-schema.ts
@@ -86,6 +86,12 @@ const createCollectionSchema = z.object({
   // Version history opt-in. Default off: capture adds a row to nextly_versions
   // on every save, which no existing caller has asked for.
   versions: z.boolean().optional(),
+  // Retention: durable versions kept per document. `false` = unlimited, a
+  // non-negative integer = keep that many, absent = the default (50). Only
+  // meaningful when `versions` is on.
+  versionsMaxPerDoc: z
+    .union([z.number().int().nonnegative(), z.literal(false)])
+    .optional(),
   // Cache-revalidation opt-out. Default on (absent): writes bust the standard
   // nextly:* tags; false persists the disable config so this collection busts
   // nothing.
@@ -286,8 +292,11 @@ export const POST = withErrorHandler(async (request: Request) => {
     // table is provisioned on the next migrate).
     localized: validated.localized === true,
     // Version history opt-in, normalized to the resolved config the column
-    // holds and every runtime reader tests.
-    versions: resolveBuilderVersions(validated.versions),
+    // holds and every runtime reader tests. Retention rides with the switch.
+    versions: resolveBuilderVersions(
+      validated.versions,
+      validated.versionsMaxPerDoc
+    ),
     // Cache-revalidation opt-out, normalized to the resolved config the write
     // path reads (null = standard tags, { disable: true } = off).
     revalidate: resolveBuilderRevalidate(validated.revalidate),

--- a/packages/nextly/src/api/singles-schema-detail.ts
+++ b/packages/nextly/src/api/singles-schema-detail.ts
@@ -197,6 +197,20 @@ export const PATCH = withErrorHandler(
 
     // Version history toggle, normalized to the resolved config the registry
     // column holds; off writes null. Mirrors the collection detail route.
+    // Retention without the on/off switch is ambiguous — the resolver needs to
+    // know whether history is enabled — so a retention-only patch is rejected
+    // rather than silently ignored. Mirrors the collection detail route.
+    if (body.versionsMaxPerDoc !== undefined && body.versions === undefined) {
+      throw NextlyError.validation({
+        errors: [
+          {
+            path: "versionsMaxPerDoc",
+            code: "MISSING_DEPENDENCY",
+            message: "versionsMaxPerDoc requires versions to be set.",
+          },
+        ],
+      });
+    }
     if (body.versions !== undefined) {
       updateData.versions = resolveBuilderVersions(
         body.versions === true,

--- a/packages/nextly/src/api/singles-schema-detail.ts
+++ b/packages/nextly/src/api/singles-schema-detail.ts
@@ -24,7 +24,10 @@ import type { FieldConfig } from "@nextly/collections";
 
 import { getService } from "../di";
 import { calculateSchemaHash } from "../domains/schema/services/schema-hash";
-import { resolveBuilderVersions } from "../domains/versions/builder-versions";
+import {
+  coerceBuilderMaxPerDoc,
+  resolveBuilderVersions,
+} from "../domains/versions/builder-versions";
 import { resolveBuilderWebhooks } from "../domains/webhooks/builder-webhooks";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
@@ -195,7 +198,10 @@ export const PATCH = withErrorHandler(
     // Version history toggle, normalized to the resolved config the registry
     // column holds; off writes null. Mirrors the collection detail route.
     if (body.versions !== undefined) {
-      updateData.versions = resolveBuilderVersions(body.versions === true);
+      updateData.versions = resolveBuilderVersions(
+        body.versions === true,
+        coerceBuilderMaxPerDoc(body.versionsMaxPerDoc)
+      );
     }
 
     // Cache-revalidation toggle, normalized to the resolved config the write

--- a/packages/nextly/src/api/versions.ts
+++ b/packages/nextly/src/api/versions.ts
@@ -101,6 +101,12 @@ export const GET = withErrorHandler(
       "limit"
     );
     const cursor = parsePositiveInt(url.searchParams.get("cursor"), "cursor");
+    // A plain string scoping the listing to one locale's versions. An empty
+    // value is treated as absent (list every locale) rather than matching a
+    // non-existent empty-string locale.
+    const localeParam = url.searchParams.get("locale");
+    const locale =
+      localeParam !== null && localeParam.length > 0 ? localeParam : undefined;
 
     // Always bounded: an unset limit still pages, and an oversized one is
     // clamped, so no single request can serialize an entire long history.
@@ -115,7 +121,11 @@ export const GET = withErrorHandler(
     // sending the client to an empty page.
     const window = await versions.list(
       { scopeKind, scopeSlug: slug, entryId: id },
-      { limit: limit + 1, ...(cursor !== undefined ? { cursor } : {}) }
+      {
+        limit: limit + 1,
+        ...(cursor !== undefined ? { cursor } : {}),
+        ...(locale !== undefined ? { locale } : {}),
+      }
     );
     const hasNext = window.length > limit;
     const rows = hasNext ? window.slice(0, limit) : window;

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -178,6 +178,7 @@ export const COLLECTION_VERSION_METHODS: Record<
         authenticatedScope: readAuthenticatedScope(p),
         limit: p.limit !== undefined ? Number(p.limit) : undefined,
         cursor: p.cursor !== undefined ? Number(p.cursor) : undefined,
+        locale: p.locale !== undefined ? String(p.locale) : undefined,
       });
       return respondList(result.items, result.meta);
     },

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -362,6 +362,7 @@ export const SINGLE_VERSION_METHODS: Record<
         authenticatedScope: readAuthenticatedScope(p),
         limit: p.limit !== undefined ? Number(p.limit) : undefined,
         cursor: p.cursor !== undefined ? Number(p.cursor) : undefined,
+        locale: p.locale !== undefined ? String(p.locale) : undefined,
       });
       return respondList(result.items, result.meta);
     },
@@ -545,6 +546,9 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
             localized?: boolean;
             // Version history opt-in; persists to dynamic_singles.versions.
             versions?: boolean;
+            // Retention: durable versions kept per document (`false` = unlimited,
+            // a number = keep that many, undefined = the default 50).
+            versionsMaxPerDoc?: number | false;
             // Cache-revalidation opt-out; persists to dynamic_singles.revalidate.
             revalidate?: boolean;
             // Webhook recording opt-out; persists to dynamic_singles.webhooks.
@@ -725,8 +729,8 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
         localized: isLocalized,
         // Persist version history from the create payload; without it a Single
         // created with the switch on is written unversioned and the switch
-        // reads as off the moment the editor loads.
-        versions: resolveBuilderVersions(b.versions),
+        // reads as off the moment the editor loads. Retention rides along.
+        versions: resolveBuilderVersions(b.versions, b.versionsMaxPerDoc),
         // Cache-revalidation opt-out from the create payload (null = standard
         // tags, { disable: true } = off), so the write path reads it back.
         revalidate: resolveBuilderRevalidate(b.revalidate),
@@ -1025,6 +1029,9 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
             // Version history toggle; honoured when defined, undefined leaves
             // the existing value untouched. Persists to dynamic_singles.versions.
             versions?: boolean;
+            // Retention: durable versions kept per document (`false` = unlimited,
+            // a number = keep that many, undefined = the default 50).
+            versionsMaxPerDoc?: number | false;
             // Cache-revalidation toggle; honoured when defined, undefined leaves
             // the existing value untouched. Persists to dynamic_singles.revalidate.
             revalidate?: boolean;
@@ -1063,7 +1070,10 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       // resolver: it aliases to a versioned config for back-compat, which would
       // stop the toggle from turning versioning off on a Draft/Published single.
       if (b.versions !== undefined) {
-        updateData.versions = resolveBuilderVersions(b.versions);
+        updateData.versions = resolveBuilderVersions(
+          b.versions,
+          b.versionsMaxPerDoc
+        );
       }
       // Cache-revalidation toggle, normalized to the resolved config the write
       // path reads; on writes null (standard tags), off writes the disable config.

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -1069,6 +1069,20 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
       // stored; off writes null. `status` is deliberately not passed to the
       // resolver: it aliases to a versioned config for back-compat, which would
       // stop the toggle from turning versioning off on a Draft/Published single.
+      // Retention without the on/off switch is ambiguous — the resolver needs
+      // the enabled state — so a retention-only patch is rejected rather than
+      // silently ignored. Mirrors the schema-detail routes.
+      if (b.versionsMaxPerDoc !== undefined && b.versions === undefined) {
+        throw NextlyError.validation({
+          errors: [
+            {
+              path: "versionsMaxPerDoc",
+              code: "MISSING_DEPENDENCY",
+              message: "versionsMaxPerDoc requires versions to be set.",
+            },
+          ],
+        });
+      }
       if (b.versions !== undefined) {
         updateData.versions = resolveBuilderVersions(
           b.versions,

--- a/packages/nextly/src/dispatcher/handlers/versions-methods.ts
+++ b/packages/nextly/src/dispatcher/handlers/versions-methods.ts
@@ -153,7 +153,10 @@ export async function listVersionsForDocument(
     {
       limit: limit + 1,
       ...(args.cursor !== undefined ? { cursor: args.cursor } : {}),
-      ...(args.locale !== undefined ? { locale: args.locale } : {}),
+      // An empty `?locale=` reaches the dispatcher as "" (the route parser keeps
+      // it); treat that as absent so both list surfaces list every locale rather
+      // than matching a non-existent empty-string locale and returning nothing.
+      ...(args.locale ? { locale: args.locale } : {}),
     }
   );
   const hasNext = window.length > limit;

--- a/packages/nextly/src/dispatcher/handlers/versions-methods.ts
+++ b/packages/nextly/src/dispatcher/handlers/versions-methods.ts
@@ -79,6 +79,8 @@ export interface VersionMethodArgs {
   authenticatedScope?: AuthenticatedScope;
   limit?: number;
   cursor?: number;
+  /** Scope the history listing to one locale's versions. */
+  locale?: string;
 }
 
 /**
@@ -151,6 +153,7 @@ export async function listVersionsForDocument(
     {
       limit: limit + 1,
       ...(args.cursor !== undefined ? { cursor: args.cursor } : {}),
+      ...(args.locale !== undefined ? { locale: args.locale } : {}),
     }
   );
   const hasNext = window.length > limit;

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -531,6 +531,24 @@ export class DynamicCollectionService extends BaseService {
     // off writes null. `status` is deliberately not passed to the resolver —
     // it aliases to a versioned config for back-compat, which would stop the
     // toggle from ever turning versioning off on a Draft/Published entity.
+    // Retention without the on/off switch is ambiguous — the resolver needs the
+    // enabled state — so a retention-only update is rejected rather than
+    // silently dropped. This is the chokepoint every collection-update caller
+    // reaches (the dispatcher forwards its raw body here).
+    if (
+      updates.versionsMaxPerDoc !== undefined &&
+      updates.versions === undefined
+    ) {
+      throw NextlyError.validation({
+        errors: [
+          {
+            path: "versionsMaxPerDoc",
+            code: "MISSING_DEPENDENCY",
+            message: "versionsMaxPerDoc requires versions to be set.",
+          },
+        ],
+      });
+    }
     if (updates.versions !== undefined) {
       metadataUpdates.versions = resolveBuilderVersions(
         updates.versions,

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -82,6 +82,9 @@ export interface CreateCollectionInput {
   localized?: boolean;
   /** Whether every save is recorded as a restorable version. */
   versions?: boolean;
+  /** Durable versions kept per document. `false` = unlimited, a number = keep
+   *  that many, undefined = the default (50). Ignored when `versions` is off. */
+  versionsMaxPerDoc?: number | false;
   /** Whether writes bust cache tags. Default on; false opts out entirely. */
   revalidate?: boolean;
   /**
@@ -110,6 +113,9 @@ export interface UpdateCollectionInput {
   localized?: boolean;
   /** Toggle version history. Honoured when defined; undefined leaves it unchanged. */
   versions?: boolean;
+  /** Retention, honoured with the switch. `false` = unlimited, a number = keep
+   *  that many, undefined = the default (50). */
+  versionsMaxPerDoc?: number | false;
   /** Toggle cache revalidation. Honoured when defined; undefined leaves it unchanged. */
   revalidate?: boolean;
   /** Toggle webhook recording. Honoured when defined; undefined leaves it unchanged. */
@@ -293,8 +299,8 @@ export class DynamicCollectionService extends BaseService {
       localized: data.localized === true,
       // Persist version history from the create payload; without it a
       // collection created with the switch on is written unversioned and the
-      // switch reads as off the moment the editor loads.
-      versions: resolveBuilderVersions(data.versions),
+      // switch reads as off the moment the editor loads. Retention rides along.
+      versions: resolveBuilderVersions(data.versions, data.versionsMaxPerDoc),
       // Persist the cache-revalidation opt-out from the create payload (null =
       // standard tags, { disable: true } = off) so the write path reads it back.
       revalidate: resolveBuilderRevalidate(data.revalidate),
@@ -526,7 +532,10 @@ export class DynamicCollectionService extends BaseService {
     // it aliases to a versioned config for back-compat, which would stop the
     // toggle from ever turning versioning off on a Draft/Published entity.
     if (updates.versions !== undefined) {
-      metadataUpdates.versions = resolveBuilderVersions(updates.versions);
+      metadataUpdates.versions = resolveBuilderVersions(
+        updates.versions,
+        updates.versionsMaxPerDoc
+      );
     }
     // Cache-revalidation toggle. The column holds the resolved config the write
     // path reads, so the boolean is normalized before storing; off writes the

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
@@ -80,9 +80,10 @@ function jsonLiteral(value: unknown, dialect: Dialect): string {
  */
 function versionsLiteral(
   versions: boolean | undefined,
+  maxPerDoc: number | false | undefined,
   dialect: Dialect
 ): string {
-  const resolved = resolveBuilderVersions(versions);
+  const resolved = resolveBuilderVersions(versions, maxPerDoc);
   return resolved === null ? "NULL" : jsonLiteral(resolved, dialect);
 }
 
@@ -237,7 +238,11 @@ export function buildCollectionMetadataUpsert(
       // the column, and a column left out of the upsert is untouched by its
       // DO UPDATE SET.
       name: "versions",
-      value: versionsLiteral(entity.versions, dialect),
+      value: versionsLiteral(
+        entity.versions,
+        entity.versionsMaxPerDoc,
+        dialect
+      ),
       update: true,
     },
     {
@@ -305,7 +310,11 @@ export function buildSingleMetadataUpsert(
       // the column, and a column left out of the upsert is untouched by its
       // DO UPDATE SET.
       name: "versions",
-      value: versionsLiteral(entity.versions, dialect),
+      value: versionsLiteral(
+        entity.versions,
+        entity.versionsMaxPerDoc,
+        dialect
+      ),
       update: true,
     },
     {

--- a/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
+++ b/packages/nextly/src/domains/schema/ui-schema/metadata-sql.ts
@@ -15,17 +15,20 @@
  * KNOWN LIMITATION (v1): metadata-only edits produce no DDL operation, so no
  * migration is generated and the change is not propagated until a schema
  * change co-occurs. This covers labels, and equally the `status`, `localized`,
- * `versions`, `revalidate` and `webhooks` flags: flipping one alone leaves the
- * deployed registry row on its previous value until the next migration for that
- * table.
+ * `versions`, `versionsMaxPerDoc` (retention), `revalidate` and `webhooks`
+ * flags: changing one alone leaves the deployed registry row on its previous
+ * value until the next migration for that table.
  *
- * `webhooks` carries the sharpest consequence of that limitation, because the
- * flag governs whether content reaches the outbox: turning recording off in the
- * Builder opts the development database out while a deployed environment keeps
- * recording and delivering until a schema change ships alongside it. Until
- * metadata-only edits generate their own migration, an operator who needs the
- * opt-out in production should set `webhooks: false` in code-first config, which
- * is republished on every boot and needs no migration.
+ * `webhooks` and `versionsMaxPerDoc` carry the sharpest consequences of that
+ * limitation. `webhooks` governs whether content reaches the outbox: turning
+ * recording off in the Builder opts the development database out while a
+ * deployed environment keeps recording and delivering until a schema change
+ * ships alongside it. `versionsMaxPerDoc` governs how much history is kept:
+ * lowering the cap (or leaving a finite one in place instead of "keep all") in
+ * the Builder does not reach a deployed environment, which keeps pruning to its
+ * old cap. Until metadata-only edits generate their own migration, an operator
+ * who needs either change in production should set it in code-first config,
+ * which is republished on every boot and needs no migration.
  *
  * @module domains/schema/ui-schema/metadata-sql
  * @since v0.0.3-alpha (Plan D2b)

--- a/packages/nextly/src/domains/versions/__tests__/builder-versions.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/builder-versions.test.ts
@@ -37,6 +37,16 @@ describe("resolveBuilderVersions", () => {
     expect(resolveBuilderVersions(true, false)?.maxPerDoc).toBe(false);
   });
 
+  it("clamps an invalid retention to the default at the chokepoint", () => {
+    // An unvalidated dispatcher path can forward a negative the cast typed as a
+    // number; retention would clamp it to zero and prune all but protected
+    // history, so the resolver coerces it back to the default here.
+    const negative = -1 as unknown as number;
+    expect(resolveBuilderVersions(true, negative)?.maxPerDoc).toBe(50);
+    const fractional = 2.5 as unknown as number;
+    expect(resolveBuilderVersions(true, fractional)?.maxPerDoc).toBe(50);
+  });
+
   it("ignores retention when the switch is off", () => {
     expect(resolveBuilderVersions(false, 10)).toBeNull();
   });

--- a/packages/nextly/src/domains/versions/__tests__/builder-versions.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/builder-versions.test.ts
@@ -5,7 +5,10 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { resolveBuilderVersions } from "../builder-versions";
+import {
+  coerceBuilderMaxPerDoc,
+  resolveBuilderVersions,
+} from "../builder-versions";
 
 describe("resolveBuilderVersions", () => {
   it("resolves the switch to history only, without drafts", () => {
@@ -19,8 +22,23 @@ describe("resolveBuilderVersions", () => {
     expect(resolved?.drafts.autosave.enabled).toBe(false);
   });
 
-  it("keeps the configured retention default", () => {
+  it("keeps the configured retention default when none is given", () => {
     expect(resolveBuilderVersions(true)?.maxPerDoc).toBe(50);
+  });
+
+  it("carries an explicit retention count", () => {
+    expect(resolveBuilderVersions(true, 10)?.maxPerDoc).toBe(10);
+    // Zero is a real setting (keep only protected versions), distinct from the
+    // default and from unlimited.
+    expect(resolveBuilderVersions(true, 0)?.maxPerDoc).toBe(0);
+  });
+
+  it("carries unlimited retention", () => {
+    expect(resolveBuilderVersions(true, false)?.maxPerDoc).toBe(false);
+  });
+
+  it("ignores retention when the switch is off", () => {
+    expect(resolveBuilderVersions(false, 10)).toBeNull();
   });
 
   it("resolves off and absent to no config at all", () => {
@@ -28,5 +46,26 @@ describe("resolveBuilderVersions", () => {
     // `enabled: false` would read as versioned to `versions?.enabled` checks.
     expect(resolveBuilderVersions(false)).toBeNull();
     expect(resolveBuilderVersions(undefined)).toBeNull();
+  });
+});
+
+describe("coerceBuilderMaxPerDoc", () => {
+  it("passes through a non-negative integer", () => {
+    expect(coerceBuilderMaxPerDoc(0)).toBe(0);
+    expect(coerceBuilderMaxPerDoc(25)).toBe(25);
+  });
+
+  it("passes through false as unlimited", () => {
+    expect(coerceBuilderMaxPerDoc(false)).toBe(false);
+  });
+
+  it("treats absent or malformed values as the default", () => {
+    // Undefined so the resolver applies the default (50) rather than rejecting.
+    expect(coerceBuilderMaxPerDoc(undefined)).toBeUndefined();
+    expect(coerceBuilderMaxPerDoc(null)).toBeUndefined();
+    expect(coerceBuilderMaxPerDoc(-1)).toBeUndefined();
+    expect(coerceBuilderMaxPerDoc(1.5)).toBeUndefined();
+    expect(coerceBuilderMaxPerDoc("10")).toBeUndefined();
+    expect(coerceBuilderMaxPerDoc(true)).toBeUndefined();
   });
 });

--- a/packages/nextly/src/domains/versions/__tests__/versions-repository.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/versions-repository.integration.test.ts
@@ -87,6 +87,38 @@ describe("VersionsRepository (integration)", () => {
     }
   });
 
+  it("includes shared (null-locale) versions in a locale filter", async () => {
+    const handle = await createTestNextly();
+    try {
+      const repo = new VersionsRepository(handle.adapter);
+      const insert = (versionNo: number, locale?: string) =>
+        repo.insertVersion({
+          ref,
+          versionNo,
+          status: "published",
+          isAutosave: false,
+          snapshot: { title: `v${versionNo}` },
+          createdBy: "user-1",
+          ...(locale ? { locale } : {}),
+        });
+      await insert(1, "en");
+      await insert(2); // shared write: no locale-specific state, so locale null
+      await insert(3, "fr");
+      await insert(4, "en");
+
+      // Filtering to "en" returns the en-specific versions AND the shared one,
+      // newest first — a shared change affects every locale's history.
+      const en = await repo.listByDoc(ref, { locale: "en" });
+      expect(en.map(m => m.versionNo)).toEqual([4, 2, 1]);
+
+      // "fr" gets its own version plus the same shared one, but not the en ones.
+      const fr = await repo.listByDoc(ref, { locale: "fr" });
+      expect(fr.map(m => m.versionNo)).toEqual([3, 2]);
+    } finally {
+      await handle.destroy();
+    }
+  });
+
   it("rejects a duplicate durable version_no for the same document", async () => {
     const handle = await createTestNextly();
     try {

--- a/packages/nextly/src/domains/versions/__tests__/versions-repository.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/versions-repository.integration.test.ts
@@ -48,6 +48,45 @@ describe("VersionsRepository (integration)", () => {
     }
   });
 
+  it("scopes listByDoc to one locale when asked", async () => {
+    const handle = await createTestNextly();
+    try {
+      const repo = new VersionsRepository(handle.adapter);
+      // A localized document captures a version per locale, interleaved.
+      const insert = (versionNo: number, locale: string) =>
+        repo.insertVersion({
+          ref,
+          versionNo,
+          status: "published",
+          isAutosave: false,
+          snapshot: { title: `v${versionNo}` },
+          createdBy: "user-1",
+          locale,
+        });
+      await insert(1, "en");
+      await insert(2, "fr");
+      await insert(3, "en");
+
+      // Unfiltered returns every locale's versions, newest first.
+      const all = await repo.listByDoc(ref);
+      expect(all.map(m => m.versionNo)).toEqual([3, 2, 1]);
+
+      // Filtered returns only the requested locale, preserving order.
+      const en = await repo.listByDoc(ref, { locale: "en" });
+      expect(en.map(m => m.versionNo)).toEqual([3, 1]);
+      expect(en.every(m => m.locale === "en")).toBe(true);
+
+      const fr = await repo.listByDoc(ref, { locale: "fr" });
+      expect(fr.map(m => m.versionNo)).toEqual([2]);
+
+      // A locale with no versions returns nothing rather than every row.
+      const de = await repo.listByDoc(ref, { locale: "de" });
+      expect(de).toEqual([]);
+    } finally {
+      await handle.destroy();
+    }
+  });
+
   it("rejects a duplicate durable version_no for the same document", async () => {
     const handle = await createTestNextly();
     try {

--- a/packages/nextly/src/domains/versions/builder-versions.ts
+++ b/packages/nextly/src/domains/versions/builder-versions.ts
@@ -53,8 +53,13 @@ export function resolveBuilderVersions(
   maxPerDoc?: number | false
 ): ResolvedVersionsConfig | null {
   if (enabled !== true) return null;
+  // Coerce at this single chokepoint so an unvalidated path (the dispatcher
+  // casts its JSON body rather than Zod-parsing it) cannot persist a negative
+  // or non-integer cap: retention clamps a negative to zero and would prune all
+  // but the protected history. An invalid value falls back to the default.
+  const safe = coerceBuilderMaxPerDoc(maxPerDoc);
   return resolveVersionsConfig({
     drafts: false,
-    ...(maxPerDoc !== undefined ? { maxPerDoc } : {}),
+    ...(safe !== undefined ? { maxPerDoc: safe } : {}),
   });
 }

--- a/packages/nextly/src/domains/versions/builder-versions.ts
+++ b/packages/nextly/src/domains/versions/builder-versions.ts
@@ -27,8 +27,34 @@ import { resolveVersionsConfig } from "./resolve-config";
  * code-first back-compat, which would leave the switch unable to turn
  * versioning off on any entity that has Draft/Published enabled.
  */
+/**
+ * Coerce an untrusted retention value from a loosely-typed request body into
+ * the `number | false | undefined` the resolver takes. `false` is unlimited; a
+ * non-negative integer is a keep-count; anything else (absent, or malformed)
+ * becomes undefined so the default (50) applies rather than a rejected request,
+ * matching how these routes coerce their other optional switches.
+ */
+export function coerceBuilderMaxPerDoc(
+  value: unknown
+): number | false | undefined {
+  if (value === false) return false;
+  if (typeof value === "number" && Number.isInteger(value) && value >= 0) {
+    return value;
+  }
+  return undefined;
+}
+
 export function resolveBuilderVersions(
-  enabled: boolean | undefined
+  enabled: boolean | undefined,
+  // Retention: how many durable versions to keep per document. `false` =
+  // unlimited; a number = keep that many; undefined = the default (50), so a
+  // caller that only knows the on/off switch keeps today's behavior. Ignored
+  // when the switch is off.
+  maxPerDoc?: number | false
 ): ResolvedVersionsConfig | null {
-  return enabled === true ? resolveVersionsConfig({ drafts: false }) : null;
+  if (enabled !== true) return null;
+  return resolveVersionsConfig({
+    drafts: false,
+    ...(maxPerDoc !== undefined ? { maxPerDoc } : {}),
+  });
 }

--- a/packages/nextly/src/domains/versions/db-api.ts
+++ b/packages/nextly/src/domains/versions/db-api.ts
@@ -10,22 +10,29 @@
 
 import type { SqlParam } from "@nextlyhq/adapter-drizzle/types";
 
-/** A single AND-ed filter condition (subset of the adapter WhereClause). */
+/** A single filter condition (subset of the adapter WhereClause). */
 export interface VersionsWhereCondition {
   column: string;
   // `<` powers keyset pagination (versionNo < cursor); `IN` powers the
-  // retention delete, which removes several rows in one statement. The
-  // adapter's WhereOperator spells the set operator uppercase.
-  op: "=" | "!=" | "<" | "IN";
+  // retention delete, which removes several rows in one statement; `IS NULL`
+  // powers the locale filter, which must also match shared (null-locale)
+  // snapshots. The adapter's WhereOperator spells the set operator uppercase.
+  op: "=" | "!=" | "<" | "IN" | "IS NULL";
   // Matches the adapter's WhereCondition.value so the adapter and the
   // transaction context both structurally satisfy VersionsDbApi (a looser
   // `unknown` here breaks that assignability under method-parameter variance).
   value?: SqlParam | SqlParam[];
 }
 
-/** Conjunction-only where (all versions queries are simple AND filters). */
+/**
+ * A where clause: a conjunction (`and`) of conditions or nested clauses, with an
+ * optional disjunction (`or`) group. Still a strict subset of the adapter's
+ * WhereClause, so both the adapter and the transaction context satisfy the port.
+ * The `or` group exists for the locale filter alone (locale X OR shared/null).
+ */
 export interface VersionsWhere {
-  and?: VersionsWhereCondition[];
+  and?: (VersionsWhereCondition | VersionsWhere)[];
+  or?: (VersionsWhereCondition | VersionsWhere)[];
 }
 
 /** Select options subset the versions repository uses. */

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -17,7 +17,11 @@ import type {
   VersionStatus,
 } from "../../schemas/versions/types";
 
-import type { VersionsDbApi, VersionsWhereCondition } from "./db-api";
+import type {
+  VersionsDbApi,
+  VersionsWhere,
+  VersionsWhereCondition,
+} from "./db-api";
 import type { PrunableVersion } from "./retention";
 
 const TABLE = "nextly_versions";
@@ -239,15 +243,27 @@ export class VersionsRepository {
       locale?: string;
     } = {}
   ): Promise<VersionMeta[]> {
-    const and = [...this.docWhere(ref)];
+    const and: (VersionsWhereCondition | VersionsWhere)[] = [
+      ...this.docWhere(ref),
+    ];
     if (!opts.includeAutosave) {
       and.push({ column: "isAutosave", op: "=", value: false });
     }
     // Scope to one locale's history when asked. A localized document captures a
     // version per locale, so the list can be narrowed to the language an editor
     // is working in; absent, every locale's versions are returned.
+    //
+    // Shared (null-locale) snapshots are included: a write touching only fields
+    // shared across locales is recorded with `locale: null` yet still changes
+    // this locale's document, so excluding it would omit real history and could
+    // present an older locale-specific row as the latest state.
     if (opts.locale !== undefined) {
-      and.push({ column: "locale", op: "=", value: opts.locale });
+      and.push({
+        or: [
+          { column: "locale", op: "=", value: opts.locale },
+          { column: "locale", op: "IS NULL" },
+        ],
+      });
     }
     // Keyset pagination: return versions strictly older than the cursor, which
     // is the last versionNo the caller already has. Stable under concurrent

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -232,11 +232,22 @@ export class VersionsRepository {
    */
   async listByDoc(
     ref: VersionRef,
-    opts: { limit?: number; includeAutosave?: boolean; cursor?: number } = {}
+    opts: {
+      limit?: number;
+      includeAutosave?: boolean;
+      cursor?: number;
+      locale?: string;
+    } = {}
   ): Promise<VersionMeta[]> {
     const and = [...this.docWhere(ref)];
     if (!opts.includeAutosave) {
       and.push({ column: "isAutosave", op: "=", value: false });
+    }
+    // Scope to one locale's history when asked. A localized document captures a
+    // version per locale, so the list can be narrowed to the language an editor
+    // is working in; absent, every locale's versions are returned.
+    if (opts.locale !== undefined) {
+      and.push({ column: "locale", op: "=", value: opts.locale });
     }
     // Keyset pagination: return versions strictly older than the cursor, which
     // is the last versionNo the caller already has. Stable under concurrent

--- a/packages/nextly/src/domains/versions/versions-service.ts
+++ b/packages/nextly/src/domains/versions/versions-service.ts
@@ -33,6 +33,8 @@ export interface VersionListOptions {
   cursor?: number;
   /** Include rolling autosave rows. Defaults to false (durable versions only). */
   includeAutosave?: boolean;
+  /** Scope the listing to one locale's versions. Absent lists every locale. */
+  locale?: string;
 }
 
 export class VersionsService {

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -489,6 +489,19 @@ function entity(kind?: "collection" | "single" | "component") {
           path: ["versions"],
         });
       }
+      // Retention rides with version history, which components do not have, so
+      // it is rejected for the same reason as `versions` above rather than
+      // round-tripping a setting no component metadata path reads.
+      if (
+        kind === STORAGE_FORMAT.manifest.entityKind &&
+        e.versionsMaxPerDoc !== undefined
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "'versionsMaxPerDoc' is not supported on components",
+          path: ["versionsMaxPerDoc"],
+        });
+      }
       // Components have no entries and no registry row of their own, so a
       // revalidation switch would persist a setting nothing reads and the
       // Builder never offers (same rationale as `versions` above).

--- a/packages/nextly/src/schemas/_zod/ui-schema.ts
+++ b/packages/nextly/src/schemas/_zod/ui-schema.ts
@@ -423,6 +423,15 @@ function entity(kind?: "collection" | "single" | "component") {
        */
       versions: z.boolean().optional(),
       /**
+       * Retention for version history: durable versions kept per document.
+       * `false` = unlimited, a non-negative integer = keep that many, absent =
+       * the default (50). Stripped like any unknown key, so it is declared here
+       * to survive a round-trip through the manifest.
+       */
+      versionsMaxPerDoc: z
+        .union([z.number().int().nonnegative(), z.literal(false)])
+        .optional(),
+      /**
        * Whether writes to this entity bust cache tags. Boolean rather than the
        * code-first `{ tags?, disable? }`: the Schema Builder offers on/off
        * (custom extra tags stay a code-first control). On is the default, so an


### PR DESCRIPTION
Completes the remaining task-022 version-history polish in one PR: three cohesive features on top of the reference-hydration work (#406/#409).

## 1. Filter version history by locale
A localized document captures a version per locale, so history reads as an interleaved jumble. Now:
- Each row shows a **language badge**, and the panel header has a **locale filter** (reusing the existing localization config; extended with an "All locales" option). Both hide automatically for non-localized documents.
- Threaded through **both** list surfaces: the REST route (`api/versions.ts`) and the dispatcher (`versions-methods` + collection/single dispatchers), down to a `locale` WHERE in `listByDoc`.
- `useVersions` keys the query by locale so switching refetches; mutations still invalidate every locale variant via the shared prefix.

## 2. "Restored from vN" lineage chip
`sourceVersionNo` was already captured and returned but never rendered. A restored version now shows a **"Restored from vN"** chip on its row and in the preview header (folded into the row's accessible name too). Pure admin rendering — no server change.

## 3. Set version retention in the Schema Builder
The builder's versioning toggle was on/off only, with no parity for code-first `versions.maxPerDoc`. The Advanced tab gains a **retention control**: *Keep all history* (unlimited), *Keep default (50)*, or *Keep last N…* (0 = keep only protected versions). The value:
- Widens `resolveBuilderVersions(enabled, maxPerDoc?)` (optional, so every existing caller keeps today's behavior) and threads through all its call sites — create/update services, both schema-detail routes, the single dispatcher, and the `ui-schema.json` manifest literal.
- Persists through the builder's create/update endpoints **and** the committable manifest (declared in the ui-schema zod so it survives a round-trip).

## Verification
- Typecheck (nextly + admin), lint (both, `--max-warnings 0`), build — all green.
- Unit: `resolveBuilderVersions`/`coerceBuilderMaxPerDoc` retention cases (9), `settings-dirty` exhaustiveness (14).
- Integration: new locale-filter case in `versions-repository.integration.test.ts` (SQLite green).
- The only failing admin tests (`SlugInput`, `BasicsTab`, 5 total) are the **pre-existing stale-mock baseline** — verified identical on a clean tree with this branch stashed; this PR adds no new failures.

## Notes
- One changeset (all fixed-group packages, patch).
- The retention select's "default (50)" reads back as its concrete number on edit (the stored config records the effective count, not whether 50 was defaulted) — intentional and honest.