### PR TITLE
fix(nextly): mark a generated app initialized only after it boots

### DIFF
--- a/.changeset/init-flag-after-boot.md
+++ b/.changeset/init-flag-after-boot.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Let a scaffolded app retry startup after a failed boot. The generated helper marked initialization complete before booting, so when the database or config was unavailable the retry returned early without ever booting.

--- a/packages/nextly/src/cli/commands/__tests__/init-helper-template.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/init-helper-template.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The startup helper a generated project gets.
+ *
+ * It lives in a template literal, so the compiler never sees it and no test
+ * runs it: every property below shipped broken at least once. These assert on
+ * the emitted text, which is the only thing that reaches a user's project.
+ */
+import { describe, expect, it } from "vitest";
+
+import { generateNextlyHelperTemplate } from "../init";
+
+/** The emitted module, with comments removed so prose cannot satisfy a check. */
+function emitted(): string {
+  const raw = generateNextlyHelperTemplate();
+  return raw
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .filter(line => !line.trim().startsWith("//"))
+    .join("\n");
+}
+
+function bodyOf(source: string, fn: string): string {
+  const start = source.indexOf(`export async function ${fn}`);
+  expect(start, `${fn} should be exported`).toBeGreaterThan(-1);
+  const rest = source.slice(start + 1);
+  const next = rest.indexOf("\nexport ");
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+describe("generated nextly helper", () => {
+  it("boots with the project's config", () => {
+    // `getNextly()` rejects a call without one, so a helper that omits it
+    // fails every startup rather than only unusual ones.
+    expect(bodyOf(emitted(), "getNextlyInstance")).toMatch(
+      /getNextly\(\{\s*config:\s*nextlyConfig/
+    );
+  });
+
+  it("does not route its two startup paths through each other", () => {
+    // Each exported path called the other, and the guard flag was set only
+    // after the await, so both recursed forever.
+    const source = emitted();
+    expect(bodyOf(source, "getNextlyInstance")).not.toContain(
+      "await initializeNextly()"
+    );
+    expect(bodyOf(source, "initializeNextly")).toContain(
+      "await getNextlyInstance()"
+    );
+  });
+
+  it("marks initialization complete only once the boot resolves", () => {
+    // Set beforehand, a failed boot leaves the app marked initialized and the
+    // retry a caller then makes returns early without ever booting.
+    const body = bodyOf(emitted(), "getNextlyInstance");
+    const boot = body.indexOf("await getNextly({");
+    const flag = body.indexOf("initialized = true");
+    expect(boot).toBeGreaterThan(-1);
+    expect(flag).toBeGreaterThan(boot);
+  });
+
+  it("reports initialization from either documented path", () => {
+    // Both options are documented, so `isNextlyInitialized()` has to answer
+    // for a caller who used the instance getter directly.
+    expect(bodyOf(emitted(), "getNextlyInstance")).toContain(
+      "initialized = true"
+    );
+  });
+});

--- a/packages/nextly/src/cli/commands/init.ts
+++ b/packages/nextly/src/cli/commands/init.ts
@@ -277,7 +277,15 @@ async function createNextlyHelper(
   logger.success("Created src/lib/nextly.ts");
 }
 
-function generateNextlyHelperTemplate(): string {
+/**
+ * The `lib/nextly.ts` a generated project gets.
+ *
+ * Exported so its output can be asserted on. It is a template literal, so
+ * nothing here is type-checked or executed by the build, and the two exported
+ * startup paths it defines have to agree about booting, about passing the
+ * config, and about when initialization is complete.
+ */
+export function generateNextlyHelperTemplate(): string {
   return `/**
  * Nextly Instance Helper
  *
@@ -315,14 +323,9 @@ export async function getNextlyInstance(): Promise<Nextly> {
   // initializeNextly() would cycle, since that function boots by calling
   // this one.
 
-  // Booting is what completes initialization, so record it here as well: a
-  // caller using this directly has initialized just as fully as one going
-  // through initializeNextly(), and isNextlyInitialized() should say so.
-  initialized = true;
-
   // Get the Nextly instance with minimal storage/image processor config
   // In a real app, you'd configure these with actual implementations
-  return getNextly({
+  const instance = await getNextly({
     // Required on every call, and the reason this module imports the config.
     config: nextlyConfig,
     storage: {
@@ -339,6 +342,12 @@ export async function getNextlyInstance(): Promise<Nextly> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Stub image processor for CLI init
     } as any,
   });
+
+  // Only once the boot has resolved. Setting it beforehand marks an app
+  // initialized when the database or config was unavailable, and the retry a
+  // caller then makes returns early without ever booting.
+  initialized = true;
+  return instance;
 }
 
 /**


### PR DESCRIPTION
The generated startup helper set its initialized flag **before** awaiting the
boot. When the database or config is unavailable, the app is left marked
initialized with no instance and no hooks — and the retry a caller then makes
returns early without ever booting.

The flag moves after the await, so a rejected boot leaves it false and a retry
retries.

Follow-up to the P2 raised on #420 after it merged.

## The generated helper now has tests

This code lives in a **template literal**. The compiler never sees it and nothing
ran it — which is how three separate defects reached users' projects in one small
function:

| defect | symptom |
|---|---|
| `getNextly()` called without `config` | rejected outright; every startup failed |
| the two exported paths awaited each other | infinite recursion on both entry points |
| the flag set before the boot | a failed boot could never be retried |

Each is now an assertion. They read the **emitted text with comments stripped**,
so prose cannot satisfy a check — a lesson from verifying the recursion fix,
where my first check matched the function name inside my own comment and reported
a cycle that wasn't there.

`generateNextlyHelperTemplate` is exported for this. Narrow, and the alternative
was scraping the source file, which is more brittle than calling the generator.

## Verification

Every assertion revert-checked against the exact defect it encodes:

| reverted | guard fires |
|---|---|
| flag back before the boot | ✅ |
| `config:` removed | ✅ |
| cycle restored | ✅ |

37 tests pass in `src/cli/commands/__tests__/`. Lint clean. Type errors are the 8
pre-existing `field-groups/migration` ones — none from this branch.

## Note for whoever owns the blocks-engine move

The pre-push build failed on `@nextlyhq/plugin-page-builder` with
`Cannot find module '@nextlyhq/blocks-engine'`. Reproduced on a **clean checkout
of main**, so it is not from this branch; `pnpm install` restores the workspace
link. Worth knowing if CI or another worktree hits it after #425.