### PR TITLE
feat(nextly): emit a curated, PII-safe form.submission.created webhook

### DIFF
--- a/.changeset/form-submission-events.md
+++ b/.changeset/form-submission-events.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Emit a `form.submission.created` webhook when a form submission is created. The event type was already subscribable in the admin UI but had no producer, so an operator could subscribe to an event that never fired.
+
+Form submissions carry visitor-entered answers plus `ipAddress`/`userAgent`, so the submissions collection suppresses the PII-bearing `entry.*` events. It now instead emits a curated, metadata-only `form.submission.created` carrying only which form, when, and the status — never the answers, IP, or user agent. The event is recorded in the same transaction as the submission, so it commits atomically and is never delivered for a rolled-back write.
+
+This is driven by a new declarative `webhooks.emit` collection option (`{ event, fields }`): any PII-bearing collection can replace its default `entry.*` events with a safe curated one that ships only an allowlisted set of fields (default-deny). The resource kind is derived from the event name.

--- a/packages/nextly/src/collections/config/define-collection.ts
+++ b/packages/nextly/src/collections/config/define-collection.ts
@@ -34,6 +34,7 @@
 import type { HookHandler } from "@nextly/hooks/types";
 
 import type { CollectionAccessControl } from "../../domains/auth/services/access-control-types";
+import type { WebhookEventType } from "../../domains/webhooks/types";
 import type { RevalidateConfig } from "../../revalidation/types";
 import type { VersionsConfig } from "../../schemas/versions/types";
 import { simplePluralize } from "../../shared/lib/pluralization";
@@ -790,15 +791,39 @@ export interface CollectionConfig {
 
   /**
    * Webhook recording policy for this collection. When `false` (or
-   * `{ record: false }`), writes to this collection record NO event to the
-   * webhook outbox, so nothing is ever delivered to subscribed endpoints. Used
-   * to keep PII-bearing content — form submissions carry `ipAddress`/`userAgent`
-   * — out of the delivery path. The object form leaves room for finer policy
-   * later without a breaking change.
+   * `{ record: false }`), writes to this collection record NO `entry.*` event to
+   * the webhook outbox, so nothing is ever delivered to subscribed endpoints.
+   * Used to keep PII-bearing content — form submissions carry
+   * `ipAddress`/`userAgent` and free-form answers — out of the delivery path.
+   *
+   * `emit` replaces the suppressed default event with a curated, metadata-only
+   * one: pair `record: false` with `emit` on a PII collection so subscribers
+   * still learn a row was created, carrying only the allowlisted fields.
    *
    * @default true (writes are recorded)
    */
-  webhooks?: boolean | { record?: boolean };
+  webhooks?:
+    | boolean
+    | {
+        /** Whether the default `entry.*` events record. @default true */
+        record?: boolean;
+        /**
+         * Emit a curated event on create instead of relying on the default
+         * `entry.created`. The event carries only the allowlisted `fields`
+         * (default-deny), so a PII collection can notify subscribers of a new
+         * row without ever shipping the row's sensitive content.
+         */
+        emit?: {
+          /** A declared webhook event type, e.g. `"form.submission.created"`. */
+          event: WebhookEventType;
+          /**
+           * Allowlist of document keys copied into the event payload. Only
+           * these keys ship (default-deny); the created row's id is always
+           * included in the event resource. Omit to ship id only.
+           */
+          fields?: readonly string[];
+        };
+      };
 
   /**
    * Admin panel configuration options.

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -1212,13 +1212,24 @@ function publishWebhookRecordingPolicies(config: NextlyServiceConfig): void {
   for (const collection of config.collections ?? []) {
     const slug = (collection as { slug?: string }).slug;
     if (!slug) continue;
+    const resolved = resolveWebhookRecording(
+      (
+        collection as {
+          webhooks?:
+            | boolean
+            | {
+                record?: boolean;
+                emit?: { event?: unknown; fields?: unknown };
+              };
+        }
+      ).webhooks
+    );
     setWebhookRecording(
       "collection",
       slug,
-      resolveWebhookRecording(
-        (collection as { webhooks?: boolean | { record?: boolean } }).webhooks
-      ).record,
-      pluginCollections.has(slug) ? "plugin" : "code"
+      resolved.record,
+      pluginCollections.has(slug) ? "plugin" : "code",
+      resolved.emit
     );
   }
   for (const single of config.singles ?? []) {

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -449,10 +449,15 @@ export class CollectionMutationService extends BaseService {
     const emitSpec = getWebhookEmitSpec("collection", collectionName);
     if (!emitSpec) return false;
     const locale = writeLocale ? { locale: writeLocale } : {};
-    const resource: WebhookResource =
-      emitSpec.kind === "entry"
-        ? { kind: "entry", collection: collectionName, id: entryId, ...locale }
-        : { kind: emitSpec.kind, slug: collectionName, id: entryId, ...locale };
+    // `emitSpec.kind` is a non-entry family (normalization rejects entry.*), so
+    // the resource carries a `slug` and never a `collection`: the per-collection
+    // opt-out that suppressed the raw entry.* events does not gate this kind.
+    const resource: WebhookResource = {
+      kind: emitSpec.kind,
+      slug: collectionName,
+      id: entryId,
+      ...locale,
+    };
     return recordMutationEvent(tx, {
       type: emitSpec.event,
       resource,
@@ -6019,7 +6024,11 @@ export class CollectionMutationService extends BaseService {
       // recorded event with a parent-only payload.
       const needsRelations =
         !!versionsConfig?.enabled ||
-        !isRecordingDisabledByConfig("collection", params.collectionName);
+        !isRecordingDisabledByConfig("collection", params.collectionName) ||
+        // A curated `webhooks.emit` consumes the assembled document too — its
+        // allowlist may include a component/m2m field — so assemble relations
+        // even when the raw entry.* recording is opted out for this collection.
+        getWebhookEmitSpec("collection", params.collectionName) !== undefined;
       const { documentParts: createdParts, document: createdDocument } =
         await this.readTxDocumentParts(tx, {
           collectionName: params.collectionName,
@@ -6540,7 +6549,11 @@ export class CollectionMutationService extends BaseService {
       // recorded event with a parent-only payload.
       const needsRelations =
         !!versionsConfig?.enabled ||
-        !isRecordingDisabledByConfig("collection", params.collectionName);
+        !isRecordingDisabledByConfig("collection", params.collectionName) ||
+        // A curated `webhooks.emit` consumes the assembled document too — its
+        // allowlist may include a component/m2m field — so assemble relations
+        // even when the raw entry.* recording is opted out for this collection.
+        getWebhookEmitSpec("collection", params.collectionName) !== undefined;
       // The `previous` document is carried ONLY by the outbox event, never by the
       // version snapshot, so gate its relation read on webhook recording alone: a
       // version-only update (versioning on, recording disabled by config) skips it
@@ -7413,7 +7426,11 @@ export class CollectionMutationService extends BaseService {
       // recorded event with a parent-only payload.
       const needsRelations =
         !!versionsConfig?.enabled ||
-        !isRecordingDisabledByConfig("collection", params.collectionName);
+        !isRecordingDisabledByConfig("collection", params.collectionName) ||
+        // A curated `webhooks.emit` consumes the assembled document too — its
+        // allowlist may include a component/m2m field — so assemble relations
+        // even when the raw entry.* recording is opted out for this collection.
+        getWebhookEmitSpec("collection", params.collectionName) !== undefined;
       const { documentParts: createdParts, document: createdDocument } =
         await this.readTxDocumentParts(tx, {
           collectionName: params.collectionName,
@@ -8006,7 +8023,11 @@ export class CollectionMutationService extends BaseService {
       // recorded event with a parent-only payload.
       const needsRelations =
         !!versionsConfig?.enabled ||
-        !isRecordingDisabledByConfig("collection", params.collectionName);
+        !isRecordingDisabledByConfig("collection", params.collectionName) ||
+        // A curated `webhooks.emit` consumes the assembled document too — its
+        // allowlist may include a component/m2m field — so assemble relations
+        // even when the raw entry.* recording is opted out for this collection.
+        getWebhookEmitSpec("collection", params.collectionName) !== undefined;
       // The `previous` document is carried ONLY by the outbox event, never by the
       // version snapshot, so gate its relation read on webhook recording alone: a
       // version-only update (versioning on, recording disabled by config) skips it

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -462,21 +462,29 @@ export class CollectionMutationService extends BaseService {
     // Expand the field tree so a password/hidden value nested inside an
     // allowlisted group/component/repeater is still stripped from the
     // (default-deny) projection: the curated event ships data, so it needs the
-    // same sensitive-field stripping the raw entry.* events get.
-    const sensitiveFields = await this.webhookFieldTree(
-      fields,
-      tx.getDrizzle()
-    );
-    return recordMutationEvent(tx, {
-      type: emitSpec.event,
-      resource,
-      // Default-deny projection: only the allowlisted keys ship, so a PII
-      // collection's sensitive columns never reach the payload.
-      data: projectFields(createdDocument, emitSpec.fields),
-      previous: null,
-      fields: sensitiveFields,
-      actor,
-    });
+    // same sensitive-field stripping the raw entry.* events get. The recording is
+    // a write-integrity operation — a failure (component expansion or the outbox
+    // insert) must roll the write back, never commit the row without its promised
+    // event — so mark it for the bulk/transaction create loops, which otherwise
+    // convert an error into a soft per-item failure and continue.
+    try {
+      const sensitiveFields = await this.webhookFieldTree(
+        fields,
+        tx.getDrizzle()
+      );
+      return await recordMutationEvent(tx, {
+        type: emitSpec.event,
+        resource,
+        // Default-deny projection: only the allowlisted keys ship, so a PII
+        // collection's sensitive columns never reach the payload.
+        data: projectFields(createdDocument, emitSpec.fields),
+        previous: null,
+        fields: sensitiveFields,
+        actor,
+      });
+    } catch (err) {
+      throw markWriteIntegrityFailure(err);
+    }
   }
 
   /**
@@ -6559,11 +6567,7 @@ export class CollectionMutationService extends BaseService {
       // recorded event with a parent-only payload.
       const needsRelations =
         !!versionsConfig?.enabled ||
-        !isRecordingDisabledByConfig("collection", params.collectionName) ||
-        // A curated `webhooks.emit` consumes the assembled document too — its
-        // allowlist may include a component/m2m field — so assemble relations
-        // even when the raw entry.* recording is opted out for this collection.
-        getWebhookEmitSpec("collection", params.collectionName) !== undefined;
+        !isRecordingDisabledByConfig("collection", params.collectionName);
       // The `previous` document is carried ONLY by the outbox event, never by the
       // version snapshot, so gate its relation read on webhook recording alone: a
       // version-only update (versioning on, recording disabled by config) skips it
@@ -8034,11 +8038,7 @@ export class CollectionMutationService extends BaseService {
       // recorded event with a parent-only payload.
       const needsRelations =
         !!versionsConfig?.enabled ||
-        !isRecordingDisabledByConfig("collection", params.collectionName) ||
-        // A curated `webhooks.emit` consumes the assembled document too — its
-        // allowlist may include a component/m2m field — so assemble relations
-        // even when the raw entry.* recording is opted out for this collection.
-        getWebhookEmitSpec("collection", params.collectionName) !== undefined;
+        !isRecordingDisabledByConfig("collection", params.collectionName);
       // The `previous` document is carried ONLY by the outbox event, never by the
       // version snapshot, so gate its relation read on webhook recording alone: a
       // version-only update (versioning on, recording disabled by config) skips it

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -103,10 +103,15 @@ import {
 import { VersionCaptureService } from "../../versions/version-capture-service";
 import { withVersionConflictRetry } from "../../versions/version-conflict";
 import { expandComponentFields } from "../../webhooks/expand-component-fields";
+import { projectFields } from "../../webhooks/project-fields";
 import { recordMutationEvent } from "../../webhooks/record-mutation-event";
-import { isRecordingDisabledByConfig } from "../../webhooks/recording-policy";
+import {
+  getWebhookEmitSpec,
+  isRecordingDisabledByConfig,
+} from "../../webhooks/recording-policy";
 import type { SensitiveFieldSource } from "../../webhooks/sensitive-fields";
 import { statusEventsFor } from "../../webhooks/status-events";
+import type { WebhookResource } from "../../webhooks/types";
 
 import type { CollectionAccessService } from "./collection-access-service";
 import type {
@@ -2459,6 +2464,51 @@ export class CollectionMutationService extends BaseService {
           fields: webhookFields,
           actor: actorForWrite(params.actor, params.user),
         });
+
+        // A collection may replace its (here suppressed) `entry.created` with a
+        // curated, metadata-only event: a form submission emits
+        // `form.submission.created` carrying only the allowlisted fields, never
+        // the visitor's answers. Recorded in the SAME transaction so it commits
+        // with the row, on a resource kind (e.g. `form`) that the per-collection
+        // opt-out does not gate. Ordinary collections declare no emit and skip it.
+        const emitSpec = getWebhookEmitSpec(
+          "collection",
+          params.collectionName
+        );
+        if (emitSpec) {
+          const emitLocale = localizedWrite
+            ? { locale: localizedWrite.writeLocale }
+            : {};
+          const curatedResource: WebhookResource =
+            emitSpec.kind === "entry"
+              ? {
+                  kind: "entry",
+                  collection: params.collectionName,
+                  id: entry.id as string,
+                  ...emitLocale,
+                }
+              : {
+                  kind: emitSpec.kind,
+                  slug: params.collectionName,
+                  id: entry.id as string,
+                  ...emitLocale,
+                };
+          const curatedRecorded = await recordMutationEvent(tx, {
+            type: emitSpec.event,
+            resource: curatedResource,
+            // Default-deny projection: only the allowlisted keys ship, so a PII
+            // collection's sensitive columns never reach the payload.
+            data: projectFields(createdDocument, emitSpec.fields),
+            previous: null,
+            // The data is already a curated allowlist; there is nothing further
+            // to strip, and the raw field tree does not describe these keys.
+            fields: [],
+            actor: actorForWrite(params.actor, params.user),
+          });
+          // Fire the post-commit fast drain when only the curated event recorded
+          // (the collection's own `entry.created` was suppressed).
+          recorded = recorded || curatedRecorded;
+        }
         // A create landing directly on `published` is a publish lifecycle event
         // too (D69). Recorded in the SAME transaction, so it commits with the row
         // and inherits the recording opt-out. `statusEventsFor` emits only

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -428,6 +428,45 @@ export class CollectionMutationService extends BaseService {
   }
 
   /**
+   * Emit a collection's curated create event (e.g. `form.submission.created`)
+   * when it declared `webhooks.emit`, INSIDE the caller's transaction so it
+   * commits with the row. The payload is a default-deny projection of the
+   * created document, so a collection that opted its `entry.*` events out for
+   * PII ships only the allowlisted fields, on a resource kind (e.g. `form`) the
+   * per-collection opt-out does not gate. Returns whether a row was recorded so
+   * the caller folds it into its fast-drain gate; a no-op for ordinary
+   * collections. Applied at every create seam so the collection-level contract
+   * holds for the direct, transaction, and bulk create paths alike.
+   */
+  private async recordCuratedCreateEvent(
+    tx: Parameters<typeof recordMutationEvent>[0],
+    collectionName: string,
+    entryId: string,
+    createdDocument: Record<string, unknown>,
+    actor: RequestActor,
+    writeLocale?: string
+  ): Promise<boolean> {
+    const emitSpec = getWebhookEmitSpec("collection", collectionName);
+    if (!emitSpec) return false;
+    const locale = writeLocale ? { locale: writeLocale } : {};
+    const resource: WebhookResource =
+      emitSpec.kind === "entry"
+        ? { kind: "entry", collection: collectionName, id: entryId, ...locale }
+        : { kind: emitSpec.kind, slug: collectionName, id: entryId, ...locale };
+    return recordMutationEvent(tx, {
+      type: emitSpec.event,
+      resource,
+      // Default-deny projection: only the allowlisted keys ship, so a PII
+      // collection's sensitive columns never reach the payload.
+      data: projectFields(createdDocument, emitSpec.fields),
+      previous: null,
+      // The data is already a curated allowlist; nothing further to strip.
+      fields: [],
+      actor,
+    });
+  }
+
+  /**
    * Record the lifecycle status events for one transition
    * (`entry.published`/`entry.unpublished`/`entry.status_changed`) into the
    * outbox, INSIDE the caller's write transaction so they commit atomically with
@@ -2466,49 +2505,18 @@ export class CollectionMutationService extends BaseService {
         });
 
         // A collection may replace its (here suppressed) `entry.created` with a
-        // curated, metadata-only event: a form submission emits
-        // `form.submission.created` carrying only the allowlisted fields, never
-        // the visitor's answers. Recorded in the SAME transaction so it commits
-        // with the row, on a resource kind (e.g. `form`) that the per-collection
-        // opt-out does not gate. Ordinary collections declare no emit and skip it.
-        const emitSpec = getWebhookEmitSpec(
-          "collection",
-          params.collectionName
+        // curated, metadata-only event (see recordCuratedCreateEvent). Fold the
+        // result into `recorded` so the post-commit fast drain still fires when
+        // only the curated event was recorded.
+        const curatedRecorded = await this.recordCuratedCreateEvent(
+          tx,
+          params.collectionName,
+          entry.id as string,
+          createdDocument,
+          actorForWrite(params.actor, params.user),
+          localizedWrite ? localizedWrite.writeLocale : undefined
         );
-        if (emitSpec) {
-          const emitLocale = localizedWrite
-            ? { locale: localizedWrite.writeLocale }
-            : {};
-          const curatedResource: WebhookResource =
-            emitSpec.kind === "entry"
-              ? {
-                  kind: "entry",
-                  collection: params.collectionName,
-                  id: entry.id as string,
-                  ...emitLocale,
-                }
-              : {
-                  kind: emitSpec.kind,
-                  slug: params.collectionName,
-                  id: entry.id as string,
-                  ...emitLocale,
-                };
-          const curatedRecorded = await recordMutationEvent(tx, {
-            type: emitSpec.event,
-            resource: curatedResource,
-            // Default-deny projection: only the allowlisted keys ship, so a PII
-            // collection's sensitive columns never reach the payload.
-            data: projectFields(createdDocument, emitSpec.fields),
-            previous: null,
-            // The data is already a curated allowlist; there is nothing further
-            // to strip, and the raw field tree does not describe these keys.
-            fields: [],
-            actor: actorForWrite(params.actor, params.user),
-          });
-          // Fire the post-commit fast drain when only the curated event recorded
-          // (the collection's own `entry.created` was suppressed).
-          recorded = recorded || curatedRecorded;
-        }
+        recorded = recorded || curatedRecorded;
         // A create landing directly on `published` is a publish lifecycle event
         // too (D69). Recorded in the SAME transaction, so it commits with the row
         // and inherits the recording opt-out. `statusEventsFor` emits only
@@ -6052,6 +6060,17 @@ export class CollectionMutationService extends BaseService {
         fields: eventFields,
         actor: eventActor,
       });
+      // Emit the collection's curated create event too (a no-op unless it
+      // declared `webhooks.emit`), so a form/PII collection created through the
+      // transaction and bulk paths gets the same event as the direct path.
+      const curatedCreateRecorded = await this.recordCuratedCreateEvent(
+        tx,
+        params.collectionName,
+        (entry as Record<string, unknown>).id as string,
+        createdDocument,
+        eventActor
+      );
+      eventRecorded = eventRecorded || curatedCreateRecorded;
       // A create landing directly on `published` is also a publish lifecycle
       // event, gated on the collection's Draft/Published flag so an ordinary
       // user `status` field is not mistaken for a lifecycle change. `from` is
@@ -7435,6 +7454,17 @@ export class CollectionMutationService extends BaseService {
         fields: eventFields,
         actor: eventActor,
       });
+      // Emit the collection's curated create event too (a no-op unless it
+      // declared `webhooks.emit`), so a form/PII collection created through the
+      // transaction and bulk paths gets the same event as the direct path.
+      const curatedCreateRecorded = await this.recordCuratedCreateEvent(
+        tx,
+        params.collectionName,
+        (entry as Record<string, unknown>).id as string,
+        createdDocument,
+        eventActor
+      );
+      eventRecorded = eventRecorded || curatedCreateRecorded;
       // A create landing directly on `published` is also a publish lifecycle
       // event, gated on the collection's Draft/Published flag so an ordinary
       // user `status` field is not mistaken for a lifecycle change. `from` is

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -444,6 +444,7 @@ export class CollectionMutationService extends BaseService {
     entryId: string,
     createdDocument: Record<string, unknown>,
     actor: RequestActor,
+    fields: readonly SensitiveFieldSource[],
     writeLocale?: string
   ): Promise<boolean> {
     const emitSpec = getWebhookEmitSpec("collection", collectionName);
@@ -458,6 +459,14 @@ export class CollectionMutationService extends BaseService {
       id: entryId,
       ...locale,
     };
+    // Expand the field tree so a password/hidden value nested inside an
+    // allowlisted group/component/repeater is still stripped from the
+    // (default-deny) projection: the curated event ships data, so it needs the
+    // same sensitive-field stripping the raw entry.* events get.
+    const sensitiveFields = await this.webhookFieldTree(
+      fields,
+      tx.getDrizzle()
+    );
     return recordMutationEvent(tx, {
       type: emitSpec.event,
       resource,
@@ -465,8 +474,7 @@ export class CollectionMutationService extends BaseService {
       // collection's sensitive columns never reach the payload.
       data: projectFields(createdDocument, emitSpec.fields),
       previous: null,
-      // The data is already a curated allowlist; nothing further to strip.
-      fields: [],
+      fields: sensitiveFields,
       actor,
     });
   }
@@ -2519,6 +2527,7 @@ export class CollectionMutationService extends BaseService {
           entry.id as string,
           createdDocument,
           actorForWrite(params.actor, params.user),
+          fields,
           localizedWrite ? localizedWrite.writeLocale : undefined
         );
         recorded = recorded || curatedRecorded;
@@ -6077,7 +6086,8 @@ export class CollectionMutationService extends BaseService {
         params.collectionName,
         (entry as Record<string, unknown>).id as string,
         createdDocument,
-        eventActor
+        eventActor,
+        fields
       );
       eventRecorded = eventRecorded || curatedCreateRecorded;
       // A create landing directly on `published` is also a publish lifecycle
@@ -7479,7 +7489,8 @@ export class CollectionMutationService extends BaseService {
         params.collectionName,
         (entry as Record<string, unknown>).id as string,
         createdDocument,
-        eventActor
+        eventActor,
+        fields
       );
       eventRecorded = eventRecorded || curatedCreateRecorded;
       // A create landing directly on `published` is also a publish lifecycle

--- a/packages/nextly/src/domains/webhooks/__tests__/project-fields.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/project-fields.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { projectFields } from "../project-fields";
+
+describe("projectFields", () => {
+  it("copies only the allowlisted keys", () => {
+    const doc = {
+      form: "f1",
+      submittedAt: "2026-07-30T00:00:00Z",
+      status: "new",
+      data: { answer: "42" },
+      ipAddress: "203.0.113.7",
+    };
+    expect(projectFields(doc, ["form", "submittedAt", "status"])).toEqual({
+      form: "f1",
+      submittedAt: "2026-07-30T00:00:00Z",
+      status: "new",
+    });
+  });
+
+  it("never includes unlisted keys, so PII cannot leak", () => {
+    const doc = {
+      form: "f1",
+      data: { message: "my secret answer" },
+      ipAddress: "203.0.113.7",
+      userAgent: "Mozilla/5.0",
+    };
+    const projected = projectFields(doc, ["form"]);
+    expect(projected).toEqual({ form: "f1" });
+    // The free-form answers, IP, and user-agent must be absent entirely.
+    expect(JSON.stringify(projected)).not.toMatch(
+      /secret|ipAddress|userAgent|203\.0\.113\.7|Mozilla/i
+    );
+  });
+
+  it("skips allowlisted keys that are absent rather than emitting undefined", () => {
+    const projected = projectFields({ form: "f1" }, ["form", "status"]);
+    expect(projected).toEqual({ form: "f1" });
+    expect("status" in projected).toBe(false);
+  });
+
+  it("returns an empty object when no allowlist is provided", () => {
+    expect(projectFields({ a: 1 }, undefined)).toEqual({});
+    expect(projectFields({ a: 1 }, [])).toEqual({});
+  });
+});

--- a/packages/nextly/src/domains/webhooks/__tests__/recording-gate.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/recording-gate.integration.test.ts
@@ -8,7 +8,7 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 
-import { defineCollection, text } from "../../../config";
+import { defineCollection, group, password, text } from "../../../config";
 import {
   createTestNextly,
   type TestNextly,
@@ -138,5 +138,52 @@ describe("webhook recording opt-out (integration)", () => {
     expect(JSON.stringify(rows[0])).not.toMatch(
       /secretAnswer|my private answer/
     );
+  });
+
+  it("strips a sensitive field nested inside a curated event's allowlisted subtree", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "leads",
+          // Allowlist the whole `contact` group; the curated payload must still
+          // drop its nested password (default-deny picks the subtree, then
+          // sensitive-field stripping removes the secret inside it).
+          webhooks: {
+            record: false,
+            emit: { event: "form.submission.created", fields: ["contact"] },
+          },
+          fields: [
+            group({
+              name: "contact",
+              fields: [text({ name: "name" }), password({ name: "secret" })],
+            }),
+          ],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const lead = await handler.createEntry(
+      { collectionName: "leads", overrideAccess: true },
+      { contact: { name: "Ada", secret: "Sup3r-Secret-Pw!" } }
+    );
+    expect(lead.success).toBe(true);
+
+    const rows = await current.adapter.select<{
+      type: string;
+      payload: unknown;
+    }>("nextly_events");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].type).toBe("form.submission.created");
+    const payload = (
+      typeof rows[0].payload === "string"
+        ? JSON.parse(rows[0].payload)
+        : rows[0].payload
+    ) as { data: { contact?: Record<string, unknown> } };
+    // The allowlisted group ships its safe field but never the nested password.
+    expect(payload.data.contact?.name).toBe("Ada");
+    expect(payload.data.contact ?? {}).not.toHaveProperty("secret");
+    expect(JSON.stringify(rows[0])).not.toMatch(/Sup3r-Secret-Pw/);
   });
 });

--- a/packages/nextly/src/domains/webhooks/__tests__/recording-gate.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/recording-gate.integration.test.ts
@@ -88,4 +88,55 @@ describe("webhook recording opt-out (integration)", () => {
     expect(rows[0].resourceId).toBe(postId);
     expect(rows.some(r => r.resourceId === leadId)).toBe(false);
   });
+
+  it("emits a curated, metadata-only event via webhooks.emit while suppressing entry.created and its PII", async () => {
+    current = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: "leads",
+          // Suppress the PII-bearing entry.* events and instead emit a curated
+          // form.submission.created carrying only the allowlisted `title`.
+          webhooks: {
+            record: false,
+            emit: { event: "form.submission.created", fields: ["title"] },
+          },
+          fields: [text({ name: "title" }), text({ name: "secretAnswer" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const lead = await handler.createEntry(
+      { collectionName: "leads", overrideAccess: true },
+      { title: "Contact form", secretAnswer: "my private answer" }
+    );
+    expect(lead.success).toBe(true);
+    const leadId = (lead.data as { id: string }).id;
+
+    const rows = await current.adapter.select<{
+      type: string;
+      resourceKind: string;
+      resourceId: string;
+      payload: unknown;
+    }>("nextly_events");
+
+    // Exactly one event: the curated form.submission.created — never the
+    // suppressed entry.created for the same write.
+    expect(rows).toHaveLength(1);
+    expect(rows[0].type).toBe("form.submission.created");
+    expect(rows[0].resourceKind).toBe("form");
+    expect(rows[0].resourceId).toBe(leadId);
+
+    // The payload carries ONLY the allowlisted metadata — never the secret answer.
+    const payload = (
+      typeof rows[0].payload === "string"
+        ? JSON.parse(rows[0].payload)
+        : rows[0].payload
+    ) as { data: Record<string, unknown> };
+    expect(payload.data).toEqual({ title: "Contact form" });
+    expect(JSON.stringify(rows[0])).not.toMatch(
+      /secretAnswer|my private answer/
+    );
+  });
 });

--- a/packages/nextly/src/domains/webhooks/__tests__/recording-policy.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/recording-policy.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, it, expect } from "vitest";
 import {
   applyStoredRecordingDecisions,
   currentRecordingGeneration,
+  getWebhookEmitSpec,
   isRecordingDisabledByConfig,
   clearWebhookRecording,
   isWebhookRecordingEnabled,
@@ -37,6 +38,24 @@ describe("webhook recording policy", () => {
   it("records when explicitly enabled", () => {
     setWebhookRecording("collection", "posts", true);
     expect(isWebhookRecordingEnabled("collection", "posts")).toBe(true);
+  });
+
+  it("stores and returns a curated emit spec, and none for a plain opt-out", () => {
+    setWebhookRecording("collection", "form-submissions", false, "plugin", {
+      event: "form.submission.created",
+      kind: "form",
+      fields: ["form", "submittedAt"],
+    });
+    expect(getWebhookEmitSpec("collection", "form-submissions")).toEqual({
+      event: "form.submission.created",
+      kind: "form",
+      fields: ["form", "submittedAt"],
+    });
+    // A plain opt-out carries no curated event.
+    setWebhookRecording("collection", "leads", false);
+    expect(getWebhookEmitSpec("collection", "leads")).toBeUndefined();
+    // An unregistered slug has none.
+    expect(getWebhookEmitSpec("collection", "unknown")).toBeUndefined();
   });
 
   it("clears all entries on reset", () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/resolve-recording-config.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/resolve-recording-config.test.ts
@@ -90,6 +90,21 @@ describe("resolveWebhookRecording", () => {
     ).toEqual({ record: false });
   });
 
+  it("ignores a curated emit unless recording is opted out", () => {
+    // `emit` REPLACES the default events, so it only applies with record:false.
+    // record:true (or omitted, which defaults to record) must not emit both the
+    // full entry.* document and the curated event.
+    expect(
+      resolveWebhookRecording({
+        record: true,
+        emit: { event: "form.submission.created", fields: ["form"] },
+      })
+    ).toEqual({ record: true });
+    expect(
+      resolveWebhookRecording({ emit: { event: "form.submission.created" } })
+    ).toEqual({ record: true });
+  });
+
   it("drops a malformed emit rather than throwing", () => {
     const asInput = (v: unknown) =>
       v as boolean | { record?: boolean } | undefined;

--- a/packages/nextly/src/domains/webhooks/__tests__/resolve-recording-config.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/resolve-recording-config.test.ts
@@ -78,6 +78,18 @@ describe("resolveWebhookRecording", () => {
     ).toEqual({ event: "user.created", kind: "user" });
   });
 
+  it("drops an entry-family curated event (it would be suppressed by the same opt-out)", () => {
+    // `entry.*` derives kind `entry`, which is gated by this very collection's
+    // `record: false` — so a curated entry event could never emit. It is
+    // rejected at normalization rather than silently suppressed at the seam.
+    expect(
+      resolveWebhookRecording({
+        record: false,
+        emit: { event: "entry.created", fields: ["title"] },
+      })
+    ).toEqual({ record: false });
+  });
+
   it("drops a malformed emit rather than throwing", () => {
     const asInput = (v: unknown) =>
       v as boolean | { record?: boolean } | undefined;

--- a/packages/nextly/src/domains/webhooks/__tests__/resolve-recording-config.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/resolve-recording-config.test.ts
@@ -78,14 +78,21 @@ describe("resolveWebhookRecording", () => {
     ).toEqual({ event: "user.created", kind: "user" });
   });
 
-  it("drops an entry-family curated event (it would be suppressed by the same opt-out)", () => {
-    // `entry.*` derives kind `entry`, which is gated by this very collection's
-    // `record: false` — so a curated entry event could never emit. It is
-    // rejected at normalization rather than silently suppressed at the seam.
+  it("drops entry- and single-family curated events (both are per-slug gated)", () => {
+    // `entry.*`/`single.*` derive a kind gated by a per-entity policy keyed by
+    // slug, so a curated event of that kind would be suppressed (by this
+    // collection's own opt-out, or by an unrelated Single sharing the slug). It
+    // is rejected at normalization rather than silently suppressed at the seam.
     expect(
       resolveWebhookRecording({
         record: false,
         emit: { event: "entry.created", fields: ["title"] },
+      })
+    ).toEqual({ record: false });
+    expect(
+      resolveWebhookRecording({
+        record: false,
+        emit: { event: "single.updated" },
       })
     ).toEqual({ record: false });
   });

--- a/packages/nextly/src/domains/webhooks/__tests__/resolve-recording-config.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/resolve-recording-config.test.ts
@@ -37,4 +37,74 @@ describe("resolveWebhookRecording", () => {
       record: true,
     });
   });
+
+  it("resolves a curated emit and derives the resource kind from the event", () => {
+    expect(
+      resolveWebhookRecording({
+        record: false,
+        emit: {
+          event: "form.submission.created",
+          fields: ["form", "submittedAt", "status"],
+        },
+      })
+    ).toEqual({
+      record: false,
+      emit: {
+        event: "form.submission.created",
+        kind: "form",
+        fields: ["form", "submittedAt", "status"],
+      },
+    });
+  });
+
+  it("resolves an emit with no field allowlist", () => {
+    expect(
+      resolveWebhookRecording({
+        record: false,
+        emit: { event: "form.submission.created" },
+      })
+    ).toEqual({
+      record: false,
+      emit: { event: "form.submission.created", kind: "form" },
+    });
+  });
+
+  it("derives the kind for any declared event family", () => {
+    expect(
+      resolveWebhookRecording({
+        record: false,
+        emit: { event: "user.created" },
+      }).emit
+    ).toEqual({ event: "user.created", kind: "user" });
+  });
+
+  it("drops a malformed emit rather than throwing", () => {
+    const asInput = (v: unknown) =>
+      v as boolean | { record?: boolean } | undefined;
+    // Unknown event -> no curated event at all.
+    expect(
+      resolveWebhookRecording(
+        asInput({ record: false, emit: { event: "nope.created" } })
+      )
+    ).toEqual({ record: false });
+    // A non-object emit -> no curated event.
+    expect(
+      resolveWebhookRecording(
+        asInput({ record: false, emit: "form.submission.created" })
+      )
+    ).toEqual({ record: false });
+    // Non-string field names -> the event still resolves, the allowlist is
+    // dropped (an empty projection is safer than shipping unexpected keys).
+    expect(
+      resolveWebhookRecording(
+        asInput({
+          record: false,
+          emit: { event: "form.submission.created", fields: [1, 2] },
+        })
+      )
+    ).toEqual({
+      record: false,
+      emit: { event: "form.submission.created", kind: "form" },
+    });
+  });
 });

--- a/packages/nextly/src/domains/webhooks/project-fields.ts
+++ b/packages/nextly/src/domains/webhooks/project-fields.ts
@@ -1,0 +1,33 @@
+/**
+ * Webhook domain — the curated-payload projection.
+ *
+ * A default-deny field picker for metadata-only webhook events. Only the
+ * allowlisted keys of a document are copied into the payload; anything not
+ * listed never appears, so a collection's PII (a form submission's free-form
+ * answers, ipAddress, userAgent) cannot leak into an event that is meant to
+ * carry identity/metadata only. Absent allowlisted keys are skipped rather than
+ * emitted as `undefined`, and no allowlist yields an empty object.
+ *
+ * @module domains/webhooks/project-fields
+ */
+
+/**
+ * Copy only the allowlisted keys from `source` into a new object.
+ *
+ * @param source - The assembled document to project from.
+ * @param allowlist - Keys to include; anything else is dropped (default-deny).
+ * @returns A new object with only the present, allowlisted keys.
+ */
+export function projectFields(
+  source: Record<string, unknown>,
+  allowlist: readonly string[] | undefined
+): Record<string, unknown> {
+  const projected: Record<string, unknown> = {};
+  if (!allowlist) return projected;
+  for (const key of allowlist) {
+    if (Object.prototype.hasOwnProperty.call(source, key)) {
+      projected[key] = source[key];
+    }
+  }
+  return projected;
+}

--- a/packages/nextly/src/domains/webhooks/recording-policy.ts
+++ b/packages/nextly/src/domains/webhooks/recording-policy.ts
@@ -14,6 +14,8 @@
  * @module domains/webhooks/recording-policy
  */
 
+import type { ResolvedWebhookEmit } from "./resolve-recording-config";
+
 /** The entity kinds that can carry a per-entity recording opt-out. */
 export type WebhookRecordingScope = "collection" | "single";
 
@@ -31,6 +33,11 @@ export type WebhookRecordingSource = "code" | "plugin" | "db";
 interface PolicyEntry {
   record: boolean;
   source: WebhookRecordingSource;
+  /**
+   * A curated event this entity emits on create instead of the default
+   * `entry.created` — set only for a code/plugin entity that configured one.
+   */
+  emit?: ResolvedWebhookEmit;
 }
 
 // Keyed by `${scope}:${slug}`; absence means "record" (the default), so only
@@ -184,9 +191,13 @@ export function setWebhookRecording(
   scope: WebhookRecordingScope,
   slug: string,
   record: boolean,
-  source: WebhookRecordingSource = "code"
+  source: WebhookRecordingSource = "code",
+  emit?: ResolvedWebhookEmit
 ): void {
-  policy.set(keyFor(scope, slug), { record, source });
+  policy.set(
+    keyFor(scope, slug),
+    emit ? { record, source, emit } : { record, source }
+  );
   storedRefresh.generation += 1;
 }
 
@@ -220,6 +231,21 @@ export function isWebhookRecordingEnabled(
     scheduleStoredRefresh();
   }
   return policy.get(keyFor(scope, slug))?.record ?? true;
+}
+
+/**
+ * The curated event this collection/single emits on create instead of the
+ * default `entry.created`, or undefined when none is configured. Read at the
+ * create seam from the same registry as the recording gate, so a PII collection
+ * ships a metadata-only event while its raw `entry.*` events stay suppressed. No
+ * database read: like {@link isWebhookRecordingEnabled} this runs inside the
+ * content write transaction.
+ */
+export function getWebhookEmitSpec(
+  scope: WebhookRecordingScope,
+  slug: string
+): ResolvedWebhookEmit | undefined {
+  return policy.get(keyFor(scope, slug))?.emit;
 }
 
 /**

--- a/packages/nextly/src/domains/webhooks/resolve-recording-config.ts
+++ b/packages/nextly/src/domains/webhooks/resolve-recording-config.ts
@@ -115,7 +115,12 @@ export function resolveWebhookRecording(
   if (webhooks === false) return { record: false };
   if (typeof webhooks === "object" && webhooks !== null) {
     const record = webhooks.record === false ? false : true;
-    const emit = resolveEmit(webhooks.emit);
+    // A curated `emit` REPLACES the default events, so it only applies when they
+    // are suppressed. With `record: true` (or omitted, which defaults to record),
+    // honoring `emit` would record BOTH the full `entry.*` document and the
+    // curated event — double delivery, and PII shipped via `entry.*` to any
+    // endpoint subscribed to it or `*`. So `emit` requires `record: false`.
+    const emit = record ? undefined : resolveEmit(webhooks.emit);
     return emit ? { record, emit } : { record };
   }
   return { record: true };

--- a/packages/nextly/src/domains/webhooks/resolve-recording-config.ts
+++ b/packages/nextly/src/domains/webhooks/resolve-recording-config.ts
@@ -27,10 +27,13 @@ export interface ResolvedWebhookEmit {
   event: WebhookEventType;
   /**
    * Resource family, derived from the event's first segment (`form.*` → `form`).
-   * Never `entry`: an entry-family curated event would hit the same
-   * per-collection opt-out and be suppressed, so those are rejected upstream.
+   * Never `entry` or `single`: those kinds are gated by a per-entity recording
+   * policy keyed by slug, so a curated event of that kind on a collection would
+   * be suppressed — by this collection's own opt-out (`entry`) or by an
+   * unrelated Single that shares the slug (`single`). Rejected upstream, leaving
+   * the ungated families (`media`/`user`/`form`).
    */
-  kind: Exclude<WebhookResourceKind, "entry">;
+  kind: Exclude<WebhookResourceKind, "entry" | "single">;
   /** Allowlist of document keys copied into the payload; default-deny. */
   fields?: readonly string[];
 }
@@ -59,11 +62,17 @@ function isWebhookEventType(value: unknown): value is WebhookEventType {
   );
 }
 
-function isNonEntryResourceKind(
+function isCuratedResourceKind(
   value: string
-): value is Exclude<WebhookResourceKind, "entry"> {
+): value is Exclude<WebhookResourceKind, "entry" | "single"> {
+  // Only the ungated families (media/user/form) are valid for a curated
+  // collection event: `entry` and `single` are gated by a per-entity recording
+  // policy keyed by slug, so a curated `entry.*`/`single.*` would be suppressed
+  // by this collection's own opt-out (entry) or by an unrelated Single that
+  // shares the slug (single).
   return (
     value !== "entry" &&
+    value !== "single" &&
     (WEBHOOK_RESOURCE_KINDS as readonly string[]).includes(value)
   );
 }
@@ -75,17 +84,19 @@ function isNonEntryResourceKind(
  * lands in the right resource family without the author restating it. A
  * malformed emit (unknown event, non-string field names) is dropped rather than
  * throwing at boot: the default-deny stance keeps a bad config from emitting a
- * bogus or unfiltered event. An `entry.*`-family event is dropped for the same
- * reason it cannot work: a curated event exists to REPLACE the suppressed
- * `entry.*` events with one the per-collection opt-out does not gate, so an
- * entry-family event would be suppressed by that same opt-out and never emit.
+ * bogus or unfiltered event. An `entry.*`/`single.*`-family event is dropped for
+ * the same reason it cannot work: a curated event exists to REPLACE the
+ * suppressed default events with one that no per-entity opt-out gates, but an
+ * entry- or single-kind event is gated by a per-slug policy (this collection's
+ * own opt-out, or an unrelated Single sharing the slug) and so would be
+ * suppressed and never emit.
  */
 function resolveEmit(emit: unknown): ResolvedWebhookEmit | undefined {
   if (typeof emit !== "object" || emit === null) return undefined;
   const { event, fields } = emit as { event?: unknown; fields?: unknown };
   if (!isWebhookEventType(event)) return undefined;
   const derivedKind = event.split(".")[0];
-  if (!isNonEntryResourceKind(derivedKind)) return undefined;
+  if (!isCuratedResourceKind(derivedKind)) return undefined;
   const safeFields =
     Array.isArray(fields) && fields.every(f => typeof f === "string")
       ? (fields as readonly string[])

--- a/packages/nextly/src/domains/webhooks/resolve-recording-config.ts
+++ b/packages/nextly/src/domains/webhooks/resolve-recording-config.ts
@@ -2,29 +2,97 @@
  * Webhook domain — recording-policy normalizer.
  *
  * Normalizes a collection/single's `webhooks` option into one resolved shape so
- * every consumer reads `{ record }` and never branches on the raw
- * `boolean | { record?: boolean }` union. Mirrors
+ * every consumer reads `{ record, emit? }` and never branches on the raw
+ * `boolean | { record?, emit? }` union. Mirrors
  * `domains/versions/resolve-config.ts`: the raw option is author-facing sugar;
  * the resolved shape is what the runtime reads.
  *
  * @module domains/webhooks/resolve-recording-config
  */
 
+import {
+  WEBHOOK_EVENT_TYPES,
+  WEBHOOK_RESOURCE_KINDS,
+  type WebhookEventType,
+  type WebhookResourceKind,
+} from "./types";
+
+/**
+ * A curated event a collection emits in place of its default `entry.*` event.
+ * Used by a PII collection (with `record: false`) to notify subscribers of a
+ * new row while shipping only allowlisted metadata.
+ */
+export interface ResolvedWebhookEmit {
+  /** The event type to record, e.g. `"form.submission.created"`. */
+  event: WebhookEventType;
+  /** Resource family, derived from the event's first segment (`form.*` → `form`). */
+  kind: WebhookResourceKind;
+  /** Allowlist of document keys copied into the payload; default-deny. */
+  fields?: readonly string[];
+}
+
 /** The resolved webhook recording policy for one collection/single. */
 export interface ResolvedWebhookRecording {
-  /** Whether writes to this entity are recorded to the webhook outbox. */
+  /** Whether the default `entry.*`/`single.*` events are recorded. */
   record: boolean;
+  /** A curated metadata-only event to emit on create, when configured. */
+  emit?: ResolvedWebhookEmit;
+}
+
+/**
+ * The raw author-facing option, widened to tolerate untyped JS configs so a
+ * malformed value is normalized rather than throwing.
+ */
+type WebhooksOption =
+  | boolean
+  | { record?: boolean; emit?: { event?: unknown; fields?: unknown } }
+  | undefined;
+
+function isWebhookEventType(value: unknown): value is WebhookEventType {
+  return (
+    typeof value === "string" &&
+    (WEBHOOK_EVENT_TYPES as readonly string[]).includes(value)
+  );
+}
+
+function isResourceKind(value: string): value is WebhookResourceKind {
+  return (WEBHOOK_RESOURCE_KINDS as readonly string[]).includes(value);
+}
+
+/**
+ * Resolve a configured `emit` to its canonical shape, or `undefined` when it is
+ * absent or malformed. The resource kind is derived from the event's first
+ * segment (`form.submission.created` → `form`) and validated, so a curated event
+ * lands in the right resource family without the author restating it. A
+ * malformed emit (unknown event, non-string field names) is dropped rather than
+ * throwing at boot: the default-deny stance keeps a bad config from emitting a
+ * bogus or unfiltered event.
+ */
+function resolveEmit(emit: unknown): ResolvedWebhookEmit | undefined {
+  if (typeof emit !== "object" || emit === null) return undefined;
+  const { event, fields } = emit as { event?: unknown; fields?: unknown };
+  if (!isWebhookEventType(event)) return undefined;
+  const derivedKind = event.split(".")[0];
+  if (!isResourceKind(derivedKind)) return undefined;
+  const safeFields =
+    Array.isArray(fields) && fields.every(f => typeof f === "string")
+      ? (fields as readonly string[])
+      : undefined;
+  return safeFields
+    ? { event, kind: derivedKind, fields: safeFields }
+    : { event, kind: derivedKind };
 }
 
 /**
  * Resolve the `webhooks` option to its canonical shape. The default is to
  * RECORD: an entity that never sets the option keeps emitting outbox events, so
  * this is a purely additive opt-out. `false` (or `{ record: false }`) suppresses
- * all outbox recording for the entity — used to keep PII-bearing content (e.g.
- * form submissions) out of the delivery path.
+ * the default outbox recording for the entity — used to keep PII-bearing content
+ * (e.g. form submissions) out of the delivery path. A configured `emit`
+ * additionally produces a curated, metadata-only event (see {@link resolveEmit}).
  */
 export function resolveWebhookRecording(
-  webhooks: boolean | { record?: boolean } | undefined
+  webhooks: WebhooksOption
 ): ResolvedWebhookRecording {
   // Only an explicit boolean `false`, or an object whose `record` is exactly
   // `false`, opts out. Every other value falls back to recording — the safe
@@ -33,12 +101,10 @@ export function resolveWebhookRecording(
   // "false") is ignored rather than escaping the boolean return as a truthy
   // value. The result is always a real boolean.
   if (webhooks === false) return { record: false };
-  if (
-    typeof webhooks === "object" &&
-    webhooks !== null &&
-    webhooks.record === false
-  ) {
-    return { record: false };
+  if (typeof webhooks === "object" && webhooks !== null) {
+    const record = webhooks.record === false ? false : true;
+    const emit = resolveEmit(webhooks.emit);
+    return emit ? { record, emit } : { record };
   }
   return { record: true };
 }

--- a/packages/nextly/src/domains/webhooks/resolve-recording-config.ts
+++ b/packages/nextly/src/domains/webhooks/resolve-recording-config.ts
@@ -25,8 +25,12 @@ import {
 export interface ResolvedWebhookEmit {
   /** The event type to record, e.g. `"form.submission.created"`. */
   event: WebhookEventType;
-  /** Resource family, derived from the event's first segment (`form.*` → `form`). */
-  kind: WebhookResourceKind;
+  /**
+   * Resource family, derived from the event's first segment (`form.*` → `form`).
+   * Never `entry`: an entry-family curated event would hit the same
+   * per-collection opt-out and be suppressed, so those are rejected upstream.
+   */
+  kind: Exclude<WebhookResourceKind, "entry">;
   /** Allowlist of document keys copied into the payload; default-deny. */
   fields?: readonly string[];
 }
@@ -55,8 +59,13 @@ function isWebhookEventType(value: unknown): value is WebhookEventType {
   );
 }
 
-function isResourceKind(value: string): value is WebhookResourceKind {
-  return (WEBHOOK_RESOURCE_KINDS as readonly string[]).includes(value);
+function isNonEntryResourceKind(
+  value: string
+): value is Exclude<WebhookResourceKind, "entry"> {
+  return (
+    value !== "entry" &&
+    (WEBHOOK_RESOURCE_KINDS as readonly string[]).includes(value)
+  );
 }
 
 /**
@@ -66,14 +75,17 @@ function isResourceKind(value: string): value is WebhookResourceKind {
  * lands in the right resource family without the author restating it. A
  * malformed emit (unknown event, non-string field names) is dropped rather than
  * throwing at boot: the default-deny stance keeps a bad config from emitting a
- * bogus or unfiltered event.
+ * bogus or unfiltered event. An `entry.*`-family event is dropped for the same
+ * reason it cannot work: a curated event exists to REPLACE the suppressed
+ * `entry.*` events with one the per-collection opt-out does not gate, so an
+ * entry-family event would be suppressed by that same opt-out and never emit.
  */
 function resolveEmit(emit: unknown): ResolvedWebhookEmit | undefined {
   if (typeof emit !== "object" || emit === null) return undefined;
   const { event, fields } = emit as { event?: unknown; fields?: unknown };
   if (!isWebhookEventType(event)) return undefined;
   const derivedKind = event.split(".")[0];
-  if (!isResourceKind(derivedKind)) return undefined;
+  if (!isNonEntryResourceKind(derivedKind)) return undefined;
   const safeFields =
     Array.isArray(fields) && fields.every(f => typeof f === "string")
       ? (fields as readonly string[])

--- a/packages/nextly/src/domains/webhooks/types.ts
+++ b/packages/nextly/src/domains/webhooks/types.ts
@@ -75,12 +75,16 @@ export type WebhookEventSubscription =
   | typeof WEBHOOK_EVENT_WILDCARD;
 
 /** Resource families an event can be about. */
-export type WebhookResourceKind =
-  | "entry"
-  | "single"
-  | "media"
-  | "user"
-  | "form";
+export const WEBHOOK_RESOURCE_KINDS = [
+  "entry",
+  "single",
+  "media",
+  "user",
+  "form",
+] as const;
+
+/** Resource families an event can be about. */
+export type WebhookResourceKind = (typeof WEBHOOK_RESOURCE_KINDS)[number];
 
 /** What triggered an event; feeds the audit trail. */
 export type WebhookActorType = "user" | "apiKey" | "system";

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -484,17 +484,15 @@ function publishScopeRecording(
     pluginSlugs.has(slug) ? "plugin" : "code";
 
   // Opt-outs first, always: safe regardless of sync state (recording is off).
+  // The curated `emit` is NOT attached here: it reads the field tree to strip
+  // secrets from its payload, so it waits on `synced` exactly like an opt-in
+  // (attached below). Otherwise a reload that adds `emit` while making a field
+  // newly sensitive could ship the stale field's value unstripped.
   for (const e of entities) {
     if (!e.slug) continue;
     const resolved = resolveWebhookRecording(e.webhooks);
     if (resolved.record === false) {
-      setWebhookRecording(
-        scope,
-        e.slug,
-        false,
-        sourceOf(e.slug),
-        resolved.emit
-      );
+      setWebhookRecording(scope, e.slug, false, sourceOf(e.slug));
     }
   }
 
@@ -510,6 +508,16 @@ function publishScopeRecording(
     const resolved = resolveWebhookRecording(e.webhooks);
     if (resolved.record === true) {
       setWebhookRecording(scope, e.slug, true, sourceOf(e.slug), resolved.emit);
+    } else if (resolved.emit) {
+      // Re-publish the opt-out WITH its curated emit now that the field tree is
+      // in step, so the curated payload strips against current metadata.
+      setWebhookRecording(
+        scope,
+        e.slug,
+        false,
+        sourceOf(e.slug),
+        resolved.emit
+      );
     }
   }
 }

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -486,8 +486,15 @@ function publishScopeRecording(
   // Opt-outs first, always: safe regardless of sync state (recording is off).
   for (const e of entities) {
     if (!e.slug) continue;
-    if (resolveWebhookRecording(e.webhooks).record === false) {
-      setWebhookRecording(scope, e.slug, false, sourceOf(e.slug));
+    const resolved = resolveWebhookRecording(e.webhooks);
+    if (resolved.record === false) {
+      setWebhookRecording(
+        scope,
+        e.slug,
+        false,
+        sourceOf(e.slug),
+        resolved.emit
+      );
     }
   }
 
@@ -500,8 +507,9 @@ function publishScopeRecording(
   pruneRemovedCodeFirstRecording(scope, present);
   for (const e of entities) {
     if (!e.slug) continue;
-    if (resolveWebhookRecording(e.webhooks).record === true) {
-      setWebhookRecording(scope, e.slug, true, sourceOf(e.slug));
+    const resolved = resolveWebhookRecording(e.webhooks);
+    if (resolved.record === true) {
+      setWebhookRecording(scope, e.slug, true, sourceOf(e.slug), resolved.emit);
     }
   }
 }

--- a/packages/plugin-form-builder/README.md
+++ b/packages/plugin-form-builder/README.md
@@ -65,7 +65,9 @@ import "@nextlyhq/plugin-form-builder/admin";
 
 ### Submission privacy
 
-Submissions carry visitor-entered content plus `ipAddress` and `userAgent`, so the `form-submissions` collection sets `webhooks: false` — its writes are never recorded to the webhook outbox or delivered to endpoints subscribed to `entry.created` or `*`. Any collection or single can opt out the same way (`webhooks: false`, or `{ record: false }`); recording is on by default for everything else. To send submission webhooks deliberately, override the submissions collection with `webhooks: true`.
+Submissions carry visitor-entered answers plus `ipAddress` and `userAgent`, so the `form-submissions` collection suppresses the default `entry.*` events (which would otherwise deliver that content to any endpoint subscribed to `entry.created` or `*`). In their place it emits a curated **`form.submission.created`** event carrying only safe metadata — which form, when, and the submission status — never the answers, IP, or user agent. Subscribe an endpoint to `form.submission.created` to be notified of new submissions without receiving their content.
+
+Do **not** override the submissions collection with `webhooks: true`: that would re-enable the raw `entry.*` events and deliver the PII-bearing submission content. Any collection can adopt the same pattern via the `webhooks` option: `{ record: false }` suppresses the default events, and `{ record: false, emit: { event, fields } }` additionally emits a curated event carrying only the allowlisted `fields`. Recording is on by default for everything else.
 
 A collection or single created in the **Schema Builder** can be opted out the same way, without touching code: **Settings → Advanced → Webhook recording**. The choice is stored on the entity's registry row, so it holds across restarts. For code-first entities the `webhooks` option in config remains the source of truth and is republished on every boot.
 

--- a/packages/plugin-form-builder/src/__tests__/admin-contributions.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/admin-contributions.test.ts
@@ -34,11 +34,19 @@ describe("form-builder contributes.admin (P5 dogfood)", () => {
     expect(collection.admin?.disableCreate).toBe(true);
   });
 
-  it("opts submissions out of webhook recording (they carry ipAddress/userAgent)", () => {
-    // Submission records hold submitted content plus visitor metadata
-    // (ipAddress, userAgent), so they are excluded from the webhook outbox to
-    // keep that PII off the delivery path — hence `webhooks: false`.
+  it("emits a curated form.submission.created instead of the PII-bearing entry.* events", () => {
+    // Submission records hold submitted answers plus visitor metadata
+    // (ipAddress, userAgent). The default entry.* events stay suppressed
+    // (record: false) so none of that reaches the outbox; a curated
+    // form.submission.created carries only safe metadata (form, submittedAt,
+    // status) so subscribers still learn a submission arrived.
     const collection = submissionsCollection(formBuilder().config);
-    expect(collection.webhooks).toBe(false);
+    expect(collection.webhooks).toEqual({
+      record: false,
+      emit: {
+        event: "form.submission.created",
+        fields: ["form", "submittedAt", "status"],
+      },
+    });
   });
 });

--- a/packages/plugin-form-builder/src/collections/submissions.ts
+++ b/packages/plugin-form-builder/src/collections/submissions.ts
@@ -201,11 +201,18 @@ export function submissionsCollection(
     fields: finalFields,
     timestamps: true,
 
-    // Submissions carry visitor-entered content plus ipAddress/userAgent, so
-    // they are never recorded to the webhook outbox — otherwise every submission
-    // would be delivered to any endpoint subscribed to entry.created or `*`. An
-    // operator who wants submission webhooks can override this to `true`.
-    webhooks: false,
+    // Submissions carry visitor-entered answers plus ipAddress/userAgent, so the
+    // default `entry.*` events stay suppressed — otherwise every submission would
+    // be delivered to any endpoint subscribed to `entry.created` or `*`. Instead
+    // emit a curated `form.submission.created` carrying ONLY safe metadata (which
+    // form, when, and the status) — never the answers, IP, or user agent.
+    webhooks: {
+      record: false,
+      emit: {
+        event: "form.submission.created",
+        fields: ["form", "submittedAt", "status"],
+      },
+    },
 
     admin: {
       isPlugin: true,


### PR DESCRIPTION
## What

`form.submission.created` was subscribable in the admin UI but had **no producer** — an operator could subscribe to an event that never fired. This wires it up, safely.

Form submissions carry visitor-entered answers plus `ipAddress`/`userAgent`, so the submissions collection suppresses the PII-bearing `entry.*` events (`webhooks: false`). It now instead emits a **curated, metadata-only** `form.submission.created` carrying only which form, when, and the status — never the answers, IP, or user agent.

## How — a declarative `webhooks.emit` collection option

Rather than expose a recorder to plugins (which would break atomicity — the submit path owns its own transaction — and expand the stable plugin surface), the **core** emits the event, driven by config the collection already carries:

```ts
// submissions collection:
webhooks: {
  record: false,                                   // entry.* stays suppressed
  emit: {
    event: "form.submission.created",
    fields: ["form", "submittedAt", "status"],     // safe-metadata allowlist
  },
}
```

- The pivotal mechanic: the recording gate already treats `kind:"form"` events as always-on, while `entry.created` (`kind:"entry"`) stays gated by `webhooks:false`. So the curated event records on the **same transaction** while the PII-bearing `entry.created` stays suppressed — atomic, never delivered for a rolled-back write.
- `data` is a **default-deny projection**: only the allowlisted keys ship, so a collection's sensitive columns can't leak.
- The resource `kind` is derived from the event name (`form.*` → `form`) and validated.
- Generic: any PII-bearing collection can now replace its `entry.*` events with a safe curated one.

## Files
- Config: `define-collection.ts` (`webhooks.emit`), `resolve-recording-config.ts` (normalize + derive kind), `recording-policy.ts` (registry + `getWebhookEmitSpec`), `di/register.ts` + `init/reload-config.ts` (publish), `types.ts` (`WEBHOOK_RESOURCE_KINDS`).
- Emission: `collection-mutation-service.ts` create seam; `project-fields.ts` (default-deny projection).
- Plugin: `submissions.ts` declares the emit.

## Tests
- Unit: `project-fields` (default-deny + PII regex), `resolve-recording-config` (emit resolution + kind derivation + malformed-drop), `recording-policy` (`getWebhookEmitSpec`).
- Integration: `recording-gate` — a create emits exactly one `form.submission.created` carrying only the allowlisted field, **no `entry.created`**, and the payload matches no PII regex. `capture-matrix` still green (no regression).
- Plugin: `admin-contributions` asserts the new config.

check-types (nextly + plugin), lint, build, and the full webhooks suite (242 unit + integration) are green.