### PR TITLE
fix(nextly): ignore a return value from an after-write hook

### DIFF
--- a/.changeset/side-effect-hook-returns.md
+++ b/.changeset/side-effect-hook-returns.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+A value returned from an `afterChange` or `afterDelete` hook no longer replaces the row. These phases run after the write has committed, so a later handler and the caller now both see the row that was persisted rather than whatever an earlier handler returned. `beforeChange`, `beforeValidate` and `afterRead` still transform as before.

--- a/packages/nextly/src/hooks/__tests__/side-effect-phase-returns.test.ts
+++ b/packages/nextly/src/hooks/__tests__/side-effect-phase-returns.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The after-write phases are side-effect phases: a handler's return does not
+ * become the row.
+ *
+ * `execute()` assigned any returned value to the data it passes on, for every
+ * phase. Because the write has already committed by then, a second
+ * `afterCreate`/`afterUpdate`/`afterDelete` handler was shown whatever the first
+ * returned rather than the row that was persisted -- and returning the result of
+ * a side-effect call is easy to do by accident. The registry's own documentation
+ * already said these returns are ignored.
+ */
+import { describe, expect, it } from "vitest";
+
+import { HookRegistry } from "../hook-registry";
+import type { HookContext } from "../types";
+
+type Row = Record<string, unknown>;
+
+function contextFor(
+  collection: string,
+  operation: string,
+  data: Row
+): HookContext<Row> {
+  return { collection, operation, data } as unknown as HookContext<Row>;
+}
+
+describe("side-effect phase return values", () => {
+  const sideEffectPhases = [
+    { hookType: "afterCreate", operation: "create" },
+    { hookType: "afterUpdate", operation: "update" },
+    { hookType: "afterDelete", operation: "delete" },
+  ] as const;
+
+  for (const { hookType, operation } of sideEffectPhases) {
+    it(`${hookType}: a second handler sees the persisted row, not the first handler's return`, async () => {
+      const registry = new HookRegistry();
+      const persisted = { id: "1", title: "Stored" };
+
+      // The accident this guards against: returning the result of a side-effect
+      // call. Here it is a plausible-looking audit record.
+      registry.register(hookType, "docs", () => ({
+        auditId: "audit-9",
+      }));
+
+      const seen: Row[] = [];
+      registry.register(hookType, "docs", ctx => {
+        seen.push(ctx.data as Row);
+      });
+
+      const result = await registry.execute(
+        hookType,
+        contextFor("docs", operation, persisted)
+      );
+
+      // What the second handler was shown.
+      expect(seen).toEqual([persisted]);
+      // And what the caller gets back, since the same value flows out.
+      expect(result).toEqual(persisted);
+    });
+  }
+
+  it("does not let a side-effect return reach the caller even with one handler", async () => {
+    // The single-handler case takes a different path through the loop than the
+    // two-handler case above, and the Single update runner assigns whatever
+    // `execute` returns onto the response document.
+    const registry = new HookRegistry();
+    const persisted = { id: "1", title: "Stored" };
+    registry.register("afterUpdate", "docs", () => ({ injected: true }));
+
+    const result = await registry.execute(
+      "afterUpdate",
+      contextFor("docs", "update", persisted)
+    );
+
+    expect(result).toEqual(persisted);
+    expect(result).not.toHaveProperty("injected");
+  });
+
+  it("still runs every side-effect handler and still propagates a throw", async () => {
+    // Ignoring the return must not turn into ignoring the handler: the phase is
+    // where cache invalidation and notifications live, and a throw is how one
+    // reports that it failed.
+    const registry = new HookRegistry();
+    const ran: string[] = [];
+    registry.register("afterCreate", "docs", () => {
+      ran.push("first");
+    });
+    registry.register("afterCreate", "docs", () => {
+      ran.push("second");
+    });
+
+    await registry.execute("afterCreate", contextFor("docs", "create", {}));
+    expect(ran).toEqual(["first", "second"]);
+
+    const throwing = new HookRegistry();
+    throwing.register("afterCreate", "docs", () => {
+      throw new Error("notification failed");
+    });
+    await expect(
+      throwing.execute("afterCreate", contextFor("docs", "create", {}))
+    ).rejects.toThrow();
+  });
+
+  describe("the mirror: transforming phases are unaffected", () => {
+    // Without these, "the return is ignored" could just as well be satisfied by
+    // a registry that ignores every return, which would break the write and read
+    // paths that depend on one.
+    const transformingPhases = [
+      { hookType: "beforeCreate", operation: "create" },
+      { hookType: "beforeUpdate", operation: "update" },
+      { hookType: "afterRead", operation: "read" },
+    ] as const;
+
+    for (const { hookType, operation } of transformingPhases) {
+      it(`${hookType}: a handler's return is passed to the next handler and to the caller`, async () => {
+        const registry = new HookRegistry();
+        registry.register(hookType, "docs", ctx => ({
+          ...(ctx.data as Row),
+          first: true,
+        }));
+
+        const seen: Row[] = [];
+        registry.register(hookType, "docs", ctx => {
+          seen.push(ctx.data as Row);
+          return { ...(ctx.data as Row), second: true };
+        });
+
+        const result = await registry.execute(
+          hookType,
+          contextFor("docs", operation, { id: "1" })
+        );
+
+        expect(seen).toEqual([{ id: "1", first: true }]);
+        expect(result).toEqual({ id: "1", first: true, second: true });
+      });
+    }
+
+    it("beforeCreate can still set a value to null deliberately", async () => {
+      // `null` is distinguished from `undefined` on purpose, so the check that
+      // skips side-effect returns must not collapse that distinction.
+      const registry = new HookRegistry();
+      registry.register("beforeCreate", "docs", () => null);
+
+      const result = await registry.execute(
+        "beforeCreate",
+        contextFor("docs", "create", { id: "1" })
+      );
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/nextly/src/hooks/hook-registry.ts
+++ b/packages/nextly/src/hooks/hook-registry.ts
@@ -19,6 +19,24 @@ import type {
 } from "./types";
 
 /**
+ * The phases whose handlers exist for their effects, not to reshape data.
+ *
+ * These run after the write has already committed, so there is nothing left for
+ * a return value to change. Honouring one would mean a second handler is shown
+ * whatever the first happened to return instead of the row that was persisted,
+ * and returning the result of a side-effect call -- a logger, a fetch, a cache
+ * write -- is an easy accident to make.
+ *
+ * `afterRead` is deliberately absent: it reshapes the response by design, and
+ * the read paths consume what it returns.
+ */
+const SIDE_EFFECT_HOOK_TYPES: ReadonlySet<HookType> = new Set([
+  "afterCreate",
+  "afterUpdate",
+  "afterDelete",
+]);
+
+/**
  * Global hook registry singleton
  *
  * Manages registration and execution of database lifecycle hooks.
@@ -221,7 +239,9 @@ export class HookRegistry {
    *
    * **Data Flow:**
    * - For `before*` hooks: Each hook can modify data, which is passed to the next hook
-   * - For `after*` hooks: Return values are ignored (used for side effects)
+   * - For the after-write hooks in {@link SIDE_EFFECT_HOOK_TYPES}: return values
+   *   are ignored, so every handler and the caller see the persisted row
+   * - For `afterRead`: the return reshapes the response and is passed on
    *
    * **Error Handling:**
    * - If any hook throws an error, execution stops immediately
@@ -274,6 +294,11 @@ export class HookRegistry {
 
     let data = context.data;
 
+    // A side-effect phase runs after the write has committed, so a return value
+    // has nothing left to change: the row stays the persisted one for every
+    // later handler and for the caller.
+    const isSideEffectPhase = SIDE_EFFECT_HOOK_TYPES.has(hookType);
+
     // Execute hooks in series (FIFO order)
     for (const handler of allHandlers) {
       try {
@@ -284,7 +309,7 @@ export class HookRegistry {
         // If hook returns undefined, keep current data unchanged
         // This allows before* hooks to intentionally set null values
         // while after* hooks can skip returning (undefined) for side effects
-        if (result !== undefined) {
+        if (!isSideEffectPhase && result !== undefined) {
           data = result;
         }
       } catch (error: unknown) {

--- a/packages/nextly/src/hooks/register-single-hooks.ts
+++ b/packages/nextly/src/hooks/register-single-hooks.ts
@@ -54,21 +54,6 @@ const HOOK_TYPE_MAPPINGS: Record<keyof SingleHooks, HookType[]> = {
 };
 
 /**
- * `afterChange` is documented as side-effect-only for Singles (cache
- * invalidation, notifications), but it maps to the shared `afterUpdate` registry
- * type whose runner in `SingleMutationService` assigns any returned value to the
- * response after the write has committed. Wrap the handler so its return is
- * discarded, keeping the API response equal to the stored Single. `beforeChange`
- * (transforms write data) and `afterRead` (transforms the response) legitimately
- * return values, so only `afterChange` is wrapped.
- */
-function discardReturnValue(handler: HookHandler): HookHandler {
-  return async context => {
-    await handler(context);
-  };
-}
-
-/**
  * Register hooks declared on code-first Single configs with the global
  * HookRegistry, so the single read/update paths execute them. Call during app
  * initialization, mirroring {@link registerCollectionHooks}.
@@ -108,18 +93,15 @@ export function registerSingleHooks(
         continue;
       }
 
-      // Discard the return of a side-effect-only phase so a handler that returns
-      // data cannot rewrite the stored Single in the response.
-      const isSideEffectOnly = hookKey === "afterChange";
+      // `afterChange` maps to `afterUpdate`, which the registry runs as a
+      // side-effect phase: a handler's return is discarded there, so the
+      // response stays equal to the stored Single without wrapping here.
       for (const hookType of hookTypes) {
         for (const handler of handlers) {
-          const registered = isSideEffectOnly
-            ? discardReturnValue(handler as HookHandler)
-            : (handler as HookHandler);
           registry.register(
             hookType,
             singleHookNamespace(single.slug),
-            registered
+            handler as HookHandler
           );
           singleHookCount++;
         }


### PR DESCRIPTION
## What

`HookRegistry.execute()` assigned whatever a handler returned to the data it passes on, for every phase. This stops doing that for the three after-write phases — `afterCreate`, `afterUpdate`, `afterDelete`.

## Why

The registry's own documentation already said this is the contract:

> **Data Flow:**
> - For `before*` hooks: Each hook can modify data, which is passed to the next hook
> - For `after*` hooks: Return values are ignored (used for side effects)

The implementation never honoured it. Because these phases run *after* the write has committed, a return value has nothing left to change — so the only thing honouring it accomplished was to show a second handler whatever the first happened to return instead of the row that was persisted. Returning the result of a side-effect call (a logger, a fetch, a cache write) is an easy accident, and it silently became the row.

The `data` a handler receives is also what the caller gets back, and `SingleMutationService` assigns that onto the response document — so on the Single update path a returning `afterChange` could rewrite the API response.

## Where the fix goes, and why not at registration

`registerSingleHooks` already defended against this by wrapping `afterChange` handlers to discard their return. `registerCollectionHooks` registers the raw handler, which is how this became reachable when code-first collection hooks started running (#420).

Copying the wrapper to the collection registrar would have worked for code-first hooks and left every other registrant exposed — stored hooks, plugins calling `registry.register("afterCreate", …)` directly — and would put the same rule in two modules that then have to stay in sync. Return semantics is a property of the *phase*, not of who registered the handler, and the registry is the one place that knows the phase. So the rule lives there, and the now-redundant Single wrapper is removed rather than left as a second copy.

The existing Single test that asserted the discard is unchanged and still passes — it now exercises the registry rule, and it fails when this fix is reverted, which is what makes removing the wrapper safe.

`afterRead` is deliberately **not** in the side-effect set: it reshapes the response by design and three read paths consume what it returns.

## Verification

- **Revert-checked.** Restoring the unconditional assignment fails all 5 discard assertions (3 phases × next-handler, the single-handler caller case, and the pre-existing Single test). The revert was proved to have applied before trusting the run, not assumed.
- **Mirror included and it must not depend on the fix.** 8 assertions cover `beforeCreate`, `beforeUpdate`, `afterRead` still transforming, and `beforeCreate` still being able to return `null` deliberately. All 8 pass *with the fix reverted*, so "returns are ignored" cannot be satisfied by a registry that ignores every return.
- Also asserted: every side-effect handler still runs, and a throw still propagates — ignoring the return must not become ignoring the handler.
- Failing-test **name sets** compared against a fresh baseline at `8c525663` over `hooks`, `domains/singles`, `domains/collections`: **identical**. 13 pre-existing failures, zero new.
- `tsc --noEmit`: 0 errors. eslint clean.

## Scope

Gap **C** of `tasks/094-collection-hook-lifecycle-spec.md`, and item 1 of task `093-collection-hook-contract-gaps`. The other gaps in those files are deliberately not touched here.
