### PR TITLE
fix(nextly): encode a JSON-column string that is not encoded JSON

### DIFF
--- a/.changeset/json-column-string-encoding.md
+++ b/.changeset/json-column-string-encoding.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+A string stored in a JSON field no longer fails the write on PostgreSQL and MySQL.
+
+A field backed by a JSON column accepts any JSON document, a plain string included. A string that is not itself encoded JSON was passed through to the driver as bare text, which PostgreSQL and MySQL reject as invalid JSON, so storing `"hello"` in a `json` field failed the write outright. On SQLite, where the column is plain text, it was stored in a form no read could recover as what was written. Such a value is now encoded, so it round-trips as the string it was.
+
+A string that already parses as JSON is still passed through untouched, so content a previous write encoded is not wrapped a second time.

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -2123,13 +2123,7 @@ export class CollectionMutationService extends BaseService {
           isJsonFieldType(field.type, field) &&
           finalData[field.name] != null
         ) {
-          const encoded = toJsonColumnValue(finalData[field.name]);
-          finalData[field.name] = encoded.value;
-          if (encoded.invalidJsonString) {
-            console.warn(
-              `[createEntry] Field "${field.name}" (type: ${field.type}) is a string but not valid JSON`
-            );
-          }
+          finalData[field.name] = toJsonColumnValue(finalData[field.name]);
         }
       });
 
@@ -4029,13 +4023,7 @@ export class CollectionMutationService extends BaseService {
           isJsonFieldType(field.type, field) &&
           finalData[field.name] != null
         ) {
-          const encoded = toJsonColumnValue(finalData[field.name]);
-          finalData[field.name] = encoded.value;
-          if (encoded.invalidJsonString) {
-            console.warn(
-              `[updateEntry] Field "${field.name}" (type: ${field.type}) is a string but not valid JSON`
-            );
-          }
+          finalData[field.name] = toJsonColumnValue(finalData[field.name]);
         }
       });
 

--- a/packages/nextly/src/domains/field-groups/services/field-group-mutation-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-mutation-service.ts
@@ -288,7 +288,7 @@ export class FieldGroupMutationService extends BaseService {
         // of the same fields, so a scalar JSON document has to be written the
         // same way on both sides or a translation reads back differently from
         // the value it was translated from.
-        out[column] = toJsonColumnValue(value).value;
+        out[column] = toJsonColumnValue(value);
       } else {
         out[column] = value;
       }
@@ -1564,7 +1564,7 @@ export class FieldGroupMutationService extends BaseService {
       const columnName = toSnakeCase(key);
 
       result[columnName] = shouldTreatAsJson(field)
-        ? toJsonColumnValue(value).value
+        ? toJsonColumnValue(value)
         : value;
     }
 

--- a/packages/nextly/src/domains/singles/services/single-utils.ts
+++ b/packages/nextly/src/domains/singles/services/single-utils.ts
@@ -569,7 +569,7 @@ export function serializeJsonFields(
     if (!("name" in field) || !field.name) continue;
 
     if (shouldTreatAsJson(field) && result[field.name] != null) {
-      result[field.name] = toJsonColumnValue(result[field.name]).value;
+      result[field.name] = toJsonColumnValue(result[field.name]);
     }
   }
 

--- a/packages/nextly/src/shared/lib/__tests__/json-column-value.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/json-column-value.test.ts
@@ -3,6 +3,11 @@
  * as much as `{}` is. Encoding only objects left a scalar to reach the driver
  * as its own type — on SQLite, where the column is plain text, a boolean bound
  * to a text column does not read back as JSON `true`.
+ *
+ * A string is the ambiguous input: it may be a document an earlier step
+ * encoded, or the logical string being stored. One half of that is not
+ * ambiguous at all — a string that does not parse cannot be an encoded
+ * document, so writing it raw is wrong under either meaning.
  */
 import { describe, expect, it } from "vitest";
 
@@ -10,32 +15,39 @@ import { toJsonColumnValue } from "../json-column-value";
 
 describe("toJsonColumnValue", () => {
   it("encodes a scalar JSON document", () => {
-    expect(toJsonColumnValue(true).value).toBe("true");
-    expect(toJsonColumnValue(42).value).toBe("42");
+    expect(toJsonColumnValue(true)).toBe("true");
+    expect(toJsonColumnValue(42)).toBe("42");
   });
 
   it("encodes objects and arrays", () => {
-    expect(toJsonColumnValue({ a: 1 }).value).toBe('{"a":1}');
-    expect(toJsonColumnValue([1, 2]).value).toBe("[1,2]");
+    expect(toJsonColumnValue({ a: 1 })).toBe('{"a":1}');
+    expect(toJsonColumnValue([1, 2])).toBe("[1,2]");
   });
 
   it("leaves an already-encoded string alone", () => {
     // Re-encoding would wrap it in quotes and change what is stored.
-    expect(toJsonColumnValue('{"a":1}').value).toBe('{"a":1}');
-    expect(toJsonColumnValue('{"a":1}').invalidJsonString).toBe(false);
+    expect(toJsonColumnValue('{"a":1}')).toBe('{"a":1}');
   });
 
-  it("reports a string that is not JSON, without altering it", () => {
-    const result = toJsonColumnValue("not json");
+  it("encodes a string that cannot be an encoded document", () => {
+    // Written raw it puts bare text where the column holds JSON, which
+    // Postgres and MySQL reject outright. Nothing could have produced it as an
+    // encoded document, so there is no double-encoding to fear.
+    expect(toJsonColumnValue("not json")).toBe('"not json"');
+  });
 
-    expect(result.value).toBe("not json");
-    expect(result.invalidJsonString).toBe(true);
+  it("round-trips a non-parsing string through a JSON parse", () => {
+    // What the read side does with the stored text, so the value a caller gets
+    // back is the string they wrote rather than a parse failure.
+    const stored = toJsonColumnValue("hello");
+
+    expect(JSON.parse(stored as string)).toBe("hello");
   });
 
   it("passes null and undefined through", () => {
     // The column is nullable and the callers skip these, so encoding them
     // would write the string "null" where a real SQL NULL belongs.
-    expect(toJsonColumnValue(null).value).toBeNull();
-    expect(toJsonColumnValue(undefined).value).toBeUndefined();
+    expect(toJsonColumnValue(null)).toBeNull();
+    expect(toJsonColumnValue(undefined)).toBeUndefined();
   });
 });

--- a/packages/nextly/src/shared/lib/json-column-value.ts
+++ b/packages/nextly/src/shared/lib/json-column-value.ts
@@ -8,19 +8,15 @@
  * column is plain text, that binds a boolean to a text column and reads back as
  * something other than what was written.
  *
+ * A string is the one input the value alone cannot classify: it may be a
+ * document an earlier step encoded, or the logical string the caller means to
+ * store. Whether it parses is the only signal available, and it is a heuristic
+ * — a logical string that happens to look like JSON is read as a document. What
+ * is NOT ambiguous is a string that does not parse: nothing can read it as an
+ * encoded document, so writing it raw is wrong under either meaning.
+ *
  * @module shared/lib/json-column-value
  */
-
-/** What a value turned into, and whether it was a string that is not JSON. */
-export interface JsonColumnValue {
-  value: unknown;
-  /**
-   * The value was already a string but does not parse as JSON. Left exactly as
-   * given — re-encoding it would double-serialize content a previous write
-   * stored — and reported so a caller can say so.
-   */
-  invalidJsonString: boolean;
-}
 
 /**
  * Encode `value` for a JSON column.
@@ -29,24 +25,26 @@ export interface JsonColumnValue {
  * callers already skip them, so encoding them here would write the string
  * `"null"` where a real SQL NULL belongs.
  */
-export function toJsonColumnValue(value: unknown): JsonColumnValue {
-  if (value === null || value === undefined) {
-    return { value, invalidJsonString: false };
-  }
+export function toJsonColumnValue(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
 
   if (typeof value === "string") {
     try {
       JSON.parse(value);
-      // Already encoded by an earlier write or by the caller; re-encoding would
-      // wrap it in quotes and change what is stored.
-      return { value, invalidJsonString: false };
+      // Parses, so it is taken as a document an earlier step already encoded.
+      // Re-encoding would wrap it in quotes and change what is stored.
+      return value;
     } catch {
-      return { value, invalidJsonString: true };
+      // Does not parse, so it is not an encoded document and there is nothing
+      // to double-encode. Written raw it puts bare text where the column holds
+      // JSON, which Postgres and MySQL reject outright; encoding it stores the
+      // string the caller actually had.
+      return JSON.stringify(value);
     }
   }
 
   // Objects, arrays, booleans and numbers all encode the same way. A boolean
   // and a number are legal JSON documents in their own right, which is why they
   // belong here rather than being passed through as the driver's own types.
-  return { value: JSON.stringify(value), invalidJsonString: false };
+  return JSON.stringify(value);
 }


### PR DESCRIPTION
Takes the P2 items deferred out of #405 (task **088**, and a verification pass on task **087**).

## What this fixes

A JSON column holds a JSON document, and a plain string is one. A string that did not itself parse as JSON was passed to the driver as bare text:

- **Postgres and MySQL reject it outright** as invalid JSON, so storing `"hello"` in a `json` field failed the write.
- **SQLite** kept it as text that no read could recover as what was written.

Such a string is now encoded. A string that *does* parse is still passed through untouched, so content an earlier step encoded is not wrapped a second time.

`invalidJsonString` and the `console.warn` each call site emitted from it are gone — the case they reported no longer occurs.

## The recorded blocker did not hold

Task 088 said this could not be fixed because `field-transform.ts:357` pre-serializes, so already-encoded strings genuinely reach the encoder. Measured on `main`: **it does not.** `transformForStorage` is re-exported from two barrels and **called from nowhere in the codebase**, and none of the four `toJsonColumnValue` call sites run it.

The two layers also disagreed on what "already serialized" means — `isAlreadySerialized` tests for `[...]`/`{...}` brackets, the encoder tests whether the string parses. They were never one pipeline.

## What is deliberately *not* fixed

The genuinely ambiguous half. A logical string that happens to look like JSON — `'{"a":1}'` meant as text, or `"true"` meant as a word — still parses and is still stored as the document it resembles. Telling those apart needs a contract decision, and it changes the meaning of rows already written, so it is not a drop-in. Recorded in task 088 under "What is still open".

Scoped this way on purpose: the half shipped here is correct under *either* resolution of that decision, so it does not pre-commit it.

## Task 087

Verified rather than assumed, and closed by design. The contract is documented in `plugins/validate-field-values.ts` and pinned by `does not descend into a component declaration`. Adding traversal would check a value that is never present, since a component's children are extracted and written separately. No code change.

## Verification

- New behaviour stub-verified: reverting to the raw write fails exactly the two new tests.
- Unit suite: **401 failures, matching the baseline by name** — none added.
- **Postgres 17 integration: 178 files, 925 tests, all passing.** MySQL leg running.
- `check-types` and `lint` clean.
