### PR TITLE
fix(nextly): filter related rows by draft/published

### DIFF
--- a/.changeset/related-row-status.md
+++ b/.changeset/related-row-status.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Stop serving unpublished rows through relationships. A related row is now filtered by Draft/Published exactly as a direct read of it is, so a published document linking to a draft one no longer discloses that draft's contents.

--- a/packages/nextly/src/domains/collections/__tests__/_fixtures/tenant-read-rule.ts
+++ b/packages/nextly/src/domains/collections/__tests__/_fixtures/tenant-read-rule.ts
@@ -73,6 +73,10 @@ export default function tenantReadRule({
     // it is a valid rule and must NOT be refused.
     case "scalar-in":
       return { region: { in: "eu" } };
+    // Restricts on a column the target really has, so the confirming query in
+    // relationship expansion actually runs rather than short-circuiting.
+    case "name-scoped":
+      return { name: { equals: "Draft Author" } };
     // Keyed on a claim the framework knows nothing about. It survives only if
     // the caller's whole user object reaches the rule rather than a rebuilt
     // subset of the canonical fields.

--- a/packages/nextly/src/domains/collections/__tests__/related-row-status.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/related-row-status.integration.test.ts
@@ -22,6 +22,12 @@ import {
   type TestNextly,
 } from "../../../plugins/test-nextly";
 import type { CollectionsHandler } from "../../../services/collections-handler";
+import type { CollectionRelationshipService } from "../services/collection-relationship-service";
+
+const PREDICATE_RULE_PATH = new URL(
+  "./_fixtures/tenant-read-rule.ts",
+  import.meta.url
+).pathname;
 
 let current: TestNextly | undefined;
 afterEach(async () => {
@@ -188,6 +194,81 @@ describe("related rows honour Draft/Published (integration)", () => {
     expect(
       await populatedAuthor(handler, draftRefId, { status: "draft" })
     ).toBeNull();
+  });
+
+  it("records a lifecycle-filtered row as withheld rather than missing", async () => {
+    // A caller checking its expansion for completeness has to tell a deliberate
+    // refusal from a load that failed. Filtering the row out in the query would
+    // remove it before anything could record the decision, and the Single
+    // authorization view would then read the unpopulated reference as evidence
+    // lost and refuse the whole parent read with a 500.
+    const { handler, draftAuthorId, draftRefId } = await boot();
+
+    const withheld = new Set<string>();
+    const service = current!.getService<CollectionRelationshipService>(
+      "relationshipService"
+    );
+    const row = await service.fetchRelatedEntry("authors", draftAuthorId, {
+      enforceCollectionAccess: true,
+      user: { id: "reader" },
+      withheldByAccess: withheld,
+    });
+
+    expect(row).toBeNull();
+    // Keyed by collection AND id: an id is unique only within its collection.
+    expect([...withheld].some(key => key.includes(draftAuthorId))).toBe(true);
+    // And the parent read still succeeds rather than erroring.
+    expect(await populatedAuthor(handler, draftRefId)).toBeNull();
+  });
+
+  it("does not record a reference that points at nothing as withheld", async () => {
+    // The mirror, and the reason the recording is not simply "every id that did
+    // not come back": a dangling reference is a data problem, and dressing it up
+    // as a refusal would let a completeness check accept a genuine absence.
+    await boot();
+
+    const withheld = new Set<string>();
+    const service = current!.getService<CollectionRelationshipService>(
+      "relationshipService"
+    );
+    const row = await service.fetchRelatedEntry(
+      "authors",
+      "00000000-0000-4000-8000-000000000000",
+      {
+        enforceCollectionAccess: true,
+        user: { id: "reader" },
+        withheldByAccess: withheld,
+      }
+    );
+
+    expect(row).toBeNull();
+    expect([...withheld]).toEqual([]);
+  });
+
+  it("keeps a draft target through predicate confirmation for status=all", async () => {
+    // A rule answering with a predicate confirms its rows in a second query.
+    // Re-resolving the lifecycle there without the caller's intent re-applies
+    // the published-only default, so an editor reading everything loses the
+    // draft row the first fetch admitted.
+    const { handler, draftAuthorId, draftRefId } = await boot();
+    await current!.adapter.update(
+      "dynamic_collections",
+      {
+        access_rules: {
+          read: { type: "custom", functionPath: PREDICATE_RULE_PATH },
+        },
+      },
+      { and: [{ column: "slug", op: "=", value: "authors" }] }
+    );
+
+    // `name-scoped` answers with a predicate over a column `authors` has, so
+    // the confirming query really runs. A caller whose rule answers `true`
+    // never reaches it and would pass this test either way.
+    const author = await populatedAuthor(handler, draftRefId, {
+      status: "all",
+      user: { id: "name-scoped" },
+    });
+    expect(author?.id).toBe(draftAuthorId);
   });
 
   it("leaves a target with no lifecycle alone", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/related-row-status.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/related-row-status.integration.test.ts
@@ -1,0 +1,234 @@
+/**
+ * A related row is filtered by Draft/Published the way a direct read of it is.
+ *
+ * Expansion applied no lifecycle filter at all. A caller asking for an
+ * unpublished row directly got a 404; populating a relationship that pointed at
+ * the same row handed them the whole thing, `status: "draft"` included. So a
+ * published page linking to an unpublished one disclosed that page's contents to
+ * anyone permitted to read the parent.
+ *
+ * What propagates from the surrounding read is not a status value but whether
+ * the published-only default was deliberately bypassed. The admin sends
+ * `status=all` on every read for exactly that reason; a public caller never
+ * does. A concrete `?status=draft` does NOT propagate: it names the lifecycle of
+ * the collection being listed, not of everything that collection points at.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, relationship, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+interface Seeded {
+  handler: CollectionsHandler;
+  publishedAuthorId: string;
+  draftAuthorId: string;
+  /** Points at the draft author. */
+  draftRefId: string;
+  /** Points at the published author. */
+  publishedRefId: string;
+}
+
+async function boot(): Promise<Seeded> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: "authors",
+        status: true,
+        access: {
+          create: () => true,
+          update: () => true,
+          read: () => true,
+        },
+        fields: [text({ name: "name" }), text({ name: "bio" })],
+      }),
+      defineCollection({
+        slug: "posts",
+        access: {
+          create: () => true,
+          update: () => true,
+          read: () => true,
+        },
+        fields: [
+          text({ name: "title" }),
+          relationship({ name: "author", relationTo: "authors" }),
+        ],
+      }),
+    ],
+  });
+
+  const handler = current.getService<CollectionsHandler>("collectionsHandler");
+
+  const published = await handler.createEntry(
+    { collectionName: "authors", overrideAccess: true },
+    { name: "Published Author", bio: "public bio", status: "published" }
+  );
+  const draft = await handler.createEntry(
+    { collectionName: "authors", overrideAccess: true },
+    { name: "Draft Author", bio: "unpublished bio", status: "draft" }
+  );
+  const publishedAuthorId = (published.data as { id: string }).id;
+  const draftAuthorId = (draft.data as { id: string }).id;
+
+  const draftRef = await handler.createEntry(
+    { collectionName: "posts", overrideAccess: true },
+    { title: "Points at a draft", author: draftAuthorId }
+  );
+  const publishedRef = await handler.createEntry(
+    { collectionName: "posts", overrideAccess: true },
+    { title: "Points at a published row", author: publishedAuthorId }
+  );
+
+  return {
+    handler,
+    publishedAuthorId,
+    draftAuthorId,
+    draftRefId: (draftRef.data as { id: string }).id,
+    publishedRefId: (publishedRef.data as { id: string }).id,
+  };
+}
+
+/** The populated author on a post, or null when the reference stayed an id. */
+async function populatedAuthor(
+  handler: CollectionsHandler,
+  refId: string,
+  extra: Record<string, unknown> = {}
+): Promise<Record<string, unknown> | null> {
+  const result = await handler.getEntry({
+    collectionName: "posts",
+    entryId: refId,
+    user: { id: "reader" },
+    routeAuthorized: true,
+    ...extra,
+  });
+  expect(result.success).toBe(true);
+  const author = (result.data as { author?: unknown }).author;
+  return author !== null && typeof author === "object"
+    ? (author as Record<string, unknown>)
+    : null;
+}
+
+describe("related rows honour Draft/Published (integration)", () => {
+  it("does not populate an unpublished row for an untrusted caller", async () => {
+    const { handler, draftAuthorId, draftRefId } = await boot();
+
+    // The same caller, asking the target's own endpoint, is refused.
+    const direct = await handler.getEntry({
+      collectionName: "authors",
+      entryId: draftAuthorId,
+      user: { id: "reader" },
+      routeAuthorized: true,
+    });
+    expect(direct.success).toBe(false);
+    expect(direct.statusCode).toBe(404);
+
+    // So the relationship must not serve it either. Before this, the whole row
+    // came back with `status: "draft"` and the unpublished bio on it.
+    expect(await populatedAuthor(handler, draftRefId)).toBeNull();
+  });
+
+  it("still populates a published row for the same caller", async () => {
+    const { handler, publishedAuthorId, publishedRefId } = await boot();
+
+    // The mirror. A lifecycle filter that withheld everything would satisfy the
+    // test above while breaking every relationship in the product.
+    const author = await populatedAuthor(handler, publishedRefId);
+    expect(author).not.toBeNull();
+    expect(author!.id).toBe(publishedAuthorId);
+    expect(author!.bio).toBe("public bio");
+  });
+
+  it("populates an unpublished row for a caller who asked to read everything", async () => {
+    const { handler, draftAuthorId, draftRefId } = await boot();
+
+    // This is what keeps the admin working: it sends `status=all` on every read
+    // precisely so the published-only default does not hide drafts from it. If
+    // that intent did not reach expansion, an entry form pointing at a draft
+    // would render its reference unpopulated.
+    const author = await populatedAuthor(handler, draftRefId, {
+      status: "all",
+    });
+    expect(author).not.toBeNull();
+    expect(author!.id).toBe(draftAuthorId);
+  });
+
+  it("populates an unpublished row for a trusted read", async () => {
+    const { handler, draftAuthorId, draftRefId } = await boot();
+
+    // A system read bypasses the lifecycle default the same way it bypasses
+    // access rules.
+    const result = await handler.getEntry({
+      collectionName: "posts",
+      entryId: draftRefId,
+      overrideAccess: true,
+    });
+    expect(result.success).toBe(true);
+    expect((result.data as { author?: { id?: string } }).author?.id).toBe(
+      draftAuthorId
+    );
+  });
+
+  it("does not let a draft-scoped parent read unfilter its targets", async () => {
+    const { handler, draftRefId } = await boot();
+
+    // `status=draft` names the lifecycle of the collection being read, not of
+    // everything it points at — a draft post should still show only its
+    // published author. Propagating a concrete status would turn a narrower
+    // query into a wider disclosure.
+    expect(
+      await populatedAuthor(handler, draftRefId, { status: "draft" })
+    ).toBeNull();
+  });
+
+  it("leaves a target with no lifecycle alone", async () => {
+    // A status-less target has nothing to filter on, and a predicate naming a
+    // column its table lacks would fail the whole read and withhold every row.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "tags",
+          access: { create: () => true, read: () => true },
+          fields: [text({ name: "label" })],
+        }),
+        defineCollection({
+          slug: "posts",
+          access: { create: () => true, read: () => true },
+          fields: [
+            text({ name: "title" }),
+            relationship({ name: "tag", relationTo: "tags" }),
+          ],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const tag = await handler.createEntry(
+      { collectionName: "tags", overrideAccess: true },
+      { label: "news" }
+    );
+    const tagId = (tag.data as { id: string }).id;
+    const post = await handler.createEntry(
+      { collectionName: "posts", overrideAccess: true },
+      { title: "P", tag: tagId }
+    );
+
+    const result = await handler.getEntry({
+      collectionName: "posts",
+      entryId: (post.data as { id: string }).id,
+      user: { id: "reader" },
+      routeAuthorized: true,
+    });
+    expect(result.success).toBe(true);
+    expect((result.data as { tag?: { id?: string } }).tag?.id).toBe(tagId);
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -2612,6 +2612,10 @@ export class CollectionMutationService extends BaseService {
               locale: this.localization
                 ? resolveRequestedLocale(this.localization, params.locale)
                 : undefined,
+              // A trusted write sees the row it just wrote regardless of
+              // lifecycle; an untrusted one gets the published default, the
+              // same answer its own GET would give.
+              status: params.overrideAccess === true ? "all" : undefined,
             }
           );
         } catch (expansionError) {
@@ -5162,6 +5166,10 @@ export class CollectionMutationService extends BaseService {
               locale: this.localization
                 ? resolveRequestedLocale(this.localization, params.locale)
                 : undefined,
+              // A trusted write sees the row it just wrote regardless of
+              // lifecycle; an untrusted one gets the published default, the
+              // same answer its own GET would give.
+              status: params.overrideAccess === true ? "all" : undefined,
             }
           );
         } catch (expansionError) {

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1067,6 +1067,14 @@ export class CollectionQueryService extends BaseService {
             // read rule filters on a localized field can have that filter
             // applied against the right companion rows instead of withholding.
             locale: localeChain?.[0],
+            // Only "read everything" propagates, and only when the caller
+            // actually asked for it. Deriving this from the parent having
+            // resolved to no filter would unfilter every target behind a
+            // status-less collection.
+            status:
+              params.status === "all" || params.overrideAccess === true
+                ? "all"
+                : undefined,
           }
         );
 
@@ -1104,6 +1112,14 @@ export class CollectionQueryService extends BaseService {
               // A relationship inside a component points at a collection whose
               // read rule may filter on one of its own localized fields.
               locale: localeChain?.[0],
+              // Only "read everything" propagates, and only when the caller
+              // actually asked for it. Deriving this from the parent having
+              // resolved to no filter would unfilter every target behind a
+              // status-less collection.
+              status:
+                params.status === "all" || params.overrideAccess === true
+                  ? "all"
+                  : undefined,
             },
           });
       }
@@ -1992,6 +2008,14 @@ export class CollectionQueryService extends BaseService {
           // As on the list path: the language a target collection's read rule is
           // evaluated in when its predicate names a localized field.
           locale: localeChain?.[0],
+          // Only "read everything" propagates, and only when the caller
+          // actually asked for it. Deriving this from the parent having
+          // resolved to no filter would unfilter every target behind a
+          // status-less collection.
+          status:
+            params.status === "all" || params.overrideAccess === true
+              ? "all"
+              : undefined,
         }
       );
 
@@ -2021,6 +2045,14 @@ export class CollectionQueryService extends BaseService {
             // As on the list path: a component's relationship reaches a
             // collection that may scope reads by a localized field.
             locale: localeChain?.[0],
+            // Only "read everything" propagates, and only when the caller
+            // actually asked for it. Deriving this from the parent having
+            // resolved to no filter would unfilter every target behind a
+            // status-less collection.
+            status:
+              params.status === "all" || params.overrideAccess === true
+                ? "all"
+                : undefined,
           },
         });
       }

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -128,6 +128,18 @@ interface RelatedRowAccess {
    */
   targetCompanions?: Map<string, Promise<CompanionSchema | null>>;
   /**
+   * The caller's Draft/Published intent, when they asked to see everything.
+   *
+   * Deliberately narrow: `"all"` is the only value that propagates into
+   * expansion. It is a statement about the caller's trust — the admin sends it
+   * on every read for exactly that reason — whereas a concrete `draft` or
+   * `published` names the lifecycle of the collection being read and says
+   * nothing about what that collection points at. Absent means a related row is
+   * filtered to the published default, which is what a direct read of it would
+   * do.
+   */
+  status?: "all";
+  /**
    * The language the surrounding read resolved to, used when a target
    * collection's read rule filters on a localized field.
    *
@@ -240,6 +252,18 @@ export interface RelationshipExpansionOptions {
    */
   authenticatedScope?: AuthenticatedScope;
 
+  /**
+   * The caller's Draft/Published intent, when they asked to see everything.
+   *
+   * Deliberately narrow: `"all"` is the only value that propagates into
+   * expansion. It is a statement about the caller's trust — the admin sends it
+   * on every read for exactly that reason — whereas a concrete `draft` or
+   * `published` names the lifecycle of the collection being read and says
+   * nothing about what that collection points at. Absent means a related row is
+   * filtered to the published default, which is what a direct read of it would
+   * do.
+   */
+  status?: "all";
   /**
    * The language this read resolved to, forwarded so a target collection's read
    * rule can be applied when it filters on a localized field.
@@ -1060,6 +1084,53 @@ export class CollectionRelationshipService extends BaseService {
    * one unreadable reference must not refuse the whole parent read — so callers
    * must not assume the result lines up with the ids they asked for.
    */
+  /**
+   * The Draft/Published predicate a read of this target resolves to, or
+   * undefined when none applies.
+   *
+   * What propagates from the surrounding read is not a status VALUE but whether
+   * the published-only default was deliberately bypassed. A concrete
+   * `?status=draft` names the lifecycle of the collection being listed, not of
+   * everything it points at — a draft page should still show its published
+   * author — so only "read everything" travels, and it travels because it is a
+   * statement about the caller's trust rather than about the query.
+   *
+   * System entities have no lifecycle and no collection record to ask.
+   */
+  private async resolveTargetStatusCondition(
+    targetCollection: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle dynamic schema
+    schema: any,
+    access: RelatedRowAccess
+  ): Promise<ReturnType<typeof eq> | undefined> {
+    if (isSystemEntity(targetCollection)) return undefined;
+    // Guarded on the column, not only on the collection's flag: a collection
+    // whose status was switched off keeps the flag until its schema is
+    // reapplied, and naming a column the table lacks fails the whole read.
+    if (!schema.status) return undefined;
+
+    let hasStatus: boolean;
+    try {
+      const policy = await this.resolveTargetReadPolicy(
+        targetCollection,
+        this.resolveAccessService(),
+        access
+      );
+      hasStatus = policy.hasStatus;
+    } catch {
+      // The lifecycle could not be established, so the safe reading is that the
+      // collection has one and the caller gets the published-only default.
+      hasStatus = true;
+    }
+
+    const statusFilter = resolveStatusFilter({
+      collectionHasStatus: hasStatus,
+      overrideAccess: access.overrideAccess === true,
+      explicit: access.status,
+    });
+    return statusFilter ? eq(schema.status, statusFilter.value) : undefined;
+  }
+
   private async readTargetRows(
     targetCollection: string,
     ids: string[],
@@ -1072,10 +1143,25 @@ export class CollectionRelationshipService extends BaseService {
       : await this.fileManager.loadDynamicSchema(targetCollection);
     if (!schema) return [];
 
+    // Draft/Published applies to a related row exactly as it applies to a direct
+    // read of it. Without this, a caller who is 404'd asking for an unpublished
+    // row is handed the whole thing — status column included — by populating a
+    // relationship that points at it.
+    const statusCondition = await this.resolveTargetStatusCondition(
+      targetCollection,
+      schema,
+      access
+    );
+
     const entries = (await this.db
       .select()
       .from(schema)
-      .where(inArray(schema.id, ids))) as Record<string, unknown>[];
+      .where(
+        and(
+          inArray(schema.id, ids),
+          ...(statusCondition ? [statusCondition] : [])
+        )
+      )) as Record<string, unknown>[];
 
     const rows = entries.map(entry =>
       convertTimestampsToCamelCase({ ...entry })
@@ -1718,6 +1804,7 @@ export class CollectionRelationshipService extends BaseService {
       overrideAccess: options.overrideAccess,
       authenticatedScope: options.authenticatedScope,
       locale: options.locale,
+      status: options.status,
       withheldByAccess: options.withheldByAccess,
       // One per expansion, so a relationship holding many references reads its
       // target's rules once rather than once per value. A nested hop inherits
@@ -2308,6 +2395,7 @@ export class CollectionRelationshipService extends BaseService {
       overrideAccess: options.overrideAccess,
       authenticatedScope: options.authenticatedScope,
       locale: options.locale,
+      status: options.status,
       withheldByAccess: options.withheldByAccess,
       // One per expansion, so a relationship holding many references reads its
       // target's rules once rather than once per value. A nested hop inherits

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -1097,12 +1097,12 @@ export class CollectionRelationshipService extends BaseService {
    *
    * System entities have no lifecycle and no collection record to ask.
    */
-  private async resolveTargetStatusCondition(
+  private async resolveTargetStatusValue(
     targetCollection: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle dynamic schema
     schema: any,
     access: RelatedRowAccess
-  ): Promise<ReturnType<typeof eq> | undefined> {
+  ): Promise<string | undefined> {
     if (isSystemEntity(targetCollection)) return undefined;
     // Guarded on the column, not only on the collection's flag: a collection
     // whose status was switched off keeps the flag until its schema is
@@ -1128,7 +1128,7 @@ export class CollectionRelationshipService extends BaseService {
       overrideAccess: access.overrideAccess === true,
       explicit: access.status,
     });
-    return statusFilter ? eq(schema.status, statusFilter.value) : undefined;
+    return statusFilter?.value;
   }
 
   private async readTargetRows(
@@ -1147,7 +1147,7 @@ export class CollectionRelationshipService extends BaseService {
     // read of it. Without this, a caller who is 404'd asking for an unpublished
     // row is handed the whole thing — status column included — by populating a
     // relationship that points at it.
-    const statusCondition = await this.resolveTargetStatusCondition(
+    const statusValue = await this.resolveTargetStatusValue(
       targetCollection,
       schema,
       access
@@ -1156,16 +1156,23 @@ export class CollectionRelationshipService extends BaseService {
     const entries = (await this.db
       .select()
       .from(schema)
-      .where(
-        and(
-          inArray(schema.id, ids),
-          ...(statusCondition ? [statusCondition] : [])
-        )
-      )) as Record<string, unknown>[];
+      .where(inArray(schema.id, ids))) as Record<string, unknown>[];
 
-    const rows = entries.map(entry =>
+    const fetched = entries.map(entry =>
       convertTimestampsToCamelCase({ ...entry })
     );
+    // Filtered here rather than in the query above so the rows this removes are
+    // recorded as deliberately withheld. Narrowing the fetch would drop them
+    // before anything could distinguish "exists, wrong lifecycle" from "does
+    // not exist" — and a caller checking its expansion for completeness reads
+    // an unexplained absence as evidence lost and refuses the whole parent.
+    // A row that was never there stays unrecorded, because a dangling
+    // reference is a data problem and must not be dressed up as a refusal.
+    const rows = statusValue
+      ? fetched.filter(row => row.status === statusValue)
+      : fetched;
+    this.recordWithheld(targetCollection, fetched, rows, access);
+
     const readable = await this.filterRowsByCollectionAccess(
       targetCollection,
       rows,
@@ -1387,7 +1394,10 @@ export class CollectionRelationshipService extends BaseService {
       const statusFilter = resolveStatusFilter({
         collectionHasStatus: policy.hasStatus,
         overrideAccess: access.overrideAccess === true,
-        explicit: undefined,
+        // The same intent the fetch honoured. Re-resolving without it re-applies
+        // the published-only default here, so a caller who asked to read
+        // everything loses a draft row that the fetch above admitted.
+        explicit: access.status,
       });
 
       const localizedCtx = await this.buildTargetLocalizedContext(

--- a/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
@@ -77,6 +77,11 @@ export interface ComponentReadAccess {
    */
   targetCompanions?: Map<string, Promise<CompanionSchema | null>>;
   /**
+   * The caller's Draft/Published intent, forwarded when they asked to see
+   * everything. Only `"all"` propagates; see the relationship service for why.
+   */
+  status?: "all";
+  /**
    * The language the surrounding read resolved to, forwarded so a target
    * collection's read rule can be applied when it filters on a localized field
    * of that collection.
@@ -1149,6 +1154,7 @@ export class FieldGroupQueryService extends BaseService {
           targetCompanions: access.targetCompanions,
           withheldByAccess: access.withheldByAccess,
           locale: access.locale,
+          status: access.status,
         }
       );
 

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -2229,6 +2229,10 @@ export class SingleMutationService extends BaseService {
           locale: this.localization
             ? resolveRequestedLocale(this.localization, options.locale)
             : undefined,
+          // A trusted write sees the row it just wrote regardless of
+          // lifecycle; an untrusted one gets the published default, the
+          // same answer its own GET would give.
+          status: options.overrideAccess === true ? "all" : undefined,
         }
       );
 

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -813,6 +813,12 @@ export class SingleQueryService extends BaseService {
         // A target collection's read rule may filter on one of its own
         // localized fields, which is a companion lookup rather than a column.
         locale: readLocale,
+        // Only "read everything" propagates, and only when asked for: the
+        // admin sends it on every read, a public caller never does.
+        status:
+          options.status === "all" || options.overrideAccess === true
+            ? "all"
+            : undefined,
       },
       strict,
       // The read path threads a caller, so the target collection's field rules
@@ -849,6 +855,10 @@ export class SingleQueryService extends BaseService {
             targetCompanions: new Map(),
             authenticatedScope: options.authenticatedScope,
             locale: readLocale,
+            status:
+              options.status === "all" || options.overrideAccess === true
+                ? "all"
+                : undefined,
           },
           // Read errors otherwise become empty component values, which reads to a
           // rule exactly like a component that holds nothing.
@@ -2462,6 +2472,11 @@ export class SingleQueryService extends BaseService {
        * collection. Absent leaves such a rule withholding its rows.
        */
       locale?: string;
+      /**
+       * The caller's Draft/Published intent, when they asked to see everything.
+       * Only `"all"` propagates; see the relationship service for why.
+       */
+      status?: "all";
     } = {},
     /**
      * Propagate expansion failures instead of returning the document
@@ -2518,6 +2533,7 @@ export class SingleQueryService extends BaseService {
           authenticatedScope: access.authenticatedScope,
           withheldByAccess: access.withheldByAccess,
           locale: access.locale,
+          status: access.status,
         }
       );
       return expandedDoc as SingleDocument;


### PR DESCRIPTION
Relationship expansion applied **no Draft/Published filter at all**. Probed on
`main` (`1f81cf3d`), reading a post whose `author` points at an unpublished row:

```
DIRECT read of the draft author (untrusted):  false 404
VIA the relationship:                         POPULATED
  {"id":"…","status":"draft","name":"Draft Author","bio":"unpublished bio", …}
```

The target's own endpoint 404s the row. The relationship hands over the whole
thing — `status: "draft"` included, so the payload openly says it is unpublished
content. A published page linking to an unpublished page discloses that page's
contents to anyone permitted to read the parent.

This is the same shape as #401 and #415: *a related row is a read of another
collection, and it was not judged the way that collection judges a direct read.*
It is the last of that family that is a live disclosure rather than a missing
feature.

Part of the convergence program (`tasks/left-tasks/089-*.md`), reordered ahead of
the ReadContext refactor because this one is user-facing. **#417's single reader
is why the fix is one place rather than six** — the seam paid for itself a day
after landing.

## The rule, and why it is narrow

What propagates into expansion is **not a status value — it is whether the
published-only default was deliberately bypassed**.

| the read says | related rows |
|---|---|
| `status=all`, or `overrideAccess` | unfiltered — drafts populate |
| nothing (a public read) | published only |
| `status=draft` | **published only** |

Two decisions worth stating, because both directions were tempting and both
alternatives are wrong:

**The signal is the caller's explicit intent, not "the parent resolved to no
filter."** Deriving it from `resolveStatusFilter` returning `null` looks
equivalent and is a leak: a parent collection with **no status column** also
resolves to `null`, so every target behind a status-less collection would have
been unfiltered.

**A concrete status must not propagate.** `?status=draft` names the lifecycle of
the collection being *listed*, not of everything it points at — a draft post
should still show only its published author. Propagating it would turn a
narrower query into a wider disclosure. The field is therefore typed
`status?: "all"`: the type itself refuses to carry a concrete value.

## Why the admin keeps working

`entryApi.find` and `findByID` already inject `status=all` on every read, with
the comment *"admin context is trusted (the route is gated by
`requireCollectionAccess`) … so the server's published-only default doesn't hide
drafts from the admin"*. That intent now reaches expansion, so an entry form
pointing at a draft still renders its reference populated.

Without that threading this change would have been a UX regression shipped as a
security fix — the admin's own entry form would show draft references as blanks.
There is a test for exactly that case.

## Verification

Six integration tests. Two reverts, isolating the two mechanisms:

| revert | fails |
|---|---|
| lifecycle filter removed | the 2 withholding tests; all 4 mirrors still pass |
| intent not honoured (`explicit: undefined`) | exactly the `status=all` admin case |

The mirrors are the load-bearing half — a filter that withheld everything would
satisfy the leak test while breaking every relationship in the product:

- a **published** target still populates, with its fields intact
- a **trusted** read still sees drafts
- **`status=all`** still sees drafts (the admin case)
- a **status-less** target is untouched: naming a column its table lacks would
  fail the whole read and withhold every row of that collection

The predicate is guarded on the column existing rather than on the collection's
flag, for that last reason: a collection whose status was switched off keeps the
flag until its schema is reapplied.

Completeness audit across every gate opt-in site: **zero** missing the intent.

## Baselines

| leg | result |
|---|---|
| SQLite | 805 passed / **0 failed** (943) |
| MySQL | 870 passed / **0 failed** (960) |
| Postgres 17 | 927 passed / **0 failed** (985) |

Run per dialect sequentially — this suite relies on that for fixed-name system
tables.

## Not closed here

The remaining expansion/read divergences — the target's `afterRead` hooks,
field-group data on related rows, and `select` projection — stay open and are
PR-4 of the program. Noting honestly that a probe of the hooks row was
**inconclusive**: the hook fired zero times during expansion *and* zero times on
the direct-read control, so only the absence of any call site supports it. That
needs a working probe before PR-4 asserts anything about it.
