### PR TITLE
feat(nextly): execute and verify the field group storage migration's steps

### DIFF
--- a/.changeset/field-group-migration-ddl.md
+++ b/.changeset/field-group-migration-ddl.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Refuses to run a schema sync while a field group storage migration is in flight. Mid-run some tables carry their old names and some their new ones, and the registry rows pointing at them move one step at a time, so a sync during that window could delete storage it could not account for.
+
+Also further groundwork for that migration: it can now execute its rename steps and check its own work. Each table rename carries the registry row that points at it, so the two cannot land apart, and every step verifies against the database rather than trusting that it ran. Index survival is checked by name, so an index dropped and replaced by another is caught rather than passing on an unchanged count. Nothing calls the migration itself yet.

--- a/.changeset/field-group-migration-ddl.md
+++ b/.changeset/field-group-migration-ddl.md
@@ -22,6 +22,8 @@
 "@nextlyhq/tsconfig": patch
 ---
 
+Fixes PostgreSQL index introspection reading indexes from the wrong table. Table names are unique per schema rather than per database, so a table with the same name in another schema had its indexes merged into the one being inspected. That could hide an index that needed creating, or report one that was never there.
+
 Refuses to run a schema sync while a field group storage migration is in flight. Mid-run some tables carry their old names and some their new ones, and the registry rows pointing at them move one step at a time, so a sync during that window could delete storage it could not account for.
 
-Also further groundwork for that migration: it can now execute its rename steps and check its own work. Each table rename carries the registry row that points at it, so the two cannot land apart, and every step verifies against the database rather than trusting that it ran. Index survival is checked by name, so an index dropped and replaced by another is caught rather than passing on an unchanged count. Nothing calls the migration itself yet.
+Also further groundwork for that migration: it can now execute its rename steps and check its own work. A table, its localization companion and the registry row pointing at them move as one step, and on PostgreSQL and SQLite they commit together. MySQL applies a schema change as soon as it is issued, so there the halves land in sequence and a resume completes whatever did not; a reader in that window sees a table as missing rather than reading anything wrong. Every step verifies against the database rather than trusting that it ran, and index survival is checked by name, so an index dropped and replaced by another is caught rather than passing on an unchanged count. Nothing calls the migration itself yet.

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -291,7 +291,15 @@ export abstract class DrizzleAdapter {
     ) {
       return (result as { rows: T[] }).rows;
     }
-    return [];
+    // Refused rather than reported as no rows. All three drivers answer one of
+    // the shapes above, so anything else means the result was not understood —
+    // and "I could not read this" must not reach a caller as "there is nothing
+    // there", which is an answer it would act on.
+    throw this.createDatabaseError(
+      "query",
+      "Drizzle statement returned a result shape this adapter does not recognise; refusing to report it as an empty result.",
+      undefined
+    );
   }
 
   /**

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -12,7 +12,7 @@
  */
 
 import { asc, desc, getColumns } from "drizzle-orm";
-import type { AnyRelations } from "drizzle-orm";
+import type { AnyRelations, SQL } from "drizzle-orm";
 
 import { buildDrizzleWhere } from "./drizzle-where";
 import type {
@@ -247,6 +247,51 @@ export abstract class DrizzleAdapter {
    */
   protected getTableObject(tableName: string): unknown {
     return this.tableResolver?.getTable(tableName) ?? null;
+  }
+
+  /**
+   * Run a Drizzle-built statement and return its rows.
+   *
+   * @remarks
+   * The CRUD methods resolve their table through the schema registry and reject
+   * any name it does not declare, which leaves no way to read from a table the
+   * ORM does not know — one mid-rename, above all — except by assembling SQL and
+   * quoting identifiers by hand. This takes Drizzle's `sql` template instead, so
+   * the dialect in use decides the quoting and the parameter binding.
+   *
+   * Concrete rather than abstract so existing adapters keep working unchanged.
+   * The three drivers disagree about both the call and the result: node-postgres
+   * returns `{ rows }`, mysql2 a `[rows, fields]` tuple, and better-sqlite3 has
+   * no `execute` at all and answers `all`. Keeping that here rather than at each
+   * call site is the point — a caller reasoning about it would be reasoning
+   * about a driver it cannot see.
+   *
+   * @param statement - Drizzle `sql` template to run
+   * @returns Rows the statement produced
+   */
+  async queryStatement<T = Record<string, unknown>>(
+    statement: SQL
+  ): Promise<T[]> {
+    if (this.getCapabilities().dialect === "sqlite") {
+      const db = this.getDrizzle<{ all(query: SQL): T[] | Promise<T[]> }>();
+      return await db.all(statement);
+    }
+    const db = this.getDrizzle<{ execute(query: SQL): Promise<unknown> }>();
+    const result = await db.execute(statement);
+    // `{ rows }` is node-postgres. A bare array is mysql2's `[rows, fields]`
+    // tuple, told apart by its first element being an array — the only test that
+    // does not depend on trusting one driver to keep its shape.
+    if (Array.isArray(result)) {
+      return (Array.isArray(result[0]) ? result[0] : result) as T[];
+    }
+    if (
+      typeof result === "object" &&
+      result !== null &&
+      Array.isArray((result as { rows?: unknown }).rows)
+    ) {
+      return (result as { rows: T[] }).rows;
+    }
+    return [];
   }
 
   /**

--- a/packages/adapter-drizzle/src/types/transaction.ts
+++ b/packages/adapter-drizzle/src/types/transaction.ts
@@ -4,6 +4,8 @@
  * @packageDocumentation
  */
 
+import type { SQL } from "drizzle-orm";
+
 import type { SqlParam } from "./core";
 import type {
   SelectOptions,
@@ -80,6 +82,28 @@ export interface TransactionContext {
    * @returns Array of result rows
    */
   execute<T = unknown>(sql: string, params?: SqlParam[]): Promise<T[]>;
+
+  /**
+   * Run a Drizzle-built statement within the transaction, for its effect.
+   *
+   * @remarks
+   * The typed CRUD methods below resolve their table through the schema
+   * registry and reject any name it does not declare. That leaves no way to
+   * write to a table addressed under a name the ORM does not know — a table
+   * mid-rename, most of all — other than assembling SQL by hand, which also
+   * means hand-picking each driver's placeholder syntax.
+   *
+   * This accepts Drizzle's `sql` template instead, so identifier quoting and
+   * parameter binding are generated for the dialect in use. Implemented per
+   * adapter because the underlying call is not uniform: node-postgres and
+   * mysql2 expose `execute`, while better-sqlite3 needs `run` and throws on a
+   * statement that returns no rows.
+   *
+   * Returns nothing: this is for statements run to change data, not to read it.
+   *
+   * @param statement - Drizzle `sql` template to run
+   */
+  runStatement(statement: SQL): Promise<void>;
 
   /**
    * Take an exclusive lock on a single row for the rest of this transaction.

--- a/packages/adapter-drizzle/src/types/transaction.ts
+++ b/packages/adapter-drizzle/src/types/transaction.ts
@@ -106,6 +106,21 @@ export interface TransactionContext {
   runStatement(statement: SQL): Promise<void>;
 
   /**
+   * Run a Drizzle-built statement within the transaction and return its rows.
+   *
+   * @remarks
+   * The reading half of `runStatement`, for the same reason: a table the schema
+   * registry does not declare cannot be reached through the typed CRUD methods,
+   * which reject the name outright. Implemented per adapter because the drivers
+   * disagree about both the call and the result — node-postgres answers
+   * `{ rows }`, mysql2 a `[rows, fields]` tuple, and better-sqlite3 needs `all`.
+   *
+   * @param statement - Drizzle `sql` template to run
+   * @returns Rows the statement produced
+   */
+  queryStatement<T = Record<string, unknown>>(statement: SQL): Promise<T[]>;
+
+  /**
    * Take an exclusive lock on a single row for the rest of this transaction.
    *
    * @remarks

--- a/packages/adapter-mysql/src/index.ts
+++ b/packages/adapter-mysql/src/index.ts
@@ -792,9 +792,18 @@ export class MySqlAdapter extends DrizzleAdapter {
         statement: SQL
       ): Promise<T[]> => {
         const result = await txDb().execute(statement);
-        // A tuple's first element is the rows; anything else is a result
-        // header from a statement that returned none.
-        return (Array.isArray(result) ? result[0] : []) as unknown as T[];
+        // A tuple's first element is the rows. Anything else was not understood,
+        // and must not reach a caller as "there is nothing there" — the same
+        // reason the pooled `queryStatement` refuses rather than answering
+        // empty.
+        if (!Array.isArray(result)) {
+          throw this.createDatabaseError(
+            "query",
+            "Drizzle statement returned a result shape this adapter does not recognise; refusing to report it as an empty result.",
+            undefined
+          );
+        }
+        return result[0] as unknown as T[];
       },
 
       lockRow: async (table: string, id: SqlParam): Promise<void> => {

--- a/packages/adapter-mysql/src/index.ts
+++ b/packages/adapter-mysql/src/index.ts
@@ -63,7 +63,7 @@ import {
   type SslConfig,
 } from "@nextlyhq/adapter-drizzle/types";
 import { checkDialectVersion } from "@nextlyhq/adapter-drizzle/version-check";
-import type { AnyRelations } from "drizzle-orm";
+import type { AnyRelations, SQL } from "drizzle-orm";
 import { drizzle, type MySql2Database } from "drizzle-orm/mysql2";
 import type {
   Pool as CallbackPool,
@@ -778,6 +778,12 @@ export class MySqlAdapter extends DrizzleAdapter {
           params as unknown[]
         );
         return rows as T[];
+      },
+
+      // Run on the transaction-bound Drizzle instance rather than the pool, so
+      // the statement is part of this transaction and sees its uncommitted rows.
+      runStatement: async (statement: SQL): Promise<void> => {
+        await txDb().execute(statement);
       },
 
       lockRow: async (table: string, id: SqlParam): Promise<void> => {

--- a/packages/adapter-mysql/src/index.ts
+++ b/packages/adapter-mysql/src/index.ts
@@ -786,6 +786,17 @@ export class MySqlAdapter extends DrizzleAdapter {
         await txDb().execute(statement);
       },
 
+      // mysql2 answers a `[rows, fields]` tuple; the transaction-bound instance
+      // keeps the read inside this transaction so it sees its uncommitted writes.
+      queryStatement: async <T = Record<string, unknown>>(
+        statement: SQL
+      ): Promise<T[]> => {
+        const result = await txDb().execute(statement);
+        // A tuple's first element is the rows; anything else is a result
+        // header from a statement that returned none.
+        return (Array.isArray(result) ? result[0] : []) as unknown as T[];
+      },
+
       lockRow: async (table: string, id: SqlParam): Promise<void> => {
         const idColumn = this.escapeIdentifier("id");
         await connection.query(

--- a/packages/adapter-postgres/src/index.ts
+++ b/packages/adapter-postgres/src/index.ts
@@ -942,6 +942,15 @@ export class PostgresAdapter extends DrizzleAdapter {
         await txDb().execute(statement);
       },
 
+      // node-postgres answers `{ rows }`; the transaction-bound instance keeps
+      // the read inside this transaction so it sees its uncommitted writes.
+      queryStatement: async <T = Record<string, unknown>>(
+        statement: SQL
+      ): Promise<T[]> => {
+        const result = await txDb().execute(statement);
+        return result.rows as T[];
+      },
+
       lockRow: async (table: string, id: SqlParam): Promise<void> => {
         const idColumn = this.escapeIdentifier("id");
         await client.query(

--- a/packages/adapter-postgres/src/index.ts
+++ b/packages/adapter-postgres/src/index.ts
@@ -91,7 +91,7 @@ import {
   isDatabaseError,
 } from "@nextlyhq/adapter-drizzle/types";
 import { checkDialectVersion } from "@nextlyhq/adapter-drizzle/version-check";
-import type { AnyRelations } from "drizzle-orm";
+import type { AnyRelations, SQL } from "drizzle-orm";
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import type { PoolClient, PoolConfig } from "pg";
 import { Pool } from "pg";
@@ -934,6 +934,12 @@ export class PostgresAdapter extends DrizzleAdapter {
       ): Promise<T[]> => {
         const result = await client.query(sql, params as unknown[]);
         return result.rows as T[];
+      },
+
+      // Run on the transaction-bound Drizzle instance rather than the pool, so
+      // the statement is part of this transaction and sees its uncommitted rows.
+      runStatement: async (statement: SQL): Promise<void> => {
+        await txDb().execute(statement);
       },
 
       lockRow: async (table: string, id: SqlParam): Promise<void> => {

--- a/packages/adapter-sqlite/src/index.ts
+++ b/packages/adapter-sqlite/src/index.ts
@@ -62,7 +62,7 @@ import {
 } from "@nextlyhq/adapter-drizzle/types";
 import { checkDialectVersion } from "@nextlyhq/adapter-drizzle/version-check";
 import type Database from "better-sqlite3";
-import type { AnyRelations } from "drizzle-orm";
+import type { AnyRelations, SQL } from "drizzle-orm";
 import {
   drizzle,
   type BetterSQLite3Database,
@@ -713,6 +713,15 @@ export class SqliteAdapter extends DrizzleAdapter {
       // opens SQLite transactions with BEGIN IMMEDIATE, which takes the write
       // lock up front and serializes writers for the whole transaction.
       lockRow: (): Promise<void> => Promise.resolve(),
+
+      // `run`, not `all`: better-sqlite3 throws on a statement that returns no
+      // rows, which is every statement this method exists to carry. The Drizzle
+      // instance is the transaction-bound one, so the statement runs inside this
+      // transaction.
+      // eslint-disable-next-line @typescript-eslint/require-await
+      runStatement: async (statement: SQL): Promise<void> => {
+        txDb().run(statement);
+      },
 
       // eslint-disable-next-line @typescript-eslint/require-await
       execute: async <T = unknown>(

--- a/packages/adapter-sqlite/src/index.ts
+++ b/packages/adapter-sqlite/src/index.ts
@@ -718,9 +718,13 @@ export class SqliteAdapter extends DrizzleAdapter {
       // rows, which is every statement this method exists to carry. The Drizzle
       // instance is the transaction-bound one, so the statement runs inside this
       // transaction.
-      // eslint-disable-next-line @typescript-eslint/require-await
-      runStatement: async (statement: SQL): Promise<void> => {
+      //
+      // better-sqlite3 is synchronous, so this resolves an already-settled
+      // promise rather than being declared `async` over a body that never
+      // awaits.
+      runStatement: (statement: SQL): Promise<void> => {
         txDb().run(statement);
+        return Promise.resolve();
       },
 
       // eslint-disable-next-line @typescript-eslint/require-await

--- a/packages/adapter-sqlite/src/index.ts
+++ b/packages/adapter-sqlite/src/index.ts
@@ -727,6 +727,12 @@ export class SqliteAdapter extends DrizzleAdapter {
         return Promise.resolve();
       },
 
+      // `all`, not `run`: this is the reading half, and better-sqlite3 returns
+      // rows only from `all`. Synchronous, so the promise is already settled.
+      queryStatement: <T = Record<string, unknown>>(
+        statement: SQL
+      ): Promise<T[]> => Promise.resolve(txDb().all(statement)),
+
       // eslint-disable-next-line @typescript-eslint/require-await
       execute: async <T = unknown>(
         sql: string,

--- a/packages/nextly/src/cli/commands/db-sync.ts
+++ b/packages/nextly/src/cli/commands/db-sync.ts
@@ -315,6 +315,7 @@ export async function runDbSync(
         adapter: adapter as unknown as DrizzleAdapter,
         logger,
         label: "db:sync",
+        mayCreateLock: options.autoSync !== false,
       },
       async () =>
         await runWithFieldTypes(configResult.fieldTypes, async () => {

--- a/packages/nextly/src/cli/commands/db-sync.ts
+++ b/packages/nextly/src/cli/commands/db-sync.ts
@@ -62,7 +62,7 @@ import type { Command } from "commander";
 
 import { getDialectTables } from "../../database/index";
 import { SchemaRegistry } from "../../database/schema-registry";
-import { assertNoMigrationInFlight } from "../../domains/field-groups/migration/sync-guard";
+import { withMigrationExcluded } from "../../domains/field-groups/migration/sync-guard";
 import { registerComponentSchemas } from "../../domains/field-groups/services/register-field-group-schemas";
 import { runWithFieldTypes } from "../../domains/schema/field-types/field-type-scope";
 import { describeError } from "../../errors/index";
@@ -286,10 +286,11 @@ export async function runDbSync(
     // config against that, and `--remove-orphaned` deletes what it cannot
     // account for. Placed after the core tables so the marker's own table is
     // guaranteed to exist, and before anything that reads or changes schema.
-    await assertNoMigrationInFlight({
-      adapter: adapter as unknown as DrizzleAdapter,
-      logger,
-    });
+    // Held across the sync rather than sampled before it. A migration starting
+    // just after a point-in-time check renames tables underneath work that has
+    // already decided what exists, and `--remove-orphaned` deletes what it
+    // cannot account for. Watch mode is deliberately outside: it never returns,
+    // and each debounced re-sync takes the exclusion for itself.
 
     // Step 4-5.5: Sync collections, singles and components.
     //
@@ -309,56 +310,70 @@ export async function runDbSync(
     // builds the `comp_` runtime tables from the same storage mappings: left
     // outside, it would shape them from a newer config than the sync that then
     // addresses them.
-    await runWithFieldTypes(configResult.fieldTypes, async () => {
-      // Step 3.6: Register the runtime schema of every component in the database. The registry
-      // built above holds STATIC system tables only, so `comp_` tables are unaddressable by
-      // the ORM until this runs — and the orphan cleanup below has to delete rows from them.
-      // Reads from `dynamic_components` rather than the config so components already removed
-      // from code are still reachable.
-      await registerComponentSchemas({
+    await withMigrationExcluded(
+      {
         adapter: adapter as unknown as DrizzleAdapter,
-        registry: schemaRegistry,
-        dialect: (adapter as unknown as DrizzleAdapter).getCapabilities()
-          .dialect,
         logger,
-      });
+        label: "db:sync",
+      },
+      async () =>
+        await runWithFieldTypes(configResult.fieldTypes, async () => {
+          // Step 3.6: Register the runtime schema of every component in the database. The registry
+          // built above holds STATIC system tables only, so `comp_` tables are unaddressable by
+          // the ORM until this runs — and the orphan cleanup below has to delete rows from them.
+          // Reads from `dynamic_components` rather than the config so components already removed
+          // from code are still reachable.
+          await registerComponentSchemas({
+            adapter: adapter as unknown as DrizzleAdapter,
+            registry: schemaRegistry,
+            dialect: (adapter as unknown as DrizzleAdapter).getCapabilities()
+              .dialect,
+            logger,
+          });
 
-      assertPluginFieldDeclarations(configResult.config);
+          assertPluginFieldDeclarations(configResult.config);
 
-      await syncCollections(configResult, adapter, options, context);
-      await syncSingles(configResult, adapter, options, context);
-      await syncComponents(configResult, adapter, options, context);
+          await syncCollections(configResult, adapter, options, context);
+          await syncSingles(configResult, adapter, options, context);
+          await syncComponents(configResult, adapter, options, context);
 
-      // Step 5.6: Create the `_locales` companion of every localized entity, which
-      // the push pipeline does not manage. Runs after all three syncs because the
-      // companion references its main table. Without this, `db:sync` left the
-      // registry saying "localized" with no table to hold translations until the
-      // app next booted, and writes in that window overwrote the default language.
-      //
-      // Gated on the same flag as the rest of the schema push: this issues DDL and
-      // can copy rows, so `--no-auto-sync` — chosen precisely to keep physical
-      // schema changes in migration files — must suppress it too.
-      //
-      // Inside the pinned scope with the syncs it follows: a companion holds the
-      // localized subset of the same fields, so it has to resolve plugin types
-      // against the config the main tables were just materialized from.
-      if (options.autoSync !== false) {
-        await ensureLocalizedCompanions(configResult.config, adapter, context);
-      }
+          // Step 5.6: Create the `_locales` companion of every localized entity, which
+          // the push pipeline does not manage. Runs after all three syncs because the
+          // companion references its main table. Without this, `db:sync` left the
+          // registry saying "localized" with no table to hold translations until the
+          // app next booted, and writes in that window overwrote the default language.
+          //
+          // Gated on the same flag as the rest of the schema push: this issues DDL and
+          // can copy rows, so `--no-auto-sync` — chosen precisely to keep physical
+          // schema changes in migration files — must suppress it too.
+          //
+          // Inside the pinned scope with the syncs it follows: a companion holds the
+          // localized subset of the same fields, so it has to resolve plugin types
+          // against the config the main tables were just materialized from.
+          if (options.autoSync !== false) {
+            await ensureLocalizedCompanions(
+              configResult.config,
+              adapter,
+              context
+            );
+          }
 
-      if (collectionCount === 0) {
-        logger.warn("No collections defined in config");
-        logger.info("Add collections to your nextly.config.ts to get started.");
-      }
+          if (collectionCount === 0) {
+            logger.warn("No collections defined in config");
+            logger.info(
+              "Add collections to your nextly.config.ts to get started."
+            );
+          }
 
-      // Step 5.6: Sync user_ext table (always — handles both code and UI fields)
-      await syncUserFields(configResult, adapter, options, context);
+          // Step 5.6: Sync user_ext table (always — handles both code and UI fields)
+          await syncUserFields(configResult, adapter, options, context);
 
-      // Step 5.7: Seed permissions for collections and singles (always, idempotent).
-      // demo content seeding moved to a Payload-style admin-triggered POST
-      // route in the project itself (src/app/admin/api/seed/route.ts).
-      await performPermissionSeeding(adapter, options, context);
-    });
+          // Step 5.7: Seed permissions for collections and singles (always, idempotent).
+          // demo content seeding moved to a Payload-style admin-triggered POST
+          // route in the project itself (src/app/admin/api/seed/route.ts).
+          await performPermissionSeeding(adapter, options, context);
+        })
+    );
 
     // Step 7: Watch mode. Gated on any entity kind this command syncs, not just
     // collections and singles: `loadConfig({ watch: true })` has already opened

--- a/packages/nextly/src/cli/commands/db-sync.ts
+++ b/packages/nextly/src/cli/commands/db-sync.ts
@@ -62,6 +62,7 @@ import type { Command } from "commander";
 
 import { getDialectTables } from "../../database/index";
 import { SchemaRegistry } from "../../database/schema-registry";
+import { assertNoMigrationInFlight } from "../../domains/field-groups/migration/sync-guard";
 import { registerComponentSchemas } from "../../domains/field-groups/services/register-field-group-schemas";
 import { runWithFieldTypes } from "../../domains/schema/field-types/field-type-scope";
 import { describeError } from "../../errors/index";
@@ -276,6 +277,19 @@ export async function runDbSync(
     // Uses drizzle-kit pushSchema() to create ALL tables from the Drizzle
     // schema definitions, guaranteeing they match 100%.
     await ensureCoreTables(adapter, options, context);
+
+    // Step 3.55: Refuse while a field group storage migration is in flight.
+    //
+    // Mid-run the database is in a shape neither the old config nor the new one
+    // describes: some tables carry pre-rename names, some post-rename, and the
+    // registry pointers move one step at a time. Everything below reconciles the
+    // config against that, and `--remove-orphaned` deletes what it cannot
+    // account for. Placed after the core tables so the marker's own table is
+    // guaranteed to exist, and before anything that reads or changes schema.
+    await assertNoMigrationInFlight({
+      adapter: adapter as unknown as DrizzleAdapter,
+      logger,
+    });
 
     // Step 4-5.5: Sync collections, singles and components.
     //

--- a/packages/nextly/src/cli/commands/dev-watcher.ts
+++ b/packages/nextly/src/cli/commands/dev-watcher.ts
@@ -10,7 +10,7 @@
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
-import { assertNoMigrationInFlight } from "../../domains/field-groups/migration/sync-guard";
+import { withMigrationExcluded } from "../../domains/field-groups/migration/sync-guard";
 import { runWithFieldTypes } from "../../domains/schema/field-types/field-type-scope";
 import { describeError } from "../../errors/index";
 import { assertPluginFieldDeclarations } from "../../shared/lib/assert-plugin-field-declarations";
@@ -81,37 +81,45 @@ export function createDebouncedSync(
         // can begin after the watcher starts, so checking only at boot leaves
         // every later save free to reconcile — and, with `--remove-orphaned`,
         // delete — tables that are halfway through being renamed.
-        await assertNoMigrationInFlight({
-          adapter: adapter as unknown as DrizzleAdapter,
-          logger,
-        });
+        //
+        // Held for the whole re-sync rather than read once at the top of it: a
+        // migration beginning a moment later would rename tables underneath work
+        // that has already decided what exists.
+        await withMigrationExcluded(
+          {
+            adapter: adapter as unknown as DrizzleAdapter,
+            logger,
+            label: "db:sync watch",
+          },
+          async () => {
+            // Unconditional, so the orphan scan still runs when the config declares none of a
+            // type: deleting the last entry of a kind is precisely what orphans its table, making
+            // a zero count the case where the scan matters most.
+            await syncCollections(configToSync, adapter, options, context);
+            await syncSingles(configToSync, adapter, options, context);
+            await syncComponents(configToSync, adapter, options, context);
 
-        // Unconditional, so the orphan scan still runs when the config declares none of a
-        // type: deleting the last entry of a kind is precisely what orphans its table, making
-        // a zero count the case where the scan matters most.
-        await syncCollections(configToSync, adapter, options, context);
-        await syncSingles(configToSync, adapter, options, context);
-        await syncComponents(configToSync, adapter, options, context);
+            // Turning on localization is a config edit, so it arrives through this
+            // watcher as often as through `db:sync`. The companion table is not part of
+            // the push pipeline, and creating it here rather than at the next boot is
+            // what keeps a running server from advertising localization it cannot store.
+            // Suppressed under `--no-auto-sync` for the same reason the rest of the
+            // push is: it issues DDL and can copy rows.
+            if (options.autoSync !== false) {
+              await ensureLocalizedCompanions(
+                configToSync.config,
+                adapter,
+                context
+              );
+            }
 
-        // Turning on localization is a config edit, so it arrives through this
-        // watcher as often as through `db:sync`. The companion table is not part of
-        // the push pipeline, and creating it here rather than at the next boot is
-        // what keeps a running server from advertising localization it cannot store.
-        // Suppressed under `--no-auto-sync` for the same reason the rest of the
-        // push is: it issues DDL and can copy rows.
-        if (options.autoSync !== false) {
-          await ensureLocalizedCompanions(
-            configToSync.config,
-            adapter,
-            context
-          );
-        }
+            // Sync user_ext table (always — handles both code and UI fields)
+            await syncUserFields(configToSync, adapter, options, context);
 
-        // Sync user_ext table (always — handles both code and UI fields)
-        await syncUserFields(configToSync, adapter, options, context);
-
-        // Seed permissions for new/updated collections and singles
-        await performPermissionSeeding(adapter, options, context);
+            // Seed permissions for new/updated collections and singles
+            await performPermissionSeeding(adapter, options, context);
+          }
+        );
       });
     } catch (error) {
       logger.error(`Re-sync failed: ${describeError(error)}`);

--- a/packages/nextly/src/cli/commands/dev-watcher.ts
+++ b/packages/nextly/src/cli/commands/dev-watcher.ts
@@ -8,6 +8,9 @@
  * @module cli/commands/dev-watcher
  */
 
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+
+import { assertNoMigrationInFlight } from "../../domains/field-groups/migration/sync-guard";
 import { runWithFieldTypes } from "../../domains/schema/field-types/field-type-scope";
 import { describeError } from "../../errors/index";
 import { assertPluginFieldDeclarations } from "../../shared/lib/assert-plugin-field-declarations";
@@ -73,6 +76,15 @@ export function createDebouncedSync(
         // type rejects — the state this check exists to keep out of the
         // database.
         assertPluginFieldDeclarations(configToSync.config);
+
+        // The same reasoning, for storage rather than declarations. A migration
+        // can begin after the watcher starts, so checking only at boot leaves
+        // every later save free to reconcile — and, with `--remove-orphaned`,
+        // delete — tables that are halfway through being renamed.
+        await assertNoMigrationInFlight({
+          adapter: adapter as unknown as DrizzleAdapter,
+          logger,
+        });
 
         // Unconditional, so the orphan scan still runs when the config declares none of a
         // type: deleting the last entry of a kind is precisely what orphans its table, making

--- a/packages/nextly/src/cli/commands/dev-watcher.ts
+++ b/packages/nextly/src/cli/commands/dev-watcher.ts
@@ -90,6 +90,7 @@ export function createDebouncedSync(
             adapter: adapter as unknown as DrizzleAdapter,
             logger,
             label: "db:sync watch",
+            mayCreateLock: options.autoSync !== false,
           },
           async () => {
             // Unconditional, so the orphan scan still runs when the config declares none of a

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/guard.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/guard.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { NextlyError } from "../../../../errors/nextly-error";
 import { resolveStorageVerdict, type StorageProbe } from "../guard";
+import type { ManifestEntry } from "../manifest";
 import { MAX_MIGRATION_STEP } from "../state";
 import type { MigratingState, MigrationState } from "../state";
 
@@ -22,12 +23,16 @@ const MIGRATED: MigrationState = {
   generation: "field-groups-v2",
   recorded: true,
 };
+const IN_FLIGHT_PLAN: ManifestEntry[] = [
+  { kind: "registry", from: "dynamic_components", to: "dynamic_field_groups" },
+];
 const IN_FLIGHT: MigratingState = {
   status: "migrating",
   direction: "up",
   migrationId: "run-1",
   step: 4,
-  plan: { manifestHash: "hash-1", planHash: "plan-1" },
+  plan: { slugsHash: "slugs-1", manifestHash: "hash-1" },
+  appliedManifest: IN_FLIGHT_PLAN,
 };
 
 function probe(over: Partial<StorageProbe> = {}): StorageProbe {
@@ -192,7 +197,8 @@ describe("field-group storage verdict", () => {
         step: 5,
         direction: "up",
         migrationId: "run-1",
-        plan: { manifestHash: "hash-1", planHash: "plan-1" },
+        plan: { slugsHash: "slugs-1", manifestHash: "hash-1" },
+        appliedManifest: IN_FLIGHT_PLAN,
       }
     );
   });
@@ -234,23 +240,21 @@ describe("field-group storage verdict", () => {
     });
   });
 
-  // An in-flight rollback with no recorded plan cannot be resumed at all:
-  // guessing the reverse from the database would rename names this migration
-  // never created.
-  it("refuses to resume a rollback that recorded no plan", () => {
-    const down: MigratingState = { ...IN_FLIGHT, direction: "down" };
-    const refusal = captureRefusal(() =>
-      resolveStorageVerdict({ state: down, probe: probe() })
-    );
-    expect(refusal.logContext?.reason).toMatch(/recorded no plan to reverse/);
-  });
-
-  // An up run derives its plan from registry rows, so it carries none.
-  it("resumes an up run without a recorded plan", () => {
-    expect(
-      resolveStorageVerdict({ state: IN_FLIGHT, probe: probe() })
-    ).toMatchObject({ action: "resume", direction: "up" });
-  });
+  // The plan travels with the verdict in both directions, because neither can
+  // rebuild it: a rollback has no other source for the names this migration
+  // created, and an up resume cannot rebuild one once each rename has rewritten
+  // its registry pointer.
+  it.each(["up", "down"] as const)(
+    "carries the recorded plan into a %s resume",
+    direction => {
+      const state: MigratingState = { ...IN_FLIGHT, direction };
+      expect(resolveStorageVerdict({ state, probe: probe() })).toMatchObject({
+        action: "resume",
+        direction,
+        appliedManifest: IN_FLIGHT.appliedManifest,
+      });
+    }
+  );
 
   // An interrupted run is interpretable only by the step list, whatever the
   // objects currently look like. The probe must not override the marker here.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/guard.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/guard.test.ts
@@ -31,7 +31,7 @@ const IN_FLIGHT: MigratingState = {
   direction: "up",
   migrationId: "run-1",
   step: 4,
-  plan: { slugsHash: "slugs-1", manifestHash: "hash-1" },
+  plan: { registryHash: "slugs-1", manifestHash: "hash-1" },
   appliedManifest: IN_FLIGHT_PLAN,
 };
 
@@ -197,7 +197,7 @@ describe("field-group storage verdict", () => {
         step: 5,
         direction: "up",
         migrationId: "run-1",
-        plan: { slugsHash: "slugs-1", manifestHash: "hash-1" },
+        plan: { registryHash: "slugs-1", manifestHash: "hash-1" },
         appliedManifest: IN_FLIGHT_PLAN,
       }
     );

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/locking-adapter.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/locking-adapter.ts
@@ -1,0 +1,110 @@
+/**
+ * An adapter double that models the migration lock rather than accepting writes.
+ *
+ * The lock is a read-modify-write over one row, so a double that let every claim
+ * succeed would certify exclusion that does not exist — and a double missing a
+ * method makes every caller look refused, which is just as misleading. Statements
+ * are compiled through a real dialect so this interprets the SQL and bound
+ * parameters an adapter would hand its driver.
+ *
+ * Shared because two suites need it: the session's own tests, and the reload path
+ * that now holds the same lock.
+ */
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+export interface LockingAdapterOptions {
+  /** Marker value the `nextly_meta` read returns, or `undefined` for none. */
+  marker?: unknown;
+  /** Pre-existing claim, so the lock reads as held. */
+  heldBy?: string | null;
+  /** Whether the lock table exists. */
+  lockTableExists?: boolean;
+}
+
+export function createLockingAdapter(options: LockingAdapterOptions = {}) {
+  const lock: { seeded: boolean; owner: string | null } = {
+    seeded: options.heldBy !== undefined,
+    owner: options.heldBy ?? null,
+  };
+  const ddl: string[] = [];
+
+  function interpret(statement: SQL): Record<string, unknown>[] {
+    const { sql: text, params } = new PgDialect().sqlToQuery(statement);
+    const flat = text.replace(/\s+/g, " ").trim();
+
+    if (
+      /^SELECT "\w+" FROM "nextly_field_group_lock" WHERE "id" = \$1$/.test(
+        flat
+      )
+    ) {
+      return lock.seeded ? [{ id: 1, owner: lock.owner }] : [];
+    }
+    if (
+      /^UPDATE "nextly_field_group_lock" SET "owner" = \$1 WHERE "id" = \$2$/.test(
+        flat
+      )
+    ) {
+      // An occupied row refuses a new claim, exactly as the real one does.
+      if (lock.owner === null) lock.owner = params[0] as string | null;
+      return [];
+    }
+    if (
+      /^UPDATE "nextly_field_group_lock" SET "owner" = NULL WHERE "id" = \$1 AND "owner" = \$2$/.test(
+        flat
+      )
+    ) {
+      if (lock.owner === params[1]) lock.owner = null;
+      return [];
+    }
+    throw new Error(`unrecognised statement: ${flat}`);
+  }
+
+  const adapter = {
+    dialect: "postgresql" as const,
+    getCapabilities: () => ({ dialect: "postgresql" }),
+    getDrizzle: () => ({
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: () =>
+              Promise.resolve(
+                options.marker === undefined
+                  ? []
+                  : [{ key: "k", value: JSON.stringify(options.marker) }]
+              ),
+          }),
+        }),
+      }),
+    }),
+    executeQuery: (sql: string) => {
+      ddl.push(sql);
+      return Promise.resolve([]);
+    },
+    queryStatement: (statement: SQL) => Promise.resolve(interpret(statement)),
+    tableExists: (name: string) =>
+      Promise.resolve(
+        name === "nextly_field_group_lock"
+          ? (options.lockTableExists ?? true)
+          : true
+      ),
+    transaction: (work: (ctx: unknown) => Promise<unknown>) =>
+      work({
+        lockRow: () => Promise.resolve(undefined),
+        insert: (_table: string, data: { owner: string | null }) => {
+          lock.seeded = true;
+          lock.owner = data.owner;
+          return Promise.resolve(data);
+        },
+        runStatement: (statement: SQL) => {
+          interpret(statement);
+          return Promise.resolve();
+        },
+        queryStatement: (statement: SQL) =>
+          Promise.resolve(interpret(statement)),
+      }),
+  } as unknown as DrizzleAdapter;
+
+  return { adapter, ownerNow: () => lock.owner, ddlIssued: () => [...ddl] };
+}

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
@@ -411,8 +411,8 @@ describe("field-group migration manifest", () => {
 
 describe("hashRegistryIdentity", () => {
   const rows = [
-    { id: "1", slug: "a" },
-    { id: "2", slug: "b" },
+    { id: "1", slug: "a", hasCompanion: false },
+    { id: "2", slug: "b", hasCompanion: false },
   ];
 
   it("does not depend on row order", () => {
@@ -423,15 +423,32 @@ describe("hashRegistryIdentity", () => {
 
   it("changes when a field group is added or removed", () => {
     const base = hashRegistryIdentity(rows);
-    expect(hashRegistryIdentity([...rows, { id: "3", slug: "c" }])).not.toBe(
-      base
-    );
+    expect(
+      hashRegistryIdentity([
+        ...rows,
+        { id: "3", slug: "c", hasCompanion: false },
+      ])
+    ).not.toBe(base);
     expect(hashRegistryIdentity([rows[0]!])).not.toBe(base);
   });
 
+  // Enabling localization creates a companion table without replacing the
+  // registry row, so id and slug alone stay identical while the storage gains a
+  // table the recorded plan does not name. A resume against that plan would move
+  // the base and leave the companion behind.
+  it("changes when a row gains storage the recorded plan does not name", () => {
+    expect(
+      hashRegistryIdentity([{ id: "1", slug: "a", hasCompanion: true }])
+    ).not.toBe(
+      hashRegistryIdentity([{ id: "1", slug: "a", hasCompanion: false }])
+    );
+  });
+
   it("distinguishes different sets of the same size", () => {
-    expect(hashRegistryIdentity([{ id: "1", slug: "a" }])).not.toBe(
-      hashRegistryIdentity([{ id: "1", slug: "b" }])
+    expect(
+      hashRegistryIdentity([{ id: "1", slug: "a", hasCompanion: false }])
+    ).not.toBe(
+      hashRegistryIdentity([{ id: "1", slug: "b", hasCompanion: false }])
     );
   });
 

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
@@ -49,8 +49,14 @@ describe("field-group migration manifest", () => {
   it("renames the table, its companion, and its discriminator", () => {
     const { entries } = buildMigrationManifest([row({ hasCompanion: true })]);
     expect(entries).toEqual([
-      { kind: "table", from: "comp_hero", to: "fg_hero" },
-      { kind: "companion", from: "comp_hero_locales", to: "fg_hero_locales" },
+      {
+        kind: "table",
+        from: "comp_hero",
+        to: "fg_hero",
+        // Carried by the table it belongs to rather than listed beside it: a
+        // companion has no registry row and cannot move on its own.
+        companion: { from: "comp_hero_locales", to: "fg_hero_locales" },
+      },
       { kind: "column", ...COLUMN_RENAME, table: "fg_hero" },
       {
         kind: "registry",
@@ -85,8 +91,7 @@ describe("field-group migration manifest", () => {
     const { entries } = buildMigrationManifest([
       row({ slug: "odd-name", tableName: "comp_odd_name", hasCompanion: true }),
     ]);
-    expect(entries).toContainEqual({
-      kind: "companion",
+    expect(entries[0]?.companion).toEqual({
       from: `comp_odd_name${STORAGE_FORMAT.companionSuffix}`,
       to: `fg_odd_name${STORAGE_FORMAT.companionSuffix}`,
     });
@@ -96,7 +101,7 @@ describe("field-group migration manifest", () => {
   // the create path accepts exactly that. Naming one would make the step fail.
   it("does not rename a companion that was never created", () => {
     const { entries } = buildMigrationManifest([row({ hasCompanion: false })]);
-    expect(entries.some(e => e.kind === "companion")).toBe(false);
+    expect(entries.every(e => e.companion === undefined)).toBe(true);
   });
 
   // The column rename runs after its table's, so addressing it by the old name
@@ -339,8 +344,15 @@ describe("field-group migration manifest", () => {
         // Still the migrated name: the column reverts before its table does.
         table: "fg_hero",
       },
-      { kind: "companion", from: "fg_hero_locales", to: "comp_hero_locales" },
-      { kind: "table", from: "fg_hero", to: "comp_hero" },
+      {
+        kind: "table",
+        from: "fg_hero",
+        to: "comp_hero",
+        // Inverted with its owner. Held as a separate entry it would have been
+        // reversed *ahead* of the table it belongs to, and nothing downstream
+        // would have recognised the pair.
+        companion: { from: "fg_hero_locales", to: "comp_hero_locales" },
+      },
     ]);
   });
 

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
@@ -4,7 +4,7 @@ import { NextlyError } from "../../../../errors/nextly-error";
 import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
 import {
   buildMigrationManifest,
-  hashSlugSet,
+  hashRegistryIdentity,
   hashManifest,
   invertManifest,
   MIGRATION_TARGET,
@@ -397,40 +397,47 @@ describe("field-group migration manifest", () => {
   });
 });
 
-describe("hashSlugSet", () => {
-  // Identity of the *set*, so row order from the registry must not change it.
+describe("hashRegistryIdentity", () => {
+  const rows = [
+    { id: "1", slug: "a" },
+    { id: "2", slug: "b" },
+  ];
+
   it("does not depend on row order", () => {
-    expect(hashSlugSet([{ slug: "a" }, { slug: "b" }])).toBe(
-      hashSlugSet([{ slug: "b" }, { slug: "a" }])
+    expect(hashRegistryIdentity(rows)).toBe(
+      hashRegistryIdentity([...rows].reverse())
     );
   });
 
-  // The question it answers: did a field group appear or disappear underneath an
-  // interrupted run? Either leaves storage the recorded plan never mentions.
   it("changes when a field group is added or removed", () => {
-    const base = hashSlugSet([{ slug: "a" }, { slug: "b" }]);
-    expect(hashSlugSet([{ slug: "a" }, { slug: "b" }, { slug: "c" }])).not.toBe(
+    const base = hashRegistryIdentity(rows);
+    expect(hashRegistryIdentity([...rows, { id: "3", slug: "c" }])).not.toBe(
       base
     );
-    expect(hashSlugSet([{ slug: "a" }])).not.toBe(base);
+    expect(hashRegistryIdentity([rows[0]!])).not.toBe(base);
   });
 
-  // The core property: which slugs, not how many. A group deleted and another
-  // created between runs leaves the count identical while the set is different,
-  // and the recorded plan mentions storage that is now absent.
   it("distinguishes different sets of the same size", () => {
-    expect(hashSlugSet([{ slug: "a" }])).not.toBe(hashSlugSet([{ slug: "b" }]));
-    expect(hashSlugSet([{ slug: "a" }, { slug: "b" }])).not.toBe(
-      hashSlugSet([{ slug: "a" }, { slug: "c" }])
+    expect(hashRegistryIdentity([{ id: "1", slug: "a" }])).not.toBe(
+      hashRegistryIdentity([{ id: "1", slug: "b" }])
     );
   });
 
-  // Slugs rather than table names, because `table_name` is rewritten as each
-  // rename commits: a name-based hash would stop matching partway through a run
-  // and refuse the resume it exists to protect.
-  it("ignores everything except the slugs", () => {
-    const rows = [{ slug: "a", tableName: "comp_a" }];
-    const renamed = [{ slug: "a", tableName: "fg_a" }];
-    expect(hashSlugSet(renamed)).toBe(hashSlugSet(rows));
+  // The whole reason the id is in here. A group deleted and recreated under the
+  // same slug is a different row, and a resume that cannot see that would adopt
+  // the new row's table as its own completed work — then rename it away on a
+  // rollback, destroying an identifier the author chose.
+  it("distinguishes a row recreated under the same slug", () => {
+    expect(hashRegistryIdentity([{ id: "1", slug: "hero" }])).not.toBe(
+      hashRegistryIdentity([{ id: "2", slug: "hero" }])
+    );
+  });
+
+  // `table_name` is rewritten as each rename commits, so anything derived from
+  // it would stop matching partway through the run it protects.
+  it("ignores everything except the id and slug", () => {
+    expect(
+      hashRegistryIdentity([{ id: "1", slug: "a", tableName: "fg_a" }] as never)
+    ).toBe(hashRegistryIdentity([{ id: "1", slug: "a" }]));
   });
 });

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/manifest.test.ts
@@ -4,6 +4,7 @@ import { NextlyError } from "../../../../errors/nextly-error";
 import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
 import {
   buildMigrationManifest,
+  hashSlugSet,
   hashManifest,
   invertManifest,
   MIGRATION_TARGET,
@@ -393,5 +394,43 @@ describe("field-group migration manifest", () => {
     expect(MIGRATION_TARGET.tablePrefix.length).toBeLessThanOrEqual(
       STORAGE_FORMAT.tablePrefix.length
     );
+  });
+});
+
+describe("hashSlugSet", () => {
+  // Identity of the *set*, so row order from the registry must not change it.
+  it("does not depend on row order", () => {
+    expect(hashSlugSet([{ slug: "a" }, { slug: "b" }])).toBe(
+      hashSlugSet([{ slug: "b" }, { slug: "a" }])
+    );
+  });
+
+  // The question it answers: did a field group appear or disappear underneath an
+  // interrupted run? Either leaves storage the recorded plan never mentions.
+  it("changes when a field group is added or removed", () => {
+    const base = hashSlugSet([{ slug: "a" }, { slug: "b" }]);
+    expect(hashSlugSet([{ slug: "a" }, { slug: "b" }, { slug: "c" }])).not.toBe(
+      base
+    );
+    expect(hashSlugSet([{ slug: "a" }])).not.toBe(base);
+  });
+
+  // The core property: which slugs, not how many. A group deleted and another
+  // created between runs leaves the count identical while the set is different,
+  // and the recorded plan mentions storage that is now absent.
+  it("distinguishes different sets of the same size", () => {
+    expect(hashSlugSet([{ slug: "a" }])).not.toBe(hashSlugSet([{ slug: "b" }]));
+    expect(hashSlugSet([{ slug: "a" }, { slug: "b" }])).not.toBe(
+      hashSlugSet([{ slug: "a" }, { slug: "c" }])
+    );
+  });
+
+  // Slugs rather than table names, because `table_name` is rewritten as each
+  // rename commits: a name-based hash would stop matching partway through a run
+  // and refuse the resume it exists to protect.
+  it("ignores everything except the slugs", () => {
+    const rows = [{ slug: "a", tableName: "comp_a" }];
+    const renamed = [{ slug: "a", tableName: "fg_a" }];
+    expect(hashSlugSet(renamed)).toBe(hashSlugSet(rows));
   });
 });

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/observer.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/observer.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../../../errors/nextly-error";
+import { findLostIndexes, refuseLostIndexes } from "../observer";
+
+describe("findLostIndexes", () => {
+  // Renaming a table keeps its indexes on all three dialects, so a name missing
+  // afterwards means one was dropped rather than moved.
+  it("names an index the rename did not carry", () => {
+    expect(findLostIndexes(["idx_a", "idx_b"], ["idx_a"])).toEqual({
+      comparable: true,
+      lost: ["idx_b"],
+    });
+  });
+
+  it("reports nothing lost when every name survived", () => {
+    expect(findLostIndexes(["idx_a"], ["idx_a", "idx_new"])).toEqual({
+      comparable: true,
+      lost: [],
+    });
+  });
+
+  // The reason this compares names rather than counts: a count survives losing
+  // one index and gaining another, which is exactly the shape being checked for.
+  it("catches a loss that leaves the count unchanged", () => {
+    const result = findLostIndexes(["idx_a", "idx_b"], ["idx_a", "idx_other"]);
+    expect(result).toEqual({ comparable: true, lost: ["idx_b"] });
+  });
+
+  // `undefined` means the snapshot tracked no index data, which is not the same
+  // as a table having none. Reading it as an empty list would report every index
+  // intact on a snapshot that never held any.
+  it.each([
+    ["the source was not observed", undefined, ["idx_a"]],
+    ["the target was not observed", ["idx_a"], undefined],
+    ["neither was observed", undefined, undefined],
+  ])("reports %s as not comparable", (_label, before, after) => {
+    expect(findLostIndexes(before, after)).toEqual({ comparable: false });
+  });
+
+  // A table that genuinely has no indexes is comparable and loses nothing;
+  // conflating this with the untracked case is the mistake the type prevents.
+  it("treats an empty list as tracked and complete", () => {
+    expect(findLostIndexes([], [])).toEqual({ comparable: true, lost: [] });
+  });
+});
+
+describe("refuseLostIndexes", () => {
+  it("names the table and every index that went missing", () => {
+    const error = refuseLostIndexes({ table: "fg_hero", lost: ["idx_b"] });
+    expect(NextlyError.is(error)).toBe(true);
+    expect(error.logContext?.reason).toMatch(
+      /did not carry the table's indexes/
+    );
+    expect(error.logContext?.table).toBe("fg_hero");
+    expect(error.logContext?.lost).toEqual(["idx_b"]);
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/reconcile.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/reconcile.test.ts
@@ -736,3 +736,62 @@ describe("ownership on a settled marker", () => {
     ).toEqual({ complete: true });
   });
 });
+
+describe("a registry row repointed at a target the run has not reached", () => {
+  // Two groups, so the plan has a table step well past the crash window.
+  const rows = [
+    row({ slug: "alpha", tableName: "comp_alpha" }),
+    row({ slug: "beta", tableName: "comp_beta" }),
+  ];
+  const entries = buildMigrationManifest(rows).entries;
+  // [table alpha, column alpha, table beta, column beta, registry]
+  const BETA_TABLE_POSITION = 3;
+
+  // The catalog has to agree with the recorded step, or the refusal under test
+  // is masked by a different one: a source still present at a position the
+  // marker calls verified is itself a refusal.
+  function reconcile(step: number, betaPointsAt: string) {
+    const alphaTable = step >= 1 ? "fg_alpha" : "comp_alpha";
+    const alphaColumn = step >= 2 ? TARGET_COLUMN : LEGACY_COLUMN;
+    const tables = ["dynamic_components", alphaTable, betaPointsAt];
+    return reconcilePlan({
+      entries,
+      rows: [
+        { ...rows[0]!, tableName: alphaTable },
+        { ...rows[1]!, tableName: betaPointsAt },
+      ],
+      tables,
+      columns: columnsFor(tables, { [alphaTable]: [alphaColumn] }),
+      run: { recorded: true, direction: "up", step },
+      direction: "up",
+      identifierCase: PRESERVING,
+    });
+  }
+
+  // Repointing a field group's storage leaves its id, slug and companion flag
+  // untouched, so the registry hash still matches and the resume proceeds. What
+  // stops the migration adopting the author's table is that no recorded progress
+  // reaches this position — the same test the catalog side already applies to
+  // objects, which is why no separate pointer check is needed for it.
+  it("refuses when the pointer moved before its step was reached", () => {
+    const refusal = capture(() => reconcile(0, "fg_beta"));
+    expect(refusal.logContext?.reason).toMatch(
+      /no recorded progress accounts for it/
+    );
+    expect(refusal.logContext?.to).toBe("fg_beta");
+    expect(refusal.logContext?.position).toBe(BETA_TABLE_POSITION);
+  });
+
+  // Inside the crash window the pointer having moved is exactly what a committed
+  // step looks like, so it must still resume.
+  it("accepts the pointer at its target once that step is reachable", () => {
+    expect(() => reconcile(BETA_TABLE_POSITION - 1, "fg_beta")).not.toThrow();
+  });
+
+  // MySQL commits DDL implicitly, so within the window a row may still address
+  // its source while the table has already moved. Refusing that would block the
+  // resume that repairs it.
+  it("accepts a pointer that has not moved yet", () => {
+    expect(() => reconcile(0, "comp_beta")).not.toThrow();
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/runner.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/runner.test.ts
@@ -5,6 +5,7 @@ import type { MetaService } from "../../../meta/services/meta-service";
 import { hashManifest, type ManifestEntry } from "../manifest";
 import { runMigrationSteps, type MigrationStep } from "../runner";
 import type { MigrationSession } from "../session";
+import { MIGRATION_MARKER_VERSION } from "../state";
 
 const SESSION = {
   dialect: "postgresql",
@@ -43,7 +44,7 @@ const MARKER_PLAN_HASH = hashManifest(MARKER_PLAN);
 // a real marker rather than just recording calls.
 function markerMeta(events: string[], migrationId: string) {
   let stored: Record<string, unknown> = {
-    version: 1,
+    version: MIGRATION_MARKER_VERSION,
     status: "migrating",
     direction: "up",
     migrationId,
@@ -147,7 +148,7 @@ describe("field-group migration runner", () => {
     const meta = markerMeta(events, "run-1");
     // The marker already reports step 1 done.
     await meta.set("k", {
-      version: 1,
+      version: MIGRATION_MARKER_VERSION,
       status: "migrating",
       direction: "up",
       migrationId: "run-1",

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/runner.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/runner.test.ts
@@ -48,7 +48,7 @@ function markerMeta(events: string[], migrationId: string) {
     direction: "up",
     migrationId,
     step: 0,
-    slugsHash: "s",
+    registryHash: "s",
     manifestHash: MARKER_PLAN_HASH,
     appliedManifest: MARKER_PLAN,
   };
@@ -152,7 +152,7 @@ describe("field-group migration runner", () => {
       direction: "up",
       migrationId: "run-1",
       step: 1,
-      slugsHash: "s",
+      registryHash: "s",
       manifestHash: MARKER_PLAN_HASH,
       appliedManifest: MARKER_PLAN,
     });

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/runner.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/runner.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { NextlyError } from "../../../../errors/nextly-error";
 import type { MetaService } from "../../../meta/services/meta-service";
+import { hashManifest, type ManifestEntry } from "../manifest";
 import { runMigrationSteps, type MigrationStep } from "../runner";
 import type { MigrationSession } from "../session";
 
@@ -32,6 +33,13 @@ function step(
 }
 
 // `advanceStep` reads the marker before writing, so the fake has to behave like
+// The marker carries the plan it is executing, and the read verifies that plan
+// against its recorded hash, so a stand-in marker has to carry both.
+const MARKER_PLAN: ManifestEntry[] = [
+  { kind: "registry", from: "dynamic_components", to: "dynamic_field_groups" },
+];
+const MARKER_PLAN_HASH = hashManifest(MARKER_PLAN);
+
 // a real marker rather than just recording calls.
 function markerMeta(events: string[], migrationId: string) {
   let stored: Record<string, unknown> = {
@@ -40,8 +48,9 @@ function markerMeta(events: string[], migrationId: string) {
     direction: "up",
     migrationId,
     step: 0,
-    manifestHash: "h",
-    planHash: "p",
+    slugsHash: "s",
+    manifestHash: MARKER_PLAN_HASH,
+    appliedManifest: MARKER_PLAN,
   };
   return {
     getEntry: vi.fn(async () => ({ present: true, value: stored })),
@@ -143,8 +152,9 @@ describe("field-group migration runner", () => {
       direction: "up",
       migrationId: "run-1",
       step: 1,
-      manifestHash: "h",
-      planHash: "p",
+      slugsHash: "s",
+      manifestHash: MARKER_PLAN_HASH,
+      appliedManifest: MARKER_PLAN,
     });
     events.length = 0;
     await runMigrationSteps({

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.integration.test.ts
@@ -1,0 +1,111 @@
+/**
+ * The migration lock, against a real server rather than a double.
+ *
+ * Every other test of this module talks to a stand-in, and a stand-in is what
+ * hid the fact that the lock could not run at all: its table is created on
+ * demand and has no Drizzle definition, so the typed CRUD path rejected the
+ * name while doubles answered the call happily. This suite exists so that class
+ * of defect cannot survive again — it exercises seed, claim, exclusion and
+ * release through the real adapter, with the table genuinely absent from the
+ * schema registry.
+ */
+import { createPostgresAdapter } from "@nextlyhq/adapter-postgres";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../../../errors/nextly-error";
+import {
+  MIGRATION_LOCK_TABLE,
+  withMigrationSession,
+  type MigrationSession,
+} from "../session";
+
+interface LockAdapter {
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  executeQuery<T = unknown>(sql: string, params?: unknown[]): Promise<T[]>;
+}
+
+describe.skipIf(!process.env.TEST_POSTGRES_URL)(
+  "field-group migration lock on a live server",
+  () => {
+    let adapter: LockAdapter;
+
+    beforeAll(async () => {
+      adapter = createPostgresAdapter({
+        url: process.env.TEST_POSTGRES_URL as string,
+      }) as unknown as LockAdapter;
+      await adapter.connect();
+      // No table, no row, and no schema registry has ever been told about it:
+      // exactly the state a first run meets.
+      await adapter.executeQuery(
+        `DROP TABLE IF EXISTS ${MIGRATION_LOCK_TABLE}`
+      );
+    });
+
+    afterAll(async () => {
+      await adapter.executeQuery(
+        `DROP TABLE IF EXISTS ${MIGRATION_LOCK_TABLE}`
+      );
+      await adapter.disconnect();
+    });
+
+    function session<T>(
+      label: string,
+      fn: (s: MigrationSession) => Promise<T>
+    ): Promise<T> {
+      return withMigrationSession(
+        {
+          // The adapter's own type; the cast is only to keep this suite's
+          // surface narrow.
+          adapter: adapter as never,
+          dialect: "postgresql",
+          label,
+        },
+        fn
+      );
+    }
+
+    async function ownerNow(): Promise<string | null> {
+      const rows = await adapter.executeQuery<{ owner: string | null }>(
+        `SELECT owner FROM ${MIGRATION_LOCK_TABLE} WHERE id = 1`
+      );
+      return rows[0]?.owner ?? null;
+    }
+
+    it("creates its table, seeds the row, claims and releases it", async () => {
+      let heldDuring: string | null = null;
+
+      await session("run-1", async () => {
+        heldDuring = await ownerNow();
+      });
+
+      // Held while the callback ran, and free afterwards. Both halves went
+      // through the real driver against a table the ORM does not declare.
+      expect(heldDuring).not.toBeNull();
+      expect(heldDuring).toContain("run-1");
+      expect(await ownerNow()).toBeNull();
+    });
+
+    it("refuses a second run while the first holds the lock", async () => {
+      const error = await session("outer", async () =>
+        session("inner", () => Promise.resolve("should not run")).catch(
+          (caught: unknown) => caught
+        )
+      );
+
+      expect(NextlyError.is(error)).toBe(true);
+      if (NextlyError.is(error)) {
+        expect(error.logContext?.reason).toMatch(/held elsewhere/);
+      }
+      // The outer run's release still happened despite the inner refusal.
+      expect(await ownerNow()).toBeNull();
+    });
+
+    it("releases the claim when the run throws", async () => {
+      await expect(
+        session("failing", () => Promise.reject(new Error("boom")))
+      ).rejects.toThrow();
+      expect(await ownerNow()).toBeNull();
+    });
+  }
+);

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -1,3 +1,5 @@
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 import { describe, expect, it, vi } from "vitest";
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
@@ -10,18 +12,60 @@ import {
   type MigrationDialect,
 } from "../session";
 
-type Where = {
-  and?: { column: string; op: string; value: unknown }[];
-};
+/**
+ * Interpret a statement the way a driver would, against a one-row lock table.
+ *
+ * The statement is compiled through a real `PgDialect` first, so the double is
+ * exercising the SQL and the bound parameters an adapter would actually hand
+ * its driver. Reimplementing the query-builder calls instead is what let this
+ * module pass its tests while being unable to run at all: the typed CRUD path
+ * resolves a table through the schema registry, which has never declared this
+ * one.
+ */
+function interpret(
+  statement: SQL,
+  rows: Map<number, { id: number; owner: string | null }>
+): Record<string, unknown>[] {
+  const { sql: text, params } = new PgDialect().sqlToQuery(statement);
+  const flat = text.replace(/\s+/g, " ").trim();
 
-/** Reads the structured predicate the adapter API uses back into plain fields. */
-function readWhere(where?: Where): { id?: number; owner?: string | null } {
-  const out: { id?: number; owner?: string | null } = {};
-  for (const c of where?.and ?? []) {
-    if (c.column === "id") out.id = c.value as number;
-    if (c.column === "owner") out.owner = c.value as string | null;
+  const select = /^SELECT "(\w+)" FROM "([^"]+)" WHERE "id" = \$1$/.exec(flat);
+  if (select) {
+    assertLockTable(select[2]);
+    const row = rows.get(params[0] as number);
+    return row === undefined ? [] : [{ ...row }];
   }
-  return out;
+
+  const claim = /^UPDATE "([^"]+)" SET "owner" = \$1 WHERE "id" = \$2$/.exec(
+    flat
+  );
+  if (claim) {
+    assertLockTable(claim[1]);
+    const row = rows.get(params[1] as number);
+    if (row === undefined) return [];
+    row.owner = params[0] as string | null;
+    return [];
+  }
+
+  const release =
+    /^UPDATE "([^"]+)" SET "owner" = NULL WHERE "id" = \$1 AND "owner" = \$2$/.exec(
+      flat
+    );
+  if (release) {
+    assertLockTable(release[1]);
+    const row = rows.get(params[0] as number);
+    // A release naming an owner must not clear a row held by someone else.
+    if (row !== undefined && row.owner === params[1]) row.owner = null;
+    return [];
+  }
+
+  throw new Error(`unrecognised statement: ${flat}`);
+}
+
+function assertLockTable(name: string | undefined): void {
+  if (name !== MIGRATION_LOCK_TABLE) {
+    throw new Error(`relation "${String(name)}" does not exist`);
+  }
 }
 
 /**
@@ -44,27 +88,16 @@ function createAdapter(options: { heldBy?: string | null } = {}) {
 
   const ctx = {
     lockRow: vi.fn(async () => undefined),
-    selectOne: vi.fn(async (_t: string, o?: { where?: Where }) => {
-      const row = rows.get(readWhere(o?.where).id ?? 1);
-      return row ? { ...row } : null;
-    }),
     insert: vi.fn(async (_t: string, data: Record<string, unknown>) => {
       const id = data.id as number;
       if (rows.has(id)) throw new Error("duplicate key");
       rows.set(id, { id, owner: (data.owner as string | null) ?? null });
       return data;
     }),
-    update: vi.fn(
-      async (_t: string, data: Record<string, unknown>, where: Where) => {
-        const cond = readWhere(where);
-        const row = rows.get(cond.id ?? 1);
-        if (!row) return [];
-        // A `where` naming an owner must not match a row held by someone else.
-        if (cond.owner !== undefined && row.owner !== cond.owner) return [];
-        row.owner = (data.owner as string | null) ?? null;
-        return [row];
-      }
-    ),
+    runStatement: vi.fn(async (statement: SQL) => {
+      interpret(statement, rows);
+    }),
+    queryStatement: vi.fn(async (statement: SQL) => interpret(statement, rows)),
   };
 
   const adapter = {
@@ -72,6 +105,10 @@ function createAdapter(options: { heldBy?: string | null } = {}) {
       ddl.push(sql);
       return [];
     }),
+    // The seed read runs outside any transaction, so it goes through the
+    // adapter rather than the transaction context.
+    queryStatement: vi.fn(async (statement: SQL) => interpret(statement, rows)),
+    tableExists: vi.fn(async () => true),
     transaction: vi.fn(async (work: (c: unknown) => Promise<unknown>) => {
       open += 1;
       peakOpen = Math.max(peakOpen, open);
@@ -93,6 +130,11 @@ function createAdapter(options: { heldBy?: string | null } = {}) {
     ctx,
     ddl,
     owner: () => rows.get(1)?.owner ?? null,
+    /** Model another process claiming the row mid-run. */
+    takeOver: (owner: string | null) => {
+      const row = rows.get(1);
+      if (row !== undefined) row.owner = owner;
+    },
     peakOpen: () => peakOpen,
   };
 }
@@ -256,11 +298,7 @@ describe("field-group migration session", () => {
       { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
       async () => {
         // Someone else takes the row over while this run is in flight.
-        h.ctx.update(
-          MIGRATION_LOCK_TABLE,
-          { owner: "run-2" },
-          { and: [{ column: "id", op: "=", value: 1 }] }
-        );
+        h.takeOver("run-2");
       }
     );
     expect(h.owner()).toBe("run-2");
@@ -329,7 +367,9 @@ describe("field-group migration session", () => {
   // the update would run the migration believing it held a lock it never took.
   it("refuses when the claim does not actually land on the row", async () => {
     const h = createAdapter({ heldBy: null });
-    h.ctx.update.mockImplementation(async () => []);
+    // The claim write silently affects nothing, which is what a lost row or a
+    // predicate that matched no rows looks like from the caller's side.
+    h.ctx.runStatement.mockImplementation(async () => undefined);
     const ran = vi.fn();
     await expect(
       withMigrationSession(

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -380,6 +380,31 @@ describe("field-group migration session", () => {
     expect(ran).not.toHaveBeenCalled();
   });
 
+  // The mirror of the sync's recovery handler, and the reason it is opt-in: a
+  // signal does not stop the work already in flight, so releasing a migration's
+  // claim would free the row while it is still renaming tables and let a second
+  // process resume the same run against a database the first is still writing.
+  it("keeps a migration's claim held when the process is interrupted", async () => {
+    const h = createAdapter({ heldBy: null });
+    const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    let ownerAfterSignal: string | null = null;
+    await withMigrationSession(
+      { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+      async () => {
+        process.emit("SIGINT");
+        await new Promise(resolve => setImmediate(resolve));
+        ownerAfterSignal = h.owner();
+      }
+    );
+
+    // Still held while the run was in flight, and released only by the ordinary
+    // exit path afterwards.
+    expect(ownerAfterSignal).not.toBeNull();
+    expect(kill).not.toHaveBeenCalled();
+    kill.mockRestore();
+  });
+
   it("uses a lock table distinct from the schema pipeline's", () => {
     expect(MIGRATION_LOCK_TABLE).toBe("nextly_field_group_lock");
     expect(MIGRATION_LOCK_TABLE).not.toBe("nextly_migrate_lock");

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/session.test.ts
@@ -386,23 +386,27 @@ describe("field-group migration session", () => {
   // process resume the same run against a database the first is still writing.
   it("keeps a migration's claim held when the process is interrupted", async () => {
     const h = createAdapter({ heldBy: null });
+    // Restored in `finally`: a failure before the restore would otherwise leave
+    // the global mocked for every later test in the file.
     const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+    try {
+      let ownerAfterSignal: string | null = null;
+      await withMigrationSession(
+        { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
+        async () => {
+          process.emit("SIGINT");
+          await new Promise(resolve => setImmediate(resolve));
+          ownerAfterSignal = h.owner();
+        }
+      );
 
-    let ownerAfterSignal: string | null = null;
-    await withMigrationSession(
-      { adapter: h.adapter, dialect: "postgresql", label: "run-1" },
-      async () => {
-        process.emit("SIGINT");
-        await new Promise(resolve => setImmediate(resolve));
-        ownerAfterSignal = h.owner();
-      }
-    );
-
-    // Still held while the run was in flight, and released only by the ordinary
-    // exit path afterwards.
-    expect(ownerAfterSignal).not.toBeNull();
-    expect(kill).not.toHaveBeenCalled();
-    kill.mockRestore();
+      // Still held while the run was in flight, and released only by the ordinary
+      // exit path afterwards.
+      expect(ownerAfterSignal).not.toBeNull();
+      expect(kill).not.toHaveBeenCalled();
+    } finally {
+      kill.mockRestore();
+    }
   });
 
   it("uses a lock table distinct from the schema pipeline's", () => {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test-d.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test-d.ts
@@ -3,7 +3,7 @@ import { expectTypeOf } from "vitest";
 import type { ManifestEntry } from "../manifest";
 import type { BeginMigrationArgs, SettleArgs } from "../state";
 
-const PLAN = { slugsHash: "s", manifestHash: "h" };
+const PLAN = { registryHash: "s", manifestHash: "h" };
 const APPLIED: ManifestEntry[] = [
   { kind: "table", from: "comp_hero", to: "fg_hero" },
 ];

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test-d.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test-d.ts
@@ -3,22 +3,20 @@ import { expectTypeOf } from "vitest";
 import type { ManifestEntry } from "../manifest";
 import type { BeginMigrationArgs, SettleArgs } from "../state";
 
-const PLAN = { manifestHash: "h", planHash: "p" };
+const PLAN = { slugsHash: "s", manifestHash: "h" };
 const APPLIED: ManifestEntry[] = [
   { kind: "table", from: "comp_hero", to: "fg_hero" },
 ];
 
-// The rules these unions exist to enforce are type-level, so they are asserted
+// The rules these shapes exist to enforce are type-level, so they are asserted
 // type-level. A runtime test cannot show that an unsafe call fails to compile,
 // and a comment claiming a field is required has already proven unenforceable
 // here once.
 
-// A `down` run reverses a recorded plan and cannot derive one, so the plan is
-// not optional for it.
-expectTypeOf<BeginMigrationArgs>().toMatchTypeOf<
-  { direction: "up" } | { direction: "down" }
->();
-
+// Both directions carry the plan. A `down` run reverses a recorded plan and
+// cannot derive one; an `up` run cannot rely on rebuilding one either, because
+// once each rename rewrites its registry pointer a rebuild omits the work
+// already done and no longer matches the recorded step positions.
 expectTypeOf({
   direction: "down" as const,
   migrationId: "r",
@@ -26,19 +24,36 @@ expectTypeOf({
   appliedManifest: APPLIED,
 }).toMatchTypeOf<BeginMigrationArgs>();
 
-// Without the plan, a down run is not a legal argument shape.
+expectTypeOf({
+  direction: "up" as const,
+  migrationId: "r",
+  plan: PLAN,
+  appliedManifest: APPLIED,
+}).toMatchTypeOf<BeginMigrationArgs>();
+
+// Starting a run without the plan it will execute is not a legal shape, in
+// either direction.
 expectTypeOf({
   direction: "down" as const,
   migrationId: "r",
   plan: PLAN,
 }).not.toMatchTypeOf<BeginMigrationArgs>();
 
-// An up run builds its plan from registry rows, so it carries none in.
 expectTypeOf({
   direction: "up" as const,
   migrationId: "r",
   plan: PLAN,
-}).toMatchTypeOf<BeginMigrationArgs>();
+}).not.toMatchTypeOf<BeginMigrationArgs>();
+
+// The identity records the slug set and the plan's own integrity. A caller
+// supplying the retired step-list hash instead of the slug hash does not
+// typecheck, so the rename cannot be half-applied at a call site.
+expectTypeOf({
+  direction: "up" as const,
+  migrationId: "r",
+  plan: { manifestHash: "h", planHash: "p" },
+  appliedManifest: APPLIED,
+}).not.toMatchTypeOf<BeginMigrationArgs>();
 
 // Settling at the migrated generation is the last moment the plan can be
 // recorded, and a rollback has no other source for it.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import { NextlyError } from "../../../../errors/nextly-error";
 import type { MetaService } from "../../../meta/services/meta-service";
-import { buildMigrationManifest } from "../manifest";
+import {
+  buildMigrationManifest,
+  hashManifest,
+  type ManifestEntry,
+} from "../manifest";
 import {
   advanceStep,
   MAX_MIGRATION_STEP,
@@ -41,6 +45,21 @@ function createMeta(initial: unknown = ABSENT): {
   return { meta, read: () => stored };
 }
 
+/**
+ * A minimal canonical plan. `parseAppliedManifest` requires exactly one registry
+ * entry in the applied direction, so a fixture without it is not a plan the
+ * marker will accept.
+ */
+const PLAN_ENTRIES: ManifestEntry[] = [
+  { kind: "table", from: "comp_hero", to: "fg_hero" },
+  { kind: "registry", from: "dynamic_components", to: "dynamic_field_groups" },
+];
+/** The hash has to describe the plan actually stored, so it is computed. */
+const PLAN_IDENTITY = {
+  slugsHash: "slugs-1",
+  manifestHash: hashManifest(PLAN_ENTRIES),
+};
+
 describe("field-group migration marker", () => {
   it("reads an absent marker as untouched legacy storage", async () => {
     const { meta } = createMeta();
@@ -56,14 +75,16 @@ describe("field-group migration marker", () => {
     await beginMigration(meta, {
       direction: "up",
       migrationId: "run-1",
-      plan: { manifestHash: "hash-1", planHash: "plan-1" },
+      plan: PLAN_IDENTITY,
+      appliedManifest: PLAN_ENTRIES,
     });
     await expect(readMigrationState(meta)).resolves.toEqual({
       status: "migrating",
       direction: "up",
       migrationId: "run-1",
       step: 0,
-      plan: { manifestHash: "hash-1", planHash: "plan-1" },
+      plan: PLAN_IDENTITY,
+      appliedManifest: PLAN_ENTRIES,
     });
   });
 
@@ -74,11 +95,13 @@ describe("field-group migration marker", () => {
     await beginMigration(meta, {
       direction: "up",
       migrationId: "run-1",
-      plan: { manifestHash: "hash-1", planHash: "plan-1" },
+      plan: PLAN_IDENTITY,
+      appliedManifest: PLAN_ENTRIES,
     });
     await advanceStep(meta, { migrationId: "run-1", step: 1 });
     await expect(readMigrationState(meta)).resolves.toMatchObject({
-      plan: { manifestHash: "hash-1", planHash: "plan-1" },
+      plan: PLAN_IDENTITY,
+      appliedManifest: PLAN_ENTRIES,
     });
   });
 
@@ -86,9 +109,9 @@ describe("field-group migration marker", () => {
   // identifier would succeed and then be rejected by the very next read,
   // turning a successful begin into an unavailable database.
   it.each([
-    ["migrationId", { migrationId: "", manifestHash: "h", planHash: "p" }],
-    ["manifestHash", { migrationId: "r", manifestHash: "", planHash: "p" }],
-    ["planHash", { migrationId: "r", manifestHash: "h", planHash: "" }],
+    ["migrationId", { migrationId: "", slugsHash: "s", manifestHash: "h" }],
+    ["slugsHash", { migrationId: "r", slugsHash: "", manifestHash: "h" }],
+    ["manifestHash", { migrationId: "r", slugsHash: "s", manifestHash: "" }],
   ])("refuses to begin a run with an empty %s", async (_label, fields) => {
     const { meta, read } = createMeta();
     await expect(
@@ -96,9 +119,10 @@ describe("field-group migration marker", () => {
         direction: "up",
         migrationId: fields.migrationId,
         plan: {
+          slugsHash: fields.slugsHash,
           manifestHash: fields.manifestHash,
-          planHash: fields.planHash,
         },
+        appliedManifest: PLAN_ENTRIES,
       })
     ).rejects.toThrowError(NextlyError);
     // Nothing may reach storage: a marker written here is exactly the
@@ -115,7 +139,8 @@ describe("field-group migration marker", () => {
     await beginMigration(meta, {
       direction: "up",
       migrationId: "run-1",
-      plan: { manifestHash: "hash-1", planHash: "plan-1" },
+      plan: PLAN_IDENTITY,
+      appliedManifest: PLAN_ENTRIES,
     });
     expect(read()).toMatchObject({ status: "migrating", step: 0 });
     expect(meta.set).toHaveBeenCalledWith(
@@ -129,7 +154,8 @@ describe("field-group migration marker", () => {
     await beginMigration(meta, {
       direction: "up",
       migrationId: "run-1",
-      plan: { manifestHash: "hash-1", planHash: "plan-1" },
+      plan: PLAN_IDENTITY,
+      appliedManifest: PLAN_ENTRIES,
     });
     await advanceStep(meta, { migrationId: "run-1", step: 1 });
     await advanceStep(meta, { migrationId: "run-1", step: 2 });
@@ -144,7 +170,8 @@ describe("field-group migration marker", () => {
     await beginMigration(meta, {
       direction: "up",
       migrationId: "run-1",
-      plan: { manifestHash: "hash-1", planHash: "plan-1" },
+      plan: PLAN_IDENTITY,
+      appliedManifest: PLAN_ENTRIES,
     });
     await expect(
       advanceStep(meta, { migrationId: "run-1", step: 2 })
@@ -165,8 +192,9 @@ describe("field-group migration marker", () => {
       direction: "up",
       migrationId: "run-1",
       step: MAX_MIGRATION_STEP,
-      manifestHash: "hash-1",
-      planHash: "plan-1",
+      slugsHash: "slugs-1",
+      manifestHash: PLAN_IDENTITY.manifestHash,
+      appliedManifest: PLAN_ENTRIES,
     });
     const before = read();
     await expect(
@@ -182,7 +210,8 @@ describe("field-group migration marker", () => {
     await beginMigration(meta, {
       direction: "up",
       migrationId: "run-1",
-      plan: { manifestHash: "hash-1", planHash: "plan-1" },
+      plan: PLAN_IDENTITY,
+      appliedManifest: PLAN_ENTRIES,
     });
     await expect(
       advanceStep(meta, { migrationId: "run-2", step: 1 })
@@ -194,7 +223,8 @@ describe("field-group migration marker", () => {
     await beginMigration(meta, {
       direction: "up",
       migrationId: "run-1",
-      plan: { manifestHash: "hash-1", planHash: "plan-1" },
+      plan: PLAN_IDENTITY,
+      appliedManifest: PLAN_ENTRIES,
     });
     await settleMigration(meta, {
       generation: "field-groups-v2",
@@ -237,7 +267,9 @@ describe("field-group migration marker", () => {
     await beginMigration(meta, {
       direction: "down",
       migrationId: "run-1",
-      plan: { manifestHash: "hash-1", planHash: "plan-1" },
+      // The recorded hash has to describe the plan being stored, so it is
+      // computed from that plan rather than reused from another fixture.
+      plan: { slugsHash: "slugs-1", manifestHash: hashManifest(applied) },
       appliedManifest: applied,
     });
     await expect(readMigrationState(meta)).resolves.toMatchObject({
@@ -338,7 +370,9 @@ describe("field-group migration marker", () => {
       beginMigration(meta, {
         direction: "down",
         migrationId: "run-1",
-        plan: { manifestHash: "h", planHash: "p" },
+        // A valid identity, so the refusal is attributable to the bad entry
+        // rather than to the identity check that runs before it.
+        plan: { slugsHash: "s", manifestHash: "h" },
         // Otherwise valid: the registry entry is present, so the refusal is
         // attributable to the bad entry rather than to a missing registry.
         appliedManifest: [
@@ -505,7 +539,18 @@ describe("field-group migration marker", () => {
         direction: "up",
         migrationId: "r",
         step: 0,
-        planHash: "p",
+        slugsHash: "s",
+      },
+    ],
+    [
+      "in-flight without a slug-set hash",
+      {
+        version: 1,
+        status: "migrating",
+        direction: "up",
+        migrationId: "r",
+        step: 0,
+        manifestHash: "h",
       },
     ],
     [
@@ -609,29 +654,106 @@ describe("field-group migration plan guard", () => {
   });
 
   // The application's schema moved: step N now names different objects.
-  it("refuses a resume whose object map changed", () => {
-    const refusal = refusalFrom({ ...PLAN, manifestHash: "hash-2" });
+  it("refuses a resume whose field group set changed", () => {
+    const refusal = refusalFrom({ ...PLAN, slugsHash: "slugs-2" });
     expect(refusal.code).toBe("SERVICE_UNAVAILABLE");
-    expect(refusal.logContext?.reason).toMatch(/object map changed/);
+    expect(refusal.logContext?.reason).toMatch(/set of field groups changed/);
   });
 
-  // Nextly itself was upgraded and its steps were added, removed or reordered.
-  // The database's own objects are untouched, so the manifest hash still
-  // matches; only the plan hash catches this, and without it a resume would
-  // continue at a step number that now means a different operation.
-  it("refuses a resume whose step list changed under an unchanged object map", () => {
-    const refusal = refusalFrom({ ...PLAN, planHash: "plan-2" });
-    expect(refusal.code).toBe("SERVICE_UNAVAILABLE");
-    expect(refusal.logContext?.reason).toMatch(/step list changed/);
+  // A field group added or removed mid-run is storage the recorded plan never
+  // mentions, which is the whole reason this comparison exists.
+  it("accepts a resume whose field group set is unchanged", () => {
+    expect(() =>
+      assertPlanUnchanged({ recorded: PLAN, current: { ...PLAN } })
+    ).not.toThrow();
   });
 
-  // The two causes are reported separately because they send an operator to
-  // different places: their own schema history, or the Nextly upgrade.
-  it("names which half of the plan moved", () => {
-    expect(
-      refusalFrom({ ...PLAN, manifestHash: "hash-2" }).logContext?.reason
-    ).not.toEqual(
-      refusalFrom({ ...PLAN, planHash: "plan-2" }).logContext?.reason
+  // The plan itself is read back rather than rebuilt, so a rename that has
+  // already committed changes table names without changing the set of slugs.
+  // Comparing names here would refuse every resume past the first step.
+  it("does not compare anything that a committed rename would change", () => {
+    expect(() =>
+      assertPlanUnchanged({
+        recorded: PLAN,
+        current: { ...PLAN, manifestHash: "a-different-plan-hash" },
+      })
+    ).not.toThrow();
+  });
+});
+
+describe("the persisted plan is the resume's authority", () => {
+  // The plan is read back rather than rebuilt, so its integrity on read is the
+  // only thing standing between a corrupted blob and a run that executes it.
+  it("refuses a plan that does not match its recorded hash", async () => {
+    const { meta } = createMeta({
+      version: 1,
+      status: "migrating",
+      direction: "up",
+      migrationId: "run-1",
+      step: 0,
+      slugsHash: "slugs-1",
+      manifestHash: "a-hash-of-something-else",
+      appliedManifest: PLAN_ENTRIES,
+    });
+    await expect(readMigrationState(meta)).rejects.toSatisfy(
+      error =>
+        NextlyError.is(error) &&
+        /does not match its recorded hash/.test(
+          String(error.logContext?.reason)
+        )
     );
+  });
+
+  // A run in flight cannot proceed without the plan it is executing, in either
+  // direction, so an absent one is corruption rather than an optional field.
+  it.each(["up", "down"] as const)(
+    "refuses an in-flight %s marker carrying no plan",
+    async direction => {
+      const { meta } = createMeta({
+        version: 1,
+        status: "migrating",
+        direction,
+        migrationId: "run-1",
+        step: 0,
+        slugsHash: "slugs-1",
+        manifestHash: PLAN_IDENTITY.manifestHash,
+      });
+      await expect(readMigrationState(meta)).rejects.toSatisfy(
+        error =>
+          NextlyError.is(error) &&
+          /carries no plan/.test(String(error.logContext?.reason))
+      );
+    }
+  );
+
+  // The writer holds itself to the reader's invariant: recording a hash that
+  // describes a different plan would make every later read refuse, stranding a
+  // run that had already begun.
+  it("refuses to begin a run whose recorded hash describes another plan", async () => {
+    const { meta, read } = createMeta();
+    await expect(
+      beginMigration(meta, {
+        direction: "up",
+        migrationId: "run-1",
+        plan: { slugsHash: "slugs-1", manifestHash: "not-this-plan" },
+        appliedManifest: PLAN_ENTRIES,
+      })
+    ).rejects.toThrowError(NextlyError);
+    expect(read()).toBe(ABSENT);
+  });
+
+  it("round-trips the plan a run is executing", async () => {
+    const { meta } = createMeta();
+    await beginMigration(meta, {
+      direction: "up",
+      migrationId: "run-1",
+      plan: PLAN_IDENTITY,
+      appliedManifest: PLAN_ENTRIES,
+    });
+    await expect(readMigrationState(meta)).resolves.toMatchObject({
+      status: "migrating",
+      appliedManifest: PLAN_ENTRIES,
+      plan: PLAN_IDENTITY,
+    });
   });
 });

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -56,7 +56,7 @@ const PLAN_ENTRIES: ManifestEntry[] = [
 ];
 /** The hash has to describe the plan actually stored, so it is computed. */
 const PLAN_IDENTITY = {
-  slugsHash: "slugs-1",
+  registryHash: "slugs-1",
   manifestHash: hashManifest(PLAN_ENTRIES),
 };
 
@@ -109,9 +109,9 @@ describe("field-group migration marker", () => {
   // identifier would succeed and then be rejected by the very next read,
   // turning a successful begin into an unavailable database.
   it.each([
-    ["migrationId", { migrationId: "", slugsHash: "s", manifestHash: "h" }],
-    ["slugsHash", { migrationId: "r", slugsHash: "", manifestHash: "h" }],
-    ["manifestHash", { migrationId: "r", slugsHash: "s", manifestHash: "" }],
+    ["migrationId", { migrationId: "", registryHash: "s", manifestHash: "h" }],
+    ["registryHash", { migrationId: "r", registryHash: "", manifestHash: "h" }],
+    ["manifestHash", { migrationId: "r", registryHash: "s", manifestHash: "" }],
   ])("refuses to begin a run with an empty %s", async (_label, fields) => {
     const { meta, read } = createMeta();
     await expect(
@@ -119,7 +119,7 @@ describe("field-group migration marker", () => {
         direction: "up",
         migrationId: fields.migrationId,
         plan: {
-          slugsHash: fields.slugsHash,
+          registryHash: fields.registryHash,
           manifestHash: fields.manifestHash,
         },
         appliedManifest: PLAN_ENTRIES,
@@ -192,7 +192,7 @@ describe("field-group migration marker", () => {
       direction: "up",
       migrationId: "run-1",
       step: MAX_MIGRATION_STEP,
-      slugsHash: "slugs-1",
+      registryHash: "slugs-1",
       manifestHash: PLAN_IDENTITY.manifestHash,
       appliedManifest: PLAN_ENTRIES,
     });
@@ -269,7 +269,7 @@ describe("field-group migration marker", () => {
       migrationId: "run-1",
       // The recorded hash has to describe the plan being stored, so it is
       // computed from that plan rather than reused from another fixture.
-      plan: { slugsHash: "slugs-1", manifestHash: hashManifest(applied) },
+      plan: { registryHash: "slugs-1", manifestHash: hashManifest(applied) },
       appliedManifest: applied,
     });
     await expect(readMigrationState(meta)).resolves.toMatchObject({
@@ -372,7 +372,7 @@ describe("field-group migration marker", () => {
         migrationId: "run-1",
         // A valid identity, so the refusal is attributable to the bad entry
         // rather than to the identity check that runs before it.
-        plan: { slugsHash: "s", manifestHash: "h" },
+        plan: { registryHash: "s", manifestHash: "h" },
         // Otherwise valid: the registry entry is present, so the refusal is
         // attributable to the bad entry rather than to a missing registry.
         appliedManifest: [
@@ -539,11 +539,11 @@ describe("field-group migration marker", () => {
         direction: "up",
         migrationId: "r",
         step: 0,
-        slugsHash: "s",
+        registryHash: "s",
       },
     ],
     [
-      "in-flight without a slug-set hash",
+      "in-flight without a registry identity hash",
       {
         version: 1,
         status: "migrating",
@@ -655,7 +655,7 @@ describe("field-group migration plan guard", () => {
 
   // The application's schema moved: step N now names different objects.
   it("refuses a resume whose field group set changed", () => {
-    const refusal = refusalFrom({ ...PLAN, slugsHash: "slugs-2" });
+    const refusal = refusalFrom({ ...PLAN, registryHash: "slugs-2" });
     expect(refusal.code).toBe("SERVICE_UNAVAILABLE");
     expect(refusal.logContext?.reason).toMatch(/set of field groups changed/);
   });
@@ -691,7 +691,7 @@ describe("the persisted plan is the resume's authority", () => {
       direction: "up",
       migrationId: "run-1",
       step: 0,
-      slugsHash: "slugs-1",
+      registryHash: "slugs-1",
       manifestHash: "a-hash-of-something-else",
       appliedManifest: PLAN_ENTRIES,
     });
@@ -715,7 +715,7 @@ describe("the persisted plan is the resume's authority", () => {
         direction,
         migrationId: "run-1",
         step: 0,
-        slugsHash: "slugs-1",
+        registryHash: "slugs-1",
         manifestHash: PLAN_IDENTITY.manifestHash,
       });
       await expect(readMigrationState(meta)).rejects.toSatisfy(
@@ -735,7 +735,7 @@ describe("the persisted plan is the resume's authority", () => {
       beginMigration(meta, {
         direction: "up",
         migrationId: "run-1",
-        plan: { slugsHash: "slugs-1", manifestHash: "not-this-plan" },
+        plan: { registryHash: "slugs-1", manifestHash: "not-this-plan" },
         appliedManifest: PLAN_ENTRIES,
       })
     ).rejects.toThrowError(NextlyError);

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -495,15 +495,17 @@ describe("field-group migration marker", () => {
   it.each([
     ["not an object", "nonsense"],
     [
-      "unknown version",
-      { version: 99, status: "settled", generation: "legacy" },
+      "unknown generation",
+      { version: MIGRATION_MARKER_VERSION, status: "settled", generation: "?" },
     ],
-    ["unknown generation", { version: 1, status: "settled", generation: "?" }],
-    ["unknown status", { version: 1, status: "elsewhere" }],
+    [
+      "unknown status",
+      { version: MIGRATION_MARKER_VERSION, status: "elsewhere" },
+    ],
     [
       "in-flight without a direction",
       {
-        version: 1,
+        version: MIGRATION_MARKER_VERSION,
         status: "migrating",
         migrationId: "r",
         step: 0,
@@ -513,7 +515,7 @@ describe("field-group migration marker", () => {
     [
       "in-flight without an id",
       {
-        version: 1,
+        version: MIGRATION_MARKER_VERSION,
         status: "migrating",
         direction: "up",
         step: 0,
@@ -523,7 +525,7 @@ describe("field-group migration marker", () => {
     [
       "in-flight with a fractional step",
       {
-        version: 1,
+        version: MIGRATION_MARKER_VERSION,
         status: "migrating",
         direction: "up",
         migrationId: "r",
@@ -534,7 +536,7 @@ describe("field-group migration marker", () => {
     [
       "in-flight without a manifest hash",
       {
-        version: 1,
+        version: MIGRATION_MARKER_VERSION,
         status: "migrating",
         direction: "up",
         migrationId: "r",
@@ -545,7 +547,7 @@ describe("field-group migration marker", () => {
     [
       "in-flight without a registry identity hash",
       {
-        version: 1,
+        version: MIGRATION_MARKER_VERSION,
         status: "migrating",
         direction: "up",
         migrationId: "r",
@@ -559,7 +561,7 @@ describe("field-group migration marker", () => {
       // position, whatever `Number.isInteger` says about it.
       "in-flight with a step beyond the safe integer range",
       {
-        version: 1,
+        version: MIGRATION_MARKER_VERSION,
         status: "migrating",
         direction: "up",
         migrationId: "r",
@@ -574,7 +576,7 @@ describe("field-group migration marker", () => {
       // rejected by the next read -- a marker with no way forward.
       "in-flight at the safe integer ceiling",
       {
-        version: 1,
+        version: MIGRATION_MARKER_VERSION,
         status: "migrating",
         direction: "up",
         migrationId: "r",
@@ -586,7 +588,7 @@ describe("field-group migration marker", () => {
     [
       "in-flight without a plan hash",
       {
-        version: 1,
+        version: MIGRATION_MARKER_VERSION,
         status: "migrating",
         direction: "up",
         migrationId: "r",
@@ -604,6 +606,35 @@ describe("field-group migration marker", () => {
     await expect(readMigrationState(meta)).rejects.toMatchObject({
       code: "SERVICE_UNAVAILABLE",
     });
+  });
+
+  // `step` is a position in a step list, and only the build that produced that
+  // list can say what position N addressed. A marker from another version is
+  // therefore refused — and refused as a version mismatch rather than as
+  // corruption, because the bytes are intact and the operator's remedy is to
+  // finish or roll back the run with the version that started it.
+  it("refuses a marker written by a different version of Nextly", async () => {
+    const { meta } = createMeta({
+      version: MIGRATION_MARKER_VERSION - 1,
+      status: "migrating",
+      direction: "up",
+      migrationId: "r",
+      step: 2,
+      registryHash: "s",
+      manifestHash: "h",
+    });
+
+    const error = await readMigrationState(meta).catch((e: unknown) => e);
+    expect(NextlyError.is(error)).toBe(true);
+    if (NextlyError.is(error)) {
+      expect(error.logContext?.reason).toBe(
+        "migration marker version is not this build's"
+      );
+      expect(error.logContext?.recordedVersion).toBe(
+        MIGRATION_MARKER_VERSION - 1
+      );
+      expect(error.logContext?.supportedVersion).toBe(MIGRATION_MARKER_VERSION);
+    }
   });
 
   // A row whose value is SQL NULL, and a row holding the JSON literal `null`,
@@ -686,7 +717,7 @@ describe("the persisted plan is the resume's authority", () => {
   // only thing standing between a corrupted blob and a run that executes it.
   it("refuses a plan that does not match its recorded hash", async () => {
     const { meta } = createMeta({
-      version: 1,
+      version: MIGRATION_MARKER_VERSION,
       status: "migrating",
       direction: "up",
       migrationId: "run-1",
@@ -710,7 +741,7 @@ describe("the persisted plan is the resume's authority", () => {
     "refuses an in-flight %s marker carrying no plan",
     async direction => {
       const { meta } = createMeta({
-        version: 1,
+        version: MIGRATION_MARKER_VERSION,
         status: "migrating",
         direction,
         migrationId: "run-1",

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/state.test.ts
@@ -613,6 +613,43 @@ describe("field-group migration marker", () => {
   // therefore refused — and refused as a version mismatch rather than as
   // corruption, because the bytes are intact and the operator's remedy is to
   // finish or roll back the run with the version that started it.
+  // The version says how a recorded *step* is read, and a settled marker has
+  // none. Gating it would make the next bump reject every marker the previous
+  // release settled, so every already-migrated installation would start
+  // refusing reads the moment it upgraded.
+  it("still reads a settled marker written by a different version", async () => {
+    const { meta } = createMeta({
+      version: MIGRATION_MARKER_VERSION - 1,
+      status: "settled",
+      generation: "field-groups-v2",
+    });
+    await expect(readMigrationState(meta)).resolves.toEqual({
+      status: "settled",
+      generation: "field-groups-v2",
+      recorded: true,
+    });
+  });
+
+  // The plan is the version-bound part: its entry format is what the version
+  // tracks. Dropping it leaves a rollback to refuse on a plan it does not have,
+  // rather than every read refusing on a plan it cannot parse.
+  it("drops a recorded plan it cannot interpret rather than refusing the read", async () => {
+    const { meta } = createMeta({
+      version: MIGRATION_MARKER_VERSION - 1,
+      status: "settled",
+      generation: "field-groups-v2",
+      // The previous build's shape, which this one no longer accepts.
+      appliedManifest: [
+        { kind: "companion", from: "comp_hero_locales", to: "fg_hero_locales" },
+      ],
+    });
+    const state = await readMigrationState(meta);
+    expect(state.status).toBe("settled");
+    expect(
+      (state as { appliedManifest?: unknown }).appliedManifest
+    ).toBeUndefined();
+  });
+
   it("refuses a marker written by a different version of Nextly", async () => {
     const { meta } = createMeta({
       version: MIGRATION_MARKER_VERSION - 1,

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/steps.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/steps.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it } from "vitest";
+
+import { identifierCaseRules } from "../../../schema/utils/resolve-catalog-name";
+import { buildMigrationManifest, invertManifest } from "../manifest";
+import type { ManifestEntry, RegistryRow } from "../manifest";
+import type { MigrationSession } from "../session";
+import {
+  buildMigrationSteps,
+  registryNameAt,
+  type ObservedColumn,
+  type StorageObserver,
+} from "../steps";
+
+const PRESERVING = identifierCaseRules({ dialect: "postgresql" });
+
+function row(over: Partial<RegistryRow> = {}): RegistryRow {
+  return { slug: "hero", tableName: "comp_hero", hasCompanion: false, ...over };
+}
+
+/**
+ * A database stand-in that applies what the steps issue.
+ *
+ * It parses the statements rather than merely recording them, so a step that
+ * emits SQL the real database would reject cannot pass here either: a rename of
+ * a table that is absent throws, exactly as a server would. A double looser than
+ * the thing it replaces certifies a path that does not exist.
+ */
+function createWorld(initial: {
+  tables: string[];
+  columns?: Record<string, ObservedColumn[]>;
+  pointers?: Record<string, string[]>;
+}) {
+  const tables = new Set(initial.tables);
+  const columns = new Map<string, ObservedColumn[]>(
+    Object.entries(initial.columns ?? {})
+  );
+  const pointers = new Map<string, string[]>(
+    Object.entries(initial.pointers ?? {})
+  );
+  const statements: string[] = [];
+  let transactions = 0;
+
+  function apply(sql: string, params: unknown[] = []): void {
+    statements.push(sql);
+    const rename = /^ALTER TABLE "(.+?)" RENAME TO "(.+?)"$/.exec(sql);
+    if (rename?.[1] !== undefined && rename[2] !== undefined) {
+      if (!tables.has(rename[1])) {
+        throw new Error(`relation "${rename[1]}" does not exist`);
+      }
+      tables.delete(rename[1]);
+      tables.add(rename[2]);
+      const cols = columns.get(rename[1]);
+      if (cols !== undefined) {
+        columns.delete(rename[1]);
+        columns.set(rename[2], cols);
+      }
+      return;
+    }
+    const renameColumn =
+      /^ALTER TABLE "(.+?)" RENAME COLUMN "(.+?)" TO "(.+?)"$/.exec(sql);
+    if (
+      renameColumn?.[1] !== undefined &&
+      renameColumn[2] !== undefined &&
+      renameColumn[3] !== undefined
+    ) {
+      const cols = columns.get(renameColumn[1]);
+      const target = cols?.find(c => c.name === renameColumn[2]);
+      if (target === undefined) {
+        throw new Error(`column "${renameColumn[2]}" does not exist`);
+      }
+      target.name = renameColumn[3];
+      return;
+    }
+    const update = /^UPDATE "(.+?)" SET "table_name" = \? WHERE/.exec(sql);
+    if (update?.[1] !== undefined) {
+      if (!tables.has(update[1])) {
+        throw new Error(`relation "${update[1]}" does not exist`);
+      }
+      const [to, from] = params as [string, string];
+      const current = pointers.get(update[1]) ?? [];
+      pointers.set(
+        update[1],
+        current.map(value => (value === from ? to : value))
+      );
+      return;
+    }
+    throw new Error(`unrecognised statement: ${sql}`);
+  }
+
+  const session = {
+    dialect: "postgresql",
+    async inTransaction<T>(work: (ctx: never) => Promise<T>): Promise<T> {
+      transactions += 1;
+      // Errors propagate exactly as a real transaction's would; swallowing them
+      // would let a step that failed look like one that succeeded.
+      return work({
+        async execute(sql: string, params?: unknown[]) {
+          apply(sql, params);
+          return [];
+        },
+      } as never);
+    },
+  } as unknown as MigrationSession;
+
+  const observer: StorageObserver = {
+    tables: async () => [...tables],
+    columns: async (_s, table) => columns.get(table),
+    pointers: async (_s, registryTable) => [
+      ...(pointers.get(registryTable) ?? []),
+    ],
+  };
+
+  return {
+    session,
+    observer,
+    statements,
+    transactionCount: () => transactions,
+    tableNames: () => [...tables],
+    pointersOf: (registry: string) => [...(pointers.get(registry) ?? [])],
+    columnsOf: (table: string) => (columns.get(table) ?? []).map(c => c.name),
+  };
+}
+
+const LEGACY_REGISTRY = "dynamic_components";
+const TARGET_REGISTRY = "dynamic_field_groups";
+const TYPE_COLUMN: ObservedColumn[] = [
+  { name: "_component_type", type: "text" },
+];
+
+describe("registryNameAt", () => {
+  const up = buildMigrationManifest([row()]).entries;
+
+  // Going up the registry renames last, so every pointer update precedes it and
+  // addresses the legacy name.
+  it("uses the legacy name for every step of an up plan", () => {
+    for (let position = 1; position <= up.length; position += 1) {
+      expect(registryNameAt(up, position)).toBe(LEGACY_REGISTRY);
+    }
+  });
+
+  // A rollback reverses the order, so the registry moves first and every later
+  // step addresses the name the rollback restored. Hardcoding either constant,
+  // or deriving it from direction alone, is wrong for one of these.
+  it("switches after the registry's own rename in a down plan", () => {
+    const down = invertManifest(up).entries;
+    expect(down[0]?.kind).toBe("registry");
+    expect(registryNameAt(down, 1)).toBe(TARGET_REGISTRY);
+    expect(registryNameAt(down, 2)).toBe(LEGACY_REGISTRY);
+    expect(registryNameAt(down, down.length)).toBe(LEGACY_REGISTRY);
+  });
+
+  it("refuses a plan with no registry rename", () => {
+    expect(() => registryNameAt([], 1)).toThrowError();
+  });
+});
+
+describe("rename steps", () => {
+  function world() {
+    return createWorld({
+      tables: [LEGACY_REGISTRY, "comp_hero"],
+      columns: { comp_hero: [...TYPE_COLUMN] },
+      pointers: { [LEGACY_REGISTRY]: ["comp_hero"] },
+    });
+  }
+
+  function stepsFor(
+    w: ReturnType<typeof createWorld>,
+    entries: ManifestEntry[]
+  ) {
+    return buildMigrationSteps({
+      entries,
+      identifierCase: PRESERVING,
+      observer: w.observer,
+    });
+  }
+
+  const entries = buildMigrationManifest([row()]).entries;
+
+  // The pairing is the point: apart, there is a window where the row addresses a
+  // table that no longer exists.
+  it("renames a table and moves its pointer in one transaction", async () => {
+    const w = world();
+    const [tableStep] = stepsFor(w, entries);
+    await tableStep?.run(w.session);
+
+    expect(w.tableNames()).toContain("fg_hero");
+    expect(w.pointersOf(LEGACY_REGISTRY)).toEqual(["fg_hero"]);
+    expect(w.transactionCount()).toBe(1);
+    await expect(tableStep?.verify(w.session)).resolves.toBe(true);
+  });
+
+  // The state the pairing exists to prevent, and the reason `verify` checks the
+  // pointer as well as the catalog.
+  it("fails verification when the rename landed but the pointer did not", async () => {
+    const w = createWorld({
+      tables: [LEGACY_REGISTRY, "fg_hero"],
+      columns: { fg_hero: [...TYPE_COLUMN] },
+      pointers: { [LEGACY_REGISTRY]: ["comp_hero"] },
+    });
+    const [tableStep] = stepsFor(w, entries);
+    await expect(tableStep?.verify(w.session)).resolves.toBe(false);
+  });
+
+  // MySQL commits DDL implicitly, so a step can be resumed with the rename
+  // already applied. Re-issuing it would fail on a source that is gone.
+  it("re-runs safely when the rename already committed", async () => {
+    const w = createWorld({
+      tables: [LEGACY_REGISTRY, "fg_hero"],
+      columns: { fg_hero: [...TYPE_COLUMN] },
+      pointers: { [LEGACY_REGISTRY]: ["comp_hero"] },
+    });
+    const [tableStep] = stepsFor(w, entries);
+    await expect(tableStep?.run(w.session)).resolves.toBeUndefined();
+    // The half that did not land is applied, and no rename is re-issued.
+    expect(w.pointersOf(LEGACY_REGISTRY)).toEqual(["fg_hero"]);
+    expect(w.statements.filter(s => s.includes("RENAME TO"))).toHaveLength(0);
+    await expect(tableStep?.verify(w.session)).resolves.toBe(true);
+  });
+
+  // A companion's name derives from its owner's `table_name`, so the owner's
+  // update already moves it; writing a pointer for it would target no row.
+  it("does not touch the pointer for a companion", async () => {
+    const withCompanion = [row({ hasCompanion: true })];
+    const w = createWorld({
+      tables: [LEGACY_REGISTRY, "comp_hero", "comp_hero_locales"],
+      columns: { comp_hero: [...TYPE_COLUMN] },
+      pointers: { [LEGACY_REGISTRY]: ["comp_hero"] },
+    });
+    const built = buildMigrationManifest(withCompanion).entries;
+    const steps = stepsFor(w, built);
+    const companionIndex = built.findIndex(e => e.kind === "companion");
+    await steps[companionIndex]?.run(w.session);
+
+    expect(w.tableNames()).toContain("fg_hero_locales");
+    expect(w.statements.filter(s => s.startsWith("UPDATE"))).toHaveLength(0);
+  });
+
+  // No registry row addresses the registry itself.
+  it("does not touch the pointer for the registry", async () => {
+    const w = world();
+    const steps = stepsFor(w, entries);
+    const registryIndex = entries.findIndex(e => e.kind === "registry");
+    await steps[registryIndex]?.run(w.session);
+
+    expect(w.tableNames()).toContain(TARGET_REGISTRY);
+    expect(w.statements.filter(s => s.startsWith("UPDATE"))).toHaveLength(0);
+  });
+
+  // Reconciliation marks work already reflected in the database. Re-issuing it
+  // would fail, and the postcondition is what is worth confirming.
+  it("verifies a satisfied entry without re-running it", async () => {
+    const w = createWorld({
+      tables: [LEGACY_REGISTRY, "fg_hero"],
+      columns: { fg_hero: [...TYPE_COLUMN] },
+      pointers: { [LEGACY_REGISTRY]: ["fg_hero"] },
+    });
+    const satisfied = entries.map(e =>
+      e.kind === "table" ? { ...e, satisfied: true } : e
+    );
+    const [tableStep] = stepsFor(w, satisfied);
+    await tableStep?.run(w.session);
+    expect(w.statements).toHaveLength(0);
+    await expect(tableStep?.verify(w.session)).resolves.toBe(true);
+  });
+});
+
+describe("column steps", () => {
+  const entries = buildMigrationManifest([row()]).entries;
+
+  it("renames the discriminator on the table the entry names", async () => {
+    const w = createWorld({
+      tables: [LEGACY_REGISTRY, "fg_hero"],
+      columns: { fg_hero: [...TYPE_COLUMN] },
+      pointers: { [LEGACY_REGISTRY]: ["fg_hero"] },
+    });
+    const steps = buildMigrationSteps({
+      entries,
+      identifierCase: PRESERVING,
+      observer: w.observer,
+    });
+    const columnIndex = entries.findIndex(e => e.kind === "column");
+    await steps[columnIndex]?.run(w.session);
+
+    expect(w.columnsOf("fg_hero")).toEqual(["_field_group_type"]);
+    await expect(steps[columnIndex]?.verify(w.session)).resolves.toBe(true);
+  });
+
+  // Renaming a column on a table that is not there cannot be a silent no-op:
+  // the discriminator is required on every field-group table.
+  it("refuses when the column's table is absent", async () => {
+    const w = createWorld({
+      tables: [LEGACY_REGISTRY],
+      pointers: { [LEGACY_REGISTRY]: ["comp_hero"] },
+    });
+    const steps = buildMigrationSteps({
+      entries,
+      identifierCase: PRESERVING,
+      observer: w.observer,
+    });
+    const columnIndex = entries.findIndex(e => e.kind === "column");
+    await expect(steps[columnIndex]?.run(w.session)).rejects.toThrowError();
+  });
+
+  it("re-runs safely when the column rename already committed", async () => {
+    const w = createWorld({
+      tables: [LEGACY_REGISTRY, "fg_hero"],
+      columns: { fg_hero: [{ name: "_field_group_type", type: "text" }] },
+      pointers: { [LEGACY_REGISTRY]: ["fg_hero"] },
+    });
+    const steps = buildMigrationSteps({
+      entries,
+      identifierCase: PRESERVING,
+      observer: w.observer,
+    });
+    const columnIndex = entries.findIndex(e => e.kind === "column");
+    await expect(steps[columnIndex]?.run(w.session)).resolves.toBeUndefined();
+    expect(w.statements).toHaveLength(0);
+    await expect(steps[columnIndex]?.verify(w.session)).resolves.toBe(true);
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/steps.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/steps.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { NextlyError } from "../../../../errors/nextly-error";
+
 import { identifierCaseRules } from "../../../schema/utils/resolve-catalog-name";
 import { buildMigrationManifest, invertManifest } from "../manifest";
 import type { ManifestEntry, RegistryRow } from "../manifest";
@@ -29,6 +31,7 @@ function createWorld(initial: {
   tables: string[];
   columns?: Record<string, ObservedColumn[]>;
   pointers?: Record<string, string[]>;
+  indexes?: Record<string, string[]>;
 }) {
   const tables = new Set(initial.tables);
   const columns = new Map<string, ObservedColumn[]>(
@@ -36,6 +39,9 @@ function createWorld(initial: {
   );
   const pointers = new Map<string, string[]>(
     Object.entries(initial.pointers ?? {})
+  );
+  const indexes = new Map<string, string[]>(
+    Object.entries(initial.indexes ?? {})
   );
   const statements: string[] = [];
   let transactions = 0;
@@ -54,6 +60,12 @@ function createWorld(initial: {
         columns.delete(rename[1]);
         columns.set(rename[2], cols);
       }
+      // Indexes follow the table on every supported dialect.
+      const idx = indexes.get(rename[1]);
+      if (idx !== undefined) {
+        indexes.delete(rename[1]);
+        indexes.set(rename[2], idx);
+      }
       return;
     }
     const renameColumn =
@@ -71,7 +83,12 @@ function createWorld(initial: {
       target.name = renameColumn[3];
       return;
     }
-    const update = /^UPDATE "(.+?)" SET "table_name" = \? WHERE/.exec(sql);
+    // `$1`/`$2`, because this world stands in for node-postgres and that is what
+    // it binds. Accepting `?` here is what let a Postgres-breaking statement pass.
+    const update =
+      /^UPDATE "(.+?)" SET "table_name" = \$1 WHERE "table_name" = \$2$/.exec(
+        sql
+      );
     if (update?.[1] !== undefined) {
       if (!tables.has(update[1])) {
         throw new Error(`relation "${update[1]}" does not exist`);
@@ -108,6 +125,7 @@ function createWorld(initial: {
     pointers: async (_s, registryTable) => [
       ...(pointers.get(registryTable) ?? []),
     ],
+    indexNames: async table => indexes.get(table),
   };
 
   return {
@@ -118,6 +136,7 @@ function createWorld(initial: {
     tableNames: () => [...tables],
     pointersOf: (registry: string) => [...(pointers.get(registry) ?? [])],
     columnsOf: (table: string) => (columns.get(table) ?? []).map(c => c.name),
+    dropIndexes: (table: string) => indexes.set(table, []),
   };
 }
 
@@ -259,7 +278,11 @@ describe("rename steps", () => {
     );
     const [tableStep] = stepsFor(w, satisfied);
     await tableStep?.run(w.session);
-    expect(w.statements).toHaveLength(0);
+    // The DDL is skipped, but the pointer repair is not: reconciliation can mark
+    // a rename satisfied while its pointer update never landed, and skipping
+    // both would fail verification on every resume, forever.
+    expect(w.statements.filter(s => s.includes("RENAME TO"))).toHaveLength(0);
+    expect(w.statements.filter(s => s.startsWith("UPDATE"))).toHaveLength(1);
     await expect(tableStep?.verify(w.session)).resolves.toBe(true);
   });
 });
@@ -316,5 +339,65 @@ describe("column steps", () => {
     await expect(steps[columnIndex]?.run(w.session)).resolves.toBeUndefined();
     expect(w.statements).toHaveLength(0);
     await expect(steps[columnIndex]?.verify(w.session)).resolves.toBe(true);
+  });
+});
+
+describe("index survival across a rename", () => {
+  const entries = buildMigrationManifest([row()]).entries;
+
+  function stepFor(w: ReturnType<typeof createWorld>) {
+    return buildMigrationSteps({
+      entries,
+      identifierCase: PRESERVING,
+      observer: w.observer,
+    })[0];
+  }
+
+  it("accepts a rename that carried the table's indexes", async () => {
+    const w = createWorld({
+      tables: [LEGACY_REGISTRY, "comp_hero"],
+      columns: { comp_hero: [...TYPE_COLUMN] },
+      pointers: { [LEGACY_REGISTRY]: ["comp_hero"] },
+      indexes: { comp_hero: ["idx_hero_slug"] },
+    });
+    const step = stepFor(w);
+    await step?.run(w.session);
+    await expect(step?.verify(w.session)).resolves.toBe(true);
+  });
+
+  // A lost index is not "not yet done" — a retry cannot bring it back — so this
+  // refuses rather than returning false and letting the runner retry forever.
+  it("refuses a rename that dropped an index", async () => {
+    const w = createWorld({
+      tables: [LEGACY_REGISTRY, "comp_hero"],
+      columns: { comp_hero: [...TYPE_COLUMN] },
+      pointers: { [LEGACY_REGISTRY]: ["comp_hero"] },
+      indexes: { comp_hero: ["idx_hero_slug"] },
+    });
+    const step = stepFor(w);
+    await step?.run(w.session);
+    // The rename landed but the index did not come with it.
+    w.dropIndexes("fg_hero");
+
+    const error = await step?.verify(w.session).catch((e: unknown) => e);
+    expect(NextlyError.is(error)).toBe(true);
+    if (NextlyError.is(error)) {
+      expect(error.logContext?.lost).toEqual(["idx_hero_slug"]);
+      expect(error.logContext?.table).toBe("fg_hero");
+    }
+  });
+
+  // On a resumed step the source is already gone, so there is no before-state.
+  // Reported as not comparable rather than as nothing lost.
+  it("does not claim index survival when the source was already renamed", async () => {
+    const w = createWorld({
+      tables: [LEGACY_REGISTRY, "fg_hero"],
+      columns: { fg_hero: [...TYPE_COLUMN] },
+      pointers: { [LEGACY_REGISTRY]: ["comp_hero"] },
+      indexes: { fg_hero: [] },
+    });
+    const step = stepFor(w);
+    await step?.run(w.session);
+    await expect(step?.verify(w.session)).resolves.toBe(true);
   });
 });

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/steps.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/steps.test.ts
@@ -401,3 +401,55 @@ describe("index survival across a rename", () => {
     await expect(step?.verify(w.session)).resolves.toBe(true);
   });
 });
+
+describe("a companion moves with its owner", () => {
+  const rows = [row({ hasCompanion: true })];
+  const entries = buildMigrationManifest(rows).entries;
+
+  function world() {
+    return createWorld({
+      tables: [LEGACY_REGISTRY, "comp_hero", "comp_hero_locales"],
+      columns: { comp_hero: [...TYPE_COLUMN] },
+      pointers: { [LEGACY_REGISTRY]: ["comp_hero"] },
+    });
+  }
+
+  // The registry derives the companion's name from the owner's `table_name`, so
+  // the moment the pointer moves it starts deriving `fg_hero_locales`. If the
+  // companion were renamed by a later independently recorded step, a crash or a
+  // concurrent reader in that window would see localized storage missing.
+  it("renames the companion in the same step that moves the pointer", async () => {
+    const w = world();
+    const [tableStep] = buildMigrationSteps({
+      entries,
+      identifierCase: PRESERVING,
+      observer: w.observer,
+    });
+    await tableStep?.run(w.session);
+
+    expect(w.tableNames()).toContain("fg_hero");
+    expect(w.tableNames()).toContain("fg_hero_locales");
+    expect(w.pointersOf(LEGACY_REGISTRY)).toEqual(["fg_hero"]);
+    // One transaction, so no window exists between the two renames and the
+    // pointer at all.
+    expect(w.transactionCount()).toBe(1);
+  });
+
+  // The companion still has its own entry and position, so the plan's shape and
+  // hash are unchanged. Its step finds the source already gone and does nothing.
+  it("leaves the companion's own step as a no-op that still verifies", async () => {
+    const w = world();
+    const steps = buildMigrationSteps({
+      entries,
+      identifierCase: PRESERVING,
+      observer: w.observer,
+    });
+    await steps[0]?.run(w.session);
+    const before = w.statements.length;
+
+    const companionIndex = entries.findIndex(e => e.kind === "companion");
+    await steps[companionIndex]?.run(w.session);
+    expect(w.statements).toHaveLength(before);
+    await expect(steps[companionIndex]?.verify(w.session)).resolves.toBe(true);
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/steps.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/steps.test.ts
@@ -453,3 +453,65 @@ describe("a companion moves with its owner", () => {
     await expect(steps[companionIndex]?.verify(w.session)).resolves.toBe(true);
   });
 });
+
+describe("observation never happens inside a step transaction", () => {
+  const entries = buildMigrationManifest([row()]).entries;
+
+  // The observer reads through the adapter, which checks out its own
+  // connection. Asking it from inside a transaction waits for a second checkout
+  // and hangs a pool sized to one, so every step must gather what it needs
+  // first. This asserts it for both step kinds, because the table path was fixed
+  // while the column path was left behind once already.
+  it.each([
+    ["table", 0],
+    // 0 = the table rename, 1 = the discriminator column, 2 = the registry.
+    ["column", 1],
+  ])(
+    "gathers observations before opening the transaction (%s)",
+    async (_k, i) => {
+      // Both names present, so each step finds the table its entry addresses:
+      // the table entry names `comp_hero`, the column entry `fg_hero`.
+      const w = createWorld({
+        tables: [LEGACY_REGISTRY, "comp_hero", "fg_hero"],
+        columns: { comp_hero: [...TYPE_COLUMN], fg_hero: [...TYPE_COLUMN] },
+        pointers: { [LEGACY_REGISTRY]: ["comp_hero"] },
+      });
+      let inTransaction = false;
+      let observedInside = false;
+      const guarded = {
+        ...w.observer,
+        tables: async (...a: Parameters<typeof w.observer.tables>) => {
+          if (inTransaction) observedInside = true;
+          return w.observer.tables(...a);
+        },
+        columns: async (...a: Parameters<typeof w.observer.columns>) => {
+          if (inTransaction) observedInside = true;
+          return w.observer.columns(...a);
+        },
+        indexNames: async (...a: Parameters<typeof w.observer.indexNames>) => {
+          if (inTransaction) observedInside = true;
+          return w.observer.indexNames(...a);
+        },
+      };
+      const session = {
+        dialect: "postgresql",
+        inTransaction: async (work: (ctx: unknown) => Promise<unknown>) => {
+          inTransaction = true;
+          try {
+            return await w.session.inTransaction(work as never);
+          } finally {
+            inTransaction = false;
+          }
+        },
+      } as unknown as typeof w.session;
+
+      const steps = buildMigrationSteps({
+        entries,
+        identifierCase: PRESERVING,
+        observer: guarded,
+      });
+      await steps[i]?.run(session);
+      expect(observedInside).toBe(false);
+    }
+  );
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/steps.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/steps.test.ts
@@ -1,3 +1,5 @@
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 import { describe, expect, it } from "vitest";
 
 import { NextlyError } from "../../../../errors/nextly-error";
@@ -46,8 +48,12 @@ function createWorld(initial: {
   const statements: string[] = [];
   let transactions = 0;
 
-  function apply(sql: string, params: unknown[] = []): void {
-    statements.push(sql);
+  function apply(raw: string, params: unknown[] = []): void {
+    statements.push(raw);
+    // Line breaks and indentation in a statement are nothing to a driver, so
+    // this world does not treat them as meaningful either. Everything that IS
+    // meaningful stays strict below: the quoting, and `$1`/`$2` binding.
+    const sql = raw.replace(/\s+/g, " ").trim();
     const rename = /^ALTER TABLE "(.+?)" RENAME TO "(.+?)"$/.exec(sql);
     if (rename?.[1] !== undefined && rename[2] !== undefined) {
       if (!tables.has(rename[1])) {
@@ -114,6 +120,15 @@ function createWorld(initial: {
         async execute(sql: string, params?: unknown[]) {
           apply(sql, params);
           return [];
+        },
+        // Compiled through a real Drizzle dialect, which is what the adapters
+        // hand their driver. A double that inspected the template object
+        // instead would accept identifiers this dialect refuses to quote and
+        // parameters it never extracts, and certify a statement no driver
+        // could run.
+        async runStatement(statement: SQL) {
+          const compiled = new PgDialect().sqlToQuery(statement);
+          apply(compiled.sql, compiled.params);
         },
       } as never);
     },
@@ -238,20 +253,20 @@ describe("rename steps", () => {
 
   // A companion's name derives from its owner's `table_name`, so the owner's
   // update already moves it; writing a pointer for it would target no row.
-  it("does not touch the pointer for a companion", async () => {
+  // A companion has no step of its own to occupy a position: it moves on its
+  // owner's entry. A second position is what left the resume crash window unable
+  // to explain the companion, and what let inversion separate the two.
+  it("gives a companion no step of its own", async () => {
     const withCompanion = [row({ hasCompanion: true })];
-    const w = createWorld({
-      tables: [LEGACY_REGISTRY, "comp_hero", "comp_hero_locales"],
-      columns: { comp_hero: [...TYPE_COLUMN] },
-      pointers: { [LEGACY_REGISTRY]: ["comp_hero"] },
-    });
     const built = buildMigrationManifest(withCompanion).entries;
-    const steps = stepsFor(w, built);
-    const companionIndex = built.findIndex(e => e.kind === "companion");
-    await steps[companionIndex]?.run(w.session);
 
-    expect(w.tableNames()).toContain("fg_hero_locales");
-    expect(w.statements.filter(s => s.startsWith("UPDATE"))).toHaveLength(0);
+    // One table entry, one column entry, one registry entry — the companion adds
+    // no fourth.
+    expect(built.map(e => e.kind)).toEqual(["table", "column", "registry"]);
+    expect(built[0]?.companion).toEqual({
+      from: "comp_hero_locales",
+      to: "fg_hero_locales",
+    });
   });
 
   // No registry row addresses the registry itself.
@@ -437,20 +452,56 @@ describe("a companion moves with its owner", () => {
 
   // The companion still has its own entry and position, so the plan's shape and
   // hash are unchanged. Its step finds the source already gone and does nothing.
-  it("leaves the companion's own step as a no-op that still verifies", async () => {
-    const w = world();
+  // MySQL commits each RENAME on its own, so a crash between the base and the
+  // companion is reachable. The resume must finish the companion rather than
+  // treat the entry as done because reconciliation marked it satisfied — which
+  // is why the step decides per table from the catalog, not per entry.
+  it("finishes a companion whose rename did not land with its owner's", async () => {
+    const w = createWorld({
+      // The torn state: base already moved, companion still under its old name.
+      tables: [LEGACY_REGISTRY, "fg_hero", "comp_hero_locales"],
+      columns: { fg_hero: [...TYPE_COLUMN] },
+      pointers: { [LEGACY_REGISTRY]: ["fg_hero"] },
+    });
+    const satisfied: ManifestEntry[] = entries.map((entry, index) =>
+      index === 0 ? { ...entry, satisfied: true } : entry
+    );
+    const steps = buildMigrationSteps({
+      entries: satisfied,
+      identifierCase: PRESERVING,
+      observer: w.observer,
+    });
+
+    await steps[0]?.run(w.session);
+
+    expect(w.tableNames()).toContain("fg_hero_locales");
+    expect(w.tableNames()).not.toContain("comp_hero_locales");
+    await expect(steps[0]?.verify(w.session)).resolves.toBe(true);
+  });
+
+  // A companion's indexes are as lost as a table's if a rename drops them, and
+  // the companion is the half with no entry of its own to check for it.
+  it("refuses when a rename dropped a companion's index", async () => {
+    const w = createWorld({
+      tables: [LEGACY_REGISTRY, "comp_hero", "comp_hero_locales"],
+      columns: { comp_hero: [...TYPE_COLUMN] },
+      pointers: { [LEGACY_REGISTRY]: ["comp_hero"] },
+      indexes: { comp_hero: ["hero_slug_ix"], comp_hero_locales: ["loc_ix"] },
+    });
     const steps = buildMigrationSteps({
       entries,
       identifierCase: PRESERVING,
       observer: w.observer,
     });
     await steps[0]?.run(w.session);
-    const before = w.statements.length;
+    w.dropIndexes("fg_hero_locales");
 
-    const companionIndex = entries.findIndex(e => e.kind === "companion");
-    await steps[companionIndex]?.run(w.session);
-    expect(w.statements).toHaveLength(before);
-    await expect(steps[companionIndex]?.verify(w.session)).resolves.toBe(true);
+    const error = await steps[0]?.verify(w.session).catch((e: unknown) => e);
+    expect(NextlyError.is(error)).toBe(true);
+    if (NextlyError.is(error)) {
+      expect(error.logContext?.table).toBe("fg_hero_locales");
+      expect(error.logContext?.lost).toEqual(["loc_ix"]);
+    }
   });
 });
 

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
@@ -160,11 +160,16 @@ describe("schema sync guard", () => {
  * The lock is the whole mechanism under test, so a double that let a second
  * claim succeed would certify exclusion that does not exist.
  */
-function lockingAdapter(options: { marker?: unknown; heldBy?: string | null }) {
+function lockingAdapter(options: {
+  marker?: unknown;
+  heldBy?: string | null;
+  lockTableExists?: boolean;
+}) {
   const lock: { seeded: boolean; owner: string | null } = {
     seeded: options.heldBy !== undefined,
     owner: options.heldBy ?? null,
   };
+  const ddl: string[] = [];
 
   function matches(where: unknown): boolean {
     const clauses =
@@ -188,8 +193,14 @@ function lockingAdapter(options: { marker?: unknown; heldBy?: string | null }) {
         }),
       }),
     }),
-    executeQuery: async () => [],
-    tableExists: async () => true,
+    executeQuery: async (sql: string) => {
+      ddl.push(sql);
+      return [];
+    },
+    tableExists: async (name: string) =>
+      name === "nextly_field_group_lock"
+        ? (options.lockTableExists ?? true)
+        : true,
     transaction: async (work: (ctx: unknown) => Promise<unknown>) =>
       work({
         lockRow: async () => undefined,
@@ -214,7 +225,7 @@ function lockingAdapter(options: { marker?: unknown; heldBy?: string | null }) {
       }),
   } as unknown as DrizzleAdapter;
 
-  return { adapter, ownerNow: () => lock.owner };
+  return { adapter, ownerNow: () => lock.owner, ddlIssued: () => [...ddl] };
 }
 
 describe("holding the exclusion for the whole sync", () => {
@@ -244,6 +255,61 @@ describe("holding the exclusion for the whole sync", () => {
 
     expect(NextlyError.is(error)).toBe(true);
     expect(work).not.toHaveBeenCalled();
+  });
+
+  // `--no-auto-sync` is chosen precisely to keep schema changes in migration
+  // files, and a role granted DML but not DDL would be refused outright by a
+  // CREATE TABLE. The sync therefore never creates the lock table.
+  it("issues no DDL while taking the exclusion", async () => {
+    const { adapter, ddlIssued } = lockingAdapter({});
+    await withMigrationExcluded({ adapter, logger, label: "db:sync" }, () =>
+      Promise.resolve()
+    );
+    expect(ddlIssued().filter(sql => /CREATE TABLE/i.test(sql))).toEqual([]);
+  });
+
+  // Absence of the lock table means no run has ever been recorded here, so
+  // there is nothing to be excluded from — and nothing worth creating a table
+  // for on a database whose role may not be allowed to.
+  it("runs the work when no lock table exists", async () => {
+    const { adapter, ddlIssued } = lockingAdapter({ lockTableExists: false });
+    const work = vi.fn(() => Promise.resolve());
+
+    await withMigrationExcluded({ adapter, logger, label: "db:sync" }, work);
+
+    expect(work).toHaveBeenCalledTimes(1);
+    expect(ddlIssued()).toEqual([]);
+  });
+
+  // Watch mode documents Ctrl+C as the way to stop, and the claim is durable
+  // with no expiry, so without this a routine interrupt would leave a claim
+  // only an operator could clear — blocking every later sync and migration.
+  it("releases the claim when the process is interrupted", async () => {
+    const { adapter, ownerNow } = lockingAdapter({});
+    const exits: string[] = [];
+    const kill = vi
+      .spyOn(process, "kill")
+      .mockImplementation((_pid: number, signal?: string | number) => {
+        exits.push(String(signal));
+        return true;
+      });
+
+    let ownerWhileHeld: string | null = null;
+    await withMigrationExcluded(
+      { adapter, logger, label: "db:sync watch" },
+      async () => {
+        ownerWhileHeld = ownerNow();
+        process.emit("SIGINT");
+        // Let the release settle before the work returns, so this observes the
+        // signal path rather than the ordinary one in `finally`.
+        await new Promise(resolve => setImmediate(resolve));
+        expect(ownerNow()).toBeNull();
+      }
+    );
+
+    expect(ownerWhileHeld).not.toBeNull();
+    expect(exits).toContain("SIGINT");
+    kill.mockRestore();
   });
 
   // Holding the lock is necessary and not sufficient. An operator who cleared a

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
@@ -1,6 +1,4 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
-import type { SQL } from "drizzle-orm";
-import { PgDialect } from "drizzle-orm/pg-core";
 import { describe, expect, it, vi } from "vitest";
 
 import { NextlyError } from "../../../../errors/nextly-error";
@@ -11,6 +9,7 @@ import {
   assertNoMigrationInFlight,
   withMigrationExcluded,
 } from "../sync-guard";
+import { createLockingAdapter } from "./helpers/locking-adapter";
 
 const PLAN: ManifestEntry[] = [
   { kind: "registry", from: "dynamic_components", to: "dynamic_field_groups" },
@@ -156,105 +155,11 @@ describe("schema sync guard", () => {
   });
 });
 
-/**
- * An adapter that models the lock row rather than accepting every write.
- *
- * The lock is the whole mechanism under test, so a double that let a second
- * claim succeed would certify exclusion that does not exist.
- */
-function lockingAdapter(options: {
-  marker?: unknown;
-  heldBy?: string | null;
-  lockTableExists?: boolean;
-}) {
-  const lock: { seeded: boolean; owner: string | null } = {
-    seeded: options.heldBy !== undefined,
-    owner: options.heldBy ?? null,
-  };
-  const ddl: string[] = [];
-
-  // Compiled through a real dialect, so the double interprets the SQL and the
-  // bound parameters an adapter would hand its driver rather than a
-  // query-builder call the lock no longer makes.
-  function interpret(statement: SQL): Record<string, unknown>[] {
-    const { sql: text, params } = new PgDialect().sqlToQuery(statement);
-    const flat = text.replace(/\s+/g, " ").trim();
-
-    if (
-      /^SELECT "\w+" FROM "nextly_field_group_lock" WHERE "id" = \$1$/.test(
-        flat
-      )
-    ) {
-      return lock.seeded ? [{ id: 1, owner: lock.owner }] : [];
-    }
-    if (
-      /^UPDATE "nextly_field_group_lock" SET "owner" = \$1 WHERE "id" = \$2$/.test(
-        flat
-      )
-    ) {
-      // An occupied row refuses a new claim, exactly as the real one does:
-      // `acquire` reads back what it wrote, so a double that overwrote a held
-      // lock would report a successful claim over a live migration.
-      if (lock.owner === null) lock.owner = params[0] as string | null;
-      return [];
-    }
-    if (
-      /^UPDATE "nextly_field_group_lock" SET "owner" = NULL WHERE "id" = \$1 AND "owner" = \$2$/.test(
-        flat
-      )
-    ) {
-      if (lock.owner === params[1]) lock.owner = null;
-      return [];
-    }
-    throw new Error(`unrecognised statement: ${flat}`);
-  }
-
-  const adapter = {
-    getCapabilities: () => ({ dialect: "postgresql" }),
-    getDrizzle: () => ({
-      select: () => ({
-        from: () => ({
-          where: () => ({
-            limit: async () =>
-              options.marker === undefined
-                ? []
-                : [{ key: "k", value: JSON.stringify(options.marker) }],
-          }),
-        }),
-      }),
-    }),
-    executeQuery: async (sql: string) => {
-      ddl.push(sql);
-      return [];
-    },
-    queryStatement: async (statement: SQL) => interpret(statement),
-    tableExists: async (name: string) =>
-      name === "nextly_field_group_lock"
-        ? (options.lockTableExists ?? true)
-        : true,
-    transaction: async (work: (ctx: unknown) => Promise<unknown>) =>
-      work({
-        lockRow: async () => undefined,
-        insert: async (_table: string, data: { owner: string | null }) => {
-          lock.seeded = true;
-          lock.owner = data.owner;
-          return data;
-        },
-        runStatement: async (statement: SQL) => {
-          interpret(statement);
-        },
-        queryStatement: async (statement: SQL) => interpret(statement),
-      }),
-  } as unknown as DrizzleAdapter;
-
-  return { adapter, ownerNow: () => lock.owner, ddlIssued: () => [...ddl] };
-}
-
 describe("holding the exclusion for the whole sync", () => {
   // The point of the change: a point-in-time read only says a migration had not
   // started by the instant of the read, and a sync runs far longer than that.
   it("holds the migration lock while the work runs, and releases it after", async () => {
-    const { adapter, ownerNow } = lockingAdapter({});
+    const { adapter, ownerNow } = createLockingAdapter({});
     let ownerDuringWork: string | null = null;
 
     await withMigrationExcluded(
@@ -270,7 +175,9 @@ describe("holding the exclusion for the whole sync", () => {
   });
 
   it("refuses, and never runs the work, while a migration holds the lock", async () => {
-    const { adapter } = lockingAdapter({ heldBy: "field-group-migration#abc" });
+    const { adapter } = createLockingAdapter({
+      heldBy: "field-group-migration#abc",
+    });
     const work = vi.fn(() => Promise.resolve());
 
     const error = await withMigrationExcluded(
@@ -286,7 +193,7 @@ describe("holding the exclusion for the whole sync", () => {
   // files, and a role granted DML but not DDL would be refused outright by a
   // CREATE TABLE. The sync therefore never creates the lock table.
   it("issues no DDL when the caller may not change schema", async () => {
-    const { adapter, ddlIssued } = lockingAdapter({});
+    const { adapter, ddlIssued } = createLockingAdapter({});
     await withMigrationExcluded(
       { adapter, logger, label: "db:sync", mayCreateLock: false },
       () => Promise.resolve()
@@ -298,7 +205,9 @@ describe("holding the exclusion for the whole sync", () => {
   // there is nothing to be excluded from — and nothing worth creating a table
   // for on a database whose role may not be allowed to.
   it("runs the work when no lock table exists and it may not create one", async () => {
-    const { adapter, ddlIssued } = lockingAdapter({ lockTableExists: false });
+    const { adapter, ddlIssued } = createLockingAdapter({
+      lockTableExists: false,
+    });
     const work = vi.fn(() => Promise.resolve());
 
     await withMigrationExcluded(
@@ -314,38 +223,42 @@ describe("holding the exclusion for the whole sync", () => {
   // with no expiry, so without this a routine interrupt would leave a claim
   // only an operator could clear — blocking every later sync and migration.
   it("releases the claim when the process is interrupted", async () => {
-    const { adapter, ownerNow } = lockingAdapter({});
+    const { adapter, ownerNow } = createLockingAdapter({});
     const exits: string[] = [];
+    // Restored in `finally`: a failure before the restore would otherwise leave
+    // the global mocked for every later test in the file.
     const kill = vi
       .spyOn(process, "kill")
       .mockImplementation((_pid: number, signal?: string | number) => {
         exits.push(String(signal));
         return true;
       });
+    try {
+      let ownerWhileHeld: string | null = null;
+      await withMigrationExcluded(
+        { adapter, logger, label: "db:sync watch", mayCreateLock: true },
+        async () => {
+          ownerWhileHeld = ownerNow();
+          process.emit("SIGINT");
+          // Let the release settle before the work returns, so this observes the
+          // signal path rather than the ordinary one in `finally`.
+          await new Promise(resolve => setImmediate(resolve));
+          expect(ownerNow()).toBeNull();
+        }
+      );
 
-    let ownerWhileHeld: string | null = null;
-    await withMigrationExcluded(
-      { adapter, logger, label: "db:sync watch", mayCreateLock: true },
-      async () => {
-        ownerWhileHeld = ownerNow();
-        process.emit("SIGINT");
-        // Let the release settle before the work returns, so this observes the
-        // signal path rather than the ordinary one in `finally`.
-        await new Promise(resolve => setImmediate(resolve));
-        expect(ownerNow()).toBeNull();
-      }
-    );
-
-    expect(ownerWhileHeld).not.toBeNull();
-    expect(exits).toContain("SIGINT");
-    kill.mockRestore();
+      expect(ownerWhileHeld).not.toBeNull();
+      expect(exits).toContain("SIGINT");
+    } finally {
+      kill.mockRestore();
+    }
   });
 
   // A sync allowed to change schema creates the lock table rather than running
   // unprotected: otherwise a first-ever migration could create it and claim it
   // while the sync was already in flight.
   it("creates the lock table when it may, so the exclusion is real", async () => {
-    const { adapter, ddlIssued, ownerNow } = lockingAdapter({
+    const { adapter, ddlIssued, ownerNow } = createLockingAdapter({
       lockTableExists: false,
     });
     let ownerDuringWork: string | null = null;
@@ -366,7 +279,7 @@ describe("holding the exclusion for the whole sync", () => {
   // dead run's lock row without settling its marker would otherwise be let
   // straight into half-renamed storage.
   it("still refuses on an in-flight marker when the lock is free", async () => {
-    const { adapter } = lockingAdapter({ marker: migrating() });
+    const { adapter } = createLockingAdapter({ marker: migrating() });
     const work = vi.fn(() => Promise.resolve());
 
     const error = await withMigrationExcluded(

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
@@ -5,7 +5,10 @@ import { NextlyError } from "../../../../errors/nextly-error";
 import type { Logger } from "../../../../shared/types";
 import { hashManifest, type ManifestEntry } from "../manifest";
 import { MIGRATION_MARKER_VERSION } from "../state";
-import { assertNoMigrationInFlight } from "../sync-guard";
+import {
+  assertNoMigrationInFlight,
+  withMigrationExcluded,
+} from "../sync-guard";
 
 const PLAN: ManifestEntry[] = [
   { kind: "registry", from: "dynamic_components", to: "dynamic_field_groups" },
@@ -108,5 +111,116 @@ describe("schema sync guard", () => {
         logger,
       })
     ).rejects.toThrowError(NextlyError);
+  });
+});
+
+/**
+ * An adapter that models the lock row rather than accepting every write.
+ *
+ * The lock is the whole mechanism under test, so a double that let a second
+ * claim succeed would certify exclusion that does not exist.
+ */
+function lockingAdapter(options: { marker?: unknown; heldBy?: string | null }) {
+  const lock: { seeded: boolean; owner: string | null } = {
+    seeded: options.heldBy !== undefined,
+    owner: options.heldBy ?? null,
+  };
+
+  function matches(where: unknown): boolean {
+    const clauses =
+      (where as { and?: { column: string; value: unknown }[] }).and ?? [];
+    return clauses.every(clause =>
+      clause.column === "owner" ? lock.owner === clause.value : true
+    );
+  }
+
+  const adapter = {
+    getCapabilities: () => ({ dialect: "postgresql" }),
+    getDrizzle: () => ({
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: async () =>
+              options.marker === undefined
+                ? []
+                : [{ key: "k", value: JSON.stringify(options.marker) }],
+          }),
+        }),
+      }),
+    }),
+    executeQuery: async () => [],
+    transaction: async (work: (ctx: unknown) => Promise<unknown>) =>
+      work({
+        lockRow: async () => undefined,
+        selectOne: async () =>
+          lock.seeded ? { id: 1, owner: lock.owner } : null,
+        insert: async (_table: string, data: { owner: string | null }) => {
+          lock.seeded = true;
+          lock.owner = data.owner;
+          return data;
+        },
+        update: async (
+          _table: string,
+          data: { owner: string | null },
+          where: unknown
+        ) => {
+          // An occupied row refuses a new claim, exactly as the real one does:
+          // `acquire` reads back what it wrote, so a double that overwrote a
+          // held lock would report a successful claim over a live migration.
+          if (matches(where)) lock.owner = data.owner;
+          return [];
+        },
+      }),
+  } as unknown as DrizzleAdapter;
+
+  return { adapter, ownerNow: () => lock.owner };
+}
+
+describe("holding the exclusion for the whole sync", () => {
+  // The point of the change: a point-in-time read only says a migration had not
+  // started by the instant of the read, and a sync runs far longer than that.
+  it("holds the migration lock while the work runs, and releases it after", async () => {
+    const { adapter, ownerNow } = lockingAdapter({});
+    let ownerDuringWork: string | null = null;
+
+    await withMigrationExcluded({ adapter, logger, label: "db:sync" }, () => {
+      ownerDuringWork = ownerNow();
+      return Promise.resolve();
+    });
+
+    expect(ownerDuringWork).not.toBeNull();
+    expect(ownerNow()).toBeNull();
+  });
+
+  it("refuses, and never runs the work, while a migration holds the lock", async () => {
+    const { adapter } = lockingAdapter({ heldBy: "field-group-migration#abc" });
+    const work = vi.fn(() => Promise.resolve());
+
+    const error = await withMigrationExcluded(
+      { adapter, logger, label: "db:sync" },
+      work
+    ).catch((caught: unknown) => caught);
+
+    expect(NextlyError.is(error)).toBe(true);
+    expect(work).not.toHaveBeenCalled();
+  });
+
+  // Holding the lock is necessary and not sufficient. An operator who cleared a
+  // dead run's lock row without settling its marker would otherwise be let
+  // straight into half-renamed storage.
+  it("still refuses on an in-flight marker when the lock is free", async () => {
+    const { adapter } = lockingAdapter({ marker: migrating() });
+    const work = vi.fn(() => Promise.resolve());
+
+    const error = await withMigrationExcluded(
+      { adapter, logger, label: "db:sync" },
+      work
+    ).catch((caught: unknown) => caught);
+
+    expect(NextlyError.is(error)).toBe(true);
+    if (NextlyError.is(error)) {
+      expect(error.logContext?.reason).toMatch(/migration is in flight/);
+    }
+    expect(work).not.toHaveBeenCalled();
   });
 });

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
@@ -18,11 +18,15 @@ const PLAN: ManifestEntry[] = [
  * A `nextly_meta` stand-in. The guard reads through `MetaService`, which selects
  * from the meta table, so the double answers that select and nothing else.
  */
-function adapterWith(marker: unknown): DrizzleAdapter {
+function adapterWith(
+  marker: unknown,
+  over: { metaTableExists?: boolean } = {}
+): DrizzleAdapter {
   return {
     // `MetaService` picks its dialect-specific table through this, so a double
     // without it answers a query the real service never issues.
     getCapabilities: () => ({ dialect: "postgresql" }),
+    tableExists: async () => over.metaTableExists ?? true,
     getDrizzle: () => ({
       select: () => ({
         from: () => ({
@@ -101,6 +105,42 @@ describe("schema sync guard", () => {
     ).resolves.toBeUndefined();
   });
 
+  // Core-table setup returns as soon as it finds `users`, so a database created
+  // before `nextly_meta` existed reaches this guard without it. No meta table
+  // means no marker was ever recorded, which is untouched storage rather than a
+  // reason to abort every sync on that database.
+  it("allows a sync on a database that has no meta table", async () => {
+    await expect(
+      assertNoMigrationInFlight({
+        adapter: adapterWith(migrating(), { metaTableExists: false }),
+        logger,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  // Absence of the table is the only thing treated as absence. A read that
+  // fails for any other reason still refuses, because an unreadable marker may
+  // describe renamed objects.
+  it("still refuses when the marker table exists but cannot be read", async () => {
+    const adapter = {
+      getCapabilities: () => ({ dialect: "postgresql" }),
+      tableExists: async () => true,
+      getDrizzle: () => ({
+        select: () => ({
+          from: () => ({
+            where: () => ({
+              limit: () => Promise.reject(new Error("connection lost")),
+            }),
+          }),
+        }),
+      }),
+    } as unknown as DrizzleAdapter;
+
+    await expect(
+      assertNoMigrationInFlight({ adapter, logger })
+    ).rejects.toThrowError();
+  });
+
   // An unreadable marker may still describe renamed objects, so it must not be
   // treated as absence — which would let the sync proceed over exactly the
   // storage this guard exists to protect.
@@ -149,6 +189,7 @@ function lockingAdapter(options: { marker?: unknown; heldBy?: string | null }) {
       }),
     }),
     executeQuery: async () => [],
+    tableExists: async () => true,
     transaction: async (work: (ctx: unknown) => Promise<unknown>) =>
       work({
         lockRow: async () => undefined,

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
@@ -1,0 +1,112 @@
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import { describe, expect, it, vi } from "vitest";
+
+import { NextlyError } from "../../../../errors/nextly-error";
+import type { Logger } from "../../../../shared/types";
+import { hashManifest, type ManifestEntry } from "../manifest";
+import { MIGRATION_MARKER_VERSION } from "../state";
+import { assertNoMigrationInFlight } from "../sync-guard";
+
+const PLAN: ManifestEntry[] = [
+  { kind: "registry", from: "dynamic_components", to: "dynamic_field_groups" },
+];
+
+/**
+ * A `nextly_meta` stand-in. The guard reads through `MetaService`, which selects
+ * from the meta table, so the double answers that select and nothing else.
+ */
+function adapterWith(marker: unknown): DrizzleAdapter {
+  return {
+    // `MetaService` picks its dialect-specific table through this, so a double
+    // without it answers a query the real service never issues.
+    getCapabilities: () => ({ dialect: "postgresql" }),
+    getDrizzle: () => ({
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: async () =>
+              marker === undefined
+                ? []
+                : [{ key: "k", value: JSON.stringify(marker) }],
+          }),
+        }),
+      }),
+    }),
+  } as unknown as DrizzleAdapter;
+}
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+} as unknown as Logger;
+
+function migrating(over: Record<string, unknown> = {}) {
+  return {
+    version: MIGRATION_MARKER_VERSION,
+    status: "migrating",
+    direction: "up",
+    migrationId: "run-1",
+    step: 2,
+    slugsHash: "slugs-1",
+    manifestHash: hashManifest(PLAN),
+    appliedManifest: PLAN,
+    ...over,
+  };
+}
+
+describe("schema sync guard", () => {
+  // Mid-run some tables carry pre-rename names and some post-rename, and the
+  // registry pointers move one step at a time. `--remove-orphaned` deletes what
+  // it cannot account for, so a sync here can drop half-renamed storage.
+  it.each(["up", "down"] as const)(
+    "refuses while a %s migration is in flight",
+    async direction => {
+      const error = await assertNoMigrationInFlight({
+        adapter: adapterWith(migrating({ direction })),
+        logger,
+      }).catch((caught: unknown) => caught);
+
+      expect(NextlyError.is(error)).toBe(true);
+      if (NextlyError.is(error)) {
+        expect(error.logContext?.reason).toMatch(/migration is in flight/);
+        // The refusal names the run so an operator can find it rather than only
+        // learning that something is wrong.
+        expect(error.logContext?.migrationId).toBe("run-1");
+        expect(error.logContext?.step).toBe(2);
+      }
+    }
+  );
+
+  it("allows a sync on a database with no marker", async () => {
+    await expect(
+      assertNoMigrationInFlight({ adapter: adapterWith(undefined), logger })
+    ).resolves.toBeUndefined();
+  });
+
+  it("allows a sync once a run has settled", async () => {
+    await expect(
+      assertNoMigrationInFlight({
+        adapter: adapterWith({
+          version: MIGRATION_MARKER_VERSION,
+          status: "settled",
+          generation: "legacy",
+        }),
+        logger,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  // An unreadable marker may still describe renamed objects, so it must not be
+  // treated as absence — which would let the sync proceed over exactly the
+  // storage this guard exists to protect.
+  it("refuses on a marker it cannot read", async () => {
+    await expect(
+      assertNoMigrationInFlight({
+        adapter: adapterWith({ version: 999, status: "migrating" }),
+        logger,
+      })
+    ).rejects.toThrowError(NextlyError);
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
@@ -1,4 +1,6 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
 import { describe, expect, it, vi } from "vitest";
 
 import { NextlyError } from "../../../../errors/nextly-error";
@@ -171,12 +173,40 @@ function lockingAdapter(options: {
   };
   const ddl: string[] = [];
 
-  function matches(where: unknown): boolean {
-    const clauses =
-      (where as { and?: { column: string; value: unknown }[] }).and ?? [];
-    return clauses.every(clause =>
-      clause.column === "owner" ? lock.owner === clause.value : true
-    );
+  // Compiled through a real dialect, so the double interprets the SQL and the
+  // bound parameters an adapter would hand its driver rather than a
+  // query-builder call the lock no longer makes.
+  function interpret(statement: SQL): Record<string, unknown>[] {
+    const { sql: text, params } = new PgDialect().sqlToQuery(statement);
+    const flat = text.replace(/\s+/g, " ").trim();
+
+    if (
+      /^SELECT "\w+" FROM "nextly_field_group_lock" WHERE "id" = \$1$/.test(
+        flat
+      )
+    ) {
+      return lock.seeded ? [{ id: 1, owner: lock.owner }] : [];
+    }
+    if (
+      /^UPDATE "nextly_field_group_lock" SET "owner" = \$1 WHERE "id" = \$2$/.test(
+        flat
+      )
+    ) {
+      // An occupied row refuses a new claim, exactly as the real one does:
+      // `acquire` reads back what it wrote, so a double that overwrote a held
+      // lock would report a successful claim over a live migration.
+      if (lock.owner === null) lock.owner = params[0] as string | null;
+      return [];
+    }
+    if (
+      /^UPDATE "nextly_field_group_lock" SET "owner" = NULL WHERE "id" = \$1 AND "owner" = \$2$/.test(
+        flat
+      )
+    ) {
+      if (lock.owner === params[1]) lock.owner = null;
+      return [];
+    }
+    throw new Error(`unrecognised statement: ${flat}`);
   }
 
   const adapter = {
@@ -197,6 +227,7 @@ function lockingAdapter(options: {
       ddl.push(sql);
       return [];
     },
+    queryStatement: async (statement: SQL) => interpret(statement),
     tableExists: async (name: string) =>
       name === "nextly_field_group_lock"
         ? (options.lockTableExists ?? true)
@@ -204,24 +235,15 @@ function lockingAdapter(options: {
     transaction: async (work: (ctx: unknown) => Promise<unknown>) =>
       work({
         lockRow: async () => undefined,
-        selectOne: async () =>
-          lock.seeded ? { id: 1, owner: lock.owner } : null,
         insert: async (_table: string, data: { owner: string | null }) => {
           lock.seeded = true;
           lock.owner = data.owner;
           return data;
         },
-        update: async (
-          _table: string,
-          data: { owner: string | null },
-          where: unknown
-        ) => {
-          // An occupied row refuses a new claim, exactly as the real one does:
-          // `acquire` reads back what it wrote, so a double that overwrote a
-          // held lock would report a successful claim over a live migration.
-          if (matches(where)) lock.owner = data.owner;
-          return [];
+        runStatement: async (statement: SQL) => {
+          interpret(statement);
         },
+        queryStatement: async (statement: SQL) => interpret(statement),
       }),
   } as unknown as DrizzleAdapter;
 

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
@@ -49,7 +49,7 @@ function migrating(over: Record<string, unknown> = {}) {
     direction: "up",
     migrationId: "run-1",
     step: 2,
-    slugsHash: "slugs-1",
+    registryHash: "slugs-1",
     manifestHash: hashManifest(PLAN),
     appliedManifest: PLAN,
     ...over,

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/sync-guard.test.ts
@@ -257,10 +257,13 @@ describe("holding the exclusion for the whole sync", () => {
     const { adapter, ownerNow } = lockingAdapter({});
     let ownerDuringWork: string | null = null;
 
-    await withMigrationExcluded({ adapter, logger, label: "db:sync" }, () => {
-      ownerDuringWork = ownerNow();
-      return Promise.resolve();
-    });
+    await withMigrationExcluded(
+      { adapter, logger, label: "db:sync", mayCreateLock: true },
+      () => {
+        ownerDuringWork = ownerNow();
+        return Promise.resolve();
+      }
+    );
 
     expect(ownerDuringWork).not.toBeNull();
     expect(ownerNow()).toBeNull();
@@ -271,7 +274,7 @@ describe("holding the exclusion for the whole sync", () => {
     const work = vi.fn(() => Promise.resolve());
 
     const error = await withMigrationExcluded(
-      { adapter, logger, label: "db:sync" },
+      { adapter, logger, label: "db:sync", mayCreateLock: true },
       work
     ).catch((caught: unknown) => caught);
 
@@ -282,10 +285,11 @@ describe("holding the exclusion for the whole sync", () => {
   // `--no-auto-sync` is chosen precisely to keep schema changes in migration
   // files, and a role granted DML but not DDL would be refused outright by a
   // CREATE TABLE. The sync therefore never creates the lock table.
-  it("issues no DDL while taking the exclusion", async () => {
+  it("issues no DDL when the caller may not change schema", async () => {
     const { adapter, ddlIssued } = lockingAdapter({});
-    await withMigrationExcluded({ adapter, logger, label: "db:sync" }, () =>
-      Promise.resolve()
+    await withMigrationExcluded(
+      { adapter, logger, label: "db:sync", mayCreateLock: false },
+      () => Promise.resolve()
     );
     expect(ddlIssued().filter(sql => /CREATE TABLE/i.test(sql))).toEqual([]);
   });
@@ -293,11 +297,14 @@ describe("holding the exclusion for the whole sync", () => {
   // Absence of the lock table means no run has ever been recorded here, so
   // there is nothing to be excluded from — and nothing worth creating a table
   // for on a database whose role may not be allowed to.
-  it("runs the work when no lock table exists", async () => {
+  it("runs the work when no lock table exists and it may not create one", async () => {
     const { adapter, ddlIssued } = lockingAdapter({ lockTableExists: false });
     const work = vi.fn(() => Promise.resolve());
 
-    await withMigrationExcluded({ adapter, logger, label: "db:sync" }, work);
+    await withMigrationExcluded(
+      { adapter, logger, label: "db:sync", mayCreateLock: false },
+      work
+    );
 
     expect(work).toHaveBeenCalledTimes(1);
     expect(ddlIssued()).toEqual([]);
@@ -318,7 +325,7 @@ describe("holding the exclusion for the whole sync", () => {
 
     let ownerWhileHeld: string | null = null;
     await withMigrationExcluded(
-      { adapter, logger, label: "db:sync watch" },
+      { adapter, logger, label: "db:sync watch", mayCreateLock: true },
       async () => {
         ownerWhileHeld = ownerNow();
         process.emit("SIGINT");
@@ -334,6 +341,27 @@ describe("holding the exclusion for the whole sync", () => {
     kill.mockRestore();
   });
 
+  // A sync allowed to change schema creates the lock table rather than running
+  // unprotected: otherwise a first-ever migration could create it and claim it
+  // while the sync was already in flight.
+  it("creates the lock table when it may, so the exclusion is real", async () => {
+    const { adapter, ddlIssued, ownerNow } = lockingAdapter({
+      lockTableExists: false,
+    });
+    let ownerDuringWork: string | null = null;
+
+    await withMigrationExcluded(
+      { adapter, logger, label: "db:sync", mayCreateLock: true },
+      () => {
+        ownerDuringWork = ownerNow();
+        return Promise.resolve();
+      }
+    );
+
+    expect(ddlIssued().some(sql => /CREATE TABLE/i.test(sql))).toBe(true);
+    expect(ownerDuringWork).not.toBeNull();
+  });
+
   // Holding the lock is necessary and not sufficient. An operator who cleared a
   // dead run's lock row without settling its marker would otherwise be let
   // straight into half-renamed storage.
@@ -342,7 +370,7 @@ describe("holding the exclusion for the whole sync", () => {
     const work = vi.fn(() => Promise.resolve());
 
     const error = await withMigrationExcluded(
-      { adapter, logger, label: "db:sync" },
+      { adapter, logger, label: "db:sync", mayCreateLock: true },
       work
     ).catch((caught: unknown) => caught);
 

--- a/packages/nextly/src/domains/field-groups/migration/guard.ts
+++ b/packages/nextly/src/domains/field-groups/migration/guard.ts
@@ -21,7 +21,11 @@ import { NextlyError } from "../../../errors/nextly-error";
 
 import type { ManifestEntry } from "./manifest";
 import { MAX_MIGRATION_STEP } from "./state";
-import type { MigrationPlanIdentity, MigrationState } from "./state";
+import type {
+  MigrationDirection,
+  MigrationPlanIdentity,
+  MigrationState,
+} from "./state";
 
 /**
  * Whether every object the migrated registry points at is actually there and
@@ -68,22 +72,19 @@ export type StorageVerdict =
   | {
       action: "resume";
       step: number;
-      direction: "up";
+      direction: MigrationDirection;
       migrationId: string;
       plan: MigrationPlanIdentity;
-    }
-  | {
       /**
-       * Resuming a rollback. The plan being reversed travels with the verdict
-       * because it cannot be derived: nothing in the database says which names
-       * this migration created, so a restarted process has no other source for
-       * the steps it still has to undo.
+       * The canonical plan the interrupted run was executing.
+       *
+       * Travels with the verdict in both directions because it cannot be
+       * rebuilt: nothing in the database says which names this migration
+       * created, and once each rename rewrites its registry pointer a rebuilt
+       * plan omits the work already done, so its step positions no longer mean
+       * what the recorded position means. An `up` resume applies it from
+       * `step + 1`; a `down` resume reverses it.
        */
-      action: "resume";
-      step: number;
-      direction: "down";
-      migrationId: string;
-      plan: MigrationPlanIdentity;
       appliedManifest: readonly ManifestEntry[];
     };
 
@@ -115,31 +116,13 @@ export function resolveStorageVerdict(args: {
     // a state only the step list can interpret. The run's own identity travels
     // with the step so the resumed run picks the right list, keeps the same id,
     // and can refuse a plan that moved underneath it.
-    if (state.direction === "down") {
-      // A rollback reverses a recorded plan. An in-flight `down` marker without
-      // one cannot be resumed at all, and guessing the reverse from the database
-      // would rename names this migration never created.
-      if (state.appliedManifest === undefined) {
-        throw refuse("an interrupted rollback recorded no plan to reverse", {
-          step: state.step,
-          migrationId: state.migrationId,
-        });
-      }
-      return {
-        action: "resume",
-        step: state.step + 1,
-        direction: "down",
-        migrationId: state.migrationId,
-        plan: state.plan,
-        appliedManifest: state.appliedManifest,
-      };
-    }
     return {
       action: "resume",
       step: state.step + 1,
-      direction: "up",
+      direction: state.direction,
       migrationId: state.migrationId,
       plan: state.plan,
+      appliedManifest: state.appliedManifest,
     };
   }
 

--- a/packages/nextly/src/domains/field-groups/migration/manifest.ts
+++ b/packages/nextly/src/domains/field-groups/migration/manifest.ts
@@ -258,13 +258,21 @@ export function buildMigrationManifest(
  * migration's own completed work — letting a resume adopt the author's table and
  * a later rollback rename it away.
  *
+ * `hasCompanion` is part of the identity because the plan's shape depends on it,
+ * not just on which rows exist. Enabling localization on a field group creates a
+ * companion table without replacing the registry row, so id and slug alone stay
+ * identical while the storage the plan describes gains a table the recorded plan
+ * never names — and the resume would move the base and leave the companion.
+ *
  * Sorted by id so the hash is a property of the set rather than of row order.
  */
 export function hashRegistryIdentity(
-  rows: readonly { id: string; slug: string }[]
+  rows: readonly { id: string; slug: string; hasCompanion: boolean }[]
 ): string {
   const canonical = JSON.stringify(
-    rows.map(row => [row.id, row.slug]).sort((a, b) => (a[0] < b[0] ? -1 : 1))
+    rows
+      .map(row => [row.id, row.slug, row.hasCompanion])
+      .sort((a, b) => (a[0] < b[0] ? -1 : 1))
   );
   return createHash("sha256").update(canonical).digest("hex");
 }

--- a/packages/nextly/src/domains/field-groups/migration/manifest.ts
+++ b/packages/nextly/src/domains/field-groups/migration/manifest.ts
@@ -60,13 +60,31 @@ export interface RegistryRow {
   hasCompanion: boolean;
 }
 
+/** A companion table's rename, carried by the entry for the table it belongs to. */
+export interface CompanionRename {
+  from: string;
+  to: string;
+}
+
 /** One thing the migration will rename. */
 export interface ManifestEntry {
-  kind: "registry" | "table" | "companion" | "column";
+  kind: "registry" | "table" | "column";
   from: string;
   to: string;
   /** Set for `column`, naming the table the column belongs to. */
   table?: string;
+  /**
+   * The localization companion that moves with this table.
+   *
+   * A property rather than an entry of its own, because a companion is not an
+   * independent object: it has no registry row, its name is derived from its
+   * owner's `table_name`, and it can never be renamed apart from its owner. As a
+   * sibling entry it occupied a second step position, which left the resume
+   * crash window unable to explain it and let `invertManifest`'s order reversal
+   * separate it from the owner it must move with. Held here, neither is
+   * expressible.
+   */
+  companion?: CompanionRename;
   /**
    * This rename is already reflected in the database.
    *
@@ -134,6 +152,17 @@ export function invertManifest(
     from: entry.to,
     to: entry.from,
     ...(entry.table === undefined ? {} : { table: entry.table }),
+    // Inverted with its owner rather than beside it. Order reverses here, so a
+    // companion held as a separate entry would come to precede the table it
+    // belongs to and stop being recognised as its companion at all.
+    ...(entry.companion === undefined
+      ? {}
+      : {
+          companion: {
+            from: entry.companion.to,
+            to: entry.companion.from,
+          },
+        }),
   }));
   return { entries: inverted, hash: hashManifest(inverted) };
 }
@@ -174,18 +203,22 @@ export function buildMigrationManifest(
     const target = retargetName(row);
 
     if (target !== null) {
-      entries.push({ kind: "table", from: row.tableName, to: target });
-
-      if (row.hasCompanion) {
-        // Derived from the table name that was read, not from the slug, so a
-        // custom-named table's companion is still found.
-        const suffix = STORAGE_FORMAT.companionSuffix;
-        entries.push({
-          kind: "companion",
-          from: `${row.tableName}${suffix}`,
-          to: `${target}${suffix}`,
-        });
-      }
+      // Derived from the table name that was read, not from the slug, so a
+      // custom-named table's companion is still found.
+      const suffix = STORAGE_FORMAT.companionSuffix;
+      entries.push({
+        kind: "table",
+        from: row.tableName,
+        to: target,
+        ...(row.hasCompanion
+          ? {
+              companion: {
+                from: `${row.tableName}${suffix}`,
+                to: `${target}${suffix}`,
+              },
+            }
+          : {}),
+      });
     }
 
     // Every field-group data table carries the discriminator column: the schema
@@ -255,8 +288,19 @@ export function hashManifest(entries: readonly ManifestEntry[]): string {
   // `satisfied` is deliberately excluded: progress is not identity. A plan whose
   // steps have partly run is the same plan, and the marker must still recognise
   // it on resume.
+  //
+  // The companion is part of the map because it names a second physical table
+  // this step moves. Omitting it would let two plans that rename the same table
+  // but disagree about whether it has a companion hash identically, and a resume
+  // would then accept a plan that moves one more object than the one recorded.
   const canonical = JSON.stringify(
-    entries.map(e => [e.kind, e.table ?? null, e.from, e.to])
+    entries.map(e => [
+      e.kind,
+      e.table ?? null,
+      e.from,
+      e.to,
+      e.companion === undefined ? null : [e.companion.from, e.companion.to],
+    ])
   );
   return createHash("sha256").update(canonical).digest("hex");
 }
@@ -365,7 +409,7 @@ function assertNoTargetConflict(
   rows: readonly RegistryRow[]
 ): void {
   const renamedAway = new Set(
-    entries.filter(e => e.kind !== "column").map(e => fold(e.from))
+    entries.flatMap(tableRenamesOf).map(rename => fold(rename.from))
   );
   // A row this plan leaves alone keeps its companion as well as its base table,
   // so both names stay occupied. Reserving only the base name let another row's
@@ -380,36 +424,50 @@ function assertNoTargetConflict(
   }
 
   const claimed = new Map<string, string>();
-  for (const entry of entries) {
-    if (entry.kind === "column") continue;
-    const key = fold(entry.to);
+  for (const rename of entries.flatMap(tableRenamesOf)) {
+    const key = fold(rename.to);
 
     if (kept.has(key)) {
       throw refuseRename(
-        entry,
+        rename,
         "migration target name is already in use",
-        `${entry.to} belongs to a field group this plan leaves unchanged`
+        `${rename.to} belongs to a field group this plan leaves unchanged`
       );
     }
     const previous = claimed.get(key);
     if (previous !== undefined) {
       throw refuseRename(
-        entry,
+        rename,
         "two objects would be renamed to the same name",
-        `${previous} also renames to ${entry.to}`
+        `${previous} also renames to ${rename.to}`
       );
     }
-    claimed.set(key, entry.from);
+    claimed.set(key, rename.from);
   }
 }
 
+/**
+ * Every physical table an entry moves: its own, and its companion's.
+ *
+ * A companion occupies a name and can collide exactly like a table that has an
+ * entry, so name checks have to see it even though it no longer has one of its
+ * own. Column entries move no table and contribute nothing.
+ */
+export function tableRenamesOf(
+  entry: ManifestEntry
+): { from: string; to: string }[] {
+  if (entry.kind === "column") return [];
+  const own = { from: entry.from, to: entry.to };
+  return entry.companion === undefined ? [own] : [own, entry.companion];
+}
+
 function refuseRename(
-  entry: ManifestEntry,
+  rename: { from: string; to: string },
   reason: string,
   detail: string
 ): NextlyError {
   return NextlyError.serviceUnavailable({
-    logMessage: `field-group migration cannot rename ${entry.from}: ${detail}`,
-    logContext: { reason, from: entry.from, to: entry.to, detail },
+    logMessage: `field-group migration cannot rename ${rename.from}: ${detail}`,
+    logContext: { reason, from: rename.from, to: rename.to, detail },
   });
 }

--- a/packages/nextly/src/domains/field-groups/migration/manifest.ts
+++ b/packages/nextly/src/domains/field-groups/migration/manifest.ts
@@ -38,6 +38,14 @@ export const MIGRATION_TARGET = {
 
 /** A registry row, as far as the migration is concerned. */
 export interface RegistryRow {
+  /**
+   * The registry row's own primary key.
+   *
+   * Stable across the run — renames rewrite `table_name`, never this — and not
+   * reusable by a row recreated under the same slug, which is what lets a resume
+   * tell a surviving field group from a replaced one.
+   */
+  id: string;
   slug: string;
   /** Read from `table_name`. Never recomputed from the slug. */
   tableName: string;
@@ -208,18 +216,23 @@ export function buildMigrationManifest(
 /**
  * Hash the set of field groups a run was planned against.
  *
- * Slugs, not table names. A slug is a field group's identity and does not change
- * for the life of a run, while `table_name` is rewritten as each rename commits —
- * so a hash over table names would stop matching partway through a run and
- * refuse the resume it exists to protect. This is what answers "did the set of
- * field groups move underneath the interrupted run", which is the question a
- * recorded step position depends on: a group created or deleted mid-run would
- * otherwise be left behind at the legacy prefix while everything else moved.
+ * Row id **and** slug, not table names. `table_name` is rewritten as each rename
+ * commits, so hashing it would stop matching partway through a run and refuse
+ * the resume it exists to protect. The id is what makes this an identity rather
+ * than a census: a slug alone cannot tell a group that survived from one that
+ * was deleted and recreated under the same name, and a recreated row carrying an
+ * author-chosen `dbName` of `fg_hero` would otherwise look exactly like the
+ * migration's own completed work — letting a resume adopt the author's table and
+ * a later rollback rename it away.
  *
- * Sorted so the hash is a property of the set rather than of row order.
+ * Sorted by id so the hash is a property of the set rather than of row order.
  */
-export function hashSlugSet(rows: readonly { slug: string }[]): string {
-  const canonical = JSON.stringify([...rows.map(row => row.slug)].sort());
+export function hashRegistryIdentity(
+  rows: readonly { id: string; slug: string }[]
+): string {
+  const canonical = JSON.stringify(
+    rows.map(row => [row.id, row.slug]).sort((a, b) => (a[0] < b[0] ? -1 : 1))
+  );
   return createHash("sha256").update(canonical).digest("hex");
 }
 

--- a/packages/nextly/src/domains/field-groups/migration/manifest.ts
+++ b/packages/nextly/src/domains/field-groups/migration/manifest.ts
@@ -206,6 +206,24 @@ export function buildMigrationManifest(
 }
 
 /**
+ * Hash the set of field groups a run was planned against.
+ *
+ * Slugs, not table names. A slug is a field group's identity and does not change
+ * for the life of a run, while `table_name` is rewritten as each rename commits —
+ * so a hash over table names would stop matching partway through a run and
+ * refuse the resume it exists to protect. This is what answers "did the set of
+ * field groups move underneath the interrupted run", which is the question a
+ * recorded step position depends on: a group created or deleted mid-run would
+ * otherwise be left behind at the legacy prefix while everything else moved.
+ *
+ * Sorted so the hash is a property of the set rather than of row order.
+ */
+export function hashSlugSet(rows: readonly { slug: string }[]): string {
+  const canonical = JSON.stringify([...rows.map(row => row.slug)].sort());
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+/**
  * Hash the plan's object map.
  *
  * Covers what will be renamed and in what order, so a schema change between an

--- a/packages/nextly/src/domains/field-groups/migration/observer.ts
+++ b/packages/nextly/src/domains/field-groups/migration/observer.ts
@@ -1,0 +1,127 @@
+/**
+ * Binds the migration's observations to the schema pipeline's introspection.
+ *
+ * The steps decide against an injected `StorageObserver` so they stay testable
+ * without a database. This is the one implementation of that seam, and it reads
+ * through `introspectLiveSnapshot` rather than issuing its own catalog queries:
+ * that function already answers the same question for all three dialects, and a
+ * second implementation of "what does this table look like" would drift from it
+ * exactly the way independent naming rules have drifted here before.
+ *
+ * @module domains/field-groups/migration/observer
+ */
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+
+import { NextlyError } from "../../../errors/nextly-error";
+import { introspectLiveSnapshot } from "../../schema/pipeline/diff/introspect-live";
+import { quoteIdent } from "../../schema/pipeline/sql-templates/identifier-quoting";
+
+import type { ObservedColumn, StorageObserver } from "./steps";
+
+/** The registry column holding a row's physical table name. */
+const REGISTRY_TABLE_NAME_COLUMN = "table_name";
+
+/**
+ * Observations a step needs that go beyond names, kept separate from
+ * `StorageObserver` so the step contract stays the smaller of the two.
+ */
+export interface IndexObserver {
+  /**
+   * A table's index names, or `undefined` when the snapshot did not track them.
+   *
+   * `undefined` is **not** "no indexes". Snapshots written before index data was
+   * recorded leave the field unset, and reading that as an empty list would
+   * report every index intact on a snapshot that never held any.
+   */
+  indexNames(table: string): Promise<string[] | undefined>;
+}
+
+/** Observe a live database through the schema pipeline's introspection. */
+export function createStorageObserver(
+  adapter: DrizzleAdapter
+): StorageObserver & IndexObserver {
+  const dialect = adapter.getCapabilities().dialect;
+
+  async function snapshotOf(table: string) {
+    const snapshot = await introspectLiveSnapshot(
+      adapter.getDrizzle(),
+      dialect,
+      [table]
+    );
+    return snapshot.tables.find(entry => entry.name === table);
+  }
+
+  return {
+    tables: async () => adapter.listTables(),
+
+    columns: async (_session, table): Promise<ObservedColumn[] | undefined> => {
+      const spec = await snapshotOf(table);
+      if (spec === undefined) return undefined;
+      return spec.columns.map(column => ({
+        name: column.name,
+        type: column.type,
+      }));
+    },
+
+    pointers: async (_session, registryTable): Promise<string[]> => {
+      // Addressed by a name the ORM's schema registry does not know: it resolves
+      // tables exactly by the name their Drizzle definition declares, and during
+      // a run the registry is under whichever name the plan has reached. The
+      // identifier is quoted; there are no values to bind.
+      const rows = await adapter.executeQuery<Record<string, unknown>>(
+        `SELECT ${quoteIdent(REGISTRY_TABLE_NAME_COLUMN, dialect)} FROM ${quoteIdent(registryTable, dialect)}`
+      );
+      return rows
+        .map(row => row[REGISTRY_TABLE_NAME_COLUMN])
+        .filter((value): value is string => typeof value === "string");
+    },
+
+    indexNames: async (table): Promise<string[] | undefined> => {
+      const spec = await snapshotOf(table);
+      if (spec === undefined) return undefined;
+      // Preserved as `undefined` rather than collapsed to `[]`, so a caller can
+      // tell "this table has no indexes" from "nobody recorded any".
+      if (spec.indexes === undefined) return undefined;
+      return spec.indexes.map(index => index.name);
+    },
+  };
+}
+
+/**
+ * Refuse when a rename did not carry a table's indexes with it.
+ *
+ * Renaming a table keeps its indexes on all three dialects, so a name missing
+ * afterwards means one was dropped rather than moved. Compared **by name**
+ * rather than by count: a count survives losing one index and gaining another,
+ * which is exactly the shape of the SQLite index loss this checks for.
+ *
+ * `before` being `undefined` means the step could not observe the source — the
+ * rename had already committed when it ran — and there is nothing to compare
+ * against. That is reported rather than silently passing, because the gap is
+ * real: a crash between a rename and its verification hides index loss, and only
+ * the end-of-run structural verification can catch it.
+ */
+export function findLostIndexes(
+  before: string[] | undefined,
+  after: string[] | undefined
+): { comparable: false } | { comparable: true; lost: string[] } {
+  if (before === undefined || after === undefined) return { comparable: false };
+  const present = new Set(after);
+  return { comparable: true, lost: before.filter(name => !present.has(name)) };
+}
+
+/** Build the refusal a lost index deserves. */
+export function refuseLostIndexes(args: {
+  table: string;
+  lost: string[];
+}): NextlyError {
+  return NextlyError.serviceUnavailable({
+    logMessage: `field-group migration lost indexes while renaming ${args.table}`,
+    logContext: {
+      reason: "rename did not carry the table's indexes",
+      table: args.table,
+      lost: args.lost,
+    },
+  });
+}

--- a/packages/nextly/src/domains/field-groups/migration/observer.ts
+++ b/packages/nextly/src/domains/field-groups/migration/observer.ts
@@ -22,25 +22,10 @@ import type { ObservedColumn, StorageObserver } from "./steps";
 /** The registry column holding a row's physical table name. */
 const REGISTRY_TABLE_NAME_COLUMN = "table_name";
 
-/**
- * Observations a step needs that go beyond names, kept separate from
- * `StorageObserver` so the step contract stays the smaller of the two.
- */
-export interface IndexObserver {
-  /**
-   * A table's index names, or `undefined` when the snapshot did not track them.
-   *
-   * `undefined` is **not** "no indexes". Snapshots written before index data was
-   * recorded leave the field unset, and reading that as an empty list would
-   * report every index intact on a snapshot that never held any.
-   */
-  indexNames(table: string): Promise<string[] | undefined>;
-}
-
 /** Observe a live database through the schema pipeline's introspection. */
 export function createStorageObserver(
   adapter: DrizzleAdapter
-): StorageObserver & IndexObserver {
+): StorageObserver {
   const dialect = adapter.getCapabilities().dialect;
 
   async function snapshotOf(table: string) {

--- a/packages/nextly/src/domains/field-groups/migration/observer.ts
+++ b/packages/nextly/src/domains/field-groups/migration/observer.ts
@@ -16,6 +16,11 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import { NextlyError } from "../../../errors/nextly-error";
 import { introspectLiveSnapshot } from "../../schema/pipeline/diff/introspect-live";
 import { quoteIdent } from "../../schema/pipeline/sql-templates/identifier-quoting";
+import {
+  indexCatalog,
+  resolveCatalogName,
+  type IdentifierCaseRules,
+} from "../../schema/utils/resolve-catalog-name";
 
 import type { ObservedColumn, StorageObserver } from "./steps";
 
@@ -24,7 +29,8 @@ const REGISTRY_TABLE_NAME_COLUMN = "table_name";
 
 /** Observe a live database through the schema pipeline's introspection. */
 export function createStorageObserver(
-  adapter: DrizzleAdapter
+  adapter: DrizzleAdapter,
+  identifierCase: IdentifierCaseRules
 ): StorageObserver {
   const dialect = adapter.getCapabilities().dialect;
 
@@ -34,7 +40,18 @@ export function createStorageObserver(
       dialect,
       [table]
     );
-    return snapshot.tables.find(entry => entry.name === table);
+    // Matched under the server's own rules, not by exact spelling. MySQL with
+    // `lower_case_table_names=1` answers a query for a mixed-case name while
+    // `information_schema` reports the lowercased one, so an exact comparison
+    // discards a snapshot that describes the very table that was asked for --
+    // and the caller then reads an existing table as missing.
+    const catalog = indexCatalog(
+      snapshot.tables.map(entry => entry.name),
+      identifierCase.tables
+    );
+    const resolved = resolveCatalogName(catalog, table);
+    if (resolved === undefined) return undefined;
+    return snapshot.tables.find(entry => entry.name === resolved);
   }
 
   return {

--- a/packages/nextly/src/domains/field-groups/migration/observer.ts
+++ b/packages/nextly/src/domains/field-groups/migration/observer.ts
@@ -12,10 +12,10 @@
  */
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import { sql } from "drizzle-orm";
 
 import { NextlyError } from "../../../errors/nextly-error";
 import { introspectLiveSnapshot } from "../../schema/pipeline/diff/introspect-live";
-import { quoteIdent } from "../../schema/pipeline/sql-templates/identifier-quoting";
 import {
   indexCatalog,
   resolveCatalogName,
@@ -69,10 +69,11 @@ export function createStorageObserver(
     pointers: async (_session, registryTable): Promise<string[]> => {
       // Addressed by a name the ORM's schema registry does not know: it resolves
       // tables exactly by the name their Drizzle definition declares, and during
-      // a run the registry is under whichever name the plan has reached. The
-      // identifier is quoted; there are no values to bind.
-      const rows = await adapter.executeQuery<Record<string, unknown>>(
-        `SELECT ${quoteIdent(REGISTRY_TABLE_NAME_COLUMN, dialect)} FROM ${quoteIdent(registryTable, dialect)}`
+      // a run the registry is under whichever name the plan has reached. Issued
+      // as a Drizzle statement so the identifier is quoted for the dialect in
+      // use rather than by hand.
+      const rows = await adapter.queryStatement(
+        sql`SELECT ${sql.identifier(REGISTRY_TABLE_NAME_COLUMN)} FROM ${sql.identifier(registryTable)}`
       );
       return rows
         .map(row => row[REGISTRY_TABLE_NAME_COLUMN])

--- a/packages/nextly/src/domains/field-groups/migration/reconcile.ts
+++ b/packages/nextly/src/domains/field-groups/migration/reconcile.ts
@@ -29,6 +29,7 @@ import type { MigratedObjectsVerification, StorageProbe } from "./guard";
 import {
   MIGRATION_TARGET,
   retargetName,
+  tableRenamesOf,
   type ManifestEntry,
   type RegistryRow,
 } from "./manifest";
@@ -510,56 +511,69 @@ function reconcileRename(
   position: number,
   run: RunRecord
 ): ManifestEntry {
-  const source = resolveCatalogName(catalog, entry.from);
-  const target = resolveCatalogName(catalog, entry.to);
+  // A table entry moves its companion as well as itself, and the two are not
+  // always in the same state: MySQL commits each rename separately, so a crash
+  // between them leaves the base migrated and the companion still under its old
+  // name. The entry only counts as done once every table it moves is done —
+  // marking it satisfied on the base alone would let the step skip a companion
+  // that is still sitting there.
+  let allApplied = true;
 
-  if (source !== undefined && target !== undefined) {
-    throw refuse("migration target name is already in use", {
-      from: entry.from,
-      to: entry.to,
-      occupiedBy: target,
+  for (const rename of tableRenamesOf(entry)) {
+    const source = resolveCatalogName(catalog, rename.from);
+    const target = resolveCatalogName(catalog, rename.to);
+
+    if (source !== undefined && target !== undefined) {
+      throw refuse("migration target name is already in use", {
+        from: rename.from,
+        to: rename.to,
+        occupiedBy: target,
+      });
+    }
+
+    if (source !== undefined) {
+      if (recordedAsDone(position, run)) {
+        throw refuse(
+          "a rename the marker records as verified has not been applied",
+          {
+            from: rename.from,
+            to: rename.to,
+            position,
+            recordedStep: run.recorded ? run.step : null,
+          }
+        );
+      }
+      allApplied = false;
+      continue;
+    }
+
+    if (target !== undefined) {
+      // Source gone, target present. Only progress that reached this position
+      // makes it our own finished work; otherwise it is an object belonging to
+      // something else, sitting on the name this migration wants, and adopting
+      // it would treat a stranger's table as migrated field-group storage.
+      if (!acceptsApplied(position, run)) {
+        throw refuse(
+          "an object using the migrated storage name exists but no recorded progress accounts for it",
+          {
+            from: rename.from,
+            to: rename.to,
+            occupiedBy: target,
+            position,
+            recordedStep: run.recorded ? run.step : null,
+          }
+        );
+      }
+      continue;
+    }
+
+    throw refuse("migration source object is missing", {
+      from: rename.from,
+      to: rename.to,
     });
   }
 
-  if (source !== undefined) {
-    if (recordedAsDone(position, run)) {
-      throw refuse(
-        "a rename the marker records as verified has not been applied",
-        {
-          from: entry.from,
-          to: entry.to,
-          position,
-          recordedStep: run.recorded ? run.step : null,
-        }
-      );
-    }
-    return entry;
-  }
-
-  if (target !== undefined) {
-    // Source gone, target present. Only progress that reached this position
-    // makes it our own finished work; otherwise it is an object belonging to
-    // something else, sitting on the name this migration wants, and adopting it
-    // would treat a stranger's table as migrated field-group storage.
-    if (!acceptsApplied(position, run)) {
-      throw refuse(
-        "an object using the migrated storage name exists but no recorded progress accounts for it",
-        {
-          from: entry.from,
-          to: entry.to,
-          occupiedBy: target,
-          position,
-          recordedStep: run.recorded ? run.step : null,
-        }
-      );
-    }
-    return { ...entry, satisfied: true };
-  }
-
-  throw refuse("migration source object is missing", {
-    from: entry.from,
-    to: entry.to,
-  });
+  return allApplied ? { ...entry, satisfied: true } : entry;
 }
 
 /**

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -124,6 +124,20 @@ export async function withMigrationSession<T>(
      * DML but not DDL would be refused outright.
      */
     requireExistingLock?: boolean;
+    /**
+     * Release the claim if the process is interrupted.
+     *
+     * For schema syncs only. Watch mode documents Ctrl+C as the way to stop, so
+     * a claim that survived it would block every later sync — but a claim is
+     * only safe to drop on a signal if whatever still holds it is harmless to
+     * run twice, and a migration is not. Releasing a migration's claim would
+     * free the row while its work is still in flight, letting a second process
+     * resume the same run against a database the first is still writing to.
+     *
+     * So the migration keeps the strict behaviour this lock was designed for: an
+     * interrupted run stays held, and an operator clears it.
+     */
+    releaseOnInterrupt?: boolean;
   },
   fn: (session: MigrationSession) => Promise<T>
 ): Promise<T> {
@@ -178,7 +192,7 @@ export async function withMigrationSession<T>(
   // deliberate; it is the wrong one for a schema sync, where the documented way
   // to stop watch mode is Ctrl+C and a stuck claim would block every later sync.
   // Releasing on the signal keeps the durable-claim design and removes its cost
-  // on the path people actually interrupt.
+  // on the path people actually interrupt — but only for callers that opt in.
   const releaseOnSignal = (signal: NodeJS.Signals): void => {
     void release(adapter, claim).finally(() => {
       process.kill(process.pid, signal);
@@ -186,8 +200,14 @@ export async function withMigrationSession<T>(
   };
   const onInterrupt = (): void => releaseOnSignal("SIGINT");
   const onTerminate = (): void => releaseOnSignal("SIGTERM");
-  process.once("SIGINT", onInterrupt);
-  process.once("SIGTERM", onTerminate);
+  // Registered only where the claim is safe to drop mid-flight. The signal does
+  // not stop `fn`, so releasing here hands the row to whoever asks next while
+  // this process is still working — survivable for a sync, which was never
+  // mutually exclusive with another sync, and not for a migration.
+  if (args.releaseOnInterrupt === true) {
+    process.once("SIGINT", onInterrupt);
+    process.once("SIGTERM", onTerminate);
+  }
 
   try {
     return await fn(session);

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -194,9 +194,16 @@ export async function withMigrationSession<T>(
   // Releasing on the signal keeps the durable-claim design and removes its cost
   // on the path people actually interrupt — but only for callers that opt in.
   const releaseOnSignal = (signal: NodeJS.Signals): void => {
-    void release(adapter, claim).finally(() => {
-      process.kill(process.pid, signal);
-    });
+    // The signal is re-raised whether or not the release succeeded: a pool torn
+    // down by the same interrupt is the likely failure, and an unobserved
+    // rejection there would surface as an unhandled rejection instead of
+    // letting the process stop. A claim left behind by a failed release is the
+    // ordinary stuck-claim case an operator already has a remedy for.
+    void release(adapter, claim)
+      .catch(() => undefined)
+      .finally(() => {
+        process.kill(process.pid, signal);
+      });
   };
   const onInterrupt = (): void => releaseOnSignal("SIGINT");
   const onTerminate = (): void => releaseOnSignal("SIGTERM");

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -93,7 +93,22 @@ export function getMigrationLockDdl(dialect: MigrationDialect): string[] {
  * two runs would rename the same objects and rewrite the same rows.
  */
 export async function withMigrationSession<T>(
-  args: { adapter: DrizzleAdapter; dialect: MigrationDialect; label: string },
+  args: {
+    adapter: DrizzleAdapter;
+    dialect: MigrationDialect;
+    label: string;
+    /**
+     * Take the lock only if it already exists, and never create it.
+     *
+     * For callers that are not the migration. The lock table is created by the
+     * migration, so its absence means no run has ever happened on this database
+     * and there is nothing to be excluded from. Creating it from those callers
+     * would issue DDL on paths that promise none — `--no-auto-sync` exists
+     * precisely to keep schema changes in migration files, and a role granted
+     * DML but not DDL would be refused outright.
+     */
+    requireExistingLock?: boolean;
+  },
   fn: (session: MigrationSession) => Promise<T>
 ): Promise<T> {
   const { adapter, dialect, label } = args;
@@ -111,7 +126,19 @@ export async function withMigrationSession<T>(
   // second. Uniqueness by construction removes that whole class of mistake.
   const claim = `${label}#${randomUUID()}`;
 
-  await ensureLockRow(adapter, dialect);
+  const session: MigrationSession = {
+    dialect,
+    inTransaction: work => adapter.transaction(work),
+  };
+
+  if (args.requireExistingLock === true) {
+    // No lock table means no run has ever been recorded here, so there is
+    // nothing to exclude and nothing worth creating a table for.
+    if (!(await adapter.tableExists(MIGRATION_LOCK_TABLE))) return fn(session);
+    await seedLockRow(adapter);
+  } else {
+    await ensureLockRow(adapter, dialect);
+  }
 
   const acquired = await acquire(adapter, claim);
   if (!acquired.ok) {
@@ -129,12 +156,30 @@ export async function withMigrationSession<T>(
     });
   }
 
-  try {
-    return await fn({
-      dialect,
-      inTransaction: work => adapter.transaction(work),
+  // A terminated process never reaches `finally`, and this lock has no expiry by
+  // design, so an interrupted holder would leave a claim that only an operator
+  // could clear. That is the right trade for a migration, which is rare and
+  // deliberate; it is the wrong one for a schema sync, where the documented way
+  // to stop watch mode is Ctrl+C and a stuck claim would block every later sync.
+  // Releasing on the signal keeps the durable-claim design and removes its cost
+  // on the path people actually interrupt.
+  const releaseOnSignal = (signal: NodeJS.Signals): void => {
+    void release(adapter, claim).finally(() => {
+      process.kill(process.pid, signal);
     });
+  };
+  const onInterrupt = (): void => releaseOnSignal("SIGINT");
+  const onTerminate = (): void => releaseOnSignal("SIGTERM");
+  process.once("SIGINT", onInterrupt);
+  process.once("SIGTERM", onTerminate);
+
+  try {
+    return await fn(session);
   } finally {
+    // Removed before releasing, so a signal arriving during an orderly release
+    // cannot start a second one.
+    process.off("SIGINT", onInterrupt);
+    process.off("SIGTERM", onTerminate);
     await release(adapter, claim);
   }
 }
@@ -152,7 +197,16 @@ async function ensureLockRow(
   for (const statement of getMigrationLockDdl(dialect)) {
     await adapter.executeQuery(statement);
   }
+  await seedLockRow(adapter);
+}
 
+/**
+ * Seed the single lock row, assuming its table is already there.
+ *
+ * Separated from the DDL so a caller that must not issue schema changes can
+ * still establish the row it needs to contend for.
+ */
+async function seedLockRow(adapter: DrizzleAdapter): Promise<void> {
   const existing = await adapter.transaction(async ctx =>
     ctx.selectOne<{ id: number }>(MIGRATION_LOCK_TABLE, {
       where: lockRowWhere(),

--- a/packages/nextly/src/domains/field-groups/migration/session.ts
+++ b/packages/nextly/src/domains/field-groups/migration/session.ts
@@ -25,10 +25,8 @@
 import { randomUUID } from "node:crypto";
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
-import type {
-  TransactionContext,
-  WhereClause,
-} from "@nextlyhq/adapter-drizzle/types";
+import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
+import { sql } from "drizzle-orm";
 
 import { NextlyError } from "../../../errors/nextly-error";
 
@@ -47,16 +45,34 @@ export const MIGRATION_LOCK_TABLE = "nextly_field_group_lock";
 /** The lock is a single row; its key never varies. */
 const LOCK_ROW_ID = 1;
 
-/** The lock row, addressed the way the adapter's query builder expects. */
-function lockRowWhere(owner?: string): WhereClause {
-  const and: WhereClause["and"] = [
-    { column: "id", op: "=", value: LOCK_ROW_ID },
-  ];
-  // Naming the owner as well makes a release affect only a row we still hold.
-  if (owner !== undefined) {
-    and.push({ column: "owner", op: "=", value: owner });
-  }
-  return { and };
+/**
+ * Read the lock row's owner inside a transaction.
+ *
+ * Issued as a Drizzle statement rather than through the typed query builder:
+ * that resolves a table through the schema registry and rejects any name the
+ * ORM does not declare, and this table is created on demand by the migration
+ * rather than declared in the static schema — the same shape the schema
+ * pipeline's own `nextly_migrate_lock` has.
+ */
+async function readOwner(
+  ctx: TransactionContext
+): Promise<{ owner: string | null } | undefined> {
+  const rows = await ctx.queryStatement<{ owner: string | null }>(
+    sql`SELECT ${sql.identifier("owner")}
+        FROM ${sql.identifier(MIGRATION_LOCK_TABLE)}
+        WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}`
+  );
+  return rows[0];
+}
+
+/** Whether the single lock row is present, read outside any transaction. */
+async function lockRowExists(adapter: DrizzleAdapter): Promise<boolean> {
+  const rows = await adapter.queryStatement(
+    sql`SELECT ${sql.identifier("id")}
+        FROM ${sql.identifier(MIGRATION_LOCK_TABLE)}
+        WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}`
+  );
+  return rows.length > 0;
 }
 
 /** What a step is handed to do its work. */
@@ -207,12 +223,7 @@ async function ensureLockRow(
  * still establish the row it needs to contend for.
  */
 async function seedLockRow(adapter: DrizzleAdapter): Promise<void> {
-  const existing = await adapter.transaction(async ctx =>
-    ctx.selectOne<{ id: number }>(MIGRATION_LOCK_TABLE, {
-      where: lockRowWhere(),
-    })
-  );
-  if (existing) return;
+  if (await lockRowExists(adapter)) return;
 
   try {
     await adapter.transaction(async ctx =>
@@ -226,12 +237,7 @@ async function seedLockRow(adapter: DrizzleAdapter): Promise<void> {
     // error the row is re-read below and required to exist.
   }
 
-  const seeded = await adapter.transaction(async ctx =>
-    ctx.selectOne<{ id: number }>(MIGRATION_LOCK_TABLE, {
-      where: lockRowWhere(),
-    })
-  );
-  if (!seeded) {
+  if (!(await lockRowExists(adapter))) {
     // Continuing here would leave nothing to lock, and a claim written against
     // an absent row would update nothing while still looking successful.
     throw NextlyError.serviceUnavailable({
@@ -259,28 +265,26 @@ async function acquire(
     // ends, so the read below cannot be overtaken between reading and writing.
     await ctx.lockRow(MIGRATION_LOCK_TABLE, LOCK_ROW_ID);
 
-    const row = await ctx.selectOne<{ owner: string | null }>(
-      MIGRATION_LOCK_TABLE,
-      { where: lockRowWhere() }
-    );
+    const row = await readOwner(ctx);
 
     // Any occupied row refuses, including one that appears to be ours. Claims
     // are unique per invocation, so a match would mean something other than
     // this call wrote it.
-    if (row === null || row.owner !== null) {
+    if (row === undefined || row.owner !== null) {
       return { ok: false, heldBy: row?.owner ?? null };
     }
 
-    await ctx.update(MIGRATION_LOCK_TABLE, { owner: claim }, lockRowWhere());
+    await ctx.runStatement(
+      sql`UPDATE ${sql.identifier(MIGRATION_LOCK_TABLE)}
+          SET ${sql.identifier("owner")} = ${claim}
+          WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}`
+    );
 
-    // Read back rather than trusting the write. `update` reports affected rows
+    // Read back rather than trusting the write. An update reports affected rows
     // inconsistently across dialects, and an absent row would otherwise update
     // nothing and still look like a successful claim, running the migration
     // with no exclusion at all.
-    const after = await ctx.selectOne<{ owner: string | null }>(
-      MIGRATION_LOCK_TABLE,
-      { where: lockRowWhere() }
-    );
+    const after = await readOwner(ctx);
     if (after?.owner !== claim) {
       return { ok: false, heldBy: after?.owner ?? null };
     }
@@ -292,10 +296,12 @@ async function acquire(
 async function release(adapter: DrizzleAdapter, claim: string): Promise<void> {
   await adapter.transaction(async ctx => {
     await ctx.lockRow(MIGRATION_LOCK_TABLE, LOCK_ROW_ID);
-    await ctx.update(
-      MIGRATION_LOCK_TABLE,
-      { owner: null },
-      lockRowWhere(claim)
+    // Naming the owner as well makes a release affect only a row we still hold.
+    await ctx.runStatement(
+      sql`UPDATE ${sql.identifier(MIGRATION_LOCK_TABLE)}
+          SET ${sql.identifier("owner")} = NULL
+          WHERE ${sql.identifier("id")} = ${LOCK_ROW_ID}
+            AND ${sql.identifier("owner")} = ${claim}`
     );
   });
 }

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -214,24 +214,14 @@ export async function readMigrationState(
 
   const marker = entry.value as unknown as StoredMarker;
 
-  if (marker.version !== MIGRATION_MARKER_VERSION) {
-    // Not reported as corruption: the bytes are intact and were written by a
-    // build whose step list this one may no longer reproduce, so a recorded
-    // position cannot be trusted to address the same work. The operator's remedy
-    // differs too — finish or roll back the run with the version that started
-    // it, rather than investigate a damaged marker.
-    throw NextlyError.serviceUnavailable({
-      logMessage:
-        "field-group migration marker was written by a different version of Nextly",
-      logContext: {
-        key: FIELD_GROUP_MIGRATION_KEY,
-        reason: "migration marker version is not this build's",
-        recordedVersion: marker.version,
-        supportedVersion: MIGRATION_MARKER_VERSION,
-      },
-    });
-  }
+  const writtenByThisBuild = marker.version === MIGRATION_MARKER_VERSION;
 
+  // A settled marker is read whatever wrote it. The version tracks how a
+  // recorded *step* is to be interpreted, and a settled marker has none — it
+  // states which generation the storage reached, which is the same fact in
+  // every build. Gating it would make the next version bump reject every marker
+  // left by the previous release, so every already-migrated installation would
+  // start refusing reads on upgrade.
   if (marker.status === "settled") {
     if (
       marker.generation !== "legacy" &&
@@ -243,10 +233,34 @@ export async function readMigrationState(
       status: "settled",
       generation: marker.generation,
       recorded: true,
-      ...(marker.appliedManifest === undefined
+      // The recorded plan is the one part that *is* version-bound: its entry
+      // format is what the version tracks, so a plan from another build cannot
+      // be executed. Omitted rather than parsed, which leaves a rollback to
+      // refuse on a plan it does not have instead of every read refusing on a
+      // plan it cannot parse.
+      ...(marker.appliedManifest === undefined || !writtenByThisBuild
         ? {}
         : { appliedManifest: parseAppliedManifest(marker.appliedManifest) }),
     };
+  }
+
+  // In flight, so `step` has to be interpreted against a step list, and only the
+  // build that produced that list can say what position N addressed.
+  if (!writtenByThisBuild) {
+    // Not reported as corruption: the bytes are intact and were written by a
+    // build whose step list this one may no longer reproduce. The operator's
+    // remedy differs too — finish or roll back the run with the version that
+    // started it, rather than investigate a damaged marker.
+    throw NextlyError.serviceUnavailable({
+      logMessage:
+        "field-group migration marker was written by a different version of Nextly",
+      logContext: {
+        key: FIELD_GROUP_MIGRATION_KEY,
+        reason: "migration marker version is not this build's",
+        recordedVersion: marker.version,
+        supportedVersion: MIGRATION_MARKER_VERSION,
+      },
+    });
   }
 
   if (marker.status === "migrating") {

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -24,8 +24,22 @@ import { hashManifest, MIGRATION_TARGET, type ManifestEntry } from "./manifest";
 /** `nextly_meta` key holding the marker. */
 export const FIELD_GROUP_MIGRATION_KEY = "field_groups.storage_migration";
 
-/** Marker payload version, so a later migration can evolve this shape. */
-export const MIGRATION_MARKER_VERSION = 1;
+/**
+ * Marker payload version.
+ *
+ * **Bump this whenever the recorded plan's entry format changes, or whenever the
+ * mapping from entries to executable steps changes.** A marker records progress
+ * as `step: N`, and a number only means something against a specific step list.
+ * The plan itself is persisted rather than rebuilt, so its *contents* cannot
+ * drift — but a build that turns those same entries into a different list of
+ * steps makes the recorded position address different work, and nothing in the
+ * plan's own bytes reveals that. This constant is what does.
+ *
+ * Version 2 is this rename engine's plan format, in which a localization
+ * companion is carried on the entry for the table it belongs to rather than
+ * occupying an entry, and therefore a step position, of its own.
+ */
+export const MIGRATION_MARKER_VERSION = 2;
 
 /**
  * Highest step the marker will hold, one below the safe-integer ceiling.
@@ -201,9 +215,21 @@ export async function readMigrationState(
   const marker = entry.value as unknown as StoredMarker;
 
   if (marker.version !== MIGRATION_MARKER_VERSION) {
-    throw markerCorrupt(
-      `marker version ${String(marker.version)} is not supported by this build`
-    );
+    // Not reported as corruption: the bytes are intact and were written by a
+    // build whose step list this one may no longer reproduce, so a recorded
+    // position cannot be trusted to address the same work. The operator's remedy
+    // differs too — finish or roll back the run with the version that started
+    // it, rather than investigate a damaged marker.
+    throw NextlyError.serviceUnavailable({
+      logMessage:
+        "field-group migration marker was written by a different version of Nextly",
+      logContext: {
+        key: FIELD_GROUP_MIGRATION_KEY,
+        reason: "migration marker version is not this build's",
+        recordedVersion: marker.version,
+        supportedVersion: MIGRATION_MARKER_VERSION,
+      },
+    });
   }
 
   if (marker.status === "settled") {

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -19,7 +19,7 @@ import { NextlyError } from "../../../errors/nextly-error";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import type { MetaService } from "../../meta/services/meta-service";
 
-import { MIGRATION_TARGET, type ManifestEntry } from "./manifest";
+import { hashManifest, MIGRATION_TARGET, type ManifestEntry } from "./manifest";
 
 /** `nextly_meta` key holding the marker. */
 export const FIELD_GROUP_MIGRATION_KEY = "field_groups.storage_migration";
@@ -91,18 +91,33 @@ export interface SettledState {
  * independent things can change that plan out from under an interrupted run,
  * and either one makes the recorded step mean something different:
  *
- * - `manifestHash` covers the object map: which tables, columns and stored keys
- *   this database's field groups resolve to. It moves when the application's
- *   schema changes.
- * - `planHash` covers the ordered step list the running build produces. It
- *   moves when Nextly itself is upgraded and steps are added, removed or
- *   reordered, which can happen while the application's schema is untouched.
+ * The plan is **persisted and read back**, never rebuilt, so the identity does
+ * not have to survive a rebuild producing the same bytes. What it must still
+ * catch is the world moving underneath a recorded position:
  *
- * Neither subsumes the other, so both are recorded and both are compared.
+ * - `slugsHash` covers which field groups exist. A group created or deleted
+ *   mid-run would leave storage the plan never mentions.
+ * - `manifestHash` covers the stored plan's own integrity.
  */
 export interface MigrationPlanIdentity {
+  /**
+   * Hash over the sorted slug set the run was planned against.
+   *
+   * Answers "did the set of field groups move underneath this run". Slugs are
+   * used rather than table names because a slug is stable for the whole run
+   * while `table_name` is rewritten as each rename commits — a hash over table
+   * names would stop matching partway through and refuse the resume it exists
+   * to protect.
+   */
+  slugsHash: string;
+  /**
+   * Hash of the persisted plan itself.
+   *
+   * A corruption check on the stored blob, not a comparison against anything
+   * rebuilt: the plan is read back rather than recomputed, so the only question
+   * left is whether what was read is what was written.
+   */
   manifestHash: string;
-  planHash: string;
 }
 
 /**
@@ -120,19 +135,21 @@ export interface MigratingState {
   step: number;
   plan: MigrationPlanIdentity;
   /**
-   * The plan being applied, carried for the whole run.
+   * The plan this run is executing, carried for the whole run.
    *
-   * Always the plan that was applied to reach migrated storage, never its
-   * inverse. A rollback reverses it at execution time; storing it pre-inverted
-   * would let a resume invert it twice and migrate forward while believing it
-   * was rolling back.
+   * Required in both directions, and always in the canonical form: the work
+   * that takes storage from legacy to migrated, never its inverse. An `up` run
+   * applies it; a `down` run reverses it at execution time. Storing it
+   * pre-inverted would let a resume invert it twice and migrate forward while
+   * believing it was rolling back.
    *
-   * A `down` run reverses what an earlier `up` recorded, so the record has to
-   * survive the transition out of `settled` and every step after it. Writing it
-   * only at settlement would lose it the moment a rollback started, leaving a
-   * crashed run with a step position and no plan to index into.
+   * This is what a resume executes. Rebuilding it instead cannot work once the
+   * registry's own pointers are rewritten with each rename: a rebuilt plan then
+   * omits every row already renamed, so it has fewer entries, different step
+   * positions, and a different hash from the one the marker recorded — and the
+   * resume would refuse the very plan it is resuming.
    */
-  appliedManifest?: ManifestEntry[];
+  appliedManifest: ManifestEntry[];
 }
 
 export type MigrationState = SettledState | MigratingState;
@@ -145,8 +162,8 @@ interface StoredMarker {
   direction?: MigrationDirection;
   migrationId?: string;
   step?: number;
+  slugsHash?: string;
   manifestHash?: string;
-  planHash?: string;
   appliedManifest?: unknown;
 }
 
@@ -208,7 +225,7 @@ export async function readMigrationState(
   }
 
   if (marker.status === "migrating") {
-    const { direction, migrationId, step, manifestHash, planHash } = marker;
+    const { direction, migrationId, step, slugsHash, manifestHash } = marker;
     if (direction !== "up" && direction !== "down") {
       throw markerCorrupt("in-flight marker carries no known direction");
     }
@@ -229,21 +246,32 @@ export async function readMigrationState(
     ) {
       throw markerCorrupt("in-flight marker carries no valid step");
     }
+    if (typeof slugsHash !== "string" || slugsHash.length === 0) {
+      throw markerCorrupt("in-flight marker carries no slug-set hash");
+    }
     if (typeof manifestHash !== "string" || manifestHash.length === 0) {
       throw markerCorrupt("in-flight marker carries no manifest hash");
     }
-    if (typeof planHash !== "string" || planHash.length === 0) {
-      throw markerCorrupt("in-flight marker carries no plan hash");
+    // A run in flight cannot proceed without the plan it is executing, so an
+    // absent one is corruption rather than an optional field.
+    if (marker.appliedManifest === undefined) {
+      throw markerCorrupt("in-flight marker carries no plan");
+    }
+    const appliedManifest = parseAppliedManifest(marker.appliedManifest);
+    // The plan is read back rather than recomputed, so this is the one check
+    // that it is still what was written. Without it a truncated or edited blob
+    // would be executed as though it were the recorded plan.
+    const actualHash = hashManifest(appliedManifest);
+    if (actualHash !== manifestHash) {
+      throw markerCorrupt("recorded plan does not match its recorded hash");
     }
     return {
       status: "migrating",
       direction,
       migrationId,
       step,
-      plan: { manifestHash, planHash },
-      ...(marker.appliedManifest === undefined
-        ? {}
-        : { appliedManifest: parseAppliedManifest(marker.appliedManifest) }),
+      plan: { slugsHash, manifestHash },
+      appliedManifest,
     };
   }
 
@@ -258,28 +286,24 @@ export async function readMigrationState(
  * step is idempotent precisely so that re-run is safe.
  */
 /**
- * Starting a run, with the plan required exactly where a run cannot do without it.
+ * Starting a run, with the plan it will execute.
  *
- * A `down` run reverses a recorded plan; it cannot derive one, because nothing in
- * the database says which names this migration created. An `up` run builds its
- * plan from registry rows, so it has none to carry in. Expressing that as a union
- * rather than an optional field with a comment means the unsafe call does not
- * typecheck — a comment saying "required" while the type says otherwise is the
- * kind of claim that goes unenforced.
+ * Required in both directions. A `down` run reverses a recorded plan and cannot
+ * derive one, because nothing in the database says which names this migration
+ * created. An `up` run cannot rely on rebuilding one either: once each rename
+ * rewrites its registry pointer, a rebuild omits the work already done and no
+ * longer matches the recorded step positions.
  */
-export type BeginMigrationArgs =
-  | {
-      direction: "up";
-      migrationId: string;
-      plan: MigrationPlanIdentity;
-      appliedManifest?: undefined;
-    }
-  | {
-      direction: "down";
-      migrationId: string;
-      plan: MigrationPlanIdentity;
-      appliedManifest: readonly ManifestEntry[];
-    };
+export interface BeginMigrationArgs {
+  direction: MigrationDirection;
+  migrationId: string;
+  plan: MigrationPlanIdentity;
+  /**
+   * The canonical legacy-to-migrated plan, required in both directions: an `up`
+   * run applies it and a `down` run reverses it, and neither can rebuild it.
+   */
+  appliedManifest: readonly ManifestEntry[];
+}
 
 export async function beginMigration(
   meta: MetaService,
@@ -289,8 +313,25 @@ export async function beginMigration(
   // next read would reject leaves the database unavailable with no way forward,
   // and an empty identifier is the easiest way to do that by accident.
   requireIdentifier(args.migrationId, "migrationId");
+  requireIdentifier(args.plan.slugsHash, "slugsHash");
   requireIdentifier(args.plan.manifestHash, "manifestHash");
-  requireIdentifier(args.plan.planHash, "planHash");
+
+  // Validated through the same function the read uses, so a write cannot
+  // produce a marker its own reader refuses -- which would strand a run after
+  // its first step had committed.
+  const appliedManifest = parseAppliedManifest(args.appliedManifest);
+  // The recorded hash has to describe the plan actually being stored, or the
+  // integrity check on read would compare against a number nothing produced.
+  const actualHash = hashManifest(appliedManifest);
+  if (actualHash !== args.plan.manifestHash) {
+    throw NextlyError.internal({
+      logContext: {
+        reason: "recorded manifest hash does not describe the recorded plan",
+        recorded: args.plan.manifestHash,
+        actual: actualHash,
+      },
+    });
+  }
 
   const marker: StoredMarker = {
     version: MIGRATION_MARKER_VERSION,
@@ -298,15 +339,9 @@ export async function beginMigration(
     direction: args.direction,
     migrationId: args.migrationId,
     step: 0,
+    slugsHash: args.plan.slugsHash,
     manifestHash: args.plan.manifestHash,
-    planHash: args.plan.planHash,
-    // Carried from the settled marker rather than dropped: a rollback has no
-    // other source for the plan it is reversing. Validated through the same
-    // function the read uses, so a write cannot produce a marker its own reader
-    // refuses -- which would strand a run after its first step had committed.
-    ...(args.appliedManifest === undefined
-      ? {}
-      : { appliedManifest: parseAppliedManifest(args.appliedManifest) }),
+    appliedManifest,
   };
   await meta.set(FIELD_GROUP_MIGRATION_KEY, marker);
 }
@@ -379,51 +414,43 @@ export async function advanceStep(
     direction: current.direction,
     migrationId: current.migrationId,
     step: args.step,
+    slugsHash: current.plan.slugsHash,
     manifestHash: current.plan.manifestHash,
-    planHash: current.plan.planHash,
     // Preserved on every step. Losing it mid-run would leave a crash with a
     // step position and no plan to index into.
-    ...(current.appliedManifest === undefined
-      ? {}
-      : { appliedManifest: current.appliedManifest }),
+    appliedManifest: current.appliedManifest,
   };
   await meta.set(FIELD_GROUP_MIGRATION_KEY, marker);
 }
 
 /**
- * Refuse to resume a run whose plan is no longer the plan that was interrupted.
+ * Refuse to resume a run whose world is no longer the world it was planned in.
  *
- * Steps are identified by position, and a position only means something
- * relative to the plan it was checked off under. Two different changes can
- * invalidate it, and they are reported separately because they point an
- * operator at different causes:
+ * The plan itself is read back from the marker rather than rebuilt, so it cannot
+ * have drifted; its integrity is checked on read against the recorded hash. What
+ * remains is whether the *set of field groups* still matches. A group created or
+ * deleted while a run was interrupted is storage the recorded plan never
+ * mentions, and continuing would leave it behind at the legacy prefix while
+ * everything else moved.
  *
- * - The object map moved: the application's schema changed between the
- *   interrupted run and this one, so step N now names different objects.
- * - The step list moved: Nextly was upgraded and its steps were added, removed
- *   or reordered, so step N is a different operation even though the database's
- *   own objects are untouched.
+ * Compared by slug rather than by table name because the pointer rewrite that
+ * accompanies each rename changes table names as the run progresses; a
+ * name-based comparison would refuse every resume past the first step, since the
+ * rows the comparison reads have themselves been rewritten by the work already
+ * done.
  *
- * Neither is reconcilable, so both refuse. Callers invoke this once they have
- * rebuilt the plan and can supply its identity, which is necessarily after the
- * resume decision itself is made.
+ * Not reconcilable, so it refuses. Callers invoke it once they have read the
+ * current registry rows and can hash their slugs.
  */
 export function assertPlanUnchanged(args: {
   recorded: MigrationPlanIdentity;
   current: MigrationPlanIdentity;
 }): void {
-  if (args.recorded.manifestHash !== args.current.manifestHash) {
+  if (args.recorded.slugsHash !== args.current.slugsHash) {
     throw planMoved(
-      "migration object map changed since the interrupted run",
-      args.recorded.manifestHash,
-      args.current.manifestHash
-    );
-  }
-  if (args.recorded.planHash !== args.current.planHash) {
-    throw planMoved(
-      "migration step list changed since the interrupted run",
-      args.recorded.planHash,
-      args.current.planHash
+      "the set of field groups changed since the interrupted run",
+      args.recorded.slugsHash,
+      args.current.slugsHash
     );
   }
 }

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -552,13 +552,8 @@ function parseAppliedManifest(value: unknown): ManifestEntry[] {
     if (!isRecord(raw)) {
       throw markerCorrupt("recorded plan contains a non-object entry");
     }
-    const { kind, from, to, table } = raw;
-    if (
-      kind !== "registry" &&
-      kind !== "table" &&
-      kind !== "companion" &&
-      kind !== "column"
-    ) {
+    const { kind, from, to, table, companion } = raw;
+    if (kind !== "registry" && kind !== "table" && kind !== "column") {
       throw markerCorrupt("recorded plan entry has no known kind");
     }
     if (typeof from !== "string" || from.length === 0) {
@@ -582,8 +577,33 @@ function parseAppliedManifest(value: unknown): ManifestEntry[] {
       from,
       to,
       ...(table === undefined ? {} : { table }),
+      ...(companion === undefined
+        ? {}
+        : { companion: readCompanion(companion) }),
     };
   });
+}
+
+/**
+ * A recorded companion rename.
+ *
+ * Validated and carried rather than dropped: the entry returned here is what a
+ * resume executes, so a companion the parser did not copy would leave the
+ * companion table behind under its old name while its owner moved — the exact
+ * split the companion was made a property to prevent.
+ */
+function readCompanion(value: unknown): { from: string; to: string } {
+  if (!isRecord(value)) {
+    throw markerCorrupt("recorded companion is not an object");
+  }
+  const { from, to } = value;
+  if (typeof from !== "string" || from.length === 0) {
+    throw markerCorrupt("recorded companion has no source name");
+  }
+  if (typeof to !== "string" || to.length === 0) {
+    throw markerCorrupt("recorded companion has no target name");
+  }
+  return { from, to };
 }
 
 // A marker that exists but cannot be read is refused rather than ignored:

--- a/packages/nextly/src/domains/field-groups/migration/state.ts
+++ b/packages/nextly/src/domains/field-groups/migration/state.ts
@@ -95,21 +95,20 @@ export interface SettledState {
  * not have to survive a rebuild producing the same bytes. What it must still
  * catch is the world moving underneath a recorded position:
  *
- * - `slugsHash` covers which field groups exist. A group created or deleted
- *   mid-run would leave storage the plan never mentions.
+ * - `registryHash` covers which field group rows exist, by id. A group created,
+ *   deleted, or replaced mid-run would leave storage the plan never mentions.
  * - `manifestHash` covers the stored plan's own integrity.
  */
 export interface MigrationPlanIdentity {
   /**
-   * Hash over the sorted slug set the run was planned against.
+   * Hash over the registry rows the run was planned against, by id and slug.
    *
-   * Answers "did the set of field groups move underneath this run". Slugs are
-   * used rather than table names because a slug is stable for the whole run
-   * while `table_name` is rewritten as each rename commits — a hash over table
-   * names would stop matching partway through and refuse the resume it exists
-   * to protect.
+   * Answers "is this still the same set of field groups". Row ids rather than
+   * table names because `table_name` is rewritten as each rename commits, and
+   * rather than slugs alone because a slug cannot tell a group that survived
+   * from one deleted and recreated under the same name.
    */
-  slugsHash: string;
+  registryHash: string;
   /**
    * Hash of the persisted plan itself.
    *
@@ -162,7 +161,7 @@ interface StoredMarker {
   direction?: MigrationDirection;
   migrationId?: string;
   step?: number;
-  slugsHash?: string;
+  registryHash?: string;
   manifestHash?: string;
   appliedManifest?: unknown;
 }
@@ -225,7 +224,7 @@ export async function readMigrationState(
   }
 
   if (marker.status === "migrating") {
-    const { direction, migrationId, step, slugsHash, manifestHash } = marker;
+    const { direction, migrationId, step, registryHash, manifestHash } = marker;
     if (direction !== "up" && direction !== "down") {
       throw markerCorrupt("in-flight marker carries no known direction");
     }
@@ -246,8 +245,8 @@ export async function readMigrationState(
     ) {
       throw markerCorrupt("in-flight marker carries no valid step");
     }
-    if (typeof slugsHash !== "string" || slugsHash.length === 0) {
-      throw markerCorrupt("in-flight marker carries no slug-set hash");
+    if (typeof registryHash !== "string" || registryHash.length === 0) {
+      throw markerCorrupt("in-flight marker carries no registry identity hash");
     }
     if (typeof manifestHash !== "string" || manifestHash.length === 0) {
       throw markerCorrupt("in-flight marker carries no manifest hash");
@@ -270,7 +269,7 @@ export async function readMigrationState(
       direction,
       migrationId,
       step,
-      plan: { slugsHash, manifestHash },
+      plan: { registryHash, manifestHash },
       appliedManifest,
     };
   }
@@ -313,7 +312,7 @@ export async function beginMigration(
   // next read would reject leaves the database unavailable with no way forward,
   // and an empty identifier is the easiest way to do that by accident.
   requireIdentifier(args.migrationId, "migrationId");
-  requireIdentifier(args.plan.slugsHash, "slugsHash");
+  requireIdentifier(args.plan.registryHash, "registryHash");
   requireIdentifier(args.plan.manifestHash, "manifestHash");
 
   // Validated through the same function the read uses, so a write cannot
@@ -339,7 +338,7 @@ export async function beginMigration(
     direction: args.direction,
     migrationId: args.migrationId,
     step: 0,
-    slugsHash: args.plan.slugsHash,
+    registryHash: args.plan.registryHash,
     manifestHash: args.plan.manifestHash,
     appliedManifest,
   };
@@ -414,7 +413,7 @@ export async function advanceStep(
     direction: current.direction,
     migrationId: current.migrationId,
     step: args.step,
-    slugsHash: current.plan.slugsHash,
+    registryHash: current.plan.registryHash,
     manifestHash: current.plan.manifestHash,
     // Preserved on every step. Losing it mid-run would leave a crash with a
     // step position and no plan to index into.
@@ -446,11 +445,11 @@ export function assertPlanUnchanged(args: {
   recorded: MigrationPlanIdentity;
   current: MigrationPlanIdentity;
 }): void {
-  if (args.recorded.slugsHash !== args.current.slugsHash) {
+  if (args.recorded.registryHash !== args.current.registryHash) {
     throw planMoved(
       "the set of field groups changed since the interrupted run",
-      args.recorded.slugsHash,
-      args.current.slugsHash
+      args.recorded.registryHash,
+      args.current.registryHash
     );
   }
 }

--- a/packages/nextly/src/domains/field-groups/migration/steps.ts
+++ b/packages/nextly/src/domains/field-groups/migration/steps.ts
@@ -141,12 +141,23 @@ export function buildMigrationSteps(args: {
     if (entry.kind === "column") {
       return columnStep(entry, { position, applied, identifierCase, observer });
     }
+    // A companion follows its owner immediately in the plan. Its rename joins
+    // the owner's step rather than standing alone, because the registry derives
+    // the companion's name from the owner's `table_name`: whichever of the two
+    // renames the pointer update is separated from, there is a window where the
+    // derived name addresses an object that does not exist. Only moving both
+    // objects and the pointer together closes it.
+    const next = entries[index + 1];
+    const companion =
+      entry.kind === "table" && next?.kind === "companion" ? next : undefined;
+
     return renameStep(entry, {
       position,
       applied,
       registryTable: registryNameAt(entries, position),
       identifierCase,
       observer,
+      companion,
     });
   });
 }
@@ -170,9 +181,13 @@ interface StepContext {
  */
 function renameStep(
   entry: ManifestEntry,
-  context: StepContext & { registryTable: string }
+  context: StepContext & {
+    registryTable: string;
+    companion?: ManifestEntry;
+  }
 ): MigrationStep {
-  const { applied, identifierCase, observer, registryTable } = context;
+  const { applied, identifierCase, observer, registryTable, companion } =
+    context;
   // Companions carry no pointer of their own: their name is derived from the
   // owner's `table_name`, so the owner's update already moves them. The registry
   // is not addressed by any row either.
@@ -206,6 +221,25 @@ function renameStep(
           await ctx.execute(
             generateSQL(
               { type: "rename_table", fromName: entry.from, toName: entry.to },
+              session.dialect
+            )
+          );
+        }
+        // Renamed before the pointer moves, so the name the registry derives
+        // always addresses an object that is there. The companion's own step
+        // later finds its source gone and does nothing, which is the same
+        // idempotence every step already relies on.
+        if (
+          companion !== undefined &&
+          resolveCatalogName(catalog, companion.from) !== undefined
+        ) {
+          await ctx.execute(
+            generateSQL(
+              {
+                type: "rename_table",
+                fromName: companion.from,
+                toName: companion.to,
+              },
               session.dialect
             )
           );

--- a/packages/nextly/src/domains/field-groups/migration/steps.ts
+++ b/packages/nextly/src/domains/field-groups/migration/steps.ts
@@ -13,32 +13,20 @@
  * @module domains/field-groups/migration/steps
  */
 
+import { sql } from "drizzle-orm";
+
 import { NextlyError } from "../../../errors/nextly-error";
 import { generateSQL } from "../../schema/pipeline/sql-templates";
-import { quoteIdent } from "../../schema/pipeline/sql-templates/identifier-quoting";
 import {
   indexCatalog,
   resolveCatalogName,
   type IdentifierCaseRules,
 } from "../../schema/utils/resolve-catalog-name";
 
-import { type ManifestEntry } from "./manifest";
+import { tableRenamesOf, type ManifestEntry } from "./manifest";
 import { findLostIndexes, refuseLostIndexes } from "./observer";
 import type { MigrationStep } from "./runner";
-import type { MigrationDialect, MigrationSession } from "./session";
-
-/**
- * Positional parameter markers for a dialect.
- *
- * node-postgres binds `$1`, `$2`; mysql2 and better-sqlite3 bind `?`. The
- * transaction context hands the statement to the driver unchanged, so emitting
- * one form everywhere makes every statement with parameters fail on the other.
- */
-function placeholders(dialect: MigrationDialect, count: number): string[] {
-  return Array.from({ length: count }, (_, index) =>
-    dialect === "postgresql" ? `$${index + 1}` : "?"
-  );
-}
+import type { MigrationSession } from "./session";
 
 /**
  * The registry column holding a row's physical table name.
@@ -141,23 +129,17 @@ export function buildMigrationSteps(args: {
     if (entry.kind === "column") {
       return columnStep(entry, { position, applied, identifierCase, observer });
     }
-    // A companion follows its owner immediately in the plan. Its rename joins
-    // the owner's step rather than standing alone, because the registry derives
-    // the companion's name from the owner's `table_name`: whichever of the two
-    // renames the pointer update is separated from, there is a window where the
-    // derived name addresses an object that does not exist. Only moving both
-    // objects and the pointer together closes it.
-    const next = entries[index + 1];
-    const companion =
-      entry.kind === "table" && next?.kind === "companion" ? next : undefined;
-
+    // The companion travels on the entry rather than beside it, so it shares
+    // this step's position. The registry derives a companion's name from its
+    // owner's `table_name`, so whichever of the two renames the pointer update
+    // were separated from, there would be a window where the derived name
+    // addresses an object that is not there.
     return renameStep(entry, {
       position,
       applied,
       registryTable: registryNameAt(entries, position),
       identifierCase,
       observer,
-      companion,
     });
   });
 }
@@ -170,33 +152,44 @@ interface StepContext {
 }
 
 /**
- * Rename a table, and move the registry pointer with it when the table is one a
- * registry row addresses.
+ * Rename a table and its companion, and move the registry pointer with them.
  *
- * Both halves are idempotent because they must survive a partial step. MySQL
- * commits DDL implicitly, so a rename can land while the pointer update fails;
- * the resume re-runs this step, finds the table already moved, and re-applies
- * the pointer. The rename tolerates that by checking the catalog first, and the
- * update is a no-op once no row still points at the old name.
+ * How atomic that is depends on the dialect, and the difference is not one this
+ * module can paper over:
+ *
+ * - **Postgres and SQLite** have transactional DDL. The renames and the pointer
+ *   update commit together or not at all, which is the guarantee this step is
+ *   shaped around: a reader never sees a pointer addressing a table that moved.
+ * - **MySQL** commits DDL implicitly. Each `RENAME TABLE` ends the transaction
+ *   it is in, so the pointer update necessarily runs in a later one. There is a
+ *   window in which a concurrent reader sees renamed tables and a stale pointer,
+ *   and no ordering closes it — moving the pointer first only swaps which side
+ *   is briefly wrong. Both intermediate states resolve to "table not found"
+ *   rather than to wrong data, and the window is bounded by the run.
+ *
+ * So on MySQL this is sequenced with repair rather than atomic, and every half
+ * is idempotent to make that repair possible: the renames check the catalog
+ * first, and the pointer update is a no-op once no row still points at the old
+ * name.
  */
 function renameStep(
   entry: ManifestEntry,
-  context: StepContext & {
-    registryTable: string;
-    companion?: ManifestEntry;
-  }
+  context: StepContext & { registryTable: string }
 ): MigrationStep {
-  const { applied, identifierCase, observer, registryTable, companion } =
-    context;
+  const { identifierCase, observer, registryTable } = context;
   // Companions carry no pointer of their own: their name is derived from the
   // owner's `table_name`, so the owner's update already moves them. The registry
   // is not addressed by any row either.
   const movesPointer = entry.kind === "table";
-  // Captured by `run` while the source still exists, and read by `verify`.
-  // `undefined` means the source was already gone when this step ran, so there
-  // is nothing to compare against — reported as not comparable rather than as
-  // nothing lost.
-  let indexesBefore: string[] | undefined;
+  // Base table first, then its companion if it has one. Both are moved by this
+  // step, so both are renamed, both are verified, and both have their indexes
+  // compared -- a companion whose indexes were dropped is as lost as a table's.
+  const renames = tableRenamesOf(entry);
+  // Captured by `run` while the sources still exist, and read by `verify`,
+  // positionally against `renames`. `undefined` means that source was already
+  // gone when this step ran, so there is nothing to compare against — reported
+  // as not comparable rather than as nothing lost.
+  let indexesBefore: (string[] | undefined)[] = [];
 
   return {
     id: `${entry.kind}:${entry.from}->${entry.to}`,
@@ -207,38 +200,33 @@ function renameStep(
       // to one.
       const present = await observer.tables(session);
       const catalog = indexCatalog(present, identifierCase.tables);
-      const source = resolveCatalogName(catalog, entry.from);
-      // Captured while the source still exists, so `verify` can tell whether the
-      // rename carried the table's indexes with it.
-      indexesBefore =
-        source === undefined ? undefined : await observer.indexNames(source);
+      const sources = renames.map(rename =>
+        resolveCatalogName(catalog, rename.from)
+      );
+      // Sequential rather than concurrent: the observer checks out a connection
+      // per call, and a pool sized to one cannot serve two at once.
+      indexesBefore = [];
+      for (const source of sources) {
+        indexesBefore.push(
+          source === undefined ? undefined : await observer.indexNames(source)
+        );
+      }
 
       await session.inTransaction(async ctx => {
-        // Re-runnable: on a resume the rename may already have committed, and
-        // issuing it again would fail on a source that is no longer there. A
-        // satisfied entry skips the DDL for the same reason.
-        if (!applied && source !== undefined) {
-          await ctx.execute(
-            generateSQL(
-              { type: "rename_table", fromName: entry.from, toName: entry.to },
-              session.dialect
-            )
-          );
-        }
-        // Renamed before the pointer moves, so the name the registry derives
-        // always addresses an object that is there. The companion's own step
-        // later finds its source gone and does nothing, which is the same
-        // idempotence every step already relies on.
-        if (
-          companion !== undefined &&
-          resolveCatalogName(catalog, companion.from) !== undefined
-        ) {
+        // Re-runnable, and decided per table rather than per entry: on a resume
+        // a rename may already have committed, and issuing it again would fail
+        // on a source that is no longer there. The catalog answers that for each
+        // table on its own, which is what a torn step needs — skipping the whole
+        // entry because reconciliation called it satisfied would strand a
+        // companion whose own rename never landed.
+        for (const [index, rename] of renames.entries()) {
+          if (sources[index] === undefined) continue;
           await ctx.execute(
             generateSQL(
               {
                 type: "rename_table",
-                fromName: companion.from,
-                toName: companion.to,
+                fromName: rename.from,
+                toName: rename.to,
               },
               session.dialect
             )
@@ -250,16 +238,16 @@ function renameStep(
         // stale and fail verification on every resume, forever. The update is
         // idempotent, so running it when it is already correct costs nothing.
         if (!movesPointer) return;
-        // Values are bound; only the table name is interpolated, through
-        // `quoteIdent`. The registry cannot be reached through Drizzle here: the
-        // schema registry looks tables up exactly by the name their Drizzle
-        // definition declares, so a table addressed under a migrated name is
-        // unregistered as far as the ORM is concerned.
-        const [toMarker, fromMarker] = placeholders(session.dialect, 2);
-        const column = quoteIdent(REGISTRY_TABLE_NAME_COLUMN, session.dialect);
-        await ctx.execute(
-          `UPDATE ${quoteIdent(registryTable, session.dialect)} SET ${column} = ${toMarker} WHERE ${column} = ${fromMarker}`,
-          [entry.to, entry.from]
+        // Issued as a Drizzle statement, which quotes the identifier and binds
+        // the values in whichever form the driver expects. The registry cannot
+        // be reached through the typed query builder here: it resolves a table
+        // through the schema registry, which knows tables only by the name their
+        // Drizzle definition declares, and mid-run the registry is under
+        // whichever name the plan has reached.
+        await ctx.runStatement(
+          sql`UPDATE ${sql.identifier(registryTable)}
+              SET ${sql.identifier(REGISTRY_TABLE_NAME_COLUMN)} = ${entry.to}
+              WHERE ${sql.identifier(REGISTRY_TABLE_NAME_COLUMN)} = ${entry.from}`
         );
       });
     },
@@ -268,20 +256,24 @@ function renameStep(
         await observer.tables(session),
         identifierCase.tables
       );
-      const target = resolveCatalogName(catalog, entry.to);
-      if (target === undefined) return false;
-      if (resolveCatalogName(catalog, entry.from) !== undefined) return false;
 
-      // Renaming a table keeps its indexes on every supported dialect, so a name
-      // missing afterwards means one was dropped rather than moved. Refuses
-      // rather than returning false: a lost index is not "not yet done", and a
-      // retry cannot bring it back.
-      const lost = findLostIndexes(
-        indexesBefore,
-        await observer.indexNames(target)
-      );
-      if (lost.comparable && lost.lost.length > 0) {
-        throw refuseLostIndexes({ table: target, lost: lost.lost });
+      for (const [index, rename] of renames.entries()) {
+        const target = resolveCatalogName(catalog, rename.to);
+        if (target === undefined) return false;
+        if (resolveCatalogName(catalog, rename.from) !== undefined)
+          return false;
+
+        // Renaming a table keeps its indexes on every supported dialect, so a
+        // name missing afterwards means one was dropped rather than moved.
+        // Refuses rather than returning false: a lost index is not "not yet
+        // done", and a retry cannot bring it back.
+        const lost = findLostIndexes(
+          indexesBefore[index],
+          await observer.indexNames(target)
+        );
+        if (lost.comparable && lost.lost.length > 0) {
+          throw refuseLostIndexes({ table: target, lost: lost.lost });
+        }
       }
 
       if (!movesPointer) return true;

--- a/packages/nextly/src/domains/field-groups/migration/steps.ts
+++ b/packages/nextly/src/domains/field-groups/migration/steps.ts
@@ -23,8 +23,22 @@ import {
 } from "../../schema/utils/resolve-catalog-name";
 
 import { type ManifestEntry } from "./manifest";
+import { findLostIndexes, refuseLostIndexes } from "./observer";
 import type { MigrationStep } from "./runner";
-import type { MigrationSession } from "./session";
+import type { MigrationDialect, MigrationSession } from "./session";
+
+/**
+ * Positional parameter markers for a dialect.
+ *
+ * node-postgres binds `$1`, `$2`; mysql2 and better-sqlite3 bind `?`. The
+ * transaction context hands the statement to the driver unchanged, so emitting
+ * one form everywhere makes every statement with parameters fail on the other.
+ */
+function placeholders(dialect: MigrationDialect, count: number): string[] {
+  return Array.from({ length: count }, (_, index) =>
+    dialect === "postgresql" ? `$${index + 1}` : "?"
+  );
+}
 
 /**
  * The registry column holding a row's physical table name.
@@ -64,6 +78,13 @@ export interface StorageObserver {
   ): Promise<ObservedColumn[] | undefined>;
   /** Every `table_name` the registry currently points at. */
   pointers(session: MigrationSession, registryTable: string): Promise<string[]>;
+  /**
+   * A table's index names, or `undefined` when they were not tracked.
+   *
+   * `undefined` is not "no indexes": a snapshot that never recorded index data
+   * would otherwise report every index intact.
+   */
+  indexNames(table: string): Promise<string[] | undefined>;
 }
 
 /**
@@ -156,17 +177,32 @@ function renameStep(
   // owner's `table_name`, so the owner's update already moves them. The registry
   // is not addressed by any row either.
   const movesPointer = entry.kind === "table";
+  // Captured by `run` while the source still exists, and read by `verify`.
+  // `undefined` means the source was already gone when this step ran, so there
+  // is nothing to compare against — reported as not comparable rather than as
+  // nothing lost.
+  let indexesBefore: string[] | undefined;
 
   return {
     id: `${entry.kind}:${entry.from}->${entry.to}`,
     async run(session) {
-      if (applied) return;
+      // Observed BEFORE the transaction opens. The observer reads through the
+      // adapter, which takes its own connection; asking it from inside the
+      // transaction would wait for a second checkout and deadlock a pool sized
+      // to one.
+      const present = await observer.tables(session);
+      const catalog = indexCatalog(present, identifierCase.tables);
+      const source = resolveCatalogName(catalog, entry.from);
+      // Captured while the source still exists, so `verify` can tell whether the
+      // rename carried the table's indexes with it.
+      indexesBefore =
+        source === undefined ? undefined : await observer.indexNames(source);
+
       await session.inTransaction(async ctx => {
-        const present = await observer.tables(session);
-        const catalog = indexCatalog(present, identifierCase.tables);
         // Re-runnable: on a resume the rename may already have committed, and
-        // issuing it again would fail on a source that is no longer there.
-        if (resolveCatalogName(catalog, entry.from) !== undefined) {
+        // issuing it again would fail on a source that is no longer there. A
+        // satisfied entry skips the DDL for the same reason.
+        if (!applied && source !== undefined) {
           await ctx.execute(
             generateSQL(
               { type: "rename_table", fromName: entry.from, toName: entry.to },
@@ -174,20 +210,21 @@ function renameStep(
             )
           );
         }
+        // Deliberately NOT skipped for a satisfied entry. MySQL commits DDL
+        // implicitly, so reconciliation can mark a rename satisfied while its
+        // pointer update never landed; skipping both would leave the pointer
+        // stale and fail verification on every resume, forever. The update is
+        // idempotent, so running it when it is already correct costs nothing.
         if (!movesPointer) return;
         // Values are bound; only the table name is interpolated, through
         // `quoteIdent`. The registry cannot be reached through Drizzle here: the
         // schema registry looks tables up exactly by the name their Drizzle
         // definition declares, so a table addressed under a migrated name is
         // unregistered as far as the ORM is concerned.
+        const [toMarker, fromMarker] = placeholders(session.dialect, 2);
+        const column = quoteIdent(REGISTRY_TABLE_NAME_COLUMN, session.dialect);
         await ctx.execute(
-          `UPDATE ${quoteIdent(registryTable, session.dialect)} SET ${quoteIdent(
-            REGISTRY_TABLE_NAME_COLUMN,
-            session.dialect
-          )} = ? WHERE ${quoteIdent(
-            REGISTRY_TABLE_NAME_COLUMN,
-            session.dialect
-          )} = ?`,
+          `UPDATE ${quoteIdent(registryTable, session.dialect)} SET ${column} = ${toMarker} WHERE ${column} = ${fromMarker}`,
           [entry.to, entry.from]
         );
       });
@@ -197,14 +234,31 @@ function renameStep(
         await observer.tables(session),
         identifierCase.tables
       );
-      if (resolveCatalogName(catalog, entry.to) === undefined) return false;
+      const target = resolveCatalogName(catalog, entry.to);
+      if (target === undefined) return false;
       if (resolveCatalogName(catalog, entry.from) !== undefined) return false;
+
+      // Renaming a table keeps its indexes on every supported dialect, so a name
+      // missing afterwards means one was dropped rather than moved. Refuses
+      // rather than returning false: a lost index is not "not yet done", and a
+      // retry cannot bring it back.
+      const lost = findLostIndexes(
+        indexesBefore,
+        await observer.indexNames(target)
+      );
+      if (lost.comparable && lost.lost.length > 0) {
+        throw refuseLostIndexes({ table: target, lost: lost.lost });
+      }
+
       if (!movesPointer) return true;
       // The pointer is checked as well as the rename, because a rename whose
       // pointer update did not land is exactly the state that leaves every row
       // addressing a table that is gone.
       const pointers = await observer.pointers(session, registryTable);
-      return pointers.includes(entry.to) && !pointers.includes(entry.from);
+      if (!pointers.includes(entry.to) || pointers.includes(entry.from)) {
+        return false;
+      }
+      return true;
     },
   };
 }

--- a/packages/nextly/src/domains/field-groups/migration/steps.ts
+++ b/packages/nextly/src/domains/field-groups/migration/steps.ts
@@ -1,0 +1,276 @@
+/**
+ * Turns a rename plan into the steps that apply it.
+ *
+ * Each step pairs the work that must not be separated. Renaming a table and
+ * updating the registry row that points at it are one logical change: apart,
+ * there is a window in which every row addresses a table that no longer exists,
+ * and the read path turns that into empty content rather than an error.
+ *
+ * No SQL is written here. `generateSQL` already emits `RENAME TABLE` and
+ * `RENAME COLUMN` for all three dialects and quotes identifiers, and Drizzle has
+ * no query-builder surface for either.
+ *
+ * @module domains/field-groups/migration/steps
+ */
+
+import { NextlyError } from "../../../errors/nextly-error";
+import { generateSQL } from "../../schema/pipeline/sql-templates";
+import { quoteIdent } from "../../schema/pipeline/sql-templates/identifier-quoting";
+import {
+  indexCatalog,
+  resolveCatalogName,
+  type IdentifierCaseRules,
+} from "../../schema/utils/resolve-catalog-name";
+
+import { type ManifestEntry } from "./manifest";
+import type { MigrationStep } from "./runner";
+import type { MigrationSession } from "./session";
+
+/**
+ * The registry column holding a row's physical table name.
+ *
+ * Not in `STORAGE_FORMAT`: the collection, single and field-group registries all
+ * spell it this way, so it names no field-group concept and does not move when
+ * that concept is renamed.
+ */
+const REGISTRY_TABLE_NAME_COLUMN = "table_name";
+
+/**
+ * What a step needs to see to check its own postcondition.
+ *
+ * Injected rather than queried here so the steps stay decidable without a
+ * database, and so catalog observation keeps one implementation instead of
+ * gaining a second one inside the migration.
+ */
+export interface ObservedColumn {
+  name: string;
+  type: string;
+}
+
+export interface StorageObserver {
+  /** Every table the catalog reports, in the catalog's own spelling. */
+  tables(session: MigrationSession): Promise<string[]>;
+  /**
+   * A table's columns, or `undefined` when the catalog has no such table.
+   *
+   * The type travels with the name because `RenameColumnOp` carries one. No
+   * dialect's rename SQL emits it today, but the operation is shared with the
+   * schema pipeline, and restating the column's own type is the only honest
+   * value for a rename that does not change it.
+   */
+  columns(
+    session: MigrationSession,
+    table: string
+  ): Promise<ObservedColumn[] | undefined>;
+  /** Every `table_name` the registry currently points at. */
+  pointers(session: MigrationSession, registryTable: string): Promise<string[]>;
+}
+
+/**
+ * The registry's name while the step at `position` runs.
+ *
+ * A pointer update has to name the registry, and which name that is depends on
+ * where the registry's own rename sits in *this* plan rather than on direction:
+ * going up it renames last, so every pointer update precedes it; a rollback
+ * reverses the order, so the registry moves first and every later update
+ * addresses it under the name the rollback restored.
+ *
+ * Derived from the plan rather than probed for. Mid-run both names can be
+ * observable on a folding server, and deciding which object is the registry from
+ * the catalog would repeat a judgement reconciliation already owns.
+ *
+ * `position` is 1-based, matching the runner and the marker.
+ */
+export function registryNameAt(
+  entries: readonly ManifestEntry[],
+  position: number
+): string {
+  const index = entries.findIndex(entry => entry.kind === "registry");
+  if (index === -1) {
+    throw NextlyError.internal({
+      logContext: { reason: "plan has no registry rename", position },
+    });
+  }
+  const registry = entries[index];
+  if (registry === undefined) {
+    throw NextlyError.internal({
+      logContext: { reason: "plan has no registry rename", position },
+    });
+  }
+  // Before its own rename the registry is still at that entry's source name;
+  // after it, at the target. The registry step itself is the boundary: while it
+  // runs, the name it starts under is the one to address.
+  return position <= index + 1 ? registry.from : registry.to;
+}
+
+/** Build the ordered steps that apply a plan. */
+export function buildMigrationSteps(args: {
+  entries: readonly ManifestEntry[];
+  identifierCase: IdentifierCaseRules;
+  observer: StorageObserver;
+}): MigrationStep[] {
+  const { entries, identifierCase, observer } = args;
+  return entries.map((entry, index) => {
+    const position = index + 1;
+    // An entry reconciliation marked satisfied is already reflected in the
+    // database. It keeps its position so later steps still index correctly, and
+    // it verifies rather than re-running: a rename that has happened cannot be
+    // issued again, and the postcondition is the thing worth confirming.
+    const applied = entry.satisfied === true;
+    if (entry.kind === "column") {
+      return columnStep(entry, { position, applied, identifierCase, observer });
+    }
+    return renameStep(entry, {
+      position,
+      applied,
+      registryTable: registryNameAt(entries, position),
+      identifierCase,
+      observer,
+    });
+  });
+}
+
+interface StepContext {
+  position: number;
+  applied: boolean;
+  identifierCase: IdentifierCaseRules;
+  observer: StorageObserver;
+}
+
+/**
+ * Rename a table, and move the registry pointer with it when the table is one a
+ * registry row addresses.
+ *
+ * Both halves are idempotent because they must survive a partial step. MySQL
+ * commits DDL implicitly, so a rename can land while the pointer update fails;
+ * the resume re-runs this step, finds the table already moved, and re-applies
+ * the pointer. The rename tolerates that by checking the catalog first, and the
+ * update is a no-op once no row still points at the old name.
+ */
+function renameStep(
+  entry: ManifestEntry,
+  context: StepContext & { registryTable: string }
+): MigrationStep {
+  const { applied, identifierCase, observer, registryTable } = context;
+  // Companions carry no pointer of their own: their name is derived from the
+  // owner's `table_name`, so the owner's update already moves them. The registry
+  // is not addressed by any row either.
+  const movesPointer = entry.kind === "table";
+
+  return {
+    id: `${entry.kind}:${entry.from}->${entry.to}`,
+    async run(session) {
+      if (applied) return;
+      await session.inTransaction(async ctx => {
+        const present = await observer.tables(session);
+        const catalog = indexCatalog(present, identifierCase.tables);
+        // Re-runnable: on a resume the rename may already have committed, and
+        // issuing it again would fail on a source that is no longer there.
+        if (resolveCatalogName(catalog, entry.from) !== undefined) {
+          await ctx.execute(
+            generateSQL(
+              { type: "rename_table", fromName: entry.from, toName: entry.to },
+              session.dialect
+            )
+          );
+        }
+        if (!movesPointer) return;
+        // Values are bound; only the table name is interpolated, through
+        // `quoteIdent`. The registry cannot be reached through Drizzle here: the
+        // schema registry looks tables up exactly by the name their Drizzle
+        // definition declares, so a table addressed under a migrated name is
+        // unregistered as far as the ORM is concerned.
+        await ctx.execute(
+          `UPDATE ${quoteIdent(registryTable, session.dialect)} SET ${quoteIdent(
+            REGISTRY_TABLE_NAME_COLUMN,
+            session.dialect
+          )} = ? WHERE ${quoteIdent(
+            REGISTRY_TABLE_NAME_COLUMN,
+            session.dialect
+          )} = ?`,
+          [entry.to, entry.from]
+        );
+      });
+    },
+    async verify(session) {
+      const catalog = indexCatalog(
+        await observer.tables(session),
+        identifierCase.tables
+      );
+      if (resolveCatalogName(catalog, entry.to) === undefined) return false;
+      if (resolveCatalogName(catalog, entry.from) !== undefined) return false;
+      if (!movesPointer) return true;
+      // The pointer is checked as well as the rename, because a rename whose
+      // pointer update did not land is exactly the state that leaves every row
+      // addressing a table that is gone.
+      const pointers = await observer.pointers(session, registryTable);
+      return pointers.includes(entry.to) && !pointers.includes(entry.from);
+    },
+  };
+}
+
+/** Rename the discriminator column on one table. */
+function columnStep(entry: ManifestEntry, context: StepContext): MigrationStep {
+  const { applied, identifierCase, observer } = context;
+  const table = entry.table;
+  if (table === undefined) {
+    throw NextlyError.internal({
+      logContext: {
+        reason: "column entry names no table",
+        from: entry.from,
+        to: entry.to,
+      },
+    });
+  }
+
+  return {
+    id: `column:${table}.${entry.from}->${entry.to}`,
+    async run(session) {
+      if (applied) return;
+      await session.inTransaction(async ctx => {
+        const columns = await observer.columns(session, table);
+        if (columns === undefined) {
+          throw NextlyError.serviceUnavailable({
+            logMessage: `field-group migration cannot rename a column on a missing table: ${table}`,
+            logContext: { reason: "column step's table is absent", table },
+          });
+        }
+        const index = indexCatalog(
+          columns.map(column => column.name),
+          identifierCase.columns
+        );
+        // Re-runnable for the same reason a table rename is.
+        const current = resolveCatalogName(index, entry.from);
+        if (current === undefined) return;
+        const observed = columns.find(column => column.name === current);
+        await ctx.execute(
+          generateSQL(
+            {
+              type: "rename_column",
+              tableName: table,
+              fromColumn: entry.from,
+              toColumn: entry.to,
+              // A rename does not change the type, so both sides restate the
+              // one the column already has.
+              fromType: observed?.type ?? "",
+              toType: observed?.type ?? "",
+            },
+            session.dialect
+          )
+        );
+      });
+    },
+    async verify(session) {
+      const columns = await observer.columns(session, table);
+      if (columns === undefined) return false;
+      const index = indexCatalog(
+        columns.map(column => column.name),
+        identifierCase.columns
+      );
+      return (
+        resolveCatalogName(index, entry.to) !== undefined &&
+        resolveCatalogName(index, entry.from) === undefined
+      );
+    },
+  };
+}

--- a/packages/nextly/src/domains/field-groups/migration/steps.ts
+++ b/packages/nextly/src/domains/field-groups/migration/steps.ts
@@ -315,8 +315,12 @@ function columnStep(entry: ManifestEntry, context: StepContext): MigrationStep {
     id: `column:${table}.${entry.from}->${entry.to}`,
     async run(session) {
       if (applied) return;
+      // Observed BEFORE the transaction, for the same reason the table path is:
+      // the observer reads through the adapter, which checks out its own
+      // connection, so asking from inside would wait for a second checkout and
+      // hang a pool sized to one.
+      const columns = await observer.columns(session, table);
       await session.inTransaction(async ctx => {
-        const columns = await observer.columns(session, table);
         if (columns === undefined) {
           throw NextlyError.serviceUnavailable({
             logMessage: `field-group migration cannot rename a column on a missing table: ${table}`,

--- a/packages/nextly/src/domains/field-groups/migration/sync-guard.ts
+++ b/packages/nextly/src/domains/field-groups/migration/sync-guard.ts
@@ -1,0 +1,54 @@
+/**
+ * Keeps schema sync away from storage a migration is halfway through renaming.
+ *
+ * `db:sync` reconciles the database against the config and, with
+ * `--remove-orphaned`, deletes entities the config no longer declares. Mid-run
+ * that reconciliation is reading a world neither the old config nor the new one
+ * describes: some tables carry their pre-rename names and some their post-rename
+ * names, and the registry rows pointing at them move one step at a time.
+ *
+ * Nothing about that is recoverable by being careful in the sync. The only safe
+ * answer is not to run, so this refuses and says how to clear the state.
+ *
+ * @module domains/field-groups/migration/sync-guard
+ */
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+
+import { NextlyError } from "../../../errors/nextly-error";
+import type { Logger } from "../../../shared/types";
+import { MetaService } from "../../meta/services/meta-service";
+
+import { readMigrationState } from "./state";
+
+/**
+ * Refuse to continue while a field-group storage migration is in flight.
+ *
+ * Call after the core tables exist — the marker lives in `nextly_meta`, so a
+ * database that has never been set up has nothing to read — and before anything
+ * that inspects or changes schema.
+ *
+ * A marker that is present but unreadable refuses through `readMigrationState`
+ * rather than being treated as absent, which is the same call this makes at
+ * runtime: an unreadable marker may still describe renamed objects.
+ */
+export async function assertNoMigrationInFlight(args: {
+  adapter: DrizzleAdapter;
+  logger: Logger;
+}): Promise<void> {
+  const state = await readMigrationState(
+    new MetaService(args.adapter, args.logger)
+  );
+  if (state.status !== "migrating") return;
+
+  throw NextlyError.serviceUnavailable({
+    logMessage:
+      "schema sync refused: a field group storage migration is in flight",
+    logContext: {
+      reason: "field group storage migration is in flight",
+      direction: state.direction,
+      migrationId: state.migrationId,
+      step: state.step,
+    },
+  });
+}

--- a/packages/nextly/src/domains/field-groups/migration/sync-guard.ts
+++ b/packages/nextly/src/domains/field-groups/migration/sync-guard.ts
@@ -19,6 +19,7 @@ import { NextlyError } from "../../../errors/nextly-error";
 import type { Logger } from "../../../shared/types";
 import { MetaService } from "../../meta/services/meta-service";
 
+import { withMigrationSession } from "./session";
 import { readMigrationState } from "./state";
 
 /**
@@ -51,4 +52,43 @@ export async function assertNoMigrationInFlight(args: {
       step: state.step,
     },
   });
+}
+
+/**
+ * Run schema sync work with a storage migration excluded for its whole duration.
+ *
+ * Reading the marker and then proceeding only answers whether a migration had
+ * started by the instant of the read. A sync takes far longer than that, and a
+ * migration beginning immediately afterwards renames tables underneath work that
+ * has already decided what exists — with `--remove-orphaned`, deciding to delete
+ * it. Exclusion has to be *held*, not sampled.
+ *
+ * The migration's own lock is what it is held with, so the two exclude each
+ * other through one mechanism rather than two that must agree. A run in flight
+ * holds it and this refuses; a run that died holds it still, by design, because
+ * there is no trustworthy clock to expire it with.
+ *
+ * The marker is then checked inside the lock, because holding it is necessary
+ * and not sufficient: an operator who cleared a dead run's lock row without
+ * settling its marker would otherwise be let straight through into exactly the
+ * half-renamed storage this exists to protect.
+ */
+export async function withMigrationExcluded<T>(
+  args: { adapter: DrizzleAdapter; logger: Logger; label: string },
+  work: () => Promise<T>
+): Promise<T> {
+  return withMigrationSession(
+    {
+      adapter: args.adapter,
+      dialect: args.adapter.getCapabilities().dialect,
+      label: args.label,
+    },
+    async () => {
+      await assertNoMigrationInFlight({
+        adapter: args.adapter,
+        logger: args.logger,
+      });
+      return work();
+    }
+  );
 }

--- a/packages/nextly/src/domains/field-groups/migration/sync-guard.ts
+++ b/packages/nextly/src/domains/field-groups/migration/sync-guard.ts
@@ -93,6 +93,10 @@ export async function withMigrationExcluded<T>(
       adapter: args.adapter,
       dialect: args.adapter.getCapabilities().dialect,
       label: args.label,
+      // A sync neither owns the lock table nor may create one: `--no-auto-sync`
+      // promises no schema changes, and its absence already means no migration
+      // has ever run here.
+      requireExistingLock: true,
     },
     async () => {
       await assertNoMigrationInFlight({

--- a/packages/nextly/src/domains/field-groups/migration/sync-guard.ts
+++ b/packages/nextly/src/domains/field-groups/migration/sync-guard.ts
@@ -85,7 +85,25 @@ export async function assertNoMigrationInFlight(args: {
  * half-renamed storage this exists to protect.
  */
 export async function withMigrationExcluded<T>(
-  args: { adapter: DrizzleAdapter; logger: Logger; label: string },
+  args: {
+    adapter: DrizzleAdapter;
+    logger: Logger;
+    label: string;
+    /**
+     * Whether this caller is allowed to issue schema changes.
+     *
+     * When it is, the lock table is created if missing, so the exclusion is
+     * real even on a database no migration has touched yet — otherwise a first
+     * migration could create the table and claim it while a sync was already
+     * running unprotected.
+     *
+     * When it is not (`--no-auto-sync`, or a role with DML but no DDL), the
+     * table cannot be created, and a database without one has never run a
+     * migration. The residual is a first-ever migration starting during that
+     * sync, which is narrower than refusing the command outright.
+     */
+    mayCreateLock: boolean;
+  },
   work: () => Promise<T>
 ): Promise<T> {
   return withMigrationSession(
@@ -93,10 +111,7 @@ export async function withMigrationExcluded<T>(
       adapter: args.adapter,
       dialect: args.adapter.getCapabilities().dialect,
       label: args.label,
-      // A sync neither owns the lock table nor may create one: `--no-auto-sync`
-      // promises no schema changes, and its absence already means no migration
-      // has ever run here.
-      requireExistingLock: true,
+      requireExistingLock: !args.mayCreateLock,
     },
     async () => {
       await assertNoMigrationInFlight({

--- a/packages/nextly/src/domains/field-groups/migration/sync-guard.ts
+++ b/packages/nextly/src/domains/field-groups/migration/sync-guard.ts
@@ -112,6 +112,10 @@ export async function withMigrationExcluded<T>(
       dialect: args.adapter.getCapabilities().dialect,
       label: args.label,
       requireExistingLock: !args.mayCreateLock,
+      // A sync's claim is safe to drop on a signal: two syncs overlapping is
+      // the state that existed before this exclusion, whereas a migration's
+      // claim must survive interruption.
+      releaseOnInterrupt: true,
     },
     async () => {
       await assertNoMigrationInFlight({

--- a/packages/nextly/src/domains/field-groups/migration/sync-guard.ts
+++ b/packages/nextly/src/domains/field-groups/migration/sync-guard.ts
@@ -22,6 +22,9 @@ import { MetaService } from "../../meta/services/meta-service";
 import { withMigrationSession } from "./session";
 import { readMigrationState } from "./state";
 
+/** The key/value table the migration marker lives in. */
+const META_TABLE = "nextly_meta";
+
 /**
  * Refuse to continue while a field-group storage migration is in flight.
  *
@@ -37,6 +40,14 @@ export async function assertNoMigrationInFlight(args: {
   adapter: DrizzleAdapter;
   logger: Logger;
 }): Promise<void> {
+  // A database that has no `nextly_meta` at all has never recorded a marker, so
+  // there is no run to be in flight. Asked explicitly rather than inferred from
+  // a failed read: an unreadable marker must still refuse, and asked explicitly
+  // rather than inferred from core-table setup either, because that returns as
+  // soon as it finds `users` and so does not establish the newer system tables
+  // on a database that predates them.
+  if (!(await args.adapter.tableExists(META_TABLE))) return;
+
   const state = await readMigrationState(
     new MetaService(args.adapter, args.logger)
   );

--- a/packages/nextly/src/domains/schema/pipeline/diff/__tests__/pg-index-schema-scope.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/__tests__/pg-index-schema-scope.integration.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Which schema's indexes a Postgres snapshot reports.
+ *
+ * `pg_class.relname` is unique per schema rather than per database, so a table
+ * name introspected without a namespace filter matches every schema that
+ * happens to hold that name. The columns are already scoped to `public`; the
+ * indexes have to be scoped the same way, or a table's snapshot carries indexes
+ * that are not on it — which reads as "this index already exists" to the diff
+ * and as "an index went missing" to anything comparing a rename's before and
+ * after.
+ *
+ * A same-named table in a second schema is not hypothetical: search_path
+ * layouts, staging copies and per-tenant schemas all produce one.
+ */
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { introspectLiveSnapshot } from "../introspect-live";
+import type { TableSpec } from "../types";
+
+const TABLE = "nextly_idxscope_posts";
+const OTHER_SCHEMA = "nextly_idxscope_other";
+const PUBLIC_INDEX = "nextly_idxscope_public_ix";
+const OTHER_INDEX = "nextly_idxscope_other_ix";
+
+describe.skipIf(!process.env.TEST_POSTGRES_URL)(
+  "postgres index introspection schema scope",
+  () => {
+    let pool: Pool;
+    let table: TableSpec | undefined;
+
+    beforeAll(async () => {
+      pool = new Pool({ connectionString: process.env.TEST_POSTGRES_URL });
+      await pool.query(`DROP TABLE IF EXISTS "${TABLE}" CASCADE`);
+      await pool.query(`DROP SCHEMA IF EXISTS "${OTHER_SCHEMA}" CASCADE`);
+
+      await pool.query(
+        `CREATE TABLE "${TABLE}" (id serial PRIMARY KEY, slug text)`
+      );
+      await pool.query(`CREATE INDEX "${PUBLIC_INDEX}" ON "${TABLE}" (slug)`);
+
+      // Same table name, different schema, different index. Only the first of
+      // those distinguishes it in a query that filters on relname alone.
+      await pool.query(`CREATE SCHEMA "${OTHER_SCHEMA}"`);
+      await pool.query(
+        `CREATE TABLE "${OTHER_SCHEMA}"."${TABLE}" (id serial PRIMARY KEY, slug text)`
+      );
+      await pool.query(
+        `CREATE INDEX "${OTHER_INDEX}" ON "${OTHER_SCHEMA}"."${TABLE}" (slug)`
+      );
+
+      const live = await introspectLiveSnapshot(
+        drizzle({ client: pool }),
+        "postgresql",
+        [TABLE]
+      );
+      table = live.tables.find(entry => entry.name === TABLE);
+    });
+
+    afterAll(async () => {
+      await pool.query(`DROP TABLE IF EXISTS "${TABLE}" CASCADE`);
+      await pool.query(`DROP SCHEMA IF EXISTS "${OTHER_SCHEMA}" CASCADE`);
+      await pool.end();
+    });
+
+    it("reports the public table's own index", () => {
+      expect(table?.indexes?.map(index => index.name)).toContain(PUBLIC_INDEX);
+    });
+
+    it("does not report an index from a same-named table in another schema", () => {
+      expect(table?.indexes?.map(index => index.name)).not.toContain(
+        OTHER_INDEX
+      );
+    });
+
+    it("reports exactly the indexes the public table has", () => {
+      // Asserted as a set as well as by name: a merge that happened to reuse an
+      // index name would pass both checks above while still describing a table
+      // this snapshot was never asked about.
+      expect(table?.indexes?.map(index => index.name).sort()).toEqual([
+        PUBLIC_INDEX,
+      ]);
+    });
+  }
+);

--- a/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
+++ b/packages/nextly/src/domains/schema/pipeline/diff/introspect-live.ts
@@ -176,14 +176,23 @@ export async function introspectLiveSnapshot(
     // Index query: join pg_index/pg_class/pg_attribute. Exclude primary keys
     // (indisprimary) and partial indexes (indpred). Expression indexes yield no
     // pg_attribute row and are naturally excluded.
+    //
+    // Scoped to `public` like the column query above. `pg_class.relname` is
+    // unique per schema, not per database, so without the namespace join a
+    // same-named table in another schema contributes its indexes to these rows
+    // and `attachIndexes` groups them under the same name — reporting indexes
+    // that are not on the table being introspected, and masking the absence of
+    // ones that should be.
     const idxResult = (await dbTyped.execute(
       sql`SELECT t.relname AS table, i.relname AS index, ix.indisunique AS unique,
                  a.attname AS column, array_position(ix.indkey, a.attnum) AS ord
           FROM pg_class t
+          JOIN pg_namespace n ON n.oid = t.relnamespace
           JOIN pg_index ix ON ix.indrelid = t.oid
           JOIN pg_class i ON i.oid = ix.indexrelid
           JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
-          WHERE t.relname IN (${tableNamesIn})
+          WHERE n.nspname = 'public'
+            AND t.relname IN (${tableNamesIn})
             AND ix.indisprimary = false
             AND ix.indpred IS NULL
             AND a.attnum > 0

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -12,6 +12,8 @@
 import { getColumns } from "drizzle-orm";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+import { createLockingAdapter } from "../../domains/field-groups/migration/__tests__/helpers/locking-adapter";
+
 import type { NextlySchemaSnapshot } from "../../domains/schema/pipeline/diff/types";
 import type { PromptDispatcher } from "../../domains/schema/pipeline/pushschema-pipeline-interfaces";
 
@@ -111,8 +113,14 @@ describe("reloadNextlyConfig", () => {
     }>;
     /** Force the metadata-only collection sync to reject, so its scope is unsynced. */
     failCollectionMetaSync?: boolean;
+    /** Seed a `nextly_meta` migration marker the storage guard will read. */
+    migrationMarker?: unknown;
   }) {
     const withAdapter = opts?.withAdapter ?? true;
+    const lockDouble = createLockingAdapter({
+      lockTableExists: false,
+      marker: opts?.migrationMarker,
+    });
     const syncCodeFirstComponentsSpy = vi.fn().mockResolvedValue({});
     const registerDynamicSchemaSpy = vi.fn();
     const updateCollectionMigrationStatusSpy = vi
@@ -124,17 +132,16 @@ describe("reloadNextlyConfig", () => {
       logger: { warn: warnSpy, info: vi.fn(), error: errorSpy },
       // The DI key is "adapter" (renamed from "databaseAdapter" — see the
       // comment in reload-config.ts line ~205 for the history).
+      // The reload holds the migration lock for its duration, so the fake has
+      // to answer the whole exclusion rather than just the marker read. Shared
+      // with the session's own suite so the two cannot drift into disagreeing
+      // about what the lock does.
       adapter: withAdapter
-        ? {
-            // dialect is a readonly property on DrizzleAdapter, not a
-            // method. Fakes must match.
+        ? Object.assign(lockDouble.adapter, {
             dialect: "sqlite" as const,
-            getDrizzle: () => ({}),
-            // The real adapter has this, and the storage guard asks it whether
-            // the marker table exists before reading it. A fake without it
-            // would make every reload look like a refused one.
-            tableExists: vi.fn().mockResolvedValue(false),
-          }
+            getCapabilities: () => ({ dialect: "sqlite" }),
+            getDrizzle: lockDouble.adapter.getDrizzle.bind(lockDouble.adapter),
+          })
         : undefined,
       collectionRegistryService: {
         syncCodeFirstCollections: opts?.failCollectionMetaSync
@@ -251,47 +258,23 @@ describe("reloadNextlyConfig", () => {
         ],
       },
     });
-    const resolver = buildResolver();
-    // A marker the storage guard reads as an in-flight run.
-    const adapter = (await resolver("adapter")) as {
-      tableExists: ReturnType<typeof vi.fn>;
-      getDrizzle: () => unknown;
-      getCapabilities?: () => { dialect: string };
-    };
-    adapter.tableExists.mockResolvedValue(true);
-    // `MetaService` picks its dialect-specific table through this; without it
-    // the read throws and the test would exercise the unexpected-error path
-    // while claiming to cover the refusal.
-    adapter.getCapabilities = () => ({ dialect: "sqlite" });
-    adapter.getDrizzle = () => ({
-      select: () => ({
-        from: () => ({
-          where: () => ({
-            limit: () =>
-              Promise.resolve([
-                {
-                  key: "field_groups.storage_migration",
-                  value: JSON.stringify({
-                    version: 2,
-                    status: "migrating",
-                    direction: "up",
-                    migrationId: "run-1",
-                    step: 1,
-                    registryHash: "r",
-                    manifestHash: "m",
-                    appliedManifest: [
-                      {
-                        kind: "registry",
-                        from: "dynamic_components",
-                        to: "dynamic_field_groups",
-                      },
-                    ],
-                  }),
-                },
-              ]),
-          }),
-        }),
-      }),
+    const resolver = buildResolver({
+      migrationMarker: {
+        version: 2,
+        status: "migrating",
+        direction: "up",
+        migrationId: "run-1",
+        step: 1,
+        registryHash: "r",
+        manifestHash: "m",
+        appliedManifest: [
+          {
+            kind: "registry",
+            from: "dynamic_components",
+            to: "dynamic_field_groups",
+          },
+        ],
+      },
     });
 
     const { reloadNextlyConfig } = await import("../reload-config");

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -130,6 +130,10 @@ describe("reloadNextlyConfig", () => {
             // method. Fakes must match.
             dialect: "sqlite" as const,
             getDrizzle: () => ({}),
+            // The real adapter has this, and the storage guard asks it whether
+            // the marker table exists before reading it. A fake without it
+            // would make every reload look like a refused one.
+            tableExists: vi.fn().mockResolvedValue(false),
           }
         : undefined,
       collectionRegistryService: {
@@ -228,6 +232,75 @@ describe("reloadNextlyConfig", () => {
     await reloadNextlyConfig({ resolver: buildResolver() });
     expect(clearConfigCacheSpy).toHaveBeenCalledTimes(1);
     expect(loadConfigSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // `next dev` routes config edits here rather than through the CLI watcher, so
+  // this is the schema-applying path most users are on. Mid-migration the
+  // database has some tables under pre-rename names and some under post-rename
+  // ones, and the apply below runs DDL plus a pre-cleanup that issues UPDATE and
+  // DELETE — work that cannot be reasoned about against half-renamed storage.
+  it("abandons the reload while a field-group migration is in flight", async () => {
+    loadConfigSpy.mockResolvedValue({
+      config: {
+        collections: [
+          {
+            slug: "posts",
+            tableName: "dc_posts",
+            fields: [{ name: "body", type: "text" }],
+          },
+        ],
+      },
+    });
+    const resolver = buildResolver();
+    // A marker the storage guard reads as an in-flight run.
+    const adapter = (await resolver("adapter")) as {
+      tableExists: ReturnType<typeof vi.fn>;
+      getDrizzle: () => unknown;
+      getCapabilities?: () => { dialect: string };
+    };
+    adapter.tableExists.mockResolvedValue(true);
+    // `MetaService` picks its dialect-specific table through this; without it
+    // the read throws and the test would exercise the unexpected-error path
+    // while claiming to cover the refusal.
+    adapter.getCapabilities = () => ({ dialect: "sqlite" });
+    adapter.getDrizzle = () => ({
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: () =>
+              Promise.resolve([
+                {
+                  key: "field_groups.storage_migration",
+                  value: JSON.stringify({
+                    version: 2,
+                    status: "migrating",
+                    direction: "up",
+                    migrationId: "run-1",
+                    step: 1,
+                    registryHash: "r",
+                    manifestHash: "m",
+                    appliedManifest: [
+                      {
+                        kind: "registry",
+                        from: "dynamic_components",
+                        to: "dynamic_field_groups",
+                      },
+                    ],
+                  }),
+                },
+              ]),
+          }),
+        }),
+      }),
+    });
+
+    const { reloadNextlyConfig } = await import("../reload-config");
+    await reloadNextlyConfig({ resolver });
+
+    expect(pipelineApplySpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("schema reload skipped")
+    );
   });
 
   it("introspects all desired tables in ONE batched call", async () => {

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -21,8 +21,10 @@
 //     which the pipeline maps to CONFIRMATION_REQUIRED_NO_TTY. We log
 //     that and keep the dev server alive.
 
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
+import { assertNoMigrationInFlight } from "../domains/field-groups/migration/sync-guard";
 import { createApplyDesiredSchema } from "../domains/schema/pipeline/apply";
 import { RealClassifier } from "../domains/schema/pipeline/classifier/classifier";
 import { extractDatabaseNameFromUrl } from "../domains/schema/pipeline/database-url";
@@ -71,6 +73,8 @@ import {
 } from "../domains/webhooks/recording-policy";
 import { collectPluginContributedSlugs } from "../domains/webhooks/recording-provenance";
 import { resolveWebhookRecording } from "../domains/webhooks/resolve-recording-config";
+import { describeError } from "../errors/index";
+import { NextlyError } from "../errors/nextly-error";
 import type { PluginFieldType } from "../plugins/contributions";
 import type { RevalidateConfig } from "../revalidation/types";
 import { getProductionNotifier } from "../runtime/notifications/index";
@@ -932,6 +936,44 @@ async function runReload(opts?: {
   // Resolution can succeed and still hand back no adapter, which is the same
   // outcome as it throwing: nothing below runs, so the reload never lands.
   if (!adapter) {
+    abandonReload();
+    return;
+  }
+
+  // `next dev` routes config edits here rather than through the CLI watcher, so
+  // this is the schema-applying path most users are on — and mid-migration it
+  // would be reading a database where some tables carry pre-rename names, some
+  // post-rename, and the registry pointers move one step at a time. The apply
+  // below runs DDL and a pre-cleanup that issues UPDATE and DELETE, so a reload
+  // in that window can act on storage it cannot account for.
+  //
+  // Abandoned rather than thrown: a reload that refuses leaves the previous
+  // config in place, which is the safe outcome, whereas an exception here
+  // reaches the dev server and turns every later request into a 500.
+  try {
+    await assertNoMigrationInFlight({
+      // `AdapterLike` is a narrow view of the registered adapter, which is a
+      // `DrizzleAdapter` at runtime.
+      adapter: adapter as unknown as DrizzleAdapter,
+      logger: logger as unknown as Parameters<
+        typeof assertNoMigrationInFlight
+      >[0]["logger"],
+    });
+  } catch (error) {
+    // Either way the reload is abandoned, because applying schema over storage
+    // whose state could not be established is the thing being prevented. They
+    // are logged differently on purpose: a refusal is routine and expected,
+    // while anything else means the check itself could not run, which would
+    // otherwise disable schema applies silently and look like nothing happened.
+    if (NextlyError.is(error)) {
+      logger.warn(
+        `[Nextly HMR] schema reload skipped: ${describeError(error)}`
+      );
+    } else {
+      logger.error(
+        `[Nextly HMR] could not determine migration state, skipping schema reload: ${describeError(error)}`
+      );
+    }
     abandonReload();
     return;
   }

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -24,7 +24,7 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
-import { assertNoMigrationInFlight } from "../domains/field-groups/migration/sync-guard";
+import { withMigrationExcluded } from "../domains/field-groups/migration/sync-guard";
 import { createApplyDesiredSchema } from "../domains/schema/pipeline/apply";
 import { RealClassifier } from "../domains/schema/pipeline/classifier/classifier";
 import { extractDatabaseNameFromUrl } from "../domains/schema/pipeline/database-url";
@@ -768,7 +768,84 @@ function startReload(opts?: {
   return started;
 }
 
+/**
+ * Run a reload with a field-group storage migration excluded throughout.
+ *
+ * `next dev` routes config edits here rather than through the CLI watcher, so
+ * this is the schema-applying path most users are on: it builds field-group
+ * diffs, applies DDL, and its pre-cleanup issues UPDATE and DELETE.
+ * Mid-migration that work reads a database where some tables carry pre-rename
+ * names and some post-rename, with the registry pointers moving one step at a
+ * time.
+ *
+ * The exclusion is *held* rather than sampled, because a migration starting
+ * between a check and the apply leaves exactly the same window open. Holding is
+ * safe here specifically because reloads are already serialized in this process
+ * — `reloadNextlyConfig` keeps one in flight and queues the next — so taking
+ * the lock cannot make a concurrent edit lose its turn.
+ *
+ * A refusal abandons the reload rather than throwing: the previous config stays
+ * in place, whereas an exception escaping here reaches the dev server and turns
+ * every later request into a 500.
+ */
 async function runReload(opts?: {
+  resolver?: ServiceResolver;
+  dispatcher?: PromptDispatcher;
+}): Promise<void> {
+  const resolveService = (name: string): unknown =>
+    opts?.resolver ? opts.resolver(name) : defaultResolver(name);
+
+  let adapter: AdapterLike | undefined;
+  let logger: LoggerLike | undefined;
+  try {
+    logger = (await resolveService("logger")) as LoggerLike;
+    adapter = (await resolveService("adapter")) as AdapterLike;
+  } catch {
+    // DI is not up yet. `applyReload` resolves again and abandons on its own,
+    // so there is nothing to exclude against and nothing to report here.
+  }
+  if (!adapter) return applyReload(opts);
+
+  // Tells a refused exclusion apart from a failure inside the reload itself,
+  // which must propagate exactly as it did before this wrapper existed.
+  let reloadStarted = false;
+  try {
+    await withMigrationExcluded(
+      {
+        // `AdapterLike` is a narrow view of the registered adapter, which is a
+        // `DrizzleAdapter` at runtime.
+        adapter: adapter as unknown as DrizzleAdapter,
+        logger: logger as unknown as Parameters<
+          typeof withMigrationExcluded
+        >[0]["logger"],
+        label: "hmr reload",
+        // This path applies DDL by design, so it may establish the lock table
+        // rather than proceeding unprotected without one.
+        mayCreateLock: true,
+      },
+      () => {
+        reloadStarted = true;
+        return applyReload(opts);
+      }
+    );
+  } catch (error) {
+    if (reloadStarted) throw error;
+    // Logged apart on purpose: a refusal is routine and expected, while a check
+    // that could not run at all would otherwise disable schema applies silently
+    // and look like nothing happened.
+    if (NextlyError.is(error)) {
+      logger?.warn(
+        `[Nextly HMR] schema reload skipped: ${describeError(error)}`
+      );
+    } else {
+      logger?.error(
+        `[Nextly HMR] could not establish migration state, skipping schema reload: ${describeError(error)}`
+      );
+    }
+  }
+}
+
+async function applyReload(opts?: {
   resolver?: ServiceResolver;
   dispatcher?: PromptDispatcher;
 }): Promise<void> {
@@ -936,44 +1013,6 @@ async function runReload(opts?: {
   // Resolution can succeed and still hand back no adapter, which is the same
   // outcome as it throwing: nothing below runs, so the reload never lands.
   if (!adapter) {
-    abandonReload();
-    return;
-  }
-
-  // `next dev` routes config edits here rather than through the CLI watcher, so
-  // this is the schema-applying path most users are on — and mid-migration it
-  // would be reading a database where some tables carry pre-rename names, some
-  // post-rename, and the registry pointers move one step at a time. The apply
-  // below runs DDL and a pre-cleanup that issues UPDATE and DELETE, so a reload
-  // in that window can act on storage it cannot account for.
-  //
-  // Abandoned rather than thrown: a reload that refuses leaves the previous
-  // config in place, which is the safe outcome, whereas an exception here
-  // reaches the dev server and turns every later request into a 500.
-  try {
-    await assertNoMigrationInFlight({
-      // `AdapterLike` is a narrow view of the registered adapter, which is a
-      // `DrizzleAdapter` at runtime.
-      adapter: adapter as unknown as DrizzleAdapter,
-      logger: logger as unknown as Parameters<
-        typeof assertNoMigrationInFlight
-      >[0]["logger"],
-    });
-  } catch (error) {
-    // Either way the reload is abandoned, because applying schema over storage
-    // whose state could not be established is the thing being prevented. They
-    // are logged differently on purpose: a refusal is routine and expected,
-    // while anything else means the check itself could not run, which would
-    // otherwise disable schema applies silently and look like nothing happened.
-    if (NextlyError.is(error)) {
-      logger.warn(
-        `[Nextly HMR] schema reload skipped: ${describeError(error)}`
-      );
-    } else {
-      logger.error(
-        `[Nextly HMR] could not determine migration state, skipping schema reload: ${describeError(error)}`
-      );
-    }
     abandonReload();
     return;
   }


### PR DESCRIPTION
Slice B1-3c of task 011. Continues from #408 (reconciliation). Five commits, each independently verified; **nothing calls the migration itself yet** except the sync guard, which is live.

## What this is

The migration could plan its renames and check that plan against the catalog. It could not yet **run** them. This makes each step executable and self-verifying, and closes the one gap that could destroy data before the migration is even wired up.

### 1. The recorded plan is what a resume executes

A resume used to rebuild its plan from registry rows and compare two hashes. That stops working the moment a rename updates its registry pointer: the rebuilt plan omits every row already renamed, so it has fewer entries, different step positions, and a different hash from the one the marker recorded — and the resume refuses the very plan it is resuming.

The plan is now persisted for both directions and read back. Identity moved with it: the stored plan is checked against a hash of itself, and "did the world move underneath this run" is answered by hashing the **sorted slug set**. Slugs, because table names are rewritten *as the run progresses* — a name-based comparison would refuse every resume past step one.

### 2. Each table rename carries its registry pointer

Renaming `comp_hero` to `fg_hero` while `dynamic_components.table_name` still says `comp_hero` leaves every row addressing a table that is gone, and the read path turns that into empty content rather than an error. The two now land in one transaction, and `verify` checks **both**.

Which name the pointer update targets is derived from the plan, not probed for: the registry renames last going up and first on a rollback, so the answer depends on position within *that* plan. Mid-run both names can be observable on a folding server, and reading it from the catalog would repeat a judgement reconciliation already owns.

Both halves are idempotent because MySQL commits DDL implicitly — a rename can land while the pointer update fails, so a resume applies only the half that is missing.

### 3. `db:sync` refuses while a migration is in flight

The highest-risk item here. Mid-run some tables carry pre-rename names and some post-rename, and `--remove-orphaned` deletes what it cannot account for. An unreadable marker refuses rather than reading as absent: absence means no migration ever ran, while an unreadable marker may still describe renamed objects.

### 4. Index survival is checked by name

From the existing `introspectLiveSnapshot` — no new adapter methods. By name rather than by count, because a count survives losing one index and gaining another, which is the exact shape of the SQLite index loss. An untracked index list stays `undefined` rather than collapsing to `[]`, so a caller cannot mistake "nothing was lost" for "nothing could be compared".

## Verification

`pnpm build` 17/17 · `pnpm check-types` 19/19 · `pnpm lint` exit 0 · full `packages/nextly` run **401**, matching the baseline measured on main, with **0 branch-only failures**.

Every behavioural change has a test proven load-bearing by breaking the implementation and confirming the intended test failed with the count unchanged — 11 breaks across the five commits.

## Worth a reviewer's attention

- **A known gap, stated rather than hidden:** the per-step index check compares before/after within one invocation. On a resumed step the rename has already committed, so there is no before-state and it reports *not comparable* rather than passing. A crash between a rename and its verification can therefore hide index loss; the backstop is B1-5's end-of-run structural verification, not a per-step guess.
- **MySQL non-transactional DDL** is reasoned about and encoded, but **not yet observed on a real server**. B1-5's 3-dialect matrix is where that gets tested.
- Two raw statements exist deliberately: the registry pointer update and its read. Both address a table by a name the ORM's schema registry cannot resolve — it looks tables up exactly by the name their Drizzle definition declares, and during a run the registry sits under whichever name the plan has reached. Values are bound; identifiers go through `quoteIdent`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a safer migration exclusion scope so schema sync (including watch-mode re-sync) can proceed while a field-group migration is in-flight.
  * Improved field-group migration planning/resume with stronger recorded plan identity handling and companion-aware behavior.
  * Added storage observation helpers to support rename/index verification.

* **Bug Fixes**
  * Improved rename reconciliation for companion moves and more reliable resume/rollback verification.
  * Postgres index introspection now properly respects schema scoping.

* **Tests**
  * Expanded migration guard, storage observation, step/reconciliation, session/lock behavior, and schema reload skip coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->