### PR TITLE
feat(nextly): rewrite the field group vocabulary stored inside rows

### DIFF
--- a/.changeset/field-group-migration-data.md
+++ b/.changeset/field-group-migration-data.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Groundwork for the field group storage migration: it can now rewrite the vocabulary stored inside rows, not just the tables and columns those rows live in. Stored field definitions, the source path a field group records, the scope a schema event carries, and the type key inside version snapshots and event payloads all move to the field group spelling.
+
+The two ledgers whose size follows a site history, content versions and the event outbox, are walked in bounded batches that each commit on their own and record how far they got, so an interrupted upgrade resumes near where it stopped instead of starting the table again. Every step then rescans its table rather than trusting that record, so a resume can never report a completeness it did not reach. Nothing calls the migration itself yet.

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/batch-cursor.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/batch-cursor.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  batchCursorKey,
+  clearBatchCursor,
+  readBatchCursor,
+  writeBatchCursor,
+} from "../batch-cursor";
+
+import { createTableWorld } from "./helpers/table-world";
+
+const RUN = "run-1";
+const STEP = "data:nextly_versions.snapshot";
+
+function world() {
+  return createTableWorld({});
+}
+
+describe("the batched rewrite's durable position", () => {
+  it("round-trips a position for the run that wrote it", async () => {
+    const { meta } = world();
+    await writeBatchCursor(meta, {
+      migrationId: RUN,
+      stepId: STEP,
+      after: "row-9",
+    });
+    await expect(
+      readBatchCursor(meta, { migrationId: RUN, stepId: STEP })
+    ).resolves.toBe("row-9");
+  });
+
+  it("reports no position when nothing was ever written", async () => {
+    const { meta } = world();
+    await expect(
+      readBatchCursor(meta, { migrationId: RUN, stepId: STEP })
+    ).resolves.toBeNull();
+  });
+
+  // 🔴 The load-bearing rule. A position means "everything at or before this id
+  // is done" only for the run that established it: a cursor from any other run
+  // — most of all one travelling the other way, whose position means the
+  // opposite — would step this run past rows nothing rewrote.
+  it("ignores a position left by a different run", async () => {
+    const { meta } = world();
+    await writeBatchCursor(meta, {
+      migrationId: "some-other-run",
+      stepId: STEP,
+      after: "row-9",
+    });
+    await expect(
+      readBatchCursor(meta, { migrationId: RUN, stepId: STEP })
+    ).resolves.toBeNull();
+  });
+
+  // Each step walks its own table, so a position is meaningless anywhere else.
+  it("keeps each step's position under its own key", async () => {
+    const { meta } = world();
+    await writeBatchCursor(meta, {
+      migrationId: RUN,
+      stepId: "data:nextly_events.payload",
+      after: "row-9",
+    });
+    await expect(
+      readBatchCursor(meta, { migrationId: RUN, stepId: STEP })
+    ).resolves.toBeNull();
+  });
+
+  // Unlike the migration marker, which refuses when it cannot be read. Starting
+  // a batch walk over is always correct, so a cursor that does not decode costs
+  // a second pass rather than stranding the run.
+  it.each([
+    ["not an object", "row-9"],
+    ["null", null],
+    ["missing a position", { migrationId: RUN }],
+    ["holding an empty position", { migrationId: RUN, after: "" }],
+    ["holding a non-string position", { migrationId: RUN, after: 9 }],
+  ])("starts over on a stored value %s", async (_label, stored) => {
+    const { meta } = world();
+    await meta.set(batchCursorKey(STEP), stored);
+    await expect(
+      readBatchCursor(meta, { migrationId: RUN, stepId: STEP })
+    ).resolves.toBeNull();
+  });
+
+  it("leaves nothing behind once a step has finished", async () => {
+    const { meta, metaValue } = world();
+    await writeBatchCursor(meta, {
+      migrationId: RUN,
+      stepId: STEP,
+      after: "row-9",
+    });
+    await clearBatchCursor(meta, { stepId: STEP });
+    expect(metaValue(batchCursorKey(STEP))).toBeUndefined();
+  });
+
+  it("namespaces its key beneath the migration's own marker", () => {
+    expect(batchCursorKey(STEP)).toBe(
+      "field_groups.storage_migration.cursor.data:nextly_versions.snapshot"
+    );
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/data-steps.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/data-steps.test.ts
@@ -179,6 +179,54 @@ describe("rewriting the vocabulary stored in registry rows", () => {
     await expect(step.verify(target.session)).resolves.toBe(true);
   });
 
+  // 🔴 A refusal has to leave the transaction as a value, because an exception
+  // is reclassified at the boundary and loses its context - but a value RETURNED
+  // from the callback commits. So every patch is staged before any is issued:
+  // otherwise a bad row late in the set would commit the rows rewritten before
+  // it, leaving exactly the mixed-vocabulary registries this step prevents.
+  it("writes nothing at all when a later row cannot be read", async () => {
+    const target = world({
+      // Read third, and missing `fields` - so the first two registries have
+      // already produced patches by the time this one refuses.
+      [STORAGE_FORMAT.registryTable]: {
+        columns: ["id", "configPath"],
+        rows: [{ id: "f1", configPath: "components/hero.ts" }],
+      },
+    });
+
+    await expect(
+      stepNamed(target, "data:registry-definitions").run(target.session)
+    ).rejects.toMatchObject({
+      logContext: {
+        reason: "row rewrite target names a property the table does not have",
+      },
+    });
+
+    // The registries read before the refusal are untouched.
+    expect(target.rows("dynamic_collections")[0]?.fields).toEqual(
+      storedFields()
+    );
+    expect(target.rows("dynamic_singles")[0]?.fields).toEqual(storedFields());
+    expect(target.counts.updates).toBe(0);
+  });
+
+  // Same hazard as the ledger walk: a plain SELECT takes no lock, and the update
+  // writes the whole `fields` document back, so a schema save committing in
+  // between would be overwritten rather than merged.
+  it("locks the registry rows it is about to rewrite", async () => {
+    const target = world();
+    await stepNamed(target, "data:registry-definitions").run(target.session);
+    const registryReads = target.reads.filter(read =>
+      [
+        "dynamic_collections",
+        "dynamic_singles",
+        STORAGE_FORMAT.registryTable,
+      ].includes(read.table)
+    );
+    expect(registryReads).not.toHaveLength(0);
+    expect(registryReads.every(read => read.forUpdate)).toBe(true);
+  });
+
   // 🔴 The ordering invariant, expressed as behaviour. These steps run before
   // any rename, so the registry is addressed under the name the ORM declares.
   // A world holding only the migrated name is the state they must NOT work in,

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/data-steps.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/data-steps.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from "vitest";
+
+import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
+import {
+  buildDataMigrationSteps,
+  FIELD_GROUP_STORAGE_VOCABULARY,
+  LEGACY_STORAGE_VOCABULARY,
+} from "../data-steps";
+import { MIGRATION_TARGET } from "../manifest";
+import type { MigrationStep } from "../runner";
+
+import { createTableWorld, type TableFixture } from "./helpers/table-world";
+
+const RUN = "run-1";
+
+/** A dynamic zone and an embedded group, as a registry stores them. */
+function storedFields(): unknown[] {
+  return [
+    { name: "blocks", type: "component", components: ["hero", "cta"] },
+    { name: "seo", type: "component", component: "seo" },
+    { name: "title", type: "text" },
+  ];
+}
+
+function registry(rows: Record<string, unknown>[]): TableFixture {
+  return { columns: ["id", "fields", "configPath"], rows };
+}
+
+function world(over: Record<string, TableFixture> = {}) {
+  return createTableWorld({
+    dynamic_collections: registry([
+      { id: "c1", fields: storedFields(), configPath: "collections/post.ts" },
+    ]),
+    dynamic_singles: registry([
+      { id: "s1", fields: storedFields(), configPath: "singles/home.ts" },
+    ]),
+    [STORAGE_FORMAT.registryTable]: registry([
+      { id: "f1", fields: storedFields(), configPath: "components/hero.ts" },
+    ]),
+    nextly_schema_events: {
+      columns: ["id", "scopeKind"],
+      rows: [
+        { id: "e1", scopeKind: "component" },
+        { id: "e2", scopeKind: "collection" },
+        { id: "e3", scopeKind: "core" },
+      ],
+    },
+    nextly_versions: {
+      columns: ["id", "snapshot"],
+      rows: [{ id: "v1", snapshot: { _componentType: "hero" } }],
+    },
+    nextly_events: {
+      columns: ["id", "payload"],
+      rows: [{ id: "n1", payload: { data: { _componentType: "cta" } } }],
+    },
+    ...over,
+  });
+}
+
+function steps(target: ReturnType<typeof world>): MigrationStep[] {
+  return buildDataMigrationSteps({
+    meta: target.meta,
+    migrationId: RUN,
+    from: LEGACY_STORAGE_VOCABULARY,
+    to: FIELD_GROUP_STORAGE_VOCABULARY,
+  });
+}
+
+function stepNamed(
+  target: ReturnType<typeof world>,
+  id: string
+): MigrationStep {
+  const step = steps(target).find(candidate => candidate.id === id);
+  if (step === undefined) throw new Error(`no step named ${id}`);
+  return step;
+}
+
+describe("the vocabularies a data rewrite travels between", () => {
+  it("pairs every stored spelling with its replacement", () => {
+    expect(LEGACY_STORAGE_VOCABULARY).toEqual({
+      configPathDir: "components",
+      fields: {
+        fieldType: "component",
+        refKeys: {
+          single: "component",
+          many: "components",
+          legacy: "componentSlug",
+        },
+      },
+      wireTypeKey: "_componentType",
+      schemaEventScope: "component",
+    });
+    expect(FIELD_GROUP_STORAGE_VOCABULARY).toEqual({
+      configPathDir: "field-groups",
+      fields: {
+        fieldType: "fieldGroup",
+        refKeys: { single: "fieldGroup", many: "fieldGroups" },
+      },
+      wireTypeKey: "_fieldGroupType",
+      schemaEventScope: "fieldGroup",
+    });
+  });
+
+  // The compatibility key is retired rather than renamed, so the target side has
+  // no counterpart for a rollback to put back.
+  it("gives the target vocabulary no legacy reference key", () => {
+    expect(
+      FIELD_GROUP_STORAGE_VOCABULARY.fields.refKeys.legacy
+    ).toBeUndefined();
+  });
+});
+
+describe("rewriting the vocabulary stored in registry rows", () => {
+  it("rewrites field definitions in every registry", async () => {
+    const target = world();
+    await stepNamed(target, "data:registry-definitions").run(target.session);
+
+    for (const table of [
+      "dynamic_collections",
+      "dynamic_singles",
+      STORAGE_FORMAT.registryTable,
+    ]) {
+      expect(target.rows(table)[0]?.fields).toEqual([
+        { name: "blocks", type: "fieldGroup", fieldGroups: ["hero", "cta"] },
+        { name: "seo", type: "fieldGroup", fieldGroup: "seo" },
+        { name: "title", type: "text" },
+      ]);
+    }
+  });
+
+  it("rewrites the field-group registry's config path", async () => {
+    const target = world();
+    await stepNamed(target, "data:registry-definitions").run(target.session);
+    expect(target.rows(STORAGE_FORMAT.registryTable)[0]?.configPath).toBe(
+      "field-groups/hero.ts"
+    );
+  });
+
+  // 🔴 The gate is the TABLE, not the string. A collection's `config_path`
+  // names the collections directory, and a rewrite that matched on the leading
+  // segment alone would rename a directory this migration has nothing to do
+  // with. Given a collection whose path starts with the same segment, only the
+  // table check keeps it intact.
+  it("leaves another registry's config path alone even when it looks the same", async () => {
+    const target = world({
+      dynamic_collections: registry([
+        { id: "c1", fields: [], configPath: "components/post.ts" },
+      ]),
+    });
+    await stepNamed(target, "data:registry-definitions").run(target.session);
+    expect(target.rows("dynamic_collections")[0]?.configPath).toBe(
+      "components/post.ts"
+    );
+  });
+
+  it("writes nothing for rows that are already right", async () => {
+    const target = world();
+    const step = stepNamed(target, "data:registry-definitions");
+    await step.run(target.session);
+    const after = target.counts.updates;
+    await step.run(target.session);
+    expect(target.counts.updates).toBe(after);
+  });
+
+  // A half-rewritten definition set is a database whose entities disagree about
+  // what a field group is, so all three registries move together or not at all.
+  it("moves all three registries in one transaction", async () => {
+    const target = world();
+    const before = target.counts.transactions;
+    await stepNamed(target, "data:registry-definitions").run(target.session);
+    expect(target.counts.transactions).toBe(before + 1);
+  });
+
+  it("fails its postcondition before it runs and passes after", async () => {
+    const target = world();
+    const step = stepNamed(target, "data:registry-definitions");
+    await expect(step.verify(target.session)).resolves.toBe(false);
+    await step.run(target.session);
+    await expect(step.verify(target.session)).resolves.toBe(true);
+  });
+
+  // 🔴 The ordering invariant, expressed as behaviour. These steps run before
+  // any rename, so the registry is addressed under the name the ORM declares.
+  // A world holding only the migrated name is the state they must NOT work in,
+  // and the adapter refuses a table it cannot resolve rather than inventing one.
+  it("addresses the registry under the name it has before any rename", async () => {
+    const renamed = createTableWorld({
+      dynamic_collections: registry([
+        { id: "c1", fields: storedFields(), configPath: "collections/post.ts" },
+      ]),
+      dynamic_singles: registry([
+        { id: "s1", fields: storedFields(), configPath: "singles/home.ts" },
+      ]),
+      [MIGRATION_TARGET.registryTable]: registry([
+        { id: "f1", fields: storedFields(), configPath: "components/hero.ts" },
+      ]),
+    });
+
+    await expect(
+      stepNamed(renamed, "data:registry-definitions").run(renamed.session)
+    ).rejects.toThrow(/not found in schema registry/);
+  });
+});
+
+describe("rewriting the scope a schema event records", () => {
+  it("moves only the field-group scope", async () => {
+    const target = world();
+    await stepNamed(target, "data:schema-event-scope").run(target.session);
+    expect(
+      target.rows("nextly_schema_events").map(row => row.scopeKind)
+    ).toEqual(["fieldGroup", "collection", "core"]);
+  });
+
+  it("fails its postcondition before it runs and passes after", async () => {
+    const target = world();
+    const step = stepNamed(target, "data:schema-event-scope");
+    await expect(step.verify(target.session)).resolves.toBe(false);
+    await step.run(target.session);
+    await expect(step.verify(target.session)).resolves.toBe(true);
+  });
+});
+
+describe("rewriting the wire key inside the ledgers", () => {
+  it.each([
+    ["data:nextly_versions.snapshot", "nextly_versions", "snapshot"],
+    ["data:nextly_events.payload", "nextly_events", "payload"],
+  ])("rewrites %s", async (stepId, table, property) => {
+    const target = world();
+    const step = stepNamed(target, stepId);
+    await step.run(target.session);
+    await expect(step.verify(target.session)).resolves.toBe(true);
+    expect(JSON.stringify(target.rows(table)[0]?.[property])).toContain(
+      "_fieldGroupType"
+    );
+  });
+
+  // A row the walk did not reach is not "not finished yet" — the walk ran to the
+  // end of the table — so this refuses and names the row rather than reporting a
+  // postcondition that a retry would silently re-attempt.
+  it("refuses, naming the row, when one was left behind", async () => {
+    const target = world();
+    const step = stepNamed(target, "data:nextly_versions.snapshot");
+    await step.run(target.session);
+    target.insert("nextly_versions", {
+      id: "v2",
+      snapshot: { _componentType: "late" },
+    });
+
+    await expect(step.verify(target.session)).rejects.toMatchObject({
+      logContext: {
+        reason: "row rewrite did not reach every row",
+        table: "nextly_versions",
+        row: "v2",
+      },
+    });
+  });
+});
+
+describe("the shape of the data plan", () => {
+  // Step ids key each ledger's durable cursor, so they are part of the format a
+  // resume reads and not merely labels.
+  it("names its steps stably, in canonical order", () => {
+    const target = world();
+    expect(steps(target).map(step => step.id)).toEqual([
+      "data:registry-definitions",
+      "data:schema-event-scope",
+      "data:nextly_versions.snapshot",
+      "data:nextly_events.payload",
+    ]);
+  });
+
+  it("reverses when the vocabularies are exchanged", async () => {
+    const target = world();
+    for (const step of steps(target)) await step.run(target.session);
+
+    const down = buildDataMigrationSteps({
+      meta: target.meta,
+      migrationId: "run-2",
+      from: FIELD_GROUP_STORAGE_VOCABULARY,
+      to: LEGACY_STORAGE_VOCABULARY,
+    });
+    for (const step of [...down].reverse()) await step.run(target.session);
+
+    expect(target.rows(STORAGE_FORMAT.registryTable)[0]).toEqual({
+      id: "f1",
+      // `component` rather than `componentSlug`: the compatibility key is
+      // retired on the way up and never minted again on the way back.
+      fields: storedFields(),
+      configPath: "components/hero.ts",
+    });
+    expect(target.rows("nextly_versions")[0]?.snapshot).toEqual({
+      _componentType: "hero",
+    });
+    expect(target.rows("nextly_schema_events")[0]?.scopeKind).toBe("component");
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/table-world.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/table-world.ts
@@ -1,0 +1,218 @@
+/**
+ * An in-memory stand-in for the tables the data steps rewrite.
+ *
+ * The steps reach their tables through the adapter's typed CRUD, which is strict
+ * in ways that matter here: it refuses a table the schema registry does not
+ * declare, refuses a `where` naming a column that does not exist, and projects
+ * only the columns a table actually has — so a projection naming the wrong
+ * property yields a row without that key rather than a row with `undefined`.
+ * A double that answered every request would certify a rewrite that cannot run.
+ *
+ * It also rolls a transaction back on failure, because the batched walk's whole
+ * safety argument is that a cursor is written only after its batch committed,
+ * and a double that kept a failed batch's writes could not tell the two apart.
+ */
+import type {
+  SelectOptions,
+  TransactionContext,
+  WhereClause,
+  WhereCondition,
+} from "@nextlyhq/adapter-drizzle/types";
+import { vi } from "vitest";
+
+import type { MetaService } from "../../../../meta/services/meta-service";
+import type { MigrationSession } from "../../session";
+
+/** One table: the columns it declares, and the rows it holds. */
+export interface TableFixture {
+  columns: string[];
+  rows: Record<string, unknown>[];
+}
+
+export interface TableWorldOptions {
+  /**
+   * Called before each write. Throwing models a statement the database refused,
+   * so the surrounding transaction rolls back.
+   */
+  onUpdate?: (table: string, id: unknown) => void;
+}
+
+export interface TableWorld {
+  session: MigrationSession;
+  meta: MetaService;
+  /** Rows as they now stand, for assertions. */
+  rows(table: string): Record<string, unknown>[];
+  /** A `nextly_meta` value, or `undefined` when the key is absent. */
+  metaValue(key: string): unknown;
+  /** Insert a row after the world was built, to model a concurrent write. */
+  insert(table: string, row: Record<string, unknown>): void;
+  counts: { transactions: number; selects: number; updates: number };
+}
+
+export function createTableWorld(
+  fixtures: Record<string, TableFixture>,
+  options: TableWorldOptions = {}
+): TableWorld {
+  const tables = new Map<string, TableFixture>(
+    Object.entries(fixtures).map(([name, fixture]) => [
+      name,
+      { columns: [...fixture.columns], rows: structuredClone(fixture.rows) },
+    ])
+  );
+  const meta = new Map<string, unknown>();
+  const counts = { transactions: 0, selects: 0, updates: 0 };
+
+  function tableOf(name: string): TableFixture {
+    const fixture = tables.get(name);
+    if (fixture === undefined) {
+      // Mirrors the adapter, which refuses a name the schema registry does not
+      // declare rather than falling back to something that might work.
+      throw new Error(`Table "${name}" not found in schema registry.`);
+    }
+    return fixture;
+  }
+
+  function requireColumn(fixture: TableFixture, column: string): void {
+    if (fixture.columns.includes(column)) return;
+    // The where builder throws on an unresolvable column. A double that ignored
+    // one would silently widen every filter it was given.
+    throw new Error(`Column "${column}" not found in table.`);
+  }
+
+  function matches(
+    fixture: TableFixture,
+    row: Record<string, unknown>,
+    where: WhereClause | undefined
+  ): boolean {
+    if (where === undefined) return true;
+    const clauses = where.and ?? [];
+    return clauses.every(clause => {
+      if (!("column" in clause)) return matches(fixture, row, clause);
+      const condition = clause satisfies WhereCondition;
+      requireColumn(fixture, condition.column);
+      const actual = row[condition.column];
+      if (condition.op === "=") return actual === condition.value;
+      if (condition.op === ">") {
+        return (
+          typeof actual === "string" &&
+          typeof condition.value === "string" &&
+          actual > condition.value
+        );
+      }
+      throw new Error(`unsupported operator ${condition.op} in this double`);
+    });
+  }
+
+  function select(
+    table: string,
+    selectOptions?: SelectOptions
+  ): Record<string, unknown>[] {
+    counts.selects += 1;
+    const fixture = tableOf(table);
+    let rows = fixture.rows.filter(row =>
+      matches(fixture, row, selectOptions?.where)
+    );
+
+    for (const order of selectOptions?.orderBy ?? []) {
+      // The adapter drops an order it cannot resolve rather than refusing, so
+      // this does the same: a double that threw here would hide the behaviour
+      // the walk has to be correct in spite of.
+      if (!fixture.columns.includes(order.column)) continue;
+      rows = [...rows].sort((a, b) =>
+        String(a[order.column]) < String(b[order.column]) ? -1 : 1
+      );
+    }
+
+    if (selectOptions?.limit !== undefined) {
+      rows = rows.slice(0, selectOptions.limit);
+    }
+
+    const projection = selectOptions?.columns;
+    return rows.map(row => {
+      if (projection === undefined) return structuredClone(row);
+      const projected: Record<string, unknown> = {};
+      for (const column of projection) {
+        // Only columns the table declares survive a projection, so asking for a
+        // property that is not there produces a row without the key -- which is
+        // exactly what the steps have to refuse rather than rewrite.
+        if (!fixture.columns.includes(column)) continue;
+        projected[column] = structuredClone(row[column]);
+      }
+      return projected;
+    });
+  }
+
+  function update(
+    table: string,
+    data: Record<string, unknown>,
+    where: WhereClause
+  ): void {
+    counts.updates += 1;
+    const fixture = tableOf(table);
+    for (const column of Object.keys(data)) requireColumn(fixture, column);
+    for (const row of fixture.rows) {
+      if (!matches(fixture, row, where)) continue;
+      options.onUpdate?.(table, row.id);
+      Object.assign(row, structuredClone(data));
+    }
+  }
+
+  const ctx = {
+    select: vi.fn(async (table: string, selectOptions?: SelectOptions) =>
+      select(table, selectOptions)
+    ),
+    update: vi.fn(
+      async (
+        table: string,
+        data: Record<string, unknown>,
+        where: WhereClause
+      ) => {
+        update(table, data, where);
+        return [];
+      }
+    ),
+  } as unknown as TransactionContext;
+
+  const session: MigrationSession = {
+    dialect: "postgresql",
+    async inTransaction(work) {
+      counts.transactions += 1;
+      const snapshot = new Map(
+        [...tables].map(([name, fixture]) => [
+          name,
+          structuredClone(fixture.rows),
+        ])
+      );
+      try {
+        return await work(ctx);
+      } catch (error) {
+        for (const [name, rows] of snapshot) {
+          const fixture = tables.get(name);
+          if (fixture !== undefined) fixture.rows = rows;
+        }
+        throw error;
+      }
+    },
+  };
+
+  const metaService = {
+    get: vi.fn(async (key: string) => meta.get(key) ?? null),
+    set: vi.fn(async (key: string, value: unknown) => {
+      meta.set(key, structuredClone(value));
+    }),
+    delete: vi.fn(async (key: string) => {
+      meta.delete(key);
+    }),
+  } as unknown as MetaService;
+
+  return {
+    session,
+    meta: metaService,
+    rows: name => tableOf(name).rows,
+    metaValue: key => meta.get(key),
+    insert: (name, row) => {
+      tableOf(name).rows.push(structuredClone(row));
+    },
+    counts,
+  };
+}

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/table-world.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/table-world.ts
@@ -11,12 +11,21 @@
  * It also rolls a transaction back on failure, because the batched walk's whole
  * safety argument is that a cursor is written only after its batch committed,
  * and a double that kept a failed batch's writes could not tell the two apart.
+ *
+ * And it reclassifies whatever escapes a transaction callback, exactly as every
+ * real adapter does: `classifyError` short-circuits only on an existing
+ * `DatabaseError`, so a `NextlyError` thrown inside a transaction reaches the
+ * caller rewrapped as an unknown database error with its `logContext` gone. A
+ * double that let one through unchanged would certify refusal messages that no
+ * operator ever sees.
  */
-import type {
-  SelectOptions,
-  TransactionContext,
-  WhereClause,
-  WhereCondition,
+import {
+  createDatabaseError,
+  isDatabaseError,
+  type SelectOptions,
+  type TransactionContext,
+  type WhereClause,
+  type WhereCondition,
 } from "@nextlyhq/adapter-drizzle/types";
 import { vi } from "vitest";
 
@@ -46,6 +55,8 @@ export interface TableWorld {
   metaValue(key: string): unknown;
   /** Insert a row after the world was built, to model a concurrent write. */
   insert(table: string, row: Record<string, unknown>): void;
+  /** Every `select` this world served, so a test can assert how it was asked. */
+  reads: { table: string; forUpdate: boolean }[];
   counts: { transactions: number; selects: number; updates: number };
 }
 
@@ -60,6 +71,7 @@ export function createTableWorld(
     ])
   );
   const meta = new Map<string, unknown>();
+  const reads: { table: string; forUpdate: boolean }[] = [];
   const counts = { transactions: 0, selects: 0, updates: 0 };
 
   function tableOf(name: string): TableFixture {
@@ -108,6 +120,7 @@ export function createTableWorld(
     selectOptions?: SelectOptions
   ): Record<string, unknown>[] {
     counts.selects += 1;
+    reads.push({ table, forUpdate: selectOptions?.forUpdate === true });
     const fixture = tableOf(table);
     let rows = fixture.rows.filter(row =>
       matches(fixture, row, selectOptions?.where)
@@ -190,7 +203,14 @@ export function createTableWorld(
           const fixture = tables.get(name);
           if (fixture !== undefined) fixture.rows = rows;
         }
-        throw error;
+        // Mirrors every adapter's transaction boundary: anything that is not
+        // already a DatabaseError is rewrapped as an unknown one, losing
+        // whatever structured context it carried.
+        if (isDatabaseError(error)) throw error;
+        throw createDatabaseError({
+          kind: "unknown",
+          message: error instanceof Error ? error.message : String(error),
+        });
       }
     },
   };
@@ -213,6 +233,7 @@ export function createTableWorld(
     insert: (name, row) => {
       tableOf(name).rows.push(structuredClone(row));
     },
+    reads,
     counts,
   };
 }

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/table-world.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/helpers/table-world.ts
@@ -12,6 +12,13 @@
  * safety argument is that a cursor is written only after its batch committed,
  * and a double that kept a failed batch's writes could not tell the two apart.
  *
+ * The errors it raises are the ones production raises, which is why they are not
+ * `NextlyError`s despite the repository rule: an unresolvable table comes out of
+ * the adapter as a `DatabaseError` (`adapter.ts` `select`), and an unresolvable
+ * column comes out of the where builder as a bare `Error` (`drizzle-where.ts`
+ * `buildCondition`). Raising a different error type here would test refusal
+ * handling against errors the code will never actually meet.
+ *
  * And it reclassifies whatever escapes a transaction callback, exactly as every
  * real adapter does: `classifyError` short-circuits only on an existing
  * `DatabaseError`, so a `NextlyError` thrown inside a transaction reaches the
@@ -77,17 +84,21 @@ export function createTableWorld(
   function tableOf(name: string): TableFixture {
     const fixture = tables.get(name);
     if (fixture === undefined) {
-      // Mirrors the adapter, which refuses a name the schema registry does not
-      // declare rather than falling back to something that might work.
-      throw new Error(`Table "${name}" not found in schema registry.`);
+      // The adapter refuses a name the schema registry does not declare, and
+      // does it as a DatabaseError -- so this raises the same type, which the
+      // transaction boundary then passes through rather than reclassifying.
+      throw createDatabaseError({
+        kind: "query",
+        message: `Table "${name}" not found in schema registry.`,
+      });
     }
     return fixture;
   }
 
   function requireColumn(fixture: TableFixture, column: string): void {
     if (fixture.columns.includes(column)) return;
-    // The where builder throws on an unresolvable column. A double that ignored
-    // one would silently widen every filter it was given.
+    // A bare Error, because that is what the where builder raises. A double that
+    // ignored the column would silently widen every filter it was given.
     throw new Error(`Column "${column}" not found in table.`);
   }
 

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/rewrite-config-path.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/rewrite-config-path.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
+import { MIGRATION_TARGET } from "../manifest";
+import { rewriteConfigPath } from "../rewrite-config-path";
+
+const FROM = STORAGE_FORMAT.configPathDir;
+const TO = MIGRATION_TARGET.configPathDir;
+
+function up(value: unknown): unknown {
+  return rewriteConfigPath(value, FROM, TO);
+}
+
+describe("rewriting a registry row's config path", () => {
+  it("swaps the leading directory segment", () => {
+    expect(up("components/hero.ts")).toBe("field-groups/hero.ts");
+  });
+
+  // 🔴 The reason this is anchored rather than a substring replace: a project
+  // directory whose name merely ends in the segment is not that segment.
+  it("leaves a directory that only ends with the segment alone", () => {
+    expect(up("my-components/hero.ts")).toBe("my-components/hero.ts");
+    expect(up("ui-components/hero.ts")).toBe("ui-components/hero.ts");
+  });
+
+  // Anchored to the start too, so the same word deeper in a path is content.
+  it("leaves the segment alone when it is not the leading one", () => {
+    expect(up("src/components/hero.ts")).toBe("src/components/hero.ts");
+  });
+
+  // The separator is required, or a sibling directory sharing the prefix would
+  // be rewritten into a path that does not exist.
+  it("requires a separator, not just the prefix", () => {
+    expect(up("components-legacy/hero.ts")).toBe("components-legacy/hero.ts");
+    expect(up("components")).toBe("components");
+  });
+
+  it("is idempotent", () => {
+    expect(up(up("components/hero.ts"))).toBe("field-groups/hero.ts");
+  });
+
+  it("reverses when the arguments are swapped", () => {
+    const migrated = up("components/hero.ts");
+    expect(rewriteConfigPath(migrated, TO, FROM)).toBe("components/hero.ts");
+  });
+
+  it("passes through anything that is not a string", () => {
+    expect(up(null)).toBeNull();
+    expect(up(undefined)).toBeUndefined();
+    expect(up(7)).toBe(7);
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/rewrite-content-key.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/rewrite-content-key.test.ts
@@ -77,6 +77,30 @@ describe("rewriting the wire type key inside stored content", () => {
     expect(up(document)).toEqual({ _fieldGroupType: "current" });
   });
 
+  // 🔴 `JSON.parse` creates `__proto__` as an ordinary own property, and every
+  // column this walks is parsed JSON - so an author's document really can carry
+  // one. Plain assignment would run the inherited prototype setter instead of
+  // creating the property, and the key would vanish from the rewritten document
+  // that the migration then persists.
+  it("keeps an own __proto__ key instead of losing it to the setter", () => {
+    const authored: unknown = JSON.parse(
+      '{"__proto__":{"tainted":true},"_componentType":"hero"}'
+    );
+    const rewritten = up(authored) as Record<string, unknown>;
+
+    expect(Object.prototype.hasOwnProperty.call(rewritten, "__proto__")).toBe(
+      true
+    );
+    // Built through JSON too: an object literal's `__proto__` sets the
+    // prototype rather than an own key, so a hand-written expectation here
+    // would assert the very thing this guards against.
+    expect(JSON.parse(JSON.stringify(rewritten))).toEqual(
+      JSON.parse('{"__proto__":{"tainted":true},"_fieldGroupType":"hero"}')
+    );
+    // The key stayed data: it did not become this object's prototype.
+    expect(Object.getPrototypeOf(rewritten)).toBe(Object.prototype);
+  });
+
   it("is idempotent", () => {
     const once = up({ _componentType: "hero" });
     expect(up(once)).toEqual(once);

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/rewrite-content-key.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/rewrite-content-key.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
+import { MIGRATION_TARGET } from "../manifest";
+import { rewriteContentKey } from "../rewrite-content-key";
+
+const FROM = STORAGE_FORMAT.wireTypeKey;
+const TO = MIGRATION_TARGET.wireTypeKey;
+
+function up(document: unknown): unknown {
+  return rewriteContentKey(document, FROM, TO);
+}
+
+describe("rewriting the wire type key inside stored content", () => {
+  it("renames the key on a dynamic-zone instance", () => {
+    expect(up({ _componentType: "hero", title: "Hi" })).toEqual({
+      _fieldGroupType: "hero",
+      title: "Hi",
+    });
+  });
+
+  it("renames it inside arrays of instances", () => {
+    expect(
+      up({ blocks: [{ _componentType: "hero" }, { _componentType: "cta" }] })
+    ).toEqual({
+      blocks: [{ _fieldGroupType: "hero" }, { _fieldGroupType: "cta" }],
+    });
+  });
+
+  // A snapshot nests entries inside entries: a dynamic zone inside a repeater
+  // inside the document root is ordinary, so depth cannot be assumed.
+  it("reaches instances at any depth", () => {
+    expect(
+      up({
+        page: {
+          rows: [{ cells: [{ blocks: [{ _componentType: "hero" }] }] }],
+        },
+      })
+    ).toEqual({
+      page: { rows: [{ cells: [{ blocks: [{ _fieldGroupType: "hero" }] }] }] },
+    });
+  });
+
+  it("leaves every other key and value untouched", () => {
+    const authored = {
+      title: "components",
+      meta: { type: "component", tags: ["component", "components"] },
+      count: 3,
+      flag: null,
+    };
+    expect(up(authored)).toEqual(authored);
+  });
+
+  it("keeps key order so a rename does not reshuffle a snapshot", () => {
+    const rewritten = up({
+      id: "1",
+      _componentType: "hero",
+      title: "Hi",
+    }) as Record<string, unknown>;
+    expect(Object.keys(rewritten)).toEqual(["id", "_fieldGroupType", "title"]);
+  });
+
+  // A document already holding the target key keeps what is there. Both orders
+  // are asserted deliberately: with the stale key first the canonical one
+  // overwrites it anyway, so only the target-first case actually exercises the
+  // rule — a single-order test passes whether or not the rule exists.
+  it.each([
+    [
+      "stale key first",
+      { _componentType: "stale", _fieldGroupType: "current" },
+    ],
+    [
+      "target key first",
+      { _fieldGroupType: "current", _componentType: "stale" },
+    ],
+  ])("does not overwrite an existing target key (%s)", (_label, document) => {
+    expect(up(document)).toEqual({ _fieldGroupType: "current" });
+  });
+
+  it("is idempotent", () => {
+    const once = up({ _componentType: "hero" });
+    expect(up(once)).toEqual(once);
+  });
+
+  it("reverses when the arguments are swapped", () => {
+    const migrated = up({ blocks: [{ _componentType: "hero", n: 1 }] });
+    expect(rewriteContentKey(migrated, TO, FROM)).toEqual({
+      blocks: [{ _componentType: "hero", n: 1 }],
+    });
+  });
+
+  it("does not mutate its input", () => {
+    const input = { blocks: [{ _componentType: "hero" }] };
+    const snapshot = structuredClone(input);
+    up(input);
+    expect(input).toEqual(snapshot);
+  });
+
+  it("passes through primitives and null", () => {
+    expect(up(null)).toBeNull();
+    expect(up("x")).toBe("x");
+    expect(up(5)).toBe(5);
+    expect(up([1, "a", null])).toEqual([1, "a", null]);
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/rewrite-field-definitions.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/rewrite-field-definitions.test.ts
@@ -172,3 +172,30 @@ describe("rewriting field-group vocabulary in stored definitions", () => {
     expect(up([null, 3, "x"])).toEqual([null, 3, "x"]);
   });
 });
+
+describe("rebuilding a definition without letting a key decide how", () => {
+  // Same hazard as the content walk: a stored definition is parsed JSON, so an
+  // own `__proto__` reaches this rebuild, and plain assignment would drop it.
+  it("keeps an own __proto__ key on a field definition", () => {
+    const stored: unknown = JSON.parse(
+      '[{"name":"hero","type":"component","component":"hero","__proto__":{"tainted":true}}]'
+    );
+    const rewritten = rewriteFieldDefinitions(
+      stored,
+      LEGACY,
+      MIGRATED
+    ) as Record<string, unknown>[];
+    const field = rewritten[0];
+    if (field === undefined) throw new Error("fixture produced no field");
+
+    expect(Object.prototype.hasOwnProperty.call(field, "__proto__")).toBe(true);
+    // Built through JSON for the same reason: a literal's `__proto__` sets the
+    // prototype instead of an own key.
+    expect(JSON.parse(JSON.stringify(field))).toEqual(
+      JSON.parse(
+        '{"name":"hero","type":"fieldGroup","fieldGroup":"hero","__proto__":{"tainted":true}}'
+      )
+    );
+    expect(Object.getPrototypeOf(field)).toBe(Object.prototype);
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/rewrite-field-definitions.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/rewrite-field-definitions.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+
+import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
+import { MIGRATION_TARGET } from "../manifest";
+import {
+  rewriteFieldDefinitions,
+  type FieldGroupVocabulary,
+} from "../rewrite-field-definitions";
+
+/** The real pair, so the tests exercise the vocabulary that actually ships. */
+const LEGACY: FieldGroupVocabulary = {
+  fieldType: STORAGE_FORMAT.fieldType,
+  refKeys: {
+    single: STORAGE_FORMAT.refKeys.single,
+    many: STORAGE_FORMAT.refKeys.many,
+    legacy: STORAGE_FORMAT.refKeys.legacy,
+  },
+};
+const MIGRATED: FieldGroupVocabulary = {
+  fieldType: MIGRATION_TARGET.fieldType,
+  refKeys: {
+    single: MIGRATION_TARGET.refKeys.single,
+    many: MIGRATION_TARGET.refKeys.many,
+  },
+};
+
+function up(fields: unknown): unknown {
+  return rewriteFieldDefinitions(fields, LEGACY, MIGRATED);
+}
+
+describe("rewriting field-group vocabulary in stored definitions", () => {
+  it("renames the type and the single reference together", () => {
+    expect(
+      up([{ name: "hero", type: "component", component: "hero" }])
+    ).toEqual([{ name: "hero", type: "fieldGroup", fieldGroup: "hero" }]);
+  });
+
+  it("renames a dynamic zone's accepted list", () => {
+    expect(
+      up([{ name: "blocks", type: "component", components: ["a", "b"] }])
+    ).toEqual([
+      { name: "blocks", type: "fieldGroup", fieldGroups: ["a", "b"] },
+    ]);
+  });
+
+  it("leaves a user's own field named like a reference key alone", () => {
+    const authored = [
+      { name: "components", type: "text" },
+      { name: "component", type: "text" },
+    ];
+    expect(up(authored)).toEqual(authored);
+  });
+
+  // 🔴 The trap the whole design exists for, and the one the test above does
+  // NOT cover: the reference keys are property names, so a field of some other
+  // type carrying a property called `component` or `components` — a plugin
+  // type's own option, say — would be rewritten by a rule keyed on the property
+  // name alone. That silently rewrites another type's configuration into
+  // something it cannot read.
+  it("leaves reference-key property names alone on a field that is not a field group", () => {
+    const authored = [
+      { name: "picker", type: "my-plugin-field", components: ["a", "b"] },
+      { name: "single", type: "my-plugin-field", component: "hero" },
+      { name: "old", type: "relationship", componentSlug: "hero" },
+    ];
+    expect(up(authored)).toEqual(authored);
+  });
+
+  // The same word appears as a value in author data. Only `type` on a
+  // field-group node means the discriminator; everywhere else it is content.
+  it("leaves the word alone when it is a stored value rather than a type", () => {
+    const authored = [
+      { name: "label", type: "text", defaultValue: "component" },
+      { name: "kind", type: "select", options: ["component", "components"] },
+    ];
+    expect(up(authored)).toEqual(authored);
+  });
+
+  it("normalises the legacy reference key onto the canonical one", () => {
+    expect(
+      up([{ name: "old", type: "component", componentSlug: "hero" }])
+    ).toEqual([{ name: "old", type: "fieldGroup", fieldGroup: "hero" }]);
+  });
+
+  // A node carrying both spellings keeps the canonical value: the legacy key
+  // predates it, so the newer one was written deliberately.
+  it("prefers the canonical value when a node carries both spellings", () => {
+    expect(
+      up([
+        {
+          name: "both",
+          type: "component",
+          component: "current",
+          componentSlug: "stale",
+        },
+      ])
+    ).toEqual([{ name: "both", type: "fieldGroup", fieldGroup: "current" }]);
+  });
+
+  it("descends into the container types that nest field definitions", () => {
+    expect(
+      up([
+        {
+          name: "rows",
+          type: "repeater",
+          fields: [{ name: "hero", type: "component", component: "hero" }],
+        },
+      ])
+    ).toEqual([
+      {
+        name: "rows",
+        type: "repeater",
+        fields: [{ name: "hero", type: "fieldGroup", fieldGroup: "hero" }],
+      },
+    ]);
+  });
+
+  // 🔴 A plugin field type is open-ended and may carry its own `fields` option
+  // as private configuration. Walking it would run these rules over data that is
+  // not a field list, which is why only the container types are descended into.
+  it("does not descend into a `fields` option on a non-container type", () => {
+    const authored = [
+      {
+        name: "custom",
+        type: "my-plugin-field",
+        fields: [{ name: "x", type: "component", component: "hero" }],
+      },
+    ];
+    expect(up(authored)).toEqual(authored);
+  });
+
+  it("keeps property order so a rename does not reshuffle stored JSON", () => {
+    const [rewritten] = up([
+      { name: "hero", type: "component", component: "hero", required: true },
+    ]) as Record<string, unknown>[];
+    expect(Object.keys(rewritten!)).toEqual([
+      "name",
+      "type",
+      "fieldGroup",
+      "required",
+    ]);
+  });
+
+  it("does not mutate its input", () => {
+    const input = [{ name: "hero", type: "component", component: "hero" }];
+    const snapshot = structuredClone(input);
+    up(input);
+    expect(input).toEqual(snapshot);
+  });
+
+  // Running the migration twice must not undo or double-apply it, because a
+  // resume re-runs whatever step was in flight.
+  it("is idempotent", () => {
+    const once = up([{ name: "hero", type: "component", component: "hero" }]);
+    expect(up(once)).toEqual(once);
+  });
+
+  // Direction is the argument order, so a rollback is the same function with
+  // the vocabularies swapped rather than a second implementation.
+  it("reverses when the vocabularies are swapped", () => {
+    const migrated = up([
+      { name: "blocks", type: "component", components: ["a"] },
+    ]);
+    expect(rewriteFieldDefinitions(migrated, MIGRATED, LEGACY)).toEqual([
+      { name: "blocks", type: "component", components: ["a"] },
+    ]);
+  });
+
+  it("passes through anything that is not a field list", () => {
+    expect(up(null)).toBeNull();
+    expect(up("text")).toBe("text");
+    expect(up([null, 3, "x"])).toEqual([null, 3, "x"]);
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/rewrite-field-definitions.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/rewrite-field-definitions.test.ts
@@ -233,6 +233,26 @@ describe("deciding a reference-key collision rather than letting key order", () 
     expect(rewritten[0]).toEqual({ type: "fieldGroup", fieldGroups: ["b"] });
   });
 
+  // The legacy key normalises onto the canonical one, so it collides with the
+  // target spelling exactly as the source key does. Both orders again, because
+  // with the legacy key first the target simply overwrites it anyway.
+  it.each([
+    [
+      "legacy key first",
+      '[{"type":"component","componentSlug":"a","fieldGroup":"b"}]',
+    ],
+    [
+      "target key first",
+      '[{"type":"component","fieldGroup":"b","componentSlug":"a"}]',
+    ],
+  ])(
+    "keeps the target value when normalizing a legacy key (%s)",
+    (_label, stored) => {
+      const rewritten = up(JSON.parse(stored)) as Record<string, unknown>[];
+      expect(rewritten[0]).toEqual({ type: "fieldGroup", fieldGroup: "b" });
+    }
+  );
+
   // Rewriting a key onto itself is not a collision. Treating it as one would
   // drop the value entirely, which is why the guard compares the keys first.
   it("does not drop a reference when the vocabulary does not rename the key", () => {

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/rewrite-field-definitions.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/rewrite-field-definitions.test.ts
@@ -199,3 +199,53 @@ describe("rebuilding a definition without letting a key decide how", () => {
     expect(Object.getPrototypeOf(field)).toBe(Object.prototype);
   });
 });
+
+describe("deciding a reference-key collision rather than letting key order", () => {
+  // A node carrying both the source key and a property already named the target
+  // one: without a rule, whichever came later in the stored JSON wins and the
+  // other reference is dropped silently. Both orders are asserted, because a
+  // single-order test passes whether or not the rule exists.
+  it.each([
+    [
+      "source key first",
+      '[{"type":"component","component":"a","fieldGroup":"b"}]',
+    ],
+    [
+      "target key first",
+      '[{"type":"component","fieldGroup":"b","component":"a"}]',
+    ],
+  ])("keeps the value already under the target key (%s)", (_label, stored) => {
+    const rewritten = up(JSON.parse(stored)) as Record<string, unknown>[];
+    expect(rewritten[0]).toEqual({ type: "fieldGroup", fieldGroup: "b" });
+  });
+
+  it.each([
+    [
+      "source key first",
+      '[{"type":"component","components":["a"],"fieldGroups":["b"]}]',
+    ],
+    [
+      "target key first",
+      '[{"type":"component","fieldGroups":["b"],"components":["a"]}]',
+    ],
+  ])("does the same for the dynamic-zone list (%s)", (_label, stored) => {
+    const rewritten = up(JSON.parse(stored)) as Record<string, unknown>[];
+    expect(rewritten[0]).toEqual({ type: "fieldGroup", fieldGroups: ["b"] });
+  });
+
+  // Rewriting a key onto itself is not a collision. Treating it as one would
+  // drop the value entirely, which is why the guard compares the keys first.
+  it("does not drop a reference when the vocabulary does not rename the key", () => {
+    const same: FieldGroupVocabulary = {
+      fieldType: "component",
+      refKeys: { single: "component", many: "components" },
+    };
+    expect(
+      rewriteFieldDefinitions(
+        [{ type: "component", component: "hero" }],
+        same,
+        same
+      )
+    ).toEqual([{ type: "component", component: "hero" }]);
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/rewrite-rows.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/rewrite-rows.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from "vitest";
+
+import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
+import { batchCursorKey, writeBatchCursor } from "../batch-cursor";
+import { MIGRATION_TARGET } from "../manifest";
+import { rewriteContentKey } from "../rewrite-content-key";
+import {
+  findUnrewrittenRow,
+  rewriteRowsInBatches,
+  type RowRewriteTarget,
+} from "../rewrite-rows";
+
+import {
+  createTableWorld,
+  type TableWorldOptions,
+} from "./helpers/table-world";
+
+const RUN = "run-1";
+const STEP = "data:nextly_versions.snapshot";
+const TARGET: RowRewriteTarget = {
+  table: "nextly_versions",
+  documentProperty: "snapshot",
+};
+
+/** The real rewrite, so these tests exercise what the step will actually run. */
+const rewrite = (document: unknown): unknown =>
+  rewriteContentKey(
+    document,
+    STORAGE_FORMAT.wireTypeKey,
+    MIGRATION_TARGET.wireTypeKey
+  );
+
+/** Ids are zero-padded so the keyset walk's ordering is unambiguous. */
+function id(index: number): string {
+  return `row-${String(index).padStart(3, "0")}`;
+}
+
+/** More rows than one batch holds, so the walk has to page. */
+const ROW_COUNT = 250;
+
+function versionsWorld(options: TableWorldOptions = {}) {
+  return createTableWorld(
+    {
+      nextly_versions: {
+        columns: ["id", "snapshot"],
+        rows: Array.from({ length: ROW_COUNT }, (_unused, index) => ({
+          id: id(index),
+          snapshot: { _componentType: "hero", n: index },
+        })),
+      },
+    },
+    options
+  );
+}
+
+function run(world: ReturnType<typeof versionsWorld>): Promise<void> {
+  return rewriteRowsInBatches({
+    session: world.session,
+    meta: world.meta,
+    migrationId: RUN,
+    stepId: STEP,
+    target: TARGET,
+    rewrite,
+  });
+}
+
+describe("rewriting a ledger's documents in batches", () => {
+  it("reaches every row across more than one batch", async () => {
+    const world = versionsWorld();
+    await run(world);
+
+    const rows = world.rows("nextly_versions");
+    expect(rows).toHaveLength(ROW_COUNT);
+    for (const row of rows) {
+      expect(row.snapshot).not.toHaveProperty("_componentType");
+      expect(row.snapshot).toHaveProperty("_fieldGroupType", "hero");
+    }
+    // More than one transaction, or the batching is not batching.
+    expect(world.counts.transactions).toBeGreaterThan(1);
+  });
+
+  it("leaves rows that need nothing alone instead of rewriting them to themselves", async () => {
+    const world = createTableWorld({
+      nextly_versions: {
+        columns: ["id", "snapshot"],
+        rows: [
+          { id: id(0), snapshot: { _fieldGroupType: "hero" } },
+          { id: id(1), snapshot: { _componentType: "cta" } },
+          { id: id(2), snapshot: { title: "plain" } },
+        ],
+      },
+    });
+    await run(world);
+    // Exactly the one row that carried the old key.
+    expect(world.counts.updates).toBe(1);
+  });
+
+  it("is idempotent: a second pass writes nothing", async () => {
+    const world = versionsWorld();
+    await run(world);
+    const after = world.counts.updates;
+    await run(world);
+    expect(world.counts.updates).toBe(after);
+  });
+
+  it("records a position as it goes, and clears it when the table is done", async () => {
+    const world = versionsWorld();
+    await run(world);
+    expect(world.metaValue(batchCursorKey(STEP))).toBeUndefined();
+  });
+
+  // 🔴 The reason a position is worth recording: a resumed run must not re-read
+  // the whole ledger. Proven by leaving a row BEFORE the cursor still carrying
+  // the old key — a walk that ignored the cursor would rewrite it.
+  it("resumes from a recorded position rather than from the start", async () => {
+    const world = versionsWorld();
+    await writeBatchCursor(world.meta, {
+      migrationId: RUN,
+      stepId: STEP,
+      after: id(199),
+    });
+    await run(world);
+
+    const rows = world.rows("nextly_versions");
+    expect(rows[0]?.snapshot).toHaveProperty("_componentType");
+    expect(rows[ROW_COUNT - 1]?.snapshot).toHaveProperty("_fieldGroupType");
+  });
+
+  // 🔴 The cursor may lag and may never lead. A batch that fails rolls back, and
+  // the position must still name the last batch that actually committed —
+  // otherwise the next run steps over rows nothing rewrote.
+  it("does not advance the position past a batch that failed", async () => {
+    const world = versionsWorld({
+      onUpdate: (_table, rowId) => {
+        if (rowId === id(210)) throw new Error("statement refused");
+      },
+    });
+
+    await expect(run(world)).rejects.toThrow("statement refused");
+
+    expect(world.metaValue(batchCursorKey(STEP))).toEqual({
+      migrationId: RUN,
+      after: id(199),
+    });
+    // The failed batch left nothing behind either.
+    expect(world.rows("nextly_versions")[205]?.snapshot).toHaveProperty(
+      "_componentType"
+    );
+  });
+
+  it("finishes a run that a previous one left part-way", async () => {
+    const failing = versionsWorld({
+      onUpdate: (_table, rowId) => {
+        if (rowId === id(210)) throw new Error("statement refused");
+      },
+    });
+    await expect(run(failing)).rejects.toThrow("statement refused");
+
+    // Same world, no longer failing: a resume picks up from the recorded
+    // position and finishes the tail.
+    const resumed = createTableWorld({
+      nextly_versions: {
+        columns: ["id", "snapshot"],
+        rows: failing.rows("nextly_versions"),
+      },
+    });
+    await resumed.meta.set(batchCursorKey(STEP), {
+      migrationId: RUN,
+      after: id(199),
+    });
+    await run(resumed);
+
+    await expect(
+      findUnrewrittenRow({ session: resumed.session, target: TARGET, rewrite })
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("checking that a batched rewrite reached everything", () => {
+  it("reports nothing outstanding once the walk has run", async () => {
+    const world = versionsWorld();
+    await run(world);
+    await expect(
+      findUnrewrittenRow({ session: world.session, target: TARGET, rewrite })
+    ).resolves.toBeUndefined();
+  });
+
+  // 🔴 This is what makes the cursor an optimisation instead of a correctness
+  // mechanism. The walk has run to the end of the table and reported success;
+  // a row it did not cover must still be found, by rescanning rather than by
+  // trusting where the batches got to.
+  it("finds a row the walk never covered", async () => {
+    const world = versionsWorld();
+    await run(world);
+    world.insert("nextly_versions", {
+      id: id(999),
+      snapshot: { _componentType: "late" },
+    });
+
+    await expect(
+      findUnrewrittenRow({ session: world.session, target: TARGET, rewrite })
+    ).resolves.toBe(id(999));
+  });
+
+  it("looks past the first batch to find one", async () => {
+    const world = versionsWorld();
+    await run(world);
+    const rows = world.rows("nextly_versions");
+    const straggler = rows[ROW_COUNT - 1];
+    if (straggler === undefined) throw new Error("fixture has no rows");
+    straggler.snapshot = { _componentType: "missed" };
+
+    await expect(
+      findUnrewrittenRow({ session: world.session, target: TARGET, rewrite })
+    ).resolves.toBe(id(ROW_COUNT - 1));
+  });
+});
+
+describe("refusing a target this cannot rewrite honestly", () => {
+  // 🔴 A projection naming a property the table does not have comes back
+  // without the key. `rewrite(undefined)` returns `undefined`, so the walk
+  // writes nothing — and the postcondition, reading the same absent property,
+  // agrees there is nothing left to do. A silent no-op reporting success is the
+  // one outcome a data migration must not have.
+  it("refuses a document property the table does not carry", async () => {
+    const world = createTableWorld({
+      nextly_versions: {
+        columns: ["id", "payload"],
+        rows: [{ id: id(0), payload: { _componentType: "hero" } }],
+      },
+    });
+
+    await expect(run(world)).rejects.toMatchObject({
+      logContext: {
+        reason: "row rewrite target names a property the table does not have",
+        property: "snapshot",
+      },
+    });
+  });
+
+  it("refuses the same way when checking the postcondition", async () => {
+    const world = createTableWorld({
+      nextly_versions: {
+        columns: ["id", "payload"],
+        rows: [{ id: id(0), payload: { _componentType: "hero" } }],
+      },
+    });
+
+    await expect(
+      findUnrewrittenRow({ session: world.session, target: TARGET, rewrite })
+    ).rejects.toMatchObject({
+      logContext: {
+        reason: "row rewrite target names a property the table does not have",
+      },
+    });
+  });
+
+  // The walk orders by this value, carries it in the cursor, and addresses every
+  // write with it, so an id it cannot compare is not something to guess at.
+  it("refuses a primary key that is not a non-empty string", async () => {
+    const world = createTableWorld({
+      nextly_versions: {
+        columns: ["id", "snapshot"],
+        rows: [{ id: 7, snapshot: { _componentType: "hero" } }],
+      },
+    });
+
+    await expect(run(world)).rejects.toMatchObject({
+      logContext: {
+        reason: "row rewrite requires a non-empty string primary key",
+        table: "nextly_versions",
+      },
+    });
+  });
+});

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/rewrite-rows.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/rewrite-rows.test.ts
@@ -95,6 +95,17 @@ describe("rewriting a ledger's documents in batches", () => {
     expect(world.counts.updates).toBe(1);
   });
 
+  // 🔴 A plain SELECT takes no lock on Postgres or MySQL, so a writer can commit
+  // between the read and the write below - and because the whole document is
+  // written back, that edit is overwritten rather than merged. `nextly_versions`
+  // rewrites its coalesced autosave row in place, so the writer is real.
+  it("locks the rows it is about to rewrite", async () => {
+    const world = versionsWorld();
+    await run(world);
+    expect(world.reads).not.toHaveLength(0);
+    expect(world.reads.every(read => read.forUpdate)).toBe(true);
+  });
+
   it("is idempotent: a second pass writes nothing", async () => {
     const world = versionsWorld();
     await run(world);
@@ -200,6 +211,43 @@ describe("checking that a batched rewrite reached everything", () => {
     await expect(
       findUnrewrittenRow({ session: world.session, target: TARGET, rewrite })
     ).resolves.toBe(id(999));
+  });
+
+  // Read-only, so it takes no write locks: it establishes a fact rather than
+  // preparing a write, and locking a whole ledger for the length of a scan would
+  // block every writer to no purpose.
+  it("does not lock the rows it only checks", async () => {
+    const world = versionsWorld();
+    await findUnrewrittenRow({
+      session: world.session,
+      target: TARGET,
+      rewrite,
+    });
+    expect(world.reads).not.toHaveLength(0);
+    expect(world.reads.some(read => read.forUpdate)).toBe(false);
+  });
+
+  // 🔴 The boundary of what the rescan can promise, made executable so it is not
+  // mistaken for a guarantee. Ids are random, so a row inserted behind the point
+  // the scan has already passed sorts before the cursor and is never visited.
+  // No cursor closes this - a row lock does not prevent an insert - which is why
+  // the migration's precondition is that these ledgers are quiesced for the run.
+  it("cannot see a row inserted behind the point it has already passed", async () => {
+    const world = versionsWorld();
+    await run(world);
+    // Sorts before every existing id, so it lands behind any cursor position
+    // the scan reaches after its first batch.
+    world.insert("nextly_versions", {
+      id: "aaa-inserted-behind",
+      snapshot: { _componentType: "late" },
+    });
+
+    // Found only because the scan restarts from the beginning each time. The
+    // case that escapes is an insert DURING the scan, which no test can stage
+    // deterministically here and which quiescence is what actually prevents.
+    await expect(
+      findUnrewrittenRow({ session: world.session, target: TARGET, rewrite })
+    ).resolves.toBe("aaa-inserted-behind");
   });
 
   it("looks past the first batch to find one", async () => {

--- a/packages/nextly/src/domains/field-groups/migration/batch-cursor.ts
+++ b/packages/nextly/src/domains/field-groups/migration/batch-cursor.ts
@@ -1,0 +1,103 @@
+/**
+ * How far a batched row rewrite got, kept across a crash.
+ *
+ * A rewrite over a table that grows without bound cannot be one transaction, so
+ * it runs in batches; without a record of where it stopped, every resume would
+ * re-read the whole table from the start.
+ *
+ * This is deliberately weaker than the migration marker next to it, and the
+ * difference is the whole design. The marker is authoritative: an unreadable one
+ * refuses, because treating it as absent would restart work that may already
+ * have renamed objects. A cursor is an **optimisation**. Starting a batch
+ * rewrite from the beginning is always correct — the rewrite is idempotent and
+ * skips rows that no longer need it — so anything unexpected here resolves to
+ * "start over" rather than to a refusal that would strand a run over a value
+ * that cannot make it wrong.
+ *
+ * Two rules keep it from becoming load-bearing by accident:
+ *
+ * - It is written only **after** its batch has committed, so it can lag and can
+ *   never lead. A cursor that could commit while its batch rolled back would
+ *   skip rows silently, which is the one failure this must not have.
+ * - It carries the run that wrote it. A resume reuses the recorded migration id,
+ *   so matching on it accepts exactly the run that produced the cursor and
+ *   ignores one left behind by any other — including a run in the other
+ *   direction, whose position means the opposite thing.
+ *
+ * @module domains/field-groups/migration/batch-cursor
+ */
+
+import type { MetaService } from "../../meta/services/meta-service";
+
+/**
+ * Prefix for the `nextly_meta` key a step's cursor lives under.
+ *
+ * Namespaced beneath the marker's own key so an operator reading the table sees
+ * the two as one migration's state, and keyed by step so a position recorded for
+ * one step can never be read as another's.
+ */
+const CURSOR_KEY_PREFIX = "field_groups.storage_migration.cursor.";
+
+/** The `nextly_meta` key holding one step's cursor. */
+export function batchCursorKey(stepId: string): string {
+  return `${CURSOR_KEY_PREFIX}${stepId}`;
+}
+
+/** Stored shape. Read defensively: every field is untrusted on the way back in. */
+interface StoredCursor {
+  migrationId: string;
+  after: string;
+}
+
+/**
+ * Where this run's rewrite of this step stopped, or `null` to start over.
+ *
+ * `null` for an absent cursor, one written by a different run, and one that does
+ * not decode — all three mean the same thing to a caller, and none of them is an
+ * error worth refusing over.
+ */
+export async function readBatchCursor(
+  meta: MetaService,
+  args: { migrationId: string; stepId: string }
+): Promise<string | null> {
+  const value = await meta.get<unknown>(batchCursorKey(args.stepId));
+  if (typeof value !== "object" || value === null) return null;
+
+  const stored = value as Partial<StoredCursor>;
+  if (stored.migrationId !== args.migrationId) return null;
+  if (typeof stored.after !== "string" || stored.after.length === 0)
+    return null;
+  return stored.after;
+}
+
+/**
+ * Record the position a committed batch reached.
+ *
+ * Call only once the batch's transaction has committed. Writing it earlier would
+ * let the cursor survive a rolled-back batch and step the next run past rows
+ * that were never rewritten.
+ */
+export async function writeBatchCursor(
+  meta: MetaService,
+  args: { migrationId: string; stepId: string; after: string }
+): Promise<void> {
+  const cursor: StoredCursor = {
+    migrationId: args.migrationId,
+    after: args.after,
+  };
+  await meta.set(batchCursorKey(args.stepId), cursor);
+}
+
+/**
+ * Drop a finished step's cursor.
+ *
+ * Not required for correctness — a cursor past the end of a table selects
+ * nothing, and one from another run is ignored — but a step that completed
+ * should leave no state behind for an operator to interpret.
+ */
+export async function clearBatchCursor(
+  meta: MetaService,
+  args: { stepId: string }
+): Promise<void> {
+  await meta.delete(batchCursorKey(args.stepId));
+}

--- a/packages/nextly/src/domains/field-groups/migration/data-steps.ts
+++ b/packages/nextly/src/domains/field-groups/migration/data-steps.ts
@@ -45,10 +45,11 @@ import {
 import {
   documentDiffers,
   findUnrewrittenRow,
-  requireProperty,
-  requireRowId,
+  readProperty,
+  readRowId,
   rewriteRowsInBatches,
   whereRowId,
+  type Narrowed,
   type RowRewriteTarget,
 } from "./rewrite-rows";
 import type { MigrationStep } from "./runner";
@@ -182,29 +183,37 @@ function registryDefinitionsStep(
   return {
     id: "data:registry-definitions",
     async run(session) {
-      await session.inTransaction(async ctx => {
+      const outcome = await session.inTransaction(async ctx => {
         for (const table of DEFINITION_TABLES) {
           for (const row of await readRegistryRows(ctx, table)) {
             const patch = registryPatch(row, table, from, to);
-            if (patch === null) continue;
-            await ctx.update(
-              table,
-              patch,
-              whereRowId(requireRowId(row, table))
-            );
+            if (!patch.ok) return patch;
+            if (patch.value === null) continue;
+            const id = readRowId(row, table);
+            if (!id.ok) return id;
+            await ctx.update(table, patch.value, whereRowId(id.value));
           }
         }
+        return { ok: true as const };
       });
+      // Raised outside the transaction, because an error escaping a callback is
+      // reclassified by the adapter into an unknown database error and loses the
+      // context naming what could not be read.
+      if (!outcome.ok) throw outcome.refusal;
     },
     async verify(session) {
-      return session.inTransaction(async ctx => {
+      const outcome = await session.inTransaction(async ctx => {
         for (const table of DEFINITION_TABLES) {
           for (const row of await readRegistryRows(ctx, table)) {
-            if (registryPatch(row, table, from, to) !== null) return false;
+            const patch = registryPatch(row, table, from, to);
+            if (!patch.ok) return patch;
+            if (patch.value !== null) return { ok: true as const, done: false };
           }
         }
-        return true;
+        return { ok: true as const, done: true };
       });
+      if (!outcome.ok) throw outcome.refusal;
+      return outcome.done;
     },
   };
 }
@@ -239,16 +248,17 @@ function registryPatch(
   table: string,
   from: FieldGroupStorageVocabulary,
   to: FieldGroupStorageVocabulary
-): Record<string, unknown> | null {
+): Narrowed<Record<string, unknown> | null> {
   const patch: Record<string, unknown> = {};
 
-  const fields = requireProperty(row, { table, property: FIELDS_PROPERTY });
+  const fields = readProperty(row, { table, property: FIELDS_PROPERTY });
+  if (!fields.ok) return fields;
   const rewrittenFields = rewriteFieldDefinitions(
-    fields,
+    fields.value,
     from.fields,
     to.fields
   );
-  if (documentDiffers(fields, rewrittenFields)) {
+  if (documentDiffers(fields.value, rewrittenFields)) {
     patch[FIELDS_PROPERTY] = rewrittenFields;
   }
 
@@ -256,21 +266,22 @@ function registryPatch(
   // A collection's `config_path` names `collections/`, and rewriting it would be
   // renaming a directory this migration has nothing to do with.
   if (table === STORAGE_FORMAT.registryTable) {
-    const configPath = requireProperty(row, {
+    const configPath = readProperty(row, {
       table,
       property: CONFIG_PATH_PROPERTY,
     });
+    if (!configPath.ok) return configPath;
     const rewrittenPath = rewriteConfigPath(
-      configPath,
+      configPath.value,
       from.configPathDir,
       to.configPathDir
     );
-    if (documentDiffers(configPath, rewrittenPath)) {
+    if (documentDiffers(configPath.value, rewrittenPath)) {
       patch[CONFIG_PATH_PROPERTY] = rewrittenPath;
     }
   }
 
-  return Object.keys(patch).length === 0 ? null : patch;
+  return { ok: true, value: Object.keys(patch).length === 0 ? null : patch };
 }
 
 /**

--- a/packages/nextly/src/domains/field-groups/migration/data-steps.ts
+++ b/packages/nextly/src/domains/field-groups/migration/data-steps.ts
@@ -1,0 +1,374 @@
+/**
+ * Turns the field-group vocabulary rewrites into migration steps.
+ *
+ * These steps move what is *inside* rows; `steps.ts` moves the tables and
+ * columns the rows live in. They are built separately because the two are
+ * different work with different guarantees — a rename is DDL and is only atomic
+ * on two of the three dialects, while every rewrite here is ordinary DML and
+ * commits or does not.
+ *
+ * 🔴 **These steps run before any rename, in both directions.** That is not a
+ * preference. The adapter's typed CRUD resolves a table through the schema
+ * registry and refuses any name the ORM does not declare, and the field-group
+ * registry is declared under its legacy name — so it is reachable through that
+ * path only while it still carries it. Going through the ORM is what makes the
+ * driver's JSON encoding the ORM's problem rather than this module's: the same
+ * column is `jsonb` on Postgres, `json` on MySQL and text-with-a-json-mode on
+ * SQLite, and two of the three hand back an object where the third hands back a
+ * string. Ordering the plan so that never has to be discovered here is worth
+ * more than the freedom to put these steps anywhere.
+ *
+ * Inverting the plan puts them last on the way down, by which point the renames
+ * have restored the names they address. So the same rule holds in both
+ * directions, and no step here has to work out which name a table is currently
+ * under.
+ *
+ * @module domains/field-groups/migration/data-steps
+ */
+
+import type {
+  TransactionContext,
+  WhereClause,
+} from "@nextlyhq/adapter-drizzle/types";
+
+import { NextlyError } from "../../../errors/nextly-error";
+import { STORAGE_FORMAT } from "../../../schemas/storage-format";
+import type { MetaService } from "../../meta/services/meta-service";
+
+import { MIGRATION_TARGET } from "./manifest";
+import { rewriteConfigPath } from "./rewrite-config-path";
+import { rewriteContentKey } from "./rewrite-content-key";
+import {
+  rewriteFieldDefinitions,
+  type FieldGroupVocabulary,
+} from "./rewrite-field-definitions";
+import {
+  documentDiffers,
+  findUnrewrittenRow,
+  requireProperty,
+  requireRowId,
+  rewriteRowsInBatches,
+  whereRowId,
+  type RowRewriteTarget,
+} from "./rewrite-rows";
+import type { MigrationStep } from "./runner";
+
+/**
+ * Every spelling of the field-group concept that is stored inside a row.
+ *
+ * One object rather than loose arguments so a direction is a single value: a
+ * rollback passes the same pair the other way round, and no caller can swap one
+ * half of a vocabulary while leaving the rest.
+ */
+export interface FieldGroupStorageVocabulary {
+  /** Leading directory segment of a registry row's `config_path`. */
+  readonly configPathDir: string;
+  /** How a stored field definition spells a field-group field. */
+  readonly fields: FieldGroupVocabulary;
+  /** The key a dynamic-zone instance announces its type under, once it is JSON. */
+  readonly wireTypeKey: string;
+  /** The `scope_kind` a schema event carries when it concerns a field group. */
+  readonly schemaEventScope: string;
+}
+
+/** What deployed databases spell today. */
+export const LEGACY_STORAGE_VOCABULARY: FieldGroupStorageVocabulary = {
+  configPathDir: STORAGE_FORMAT.configPathDir,
+  fields: {
+    fieldType: STORAGE_FORMAT.fieldType,
+    refKeys: STORAGE_FORMAT.refKeys,
+  },
+  wireTypeKey: STORAGE_FORMAT.wireTypeKey,
+  schemaEventScope: STORAGE_FORMAT.schemaEventScope,
+};
+
+/**
+ * What they spell afterwards.
+ *
+ * `refKeys` carries no legacy spelling, which is what retires that key rather
+ * than renaming it: rows holding it are normalised onto the canonical one, and
+ * a rollback has none to put back because nothing ever wrote it.
+ */
+export const FIELD_GROUP_STORAGE_VOCABULARY: FieldGroupStorageVocabulary = {
+  configPathDir: MIGRATION_TARGET.configPathDir,
+  fields: {
+    fieldType: MIGRATION_TARGET.fieldType,
+    refKeys: MIGRATION_TARGET.refKeys,
+  },
+  wireTypeKey: MIGRATION_TARGET.wireTypeKey,
+  schemaEventScope: MIGRATION_TARGET.schemaEventScope,
+};
+
+/**
+ * Registry tables holding stored field definitions.
+ *
+ * Spelled here rather than taken from `STORAGE_FORMAT`, because only one of them
+ * names the field-group concept. The other two are collection and single
+ * storage, and they hold field-group *references* inside their own definitions —
+ * which is exactly why they have to be rewritten too, and why they do not move
+ * when the concept is renamed.
+ */
+const DEFINITION_TABLES = [
+  "dynamic_collections",
+  "dynamic_singles",
+  STORAGE_FORMAT.registryTable,
+] as const;
+
+/** Property holding a registry row's stored field definitions. */
+const FIELDS_PROPERTY = "fields";
+
+/** Property holding a registry row's source-file path. */
+const CONFIG_PATH_PROPERTY = "configPath";
+
+/** The schema-event ledger, and the property naming what an event was about. */
+const SCHEMA_EVENTS_TABLE = "nextly_schema_events";
+const SCOPE_KIND_PROPERTY = "scopeKind";
+
+/**
+ * Ledgers carrying the wire key inside a stored document.
+ *
+ * Both grow with a site's activity rather than with its schema, so both are
+ * walked in batches. `nextly_events` was planned as small and bounded; it is a
+ * ledger under a retention window exactly like `nextly_versions`, and sizing one
+ * for growth but not the other would be a guess about which fills up first.
+ */
+const CONTENT_TARGETS: readonly RowRewriteTarget[] = [
+  { table: "nextly_versions", documentProperty: "snapshot" },
+  { table: "nextly_events", documentProperty: "payload" },
+];
+
+/**
+ * Build the steps that rewrite stored vocabulary, in canonical order.
+ *
+ * Direction is which vocabulary is passed as which argument. A rollback is this
+ * call with the two exchanged, and the resulting steps reversed along with the
+ * rest of the plan.
+ */
+export function buildDataMigrationSteps(args: {
+  meta: MetaService;
+  migrationId: string;
+  from: FieldGroupStorageVocabulary;
+  to: FieldGroupStorageVocabulary;
+}): MigrationStep[] {
+  const { meta, migrationId, from, to } = args;
+
+  return [
+    registryDefinitionsStep(from, to),
+    schemaEventScopeStep(from, to),
+    ...CONTENT_TARGETS.map(target =>
+      contentStep({ meta, migrationId, target, from, to })
+    ),
+  ];
+}
+
+/**
+ * Rewrite the vocabulary stored in registry rows.
+ *
+ * One step over all three registries, in one transaction, deliberately not
+ * batched. The runtime builds its schema from these rows, so a half-rewritten
+ * set is not partial progress — it is a database whose entities disagree about
+ * what a field group is. The set is bounded by how many collections, singles and
+ * field groups a project declares, which is the one thing here that does not
+ * grow with use.
+ *
+ * `config_path` travels with it because it is a second spelling on the same rows
+ * of the same registry: splitting them would mean reading those rows twice to
+ * write two columns that are only ever wrong together.
+ */
+function registryDefinitionsStep(
+  from: FieldGroupStorageVocabulary,
+  to: FieldGroupStorageVocabulary
+): MigrationStep {
+  return {
+    id: "data:registry-definitions",
+    async run(session) {
+      await session.inTransaction(async ctx => {
+        for (const table of DEFINITION_TABLES) {
+          for (const row of await readRegistryRows(ctx, table)) {
+            const patch = registryPatch(row, table, from, to);
+            if (patch === null) continue;
+            await ctx.update(
+              table,
+              patch,
+              whereRowId(requireRowId(row, table))
+            );
+          }
+        }
+      });
+    },
+    async verify(session) {
+      return session.inTransaction(async ctx => {
+        for (const table of DEFINITION_TABLES) {
+          for (const row of await readRegistryRows(ctx, table)) {
+            if (registryPatch(row, table, from, to) !== null) return false;
+          }
+        }
+        return true;
+      });
+    },
+  };
+}
+
+/**
+ * Read one registry's rows, projecting only what is rewritten here.
+ *
+ * `config_path` is projected for every registry even though only the field-group
+ * one names the field-group directory. All three declare the column, and asking
+ * for it uniformly is what lets `registryPatch` decide by table rather than by
+ * which columns happen to have arrived.
+ */
+async function readRegistryRows(
+  ctx: TransactionContext,
+  table: string
+): Promise<Record<string, unknown>[]> {
+  return ctx.select<Record<string, unknown>>(table, {
+    columns: ["id", FIELDS_PROPERTY, CONFIG_PATH_PROPERTY],
+  });
+}
+
+/**
+ * What one registry row must be updated to, or `null` when it is already right.
+ *
+ * The same function decides what `run` writes and what `verify` looks for, so
+ * the two cannot disagree about whether a row still needs work — a step that
+ * ran and then failed its own postcondition is what two implementations of this
+ * question would eventually produce.
+ */
+function registryPatch(
+  row: Record<string, unknown>,
+  table: string,
+  from: FieldGroupStorageVocabulary,
+  to: FieldGroupStorageVocabulary
+): Record<string, unknown> | null {
+  const patch: Record<string, unknown> = {};
+
+  const fields = requireProperty(row, { table, property: FIELDS_PROPERTY });
+  const rewrittenFields = rewriteFieldDefinitions(
+    fields,
+    from.fields,
+    to.fields
+  );
+  if (documentDiffers(fields, rewrittenFields)) {
+    patch[FIELDS_PROPERTY] = rewrittenFields;
+  }
+
+  // Only the field-group registry records a path under the renamed directory.
+  // A collection's `config_path` names `collections/`, and rewriting it would be
+  // renaming a directory this migration has nothing to do with.
+  if (table === STORAGE_FORMAT.registryTable) {
+    const configPath = requireProperty(row, {
+      table,
+      property: CONFIG_PATH_PROPERTY,
+    });
+    const rewrittenPath = rewriteConfigPath(
+      configPath,
+      from.configPathDir,
+      to.configPathDir
+    );
+    if (documentDiffers(configPath, rewrittenPath)) {
+      patch[CONFIG_PATH_PROPERTY] = rewrittenPath;
+    }
+  }
+
+  return Object.keys(patch).length === 0 ? null : patch;
+}
+
+/**
+ * Rewrite the scope a schema event records.
+ *
+ * The one value in this migration that is a whole column rather than something
+ * inside a document, so it is a single conditional update rather than a
+ * read-modify-write. Exact equality, not a pattern: the column also holds
+ * `collection`, `single`, `core` and `global`, and only one of those is the word
+ * being renamed.
+ */
+function schemaEventScopeStep(
+  from: FieldGroupStorageVocabulary,
+  to: FieldGroupStorageVocabulary
+): MigrationStep {
+  const stale: WhereClause = {
+    and: [
+      { column: SCOPE_KIND_PROPERTY, op: "=", value: from.schemaEventScope },
+    ],
+  };
+
+  return {
+    id: "data:schema-event-scope",
+    async run(session) {
+      await session.inTransaction(async ctx => {
+        await ctx.update(
+          SCHEMA_EVENTS_TABLE,
+          { [SCOPE_KIND_PROPERTY]: to.schemaEventScope },
+          stale
+        );
+      });
+    },
+    async verify(session) {
+      return session.inTransaction(async ctx => {
+        // Asks for one row rather than a count: the question is whether any
+        // remain, and a single row answers it without reading the ledger.
+        const remaining = await ctx.select<Record<string, unknown>>(
+          SCHEMA_EVENTS_TABLE,
+          { columns: ["id"], where: stale, limit: 1 }
+        );
+        return remaining.length === 0;
+      });
+    },
+  };
+}
+
+/**
+ * Rewrite the wire key inside one ledger's stored documents.
+ *
+ * Batched and checkpointed, because these are the tables whose size follows a
+ * site's history. `verify` rescans the whole table rather than trusting where
+ * the batches got to, which is what keeps the checkpoint an optimisation: a
+ * cursor that was wrong fails the step instead of passing one that skipped rows.
+ */
+function contentStep(args: {
+  meta: MetaService;
+  migrationId: string;
+  target: RowRewriteTarget;
+  from: FieldGroupStorageVocabulary;
+  to: FieldGroupStorageVocabulary;
+}): MigrationStep {
+  const { meta, migrationId, target, from, to } = args;
+  const stepId = `data:${target.table}.${target.documentProperty}`;
+  const rewrite = (document: unknown): unknown =>
+    rewriteContentKey(document, from.wireTypeKey, to.wireTypeKey);
+
+  return {
+    id: stepId,
+    async run(session) {
+      await rewriteRowsInBatches({
+        session,
+        meta,
+        migrationId,
+        stepId,
+        target,
+        rewrite,
+      });
+    },
+    async verify(session) {
+      const unrewritten = await findUnrewrittenRow({
+        session,
+        target,
+        rewrite,
+      });
+      if (unrewritten === undefined) return true;
+      // Named rather than merely reported false. A row the walk did not reach is
+      // not "not finished yet" — the walk ran to the end of the table — so an
+      // operator needs the row to look at, and a retry needs to be understood as
+      // a retry of something that already claimed to be done.
+      throw NextlyError.serviceUnavailable({
+        logMessage: `field-group migration left a row carrying the old vocabulary: ${target.table}`,
+        logContext: {
+          reason: "row rewrite did not reach every row",
+          table: target.table,
+          property: target.documentProperty,
+          row: unrewritten,
+        },
+      });
+    },
+  };
+}

--- a/packages/nextly/src/domains/field-groups/migration/data-steps.ts
+++ b/packages/nextly/src/domains/field-groups/migration/data-steps.ts
@@ -115,6 +115,9 @@ const DEFINITION_TABLES = [
   STORAGE_FORMAT.registryTable,
 ] as const;
 
+/** The columns one registry row needs written back. */
+type Patch = Record<string, unknown>;
+
 /** Property holding a registry row's stored field definitions. */
 const FIELDS_PROPERTY = "fields";
 
@@ -184,6 +187,14 @@ function registryDefinitionsStep(
     id: "data:registry-definitions",
     async run(session) {
       const outcome = await session.inTransaction(async ctx => {
+        // Every patch is computed before any of them is issued. A refusal has
+        // to leave the transaction as a value rather than as an exception —
+        // the adapter reclassifies anything thrown out of a callback and
+        // discards the context naming what could not be read — and a value
+        // returned from the callback COMMITS. Staging first is what keeps that
+        // from committing the rows already rewritten and leaving exactly the
+        // mixed-vocabulary registry set this step exists to prevent.
+        const staged: { table: string; id: string; patch: Patch }[] = [];
         for (const table of DEFINITION_TABLES) {
           for (const row of await readRegistryRows(ctx, table)) {
             const patch = registryPatch(row, table, from, to);
@@ -191,14 +202,14 @@ function registryDefinitionsStep(
             if (patch.value === null) continue;
             const id = readRowId(row, table);
             if (!id.ok) return id;
-            await ctx.update(table, patch.value, whereRowId(id.value));
+            staged.push({ table, id: id.value, patch: patch.value });
           }
+        }
+        for (const write of staged) {
+          await ctx.update(write.table, write.patch, whereRowId(write.id));
         }
         return { ok: true as const };
       });
-      // Raised outside the transaction, because an error escaping a callback is
-      // reclassified by the adapter into an unknown database error and loses the
-      // context naming what could not be read.
       if (!outcome.ok) throw outcome.refusal;
     },
     async verify(session) {
@@ -225,6 +236,11 @@ function registryDefinitionsStep(
  * one names the field-group directory. All three declare the column, and asking
  * for it uniformly is what lets `registryPatch` decide by table rather than by
  * which columns happen to have arrived.
+ *
+ * Locked, for the same reason the ledger walk locks: a plain `SELECT` takes no
+ * lock on Postgres or MySQL, and the update writes the whole `fields` document
+ * back, so a schema save committing in between would be overwritten rather than
+ * merged — a silently lost schema change.
  */
 async function readRegistryRows(
   ctx: TransactionContext,
@@ -232,6 +248,7 @@ async function readRegistryRows(
 ): Promise<Record<string, unknown>[]> {
   return ctx.select<Record<string, unknown>>(table, {
     columns: ["id", FIELDS_PROPERTY, CONFIG_PATH_PROPERTY],
+    forUpdate: true,
   });
 }
 
@@ -248,8 +265,8 @@ function registryPatch(
   table: string,
   from: FieldGroupStorageVocabulary,
   to: FieldGroupStorageVocabulary
-): Narrowed<Record<string, unknown> | null> {
-  const patch: Record<string, unknown> = {};
+): Narrowed<Patch | null> {
+  const patch: Patch = {};
 
   const fields = readProperty(row, { table, property: FIELDS_PROPERTY });
   if (!fields.ok) return fields;

--- a/packages/nextly/src/domains/field-groups/migration/manifest.ts
+++ b/packages/nextly/src/domains/field-groups/migration/manifest.ts
@@ -26,6 +26,12 @@ import { normalizeIdentifier } from "../../singles/services/resolve-single-table
 /**
  * The names storage moves to.
  *
+ * Every entry is the counterpart of a `STORAGE_FORMAT` value, and the two files
+ * are read together: `STORAGE_FORMAT` is what a database says today, this is
+ * what it says afterwards. Keeping the pairs in one place is what lets a plan
+ * and the rewrite that applies it be checked against each other rather than
+ * matched by eye.
+ *
  * `dynamic_field_groups` is parallel to `dynamic_collections` and
  * `dynamic_singles`. `fg_` is deliberately shorter than the prefix it replaces,
  * so no name that fits an identifier limit today can overflow one by migrating.
@@ -34,6 +40,38 @@ export const MIGRATION_TARGET = {
   registryTable: "dynamic_field_groups",
   tablePrefix: "fg_",
   columnType: "_field_group_type",
+
+  /** Directory segment a registry row's `config_path` records. */
+  configPathDir: "field-groups",
+
+  /** Discriminator a stored field definition's `type` carries. */
+  fieldType: "fieldGroup",
+
+  /**
+   * The key a dynamic-zone instance announces its type under once it is JSON.
+   *
+   * Read by user application code out of a dynamic zone, so this is a public
+   * contract and not only an on-disk one. It pairs with `columnType`: the same
+   * value, spelled for the database and spelled for the wire.
+   */
+  wireTypeKey: "_fieldGroupType",
+
+  /**
+   * Property names a stored field definition uses to reference a field group.
+   *
+   * There is no counterpart to `STORAGE_FORMAT.refKeys.legacy`, deliberately.
+   * That spelling is read-only compatibility — nothing writes it — so renaming
+   * it would mint a fresh obsolete key that nothing writes either. Rows
+   * carrying it are normalised onto `single` instead, which retires the concept
+   * rather than translating it.
+   */
+  refKeys: {
+    single: "fieldGroup",
+    many: "fieldGroups",
+  },
+
+  /** Scope kind a schema event carries when it concerns a field group. */
+  schemaEventScope: "fieldGroup",
 } as const;
 
 /** A registry row, as far as the migration is concerned. */

--- a/packages/nextly/src/domains/field-groups/migration/rewrite-config-path.ts
+++ b/packages/nextly/src/domains/field-groups/migration/rewrite-config-path.ts
@@ -1,0 +1,32 @@
+/**
+ * Rewrites the directory segment a registry row's `config_path` records.
+ *
+ * The value is composed as `<dir>/<slug>.ts`, so the segment being renamed is
+ * always the leading one. That is what makes this safe to do by string: the
+ * rewrite is anchored to the start and to a following separator, so a project
+ * directory legitimately called `my-components/` is untouched, and so is a
+ * `components/` appearing deeper in a path.
+ *
+ * A value that does not start with the segment is returned unchanged rather
+ * than repaired. This runs over rows written by older versions, and a path this
+ * module does not recognise is one it has no business reshaping.
+ *
+ * @module domains/field-groups/migration/rewrite-config-path
+ */
+
+/**
+ * Swap a leading directory segment.
+ *
+ * Direction is the argument order, so a rollback is the same call with `from`
+ * and `to` exchanged.
+ */
+export function rewriteConfigPath(
+  value: unknown,
+  from: string,
+  to: string
+): unknown {
+  if (typeof value !== "string") return value;
+  const prefix = `${from}/`;
+  if (!value.startsWith(prefix)) return value;
+  return `${to}/${value.slice(prefix.length)}`;
+}

--- a/packages/nextly/src/domains/field-groups/migration/rewrite-content-key.ts
+++ b/packages/nextly/src/domains/field-groups/migration/rewrite-content-key.ts
@@ -1,0 +1,62 @@
+/**
+ * Renames the key a dynamic-zone instance announces its type under, inside a
+ * stored content document.
+ *
+ * This is a different problem from rewriting a field *definition*, and the two
+ * are deliberately not one function. A definition is a structure this codebase
+ * authored, so it can be walked by node kind and every rewrite anchored to a
+ * node already identified as a field group. A content document is the author's
+ * data: an entry snapshot or a webhook envelope, whose shape is whatever their
+ * fields produced. There is no definition tree to steer by.
+ *
+ * Nor can the entry's *current* field definitions steer it. A snapshot was
+ * written under the schema of its day, so a field since deleted or retyped has
+ * no definition to guide a walk — and those are precisely the oldest documents,
+ * the ones a rename most needs to reach. A guided walk would leave them behind
+ * while reporting success.
+ *
+ * So this targets the key itself, everywhere in the document. The exposure is
+ * an author's own JSON holding a key of the same name; the key is underscore
+ * prefixed and reserved by the storage format, which is what makes that
+ * acceptable rather than merely unlikely.
+ *
+ * @module domains/field-groups/migration/rewrite-content-key
+ */
+
+/**
+ * Rename one key throughout a JSON document.
+ *
+ * Returns a new structure and leaves the input untouched, so a caller writes
+ * back only when the whole document rewrote cleanly.
+ *
+ * Direction is the argument order, so a rollback is this call with `from` and
+ * `to` exchanged.
+ */
+export function rewriteContentKey(
+  document: unknown,
+  from: string,
+  to: string
+): unknown {
+  if (Array.isArray(document)) {
+    return document.map(entry => rewriteContentKey(entry, from, to));
+  }
+  if (!isRecord(document)) return document;
+
+  const rewritten: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(document)) {
+    // Rebuilt in place rather than deleted and reappended, so the renamed key
+    // keeps its position. A snapshot is read by humans when a restore is being
+    // judged, and reordering every instance would be a large meaningless diff.
+    const name = key === from ? to : key;
+    // A document already carrying the target key keeps what is there rather
+    // than being overwritten by a stale one. Nothing writes both today; this
+    // decides the collision rather than leaving it to key order.
+    if (name === to && key !== to && to in document) continue;
+    rewritten[name] = rewriteContentKey(value, from, to);
+  }
+  return rewritten;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/nextly/src/domains/field-groups/migration/rewrite-content-key.ts
+++ b/packages/nextly/src/domains/field-groups/migration/rewrite-content-key.ts
@@ -15,10 +15,20 @@
  * the ones a rename most needs to reach. A guided walk would leave them behind
  * while reporting success.
  *
- * So this targets the key itself, everywhere in the document. The exposure is
- * an author's own JSON holding a key of the same name; the key is underscore
- * prefixed and reserved by the storage format, which is what makes that
- * acceptable rather than merely unlikely.
+ * So this targets the key itself, everywhere in the document, and the exposure
+ * is real rather than hypothetical: a `json` field accepts anything JSON can
+ * represent and nothing more (`shared/lib/entry-validation.ts:561-575`), so an
+ * author's own object holding this key is valid content and would be renamed
+ * with the rest. The key is underscore-prefixed and documented as belonging to
+ * the storage format, but that is a convention here, not something enforced.
+ *
+ * It is accepted rather than solved because the alternative is worse. Guiding
+ * the walk by the entry's field definitions would skip exactly the rows a
+ * complete rename most needs to reach, for the reason above, while reporting
+ * success — a silent partial rename is a worse failure than a rare collision
+ * that is visible in the data. The trade is recorded in
+ * `tasks/011-B1-4-DESIGN.md` §0.1, and it rests on there being no production
+ * data yet.
  *
  * @module domains/field-groups/migration/rewrite-content-key
  */

--- a/packages/nextly/src/domains/field-groups/migration/rewrite-content-key.ts
+++ b/packages/nextly/src/domains/field-groups/migration/rewrite-content-key.ts
@@ -23,6 +23,8 @@
  * @module domains/field-groups/migration/rewrite-content-key
  */
 
+import { setOwnProperty } from "./set-own-property";
+
 /**
  * Rename one key throughout a JSON document.
  *
@@ -52,7 +54,7 @@ export function rewriteContentKey(
     // than being overwritten by a stale one. Nothing writes both today; this
     // decides the collision rather than leaving it to key order.
     if (name === to && key !== to && to in document) continue;
-    rewritten[name] = rewriteContentKey(value, from, to);
+    setOwnProperty(rewritten, name, rewriteContentKey(value, from, to));
   }
   return rewritten;
 }

--- a/packages/nextly/src/domains/field-groups/migration/rewrite-content-key.ts
+++ b/packages/nextly/src/domains/field-groups/migration/rewrite-content-key.ts
@@ -26,9 +26,7 @@
  * the walk by the entry's field definitions would skip exactly the rows a
  * complete rename most needs to reach, for the reason above, while reporting
  * success — a silent partial rename is a worse failure than a rare collision
- * that is visible in the data. The trade is recorded in
- * `tasks/011-B1-4-DESIGN.md` §0.1, and it rests on there being no production
- * data yet.
+ * that is visible in the data.
  *
  * @module domains/field-groups/migration/rewrite-content-key
  */

--- a/packages/nextly/src/domains/field-groups/migration/rewrite-field-definitions.ts
+++ b/packages/nextly/src/domains/field-groups/migration/rewrite-field-definitions.ts
@@ -118,8 +118,14 @@ function rewriteField(
     ) {
       // Normalised onto the canonical key, not renamed. A node carrying both
       // keeps the canonical value: the legacy one predates it, so the newer
-      // spelling is the one that was written deliberately.
-      if (!(from.refKeys.single in field)) {
+      // spelling is the one that was written deliberately. That holds for the
+      // canonical key in either vocabulary — the source spelling, which this
+      // node may still carry, and the target spelling, which is where the value
+      // is headed and which the source-key branches above equally protect.
+      if (
+        !(from.refKeys.single in field) &&
+        !keptUnderTarget(field, key, to.refKeys.single)
+      ) {
         setOwnProperty(rewritten, to.refKeys.single, value);
       }
       continue;

--- a/packages/nextly/src/domains/field-groups/migration/rewrite-field-definitions.ts
+++ b/packages/nextly/src/domains/field-groups/migration/rewrite-field-definitions.ts
@@ -19,6 +19,8 @@
  * @module domains/field-groups/migration/rewrite-field-definitions
  */
 
+import { setOwnProperty } from "./set-own-property";
+
 /**
  * The field types whose definitions nest further field definitions.
  *
@@ -88,15 +90,15 @@ function rewriteField(
   // be a large, meaningless change on top of a small meaningful one.
   for (const [key, value] of Object.entries(field)) {
     if (isFieldGroup && key === "type") {
-      rewritten[key] = to.fieldType;
+      setOwnProperty(rewritten, key, to.fieldType);
       continue;
     }
     if (isFieldGroup && key === from.refKeys.single) {
-      rewritten[to.refKeys.single] = value;
+      setOwnProperty(rewritten, to.refKeys.single, value);
       continue;
     }
     if (isFieldGroup && key === from.refKeys.many) {
-      rewritten[to.refKeys.many] = value;
+      setOwnProperty(rewritten, to.refKeys.many, value);
       continue;
     }
     if (
@@ -108,15 +110,15 @@ function rewriteField(
       // keeps the canonical value: the legacy one predates it, so the newer
       // spelling is the one that was written deliberately.
       if (!(from.refKeys.single in field)) {
-        rewritten[to.refKeys.single] = value;
+        setOwnProperty(rewritten, to.refKeys.single, value);
       }
       continue;
     }
     if (key === "fields" && isContainer(field.type)) {
-      rewritten[key] = rewriteFieldDefinitions(value, from, to);
+      setOwnProperty(rewritten, key, rewriteFieldDefinitions(value, from, to));
       continue;
     }
-    rewritten[key] = value;
+    setOwnProperty(rewritten, key, value);
   }
 
   return rewritten;

--- a/packages/nextly/src/domains/field-groups/migration/rewrite-field-definitions.ts
+++ b/packages/nextly/src/domains/field-groups/migration/rewrite-field-definitions.ts
@@ -1,0 +1,131 @@
+/**
+ * Rewrites the field-group vocabulary inside a stored field definition list.
+ *
+ * These definitions are not history: the runtime builds its schema from them, so
+ * a spelling left behind here is a live definition the code can no longer read.
+ * They are also the place where a careless rewrite does the most damage, because
+ * the same word means two different things depending on where it sits:
+ *
+ * - `component` is the **value** of `type` on a field-group field, and
+ * - `component` is also a **property name** on that same node, naming which
+ *   field group it points at.
+ *
+ * So a rewrite keyed on strings, or on property names without checking the node
+ * they belong to, corrupts author schema: a user may legitimately have named
+ * their own field `components`, or stored the string `component` inside a
+ * default value. Every rule below is therefore anchored to a node this module
+ * has already identified as a field-group field.
+ *
+ * @module domains/field-groups/migration/rewrite-field-definitions
+ */
+
+/**
+ * The field types whose definitions nest further field definitions.
+ *
+ * Only these two containers hold a field list. A plugin field type is
+ * open-ended and may carry its own `fields` option as private configuration, so
+ * descending into `fields` on any other type would run these rules over data
+ * that is not a field list at all. This mirrors the same rule the payload
+ * validator applies when it walks declarations.
+ */
+const CONTAINER_FIELD_TYPES: ReadonlySet<string> = new Set([
+  "repeater",
+  "group",
+]);
+
+/** One side of the rename: how a vocabulary spells a field-group field. */
+export interface FieldGroupVocabulary {
+  /** The value a field-group field's `type` carries. */
+  readonly fieldType: string;
+  readonly refKeys: {
+    /** Property naming the one field group an embedded field points at. */
+    readonly single: string;
+    /** Property listing the field groups a dynamic zone accepts. */
+    readonly many: string;
+    /**
+     * A read-only compatibility spelling of `single`, if this vocabulary has
+     * one. Rows carrying it are normalised onto `single` rather than translated,
+     * which retires the concept instead of giving it a new name.
+     */
+    readonly legacy?: string;
+  };
+}
+
+/**
+ * Rewrite every field-group field in a stored definition list.
+ *
+ * Returns a new structure; the input is not mutated, because the caller writes
+ * the result back only if the whole document rewrote cleanly.
+ *
+ * Direction is expressed by which vocabulary is passed as which argument, so a
+ * rollback is this function with the arguments swapped rather than a second
+ * implementation. The one asymmetry is deliberate: `legacy` is normalised away
+ * going forward and never reintroduced going back, because nothing wrote it in
+ * the first place and a rollback that minted it would be inventing history.
+ */
+export function rewriteFieldDefinitions(
+  fields: unknown,
+  from: FieldGroupVocabulary,
+  to: FieldGroupVocabulary
+): unknown {
+  if (!Array.isArray(fields)) return fields;
+  return fields.map(field => rewriteField(field, from, to));
+}
+
+function rewriteField(
+  field: unknown,
+  from: FieldGroupVocabulary,
+  to: FieldGroupVocabulary
+): unknown {
+  if (!isRecord(field)) return field;
+
+  const isFieldGroup = field.type === from.fieldType;
+  const rewritten: Record<string, unknown> = {};
+
+  // Rebuilt key by key rather than deleted-and-reassigned, so a renamed
+  // property keeps its position. Stored JSON is read by humans in the Schema
+  // Builder and diffed in review; reordering every field-group definition would
+  // be a large, meaningless change on top of a small meaningful one.
+  for (const [key, value] of Object.entries(field)) {
+    if (isFieldGroup && key === "type") {
+      rewritten[key] = to.fieldType;
+      continue;
+    }
+    if (isFieldGroup && key === from.refKeys.single) {
+      rewritten[to.refKeys.single] = value;
+      continue;
+    }
+    if (isFieldGroup && key === from.refKeys.many) {
+      rewritten[to.refKeys.many] = value;
+      continue;
+    }
+    if (
+      isFieldGroup &&
+      from.refKeys.legacy !== undefined &&
+      key === from.refKeys.legacy
+    ) {
+      // Normalised onto the canonical key, not renamed. A node carrying both
+      // keeps the canonical value: the legacy one predates it, so the newer
+      // spelling is the one that was written deliberately.
+      if (!(from.refKeys.single in field)) {
+        rewritten[to.refKeys.single] = value;
+      }
+      continue;
+    }
+    if (key === "fields" && isContainer(field.type)) {
+      rewritten[key] = rewriteFieldDefinitions(value, from, to);
+      continue;
+    }
+    rewritten[key] = value;
+  }
+
+  return rewritten;
+}
+
+function isContainer(type: unknown): boolean {
+  return typeof type === "string" && CONTAINER_FIELD_TYPES.has(type);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/nextly/src/domains/field-groups/migration/rewrite-field-definitions.ts
+++ b/packages/nextly/src/domains/field-groups/migration/rewrite-field-definitions.ts
@@ -93,12 +93,22 @@ function rewriteField(
       setOwnProperty(rewritten, key, to.fieldType);
       continue;
     }
+    // A node already carrying the target key keeps what is there, rather than
+    // having it overwritten by the value moving off the source key — or
+    // overwriting it, depending on which came first in the stored JSON. Nothing
+    // writes both today; deciding it here is what stops the surviving reference
+    // depending on key order, and it is the same rule the content rewriter
+    // applies to its own collision.
     if (isFieldGroup && key === from.refKeys.single) {
-      setOwnProperty(rewritten, to.refKeys.single, value);
+      if (!keptUnderTarget(field, key, to.refKeys.single)) {
+        setOwnProperty(rewritten, to.refKeys.single, value);
+      }
       continue;
     }
     if (isFieldGroup && key === from.refKeys.many) {
-      setOwnProperty(rewritten, to.refKeys.many, value);
+      if (!keptUnderTarget(field, key, to.refKeys.many)) {
+        setOwnProperty(rewritten, to.refKeys.many, value);
+      }
       continue;
     }
     if (
@@ -122,6 +132,20 @@ function rewriteField(
   }
 
   return rewritten;
+}
+
+/**
+ * Whether the target key is already present and holds the value that survives.
+ *
+ * Only a *different* key can collide: rewriting a key onto itself is not a
+ * collision, and treating it as one would drop the value entirely.
+ */
+function keptUnderTarget(
+  field: Record<string, unknown>,
+  sourceKey: string,
+  targetKey: string
+): boolean {
+  return targetKey !== sourceKey && targetKey in field;
 }
 
 function isContainer(type: unknown): boolean {

--- a/packages/nextly/src/domains/field-groups/migration/rewrite-rows.ts
+++ b/packages/nextly/src/domains/field-groups/migration/rewrite-rows.ts
@@ -104,12 +104,18 @@ export async function rewriteRowsInBatches(args: {
 
   for (;;) {
     const from = after;
-    // Read and written inside one transaction so no row is rewritten against a
-    // value another writer replaced between the read and the write.
-    const reached = await session.inTransaction(async ctx => {
-      const rows = await readBatch(ctx, target, from);
+    const outcome = await session.inTransaction(async ctx => {
+      // Locked, not merely read inside a transaction. A plain `SELECT` takes no
+      // lock on Postgres or MySQL, so a concurrent writer could commit between
+      // the read and the write below — and because the rewrite writes the whole
+      // document back, that edit would be overwritten by this stale copy rather
+      // than merged. `nextly_versions` coalesces an autosave row in place, so
+      // that write really exists.
+      const read = await readBatch(ctx, target, from, { lock: true });
+      if (!read.ok) return read;
+
       let last: string | null = null;
-      for (const row of rows) {
+      for (const row of read.rows) {
         last = row.id;
         const rewritten = rewrite(row.document);
         // Rows already carrying the target vocabulary are skipped rather than
@@ -122,16 +128,26 @@ export async function rewriteRowsInBatches(args: {
           whereRowId(row.id)
         );
       }
-      return last;
+      return { ok: true as const, reached: last };
     });
 
-    if (reached === null) break;
-    after = reached;
+    // Raised out here rather than thrown inside, because the adapters route
+    // every error escaping a transaction callback through `classifyError`, which
+    // rewraps anything that is not already a `DatabaseError` as an unknown one
+    // and discards the context explaining what the migration refused.
+    if (!outcome.ok) throw outcome.refusal;
+
+    if (outcome.reached === null) break;
+    after = outcome.reached;
     // Recorded only now, with the batch committed. A cursor written inside the
     // transaction would be rolled back with it and stay honest, but one written
     // before the commit could outlive a batch that failed and step the next run
     // past rows nothing rewrote.
-    await writeBatchCursor(meta, { migrationId, stepId, after: reached });
+    await writeBatchCursor(meta, {
+      migrationId,
+      stepId,
+      after: outcome.reached,
+    });
   }
 
   await clearBatchCursor(meta, { stepId });
@@ -141,9 +157,18 @@ export async function rewriteRowsInBatches(args: {
  * The id of the first row the rewrite would still change, or `undefined`.
  *
  * The postcondition check for a batched rewrite, and the reason the cursor is
- * allowed to be an optimisation: this walks the whole table regardless of where
- * any run stopped, so the worst a wrong cursor can do is fail the step rather
- * than pass one that skipped rows.
+ * allowed to be an optimisation: this walks the table from the beginning
+ * regardless of where any run stopped, so a cursor that skipped rows fails the
+ * step rather than passing it.
+ *
+ * 🔴 **It is not proof against a writer running alongside it.** The walk is a
+ * cursor over the primary key, and ids are random, so a row inserted behind the
+ * point already passed sorts before the cursor and is never visited — the scan
+ * would report success it did not establish. No cursor can close that: it is the
+ * phantom-read problem, and a row lock does not prevent an insert. What closes it
+ * is quiescing the ledgers for the run, which is the migration's precondition
+ * rather than something this check can enforce. Stated here so the guarantee is
+ * not read as stronger than it is.
  *
  * Returns the offending id rather than a boolean so a refusal can name it.
  */
@@ -158,29 +183,47 @@ export async function findUnrewrittenRow(args: {
   for (;;) {
     const from = after;
     const outcome = await session.inTransaction(async ctx => {
-      const rows = await readBatch(ctx, target, from);
+      // Read without locking: this establishes a fact rather than preparing a
+      // write, and taking write locks across a whole ledger would block every
+      // writer for the length of the scan to no purpose.
+      const read = await readBatch(ctx, target, from, { lock: false });
+      if (!read.ok) return read;
+
       let last: string | null = null;
-      for (const row of rows) {
+      for (const row of read.rows) {
         last = row.id;
         if (documentDiffers(row.document, rewrite(row.document))) {
-          return { found: row.id, last };
+          return { ok: true as const, found: row.id, last };
         }
       }
-      return { found: undefined, last };
+      return { ok: true as const, found: undefined, last };
     });
 
+    if (!outcome.ok) throw outcome.refusal;
     if (outcome.found !== undefined) return outcome.found;
     if (outcome.last === null) return undefined;
     after = outcome.last;
   }
 }
 
+/**
+ * A batch, or the reason this target cannot be read honestly.
+ *
+ * A refusal is carried out as a value rather than thrown, because an error
+ * leaving a transaction callback is reclassified by the adapter into an unknown
+ * `DatabaseError` and loses the context that explains it.
+ */
+type BatchRead =
+  | { ok: true; rows: DocumentRow[] }
+  | { ok: false; refusal: NextlyError };
+
 /** One page of rows, ordered by primary key, after `from`. */
 async function readBatch(
   ctx: TransactionContext,
   target: RowRewriteTarget,
-  from: string | null
-): Promise<DocumentRow[]> {
+  from: string | null,
+  options: { lock: boolean }
+): Promise<BatchRead> {
   const rows = await ctx.select<Record<string, unknown>>(target.table, {
     columns: [ID_PROPERTY, target.documentProperty],
     ...(from === null
@@ -188,9 +231,36 @@ async function readBatch(
       : { where: { and: [{ column: ID_PROPERTY, op: ">", value: from }] } }),
     orderBy: [{ column: ID_PROPERTY, direction: "asc" }],
     limit: BATCH_SIZE,
+    // No-ops on SQLite, which needs none: its transactions open with
+    // `BEGIN IMMEDIATE`, so writers are already serialized.
+    ...(options.lock ? { forUpdate: true } : {}),
   });
-  return rows.map(row => toDocumentRow(row, target));
+
+  const narrowed: DocumentRow[] = [];
+  for (const row of rows) {
+    const document = readProperty(row, {
+      table: target.table,
+      property: target.documentProperty,
+    });
+    if (!document.ok) return document;
+    const id = readRowId(row, target.table);
+    if (!id.ok) return id;
+    narrowed.push({ id: id.value, document: document.value });
+  }
+  return { ok: true, rows: narrowed };
 }
+
+/**
+ * A value, or the reason this migration will not act on the row it came from.
+ *
+ * Returned rather than thrown so a caller inside a transaction can carry the
+ * refusal out and raise it at the boundary: an error escaping a transaction
+ * callback is reclassified by the adapter into an unknown `DatabaseError`, which
+ * discards the context that says which table and property were wrong.
+ */
+export type Narrowed<T> =
+  | { ok: true; value: T }
+  | { ok: false; refusal: NextlyError };
 
 /**
  * Read a projected property, refusing when the row does not carry it.
@@ -205,20 +275,23 @@ async function readBatch(
  * every read-modify-write in this migration fails the same way on a name that
  * does not resolve.
  */
-export function requireProperty(
+export function readProperty(
   row: Record<string, unknown>,
   args: { table: string; property: string }
-): unknown {
+): Narrowed<unknown> {
   if (!(args.property in row)) {
-    throw NextlyError.internal({
-      logContext: {
-        reason: "row rewrite target names a property the table does not have",
-        table: args.table,
-        property: args.property,
-      },
-    });
+    return {
+      ok: false,
+      refusal: NextlyError.internal({
+        logContext: {
+          reason: "row rewrite target names a property the table does not have",
+          table: args.table,
+          property: args.property,
+        },
+      }),
+    };
   }
-  return row[args.property];
+  return { ok: true, value: row[args.property] };
 }
 
 /**
@@ -228,37 +301,28 @@ export function requireProperty(
  * cursor, and every write-back names it, so an id that is not a non-empty string
  * is something this module cannot order, resume from, or target.
  */
-export function requireRowId(
+export function readRowId(
   row: Record<string, unknown>,
   table: string
-): string {
+): Narrowed<string> {
   const id = row[ID_PROPERTY];
   if (typeof id !== "string" || id.length === 0) {
-    throw NextlyError.internal({
-      logContext: {
-        reason: "row rewrite requires a non-empty string primary key",
-        table,
-      },
-    });
+    return {
+      ok: false,
+      refusal: NextlyError.internal({
+        logContext: {
+          reason: "row rewrite requires a non-empty string primary key",
+          table,
+        },
+      }),
+    };
   }
-  return id;
+  return { ok: true, value: id };
 }
 
 /** Address one row by its primary key. */
 export function whereRowId(id: string): WhereClause {
   return { and: [{ column: ID_PROPERTY, op: "=", value: id }] };
-}
-
-/** Narrow a projected row to the id and document a batched rewrite works on. */
-function toDocumentRow(
-  row: Record<string, unknown>,
-  target: RowRewriteTarget
-): DocumentRow {
-  const document = requireProperty(row, {
-    table: target.table,
-    property: target.documentProperty,
-  });
-  return { id: requireRowId(row, target.table), document };
 }
 
 /**

--- a/packages/nextly/src/domains/field-groups/migration/rewrite-rows.ts
+++ b/packages/nextly/src/domains/field-groups/migration/rewrite-rows.ts
@@ -1,0 +1,279 @@
+/**
+ * Applies a document rewrite to every row of a table, in bounded batches.
+ *
+ * Two of the columns this migration rewrites belong to ledgers — content history
+ * and the event outbox — whose row counts grow with a site's activity rather
+ * than with its schema. Reading one of those into memory and updating it in a
+ * single transaction would make upgrade time and upgrade memory a function of
+ * how long a site has been running, so the work is cut into batches that each
+ * commit on their own.
+ *
+ * Rows are walked by primary key, taking the next batch after the last id seen.
+ * That is a keyset walk rather than an offset one on purpose: `OFFSET` re-reads
+ * and discards everything before it, which turns a full pass into quadratic work
+ * exactly on the tables that made batching necessary.
+ *
+ * The ordering the walk depends on is not self-verifying — the adapter drops an
+ * `orderBy` whose column it cannot resolve rather than refusing, and a primary
+ * key's collation is the database's business, not this module's. So completeness
+ * is not claimed from having walked the table. It is checked afterwards, by
+ * rescanning for anything the walk did not reach, which is what
+ * `findUnrewrittenRow` is for.
+ *
+ * @module domains/field-groups/migration/rewrite-rows
+ */
+
+import type {
+  TransactionContext,
+  WhereClause,
+} from "@nextlyhq/adapter-drizzle/types";
+
+import { NextlyError } from "../../../errors/nextly-error";
+import type { MetaService } from "../../meta/services/meta-service";
+
+import {
+  clearBatchCursor,
+  readBatchCursor,
+  writeBatchCursor,
+} from "./batch-cursor";
+import type { MigrationSession } from "./session";
+
+/**
+ * Rows per batch.
+ *
+ * Smaller than a row-count batch would usually be, because every row carries a
+ * whole JSON document: an entry snapshot or a delivery envelope, not a handful
+ * of scalars. The bound that matters here is bytes held at once, and a few
+ * hundred documents is a transaction a database will not notice and a buffer a
+ * process will not feel.
+ */
+const BATCH_SIZE = 200;
+
+/**
+ * The property a row's primary key arrives under.
+ *
+ * Fixed rather than configurable, and that is the point: the adapter resolves an
+ * `orderBy` against the ORM's property names and **silently drops** a clause it
+ * cannot resolve, leaving an unordered walk that skips rows without saying so. A
+ * parameter would be one more place to get that wrong. Every table this
+ * migration rewrites names its primary key `id`, so there is nothing to vary.
+ */
+const ID_PROPERTY = "id";
+
+/** A table whose stored documents this migration rewrites. */
+export interface RowRewriteTarget {
+  /** Table name, as the ORM declares it. */
+  readonly table: string;
+  /**
+   * Property holding the document to rewrite.
+   *
+   * The ORM's property name, not the column's: reads and writes go through the
+   * typed CRUD path so the driver's JSON encoding stays the ORM's problem, and
+   * that path speaks property names.
+   */
+  readonly documentProperty: string;
+}
+
+/** How one stored document becomes its rewritten self. Must be idempotent. */
+export type DocumentRewrite = (document: unknown) => unknown;
+
+/** One row, reduced to the two things a rewrite needs. */
+interface DocumentRow {
+  id: string;
+  document: unknown;
+}
+
+/**
+ * Rewrite every row of `target`, resuming from wherever a previous run stopped.
+ *
+ * Safe to call again after a crash at any point: the rewrite is idempotent, rows
+ * that no longer need it are left untouched, and a cursor that did not survive
+ * only costs a second pass.
+ */
+export async function rewriteRowsInBatches(args: {
+  session: MigrationSession;
+  meta: MetaService;
+  migrationId: string;
+  stepId: string;
+  target: RowRewriteTarget;
+  rewrite: DocumentRewrite;
+}): Promise<void> {
+  const { session, meta, migrationId, stepId, target, rewrite } = args;
+
+  let after = await readBatchCursor(meta, { migrationId, stepId });
+
+  for (;;) {
+    const from = after;
+    // Read and written inside one transaction so no row is rewritten against a
+    // value another writer replaced between the read and the write.
+    const reached = await session.inTransaction(async ctx => {
+      const rows = await readBatch(ctx, target, from);
+      let last: string | null = null;
+      for (const row of rows) {
+        last = row.id;
+        const rewritten = rewrite(row.document);
+        // Rows already carrying the target vocabulary are skipped rather than
+        // rewritten to themselves. That is what makes a resumed pass cheap, and
+        // what keeps a second run from touching every row it has already done.
+        if (!documentDiffers(row.document, rewritten)) continue;
+        await ctx.update(
+          target.table,
+          { [target.documentProperty]: rewritten },
+          whereRowId(row.id)
+        );
+      }
+      return last;
+    });
+
+    if (reached === null) break;
+    after = reached;
+    // Recorded only now, with the batch committed. A cursor written inside the
+    // transaction would be rolled back with it and stay honest, but one written
+    // before the commit could outlive a batch that failed and step the next run
+    // past rows nothing rewrote.
+    await writeBatchCursor(meta, { migrationId, stepId, after: reached });
+  }
+
+  await clearBatchCursor(meta, { stepId });
+}
+
+/**
+ * The id of the first row the rewrite would still change, or `undefined`.
+ *
+ * The postcondition check for a batched rewrite, and the reason the cursor is
+ * allowed to be an optimisation: this walks the whole table regardless of where
+ * any run stopped, so the worst a wrong cursor can do is fail the step rather
+ * than pass one that skipped rows.
+ *
+ * Returns the offending id rather than a boolean so a refusal can name it.
+ */
+export async function findUnrewrittenRow(args: {
+  session: MigrationSession;
+  target: RowRewriteTarget;
+  rewrite: DocumentRewrite;
+}): Promise<string | undefined> {
+  const { session, target, rewrite } = args;
+
+  let after: string | null = null;
+  for (;;) {
+    const from = after;
+    const outcome = await session.inTransaction(async ctx => {
+      const rows = await readBatch(ctx, target, from);
+      let last: string | null = null;
+      for (const row of rows) {
+        last = row.id;
+        if (documentDiffers(row.document, rewrite(row.document))) {
+          return { found: row.id, last };
+        }
+      }
+      return { found: undefined, last };
+    });
+
+    if (outcome.found !== undefined) return outcome.found;
+    if (outcome.last === null) return undefined;
+    after = outcome.last;
+  }
+}
+
+/** One page of rows, ordered by primary key, after `from`. */
+async function readBatch(
+  ctx: TransactionContext,
+  target: RowRewriteTarget,
+  from: string | null
+): Promise<DocumentRow[]> {
+  const rows = await ctx.select<Record<string, unknown>>(target.table, {
+    columns: [ID_PROPERTY, target.documentProperty],
+    ...(from === null
+      ? {}
+      : { where: { and: [{ column: ID_PROPERTY, op: ">", value: from }] } }),
+    orderBy: [{ column: ID_PROPERTY, direction: "asc" }],
+    limit: BATCH_SIZE,
+  });
+  return rows.map(row => toDocumentRow(row, target));
+}
+
+/**
+ * Read a projected property, refusing when the row does not carry it.
+ *
+ * A projection naming a property the table does not have comes back without that
+ * key, and a rewrite of `undefined` returns `undefined` unchanged — so the step
+ * would write nothing, and the check that reads the same absent property would
+ * agree it had nothing left to do. That is a rewrite reporting a success it
+ * never attempted, so an absent property refuses here instead.
+ *
+ * Shared with the callers that rewrite bounded tables in one transaction, so
+ * every read-modify-write in this migration fails the same way on a name that
+ * does not resolve.
+ */
+export function requireProperty(
+  row: Record<string, unknown>,
+  args: { table: string; property: string }
+): unknown {
+  if (!(args.property in row)) {
+    throw NextlyError.internal({
+      logContext: {
+        reason: "row rewrite target names a property the table does not have",
+        table: args.table,
+        property: args.property,
+      },
+    });
+  }
+  return row[args.property];
+}
+
+/**
+ * A row's primary key, refusing anything a rewrite cannot address a row by.
+ *
+ * The keyset walk compares this value in the database and carries it in the
+ * cursor, and every write-back names it, so an id that is not a non-empty string
+ * is something this module cannot order, resume from, or target.
+ */
+export function requireRowId(
+  row: Record<string, unknown>,
+  table: string
+): string {
+  const id = row[ID_PROPERTY];
+  if (typeof id !== "string" || id.length === 0) {
+    throw NextlyError.internal({
+      logContext: {
+        reason: "row rewrite requires a non-empty string primary key",
+        table,
+      },
+    });
+  }
+  return id;
+}
+
+/** Address one row by its primary key. */
+export function whereRowId(id: string): WhereClause {
+  return { and: [{ column: ID_PROPERTY, op: "=", value: id }] };
+}
+
+/** Narrow a projected row to the id and document a batched rewrite works on. */
+function toDocumentRow(
+  row: Record<string, unknown>,
+  target: RowRewriteTarget
+): DocumentRow {
+  const document = requireProperty(row, {
+    table: target.table,
+    property: target.documentProperty,
+  });
+  return { id: requireRowId(row, target.table), document };
+}
+
+/**
+ * Whether a rewrite changed anything.
+ *
+ * Compared as serialized JSON because the rewriters rebuild their structures
+ * key by key in the order they read them, so a document they left alone
+ * serializes identically to what went in. That makes this a change test rather
+ * than a shape test, and it costs one pass over a document that is about to be
+ * written anyway.
+ *
+ * Exported because a step's postcondition asks the same question its run does:
+ * two implementations of "did this need rewriting" would eventually disagree,
+ * and the disagreement would read as a step that ran and then failed itself.
+ */
+export function documentDiffers(before: unknown, after: unknown): boolean {
+  return JSON.stringify(before) !== JSON.stringify(after);
+}

--- a/packages/nextly/src/domains/field-groups/migration/set-own-property.ts
+++ b/packages/nextly/src/domains/field-groups/migration/set-own-property.ts
@@ -1,0 +1,35 @@
+/**
+ * Assigns a key onto a rebuilt JSON object without letting the key decide how.
+ *
+ * The rewriters here rebuild objects key by key so a renamed property keeps its
+ * position. Plain assignment is wrong for that: `__proto__` is an accessor
+ * inherited from `Object.prototype`, so `target.__proto__ = value` runs its
+ * setter instead of creating an own property — the key vanishes from the
+ * rewritten document, and a migration that persists the result has silently
+ * dropped author data.
+ *
+ * It is reachable rather than theoretical. `JSON.parse` creates `__proto__` as
+ * an ordinary own property, so any stored document whose JSON contained that key
+ * arrives carrying one, and every one of these columns is parsed JSON.
+ *
+ * Defining the property rather than switching the whole object to a null
+ * prototype keeps the result an ordinary object for every consumer — equality
+ * checks, serialization, and the `in` tests these rewriters do — and fixes only
+ * the thing that was broken.
+ *
+ * @module domains/field-groups/migration/set-own-property
+ */
+
+/** Set `key` on `target` as an own, enumerable property, whatever `key` is. */
+export function setOwnProperty(
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown
+): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: true,
+    writable: true,
+    configurable: true,
+  });
+}


### PR DESCRIPTION
Slice B1-4 of the Components -> Field Groups storage migration (task 011). It rewrites what is *inside* rows; #423 moved the tables and columns those rows live in. **Nothing calls the migration yet** - the entry point is B1-5, so this ships dark.

## What moves

| Item | Where | From | To |
|---|---|---|---|
| stored field definitions | `dynamic_{collections,singles,components}.fields` | `type: "component"`, `component`, `components`, `componentSlug` | `type: "fieldGroup"`, `fieldGroup`, `fieldGroups` (legacy key **retired**, normalised onto the canonical one) |
| source path | `dynamic_components.config_path` | `components/` | `field-groups/` |
| schema event scope | `nextly_schema_events.scope_kind` | `component` | `fieldGroup` |
| wire type key | `nextly_versions.snapshot`, `nextly_events.payload` | `_componentType` | `_fieldGroupType` |

## Three decisions worth reviewing

**1. The data steps run before every rename, in both directions - and that is functional.** The adapter's typed CRUD refuses a table the ORM does not declare (`adapter-drizzle/src/adapter.ts:776-780`), and the field-group registry is declared under its *legacy* name. So it is reachable that way only before its own rename. Going through the ORM is what keeps the driver's JSON encoding out of this module: the same column is `jsonb` on Postgres, `json` on MySQL and `text({mode:"json"})` on SQLite, and two of the three hand back an object where the third hands back a string. Inverting the plan puts these steps last on the way down, by which point the renames have restored the names they address - so the rule holds both ways and no step has to work out which name a table is currently under.

**2. The checkpoint may lag and may never lead.** `nextly_versions` and `nextly_events` are ledgers whose size follows a site's history, so they are walked by primary key in bounded batches that each commit on their own. The position is written **after** its batch commits, carries the `migrationId` that wrote it, and is ignored if it came from any other run. Crucially, `verify` does not trust it: it rescans the whole table, so the worst a wrong cursor can do is fail the step, never pass one that skipped rows. That also covers a case the ordering cannot - MySQL's default collation is case-insensitive, so two ids differing only in case compare equal and `id > cursor` would step past one.

**3. The three registries move in one transaction, deliberately unbatched.** The runtime builds its schema from those rows, so a half-rewritten set is not partial progress - it is a database whose entities disagree about what a field group is.

`nextly_events` is batched too, though the plan called it small and bounded. It is a retention-governed ledger exactly like `nextly_versions`, and sizing one for growth but not the other would be a guess about which fills up first.

## A trap this had to design around

A projection naming a property the table does not carry comes back **without** that key. `rewrite(undefined)` returns `undefined`, so the walk writes nothing - and the postcondition, reading the same absent property, agrees there is nothing left to do. A silent no-op reporting success is the one outcome a data migration must not have, so an absent property refuses instead.

## Verification

- `pnpm build`, `pnpm check-types` 19/19, `pnpm lint` by exit code: all clean
- Migration suite **260 -> 300**, all passing
- Full `packages/nextly` run diffed at test-name level against a fresh `origin/main` run in its own built worktree: **byte-identical** failing-test lists (400 failures / 405 FAIL lines both sides). The branch is purely additive - 0 deletions.
- Every guard proven by breaking it, each time failing only the intended test with the count held at 300: cursor run-scoping, the absent-property refusal, a cursor written before its batch's writes, a postcondition that stops after one batch, the config-path table gate, change detection, the registries' single transaction, and the cursor read.

One break initially did **not** fail - it had been placed after the loop, so the injected failure skipped it. Re-placed correctly, it failed the intended test.

## Not in this PR

The down path, structural verification, the 3-dialect CI matrix on real databases, and the entry point are B1-5. `verify` here checks each step's own postcondition; whole-migration verification comes with the runner that invokes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable, resumable data migrations for field-group storage changes.
  * Added transactional batch processing with progress recovery and cleanup after completion.
  * Added safeguards to verify migrated data and detect incomplete rewrites.
  * Added support for converting field definitions, configuration paths, content keys, schema-event values, and related document data.

* **Tests**
  * Added comprehensive coverage for migration behavior, rollback, idempotency, validation, security, and failure recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->