### PR TITLE
refactor(nextly): read every related row through one path

### DIFF
--- a/.changeset/expansion-fetch-seam.md
+++ b/.changeset/expansion-fetch-seam.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Read every related row through one code path, so a capability added to relationship population applies everywhere a relationship is populated instead of at whichever call sites were remembered.

--- a/packages/nextly/src/domains/collections/services/__tests__/related-row-fetch-seam.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/related-row-fetch-seam.test.ts
@@ -1,0 +1,78 @@
+/**
+ * A related row is fetched in exactly one place.
+ *
+ * Six call sites used to select from a target table themselves, and every
+ * capability a related row was missing had to be added to each of them and then
+ * audited for the one that was forgotten — an audit that has been run three
+ * times (the caller's scope, the read locale, and two per-request caches). One
+ * reader is what makes the next capability a single change instead of a sweep.
+ *
+ * Guarded structurally because the invariant is about where code MAY fetch, and
+ * a behavioural test cannot see a seventh fetch site that happens to agree with
+ * the other six today. This is the check that fails when someone adds one.
+ */
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const SOURCE = new URL("../collection-relationship-service.ts", import.meta.url)
+  .pathname;
+
+/**
+ * The queries allowed to read rows directly, each for a stated reason. A new
+ * entry here is a decision, which is the point: adding one means explaining why
+ * this row does not go through the reader every other row goes through.
+ */
+const ALLOWED_DIRECT_READS = [
+  "readTargetRows — the reader itself",
+  "narrowByTargetPredicate — re-reads under the rule's own predicate, so the row and the authorization to serve it come from one query",
+  "fetchMediaByIds — media is not a collection: no read rules, no hooks, and its own URL absolutization",
+] as const;
+
+describe("related rows are fetched through one reader", () => {
+  it("has exactly one direct read per documented reason", () => {
+    const source = readFileSync(SOURCE, "utf8");
+
+    // Drizzle's builder is the only way this service reads a table, so counting
+    // `.select()` counts the fetch sites.
+    const directReads = source.match(/\.select\(\)/g) ?? [];
+
+    expect(
+      directReads,
+      `expected one direct read per documented reason:\n` +
+        ALLOWED_DIRECT_READS.map(reason => `  - ${reason}`).join("\n") +
+        `\n\nIf you added a fetch, route it through readTargetRows so it inherits ` +
+        `the target collection's read rules, redaction, and everything added to ` +
+        `expansion later. If it genuinely cannot, add it above with its reason.`
+    ).toHaveLength(ALLOWED_DIRECT_READS.length);
+  });
+
+  it("routes every relationship fetch through the reader", () => {
+    const source = readFileSync(SOURCE, "utf8");
+
+    // The reader plus its callers. Fewer than this means a path was rewired to
+    // fetch for itself again.
+    const usages = source.match(/readTargetRows\(/g) ?? [];
+
+    expect(usages.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("assembles an IN clause by hand only where Drizzle cannot", () => {
+    const source = readFileSync(SOURCE, "utf8");
+
+    // Junction tables are created by the many-to-many machinery and are not in
+    // the Drizzle schema, so there is no table object to give `inArray` and the
+    // list has to be built. Reading a target COLLECTION is different: it has a
+    // schema, and the one hand-built list there was justified as MySQL
+    // compatibility while the sibling batch path bound the same filter with
+    // `inArray` and passed on MySQL.
+    const handBuilt = source.match(/IN \(\$\{/g) ?? [];
+
+    expect(
+      handBuilt,
+      "the junction-table read is the only place a list may be assembled by " +
+        "hand. Anything with a Drizzle table object should use `inArray`, and " +
+        "reading a target collection's rows should go through readTargetRows."
+    ).toHaveLength(1);
+  });
+});

--- a/packages/nextly/src/domains/collections/services/__tests__/relationship-redaction.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/relationship-redaction.test.ts
@@ -42,15 +42,19 @@ function silentLogger() {
 }
 
 /**
- * Minimal adapter whose Drizzle handle answers the single-row
- * `select().from().where().limit()` chain fetchRelatedEntry uses.
+ * Minimal adapter whose Drizzle handle answers the
+ * `select().from().where()` chain every related-row read uses.
+ *
+ * Resolves at `where()` rather than at a trailing `limit()`: one reader now
+ * fetches by id list, so a single reference is a one-element list rather than a
+ * limited query. A double that still answered only the limited shape would
+ * resolve to nothing here and report a refusal that never happened.
  */
 function adapterReturning(row: Record<string, unknown> | null) {
   const chain = {
     select: () => chain,
     from: () => chain,
-    where: () => chain,
-    limit: () => Promise.resolve(row ? [row] : []),
+    where: () => Promise.resolve(row ? [row] : []),
   };
   return {
     getDrizzle: () => chain,

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -1041,6 +1041,57 @@ export class CollectionRelationshipService extends BaseService {
    * has not been given the caller yet would judge everyone anonymous and hide
    * rows from entitled callers.
    */
+  /**
+   * Read the rows a relationship points at, as this caller may see them.
+   *
+   * The only place a related row is fetched. Six call sites used to repeat the
+   * same five steps — resolve the schema, select by id, normalize timestamps,
+   * apply the target collection's read rules, redact its protected fields — and
+   * every capability a related row was missing had to be added to each of them
+   * and then audited for the one that was forgotten. That audit has been run
+   * three times: for the caller's scope, for the read locale, and for two
+   * caches. Behind one seam each of those becomes a single change.
+   *
+   * System entities keep the lean path deliberately: they have no collection
+   * record, so no stored rules and no hooks apply, and their secrets are
+   * stripped by column name during redaction instead.
+   *
+   * Returns only the rows this caller may read. A refused row is simply absent —
+   * one unreadable reference must not refuse the whole parent read — so callers
+   * must not assume the result lines up with the ids they asked for.
+   */
+  private async readTargetRows(
+    targetCollection: string,
+    ids: string[],
+    access: RelatedRowAccess
+  ): Promise<Record<string, unknown>[]> {
+    if (ids.length === 0) return [];
+
+    const schema = isSystemEntity(targetCollection)
+      ? getSystemEntityTable(targetCollection)
+      : await this.fileManager.loadDynamicSchema(targetCollection);
+    if (!schema) return [];
+
+    const entries = (await this.db
+      .select()
+      .from(schema)
+      .where(inArray(schema.id, ids))) as Record<string, unknown>[];
+
+    const rows = entries.map(entry =>
+      convertTimestampsToCamelCase({ ...entry })
+    );
+    const readable = await this.filterRowsByCollectionAccess(
+      targetCollection,
+      rows,
+      access
+    );
+    // Redaction runs before any caller derives a label from a row: a label
+    // copies a field's value under another key, so one taken from an unredacted
+    // row survives the redaction of its own source field.
+    await this.redactRelatedRows(targetCollection, readable, access);
+    return readable;
+  }
+
   private async filterRowsByCollectionAccess(
     targetCollection: string,
     rows: Record<string, unknown>[],
@@ -2062,24 +2113,11 @@ export class CollectionRelationshipService extends BaseService {
           field.options?.targetLabelField
         );
 
-        // Batch fetch all entries from system entity
-        const entries = await this.db
-          .select()
-          .from(targetSchema)
-          .where(inArray(targetSchema.id, relatedIds));
-
-        // Redact before labelling, for the same reason as the dynamic branch
-        // below: the label copies a field value under another key, so it must
-        // be taken from a row that has already been stripped.
-        const rows = entries.map((entry: Record<string, unknown>) =>
-          convertTimestampsToCamelCase({ ...entry })
-        );
-        const readable = await this.filterRowsByCollectionAccess(
+        const readable = await this.readTargetRows(
           targetCollection,
-          rows,
+          relatedIds,
           access
         );
-        await this.redactRelatedRows(targetCollection, readable, access);
         for (const row of readable) {
           resultMap.set(row.id as string, {
             ...row,
@@ -2088,32 +2126,16 @@ export class CollectionRelationshipService extends BaseService {
         }
       } else {
         // Handle dynamic collections
-        const targetSchema =
-          await this.fileManager.loadDynamicSchema(targetCollection);
         const labelField = await this.getBestLabelField(
           targetCollection,
           field.options?.targetLabelField
         );
 
-        // Batch fetch all entries using Drizzle's inArray helper
-        const entries = await this.db
-          .select()
-          .from(targetSchema)
-          .where(inArray(targetSchema.id, relatedIds));
-
-        // Redact BEFORE deriving the label. The label is a copy of a field's
-        // value under a different key, so a label taken from a row that has not
-        // been redacted yet survives the redaction of its own source field and
-        // hands back the protected value under `label`.
-        const rows = entries.map((entry: Record<string, unknown>) =>
-          convertTimestampsToCamelCase({ ...entry })
-        );
-        const readable = await this.filterRowsByCollectionAccess(
+        const readable = await this.readTargetRows(
           targetCollection,
-          rows,
+          relatedIds,
           access
         );
-        await this.redactRelatedRows(targetCollection, readable, access);
         for (const row of readable) {
           resultMap.set(row.id as string, {
             ...row,
@@ -2211,48 +2233,13 @@ export class CollectionRelationshipService extends BaseService {
         return resultMap;
       }
 
-      // Batch fetch all target entries
-      const targetSchema =
-        await this.fileManager.loadDynamicSchema(targetCollectionName);
       const labelField = await this.getBestLabelField(
         targetCollectionName,
         field.options?.targetLabelField
       );
-
-      console.log(
-        `[ManyToMany Expand] Target collection: ${targetCollectionName}, Label field: ${labelField}`
-      );
-
-      // Batch fetch all target entries using Drizzle's inArray
-      const targetEntries = await this.db
-        .select()
-        .from(targetSchema)
-        .where(inArray(targetSchema.id, allTargetIds));
-
-      console.log(
-        `[ManyToMany Expand] Fetched ${targetEntries.length} target entries`
-      );
-      if (targetEntries.length > 0) {
-        console.log(
-          `[ManyToMany Expand] Sample entry:`,
-          JSON.stringify(targetEntries[0], null, 2)
-        );
-      }
-
-      // Redact before labelling: the label copies a field's value under
-      // another key, so taking it from an unredacted row would return a
-      // protected value that the redaction of its source field cannot reach.
-      const targetRows = targetEntries.map((entry: Record<string, unknown>) =>
-        convertTimestampsToCamelCase({ ...entry })
-      );
-      const readableTargetRows = await this.filterRowsByCollectionAccess(
+      const readableTargetRows = await this.readTargetRows(
         targetCollectionName,
-        targetRows,
-        access
-      );
-      await this.redactRelatedRows(
-        targetCollectionName,
-        readableTargetRows,
+        allTargetIds,
         access
       );
 
@@ -2262,9 +2249,6 @@ export class CollectionRelationshipService extends BaseService {
           // Falls back to the id when the label's source field did not survive
           // redaction.
           const label = row[labelField] || row.id;
-          console.log(
-            `[ManyToMany Expand] Entry ${String(row.id)}: labelField="${labelField}", value="${String(label)}"`
-          );
           return [row.id, { ...row, label }];
         })
       );
@@ -2894,55 +2878,15 @@ export class CollectionRelationshipService extends BaseService {
     access: RelatedRowAccess = {}
   ): Promise<Record<string, unknown> | null> {
     try {
-      // Check if this is a system entity (like "users")
-      if (isSystemEntity(collectionName)) {
-        const targetSchema = getSystemEntityTable(collectionName);
-        if (!targetSchema) {
-          return null;
-        }
-
-        const [entry] = await this.db
-          .select()
-          .from(targetSchema)
-          .where(eq(targetSchema.id, entryId))
-          .limit(1);
-
-        if (!entry) return null;
-        const normalized = convertTimestampsToCamelCase({ ...entry });
-        const [readable] = await this.filterRowsByCollectionAccess(
-          collectionName,
-          [normalized],
-          access
-        );
-        // Reads as absent rather than as an error: one unreadable reference
-        // must not refuse the whole parent read, and the caller learns no more
-        // than a reference pointing at nothing would tell them.
-        if (!readable) return null;
-        await this.redactRelatedRows(collectionName, [readable], access);
-        return readable;
-      } else {
-        // Handle dynamic collections
-        const schema = await this.fileManager.loadDynamicSchema(collectionName);
-        const [entry] = await this.db
-          .select()
-          .from(schema)
-          .where(eq(schema.id, entryId))
-          .limit(1);
-
-        if (!entry) return null;
-        const normalized = convertTimestampsToCamelCase({ ...entry });
-        const [readable] = await this.filterRowsByCollectionAccess(
-          collectionName,
-          [normalized],
-          access
-        );
-        // Reads as absent rather than as an error: one unreadable reference
-        // must not refuse the whole parent read, and the caller learns no more
-        // than a reference pointing at nothing would tell them.
-        if (!readable) return null;
-        await this.redactRelatedRows(collectionName, [readable], access);
-        return readable;
-      }
+      const [readable] = await this.readTargetRows(
+        collectionName,
+        [entryId],
+        access
+      );
+      // Reads as absent rather than as an error: one unreadable reference must
+      // not refuse the whole parent read, and the caller learns no more than a
+      // reference pointing at nothing would tell them.
+      return readable ?? null;
     } catch {
       return null;
     }
@@ -3055,32 +2999,15 @@ export class CollectionRelationshipService extends BaseService {
         return [];
       }
 
-      // Fetch the actual entries using MySQL-compatible IN clause
-      const targetSchema =
-        await this.fileManager.loadDynamicSchema(targetCollectionName);
-
-      // Build IN clause with parameterized values for MySQL compatibility
-      const placeholders = sql.join(
-        relatedIds.map((id: string) => sql`${id}`),
-        sql.raw(", ")
-      );
-
-      const entries = await this.db
-        .select()
-        .from(targetSchema)
-        .where(sql`${targetSchema.id} IN (${placeholders})`);
-
-      const normalized = (entries || []).map((entry: Record<string, unknown>) =>
-        convertTimestampsToCamelCase({ ...entry })
-      );
-      const readable = await this.filterRowsByCollectionAccess(
+      // Through the shared reader, which binds the id list with Drizzle's
+      // `inArray` rather than assembling the IN clause by hand. The sibling
+      // many-to-many batch path has always used `inArray` and passes on MySQL,
+      // so the hand-built list this replaces was not buying compatibility.
+      return await this.readTargetRows(
         targetCollectionName,
-        normalized,
+        relatedIds,
         access
       );
-      // Strip related-row secrets before rows are spread into responses.
-      await this.redactRelatedRows(targetCollectionName, readable, access);
-      return readable;
     } catch (error) {
       console.error("Failed to fetch many-to-many relations:", error);
       return [];


### PR DESCRIPTION
**PR 1 of 5** in the expansion/read-path convergence program. Design:
`tasks/2026-07-30-expansion-read-path-convergence-design.md`. Task:
`tasks/left-tasks/089-expansion-read-path-convergence.md`.

Behaviour-preserving by construction. That is the point of it: PRs 1-3 change no
behaviour, which is what makes PR-4 — where a related row starts coming out of
the real read pipeline — a reviewable change rather than a rewrite.

## Why

Relationship expansion is a second read path. Six call sites each resolved the
target schema, selected by id, normalized timestamps, applied the target
collection's read rules and redacted its fields. So every capability a related
row was missing had to be added to all six and then audited for the one that was
forgotten. That audit has now been run three times — for the caller's scope
(#401), and for the read locale plus two per-request caches (#415).

The list of capabilities a related row still lacks is not shrinking. Five remain,
and three of them were found by grepping for call sites that do not exist
(`hookService`, `fieldGroupDataService`, projection: zero references in a
~3000-line file). Behind one reader, each becomes a single change.

## What changed

`readTargetRows` is the only place a related row is fetched. Same steps, same
order. `fetchRelatedEntry`'s two branches collapsed into one call because they
differed only in which schema they resolved — which is the clearest evidence the
duplication was accidental.

Net **-73 lines** (72 added, 145 removed).

Three direct reads remain, each for a stated reason, and the reasons are asserted
rather than assumed:

| read | why it stays separate |
|---|---|
| `readTargetRows` | the reader itself |
| `narrowByTargetPredicate` | re-reads under the rule's own predicate, so the row and the authorization to serve it come from one query (the TOCTOU fix in #401) |
| `fetchMediaByIds` | media is not a collection: no read rules, no hooks, its own URL absolutization |

Media and system entities stay lean deliberately. A system entity has no
collection record, so no stored rules and no hooks apply, and its secrets are
stripped by column name during redaction instead.

## Two things this turned up

**The hand-built `IN` clause was not buying MySQL compatibility — it was costing
coverage.** The many-to-many fetch assembled its list by hand with a comment
saying `MySQL-compatible IN clause`, while the sibling batch path bound the same
filter with `inArray` and had always passed on MySQL. Routing it through the
reader took the MySQL adapter leg from **10 passed + 1 skipped to 12 passed, 0
skipped**. Raw SQL in product code is also against the conventions.

Junction tables keep raw SQL, and that is not the same case: they are created by
the many-to-many machinery and are not in the Drizzle schema, so there is no
table object to bind against.

**Four `console.log("[ManyToMany Expand] …")` statements** in the refactored
paths are gone.

## The fetch sites are pinned structurally

`related-row-fetch-seam.test.ts` asserts one direct read per documented reason.
A behavioural test cannot see a *seventh* fetch site that happens to agree with
the other six today, and the invariant this PR buys is about where code may fetch
at all — so the guard has to be structural to be worth anything.

It fired on its first run, against the junction-table read: my assertion was
broader than the invariant. It now distinguishes "cannot use Drizzle" from "did
not", and names the offending site when it fails.

## Verification

| leg | result |
|---|---|
| SQLite | 799 passed / **0 failed** (937) |
| MySQL | 863 passed / **0 failed** (953), skips 138 → 90 |
| Postgres 17 | 921 passed / **0 failed** (979) |
| unit | failing-test **name set identical** to base: 401 both sides, zero unique either way |

Run per dialect sequentially — this suite relies on that for fixed-name system
tables.

**One real breakage, caught by name set and not by count.** Unit failures went
401 → 414, and the difference was explainable by main having moved (it had). The
name set showed all 13 in one file: the unit test for the service being
refactored. Its double resolved on a trailing `.limit()`; the reader fetches by
id list, so a single reference is now a one-element `inArray` and nothing calls
`.limit()` any more — the double resolved to nothing, the fetch hit its catch,
and thirteen tests asserted a refusal that never happened.

Fixed in the double, not by contorting the reader back to the old shape. And
because a double had just been loosened, it was re-checked for discrimination:
skipping redaction in the reader fails 11 of its 18 tests.

## Next in the program

PR-2 introduces a ReadContext (caller identity + per-request caches + a `seen`
map), retiring the thread-it-to-N-sites bug class. PR-3 extracts the read
assembly pipeline. PR-4 swaps this reader's body to use it, which closes all five
remaining divergences at once. PR-5 adds projection, without which PR-4 makes
every relationship strictly heavier.
