### PR TITLE
feat(nextly): draft/published split for non-localized collections

### DIFF
--- a/.changeset/draft-published-split.md
+++ b/.changeset/draft-published-split.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+You can now edit a published document without changing what visitors see.
+
+Saving changes to a published document (without choosing Publish) now keeps them as a pending draft: the live version stays exactly as it was until you publish. Clicking Publish brings the whole pending draft live at once, including fields the Publish action itself did not resend, and Unpublish does the same in reverse while returning the document to draft. Trusted editors see their pending edits when they open the document; anonymous and published-only reads always get the live version. This applies to non-localized collections that have draft/published status with drafts-enabled versioning; localized collections are unchanged for now.

--- a/packages/nextly/src/collections/config/define-collection.ts
+++ b/packages/nextly/src/collections/config/define-collection.ts
@@ -770,14 +770,21 @@ export interface CollectionConfig {
    * written inside the same transaction as the write. Omitted = unversioned
    * (zero cost).
    *
-   * Reserved (accepted but NOT yet enforced): the `drafts`, `autosave`, and
-   * `maxPerDoc` retention settings on {@link VersionsConfig} are parsed and
-   * persisted for forward compatibility, but the draft/publish split, autosave
-   * coalescing, and retention pruning are not wired up yet, so at this stage
-   * enabling versioning is capture/history only regardless of those settings.
-   * The deprecated `status: true` alias likewise does not yet drive a version
-   * draft lifecycle; use the separate `status` option for the draft/published
-   * column.
+   * The draft/publish split is active when the collection sets `status: true`
+   * and versioning resolves `drafts.enabled` to true (`versions: true`, where
+   * drafts default on, or `versions: { drafts: true }`; `versions: { drafts:
+   * false }` and `status: true` on its own stay history-only). A status-less
+   * update to a currently published document is then stored as a single
+   * coalesced working draft in `nextly_versions` and the live row is left
+   * unchanged instead of overwriting the published content; a later publish
+   * promotes that draft onto the live row. The split additionally requires the
+   * collection to be non-localized, every reachable component schema to resolve
+   * and be non-localized, and no reachable field to be a password; otherwise a
+   * status-less write goes straight to the live row as before.
+   *
+   * Still accepted but NOT yet enforced: `autosave` coalescing and the
+   * `maxPerDoc` retention pruning on {@link VersionsConfig} are parsed and
+   * persisted for forward compatibility.
    *
    * @default undefined (unversioned)
    */

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -8,6 +8,7 @@ import {
   defineCollection,
   defineFieldGroup,
   fieldGroup,
+  password,
   relationship,
   text,
 } from "../../../../config";
@@ -650,6 +651,44 @@ describe("draft/published split — promote on publish (integration)", () => {
     const rel = linker?.rel;
     expect(rel !== null && typeof rel === "object").toBe(true);
     expect((rel as { name?: string })?.name).toBe("t1");
+  });
+
+  it("keeps a status-less edit live (no draft) when the collection has a password field", async () => {
+    handle = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" }), password({ name: "secret" })],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService<CollectionsHandler>("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, {
+      title: "live",
+      secret: "s3cret-value",
+      status: "published",
+    });
+    const [row] = await handle.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    // A password field cannot ride safely in a working draft, so the collection
+    // is ineligible for the split and a status-less edit writes the live row
+    // directly rather than storing a draft.
+    const res = await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "edited" }
+    );
+    expect(res.success).toBe(true);
+
+    const [live] = await handle.adapter.select<LiveRow>(TABLE);
+    expect(live.title).toBe("edited");
+    expect(await workingDraftCount(id)).toBe(0);
   });
 });
 

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -1190,6 +1190,38 @@ describe("draft/published split — promote on publish (integration)", () => {
     expect(seo?.metaDesc).toBe("live-desc");
   });
 
+  it("404s a status=draft read when no working draft exists", async () => {
+    handle = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, { title: "live", status: "published" });
+    const [row] = await handle.adapter.select<{ id: string }>(TABLE);
+    const id = row.id;
+
+    // No draft was ever saved. A status=draft read that opts into the working
+    // draft must not fall back to the published row; it 404s like the filter would.
+    const res = await entries.getEntry({
+      ...ctx,
+      entryId: id,
+      status: "draft",
+      includeWorkingDraft: true,
+    });
+    expect(res.success).toBe(false);
+    expect(res.statusCode).toBe(404);
+  });
+
   it("deletes the working-draft sidecar when the entry is deleted", async () => {
     const entries = await boot();
     const ctx = { collectionName: COLLECTION, overrideAccess: true };

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -137,7 +137,11 @@ describe("draft/published split — updateEntry (integration)", () => {
 
     // One coalesced draft holding BOTH edits.
     expect(await workingDraftCount(id)).toBe(1);
-    const draftRead = await entries.getEntry({ ...ctx, entryId: id });
+    const draftRead = await entries.getEntry({
+      ...ctx,
+      entryId: id,
+      includeWorkingDraft: true,
+    });
     const data = draftRead.data as { title?: string; body?: string };
     expect(data.title).toBe("draft-t");
     expect(data.body).toBe("draft-b");
@@ -161,9 +165,13 @@ describe("draft/published split — updateEntry (integration)", () => {
       { title: "edited-in-draft" }
     );
 
-    // Draft view: no explicit status on a trusted read resolves the status
-    // filter to null, so the overlay returns the pending edit.
-    const draftRead = await entries.getEntry({ ...ctx, entryId: id });
+    // Draft view: the editor opts in to the working draft, so the overlay
+    // returns the pending edit.
+    const draftRead = await entries.getEntry({
+      ...ctx,
+      entryId: id,
+      includeWorkingDraft: true,
+    });
     expect((draftRead.data as { title?: string }).title).toBe(
       "edited-in-draft"
     );
@@ -206,24 +214,39 @@ describe("draft/published split — updateEntry (integration)", () => {
     );
 
     // An authenticated read with access enforced (no overrideAccess, no
-    // routeAuthorized) — the Direct API findByID shape — surfaces the editor's
-    // own pending draft, because they can update this (public) collection.
+    // routeAuthorized) that opts into the working draft — the Direct API editor
+    // shape — surfaces the editor's own pending draft, because they can update
+    // this (public) collection.
     const editorRead = await entries.getEntry({
       collectionName: COLLECTION,
       entryId: id,
       user: { id: "editor-1" },
       overrideAccess: false,
+      includeWorkingDraft: true,
     });
     expect(editorRead.success).toBe(true);
     expect((editorRead.data as { title?: string }).title).toBe(
       "edited-in-draft"
     );
 
-    // An anonymous read (no user) never surfaces a draft — only the live row.
+    // The SAME editor, but a status-less read WITHOUT the opt-in — the shape an
+    // internal caller such as duplicate uses — gets the live row, never the
+    // draft, so a duplicate copies published content.
+    const internalRead = await entries.getEntry({
+      collectionName: COLLECTION,
+      entryId: id,
+      user: { id: "editor-1" },
+      overrideAccess: false,
+    });
+    expect((internalRead.data as { title?: string }).title).toBe("live");
+
+    // An anonymous read (no user) never surfaces a draft even with the opt-in —
+    // only the live row.
     const anonRead = await entries.getEntry({
       collectionName: COLLECTION,
       entryId: id,
       overrideAccess: false,
+      includeWorkingDraft: true,
     });
     expect(anonRead.success).toBe(true);
     expect((anonRead.data as { title?: string }).title).toBe("live");
@@ -258,14 +281,16 @@ describe("draft/published split — updateEntry (integration)", () => {
     );
 
     // The REST dispatcher sets routeAuthorized from the READ authorization, so a
-    // read-only authenticated caller arrives with routeAuthorized:true. The draft
-    // must stay hidden because they cannot update the document.
+    // read-only authenticated caller arrives with routeAuthorized:true. Even
+    // opting into the working draft, it must stay hidden because they cannot
+    // update the document.
     const readerRead = await entries.getEntry({
       collectionName: COLLECTION,
       entryId: id,
       user: { id: "reader-1" },
       routeAuthorized: true,
       overrideAccess: false,
+      includeWorkingDraft: true,
     });
     expect(readerRead.success).toBe(true);
     expect((readerRead.data as { title?: string }).title).toBe("live");

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -902,6 +902,77 @@ describe("draft/published split — promote on publish (integration)", () => {
     expect(meta.secret).not.toBe("draft-secret");
   });
 
+  it("re-evaluates a draft field's access against a sibling changed by the publish patch", async () => {
+    handle = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          access: {
+            read: () => true,
+            update: () => true,
+            publish: () => true,
+          },
+          fields: [
+            text({ name: "title" }),
+            text({ name: "approved" }),
+            text({
+              name: "secret",
+              // Writable only while its sibling `approved` is "yes".
+              access: {
+                update: (args: { data?: { approved?: unknown } }) =>
+                  args.data?.approved === "yes",
+              },
+            }),
+          ],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+
+    await entries.createEntry(
+      { collectionName: COLLECTION, overrideAccess: true },
+      {
+        title: "live",
+        approved: "no",
+        secret: "live-secret",
+        status: "published",
+      }
+    );
+    const [row] = await handle.adapter.select<{ id: string }>(TABLE);
+    const id = row.id;
+
+    // A trusted draft sets approved=yes and the (then-writable) secret.
+    await entries.updateEntry(
+      { collectionName: COLLECTION, entryId: id, overrideAccess: true },
+      { approved: "yes", secret: "draft-secret" }
+    );
+
+    // A non-override editor publishes AND flips approved back to "no" in the same
+    // patch: the gated secret must be re-denied against that final value, not the
+    // draft's stale sibling.
+    const res = await entries.updateEntry(
+      {
+        collectionName: COLLECTION,
+        entryId: id,
+        user: { id: "editor" },
+        overrideAccess: false,
+      },
+      { status: "published", approved: "no" }
+    );
+    expect(res.success).toBe(true);
+
+    const [live] = await handle.adapter.select<{
+      approved: string;
+      secret: string;
+    }>(TABLE);
+    expect(live.approved).toBe("no");
+    expect(live.secret).not.toBe("draft-secret");
+  });
+
   it("deletes the working-draft sidecar when the entry is deleted", async () => {
     const entries = await boot();
     const ctx = { collectionName: COLLECTION, overrideAccess: true };

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -271,4 +271,63 @@ describe("draft/published split — promote on publish (integration)", () => {
     expect(after.status).toBe("published");
     expect(await workingDraftCount(id)).toBe(0);
   });
+
+  it("requires publish permission to promote a draft on an already-published document", async () => {
+    handle = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" }), text({ name: "body" })],
+        }),
+      ],
+    });
+    const handler = handle.getService<CollectionsHandler>("collectionsHandler");
+
+    // Publish, then stash a pending draft via a trusted status-less edit.
+    const created = await handler.createEntry(
+      { collectionName: COLLECTION, overrideAccess: true },
+      { title: "live-t", body: "live-b", status: "published" }
+    );
+    const id = (created.data as { id: string }).id;
+    await handler.updateEntry(
+      { collectionName: COLLECTION, entryId: id, overrideAccess: true },
+      { title: "draft-t" }
+    );
+    expect(await workingDraftCount(id)).toBe(1);
+
+    // A route-authorized user without publish permission "re-publishes" the
+    // already-published row (a no-op status transition). Folding the draft is a
+    // publish, so it must be denied and leave the draft intact — otherwise an
+    // editor could push pending content live without publish permission.
+    const denied = await handler.updateEntry(
+      {
+        collectionName: COLLECTION,
+        entryId: id,
+        userId: "user-no-publish",
+        routeAuthorized: true,
+      },
+      { status: "published" }
+    );
+    expect(denied.success).toBe(false);
+    expect(denied.statusCode).toBe(403);
+
+    // Live content unchanged, the working draft still present.
+    const [live] = await handle.adapter.select<LiveRow>(TABLE);
+    expect(live.title).toBe("live-t");
+    expect(live.body).toBe("live-b");
+    expect(await workingDraftCount(id)).toBe(1);
+
+    // A trusted publish still promotes it — the gate enforces the missing
+    // permission, it does not blanket-block promotion.
+    const allowed = await handler.updateEntry(
+      { collectionName: COLLECTION, entryId: id, overrideAccess: true },
+      { status: "published" }
+    );
+    expect(allowed.success).toBe(true);
+    const [promoted] = await handle.adapter.select<LiveRow>(TABLE);
+    expect(promoted.title).toBe("draft-t");
+    expect(await workingDraftCount(id)).toBe(0);
+  });
 });

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -47,7 +47,7 @@ async function boot(): Promise<CollectionEntryService> {
     ],
   });
   return handle
-    .getService<CollectionsHandler>("collectionsHandler")
+    .getService("collectionsHandler")
     .getEntryService() as CollectionEntryService;
 }
 
@@ -214,7 +214,7 @@ describe("draft/published split — updateEntry (integration)", () => {
       ],
     });
     const entries = handle
-      .getService<CollectionsHandler>("collectionsHandler")
+      .getService("collectionsHandler")
       .getEntryService() as CollectionEntryService;
     const trusted = { collectionName: COLLECTION, overrideAccess: true };
 
@@ -279,7 +279,7 @@ describe("draft/published split — updateEntry (integration)", () => {
       ],
     });
     const entries = handle
-      .getService<CollectionsHandler>("collectionsHandler")
+      .getService("collectionsHandler")
       .getEntryService() as CollectionEntryService;
 
     await entries.createEntry(
@@ -448,7 +448,7 @@ describe("draft/published split — promote on publish (integration)", () => {
         }),
       ],
     });
-    const handler = handle.getService<CollectionsHandler>("collectionsHandler");
+    const handler = handle.getService("collectionsHandler");
 
     // Publish, then stash a pending draft via a trusted status-less edit.
     const created = await handler.createEntry(
@@ -514,7 +514,7 @@ describe("draft/published split — promote on publish (integration)", () => {
       ],
     });
     const entries = handle
-      .getService<CollectionsHandler>("collectionsHandler")
+      .getService("collectionsHandler")
       .getEntryService() as CollectionEntryService;
     const ctx = { collectionName: COLLECTION, overrideAccess: true };
 
@@ -618,7 +618,7 @@ describe("draft/published split — promote on publish (integration)", () => {
       ],
     });
     const entries = handle
-      .getService<CollectionsHandler>("collectionsHandler")
+      .getService("collectionsHandler")
       .getEntryService() as CollectionEntryService;
     const ctx = { collectionName: COLLECTION, overrideAccess: true };
 
@@ -666,7 +666,7 @@ describe("draft/published split — promote on publish (integration)", () => {
       ],
     });
     const entries = handle
-      .getService<CollectionsHandler>("collectionsHandler")
+      .getService("collectionsHandler")
       .getEntryService() as CollectionEntryService;
     const ctx = { collectionName: COLLECTION, overrideAccess: true };
 
@@ -713,7 +713,7 @@ describe("draft/published split — promote on publish (integration)", () => {
       ],
     });
     const entries = handle
-      .getService<CollectionsHandler>("collectionsHandler")
+      .getService("collectionsHandler")
       .getEntryService() as CollectionEntryService;
     const ctx = { collectionName: COLLECTION, overrideAccess: true };
 
@@ -775,7 +775,7 @@ describe("draft/published split — promote on publish (integration)", () => {
       ],
     });
     const entries = handle
-      .getService<CollectionsHandler>("collectionsHandler")
+      .getService("collectionsHandler")
       .getEntryService() as CollectionEntryService;
 
     // Seed a published row with a secret, via a trusted context.
@@ -842,7 +842,7 @@ describe("draft/published split — promote on publish (integration)", () => {
       ],
     });
     const entries = handle
-      .getService<CollectionsHandler>("collectionsHandler")
+      .getService("collectionsHandler")
       .getEntryService() as CollectionEntryService;
     const ctx = { collectionName: COLLECTION, overrideAccess: true };
 
@@ -898,7 +898,7 @@ describe("draft/published split — promote on publish (integration)", () => {
       ],
     });
     const entries = handle
-      .getService<CollectionsHandler>("collectionsHandler")
+      .getService("collectionsHandler")
       .getEntryService() as CollectionEntryService;
     const ctx = { collectionName: COLLECTION, overrideAccess: true };
 
@@ -947,7 +947,7 @@ describe("draft/published split — promote on publish (integration)", () => {
       ],
     });
     const entries = handle
-      .getService<CollectionsHandler>("collectionsHandler")
+      .getService("collectionsHandler")
       .getEntryService() as CollectionEntryService;
     const ctx = { collectionName: COLLECTION, overrideAccess: true };
 
@@ -1014,7 +1014,7 @@ describe("draft/published split — schema and component eligibility (integratio
     } as Parameters<typeof createAdapter>[0]);
     handle = await createTestNextly({ ...opts, adapter });
     return handle
-      .getService<CollectionsHandler>("collectionsHandler")
+      .getService("collectionsHandler")
       .getEntryService() as CollectionEntryService;
   }
 

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -690,6 +690,63 @@ describe("draft/published split — promote on publish (integration)", () => {
     expect(live.title).toBe("edited");
     expect(await workingDraftCount(id)).toBe(0);
   });
+
+  it("accumulates disjoint sub-field edits of a single component across draft saves", async () => {
+    handle = await createTestNextly({
+      fieldGroups: [
+        defineFieldGroup({
+          slug: "seo",
+          fields: [text({ name: "metaTitle" }), text({ name: "metaDesc" })],
+        }),
+      ],
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [
+            text({ name: "title" }),
+            fieldGroup({ name: "seo", component: "seo" }),
+          ],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService<CollectionsHandler>("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, {
+      title: "live",
+      seo: { metaTitle: "live-title", metaDesc: "live-desc" },
+      status: "published",
+    });
+    const [row] = await handle.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    // Two draft saves each touching a DIFFERENT sub-field of the same component.
+    await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { seo: { metaTitle: "draft-title" } }
+    );
+    await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { seo: { metaDesc: "draft-desc" } }
+    );
+    expect(await workingDraftCount(id)).toBe(1);
+
+    // Both pending sub-field edits survive on the coalesced draft.
+    const draftRead = await entries.getEntry({
+      ...ctx,
+      entryId: id,
+      includeWorkingDraft: true,
+    });
+    const seo = (
+      draftRead.data as { seo?: { metaTitle?: string; metaDesc?: string } }
+    ).seo;
+    expect(seo?.metaTitle).toBe("draft-title");
+    expect(seo?.metaDesc).toBe("draft-desc");
+  });
 });
 
 // The split coalesces a working draft under one unlocalized slot and promotes it

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -1201,6 +1201,45 @@ describe("draft/published split — promote on publish (integration)", () => {
       .event?.startsAt;
     expect(startsAt instanceof Date).toBe(true);
   });
+
+  it("returns dates as Date objects when a reused draft leaves them untouched", async () => {
+    handle = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" }), date({ name: "publishAt" })],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, {
+      title: "live",
+      publishAt: new Date("2026-01-01T00:00:00.000Z"),
+      status: "published",
+    });
+    const [row] = await handle.adapter.select<{ id: string }>(TABLE);
+    const id = row.id;
+
+    // The first status-less save stores the working draft (the date becomes JSON).
+    await entries.updateEntry({ ...ctx, entryId: id }, { title: "draft one" });
+    // The second save reuses that draft. `publishAt` is untouched, so it is read
+    // back from the JSON snapshot as a string; the response and the afterUpdate
+    // hooks must still see a Date, matching an ordinary update.
+    const res = await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "draft two" }
+    );
+
+    const publishAt = (res.data as { publishAt?: unknown }).publishAt;
+    expect(publishAt instanceof Date).toBe(true);
+    expect((publishAt as Date).toISOString()).toBe("2026-01-01T00:00:00.000Z");
+  });
 });
 
 // The split coalesces a working draft under one unlocalized slot and promotes it
@@ -1341,6 +1380,54 @@ describe("draft/published split — schema and component eligibility (integratio
     // The draft is still surfaced...
     expect(data.title).toBe("draft-title");
     // ...but the field the schema no longer declares does not leak through.
+    expect("subtitle" in data).toBe(false);
+  });
+
+  it("drops a field the schema removed from a reused draft's write and response", async () => {
+    const entries = await bootFile({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" }), text({ name: "subtitle" })],
+        }),
+      ],
+    });
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, { title: "live", status: "published" });
+    const [row] = await handle!.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    // The first status-less save writes `subtitle` into the working-draft snapshot.
+    await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "draft-one", subtitle: "pending" }
+    );
+    await handle!.destroy();
+    handle = undefined;
+
+    // Reboot without `subtitle`; the sidecar JSON still carries it.
+    const reopened = await bootFile({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+
+    // A second status-less save reuses the stale snapshot. The removed field must
+    // not reach the response or the afterUpdate hooks, matching the read overlay.
+    const res = await reopened.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "draft-two" }
+    );
+    const data = res.data as Record<string, unknown>;
+    expect(data.title).toBe("draft-two");
     expect("subtitle" in data).toBe(false);
   });
 

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -1017,6 +1017,84 @@ describe("draft/published split — promote on publish (integration)", () => {
     expect(live.secret).not.toBe("draft-secret");
   });
 
+  it("does not promote a caller's component value a field-access rule denies", async () => {
+    // The scalar case above is caught by the merged access pass, but a component
+    // (and m2m) value is EXTRACTED out of the caller payload before promotion, so
+    // it must be folded back into the access-checked document or the caller's copy
+    // is persisted after the pass denies the draft's copy.
+    handle = await createTestNextly({
+      fieldGroups: [
+        defineFieldGroup({ slug: "promo", fields: [text({ name: "label" })] }),
+      ],
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          access: {
+            read: () => true,
+            update: () => true,
+            publish: () => true,
+          },
+          fields: [
+            text({ name: "approved" }),
+            fieldGroup({
+              name: "promo",
+              component: "promo",
+              // Denied only when its sibling `approved` is explicitly "no", so a
+              // publish that omits `approved` passes the caller-payload gate while
+              // the pending draft's `approved: "no"` must still deny it.
+              access: {
+                update: (args: { data?: { approved?: unknown } }) =>
+                  args.data?.approved !== "no",
+              },
+            }),
+          ],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+
+    await entries.createEntry(
+      { collectionName: COLLECTION, overrideAccess: true },
+      { approved: "yes", promo: { label: "live" }, status: "published" }
+    );
+    const [row] = await handle.adapter.select<{ id: string }>(TABLE);
+    const id = row.id;
+
+    // A trusted draft sets approved="no" (which denies promo) and stages a promo.
+    await entries.updateEntry(
+      { collectionName: COLLECTION, entryId: id, overrideAccess: true },
+      { approved: "no", promo: { label: "draft" } }
+    );
+
+    // A non-override editor publishes, carrying a new promo but NOT `approved`: the
+    // caller-payload gate allows promo (approved absent), but the merged document
+    // carries the draft's `approved: "no"`, so the extracted component must be
+    // re-denied against that final value and NOT promoted.
+    const res = await entries.updateEntry(
+      {
+        collectionName: COLLECTION,
+        entryId: id,
+        user: { id: "editor" },
+        overrideAccess: false,
+      },
+      { status: "published", promo: { label: "caller" } }
+    );
+    expect(res.success).toBe(true);
+
+    const readBack = await entries.getEntry({
+      collectionName: COLLECTION,
+      entryId: id,
+      overrideAccess: true,
+    });
+    expect((readBack.data as { approved?: string }).approved).toBe("no");
+    const promo = (readBack.data as { promo?: { label?: string } }).promo;
+    expect(promo?.label).toBe("live");
+  });
+
   it("deletes the working-draft sidecar when the entry is deleted", async () => {
     const entries = await boot();
     const ctx = { collectionName: COLLECTION, overrideAccess: true };

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -1222,6 +1222,38 @@ describe("draft/published split — promote on publish (integration)", () => {
     expect(res.statusCode).toBe(404);
   });
 
+  it("returns a never-published draft row for a status=draft read", async () => {
+    handle = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, { title: "draft-only", status: "draft" });
+    const [row] = await handle.adapter.select<{ id: string }>(TABLE);
+    const id = row.id;
+
+    // The main row is itself a draft (never published), so it matches the filter
+    // directly and must be returned rather than 404'd by the working-draft opt-in.
+    const res = await entries.getEntry({
+      ...ctx,
+      entryId: id,
+      status: "draft",
+      includeWorkingDraft: true,
+    });
+    expect(res.success).toBe(true);
+    expect((res.data as { title?: string }).title).toBe("draft-only");
+  });
+
   it("gives afterUpdate the prior working draft as originalData on a repeat save", async () => {
     const seen: unknown[] = [];
     handle = await createTestNextly({

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -1095,6 +1095,49 @@ describe("draft/published split — promote on publish (integration)", () => {
     expect(promo?.label).toBe("live");
   });
 
+  it("edits a localized collection live without a working draft", async () => {
+    // A localized document is ineligible for the split (a disqualifier known
+    // without the registry), so a status-less edit writes the live row directly
+    // and stores no working draft even when the schema references a component.
+    handle = await createTestNextly({
+      localization: { locales: ["en", "es"], defaultLocale: "en" },
+      fieldGroups: [
+        defineFieldGroup({ slug: "promo", fields: [text({ name: "label" })] }),
+      ],
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          localized: true,
+          versions: { drafts: true },
+          fields: [
+            text({ name: "title" }),
+            fieldGroup({ name: "promo", component: "promo" }),
+          ],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, { title: "live", status: "published" });
+    const [row] = await handle.adapter.select<{ id: string }>(TABLE);
+    const id = row.id;
+
+    const res = await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "edited" }
+    );
+    expect(res.success).toBe(true);
+    expect(await workingDraftCount(id)).toBe(0);
+    // A localized collection keeps its text per locale, so read the live value
+    // back through getEntry rather than the main row.
+    const read = await entries.getEntry({ ...ctx, entryId: id, locale: "en" });
+    expect((read.data as { title?: string }).title).toBe("edited");
+  });
+
   it("deletes the working-draft sidecar when the entry is deleted", async () => {
     const entries = await boot();
     const ctx = { collectionName: COLLECTION, overrideAccess: true };

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -1,6 +1,16 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { defineCollection, text } from "../../../../config";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  defineCollection,
+  defineFieldGroup,
+  fieldGroup,
+  text,
+} from "../../../../config";
+import { createAdapter } from "../../../../database/factory";
 import {
   createTestNextly,
   type TestNextly,
@@ -481,5 +491,179 @@ describe("draft/published split — promote on publish (integration)", () => {
     const [promoted] = await handle.adapter.select<LiveRow>(TABLE);
     expect(promoted.title).toBe("draft-t");
     expect(await workingDraftCount(id)).toBe(0);
+  });
+});
+
+// The split coalesces a working draft under one unlocalized slot and promotes it
+// as plain columns, so it is only safe on a collection whose reachable component
+// schemas are all resolvable and non-localized. These cases cover the schema
+// changing AFTER a draft was written (a field dropped, a component turning
+// localized), which the write gate and the read overlay must both react to.
+describe("draft/published split — schema and component eligibility (integration)", () => {
+  let dir: string;
+  let dbPath: string;
+  // createTestNextly snapshots DB_DIALECT when it builds an adapter; these tests
+  // build their own adapter first, so the prior value is restored to keep the
+  // single-fork run from resolving later files' schema behaviour as SQLite.
+  let previousDialect: string | undefined;
+
+  beforeEach(() => {
+    previousDialect = process.env.DB_DIALECT;
+    dir = mkdtempSync(join(tmpdir(), "nextly-draft-split-"));
+    dbPath = join(dir, "test.db");
+  });
+
+  afterEach(() => {
+    if (previousDialect === undefined) delete process.env.DB_DIALECT;
+    else process.env.DB_DIALECT = previousDialect;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // A file-backed SQLite boot so a second boot on the same path sees the rows
+  // (and the working draft) the first boot wrote, with a changed schema.
+  async function bootFile(
+    opts: Parameters<typeof createTestNextly>[0]
+  ): Promise<CollectionEntryService> {
+    process.env.DB_DIALECT = "sqlite";
+    const adapter = await createAdapter({
+      type: "sqlite",
+      url: `file:${dbPath}`,
+    } as Parameters<typeof createAdapter>[0]);
+    handle = await createTestNextly({ ...opts, adapter });
+    return handle
+      .getService<CollectionsHandler>("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+  }
+
+  const localization = { locales: ["en", "es"], defaultLocale: "en" };
+
+  const withHero = (
+    heroLocalized: boolean
+  ): Parameters<typeof createTestNextly>[0] => ({
+    localization,
+    fieldGroups: [
+      defineFieldGroup({
+        slug: "hero",
+        localized: heroLocalized,
+        fields: [text({ name: "heading" })],
+      }),
+    ],
+    collections: [
+      defineCollection({
+        slug: COLLECTION,
+        status: true,
+        versions: { drafts: true },
+        fields: [
+          text({ name: "title" }),
+          fieldGroup({ name: "hero", component: "hero" }),
+        ],
+      }),
+    ],
+  });
+
+  it("keeps a status-less edit live (no draft) when the collection embeds a localized component", async () => {
+    const entries = await bootFile(withHero(true));
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, { title: "live", status: "published" });
+    const [row] = await handle!.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    // A localized component makes the collection ineligible for the split, so a
+    // status-less edit writes the live row directly rather than storing a draft.
+    const res = await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "edited" }
+    );
+    expect(res.success).toBe(true);
+
+    const [live] = await handle!.adapter.select<LiveRow>(TABLE);
+    expect(live.title).toBe("edited");
+    expect(await workingDraftCount(id)).toBe(0);
+  });
+
+  it("prunes fields the current schema no longer declares from a draft read", async () => {
+    const entries = await bootFile({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [
+            text({ name: "title" }),
+            text({ name: "body" }),
+            text({ name: "subtitle" }),
+          ],
+        }),
+      ],
+    });
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, { title: "live", status: "published" });
+    const [row] = await handle!.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    // Store a draft that carries `subtitle`, then drop `subtitle` from the schema.
+    await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "draft-title", subtitle: "pending" }
+    );
+    await handle!.destroy();
+    handle = undefined;
+
+    const reopened = await bootFile({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" }), text({ name: "body" })],
+        }),
+      ],
+    });
+
+    const draftRead = await reopened.getEntry({
+      collectionName: COLLECTION,
+      entryId: id,
+      overrideAccess: true,
+      includeWorkingDraft: true,
+    });
+    const data = draftRead.data as Record<string, unknown>;
+    // The draft is still surfaced...
+    expect(data.title).toBe("draft-title");
+    // ...but the field the schema no longer declares does not leak through.
+    expect("subtitle" in data).toBe(false);
+  });
+
+  it("stops overlaying the draft when an embedded component becomes localized after the draft was written", async () => {
+    const entries = await bootFile(withHero(false));
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, { title: "live", status: "published" });
+    const [row] = await handle!.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    // Non-localized component: the split is on, so a status-less edit stores a draft.
+    await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "draft-title" }
+    );
+    expect(await workingDraftCount(id)).toBe(1);
+
+    await handle!.destroy();
+    handle = undefined;
+
+    // Re-open with the component now localized: no write can consume the sidecar
+    // (the mutation path stopped promoting and deleting it), so the read overlay
+    // must fall back to the live row rather than shadow it with a stale draft.
+    const reopened = await bootFile(withHero(true));
+
+    const draftRead = await reopened.getEntry({
+      collectionName: COLLECTION,
+      entryId: id,
+      overrideAccess: true,
+      includeWorkingDraft: true,
+    });
+    expect((draftRead.data as { title?: string }).title).toBe("live");
   });
 });

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -9,6 +9,7 @@ import {
   defineCollection,
   defineFieldGroup,
   fieldGroup,
+  group,
   password,
   relationship,
   text,
@@ -812,6 +813,98 @@ describe("draft/published split — promote on publish (integration)", () => {
     expect(live.title).toBe("draft-title");
     // ...but the field the publisher may not write keeps its live value.
     expect(live.secret).toBe("live-secret");
+  });
+
+  it("does not promote a denied field nested in a group", async () => {
+    handle = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          access: {
+            read: () => true,
+            update: () => true,
+            publish: () => true,
+          },
+          fields: [
+            text({ name: "title" }),
+            group({
+              name: "meta",
+              fields: [
+                text({ name: "note" }),
+                text({
+                  name: "secret",
+                  access: {
+                    update: (args: { req?: { user?: { id?: string } } }) =>
+                      args.req?.user?.id === "admin",
+                  },
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+
+    await entries.createEntry(
+      { collectionName: COLLECTION, overrideAccess: true },
+      {
+        title: "live",
+        meta: { note: "live-note", secret: "live-secret" },
+        status: "published",
+      }
+    );
+    const [row] = await handle.adapter.select<{ id: string }>(TABLE);
+    const id = row.id;
+
+    // A trusted draft edit changes both the allowed and the restricted nested field.
+    await entries.updateEntry(
+      { collectionName: COLLECTION, entryId: id, overrideAccess: true },
+      { meta: { note: "draft-note", secret: "draft-secret" } }
+    );
+
+    // A non-admin editor publishes: field access denies the NESTED meta.secret.
+    const res = await entries.updateEntry(
+      {
+        collectionName: COLLECTION,
+        entryId: id,
+        user: { id: "editor" },
+        overrideAccess: false,
+      },
+      { status: "published" }
+    );
+    expect(res.success).toBe(true);
+
+    const [live] = await handle.adapter.select<{ meta: unknown }>(TABLE);
+    const meta = (
+      typeof live.meta === "string" ? JSON.parse(live.meta) : live.meta
+    ) as { note?: string; secret?: string };
+    // The allowed nested field is promoted...
+    expect(meta.note).toBe("draft-note");
+    // ...but the denied nested field's pending value is NOT published.
+    expect(meta.secret).not.toBe("draft-secret");
+  });
+
+  it("deletes the working-draft sidecar when the entry is deleted", async () => {
+    const entries = await boot();
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, { title: "live", status: "published" });
+    const [row] = await handle!.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    // A pending draft leaves a sidecar in nextly_versions.
+    await entries.updateEntry({ ...ctx, entryId: id }, { title: "drafted" });
+    expect(await workingDraftCount(id)).toBe(1);
+
+    // Deleting the entry must remove the sidecar too, not orphan it.
+    const deleted = await entries.deleteEntry({ ...ctx, entryId: id });
+    expect(deleted.success).toBe(true);
+    expect(await workingDraftCount(id)).toBe(0);
   });
 
   it("recursively merges nested single-component sub-field edits across draft saves", async () => {

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -560,6 +560,38 @@ describe("draft/published split — promote on publish (integration)", () => {
     });
     expect(draftRow.snapshot.hero?._componentType).toBe("hero");
   });
+
+  it("does not fold or delete a working draft when restoring a version", async () => {
+    const entries = await boot();
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, {
+      title: "live",
+      body: "b",
+      status: "published",
+    });
+    const [row] = await handle!.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    // A pending draft edit.
+    await entries.updateEntry({ ...ctx, entryId: id }, { title: "drafted" });
+    expect(await workingDraftCount(id)).toBe(1);
+
+    // A restore write names a status and carries sourceVersionNo. It must apply
+    // the restore payload directly, not fold the unrelated pending draft into
+    // the live row, and must leave the draft in place rather than deleting it.
+    const restore = await entries.updateEntry(
+      { ...ctx, entryId: id, sourceVersionNo: 1 },
+      { title: "restored", body: "b", status: "published" }
+    );
+    expect(restore.success).toBe(true);
+
+    // The live row is the restored payload, not the draft's "drafted" title.
+    const [live] = await handle!.adapter.select<LiveRow>(TABLE);
+    expect(live.title).toBe("restored");
+    // The pending draft survived the restore.
+    expect(await workingDraftCount(id)).toBe(1);
+  });
 });
 
 // The split coalesces a working draft under one unlocalized slot and promotes it

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -98,4 +98,34 @@ describe("draft/published split — updateEntry (integration)", () => {
     // No durable (numbered) version was stamped for the draft edit.
     expect(await durableCount()).toBe(durableBefore);
   });
+
+  it("surfaces the working draft on a trusted draft-view read, but the live row on a published-view read", async () => {
+    const entries = await boot();
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, { title: "live", status: "published" });
+    const [row] = await handle!.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "edited-in-draft" }
+    );
+
+    // Draft view: no explicit status on a trusted read resolves the status
+    // filter to null, so the overlay returns the pending edit.
+    const draftRead = await entries.getEntry({ ...ctx, entryId: id });
+    expect((draftRead.data as { title?: string }).title).toBe(
+      "edited-in-draft"
+    );
+
+    // Published view: an explicit status filter suppresses the overlay, so the
+    // live (unchanged) row is returned.
+    const publishedRead = await entries.getEntry({
+      ...ctx,
+      entryId: id,
+      status: "published",
+    });
+    expect((publishedRead.data as { title?: string }).title).toBe("live");
+  });
 });

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -8,7 +8,7 @@ import {
 import type { CollectionsHandler } from "../../../../services/collections-handler";
 import type { CollectionEntryService } from "../../../../services/collections/collection-entry-service";
 
-// Stage B walking skeleton: on a split-enabled collection (a draft/publish
+// On a split-enabled collection (a draft/publish
 // lifecycle + drafts-enabled versioning), an update to a PUBLISHED document that
 // names no status is non-destructive — the live row is left untouched and the
 // pending edit is stored as the working draft.

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -1723,6 +1723,50 @@ describe("draft/published split — schema and component eligibility (integratio
     expect(await workingDraftCount(id)).toBe(0);
   });
 
+  it("clears a stale working draft after versioning is disabled", async () => {
+    const entries = await bootFile({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, { title: "live", status: "published" });
+    const [row] = await handle!.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    await entries.updateEntry({ ...ctx, entryId: id }, { title: "pending" });
+    expect(await workingDraftCount(id)).toBe(1);
+    await handle!.destroy();
+    handle = undefined;
+
+    // Reboot with versioning off (the status column stays). `versionsConfig` is
+    // now null, so a gate keyed on it would leave the sidecar behind to resurface
+    // if drafts were re-enabled; the next live write must drop it.
+    const reopened = await bootFile({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: false,
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+
+    const res = await reopened.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "edited" }
+    );
+    expect(res.success).toBe(true);
+    expect(await workingDraftCount(id)).toBe(0);
+  });
+
   it("stops overlaying the draft when an embedded component becomes localized after the draft was written", async () => {
     const entries = await bootFile(withHero(false));
     const ctx = { collectionName: COLLECTION, overrideAccess: true };

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../../services/collections-handler";
+import type { CollectionEntryService } from "../../../../services/collections/collection-entry-service";
+
+// Stage B walking skeleton: on a split-enabled collection (a draft/publish
+// lifecycle + drafts-enabled versioning), an update to a PUBLISHED document that
+// names no status is non-destructive — the live row is left untouched and the
+// pending edit is stored as the working draft.
+let handle: TestNextly | undefined;
+
+afterEach(async () => {
+  await handle?.destroy();
+  handle = undefined;
+});
+
+const COLLECTION = "posts";
+const TABLE = "dc_posts";
+
+async function boot(): Promise<CollectionEntryService> {
+  handle = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: COLLECTION,
+        status: true,
+        versions: { drafts: true },
+        fields: [text({ name: "title" })],
+      }),
+    ],
+  });
+  return handle
+    .getService<CollectionsHandler>("collectionsHandler")
+    .getEntryService() as CollectionEntryService;
+}
+
+type LiveRow = { id: string; title: string; status: string };
+type VersionRow = {
+  snapshot: { title?: string };
+  status: string;
+  versionNo: number | null;
+};
+
+describe("draft/published split — updateEntry (integration)", () => {
+  it("stores a status-less edit of a published doc as a working draft, leaving the live row untouched", async () => {
+    const entries = await boot();
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, { title: "live", status: "published" });
+    const [liveBefore] = await handle!.adapter.select<LiveRow>(TABLE);
+    expect(liveBefore.status).toBe("published");
+    const id = liveBefore.id;
+
+    const durableCount = async (): Promise<number> =>
+      (
+        await handle!.adapter.select<VersionRow>("nextly_versions", {
+          where: {
+            and: [
+              { column: "entryId", op: "=", value: id },
+              { column: "versionNo", op: "IS NOT NULL" },
+            ],
+          },
+        })
+      ).length;
+    const durableBefore = await durableCount();
+
+    // Edit with NO status -> non-destructive draft edit.
+    const res = await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "edited-in-draft" }
+    );
+    expect(res.success).toBe(true);
+
+    // The live row is unchanged: title AND status.
+    const [liveAfter] = await handle!.adapter.select<LiveRow>(TABLE);
+    expect(liveAfter.title).toBe("live");
+    expect(liveAfter.status).toBe("published");
+
+    // The edit lives in exactly one working draft (status='draft', no version
+    // number, not autosave) carrying the new title.
+    const drafts = await handle!.adapter.select<VersionRow>("nextly_versions", {
+      where: {
+        and: [
+          { column: "entryId", op: "=", value: id },
+          { column: "isAutosave", op: "=", value: false },
+          { column: "versionNo", op: "IS NULL" },
+          { column: "status", op: "=", value: "draft" },
+        ],
+      },
+    });
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].snapshot.title).toBe("edited-in-draft");
+
+    // No durable (numbered) version was stamped for the draft edit.
+    expect(await durableCount()).toBe(durableBefore);
+  });
+});

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -610,6 +610,50 @@ describe("draft/published split — promote on publish (integration)", () => {
     expect(await workingDraftCount(id)).toBe(1);
   });
 
+  it("drops the working draft when a restore lands a non-published status", async () => {
+    handle = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" }), text({ name: "body" })],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, {
+      title: "live",
+      body: "b",
+      status: "published",
+    });
+    const [row] = await handle.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    // A pending draft edit over the published row.
+    await entries.updateEntry({ ...ctx, entryId: id }, { title: "drafted" });
+    expect(await workingDraftCount(id)).toBe(1);
+
+    // A restore that lands a non-published status turns the live row into a draft,
+    // breaking the working-draft invariant (a sidecar is pending edits OVER a
+    // published row). The restore does not fold the sidecar, so leaving it would
+    // let editor reads overlay stale edits and a later publish promote them over
+    // the restored content. It must be dropped.
+    const restore = await entries.updateEntry(
+      { ...ctx, entryId: id, sourceVersionNo: 1 },
+      { title: "restored", body: "b", status: "draft" }
+    );
+    expect(restore.success).toBe(true);
+
+    const [live] = await handle.adapter.select<LiveRow>(TABLE);
+    expect(live.title).toBe("restored");
+    expect(await workingDraftCount(id)).toBe(0);
+  });
+
   it("expands relationships inside a draft component at depth > 0", async () => {
     handle = await createTestNextly({
       fieldGroups: [

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -734,4 +734,60 @@ describe("draft/published split — schema and component eligibility (integratio
     });
     expect((draftRead.data as { title?: string }).title).toBe("live");
   });
+
+  it("rejects a publish when the pending draft violates a tightened schema rule", async () => {
+    const entries = await bootFile({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" }), text({ name: "subtitle" })],
+        }),
+      ],
+    });
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, {
+      title: "live",
+      subtitle: "initial",
+      status: "published",
+    });
+    const [row] = await handle!.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    // Draft a short subtitle, then tighten the schema to require a longer one.
+    await entries.updateEntry({ ...ctx, entryId: id }, { subtitle: "ab" });
+    expect(await workingDraftCount(id)).toBe(1);
+    await handle!.destroy();
+    handle = undefined;
+
+    const reopened = await bootFile({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [
+            text({ name: "title" }),
+            text({ name: "subtitle", minLength: 5 }),
+          ],
+        }),
+      ],
+    });
+
+    // Publishing folds the draft (subtitle "ab") into the live write; the value
+    // now violates minLength, so the promote is rejected rather than publishing
+    // an invalid document.
+    const res = await reopened.updateEntry(
+      { ...ctx, entryId: id },
+      { status: "published" }
+    );
+    expect(res.success).toBe(false);
+    expect(res.statusCode).toBe(400);
+
+    // The draft survives (the transaction rolled back), so the pending edit is
+    // not lost by a rejected publish.
+    expect(await workingDraftCount(id)).toBe(1);
+  });
 });

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -117,6 +117,37 @@ describe("draft/published split — updateEntry (integration)", () => {
     expect(await durableCount()).toBe(durableBefore);
   });
 
+  it("accumulates disjoint status-less edits onto the working draft instead of overwriting them", async () => {
+    const entries = await boot();
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, {
+      title: "live-t",
+      body: "live-b",
+      status: "published",
+    });
+    const [row] = await handle!.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    // Two SEPARATE status-less saves touching different fields. The second must
+    // build on the pending draft, not re-derive from the live row (which would
+    // revert the first edit).
+    await entries.updateEntry({ ...ctx, entryId: id }, { title: "draft-t" });
+    await entries.updateEntry({ ...ctx, entryId: id }, { body: "draft-b" });
+
+    // One coalesced draft holding BOTH edits.
+    expect(await workingDraftCount(id)).toBe(1);
+    const draftRead = await entries.getEntry({ ...ctx, entryId: id });
+    const data = draftRead.data as { title?: string; body?: string };
+    expect(data.title).toBe("draft-t");
+    expect(data.body).toBe("draft-b");
+
+    // The live row is still fully untouched.
+    const [live] = await handle!.adapter.select<LiveRow>(TABLE);
+    expect(live.title).toBe("live-t");
+    expect(live.body).toBe("live-b");
+  });
+
   it("surfaces the working draft on a trusted draft-view read, but the live row on a published-view read", async () => {
     const entries = await boot();
     const ctx = { collectionName: COLLECTION, overrideAccess: true };

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -29,7 +29,7 @@ async function boot(): Promise<CollectionEntryService> {
         slug: COLLECTION,
         status: true,
         versions: { drafts: true },
-        fields: [text({ name: "title" })],
+        fields: [text({ name: "title" }), text({ name: "body" })],
       }),
     ],
   });
@@ -38,12 +38,27 @@ async function boot(): Promise<CollectionEntryService> {
     .getEntryService() as CollectionEntryService;
 }
 
-type LiveRow = { id: string; title: string; status: string };
+type LiveRow = { id: string; title: string; body: string; status: string };
 type VersionRow = {
-  snapshot: { title?: string };
+  snapshot: { title?: string; body?: string };
   status: string;
   versionNo: number | null;
 };
+
+async function workingDraftCount(id: string): Promise<number> {
+  return (
+    await handle!.adapter.select<VersionRow>("nextly_versions", {
+      where: {
+        and: [
+          { column: "entryId", op: "=", value: id },
+          { column: "isAutosave", op: "=", value: false },
+          { column: "versionNo", op: "IS NULL" },
+          { column: "status", op: "=", value: "draft" },
+        ],
+      },
+    })
+  ).length;
+}
 
 describe("draft/published split — updateEntry (integration)", () => {
   it("stores a status-less edit of a published doc as a working draft, leaving the live row untouched", async () => {
@@ -127,5 +142,133 @@ describe("draft/published split — updateEntry (integration)", () => {
       status: "published",
     });
     expect((publishedRead.data as { title?: string }).title).toBe("live");
+  });
+});
+
+// Publishing a document that has a pending working draft must apply the draft's
+// whole content to the live row, not just the fields the publish call carried —
+// the admin Publish button sends only the fields dirtied this session, so a
+// status-only publish still has to bring the accumulated edits live. Unpublish
+// is the same fold with a draft target status.
+describe("draft/published split — promote on publish (integration)", () => {
+  it("promotes the whole working draft to the live row when the publish omits its fields", async () => {
+    const entries = await boot();
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, {
+      title: "live-t",
+      body: "live-b",
+      status: "published",
+    });
+    const [before] = await handle!.adapter.select<LiveRow>(TABLE);
+    const id = before.id;
+
+    // A status-less edit stores the pending title AND body as one working draft.
+    await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "draft-t", body: "draft-b" }
+    );
+    expect(await workingDraftCount(id)).toBe(1);
+    const [mid] = await handle!.adapter.select<LiveRow>(TABLE);
+    expect(mid.title).toBe("live-t");
+    expect(mid.body).toBe("live-b");
+
+    // Publish carrying ONLY the status (the admin Publish button on an unedited
+    // pending draft) must promote the draft's title and body to the live row.
+    const res = await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { status: "published" }
+    );
+    expect(res.success).toBe(true);
+
+    const [after] = await handle!.adapter.select<LiveRow>(TABLE);
+    expect(after.title).toBe("draft-t");
+    expect(after.body).toBe("draft-b");
+    expect(after.status).toBe("published");
+    // The sidecar draft is consumed in the same transaction.
+    expect(await workingDraftCount(id)).toBe(0);
+  });
+
+  it("overlays the publish payload on the draft, with the caller winning per field", async () => {
+    const entries = await boot();
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, {
+      title: "live-t",
+      body: "live-b",
+      status: "published",
+    });
+    const [before] = await handle!.adapter.select<LiveRow>(TABLE);
+    const id = before.id;
+
+    await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "draft-t", body: "draft-b" }
+    );
+
+    // Publish re-titles in the same call: the payload's title wins, the draft
+    // supplies the body the payload did not carry.
+    await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "final-t", status: "published" }
+    );
+
+    const [after] = await handle!.adapter.select<LiveRow>(TABLE);
+    expect(after.title).toBe("final-t");
+    expect(after.body).toBe("draft-b");
+    expect(after.status).toBe("published");
+    expect(await workingDraftCount(id)).toBe(0);
+  });
+
+  it("folds the draft into the live row as a draft on unpublish, clearing the sidecar", async () => {
+    const entries = await boot();
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, {
+      title: "live-t",
+      body: "live-b",
+      status: "published",
+    });
+    const [before] = await handle!.adapter.select<LiveRow>(TABLE);
+    const id = before.id;
+
+    await entries.updateEntry({ ...ctx, entryId: id }, { title: "draft-t" });
+
+    // Unpublish names status:draft, so the accumulated draft content lands on
+    // the live row and the row itself is retracted to draft.
+    await entries.updateEntry({ ...ctx, entryId: id }, { status: "draft" });
+
+    const [after] = await handle!.adapter.select<LiveRow>(TABLE);
+    expect(after.title).toBe("draft-t");
+    expect(after.body).toBe("live-b");
+    expect(after.status).toBe("draft");
+    expect(await workingDraftCount(id)).toBe(0);
+  });
+
+  it("publishes normally when no working draft exists", async () => {
+    const entries = await boot();
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, {
+      title: "live-t",
+      body: "live-b",
+      status: "draft",
+    });
+    const [before] = await handle!.adapter.select<LiveRow>(TABLE);
+    const id = before.id;
+
+    // First publish of a never-drafted document: no sidecar to fold, the
+    // payload is written as-is.
+    const res = await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "pub-t", status: "published" }
+    );
+    expect(res.success).toBe(true);
+
+    const [after] = await handle!.adapter.select<LiveRow>(TABLE);
+    expect(after.title).toBe("pub-t");
+    expect(after.body).toBe("live-b");
+    expect(after.status).toBe("published");
+    expect(await workingDraftCount(id)).toBe(0);
   });
 });

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -1042,4 +1042,52 @@ describe("draft/published split — schema and component eligibility (integratio
     // not lost by a rejected publish.
     expect(await workingDraftCount(id)).toBe(1);
   });
+
+  it("invalidates a stale working draft when drafts are turned off", async () => {
+    const entries = await bootFile({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, { title: "live", status: "published" });
+    const [row] = await handle!.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    // Store a working draft while the split is enabled.
+    await entries.updateEntry({ ...ctx, entryId: id }, { title: "drafted" });
+    expect(await workingDraftCount(id)).toBe(1);
+    await handle!.destroy();
+    handle = undefined;
+
+    // Re-open with drafts turned off: a status-less edit writes the live row
+    // directly and must invalidate the now-unpromotable sidecar so re-enabling
+    // drafts later cannot resurrect it over the intervening live edits.
+    const reopened = await bootFile({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: false },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+
+    const res = await reopened.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "live-edit" }
+    );
+    expect(res.success).toBe(true);
+
+    const [live] = await handle!.adapter.select<LiveRow>(TABLE);
+    expect(live.title).toBe("live-edit");
+    expect(await workingDraftCount(id)).toBe(0);
+  });
 });

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -198,6 +198,19 @@ describe("draft/published split — updateEntry (integration)", () => {
       status: "published",
     });
     expect((publishedRead.data as { title?: string }).title).toBe("live");
+
+    // Explicit status=draft view WITH the opt-in: the live row stays published,
+    // so the draft-only status filter must not 404 before the overlay runs.
+    const draftStatusRead = await entries.getEntry({
+      ...ctx,
+      entryId: id,
+      status: "draft",
+      includeWorkingDraft: true,
+    });
+    expect(draftStatusRead.success).toBe(true);
+    expect((draftStatusRead.data as { title?: string }).title).toBe(
+      "edited-in-draft"
+    );
   });
 
   it("surfaces the working draft to an access-enforced authenticated editor, but not to an anonymous read", async () => {
@@ -1067,6 +1080,55 @@ describe("draft/published split — promote on publish (integration)", () => {
     const publishAt = (draftRead.data as { publishAt?: unknown }).publishAt;
     expect(publishAt instanceof Date).toBe(true);
     expect((publishAt as Date).toISOString()).toBe("2026-06-15T00:00:00.000Z");
+  });
+
+  it("rehydrates date fields nested inside a draft component", async () => {
+    handle = await createTestNextly({
+      fieldGroups: [
+        defineFieldGroup({
+          slug: "event",
+          fields: [text({ name: "name" }), date({ name: "startsAt" })],
+        }),
+      ],
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [
+            text({ name: "title" }),
+            fieldGroup({ name: "event", component: "event" }),
+          ],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, {
+      title: "live",
+      event: { name: "launch", startsAt: new Date("2026-03-01T00:00:00.000Z") },
+      status: "published",
+    });
+    const [row] = await handle.adapter.select<{ id: string }>(TABLE);
+    const id = row.id;
+
+    await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { event: { startsAt: new Date("2026-09-09T00:00:00.000Z") } }
+    );
+
+    const draftRead = await entries.getEntry({
+      ...ctx,
+      entryId: id,
+      includeWorkingDraft: true,
+    });
+    // The date nested in the component comes back as a Date, like a live read.
+    const startsAt = (draftRead.data as { event?: { startsAt?: unknown } })
+      .event?.startsAt;
+    expect(startsAt instanceof Date).toBe(true);
   });
 });
 

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -1596,6 +1596,49 @@ describe("draft/published split — schema and component eligibility (integratio
     expect("subtitle" in data).toBe(false);
   });
 
+  it("clears a stale working draft when the status lifecycle is removed", async () => {
+    const entries = await bootFile({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, { title: "live", status: "published" });
+    const [row] = await handle!.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    // Store a working draft, then drop `status` from the schema (versioning stays
+    // on). `collectionHasStatus` is now false, so the old status-scoped guard left
+    // the sidecar behind; the next live write must drop it.
+    await entries.updateEntry({ ...ctx, entryId: id }, { title: "pending" });
+    expect(await workingDraftCount(id)).toBe(1);
+    await handle!.destroy();
+    handle = undefined;
+
+    const reopened = await bootFile({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          versions: { drafts: true },
+          fields: [text({ name: "title" })],
+        }),
+      ],
+    });
+
+    const res = await reopened.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "edited" }
+    );
+    expect(res.success).toBe(true);
+    expect(await workingDraftCount(id)).toBe(0);
+  });
+
   it("stops overlaying the draft when an embedded component becomes localized after the draft was written", async () => {
     const entries = await bootFile(withHero(false));
     const ctx = { collectionName: COLLECTION, overrideAccess: true };

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
+  date,
   defineCollection,
   defineFieldGroup,
   fieldGroup,
@@ -932,6 +933,47 @@ describe("draft/published split — promote on publish (integration)", () => {
     ).seo;
     expect(seo?.metaTitle).toBe("draft-mt");
     expect(seo?.metaDesc).toBe("pub-md");
+  });
+
+  it("rehydrates date fields to Date objects on a draft read", async () => {
+    handle = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [text({ name: "title" }), date({ name: "publishAt" })],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService<CollectionsHandler>("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, {
+      title: "live",
+      publishAt: new Date("2026-01-01T00:00:00.000Z"),
+      status: "published",
+    });
+    const [row] = await handle.adapter.select<{ id: string }>(TABLE);
+    const id = row.id;
+
+    await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { publishAt: new Date("2026-06-15T00:00:00.000Z") }
+    );
+
+    const draftRead = await entries.getEntry({
+      ...ctx,
+      entryId: id,
+      includeWorkingDraft: true,
+    });
+    // The snapshot stores the date as an ISO string; the overlay must rehydrate
+    // it to a Date, matching a live read (whose afterRead hooks receive Dates).
+    const publishAt = (draftRead.data as { publishAt?: unknown }).publishAt;
+    expect(publishAt instanceof Date).toBe(true);
+    expect((publishAt as Date).toISOString()).toBe("2026-06-15T00:00:00.000Z");
   });
 });
 

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -8,6 +8,7 @@ import {
   defineCollection,
   defineFieldGroup,
   fieldGroup,
+  relationship,
   text,
 } from "../../../../config";
 import { createAdapter } from "../../../../database/factory";
@@ -591,6 +592,64 @@ describe("draft/published split — promote on publish (integration)", () => {
     expect(live.title).toBe("restored");
     // The pending draft survived the restore.
     expect(await workingDraftCount(id)).toBe(1);
+  });
+
+  it("expands relationships inside a draft component at depth > 0", async () => {
+    handle = await createTestNextly({
+      fieldGroups: [
+        defineFieldGroup({
+          slug: "linker",
+          fields: [relationship({ name: "rel", relationTo: "tags" })],
+        }),
+      ],
+      collections: [
+        defineCollection({ slug: "tags", fields: [text({ name: "name" })] }),
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [
+            text({ name: "title" }),
+            fieldGroup({ name: "linker", component: "linker" }),
+          ],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService<CollectionsHandler>("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    const tag = await entries.createEntry(
+      { collectionName: "tags", overrideAccess: true },
+      { name: "t1" }
+    );
+    const tagId = (tag.data as { id: string }).id;
+
+    await entries.createEntry(ctx, {
+      title: "live",
+      linker: { rel: tagId },
+      status: "published",
+    });
+    const [row] = await handle.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    // A status-less edit stores the component in the draft snapshot with its
+    // relation captured as an id.
+    await entries.updateEntry({ ...ctx, entryId: id }, { title: "drafted" });
+
+    // A draft read at depth 1 must expand the relation inside the component, like
+    // a live read, rather than leaving it a bare id.
+    const draftRead = await entries.getEntry({
+      ...ctx,
+      entryId: id,
+      includeWorkingDraft: true,
+      depth: 1,
+    });
+    const linker = (draftRead.data as { linker?: { rel?: unknown } }).linker;
+    const rel = linker?.rel;
+    expect(rel !== null && typeof rel === "object").toBe(true);
+    expect((rel as { name?: string })?.name).toBe("t1");
   });
 });
 

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -1138,6 +1138,58 @@ describe("draft/published split — promote on publish (integration)", () => {
     expect((read.data as { title?: string }).title).toBe("edited");
   });
 
+  it("keeps a live single component's other sub-fields on a first partial draft save", async () => {
+    handle = await createTestNextly({
+      fieldGroups: [
+        defineFieldGroup({
+          slug: "seo",
+          fields: [text({ name: "metaTitle" }), text({ name: "metaDesc" })],
+        }),
+      ],
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [
+            text({ name: "title" }),
+            fieldGroup({ name: "seo", component: "seo" }),
+          ],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, {
+      title: "live",
+      seo: { metaTitle: "live-title", metaDesc: "live-desc" },
+      status: "published",
+    });
+    const [row] = await handle.adapter.select<{ id: string }>(TABLE);
+    const id = row.id;
+
+    // The FIRST status-less save changes only seo.metaTitle. With no sidecar yet,
+    // the draft must still keep the live seo.metaDesc rather than dropping it.
+    await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { seo: { metaTitle: "draft-title" } }
+    );
+
+    const draftRead = await entries.getEntry({
+      ...ctx,
+      entryId: id,
+      includeWorkingDraft: true,
+    });
+    const seo = (
+      draftRead.data as { seo?: { metaTitle?: string; metaDesc?: string } }
+    ).seo;
+    expect(seo?.metaTitle).toBe("draft-title");
+    expect(seo?.metaDesc).toBe("live-desc");
+  });
+
   it("deletes the working-draft sidecar when the entry is deleted", async () => {
     const entries = await boot();
     const ctx = { collectionName: COLLECTION, overrideAccess: true };

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -1222,6 +1222,50 @@ describe("draft/published split — promote on publish (integration)", () => {
     expect(res.statusCode).toBe(404);
   });
 
+  it("gives afterUpdate the prior working draft as originalData on a repeat save", async () => {
+    const seen: unknown[] = [];
+    handle = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          hooks: {
+            // Config `afterChange` maps to the runtime `afterUpdate` phase.
+            afterChange: [
+              ctx => {
+                seen.push(ctx.originalData);
+              },
+            ],
+          },
+          fields: [text({ name: "title" }), text({ name: "body" })],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, {
+      title: "live",
+      body: "b",
+      status: "published",
+    });
+    const [row] = await handle.adapter.select<{ id: string }>(TABLE);
+    const id = row.id;
+
+    // The first status-less save stores the draft (title becomes draft1).
+    await entries.updateEntry({ ...ctx, entryId: id }, { title: "draft1" });
+    // The second save touches only body. The afterUpdate hook's originalData must
+    // be the PRIOR draft (title=draft1), not the unchanged published row.
+    seen.length = 0;
+    await entries.updateEntry({ ...ctx, entryId: id }, { body: "b2" });
+
+    expect(seen).toHaveLength(1);
+    expect((seen[0] as { title?: string }).title).toBe("draft1");
+  });
+
   it("deletes the working-draft sidecar when the entry is deleted", async () => {
     const entries = await boot();
     const ctx = { collectionName: COLLECTION, overrideAccess: true };

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -492,6 +492,74 @@ describe("draft/published split — promote on publish (integration)", () => {
     expect(promoted.title).toBe("draft-t");
     expect(await workingDraftCount(id)).toBe(0);
   });
+
+  it("keeps the internal single-component tag out of a draft response and read but in the stored snapshot", async () => {
+    handle = await createTestNextly({
+      fieldGroups: [
+        defineFieldGroup({ slug: "hero", fields: [text({ name: "heading" })] }),
+      ],
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [
+            text({ name: "title" }),
+            fieldGroup({ name: "hero", component: "hero" }),
+          ],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService<CollectionsHandler>("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, {
+      title: "live",
+      hero: { heading: "h1" },
+      status: "published",
+    });
+    const [row] = await handle.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    // A status-less edit of the single-component field.
+    const res = await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { hero: { heading: "h2" } }
+    );
+    const resHero = (res.data as { hero?: Record<string, unknown> }).hero;
+    expect(resHero?.heading).toBe("h2");
+    // The mutation response omits the internal single-component marker that a
+    // dynamic zone would carry but an ordinary read of a single component does not.
+    expect(resHero && "_componentType" in resHero).toBe(false);
+
+    // The draft read overlay omits it too.
+    const draftRead = await entries.getEntry({
+      ...ctx,
+      entryId: id,
+      includeWorkingDraft: true,
+    });
+    const readHero = (draftRead.data as { hero?: Record<string, unknown> })
+      .hero;
+    expect(readHero?.heading).toBe("h2");
+    expect(readHero && "_componentType" in readHero).toBe(false);
+
+    // The STORED snapshot retains the marker so a promote can still resolve the
+    // component's schema even if the field is later retargeted.
+    const [draftRow] = await handle.adapter.select<{
+      snapshot: { hero?: Record<string, unknown> };
+    }>("nextly_versions", {
+      where: {
+        and: [
+          { column: "entryId", op: "=", value: id },
+          { column: "versionNo", op: "IS NULL" },
+          { column: "status", op: "=", value: "draft" },
+        ],
+      },
+    });
+    expect(draftRow.snapshot.hero?._componentType).toBe("hero");
+  });
 });
 
 // The split coalesces a working draft under one unlocalized slot and promotes it

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -146,6 +146,57 @@ describe("draft/published split — updateEntry (integration)", () => {
     });
     expect((publishedRead.data as { title?: string }).title).toBe("live");
   });
+
+  it("surfaces the working draft to an access-enforced authenticated editor, but not to an anonymous read", async () => {
+    // A collection whose reads are access-enforced: only an authenticated caller
+    // reads it, and everyone who reads it may also update it.
+    handle = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          access: { read: () => true, update: () => true },
+          fields: [text({ name: "title" }), text({ name: "body" })],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService<CollectionsHandler>("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const trusted = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(trusted, { title: "live", status: "published" });
+    const [row] = await handle.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+    await entries.updateEntry(
+      { ...trusted, entryId: id },
+      { title: "edited-in-draft" }
+    );
+
+    // An authenticated read with access enforced (no overrideAccess, no
+    // routeAuthorized) — the Direct API findByID shape — surfaces the editor's
+    // own pending draft, because they can update this (public) collection.
+    const editorRead = await entries.getEntry({
+      collectionName: COLLECTION,
+      entryId: id,
+      user: { id: "editor-1" },
+      overrideAccess: false,
+    });
+    expect(editorRead.success).toBe(true);
+    expect((editorRead.data as { title?: string }).title).toBe(
+      "edited-in-draft"
+    );
+
+    // An anonymous read (no user) never surfaces a draft — only the live row.
+    const anonRead = await entries.getEntry({
+      collectionName: COLLECTION,
+      entryId: id,
+      overrideAccess: false,
+    });
+    expect(anonRead.success).toBe(true);
+    expect((anonRead.data as { title?: string }).title).toBe("live");
+  });
 });
 
 // Publishing a document that has a pending working draft must apply the draft's

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -747,6 +747,71 @@ describe("draft/published split — promote on publish (integration)", () => {
     expect(seo?.metaTitle).toBe("draft-title");
     expect(seo?.metaDesc).toBe("draft-desc");
   });
+
+  it("does not promote a draft field the publisher's field-level access denies", async () => {
+    handle = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          access: {
+            read: () => true,
+            update: () => true,
+            publish: () => true,
+          },
+          fields: [
+            text({ name: "title" }),
+            text({
+              name: "secret",
+              access: {
+                update: (args: { req?: { user?: { id?: string } } }) =>
+                  args.req?.user?.id === "admin",
+              },
+            }),
+          ],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService<CollectionsHandler>("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+
+    // Seed a published row with a secret, via a trusted context.
+    await entries.createEntry(
+      { collectionName: COLLECTION, overrideAccess: true },
+      { title: "live", secret: "live-secret", status: "published" }
+    );
+    const [row] = await handle.adapter.select<{ id: string }>(TABLE);
+    const id = row.id;
+
+    // A trusted draft edit changes BOTH the title and the restricted secret.
+    await entries.updateEntry(
+      { collectionName: COLLECTION, entryId: id, overrideAccess: true },
+      { title: "draft-title", secret: "draft-secret" }
+    );
+
+    // A non-admin editor publishes: field-level write access denies "secret".
+    const res = await entries.updateEntry(
+      {
+        collectionName: COLLECTION,
+        entryId: id,
+        user: { id: "editor" },
+        overrideAccess: false,
+      },
+      { status: "published" }
+    );
+    expect(res.success).toBe(true);
+
+    const [live] = await handle.adapter.select<{
+      title: string;
+      secret: string;
+    }>(TABLE);
+    // The allowed field is promoted...
+    expect(live.title).toBe("draft-title");
+    // ...but the field the publisher may not write keeps its live value.
+    expect(live.secret).toBe("live-secret");
+  });
 });
 
 // The split coalesces a working draft under one unlocalized slot and promotes it

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -228,6 +228,48 @@ describe("draft/published split — updateEntry (integration)", () => {
     expect(anonRead.success).toBe(true);
     expect((anonRead.data as { title?: string }).title).toBe("live");
   });
+
+  it("does not leak a draft to a read-only authenticated caller even with routeAuthorized", async () => {
+    // Reads are allowed, updates are not: a read-only role.
+    handle = await createTestNextly({
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          access: { read: () => true, update: () => false },
+          fields: [text({ name: "title" }), text({ name: "body" })],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService<CollectionsHandler>("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+
+    await entries.createEntry(
+      { collectionName: COLLECTION, overrideAccess: true },
+      { title: "live", status: "published" }
+    );
+    const [row] = await handle.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+    await entries.updateEntry(
+      { collectionName: COLLECTION, entryId: id, overrideAccess: true },
+      { title: "edited-in-draft" }
+    );
+
+    // The REST dispatcher sets routeAuthorized from the READ authorization, so a
+    // read-only authenticated caller arrives with routeAuthorized:true. The draft
+    // must stay hidden because they cannot update the document.
+    const readerRead = await entries.getEntry({
+      collectionName: COLLECTION,
+      entryId: id,
+      user: { id: "reader-1" },
+      routeAuthorized: true,
+      overrideAccess: false,
+    });
+    expect(readerRead.success).toBe(true);
+    expect((readerRead.data as { title?: string }).title).toBe("live");
+  });
 });
 
 // Publishing a document that has a pending working draft must apply the draft's

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -89,6 +89,9 @@ describe("draft/published split — updateEntry (integration)", () => {
       { title: "edited-in-draft" }
     );
     expect(res.success).toBe(true);
+    // The response reflects the pending draft the caller just saved, not the
+    // unchanged live row the transaction re-fetches.
+    expect((res.data as { title?: string }).title).toBe("edited-in-draft");
 
     // The live row is unchanged: title AND status.
     const [liveAfter] = await handle!.adapter.select<LiveRow>(TABLE);

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -812,6 +812,127 @@ describe("draft/published split — promote on publish (integration)", () => {
     // ...but the field the publisher may not write keeps its live value.
     expect(live.secret).toBe("live-secret");
   });
+
+  it("recursively merges nested single-component sub-field edits across draft saves", async () => {
+    handle = await createTestNextly({
+      fieldGroups: [
+        defineFieldGroup({
+          slug: "social",
+          fields: [text({ name: "twitter" }), text({ name: "facebook" })],
+        }),
+        defineFieldGroup({
+          slug: "seo",
+          fields: [
+            text({ name: "metaTitle" }),
+            fieldGroup({ name: "social", component: "social" }),
+          ],
+        }),
+      ],
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [
+            text({ name: "title" }),
+            fieldGroup({ name: "seo", component: "seo" }),
+          ],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService<CollectionsHandler>("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    const created = await entries.createEntry(ctx, {
+      title: "live",
+      status: "published",
+    });
+    expect(created.success).toBe(true);
+    const id = (created.data as { id: string }).id;
+
+    // Two saves each touching a DIFFERENT field of the DEEPLY NESTED component.
+    await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { seo: { social: { twitter: "draft-tw" } } }
+    );
+    await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { seo: { social: { facebook: "draft-fb" } } }
+    );
+
+    const draftRead = await entries.getEntry({
+      ...ctx,
+      entryId: id,
+      includeWorkingDraft: true,
+    });
+    const social = (
+      draftRead.data as {
+        seo?: { social?: { twitter?: string; facebook?: string } };
+      }
+    ).seo?.social;
+    expect(social?.twitter).toBe("draft-tw");
+    expect(social?.facebook).toBe("draft-fb");
+  });
+
+  it("merges a partial component publish patch into the promoted draft", async () => {
+    handle = await createTestNextly({
+      fieldGroups: [
+        defineFieldGroup({
+          slug: "seo",
+          fields: [text({ name: "metaTitle" }), text({ name: "metaDesc" })],
+        }),
+      ],
+      collections: [
+        defineCollection({
+          slug: COLLECTION,
+          status: true,
+          versions: { drafts: true },
+          fields: [
+            text({ name: "title" }),
+            fieldGroup({ name: "seo", component: "seo" }),
+          ],
+        }),
+      ],
+    });
+    const entries = handle
+      .getService<CollectionsHandler>("collectionsHandler")
+      .getEntryService() as CollectionEntryService;
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, {
+      title: "live",
+      seo: { metaTitle: "live-mt", metaDesc: "live-md" },
+      status: "published",
+    });
+    const [row] = await handle.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    // A draft edit changes one sub-field of the component.
+    await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { seo: { metaTitle: "draft-mt" } }
+    );
+
+    // Publish sends a partial patch for a DIFFERENT sub-field. The pending edit
+    // and the publish patch must both reach the live row.
+    await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { status: "published", seo: { metaDesc: "pub-md" } }
+    );
+
+    const liveRead = await entries.getEntry({
+      ...ctx,
+      entryId: id,
+      status: "published",
+    });
+    const seo = (
+      liveRead.data as { seo?: { metaTitle?: string; metaDesc?: string } }
+    ).seo;
+    expect(seo?.metaTitle).toBe("draft-mt");
+    expect(seo?.metaDesc).toBe("pub-md");
+  });
 });
 
 // The split coalesces a working draft under one unlocalized slot and promotes it

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -5071,30 +5071,32 @@ export class CollectionMutationService extends BaseService {
                 fields as unknown as FieldConfig[],
                 promoteRestoreCtx
               );
-              // Re-apply the current field-level write access to the locked
-              // draft the fold actually persists, so a value the publisher may
-              // not write is not promoted — at every depth. Filtering the merged
-              // advisory copy pre-transaction only recorded whole top-level
-              // containers it removed; running the filter on this authoritative
-              // snapshot also drops a denied value nested in a group or repeater.
-              // `applyFieldWriteAccess` is already used inside the caller-owned
-              // transaction paths, so running it here is consistent.
+              // Merge the locked draft with the caller's payload (caller wins)
+              // BEFORE filtering, then re-apply the current field-level write
+              // access to that authoritative merged document. A rule that depends
+              // on a sibling the publish patch supplies (e.g. a field writable
+              // only when `approved` is true, where the publish sets it false) is
+              // then judged on the real final values, and a denied value is
+              // dropped at any depth (top-level or nested in a group/repeater/
+              // component). `applyFieldWriteAccess` is already used inside the
+              // caller-owned transaction paths, so running it here is consistent.
+              const mergedPromoteData = { ...draftInput, ...finalData };
               await applyFieldWriteAccess({
                 kind: "collection",
                 slug: params.collectionName,
-                data: draftInput,
+                data: mergedPromoteData,
                 operation: "update",
                 user: params.user,
                 overrideAccess: params.overrideAccess,
                 id: params.entryId,
               });
               const draftParts = this.shapeWriteParts(
-                draftInput,
+                mergedPromoteData,
                 fields,
                 manyToManyFields,
                 collection
               );
-              finalData = { ...draftInput, ...finalData };
+              finalData = mergedPromoteData;
               // Merge a patch-shaped single-component publish (the caller may
               // send only the sub-fields it changed) onto the draft's component
               // rather than replacing it, so a pending sub-field edit is promoted

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -103,6 +103,7 @@ import {
 import { resolveComponentSchemas } from "../../versions/restore-version";
 import {
   resolveComponentFieldMap,
+  stripSingleComponentTags,
   tagComponentTypes,
   tagNestedComponentTypes,
 } from "../../versions/tag-component-types";
@@ -1582,13 +1583,15 @@ export class CollectionMutationService extends BaseService {
     ): void => {
       if (!field.name) return;
       const value = owner[field.name];
-      const instances = Array.isArray(value)
-        ? value
-        : value != null
-          ? [value]
-          : [];
+      const isArray = Array.isArray(value);
+      const instances = isArray ? value : value != null ? [value] : [];
+      const kept: unknown[] = [];
+      let dropped = false;
       for (const inst of instances) {
-        if (!inst || typeof inst !== "object") continue;
+        if (!inst || typeof inst !== "object") {
+          kept.push(inst);
+          continue;
+        }
         const tagged = (inst as Record<string, unknown>)._componentType;
         const slug =
           typeof tagged === "string"
@@ -1597,8 +1600,22 @@ export class CollectionMutationService extends BaseService {
               ? slugs[0]
               : undefined;
         const cfields = slug ? componentFields.get(slug) : undefined;
-        if (cfields) stripInstance(inst, cfields);
+        if (cfields) {
+          stripInstance(inst, cfields);
+          kept.push(inst);
+        } else {
+          // The instance's schema cannot be resolved (a dynamic-zone row naming
+          // a component the field does not allow, or one absent from the
+          // registry), so a password nested inside it cannot be located and
+          // removed. Drop the instance rather than store an un-inspected value
+          // in plaintext, the same safe direction the restore filter takes for
+          // an unknown subtree.
+          dropped = true;
+        }
       }
+      if (!dropped) return;
+      if (isArray) owner[field.name] = kept;
+      else delete owner[field.name];
     };
     for (const field of schema) {
       const slugs = declaredSlugs(field);
@@ -5274,7 +5291,17 @@ export class CollectionMutationService extends BaseService {
                     ...patchFields,
                   };
                 }
-                workingDraftDocument = draftDocument;
+                // The response and hooks see the draft as an ordinary read, so
+                // the single-component type markers the persisted snapshot needs
+                // for promotion are stripped from that copy (a dynamic zone's own
+                // row type stays, as a read carries it). The read overlay does the
+                // same via the schema-aware prune; the persisted `draftDocument`
+                // below keeps its markers.
+                workingDraftDocument = stripSingleComponentTags(
+                  draftDocument,
+                  fields as unknown as FieldConfig[],
+                  slug => splitComponentSchemas?.get(slug)?.fields
+                );
                 await draftRepo.upsertWorkingDraft({
                   ref: draftRef,
                   // The split is non-localized only, so the working draft is one

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -99,6 +99,7 @@ import { assembleDocument } from "../../versions/assemble-document";
 import { captureInTx } from "../../versions/capture-in-tx";
 import {
   buildRestorePayload,
+  type ComponentSchemas,
   type RestoreSchemaContext,
 } from "../../versions/restore-snapshot";
 import { resolveComponentSchemas } from "../../versions/restore-version";
@@ -1479,6 +1480,59 @@ export class CollectionMutationService extends BaseService {
     );
     const status = rows[0]?._status;
     return typeof status === "string" ? status : null;
+  }
+
+  /**
+   * Overlay `patch` onto `base`, recursively merging single (non-repeatable)
+   * component objects instead of replacing them.
+   *
+   * A patch-shaped save carries only the sub-fields it changed, so replacing a
+   * component's whole object would drop sub-fields an earlier save set. Recurses
+   * according to the resolved component schemas so a component nested inside a
+   * component is merged at every depth. A dynamic zone (array), a repeatable
+   * component, and a scalar are replaced whole (patch wins).
+   */
+  private mergeSingleComponentPatches(
+    base: Record<string, unknown>,
+    patch: Record<string, unknown>,
+    fields: FieldConfig[],
+    componentSchemas: ComponentSchemas | null
+  ): Record<string, unknown> {
+    const byName = new Map<string, FieldConfig>();
+    for (const f of fields) {
+      const name = (f as { name?: unknown }).name;
+      if (typeof name === "string") byName.set(name, f);
+    }
+    const out: Record<string, unknown> = { ...base };
+    for (const [key, patchVal] of Object.entries(patch)) {
+      const field = byName.get(key);
+      const slug =
+        field &&
+        typeof (field as { component?: unknown }).component === "string" &&
+        (field as { repeatable?: unknown }).repeatable !== true
+          ? ((field as { component?: string }).component as string)
+          : undefined;
+      const baseVal = out[key];
+      if (
+        slug !== undefined &&
+        baseVal !== null &&
+        typeof baseVal === "object" &&
+        !Array.isArray(baseVal) &&
+        patchVal !== null &&
+        typeof patchVal === "object" &&
+        !Array.isArray(patchVal)
+      ) {
+        out[key] = this.mergeSingleComponentPatches(
+          baseVal as Record<string, unknown>,
+          patchVal as Record<string, unknown>,
+          componentSchemas?.get(slug)?.fields ?? [],
+          componentSchemas
+        );
+      } else {
+        out[key] = patchVal;
+      }
+    }
+    return out;
   }
 
   /**
@@ -5032,10 +5086,18 @@ export class CollectionMutationService extends BaseService {
                 collection
               );
               finalData = { ...draftInput, ...finalData };
-              componentFieldData = {
-                ...draftParts.componentFieldData,
-                ...componentFieldData,
-              };
+              // Merge a patch-shaped single-component publish (the caller may
+              // send only the sub-fields it changed) onto the draft's component
+              // rather than replacing it, so a pending sub-field edit is promoted
+              // instead of reverting to the live value. Recurses into nested
+              // single components; a dynamic zone and a repeatable component are
+              // replaced whole.
+              componentFieldData = this.mergeSingleComponentPatches(
+                draftParts.componentFieldData,
+                componentFieldData,
+                fields as unknown as FieldConfig[],
+                splitComponentSchemas
+              );
               manyToManyData = {
                 ...draftParts.manyToManyData,
                 ...manyToManyData,
@@ -5411,43 +5473,17 @@ export class CollectionMutationService extends BaseService {
                   );
                   // A single (non-repeatable) component holds an object of
                   // sub-fields, and a patch-shaped save carries only the ones it
-                  // changed. Replacing the whole key would drop sub-field edits an
-                  // earlier draft save made, so merge this patch's component object
-                  // onto the existing draft's rather than overwriting it. A dynamic
-                  // zone (array) and a scalar are still replaced whole.
-                  const singleComponentKeys = new Set(
-                    fields
-                      .filter(
-                        f =>
-                          typeof (f as { component?: unknown }).component ===
-                            "string" &&
-                          (f as { repeatable?: unknown }).repeatable !== true
-                      )
-                      .map(f => (f as { name?: unknown }).name)
-                      .filter((n): n is string => typeof n === "string")
+                  // changed. Recursively merge this patch's component objects onto
+                  // the existing draft's (descending into nested single components)
+                  // rather than overwriting them, so disjoint sub-field edits from
+                  // separate saves coalesce at any depth. A dynamic zone, a
+                  // repeatable component, and a scalar are replaced whole.
+                  draftDocument = this.mergeSingleComponentPatches(
+                    existingSnapshot,
+                    patchFields,
+                    fields as unknown as FieldConfig[],
+                    splitComponentSchemas
                   );
-                  for (const key of Object.keys(patchFields)) {
-                    if (!singleComponentKeys.has(key)) continue;
-                    const prev = existingSnapshot[key];
-                    const next = patchFields[key];
-                    if (
-                      prev !== null &&
-                      typeof prev === "object" &&
-                      !Array.isArray(prev) &&
-                      next !== null &&
-                      typeof next === "object" &&
-                      !Array.isArray(next)
-                    ) {
-                      patchFields[key] = {
-                        ...(prev as Record<string, unknown>),
-                        ...(next as Record<string, unknown>),
-                      };
-                    }
-                  }
-                  draftDocument = {
-                    ...existingSnapshot,
-                    ...patchFields,
-                  };
                 }
                 // The response and hooks see the draft as an ordinary read, so
                 // the single-component type markers the persisted snapshot needs

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -105,8 +105,8 @@ import {
 import { resolveComponentSchemas } from "../../versions/restore-version";
 import {
   addressableFields,
+  rehydrateSnapshotDates,
   resolveComponentFieldMap,
-  stripSingleComponentTags,
   tagComponentTypes,
   tagNestedComponentTypes,
 } from "../../versions/tag-component-types";
@@ -5497,16 +5497,66 @@ export class CollectionMutationService extends BaseService {
                   );
                 }
                 // The response and hooks see the draft as an ordinary read, so
-                // the single-component type markers the persisted snapshot needs
-                // for promotion are stripped from that copy (a dynamic zone's own
-                // row type stays, as a read carries it). The read overlay does the
-                // same via the schema-aware prune; the persisted `draftDocument`
-                // below keeps its markers.
-                workingDraftDocument = stripSingleComponentTags(
+                // shape the accumulated snapshot through the current schema the
+                // same way the read overlay does: a field a later schema change
+                // removed or renamed (which the persisted snapshot still carries)
+                // is pruned, single-component type markers are dropped (a dynamic
+                // zone keeps its own row type, as a read carries it), and JSON
+                // date strings become Date at every depth. Without this the hooks
+                // and the mutation result would see an obsolete field or an ISO
+                // string where an ordinary update supplies a Date. The persisted
+                // `draftDocument` below keeps its markers for promotion.
+                const responseDeclaredFields =
+                  fields as unknown as FieldConfig[];
+                const draftIsPluginCollection =
+                  (collection as { admin?: { isPlugin?: boolean } }).admin
+                    ?.isPlugin === true;
+                const { payload: shapedDraftDocument } = buildRestorePayload(
                   draftDocument,
-                  fields as unknown as FieldConfig[],
-                  slug => splitComponentSchemas?.get(slug)?.fields
+                  responseDeclaredFields,
+                  {
+                    hasStatus: collectionHasStatus,
+                    hasSlug:
+                      !draftIsPluginCollection ||
+                      responseDeclaredFields.some(f => f.name === "slug"),
+                    hasTitle:
+                      !draftIsPluginCollection ||
+                      responseDeclaredFields.some(f => f.name === "title"),
+                    componentSchemas: splitComponentSchemas ?? undefined,
+                    documentLocalized: false,
+                    localeUnknown: false,
+                  }
                 );
+                // buildRestorePayload drops immutable system columns, but a
+                // mutation response and its hooks still expect the id and
+                // timestamps the snapshot carries, so copy them back and
+                // rehydrate the two system timestamps, mirroring the read overlay.
+                for (const key of [
+                  "id",
+                  "createdAt",
+                  "created_at",
+                  "updatedAt",
+                  "updated_at",
+                ]) {
+                  if (key in draftDocument) {
+                    shapedDraftDocument[key] = draftDocument[key];
+                  }
+                }
+                for (const key of ["createdAt", "updatedAt"]) {
+                  const value = shapedDraftDocument[key];
+                  if (typeof value === "string") {
+                    const parsed = new Date(value);
+                    if (!Number.isNaN(parsed.getTime())) {
+                      shapedDraftDocument[key] = parsed;
+                    }
+                  }
+                }
+                rehydrateSnapshotDates(
+                  shapedDraftDocument,
+                  responseDeclaredFields,
+                  splitComponentSchemas ?? null
+                );
+                workingDraftDocument = shapedDraftDocument;
                 await draftRepo.upsertWorkingDraft({
                   ref: draftRef,
                   // The split is non-localized only, so the working draft is one

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -73,6 +73,7 @@ import {
 } from "../../../shared/lib/field-transform";
 import { toJsonColumnValue } from "../../../shared/lib/json-column-value";
 import {
+  hasPasswordField,
   hashPasswordFieldValues,
   stripPasswordFieldValues,
   stripSystemOwnerField,
@@ -4486,11 +4487,27 @@ export class CollectionMutationService extends BaseService {
             schema => schema.localized || !schema.resolved
           )
         : false;
+      // A password field cannot ride safely in a working draft: the snapshot
+      // strips passwords so no plaintext credential is stored at rest, and the
+      // promote filter drops any field whose subtree holds one, so a draft can
+      // neither carry a password change nor preserve an ordinary edit made
+      // alongside a password in the same component. Until drafts persist password
+      // changes through a secure path, a collection with a reachable password
+      // field (top-level or inside a reachable component) is excluded from the
+      // split and edits the live row directly, exactly as before the split.
+      const hasReachablePassword =
+        hasPasswordField(fields) ||
+        (splitComponentSchemas
+          ? [...splitComponentSchemas.values()].some(schema =>
+              hasPasswordField(schema.fields)
+            )
+          : false);
       const splitEnabled =
         collectionHasStatus &&
         versionsConfig?.drafts?.enabled === true &&
         !documentLocalized &&
-        !hasIneligibleComponent;
+        !hasIneligibleComponent &&
+        !hasReachablePassword;
       // No status named ⇒ neither the main row nor the write-locale companion
       // `_status` is being set (matches the transition guard's own build gate at
       // `transitionNextStatus !== undefined`).

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -5666,13 +5666,17 @@ export class CollectionMutationService extends BaseService {
               }
 
               // Invalidate a stale working draft when the split no longer applies
-              // to a status collection: drafts were turned off, or the collection
-              // became localized / password-bearing / gained an ineligible
-              // component after a draft was written. This write went straight to
-              // the live row, so a retained sidecar can never be promoted and,
-              // were the split re-enabled, would shadow the edits made meanwhile.
-              // A no-op when no sidecar exists.
-              if (!splitEnabled && collectionHasStatus) {
+              // to a versioned collection: drafts were turned off, the status
+              // lifecycle was removed, or the collection became localized /
+              // password-bearing / gained an ineligible component after a draft
+              // was written. Gated on versioning (a sidecar only ever exists under
+              // it) rather than the current status flag, so removing `status`
+              // itself — which clears `collectionHasStatus` — still drops the now
+              // unreachable sidecar. This write went straight to the live row, so a
+              // retained sidecar can never be promoted and, were the split re-
+              // enabled, would shadow the edits made meanwhile. A no-op when none
+              // exists.
+              if (!splitEnabled && versionsConfig?.enabled === true) {
                 await new VersionsRepository(tx).deleteWorkingDraft(
                   {
                     scopeKind: "collection",

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4666,9 +4666,25 @@ export class CollectionMutationService extends BaseService {
           data: componentFieldData,
           locale: params.locale,
         })) ?? new Map<string, boolean>();
+      // `withVersionConflictRetry` re-runs the closure on a version_no conflict,
+      // and the promote fold inside it rebinds these payloads (and sets the
+      // pending-draft document). Capture the caller's own shaped input so each
+      // attempt starts from it rather than from a prior attempt's merged draft.
+      const baseFinalData = { ...finalData };
+      const baseManyToManyData = { ...manyToManyData };
+      const baseComponentFieldData = { ...componentFieldData };
       await withVersionConflictRetry(() =>
         this.adapter.transaction(async tx => {
           recorded = false;
+          // Reset the payloads the promote fold rebinds, so a retried attempt
+          // re-decides the split from the caller's input; and clear the pending
+          // draft document, so a stale one from a promoted attempt cannot suppress
+          // the outbox/reaction events or the revalidation intent of a committed
+          // live write on the retry.
+          finalData = { ...baseFinalData };
+          manyToManyData = { ...baseManyToManyData };
+          componentFieldData = { ...baseComponentFieldData };
+          workingDraftDocument = undefined;
           // `let` because promote-on-publish rebinds it from the merged
           // draft+payload after the working draft is folded in below.
           let updatePayload = {

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4536,6 +4536,55 @@ export class CollectionMutationService extends BaseService {
           }
         : null;
 
+      // Revalidate the promoted draft against the CURRENT schema before the
+      // transaction opens. The caller validation above ran on the caller's
+      // payload only, which for a publish is just `{ status }`; promote then
+      // folds the whole accumulated draft into the live write, so a draft field
+      // the schema has since made stricter (a tightened `minLength`/`max`/
+      // `pattern`/`options`, or an emptied value that is now required) would
+      // otherwise reach the live row unchecked. Read the draft advisory rather
+      // than under the promote's row lock — validators are pure of the write
+      // connection, but a lock taken here would be a second one against a small
+      // pool — and validate the SAME merged shape the in-transaction fold
+      // persists (`buildRestorePayload` output with the caller's fields on top).
+      // The fold below stays authoritative for the write; this only gates it.
+      if (promotePossible && promoteRestoreCtx) {
+        const advisoryDraft = await new VersionsRepository(
+          this.adapter
+        ).findWorkingDraft(
+          {
+            scopeKind: "collection",
+            scopeSlug: params.collectionName,
+            entryId: params.entryId,
+          },
+          null
+        );
+        if (advisoryDraft) {
+          const { payload: draftInput } = buildRestorePayload(
+            advisoryDraft.snapshot,
+            fields as unknown as FieldConfig[],
+            promoteRestoreCtx
+          );
+          const mergedForValidation = { ...draftInput, ...finalData };
+          const localeCtx = await this.localizedRequiredContext(
+            params.collectionName,
+            params.locale
+          );
+          const promoteIssues = await validateEntryData(
+            this.validationView(mergedForValidation, fields),
+            attachFieldValidators("collection", params.collectionName, fields),
+            {
+              mode: "update",
+              req: params.user ? { user: params.user } : {},
+              ...localeCtx,
+            }
+          );
+          if (promoteIssues.length > 0) {
+            throw NextlyError.validation({ errors: promoteIssues });
+          }
+        }
+      }
+
       // Retry the whole content+capture transaction on a version_no allocation
       // race (concurrent updates to the same doc); the re-run re-reads the max.
       // The content UPDATE is a deterministic SET, so re-applying it is safe.

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4515,7 +4515,14 @@ export class CollectionMutationService extends BaseService {
       // unused unless a draft is found under the row lock below. `promotePossible`
       // is the publish/unpublish counterpart of the status-less draft edit: the
       // two are disjoint on `namesNoStatus`.
-      const promotePossible = splitEnabled && !namesNoStatus;
+      // A restore write (a `sourceVersionNo` is set) names the restored version's
+      // status and so is not status-less, but it is not a publish of the pending
+      // draft either: folding the draft would fill fields the historical snapshot
+      // omits with unrelated pending edits and then delete the draft. Apply the
+      // restore payload directly and leave any working draft in place.
+      const isRestoreWrite =
+        params.sourceVersionNo !== undefined && params.sourceVersionNo !== null;
+      const promotePossible = splitEnabled && !namesNoStatus && !isRestoreWrite;
       const isPluginForRestore =
         (
           (collection as Record<string, unknown>).admin as

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -5680,18 +5680,17 @@ export class CollectionMutationService extends BaseService {
                 );
               }
 
-              // Invalidate a stale working draft when the split no longer applies
-              // to a versioned collection: drafts were turned off, the status
+              // Invalidate a stale working draft on any live write the split no
+              // longer covers: drafts were turned off, versioning or the status
               // lifecycle was removed, or the collection became localized /
-              // password-bearing / gained an ineligible component after a draft
-              // was written. Gated on versioning (a sidecar only ever exists under
-              // it) rather than the current status flag, so removing `status`
-              // itself — which clears `collectionHasStatus` — still drops the now
-              // unreachable sidecar. This write went straight to the live row, so a
-              // retained sidecar can never be promoted and, were the split re-
-              // enabled, would shadow the edits made meanwhile. A no-op when none
-              // exists.
-              if (!splitEnabled && versionsConfig?.enabled === true) {
+              // password-bearing / gained an ineligible component after a draft was
+              // written. Once status or versioning is dropped the config no longer
+              // signals that a sidecar could exist, so this cannot be narrowed to
+              // the current status/versioning flags — a removed lifecycle would
+              // leave the sidecar to resurface if the split were re-enabled. The
+              // delete is a cheap indexed no-op when none exists, and it never hits
+              // a just-stored draft: that path keeps `splitEnabled` true.
+              if (!splitEnabled) {
                 await new VersionsRepository(tx).deleteWorkingDraft(
                   {
                     scopeKind: "collection",

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -5607,6 +5607,31 @@ export class CollectionMutationService extends BaseService {
                 );
               }
 
+              // A restore that lands a non-published status turns the live row
+              // into a draft, which breaks the working-draft invariant: a sidecar
+              // is pending edits OVER a published row, and once the row is a draft
+              // no status-less edit can accumulate onto it (storeAsWorkingDraft
+              // needs a published row) while editor reads still overlay the stale
+              // sidecar and a later publish would promote it over the restored
+              // content. A restore deliberately does not fold the sidecar, so drop
+              // it here. A no-op when none exists; a restore to `published` keeps
+              // the invariant and is left untouched.
+              if (
+                isRestoreWrite &&
+                splitEnabled &&
+                transitionNextStatus !== undefined &&
+                transitionNextStatus !== "published"
+              ) {
+                await new VersionsRepository(tx).deleteWorkingDraft(
+                  {
+                    scopeKind: "collection",
+                    scopeSlug: params.collectionName,
+                    entryId: params.entryId,
+                  },
+                  null
+                );
+              }
+
               // Append the outbox event in the same transaction, so it commits
               // with the entry and is never recorded for a write that rolls back.
               // `recorded` is false when the collection opted out of recording. A

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4457,17 +4457,23 @@ export class CollectionMutationService extends BaseService {
       // A localized component stores its values per locale, but a working draft
       // is keyed under one unlocalized slot, so a draft saved under one locale
       // would be promoted under another and misfile the translation into the
-      // wrong companion. Until per-locale drafts exist, a collection that embeds
-      // a localized component is excluded from the split, alongside a localized
-      // document.
-      const hasLocalizedComponent = splitComponentSchemas
-        ? [...splitComponentSchemas.values()].some(schema => schema.localized)
+      // wrong companion. A component whose schema cannot be resolved is treated
+      // the same way: it could itself be localized, and promoting a draft while
+      // it stays unresolvable drops the component subtree (the restore filter
+      // cannot see inside a schema it cannot load) before the sidecar is deleted,
+      // silently losing the pending edit. Until per-locale drafts exist, either
+      // kind of component makes the collection ineligible for the split,
+      // alongside a localized document.
+      const hasIneligibleComponent = splitComponentSchemas
+        ? [...splitComponentSchemas.values()].some(
+            schema => schema.localized || !schema.resolved
+          )
         : false;
       const splitEnabled =
         collectionHasStatus &&
         versionsConfig?.drafts?.enabled === true &&
         !documentLocalized &&
-        !hasLocalizedComponent;
+        !hasIneligibleComponent;
       // No status named ⇒ neither the main row nor the write-locale companion
       // `_status` is being set (matches the transition guard's own build gate at
       // `transitionNextStatus !== undefined`).

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4497,6 +4497,46 @@ export class CollectionMutationService extends BaseService {
           }
         : null;
 
+      // When a publish could promote a working draft, the draft's components are
+      // folded into the write INSIDE the transaction — after the preflight below.
+      // A promoted localized component whose companion exists would otherwise
+      // reach the write with no presence entry and be misfiled (default locale)
+      // or refused (non-default). Read the draft on the pooled connection here
+      // (advisory only: the authoritative fetch runs under the row lock in the
+      // transaction, and this write neither stores nor deletes it) and turn its
+      // snapshot into a restore input, so the preflight probes exactly the
+      // component types the fold will write. The caller's own components override
+      // the draft's per field, matching the in-transaction merge.
+      const promoteComponentPreview: Record<string, unknown> = {};
+      if (promotePossible && promoteRestoreCtx) {
+        const advisoryDraft = await new VersionsRepository(
+          this.adapter
+        ).findWorkingDraft(
+          {
+            scopeKind: "collection",
+            scopeSlug: params.collectionName,
+            entryId: params.entryId,
+          },
+          null
+        );
+        if (advisoryDraft) {
+          const { payload: advisoryInput } = buildRestorePayload(
+            advisoryDraft.snapshot,
+            fields as unknown as FieldConfig[],
+            promoteRestoreCtx
+          );
+          for (const field of fields) {
+            if (
+              isFieldGroupField(field) &&
+              field.name &&
+              advisoryInput[field.name] !== undefined
+            ) {
+              promoteComponentPreview[field.name] = advisoryInput[field.name];
+            }
+          }
+        }
+      }
+
       // Retry the whole content+capture transaction on a version_no allocation
       // race (concurrent updates to the same doc); the re-run re-reads the max.
       // The content UPDATE is a deterministic SET, so re-applying it is safe.
@@ -4512,6 +4552,13 @@ export class CollectionMutationService extends BaseService {
       // resolves, so a rolled-back attempt (a version conflict) or a commit
       // failure never flags a durable event that isn't there.
       let recorded = false;
+      // Set when this update was stored as a working draft (see the split below).
+      // The live row is left untouched, so the row re-fetched after the
+      // transaction is the OLD published content; the response, afterUpdate/
+      // afterChange hooks, and the reaction event must use this pending document
+      // instead, and the public revalidation and reaction event are skipped
+      // because the live document a visitor sees did not change.
+      let workingDraftDocument: Record<string, unknown> | undefined;
       // Verify every localized field group in this payload can actually be written
       // BEFORE the transaction opens. Inside it the probes would borrow a second
       // connection and deadlock a single-connection pool, and a NextlyError raised in
@@ -4520,7 +4567,9 @@ export class CollectionMutationService extends BaseService {
       const fieldGroupPresence =
         (await this.fieldGroupDataService?.assertLocalizedFieldGroupsWritable({
           fields: fields as unknown as FieldConfig[],
-          data: componentFieldData,
+          // The draft's component types are included so a promote that folds them
+          // in has their companion presence resolved here, off the transaction.
+          data: { ...promoteComponentPreview, ...componentFieldData },
           locale: params.locale,
         })) ?? new Map<string, boolean>();
       await withVersionConflictRetry(() =>
@@ -5207,6 +5256,11 @@ export class CollectionMutationService extends BaseService {
                   fields,
                   tx
                 );
+                // Reused after the transaction as the response/hook document,
+                // since the live row the re-fetch returns is the unchanged
+                // published content.
+                const draftDocument = assembleDocument(draftParts);
+                workingDraftDocument = draftDocument;
                 await new VersionsRepository(tx).upsertWorkingDraft({
                   ref: {
                     scopeKind: "collection",
@@ -5220,7 +5274,7 @@ export class CollectionMutationService extends BaseService {
                   // arrives under a different locale in a localization-configured
                   // app. The read overlay and promote use the same null key.
                   locale: null,
-                  snapshot: assembleDocument(draftParts),
+                  snapshot: draftDocument,
                   createdBy: params.user?.id ?? null,
                 });
               }
@@ -5422,29 +5476,41 @@ export class CollectionMutationService extends BaseService {
       // recording/revalidation opt-outs below.
       committedWrite = true;
 
+      // A pure draft edit leaves the live row untouched, so the re-fetched
+      // `updated` is the OLD published content. Everything that reports what this
+      // update produced — the response, the afterUpdate/afterChange hooks — uses
+      // the pending draft document instead.
+      const responseSource = (workingDraftDocument ?? updated) as Record<
+        string,
+        unknown
+      >;
+
       // The tags this update invalidates: the id and current-slug tags, plus the
       // previous-slug tag when the slug changed (captured in the transaction), so
       // a read cached under the old URL clears. Built on the committed write, NOT
       // the outbox-event flag: reaching here past the 404 guard means the row was
       // written, so an opted-out (`webhooks: false`) update — which records no
-      // event — must still bust its tags, exactly as create and delete do.
-      revalidationIntent = buildEntryRevalidationIntent(
-        params.collectionName,
-        readRevalidateConfig(collection),
-        {
-          id: params.entryId,
-          slug: readStringField(updated as Record<string, unknown>, "slug"),
-          previousSlug,
-          locale: localizedUpdate?.writeLocale,
-        }
-      );
+      // event — must still bust its tags, exactly as create and delete do. A
+      // draft edit changes nothing a visitor sees, so it busts no public tags.
+      if (!workingDraftDocument) {
+        revalidationIntent = buildEntryRevalidationIntent(
+          params.collectionName,
+          readRevalidateConfig(collection),
+          {
+            id: params.entryId,
+            slug: readStringField(updated as Record<string, unknown>, "slug"),
+            previousSlug,
+            locale: localizedUpdate?.writeLocale,
+          }
+        );
+      }
 
       // Execute afterUpdate hooks (code-registered)
       // Hooks run after database update completes (for side effects)
       const afterContext = this.hookService.buildHookContext({
         collection: params.collectionName,
         operation: "update" as const,
-        data: updated,
+        data: responseSource,
         originalData: existingEntry,
         user: params.user,
         context: sharedContext, // Pass shared context from beforeUpdate
@@ -5459,20 +5525,24 @@ export class CollectionMutationService extends BaseService {
         this.hookService.buildPrebuiltHookContext(
           params.collectionName,
           "update",
-          updated,
+          responseSource,
           this.queryDatabaseFn,
           params.user,
           sharedContext
         )
       );
 
-      // Post-commit reaction event (D8/D51).
-      emitCollectionEvent(
-        "updated",
-        params.collectionName,
-        updated,
-        params.user
-      );
+      // Post-commit reaction event (D8/D51). Skipped for a pure draft edit: the
+      // live document did not change, so no cache reaction is owed — mirroring
+      // the outbox `entry.updated` event, which is already suppressed above.
+      if (!workingDraftDocument) {
+        emitCollectionEvent(
+          "updated",
+          params.collectionName,
+          updated,
+          params.user
+        );
+      }
 
       // D69 document-level status events. Status is a user-defined field;
       // emit only when a `status` field value actually changed on update.
@@ -5526,15 +5596,19 @@ export class CollectionMutationService extends BaseService {
         });
       }
 
-      // Deserialize JSON fields (richtext, blocks, array, group, json) for response
+      // Deserialize JSON fields (richtext, blocks, array, group, json) for
+      // response. A no-op on the draft document, whose JSON fields are already
+      // parsed by the snapshot builder.
       fields.forEach(field => {
         if (
           isJsonFieldType(field.type, field) &&
-          updated[field.name] &&
-          typeof updated[field.name] === "string"
+          responseSource[field.name] &&
+          typeof responseSource[field.name] === "string"
         ) {
           try {
-            updated[field.name] = JSON.parse(updated[field.name] as string);
+            responseSource[field.name] = JSON.parse(
+              responseSource[field.name] as string
+            );
           } catch {
             // If parsing fails, keep as string
           }
@@ -5548,17 +5622,19 @@ export class CollectionMutationService extends BaseService {
         kind: "collection",
         slug: params.collectionName,
         phase: "afterChange",
-        data: updated as Record<string, unknown>,
+        data: responseSource,
         operation: "update",
         user: params.user,
       });
 
-      // Expand relationships in response if depth is specified
-      let responseEntry = updated;
+      // Expand relationships in response if depth is specified. Runs on the
+      // draft document too for a draft edit, so a trusted editor's save response
+      // populates top-level relations at the requested depth just like a read.
+      let responseEntry = responseSource;
       if (depth !== undefined && depth > 0) {
         try {
           responseEntry = await this.relationshipService.expandRelationships(
-            updated,
+            responseSource,
             params.collectionName,
             fields,
             {
@@ -5597,7 +5673,7 @@ export class CollectionMutationService extends BaseService {
       // Redact the response: drop write-only password hashes and any field
       // the caller may write but not read (parity with the query path).
       await this.redactResponseFields(
-        responseEntry as Record<string, unknown>,
+        responseEntry,
         fields,
         {
           user: params.user,

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1510,9 +1510,19 @@ export class CollectionMutationService extends BaseService {
       : new Map<string, FieldConfig[]>();
     const resolve = (slug: string) => componentFields.get(slug);
 
+    const components = tagComponentTypes(parts.components, schema, resolve);
+    // A working draft stores the caller's RAW component input (the component
+    // saver that hashes nested passwords is skipped for a draft edit), so a
+    // password field inside a component would otherwise land in the snapshot in
+    // plaintext and leak on a trusted draft read. The normal capture path reads
+    // components back through the query layer, which already strips them, so
+    // this is a no-op there. Runs after tagging so a dynamic zone's per-instance
+    // `_componentType` resolves each row's own schema.
+    this.stripComponentPasswordsInPlace(components, schema, componentFields);
+
     return {
       ...parts,
-      components: tagComponentTypes(parts.components, schema, resolve),
+      components,
       // A component declared inside a group or repeater rides in that
       // container's JSON on the parent row rather than appearing as its own
       // key, so it has to be reached through the row.
@@ -1522,6 +1532,78 @@ export class CollectionMutationService extends BaseService {
         resolve
       ) as Record<string, unknown>,
     };
+  }
+
+  /**
+   * Delete password-field values from component instances in a snapshot's
+   * component map, descending through nested components. `stripPasswordFieldValues`
+   * handles a component instance's own passwords and any nested in a
+   * group/repeater, but cannot follow a component referenced by slug; this
+   * resolves each instance's schema (from the tagged `_componentType`, or the
+   * field's single declared component) and recurses so a password two components
+   * deep is removed too. Mutates in place: on every path that reaches here the
+   * component data has already been saved (promote) or will never be saved
+   * (draft edit), so stripping the snapshot copy cannot affect a live write.
+   */
+  private stripComponentPasswordsInPlace(
+    components: Record<string, unknown>,
+    schema: FieldConfig[],
+    componentFields: Map<string, FieldConfig[]>
+  ): void {
+    const declaredSlugs = (field: FieldConfig): string[] => {
+      const one = (field as { component?: unknown }).component;
+      const many = (field as { components?: unknown }).components;
+      const slugs: string[] = [];
+      if (typeof one === "string") slugs.push(one);
+      if (Array.isArray(many)) {
+        for (const s of many) if (typeof s === "string") slugs.push(s);
+      }
+      return slugs;
+    };
+    const stripInstance = (instance: unknown, cfields: FieldConfig[]): void => {
+      if (
+        !instance ||
+        typeof instance !== "object" ||
+        Array.isArray(instance)
+      ) {
+        return;
+      }
+      const rec = instance as Record<string, unknown>;
+      stripPasswordFieldValues(rec, cfields);
+      for (const child of cfields) {
+        const childSlugs = declaredSlugs(child);
+        if (childSlugs.length > 0) stripField(rec, child, childSlugs);
+      }
+    };
+    const stripField = (
+      owner: Record<string, unknown>,
+      field: FieldConfig,
+      slugs: string[]
+    ): void => {
+      if (!field.name) return;
+      const value = owner[field.name];
+      const instances = Array.isArray(value)
+        ? value
+        : value != null
+          ? [value]
+          : [];
+      for (const inst of instances) {
+        if (!inst || typeof inst !== "object") continue;
+        const tagged = (inst as Record<string, unknown>)._componentType;
+        const slug =
+          typeof tagged === "string"
+            ? tagged
+            : slugs.length === 1
+              ? slugs[0]
+              : undefined;
+        const cfields = slug ? componentFields.get(slug) : undefined;
+        if (cfields) stripInstance(inst, cfields);
+      }
+    };
+    for (const field of schema) {
+      const slugs = declaredSlugs(field);
+      if (slugs.length > 0) stripField(components, field, slugs);
+    }
   }
 
   private async buildFullSnapshotRelations(
@@ -4722,15 +4804,48 @@ export class CollectionMutationService extends BaseService {
           if (promotePossible && promoteRestoreCtx) {
             const workingDraft = await new VersionsRepository(
               tx
+              // The split is non-localized only, so the working draft is keyed
+              // under the unlocalized `locale IS NULL` slot — the same key the
+              // read overlay and the store use, so a publish under any request
+              // locale still finds the pending draft it would show the editor.
             ).findWorkingDraft(
               {
                 scopeKind: "collection",
                 scopeSlug: params.collectionName,
                 entryId: params.entryId,
               },
-              this.componentSnapshotLocale(params.locale)
+              null
             );
             if (workingDraft) {
+              // Promoting a working draft publishes (or unpublishes) its pending
+              // content, so it needs the same permission as a status transition
+              // even when the main-row status does not change: a
+              // published -> published re-publish is a no-op for the transition
+              // guard above, yet folding the draft still pushes pending content
+              // live. Enforce the pre-resolved guard here against the row-locked
+              // document. For a real transition the guard already fired and
+              // passed above, so this is a no-op re-check; for the no-op
+              // re-publish it is the only place the publish permission is
+              // enforced.
+              if (transitionGuard) {
+                if (transitionGuard.permissionDenied) {
+                  transitionDeniedResult = transitionGuard.permissionDenied;
+                  throw new StatusTransitionDeniedError();
+                }
+                if (transitionGuard.documentRule && preUpdateRow) {
+                  const promoteDenied =
+                    await this.accessService.evaluateTransitionDocumentRule(
+                      transitionGuard.documentRule.accessRules,
+                      transitionGuard.op,
+                      transitionGuard.documentRule.user,
+                      preUpdateRow as Record<string, unknown>
+                    );
+                  if (promoteDenied) {
+                    transitionDeniedResult = promoteDenied;
+                    throw new StatusTransitionDeniedError();
+                  }
+                }
+              }
               // The snapshot is stored read-shaped, so buildRestorePayload turns
               // it into a safe update input (immutable ids stripped, removed
               // columns and password fields dropped, component subtrees whose
@@ -5098,13 +5213,13 @@ export class CollectionMutationService extends BaseService {
                     scopeSlug: params.collectionName,
                     entryId: params.entryId,
                   },
-                  // The resolved request locale (null when localization is off),
-                  // which is exactly what the read overlay looks the draft up
-                  // under (`localeChain[0] ?? null`) and what a later publish uses
-                  // to promote it — so store, overlay, and promote never drift.
-                  // The split is non-localized-only, so this captures the single
-                  // per-locale component snapshot for one logical document.
-                  locale: this.componentSnapshotLocale(params.locale),
+                  // The split is non-localized only, so the working draft is one
+                  // logical document with no per-locale variant: key it under the
+                  // unlocalized `locale IS NULL` slot. Keying it by the resolved
+                  // request locale would orphan it when a later read or publish
+                  // arrives under a different locale in a localization-configured
+                  // app. The read overlay and promote use the same null key.
+                  locale: null,
                   snapshot: assembleDocument(draftParts),
                   createdBy: params.user?.id ?? null,
                 });
@@ -5123,7 +5238,8 @@ export class CollectionMutationService extends BaseService {
                     scopeSlug: params.collectionName,
                     entryId: params.entryId,
                   },
-                  this.componentSnapshotLocale(params.locale)
+                  // Same unlocalized key the fetch and store use.
+                  null
                 );
               }
 

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -104,6 +104,7 @@ import {
 } from "../../versions/restore-snapshot";
 import { resolveComponentSchemas } from "../../versions/restore-version";
 import {
+  addressableFields,
   resolveComponentFieldMap,
   stripSingleComponentTags,
   tagComponentTypes,
@@ -1498,8 +1499,12 @@ export class CollectionMutationService extends BaseService {
     fields: FieldConfig[],
     componentSchemas: ComponentSchemas | null
   ): Record<string, unknown> {
+    // Flatten unnamed presentational groups (matching `tagComponentTypes`): a
+    // single component declared inside such a group stores its value at the
+    // enclosing level, so without flattening the lookup would miss it and treat
+    // it as a scalar, replacing rather than merging a nested component patch.
     const byName = new Map<string, FieldConfig>();
-    for (const f of fields) {
+    for (const f of addressableFields(fields)) {
       const name = (f as { name?: unknown }).name;
       if (typeof name === "string") byName.set(name, f);
     }
@@ -4626,10 +4631,6 @@ export class CollectionMutationService extends BaseService {
       // pool — and validate the SAME merged shape the in-transaction fold
       // persists (`buildRestorePayload` output with the caller's fields on top).
       // The fold below stays authoritative for the write; this only gates it.
-      // Draft fields the current field-level write access denies the publisher,
-      // computed with the caller-payload gate, so the in-transaction fold can
-      // drop them and keep the live value rather than publish a denied edit.
-      const promoteDeniedDraftFields = new Set<string>();
       if (promotePossible && promoteRestoreCtx) {
         const advisoryDraft = await new VersionsRepository(
           this.adapter
@@ -4648,14 +4649,14 @@ export class CollectionMutationService extends BaseService {
             promoteRestoreCtx
           );
           const merged = { ...draftInput, ...finalData };
-          // Field-level write access on the MERGED promoted payload. The caller
-          // gate above ran on the caller's payload only (a publish sends just the
-          // status), but promote folds the whole draft in, so a field the current
-          // policy denies THIS publisher — including a draft authored by a
-          // different user — would otherwise be published. Applied pre-tx like the
-          // caller gate so an access rule that reads the DB stays off the write
-          // connection; the denied draft fields are recorded and dropped from the
-          // in-transaction fold below, leaving the live value in place.
+          // Field-level write access on the MERGED promoted payload, so the
+          // validation below gates only the values the publisher may write: the
+          // caller gate above ran on the caller's payload only (a publish sends
+          // just the status), but promote folds the whole draft in. The
+          // authoritative filtering runs again on the locked draft inside the
+          // transaction (see the promote block), so a denied value nested in a
+          // group or repeater is dropped too, not only a fully denied top-level
+          // container.
           await applyFieldWriteAccess({
             kind: "collection",
             slug: params.collectionName,
@@ -4665,9 +4666,6 @@ export class CollectionMutationService extends BaseService {
             overrideAccess: params.overrideAccess,
             id: params.entryId,
           });
-          for (const key of Object.keys(draftInput)) {
-            if (!(key in merged)) promoteDeniedDraftFields.add(key);
-          }
           const localeCtx = await this.localizedRequiredContext(
             params.collectionName,
             params.locale
@@ -5073,12 +5071,23 @@ export class CollectionMutationService extends BaseService {
                 fields as unknown as FieldConfig[],
                 promoteRestoreCtx
               );
-              // A draft field the current field-level write access denies the
-              // publisher (resolved pre-transaction above) is not folded into the
-              // live write: the live value is kept rather than publishing an edit
-              // the caller may not make.
-              for (const key of promoteDeniedDraftFields)
-                delete draftInput[key];
+              // Re-apply the current field-level write access to the locked
+              // draft the fold actually persists, so a value the publisher may
+              // not write is not promoted — at every depth. Filtering the merged
+              // advisory copy pre-transaction only recorded whole top-level
+              // containers it removed; running the filter on this authoritative
+              // snapshot also drops a denied value nested in a group or repeater.
+              // `applyFieldWriteAccess` is already used inside the caller-owned
+              // transaction paths, so running it here is consistent.
+              await applyFieldWriteAccess({
+                kind: "collection",
+                slug: params.collectionName,
+                data: draftInput,
+                operation: "update",
+                user: params.user,
+                overrideAccess: params.overrideAccess,
+                id: params.entryId,
+              });
               const draftParts = this.shapeWriteParts(
                 draftInput,
                 fields,
@@ -6211,6 +6220,19 @@ export class CollectionMutationService extends BaseService {
         // duplicate `entry.deleted` for a row it did not remove.
         if (deletedCount === 0) return;
         deletedRow = true;
+
+        // Remove any pending working-draft sidecar for the deleted entry in the
+        // same transaction: it is keyed by entry id and excluded from history and
+        // retention queries, so after the row it belongs to is gone it would
+        // otherwise linger unreachable in nextly_versions. A no-op when none.
+        await new VersionsRepository(tx).deleteWorkingDraft(
+          {
+            scopeKind: "collection",
+            scopeSlug: params.collectionName,
+            entryId: params.entryId,
+          },
+          null
+        );
 
         // The removed document's final state ships as `data`; there is no
         // post-delete state, so `previous` is null (mirroring create, which
@@ -7643,6 +7665,18 @@ export class CollectionMutationService extends BaseService {
         };
       }
       deleteNeedsRollback = true;
+
+      // Remove any pending working-draft sidecar for the deleted entry in the
+      // same transaction, so it does not linger unreachable in nextly_versions
+      // after its row is gone. A no-op when none exists.
+      await new VersionsRepository(tx).deleteWorkingDraft(
+        {
+          scopeKind: "collection",
+          scopeSlug: params.collectionName,
+          entryId: params.entryId,
+        },
+        null
+      );
 
       // Append the outbox event in the same transaction so a delete performed
       // through this helper (batch/cascade/internal) is observable too, in the
@@ -9171,6 +9205,18 @@ export class CollectionMutationService extends BaseService {
         };
       }
       deleteNeedsRollback = true;
+
+      // Remove any pending working-draft sidecar for the deleted entry in the
+      // same transaction, so a batch delete does not leave it unreachable in
+      // nextly_versions after its row is gone. A no-op when none exists.
+      await new VersionsRepository(tx).deleteWorkingDraft(
+        {
+          scopeKind: "collection",
+          scopeSlug: params.collectionName,
+          entryId,
+        },
+        null
+      );
 
       // Append the outbox event in the same transaction so a batch delete
       // through this helper is observable too, in the same shape as the

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4572,6 +4572,10 @@ export class CollectionMutationService extends BaseService {
       // pool — and validate the SAME merged shape the in-transaction fold
       // persists (`buildRestorePayload` output with the caller's fields on top).
       // The fold below stays authoritative for the write; this only gates it.
+      // Draft fields the current field-level write access denies the publisher,
+      // computed with the caller-payload gate, so the in-transaction fold can
+      // drop them and keep the live value rather than publish a denied edit.
+      const promoteDeniedDraftFields = new Set<string>();
       if (promotePossible && promoteRestoreCtx) {
         const advisoryDraft = await new VersionsRepository(
           this.adapter
@@ -4589,13 +4593,33 @@ export class CollectionMutationService extends BaseService {
             fields as unknown as FieldConfig[],
             promoteRestoreCtx
           );
-          const mergedForValidation = { ...draftInput, ...finalData };
+          const merged = { ...draftInput, ...finalData };
+          // Field-level write access on the MERGED promoted payload. The caller
+          // gate above ran on the caller's payload only (a publish sends just the
+          // status), but promote folds the whole draft in, so a field the current
+          // policy denies THIS publisher — including a draft authored by a
+          // different user — would otherwise be published. Applied pre-tx like the
+          // caller gate so an access rule that reads the DB stays off the write
+          // connection; the denied draft fields are recorded and dropped from the
+          // in-transaction fold below, leaving the live value in place.
+          await applyFieldWriteAccess({
+            kind: "collection",
+            slug: params.collectionName,
+            data: merged,
+            operation: "update",
+            user: params.user,
+            overrideAccess: params.overrideAccess,
+            id: params.entryId,
+          });
+          for (const key of Object.keys(draftInput)) {
+            if (!(key in merged)) promoteDeniedDraftFields.add(key);
+          }
           const localeCtx = await this.localizedRequiredContext(
             params.collectionName,
             params.locale
           );
           const promoteIssues = await validateEntryData(
-            this.validationView(mergedForValidation, fields),
+            this.validationView(merged, fields),
             attachFieldValidators("collection", params.collectionName, fields),
             {
               mode: "update",
@@ -4979,6 +5003,12 @@ export class CollectionMutationService extends BaseService {
                 fields as unknown as FieldConfig[],
                 promoteRestoreCtx
               );
+              // A draft field the current field-level write access denies the
+              // publisher (resolved pre-transaction above) is not folded into the
+              // live write: the live value is kept rather than publishing an edit
+              // the caller may not make.
+              for (const key of promoteDeniedDraftFields)
+                delete draftInput[key];
               const draftParts = this.shapeWriteParts(
                 draftInput,
                 fields,

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -103,6 +103,7 @@ import {
 } from "../../versions/tag-component-types";
 import { VersionCaptureService } from "../../versions/version-capture-service";
 import { withVersionConflictRetry } from "../../versions/version-conflict";
+import { VersionsRepository } from "../../versions/versions-repository";
 import { expandComponentFields } from "../../webhooks/expand-component-fields";
 import { projectFields } from "../../webhooks/project-fields";
 import { recordMutationEvent } from "../../webhooks/record-mutation-event";
@@ -4315,6 +4316,17 @@ export class CollectionMutationService extends BaseService {
       const versionsConfig = (collection as Record<string, unknown>)
         .versions as ResolvedVersionsConfig | null | undefined;
 
+      // Stage B draft/published split: an update to a PUBLISHED document that
+      // names no status is non-destructive on a split-enabled collection — it is
+      // stored as the working draft, leaving the live row untouched. Requires the
+      // draft/publish lifecycle (`status`) and drafts-enabled versioning.
+      const splitEnabled =
+        collectionHasStatus && versionsConfig?.drafts?.enabled === true;
+      // No status named ⇒ neither the main row nor the write-locale companion
+      // `_status` is being set (matches the transition guard's own build gate at
+      // `transitionNextStatus !== undefined`).
+      const namesNoStatus = transitionNextStatus === undefined;
+
       // Resolved BEFORE the transaction opens, for the reason given on the
       // create path: expansion reads the component registry on the pooled
       // connection. Hoisting it also keeps a conflict retry from re-running the
@@ -4361,6 +4373,9 @@ export class CollectionMutationService extends BaseService {
           // This locale's committed status before the write, reused by both the
           // prior document and the post-write overlay so the two stay symmetric.
           let committedLocaleStatus: string | null = null;
+          // Stage B: set once the row-locked prior state is read below — true
+          // when this update should be stored as the working draft.
+          let storeAsWorkingDraft = false;
 
           // Take the row lock the UPDATE below needs anyway, before reading the
           // prior state. Without it two concurrent updates to the same entry
@@ -4531,6 +4546,20 @@ export class CollectionMutationService extends BaseService {
             }
           }
 
+          // Stage B: decide the draft edit from the ROW-LOCKED prior status —
+          // the main row, or the write locale's companion `_status` — the same
+          // locked reads the transition guard uses, so the decision is
+          // TOCTOU-safe (a concurrent publish/unpublish committed before the
+          // lock is seen). A never-published (`draft`) or per-locale-absent
+          // (`null`) document fails the test and edits in place.
+          const draftLiveStatus = isNonDefaultLocaleStatusWrite
+            ? committedLocaleStatus
+            : (((preUpdateRow as { status?: unknown } | undefined)?.status as
+                | string
+                | undefined) ?? null);
+          storeAsWorkingDraft =
+            splitEnabled && namesNoStatus && draftLiveStatus === "published";
+
           // TOCTOU-safe authorization: classify the transition against the
           // status just read UNDER THE ROW LOCK (`preUpdateRow` /
           // `committedLocaleStatus`), not the pre-transaction read, and enforce
@@ -4615,16 +4644,28 @@ export class CollectionMutationService extends BaseService {
             })
             .join(", ");
           sqlParams.push(params.entryId);
-          await tx.execute(
-            `UPDATE ${quoteId(tableName)} SET ${setClauses} WHERE ${quoteId("id")} = ${makePlaceholder()}`,
-            sqlParams as (string | number | boolean | Date | null | undefined)[]
-          );
+          // Stage B: skip the live-row UPDATE for a draft edit — the pending
+          // change is stored as the working draft below, not written to the row.
+          if (!storeAsWorkingDraft) {
+            await tx.execute(
+              `UPDATE ${quoteId(tableName)} SET ${setClauses} WHERE ${quoteId("id")} = ${makePlaceholder()}`,
+              sqlParams as (
+                | string
+                | number
+                | boolean
+                | Date
+                | null
+                | undefined
+              )[]
+            );
+          }
 
           // Capture the committed per-locale `_status` BEFORE the upsert so the
           // post-commit event can report the real prior value. Only when the
           // write actually changes this locale's status (companion `_status` is
           // present only when `status` was explicitly in the patch).
           if (
+            !storeAsWorkingDraft &&
             localizedUpdate &&
             typeof localizedUpdate.companionData._status === "string"
           ) {
@@ -4639,6 +4680,7 @@ export class CollectionMutationService extends BaseService {
           // i18n M5: upsert the translatable values into the companion row for the write's locale
           // (same transaction). Only the provided localized columns are touched.
           if (
+            !storeAsWorkingDraft &&
             localizedUpdate &&
             Object.keys(localizedUpdate.companionData).length > 0
           ) {
@@ -4660,6 +4702,7 @@ export class CollectionMutationService extends BaseService {
 
           // Save component field data to separate comp_{slug} tables
           if (
+            !storeAsWorkingDraft &&
             this.fieldGroupDataService &&
             Object.keys(attemptComponentData).length > 0
           ) {
@@ -4684,7 +4727,10 @@ export class CollectionMutationService extends BaseService {
           // tx-scoped Drizzle handle binds the junction writes to this tx.
           const txExecutor = tx.getDrizzle<RelationshipDbExecutor>();
           for (const field of manyToManyFields) {
-            if (manyToManyData[field.name] !== undefined) {
+            if (
+              !storeAsWorkingDraft &&
+              manyToManyData[field.name] !== undefined
+            ) {
               await this.relationshipService.deleteManyToManyRelations(
                 params.collectionName,
                 params.entryId,
@@ -4843,7 +4889,7 @@ export class CollectionMutationService extends BaseService {
                 // locale-specific too — the singles path counts it the same way.
                 Object.keys(snapshotComponents ?? {}).length > 0;
 
-              if (versionsConfig?.enabled) {
+              if (versionsConfig?.enabled && !storeAsWorkingDraft) {
                 await captureInTx(tx, this.versionCapture, {
                   ref: {
                     scopeKind: "collection",
@@ -4885,26 +4931,65 @@ export class CollectionMutationService extends BaseService {
                 });
               }
 
+              // Stage B: a status-less update to a published document is stored
+              // as the working draft — the live row and its relations were left
+              // untouched above — instead of updating the live row and capturing
+              // a published version. The parent overlay already produced the
+              // intended parent with no write; overlay the in-memory intended
+              // relations onto the (unchanged) live relations read for the
+              // snapshot so a changed component/m2m field is reflected.
+              if (storeAsWorkingDraft) {
+                const draftParts = await this.snapshotPartsFor(
+                  {
+                    parentRow,
+                    components: {
+                      ...snapshotComponents,
+                      ...componentFieldData,
+                    },
+                    manyToMany: { ...snapshotM2M, ...manyToManyData },
+                  },
+                  fields,
+                  tx
+                );
+                await new VersionsRepository(tx).upsertWorkingDraft({
+                  ref: {
+                    scopeKind: "collection",
+                    scopeSlug: params.collectionName,
+                    entryId: params.entryId,
+                  },
+                  locale: capturedLocaleState
+                    ? (localizedUpdate?.writeLocale ??
+                      this.componentSnapshotLocale(params.locale))
+                    : null,
+                  snapshot: assembleDocument(draftParts),
+                  createdBy: params.user?.id ?? null,
+                });
+              }
+
               // Append the outbox event in the same transaction, so it commits
               // with the entry and is never recorded for a write that rolls back.
-              // `recorded` is false when the collection opted out of recording.
+              // `recorded` is false when the collection opted out of recording. A
+              // draft edit records no public event: the live document did not
+              // change.
               const updatedDocument = assembleDocument(documentParts);
-              recorded = await recordMutationEvent(tx, {
-                type: "entry.updated",
-                resource: {
-                  kind: "entry",
-                  collection: params.collectionName,
-                  id: params.entryId,
-                  // The resolved write locale — see the create path.
-                  ...(localizedUpdate
-                    ? { locale: localizedUpdate.writeLocale }
-                    : {}),
-                },
-                data: updatedDocument,
-                previous: previousDocument,
-                fields: webhookFields,
-                actor: actorForWrite(params.actor, params.user),
-              });
+              if (!storeAsWorkingDraft) {
+                recorded = await recordMutationEvent(tx, {
+                  type: "entry.updated",
+                  resource: {
+                    kind: "entry",
+                    collection: params.collectionName,
+                    id: params.entryId,
+                    // The resolved write locale — see the create path.
+                    ...(localizedUpdate
+                      ? { locale: localizedUpdate.writeLocale }
+                      : {}),
+                  },
+                  data: updatedDocument,
+                  previous: previousDocument,
+                  fields: webhookFields,
+                  actor: actorForWrite(params.actor, params.user),
+                });
+              }
 
               // D69 status lifecycle events, recorded in the SAME transaction as
               // entry.updated (mirrors the post-commit transitionStatus, but

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1484,6 +1484,71 @@ export class CollectionMutationService extends BaseService {
   }
 
   /**
+   * Assemble the document a draft promotion actually persists: the draft with the
+   * caller's scalars overlaid, the caller's single-component patches merged onto
+   * the draft's components (a patch wins per sub-field, recursing into nested
+   * single components; a dynamic zone, a repeatable component, and a many-to-many
+   * set are replaced whole). `shapeWriteParts` extracts component and m2m fields
+   * out of the caller payload before promotion, so field-level write access and
+   * validation would otherwise judge the draft's OLD copy of those fields while
+   * the caller's copy is folded back in and persisted. Building the full document
+   * here lets the access and validation passes see the real final values, at every
+   * depth, for column, component, and many-to-many fields alike.
+   */
+  private assemblePromotedDocument(
+    draftInput: Record<string, unknown>,
+    callerScalars: Record<string, unknown>,
+    callerComponentData: Record<string, unknown>,
+    callerManyToManyData: Record<string, string[]>,
+    fields: FieldDefinition[],
+    manyToManyFields: FieldDefinition[],
+    componentSchemas: ComponentSchemas | null
+  ): Record<string, unknown> {
+    // Read the draft's own component and m2m values straight off the draft
+    // document, NOT through `shapeWriteParts` — that serializes groups/json to
+    // strings and would hide a nested field from the access and validation passes
+    // that run on the returned document. These only seed the merges below; the
+    // merged values overwrite the same keys in the returned document.
+    const draftComponents: Record<string, unknown> = {};
+    for (const field of fields) {
+      if (!isFieldGroupField(field)) continue;
+      const name = (field as { name?: unknown }).name;
+      if (typeof name === "string" && name in draftInput) {
+        draftComponents[name] = draftInput[name];
+      }
+    }
+    const draftManyToMany: Record<string, string[]> = {};
+    for (const field of manyToManyFields) {
+      if (!(field.name in draftInput)) continue;
+      const value = draftInput[field.name];
+      draftManyToMany[field.name] = Array.isArray(value)
+        ? (value as string[])
+        : value == null
+          ? []
+          : [value as string];
+    }
+    // Caller scalars win over the draft; the caller's single-component patches
+    // merge onto the draft's components (a patch wins per sub-field); the caller's
+    // m2m replaces the draft's.
+    const mergedComponents = this.mergeSingleComponentPatches(
+      draftComponents,
+      callerComponentData,
+      fields as unknown as FieldConfig[],
+      componentSchemas
+    );
+    const mergedManyToMany = {
+      ...draftManyToMany,
+      ...callerManyToManyData,
+    };
+    return {
+      ...draftInput,
+      ...callerScalars,
+      ...mergedComponents,
+      ...mergedManyToMany,
+    };
+  }
+
+  /**
    * Overlay `patch` onto `base`, recursively merging single (non-repeatable)
    * component objects instead of replacing them.
    *
@@ -4648,15 +4713,24 @@ export class CollectionMutationService extends BaseService {
             fields as unknown as FieldConfig[],
             promoteRestoreCtx
           );
-          const merged = { ...draftInput, ...finalData };
-          // Field-level write access on the MERGED promoted payload, so the
-          // validation below gates only the values the publisher may write: the
-          // caller gate above ran on the caller's payload only (a publish sends
-          // just the status), but promote folds the whole draft in. The
-          // authoritative filtering runs again on the locked draft inside the
-          // transaction (see the promote block), so a denied value nested in a
-          // group or repeater is dropped too, not only a fully denied top-level
-          // container.
+          // Assemble the full document the promotion will persist so both the
+          // access filter and the validation below judge the real final values.
+          // The caller gate above ran on the caller's payload only (a publish
+          // sends just the status), and `shapeWriteParts` has already pulled the
+          // caller's component and m2m fields out of `finalData`; folding them back
+          // in gates a denied value at every depth (top-level, or nested in a
+          // group/repeater/component) and covers component and m2m fields, not only
+          // columns. The authoritative pass runs again on the locked draft in the
+          // transaction (see the promote block).
+          const merged = this.assemblePromotedDocument(
+            draftInput,
+            finalData,
+            componentFieldData,
+            manyToManyData,
+            fields,
+            manyToManyFields,
+            splitComponentSchemas
+          );
           await applyFieldWriteAccess({
             kind: "collection",
             slug: params.collectionName,
@@ -5071,16 +5145,26 @@ export class CollectionMutationService extends BaseService {
                 fields as unknown as FieldConfig[],
                 promoteRestoreCtx
               );
-              // Merge the locked draft with the caller's payload (caller wins)
-              // BEFORE filtering, then re-apply the current field-level write
-              // access to that authoritative merged document. A rule that depends
-              // on a sibling the publish patch supplies (e.g. a field writable
-              // only when `approved` is true, where the publish sets it false) is
-              // then judged on the real final values, and a denied value is
-              // dropped at any depth (top-level or nested in a group/repeater/
-              // component). `applyFieldWriteAccess` is already used inside the
-              // caller-owned transaction paths, so running it here is consistent.
-              const mergedPromoteData = { ...draftInput, ...finalData };
+              // Assemble the full document the promotion persists (the locked
+              // draft, the caller's scalars overlaid, the caller's single-component
+              // patches merged onto the draft's components, and the caller's m2m),
+              // then filter it through the current field-level write access. A rule
+              // that depends on a sibling the publish patch supplies (e.g. a field
+              // writable only when `approved` is true, where the publish sets it
+              // false) is judged on the real final values, and a denied value is
+              // dropped at any depth for column, component, and m2m fields alike.
+              // Re-extracting the write parts from the FILTERED document keeps a
+              // denied component/m2m value out of the persisted parts, which the
+              // earlier after-access merge would have restored.
+              const mergedPromoteData = this.assemblePromotedDocument(
+                draftInput,
+                finalData,
+                componentFieldData,
+                manyToManyData,
+                fields,
+                manyToManyFields,
+                splitComponentSchemas
+              );
               await applyFieldWriteAccess({
                 kind: "collection",
                 slug: params.collectionName,
@@ -5097,22 +5181,8 @@ export class CollectionMutationService extends BaseService {
                 collection
               );
               finalData = mergedPromoteData;
-              // Merge a patch-shaped single-component publish (the caller may
-              // send only the sub-fields it changed) onto the draft's component
-              // rather than replacing it, so a pending sub-field edit is promoted
-              // instead of reverting to the live value. Recurses into nested
-              // single components; a dynamic zone and a repeatable component are
-              // replaced whole.
-              componentFieldData = this.mergeSingleComponentPatches(
-                draftParts.componentFieldData,
-                componentFieldData,
-                fields as unknown as FieldConfig[],
-                splitComponentSchemas
-              );
-              manyToManyData = {
-                ...draftParts.manyToManyData,
-                ...manyToManyData,
-              };
+              componentFieldData = draftParts.componentFieldData;
+              manyToManyData = draftParts.manyToManyData;
               updatePayload = {
                 ...stripImmutableSystemFields(finalData),
                 updatedAt: updatePayload.updatedAt,

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -5542,36 +5542,51 @@ export class CollectionMutationService extends BaseService {
                   draftRef,
                   null
                 );
-                let draftDocument = patchedDocument;
-                if (existingDraft) {
-                  const existingSnapshot = existingDraft.snapshot as Record<
-                    string,
-                    unknown
-                  >;
-                  const touched = new Set<string>([
-                    ...Object.keys(updatePayload),
-                    ...Object.keys(componentFieldData),
-                    ...Object.keys(manyToManyData),
-                  ]);
-                  const patchFields = Object.fromEntries(
-                    Object.entries(patchedDocument).filter(([key]) =>
-                      touched.has(key)
-                    )
-                  );
-                  // A single (non-repeatable) component holds an object of
-                  // sub-fields, and a patch-shaped save carries only the ones it
-                  // changed. Recursively merge this patch's component objects onto
-                  // the existing draft's (descending into nested single components)
-                  // rather than overwriting them, so disjoint sub-field edits from
-                  // separate saves coalesce at any depth. A dynamic zone, a
-                  // repeatable component, and a scalar are replaced whole.
-                  draftDocument = this.mergeSingleComponentPatches(
-                    existingSnapshot,
-                    patchFields,
-                    fields as unknown as FieldConfig[],
-                    splitComponentSchemas
-                  );
-                }
+                // The fields this save actually touched, at the assembled read
+                // shape. `patchedDocument` overlaid the current patch onto the live
+                // relations and REPLACED a single component whole, so a partial
+                // patch is captured here (touched keys only) and merged onto the
+                // base below rather than replacing it.
+                const touched = new Set<string>([
+                  ...Object.keys(updatePayload),
+                  ...Object.keys(componentFieldData),
+                  ...Object.keys(manyToManyData),
+                ]);
+                const patchFields = Object.fromEntries(
+                  Object.entries(patchedDocument).filter(([key]) =>
+                    touched.has(key)
+                  )
+                );
+                // Accumulate onto the existing working draft, or onto the live
+                // document on the first save. The live base is assembled through
+                // the same snapshot shaping so its components carry the type markers
+                // promotion needs, and merging (not replacing) keeps a live single
+                // component's other sub-fields when the patch only changed some.
+                const draftBase = existingDraft
+                  ? (existingDraft.snapshot as Record<string, unknown>)
+                  : assembleDocument(
+                      await this.snapshotPartsFor(
+                        {
+                          parentRow,
+                          components: snapshotComponents ?? {},
+                          manyToMany: snapshotM2M ?? {},
+                        },
+                        fields,
+                        tx
+                      )
+                    );
+                // A single (non-repeatable) component holds an object of sub-fields,
+                // and a patch-shaped save carries only the ones it changed. Merge
+                // the patch's component objects onto the base recursively (into
+                // nested single components) rather than overwriting them, so
+                // disjoint sub-field edits coalesce at any depth. A dynamic zone, a
+                // repeatable component, and a scalar are replaced whole.
+                const draftDocument = this.mergeSingleComponentPatches(
+                  draftBase,
+                  patchFields,
+                  fields as unknown as FieldConfig[],
+                  splitComponentSchemas
+                );
                 // The response and hooks see the draft as an ordinary read, so
                 // shape the accumulated snapshot through the current schema the
                 // same way the read overlay does: a field a later schema change

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4435,7 +4435,7 @@ export class CollectionMutationService extends BaseService {
       const versionsConfig = (collection as Record<string, unknown>)
         .versions as ResolvedVersionsConfig | null | undefined;
 
-      // Stage B draft/published split: an update to a PUBLISHED document that
+      // The draft/published split: an update to a PUBLISHED document that
       // names no status is non-destructive on a split-enabled collection — it is
       // stored as the working draft, leaving the live row untouched, and a
       // publish later promotes that draft to the live row. Requires the
@@ -4482,7 +4482,7 @@ export class CollectionMutationService extends BaseService {
         fields
       );
 
-      // Stage B promote-on-publish: a publish or unpublish on a split collection
+      // Promote-on-publish: a publish or unpublish on a split collection
       // must apply the whole accumulated working draft to the live row, not only
       // the dirty fields the caller sent (the admin Publish sends just the fields
       // touched this session). The component schemas the draft snapshot is
@@ -4559,7 +4559,7 @@ export class CollectionMutationService extends BaseService {
           // This locale's committed status before the write, reused by both the
           // prior document and the post-write overlay so the two stay symmetric.
           let committedLocaleStatus: string | null = null;
-          // Stage B: set once the row-locked prior state is read below — true
+          // Set once the row-locked prior state is read below — true
           // when this update should be stored as the working draft.
           let storeAsWorkingDraft = false;
 
@@ -4732,7 +4732,7 @@ export class CollectionMutationService extends BaseService {
             }
           }
 
-          // Stage B: decide the draft edit from the ROW-LOCKED prior status —
+          // Decide the draft edit from the ROW-LOCKED prior status —
           // the main row, or the write locale's companion `_status` — the same
           // locked reads the transition guard uses, so the decision is
           // TOCTOU-safe (a concurrent publish/unpublish committed before the
@@ -4813,7 +4813,7 @@ export class CollectionMutationService extends BaseService {
             }
           }
 
-          // Stage B promote-on-publish: with the row lock held and the publish
+          // Promote-on-publish: with the row lock held and the publish
           // authorized above, fold any accumulated working draft into this write
           // so the live row receives the draft's whole content with the caller's
           // fields overlaid. The admin Publish sends only the fields dirtied this
@@ -4923,7 +4923,7 @@ export class CollectionMutationService extends BaseService {
             })
             .join(", ");
           sqlParams.push(params.entryId);
-          // Stage B: skip the live-row UPDATE for a draft edit — the pending
+          // Skip the live-row UPDATE for a draft edit — the pending
           // change is stored as the working draft below, not written to the row.
           if (!storeAsWorkingDraft) {
             await tx.execute(
@@ -5210,7 +5210,7 @@ export class CollectionMutationService extends BaseService {
                 });
               }
 
-              // Stage B: a status-less update to a published document is stored
+              // A status-less update to a published document is stored
               // as the working draft — the live row and its relations were left
               // untouched above — instead of updating the live row and capturing
               // a published version. The parent overlay already produced the
@@ -5283,7 +5283,7 @@ export class CollectionMutationService extends BaseService {
                 });
               }
 
-              // Stage B promote-on-publish: the accumulated draft has been folded
+              // Promote-on-publish: the accumulated draft has been folded
               // into the live write above, so drop the sidecar in the SAME
               // transaction — its content is now the live row, and a surviving
               // draft would shadow the freshly published document on the next

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -97,6 +97,11 @@ import {
 import { assembleDocument } from "../../versions/assemble-document";
 import { captureInTx } from "../../versions/capture-in-tx";
 import {
+  buildRestorePayload,
+  type RestoreSchemaContext,
+} from "../../versions/restore-snapshot";
+import { resolveComponentSchemas } from "../../versions/restore-version";
+import {
   resolveComponentFieldMap,
   tagComponentTypes,
   tagNestedComponentTypes,
@@ -1128,6 +1133,164 @@ export class CollectionMutationService extends BaseService {
       localizedFieldValues,
       hasStatus: companion.hasStatus,
     };
+  }
+
+  /**
+   * Turn post-hook update input into the column/relation shapes the write path
+   * persists, mutating `data` in place into the main-row payload and returning
+   * the pieces that live outside it. Relationships and uploads are reduced to
+   * ids; component and many-to-many fields are pulled out of `data` (they store
+   * in their own tables); JSON, date, slug, and upload columns are serialized.
+   *
+   * Pure and free of database access, so it runs the same off-transaction for a
+   * normal write and inside the transaction when a publish promotes an
+   * accumulated working draft — the draft's stored snapshot is shaped through
+   * this exact path so promoted content reaches the row identically to a direct
+   * write. `manyToManyFields` is passed in rather than recomputed because the
+   * caller reuses the same list for the junction rewrite later in the write.
+   */
+  private shapeWriteParts(
+    data: Record<string, unknown>,
+    fields: FieldDefinition[],
+    manyToManyFields: FieldDefinition[],
+    collection: unknown
+  ): {
+    manyToManyData: Record<string, string[]>;
+    componentFieldData: Record<string, unknown>;
+  } {
+    // Normalize relationship field values (extract IDs from objects with display properties)
+    // This must happen before many-to-many extraction and JSON serialization
+    // Walks containers too: a reference left populated inside a group or
+    // repeater is serialized to JSON as the row and never read back as a
+    // reference.
+    normalizeRelationshipFields(data, fields as unknown as FieldConfig[]);
+
+    // Normalize upload field values (extract IDs from populated media objects)
+    normalizeUploadFields(data, fields);
+
+    const manyToManyData: Record<string, string[]> = {};
+
+    // Extract many-to-many data from data (after hooks)
+    manyToManyFields.forEach(field => {
+      if (data[field.name] !== undefined) {
+        manyToManyData[field.name] = Array.isArray(data[field.name])
+          ? (data[field.name] as string[])
+          : data[field.name] === null
+            ? []
+            : [data[field.name] as string];
+        delete data[field.name]; // Remove from main update
+      }
+    });
+
+    // Extract component field data (stored in separate comp_{slug} tables)
+    // Component fields should not be stored in the collection table
+    const componentFieldData: Record<string, unknown> = {};
+    fields.forEach(field => {
+      if (isFieldGroupField(field) && data[field.name] !== undefined) {
+        componentFieldData[field.name] = data[field.name];
+        delete data[field.name]; // Remove from main update
+      }
+    });
+
+    // Normalize relationship data inside repeater/group fields before serialization.
+    // The admin panel may send full relationship objects ({id, title, slug, ...})
+    // inside repeater rows — strip these down to just IDs to prevent bloated JSON.
+    fields.forEach(field => {
+      if (
+        (field.type === "repeater" || field.type === "group") &&
+        data[field.name] != null &&
+        typeof data[field.name] === "object"
+      ) {
+        const nestedFields = field.fields || [];
+        if (
+          nestedFields.some(
+            f =>
+              isRelationshipField(f.type) ||
+              f.type === "repeater" ||
+              f.type === "group"
+          )
+        ) {
+          if (field.type === "repeater" && Array.isArray(data[field.name])) {
+            data[field.name] = (data[field.name] as unknown[]).map(
+              (row: unknown) =>
+                row && typeof row === "object" && !Array.isArray(row)
+                  ? normalizeNestedRelationships(
+                      row as Record<string, unknown>,
+                      nestedFields
+                    )
+                  : row
+            );
+          } else if (
+            field.type === "group" &&
+            !Array.isArray(data[field.name])
+          ) {
+            data[field.name] = normalizeNestedRelationships(
+              data[field.name] as Record<string, unknown>,
+              nestedFields
+            );
+          }
+        }
+      }
+    });
+
+    // Serialize JSON fields (richtext, blocks, array, group, json)
+    fields.forEach(field => {
+      if (isJsonFieldType(field.type, field) && data[field.name] != null) {
+        data[field.name] = toJsonColumnValue(data[field.name]);
+      }
+    });
+
+    this.serializeHasManyRelationships(data, fields);
+
+    // Convert date-field strings into `Date` objects so Drizzle can bind
+    // them to `timestamp` columns. See `coerceDateFieldsToDate` for the
+    // failure mode this guards against.
+    coerceDateFieldsToDate(data, fields);
+
+    // Sanitize slug if provided in update
+    // - Dynamic collections (UI-created) always have a slug column
+    // - Plugin collections (isPlugin: true) only have slug if explicitly defined
+    const isPluginCollection =
+      (
+        (collection as Record<string, unknown>).admin as
+          | Record<string, unknown>
+          | undefined
+      )?.isPlugin === true;
+    const hasSlugField = fields.some(f => f.name === "slug");
+    const shouldHandleSlug = isPluginCollection ? hasSlugField : true;
+
+    if (shouldHandleSlug && data.slug !== undefined) {
+      if (typeof data.slug === "string" && data.slug.trim()) {
+        data.slug = generateSlug(data.slug);
+      } else {
+        // If slug is empty/null, remove it from update to keep existing value
+        delete data.slug;
+      }
+    }
+
+    // Final safety pass: ensure upload field values are IDs, not populated objects.
+    fields.forEach(field => {
+      if (field.type === "upload" && data[field.name] != null) {
+        const val = data[field.name];
+        if (typeof val === "object" && val !== null && !Array.isArray(val)) {
+          data[field.name] =
+            "id" in val &&
+            typeof (val as Record<string, unknown>).id === "string"
+              ? (val as Record<string, unknown>).id
+              : null;
+        } else if (Array.isArray(val)) {
+          data[field.name] = val.map((item: unknown) =>
+            typeof item === "string"
+              ? item
+              : typeof item === "object" && item !== null && "id" in item
+                ? (item as Record<string, unknown>).id
+                : item
+          );
+        }
+      }
+    });
+
+    return { manyToManyData, componentFieldData };
   }
 
   /**
@@ -3931,8 +4094,10 @@ export class CollectionMutationService extends BaseService {
             sharedContext
           )
         );
-      const finalData = (storedBeforeResult.data ??
-        dataAfterCodeHooks) as Record<string, unknown>;
+      let finalData = (storedBeforeResult.data ?? dataAfterCodeHooks) as Record<
+        string,
+        unknown
+      >;
 
       // Password fields store bcrypt hashes, never the submitted value.
       // Runs after hooks (so hooks see the plaintext they may validate
@@ -4011,156 +4176,28 @@ export class CollectionMutationService extends BaseService {
       // gate agree even when a hook set the undefined.
       stripUndefinedStatus(finalData);
 
-      // Normalize relationship field values (extract IDs from objects with display properties)
-      // This must happen before many-to-many extraction and JSON serialization
-      // Walks containers too: a reference left populated inside a group or
-      // repeater is serialized to JSON as the row and never read back as a
-      // reference.
-      normalizeRelationshipFields(
-        finalData,
-        fields as unknown as FieldConfig[]
-      );
-
-      // Normalize upload field values (extract IDs from populated media objects)
-      normalizeUploadFields(finalData, fields);
-
-      // Separate regular fields from many-to-many relations
+      // Many-to-many field defs drive both the extraction inside shapeWriteParts
+      // and the junction rewrite later in this transaction, so they are resolved
+      // once here and reused rather than recomputed.
       const manyToManyFields = fields.filter(
         f =>
           f.type === "relationship" &&
-          // Only UI-built manyToMany routes through a junction table.
-          // Code-first `hasMany: true` is stored as a JSON array on the
-          // parent column (see field-column-descriptor.ts kind="json")
-          // and is serialized later in the same finalData pass.
+          // Only UI-built manyToMany routes through a junction table. Code-first
+          // `hasMany: true` is stored as a JSON array on the parent column and is
+          // serialized in the same shaping pass.
           f.options?.relationType === "manyToMany"
       );
-      const manyToManyData: Record<string, string[]> = {};
 
-      // Extract many-to-many data from finalData (after hooks)
-      manyToManyFields.forEach(field => {
-        if (finalData[field.name] !== undefined) {
-          manyToManyData[field.name] = Array.isArray(finalData[field.name])
-            ? (finalData[field.name] as string[])
-            : finalData[field.name] === null
-              ? []
-              : [finalData[field.name] as string];
-          delete finalData[field.name]; // Remove from main update
-        }
-      });
-
-      // Extract component field data (stored in separate comp_{slug} tables)
-      // Component fields should not be stored in the collection table
-      const componentFieldData: Record<string, unknown> = {};
-      fields.forEach(field => {
-        if (isFieldGroupField(field) && finalData[field.name] !== undefined) {
-          componentFieldData[field.name] = finalData[field.name];
-          delete finalData[field.name]; // Remove from main update
-        }
-      });
-
-      // Normalize relationship data inside repeater/group fields before serialization.
-      // The admin panel may send full relationship objects ({id, title, slug, ...})
-      // inside repeater rows — strip these down to just IDs to prevent bloated JSON.
-      fields.forEach(field => {
-        if (
-          (field.type === "repeater" || field.type === "group") &&
-          finalData[field.name] != null &&
-          typeof finalData[field.name] === "object"
-        ) {
-          const nestedFields = field.fields || [];
-          if (
-            nestedFields.some(
-              f =>
-                isRelationshipField(f.type) ||
-                f.type === "repeater" ||
-                f.type === "group"
-            )
-          ) {
-            if (
-              field.type === "repeater" &&
-              Array.isArray(finalData[field.name])
-            ) {
-              finalData[field.name] = (finalData[field.name] as unknown[]).map(
-                (row: unknown) =>
-                  row && typeof row === "object" && !Array.isArray(row)
-                    ? normalizeNestedRelationships(
-                        row as Record<string, unknown>,
-                        nestedFields
-                      )
-                    : row
-              );
-            } else if (
-              field.type === "group" &&
-              !Array.isArray(finalData[field.name])
-            ) {
-              finalData[field.name] = normalizeNestedRelationships(
-                finalData[field.name] as Record<string, unknown>,
-                nestedFields
-              );
-            }
-          }
-        }
-      });
-
-      // Serialize JSON fields (richtext, blocks, array, group, json)
-      fields.forEach(field => {
-        if (
-          isJsonFieldType(field.type, field) &&
-          finalData[field.name] != null
-        ) {
-          finalData[field.name] = toJsonColumnValue(finalData[field.name]);
-        }
-      });
-
-      this.serializeHasManyRelationships(finalData, fields);
-
-      // Convert date-field strings into `Date` objects so Drizzle can bind
-      // them to `timestamp` columns. See `coerceDateFieldsToDate` for the
-      // failure mode this guards against.
-      coerceDateFieldsToDate(finalData, fields);
-
-      // Sanitize slug if provided in update
-      // - Dynamic collections (UI-created) always have a slug column
-      // - Plugin collections (isPlugin: true) only have slug if explicitly defined
-      const isPluginCollection =
-        (
-          (collection as Record<string, unknown>).admin as
-            | Record<string, unknown>
-            | undefined
-        )?.isPlugin === true;
-      const hasSlugField = fields.some(f => f.name === "slug");
-      const shouldHandleSlug = isPluginCollection ? hasSlugField : true;
-
-      if (shouldHandleSlug && finalData.slug !== undefined) {
-        if (typeof finalData.slug === "string" && finalData.slug.trim()) {
-          finalData.slug = generateSlug(finalData.slug);
-        } else {
-          // If slug is empty/null, remove it from update to keep existing value
-          delete finalData.slug;
-        }
-      }
-
-      // Final safety pass: ensure upload field values are IDs, not populated objects.
-      fields.forEach(field => {
-        if (field.type === "upload" && finalData[field.name] != null) {
-          const val = finalData[field.name];
-          if (typeof val === "object" && val !== null && !Array.isArray(val)) {
-            finalData[field.name] =
-              "id" in val &&
-              typeof (val as Record<string, unknown>).id === "string"
-                ? (val as Record<string, unknown>).id
-                : null;
-          } else if (Array.isArray(val)) {
-            finalData[field.name] = val.map((item: unknown) =>
-              typeof item === "string"
-                ? item
-                : typeof item === "object" && item !== null && "id" in item
-                  ? (item as Record<string, unknown>).id
-                  : item
-            );
-          }
-        }
-      });
+      // Shape the post-hook input into the row payload (mutating finalData) plus
+      // the component and many-to-many pieces that persist outside the main row.
+      // `let` because a publish that promotes an accumulated working draft
+      // rebinds these to the merged draft+payload shape below.
+      let { manyToManyData, componentFieldData } = this.shapeWriteParts(
+        finalData,
+        fields,
+        manyToManyFields,
+        collection
+      );
 
       // Update main entry
       // Use Date object (not .toISOString() string) because Drizzle's timestamp()
@@ -4318,10 +4355,19 @@ export class CollectionMutationService extends BaseService {
 
       // Stage B draft/published split: an update to a PUBLISHED document that
       // names no status is non-destructive on a split-enabled collection — it is
-      // stored as the working draft, leaving the live row untouched. Requires the
-      // draft/publish lifecycle (`status`) and drafts-enabled versioning.
+      // stored as the working draft, leaving the live row untouched, and a
+      // publish later promotes that draft to the live row. Requires the
+      // draft/publish lifecycle (`status`) and drafts-enabled versioning, and is
+      // scoped to non-localized collections: a localized document keeps
+      // draft/published state per locale, so coalescing per-locale drafts and
+      // aligning the working-draft locale key with the read overlay needs its own
+      // design and is handled separately.
+      const documentLocalized =
+        (collection as { localized?: boolean }).localized === true;
       const splitEnabled =
-        collectionHasStatus && versionsConfig?.drafts?.enabled === true;
+        collectionHasStatus &&
+        versionsConfig?.drafts?.enabled === true &&
+        !documentLocalized;
       // No status named ⇒ neither the main row nor the write-locale companion
       // `_status` is being set (matches the transition guard's own build gate at
       // `transitionNextStatus !== undefined`).
@@ -4335,6 +4381,39 @@ export class CollectionMutationService extends BaseService {
         params.collectionName,
         fields
       );
+
+      // Stage B promote-on-publish: a publish or unpublish on a split collection
+      // must apply the whole accumulated working draft to the live row, not only
+      // the dirty fields the caller sent (the admin Publish sends just the fields
+      // touched this session). The component schemas the draft snapshot is
+      // filtered against are read from the registry here, off the transaction —
+      // the same pooled-connection reason as `webhookFields` — and the restore
+      // context records which system columns the live row actually has. Both are
+      // unused unless a draft is found under the row lock below. `promotePossible`
+      // is the publish/unpublish counterpart of the status-less draft edit: the
+      // two are disjoint on `namesNoStatus`.
+      const promotePossible = splitEnabled && !namesNoStatus;
+      const isPluginForRestore =
+        (
+          (collection as Record<string, unknown>).admin as
+            | Record<string, unknown>
+            | undefined
+        )?.isPlugin === true;
+      const promoteRestoreCtx: RestoreSchemaContext | null = promotePossible
+        ? {
+            hasStatus: collectionHasStatus,
+            hasSlug: !isPluginForRestore || fields.some(f => f.name === "slug"),
+            hasTitle:
+              !isPluginForRestore || fields.some(f => f.name === "title"),
+            componentSchemas: await resolveComponentSchemas(
+              fields as unknown as FieldConfig[]
+            ),
+            // The split is non-localized-only, so the document holds no per-locale
+            // values and the snapshot's locale is the resolved request locale.
+            documentLocalized: false,
+            localeUnknown: false,
+          }
+        : null;
 
       // Retry the whole content+capture transaction on a version_no allocation
       // race (concurrent updates to the same doc); the re-run re-reads the max.
@@ -4365,7 +4444,9 @@ export class CollectionMutationService extends BaseService {
       await withVersionConflictRetry(() =>
         this.adapter.transaction(async tx => {
           recorded = false;
-          const updatePayload = {
+          // `let` because promote-on-publish rebinds it from the merged
+          // draft+payload after the working draft is folded in below.
+          let updatePayload = {
             ...stripImmutableSystemFields(finalData),
             updatedAt: new Date(),
           };
@@ -4624,6 +4705,66 @@ export class CollectionMutationService extends BaseService {
                   throw new StatusTransitionDeniedError();
                 }
               }
+            }
+          }
+
+          // Stage B promote-on-publish: with the row lock held and the publish
+          // authorized above, fold any accumulated working draft into this write
+          // so the live row receives the draft's whole content with the caller's
+          // fields overlaid. The admin Publish sends only the fields dirtied this
+          // session, so without this a publish drops edits made in earlier ones.
+          // Fetched here, under the lock, so a concurrent draft edit is
+          // serialized: it either lands before this read (and is promoted) or
+          // after this transaction commits (against the now-published row). The
+          // draft is deleted in the same transaction below, so promote is atomic:
+          // any failure rolls back the live write and leaves the draft intact.
+          let promotedDraft = false;
+          if (promotePossible && promoteRestoreCtx) {
+            const workingDraft = await new VersionsRepository(
+              tx
+            ).findWorkingDraft(
+              {
+                scopeKind: "collection",
+                scopeSlug: params.collectionName,
+                entryId: params.entryId,
+              },
+              this.componentSnapshotLocale(params.locale)
+            );
+            if (workingDraft) {
+              // The snapshot is stored read-shaped, so buildRestorePayload turns
+              // it into a safe update input (immutable ids stripped, removed
+              // columns and password fields dropped, component subtrees whose
+              // schema no longer resolves reported rather than written blind).
+              // Shaping that input through the SAME pure pass the caller's input
+              // took yields matching column and relation parts, so merging the
+              // caller over the draft (caller wins per key, including the
+              // published/draft `status`) and rebinding makes the writes below
+              // persist the promoted content with no separate code path.
+              const { payload: draftInput } = buildRestorePayload(
+                workingDraft.snapshot,
+                fields as unknown as FieldConfig[],
+                promoteRestoreCtx
+              );
+              const draftParts = this.shapeWriteParts(
+                draftInput,
+                fields,
+                manyToManyFields,
+                collection
+              );
+              finalData = { ...draftInput, ...finalData };
+              componentFieldData = {
+                ...draftParts.componentFieldData,
+                ...componentFieldData,
+              };
+              manyToManyData = {
+                ...draftParts.manyToManyData,
+                ...manyToManyData,
+              };
+              updatePayload = {
+                ...stripImmutableSystemFields(finalData),
+                updatedAt: updatePayload.updatedAt,
+              };
+              promotedDraft = true;
             }
           }
 
@@ -4957,13 +5098,33 @@ export class CollectionMutationService extends BaseService {
                     scopeSlug: params.collectionName,
                     entryId: params.entryId,
                   },
-                  locale: capturedLocaleState
-                    ? (localizedUpdate?.writeLocale ??
-                      this.componentSnapshotLocale(params.locale))
-                    : null,
+                  // The resolved request locale (null when localization is off),
+                  // which is exactly what the read overlay looks the draft up
+                  // under (`localeChain[0] ?? null`) and what a later publish uses
+                  // to promote it — so store, overlay, and promote never drift.
+                  // The split is non-localized-only, so this captures the single
+                  // per-locale component snapshot for one logical document.
+                  locale: this.componentSnapshotLocale(params.locale),
                   snapshot: assembleDocument(draftParts),
                   createdBy: params.user?.id ?? null,
                 });
+              }
+
+              // Stage B promote-on-publish: the accumulated draft has been folded
+              // into the live write above, so drop the sidecar in the SAME
+              // transaction — its content is now the live row, and a surviving
+              // draft would shadow the freshly published document on the next
+              // trusted read. Uses the locale key the fetch used, so it removes
+              // exactly the row that was promoted.
+              if (promotedDraft) {
+                await new VersionsRepository(tx).deleteWorkingDraft(
+                  {
+                    scopeKind: "collection",
+                    scopeSlug: params.collectionName,
+                    entryId: params.entryId,
+                  },
+                  this.componentSnapshotLocale(params.locale)
+                );
               }
 
               // Append the outbox event in the same transaction, so it commits

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4590,10 +4590,16 @@ export class CollectionMutationService extends BaseService {
         (collection as { localized?: boolean }).localized === true;
       // The component schemas reachable from this collection, resolved once off
       // the transaction (registry reads on the pooled connection, the same reason
-      // as `webhookFields` below) and reused by the promote path. Only resolved
-      // when the split could otherwise apply.
+      // as `webhookFields` below) and reused by the promote path. Skipped when a
+      // disqualifier already known without the registry rules the split out: a
+      // localized document or a top-level password field. Component resolution can
+      // fail on a transient registry error, so an ordinary live write on such a
+      // collection must not acquire that dependency for a split it can never take.
       const splitComponentSchemas =
-        collectionHasStatus && versionsConfig?.drafts?.enabled === true
+        collectionHasStatus &&
+        versionsConfig?.drafts?.enabled === true &&
+        !documentLocalized &&
+        !hasPasswordField(fields)
           ? await resolveComponentSchemas(fields as unknown as FieldConfig[])
           : null;
       // A localized component stores its values per locale, but a working draft

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -1549,6 +1549,50 @@ export class CollectionMutationService extends BaseService {
   }
 
   /**
+   * Shape a working-draft snapshot into the read document the response and hooks
+   * see, the same way the read overlay does: prune it to the current schema
+   * (dropping a field a later change removed and the single-component type markers
+   * the persisted snapshot keeps for promotion), copy back the immutable id and
+   * timestamp columns `buildRestorePayload` holds out, and rehydrate JSON date
+   * strings to Date at every depth. Used for the newly accumulated draft and for
+   * the prior draft the afterUpdate hooks compare against.
+   */
+  private shapeDraftForResponse(
+    rawDraft: Record<string, unknown>,
+    fields: FieldConfig[],
+    componentSchemas: ComponentSchemas | null,
+    collectionHasStatus: boolean,
+    isPluginCollection: boolean
+  ): Record<string, unknown> {
+    const { payload } = buildRestorePayload(rawDraft, fields, {
+      hasStatus: collectionHasStatus,
+      hasSlug: !isPluginCollection || fields.some(f => f.name === "slug"),
+      hasTitle: !isPluginCollection || fields.some(f => f.name === "title"),
+      componentSchemas: componentSchemas ?? undefined,
+      documentLocalized: false,
+      localeUnknown: false,
+    });
+    for (const key of [
+      "id",
+      "createdAt",
+      "created_at",
+      "updatedAt",
+      "updated_at",
+    ]) {
+      if (key in rawDraft) payload[key] = rawDraft[key];
+    }
+    for (const key of ["createdAt", "updatedAt"]) {
+      const value = payload[key];
+      if (typeof value === "string") {
+        const parsed = new Date(value);
+        if (!Number.isNaN(parsed.getTime())) payload[key] = parsed;
+      }
+    }
+    rehydrateSnapshotDates(payload, fields, componentSchemas);
+    return payload;
+  }
+
+  /**
    * Overlay `patch` onto `base`, recursively merging single (non-repeatable)
    * component objects instead of replacing them.
    *
@@ -4787,6 +4831,10 @@ export class CollectionMutationService extends BaseService {
       // instead, and the public revalidation and reaction event are skipped
       // because the live document a visitor sees did not change.
       let workingDraftDocument: Record<string, unknown> | undefined;
+      // The prior working draft (shaped like a read), set only when a later
+      // status-less save accumulates onto an existing draft, so the afterUpdate
+      // hooks diff against it rather than the unchanged published row.
+      let priorWorkingDraftDocument: Record<string, unknown> | undefined;
       // Verify every localized field group in this payload can actually be written
       // BEFORE the transaction opens. Inside it the probes would borrow a second
       // connection and deadlock a single-connection pool, and a NextlyError raised in
@@ -5589,65 +5637,34 @@ export class CollectionMutationService extends BaseService {
                 );
                 // The response and hooks see the draft as an ordinary read, so
                 // shape the accumulated snapshot through the current schema the
-                // same way the read overlay does: a field a later schema change
-                // removed or renamed (which the persisted snapshot still carries)
-                // is pruned, single-component type markers are dropped (a dynamic
-                // zone keeps its own row type, as a read carries it), and JSON
-                // date strings become Date at every depth. Without this the hooks
-                // and the mutation result would see an obsolete field or an ISO
-                // string where an ordinary update supplies a Date. The persisted
-                // `draftDocument` below keeps its markers for promotion.
+                // same way the read overlay does. The persisted `draftDocument`
+                // below keeps its markers for promotion.
                 const responseDeclaredFields =
                   fields as unknown as FieldConfig[];
                 const draftIsPluginCollection =
                   (collection as { admin?: { isPlugin?: boolean } }).admin
                     ?.isPlugin === true;
-                const { payload: shapedDraftDocument } = buildRestorePayload(
+                workingDraftDocument = this.shapeDraftForResponse(
                   draftDocument,
                   responseDeclaredFields,
-                  {
-                    hasStatus: collectionHasStatus,
-                    hasSlug:
-                      !draftIsPluginCollection ||
-                      responseDeclaredFields.some(f => f.name === "slug"),
-                    hasTitle:
-                      !draftIsPluginCollection ||
-                      responseDeclaredFields.some(f => f.name === "title"),
-                    componentSchemas: splitComponentSchemas ?? undefined,
-                    documentLocalized: false,
-                    localeUnknown: false,
-                  }
+                  splitComponentSchemas ?? null,
+                  collectionHasStatus,
+                  draftIsPluginCollection
                 );
-                // buildRestorePayload drops immutable system columns, but a
-                // mutation response and its hooks still expect the id and
-                // timestamps the snapshot carries, so copy them back and
-                // rehydrate the two system timestamps, mirroring the read overlay.
-                for (const key of [
-                  "id",
-                  "createdAt",
-                  "created_at",
-                  "updatedAt",
-                  "updated_at",
-                ]) {
-                  if (key in draftDocument) {
-                    shapedDraftDocument[key] = draftDocument[key];
-                  }
+                // The afterUpdate/afterChange hooks compare against the document
+                // BEFORE this save: the published row on the first draft save, but
+                // the prior working draft on a later one, so a hook diffing old and
+                // new does not see an earlier save's edits as changing again. Shape
+                // it the same way so the comparison is like-for-like.
+                if (existingDraft) {
+                  priorWorkingDraftDocument = this.shapeDraftForResponse(
+                    existingDraft.snapshot as Record<string, unknown>,
+                    responseDeclaredFields,
+                    splitComponentSchemas ?? null,
+                    collectionHasStatus,
+                    draftIsPluginCollection
+                  );
                 }
-                for (const key of ["createdAt", "updatedAt"]) {
-                  const value = shapedDraftDocument[key];
-                  if (typeof value === "string") {
-                    const parsed = new Date(value);
-                    if (!Number.isNaN(parsed.getTime())) {
-                      shapedDraftDocument[key] = parsed;
-                    }
-                  }
-                }
-                rehydrateSnapshotDates(
-                  shapedDraftDocument,
-                  responseDeclaredFields,
-                  splitComponentSchemas ?? null
-                );
-                workingDraftDocument = shapedDraftDocument;
                 await draftRepo.upsertWorkingDraft({
                   ref: draftRef,
                   // The split is non-localized only, so the working draft is one
@@ -5940,7 +5957,10 @@ export class CollectionMutationService extends BaseService {
         collection: params.collectionName,
         operation: "update" as const,
         data: responseSource,
-        originalData: existingEntry,
+        // On a repeat status-less save `responseSource` is the accumulated draft,
+        // so diff it against the prior draft rather than the unchanged published
+        // row; otherwise a hook reports an earlier save's fields as changing again.
+        originalData: priorWorkingDraftDocument ?? existingEntry,
         user: params.user,
         context: sharedContext, // Pass shared context from beforeUpdate
       });

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -5476,6 +5476,24 @@ export class CollectionMutationService extends BaseService {
                 );
               }
 
+              // Invalidate a stale working draft when the split no longer applies
+              // to a status collection: drafts were turned off, or the collection
+              // became localized / password-bearing / gained an ineligible
+              // component after a draft was written. This write went straight to
+              // the live row, so a retained sidecar can never be promoted and,
+              // were the split re-enabled, would shadow the edits made meanwhile.
+              // A no-op when no sidecar exists.
+              if (!splitEnabled && collectionHasStatus) {
+                await new VersionsRepository(tx).deleteWorkingDraft(
+                  {
+                    scopeKind: "collection",
+                    scopeSlug: params.collectionName,
+                    entryId: params.entryId,
+                  },
+                  null
+                );
+              }
+
               // Append the outbox event in the same transaction, so it commits
               // with the entry and is never recorded for a write that rolls back.
               // `recorded` is false when the collection opted out of recording. A

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -5256,17 +5256,47 @@ export class CollectionMutationService extends BaseService {
                   fields,
                   tx
                 );
+                // This document is built from the live parent + relations with
+                // only the CURRENT patch overlaid. Accumulate it onto an existing
+                // working draft rather than the live row: a second status-less
+                // save of different fields would otherwise re-derive from live and
+                // revert the first pending edit. Read the draft under the row lock
+                // (already held above) and, when one exists, overlay only the
+                // fields this patch touched onto it, at the assembled read shape.
                 // Reused after the transaction as the response/hook document,
                 // since the live row the re-fetch returns is the unchanged
                 // published content.
-                const draftDocument = assembleDocument(draftParts);
+                const draftRepo = new VersionsRepository(tx);
+                const patchedDocument = assembleDocument(draftParts);
+                const draftRef = {
+                  scopeKind: "collection" as const,
+                  scopeSlug: params.collectionName,
+                  entryId: params.entryId,
+                };
+                const existingDraft = await draftRepo.findWorkingDraft(
+                  draftRef,
+                  null
+                );
+                let draftDocument = patchedDocument;
+                if (existingDraft) {
+                  const touched = new Set<string>([
+                    ...Object.keys(updatePayload),
+                    ...Object.keys(componentFieldData),
+                    ...Object.keys(manyToManyData),
+                  ]);
+                  const patchFields = Object.fromEntries(
+                    Object.entries(patchedDocument).filter(([key]) =>
+                      touched.has(key)
+                    )
+                  );
+                  draftDocument = {
+                    ...(existingDraft.snapshot as Record<string, unknown>),
+                    ...patchFields,
+                  };
+                }
                 workingDraftDocument = draftDocument;
-                await new VersionsRepository(tx).upsertWorkingDraft({
-                  ref: {
-                    scopeKind: "collection",
-                    scopeSlug: params.collectionName,
-                    entryId: params.entryId,
-                  },
+                await draftRepo.upsertWorkingDraft({
+                  ref: draftRef,
                   // The split is non-localized only, so the working draft is one
                   // logical document with no per-locale variant: key it under the
                   // unlocalized `locale IS NULL` slot. Keying it by the resolved

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -4446,10 +4446,28 @@ export class CollectionMutationService extends BaseService {
       // design and is handled separately.
       const documentLocalized =
         (collection as { localized?: boolean }).localized === true;
+      // The component schemas reachable from this collection, resolved once off
+      // the transaction (registry reads on the pooled connection, the same reason
+      // as `webhookFields` below) and reused by the promote path. Only resolved
+      // when the split could otherwise apply.
+      const splitComponentSchemas =
+        collectionHasStatus && versionsConfig?.drafts?.enabled === true
+          ? await resolveComponentSchemas(fields as unknown as FieldConfig[])
+          : null;
+      // A localized component stores its values per locale, but a working draft
+      // is keyed under one unlocalized slot, so a draft saved under one locale
+      // would be promoted under another and misfile the translation into the
+      // wrong companion. Until per-locale drafts exist, a collection that embeds
+      // a localized component is excluded from the split, alongside a localized
+      // document.
+      const hasLocalizedComponent = splitComponentSchemas
+        ? [...splitComponentSchemas.values()].some(schema => schema.localized)
+        : false;
       const splitEnabled =
         collectionHasStatus &&
         versionsConfig?.drafts?.enabled === true &&
-        !documentLocalized;
+        !documentLocalized &&
+        !hasLocalizedComponent;
       // No status named ⇒ neither the main row nor the write-locale companion
       // `_status` is being set (matches the transition guard's own build gate at
       // `transitionNextStatus !== undefined`).
@@ -4487,55 +4505,13 @@ export class CollectionMutationService extends BaseService {
             hasSlug: !isPluginForRestore || fields.some(f => f.name === "slug"),
             hasTitle:
               !isPluginForRestore || fields.some(f => f.name === "title"),
-            componentSchemas: await resolveComponentSchemas(
-              fields as unknown as FieldConfig[]
-            ),
+            componentSchemas: splitComponentSchemas ?? undefined,
             // The split is non-localized-only, so the document holds no per-locale
             // values and the snapshot's locale is the resolved request locale.
             documentLocalized: false,
             localeUnknown: false,
           }
         : null;
-
-      // When a publish could promote a working draft, the draft's components are
-      // folded into the write INSIDE the transaction — after the preflight below.
-      // A promoted localized component whose companion exists would otherwise
-      // reach the write with no presence entry and be misfiled (default locale)
-      // or refused (non-default). Read the draft on the pooled connection here
-      // (advisory only: the authoritative fetch runs under the row lock in the
-      // transaction, and this write neither stores nor deletes it) and turn its
-      // snapshot into a restore input, so the preflight probes exactly the
-      // component types the fold will write. The caller's own components override
-      // the draft's per field, matching the in-transaction merge.
-      const promoteComponentPreview: Record<string, unknown> = {};
-      if (promotePossible && promoteRestoreCtx) {
-        const advisoryDraft = await new VersionsRepository(
-          this.adapter
-        ).findWorkingDraft(
-          {
-            scopeKind: "collection",
-            scopeSlug: params.collectionName,
-            entryId: params.entryId,
-          },
-          null
-        );
-        if (advisoryDraft) {
-          const { payload: advisoryInput } = buildRestorePayload(
-            advisoryDraft.snapshot,
-            fields as unknown as FieldConfig[],
-            promoteRestoreCtx
-          );
-          for (const field of fields) {
-            if (
-              isFieldGroupField(field) &&
-              field.name &&
-              advisoryInput[field.name] !== undefined
-            ) {
-              promoteComponentPreview[field.name] = advisoryInput[field.name];
-            }
-          }
-        }
-      }
 
       // Retry the whole content+capture transaction on a version_no allocation
       // race (concurrent updates to the same doc); the re-run re-reads the max.
@@ -4567,9 +4543,7 @@ export class CollectionMutationService extends BaseService {
       const fieldGroupPresence =
         (await this.fieldGroupDataService?.assertLocalizedFieldGroupsWritable({
           fields: fields as unknown as FieldConfig[],
-          // The draft's component types are included so a promote that folds them
-          // in has their companion presence resolved here, off the transaction.
-          data: { ...promoteComponentPreview, ...componentFieldData },
+          data: componentFieldData,
           locale: params.locale,
         })) ?? new Map<string, boolean>();
       await withVersionConflictRetry(() =>

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -5349,6 +5349,10 @@ export class CollectionMutationService extends BaseService {
                 );
                 let draftDocument = patchedDocument;
                 if (existingDraft) {
+                  const existingSnapshot = existingDraft.snapshot as Record<
+                    string,
+                    unknown
+                  >;
                   const touched = new Set<string>([
                     ...Object.keys(updatePayload),
                     ...Object.keys(componentFieldData),
@@ -5359,8 +5363,43 @@ export class CollectionMutationService extends BaseService {
                       touched.has(key)
                     )
                   );
+                  // A single (non-repeatable) component holds an object of
+                  // sub-fields, and a patch-shaped save carries only the ones it
+                  // changed. Replacing the whole key would drop sub-field edits an
+                  // earlier draft save made, so merge this patch's component object
+                  // onto the existing draft's rather than overwriting it. A dynamic
+                  // zone (array) and a scalar are still replaced whole.
+                  const singleComponentKeys = new Set(
+                    fields
+                      .filter(
+                        f =>
+                          typeof (f as { component?: unknown }).component ===
+                            "string" &&
+                          (f as { repeatable?: unknown }).repeatable !== true
+                      )
+                      .map(f => (f as { name?: unknown }).name)
+                      .filter((n): n is string => typeof n === "string")
+                  );
+                  for (const key of Object.keys(patchFields)) {
+                    if (!singleComponentKeys.has(key)) continue;
+                    const prev = existingSnapshot[key];
+                    const next = patchFields[key];
+                    if (
+                      prev !== null &&
+                      typeof prev === "object" &&
+                      !Array.isArray(prev) &&
+                      next !== null &&
+                      typeof next === "object" &&
+                      !Array.isArray(next)
+                    ) {
+                      patchFields[key] = {
+                        ...(prev as Record<string, unknown>),
+                        ...(next as Record<string, unknown>),
+                      };
+                    }
+                  }
                   draftDocument = {
-                    ...(existingDraft.snapshot as Record<string, unknown>),
+                    ...existingSnapshot,
                     ...patchFields,
                   };
                 }

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -2241,6 +2241,10 @@ export class CollectionQueryService extends BaseService {
       // routeAuthorized` excludes an anonymous caller passing `?status=all`.
       const draftView =
         (collectionForStatus as { status?: boolean }).status === true &&
+        // The working-draft split is non-localized-only (the write path stores
+        // no draft for a localized collection), so skip the lookup there rather
+        // than issue a read that can only miss.
+        (collectionForStatus as { localized?: boolean }).localized !== true &&
         statusFilter === null &&
         (params.overrideAccess === true || params.routeAuthorized === true);
       if (draftView) {

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -2352,13 +2352,26 @@ export class CollectionQueryService extends BaseService {
           // same schema-aware prune the promote path applies is reused, then the
           // identity and timestamp columns it holds back (a restore must not
           // resubmit them, a read carries them) are copied back from the snapshot.
+          // Which system columns the row actually has, mirroring the promote and
+          // restore paths: a plugin collection gets no synthesized slug/title, so
+          // telling the prune those columns exist would keep an obsolete snapshot
+          // key the current schema no longer declares. `status` is present because
+          // the draft eligibility above required it.
+          const declaredFields = fields as FieldConfig[];
+          const isPluginCollection =
+            (collection as { admin?: { isPlugin?: boolean } }).admin
+              ?.isPlugin === true;
           const { payload: shapedDraft } = buildRestorePayload(
             rawSnapshot,
-            fields as FieldConfig[],
+            declaredFields,
             {
               hasStatus: true,
-              hasSlug: true,
-              hasTitle: true,
+              hasSlug:
+                !isPluginCollection ||
+                declaredFields.some(f => f.name === "slug"),
+              hasTitle:
+                !isPluginCollection ||
+                declaredFields.some(f => f.name === "title"),
               componentSchemas: draftComponentSchemas ?? undefined,
               documentLocalized: false,
               localeUnknown: false,

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -2022,6 +2022,17 @@ export class CollectionQueryService extends BaseService {
      * copy). Undefined for session/system callers.
      */
     authenticatedScope?: AuthenticatedScope;
+    /**
+     * Whether the caller is an editor asking to SEE the working draft (pending
+     * unpublished edits) in place of the live row. Opt-in on purpose: a
+     * status-less read is the default for many internal callers (duplicate,
+     * reference labels), and they must keep seeing the published row, so draft
+     * visibility follows an explicit editor-view intent rather than every
+     * status-less read. Still gated by trust below (overrideAccess, or an actual
+     * update-capability decision against the loaded row), so setting it does not
+     * expose a draft to a caller who cannot edit the document.
+     */
+    includeWorkingDraft?: boolean;
   }): Promise<CollectionServiceResult> {
     try {
       const accessUser = params.overrideAccess ? undefined : params.user;
@@ -2254,22 +2265,23 @@ export class CollectionQueryService extends BaseService {
             versions?: { drafts?: { enabled?: boolean } };
           }
         ).versions?.drafts?.enabled === true &&
-        // Not an explicit published-only (or other specific-status) view. A
-        // trusted read's default resolves `statusFilter` to null; an
-        // access-enforced authenticated read defaults to a published-only
-        // filter, so the default view (no explicit `status`) is allowed too — an
-        // editor opening the document is asking to edit it, not to see the
-        // published copy. An explicit `?status=published` still suppresses the
-        // draft.
-        (statusFilter === null || params.status === undefined);
-      // A pending draft is surfaced only to a caller trusted to EDIT the
-      // document. `overrideAccess` is the only flag that attests that here.
+        // The caller explicitly asked to see the working draft (an editor
+        // opening the document to edit). This is opt-in on purpose: many
+        // internal callers issue a status-less read (duplicate, reference
+        // labels) and must keep seeing the published row, so draft visibility
+        // follows an explicit editor intent, not every status-less read.
+        params.includeWorkingDraft === true &&
+        // An explicit published view still suppresses the draft.
+        params.status !== "published";
+      // Even with the opt-in, a pending draft is surfaced only to a caller
+      // trusted to EDIT the document. `overrideAccess` attests that directly.
       // `routeAuthorized` is NOT trusted: on this read path the REST dispatcher
       // sets it from `!!user` after authorizing the READ, so it attests read, not
       // update — trusting it would leak drafts to a read-only authenticated
       // caller. Every non-override authenticated caller is instead judged by an
-      // actual update-capability probe, so an editor sees their own pending draft
-      // through any surface while a public or read-only caller never does.
+      // actual update-capability probe against the LOADED row, so an owner-only
+      // update rule (which the coarse check passes pending a row-level predicate)
+      // does not treat a non-owner reader as an editor.
       let draftView = false;
       if (draftEligible) {
         if (params.overrideAccess === true) {
@@ -2280,7 +2292,7 @@ export class CollectionQueryService extends BaseService {
             "update",
             params.user,
             entryId,
-            undefined,
+            entry as Record<string, unknown>,
             params.overrideAccess,
             // The route attested a read, never an update, so the update grant is
             // checked rather than assumed from `routeAuthorized`.
@@ -2307,13 +2319,16 @@ export class CollectionQueryService extends BaseService {
         if (workingDraft) {
           let draftEntry = workingDraft.snapshot as Record<string, unknown>;
           // The snapshot stores top-level relations as ids (captured at depth 0),
-          // so expand them at the requested depth to match a live read. Only
-          // relationship expansion runs here, never component population: the
-          // snapshot already carries the draft's own component values, and
-          // re-reading components from their tables would replace the pending
-          // edits with live content — the reason the overlay sits after the live
-          // assembly at all.
-          if (params.depth !== undefined && params.depth > 0) {
+          // so expand them at the requested depth to match a live read. The live
+          // assembly forwards `params.depth` unconditionally and
+          // `expandRelationships` applies its own default when it is undefined,
+          // so guard only the explicit `depth === 0` (ids-only) case — otherwise
+          // a draft read that omits depth would return bare ids while the live
+          // read for the same request expands. Only relationship expansion runs
+          // here, never component population: the snapshot already carries the
+          // draft's own component values, and re-reading components from their
+          // tables would replace the pending edits with live content.
+          if (params.depth !== 0) {
             draftEntry = await this.relationshipService.expandRelationships(
               draftEntry,
               params.collectionName,

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -21,6 +21,7 @@ import type { RichTextOutputFormat } from "@nextly/lib/rich-text-html";
 import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 
 import type { AuthenticatedScope } from "../../../auth/authenticated-scope";
+import { isFieldGroupField } from "../../../collections/fields/guards";
 import type { FieldConfig } from "../../../collections/fields/types";
 import { NextlyError } from "../../../errors/nextly-error";
 import { getFilterRegistry, FilterSeams } from "../../../filters";
@@ -95,7 +96,10 @@ import {
   resolveRequestedLocale,
 } from "../../i18n/resolve-locale";
 import { resolveComponentTableName } from "../../schema/utils/resolve-table-name";
-import { buildRestorePayload } from "../../versions/restore-snapshot";
+import {
+  buildRestorePayload,
+  type ComponentSchemas,
+} from "../../versions/restore-snapshot";
 import { resolveComponentSchemas } from "../../versions/restore-version";
 import { VersionsRepository } from "../../versions/versions-repository";
 
@@ -2377,22 +2381,37 @@ export class CollectionQueryService extends BaseService {
           // draft's own component values, and re-reading components from their
           // tables would replace the pending edits with live content.
           if (params.depth !== 0) {
+            const expandOptions: Parameters<
+              CollectionRelationshipService["expandRelationships"]
+            >[3] = {
+              depth: params.depth,
+              enforceFieldAccess: true,
+              user: params.user,
+              overrideAccess: params.overrideAccess,
+              authenticatedScope: params.authenticatedScope,
+              locale: localeChain?.[0],
+              status:
+                params.status === "all" || params.overrideAccess === true
+                  ? "all"
+                  : undefined,
+            };
             draftEntry = await this.relationshipService.expandRelationships(
               draftEntry,
               params.collectionName,
               fields,
-              {
-                depth: params.depth,
-                enforceFieldAccess: true,
-                user: params.user,
-                overrideAccess: params.overrideAccess,
-                authenticatedScope: params.authenticatedScope,
-                locale: localeChain?.[0],
-                status:
-                  params.status === "all" || params.overrideAccess === true
-                    ? "all"
-                    : undefined,
-              }
+              expandOptions
+            );
+            // The parent-schema expansion above does not traverse component
+            // fields, so a relationship inside a draft component would stay an id
+            // while a live read populates it through the component data service.
+            // Expand those relations on the snapshot's own component values, so a
+            // draft read matches a live read at depth > 0 without re-reading the
+            // live component rows (which would replace the pending edits).
+            draftEntry = await this.expandDraftComponentRelations(
+              draftEntry,
+              fields as FieldConfig[],
+              draftComponentSchemas,
+              expandOptions
             );
           }
           expandedEntry = draftEntry;
@@ -2522,6 +2541,95 @@ export class CollectionQueryService extends BaseService {
   // ============================================================
   // PRIVATE HELPER METHODS
   // ============================================================
+
+  /**
+   * Expand relationship fields nested inside a working draft's component values,
+   * using each component's own schema and WITHOUT re-reading the component rows.
+   *
+   * The parent-schema `expandRelationships` does not traverse component fields,
+   * so a relationship inside a draft component would otherwise stay an id on a
+   * draft read while a live read populates it. The draft snapshot already carries
+   * the component values (re-reading them would replace the pending edits with
+   * live content), so this walks and expands them in place.
+   */
+  private async expandDraftComponentRelations(
+    entry: Record<string, unknown>,
+    parentFields: FieldConfig[],
+    componentSchemas: ComponentSchemas | null,
+    options: Parameters<CollectionRelationshipService["expandRelationships"]>[3]
+  ): Promise<Record<string, unknown>> {
+    if (!componentSchemas) return entry;
+    const out = { ...entry };
+    for (const field of parentFields) {
+      if (!isFieldGroupField(field)) continue;
+      const name = (field as { name?: unknown }).name;
+      if (typeof name !== "string" || !(name in out)) continue;
+      out[name] = await this.expandComponentInstanceRelations(
+        out[name],
+        field,
+        componentSchemas,
+        options
+      );
+    }
+    return out;
+  }
+
+  /**
+   * Expand one component value, or each element when the field is repeatable or a
+   * dynamic zone, resolving each instance against its own component schema.
+   */
+  private async expandComponentInstanceRelations(
+    value: unknown,
+    field: FieldConfig,
+    componentSchemas: ComponentSchemas,
+    options: Parameters<CollectionRelationshipService["expandRelationships"]>[3]
+  ): Promise<unknown> {
+    if (Array.isArray(value)) {
+      return Promise.all(
+        value.map(item =>
+          this.expandComponentInstanceRelations(
+            item,
+            field,
+            componentSchemas,
+            options
+          )
+        )
+      );
+    }
+    if (value === null || typeof value !== "object") return value;
+
+    const instance = value as Record<string, unknown>;
+    // A dynamic-zone row records the component it holds; a single-component field
+    // takes it from the field's declared slug.
+    const tagged = instance._componentType;
+    const declared = (field as { component?: unknown }).component;
+    const slug =
+      typeof tagged === "string"
+        ? tagged
+        : typeof declared === "string"
+          ? declared
+          : undefined;
+    if (slug === undefined) return instance;
+
+    const schema = componentSchemas.get(slug);
+    if (!schema || !schema.resolved) return instance;
+
+    // Expand this component's own relationship fields, then recurse into any
+    // component nested inside it.
+    let expanded = await this.relationshipService.expandRelationships(
+      instance,
+      slug,
+      schema.fields as unknown as FieldDefinition[],
+      options
+    );
+    expanded = await this.expandDraftComponentRelations(
+      expanded,
+      schema.fields,
+      componentSchemas,
+      options
+    );
+    return expanded;
+  }
 
   /**
    * Build WHERE condition for full-text search across multiple fields.

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -2271,7 +2271,34 @@ export class CollectionQueryService extends BaseService {
           null
         );
         if (workingDraft) {
-          expandedEntry = workingDraft.snapshot as Record<string, unknown>;
+          let draftEntry = workingDraft.snapshot as Record<string, unknown>;
+          // The snapshot stores top-level relations as ids (captured at depth 0),
+          // so expand them at the requested depth to match a live read. Only
+          // relationship expansion runs here, never component population: the
+          // snapshot already carries the draft's own component values, and
+          // re-reading components from their tables would replace the pending
+          // edits with live content — the reason the overlay sits after the live
+          // assembly at all.
+          if (params.depth !== undefined && params.depth > 0) {
+            draftEntry = await this.relationshipService.expandRelationships(
+              draftEntry,
+              params.collectionName,
+              fields,
+              {
+                depth: params.depth,
+                enforceFieldAccess: true,
+                user: params.user,
+                overrideAccess: params.overrideAccess,
+                authenticatedScope: params.authenticatedScope,
+                locale: localeChain?.[0],
+                status:
+                  params.status === "all" || params.overrideAccess === true
+                    ? "all"
+                    : undefined,
+              }
+            );
+          }
+          expandedEntry = draftEntry;
         }
       }
 

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -95,6 +95,7 @@ import {
   resolveRequestedLocale,
 } from "../../i18n/resolve-locale";
 import { resolveComponentTableName } from "../../schema/utils/resolve-table-name";
+import { VersionsRepository } from "../../versions/versions-repository";
 
 import type { CollectionAccessService } from "./collection-access-service";
 import type { CollectionHookService } from "./collection-hook-service";
@@ -2226,6 +2227,36 @@ export class CollectionQueryService extends BaseService {
                 : undefined,
           },
         });
+      }
+
+      // Stage B: on a trusted draft-view read, surface the working draft
+      // (pending edits to a published document) in place of the live row, when
+      // one exists. Placed AFTER the live assembly above so re-reading LIVE
+      // relations/components/localized values by the shared entry id cannot
+      // clobber the draft's values, and BEFORE the redaction/shaping below so
+      // the snapshot's owner column, password values, and field-level read
+      // access are stripped and enforced like any other read. Never surfaced for
+      // a published-only or untrusted read: `statusFilter === null` excludes the
+      // published default and `?status=published`, and `overrideAccess ||
+      // routeAuthorized` excludes an anonymous caller passing `?status=all`.
+      const draftView =
+        (collectionForStatus as { status?: boolean }).status === true &&
+        statusFilter === null &&
+        (params.overrideAccess === true || params.routeAuthorized === true);
+      if (draftView) {
+        const workingDraft = await new VersionsRepository(
+          this.adapter
+        ).findWorkingDraft(
+          {
+            scopeKind: "collection",
+            scopeSlug: params.collectionName,
+            entryId,
+          },
+          localeChain?.[0] ?? null
+        );
+        if (workingDraft) {
+          expandedEntry = workingDraft.snapshot as Record<string, unknown>;
+        }
       }
 
       // Redact password hashes BEFORE any afterRead hook runs (a hook could

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -101,6 +101,7 @@ import {
   type ComponentSchemas,
 } from "../../versions/restore-snapshot";
 import { resolveComponentSchemas } from "../../versions/restore-version";
+import { addressableFields } from "../../versions/tag-component-types";
 import { VersionsRepository } from "../../versions/versions-repository";
 
 import type { CollectionAccessService } from "./collection-access-service";
@@ -2107,8 +2108,22 @@ export class CollectionQueryService extends BaseService {
       const ownerCondition = ownerConstraint
         ? eq(schema[ownerConstraint.field], ownerConstraint.value)
         : null;
+      // An explicit `status: "draft"` view that opts into the working draft must
+      // not filter the live row to draft-only: the split keeps the main row
+      // published, so that predicate would 404 before the overlay below can
+      // surface the pending draft. Drop it for a drafts-enabled collection when
+      // `includeWorkingDraft` is set; the overlay returns the draft (or the live
+      // row when none exists). Every other status filter is applied as usual.
+      const suppressDraftStatusFilter =
+        params.includeWorkingDraft === true &&
+        statusFilter?.value === "draft" &&
+        (
+          collectionForStatus as {
+            versions?: { drafts?: { enabled?: boolean } };
+          }
+        ).versions?.drafts?.enabled === true;
       const statusCondition =
-        statusFilter && schema.status
+        statusFilter && schema.status && !suppressDraftStatusFilter
           ? eq(schema.status, statusFilter.value)
           : null;
       const whereParts = [idCondition, ownerCondition, statusCondition].filter(
@@ -2434,20 +2449,21 @@ export class CollectionQueryService extends BaseService {
           // Snapshot serialization turned Date values into ISO strings, but an
           // ordinary live read hands the afterRead hooks Drizzle-decoded Date
           // objects, so a hook that calls date methods would fail only for a
-          // drafted entry. Rehydrate the declared date fields and the system
-          // timestamps to Date before the read pipeline runs below.
-          for (const dateKey of [
-            ...declaredFields.filter(f => f.type === "date").map(f => f.name),
-            "createdAt",
-            "updatedAt",
-          ]) {
-            if (typeof dateKey !== "string") continue;
-            const value = draftEntry[dateKey];
+          // drafted entry. Rehydrate the system timestamps and every declared
+          // date field — including those nested inside components — to Date
+          // before the read pipeline runs below.
+          for (const key of ["createdAt", "updatedAt"]) {
+            const value = draftEntry[key];
             if (typeof value === "string") {
               const parsed = new Date(value);
-              if (!Number.isNaN(parsed.getTime())) draftEntry[dateKey] = parsed;
+              if (!Number.isNaN(parsed.getTime())) draftEntry[key] = parsed;
             }
           }
+          this.rehydrateComponentDates(
+            draftEntry,
+            declaredFields,
+            draftComponentSchemas
+          );
           expandedEntry = draftEntry;
         }
       }
@@ -2663,6 +2679,64 @@ export class CollectionQueryService extends BaseService {
       options
     );
     return expanded;
+  }
+
+  /**
+   * Convert serialized ISO date strings back to Date in place, descending into
+   * component values against their resolved schemas.
+   *
+   * The working-draft snapshot is JSON, so a `date` field — at the top level or
+   * nested in a single or dynamic-zone component — comes back as a string, while
+   * a live read hands the afterRead hooks a Drizzle-decoded Date. Unnamed
+   * presentational groups are flattened (matching the type tagger) so a date or
+   * component declared inside one is still reached.
+   */
+  private rehydrateComponentDates(
+    value: Record<string, unknown>,
+    fields: FieldConfig[],
+    componentSchemas: ComponentSchemas | null
+  ): void {
+    for (const field of addressableFields(fields)) {
+      const name = (field as { name?: unknown }).name;
+      if (typeof name !== "string" || !(name in value)) continue;
+
+      if (field.type === "date") {
+        const raw = value[name];
+        if (typeof raw === "string") {
+          const parsed = new Date(raw);
+          if (!Number.isNaN(parsed.getTime())) value[name] = parsed;
+        }
+        continue;
+      }
+
+      const single = (field as { component?: unknown }).component;
+      const many = (field as { components?: unknown }).components;
+      if (typeof single !== "string" && !Array.isArray(many)) continue;
+
+      const compValue = value[name];
+      const instances = Array.isArray(compValue)
+        ? compValue
+        : compValue != null
+          ? [compValue]
+          : [];
+      for (const instance of instances) {
+        if (instance === null || typeof instance !== "object") continue;
+        const rec = instance as Record<string, unknown>;
+        const tagged = rec._componentType;
+        const slug =
+          typeof tagged === "string"
+            ? tagged
+            : typeof single === "string"
+              ? single
+              : undefined;
+        const compFields = slug
+          ? componentSchemas?.get(slug)?.fields
+          : undefined;
+        if (compFields) {
+          this.rehydrateComponentDates(rec, compFields, componentSchemas);
+        }
+      }
+    }
   }
 
   /**

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -2263,16 +2263,16 @@ export class CollectionQueryService extends BaseService {
         // draft.
         (statusFilter === null || params.status === undefined);
       // A pending draft is surfaced only to a caller trusted to EDIT the
-      // document. The trusted write paths already attest that: overrideAccess, or
-      // the REST route's `routeAuthorized` update attestation. An access-enforced
-      // authenticated read (the Direct API `findByID` with a user) forwards
-      // neither flag, so an editor who can update the collection would otherwise
-      // never see their own pending draft. Probe update capability as a fallback
-      // — only here, so the common trusted paths pay no extra access check, and a
-      // public or read-only caller (no update grant) still never sees a draft.
+      // document. `overrideAccess` is the only flag that attests that here.
+      // `routeAuthorized` is NOT trusted: on this read path the REST dispatcher
+      // sets it from `!!user` after authorizing the READ, so it attests read, not
+      // update — trusting it would leak drafts to a read-only authenticated
+      // caller. Every non-override authenticated caller is instead judged by an
+      // actual update-capability probe, so an editor sees their own pending draft
+      // through any surface while a public or read-only caller never does.
       let draftView = false;
       if (draftEligible) {
-        if (params.overrideAccess === true || params.routeAuthorized === true) {
+        if (params.overrideAccess === true) {
           draftView = true;
         } else if (params.user !== undefined) {
           const updateDenied = await this.accessService.checkCollectionAccess(

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -95,6 +95,8 @@ import {
   resolveRequestedLocale,
 } from "../../i18n/resolve-locale";
 import { resolveComponentTableName } from "../../schema/utils/resolve-table-name";
+import { buildRestorePayload } from "../../versions/restore-snapshot";
+import { resolveComponentSchemas } from "../../versions/restore-version";
 import { VersionsRepository } from "../../versions/versions-repository";
 
 import type { CollectionAccessService } from "./collection-access-service";
@@ -2316,8 +2318,54 @@ export class CollectionQueryService extends BaseService {
           // found regardless of the request locale.
           null
         );
-        if (workingDraft) {
-          let draftEntry = workingDraft.snapshot as Record<string, unknown>;
+        // Mirror the write gate's reachable-component check before overlaying:
+        // a component that turned localized, or that can no longer be resolved,
+        // after this draft was written cannot have its sidecar promoted or
+        // deleted by any write, so the live row must not be shadowed by a draft
+        // nothing can complete. Resolved only once a draft actually exists, to
+        // keep the registry reads off the common read path; the schemas double
+        // as the prune filter below.
+        const draftComponentSchemas = workingDraft
+          ? await resolveComponentSchemas(fields as FieldConfig[])
+          : null;
+        const draftComponentIneligible = draftComponentSchemas
+          ? [...draftComponentSchemas.values()].some(
+              schema => schema.localized || !schema.resolved
+            )
+          : false;
+        if (workingDraft && !draftComponentIneligible) {
+          const rawSnapshot = workingDraft.snapshot as Record<string, unknown>;
+          // Shape the snapshot to the current schema before exposing it. A field
+          // removed or renamed while the draft was pending leaves a key the
+          // snapshot still carries; the password strip and field read-access
+          // below inspect only currently declared fields, so an obsolete value
+          // would otherwise reach the afterRead hooks and the response even
+          // though a live read of the same document no longer returns it. The
+          // same schema-aware prune the promote path applies is reused, then the
+          // identity and timestamp columns it holds back (a restore must not
+          // resubmit them, a read carries them) are copied back from the snapshot.
+          const { payload: shapedDraft } = buildRestorePayload(
+            rawSnapshot,
+            fields as FieldConfig[],
+            {
+              hasStatus: true,
+              hasSlug: true,
+              hasTitle: true,
+              componentSchemas: draftComponentSchemas ?? undefined,
+              documentLocalized: false,
+              localeUnknown: false,
+            }
+          );
+          for (const key of [
+            "id",
+            "createdAt",
+            "created_at",
+            "updatedAt",
+            "updated_at",
+          ]) {
+            if (key in rawSnapshot) shapedDraft[key] = rawSnapshot[key];
+          }
+          let draftEntry = shapedDraft;
           // The snapshot stores top-level relations as ids (captured at depth 0),
           // so expand them at the requested depth to match a live read. The live
           // assembly forwards `params.depth` unconditionally and

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -2322,22 +2322,26 @@ export class CollectionQueryService extends BaseService {
           // found regardless of the request locale.
           null
         );
-        // Mirror the write gate's reachable-component check before overlaying:
-        // a component that turned localized, or that can no longer be resolved,
-        // after this draft was written cannot have its sidecar promoted or
-        // deleted by any write, so the live row must not be shadowed by a draft
-        // nothing can complete. Resolved only once a draft actually exists, to
-        // keep the registry reads off the common read path; the schemas double
-        // as the prune filter below.
+        // Mirror the write gate's eligibility check before overlaying: a
+        // component that turned localized or unresolvable after this draft was
+        // written — or a password field that appeared on the collection or a
+        // reachable component — makes the sidecar unpromotable by any write, so
+        // the live row must not be shadowed by a draft nothing can complete.
+        // Resolved only once a draft actually exists, to keep the registry reads
+        // off the common read path; the schemas double as the prune filter below.
         const draftComponentSchemas = workingDraft
           ? await resolveComponentSchemas(fields as FieldConfig[])
           : null;
-        const draftComponentIneligible = draftComponentSchemas
-          ? [...draftComponentSchemas.values()].some(
-              schema => schema.localized || !schema.resolved
+        const draftIneligible = draftComponentSchemas
+          ? hasPasswordField(fields) ||
+            [...draftComponentSchemas.values()].some(
+              schema =>
+                schema.localized ||
+                !schema.resolved ||
+                hasPasswordField(schema.fields)
             )
           : false;
-        if (workingDraft && !draftComponentIneligible) {
+        if (workingDraft && !draftIneligible) {
           const rawSnapshot = workingDraft.snapshot as Record<string, unknown>;
           // Shape the snapshot to the current schema before exposing it. A field
           // removed or renamed while the draft was pending leaves a key the

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -2117,6 +2117,12 @@ export class CollectionQueryService extends BaseService {
       const suppressDraftStatusFilter =
         params.includeWorkingDraft === true &&
         statusFilter?.value === "draft" &&
+        // Only in the split's own domain: a non-localized status collection with
+        // drafts on. Outside it (a localized collection, or one with no status
+        // column) the normal draft predicate must stand, so a draft-status read
+        // still filters correctly and the no-draft 404 below does not apply.
+        (collectionForStatus as { status?: boolean }).status === true &&
+        (collectionForStatus as { localized?: boolean }).localized !== true &&
         (
           collectionForStatus as {
             versions?: { drafts?: { enabled?: boolean } };
@@ -2304,6 +2310,10 @@ export class CollectionQueryService extends BaseService {
       // update rule (which the coarse check passes pending a row-level predicate)
       // does not treat a non-owner reader as an editor.
       let draftView = false;
+      // Set once a working draft is actually surfaced. When the draft predicate
+      // was suppressed but nothing is overlaid, the loaded row is the published
+      // one, which an explicit draft filter must not return (see the 404 below).
+      let draftOverlaid = false;
       if (draftEligible) {
         if (params.overrideAccess === true) {
           draftView = true;
@@ -2465,7 +2475,23 @@ export class CollectionQueryService extends BaseService {
             draftComponentSchemas
           );
           expandedEntry = draftEntry;
+          draftOverlaid = true;
         }
+      }
+
+      // An explicit `status: "draft"` read that opted into the working draft
+      // dropped the draft predicate above so the published main row could be
+      // loaded for the overlay. When no draft was actually surfaced (none exists,
+      // it turned ineligible, or the caller is not trusted to edit), the loaded
+      // row is the published one, which the draft filter would never have matched.
+      // Return 404 rather than hand back content the caller did not ask for.
+      if (suppressDraftStatusFilter && !draftOverlaid) {
+        return {
+          success: false,
+          statusCode: 404,
+          message: "Entry not found",
+          data: null,
+        };
       }
 
       // Redact password hashes BEFORE any afterRead hook runs (a hook could

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -101,7 +101,7 @@ import {
   type ComponentSchemas,
 } from "../../versions/restore-snapshot";
 import { resolveComponentSchemas } from "../../versions/restore-version";
-import { addressableFields } from "../../versions/tag-component-types";
+import { rehydrateSnapshotDates } from "../../versions/tag-component-types";
 import { VersionsRepository } from "../../versions/versions-repository";
 
 import type { CollectionAccessService } from "./collection-access-service";
@@ -2459,7 +2459,7 @@ export class CollectionQueryService extends BaseService {
               if (!Number.isNaN(parsed.getTime())) draftEntry[key] = parsed;
             }
           }
-          this.rehydrateComponentDates(
+          rehydrateSnapshotDates(
             draftEntry,
             declaredFields,
             draftComponentSchemas
@@ -2679,64 +2679,6 @@ export class CollectionQueryService extends BaseService {
       options
     );
     return expanded;
-  }
-
-  /**
-   * Convert serialized ISO date strings back to Date in place, descending into
-   * component values against their resolved schemas.
-   *
-   * The working-draft snapshot is JSON, so a `date` field — at the top level or
-   * nested in a single or dynamic-zone component — comes back as a string, while
-   * a live read hands the afterRead hooks a Drizzle-decoded Date. Unnamed
-   * presentational groups are flattened (matching the type tagger) so a date or
-   * component declared inside one is still reached.
-   */
-  private rehydrateComponentDates(
-    value: Record<string, unknown>,
-    fields: FieldConfig[],
-    componentSchemas: ComponentSchemas | null
-  ): void {
-    for (const field of addressableFields(fields)) {
-      const name = (field as { name?: unknown }).name;
-      if (typeof name !== "string" || !(name in value)) continue;
-
-      if (field.type === "date") {
-        const raw = value[name];
-        if (typeof raw === "string") {
-          const parsed = new Date(raw);
-          if (!Number.isNaN(parsed.getTime())) value[name] = parsed;
-        }
-        continue;
-      }
-
-      const single = (field as { component?: unknown }).component;
-      const many = (field as { components?: unknown }).components;
-      if (typeof single !== "string" && !Array.isArray(many)) continue;
-
-      const compValue = value[name];
-      const instances = Array.isArray(compValue)
-        ? compValue
-        : compValue != null
-          ? [compValue]
-          : [];
-      for (const instance of instances) {
-        if (instance === null || typeof instance !== "object") continue;
-        const rec = instance as Record<string, unknown>;
-        const tagged = rec._componentType;
-        const slug =
-          typeof tagged === "string"
-            ? tagged
-            : typeof single === "string"
-              ? single
-              : undefined;
-        const compFields = slug
-          ? componentSchemas?.get(slug)?.fields
-          : undefined;
-        if (compFields) {
-          this.rehydrateComponentDates(rec, compFields, componentSchemas);
-        }
-      }
-    }
   }
 
   /**

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -2431,6 +2431,23 @@ export class CollectionQueryService extends BaseService {
               expandOptions
             );
           }
+          // Snapshot serialization turned Date values into ISO strings, but an
+          // ordinary live read hands the afterRead hooks Drizzle-decoded Date
+          // objects, so a hook that calls date methods would fail only for a
+          // drafted entry. Rehydrate the declared date fields and the system
+          // timestamps to Date before the read pipeline runs below.
+          for (const dateKey of [
+            ...declaredFields.filter(f => f.type === "date").map(f => f.name),
+            "createdAt",
+            "updatedAt",
+          ]) {
+            if (typeof dateKey !== "string") continue;
+            const value = draftEntry[dateKey];
+            if (typeof value === "string") {
+              const parsed = new Date(value);
+              if (!Number.isNaN(parsed.getTime())) draftEntry[dateKey] = parsed;
+            }
+          }
           expandedEntry = draftEntry;
         }
       }

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -2481,11 +2481,17 @@ export class CollectionQueryService extends BaseService {
 
       // An explicit `status: "draft"` read that opted into the working draft
       // dropped the draft predicate above so the published main row could be
-      // loaded for the overlay. When no draft was actually surfaced (none exists,
-      // it turned ineligible, or the caller is not trusted to edit), the loaded
-      // row is the published one, which the draft filter would never have matched.
-      // Return 404 rather than hand back content the caller did not ask for.
-      if (suppressDraftStatusFilter && !draftOverlaid) {
+      // loaded for the overlay. When no draft was surfaced (none exists, it turned
+      // ineligible, or the caller is not trusted to edit) AND the loaded row is not
+      // itself a draft, the row is the published one the draft filter would never
+      // have matched, so 404 rather than hand back content the caller did not ask
+      // for. A never-published entry whose main row IS `draft` matches the filter
+      // directly and is returned as loaded.
+      if (
+        suppressDraftStatusFilter &&
+        !draftOverlaid &&
+        (expandedEntry as { status?: unknown }).status !== statusFilter?.value
+      ) {
         return {
           success: false,
           statusCode: 404,

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -2245,6 +2245,15 @@ export class CollectionQueryService extends BaseService {
         // no draft for a localized collection), so skip the lookup there rather
         // than issue a read that can only miss.
         (collectionForStatus as { localized?: boolean }).localized !== true &&
+        // Only when drafts are still enabled. If the collection turned drafts
+        // off after a working draft was written, the write path no longer
+        // promotes or deletes it, so surfacing it here would shadow the live
+        // document with a sidecar nothing can ever consume.
+        (
+          collectionForStatus as {
+            versions?: { drafts?: { enabled?: boolean } };
+          }
+        ).versions?.drafts?.enabled === true &&
         statusFilter === null &&
         (params.overrideAccess === true || params.routeAuthorized === true);
       if (draftView) {
@@ -2256,7 +2265,10 @@ export class CollectionQueryService extends BaseService {
             scopeSlug: params.collectionName,
             entryId,
           },
-          localeChain?.[0] ?? null
+          // Non-localized split: the draft is keyed under the unlocalized
+          // `locale IS NULL` slot, matching the store and promote, so it is
+          // found regardless of the request locale.
+          null
         );
         if (workingDraft) {
           expandedEntry = workingDraft.snapshot as Record<string, unknown>;

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -2240,7 +2240,7 @@ export class CollectionQueryService extends BaseService {
         });
       }
 
-      // Stage B: on a trusted draft-view read, surface the working draft
+      // On a trusted draft-view read, surface the working draft
       // (pending edits to a published document) in place of the live row, when
       // one exists. Placed AFTER the live assembly above so re-reading LIVE
       // relations/components/localized values by the shared entry id cannot

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -2239,7 +2239,7 @@ export class CollectionQueryService extends BaseService {
       // a published-only or untrusted read: `statusFilter === null` excludes the
       // published default and `?status=published`, and `overrideAccess ||
       // routeAuthorized` excludes an anonymous caller passing `?status=all`.
-      const draftView =
+      const draftEligible =
         (collectionForStatus as { status?: boolean }).status === true &&
         // The working-draft split is non-localized-only (the write path stores
         // no draft for a localized collection), so skip the lookup there rather
@@ -2254,8 +2254,42 @@ export class CollectionQueryService extends BaseService {
             versions?: { drafts?: { enabled?: boolean } };
           }
         ).versions?.drafts?.enabled === true &&
-        statusFilter === null &&
-        (params.overrideAccess === true || params.routeAuthorized === true);
+        // Not an explicit published-only (or other specific-status) view. A
+        // trusted read's default resolves `statusFilter` to null; an
+        // access-enforced authenticated read defaults to a published-only
+        // filter, so the default view (no explicit `status`) is allowed too — an
+        // editor opening the document is asking to edit it, not to see the
+        // published copy. An explicit `?status=published` still suppresses the
+        // draft.
+        (statusFilter === null || params.status === undefined);
+      // A pending draft is surfaced only to a caller trusted to EDIT the
+      // document. The trusted write paths already attest that: overrideAccess, or
+      // the REST route's `routeAuthorized` update attestation. An access-enforced
+      // authenticated read (the Direct API `findByID` with a user) forwards
+      // neither flag, so an editor who can update the collection would otherwise
+      // never see their own pending draft. Probe update capability as a fallback
+      // — only here, so the common trusted paths pay no extra access check, and a
+      // public or read-only caller (no update grant) still never sees a draft.
+      let draftView = false;
+      if (draftEligible) {
+        if (params.overrideAccess === true || params.routeAuthorized === true) {
+          draftView = true;
+        } else if (params.user !== undefined) {
+          const updateDenied = await this.accessService.checkCollectionAccess(
+            params.collectionName,
+            "update",
+            params.user,
+            entryId,
+            undefined,
+            params.overrideAccess,
+            // The route attested a read, never an update, so the update grant is
+            // checked rather than assumed from `routeAuthorized`.
+            false,
+            params.authenticatedScope
+          );
+          draftView = !updateDenied;
+        }
+      }
       if (draftView) {
         const workingDraft = await new VersionsRepository(
           this.adapter

--- a/packages/nextly/src/domains/versions/__tests__/resolve-config.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/resolve-config.test.ts
@@ -58,16 +58,20 @@ describe("resolveVersionsConfig", () => {
     expect(resolveVersionsConfig({ maxPerDoc: false })?.maxPerDoc).toBe(false);
   });
 
-  it("status:true alone aliases to versions:{drafts:true}", () => {
-    expect(resolveVersionsConfig(undefined, true)).toEqual(
-      resolveVersionsConfig({ drafts: true })
-    );
+  it("status:true alone enables history-only versioning, not the working-draft split", () => {
+    const resolved = resolveVersionsConfig(undefined, true);
+    // Versioned (history is captured) but the draft/published split is OFF — the
+    // split is opt-in via an explicit versions:{drafts:true}.
+    expect(resolved?.enabled).toBe(true);
+    expect(resolved?.drafts.enabled).toBe(false);
+    expect(resolved).toEqual(resolveVersionsConfig({ drafts: false }));
   });
 
   it("an explicit versions option wins over status", () => {
     // status would enable, but versions:false disables.
     expect(resolveVersionsConfig(false, true)).toBeNull();
-    // versions:{drafts:false} (history-only) wins over status:true (drafts).
+    // An explicit versions:{drafts:false} resolves to history-only regardless of
+    // the status flag.
     expect(resolveVersionsConfig({ drafts: false }, true)?.drafts.enabled).toBe(
       false
     );

--- a/packages/nextly/src/domains/versions/__tests__/restore-version.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/restore-version.test.ts
@@ -55,7 +55,7 @@ import {
   applyFieldReadAccess,
   applyFieldWriteAccess,
 } from "../../../shared/lib/field-level-registry";
-import { restoreVersion } from "../restore-version";
+import { resolveComponentSchemas, restoreVersion } from "../restore-version";
 
 const user = { id: "u1" };
 const base = {
@@ -663,5 +663,40 @@ describe("restoreVersion", () => {
     ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
 
     expect(getVersionSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveComponentSchemas", () => {
+  const fieldsWithComponent: Parameters<typeof resolveComponentSchemas>[0] = [
+    { name: "hero", type: "component", component: "heroBlock" },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("propagates a registry lookup failure instead of marking the component unresolved", async () => {
+    // A thrown lookup is not proof the component is gone. Collapsing it into an
+    // "unresolved" marker lets a transient registry failure masquerade as a
+    // missing component, and callers then drop or expose that subtree.
+    componentSpy.mockRejectedValue(new Error("registry offline"));
+
+    await expect(
+      resolveComponentSchemas(fieldsWithComponent)
+    ).rejects.toThrow();
+  });
+
+  it("marks a genuinely missing component unresolved without throwing", async () => {
+    // A null record is a confirmed absence, not an error: the subtree is treated
+    // as unknown and dropped, and the call still succeeds.
+    componentSpy.mockResolvedValue(null);
+
+    const schemas = await resolveComponentSchemas(fieldsWithComponent);
+
+    expect(schemas.get("heroBlock")).toEqual({
+      fields: [],
+      localized: false,
+      resolved: false,
+    });
   });
 });

--- a/packages/nextly/src/domains/versions/__tests__/tag-component-types.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/tag-component-types.test.ts
@@ -4,11 +4,16 @@
  * event, whose payload is documented as read shape. Tagging is what separates
  * them, so not mutating the shared object is the whole point.
  */
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect } from "vitest";
 
 import type { FieldConfig } from "../../../collections/fields/types";
+import {
+  clearFieldTypes,
+  registerFieldType,
+} from "../../schema/field-types/field-type-registry";
 import { NextlyError } from "../../../errors";
 import {
+  rehydrateSnapshotDates,
   resolveComponentFieldMap,
   tagComponentTypes,
   tagNestedComponentTypes,
@@ -463,5 +468,44 @@ describe("resolveComponentFieldMap", () => {
         }
       )
     ).rejects.toThrow(NextlyError);
+  });
+});
+
+describe("rehydrateSnapshotDates", () => {
+  afterEach(() => {
+    clearFieldTypes();
+  });
+
+  it("rehydrates a built-in date field's ISO string to a Date", () => {
+    const value: Record<string, unknown> = {
+      when: "2026-01-01T00:00:00.000Z",
+    };
+    rehydrateSnapshotDates(
+      value,
+      [{ name: "when", type: "date" }] as FieldConfig[],
+      null
+    );
+    expect(value.when instanceof Date).toBe(true);
+  });
+
+  it("rehydrates a timestamp-backed plugin field, matching a live read", () => {
+    // A plugin type binds to the date column, so its working-draft snapshot value
+    // is an ISO string like a built-in date; a literal `type === "date"` check
+    // would miss it and hand a hook a string where a live read supplies a Date.
+    registerFieldType({
+      type: "occurred",
+      storage: "timestamp",
+      component: "@acme/when/admin#When",
+      surfaces: ["entries", "singles", "components"],
+    });
+    const value: Record<string, unknown> = {
+      when: "2026-02-02T00:00:00.000Z",
+    };
+    rehydrateSnapshotDates(
+      value,
+      [{ name: "when", type: "occurred" }] as FieldConfig[],
+      null
+    );
+    expect(value.when instanceof Date).toBe(true);
   });
 });

--- a/packages/nextly/src/domains/versions/__tests__/working-draft.integration.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/working-draft.integration.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+
+import { createTestNextly } from "../../../plugins/test-nextly";
+import { VersionsRepository, type VersionRef } from "../versions-repository";
+
+// The working draft is a sidecar row in nextly_versions (status='draft',
+// version_no NULL, is_autosave=false), one per document per locale. It lets a
+// published document be edited without changing the live row until publish
+// promotes it. These tests prove it coexists with durable history without
+// corrupting the durable reads, which assume a non-autosave row carries a
+// version number.
+describe("working-draft repository (integration)", () => {
+  const ref: VersionRef = {
+    scopeKind: "collection",
+    scopeSlug: "posts",
+    entryId: "e-wd-1",
+  };
+
+  const sortedNos = (rows: { versionNo: number | null }[]): (number | null)[] =>
+    [...rows.map(r => r.versionNo)].sort((a, b) => Number(a) - Number(b));
+
+  it("coalesces to one working draft per document+locale and finds it", async () => {
+    const handle = await createTestNextly();
+    try {
+      const repo = new VersionsRepository(handle.adapter);
+
+      await repo.upsertWorkingDraft({
+        ref,
+        locale: null,
+        snapshot: { title: "first" },
+        createdBy: "u1",
+      });
+      // A second save for the same (document, locale) rewrites the SAME row in
+      // place rather than adding another.
+      await repo.upsertWorkingDraft({
+        ref,
+        locale: null,
+        snapshot: { title: "second" },
+        createdBy: "u2",
+      });
+
+      const found = await repo.findWorkingDraft(ref, null);
+      expect(found?.snapshot).toEqual({ title: "second" });
+      expect(found?.status).toBe("draft");
+      expect(found?.versionNo).toBeNull();
+      expect(found?.isAutosave).toBe(false);
+      expect(found?.createdBy).toBe("u2");
+
+      // Exactly one working-draft row exists for this document+locale.
+      const rows = await handle.adapter.select<{ id: string }>(
+        "nextly_versions",
+        {
+          where: {
+            and: [
+              { column: "entryId", op: "=", value: ref.entryId },
+              { column: "isAutosave", op: "=", value: false },
+              { column: "versionNo", op: "IS NULL" },
+            ],
+          },
+        }
+      );
+      expect(rows).toHaveLength(1);
+    } finally {
+      await handle.destroy();
+    }
+  });
+
+  it("does not corrupt getMaxVersionNo, retention, or history", async () => {
+    const handle = await createTestNextly();
+    try {
+      const repo = new VersionsRepository(handle.adapter);
+
+      // Two durable published versions.
+      await repo.insertVersion({
+        ref,
+        versionNo: 1,
+        status: "published",
+        isAutosave: false,
+        snapshot: { v: 1 },
+      });
+      await repo.insertVersion({
+        ref,
+        versionNo: 2,
+        status: "published",
+        isAutosave: false,
+        snapshot: { v: 2 },
+      });
+      // A working draft on top of the published history.
+      await repo.upsertWorkingDraft({
+        ref,
+        locale: null,
+        snapshot: { draft: true },
+        createdBy: "u1",
+      });
+
+      // The working draft must NOT be seen as the latest durable version, or the
+      // next durable capture would allocate a colliding number.
+      expect(await repo.getMaxVersionNo(ref)).toBe(2);
+
+      // History excludes the working draft (surfaced via findWorkingDraft, not
+      // as a phantom null-versionNo history entry).
+      expect(sortedNos(await repo.listByDoc(ref))).toEqual([1, 2]);
+
+      // Retention candidates exclude the working draft (never counted toward the
+      // cap, never pruned as if it were history).
+      expect(sortedNos(await repo.listDurableForPrune(ref))).toEqual([1, 2]);
+    } finally {
+      await handle.destroy();
+    }
+  });
+
+  it("scopes the working draft per locale and deletes one locale independently", async () => {
+    const handle = await createTestNextly();
+    try {
+      const repo = new VersionsRepository(handle.adapter);
+
+      await repo.upsertWorkingDraft({
+        ref,
+        locale: "en",
+        snapshot: { l: "en" },
+        createdBy: "u1",
+      });
+      await repo.upsertWorkingDraft({
+        ref,
+        locale: "de",
+        snapshot: { l: "de" },
+        createdBy: "u1",
+      });
+
+      expect((await repo.findWorkingDraft(ref, "en"))?.snapshot).toEqual({
+        l: "en",
+      });
+      expect((await repo.findWorkingDraft(ref, "de"))?.snapshot).toEqual({
+        l: "de",
+      });
+
+      const deleted = await repo.deleteWorkingDraft(ref, "en");
+      expect(deleted).toBe(1);
+      expect(await repo.findWorkingDraft(ref, "en")).toBeUndefined();
+      expect(await repo.findWorkingDraft(ref, "de")).toBeTruthy();
+    } finally {
+      await handle.destroy();
+    }
+  });
+});

--- a/packages/nextly/src/domains/versions/db-api.ts
+++ b/packages/nextly/src/domains/versions/db-api.ts
@@ -16,8 +16,11 @@ export interface VersionsWhereCondition {
   // `<` powers keyset pagination (versionNo < cursor); `IN` powers the
   // retention delete, which removes several rows in one statement; `IS NULL`
   // powers the locale filter, which must also match shared (null-locale)
-  // snapshots. The adapter's WhereOperator spells the set operator uppercase.
-  op: "=" | "!=" | "<" | "IN" | "IS NULL";
+  // snapshots; `IS NOT NULL` powers the durable-version filter, which excludes
+  // the working draft (a non-autosave row with no version number) from reads
+  // that assume a non-autosave row carries a sequence number. The adapter's
+  // WhereOperator spells the set operator uppercase.
+  op: "=" | "!=" | "<" | "IN" | "IS NULL" | "IS NOT NULL";
   // Matches the adapter's WhereCondition.value so the adapter and the
   // transaction context both structurally satisfy VersionsDbApi (a looser
   // `unknown` here breaks that assignability under method-parameter variance).

--- a/packages/nextly/src/domains/versions/resolve-config.ts
+++ b/packages/nextly/src/domains/versions/resolve-config.ts
@@ -24,9 +24,11 @@ export const DEFAULT_MAX_PER_DOC = 50;
  * Resolve the effective versioning config for an entity.
  *
  * @param versions - the entity's `versions` option (`boolean | VersionsConfig`)
- * @param status - the legacy `status` flag; `status: true` alone is a
- *   deprecated alias for `versions: { drafts: true }`. An explicit `versions`
- *   option always wins over `status`.
+ * @param status - the draft/publish lifecycle flag. `status: true` alone
+ *   enables history-only versioning (every write is a restorable version) but
+ *   NOT the working-draft split: editing a published document in place stays the
+ *   default. The split is opt-in via an explicit `versions: { drafts: true }`.
+ *   An explicit `versions` option always wins over `status`.
  * @returns the canonical resolved config, or `null` when the entity is
  *   unversioned.
  */
@@ -34,13 +36,17 @@ export function resolveVersionsConfig(
   versions: boolean | VersionsConfig | undefined,
   status?: boolean
 ): ResolvedVersionsConfig | null {
-  // `status: true` (alone) aliases to `versions: { drafts: true }`; an explicit
-  // `versions` option takes precedence over the legacy flag.
+  // `status: true` alone enables the draft/publish lifecycle and history-only
+  // versioning, but NOT the working-draft split — editing a published document
+  // in place stays the default. The split (non-destructive edits to a published
+  // document) is opt-in via an explicit `versions: { drafts: true }`, or
+  // `versions: true` where drafts default on. An explicit `versions` option
+  // always takes precedence over this lifecycle flag.
   const effective: boolean | VersionsConfig | undefined =
     versions !== undefined
       ? versions
       : status === true
-        ? { drafts: true }
+        ? { drafts: false }
         : undefined;
 
   // `null`/`false`/absent all mean unversioned. A falsy check (untyped JS could

--- a/packages/nextly/src/domains/versions/restore-version.ts
+++ b/packages/nextly/src/domains/versions/restore-version.ts
@@ -117,10 +117,12 @@ async function describeEntity(
  * Child fields for every component the schema references, keyed by slug.
  *
  * A component field names its schema rather than carrying it, so the payload
- * filter cannot see inside one without this. A component that fails to load is
- * simply absent, which makes the filter treat that subtree as unknown and drop
- * it — the safe direction, since resubmitting a subtree it cannot inspect could
- * overwrite a nested credential.
+ * filter cannot see inside one without this. A component the registry reports
+ * as absent (no record) is marked unresolved, which makes the filter treat that
+ * subtree as unknown and drop it — the safe direction, since resubmitting a
+ * subtree it cannot inspect could overwrite a nested credential. A lookup that
+ * throws is the different case: it is not proof the component is gone, so the
+ * error propagates rather than being recorded as an absence.
  */
 export async function resolveComponentSchemas(
   fields: FieldConfig[]
@@ -171,11 +173,19 @@ export async function resolveComponentSchemas(
               (record as { localized?: unknown } | null)?.localized === true,
             resolved: record !== null && record !== undefined,
           });
-        } catch {
-          // Recorded as empty so the slug is not retried; an unresolved
-          // subtree is treated as unknown and dropped, which is the safe
-          // direction. See the note above.
-          resolved.set(slug, { fields: [], localized: false, resolved: false });
+        } catch (cause) {
+          // A missing component returns null above; a throw here is a lookup
+          // failure (registry or database), not a confirmed absence. Recording
+          // it as unresolved would let a transient error masquerade as a
+          // deleted component, and a caller that drops or publishes an unknown
+          // subtree would then silently discard or expose data. Propagate so
+          // the request fails and can be retried; a typed error is preserved.
+          throw cause instanceof NextlyError
+            ? cause
+            : NextlyError.internal({
+                cause: cause instanceof Error ? cause : undefined,
+                logContext: { component: slug },
+              });
         }
       })
     );

--- a/packages/nextly/src/domains/versions/restore-version.ts
+++ b/packages/nextly/src/domains/versions/restore-version.ts
@@ -122,7 +122,7 @@ async function describeEntity(
  * it — the safe direction, since resubmitting a subtree it cannot inspect could
  * overwrite a nested credential.
  */
-async function resolveComponentSchemas(
+export async function resolveComponentSchemas(
   fields: FieldConfig[]
 ): Promise<ComponentSchemas> {
   const slugs = new Set<string>();

--- a/packages/nextly/src/domains/versions/tag-component-types.ts
+++ b/packages/nextly/src/domains/versions/tag-component-types.ts
@@ -248,6 +248,143 @@ export function tagNestedComponentTypes(
 }
 
 /**
+ * Remove the single-component `_componentType` markers a snapshot carries from a
+ * document about to be served as an ordinary read — a mutation response or a
+ * hook argument assembled from a working-draft snapshot.
+ *
+ * `tagComponentTypes` stamps a single-component value with its slug so a restore
+ * can resolve the component even if the field is later retargeted, but an
+ * ordinary read of a single component omits it (the schema implies the type). A
+ * dynamic zone's row type is editor-chosen and part of read shape, so it is
+ * kept; only the components nested inside a row are cleaned. The inverse of the
+ * tag walk, sharing its field classification.
+ *
+ * Returns a new object; the tagged snapshot the input came from is untouched, so
+ * the persisted copy keeps the markers a promote needs.
+ */
+export function stripSingleComponentTags(
+  document: Record<string, unknown>,
+  fields: FieldConfig[],
+  resolve?: ComponentFieldResolver
+): Record<string, unknown> {
+  return stripFieldsIn(document, fields, resolve, new Set());
+}
+
+function stripFieldsIn(
+  source: Record<string, unknown>,
+  fields: FieldConfig[],
+  resolve: ComponentFieldResolver | undefined,
+  seen: Set<object>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...source };
+
+  for (const field of addressableFields(fields)) {
+    if (typeof field.name !== "string") continue;
+    if (!Object.prototype.hasOwnProperty.call(source, field.name)) continue;
+
+    const value = source[field.name];
+
+    const slug = singleComponentSlug(field);
+    if (slug !== undefined) {
+      out[field.name] = stripSingleValue(value, slug, resolve, seen);
+      continue;
+    }
+
+    const zone = dynamicZoneSlugs(field);
+    if (zone !== undefined) {
+      out[field.name] = stripZoneRows(value, zone, resolve, seen);
+      continue;
+    }
+
+    const children = (field as { fields?: unknown }).fields;
+    if (Array.isArray(children)) {
+      out[field.name] = stripNestedTags(
+        value,
+        children as FieldConfig[],
+        resolve,
+        seen
+      );
+    }
+  }
+
+  return out;
+}
+
+/** Strip the marker off a single-component value, descending into its own fields. */
+function stripSingleValue(
+  value: unknown,
+  slug: string,
+  resolve: ComponentFieldResolver | undefined,
+  seen: Set<object>
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map(item => stripSingleValue(item, slug, resolve, seen));
+  }
+  if (typeof value !== "object" || value === null) return value;
+
+  const source = value as Record<string, unknown>;
+  if (seen.has(source)) return source;
+
+  const ownFields = resolve?.(slug);
+  if (!ownFields) {
+    const bare = { ...source };
+    delete bare[STORAGE_FORMAT.wireTypeKey];
+    return bare;
+  }
+
+  seen.add(source);
+  const inner = stripFieldsIn(source, ownFields, resolve, seen);
+  seen.delete(source);
+
+  const out = { ...inner };
+  delete out[STORAGE_FORMAT.wireTypeKey];
+  return out;
+}
+
+/** Keep a zone row's own editor-chosen type; clean single components inside it. */
+function stripZoneRows(
+  value: unknown,
+  allowed: string[],
+  resolve: ComponentFieldResolver | undefined,
+  seen: Set<object>
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map(row => stripZoneRows(row, allowed, resolve, seen));
+  }
+  if (typeof value !== "object" || value === null) return value;
+
+  const source = value as Record<string, unknown>;
+  if (seen.has(source)) return source;
+
+  const rowType = source[STORAGE_FORMAT.wireTypeKey];
+  if (typeof rowType !== "string" || !allowed.includes(rowType)) return source;
+
+  const ownFields = resolve?.(rowType);
+  if (!ownFields) return source;
+
+  seen.add(source);
+  const out = stripFieldsIn(source, ownFields, resolve, seen);
+  seen.delete(source);
+
+  return out;
+}
+
+/** Reach single components nested inside a group or repeater's stored JSON. */
+function stripNestedTags(
+  value: unknown,
+  fields: FieldConfig[],
+  resolve: ComponentFieldResolver | undefined,
+  seen: Set<object>
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map(row => stripNestedTags(row, fields, resolve, seen));
+  }
+  if (typeof value !== "object" || value === null) return value;
+
+  return stripFieldsIn(value as Record<string, unknown>, fields, resolve, seen);
+}
+
+/**
  * Every component schema the fields reach, keyed by slug.
  *
  * Resolved to a fixed point so a component embedded in another component is

--- a/packages/nextly/src/domains/versions/tag-component-types.ts
+++ b/packages/nextly/src/domains/versions/tag-component-types.ts
@@ -18,6 +18,7 @@
 
 import type { FieldConfig } from "../../collections/fields/types";
 import { STORAGE_FORMAT } from "../../schemas/storage-format";
+import { storageTypeToken } from "../../shared/lib/plugin-storage";
 
 import type { ComponentSchemas } from "./restore-snapshot";
 
@@ -466,7 +467,9 @@ export function rehydrateSnapshotDates(
     const name = (field as { name?: unknown }).name;
     if (typeof name !== "string" || !(name in value)) continue;
 
-    if (field.type === "date") {
+    // A timestamp-backed plugin type serializes to a string too, so resolve the
+    // storage primitive rather than matching the literal `date` type token.
+    if (storageTypeToken(field) === "date") {
       const raw = value[name];
       if (typeof raw === "string") {
         const parsed = new Date(raw);

--- a/packages/nextly/src/domains/versions/tag-component-types.ts
+++ b/packages/nextly/src/domains/versions/tag-component-types.ts
@@ -38,7 +38,7 @@ export type ComponentFieldResolver = (
  * would leave a component inside a layout group untagged, and that grouping is
  * common enough to be the usual case rather than an edge one.
  */
-function addressableFields(fields: FieldConfig[]): FieldConfig[] {
+export function addressableFields(fields: FieldConfig[]): FieldConfig[] {
   const flat: FieldConfig[] = [];
 
   for (const field of fields) {

--- a/packages/nextly/src/domains/versions/tag-component-types.ts
+++ b/packages/nextly/src/domains/versions/tag-component-types.ts
@@ -19,6 +19,8 @@
 import type { FieldConfig } from "../../collections/fields/types";
 import { STORAGE_FORMAT } from "../../schemas/storage-format";
 
+import type { ComponentSchemas } from "./restore-snapshot";
+
 /**
  * Looks up a component's own fields by slug.
  *
@@ -441,4 +443,62 @@ export async function resolveComponentFieldMap(
   }
 
   return resolved;
+}
+
+/**
+ * Rehydrate JSON date strings in a working-draft snapshot to Date objects,
+ * in place.
+ *
+ * A working-draft snapshot is stored as JSON, so a `date` field — at the top
+ * level or nested in a single or dynamic-zone component — comes back as an ISO
+ * string, while a live read hands the hooks a Drizzle-decoded Date. Walking
+ * `addressableFields` flattens unnamed presentational groups (matching the type
+ * tagger), so a date or component declared inside one is still reached. A
+ * dynamic-zone instance carries its own `_componentType`; a single component
+ * takes the field's declared slug.
+ */
+export function rehydrateSnapshotDates(
+  value: Record<string, unknown>,
+  fields: FieldConfig[],
+  componentSchemas: ComponentSchemas | null
+): void {
+  for (const field of addressableFields(fields)) {
+    const name = (field as { name?: unknown }).name;
+    if (typeof name !== "string" || !(name in value)) continue;
+
+    if (field.type === "date") {
+      const raw = value[name];
+      if (typeof raw === "string") {
+        const parsed = new Date(raw);
+        if (!Number.isNaN(parsed.getTime())) value[name] = parsed;
+      }
+      continue;
+    }
+
+    const single = (field as { component?: unknown }).component;
+    const many = (field as { components?: unknown }).components;
+    if (typeof single !== "string" && !Array.isArray(many)) continue;
+
+    const compValue = value[name];
+    const instances = Array.isArray(compValue)
+      ? compValue
+      : compValue != null
+        ? [compValue]
+        : [];
+    for (const instance of instances) {
+      if (instance === null || typeof instance !== "object") continue;
+      const rec = instance as Record<string, unknown>;
+      const tagged = rec[STORAGE_FORMAT.wireTypeKey];
+      const slug =
+        typeof tagged === "string"
+          ? tagged
+          : typeof single === "string"
+            ? single
+            : undefined;
+      const compFields = slug ? componentSchemas?.get(slug)?.fields : undefined;
+      if (compFields) {
+        rehydrateSnapshotDates(rec, compFields, componentSchemas);
+      }
+    }
+  }
 }

--- a/packages/nextly/src/domains/versions/versions-repository.ts
+++ b/packages/nextly/src/domains/versions/versions-repository.ts
@@ -133,23 +133,8 @@ export class VersionsRepository {
         logContext: { reason: "autosave-version-has-version-no" },
       });
     }
-    // `snapshot` is `unknown`; serialize defensively. JSON.stringify returns
-    // `undefined` for a top-level function/symbol/undefined and THROWS for a
-    // circular reference or a BigInt. Either way the NOT NULL snapshot column
-    // must not receive a bad value, so both cases are wrapped as a NextlyError.
-    let serializedSnapshot: string;
-    try {
-      const serialized = JSON.stringify(input.snapshot);
-      if (typeof serialized !== "string") {
-        throw new TypeError("snapshot did not serialize to a JSON string");
-      }
-      serializedSnapshot = serialized;
-    } catch (cause) {
-      throw NextlyError.internal({
-        cause: cause instanceof Error ? cause : undefined,
-        logContext: { reason: "version-snapshot-not-serializable" },
-      });
-    }
+    // `snapshot` is `unknown`; serialize defensively (see serializeSnapshot).
+    const serializedSnapshot = this.serializeSnapshot(input.snapshot);
     await this.db.insert(
       TABLE,
       {
@@ -186,6 +171,155 @@ export class VersionsRepository {
   }
 
   /**
+   * Serialize a snapshot for the NOT NULL `snapshot` column.
+   *
+   * `snapshot` is `unknown`; serialize defensively. `JSON.stringify` returns
+   * `undefined` for a top-level function/symbol/undefined and THROWS for a
+   * circular reference or a BigInt. Either way the column must not receive a
+   * bad value, so both cases surface as a NextlyError rather than a driver
+   * error or a NULL write.
+   */
+  private serializeSnapshot(snapshot: unknown): string {
+    try {
+      const serialized = JSON.stringify(snapshot);
+      if (typeof serialized !== "string") {
+        throw new TypeError("snapshot did not serialize to a JSON string");
+      }
+      return serialized;
+    } catch (cause) {
+      throw NextlyError.internal({
+        cause: cause instanceof Error ? cause : undefined,
+        logContext: { reason: "version-snapshot-not-serializable" },
+      });
+    }
+  }
+
+  /**
+   * A locale match for the working-draft lookup. Unlocalized documents keep a
+   * single working draft under `locale IS NULL`; a localized document keeps one
+   * per language, so the lookup must match the exact write locale. An `= value`
+   * comparison never matches NULL, which is the intended distinction between
+   * the two cases.
+   */
+  private localeCondition(locale: string | null): VersionsWhereCondition {
+    return locale == null
+      ? { column: "locale", op: "IS NULL" }
+      : { column: "locale", op: "=", value: locale };
+  }
+
+  /**
+   * The predicate identifying THE working draft of a document in one locale:
+   * the sidecar draft row holding pending edits to a published document that
+   * has not been promoted to the live row. A working draft is the only
+   * non-autosave row carrying no version number (durable history rows always
+   * take a sequence number; autosave rows set `isAutosave = true`), so this
+   * shape is unambiguous and matches the partial unique index that keeps it to
+   * one per document per locale.
+   */
+  private workingDraftWhere(
+    ref: VersionRef,
+    locale: string | null
+  ): VersionsWhere {
+    return {
+      and: [
+        ...this.docWhere(ref),
+        { column: "isAutosave", op: "=", value: false },
+        { column: "versionNo", op: "IS NULL" },
+        { column: "status", op: "=", value: "draft" },
+        this.localeCondition(locale),
+      ],
+    };
+  }
+
+  /**
+   * Insert or update the coalesced working draft for a document in one locale.
+   *
+   * There is exactly one working draft per (document, locale): editing a
+   * published document repeatedly rewrites this row in place rather than piling
+   * up draft rows, so `updatedAt` advances and the snapshot always holds the
+   * latest pending edit. The live content row is never touched here — this is
+   * the sidecar that lets a published document be edited without changing what
+   * the public sees until publish promotes it.
+   */
+  async upsertWorkingDraft(input: {
+    ref: VersionRef;
+    locale: string | null;
+    snapshot: unknown;
+    createdBy?: string | null;
+  }): Promise<void> {
+    const now = new Date();
+    const serializedSnapshot = this.serializeSnapshot(input.snapshot);
+    const where = this.workingDraftWhere(input.ref, input.locale);
+    // Project only the id: the existence check must not transfer the (possibly
+    // large) snapshot of the row it is about to overwrite.
+    const existing = await this.db.select<{ id: string }>(TABLE, {
+      columns: ["id"],
+      where,
+      limit: 1,
+    });
+    if (existing[0]) {
+      await this.db.update(
+        TABLE,
+        {
+          snapshot: serializedSnapshot,
+          createdBy: input.createdBy ?? null,
+          updatedAt: now,
+        },
+        where
+      );
+      return;
+    }
+    await this.db.insert(
+      TABLE,
+      {
+        id: crypto.randomUUID(),
+        scopeKind: input.ref.scopeKind,
+        scopeSlug: input.ref.scopeSlug,
+        entryId: input.ref.entryId,
+        // A working draft is neither a durable history version (no sequence
+        // number) nor an autosave row; it is the sidecar draft head.
+        versionNo: null,
+        status: "draft",
+        isAutosave: false,
+        // Pre-stringified for the same cross-dialect reason as insertVersion:
+        // the transaction insert path binds this value straight into the driver
+        // query with no column-type awareness.
+        snapshot: serializedSnapshot,
+        label: null,
+        locale: input.locale ?? null,
+        sourceVersionNo: null,
+        createdBy: input.createdBy ?? null,
+        createdAt: now,
+        updatedAt: now,
+      },
+      { returning: [] }
+    );
+  }
+
+  /** Fetch the working draft (snapshot included) for a document in one locale. */
+  async findWorkingDraft(
+    ref: VersionRef,
+    locale: string | null
+  ): Promise<VersionRow | undefined> {
+    const rows = await this.db.select<VersionRow>(TABLE, {
+      where: this.workingDraftWhere(ref, locale),
+      limit: 1,
+    });
+    return rows[0];
+  }
+
+  /**
+   * Delete the working draft for a document in one locale, returning the number
+   * of rows removed. Called when the draft is promoted (published) or discarded.
+   */
+  async deleteWorkingDraft(
+    ref: VersionRef,
+    locale: string | null
+  ): Promise<number> {
+    return this.db.delete(TABLE, this.workingDraftWhere(ref, locale));
+  }
+
+  /**
    * Highest durable (non-autosave) version_no for a document, or 0 if none.
    * The caller allocates the next number as `getMaxVersionNo(ref) + 1`. When
    * invoked with the transaction context this read runs inside the caller's
@@ -203,6 +337,11 @@ export class VersionsRepository {
         and: [
           ...this.docWhere(ref),
           { column: "isAutosave", op: "=", value: false },
+          // Exclude the working draft (a non-autosave row with no version
+          // number). Without this it sorts first under `versionNo DESC` (NULLS
+          // FIRST on Postgres) and this returns 0 even when durable versions
+          // exist, so the next capture allocates a colliding version number.
+          { column: "versionNo", op: "IS NOT NULL" },
         ],
       },
       orderBy: [{ column: "versionNo", direction: "desc" }],
@@ -246,8 +385,20 @@ export class VersionsRepository {
     const and: (VersionsWhereCondition | VersionsWhere)[] = [
       ...this.docWhere(ref),
     ];
-    if (!opts.includeAutosave) {
+    if (opts.includeAutosave) {
+      // Include autosave rows, but still exclude the working draft (a
+      // non-autosave row with no version number): it is the live pending edit
+      // surfaced via findWorkingDraft, not a history entry.
+      and.push({
+        or: [
+          { column: "versionNo", op: "IS NOT NULL" },
+          { column: "isAutosave", op: "=", value: true },
+        ],
+      });
+    } else {
+      // Durable history only: no autosave rows, and not the working draft.
       and.push({ column: "isAutosave", op: "=", value: false });
+      and.push({ column: "versionNo", op: "IS NOT NULL" });
     }
     // Scope to one locale's history when asked. A localized document captures a
     // version per locale, so the list can be narrowed to the language an editor
@@ -317,6 +468,10 @@ export class VersionsRepository {
         and: [
           ...this.docWhere(ref),
           { column: "isAutosave", op: "=", value: false },
+          // The working draft is not a durable version and must never enter the
+          // retention candidate set (it would be counted toward the cap, or
+          // pruned as if it were history).
+          { column: "versionNo", op: "IS NOT NULL" },
         ],
       },
       orderBy: [

--- a/packages/nextly/src/schemas/versions/types.ts
+++ b/packages/nextly/src/schemas/versions/types.ts
@@ -40,10 +40,12 @@ export function isVersionStatus(v: unknown): v is VersionStatus {
  * enabled; drafts add a draft/publish lifecycle; autosave coalesces the
  * in-progress draft. See the design spec section 3.
  *
- * NOTE (current stage): only history/capture is enforced today. `drafts`,
- * `autosave`, and `maxPerDoc` are parsed and persisted but not yet acted upon
- * (draft/publish split, autosave coalescing, and retention pruning are later
- * stages), so any versioning-enabled entity captures history only for now.
+ * NOTE (current stage): history/capture and the `drafts` draft/publish split
+ * are enforced. On a `status: true` collection with drafts resolved on, a
+ * status-less update to a published, non-localized document is stored as a
+ * coalesced working draft instead of overwriting the live row, and publishing
+ * promotes it. `autosave` coalescing and `maxPerDoc` retention pruning are
+ * parsed and persisted but not yet acted upon.
  */
 export interface VersionsConfig {
   /**

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -221,6 +221,12 @@ export class CollectionEntryService extends BaseService {
      * query service which maps it to a SQL predicate.
      */
     status?: "published" | "draft" | "all";
+    /**
+     * Opt in to the working-draft overlay (draft/published split): a trusted
+     * editor read returns the pending working draft in place of the live row.
+     * Forwarded to the query service, which gates it on update trust.
+     */
+    includeWorkingDraft?: boolean;
     /** Requested content locale (i18n M4) — forwarded to the query service. */
     locale?: string;
     /** Fallback control (`false`/`"none"` disables fallback). */


### PR DESCRIPTION
## What

The core of the draft/published split (Workflows item 9, Stage B): editing a
published document no longer overwrites what visitors see. Pending edits are
stored as a coalesced **working draft**; the live row is untouched until you
publish, which promotes the whole draft at once. Unpublish is the same fold in
reverse.

This is the `packages/nextly` engine. The existing admin Save/Publish buttons
already drive it (Save on a published doc → draft edit; Publish → promote); a
"pending changes" indicator and a Discard action are a follow-up admin PR.

## The model (hybrid)

- The main row stays the live/published row — it keeps its `status` column and
  all of Stage A's publish/unpublish permissions.
- A status-less update to a **published** doc is non-destructive: it writes a
  single coalesced working-draft row in `nextly_versions` (`status='draft'`,
  `versionNo=NULL`, `isAutosave=false`), leaving the live row and its relations
  untouched.
- A trusted, draft-view read overlays the working draft; anonymous and
  published-only reads always get the live row.
- **Publish promotes.** The admin sends only the fields dirtied this session, so
  publish folds the accumulated draft into the live write (draft snapshot →
  update input via the restore primitive, caller's fields overlaid per key, then
  the existing row / companion / component / many-to-many writes), and deletes
  the sidecar in the same transaction (atomic). Unpublish = the same fold with a
  draft target status.

## Commits

1. **add working-draft storage to the versions repository** — repository
   methods plus the durable-read exclusions that stop a draft from corrupting
   version allocation, retention, and history.
2. **edit a published document as a draft without going live** — the updateEntry
   draft routing, opt-in via `versions: { drafts: true }`.
3. **surface the working draft on a trusted draft-view read** — the read
   overlay, upstream of redaction and downstream of live assembly.
4. **promote the working draft to the live row on publish** — promote/unpublish,
   plus a pure `shapeWriteParts` extraction so the draft is shaped into columns
   exactly like a direct write.

## Scope

Non-localized collections with `status: true` + `versions: { drafts: true }`.
Localized collections keep per-locale draft state, whose locale-key alignment
with the read overlay needs its own design, so they are explicitly excluded
(store, overlay, and promote all gate on it). Deferred to follow-ups: a Discard
action + admin "pending changes" indicator, singles parity, page-builder opt-in,
cross-session draft accumulation, a DB partial-unique index, and
optimistic-concurrency hardening.

## Testing

- New integration suite (`draft-published-split.integration.test.ts`): a draft
  edit leaves live untouched and stores one draft; draft-view vs published-view
  read; promote applies fields the publish omitted; the publish payload overlays
  the draft (caller wins); unpublish folds to draft; publish with no draft writes
  normally.
- Green on all three dialects — SQLite, Postgres 17, MySQL. The Postgres
  NULLS-ordering path (version allocation vs the null-`versionNo` draft) is
  specifically covered.
- Regression across `versions` / `i18n` / `collections` is clean. The 11
  pre-existing `createEntry`/`deleteEntry` unit failures are the known stale-mock
  baseline — identical on `main`.

## Review asks

- The promote merge is at column/parts shape. This is valid **because** the
  split is non-localized-only (status is a plain main column, never routed to a
  companion `_status`). Please sanity-check that framing.
- The working-draft locale key is the resolved request locale in store, overlay,
  and promote alike — please confirm they cannot drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in working drafts for published, non-localized content.
  * Draft edits accumulate without changing live content until published or unpublished.
  * Authorized editors can preview draft overlays, while published-only reads remain unchanged.
  * Publishing and unpublishing promote the complete working draft.
  * Added locale-specific drafts and improved support for relationships, uploads, nested data, and components.
  * Passwords are protected in version snapshots.

* **Bug Fixes**
  * Prevented draft-only edits from triggering live-content updates or revalidation.
  * Rejected unauthorized draft promotion attempts.
  * Improved restore isolation, date handling, and fallback behavior for unavailable component schemas or password fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->