### PR TITLE
refactor(nextly): declare the related-row read context once

### DIFF
--- a/.changeset/related-row-read-context.md
+++ b/.changeset/related-row-read-context.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Declare the context a related-row read carries once instead of in each layer that expands a relationship, and type the target table columns such a read uses.

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -16,7 +16,6 @@ import {
   AccessControlService,
   DEFAULT_OWNER_FIELD,
 } from "../../../services/access";
-import type { CollectionAccessRules } from "../../../services/access";
 import {
   describeUntranslatableConstraint,
   stripNoOpConstraintMembers,
@@ -34,6 +33,10 @@ import {
   buildWhereClause,
   type WhereFilter,
 } from "../../../services/collections/query-operators";
+import type {
+  RelatedRowReadContext,
+  TargetReadPolicy,
+} from "../../../services/collections/related-row-read-context";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
 import { applyFieldReadAccess } from "../../../shared/lib/field-level-registry";
@@ -74,97 +77,14 @@ export const MAX_RELATIONSHIP_DEPTH = 5;
  * helpers need only these two of its fields, and passing the whole options bag
  * down would let a depth value leak into a redaction decision.
  */
-interface RelatedRowAccess {
-  /**
-   * Whether to evaluate the target collection's field read rules at all.
-   *
-   * Off unless a caller opts in, because "no user supplied" and "anonymous
-   * caller" are indistinguishable here and they demand opposite outcomes: an
-   * anonymous REST read must be judged (and denied), while an expansion entry
-   * point that simply has not been given the caller yet must keep behaving as
-   * it does today rather than start stripping fields from everyone. Every entry
-   * point opts in as its own caller forwarding lands.
-   */
-  enforceFieldAccess?: boolean;
-  /**
-   * Evaluate the TARGET collection's own read rules, independently of whether
-   * this caller redacts fields. A Single's authorization view wants the second
-   * without the first: its rule must read real field values, and must still not
-   * be shown a row the response will withhold.
-   */
-  enforceCollectionAccess?: boolean;
-  user?: Record<string, unknown>;
-  overrideAccess?: boolean;
-  /**
-   * The caller's authenticated scope. A scoped API key is judged on its OWN
-   * stamped grant, never on its owner's roles, so the super-admin bypass and
-   * the owner predicate both have to know about one.
-   */
-  authenticatedScope?: AuthenticatedScope;
-  /**
-   * Ids withheld because the target collection's rules refused this caller.
-   *
-   * A caller that checks its expansion for completeness cannot otherwise tell
-   * a deliberate refusal from a load that failed, and would report the first
-   * as evidence that went missing.
-   */
-  withheldByAccess?: Set<string>;
-  /**
-   * Target read policies already resolved during this expansion, so a
-   * relationship holding many references reads its collection's metadata once
-   * instead of once per value.
-   */
-  targetPolicies?: Map<string, Promise<TargetReadPolicy>>;
-  /**
-   * Companion schemas already looked up during this expansion, for the same
-   * reason {@link RelatedRowAccess.targetPolicies} exists.
-   *
-   * Loading one costs a collection-metadata read even though the built table is
-   * itself cached, and a `hasMany` relationship on the single-entry path
-   * confirms one reference at a time — so resolving per confirmation turns a
-   * relationship with hundreds of values into hundreds of metadata reads.
-   * Populated only when a rule actually needs a companion filter, so a target
-   * without one pays nothing.
-   */
-  targetCompanions?: Map<string, Promise<CompanionSchema | null>>;
-  /**
-   * The caller's Draft/Published intent, when they asked to see everything.
-   *
-   * Deliberately narrow: `"all"` is the only value that propagates into
-   * expansion. It is a statement about the caller's trust — the admin sends it
-   * on every read for exactly that reason — whereas a concrete `draft` or
-   * `published` names the lifecycle of the collection being read and says
-   * nothing about what that collection points at. Absent means a related row is
-   * filtered to the published default, which is what a direct read of it would
-   * do.
-   */
-  status?: "all";
-  /**
-   * The language the surrounding read resolved to, used when a target
-   * collection's read rule filters on a localized field.
-   *
-   * Already resolved by the caller — the requested locale, or the default when
-   * none was asked for — because resolving it needs the localization config and
-   * this service has none. Absent means no companion filter can be built, so
-   * such a rule withholds its rows.
-   *
-   * This does NOT make expansion return a related row's translated values: a
-   * related row is still read from its main table. It decides only which
-   * language a rule's predicate is evaluated against.
-   */
-  locale?: string;
-}
-
-/** A target collection's read policy, as one expansion needs it. */
-export interface TargetReadPolicy {
-  rules: CollectionAccessRules | undefined;
-  /**
-   * Whether the collection has Draft/Published, so a read of it can resolve the
-   * status its rows are filtered by. Taken from the same record the rules come
-   * from rather than looked up separately.
-   */
-  hasStatus: boolean;
-}
+/**
+ * The caller a related row is fetched, judged and redacted for.
+ *
+ * The shared shape, carried unchanged by every layer that can reach a related
+ * row. Kept as a local name because this service refers to it constantly and
+ * "access" reads better at those call sites than the full noun.
+ */
+type RelatedRowAccess = RelatedRowReadContext;
 
 /**
  * Options for relationship expansion.

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -923,6 +923,20 @@ export type RelationshipDbExecutor = {
   execute?(query: unknown): Promise<unknown>;
 };
 
+// The columns a related-row read reaches for on a target's table.
+//
+// A dynamic collection's Drizzle table is built at runtime from stored field
+// metadata, so there is no compile-time type for it and the loader hands back
+// an untyped value. Naming the two columns that are actually read keeps those
+// accesses checked, and keeps the rest of the table opaque rather than
+// asserting a shape it may not have: `status` is optional because a collection
+// without Draft/Published has no such column, and `id` is `unknown` because it
+// is only ever handed to Drizzle as a column reference, never read as a value.
+type TargetTableColumns = {
+  id: unknown;
+  status?: unknown;
+};
+
 export class CollectionRelationshipService extends BaseService {
   /**
    * Decides whether a caller may read a TARGET collection at all.
@@ -1019,8 +1033,7 @@ export class CollectionRelationshipService extends BaseService {
    */
   private async resolveTargetStatusValue(
     targetCollection: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle dynamic schema
-    schema: any,
+    schema: TargetTableColumns,
     access: RelatedRowAccess
   ): Promise<string | undefined> {
     if (isSystemEntity(targetCollection)) return undefined;
@@ -1457,8 +1470,7 @@ export class CollectionRelationshipService extends BaseService {
    */
   private async buildTargetLocalizedContext(
     targetCollection: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle dynamic schema
-    schema: any,
+    schema: TargetTableColumns,
     access: RelatedRowAccess,
     constraint: Record<string, unknown>,
     /** The status a read of this target resolves to, or undefined for none. */

--- a/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-query-service.ts
@@ -1,17 +1,15 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
-import type { AuthenticatedScope } from "../../../auth/authenticated-scope";
 import type { FieldConfig } from "../../../collections/fields/types";
 import type { FieldGroupFieldConfig } from "../../../collections/fields/types/component";
 import type { DynamicFieldGroupRecord } from "../../../schemas/dynamic-field-groups/types";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
-import type { CompanionSchema } from "../../../services/collection-file-manager";
 import type { CollectionRelationshipService } from "../../../services/collections/collection-relationship-service";
+import type { RelatedRowReadContext } from "../../../services/collections/related-row-read-context";
 import type { FieldGroupRegistryService } from "../../../services/field-groups/field-group-registry-service";
 import { BaseService } from "../../../shared/base-service";
 import { stripPasswordFieldValues } from "../../../shared/lib/password-fields";
 import type { Logger } from "../../../shared/types";
-import type { TargetReadPolicy } from "../../collections/services/collection-relationship-service";
 import {
   isMissingCompanionTableError,
   populateCompanionFields,
@@ -40,59 +38,14 @@ import {
  * The caller context a component's related rows are judged against, mirroring
  * the relationship service's own options so it can be forwarded unchanged.
  */
-export interface ComponentReadAccess {
-  enforceFieldAccess?: boolean;
-  user?: Record<string, unknown>;
-  overrideAccess?: boolean;
-  /**
-   * The caller's authenticated scope, forwarded to relationship expansion.
-   *
-   * A relationship reached through a field group is populated by the same
-   * service a top-level one is, and a scoped API key must not inherit its
-   * owner's super-admin bypass there either.
-   */
-  authenticatedScope?: AuthenticatedScope;
-  /**
-   * Ids withheld because a target collection refused the caller, so a
-   * completeness check can tell a refusal from a load that failed.
-   */
-  withheldByAccess?: Set<string>;
-  /**
-   * Evaluate the target collection's own read rules even when field redaction
-   * is off, so an authorization view is not shown a row the response withholds.
-   */
-  enforceCollectionAccess?: boolean;
-  /**
-   * Target read policies resolved during this population.
-   *
-   * Component rows are expanded concurrently, and rows pointing at the same
-   * target would otherwise each resolve its policy — so one map is shared
-   * across them all rather than created per row.
-   */
-  targetPolicies?: Map<string, Promise<TargetReadPolicy>>;
-  /**
-   * Companion schemas resolved during this population, shared for the same
-   * reason the policy map is: component rows are expanded concurrently and rows
-   * pointing at the same target would otherwise each re-read its metadata.
-   */
-  targetCompanions?: Map<string, Promise<CompanionSchema | null>>;
-  /**
-   * The caller's Draft/Published intent, forwarded when they asked to see
-   * everything. Only `"all"` propagates; see the relationship service for why.
-   */
-  status?: "all";
-  /**
-   * The language the surrounding read resolved to, forwarded so a target
-   * collection's read rule can be applied when it filters on a localized field
-   * of that collection.
-   *
-   * Separate from this population's own `locale`, which decides which
-   * translation of the COMPONENT's fields to overlay. The two are the same
-   * language on every current caller, but they answer different questions and a
-   * component read that resolved no locale must not silently borrow one.
-   */
-  locale?: string;
-}
+/**
+ * The caller context a component's related rows are judged against.
+ *
+ * A relationship reached through a field group is populated by the same service
+ * a top-level one is, so it carries the same context rather than a parallel
+ * declaration of it.
+ */
+export type ComponentReadAccess = RelatedRowReadContext;
 
 export interface PopulateComponentDataParams {
   /** The entry to populate with component data */

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -46,6 +46,7 @@ import {
 } from "../../../services/access";
 import { GENERIC_DEFAULT_OWNER_FIELD } from "../../../services/access/types";
 import type { CollectionRelationshipService } from "../../../services/collections/collection-relationship-service";
+import type { RelatedRowReadContext } from "../../../services/collections/related-row-read-context";
 import type { CollectionsHandler } from "../../../services/collections-handler";
 import type { FieldGroupDataService } from "../../../services/field-groups/field-group-data-service";
 import { BaseService } from "../../../shared/base-service";
@@ -2449,35 +2450,7 @@ export class SingleQueryService extends BaseService {
     // collection's fields. Enforcement is opt-in because a caller that has not
     // supplied a user is indistinguishable from an anonymous one here, and
     // enforcing for the former strips protected fields from everybody.
-    access: {
-      enforceFieldAccess?: boolean;
-      /**
-       * Evaluate the target collection's own read rules even when field
-       * redaction is off, so the authorization view is not shown a row the
-       * response will withhold.
-       */
-      enforceCollectionAccess?: boolean;
-      user?: UserContext;
-      overrideAccess?: boolean;
-      /**
-       * The caller's authenticated scope. A scoped API key is judged on its
-       * own grant, so it must not inherit its owner's super-admin bypass when
-       * a related row's collection rules are evaluated.
-       */
-      authenticatedScope?: AuthenticatedScope;
-      withheldByAccess?: Set<string>;
-      /**
-       * The language this read resolved to, so a target collection's read rule
-       * can be applied when its predicate names a localized field of that
-       * collection. Absent leaves such a rule withholding its rows.
-       */
-      locale?: string;
-      /**
-       * The caller's Draft/Published intent, when they asked to see everything.
-       * Only `"all"` propagates; see the relationship service for why.
-       */
-      status?: "all";
-    } = {},
+    access: RelatedRowReadContext = {},
     /**
      * Propagate expansion failures instead of returning the document
      * unexpanded. A response is better served incomplete than not at all, but a
@@ -2528,7 +2501,7 @@ export class SingleQueryService extends BaseService {
           // rather than having them stripped as if nobody were asking.
           enforceFieldAccess: access.enforceFieldAccess,
           enforceCollectionAccess: access.enforceCollectionAccess,
-          user: access.user as Record<string, unknown> | undefined,
+          user: access.user,
           overrideAccess: access.overrideAccess,
           authenticatedScope: access.authenticatedScope,
           withheldByAccess: access.withheldByAccess,

--- a/packages/nextly/src/services/collections/related-row-read-context.ts
+++ b/packages/nextly/src/services/collections/related-row-read-context.ts
@@ -1,0 +1,115 @@
+/**
+ * Who is asking for a related row, and what has already been resolved for them.
+ *
+ * Populating a relationship is a read of another collection, so it needs the
+ * same things any read needs: the caller, what they are trusted with, the
+ * language and lifecycle they asked for, and somewhere to memoise per-request
+ * lookups. Every layer that can reach a related row — a collection read, a
+ * Single read, a field group, a write response — carries this same set.
+ *
+ * It was previously declared separately in each of those layers. Adding one
+ * concern then meant editing every declaration and auditing every call site for
+ * the one that was forgotten, which has happened five times: the caller's
+ * authenticated scope, the read locale, two per-request caches, and the
+ * Draft/Published intent. Declared once, the next concern is one edit.
+ *
+ * @module services/collections/related-row-read-context
+ */
+
+import type { AuthenticatedScope } from "../../auth/authenticated-scope";
+import type { CollectionAccessRules } from "../access";
+import type { CompanionSchema } from "../collection-file-manager";
+
+/**
+ * A target collection's read policy, as one expansion needs it.
+ *
+ * Declared here rather than in the service that resolves it so the context and
+ * everything it carries live together, and so a layer that only forwards the
+ * cache does not have to import from the service that fills it.
+ */
+export interface TargetReadPolicy {
+  rules: CollectionAccessRules | undefined;
+  /**
+   * Whether the collection has Draft/Published, so a read of it can resolve the
+   * status its rows are filtered by. Taken from the same record the rules come
+   * from rather than looked up separately.
+   */
+  hasStatus: boolean;
+}
+
+export interface RelatedRowReadContext {
+  /**
+   * The caller a related row is judged and redacted for. Absent means
+   * anonymous, which is the same answer their own read would get.
+   */
+  user?: Record<string, unknown>;
+
+  /** Trusted read: stored rules and the lifecycle default are both bypassed. */
+  overrideAccess?: boolean;
+
+  /**
+   * The caller's authenticated scope. A scoped API key is judged on its OWN
+   * stamped grant and never on its owner's roles, so a super-admin-owned key
+   * must not inherit the bypass its owner's session would get.
+   */
+  authenticatedScope?: AuthenticatedScope;
+
+  /**
+   * The language the surrounding read resolved to, used when a target
+   * collection's read rule filters on a localized field.
+   *
+   * Already resolved by the caller — the requested locale, or the default when
+   * none was asked for — because resolving it needs the localization config,
+   * which the layers below do not have.
+   */
+  locale?: string;
+
+  /**
+   * The caller's Draft/Published intent, when they asked to see everything.
+   *
+   * Deliberately narrow. `"all"` is a statement about the caller's trust and
+   * propagates; a concrete `draft` or `published` names the lifecycle of the
+   * collection being read and says nothing about what it points at, so it does
+   * not. Typed so a concrete value cannot be threaded here by mistake.
+   */
+  status?: "all";
+
+  /**
+   * Evaluate the target collection's FIELD read rules on the rows this pulls
+   * in. Opt-in because "no caller supplied" and "anonymous caller" are
+   * indistinguishable here and demand opposite outcomes.
+   */
+  enforceFieldAccess?: boolean;
+
+  /**
+   * Evaluate the target collection's own read rules, independently of whether
+   * fields are redacted. A Single's authorization view wants the second without
+   * the first: its rule must read real values, and must still not be shown a row
+   * the response will withhold.
+   */
+  enforceCollectionAccess?: boolean;
+
+  /**
+   * Ids withheld because a target collection refused this caller, keyed by
+   * collection and id.
+   *
+   * A caller checking its expansion for completeness cannot otherwise tell a
+   * deliberate refusal from a load that failed, and would report the first as
+   * evidence that went missing.
+   */
+  withheldByAccess?: Set<string>;
+
+  /**
+   * Read policies already resolved during this expansion, so a relationship
+   * holding many references reads its target's metadata once rather than once
+   * per value. Holds the PENDING lookup: references resolve concurrently, so
+   * caching only the settled value helps none of them.
+   */
+  targetPolicies?: Map<string, Promise<TargetReadPolicy>>;
+
+  /**
+   * Companion schemas already looked up during this expansion, for the same
+   * reason. Populated only when a rule actually needs a companion filter.
+   */
+  targetCompanions?: Map<string, Promise<CompanionSchema | null>>;
+}


### PR DESCRIPTION
## What

Populating a relationship is a read of another collection, so it needs what any read needs: the caller, what they are trusted with, the language and lifecycle they asked for, and somewhere to memoise per-request lookups. That set was declared separately in four layers — the relationship service, the Single query service, the field-group query service, and the collection query service.

This declares it once as `RelatedRowReadContext` and has the four layers import it.

## Why

Adding a concern meant editing every declaration and auditing every call site for the one that was forgotten. That has happened five times: the caller's authenticated scope, the read locale, two per-request caches, and the Draft/Published intent. Each time, a layer that was missed kept compiling and silently expanded relationships with less context than the others.

Declared once, the next concern is one edit.

## Also

Replaces the two `any` parameters for a target's Drizzle table with a named structural type, removing two `eslint-disable` comments (one added in #418, which the review asked to have cleaned up alongside the next relationship-service change).

A dynamic collection's table is built at runtime from stored field metadata, so there is no compile-time type for it. Rather than assert a shape, `TargetTableColumns` names the two columns these functions actually reach for and leaves the rest opaque — `status` optional because a collection without Draft/Published has no such column, `id` as `unknown` because it is only ever handed to Drizzle as a column reference. This follows the existing `PermissionsTableLike` precedent in `permission-service.ts`.

## Verification

- No behaviour change is intended, and none is asserted — this is a declaration merge.
- Failing-test **name sets** compared against a fresh baseline at `8c525663` over `domains/collections`, `domains/singles`, `domains/field-groups`: **identical**. 12 pre-existing failures, zero new, zero fixed.
- `tsc --noEmit` across `packages/nextly`: 0 errors.
- eslint clean on all four touched files.

## Net

-178 / +139 across four files, plus one new shared declaration.
