### PR TITLE
fix(plugin-form-builder): allow a form update that omits its fields

### DIFF
--- a/.changeset/form-builder-partial-update.md
+++ b/.changeset/form-builder-partial-update.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Let a form be updated without resending its fields. Changing a form's name or settings failed with "Form must have at least one field" because an absent `fields` in the patch was treated as an empty one.

--- a/packages/plugin-form-builder/src/collections/__tests__/forms-hooks.test.ts
+++ b/packages/plugin-form-builder/src/collections/__tests__/forms-hooks.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The forms `beforeValidate` hook, against partial updates.
+ *
+ * "A form must have at least one field" was checked by treating an absent
+ * `fields` as an empty one. An update carries the patch rather than the merged
+ * document, so renaming a form — or changing any setting that is not its fields
+ * — arrived with `fields` undefined and was rejected, even though the form's
+ * fields were untouched and still there.
+ *
+ * Core already documents the rule this now follows: on update only the fields
+ * present in the patch are checked, so a required value cannot be blanked but
+ * an untouched one is not re-validated.
+ *
+ * These run against the hook itself rather than a booted instance, because that
+ * is the level the decision is made at and the level a future edit would break.
+ */
+import type { HookContext } from "nextly";
+import { describe, expect, it } from "vitest";
+
+import { formsCollection } from "../forms";
+import type { ResolvedFormBuilderConfig } from "../../types";
+
+/** The hook under test, as the collection factory produces it. */
+function beforeValidate(): (context: HookContext) => unknown {
+  const collection = formsCollection({
+    formOverrides: { slug: "forms" },
+    formSubmissionOverrides: {},
+    // Read by the factory while assembling the collection; the hook under test
+    // does not consult it, but building the collection at all requires it.
+    redirectRelationships: [],
+  } as unknown as ResolvedFormBuilderConfig);
+  const hooks = (
+    collection as unknown as {
+      hooks?: { beforeValidate?: Array<(context: HookContext) => unknown> };
+    }
+  ).hooks;
+  const handler = hooks?.beforeValidate?.[0];
+  if (!handler) throw new Error("forms collection has no beforeValidate hook");
+  return handler;
+}
+
+function run(data: Record<string, unknown>, operation: string): unknown {
+  return beforeValidate()({ data, operation } as unknown as HookContext);
+}
+
+describe("forms beforeValidate", () => {
+  it("accepts a partial update that does not touch fields", () => {
+    // The regression: a rename carries only `name`, and the form's existing
+    // fields are not in the patch.
+    expect(() => run({ name: "Renamed" }, "update")).not.toThrow();
+  });
+
+  it("still rejects an update that empties the fields", () => {
+    // The mirror. Skipping the check whenever `fields` is absent must not also
+    // skip it when the patch deliberately sets it to nothing.
+    expect(() => run({ fields: [] }, "update")).toThrow(/at least one field/i);
+  });
+
+  it("rejects a create with no fields", () => {
+    // On create the patch IS the document, so an absent `fields` really means
+    // the form has none.
+    expect(() => run({ name: "New" }, "create")).toThrow(/at least one field/i);
+  });
+
+  it("rejects a create with an empty fields array", () => {
+    expect(() => run({ name: "New", fields: [] }, "create")).toThrow(
+      /at least one field/i
+    );
+  });
+
+  it("accepts a create that has fields", () => {
+    expect(() =>
+      run({ name: "New", fields: [{ name: "email" }] }, "create")
+    ).not.toThrow();
+  });
+
+  it("accepts an update that replaces the fields", () => {
+    expect(() => run({ fields: [{ name: "email" }] }, "update")).not.toThrow();
+  });
+});

--- a/packages/plugin-form-builder/src/collections/forms.ts
+++ b/packages/plugin-form-builder/src/collections/forms.ts
@@ -378,10 +378,16 @@ export function formsCollection(
               .replace(/^-+|-+$/g, "");
           }
 
-          // Validation: Ensure fields array is not empty
-          // We check for length 0 to prevent empty forms from being saved
+          // A form must have at least one field, checked against what the
+          // write actually sets. An update carries the patch rather than the
+          // merged document, so treating an absent `fields` as empty rejects
+          // every partial update -- renaming a form, or changing a setting --
+          // even though its fields are untouched and still there.
+          const setsFields =
+            operation === "create" || data?.fields !== undefined;
           if (
             data &&
+            setsFields &&
             (data.fields === undefined ||
               (Array.isArray(data.fields) && data.fields.length === 0))
           ) {


### PR DESCRIPTION
Changing a form's name — or any setting other than its fields — fails with
**"Form must have at least one field."**

The `beforeValidate` hook treated an absent `fields` as an empty one:

```ts
if (data && (data.fields === undefined || (Array.isArray(data.fields) && data.fields.length === 0))) {
  throw new Error("Form must have at least one field.");
}
```

An update carries the **patch**, not the merged document, so a rename arrives
with `fields` undefined even though the form's fields are untouched and still
there.

## The fix

The check now runs against what the write actually sets: always on create, where
the patch *is* the document, and on update only when the patch supplies `fields`.

That is the rule the core write path already applies to required values — on
update only the fields present in the patch are re-validated, so a required value
cannot be blanked but an untouched one is not re-checked. The hook was
contradicting it.

Note the slug branch of this same hook was **already** operation-aware. This was
the one condition that was not.

## Why now

Found by codex reviewing #420, which registers code-first collection hooks at
boot. This hook is contributed by the plugin as a collection hook, so it has
never actually run — #420 turns it on, and merging that without this would break
every partial update of a form.

This is a prerequisite for #420 and stands on its own regardless: the hook is
wrong about partial updates whether or not it currently executes.

Corroborating evidence that these hooks never ran, from the plugin's own source
(`submissions.ts`):

> *"The edit stamp for updates is registered in plugin.ts init — direct registry
> hooks are the path that runs for every API surface."*

The author routed around the collection-hook path deliberately.

## Verification

Six unit tests against the hook itself, which is the level the decision is made
at:

- a partial update that does not touch fields is **accepted** (the regression)
- an update that sets `fields: []` is still **rejected** (the mirror — skipping
  the check when `fields` is absent must not skip it when it is deliberately
  emptied)
- create with no fields, and create with `fields: []`, both still rejected
- create with fields, and an update that replaces fields, both accepted

Revert-verified: with the guard removed, exactly the partial-update case fails
and all five mirrors still pass.

## Audit

Every hook in the first-party plugins was checked for the same assumption.
`submissions.ts` guards correctly on `operation === "create"`; `plugin.ts`
registers its `afterRead` directly on the registry. This was the only instance.