### PR TITLE
fix(nextly): scope read-hook reentrancy per collection

### DIFF
--- a/.changeset/loud-cameras-shake.md
+++ b/.changeset/loud-cameras-shake.md
@@ -1,0 +1,35 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Apply read hooks per collection, and hand them the values a caller sees.
+
+A read hook that reads a different collection now runs that collection's own
+hooks instead of silently skipping them, so a hook cannot reach rows the other
+collection withholds. A hook reading the collection it is already running for
+still skips them, which is what stops it calling itself without end.
+
+`afterRead` is now handed decoded JSON values rather than the storage encoding
+SQLite returns, and a related row now gets the target collection's own field
+`afterRead` hooks, so a field masked on the target's endpoint stays masked when
+it is reached through a relationship.

--- a/.changeset/loud-cameras-shake.md
+++ b/.changeset/loud-cameras-shake.md
@@ -30,6 +30,6 @@ collection withholds. A hook reading the collection it is already running for
 still skips them, which is what stops it calling itself without end.
 
 `afterRead` is now handed decoded JSON values rather than the storage encoding
-SQLite returns, and a related row now gets the target collection's own field
-`afterRead` hooks, so a field masked on the target's endpoint stays masked when
-it is reached through a relationship.
+SQLite returns, so a hook reads the value the field was configured with instead
+of a string. Field hooks are also declared with the context they are actually
+given, which includes the field's value and name.

--- a/packages/nextly/src/collections/fields/types/base.ts
+++ b/packages/nextly/src/collections/fields/types/base.ts
@@ -12,7 +12,7 @@
 
 import type React from "react";
 
-import type { HookHandler } from "@nextly/hooks/types";
+import type { FieldHookHandler } from "@nextly/hooks/types";
 
 // ============================================================
 // Field Type Union
@@ -456,25 +456,25 @@ export interface FieldHooks {
    * Runs before field validation.
    * Can transform the field value before validation rules are applied.
    */
-  beforeValidate?: HookHandler[];
+  beforeValidate?: FieldHookHandler[];
 
   /**
    * Runs before the field value is saved to the database.
    * Can transform the final value to be stored.
    */
-  beforeChange?: HookHandler[];
+  beforeChange?: FieldHookHandler[];
 
   /**
    * Runs after the field value has been saved to the database.
    * Useful for side effects like sending notifications.
    */
-  afterChange?: HookHandler[];
+  afterChange?: FieldHookHandler[];
 
   /**
    * Runs after the field value is read from the database.
    * Can transform the value before it's returned to the client.
    */
-  afterRead?: HookHandler[];
+  afterRead?: FieldHookHandler[];
 }
 
 // ============================================================

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -24,6 +24,10 @@ export {
   type HookHandler,
 } from "./collections/config/define-collection";
 
+// The context a FIELD-level hook is handed. `FieldHooks` is already public
+// through the field types below, so the handler it is declared with is too.
+export type { FieldHookContext, FieldHookHandler } from "./hooks/types";
+
 // Single configuration (defineSingle, SingleConfig, etc.)
 export {
   defineSingle,

--- a/packages/nextly/src/domains/collections/__tests__/read-hooks-narrow-query.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/read-hooks-narrow-query.integration.test.ts
@@ -8,7 +8,13 @@
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { defineCollection, text } from "../../../config";
+import {
+  defineCollection,
+  defineFieldGroup,
+  fieldGroup,
+  json,
+  text,
+} from "../../../config";
 import {
   registerBeforeOperationHook,
   registerHook,
@@ -24,6 +30,10 @@ import {
 // Integration files share fixed system-table names, so this suite keeps its own
 // collection slug to avoid colliding with a concurrently-running file.
 const SLUG = "readhook_articles";
+// A second collection, for the reads a hook makes into something other than the
+// collection it is running for.
+const OTHER = "readhook_tenants";
+const COMPONENT = "readhook_meta";
 
 let current: TestNextly | undefined;
 afterEach(async () => {
@@ -34,35 +44,83 @@ afterEach(async () => {
 const articles = () =>
   defineCollection({
     slug: SLUG,
-    fields: [text({ name: "title" }), text({ name: "tenant" })],
+    fields: [
+      text({ name: "title" }),
+      text({ name: "tenant" }),
+      // A geo predicate names a field holding a `[longitude, latitude]` tuple.
+      json({ name: "location" }),
+      // Component values live in their own table, so a predicate on one becomes
+      // an EXISTS subquery rather than a column comparison.
+      fieldGroup({ name: "meta", component: COMPONENT }),
+    ],
   });
 
 async function boot(): Promise<TestNextly> {
-  current = await createTestNextly({ collections: [articles()] });
+  current = await createTestNextly({
+    fieldGroups: [
+      defineFieldGroup({
+        slug: COMPONENT,
+        fields: [text({ name: "heading" })],
+      }),
+    ],
+    collections: [
+      articles(),
+      defineCollection({ slug: OTHER, fields: [text({ name: "name" })] }),
+    ],
+  });
   return current;
 }
 
+type ReadHandler = {
+  listEntries: (p: Record<string, unknown>) => Promise<{
+    success: boolean;
+    statusCode?: number;
+    message?: string;
+    data: { docs: Record<string, unknown>[]; totalDocs: number } | null;
+  }>;
+  countEntries: (p: Record<string, unknown>) => Promise<{
+    success: boolean;
+    statusCode?: number;
+    message?: string;
+    data: { totalDocs: number } | null;
+  }>;
+  getEntry: (p: Record<string, unknown>) => Promise<{
+    success: boolean;
+    data: Record<string, unknown> | null;
+  }>;
+};
+
 function handlerOf(t: TestNextly) {
-  return t.getService("collectionsHandler") as unknown as {
-    listEntries: (p: Record<string, unknown>) => Promise<{
-      success: boolean;
-      data: { docs: Record<string, unknown>[]; totalDocs: number } | null;
-    }>;
-    countEntries: (p: Record<string, unknown>) => Promise<{
-      success: boolean;
-      data: { totalDocs: number } | null;
-    }>;
-  };
+  return t.getService("collectionsHandler") as unknown as ReadHandler;
 }
 
-async function seed(t: TestNextly): Promise<void> {
+async function seed(t: TestNextly): Promise<string[]> {
+  const ids: string[] = [];
   for (const data of [
-    { title: "a", tenant: "t1" },
-    { title: "b", tenant: "t1" },
-    { title: "c", tenant: "t2" },
+    {
+      title: "a",
+      tenant: "t1",
+      location: [-74.006, 40.7128],
+      meta: { heading: "keep" },
+    },
+    {
+      title: "b",
+      tenant: "t1",
+      location: [-0.1276, 51.5074],
+      meta: { heading: "drop" },
+    },
+    {
+      title: "c",
+      tenant: "t2",
+      location: [-0.1276, 51.5074],
+      meta: { heading: "drop" },
+    },
   ]) {
-    await t.nextly.create({ collection: SLUG, data });
+    const row = await t.nextly.create({ collection: SLUG, data });
+    ids.push(String((row as { id?: unknown }).id ?? ""));
   }
+  await t.nextly.create({ collection: OTHER, data: { name: "t1" } });
+  return ids;
 }
 
 describe("read hooks narrow the query", () => {
@@ -186,6 +244,171 @@ describe("read hooks narrow the query", () => {
       expect(listed.data!.totalDocs).toBe(3);
     } finally {
       unregisterHook("beforeRead", SLUG, clear);
+    }
+  });
+
+  it("a predicate on a component field narrows the total, not only the rows", async () => {
+    // Component predicates become EXISTS subqueries and are held apart from the
+    // rest of the filter while that happens. Handing the count the filter with
+    // them already removed leaves it counting every row, so a caller sees one
+    // row beside a total of three.
+    const t = await boot();
+    await seed(t);
+
+    const listed = await handlerOf(t).listEntries({
+      collectionName: SLUG,
+      overrideAccess: true,
+      where: { "meta.heading": { equals: "keep" } },
+    });
+
+    expect(listed.success).toBe(true);
+    expect(listed.data!.docs).toHaveLength(1);
+    expect(listed.data!.totalDocs).toBe(1);
+  });
+
+  it("beforeOperation returning args without a filter clears it", async () => {
+    // Returning an args object replaces the arguments, so omitting `where` is a
+    // decision to drop the caller's filter. Falling back to the caller's filter
+    // when the returned one is absent would make that impossible to express.
+    const t = await boot();
+    await seed(t);
+
+    const dropFilter: BeforeOperationHandler = () => ({});
+    registerBeforeOperationHook(SLUG, dropFilter);
+
+    try {
+      const listed = await handlerOf(t).listEntries({
+        collectionName: SLUG,
+        overrideAccess: true,
+        where: { tenant: { equals: "t1" } },
+      });
+
+      // The caller asked for t1 -- two rows -- and the hook dropped that.
+      expect(listed.data!.docs).toHaveLength(3);
+    } finally {
+      unregisterBeforeOperationHook(SLUG, dropFilter);
+    }
+  });
+
+  it("beforeRead can scope an unfiltered read by assigning in place", async () => {
+    // Hooks documented as modifying query parameters assign onto what they are
+    // given and return nothing. On a read with no filter there is nothing to
+    // assign onto unless the phase is handed an object, and such a handler would
+    // throw on exactly the reads that most need scoping.
+    const t = await boot();
+    await seed(t);
+
+    const scopeInPlace: HookHandler = ctx => {
+      (ctx.data as Record<string, unknown>).tenant = { equals: "t1" };
+    };
+    registerHook("beforeRead", SLUG, scopeInPlace);
+
+    try {
+      const listed = await handlerOf(t).listEntries({
+        collectionName: SLUG,
+        overrideAccess: true,
+      });
+
+      expect(listed.success).toBe(true);
+      expect(listed.data!.docs).toHaveLength(2);
+      expect(listed.data!.totalDocs).toBe(2);
+    } finally {
+      unregisterHook("beforeRead", SLUG, scopeInPlace);
+    }
+  });
+
+  it("a geo predicate is refused on a count rather than silently ignored", async () => {
+    // Geo operators are evaluated over fetched rows, and a count fetches none.
+    // No SQL is emitted for them, so counting one returns the total the geo
+    // filter was meant to reduce -- every row, beside a list showing far fewer.
+    const t = await boot();
+    await seed(t);
+
+    const refused = await handlerOf(t).countEntries({
+      collectionName: SLUG,
+      overrideAccess: true,
+      where: { location: { near: "-74.006,40.7128,10000" } },
+    });
+
+    expect(refused.success).toBe(false);
+    expect(refused.statusCode).toBe(400);
+    expect(refused.message).toContain("geo filter cannot be counted");
+
+    // The control: the same count without the geo operator answers normally, so
+    // the refusal is the geo predicate and not a broken count.
+    const counted = await handlerOf(t).countEntries({
+      collectionName: SLUG,
+      overrideAccess: true,
+      where: { tenant: { equals: "t1" } },
+    });
+    expect(counted.success).toBe(true);
+    expect(counted.data!.totalDocs).toBe(2);
+  });
+
+  it("a read hook reading another collection runs that collection's hooks", async () => {
+    // The other collection's hooks may be what scopes it to a tenant or hides
+    // soft-deleted rows. Suppressing them because some read is in progress hands
+    // the handler rows that collection withholds from everyone else.
+    const t = await boot();
+    await seed(t);
+
+    let otherRuns = 0;
+    const otherHook: HookHandler = ctx => {
+      otherRuns++;
+      return ctx.data;
+    };
+    const readsOther: HookHandler = async ctx => {
+      await handlerOf(t).listEntries({
+        collectionName: OTHER,
+        overrideAccess: true,
+      });
+      return ctx.data;
+    };
+    registerHook("beforeRead", OTHER, otherHook);
+    registerHook("beforeRead", SLUG, readsOther);
+
+    try {
+      await handlerOf(t).listEntries({
+        collectionName: SLUG,
+        overrideAccess: true,
+      });
+      expect(otherRuns).toBe(1);
+    } finally {
+      unregisterHook("beforeRead", SLUG, readsOther);
+      unregisterHook("beforeRead", OTHER, otherHook);
+    }
+  });
+
+  it("a read hook reading its own collection by id does not re-enter itself", async () => {
+    // The detail path runs the same phase the handler is already in, so without
+    // the guard the handler calls itself through every nested read. The counter
+    // caps it because an unguarded run does not stop on its own.
+    const t = await boot();
+    const ids = await seed(t);
+
+    let runs = 0;
+    const readsSelf: HookHandler = async ctx => {
+      runs++;
+      if (runs < 10) {
+        await handlerOf(t).getEntry({
+          collectionName: SLUG,
+          entryId: ids[0],
+          overrideAccess: true,
+        });
+      }
+      return ctx.data;
+    };
+    registerHook("beforeRead", SLUG, readsSelf);
+
+    try {
+      const listed = await handlerOf(t).listEntries({
+        collectionName: SLUG,
+        overrideAccess: true,
+      });
+      expect(listed.success).toBe(true);
+      expect(runs).toBe(1);
+    } finally {
+      unregisterHook("beforeRead", SLUG, readsSelf);
     }
   });
 

--- a/packages/nextly/src/domains/collections/__tests__/read-hooks-see-final-values.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/read-hooks-see-final-values.integration.test.ts
@@ -20,6 +20,10 @@ const DOCS = "finalval_docs";
 const AUTHORS = "finalval_authors";
 const POSTS = "finalval_posts";
 
+// What the related-row field hook was handed. The hook is declared inside the
+// fixture, so the assertion reads it from here.
+const profileHookSaw: unknown[] = [];
+
 let current: TestNextly | undefined;
 afterEach(async () => {
   await current?.destroy();
@@ -67,6 +71,27 @@ async function boot(): Promise<TestNextly> {
           text({
             name: "secret",
             hooks: { afterRead: [() => "REDACTED"] },
+          }),
+          // A hook doing ordinary object work. Handed the storage encoding it
+          // throws, and the relationship fetch reads the failure as an absent
+          // row.
+          json({
+            name: "profile",
+            hooks: {
+              afterRead: [
+                ({ value }) => {
+                  // A row that has no profile at all is not what this is
+                  // about, so it passes through.
+                  if (value === null || value === undefined) return value;
+                  // Ordinary object work. Handed the storage encoding, `tags`
+                  // is undefined and this throws -- and the relationship fetch
+                  // reads that failure as an absent row.
+                  const v = value as { tags: string[] };
+                  profileHookSaw.push(v.tags.length);
+                  return value;
+                },
+              ],
+            },
           }),
         ],
       }),
@@ -179,5 +204,115 @@ describe("read hooks see the values a caller sees", () => {
     const related = expanded.data!.author as Record<string, unknown>;
     expect(related).toBeTruthy();
     expect(related.secret).toBe("REDACTED");
+  });
+  it("a target's field hook is handed decoded values through a relationship", async () => {
+    // Related rows are read straight from the table, so on SQLite their JSON
+    // columns are strings. A hook doing object work throws on one, and the
+    // relationship fetch reports that failure as an absent row -- the relation
+    // disappears rather than erroring.
+    profileHookSaw.length = 0;
+    const t = await boot();
+    await t.nextly.create({
+      collection: AUTHORS,
+      data: { name: "a", secret: "s", profile: { tags: ["x", "y"] } },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "p", author: authorId },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    // The reads above went through the DIRECT path, which decodes and runs the
+    // same hook. Cleared here so what follows can only have come from the
+    // expansion.
+    profileHookSaw.length = 0;
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      overrideAccess: true,
+      depth: 1,
+    });
+
+    // The relation survived, and the hook read the tags rather than choking on
+    // a string. The row itself keeps its stored encoding on the way out, which
+    // is why this asserts what the hook was handed.
+    expect(expanded.data!.author).toBeTruthy();
+    expect(profileHookSaw).toContain(2);
+  });
+
+  it("related field hooks stay out of an evidence-gathering read", async () => {
+    // A caller clearing `enforceFieldAccess` is assembling the row a
+    // document-dependent access rule is judged on, and wants it unredacted. A
+    // masking hook running there would rewrite the evidence before the rule
+    // sees it, and would fire its side effects for a request not yet allowed.
+    const t = await boot();
+    await t.nextly.create({
+      collection: AUTHORS,
+      data: { name: "a", secret: "TOP_SECRET", profile: { tags: [] } },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+
+    const service = t.getService("relationshipService") as unknown as {
+      batchFetchRelatedEntries: (
+        target: string,
+        ids: string[],
+        field: Record<string, unknown>,
+        access: Record<string, unknown>
+      ) => Promise<Map<string, Record<string, unknown>>>;
+    };
+    const field = { name: "author", type: "relationship", relationTo: AUTHORS };
+
+    const evidence = await service.batchFetchRelatedEntries(
+      AUTHORS,
+      [authorId],
+      field,
+      { enforceFieldAccess: false, overrideAccess: true }
+    );
+    expect(evidence.get(authorId)!.secret).toBe("TOP_SECRET");
+
+    // The control: the same fetch for a real read does mask it, so the
+    // difference is the flag and not a hook that never ran.
+    const served = await service.batchFetchRelatedEntries(
+      AUTHORS,
+      [authorId],
+      field,
+      { enforceFieldAccess: true, overrideAccess: true }
+    );
+    expect(served.get(authorId)!.secret).toBe("REDACTED");
+  });
+
+  it("a value a hook returns is not decoded a second time", async () => {
+    // The decode cannot tell an already-decoded string from storage encoding,
+    // so a second pass over what the hooks returned re-parses anything that
+    // still looks like JSON. Running it once, before the hooks, is what makes
+    // a hook's own value survive intact.
+    const t = await boot();
+    await t.nextly.create({
+      collection: DOCS,
+      data: { title: "d", config: { mode: "live" } },
+    });
+
+    const jsonLooking = '{"mode":"live"}';
+    const setString: HookHandler = ctx => {
+      const rows = ctx.data as Record<string, unknown>[];
+      rows[0].config = jsonLooking;
+      return ctx.data;
+    };
+    registerHook("afterRead", DOCS, setString);
+
+    try {
+      const listed = await handlerOf(t).listEntries({
+        collectionName: DOCS,
+        overrideAccess: true,
+      });
+
+      // The hook set a string. A second decode would hand the caller an object
+      // the hook never produced.
+      expect(listed.data!.docs[0].config).toBe(jsonLooking);
+    } finally {
+      unregisterHook("afterRead", DOCS, setString);
+    }
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/read-hooks-see-final-values.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/read-hooks-see-final-values.integration.test.ts
@@ -1,12 +1,12 @@
-// What a read hook is handed, and where a target's own hooks reach.
+// What a read hook is handed.
 //
-// Two halves of one promise: a hook is documented against the value the field
-// was configured with, and a related row is documented as getting the target
-// collection's own treatment. Both were true only for a direct read.
+// A hook is documented against the value the field was configured with, but
+// `afterRead` ran before JSON columns were decoded, so on SQLite every handler
+// received the storage encoding instead.
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { defineCollection, json, relationship, text } from "../../../config";
+import { defineCollection, json, text } from "../../../config";
 import { registerHook, unregisterHook } from "../../../hooks";
 import type { HookHandler } from "../../../hooks/types";
 import {
@@ -17,12 +17,6 @@ import {
 // Integration files share fixed system-table names, so this suite keeps its own
 // slugs to avoid colliding with a concurrently-running file.
 const DOCS = "finalval_docs";
-const AUTHORS = "finalval_authors";
-const POSTS = "finalval_posts";
-
-// What the related-row field hook was handed. The hook is declared inside the
-// fixture, so the assertion reads it from here.
-const profileHookSaw: unknown[] = [];
 
 let current: TestNextly | undefined;
 afterEach(async () => {
@@ -61,46 +55,6 @@ async function boot(): Promise<TestNextly> {
       defineCollection({
         slug: DOCS,
         fields: [text({ name: "title" }), json({ name: "config" })],
-      }),
-      defineCollection({
-        slug: AUTHORS,
-        fields: [
-          text({ name: "name" }),
-          // The transforming half of a field's read protections: the value the
-          // target's own endpoint returns is the masked one.
-          text({
-            name: "secret",
-            hooks: { afterRead: [() => "REDACTED"] },
-          }),
-          // A hook doing ordinary object work. Handed the storage encoding it
-          // throws, and the relationship fetch reads the failure as an absent
-          // row.
-          json({
-            name: "profile",
-            hooks: {
-              afterRead: [
-                ({ value }) => {
-                  // A row that has no profile at all is not what this is
-                  // about, so it passes through.
-                  if (value === null || value === undefined) return value;
-                  // Ordinary object work. Handed the storage encoding, `tags`
-                  // is undefined and this throws -- and the relationship fetch
-                  // reads that failure as an absent row.
-                  const v = value as { tags: string[] };
-                  profileHookSaw.push(v.tags.length);
-                  return value;
-                },
-              ],
-            },
-          }),
-        ],
-      }),
-      defineCollection({
-        slug: POSTS,
-        fields: [
-          text({ name: "title" }),
-          relationship({ name: "author", relationTo: AUTHORS }),
-        ],
       }),
     ],
   });
@@ -168,119 +122,6 @@ describe("read hooks see the values a caller sees", () => {
     } finally {
       unregisterHook("afterRead", DOCS, record);
     }
-  });
-
-  it("a target's field afterRead applies to a row reached through a relationship", async () => {
-    // The control below shows the target masks the field on its own endpoint.
-    // Reaching the same row through a relationship must not be the way around
-    // that: expansion may be stricter than the target's endpoint, never looser.
-    const t = await boot();
-    await t.nextly.create({
-      collection: AUTHORS,
-      data: { name: "a", secret: "TOP_SECRET" },
-    });
-    const authorId = await onlyId(t, AUTHORS);
-    await t.nextly.create({
-      collection: POSTS,
-      data: { title: "p", author: authorId },
-    });
-    const postId = await onlyId(t, POSTS);
-
-    // Control: the target's own endpoint masks it.
-    const direct = await handlerOf(t).getEntry({
-      collectionName: AUTHORS,
-      entryId: authorId,
-      overrideAccess: true,
-    });
-    expect(direct.data!.secret).toBe("REDACTED");
-
-    const expanded = await handlerOf(t).getEntry({
-      collectionName: POSTS,
-      entryId: postId,
-      overrideAccess: true,
-      depth: 1,
-    });
-
-    const related = expanded.data!.author as Record<string, unknown>;
-    expect(related).toBeTruthy();
-    expect(related.secret).toBe("REDACTED");
-  });
-  it("a target's field hook is handed decoded values through a relationship", async () => {
-    // Related rows are read straight from the table, so on SQLite their JSON
-    // columns are strings. A hook doing object work throws on one, and the
-    // relationship fetch reports that failure as an absent row -- the relation
-    // disappears rather than erroring.
-    profileHookSaw.length = 0;
-    const t = await boot();
-    await t.nextly.create({
-      collection: AUTHORS,
-      data: { name: "a", secret: "s", profile: { tags: ["x", "y"] } },
-    });
-    const authorId = await onlyId(t, AUTHORS);
-    await t.nextly.create({
-      collection: POSTS,
-      data: { title: "p", author: authorId },
-    });
-    const postId = await onlyId(t, POSTS);
-
-    // The reads above went through the DIRECT path, which decodes and runs the
-    // same hook. Cleared here so what follows can only have come from the
-    // expansion.
-    profileHookSaw.length = 0;
-
-    const expanded = await handlerOf(t).getEntry({
-      collectionName: POSTS,
-      entryId: postId,
-      overrideAccess: true,
-      depth: 1,
-    });
-
-    // The relation survived, and the hook read the tags rather than choking on
-    // a string. The row itself keeps its stored encoding on the way out, which
-    // is why this asserts what the hook was handed.
-    expect(expanded.data!.author).toBeTruthy();
-    expect(profileHookSaw).toContain(2);
-  });
-
-  it("related field hooks stay out of an evidence-gathering read", async () => {
-    // A caller clearing `enforceFieldAccess` is assembling the row a
-    // document-dependent access rule is judged on, and wants it unredacted. A
-    // masking hook running there would rewrite the evidence before the rule
-    // sees it, and would fire its side effects for a request not yet allowed.
-    const t = await boot();
-    await t.nextly.create({
-      collection: AUTHORS,
-      data: { name: "a", secret: "TOP_SECRET", profile: { tags: [] } },
-    });
-    const authorId = await onlyId(t, AUTHORS);
-
-    const service = t.getService("relationshipService") as unknown as {
-      batchFetchRelatedEntries: (
-        target: string,
-        ids: string[],
-        field: Record<string, unknown>,
-        access: Record<string, unknown>
-      ) => Promise<Map<string, Record<string, unknown>>>;
-    };
-    const field = { name: "author", type: "relationship", relationTo: AUTHORS };
-
-    const evidence = await service.batchFetchRelatedEntries(
-      AUTHORS,
-      [authorId],
-      field,
-      { enforceFieldAccess: false, overrideAccess: true }
-    );
-    expect(evidence.get(authorId)!.secret).toBe("TOP_SECRET");
-
-    // The control: the same fetch for a real read does mask it, so the
-    // difference is the flag and not a hook that never ran.
-    const served = await service.batchFetchRelatedEntries(
-      AUTHORS,
-      [authorId],
-      field,
-      { enforceFieldAccess: true, overrideAccess: true }
-    );
-    expect(served.get(authorId)!.secret).toBe("REDACTED");
   });
 
   it("a value a hook returns is not decoded a second time", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/read-hooks-see-final-values.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/read-hooks-see-final-values.integration.test.ts
@@ -1,0 +1,183 @@
+// What a read hook is handed, and where a target's own hooks reach.
+//
+// Two halves of one promise: a hook is documented against the value the field
+// was configured with, and a related row is documented as getting the target
+// collection's own treatment. Both were true only for a direct read.
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, json, relationship, text } from "../../../config";
+import { registerHook, unregisterHook } from "../../../hooks";
+import type { HookHandler } from "../../../hooks/types";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+// Integration files share fixed system-table names, so this suite keeps its own
+// slugs to avoid colliding with a concurrently-running file.
+const DOCS = "finalval_docs";
+const AUTHORS = "finalval_authors";
+const POSTS = "finalval_posts";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+type ReadHandler = {
+  listEntries: (p: Record<string, unknown>) => Promise<{
+    success: boolean;
+    data: { docs: Record<string, unknown>[]; totalDocs: number } | null;
+  }>;
+  getEntry: (p: Record<string, unknown>) => Promise<{
+    success: boolean;
+    data: Record<string, unknown> | null;
+  }>;
+};
+
+function handlerOf(t: TestNextly) {
+  return t.getService("collectionsHandler") as unknown as ReadHandler;
+}
+
+// The id is read back rather than taken from the create call, so the fixture
+// does not depend on that call's envelope shape.
+async function onlyId(t: TestNextly, collection: string): Promise<string> {
+  const listed = await handlerOf(t).listEntries({
+    collectionName: collection,
+    overrideAccess: true,
+  });
+  return String(listed.data!.docs[0].id);
+}
+
+async function boot(): Promise<TestNextly> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: DOCS,
+        fields: [text({ name: "title" }), json({ name: "config" })],
+      }),
+      defineCollection({
+        slug: AUTHORS,
+        fields: [
+          text({ name: "name" }),
+          // The transforming half of a field's read protections: the value the
+          // target's own endpoint returns is the masked one.
+          text({
+            name: "secret",
+            hooks: { afterRead: [() => "REDACTED"] },
+          }),
+        ],
+      }),
+      defineCollection({
+        slug: POSTS,
+        fields: [
+          text({ name: "title" }),
+          relationship({ name: "author", relationTo: AUTHORS }),
+        ],
+      }),
+    ],
+  });
+  return current;
+}
+
+describe("read hooks see the values a caller sees", () => {
+  it("afterRead is handed a decoded JSON value, not the storage encoding", async () => {
+    // SQLite has no JSON type, so these columns come back as strings. A hook
+    // that reads `entry.config.mode` gets `undefined` from a string, and one
+    // that assigns onto it throws -- on SQLite only, which is the default
+    // development database.
+    const t = await boot();
+    await t.nextly.create({
+      collection: DOCS,
+      data: { title: "d", config: { mode: "live" } },
+    });
+
+    const seen: unknown[] = [];
+    const record: HookHandler = ctx => {
+      const rows = ctx.data as Record<string, unknown>[];
+      seen.push(rows[0]?.config);
+      return ctx.data;
+    };
+    registerHook("afterRead", DOCS, record);
+
+    try {
+      await handlerOf(t).listEntries({
+        collectionName: DOCS,
+        overrideAccess: true,
+      });
+
+      expect(seen).toHaveLength(1);
+      expect(typeof seen[0]).toBe("object");
+      expect(seen[0]).toEqual({ mode: "live" });
+    } finally {
+      unregisterHook("afterRead", DOCS, record);
+    }
+  });
+
+  it("afterRead on a read by id is handed a decoded JSON value too", async () => {
+    const t = await boot();
+    await t.nextly.create({
+      collection: DOCS,
+      data: { title: "d", config: { mode: "live" } },
+    });
+    const docId = await onlyId(t, DOCS);
+
+    const seen: unknown[] = [];
+    const record: HookHandler = ctx => {
+      seen.push((ctx.data as Record<string, unknown>).config);
+      return ctx.data;
+    };
+    registerHook("afterRead", DOCS, record);
+
+    try {
+      await handlerOf(t).getEntry({
+        collectionName: DOCS,
+        entryId: docId,
+        overrideAccess: true,
+      });
+
+      expect(seen).toHaveLength(1);
+      expect(seen[0]).toEqual({ mode: "live" });
+    } finally {
+      unregisterHook("afterRead", DOCS, record);
+    }
+  });
+
+  it("a target's field afterRead applies to a row reached through a relationship", async () => {
+    // The control below shows the target masks the field on its own endpoint.
+    // Reaching the same row through a relationship must not be the way around
+    // that: expansion may be stricter than the target's endpoint, never looser.
+    const t = await boot();
+    await t.nextly.create({
+      collection: AUTHORS,
+      data: { name: "a", secret: "TOP_SECRET" },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "p", author: authorId },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    // Control: the target's own endpoint masks it.
+    const direct = await handlerOf(t).getEntry({
+      collectionName: AUTHORS,
+      entryId: authorId,
+      overrideAccess: true,
+    });
+    expect(direct.data!.secret).toBe("REDACTED");
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      overrideAccess: true,
+      depth: 1,
+    });
+
+    const related = expanded.data!.author as Record<string, unknown>;
+    expect(related).toBeTruthy();
+    expect(related.secret).toBe("REDACTED");
+  });
+});

--- a/packages/nextly/src/domains/collections/services/__tests__/decode-json-field-values.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/decode-json-field-values.test.ts
@@ -44,4 +44,24 @@ describe("decodeJsonFieldValues", () => {
     decodeJsonFieldValues(rows, [jsonField("config")]);
     expect(rows[0].config).toBe("not json");
   });
+
+  it("decodes a richText locale map that never set localized explicitly", () => {
+    // Text-like types localize by default in a localized collection, so the
+    // builder never materializes the flag. Reading the raw flag leaves these
+    // maps encoded and hands hooks and callers strings where Lexical objects
+    // are documented.
+    const rows = [{ body: { en: '{"root":{}}', fr: '{"root":{}}' } }];
+    decodeJsonFieldValues(rows, [{ name: "body", type: "richText" }], "all");
+    expect(rows[0].body).toEqual({ en: { root: {} }, fr: { root: {} } });
+  });
+
+  it("leaves a richText field alone when it opts out of localization", () => {
+    const rows = [{ body: { en: '{"root":{}}' } }];
+    decodeJsonFieldValues(
+      rows,
+      [{ name: "body", type: "richText", localized: false }],
+      "all"
+    );
+    expect(rows[0].body).toEqual({ en: '{"root":{}}' });
+  });
 });

--- a/packages/nextly/src/domains/collections/services/__tests__/decode-json-field-values.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/decode-json-field-values.test.ts
@@ -1,0 +1,47 @@
+// The decode that runs before a read's hooks.
+//
+// `locale=all` is the only shape where a field's value is a language-keyed map,
+// and only a localized field is ever read that way. A driver that parses JSON
+// hands back a plain object for a shared field, so the two are told apart by
+// the field's own declaration rather than by looking at the value.
+
+import { describe, expect, it } from "vitest";
+
+import { decodeJsonFieldValues } from "../collection-utils";
+
+const jsonField = (name: string, localized = false) => ({
+  name,
+  type: "json",
+  localized,
+});
+
+describe("decodeJsonFieldValues", () => {
+  it("decodes a storage-encoded value", () => {
+    const rows = [{ config: '{"mode":"live"}' }];
+    decodeJsonFieldValues(rows, [jsonField("config")]);
+    expect(rows[0].config).toEqual({ mode: "live" });
+  });
+
+  it("leaves a shared JSON object alone under locale=all", () => {
+    // The value is the field's own object. Read as a locale map, its string
+    // properties get parsed and the caller receives types the row never held.
+    const rows = [{ config: { mode: "true", retries: "3" } }];
+    decodeJsonFieldValues(rows, [jsonField("config")], "all");
+    expect(rows[0].config).toEqual({ mode: "true", retries: "3" });
+  });
+
+  it("decodes each locale of a localized field under locale=all", () => {
+    const rows = [{ config: { en: '{"mode":"live"}', fr: '{"mode":"test"}' } }];
+    decodeJsonFieldValues(rows, [jsonField("config", true)], "all");
+    expect(rows[0].config).toEqual({
+      en: { mode: "live" },
+      fr: { mode: "test" },
+    });
+  });
+
+  it("keeps text that is not JSON as the value it is", () => {
+    const rows = [{ config: "not json" }];
+    decodeJsonFieldValues(rows, [jsonField("config")]);
+    expect(rows[0].config).toBe("not json");
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -347,16 +347,53 @@ export class CollectionQueryService extends BaseService {
    * caller's filter reaches the query untouched.
    */
   /**
-   * Marks that a read's hooks are running on this async call stack.
+   * The collections whose read hooks are running on this async call stack.
    *
-   * A `beforeRead` handler may call `nextly.count()` -- for a quota check, or
-   * for related state -- and that was safe while the count ran no hooks. Now
-   * that it does, the nested count would run the same handler again, and that
-   * handler would count again. The guard makes a nested read use the filter it
-   * was given and run no hooks, which is the behaviour such handlers were
-   * written against.
+   * A read handler may read again -- a `count()` for a quota, a `findByID()`
+   * for related state -- and that was safe while a count ran no hooks. Now
+   * that every read path runs them, a nested read of the collection the
+   * handler is already running for would call that handler a second time, and
+   * so on without end.
+   *
+   * Scoped per collection, not per call stack: a nested read of a DIFFERENT
+   * collection is an ordinary read and must run that collection's own hooks.
+   * Those hooks may be what scopes it to a tenant or hides soft-deleted rows,
+   * so suppressing them would hand the handler rows the other collection
+   * withholds -- a silent widening, which is worse than the recursion this
+   * guards against.
+   *
+   * Keyed by collection rather than by individual handler because handlers can
+   * cycle in pairs (a handler on A reads B, a handler on B reads A) and only a
+   * per-collection key breaks that. The cost is that a handler re-reading its
+   * own collection runs unhooked, which is what such handlers were written
+   * against.
    */
-  private static readonly readHooksRunning = new AsyncLocalStorage<true>();
+  private static readonly activeReadHookCollections = new AsyncLocalStorage<
+    ReadonlySet<string>
+  >();
+
+  /** True when this collection's read hooks are already running up-stack. */
+  private static readHooksActiveFor(collectionName: string): boolean {
+    return (
+      CollectionQueryService.activeReadHookCollections
+        .getStore()
+        ?.has(collectionName) ?? false
+    );
+  }
+
+  /**
+   * Runs `run` with this collection marked active, preserving any collection
+   * already marked so an A-reads-B-reads-A cycle still terminates.
+   */
+  private static withReadHookScope<T>(
+    collectionName: string,
+    run: () => Promise<T>
+  ): Promise<T> {
+    const active = CollectionQueryService.activeReadHookCollections.getStore();
+    const nested = new Set(active ?? []);
+    nested.add(collectionName);
+    return CollectionQueryService.activeReadHookCollections.run(nested, run);
+  }
 
   private async resolveReadWhere(params: {
     collectionName: string;
@@ -364,63 +401,164 @@ export class CollectionQueryService extends BaseService {
     user?: UserContext;
     sharedContext: Record<string, unknown>;
   }): Promise<WhereFilter | undefined> {
-    // Already inside a read's hooks: this call came from a handler, so it uses
-    // the filter it was given and runs nothing.
-    if (CollectionQueryService.readHooksRunning.getStore()) {
+    // Already inside this collection's read hooks: the call came from one of
+    // its own handlers, so it uses the filter it was given and runs nothing.
+    if (CollectionQueryService.readHooksActiveFor(params.collectionName)) {
       return params.where;
     }
     const seededWhere = params.where ?? {};
-    return CollectionQueryService.readHooksRunning.run(true, async () => {
-      const beforeOpArgs =
-        await this.hookService.hookRegistry.executeBeforeOperation({
-          collection: params.collectionName,
-          operation: "read",
-          // An object, for the same reason `beforeRead` gets one below: a
-          // handler scoping in place (`ctx.args.where.tenant = ...`) would
-          // otherwise throw on every unfiltered read instead of adding its
-          // predicate. The settled filter keeps `undefined` as its own value.
-          args: { where: seededWhere },
-          user: params.user
-            ? { id: params.user.id, email: params.user.email }
-            : undefined,
-          context: params.sharedContext,
-        });
+    return CollectionQueryService.withReadHookScope(
+      params.collectionName,
+      async () => {
+        const beforeOpArgs =
+          await this.hookService.hookRegistry.executeBeforeOperation({
+            collection: params.collectionName,
+            operation: "read",
+            // An object, for the same reason `beforeRead` gets one below: a
+            // handler scoping in place (`ctx.args.where.tenant = ...`) would
+            // otherwise throw on every unfiltered read instead of adding its
+            // predicate. The settled filter keeps `undefined` as its own value.
+            args: { where: seededWhere },
+            user: params.user
+              ? { id: params.user.id, email: params.user.email }
+              : undefined,
+            context: params.sharedContext,
+          });
 
-      // Returning an args object replaces the arguments wholesale, so a handler
-      // that omits `where` -- or sets it to `undefined` -- is clearing the filter,
-      // not declining to change it. Only the absence of a returned object leaves
-      // the caller's filter in place.
-      // The seeded object is an input convenience, not a filter. If it comes
-      // back untouched and still empty, the read has no filter -- turning that
-      // into `{}` would make every downstream `if (where)` believe one exists.
-      const returnedWhere = beforeOpArgs ? beforeOpArgs.where : params.where;
-      const afterBeforeOperation = (
-        returnedWhere === seededWhere && Object.keys(seededWhere).length === 0
-          ? params.where
-          : returnedWhere
-      ) as WhereFilter | undefined;
+        // Returning an args object replaces the arguments wholesale, so a handler
+        // that omits `where` -- or sets it to `undefined` -- is clearing the filter,
+        // not declining to change it. Only the absence of a returned object leaves
+        // the caller's filter in place.
+        // The seeded object is an input convenience, not a filter. If it comes
+        // back untouched and still empty, the read has no filter -- turning that
+        // into `{}` would make every downstream `if (where)` believe one exists.
+        const returnedWhere = beforeOpArgs ? beforeOpArgs.where : params.where;
+        const afterBeforeOperation = (
+          returnedWhere === seededWhere && Object.keys(seededWhere).length === 0
+            ? params.where
+            : returnedWhere
+        ) as WhereFilter | undefined;
 
-      const beforeReadResult = await this.hookService.hookRegistry.execute(
-        "beforeRead",
-        this.hookService.buildHookContext({
-          collection: params.collectionName,
-          operation: "read" as const,
-          // Always an object: handlers documented as "modify query parameters"
-          // assign onto it in place, and handing them `undefined` would throw on
-          // every unfiltered read rather than adding their predicate.
-          data: afterBeforeOperation ?? {},
-          user: params.user,
-          context: params.sharedContext,
-        })
-      );
+        const beforeReadResult = await this.hookService.hookRegistry.execute(
+          "beforeRead",
+          this.hookService.buildHookContext({
+            collection: params.collectionName,
+            operation: "read" as const,
+            // Always an object: handlers documented as "modify query parameters"
+            // assign onto it in place, and handing them `undefined` would throw on
+            // every unfiltered read rather than adding their predicate.
+            data: afterBeforeOperation ?? {},
+            user: params.user,
+            context: params.sharedContext,
+          })
+        );
 
-      // `undefined` means the hook returned nothing, so the filter is unchanged;
-      // `null` is a deliberate return the registry preserves, and it means the
-      // hook cleared the filter. Collapsing the two would leave a hook unable to
-      // widen a read it had decided should not be narrowed.
-      if (beforeReadResult === undefined) return afterBeforeOperation;
-      return beforeReadResult ?? undefined;
-    });
+        // `undefined` means the hook returned nothing, so the filter is unchanged;
+        // `null` is a deliberate return the registry preserves, and it means the
+        // hook cleared the filter. Collapsing the two would leave a hook unable to
+        // widen a read it had decided should not be narrowed.
+        if (beforeReadResult === undefined) return afterBeforeOperation;
+        return beforeReadResult ?? undefined;
+      }
+    );
+  }
+
+  /**
+   * Turns storage-encoded JSON columns back into the values the field was
+   * configured with.
+   *
+   * SQLite has no JSON type, so richtext, blocks, array, group and json fields
+   * come back as strings. Every consumer after this point -- hooks, field-level
+   * access, the caller -- is documented against the configured value, so the
+   * decode belongs before the first of them rather than between them.
+   */
+  private decodeJsonFieldValues(
+    entries: Record<string, unknown>[],
+    fields: FieldDefinition[],
+    locale: string | undefined
+  ): void {
+    for (const entry of entries) {
+      for (const field of fields) {
+        if (!isJsonFieldType(field.type, field)) continue;
+        const value = entry[field.name];
+        if (typeof value === "string") {
+          try {
+            entry[field.name] = JSON.parse(value);
+          } catch {
+            // Not JSON after all; the stored string is the value.
+          }
+        } else if (
+          locale === "all" &&
+          value !== null &&
+          typeof value === "object"
+        ) {
+          // `locale=all` yields a language-keyed map of raw companion values, so
+          // each locale's string is decoded to match the shape a single-locale
+          // read returns.
+          const keyed = value as Record<string, unknown>;
+          for (const code of Object.keys(keyed)) {
+            if (typeof keyed[code] === "string") {
+              try {
+                keyed[code] = JSON.parse(keyed[code]);
+              } catch {
+                // Not JSON after all; the stored string is the value.
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * The detail read's half of {@link resolveReadWhere}: runs `beforeOperation`
+   * and `beforeRead` for a read by id and returns the id they settled on.
+   *
+   * Deliberately the same check-then-enter shape as the list half. A detail
+   * read reached from another read's handler must skip its hooks for the same
+   * reason a nested list does, and holding both to one shape is what keeps the
+   * guard from being applied to one path and not the other.
+   */
+  private async resolveReadEntryId(params: {
+    collectionName: string;
+    entryId: string;
+    user?: UserContext;
+    sharedContext: Record<string, unknown>;
+  }): Promise<string> {
+    if (CollectionQueryService.readHooksActiveFor(params.collectionName)) {
+      return params.entryId;
+    }
+    return CollectionQueryService.withReadHookScope(
+      params.collectionName,
+      async () => {
+        const beforeOpArgs =
+          await this.hookService.hookRegistry.executeBeforeOperation({
+            collection: params.collectionName,
+            operation: "read",
+            args: { id: params.entryId },
+            user: params.user
+              ? { id: params.user.id, email: params.user.email }
+              : undefined,
+            context: params.sharedContext,
+          });
+
+        // Use the modified id when beforeOperation returned one.
+        const resolvedId = beforeOpArgs?.id ?? params.entryId;
+
+        await this.hookService.hookRegistry.execute(
+          "beforeRead",
+          this.hookService.buildHookContext({
+            collection: params.collectionName,
+            operation: "read" as const,
+            data: { entryId: resolvedId },
+            user: params.user,
+            context: params.sharedContext,
+          })
+        );
+
+        return resolvedId;
+      }
+    );
   }
 
   private buildLocalizedQueryContext(
@@ -1271,6 +1409,11 @@ export class CollectionQueryService extends BaseService {
         stripSystemOwnerField(entry);
       }
 
+      // Decode before any afterRead hook runs. A hook is documented against the
+      // configured value, and on SQLite these columns are strings, so decoding
+      // after the hooks handed every one of them the storage encoding instead.
+      this.decodeJsonFieldValues(expandedEntries, fields, params.locale);
+
       // Execute afterRead hooks (code-registered)
       // Hooks can transform the fetched data
       const afterContext = this.hookService.buildHookContext({
@@ -1328,40 +1471,13 @@ export class CollectionQueryService extends BaseService {
         }
       }
 
-      // Deserialize JSON fields (richtext, blocks, array, group, json) for all entries
-      finalData = (finalData as Record<string, unknown>[]).map(entry => {
-        fields.forEach(field => {
-          if (!isJsonFieldType(field.type, field)) return;
-          const value = entry[field.name];
-          if (typeof value === "string") {
-            try {
-              entry[field.name] = JSON.parse(value);
-            } catch {
-              // If parsing fails, keep as string
-            }
-          } else if (
-            params.locale === "all" &&
-            value !== null &&
-            typeof value === "object"
-          ) {
-            // locale=all yields a language-keyed map of raw companion values;
-            // parse each locale's JSON string so nested shapes match the
-            // parsed objects a single-locale read returns.
-            const keyed = value as Record<string, unknown>;
-            for (const code of Object.keys(keyed)) {
-              if (typeof keyed[code] === "string") {
-                try {
-                  keyed[code] = JSON.parse(keyed[code]);
-                } catch {
-                  // If parsing fails, keep as string
-                }
-              }
-            }
-          }
-        });
-
-        return entry;
-      });
+      // A hook may return values it built itself, so the decode runs again over
+      // what they settled on. Already-decoded values are left alone.
+      this.decodeJsonFieldValues(
+        finalData as Record<string, unknown>[],
+        fields,
+        params.locale
+      );
 
       // Field-level afterRead hooks + read access (code-first functions
       // resolved via the field-level registry): hooks may transform values;
@@ -1988,46 +2104,14 @@ export class CollectionQueryService extends BaseService {
       // Shared context between all hooks in this request
       const sharedContext: Record<string, unknown> = { ...params.context };
 
-      // Execute beforeOperation hooks FIRST (before operation-specific hooks)
-      // Can modify operation arguments (id) or throw to abort
-      // Marked for the whole detail read, not only the list one: a handler here
-      // may call `nextly.count()` too, and an unguarded detail path lets it
-      // re-enter its own hook through the count that now runs them.
-      const entryId = await CollectionQueryService.readHooksRunning.run(
-        true,
-        async () => {
-          const beforeOpArgs =
-            await this.hookService.hookRegistry.executeBeforeOperation({
-              collection: params.collectionName,
-              operation: "read",
-              args: { id: params.entryId },
-              user: params.user
-                ? { id: params.user.id, email: params.user.email }
-                : undefined,
-              context: sharedContext,
-            });
-
-          // Use modified id if returned by beforeOperation
-          const resolvedId = beforeOpArgs?.id ?? params.entryId;
-
-          // Execute beforeRead hooks
-          // Hooks can be used to modify query parameters or add filters
-          const beforeContext = this.hookService.buildHookContext({
-            collection: params.collectionName,
-            operation: "read" as const,
-            data: { entryId: resolvedId },
-            user: params.user,
-            context: sharedContext,
-          });
-
-          await this.hookService.hookRegistry.execute(
-            "beforeRead",
-            beforeContext
-          );
-
-          return resolvedId;
-        }
-      );
+      // `beforeOperation` runs first and may rewrite the id, then `beforeRead`
+      // sees the id it settled on.
+      const entryId = await this.resolveReadEntryId({
+        collectionName: params.collectionName,
+        entryId: params.entryId,
+        user: params.user,
+        sharedContext,
+      });
 
       // When read access is `owner-only`, fold the ownership
       // predicate into the SQL WHERE clause. A non-owner gets a 404
@@ -2209,6 +2293,11 @@ export class CollectionQueryService extends BaseService {
       // Always strip the system owner column (see listEntries).
       stripSystemOwnerField(expandedEntry);
 
+      // Decode before any afterRead hook runs, for the same reason as the list
+      // path: a hook is documented against the configured value, not the
+      // storage encoding SQLite hands back.
+      this.decodeJsonFieldValues([expandedEntry], fields, params.locale);
+
       // Execute afterRead hooks (code-registered)
       // Hooks can transform the fetched data
       const afterContext = this.hookService.buildHookContext({
@@ -2262,36 +2351,9 @@ export class CollectionQueryService extends BaseService {
       // Same defense in depth for the owner column.
       stripSystemOwnerField(finalData);
 
-      // Deserialize JSON fields (richtext, blocks, array, group, json) for response
-      fields.forEach(field => {
-        if (!isJsonFieldType(field.type, field)) return;
-        const value = finalData[field.name];
-        if (typeof value === "string") {
-          try {
-            finalData[field.name] = JSON.parse(value);
-          } catch {
-            // If parsing fails, keep as string
-          }
-        } else if (
-          params.locale === "all" &&
-          value !== null &&
-          typeof value === "object"
-        ) {
-          // locale=all yields a language-keyed map of raw companion values;
-          // parse each locale's JSON string so nested shapes match the parsed
-          // objects a single-locale read returns.
-          const keyed = value as Record<string, unknown>;
-          for (const code of Object.keys(keyed)) {
-            if (typeof keyed[code] === "string") {
-              try {
-                keyed[code] = JSON.parse(keyed[code]);
-              } catch {
-                // If parsing fails, keep as string
-              }
-            }
-          }
-        }
-      });
+      // A hook may return values it built itself, so the decode runs again over
+      // what they settled on. Already-decoded values are left alone.
+      this.decodeJsonFieldValues([finalData], fields, params.locale);
 
       // Field-level afterRead hooks + read access — same semantics as the
       // list path above.

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -103,7 +103,7 @@ import {
   getTableName,
   getSearchableFields,
   getMinSearchLength,
-  isJsonFieldType,
+  decodeJsonFieldValues,
 } from "./collection-utils";
 
 export class CollectionQueryService extends BaseService {
@@ -461,53 +461,6 @@ export class CollectionQueryService extends BaseService {
         return beforeReadResult ?? undefined;
       }
     );
-  }
-
-  /**
-   * Turns storage-encoded JSON columns back into the values the field was
-   * configured with.
-   *
-   * SQLite has no JSON type, so richtext, blocks, array, group and json fields
-   * come back as strings. Every consumer after this point -- hooks, field-level
-   * access, the caller -- is documented against the configured value, so the
-   * decode belongs before the first of them rather than between them.
-   */
-  private decodeJsonFieldValues(
-    entries: Record<string, unknown>[],
-    fields: FieldDefinition[],
-    locale: string | undefined
-  ): void {
-    for (const entry of entries) {
-      for (const field of fields) {
-        if (!isJsonFieldType(field.type, field)) continue;
-        const value = entry[field.name];
-        if (typeof value === "string") {
-          try {
-            entry[field.name] = JSON.parse(value);
-          } catch {
-            // Not JSON after all; the stored string is the value.
-          }
-        } else if (
-          locale === "all" &&
-          value !== null &&
-          typeof value === "object"
-        ) {
-          // `locale=all` yields a language-keyed map of raw companion values, so
-          // each locale's string is decoded to match the shape a single-locale
-          // read returns.
-          const keyed = value as Record<string, unknown>;
-          for (const code of Object.keys(keyed)) {
-            if (typeof keyed[code] === "string") {
-              try {
-                keyed[code] = JSON.parse(keyed[code]);
-              } catch {
-                // Not JSON after all; the stored string is the value.
-              }
-            }
-          }
-        }
-      }
-    }
   }
 
   /**
@@ -1412,7 +1365,7 @@ export class CollectionQueryService extends BaseService {
       // Decode before any afterRead hook runs. A hook is documented against the
       // configured value, and on SQLite these columns are strings, so decoding
       // after the hooks handed every one of them the storage encoding instead.
-      this.decodeJsonFieldValues(expandedEntries, fields, params.locale);
+      decodeJsonFieldValues(expandedEntries, fields, params.locale);
 
       // Execute afterRead hooks (code-registered)
       // Hooks can transform the fetched data
@@ -1470,14 +1423,6 @@ export class CollectionQueryService extends BaseService {
           stripPasswordFieldValues(entry, fields);
         }
       }
-
-      // A hook may return values it built itself, so the decode runs again over
-      // what they settled on. Already-decoded values are left alone.
-      this.decodeJsonFieldValues(
-        finalData as Record<string, unknown>[],
-        fields,
-        params.locale
-      );
 
       // Field-level afterRead hooks + read access (code-first functions
       // resolved via the field-level registry): hooks may transform values;
@@ -2296,7 +2241,7 @@ export class CollectionQueryService extends BaseService {
       // Decode before any afterRead hook runs, for the same reason as the list
       // path: a hook is documented against the configured value, not the
       // storage encoding SQLite hands back.
-      this.decodeJsonFieldValues([expandedEntry], fields, params.locale);
+      decodeJsonFieldValues([expandedEntry], fields, params.locale);
 
       // Execute afterRead hooks (code-registered)
       // Hooks can transform the fetched data
@@ -2350,10 +2295,6 @@ export class CollectionQueryService extends BaseService {
       }
       // Same defense in depth for the owner column.
       stripSystemOwnerField(finalData);
-
-      // A hook may return values it built itself, so the decode runs again over
-      // what they settled on. Already-decoded values are left alone.
-      this.decodeJsonFieldValues([finalData], fields, params.locale);
 
       // Field-level afterRead hooks + read access — same semantics as the
       // list path above.

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -39,7 +39,10 @@ import type {
 } from "../../../services/collections/related-row-read-context";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
-import { applyFieldReadAccess } from "../../../shared/lib/field-level-registry";
+import {
+  applyFieldReadAccess,
+  runFieldHooks,
+} from "../../../shared/lib/field-level-registry";
 import {
   hasPasswordField,
   stripPasswordFieldValues,
@@ -2836,7 +2839,38 @@ export class CollectionRelationshipService extends BaseService {
         stripPasswordFieldValues(row, targetFields);
       }
     }
+    await this.runRelatedRowFieldHooks(targetCollection, rows, access);
     await this.applyRelatedRowReadAccess(targetCollection, rows, access);
+  }
+
+  /**
+   * Run the TARGET collection's field-level `afterRead` hooks over related rows.
+   *
+   * These hooks are how a field masks or rewrites itself on the way out -- the
+   * transforming half of the same pair whose access half is
+   * `applyRelatedRowReadAccess`. A direct read of the target runs both, so
+   * skipping them here hands a caller through a relationship the value the
+   * target's own endpoint would never return.
+   *
+   * Ordered before the access pass, exactly as a direct read orders them, so a
+   * field the rules deny is dropped after its hook has run rather than being
+   * transformed once it is already gone.
+   */
+  private async runRelatedRowFieldHooks(
+    targetCollection: string,
+    rows: Record<string, unknown>[],
+    access: RelatedRowAccess
+  ): Promise<void> {
+    for (const row of rows) {
+      await runFieldHooks({
+        kind: "collection",
+        slug: targetCollection,
+        phase: "afterRead",
+        data: row,
+        operation: "read",
+        user: access.user,
+      });
+    }
   }
 
   /**

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -39,10 +39,7 @@ import type {
 } from "../../../services/collections/related-row-read-context";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
-import {
-  applyFieldReadAccess,
-  runFieldHooks,
-} from "../../../shared/lib/field-level-registry";
+import { applyFieldReadAccess } from "../../../shared/lib/field-level-registry";
 import {
   hasPasswordField,
   stripPasswordFieldValues,
@@ -53,7 +50,6 @@ import type { DynamicCollectionService } from "../../dynamic-collections";
 
 import { CollectionAccessService } from "./collection-access-service";
 import type { UserContext } from "./collection-types";
-import { decodeJsonFieldValues, isJsonFieldType } from "./collection-utils";
 
 /**
  * System-entity columns that hold secrets and must never ride along a
@@ -2840,90 +2836,7 @@ export class CollectionRelationshipService extends BaseService {
         stripPasswordFieldValues(row, targetFields);
       }
     }
-    // Related rows come straight from the table, so on SQLite their JSON
-    // columns are still strings. A field hook is documented against the
-    // configured value, so the decode is scoped to the hook pass: a related row
-    // keeps its stored encoding on the way out, and the access pass below reads
-    // inside that encoding.
-    await this.withDecodedJsonFields(rows, targetFields, () =>
-      this.runRelatedRowFieldHooks(targetCollection, rows, access)
-    );
     await this.applyRelatedRowReadAccess(targetCollection, rows, access);
-  }
-
-  /**
-   * Decode the JSON-encoded fields of `rows`, run `work`, then put the encoding
-   * back.
-   *
-   * A related row carries its stored shape all the way out -- redaction reads
-   * and rewrites inside the encoded string, and callers receive the column as
-   * it is stored. Field hooks are the exception: they are declared against the
-   * configured value, so they see it decoded and whatever they leave behind is
-   * re-encoded before anything downstream looks at it.
-   *
-   * Only fields that arrived encoded are restored, so a value that was never a
-   * string is left as it is, as is one whose text was not JSON after all.
-   */
-  private async withDecodedJsonFields<T>(
-    rows: Record<string, unknown>[],
-    fields: FieldDefinition[],
-    work: () => Promise<T>
-  ): Promise<T> {
-    const encoded: Array<[Record<string, unknown>, string]> = [];
-    for (const row of rows) {
-      for (const field of fields) {
-        if (!isJsonFieldType(field.type, field)) continue;
-        if (typeof row[field.name] === "string")
-          encoded.push([row, field.name]);
-      }
-    }
-    decodeJsonFieldValues(rows, fields);
-    try {
-      return await work();
-    } finally {
-      for (const [row, name] of encoded) {
-        if (typeof row[name] !== "string")
-          row[name] = JSON.stringify(row[name]);
-      }
-    }
-  }
-
-  /**
-   * Run the TARGET collection's field-level `afterRead` hooks over related rows.
-   *
-   * These hooks are how a field masks or rewrites itself on the way out -- the
-   * transforming half of the same pair whose access half is
-   * `applyRelatedRowReadAccess`. A direct read of the target runs both, so
-   * skipping them here hands a caller through a relationship the value the
-   * target's own endpoint would never return.
-   *
-   * Ordered before the access pass, exactly as a direct read orders them, so a
-   * field the rules deny is dropped after its hook has run rather than being
-   * transformed once it is already gone.
-   *
-   * Gated on the same flag as that access pass, because a caller clearing it is
-   * not asking for a lighter read: it is assembling the evidence a
-   * document-dependent rule is judged on, and wants the row unredacted. Running
-   * these hooks there would let a masking hook rewrite the evidence before the
-   * rule sees it, and would fire their side effects for a request that has not
-   * been authorized yet.
-   */
-  private async runRelatedRowFieldHooks(
-    targetCollection: string,
-    rows: Record<string, unknown>[],
-    access: RelatedRowAccess
-  ): Promise<void> {
-    if (!access.enforceFieldAccess) return;
-    for (const row of rows) {
-      await runFieldHooks({
-        kind: "collection",
-        slug: targetCollection,
-        phase: "afterRead",
-        data: row,
-        operation: "read",
-        user: access.user,
-      });
-    }
   }
 
   /**

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -53,6 +53,7 @@ import type { DynamicCollectionService } from "../../dynamic-collections";
 
 import { CollectionAccessService } from "./collection-access-service";
 import type { UserContext } from "./collection-types";
+import { decodeJsonFieldValues, isJsonFieldType } from "./collection-utils";
 
 /**
  * System-entity columns that hold secrets and must never ride along a
@@ -2839,8 +2840,52 @@ export class CollectionRelationshipService extends BaseService {
         stripPasswordFieldValues(row, targetFields);
       }
     }
-    await this.runRelatedRowFieldHooks(targetCollection, rows, access);
+    // Related rows come straight from the table, so on SQLite their JSON
+    // columns are still strings. A field hook is documented against the
+    // configured value, so the decode is scoped to the hook pass: a related row
+    // keeps its stored encoding on the way out, and the access pass below reads
+    // inside that encoding.
+    await this.withDecodedJsonFields(rows, targetFields, () =>
+      this.runRelatedRowFieldHooks(targetCollection, rows, access)
+    );
     await this.applyRelatedRowReadAccess(targetCollection, rows, access);
+  }
+
+  /**
+   * Decode the JSON-encoded fields of `rows`, run `work`, then put the encoding
+   * back.
+   *
+   * A related row carries its stored shape all the way out -- redaction reads
+   * and rewrites inside the encoded string, and callers receive the column as
+   * it is stored. Field hooks are the exception: they are declared against the
+   * configured value, so they see it decoded and whatever they leave behind is
+   * re-encoded before anything downstream looks at it.
+   *
+   * Only fields that arrived encoded are restored, so a value that was never a
+   * string is left as it is, as is one whose text was not JSON after all.
+   */
+  private async withDecodedJsonFields<T>(
+    rows: Record<string, unknown>[],
+    fields: FieldDefinition[],
+    work: () => Promise<T>
+  ): Promise<T> {
+    const encoded: Array<[Record<string, unknown>, string]> = [];
+    for (const row of rows) {
+      for (const field of fields) {
+        if (!isJsonFieldType(field.type, field)) continue;
+        if (typeof row[field.name] === "string")
+          encoded.push([row, field.name]);
+      }
+    }
+    decodeJsonFieldValues(rows, fields);
+    try {
+      return await work();
+    } finally {
+      for (const [row, name] of encoded) {
+        if (typeof row[name] !== "string")
+          row[name] = JSON.stringify(row[name]);
+      }
+    }
   }
 
   /**
@@ -2855,12 +2900,20 @@ export class CollectionRelationshipService extends BaseService {
    * Ordered before the access pass, exactly as a direct read orders them, so a
    * field the rules deny is dropped after its hook has run rather than being
    * transformed once it is already gone.
+   *
+   * Gated on the same flag as that access pass, because a caller clearing it is
+   * not asking for a lighter read: it is assembling the evidence a
+   * document-dependent rule is judged on, and wants the row unredacted. Running
+   * these hooks there would let a masking hook rewrite the evidence before the
+   * rule sees it, and would fire their side effects for a request that has not
+   * been authorized yet.
    */
   private async runRelatedRowFieldHooks(
     targetCollection: string,
     rows: Record<string, unknown>[],
     access: RelatedRowAccess
   ): Promise<void> {
+    if (!access.enforceFieldAccess) return;
     for (const row of rows) {
       await runFieldHooks({
         kind: "collection",

--- a/packages/nextly/src/domains/collections/services/collection-utils.ts
+++ b/packages/nextly/src/domains/collections/services/collection-utils.ts
@@ -9,6 +9,7 @@
 import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 
 import { storageTypeToken } from "../../../shared/lib/plugin-storage";
+import { isFieldLocalized } from "../../i18n/classify-fields";
 
 /**
  * Field types that are always stored as JSON in the database.
@@ -376,7 +377,12 @@ export function getMinSearchLength(
  * decode belongs before the first of them.
  *
  * The `locale=all` shape is a language-keyed map, but only a LOCALIZED field
- * is ever read that way. A shared JSON field is a plain object on a driver that
+ * is ever read that way, and localization is a CLASSIFICATION rather than a
+ * flag: text-like types (including `richText`) localize by default in a
+ * localized collection without ever materializing `localized: true`. Reading
+ * the raw flag would leave those maps encoded. The master switch is passed as
+ * enabled because a shared field still classifies as not localized, so a
+ * collection that never opted in has no maps to mistake. A shared JSON field is a plain object on a driver that
  * parses JSON, so treating every object as a locale map would parse its own
  * string properties and hand back values the row never held.
  *
@@ -408,7 +414,7 @@ export function decodeJsonFieldValues(
         }
       } else if (
         locale === "all" &&
-        field.localized === true &&
+        isFieldLocalized(field, true) &&
         value !== null &&
         typeof value === "object"
       ) {

--- a/packages/nextly/src/domains/collections/services/collection-utils.ts
+++ b/packages/nextly/src/domains/collections/services/collection-utils.ts
@@ -365,3 +365,60 @@ export function getMinSearchLength(
       ?.search as Record<string, unknown> | undefined);
   return (searchConfig?.minSearchLength as number) ?? 2;
 }
+
+/**
+ * Turn storage-encoded JSON columns back into the values the field was
+ * configured with.
+ *
+ * SQLite has no JSON type, so richtext, blocks, array, group and json fields
+ * come back as strings. Every consumer after this point -- hooks, field-level
+ * access, the caller -- is documented against the configured value, so the
+ * decode belongs before the first of them.
+ *
+ * Runs exactly once per read. A second pass cannot tell an already-decoded
+ * string from storage encoding, so a field holding the string `"123"` would
+ * decode to the number `123` on the second visit; `"true"` and `"null"` fail
+ * the same way.
+ */
+export function decodeJsonFieldValues(
+  entries: Record<string, unknown>[],
+  fields: {
+    name: string;
+    type: string;
+    hasMany?: boolean;
+    relationTo?: unknown;
+  }[],
+  locale?: string
+): void {
+  for (const entry of entries) {
+    for (const field of fields) {
+      if (!isJsonFieldType(field.type, field)) continue;
+      const value = entry[field.name];
+      if (typeof value === "string") {
+        try {
+          entry[field.name] = JSON.parse(value);
+        } catch {
+          // Not JSON after all; the stored string is the value.
+        }
+      } else if (
+        locale === "all" &&
+        value !== null &&
+        typeof value === "object"
+      ) {
+        // `locale=all` yields a language-keyed map of raw companion values, so
+        // each locale's string is decoded to match the shape a single-locale
+        // read returns.
+        const keyed = value as Record<string, unknown>;
+        for (const code of Object.keys(keyed)) {
+          if (typeof keyed[code] === "string") {
+            try {
+              keyed[code] = JSON.parse(keyed[code]);
+            } catch {
+              // Not JSON after all; the stored string is the value.
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/nextly/src/domains/collections/services/collection-utils.ts
+++ b/packages/nextly/src/domains/collections/services/collection-utils.ts
@@ -375,6 +375,11 @@ export function getMinSearchLength(
  * access, the caller -- is documented against the configured value, so the
  * decode belongs before the first of them.
  *
+ * The `locale=all` shape is a language-keyed map, but only a LOCALIZED field
+ * is ever read that way. A shared JSON field is a plain object on a driver that
+ * parses JSON, so treating every object as a locale map would parse its own
+ * string properties and hand back values the row never held.
+ *
  * Runs exactly once per read. A second pass cannot tell an already-decoded
  * string from storage encoding, so a field holding the string `"123"` would
  * decode to the number `123` on the second visit; `"true"` and `"null"` fail
@@ -387,6 +392,7 @@ export function decodeJsonFieldValues(
     type: string;
     hasMany?: boolean;
     relationTo?: unknown;
+    localized?: boolean;
   }[],
   locale?: string
 ): void {
@@ -402,6 +408,7 @@ export function decodeJsonFieldValues(
         }
       } else if (
         locale === "all" &&
+        field.localized === true &&
         value !== null &&
         typeof value === "object"
       ) {

--- a/packages/nextly/src/hooks/types.ts
+++ b/packages/nextly/src/hooks/types.ts
@@ -316,6 +316,43 @@ export type HookHandler<T = any> = (
 ) => Promise<T | void> | T | void;
 
 /**
+ * What a FIELD-level hook is handed.
+ *
+ * A field hook is scoped to one field, so it is given that field's value and
+ * name alongside the row it belongs to. This is deliberately NOT
+ * {@link HookContext}: a collection-level hook receives the whole document as
+ * `data` and has no single field in view, while a field hook is called once per
+ * field and returns that field's replacement value.
+ */
+export interface FieldHookContext<T = unknown> {
+  /** Collection or single the field belongs to. */
+  collection: string;
+
+  /** Operation that triggered the hook. */
+  operation: "create" | "read" | "update" | "delete";
+
+  /** Name of the field this call is for. */
+  fieldName: string;
+
+  /** The field's current value. */
+  value: T;
+
+  /** The row the field belongs to, so a hook can read its siblings. */
+  data: Record<string, unknown>;
+
+  /** The authenticated caller, when there is one. */
+  user?: Record<string, unknown>;
+}
+
+/**
+ * A field-level hook. Returning a value replaces the field's value; returning
+ * nothing leaves it as it was.
+ */
+export type FieldHookHandler<T = unknown> = (
+  context: FieldHookContext<T>
+) => Promise<T | void> | T | void;
+
+/**
  * Hook registration options (for future extensibility)
  *
  * Reserved for future features like:

--- a/packages/nextly/src/shared/lib/field-level-registry.ts
+++ b/packages/nextly/src/shared/lib/field-level-registry.ts
@@ -26,6 +26,8 @@
  * @module shared/lib/field-level-registry
  */
 
+import type { FieldHookHandler } from "../../hooks/types";
+
 import { detachData } from "./detach";
 import type { ValidatableField } from "./entry-validation";
 
@@ -41,14 +43,9 @@ type FieldAccessFn = (args: {
   data?: Record<string, unknown>;
 }) => MaybePromise<boolean>;
 
-type FieldHookFn = (context: {
-  collection: string;
-  operation: "create" | "read" | "update" | "delete";
-  fieldName: string;
-  value: unknown;
-  data: Record<string, unknown>;
-  user?: Record<string, unknown>;
-}) => MaybePromise<unknown>;
+// The registry stores exactly what a field hook is declared as, so the shape
+// lives in one place rather than being restated here.
+type FieldHookFn = FieldHookHandler;
 
 export interface FieldFunctions {
   validate?: ValidatableField["validate"];


### PR DESCRIPTION
Follow-up to #439. Closes the debt that PR left behind, and the two P1 review
threads on it that were still unresolved when it merged.

## The guard shipped in the wrong shape

#439 added a reentrancy guard so a read hook could not call itself through the
`count()` that PR made run hooks. It was a single flag meaning "some read's
hooks are running". Two consequences, both of which reviewers flagged:

- A handler on collection A reading collection **B** suppressed **B's** hooks.
  Those may be what scopes B to a tenant or hides its soft-deleted rows, so A
  received rows B withholds from everyone else. A silent widening is worse than
  the recursion the guard was added to prevent.
- `getEntry` entered the scope without ever consulting it, so a handler reaching
  a row by id still called itself through every nested read.

It is now keyed by collection. A nested read of a different collection runs its
own hooks; re-entry into the same collection is refused, which is what
terminates an A -> B -> A cycle. The detail path resolves its id through
`resolveReadEntryId`, deliberately the same check-then-enter shape as
`resolveReadWhere` -- this guard has been half-applied twice, and holding both
paths to one shape is what stops a third.

Keyed by collection rather than by handler because handlers cycle in pairs, and
only a per-collection key breaks that.

## Hooks now see the values a caller sees

- **`afterRead` ran before JSON columns were decoded.** On SQLite these come
  back as strings, so every collection-level handler received the storage
  encoding -- while field-level handlers, which already ran after the decode,
  received the configured value. One phase, two contracts, depending on where
  the handler was declared. The decode is now one helper shared by both read
  paths, run before the first handler and again over what they returned.
- **A related row skipped the target's field `afterRead` hooks.** The
  transforming half of a field's read protections was bypassed by reaching the
  row through a relationship, while the access half already applied. Both now
  run in `redactRelatedRows`, in the order a direct read uses.

## Coverage for the six #439 fixes that shipped without it

Each was reasoned and typechecked but had no test that could tell it from its
absence. Every one below was proven by reverting the fix, confirming the revert
applied, rebuilding, and watching the named test fail:

| fix | reverted | with fix |
|---|---|---|
| component predicate reaches the nested count | 1 row, **total 3** | total 1 |
| `beforeOperation` clearing the filter | 2 rows | 3 rows |
| `beforeRead` handed an object | read **fails** | 2 rows |
| geo predicate refused on a count | **succeeds, total 3** (list returns 0) | 400 |
| `getEntry` honours the guard | **10 re-entries** | 1 |
| nested read of another collection | **0 hook runs** | 1 |

The geo row is the sharpest: before the refusal, `count()` answered 3 beside a
list of 0, because no SQL is emitted for a geo operator and the count therefore
described exactly the rows the filter existed to exclude.

## Verification

- 15 integration tests across the two read-hook suites, all revert-checked
  individually.
- Full `nextly` integration suite: **839 passed, 0 failed** (160 files).
- Unit failing-test **name sets** identical to `origin/main` before and after
  (13 both sides, the known pre-existing baseline). Nothing added, nothing
  masked.

## One decision for you

Gap I is closed for **field-level** `afterRead`. Whether the target's
**collection-level** `afterRead` should also run over related rows is a contract
question, not an oversight: that phase is handed a whole document, and a related
row is a projection, so running it there would hand handlers input no direct
read produces. Both readings are written up in
`tasks/094-collection-hook-lifecycle-spec.md`. The field-level fix closes the
leak the gap was filed for either way, since that is the mechanism a redacting
field actually uses.
