### PR TITLE
test(nextly): give the component-data doubles the method the write path calls

### DIFF
--- a/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
@@ -269,6 +269,14 @@ export function createMockComponentDataService(): MockRecord {
         Promise.resolve(params.entry)
       ),
     saveComponentData: vi.fn().mockResolvedValue(undefined),
+    saveComponentDataInTransaction: vi.fn().mockResolvedValue(undefined),
+    // Asked before the caller opens its transaction, and its result is handed
+    // to `saveComponentDataInTransaction`. An empty map is what production
+    // returns when no localization is configured, which is the shape these
+    // suites exercise. Built per call so one test cannot mutate another's.
+    assertLocalizedFieldGroupsWritable: vi
+      .fn()
+      .mockImplementation(async () => new Map<string, boolean>()),
     deleteComponentData: vi.fn().mockResolvedValue(undefined),
   };
 }

--- a/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
@@ -269,6 +269,9 @@ export function createMockComponentDataService(): MockRecord {
         Promise.resolve(params.entry)
       ),
     saveComponentData: vi.fn().mockResolvedValue(undefined),
+    // The collection write saves component rows inside its own transaction,
+    // handing this the presence map resolved beforehand. Absent from the double,
+    // the write threw partway and the failure read as a denied or errored save.
     saveComponentDataInTransaction: vi.fn().mockResolvedValue(undefined),
     // Asked before the caller opens its transaction, and its result is handed
     // to `saveComponentDataInTransaction`. An empty map is what production

--- a/packages/nextly/src/domains/singles/__tests__/single-test-helpers.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-test-helpers.ts
@@ -157,6 +157,13 @@ export function createMockComponentDataService(): MockRecord {
       ),
     saveComponentData: vi.fn().mockResolvedValue(undefined),
     saveComponentDataInTransaction: vi.fn().mockResolvedValue(undefined),
+    // Asked before the caller opens its transaction, and its result is handed
+    // to `saveComponentDataInTransaction`. An empty map is what production
+    // returns when no localization is configured, which is the shape these
+    // suites exercise. Built per call so one test cannot mutate another's.
+    assertLocalizedFieldGroupsWritable: vi
+      .fn()
+      .mockImplementation(async () => new Map<string, boolean>()),
     deleteComponentData: vi.fn().mockResolvedValue(undefined),
     // The webhook field tree expands component references to find nested
     // secrets; null = no nested component schema for this slug in the mock.


### PR DESCRIPTION
Restores the nextly unit baseline from **430 back to 401**.

## What happened

#382 added three production call sites:

- `collections/services/collection-mutation-service.ts:2269` and `:4286`
- `singles/services/single-mutation-service.ts:934`

all of the form:

```ts
await this.fieldGroupDataService?.assertLocalizedFieldGroupsWritable({ ... })
```

The optional chain guards the **service**, not the method. Every mutation suite builds a `fieldGroupDataService` double that exists but did not implement it, so the call was `undefined(...)` and threw. The method appeared **zero times** anywhere under a test file.

One cause, three unrelated-looking symptoms:

| Suite | n | Symptom |
|---|---|---|
| `single-entry-service.test.ts` | 19 | `expected false to be true`, with the missing-function text in the returned error |
| `collection-access.test.ts` | 7 | `expected 500 to be 403` — the TypeError escapes before the deny can answer |
| `collection-hooks` / `-mutation` | 3 | write aborts after `beforeUpdate`, so the recorded hook order lacks its tail |

## The fix

Both `createMockComponentDataService` factories now provide the method, returning an empty `Map<string, boolean>` — what production returns when no localization is configured, which is the shape these suites exercise. Built per call so one test cannot mutate another's. The collections factory also gained `saveComponentDataInTransaction`, which it was missing for the same reason.

This is test-double work only; no production code is touched, so there is no changeset.

## Verification

- Full nextly unit suite: **401 failing names**, compared by NAME against a built `origin/main` worktree at `b448e6d0` (430). Exactly **29 fixed, 0 introduced** — `comm` both directions.
- The 11 failures remaining in those four suites are pre-existing, present in the 401-era baseline from before #382.
- Load-bearing: removing the method from the singles factory restores exactly the 19 singles failures.
- `pnpm check-types` and `pnpm lint` clean.

## Worth a separate look

AGENTS.md says the failing baseline must never be added to. 29 new failures merged anyway, so whatever guards that did not hold here. Context is recorded in `tasks/left-tasks/049-test-baseline-repair.md`.