### PR TITLE
fix(nextly): apply a target collection's read rule to its localized fields

### DIFF
--- a/.changeset/localized-target-read-predicates.md
+++ b/.changeset/localized-target-read-predicates.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Apply a target collection's read rule when it filters on one of that collection's localized fields, so populating a relationship returns the rows the rule permits instead of withholding every one of them.

--- a/packages/nextly/src/domains/collections/__tests__/_fixtures/localized-target-read-rule.ts
+++ b/packages/nextly/src/domains/collections/__tests__/_fixtures/localized-target-read-rule.ts
@@ -1,0 +1,27 @@
+/**
+ * A stored `custom` read rule whose constraint filters on a LOCALIZED field of
+ * the collection it guards, as a real module so the access service's dynamic
+ * `import(functionPath)` can load it.
+ *
+ * A localized field has no column on the main table — its values live in the
+ * collection's `_locales` companion, one row per language — so the predicate can
+ * only be applied as a subquery against that table, in a named language.
+ */
+export default function localizedTargetReadRule({
+  req,
+}: {
+  req: { user?: { id?: string } };
+}): unknown {
+  switch (req.user?.id) {
+    // Readable only where the translation being read says "emea".
+    case "emea-only":
+      return { region: { equals: "emea" } };
+    // A dotted path on the same localized field. Translation discards the
+    // suffix and compares the base value, which is a DIFFERENT predicate rather
+    // than a narrower one, so it must be refused however it is stored.
+    case "dotted-localized":
+      return { "region.code": { equals: "emea" } };
+    default:
+      return true;
+  }
+}

--- a/packages/nextly/src/domains/collections/__tests__/_fixtures/localized-target-read-rule.ts
+++ b/packages/nextly/src/domains/collections/__tests__/_fixtures/localized-target-read-rule.ts
@@ -16,6 +16,10 @@ export default function localizedTargetReadRule({
     // Readable only where the translation being read says "emea".
     case "emea-only":
       return { region: { equals: "emea" } };
+    // A predicate naming only a field the MAIN table has. Nothing here needs a
+    // companion, so nothing should be looked up for it.
+    case "title-only":
+      return { title: { equals: "EMEA page" } };
     // A dotted path on the same localized field. Translation discards the
     // suffix and compares the base value, which is a DIFFERENT predicate rather
     // than a narrower one, so it must be refused however it is stored.

--- a/packages/nextly/src/domains/collections/__tests__/localized-target-predicate.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/localized-target-predicate.integration.test.ts
@@ -1,0 +1,319 @@
+/**
+ * A target collection's read rule may scope reads by one of its own LOCALIZED
+ * fields. Populating a relationship has to apply that filter the way the
+ * collection's own list read applies it.
+ *
+ * A localized value is not a column on the main table: it lives in the
+ * collection's `_locales` companion, one row per language, and reaches SQL as a
+ * correlated EXISTS. Expansion had no companion context, so such a field looked
+ * like a column the target does not have — the predicate was reported
+ * untranslatable and every row behind the rule was withheld, while a list read
+ * of the same collection by the same caller returned them.
+ *
+ * Withholding was the safe half: a filter that cannot be applied must not be
+ * dropped, or the read runs under a weaker predicate than the rule states. What
+ * was missing is the language, and it can only come from the read that asked.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, relationship, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const RULE_PATH = new URL(
+  "./_fixtures/localized-target-read-rule.ts",
+  import.meta.url
+).pathname;
+
+interface Seeded {
+  handler: CollectionsHandler;
+  /** `region` is "emea" in en and "apac" in de. */
+  emeaId: string;
+  /** `region` is "apac" in every locale. */
+  apacId: string;
+  /** Points at both pages through one `hasMany` reference. */
+  refId: string;
+}
+
+/**
+ * `pages` is localized and guarded by a rule filtering on its localized
+ * `region`; `refs` points at two of its rows through one relationship.
+ *
+ * The two pages differ in the language their permitted value lives in, so a
+ * filter applied against the wrong companion row — or against none — gives a
+ * visibly different answer from the right one.
+ */
+async function boot(): Promise<Seeded> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: "pages",
+        localized: true,
+        fields: [
+          text({ name: "title", localized: false }),
+          text({ name: "region" }),
+        ],
+      }),
+      defineCollection({
+        slug: "refs",
+        fields: [
+          text({ name: "name" }),
+          relationship({ name: "targets", relationTo: "pages", hasMany: true }),
+        ],
+      }),
+    ],
+    localization: { locales: ["en", "de"], defaultLocale: "en" },
+  });
+
+  const handler = current.getService<CollectionsHandler>("collectionsHandler");
+
+  const emea = await handler.createEntry(
+    { collectionName: "pages", overrideAccess: true },
+    { title: "EMEA page", region: "emea" }
+  );
+  const apac = await handler.createEntry(
+    { collectionName: "pages", overrideAccess: true },
+    { title: "APAC page", region: "apac" }
+  );
+  const emeaId = (emea.data as { id: string }).id;
+  const apacId = (apac.data as { id: string }).id;
+
+  // The German translation of the permitted page says something else, so the
+  // language the filter names decides whether it is readable.
+  await handler.updateEntry({
+    collectionName: "pages",
+    entryId: emeaId,
+    data: { region: "apac" },
+    locale: "de",
+    overrideAccess: true,
+  });
+
+  const ref = await handler.createEntry(
+    { collectionName: "refs", overrideAccess: true },
+    { name: "r", targets: [emeaId, apacId] }
+  );
+
+  await current.adapter.update(
+    "dynamic_collections",
+    { access_rules: { read: { type: "custom", functionPath: RULE_PATH } } },
+    { and: [{ column: "slug", op: "=", value: "pages" }] }
+  );
+
+  return { handler, emeaId, apacId, refId: (ref.data as { id: string }).id };
+}
+
+/** The ids that actually became rows, in the order the reference holds them. */
+async function populatedIds(
+  handler: CollectionsHandler,
+  refId: string,
+  userId: string,
+  locale?: string
+): Promise<string[]> {
+  const result = await handler.getEntry({
+    collectionName: "refs",
+    entryId: refId,
+    user: { id: userId },
+    routeAuthorized: true,
+    ...(locale ? { locale } : {}),
+  });
+  expect(result.success).toBe(true);
+  const targets = (result.data as { targets?: unknown[] }).targets ?? [];
+  // An unpopulated reference stays a bare id string; a populated one is the row.
+  return targets
+    .filter(
+      (value): value is { id: string } =>
+        typeof value === "object" && value !== null && "id" in value
+    )
+    .map(row => row.id);
+}
+
+/** The ids the target collection's own list read returns for this caller. */
+async function listedIds(
+  handler: CollectionsHandler,
+  userId: string,
+  locale?: string
+): Promise<string[]> {
+  const result = await handler.listEntries({
+    collectionName: "pages",
+    user: { id: userId },
+    routeAuthorized: true,
+    ...(locale ? { locale } : {}),
+  });
+  expect(result.success).toBe(true);
+  return (result.data!.docs as { id: string }[]).map(doc => doc.id);
+}
+
+describe("localized target read predicates (integration)", () => {
+  it("populates a row its target's localized predicate admits", async () => {
+    const { handler, emeaId, refId } = await boot();
+
+    // The rule permits exactly this row in the language being read. Without a
+    // companion context the predicate is untranslatable and both rows are
+    // withheld, so the reference comes back as bare ids.
+    expect(await populatedIds(handler, refId, "emea-only")).toEqual([emeaId]);
+  });
+
+  it("still withholds a row the localized predicate excludes", async () => {
+    const { handler, apacId, refId } = await boot();
+
+    // The mirror, and the reason the test above is not simply the gate being
+    // switched off: the row whose translation the rule excludes must stay
+    // unpopulated.
+    expect(await populatedIds(handler, refId, "emea-only")).not.toContain(
+      apacId
+    );
+  });
+
+  it("judges the predicate in the language being read", async () => {
+    const { handler, emeaId, refId } = await boot();
+
+    // Same rule, same row, different language: its German translation says
+    // "apac", so reading in German must not populate it. This is what fails
+    // when a filter is applied against whichever companion row exists rather
+    // than the one for the requested locale.
+    expect(await populatedIds(handler, refId, "emea-only", "en")).toEqual([
+      emeaId,
+    ]);
+    expect(await populatedIds(handler, refId, "emea-only", "de")).toEqual([]);
+  });
+
+  it("agrees with the target collection's own list read", async () => {
+    const { handler, refId } = await boot();
+
+    // The property the whole change exists to establish: a row is readable
+    // through a relationship exactly when the collection that owns it says it
+    // is readable. Asserted per language, because the rule answers each one
+    // differently.
+    for (const locale of ["en", "de"]) {
+      expect(await populatedIds(handler, refId, "emea-only", locale)).toEqual(
+        await listedIds(handler, "emea-only", locale)
+      );
+    }
+  });
+
+  it("withholds when the read asked for every language at once", async () => {
+    const { handler, refId } = await boot();
+
+    // `locale=all` returns language-keyed values rather than one translation,
+    // so there is no single language for a companion filter to name. Withholding
+    // is the honest answer: applying the filter to an arbitrary language would
+    // decide the read on a translation the caller never asked about.
+    expect(await populatedIds(handler, refId, "emea-only", "all")).toEqual([]);
+  });
+
+  it("does not admit a row whose permitted translation is only a draft", async () => {
+    // The target's own list read constrains the companion filter by the status
+    // it resolved for this caller, so an unpublished translation cannot satisfy
+    // it. Expansion has to do the same: a draft translation holding the
+    // permitted value would otherwise make population the more permissive way
+    // in, which is the shape of every bug in this area.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "pages",
+          localized: true,
+          status: true,
+          access: { create: () => true, update: () => true },
+          fields: [
+            text({ name: "title", localized: false }),
+            text({ name: "region" }),
+          ],
+        }),
+        defineCollection({
+          slug: "refs",
+          fields: [
+            text({ name: "name" }),
+            relationship({
+              name: "targets",
+              relationTo: "pages",
+              hasMany: true,
+            }),
+          ],
+        }),
+      ],
+      localization: { locales: ["en", "de"], defaultLocale: "en" },
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const page = await handler.createEntry(
+      { collectionName: "pages", overrideAccess: true },
+      { title: "Page", region: "apac", status: "published" }
+    );
+    const pageId = (page.data as { id: string }).id;
+    const ref = await handler.createEntry(
+      { collectionName: "refs", overrideAccess: true },
+      { name: "r", targets: [pageId] }
+    );
+    const refId = (ref.data as { id: string }).id;
+    await current.adapter.update(
+      "dynamic_collections",
+      { access_rules: { read: { type: "custom", functionPath: RULE_PATH } } },
+      { and: [{ column: "slug", op: "=", value: "pages" }] }
+    );
+
+    // The German translation carries the permitted value and is NOT published.
+    // Written into the migration-owned companion table directly, through the
+    // typed adapter: the write path cannot currently produce this state (a
+    // localized update of a status-enabled collection fails), and the state is
+    // the premise of the test rather than the thing under test.
+    await current.adapter.insert("dc_pages_locales", {
+      _parent: pageId,
+      _locale: "de",
+      _status: "draft",
+      region: "emea",
+    });
+
+    // Asserted, not assumed: the row has to be there AND be a draft, or the
+    // withholding below would prove nothing (an absent row withholds too).
+    const seeded = (
+      (await current.adapter.select("dc_pages_locales")) as Record<
+        string,
+        unknown
+      >[]
+    ).find(row => row._locale === "de");
+    expect(seeded, "the German translation should exist").toBeDefined();
+    expect(seeded!._status).toBe("draft");
+    expect(seeded!.region).toBe("emea");
+
+    expect(await populatedIds(handler, refId, "emea-only", "de")).toEqual([]);
+
+    // Publishing that same translation admits the row, so the withholding above
+    // is about its status and not about the language, the value, or a missing
+    // companion row.
+    await current.adapter.update(
+      "dc_pages_locales",
+      { _status: "published" },
+      {
+        and: [
+          { column: "_parent", op: "=", value: pageId },
+          { column: "_locale", op: "=", value: "de" },
+        ],
+      }
+    );
+
+    expect(await populatedIds(handler, refId, "emea-only", "de")).toEqual([
+      pageId,
+    ]);
+  });
+
+  it("withholds a localized predicate that cannot be translated exactly", async () => {
+    const { handler, refId } = await boot();
+
+    // Having a companion context does not make every shape applicable. A dotted
+    // path translates to a comparison against the whole value, which is a
+    // different predicate than the rule states — so it is still refused, and
+    // refusal still reads as an absent relationship rather than an error.
+    expect(await populatedIds(handler, refId, "dotted-localized")).toEqual([]);
+  });
+});

--- a/packages/nextly/src/domains/collections/__tests__/localized-target-predicate.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/localized-target-predicate.integration.test.ts
@@ -169,6 +169,58 @@ async function listedIds(
   return (result.data!.docs as { id: string }[]).map(doc => doc.id);
 }
 
+/**
+ * A status-enabled localized `pages` guarded by the same rule, with one row that
+ * `refs` points at. The main row's status is the caller's to choose, because
+ * status and per-locale status answer separately and each has to be pinned.
+ */
+async function bootStatusPages(mainStatus: "draft" | "published"): Promise<{
+  handler: CollectionsHandler;
+  pageId: string;
+  refId: string;
+}> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: "pages",
+        localized: true,
+        status: true,
+        access: { create: () => true, update: () => true },
+        fields: [
+          text({ name: "title", localized: false }),
+          text({ name: "region" }),
+        ],
+      }),
+      defineCollection({
+        slug: "refs",
+        fields: [
+          text({ name: "name" }),
+          relationship({ name: "targets", relationTo: "pages", hasMany: true }),
+        ],
+      }),
+    ],
+    localization: { locales: ["en", "de"], defaultLocale: "en" },
+  });
+  const handler = current.getService<CollectionsHandler>("collectionsHandler");
+
+  const page = await handler.createEntry(
+    { collectionName: "pages", overrideAccess: true },
+    { title: "Page", region: "apac", status: mainStatus }
+  );
+  const pageId = (page.data as { id: string }).id;
+  const ref = await handler.createEntry(
+    { collectionName: "refs", overrideAccess: true },
+    { name: "r", targets: [pageId] }
+  );
+  const refId = (ref.data as { id: string }).id;
+  await current.adapter.update(
+    "dynamic_collections",
+    { access_rules: { read: { type: "custom", functionPath: RULE_PATH } } },
+    { and: [{ column: "slug", op: "=", value: "pages" }] }
+  );
+  return { handler, pageId, refId };
+}
+
 describe("localized target read predicates (integration)", () => {
   it("populates a row its target's localized predicate admits", async () => {
     const { handler, emeaId, refId } = await boot();
@@ -237,57 +289,13 @@ describe("localized target read predicates (integration)", () => {
     // it. Expansion has to do the same: a draft translation holding the
     // permitted value would otherwise make population the more permissive way
     // in, which is the shape of every bug in this area.
-    current = await createTestNextly({
-      collections: [
-        defineCollection({
-          slug: "pages",
-          localized: true,
-          status: true,
-          access: { create: () => true, update: () => true },
-          fields: [
-            text({ name: "title", localized: false }),
-            text({ name: "region" }),
-          ],
-        }),
-        defineCollection({
-          slug: "refs",
-          fields: [
-            text({ name: "name" }),
-            relationship({
-              name: "targets",
-              relationTo: "pages",
-              hasMany: true,
-            }),
-          ],
-        }),
-      ],
-      localization: { locales: ["en", "de"], defaultLocale: "en" },
-    });
-    const handler =
-      current.getService<CollectionsHandler>("collectionsHandler");
-
-    const page = await handler.createEntry(
-      { collectionName: "pages", overrideAccess: true },
-      { title: "Page", region: "apac", status: "published" }
-    );
-    const pageId = (page.data as { id: string }).id;
-    const ref = await handler.createEntry(
-      { collectionName: "refs", overrideAccess: true },
-      { name: "r", targets: [pageId] }
-    );
-    const refId = (ref.data as { id: string }).id;
-    await current.adapter.update(
-      "dynamic_collections",
-      { access_rules: { read: { type: "custom", functionPath: RULE_PATH } } },
-      { and: [{ column: "slug", op: "=", value: "pages" }] }
-    );
+    const { handler, pageId, refId } = await bootStatusPages("published");
 
     // The German translation carries the permitted value and is NOT published.
-    // Written into the migration-owned companion table directly, through the
-    // typed adapter: the write path cannot currently produce this state (a
-    // localized update of a status-enabled collection fails), and the state is
-    // the premise of the test rather than the thing under test.
-    await current.adapter.insert("dc_pages_locales", {
+    // Seeded straight into the migration-owned companion through the typed
+    // adapter: the test needs one exact per-locale state, and stating it beats
+    // arranging a sequence of writes that happens to produce it.
+    await current!.adapter.insert("dc_pages_locales", {
       _parent: pageId,
       _locale: "de",
       _status: "draft",
@@ -297,7 +305,7 @@ describe("localized target read predicates (integration)", () => {
     // Asserted, not assumed: the row has to be there AND be a draft, or the
     // withholding below would prove nothing (an absent row withholds too).
     const seeded = (
-      (await current.adapter.select("dc_pages_locales")) as Record<
+      (await current!.adapter.select("dc_pages_locales")) as Record<
         string,
         unknown
       >[]
@@ -327,6 +335,48 @@ describe("localized target read predicates (integration)", () => {
     ]);
   });
 
+  it("does not admit a draft row whose published translation satisfies the rule", async () => {
+    // The other half of the status question, and the one the first version of
+    // this change got wrong: the companion EXISTS was constrained by the
+    // resolved status while the query selecting the MAIN row was not. A row
+    // whose main record is a draft but whose translation is published then
+    // satisfied the filter and came back, though the target's own list read
+    // excludes it for having a draft main row.
+    const { handler, pageId, refId } = await bootStatusPages("draft");
+
+    await current!.adapter.insert("dc_pages_locales", {
+      _parent: pageId,
+      _locale: "de",
+      _status: "published",
+      region: "emea",
+    });
+
+    // The disagreement, stated as the premise: the collection that owns this row
+    // does not serve it to this caller.
+    expect(await listedIds(handler, "emea-only", "de")).toEqual([]);
+    // So expansion must not serve it either.
+    expect(await populatedIds(handler, refId, "emea-only", "de")).toEqual([]);
+  });
+
+  it("still admits a published row whose published translation satisfies the rule", async () => {
+    // The mirror. Filtering the main row by status must not withhold the rows
+    // that pass it, which is what a status predicate applied to the wrong
+    // column — or to a collection without the column — would do.
+    const { handler, pageId, refId } = await bootStatusPages("published");
+
+    await current!.adapter.insert("dc_pages_locales", {
+      _parent: pageId,
+      _locale: "de",
+      _status: "published",
+      region: "emea",
+    });
+
+    expect(await listedIds(handler, "emea-only", "de")).toEqual([pageId]);
+    expect(await populatedIds(handler, refId, "emea-only", "de")).toEqual([
+      pageId,
+    ]);
+  });
+
   it("looks the target's companion schema up once for the whole expansion", async () => {
     // Pinned by measurement rather than by intent. The built companion table is
     // cached inside the file manager, but every lookup still costs a collection
@@ -350,6 +400,32 @@ describe("localized target read predicates (integration)", () => {
         call => call[0] === "pages"
       ).length;
       expect(pagesLookups).toBe(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("looks up no companion for a predicate naming only real columns", async () => {
+    // The ordinary case, and the one that must stay free: an owner or tenant
+    // predicate on a plain column has nothing to resolve in a companion, so a
+    // localized application should not pay a metadata read per target for the
+    // possibility. Counted rather than reasoned about, for the same reason as
+    // the test above.
+    const { handler, emeaId, refId } = await boot();
+    const spy = vi.spyOn(
+      CollectionFileManager.prototype,
+      "loadCompanionSchema"
+    );
+    try {
+      // The predicate really ran — without this the zero below would also be
+      // satisfied by a rule that never reached the narrowing at all.
+      expect(await populatedIds(handler, refId, "title-only")).toEqual([
+        emeaId,
+      ]);
+
+      expect(spy.mock.calls.filter(call => call[0] === "pages")).toHaveLength(
+        0
+      );
     } finally {
       spy.mockRestore();
     }

--- a/packages/nextly/src/domains/collections/__tests__/localized-target-predicate.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/localized-target-predicate.integration.test.ts
@@ -90,13 +90,28 @@ async function boot(): Promise<Seeded> {
 
   // The German translation of the permitted page says something else, so the
   // language the filter names decides whether it is readable.
-  await handler.updateEntry({
-    collectionName: "pages",
-    entryId: emeaId,
-    data: { region: "apac" },
-    locale: "de",
-    overrideAccess: true,
-  });
+  const translated = await handler.updateEntry(
+    {
+      collectionName: "pages",
+      entryId: emeaId,
+      locale: "de",
+      overrideAccess: true,
+    },
+    { region: "apac" }
+  );
+  expect(translated.success, "the German translation should be written").toBe(
+    true
+  );
+  // Asserted because an absent translation withholds for the same reason a
+  // non-matching one does: without this, a test asserting "German withholds"
+  // would pass on a page that simply has no German row.
+  const german = (
+    (await current.adapter.select("dc_pages_locales")) as Record<
+      string,
+      unknown
+    >[]
+  ).find(row => row._parent === emeaId && row._locale === "de");
+  expect(german?.region).toBe("apac");
 
   const ref = await handler.createEntry(
     { collectionName: "refs", overrideAccess: true },

--- a/packages/nextly/src/domains/collections/__tests__/localized-target-predicate.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/localized-target-predicate.integration.test.ts
@@ -206,10 +206,14 @@ describe("localized target read predicates (integration)", () => {
   it("agrees with the target collection's own list read", async () => {
     const { handler, refId } = await boot();
 
-    // The property the whole change exists to establish: a row is readable
-    // through a relationship exactly when the collection that owns it says it
-    // is readable. Asserted per language, because the rule answers each one
-    // differently.
+    // What this change exists to establish: for a rule filtering on a localized
+    // field, expansion admits exactly the rows the collection's own list read
+    // admits. Asserted per language, because the rule answers each differently.
+    //
+    // Scoped to that rule deliberately. The two paths still differ elsewhere —
+    // a list read filters main rows by status and expansion does not, and
+    // `getEntry` applies no query predicate at all — so a blanket equality
+    // between them would be asserting something untrue.
     for (const locale of ["en", "de"]) {
       expect(await populatedIds(handler, refId, "emea-only", locale)).toEqual(
         await listedIds(handler, "emea-only", locale)

--- a/packages/nextly/src/domains/collections/__tests__/localized-target-predicate.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/localized-target-predicate.integration.test.ts
@@ -15,13 +15,14 @@
  * was missing is the language, and it can only come from the read that asked.
  */
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { defineCollection, relationship, text } from "../../../config";
 import {
   createTestNextly,
   type TestNextly,
 } from "../../../plugins/test-nextly";
+import { CollectionFileManager } from "../../../services/collection-file-manager";
 import type { CollectionsHandler } from "../../../services/collections-handler";
 
 let current: TestNextly | undefined;
@@ -320,6 +321,34 @@ describe("localized target read predicates (integration)", () => {
     expect(await populatedIds(handler, refId, "emea-only", "de")).toEqual([
       pageId,
     ]);
+  });
+
+  it("looks the target's companion schema up once for the whole expansion", async () => {
+    // Pinned by measurement rather than by intent. The built companion table is
+    // cached inside the file manager, but every lookup still costs a collection
+    // metadata read — and the single-entry `hasMany` path confirms one reference
+    // at a time, so an uncached lookup scales with the number of references
+    // rather than the number of target collections.
+    const { handler, refId } = await boot();
+    // Spied after boot so only what the read does is counted, and on the
+    // prototype because the file manager is built inside the collection
+    // service's factory rather than registered under its own name.
+    const spy = vi.spyOn(
+      CollectionFileManager.prototype,
+      "loadCompanionSchema"
+    );
+    try {
+      // Both references are confirmed, so the count describes a real walk over
+      // more than one value rather than a single-reference shortcut.
+      expect(await populatedIds(handler, refId, "emea-only")).toHaveLength(1);
+
+      const pagesLookups = spy.mock.calls.filter(
+        call => call[0] === "pages"
+      ).length;
+      expect(pagesLookups).toBe(1);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("withholds a localized predicate that cannot be translated exactly", async () => {

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -2606,6 +2606,12 @@ export class CollectionMutationService extends BaseService {
               user: params.user,
               overrideAccess: params.overrideAccess,
               authenticatedScope: params.authenticatedScope,
+              // The language just written, so a target collection whose read
+              // rule filters on one of its own localized fields is judged in
+              // the same language the response reports.
+              locale: this.localization
+                ? resolveRequestedLocale(this.localization, params.locale)
+                : undefined,
             }
           );
         } catch (expansionError) {
@@ -5150,6 +5156,12 @@ export class CollectionMutationService extends BaseService {
               user: params.user,
               overrideAccess: params.overrideAccess,
               authenticatedScope: params.authenticatedScope,
+              // The language just written, so a target collection whose read
+              // rule filters on one of its own localized fields is judged in
+              // the same language the response reports.
+              locale: this.localization
+                ? resolveRequestedLocale(this.localization, params.locale)
+                : undefined,
             }
           );
         } catch (expansionError) {

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -39,6 +39,7 @@ import type {
 import type { CollectionRelationshipService } from "../../../services/collections/collection-relationship-service";
 import {
   buildDrizzleCondition,
+  buildLocalizedWhereExists,
   type LocalizedQueryContext,
 } from "../../../services/collections/drizzle-condition";
 import {
@@ -320,101 +321,6 @@ export class CollectionQueryService extends BaseService {
         companion.hasStatus && statusFilterValue
           ? statusFilterValue
           : undefined,
-    });
-  }
-
-  /**
-   * Build a companion EXISTS condition for a where-filter on a localized field (i18n M4c).
-   * Maps the where operator to a SQL predicate on the companion column for the requested locale.
-   * Returns `undefined` for operators not supported over the companion (caller falls through).
-   */
-  private buildLocalizedWhereExists(
-    ctx: LocalizedQueryContext,
-    column: string,
-    op: string,
-    value: unknown,
-    dialect: string
-  ): ReturnType<typeof sql> | undefined {
-    const t = sql.identifier(ctx.companionTableName);
-    const col = sql.identifier(column);
-    let valueCondition: ReturnType<typeof sql> | undefined;
-    switch (op) {
-      case "=":
-        valueCondition = sql`${t}.${col} = ${value}`;
-        break;
-      case "!=":
-        valueCondition = sql`${t}.${col} <> ${value}`;
-        break;
-      case ">":
-        valueCondition = sql`${t}.${col} > ${value}`;
-        break;
-      case ">=":
-        valueCondition = sql`${t}.${col} >= ${value}`;
-        break;
-      case "<":
-        valueCondition = sql`${t}.${col} < ${value}`;
-        break;
-      case "<=":
-        valueCondition = sql`${t}.${col} <= ${value}`;
-        break;
-      case "LIKE":
-        valueCondition = sql`${t}.${col} LIKE ${value}`;
-        break;
-      case "ILIKE":
-        valueCondition =
-          dialect === "postgresql"
-            ? sql`${t}.${col} ILIKE ${value}`
-            : sql`${t}.${col} LIKE ${value}`;
-        break;
-      case "IS NULL": {
-        // A localized field is absent for the locale when no companion row holds
-        // a value — an untranslated entry usually has no companion row at all.
-        // Match those with NOT EXISTS(row with a value) rather than
-        // EXISTS(col IS NULL), which would require a companion row to exist.
-        const present = buildCompanionExists({
-          companionTableName: ctx.companionTableName,
-          mainIdColumn: ctx.mainIdColumn,
-          locale: ctx.locale,
-          valueCondition: sql`${t}.${col} IS NOT NULL`,
-          statusValue: ctx.statusValue,
-        });
-        return sql`NOT ${present}`;
-      }
-      case "IS NOT NULL":
-        valueCondition = sql`${t}.${col} IS NOT NULL`;
-        break;
-      case "IN":
-        if (Array.isArray(value) && value.length > 0) {
-          // Expand the array into an SQL list; a bare array bind would emit
-          // `col IN $1` and compare against the whole array as one value.
-          const inList = sql.join(
-            value.map(v => sql`${v}`),
-            sql`, `
-          );
-          valueCondition = sql`${t}.${col} IN (${inList})`;
-        }
-        break;
-      case "NOT IN":
-        if (Array.isArray(value) && value.length > 0) {
-          // Expand into an SQL list, mirroring the IN case; without this the
-          // localized not_in filter is silently dropped and excludes nothing.
-          const notInList = sql.join(
-            value.map(v => sql`${v}`),
-            sql`, `
-          );
-          valueCondition = sql`${t}.${col} NOT IN (${notInList})`;
-        }
-        break;
-      default:
-        return undefined;
-    }
-    if (!valueCondition) return undefined;
-    return buildCompanionExists({
-      companionTableName: ctx.companionTableName,
-      mainIdColumn: ctx.mainIdColumn,
-      locale: ctx.locale,
-      valueCondition,
-      statusValue: ctx.statusValue,
     });
   }
 
@@ -1157,6 +1063,10 @@ export class CollectionQueryService extends BaseService {
             user: params.user,
             overrideAccess: params.overrideAccess,
             authenticatedScope: params.authenticatedScope,
+            // The language this read resolved to, so a target collection whose
+            // read rule filters on a localized field can have that filter
+            // applied against the right companion rows instead of withholding.
+            locale: localeChain?.[0],
           }
         );
 
@@ -1190,6 +1100,9 @@ export class CollectionQueryService extends BaseService {
               // Shared across every component row this listing expands, so
               // rows pointing at the same target resolve its policy once.
               targetPolicies: new Map(),
+              // A relationship inside a component points at a collection whose
+              // read rule may filter on one of its own localized fields.
+              locale: localeChain?.[0],
             },
           });
       }
@@ -2013,13 +1926,19 @@ export class CollectionQueryService extends BaseService {
         };
       }
 
+      // Resolved once and reused: relationship expansion below needs the same
+      // language, so deriving it twice would let the two drift.
+      const localeChain = this.resolveLocaleChain(
+        params.locale,
+        params.fallbackLocale
+      );
       // i18n M4: resolve localized fields from the companion `_locales` table for the
       // requested language (with fallback) BEFORE relationship expansion / hooks, so every
       // downstream consumer sees the translated values. No-op for non-localized collections.
       await this.populateLocalized(
         params.collectionName,
         [entry as Record<string, unknown>],
-        this.resolveLocaleChain(params.locale, params.fallbackLocale),
+        localeChain,
         undefined,
         statusFilter?.value ?? null // i18n M6: per-locale published filter
       );
@@ -2069,6 +1988,9 @@ export class CollectionQueryService extends BaseService {
           user: params.user,
           overrideAccess: params.overrideAccess,
           authenticatedScope: params.authenticatedScope,
+          // As on the list path: the language a target collection's read rule is
+          // evaluated in when its predicate names a localized field.
+          locale: localeChain?.[0],
         }
       );
 
@@ -2095,6 +2017,9 @@ export class CollectionQueryService extends BaseService {
             user: params.user,
             overrideAccess: params.overrideAccess,
             authenticatedScope: params.authenticatedScope,
+            // As on the list path: a component's relationship reaches a
+            // collection that may scope reads by a localized field.
+            locale: localeChain?.[0],
           },
         });
       }
@@ -2346,8 +2271,7 @@ export class CollectionQueryService extends BaseService {
       schema,
       dialect,
       localizedCtx,
-      (ctx, column, op, value, d) =>
-        this.buildLocalizedWhereExists(ctx, column, op, value, d)
+      buildLocalizedWhereExists
     );
   }
 

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1100,6 +1100,7 @@ export class CollectionQueryService extends BaseService {
               // Shared across every component row this listing expands, so
               // rows pointing at the same target resolve its policy once.
               targetPolicies: new Map(),
+              targetCompanions: new Map(),
               // A relationship inside a component points at a collection whose
               // read rule may filter on one of its own localized fields.
               locale: localeChain?.[0],

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -21,7 +21,10 @@ import {
   describeUntranslatableConstraint,
   stripNoOpConstraintMembers,
 } from "../../../services/access/constraint-shape";
-import type { CollectionFileManager } from "../../../services/collection-file-manager";
+import type {
+  CollectionFileManager,
+  CompanionSchema,
+} from "../../../services/collection-file-manager";
 import {
   buildDrizzleCondition,
   buildLocalizedWhereExists,
@@ -113,6 +116,18 @@ interface RelatedRowAccess {
    */
   targetPolicies?: Map<string, Promise<TargetReadPolicy>>;
   /**
+   * Companion schemas already looked up during this expansion, for the same
+   * reason {@link RelatedRowAccess.targetPolicies} exists.
+   *
+   * Loading one costs a collection-metadata read even though the built table is
+   * itself cached, and a `hasMany` relationship on the single-entry path
+   * confirms one reference at a time — so resolving per confirmation turns a
+   * relationship with hundreds of values into hundreds of metadata reads.
+   * Populated only when a rule actually needs a companion filter, so a target
+   * without one pays nothing.
+   */
+  targetCompanions?: Map<string, Promise<CompanionSchema | null>>;
+  /**
    * The language the surrounding read resolved to, used when a target
    * collection's read rule filters on a localized field.
    *
@@ -201,6 +216,14 @@ export interface RelationshipExpansionOptions {
    * @internal
    */
   targetPolicies?: Map<string, Promise<TargetReadPolicy>>;
+
+  /**
+   * Companion schemas already looked up during this expansion, carried by a
+   * nested hop for the same reason the policy map is.
+   *
+   * @internal
+   */
+  targetCompanions?: Map<string, Promise<CompanionSchema | null>>;
 
   /**
    * The caller's authenticated scope, when one applies.
@@ -1293,6 +1316,25 @@ export class CollectionRelationshipService extends BaseService {
   }
 
   /**
+   * The target collection's companion schema, looked up once per expansion.
+   *
+   * The PENDING lookup is cached rather than its result: references are
+   * confirmed concurrently, so every one of them reaches this point before the
+   * first has anything to store, and caching only the settled value leaves each
+   * issuing its own metadata read.
+   */
+  private resolveTargetCompanion(
+    targetCollection: string,
+    access: RelatedRowAccess
+  ): Promise<CompanionSchema | null> {
+    const cached = access.targetCompanions?.get(targetCollection);
+    if (cached) return cached;
+    const pending = this.fileManager.loadCompanionSchema(targetCollection);
+    access.targetCompanions?.set(targetCollection, pending);
+    return pending;
+  }
+
+  /**
    * The companion context a predicate on a localized field of the TARGET
    * collection needs, or null when there is none to build.
    *
@@ -1315,8 +1357,10 @@ export class CollectionRelationshipService extends BaseService {
     access: RelatedRowAccess
   ): Promise<LocalizedQueryContext | null> {
     if (!access.locale || isSystemEntity(targetCollection)) return null;
-    const companion =
-      await this.fileManager.loadCompanionSchema(targetCollection);
+    const companion = await this.resolveTargetCompanion(
+      targetCollection,
+      access
+    );
     if (!companion || companion.localizedFields.length === 0) return null;
 
     // The status an untrusted read of this target resolves to, asked of the
@@ -1589,6 +1633,10 @@ export class CollectionRelationshipService extends BaseService {
       // the outermost call, because a collection's rules can change between
       // requests.
       targetPolicies: options.targetPolicies ?? new Map(),
+      // Shared and inherited exactly as the policy map is, for the same reason:
+      // a nested hop starting its own would re-read the metadata of a collection
+      // an ancestor already looked up.
+      targetCompanions: options.targetCompanions ?? new Map(),
     };
 
     // Clamp depth to valid range
@@ -2242,6 +2290,10 @@ export class CollectionRelationshipService extends BaseService {
       // the outermost call, because a collection's rules can change between
       // requests.
       targetPolicies: options.targetPolicies ?? new Map(),
+      // Shared and inherited exactly as the policy map is, for the same reason:
+      // a nested hop starting its own would re-read the metadata of a collection
+      // an ancestor already looked up.
+      targetCompanions: options.targetCompanions ?? new Map(),
     };
 
     // Clamp depth to valid range

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -11,6 +11,7 @@ import {
   keysToCamelCase,
 } from "../../../lib/case-conversion";
 import { absolutizeMediaUrls } from "../../../lib/media-variant";
+import { resolveStatusFilter } from "../../../lib/status-filter";
 import {
   AccessControlService,
   DEFAULT_OWNER_FIELD,
@@ -21,7 +22,11 @@ import {
   stripNoOpConstraintMembers,
 } from "../../../services/access/constraint-shape";
 import type { CollectionFileManager } from "../../../services/collection-file-manager";
-import { buildDrizzleCondition } from "../../../services/collections/drizzle-condition";
+import {
+  buildDrizzleCondition,
+  buildLocalizedWhereExists,
+  type LocalizedQueryContext,
+} from "../../../services/collections/drizzle-condition";
 import {
   buildWhereClause,
   type WhereFilter,
@@ -107,6 +112,20 @@ interface RelatedRowAccess {
    * instead of once per value.
    */
   targetPolicies?: Map<string, Promise<TargetReadPolicy>>;
+  /**
+   * The language the surrounding read resolved to, used when a target
+   * collection's read rule filters on a localized field.
+   *
+   * Already resolved by the caller — the requested locale, or the default when
+   * none was asked for — because resolving it needs the localization config and
+   * this service has none. Absent means no companion filter can be built, so
+   * such a rule withholds its rows.
+   *
+   * This does NOT make expansion return a related row's translated values: a
+   * related row is still read from its main table. It decides only which
+   * language a rule's predicate is evaluated against.
+   */
+  locale?: string;
 }
 
 /** A target collection's read policy, as one expansion needs it. */
@@ -191,6 +210,15 @@ export interface RelationshipExpansionOptions {
    * owner's session would get.
    */
   authenticatedScope?: AuthenticatedScope;
+
+  /**
+   * The language this read resolved to, forwarded so a target collection's read
+   * rule can be applied when it filters on a localized field.
+   *
+   * Pass the resolved locale, not the raw request parameter: see
+   * {@link RelatedRowAccess.locale}.
+   */
+  locale?: string;
 }
 
 /**
@@ -1070,7 +1098,8 @@ export class CollectionRelationshipService extends BaseService {
         this.narrowByTargetPredicate(
           targetCollection,
           group,
-          predicates.get(key) as Record<string, unknown>
+          predicates.get(key) as Record<string, unknown>,
+          access
         )
       )
     );
@@ -1172,7 +1201,8 @@ export class CollectionRelationshipService extends BaseService {
   private async narrowByTargetPredicate(
     targetCollection: string,
     rows: Record<string, unknown>[],
-    constraint: Record<string, unknown>
+    constraint: Record<string, unknown>,
+    access: RelatedRowAccess
   ): Promise<Record<string, unknown>[] | null> {
     try {
       const schema = isSystemEntity(targetCollection)
@@ -1180,12 +1210,22 @@ export class CollectionRelationshipService extends BaseService {
         : await this.fileManager.loadDynamicSchema(targetCollection);
       if (!schema) return [];
 
+      const localizedCtx = await this.buildTargetLocalizedContext(
+        targetCollection,
+        schema,
+        access
+      );
+
       const untranslatable = describeUntranslatableConstraint(
         constraint,
         name => Object.prototype.hasOwnProperty.call(schema, name),
-        // No companion support on this path, so a filter on a localized field
-        // is reported untranslatable here rather than quietly dropped.
-        () => false
+        // A localized field has no column on the main table, so it counts as
+        // translatable only while a companion context is in hand. Without one
+        // it is reported untranslatable and the rows are withheld, rather than
+        // the member being dropped and the read running under a weaker
+        // predicate than the rule states.
+        name =>
+          Boolean(localizedCtx?.localizedFields.some(f => f.name === name))
       );
       if (untranslatable !== null) {
         this.logger.warn(
@@ -1203,7 +1243,9 @@ export class CollectionRelationshipService extends BaseService {
       const condition = buildDrizzleCondition(
         buildWhereClause(restricting as WhereFilter),
         schema,
-        this.adapter.dialect ?? "postgresql"
+        this.adapter.dialect ?? "postgresql",
+        localizedCtx,
+        buildLocalizedWhereExists
       );
       // A constraint that restricts on paper and compiles to nothing would
       // admit every row. Withhold instead: the rule asked to narrow.
@@ -1248,6 +1290,55 @@ export class CollectionRelationshipService extends BaseService {
       // caller must not report this as a refusal — nothing was decided.
       return null;
     }
+  }
+
+  /**
+   * The companion context a predicate on a localized field of the TARGET
+   * collection needs, or null when there is none to build.
+   *
+   * A localized field has no column on the main table — it lives in the
+   * collection's `_locales` companion, one row per language — so a predicate
+   * naming one can only be applied as a subquery against that table. Without
+   * this the field looked like a column the target does not have, and every row
+   * behind such a rule was withheld from expansion while a list read of the
+   * same collection returned them.
+   *
+   * Null when the target is not localized, or when no locale reached this
+   * expansion: a companion filter has to name one language, and the read that
+   * asked for every language at once (or never said) has no single answer.
+   * Withholding is the outcome then, unchanged from before.
+   */
+  private async buildTargetLocalizedContext(
+    targetCollection: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle dynamic schema
+    schema: any,
+    access: RelatedRowAccess
+  ): Promise<LocalizedQueryContext | null> {
+    if (!access.locale || isSystemEntity(targetCollection)) return null;
+    const companion =
+      await this.fileManager.loadCompanionSchema(targetCollection);
+    if (!companion || companion.localizedFields.length === 0) return null;
+
+    // The status an untrusted read of this target resolves to, asked of the
+    // helper that owns that decision rather than restated here. A companion row
+    // in another state must not satisfy the filter: a draft translation holding
+    // the permitted value would otherwise admit a row that the target's own
+    // list read, filtering on the same resolved status, excludes.
+    const statusFilter = resolveStatusFilter({
+      collectionHasStatus: companion.hasStatus,
+      overrideAccess: access.overrideAccess === true,
+      explicit: undefined,
+    });
+
+    return {
+      companionTableName: companion.companionTableName,
+      localizedFields: companion.localizedFields,
+      // The same table object the confirming query selects FROM, so the
+      // companion's `_parent` correlates against the row being judged.
+      mainIdColumn: schema.id,
+      locale: access.locale,
+      statusValue: statusFilter?.value,
+    };
   }
 
   /**
@@ -1488,6 +1579,7 @@ export class CollectionRelationshipService extends BaseService {
       user: options.user,
       overrideAccess: options.overrideAccess,
       authenticatedScope: options.authenticatedScope,
+      locale: options.locale,
       withheldByAccess: options.withheldByAccess,
       // One per expansion, so a relationship holding many references reads its
       // target's rules once rather than once per value. A nested hop inherits
@@ -2140,6 +2232,7 @@ export class CollectionRelationshipService extends BaseService {
       user: options.user,
       overrideAccess: options.overrideAccess,
       authenticatedScope: options.authenticatedScope,
+      locale: options.locale,
       withheldByAccess: options.withheldByAccess,
       // One per expansion, so a relationship holding many references reads its
       // target's rules once rather than once per value. A nested hop inherits

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -146,6 +146,12 @@ interface RelatedRowAccess {
 /** A target collection's read policy, as one expansion needs it. */
 export interface TargetReadPolicy {
   rules: CollectionAccessRules | undefined;
+  /**
+   * Whether the collection has Draft/Published, so a read of it can resolve the
+   * status its rows are filtered by. Taken from the same record the rules come
+   * from rather than looked up separately.
+   */
+  hasStatus: boolean;
 }
 
 /**
@@ -1122,7 +1128,8 @@ export class CollectionRelationshipService extends BaseService {
           targetCollection,
           group,
           predicates.get(key) as Record<string, unknown>,
-          access
+          access,
+          policy
         )
       )
     );
@@ -1201,6 +1208,7 @@ export class CollectionRelationshipService extends BaseService {
         rules: accessService.getAccessRules(
           collection as Record<string, unknown>
         ),
+        hasStatus: (collection as { status?: boolean }).status === true,
       };
     })();
     access.targetPolicies?.set(targetCollection, pending);
@@ -1225,7 +1233,8 @@ export class CollectionRelationshipService extends BaseService {
     targetCollection: string,
     rows: Record<string, unknown>[],
     constraint: Record<string, unknown>,
-    access: RelatedRowAccess
+    access: RelatedRowAccess,
+    policy: TargetReadPolicy
   ): Promise<Record<string, unknown>[] | null> {
     try {
       const schema = isSystemEntity(targetCollection)
@@ -1233,10 +1242,23 @@ export class CollectionRelationshipService extends BaseService {
         : await this.fileManager.loadDynamicSchema(targetCollection);
       if (!schema) return [];
 
+      // The status a read of this target resolves to for this caller, asked of
+      // the helper that owns that decision rather than restated here. It applies
+      // to the row AND to any companion row consulted about it: constraining
+      // only one of the two admits a draft row whose published translation
+      // satisfies the rule.
+      const statusFilter = resolveStatusFilter({
+        collectionHasStatus: policy.hasStatus,
+        overrideAccess: access.overrideAccess === true,
+        explicit: undefined,
+      });
+
       const localizedCtx = await this.buildTargetLocalizedContext(
         targetCollection,
         schema,
-        access
+        access,
+        constraint,
+        statusFilter?.value
       );
 
       const untranslatable = describeUntranslatableConstraint(
@@ -1287,13 +1309,23 @@ export class CollectionRelationshipService extends BaseService {
       // ownership or tenant reassignment that also replaced the contents — the
       // caller would be handed the version that belonged to whoever held it
       // before. Authorization and the data it admits come from one read.
+      // Guarded on the column and not on the flag alone: naming a column the
+      // table does not have fails the whole query, and the catch below would
+      // then withhold every row of the collection.
+      const statusCondition =
+        statusFilter && schema.status
+          ? eq(schema.status, statusFilter.value)
+          : undefined;
       const admitted = (await this.db
         .select()
         .from(schema)
-        .where(and(inArray(schema.id, ids), condition))) as Record<
-        string,
-        unknown
-      >[];
+        .where(
+          and(
+            inArray(schema.id, ids),
+            ...(statusCondition ? [statusCondition] : []),
+            condition
+          )
+        )) as Record<string, unknown>[];
       const fresh = new Map(
         admitted.map(row => {
           const normalized = convertTimestampsToCamelCase({ ...row });
@@ -1349,30 +1381,37 @@ export class CollectionRelationshipService extends BaseService {
    * expansion: a companion filter has to name one language, and the read that
    * asked for every language at once (or never said) has no single answer.
    * Withholding is the outcome then, unchanged from before.
+   *
+   * Also null when the constraint names only columns the target already has.
+   * Looking a companion up costs a collection-metadata read, and the ordinary
+   * case — an owner or tenant predicate on a plain column — has nothing to
+   * resolve there, so a localized application would pay for every target it
+   * populates without a companion filter ever being built.
    */
   private async buildTargetLocalizedContext(
     targetCollection: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle dynamic schema
     schema: any,
-    access: RelatedRowAccess
+    access: RelatedRowAccess,
+    constraint: Record<string, unknown>,
+    /** The status a read of this target resolves to, or undefined for none. */
+    statusValue: string | undefined
   ): Promise<LocalizedQueryContext | null> {
     if (!access.locale || isSystemEntity(targetCollection)) return null;
+    // Judged on the raw constraint keys, which is what the untranslatable check
+    // inspects: a member naming something the table does not have is either a
+    // localized field or a mistake, and both have to reach that check with the
+    // same information it would otherwise be missing.
+    const namesNonColumn = Object.keys(constraint).some(
+      field => !Object.prototype.hasOwnProperty.call(schema, field)
+    );
+    if (!namesNonColumn) return null;
+
     const companion = await this.resolveTargetCompanion(
       targetCollection,
       access
     );
     if (!companion || companion.localizedFields.length === 0) return null;
-
-    // The status an untrusted read of this target resolves to, asked of the
-    // helper that owns that decision rather than restated here. A companion row
-    // in another state must not satisfy the filter: a draft translation holding
-    // the permitted value would otherwise admit a row that the target's own
-    // list read, filtering on the same resolved status, excludes.
-    const statusFilter = resolveStatusFilter({
-      collectionHasStatus: companion.hasStatus,
-      overrideAccess: access.overrideAccess === true,
-      explicit: undefined,
-    });
 
     return {
       companionTableName: companion.companionTableName,
@@ -1381,7 +1420,11 @@ export class CollectionRelationshipService extends BaseService {
       // companion's `_parent` correlates against the row being judged.
       mainIdColumn: schema.id,
       locale: access.locale,
-      statusValue: statusFilter?.value,
+      // A companion row in another state must not satisfy the filter: a draft
+      // translation holding the permitted value would otherwise admit a row the
+      // target's own list read, filtering on the same status, excludes. Gated on
+      // the companion having the column, matching the read path.
+      statusValue: companion.hasStatus ? statusValue : undefined,
     };
   }
 

--- a/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
@@ -69,6 +69,17 @@ export interface ComponentReadAccess {
    * across them all rather than created per row.
    */
   targetPolicies?: Map<string, Promise<TargetReadPolicy>>;
+  /**
+   * The language the surrounding read resolved to, forwarded so a target
+   * collection's read rule can be applied when it filters on a localized field
+   * of that collection.
+   *
+   * Separate from this population's own `locale`, which decides which
+   * translation of the COMPONENT's fields to overlay. The two are the same
+   * language on every current caller, but they answer different questions and a
+   * component read that resolved no locale must not silently borrow one.
+   */
+  locale?: string;
 }
 
 export interface PopulateComponentDataParams {
@@ -1129,6 +1140,7 @@ export class FieldGroupQueryService extends BaseService {
           authenticatedScope: access.authenticatedScope,
           targetPolicies: access.targetPolicies,
           withheldByAccess: access.withheldByAccess,
+          locale: access.locale,
         }
       );
 

--- a/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
@@ -5,6 +5,7 @@ import type { FieldConfig } from "../../../collections/fields/types";
 import type { FieldGroupFieldConfig } from "../../../collections/fields/types/component";
 import type { DynamicFieldGroupRecord } from "../../../schemas/dynamic-field-groups/types";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
+import type { CompanionSchema } from "../../../services/collection-file-manager";
 import type { CollectionRelationshipService } from "../../../services/collections/collection-relationship-service";
 import type { FieldGroupRegistryService } from "../../../services/field-groups/field-group-registry-service";
 import { BaseService } from "../../../shared/base-service";
@@ -69,6 +70,12 @@ export interface ComponentReadAccess {
    * across them all rather than created per row.
    */
   targetPolicies?: Map<string, Promise<TargetReadPolicy>>;
+  /**
+   * Companion schemas resolved during this population, shared for the same
+   * reason the policy map is: component rows are expanded concurrently and rows
+   * pointing at the same target would otherwise each re-read its metadata.
+   */
+  targetCompanions?: Map<string, Promise<CompanionSchema | null>>;
   /**
    * The language the surrounding read resolved to, forwarded so a target
    * collection's read rule can be applied when it filters on a localized field
@@ -1139,6 +1146,7 @@ export class FieldGroupQueryService extends BaseService {
           overrideAccess: access.overrideAccess,
           authenticatedScope: access.authenticatedScope,
           targetPolicies: access.targetPolicies,
+          targetCompanions: access.targetCompanions,
           withheldByAccess: access.withheldByAccess,
           locale: access.locale,
         }

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -2223,6 +2223,12 @@ export class SingleMutationService extends BaseService {
           user: options.user,
           overrideAccess: options.overrideAccess,
           authenticatedScope: options.authenticatedScope,
+          // The language just written: a target collection's read rule may
+          // scope reads by one of its own localized fields, and that filter
+          // needs to name a language to be applied at all.
+          locale: this.localization
+            ? resolveRequestedLocale(this.localization, options.locale)
+            : undefined,
         }
       );
 

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -787,6 +787,12 @@ export class SingleQueryService extends BaseService {
     doc = this.deserializeJsonFields(doc, singleMeta.fields);
     params.captureReferences?.(doc);
     doc = await this.expandUploadFields(doc, singleMeta.fields);
+    // The language this read resolved to, shared by both expansions below so a
+    // related row and a related row inside a component are judged alike.
+    const readLocale = this.resolveLocaleChain(
+      options.locale,
+      options.fallbackLocale
+    )?.[0];
     doc = await this.expandRelationshipFields(
       doc,
       singleMeta.fields,
@@ -804,6 +810,9 @@ export class SingleQueryService extends BaseService {
         // Collects the references a target collection refused, so the
         // completeness check below reads them as absent on purpose.
         withheldByAccess: params.withheldByAccess,
+        // A target collection's read rule may filter on one of its own
+        // localized fields, which is a companion lookup rather than a column.
+        locale: readLocale,
       },
       strict,
       // The read path threads a caller, so the target collection's field rules
@@ -838,6 +847,7 @@ export class SingleQueryService extends BaseService {
             withheldByAccess: params.withheldByAccess,
             targetPolicies: new Map(),
             authenticatedScope: options.authenticatedScope,
+            locale: readLocale,
           },
           // Read errors otherwise become empty component values, which reads to a
           // rule exactly like a component that holds nothing.
@@ -2445,6 +2455,12 @@ export class SingleQueryService extends BaseService {
        */
       authenticatedScope?: AuthenticatedScope;
       withheldByAccess?: Set<string>;
+      /**
+       * The language this read resolved to, so a target collection's read rule
+       * can be applied when its predicate names a localized field of that
+       * collection. Absent leaves such a rule withholding its rows.
+       */
+      locale?: string;
     } = {},
     /**
      * Propagate expansion failures instead of returning the document
@@ -2500,6 +2516,7 @@ export class SingleQueryService extends BaseService {
           overrideAccess: access.overrideAccess,
           authenticatedScope: access.authenticatedScope,
           withheldByAccess: access.withheldByAccess,
+          locale: access.locale,
         }
       );
       return expandedDoc as SingleDocument;

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -846,6 +846,7 @@ export class SingleQueryService extends BaseService {
             // too, and the rows of one population share a policy cache.
             withheldByAccess: params.withheldByAccess,
             targetPolicies: new Map(),
+            targetCompanions: new Map(),
             authenticatedScope: options.authenticatedScope,
             locale: readLocale,
           },

--- a/packages/nextly/src/services/collections/__tests__/localized-where-exists.test.ts
+++ b/packages/nextly/src/services/collections/__tests__/localized-where-exists.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Every operator the where translator can emit has to be expressible against a
+ * companion table.
+ *
+ * A filter on a localized field is resolved by `buildLocalizedWhereExists`
+ * before the column lookup, and the column lookup cannot resolve such a field —
+ * it has no column on the main table. So an operator this returns `undefined`
+ * for is not approximated or refused, it is DROPPED: the member disappears and
+ * its siblings decide alone. For a caller's own filter that is merely wrong; for
+ * an access constraint it means the read runs under a weaker predicate than the
+ * rule states.
+ *
+ * Nothing in the type system ties the two sets together, so this asserts it.
+ * Adding an operator to the where translator without adding it here should fail
+ * this test rather than silently widen a localized access rule.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  buildWhereClause,
+  getSupportedOperators,
+  type WhereFilter,
+} from "../../../domains/collections/query/query-operators";
+import {
+  buildLocalizedWhereExists,
+  type LocalizedQueryContext,
+} from "../drizzle-condition";
+
+const CTX: LocalizedQueryContext = {
+  companionTableName: "dc_pages_locales",
+  localizedFields: [{ name: "region", column: "region" }],
+  // Only interpolated into the emitted SQL, never inspected here.
+  mainIdColumn: "id",
+  locale: "en",
+};
+
+/**
+ * A value each operator accepts, so the translator emits a condition rather
+ * than skipping the member for an unusable value.
+ */
+function sampleValue(operator: string): unknown {
+  if (operator === "in" || operator === "not_in") return ["emea"];
+  if (operator === "exists") return true;
+  return "emea";
+}
+
+/** The internal operators `buildWhereClause` produces for the public set. */
+function internalOperators(): {
+  operator: string;
+  op: string;
+  value: unknown;
+}[] {
+  return getSupportedOperators().map(operator => {
+    const value = sampleValue(operator);
+    const clause = buildWhereClause({
+      region: { [operator]: value },
+    } as WhereFilter);
+    const condition = clause?.and?.[0] as
+      | { op: string; value: unknown }
+      | undefined;
+    expect(
+      condition,
+      `buildWhereClause emitted nothing for "${operator}"`
+    ).toBeDefined();
+    return { operator, op: condition!.op, value: condition!.value };
+  });
+}
+
+describe("localized companion filters cover every translated operator", () => {
+  it.each(internalOperators())(
+    'expresses "$operator" ($op) against the companion table',
+    ({ operator, op, value }) => {
+      const condition = buildLocalizedWhereExists(
+        CTX,
+        "region",
+        op,
+        value,
+        "postgresql"
+      );
+
+      expect(
+        condition,
+        `operator "${operator}" translates to "${op}", which has no companion ` +
+          `form — a filter using it on a localized field would be dropped`
+      ).toBeDefined();
+    }
+  );
+
+  it("returns nothing for an operator it does not know", () => {
+    // The other half of the contract: an unrecognized operator must come back
+    // empty so the caller's own untranslatable check can refuse it, rather than
+    // being turned into some nearby condition.
+    expect(
+      buildLocalizedWhereExists(CTX, "region", "BETWEEN", [1, 2], "postgresql")
+    ).toBeUndefined();
+  });
+
+  it("constrains the companion row by locale", () => {
+    const condition = buildLocalizedWhereExists(
+      CTX,
+      "region",
+      "=",
+      "emea",
+      "postgresql"
+    );
+
+    // The locale has to reach the subquery: without it the filter matches a
+    // value in ANY language, which for an access rule admits rows on the
+    // strength of a translation the caller never asked for.
+    expect(condition!.queryChunks.length).toBeGreaterThan(0);
+    expect(JSON.stringify(condition)).toContain("_locale");
+  });
+
+  it("filters an untranslated field with NOT EXISTS rather than a null compare", () => {
+    // A field with no translation for the locale usually has no companion row at
+    // all, so `EXISTS(col IS NULL)` would match nothing and quietly exclude
+    // every untranslated row.
+    const condition = buildLocalizedWhereExists(
+      CTX,
+      "region",
+      "IS NULL",
+      null,
+      "postgresql"
+    );
+
+    expect(JSON.stringify(condition)).toContain("NOT");
+  });
+});

--- a/packages/nextly/src/services/collections/drizzle-condition.ts
+++ b/packages/nextly/src/services/collections/drizzle-condition.ts
@@ -30,9 +30,11 @@ import {
   isNull,
   isNotNull,
   or,
+  sql,
 } from "drizzle-orm";
 
 import type { LocalizedFieldRef } from "../../domains/i18n/companion-join";
+import { buildCompanionExists } from "../../domains/i18n/companion-join";
 
 import type { buildWhereClause } from "./query-operators";
 
@@ -65,6 +67,108 @@ export type LocalizedExistsBuilder = (
   value: unknown,
   dialect: string
 ) => SQL | undefined;
+
+/**
+ * Translate a filter on a localized field into a companion-table EXISTS.
+ *
+ * Sits beside the condition builder it feeds for the same reason that one is
+ * shared: a localized field is filtered by a subquery rather than a column, so
+ * a second implementation of this mapping would be free to disagree about an
+ * operator — and here the disagreement is invisible, because a filter that
+ * matches the wrong companion rows still returns a plausible result set.
+ *
+ * Returns `undefined` for an operator with no companion equivalent, leaving the
+ * caller to treat the filter as untranslated rather than as unrestricted.
+ */
+export function buildLocalizedWhereExists(
+  ctx: LocalizedQueryContext,
+  column: string,
+  op: string,
+  value: unknown,
+  dialect: string
+): SQL | undefined {
+  const t = sql.identifier(ctx.companionTableName);
+  const col = sql.identifier(column);
+  let valueCondition: SQL | undefined;
+  switch (op) {
+    case "=":
+      valueCondition = sql`${t}.${col} = ${value}`;
+      break;
+    case "!=":
+      valueCondition = sql`${t}.${col} <> ${value}`;
+      break;
+    case ">":
+      valueCondition = sql`${t}.${col} > ${value}`;
+      break;
+    case ">=":
+      valueCondition = sql`${t}.${col} >= ${value}`;
+      break;
+    case "<":
+      valueCondition = sql`${t}.${col} < ${value}`;
+      break;
+    case "<=":
+      valueCondition = sql`${t}.${col} <= ${value}`;
+      break;
+    case "LIKE":
+      valueCondition = sql`${t}.${col} LIKE ${value}`;
+      break;
+    case "ILIKE":
+      valueCondition =
+        dialect === "postgresql"
+          ? sql`${t}.${col} ILIKE ${value}`
+          : sql`${t}.${col} LIKE ${value}`;
+      break;
+    case "IS NULL": {
+      // A localized field is absent for the locale when no companion row holds
+      // a value — an untranslated entry usually has no companion row at all.
+      // Match those with NOT EXISTS(row with a value) rather than
+      // EXISTS(col IS NULL), which would require a companion row to exist.
+      const present = buildCompanionExists({
+        companionTableName: ctx.companionTableName,
+        mainIdColumn: ctx.mainIdColumn,
+        locale: ctx.locale,
+        valueCondition: sql`${t}.${col} IS NOT NULL`,
+        statusValue: ctx.statusValue,
+      });
+      return sql`NOT ${present}`;
+    }
+    case "IS NOT NULL":
+      valueCondition = sql`${t}.${col} IS NOT NULL`;
+      break;
+    case "IN":
+      if (Array.isArray(value) && value.length > 0) {
+        // Expand the array into an SQL list; a bare array bind would emit
+        // `col IN $1` and compare against the whole array as one value.
+        const inList = sql.join(
+          value.map(v => sql`${v}`),
+          sql`, `
+        );
+        valueCondition = sql`${t}.${col} IN (${inList})`;
+      }
+      break;
+    case "NOT IN":
+      if (Array.isArray(value) && value.length > 0) {
+        // Expand into an SQL list, mirroring the IN case; without this the
+        // localized not_in filter is silently dropped and excludes nothing.
+        const notInList = sql.join(
+          value.map(v => sql`${v}`),
+          sql`, `
+        );
+        valueCondition = sql`${t}.${col} NOT IN (${notInList})`;
+      }
+      break;
+    default:
+      return undefined;
+  }
+  if (!valueCondition) return undefined;
+  return buildCompanionExists({
+    companionTableName: ctx.companionTableName,
+    mainIdColumn: ctx.mainIdColumn,
+    locale: ctx.locale,
+    valueCondition,
+    statusValue: ctx.statusValue,
+  });
+}
 
 export function buildDrizzleCondition(
   whereClause: ReturnType<typeof buildWhereClause>,


### PR DESCRIPTION
A stored read rule can scope a collection by one of its own **localized**
fields. Those values are not columns on the main table — they live in the
collection's `_locales` companion, one row per language — so relationship
expansion saw a field the target does not have, reported the predicate
untranslatable, and withheld **every** row behind the rule. The same caller
listing that collection directly got them.

Continues #401, which made expansion ask the target collection before populating
its rows. This closes the one case that PR deliberately left open, and it is the
same bug class as everything before it: *a related row is a read of another
collection, and it was not being judged the way that collection judges a direct
read.*

## Re-audit probe, on `main` @ `1e0ef917`

`pages` has a localized `region` and the stored rule `{ region: { equals: "emea" } }`:

```
DIRECT LIST        ["EMEA page"]     predicate applied through the companion EXISTS
DIRECT GET emea    200               predicate not applied at all (known endpoint gap)
DIRECT GET apac    200               ditto: the excluded row is still readable directly
VIA RELATIONSHIP   "<bare id>"       withheld, though the rule permits it
```

The probe also settled a fact the plan had left implicit: a localized field has
**no main-table column**, so this was a total withhold rather than a filter
quietly running against default-language content.

## What changed

`buildTargetLocalizedContext` loads the **target** collection's companion schema
and builds the same `LocalizedQueryContext` the list path builds for the
collection it is reading.

`buildLocalizedWhereExists` moves out of `CollectionQueryService` into
`services/collections/drizzle-condition.ts`, beside the condition builder it
feeds. One implementation now serves a caller's own `where`, a stored constraint
on a read, and the same constraint during expansion — the anti-drift move #401
made for `buildDrizzleCondition`, applied to the piece that was still private.

| Decision | Why |
|---|---|
| the locale comes from the read, already resolved | resolving one needs the localization config, which this service does not have; the read paths already compute the chain and pass its head |
| `locale=all` builds no context, so such a rule still withholds | a companion filter has to name one language; choosing one would decide the read on a translation the caller never asked about |
| chain **head** only, not the fallback chain | exactly what the list path filters on, so the two agree — a translation existing only in the fallback locale satisfies neither |
| the EXISTS is constrained by the target's resolved status | an unpublished translation holding the permitted value would otherwise admit a row the target's own list read excludes, making expansion **looser** |
| the status comes from `resolveStatusFilter`, not restated here | if the default for an untrusted read ever changes, expansion follows instead of drifting |
| still withholds a shape that cannot translate exactly | a companion context does not make a dotted path applicable; refusal still reads as an absent relationship, never an error |

Threaded through every site that opts the gate in — collection list and single
read, both collection write responses, the Single read and write response, and
both component paths. Audited mechanically to zero misses.

## A latent hazard, found and pinned

`buildDrizzleCondition` tries the localized EXISTS builder first and falls
through to a column lookup, which cannot resolve a localized field. So an
operator the EXISTS builder does not implement is not refused — it is **dropped**,
and the sibling members decide alone. Every operator `OPERATOR_MAP` can emit is
implemented today, so there is no live gap, but nothing tied the two sets
together. `localized-where-exists.test.ts` now asserts the coverage and fails
with the offending operator named.

## One N+1 introduced, caught, and pinned

`loadCompanionSchema` caches the table object it builds but issues a collection
metadata read on **every** call — and the single-entry `hasMany` path confirms one
reference at a time, so a relationship with many values paid one read per value.
That is the cost the `targetPolicies` cache exists to remove, reintroduced beside
it. The companion lookup is now cached per expansion the same way: pending
promise (references are confirmed concurrently, so caching the settled value
helps nobody), inherited by nested hops (a child must not re-read what an
ancestor already looked up), and populated only when a rule actually needs a
companion filter.

Pinned by counting lookups, not by inspection — the round-3 lesson from #401 was
that a cache which stops working looks exactly like one that works.

## Verification

Eight integration tests and 15 unit tests, every fix revert-checked. Four
separate reverts, because four mechanisms are involved:

- **companion context removed** → 4 fail (admission, language, parity, status);
  the 3 withholding tests still pass, which is the pre-fix behaviour correctly
  unchanged.
- **read locale ignored, hardcoded** → 3 fail (language, parity, status).
- **an operator's companion form removed** → the unit guard fails, naming it.
- **companion cache disabled** → the lookup count goes 1 → 2.

The mirror is explicit: the row whose translation the rule excludes must stay
unpopulated, and the parity test asserts the populated set equals the target's
own list result **per language**.

One test-method correction worth recording: `updateEntry(params, body)` takes its
payload as a second argument. Passing `data` inside `params` writes nothing, so
the German translation the language assertions read never existed and
"reading in German withholds" passed because there was **no** German row rather
than because the German row said something else. Fixed, and both cases now assert
the row exists before reading it. The 500 that misuse produces
(`Cannot read properties of undefined (reading 'slug')`) reproduces identically on
unmodified `main` and is an invalid call, not a product defect.

Baselines: SQLite integration **793 passed / 0 failed** (927 with the
dialect-gated skips); unit failing-test name set compared against a fresh
baseline captured at the same commit.

## Not in this PR

- **Batching the single-entry `hasMany` load** — a change to how expansion
  *loads*, not how it authorizes. Tracked in `tasks/left-tasks/081-*.md`.
- **A populated related row carries no translations at all.** Probed and
  confirmed: expansion reads the target's main table and never overlays the
  companion, so a related row's localized fields are absent rather than stale.
  Separate gap, recorded as item 6 of `tasks/left-tasks/042-i18n-followups-batch.md`.
- **`getEntry` ignores custom query predicates**, so expansion is now stricter
  than that endpoint for predicate-scoped collections. That gap belongs to the
  endpoint; expansion should not be loosened to match it.
