### PR TITLE
fix(nextly): clear the hook registry when services shut down

### DIFF
--- a/.changeset/olive-donkeys-repeat.md
+++ b/.changeset/olive-donkeys-repeat.md
@@ -1,0 +1,31 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Clear the hook registry when services shut down.
+
+The registry is process-global and outlives the DI container, but handlers are
+registered from config on every init. Re-initializing in one process therefore
+left the previous instance's handlers in place and appended a fresh copy of
+each, so every hook ran twice per operation and the dead instance's handlers
+ran alongside the new ones.

--- a/packages/nextly/src/di/__tests__/shutdown-clears-hook-registry.test.ts
+++ b/packages/nextly/src/di/__tests__/shutdown-clears-hook-registry.test.ts
@@ -9,7 +9,11 @@
 import { describe, expect, it } from "vitest";
 
 import { clearServices } from "../register";
-import { getHookRegistry, resetHookRegistry } from "../../hooks/hook-registry";
+import {
+  getHookRegistry,
+  HookRegistry,
+  resetHookRegistry,
+} from "../../hooks/hook-registry";
 import type { HookHandler } from "../../hooks/types";
 
 const SLUG = "shutdown_registry_posts";
@@ -53,5 +57,31 @@ describe("clearing services clears the hook registry", () => {
 
     expect(runs).toBe(1);
     resetHookRegistry();
+  });
+
+  it("clears the registry that was registered into, not just the global one", async () => {
+    // A caller may supply its own registry through `NextlyServiceConfig`, and
+    // that is the instance the built-in, configured and plugin handlers go
+    // into. Resetting only the process-global singleton would leave it holding
+    // a full set for the next registration to append to.
+    //
+    // The marker is set here rather than by booting services, so this covers
+    // the clearing branch; `registerServices` setting it is covered by types.
+    resetHookRegistry();
+    const custom = new HookRegistry();
+    const handler: HookHandler = ctx => ctx.data;
+    custom.register("beforeCreate", SLUG, handler);
+
+    const marker = globalThis as unknown as {
+      __nextly_activeHookRegistry?: HookRegistry;
+    };
+    marker.__nextly_activeHookRegistry = custom;
+
+    expect(custom.hasHooks("beforeCreate", SLUG)).toBe(true);
+
+    clearServices();
+
+    expect(custom.hasHooks("beforeCreate", SLUG)).toBe(false);
+    marker.__nextly_activeHookRegistry = undefined;
   });
 });

--- a/packages/nextly/src/di/__tests__/shutdown-clears-hook-registry.test.ts
+++ b/packages/nextly/src/di/__tests__/shutdown-clears-hook-registry.test.ts
@@ -1,0 +1,57 @@
+// The hook registry outlives the DI container, so clearing services has to
+// clear it too.
+//
+// Handlers are registered from config on every init. A registry that survives a
+// shutdown therefore hands the next instance in the same process a second copy
+// of every configured handler, running alongside the dead instance's own -- the
+// same hazard the webhook recording policy and activation are cleared for.
+
+import { describe, expect, it } from "vitest";
+
+import { clearServices } from "../register";
+import { getHookRegistry, resetHookRegistry } from "../../hooks/hook-registry";
+import type { HookHandler } from "../../hooks/types";
+
+const SLUG = "shutdown_registry_posts";
+
+describe("clearing services clears the hook registry", () => {
+  it("a hook registered before the clear is gone after it", () => {
+    resetHookRegistry();
+    const handler: HookHandler = ctx => ctx.data;
+    getHookRegistry().register("beforeCreate", SLUG, handler);
+
+    // The control: without it, "gone after the clear" cannot be told apart from
+    // a registration that never took.
+    expect(getHookRegistry().hasHooks("beforeCreate", SLUG)).toBe(true);
+
+    clearServices();
+
+    expect(getHookRegistry().hasHooks("beforeCreate", SLUG)).toBe(false);
+  });
+
+  it("re-registering after a clear runs the handler once, not twice", async () => {
+    // What the leak actually costs. Registration appends, so a second init
+    // against a registry that was never cleared runs every handler twice per
+    // operation -- doubling side effects, not just wasting a call.
+    resetHookRegistry();
+    let runs = 0;
+    const handler: HookHandler = ctx => {
+      runs++;
+      return ctx.data;
+    };
+
+    getHookRegistry().register("beforeCreate", SLUG, handler);
+    clearServices();
+    getHookRegistry().register("beforeCreate", SLUG, handler);
+
+    await getHookRegistry().execute("beforeCreate", {
+      collection: SLUG,
+      operation: "create",
+      data: { title: "t" },
+      context: {},
+    });
+
+    expect(runs).toBe(1);
+    resetHookRegistry();
+  });
+});

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -75,7 +75,7 @@ import { getEventBus } from "../events/event-bus";
 import type { FieldGroupConfig } from "../field-groups/config/types";
 import { registerActivityLogHooks } from "../hooks/activity-log-hooks";
 import type { HookRegistry } from "../hooks/hook-registry";
-import { getHookRegistry } from "../hooks/hook-registry";
+import { getHookRegistry, resetHookRegistry } from "../hooks/hook-registry";
 import { registerCollectionHooks } from "../hooks/register-collection-hooks";
 import { registerSingleHooks } from "../hooks/register-single-hooks";
 import { createSanitizationHook } from "../hooks/sanitization-hooks";
@@ -2535,6 +2535,11 @@ export async function shutdownServices(): Promise<void> {
     // process-global too, and its provider closes over this container's
     // registry; clear it so a later instance never resolves a dead one.
     resetWebhookActivation();
+    // Hooks live in a process-global registry too. Registration runs from
+    // config on every init, so leaving it populated means a second instance in
+    // the same process appends a fresh copy of every handler and runs the dead
+    // instance's alongside the new one.
+    resetHookRegistry();
     globalForReg.__nextly_isRegistered = false;
   }
 }
@@ -2552,6 +2557,9 @@ export function clearServices(): void {
   // Clear the process-global recording activation for the same reason; its
   // provider closes over this container's registry.
   resetWebhookActivation();
+  // Cleared with the container for the same reason: re-initializing would
+  // otherwise register every configured hook a second time.
+  resetHookRegistry();
   globalForReg.__nextly_isRegistered = false;
 }
 

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -344,6 +344,12 @@ const globalForReg = globalThis as unknown as {
     plugin: PluginDefinition;
     context: PluginContext;
   }>;
+  /**
+   * The registry `registerServices` actually registered into. A caller may
+   * supply its own, and clearing the process-global one would leave that
+   * instance's handlers in place for the next registration to append to.
+   */
+  __nextly_activeHookRegistry?: HookRegistry;
 };
 
 // ============================================================
@@ -465,6 +471,9 @@ export async function registerServices(
   // "executeBeforeOperation is not a function" in production. Defaulting here
   // also ensures sanitization + activity-log "*" hooks register on every boot.
   const hookRegistry = providedHookRegistry ?? getHookRegistry();
+  // Remembered so shutdown clears the registry that was written to, not
+  // whichever one happens to be global at the time.
+  globalForReg.__nextly_activeHookRegistry = hookRegistry;
 
   const resolvedLogger = logger ?? consoleLogger;
   const resolvedBasePath = basePath ?? process.cwd();
@@ -2496,6 +2505,25 @@ export function isServicesRegistered(): boolean {
  * shutting down the application to ensure proper cleanup of database
  * connections and other resources.
  */
+/**
+ * Clear the registry `registerServices` wrote to, falling back to the global
+ * one when nothing has registered yet.
+ *
+ * A caller can supply its own `hookRegistry`, and that is the instance the
+ * built-in, configured and plugin handlers went into; resetting only the
+ * process-global singleton would leave it holding a full set for the next
+ * registration to append to.
+ */
+function clearActiveHookRegistry(): void {
+  const active = globalForReg.__nextly_activeHookRegistry;
+  if (active) {
+    active.clear();
+    globalForReg.__nextly_activeHookRegistry = undefined;
+    return;
+  }
+  resetHookRegistry();
+}
+
 export async function shutdownServices(): Promise<void> {
   if (!globalForReg.__nextly_isRegistered) {
     return;
@@ -2535,11 +2563,11 @@ export async function shutdownServices(): Promise<void> {
     // process-global too, and its provider closes over this container's
     // registry; clear it so a later instance never resolves a dead one.
     resetWebhookActivation();
-    // Hooks live in a process-global registry too. Registration runs from
-    // config on every init, so leaving it populated means a second instance in
-    // the same process appends a fresh copy of every handler and runs the dead
-    // instance's alongside the new one.
-    resetHookRegistry();
+    // Hooks live in a registry that outlives the container. Registration runs
+    // from config on every init, so leaving it populated means a second
+    // instance in the same process appends a fresh copy of every handler and
+    // runs the dead instance's alongside the new one.
+    clearActiveHookRegistry();
     globalForReg.__nextly_isRegistered = false;
   }
 }
@@ -2559,7 +2587,7 @@ export function clearServices(): void {
   resetWebhookActivation();
   // Cleared with the container for the same reason: re-initializing would
   // otherwise register every configured hook a second time.
-  resetHookRegistry();
+  clearActiveHookRegistry();
   globalForReg.__nextly_isRegistered = false;
 }
 

--- a/packages/nextly/src/hooks/hook-registry.ts
+++ b/packages/nextly/src/hooks/hook-registry.ts
@@ -648,10 +648,12 @@ export function getHookRegistry(): HookRegistry {
 }
 
 /**
- * Reset the global hook registry (for testing only)
+ * Clear every hook from the global registry.
  *
- * Clears all registered hooks from the global registry.
- * Should only be used in test cleanup.
+ * Called when services shut down or are cleared, because the registry outlives
+ * the DI container: handlers are registered from config on each init, so a
+ * registry left populated would hand a second instance in the same process a
+ * duplicate of every handler plus the dead instance's own.
  *
  * @internal
  * @example


### PR DESCRIPTION
Gap **J** from `tasks/094-collection-hook-lifecycle-spec.md`, reported on #420.

## The defect

The hook registry is process-global and outlives the DI container, but handlers
are registered from config on every init. `shutdownServices()` cleared the
container and left the registry populated, so a second `getNextly()` in the same
process appended a fresh copy of every configured handler on top of the dead
instance's.

The cost is not a wasted call. Registration appends, so every hook fires **twice
per operation** — an `afterCreate` that sends a notification sends two, and one
of the two runs against the shut-down instance.

## The fix

`resetHookRegistry()` is now called in both `shutdownServices` and
`clearServices`, next to `resetWebhookRecordingPolicy()` and
`resetWebhookActivation()`. Those two are process-global for exactly the same
reason and were already cleared there, with comments describing the same
stale-instance hazard — the hook registry was the missing third. This follows
the established pattern rather than inventing one.

`resetHookRegistry`'s docstring said "for testing only", which is no longer
true; it now says why shutdown owns it.

## Verification

Two tests in `src/di/__tests__/shutdown-clears-hook-registry.test.ts`:

- a hook registered before the clear is gone after it, with a control assertion
  first so "gone" cannot be confused with a registration that never took
- re-registering after a clear runs the handler **once**, asserted by executing
  the phase and counting — this is the one that measures the actual harm

Both fail with the fix reverted (revert confirmed by grep: 2 call sites → 0),
and pass restored.

`pnpm run check-types` clean (both tsconfigs). Failing-test name sets across
`src/hooks src/domains/collections src/di` are identical to `origin/main` — 22
pre-existing on both sides, and the only delta was the 2 tests added here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed service shutdown and reinitialization so registered handlers are fully cleared.
  * Prevented stale or duplicate handlers from running after services are registered again.
  * Ensured custom registries are cleared correctly, not just the default registry.

* **Documentation**
  * Clarified when hook registries are reset and how stale handlers are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->