### PR TITLE
fix(nextly): check an empty default and refuse options json cannot hold

### DIFF
--- a/.changeset/plugin-default-gaps.md
+++ b/.changeset/plugin-default-gaps.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+The page builder now states the core version it actually needs, an empty default is checked against the column it will occupy, and a user field's plugin options are refused when JSON cannot hold them unchanged.
+
+`@nextlyhq/plugin-page-builder` requires `nextly` 0.0.2-alpha.49 or newer, the release that first exports `pluginField`. Installed against an older core it now fails at install rather than throwing when a `blocks()` field is evaluated.
+
+A single's default that resolves to an empty value is validated against the field's storage primitive and its type's own rules, instead of being treated as a field the writer left alone; a number-backed default of `""` no longer reaches the insert. Options declared on a code-defined user field are refused when they are values JSON cannot represent — a `Date`, `Set`, `Map`, `BigInt`, function or cycle — which previously either reached the admin component reshaped or failed the whole startup sync.

--- a/packages/nextly/src/cli/commands/__tests__/build-entity-validation.test.ts
+++ b/packages/nextly/src/cli/commands/__tests__/build-entity-validation.test.ts
@@ -150,6 +150,10 @@ describe("nextly build refuses a field type no plugin offers", () => {
   });
 
   it("accepts a type that did opt into this surface", async () => {
+    // The refusals above are specific to a type the entries surface does not
+    // accept, so a type that did opt in has to stay accepted — otherwise the
+    // gate would reject every contributed collection field rather than the
+    // wrong-surface ones it exists to catch.
     registerFieldType({
       type: "rating",
       storage: "number",

--- a/packages/nextly/src/domains/singles/__tests__/plugin-default-validation.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/plugin-default-validation.test.ts
@@ -109,6 +109,37 @@ describe("assertValidPluginDefault", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("refuses an empty default the storage primitive cannot hold", async () => {
+    // An empty submission means "not provided" and only `required` applies to
+    // it. An empty DEFAULT is what the column will hold, so judging it as an
+    // omission let a number-backed `() => ""` reach the insert unchecked.
+    registerFieldType({
+      type: "rating",
+      storage: "number",
+      component: "@acme/ratings/admin#Input",
+    });
+
+    await expect(
+      assertValidPluginDefault(
+        { name: "score", type: "rating" },
+        "",
+        "homepage"
+      )
+    ).rejects.toBeInstanceOf(NextlyError);
+  });
+
+  it("still accepts an empty default the primitive can hold", async () => {
+    registerFieldType({
+      type: "note",
+      storage: "text",
+      component: "@acme/notes/admin#Input",
+    });
+
+    await expect(
+      assertValidPluginDefault({ name: "body", type: "note" }, "", "homepage")
+    ).resolves.toBeUndefined();
+  });
+
   it("does not enforce required, which a default cannot violate", async () => {
     // The default IS the value, so absence is not a violation here; enforcing
     // it would refuse configs that boot today.

--- a/packages/nextly/src/domains/singles/services/single-utils.ts
+++ b/packages/nextly/src/domains/singles/services/single-utils.ts
@@ -155,6 +155,10 @@ export async function assertValidPluginDefault(
 
   const issues = await validateEntryData({ [name]: value }, [checked], {
     mode: "create",
+    // The value IS the default, so an empty one is what the column will hold
+    // rather than a field the writer left alone. Judged as an omission it
+    // skipped both the primitive check and the type's own rules.
+    emptyIsAValue: true,
   });
 
   if (issues.length === 0) return;

--- a/packages/nextly/src/shared/lib/__tests__/user-field-plugin-options.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/user-field-plugin-options.test.ts
@@ -50,6 +50,50 @@ describe("carriedUserFieldOptions", () => {
     expect(carried).toMatchObject({ min: 1, max: 5 });
   });
 
+  it("refuses an option the JSON column would reshape", () => {
+    // A Set becomes `{}` and a Date becomes a string once persisted, so the
+    // component is handed something other than what was declared. Refused at
+    // the declaration rather than discovered in the editor.
+    for (const value of [new Set([1]), new Map(), new Date()]) {
+      expect(() =>
+        carriedUserFieldOptions(
+          field({ name: "score", type: "rating", pluginOptions: { value } })
+        )
+      ).toThrow();
+    }
+  });
+
+  it("refuses an option that cannot be serialized at all", () => {
+    // These throw during serialization, which would take the whole code-field
+    // sync down rather than failing this one declaration.
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+
+    for (const value of [1n, cyclic]) {
+      expect(() =>
+        carriedUserFieldOptions(
+          field({ name: "score", type: "rating", pluginOptions: { value } })
+        )
+      ).toThrow();
+    }
+  });
+
+  it("accepts the JSON shapes an option is actually written in", () => {
+    expect(
+      carriedUserFieldOptions(
+        field({
+          name: "score",
+          type: "rating",
+          pluginOptions: {
+            scale: 5,
+            labels: ["low", "high"],
+            nested: { allow: true, note: null },
+          },
+        })
+      )
+    ).toMatchObject({ scale: 5 });
+  });
+
   it("refuses an option that would restate the field's identity", () => {
     // The folded record restates `type` and `name` as the identity a type is
     // handed, so an option under either would be replaced before the type that

--- a/packages/nextly/src/shared/lib/entry-validation.ts
+++ b/packages/nextly/src/shared/lib/entry-validation.ts
@@ -89,6 +89,21 @@ export interface ValidateEntryOptions {
    * required LOCALIZED field pass because it falls back to the default language.
    */
   enforceLocalizedRequired?: boolean;
+  /**
+   * Whether an empty value is the value being judged rather than an omission.
+   *
+   * A submission that arrives empty means "not provided", so only `required`
+   * has anything to say about it. A resolved DEFAULT that is empty is different:
+   * it is what the config states the column will hold, so it still has to
+   * satisfy that column. Without this an empty default reaches the insert with
+   * neither the storage-primitive check nor the type's own `validate` having
+   * run — a number-backed `defaultValue: () => ""` fails at the database, or
+   * stores the wrong representation on SQLite.
+   *
+   * `null` and `undefined` are unaffected: they mean no value under either
+   * reading, and the callers that seed defaults filter them out first.
+   */
+  emptyIsAValue?: boolean;
 }
 
 /** Flat-or-nested rule lookup (builder writes `validation.*`, code-first is flat). */
@@ -246,7 +261,14 @@ async function validateFieldValue(
     Array.isArray(value) &&
     !field.hasMany &&
     (field.type === "select" || field.type === "radio");
-  if (isEmpty(value) && !isProvidedEmptyList && !isScalarChoiceArray) {
+  const emptyIsOmission =
+    !options.emptyIsAValue || value === null || value === undefined;
+  if (
+    isEmpty(value) &&
+    emptyIsOmission &&
+    !isProvidedEmptyList &&
+    !isScalarChoiceArray
+  ) {
     if (isRequired(field) && requiredIsEnforced(field, path, options)) {
       issues.push({
         path,

--- a/packages/nextly/src/shared/lib/user-field-plugin-options.ts
+++ b/packages/nextly/src/shared/lib/user-field-plugin-options.ts
@@ -52,6 +52,70 @@ const NORMALIZED_USER_FIELD_KEYS: readonly string[] = [
   "admin",
 ];
 
+/**
+ * Whether a carried option is one of the shapes JSON actually has.
+ *
+ * The options are persisted as JSON and read back to rebuild the field the
+ * plugin's editor is handed, so a value JSON cannot represent does not merely
+ * store awkwardly — it reaches the component as something else. A `Set` or
+ * `Map` becomes `{}`, a `Date` becomes a string, a function or `undefined`
+ * disappears, and a `BigInt` or a cycle throws mid-serialization and takes the
+ * whole code-field sync with it.
+ *
+ * Tested structurally rather than by round-tripping the encoding: `new Set()`
+ * and `{}` serialize to the same bytes, so a re-serialize comparison calls the
+ * lossy conversion a success. What matters is whether the value was already one
+ * of JSON's own shapes, not whether it can be coerced into one.
+ */
+function isJsonShape(value: unknown, seen: Set<object> = new Set()): boolean {
+  if (value === null) return true;
+  const kind = typeof value;
+  if (kind === "string" || kind === "boolean") return true;
+  if (kind === "number") return Number.isFinite(value);
+  if (kind !== "object") return false;
+
+  const asObject = value as object;
+  // A cycle cannot be serialized at all; guarding here reports it as a bad
+  // option instead of throwing out of the walk.
+  if (seen.has(asObject)) return false;
+  seen.add(asObject);
+
+  if (Array.isArray(value)) {
+    return value.every(entry => isJsonShape(entry, seen));
+  }
+  // Only a plain object: anything with a different prototype (Date, Set, Map, a
+  // class instance) loses what makes it that thing when serialized.
+  const proto = Object.getPrototypeOf(asObject);
+  if (proto !== Object.prototype && proto !== null) return false;
+  return Object.values(asObject).every(entry => isJsonShape(entry, seen));
+}
+
+/**
+ * Refuse carried options the JSON column cannot hold unchanged.
+ *
+ * Raised where the options are folded rather than at the write, so codegen and
+ * the startup sync reject the same declaration for the same reason instead of
+ * one generating types for a field the other cannot store.
+ */
+function assertJsonSafeOptions(
+  carried: Record<string, unknown>,
+  fieldName: unknown
+): void {
+  const offending = Object.keys(carried).filter(
+    key => !isJsonShape(carried[key])
+  );
+  if (offending.length === 0) return;
+  throw NextlyError.validation({
+    errors: offending.map(key => ({
+      path: `users.fields.${String(fieldName)}.${key}`,
+      code: "INVALID_TYPE",
+      message:
+        `'${key}' cannot be stored: a user field's options are persisted as ` +
+        `JSON, and this value does not survive that unchanged`,
+    })),
+  });
+}
+
 /** The declared options a user field carries beyond the modelled set. */
 export function carriedUserFieldOptions(
   field: UserFieldConfig
@@ -108,5 +172,7 @@ export function carriedUserFieldOptions(
     for (const [key, value] of Object.entries(container)) collect(key, value);
   }
 
-  return Object.keys(carried).length > 0 ? carried : null;
+  if (Object.keys(carried).length === 0) return null;
+  assertJsonSafeOptions(carried, (field as { name?: unknown }).name);
+  return carried;
 }

--- a/packages/plugin-page-builder/src/fields/__tests__/blocks-field.integration.test.ts
+++ b/packages/plugin-page-builder/src/fields/__tests__/blocks-field.integration.test.ts
@@ -54,6 +54,9 @@ interface SingleEntryService {
 }
 
 /** Every dialect the harness supports, so an unreachable one is skipped visibly. */
+// `postgresql` is the token `TestDialect` declares; the harness matches on it
+// exactly. Spelled `postgres` the leg matched nothing and silently never ran,
+// so this suite reported a coverage it did not have.
 const ALL_DIALECTS: readonly TestDialect[] = ["sqlite", "postgresql", "mysql"];
 
 /**

--- a/packages/plugin-page-builder/src/fields/blocks-options.ts
+++ b/packages/plugin-page-builder/src/fields/blocks-options.ts
@@ -17,6 +17,9 @@
  */
 
 import type { BlockDocument, DocumentKind } from "@nextlyhq/blocks-engine";
+// Taken from the SDK rather than the core entry: the SDK is the only import
+// surface a plugin author is offered, and a first-party plugin reaching past it
+// is the example third parties copy.
 import type {
   FieldAdminOptions,
   FieldConfig,

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -17,7 +17,12 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) =>
   definePlugin({
     name: "@nextlyhq/plugin-page-builder",
     version: "0.0.2-alpha.29",
-    nextly: ">=0.0.2-alpha.21",
+    // `blocks()` builds its field with `pluginField`, which core first exports
+    // in alpha.49. Against an earlier core that import resolves to `undefined`
+    // and every `blocks()` call throws while the config is evaluated, so the
+    // floor states the version carrying the API rather than the one this plugin
+    // was first published against.
+    nextly: ">=0.0.2-alpha.49",
     // Identity metadata for the admin plugins page, mirroring package.json.
     author: "Nextly",
     homepage: "https://nextlyhq.com",


### PR DESCRIPTION
Closes the six findings left unresolved when #435 merged, and takes the version-floor P1 that #427 unblocked.

## What this fixes

**The page builder declared a core version it does not work against.** `blocks()` builds its field with `pluginField`, which core first exports in alpha.49, while the floor still said alpha.21 — so installing the published plugin against an older core satisfied the check and then threw while the config was evaluated. The floor could not be raised in #435 because the workspace was still on alpha.48 and the plugin's own compatibility check refused to load; #427 bumped the workspace, so the floor and the workspace now agree.

**An empty default skipped every check.** #435 stripped `required` before handing a resolved default to the shared walker, so a default that boots today would not be newly refused. That also made the walker classify an empty value as an omission and return before both the storage-primitive check and the type's own `validate` — so a number-backed `defaultValue: () => ""` still reached the insert, which is the case that change existed to close. The walker now takes an explicit `emptyIsAValue`, so a caller can say it is judging a default rather than a submission. `null` and `undefined` are unaffected: they mean no value under either reading.

**A user field's plugin options were persisted without checking JSON can hold them.** They are stored in a JSON column and read back to rebuild the field the plugin's editor receives, so a `Date`, `Set`, `Map`, `BigInt`, function or cycle either arrived reshaped or threw mid-serialization and took the whole code-field sync with it. Refused now at the point the options are folded, so codegen and the startup sync reject the same declaration for the same reason.

Plus the three explanatory comments AGENTS.md requires, on changes made in #435.

## Note on the JSON-safety check

The first implementation compared a value against its own re-serialized form, and it was wrong: `new Set()` and `{}` serialize to the same bytes, so the lossy conversion was scored as a success. The test caught it. It is a structural check of JSON's own shapes now — what matters is whether the value already was one, not whether it can be coerced into one.

## 088 is deliberately not here, and the task file has been corrected

This PR was meant to carry the JSON-column string contract too. Tracing the values shows it cannot land safely yet, and the reason recorded in that task was wrong.

The task said the blocker no longer held because `transformForStorage` is dead code. `transformForStorage` is dead, but that is not the question — the question is whether ANY value arriving at the five `toJsonColumnValue` call sites is already serialized, and three are:

| Pre-serializer | Reaches the encoder at |
|---|---|
| `single-utils.ts:221` — a JSON-backed contributed empty | `single-utils.ts:585` |
| `collection-mutation-service.ts:1508` — hasMany relationship arrays | `collection-mutation-service.ts:2191`, `:4110` |
| `single-utils.ts:42` — `EMPTY_LEXICAL_DOCUMENT`, a pre-stringified richText default | `single-utils.ts:585` |

Encoding unconditionally today would double-encode all three, silently and on the happy path. The task now records the corrected order: remove the pre-serializers so encoding happens once at the boundary, then flip the encoder, then run the three-dialect matrix.

## Verification

- build 17/17 · typecheck 0 · lint 0
- `nextly` **400 failed / 37 failed files** — the known baseline, unchanged
- Both new behaviours stub-verified: the covered code disabled, and *that* test confirmed failing
