### PR TITLE
fix(nextly): run the hooks declared on a code-first collection

### DIFF
--- a/.changeset/collection-hooks-registration.md
+++ b/.changeset/collection-hooks-registration.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Run the hooks declared on a code-first collection. `defineCollection({ hooks })` registered nothing at boot, so a declared beforeChange, afterChange, beforeRead or afterRead never ran and the operation reported success regardless.

--- a/packages/nextly/src/cli/commands/init.ts
+++ b/packages/nextly/src/cli/commands/init.ts
@@ -310,10 +310,10 @@ let initialized = false;
  * It also registers any code-first collection hooks.
  */
 export async function getNextlyInstance(): Promise<Nextly> {
-  // Register hooks if not already done
-  if (!initialized) {
-    await initializeNextly();
-  }
+  // Straight to the boot. It registers the config's collection hooks itself,
+  // so there is nothing to arrange first -- and routing through
+  // initializeNextly() would cycle, since that function boots by calling
+  // this one.
 
   // Get the Nextly instance with minimal storage/image processor config
   // In a real app, you'd configure these with actual implementations
@@ -347,10 +347,10 @@ export async function initializeNextly(): Promise<void> {
 
   try {
     // Boot Nextly, which is what registers the config's collection hooks.
-    // Doing that here as well would append the same handlers a second time
-    // and run every hook twice, so this defers to the one boot rather than
-    // repeating it -- and calling it is what makes those hooks exist, so
-    // this cannot simply do nothing.
+    // Registering them here as well would append the same handlers a second
+    // time and run every hook twice, so this defers to the one boot rather
+    // than repeating it -- and it has to call something, since a function that
+    // reports success without booting leaves an app with no hooks at all.
     await getNextlyInstance();
 
     initialized = true;

--- a/packages/nextly/src/cli/commands/init.ts
+++ b/packages/nextly/src/cli/commands/init.ts
@@ -346,9 +346,12 @@ export async function initializeNextly(): Promise<void> {
   }
 
   try {
-    // Collection hooks are registered by Nextly's own boot, so there is
-    // nothing to register here. Doing it again would append the same
-    // handlers a second time and run every hook twice.
+    // Boot Nextly, which is what registers the config's collection hooks.
+    // Doing that here as well would append the same handlers a second time
+    // and run every hook twice, so this defers to the one boot rather than
+    // repeating it -- and calling it is what makes those hooks exist, so
+    // this cannot simply do nothing.
+    await getNextlyInstance();
 
     initialized = true;
     console.log("[Nextly] Initialized successfully");

--- a/packages/nextly/src/cli/commands/init.ts
+++ b/packages/nextly/src/cli/commands/init.ts
@@ -296,7 +296,7 @@ function generateNextlyHelperTemplate(): string {
  * \`\`\`
  */
 
-import { getNextly, registerCollectionHooks, type Nextly } from "nextly";
+import { getNextly, type Nextly } from "nextly";
 import nextlyConfig from "../../nextly.config";
 
 // Track initialization state
@@ -346,13 +346,9 @@ export async function initializeNextly(): Promise<void> {
   }
 
   try {
-    // Register code-first collection hooks with the global registry
-    if (nextlyConfig.collections && nextlyConfig.collections.length > 0) {
-      const result = registerCollectionHooks(nextlyConfig.collections);
-      console.log(
-        \`[Nextly] Registered \${result.totalHooks} hooks for \${result.collections.length} collections\`
-      );
-    }
+    // Collection hooks are registered by Nextly's own boot, so there is
+    // nothing to register here. Doing it again would append the same
+    // handlers a second time and run every hook twice.
 
     initialized = true;
     console.log("[Nextly] Initialized successfully");

--- a/packages/nextly/src/cli/commands/init.ts
+++ b/packages/nextly/src/cli/commands/init.ts
@@ -315,9 +315,16 @@ export async function getNextlyInstance(): Promise<Nextly> {
   // initializeNextly() would cycle, since that function boots by calling
   // this one.
 
+  // Booting is what completes initialization, so record it here as well: a
+  // caller using this directly has initialized just as fully as one going
+  // through initializeNextly(), and isNextlyInitialized() should say so.
+  initialized = true;
+
   // Get the Nextly instance with minimal storage/image processor config
   // In a real app, you'd configure these with actual implementations
   return getNextly({
+    // Required on every call, and the reason this module imports the config.
+    config: nextlyConfig,
     storage: {
       upload: async () => ({ path: "", url: "" }),
       delete: async () => {},

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -870,12 +870,11 @@ export async function registerServices(
     registerActivityLogHooks(hookRegistry);
     resolvedLogger.info?.("Activity log hooks registered");
 
-    // Registered after plugins initialize, not before. A hook may reach the
-    // Direct API through `req.nextly`, and that binding does not exist until
-    // service registration returns -- so registering earlier hands a hook an
-    // API that is not there yet. A plugin's `init` writing through the managed
-    // services therefore bypasses these hooks, which is recorded as its own
-    // problem rather than traded for a broken one.
+    // Registered after plugins initialize, because a hook may reach the Direct
+    // API through `req.nextly` and that binding does not exist until service
+    // registration returns -- registering earlier would hand a hook an API that
+    // is not there yet. The consequence is that a plugin's `init` writing
+    // through the managed services does so before these hooks exist.
     if (
       transformedConfig.collections &&
       transformedConfig.collections.length > 0

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -843,36 +843,6 @@ export async function registerServices(
   await syncCodeFirstSingles(adapter, resolvedLogger, transformedConfig);
 
   // ----------------------------------------
-  // Layer 6b: Register code-first collection hooks
-  // ----------------------------------------
-  // Before plugins initialize, not after: a plugin's `init` is given the live
-  // managed collection services and may read, write or seed through them, and
-  // anything it writes has to pass the same declared hooks every later request
-  // does. Registering afterwards would let initialization data skip the
-  // transformations and invariants that apply to everything else.
-  if (hookRegistry) {
-    if (
-      transformedConfig.collections &&
-      transformedConfig.collections.length > 0
-    ) {
-      const disabledCollectionSlugs = collectPluginContributedSlugs(
-        resolvedPlugins.filter(plugin => plugin.enabled === false),
-        "collections"
-      );
-      const hookedCollections = transformedConfig.collections.filter(
-        collection => !disabledCollectionSlugs.has(collection.slug)
-      );
-      const collectionHooks = registerCollectionHooks(
-        hookedCollections,
-        hookRegistry
-      );
-      resolvedLogger.info?.(
-        `Registered ${collectionHooks.totalHooks} hook(s) for ${collectionHooks.collections.length} collection(s)`
-      );
-    }
-  }
-
-  // ----------------------------------------
   // Layer 7: Initialize Plugins
   // ----------------------------------------
   // Stash the resolved plugins + their contexts so shutdownServices can run
@@ -899,6 +869,32 @@ export async function registerServices(
 
     registerActivityLogHooks(hookRegistry);
     resolvedLogger.info?.("Activity log hooks registered");
+
+    // Registered after plugins initialize, not before. A hook may reach the
+    // Direct API through `req.nextly`, and that binding does not exist until
+    // service registration returns -- so registering earlier hands a hook an
+    // API that is not there yet. A plugin's `init` writing through the managed
+    // services therefore bypasses these hooks, which is recorded as its own
+    // problem rather than traded for a broken one.
+    if (
+      transformedConfig.collections &&
+      transformedConfig.collections.length > 0
+    ) {
+      const disabledCollectionSlugs = collectPluginContributedSlugs(
+        resolvedPlugins.filter(plugin => plugin.enabled === false),
+        "collections"
+      );
+      const hookedCollections = transformedConfig.collections.filter(
+        collection => !disabledCollectionSlugs.has(collection.slug)
+      );
+      const collectionHooks = registerCollectionHooks(
+        hookedCollections,
+        hookRegistry
+      );
+      resolvedLogger.info?.(
+        `Registered ${collectionHooks.totalHooks} hook(s) for ${collectionHooks.collections.length} collection(s)`
+      );
+    }
 
     // Register hooks declared on code-first Singles so they run on the read and
     // update paths for every consumer (Direct API, REST, tests), not only apps

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -843,6 +843,36 @@ export async function registerServices(
   await syncCodeFirstSingles(adapter, resolvedLogger, transformedConfig);
 
   // ----------------------------------------
+  // Layer 6b: Register code-first collection hooks
+  // ----------------------------------------
+  // Before plugins initialize, not after: a plugin's `init` is given the live
+  // managed collection services and may read, write or seed through them, and
+  // anything it writes has to pass the same declared hooks every later request
+  // does. Registering afterwards would let initialization data skip the
+  // transformations and invariants that apply to everything else.
+  if (hookRegistry) {
+    if (
+      transformedConfig.collections &&
+      transformedConfig.collections.length > 0
+    ) {
+      const disabledCollectionSlugs = collectPluginContributedSlugs(
+        resolvedPlugins.filter(plugin => plugin.enabled === false),
+        "collections"
+      );
+      const hookedCollections = transformedConfig.collections.filter(
+        collection => !disabledCollectionSlugs.has(collection.slug)
+      );
+      const collectionHooks = registerCollectionHooks(
+        hookedCollections,
+        hookRegistry
+      );
+      resolvedLogger.info?.(
+        `Registered ${collectionHooks.totalHooks} hook(s) for ${collectionHooks.collections.length} collection(s)`
+      );
+    }
+  }
+
+  // ----------------------------------------
   // Layer 7: Initialize Plugins
   // ----------------------------------------
   // Stash the resolved plugins + their contexts so shutdownServices can run
@@ -869,32 +899,6 @@ export async function registerServices(
 
     registerActivityLogHooks(hookRegistry);
     resolvedLogger.info?.("Activity log hooks registered");
-
-    // Register hooks declared on code-first collections, on the same terms as
-    // the Singles block below. Without this the collection half of the
-    // documented hooks API is inert: the read and write paths ask the registry
-    // for a collection's handlers and it is always empty, so a declared
-    // `beforeChange` or `afterRead` never runs and the operation reports
-    // success regardless.
-    if (
-      transformedConfig.collections &&
-      transformedConfig.collections.length > 0
-    ) {
-      const disabledCollectionSlugs = collectPluginContributedSlugs(
-        resolvedPlugins.filter(plugin => plugin.enabled === false),
-        "collections"
-      );
-      const hookedCollections = transformedConfig.collections.filter(
-        collection => !disabledCollectionSlugs.has(collection.slug)
-      );
-      const collectionHooks = registerCollectionHooks(
-        hookedCollections,
-        hookRegistry
-      );
-      resolvedLogger.info?.(
-        `Registered ${collectionHooks.totalHooks} hook(s) for ${collectionHooks.collections.length} collection(s)`
-      );
-    }
 
     // Register hooks declared on code-first Singles so they run on the read and
     // update paths for every consumer (Direct API, REST, tests), not only apps

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -76,6 +76,7 @@ import type { FieldGroupConfig } from "../field-groups/config/types";
 import { registerActivityLogHooks } from "../hooks/activity-log-hooks";
 import type { HookRegistry } from "../hooks/hook-registry";
 import { getHookRegistry } from "../hooks/hook-registry";
+import { registerCollectionHooks } from "../hooks/register-collection-hooks";
 import { registerSingleHooks } from "../hooks/register-single-hooks";
 import { createSanitizationHook } from "../hooks/sanitization-hooks";
 import type { PluginPermission, PluginRole } from "../plugins/contributions";
@@ -868,6 +869,32 @@ export async function registerServices(
 
     registerActivityLogHooks(hookRegistry);
     resolvedLogger.info?.("Activity log hooks registered");
+
+    // Register hooks declared on code-first collections, on the same terms as
+    // the Singles block below. Without this the collection half of the
+    // documented hooks API is inert: the read and write paths ask the registry
+    // for a collection's handlers and it is always empty, so a declared
+    // `beforeChange` or `afterRead` never runs and the operation reports
+    // success regardless.
+    if (
+      transformedConfig.collections &&
+      transformedConfig.collections.length > 0
+    ) {
+      const disabledCollectionSlugs = collectPluginContributedSlugs(
+        resolvedPlugins.filter(plugin => plugin.enabled === false),
+        "collections"
+      );
+      const hookedCollections = transformedConfig.collections.filter(
+        collection => !disabledCollectionSlugs.has(collection.slug)
+      );
+      const collectionHooks = registerCollectionHooks(
+        hookedCollections,
+        hookRegistry
+      );
+      resolvedLogger.info?.(
+        `Registered ${collectionHooks.totalHooks} hook(s) for ${collectionHooks.collections.length} collection(s)`
+      );
+    }
 
     // Register hooks declared on code-first Singles so they run on the read and
     // update paths for every consumer (Direct API, REST, tests), not only apps

--- a/packages/nextly/src/domains/collections/__tests__/code-first-collection-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/code-first-collection-hooks.integration.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Hooks declared on a code-first collection actually run.
+ *
+ * `defineCollection({ hooks })` is the documented way to write collection
+ * hooks — the collections guide's own worked example is a `beforeChange` that
+ * generates a slug on create — but nothing registered them. Singles' hooks were
+ * registered at boot and collections' were not, so the read and write paths
+ * asked the registry for a collection's handlers and always got none. A declared
+ * hook simply never ran, and the operation reported success.
+ *
+ * Asserted end to end through a booted instance rather than against a mocked
+ * registry. The existing unit tests mock the registry and assert that the read
+ * path CALLS it, which is true and was true throughout: they check the consumer,
+ * and the missing half was the producer.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import { resetHookRegistry } from "../../../hooks/hook-registry";
+import { definePlugin } from "../../../plugins/plugin-context";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+  // Hooks register into the process-wide registry; clear between tests so one
+  // boot's handlers cannot answer for the next.
+  resetHookRegistry();
+});
+
+describe("code-first collection hooks (integration)", () => {
+  it("runs every declared lifecycle hook", async () => {
+    const fired: string[] = [];
+    const record =
+      (name: string) =>
+      async (ctx: { data?: unknown }): Promise<unknown> => {
+        fired.push(name);
+        return ctx.data;
+      };
+
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "docs",
+          access: { create: () => true, read: () => true, update: () => true },
+          hooks: {
+            beforeChange: [record("beforeChange")],
+            afterChange: [record("afterChange")],
+            beforeRead: [record("beforeRead")],
+            afterRead: [record("afterRead")],
+          },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const created = await handler.createEntry(
+      { collectionName: "docs", overrideAccess: true },
+      { title: "T" }
+    );
+    expect(created.success).toBe(true);
+    expect(fired).toContain("beforeChange");
+    expect(fired).toContain("afterChange");
+
+    fired.length = 0;
+    const read = await handler.getEntry({
+      collectionName: "docs",
+      entryId: (created.data as { id: string }).id,
+      user: { id: "u1" },
+      routeAuthorized: true,
+    });
+    expect(read.success).toBe(true);
+    expect(fired).toContain("beforeRead");
+    expect(fired).toContain("afterRead");
+  });
+
+  it("lets a beforeChange hook transform what is written", async () => {
+    // The guide's own example: derive a value on create. A hook that only
+    // "fires" without its return value being used would satisfy the test above
+    // while still being useless.
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "docs",
+          access: { create: () => true, read: () => true },
+          hooks: {
+            beforeChange: [
+              async ({ data }: { data?: Record<string, unknown> }) => ({
+                ...data,
+                title: `${String(data?.title ?? "")} (checked)`,
+              }),
+            ],
+          },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    const created = await handler.createEntry(
+      { collectionName: "docs", overrideAccess: true },
+      { title: "Draft" }
+    );
+
+    expect(created.success).toBe(true);
+    expect((created.data as { title?: string }).title).toBe("Draft (checked)");
+  });
+
+  it("does not run hooks from a collection a disabled plugin contributed", async () => {
+    // A disabled plugin's contributions stay in the config so the schema stays
+    // deterministic, but the lifecycle's behaviour-skip contract means its
+    // runtime hooks must not fire — the same carve-out Singles registration
+    // makes.
+    const fired: string[] = [];
+
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "kept",
+          access: { create: () => true, read: () => true },
+          hooks: {
+            beforeChange: [
+              async ({ data }: { data?: unknown }) => {
+                fired.push("kept");
+                return data;
+              },
+            ],
+          },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+      plugins: [
+        definePlugin({
+          name: "@test/disabled-hooks",
+          version: "1.0.0",
+          nextly: ">=0.0.0",
+          enabled: false,
+          // Declared through `contributes` rather than added in `setup`: that is
+          // the shape the disabled-slug filter reads, for collections exactly as
+          // for singles.
+          contributes: {
+            collections: [
+              defineCollection({
+                slug: "fromdisabled",
+                access: { create: () => true, read: () => true },
+                hooks: {
+                  beforeChange: [
+                    async ({ data }: { data?: unknown }) => {
+                      fired.push("from-disabled");
+                      return data;
+                    },
+                  ],
+                },
+                fields: [text({ name: "title" })],
+              }),
+            ],
+          },
+        }),
+      ],
+    });
+
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    await handler.createEntry(
+      { collectionName: "kept", overrideAccess: true },
+      { title: "T" }
+    );
+
+    expect(fired).toEqual(["kept"]);
+  });
+});

--- a/packages/nextly/src/domains/collections/__tests__/code-first-collection-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/code-first-collection-hooks.integration.test.ts
@@ -47,7 +47,7 @@ describe("code-first collection hooks (integration)", () => {
     current = await createTestNextly({
       collections: [
         defineCollection({
-          slug: "docs",
+          slug: "cfhdocs",
           access: { create: () => true, read: () => true, update: () => true },
           hooks: {
             beforeChange: [record("beforeChange")],
@@ -64,7 +64,7 @@ describe("code-first collection hooks (integration)", () => {
       current.getService<CollectionsHandler>("collectionsHandler");
 
     const created = await handler.createEntry(
-      { collectionName: "docs", overrideAccess: true },
+      { collectionName: "cfhdocs", overrideAccess: true },
       { title: "T" }
     );
     expect(created.success).toBe(true);
@@ -73,7 +73,7 @@ describe("code-first collection hooks (integration)", () => {
 
     fired.length = 0;
     const read = await handler.getEntry({
-      collectionName: "docs",
+      collectionName: "cfhdocs",
       entryId: (created.data as { id: string }).id,
       user: { id: "u1" },
       routeAuthorized: true,
@@ -90,7 +90,7 @@ describe("code-first collection hooks (integration)", () => {
     current = await createTestNextly({
       collections: [
         defineCollection({
-          slug: "docs",
+          slug: "cfhdocs",
           access: { create: () => true, read: () => true },
           hooks: {
             beforeChange: [
@@ -108,7 +108,7 @@ describe("code-first collection hooks (integration)", () => {
     const handler =
       current.getService<CollectionsHandler>("collectionsHandler");
     const created = await handler.createEntry(
-      { collectionName: "docs", overrideAccess: true },
+      { collectionName: "cfhdocs", overrideAccess: true },
       { title: "Draft" }
     );
 
@@ -126,12 +126,12 @@ describe("code-first collection hooks (integration)", () => {
     current = await createTestNextly({
       collections: [
         defineCollection({
-          slug: "kept",
+          slug: "cfhkept",
           access: { create: () => true, read: () => true },
           hooks: {
             beforeChange: [
               async ({ data }: { data?: unknown }) => {
-                fired.push("kept");
+                fired.push("cfhkept");
                 return data;
               },
             ],
@@ -151,7 +151,7 @@ describe("code-first collection hooks (integration)", () => {
           contributes: {
             collections: [
               defineCollection({
-                slug: "fromdisabled",
+                slug: "cfhfromdisabled",
                 access: { create: () => true, read: () => true },
                 hooks: {
                   beforeChange: [
@@ -172,10 +172,10 @@ describe("code-first collection hooks (integration)", () => {
     const handler =
       current.getService<CollectionsHandler>("collectionsHandler");
     await handler.createEntry(
-      { collectionName: "kept", overrideAccess: true },
+      { collectionName: "cfhkept", overrideAccess: true },
       { title: "T" }
     );
 
-    expect(fired).toEqual(["kept"]);
+    expect(fired).toEqual(["cfhkept"]);
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/code-first-collection-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/code-first-collection-hooks.integration.test.ts
@@ -18,6 +18,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { defineCollection, text } from "../../../config";
 import { resetHookRegistry } from "../../../hooks/hook-registry";
+import { registerCollectionHooks } from "../../../hooks/register-collection-hooks";
 import { definePlugin } from "../../../plugins/plugin-context";
 import {
   createTestNextly,
@@ -114,6 +115,44 @@ describe("code-first collection hooks (integration)", () => {
 
     expect(created.success).toBe(true);
     expect((created.data as { title?: string }).title).toBe("Draft (checked)");
+  });
+
+  it("runs a hook once when the same config is registered twice", async () => {
+    // A scaffolded app registers its collections' hooks itself and then boots,
+    // which registers them again. Appending both copies runs every hook twice:
+    // a transformation is applied twice and any side effect is duplicated.
+    const fired: string[] = [];
+
+    // Held so the second registration below uses the very same function
+    // references a scaffolded app would, which is what makes the duplicate a
+    // duplicate.
+    const docs = defineCollection({
+      slug: "docs",
+      access: { create: () => true, read: () => true },
+      hooks: {
+        beforeChange: [
+          async ({ data }: { data?: unknown }) => {
+            fired.push("beforeChange");
+            return data;
+          },
+        ],
+      },
+      fields: [text({ name: "title" })],
+    });
+
+    current = await createTestNextly({ collections: [docs] });
+
+    // The registration a scaffolded app performs before booting.
+    registerCollectionHooks([docs]);
+
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+    await handler.createEntry(
+      { collectionName: "docs", overrideAccess: true },
+      { title: "T" }
+    );
+
+    expect(fired).toEqual(["beforeChange"]);
   });
 
   it("does not run hooks from a collection a disabled plugin contributed", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/code-first-collection-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/code-first-collection-hooks.integration.test.ts
@@ -18,7 +18,6 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { defineCollection, text } from "../../../config";
 import { resetHookRegistry } from "../../../hooks/hook-registry";
-import { registerCollectionHooks } from "../../../hooks/register-collection-hooks";
 import { definePlugin } from "../../../plugins/plugin-context";
 import {
   createTestNextly,
@@ -115,44 +114,6 @@ describe("code-first collection hooks (integration)", () => {
 
     expect(created.success).toBe(true);
     expect((created.data as { title?: string }).title).toBe("Draft (checked)");
-  });
-
-  it("runs a hook once when the same config is registered twice", async () => {
-    // A scaffolded app registers its collections' hooks itself and then boots,
-    // which registers them again. Appending both copies runs every hook twice:
-    // a transformation is applied twice and any side effect is duplicated.
-    const fired: string[] = [];
-
-    // Held so the second registration below uses the very same function
-    // references a scaffolded app would, which is what makes the duplicate a
-    // duplicate.
-    const docs = defineCollection({
-      slug: "docs",
-      access: { create: () => true, read: () => true },
-      hooks: {
-        beforeChange: [
-          async ({ data }: { data?: unknown }) => {
-            fired.push("beforeChange");
-            return data;
-          },
-        ],
-      },
-      fields: [text({ name: "title" })],
-    });
-
-    current = await createTestNextly({ collections: [docs] });
-
-    // The registration a scaffolded app performs before booting.
-    registerCollectionHooks([docs]);
-
-    const handler =
-      current.getService<CollectionsHandler>("collectionsHandler");
-    await handler.createEntry(
-      { collectionName: "docs", overrideAccess: true },
-      { title: "T" }
-    );
-
-    expect(fired).toEqual(["beforeChange"]);
   });
 
   it("does not run hooks from a collection a disabled plugin contributed", async () => {

--- a/packages/nextly/src/hooks/hook-registry.ts
+++ b/packages/nextly/src/hooks/hook-registry.ts
@@ -97,19 +97,7 @@ export class HookRegistry {
       this.hooks.set(key, []);
     }
 
-    const handlers = this.hooks.get(key)!;
-    // The same function, for the same hook and collection, twice is never
-    // something a caller wants: it runs the handler twice, applying a
-    // transformation twice and duplicating whatever side effect it has. It
-    // happens when two boot paths register the same config -- a scaffolded app
-    // that registers its collections' hooks itself and then boots, which
-    // registers them again -- and the second registration is redundant rather
-    // than additional. Compared by identity, so two distinct functions that
-    // happen to do the same thing both still register.
-    if (handlers.includes(handler)) {
-      return;
-    }
-    handlers.push(handler);
+    this.hooks.get(key)!.push(handler);
   }
 
   /**

--- a/packages/nextly/src/hooks/hook-registry.ts
+++ b/packages/nextly/src/hooks/hook-registry.ts
@@ -97,7 +97,19 @@ export class HookRegistry {
       this.hooks.set(key, []);
     }
 
-    this.hooks.get(key)!.push(handler);
+    const handlers = this.hooks.get(key)!;
+    // The same function, for the same hook and collection, twice is never
+    // something a caller wants: it runs the handler twice, applying a
+    // transformation twice and duplicating whatever side effect it has. It
+    // happens when two boot paths register the same config -- a scaffolded app
+    // that registers its collections' hooks itself and then boots, which
+    // registers them again -- and the second registration is redundant rather
+    // than additional. Compared by identity, so two distinct functions that
+    // happen to do the same thing both still register.
+    if (handlers.includes(handler)) {
+      return;
+    }
+    handlers.push(handler);
   }
 
   /**

--- a/packages/nextly/src/hooks/register-collection-hooks.ts
+++ b/packages/nextly/src/hooks/register-collection-hooks.ts
@@ -62,6 +62,27 @@ export interface RegisterCollectionHooksResult {
  * (beforeChange/afterChange) which needs to be mapped to the
  * HookRegistry types (beforeCreate/beforeUpdate, etc.)
  */
+/**
+ * What this module has already registered, per registry.
+ *
+ * Held here rather than in the registry because the registry deliberately
+ * allows the same function to be subscribed more than once: two plugins may
+ * share a handler, and one unsubscribing must not silence the other. Only this
+ * path can tell that a second call describes declarations it already
+ * registered.
+ *
+ * Weakly keyed, so a registry that goes out of scope -- one per test, for
+ * instance -- takes its bookkeeping with it.
+ */
+const registeredByRegistry = new WeakMap<
+  HookRegistry,
+  Map<string, Set<HookHandler>>
+>();
+
+function registrationKey(hookType: HookType, collection: string): string {
+  return `${hookType}:${collection}`;
+}
+
 const HOOK_TYPE_MAPPINGS: Record<keyof CollectionHooks, HookType[]> = {
   beforeOperation: ["beforeOperation"],
   beforeValidate: ["beforeCreate", "beforeUpdate"], // Validate runs before create/update
@@ -127,6 +148,25 @@ export function registerCollectionHooks(
   collections: CollectionConfig[],
   registry: HookRegistry = getHookRegistry()
 ): RegisterCollectionHooksResult {
+  let registered = registeredByRegistry.get(registry);
+  if (!registered) {
+    registered = new Map<string, Set<HookHandler>>();
+    registeredByRegistry.set(registry, registered);
+  }
+  const rememberRegistration = (
+    hookType: HookType,
+    collection: string,
+    handler: HookHandler
+  ): void => {
+    const key = registrationKey(hookType, collection);
+    let handlers = registered.get(key);
+    if (!handlers) {
+      handlers = new Set<HookHandler>();
+      registered.set(key, handlers);
+    }
+    handlers.add(handler);
+  };
+
   const result: RegisterCollectionHooksResult = {
     collections: [],
     totalHooks: 0,
@@ -146,21 +186,47 @@ export function registerCollectionHooks(
 
     let collectionHookCount = 0;
 
-    // Register each hook type
-    for (const [hookKey, handlers] of Object.entries(collection.hooks)) {
+    // Driven by the mapping's own order, not the config object's. Two phases
+    // can map onto the same queue -- `beforeValidate` and `beforeChange` both
+    // become `beforeCreate`/`beforeUpdate` -- so the order they are registered
+    // in IS their runtime order. Iterating the author's object would make that
+    // depend on which key they happened to type first, and a collection
+    // declaring `beforeChange` above `beforeValidate` would run its validation
+    // transformation after the write hook that expects it. The mapping is
+    // declared in the documented execution order, so following it keeps the
+    // two in step.
+    for (const hookKey of Object.keys(
+      HOOK_TYPE_MAPPINGS
+    ) as (keyof CollectionHooks)[]) {
+      const handlers = collection.hooks[hookKey];
       if (!handlers || !Array.isArray(handlers) || handlers.length === 0) {
         continue;
       }
 
-      const hookTypes = HOOK_TYPE_MAPPINGS[hookKey as keyof CollectionHooks];
-      if (!hookTypes) {
-        continue;
-      }
+      const hookTypes = HOOK_TYPE_MAPPINGS[hookKey];
 
       // Register handlers for each mapped hook type
       for (const hookType of hookTypes) {
         for (const handler of handlers) {
-          registry.register(hookType, collection.slug, handler as HookHandler);
+          // A scaffolded app registers its collections' hooks itself and then
+          // boots, which registers the same config again. Appending both copies
+          // runs every hook twice: a transformation applied twice, and any side
+          // effect duplicated.
+          //
+          // Skipped here rather than in the registry, which deliberately allows
+          // the same function to be subscribed more than once -- two plugins may
+          // share a handler, and one unsubscribing must not silence the other.
+          // This path is different: it re-registers declarations that are
+          // already registered, so the second copy is redundant rather than
+          // additional. Identity comparison, so two distinct functions that
+          // happen to do the same thing both still register.
+          const alreadyRegistered = registered
+            .get(registrationKey(hookType, collection.slug))
+            ?.has(handler);
+          if (alreadyRegistered) continue;
+
+          registry.register(hookType, collection.slug, handler);
+          rememberRegistration(hookType, collection.slug, handler);
           collectionHookCount++;
         }
       }

--- a/packages/nextly/src/hooks/register-collection-hooks.ts
+++ b/packages/nextly/src/hooks/register-collection-hooks.ts
@@ -27,7 +27,7 @@ import type {
 } from "../collections/config/define-collection";
 
 import { getHookRegistry, type HookRegistry } from "./hook-registry";
-import type { HookType, HookHandler } from "./types";
+import type { HookType } from "./types";
 
 /**
  * Result of registering collection hooks
@@ -62,27 +62,6 @@ export interface RegisterCollectionHooksResult {
  * (beforeChange/afterChange) which needs to be mapped to the
  * HookRegistry types (beforeCreate/beforeUpdate, etc.)
  */
-/**
- * What this module has already registered, per registry.
- *
- * Held here rather than in the registry because the registry deliberately
- * allows the same function to be subscribed more than once: two plugins may
- * share a handler, and one unsubscribing must not silence the other. Only this
- * path can tell that a second call describes declarations it already
- * registered.
- *
- * Weakly keyed, so a registry that goes out of scope -- one per test, for
- * instance -- takes its bookkeeping with it.
- */
-const registeredByRegistry = new WeakMap<
-  HookRegistry,
-  Map<string, Set<HookHandler>>
->();
-
-function registrationKey(hookType: HookType, collection: string): string {
-  return `${hookType}:${collection}`;
-}
-
 const HOOK_TYPE_MAPPINGS: Record<keyof CollectionHooks, HookType[]> = {
   beforeOperation: ["beforeOperation"],
   beforeValidate: ["beforeCreate", "beforeUpdate"], // Validate runs before create/update
@@ -148,25 +127,6 @@ export function registerCollectionHooks(
   collections: CollectionConfig[],
   registry: HookRegistry = getHookRegistry()
 ): RegisterCollectionHooksResult {
-  let registered = registeredByRegistry.get(registry);
-  if (!registered) {
-    registered = new Map<string, Set<HookHandler>>();
-    registeredByRegistry.set(registry, registered);
-  }
-  const rememberRegistration = (
-    hookType: HookType,
-    collection: string,
-    handler: HookHandler
-  ): void => {
-    const key = registrationKey(hookType, collection);
-    let handlers = registered.get(key);
-    if (!handlers) {
-      handlers = new Set<HookHandler>();
-      registered.set(key, handlers);
-    }
-    handlers.add(handler);
-  };
-
   const result: RegisterCollectionHooksResult = {
     collections: [],
     totalHooks: 0,
@@ -208,25 +168,7 @@ export function registerCollectionHooks(
       // Register handlers for each mapped hook type
       for (const hookType of hookTypes) {
         for (const handler of handlers) {
-          // A scaffolded app registers its collections' hooks itself and then
-          // boots, which registers the same config again. Appending both copies
-          // runs every hook twice: a transformation applied twice, and any side
-          // effect duplicated.
-          //
-          // Skipped here rather than in the registry, which deliberately allows
-          // the same function to be subscribed more than once -- two plugins may
-          // share a handler, and one unsubscribing must not silence the other.
-          // This path is different: it re-registers declarations that are
-          // already registered, so the second copy is redundant rather than
-          // additional. Identity comparison, so two distinct functions that
-          // happen to do the same thing both still register.
-          const alreadyRegistered = registered
-            .get(registrationKey(hookType, collection.slug))
-            ?.has(handler);
-          if (alreadyRegistered) continue;
-
           registry.register(hookType, collection.slug, handler);
-          rememberRegistration(hookType, collection.slug, handler);
           collectionHookCount++;
         }
       }


### PR DESCRIPTION
`defineCollection({ hooks })` — the documented, exported, code-first hooks API —
registered nothing at boot, so no hook of any lifecycle ever ran. Probed on
`main`, a collection declaring all four lifecycles:

```
create: true 201
read:   true 200
hooks that fired: (NONE)
```

Both operations succeeded and nothing fired. `docs/configuration/collections.mdx`
teaches this API, and its own worked example is a `beforeChange` that generates a
slug on create — that example did not work.

## Mechanism

`registerSingleHooks(...)` is called during boot at `di/register.ts:890`.
`registerCollectionHooks(...)` had **no runtime caller** — its only call site was
`cli/commands/init.ts`. Singles' code-first hooks worked and collections' did not.
`register-single-hooks.ts` describes itself as "the twin of
`registerCollectionHooks`"; it is the twin that was called.

## What this PR does, after the review narrowed it

1. **Registers the hooks**, beside the singles block, skipping a disabled
   plugin's collections and appending rather than replacing.
2. **Before plugin initialization**, so anything a plugin's `init` seeds through
   the managed services passes the same declared hooks every later request does.
3. **In the documented phase order**, driven by `HOOK_TYPE_MAPPINGS` rather than
   the config object's key order. This matters because `beforeValidate` and
   `beforeChange` map onto the same queue, so registration order *is* runtime
   order.
4. **Removes the scaffold's now-redundant registration**, which would otherwise
   register the same config twice and run every hook twice.

## What it deliberately does not do

The review surfaced that registration sits on top of several latent contract
mismatches. It did not create them — it makes them reachable — and each is a
place the collection path disagrees with the singles path, which got them right.
The form-builder `beforeValidate` bug (#424, merged) was the first of that family
and had to land before this one.

Filed rather than folded in, each with its reasoning on its thread:

| task | |
|---|---|
| `091-hook-registry-provenance` | HMR refresh + disabled-plugin `setup()` collections — one missing capability seen from two sides. The obvious HMR fix would delete form-builder's own `afterRead` on `forms`. |
| `092-beforeread-hook-result-discarded` | `beforeRead`'s return is discarded, so a hook returning a tenant filter restricts nothing. Changes which rows a read returns; deserves isolated review. |
| `093-collection-hook-contract-gaps` | `afterChange`/`afterDelete` returns corrupting the next handler; `beforeOperation` context shape; idempotence for already-scaffolded apps. |

**One negative result recorded in 093, because it is the likely re-attempt:**
deduplicating handlers by identity was tried here and reverted. It cannot
distinguish a config re-registered by a second boot path from a function the
author deliberately declared twice — listed twice, or reused for `beforeValidate`
and `beforeChange` — and the bookkeeping goes stale against every clearing path,
breaking `reregisterCollectionHooks`, which clears and re-registers by design.

## Verification

Three integration tests, asserted through a booted instance:

1. every declared lifecycle fires, on create and on read
2. a `beforeChange` **return value changes what is written** (`"Draft"` in,
   `"Draft (checked)"` stored) — a hook that fires without its result being used
   would satisfy (1) and still be useless
3. a disabled plugin's collection hooks do **not** fire

All three fail with the registration reverted.

`collection-hooks.test.ts` has 23 passing tests about hook order and arguments —
against a **mocked** registry, asserting the read path *calls* it. They cover the
consumer; the missing half was the producer, which is why these are
integration-level.

Baselines: SQLite integration **815 passed / 0 failed** (953); unit failing-test
**name set identical** to a same-commit baseline (401 both sides, zero new);
registry suite 51/51; types and lint clean.