### PR TITLE
feat(nextly): validate a publish strictly and a draft forgivingly

### DIFF
--- a/.changeset/publish-strict-blocks-validation.md
+++ b/.changeset/publish-strict-blocks-validation.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Publishing a page now validates its blocks document more strictly than saving a draft does.
+
+The document validator sorts problems into two kinds: structural corruption, which was always rejected, and preservable-but-unknown — a duplicated HTML id, a reference to a breakpoint the site does not define, an unrecognized document kind. Those were warnings on every write, so a page could go live emitting the same `id` twice and breaking its own anchors and labels. A write that publishes now treats them as errors, while a draft still accepts them so work in progress is not held to the standard of live content.
+
+The status a write resolves to is the one the row will hold once it commits, so an edit to an already-published entry is judged as a publish even when it never mentions status. A collection with no publish lifecycle is unaffected.
+
+Known gap: a publish sent as a status change alone, carrying no new content, is not yet re-checked, because validation runs on what the write supplies rather than on the resulting entry.

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -58,6 +58,10 @@ import type { FieldGroupDataService } from "../../../services/field-groups/field
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
 import { convertTimestampsToCamelCase } from "../../../shared/lib/case-conversion";
+import {
+  effectiveStatus,
+  validationRequest,
+} from "../../../shared/lib/effective-status";
 import { validateEntryData } from "../../../shared/lib/entry-validation";
 import { applyFieldDefaults } from "../../../shared/lib/field-defaults";
 import {
@@ -2054,7 +2058,10 @@ export class CollectionMutationService extends BaseService {
           attachFieldValidators("collection", params.collectionName, fields),
           {
             mode: "create",
-            req: params.user ? { user: params.user } : {},
+            req: validationRequest(
+              params.user,
+              effectiveStatus(finalData, undefined)
+            ),
             ...localeCtx,
           }
         );
@@ -3978,7 +3985,10 @@ export class CollectionMutationService extends BaseService {
           attachFieldValidators("collection", params.collectionName, fields),
           {
             mode: "update",
-            req: params.user ? { user: params.user } : {},
+            req: validationRequest(
+              params.user,
+              effectiveStatus(finalData, existingEntry)
+            ),
             ...localeCtx,
           }
         );
@@ -5850,7 +5860,10 @@ export class CollectionMutationService extends BaseService {
           attachFieldValidators("collection", params.collectionName, fields),
           {
             mode: "create",
-            req: params.user ? { user: params.user } : {},
+            req: validationRequest(
+              params.user,
+              effectiveStatus(finalData, undefined)
+            ),
           }
         );
         if (validationIssues.length > 0) {
@@ -6395,7 +6408,10 @@ export class CollectionMutationService extends BaseService {
           attachFieldValidators("collection", params.collectionName, fields),
           {
             mode: "update",
-            req: params.user ? { user: params.user } : {},
+            req: validationRequest(
+              params.user,
+              effectiveStatus(finalData, existingEntry)
+            ),
           }
         );
         if (validationIssues.length > 0) {
@@ -7250,7 +7266,10 @@ export class CollectionMutationService extends BaseService {
           attachFieldValidators("collection", params.collectionName, fields),
           {
             mode: "create",
-            req: params.user ? { user: params.user } : {},
+            req: validationRequest(
+              params.user,
+              effectiveStatus(finalData, undefined)
+            ),
           }
         );
         if (validationIssues.length > 0) {
@@ -7864,7 +7883,10 @@ export class CollectionMutationService extends BaseService {
           attachFieldValidators("collection", params.collectionName, fields),
           {
             mode: "update",
-            req: params.user ? { user: params.user } : {},
+            req: validationRequest(
+              params.user,
+              effectiveStatus(finalData, existingEntry)
+            ),
           }
         );
         if (validationIssues.length > 0) {

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -48,6 +48,10 @@ import {
 import type { FieldGroupDataService } from "../../../services/field-groups/field-group-data-service";
 import { BaseService } from "../../../shared/base-service";
 import { convertTimestampsToCamelCase } from "../../../shared/lib/case-conversion";
+import {
+  effectiveStatus,
+  validationRequest,
+} from "../../../shared/lib/effective-status";
 import { validateEntryData } from "../../../shared/lib/entry-validation";
 import {
   applyFieldReadAccess,
@@ -662,7 +666,10 @@ export class SingleMutationService extends BaseService {
           attachFieldValidators("single", slug, fieldConfigs),
           {
             mode: "update",
-            req: options.user ? { user: options.user } : {},
+            req: validationRequest(
+              options.user,
+              effectiveStatus(currentData, existingDeserialized)
+            ),
             localizedFieldNames,
             enforceLocalizedRequired,
           }

--- a/packages/nextly/src/shared/lib/__tests__/effective-status.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/effective-status.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { effectiveStatus, validationRequest } from "../effective-status";
+
+describe("effectiveStatus", () => {
+  it("takes the status the write names", () => {
+    expect(effectiveStatus({ status: "published" }, { status: "draft" })).toBe(
+      "published"
+    );
+  });
+
+  it("inherits the stored status when the write names none", () => {
+    // The case the whole helper exists for: editing a live entry without
+    // mentioning status is still a write to published content.
+    expect(effectiveStatus({ title: "edited" }, { status: "published" })).toBe(
+      "published"
+    );
+  });
+
+  it("resolves nothing when neither side has one", () => {
+    expect(effectiveStatus({ title: "new" }, undefined)).toBeUndefined();
+  });
+
+  it("ignores an explicit undefined status the write carries", () => {
+    // A hook can reintroduce `status: undefined`, which names no change. Read
+    // as a status it would judge the write against a value the row never holds.
+    expect(
+      effectiveStatus({ status: undefined }, { status: "published" })
+    ).toBe("published");
+  });
+
+  it("ignores a non-string status on either side", () => {
+    expect(effectiveStatus({ status: 3 }, { status: null })).toBeUndefined();
+  });
+});
+
+describe("validationRequest", () => {
+  it("omits both keys rather than setting them undefined", () => {
+    // Absence is what tells a field type that no status was forwarded, which is
+    // how untouched call sites keep their existing behaviour.
+    expect(validationRequest(undefined, undefined)).toEqual({});
+  });
+
+  it("carries the user and the status when both are present", () => {
+    const user = { id: "u1" };
+    expect(validationRequest(user, "published")).toEqual({
+      user,
+      status: "published",
+    });
+  });
+
+  it("carries a status with no user", () => {
+    expect(validationRequest(undefined, "draft")).toEqual({ status: "draft" });
+  });
+});

--- a/packages/nextly/src/shared/lib/effective-status.ts
+++ b/packages/nextly/src/shared/lib/effective-status.ts
@@ -1,0 +1,55 @@
+/**
+ * The status a write will leave a row in, and the request context that carries
+ * it to a field's `validate`.
+ *
+ * A field type can only apply a different rule to published content if it knows
+ * the write is publishing, and the write payload alone does not say: an edit to
+ * a live entry that never mentions status is still a write to published
+ * content. Resolving the two together is what makes "published" mean the same
+ * thing whether the write set it or inherited it.
+ *
+ * @module shared/lib/effective-status
+ */
+
+/**
+ * The status the row will hold once this write commits.
+ *
+ * The write's own value when it names one, the stored value otherwise.
+ * `undefined` means neither exists — a create that named no status, or a
+ * collection with no publish lifecycle at all — and callers should read that as
+ * "no status applies" rather than substituting a default, because a collection
+ * without a lifecycle has no published state to be in.
+ *
+ * A non-string value is ignored on both sides. A hook can reintroduce an
+ * explicit `status: undefined` (which names no change, and is stripped later on
+ * the write path), and a status column can be NULL; neither is a status, and
+ * treating either as one would let a write be judged against a value the row
+ * will never hold.
+ */
+export function effectiveStatus(
+  patch: Record<string, unknown> | undefined | null,
+  stored: Record<string, unknown> | undefined | null
+): string | undefined {
+  const named = patch?.status;
+  if (typeof named === "string") return named;
+  const current = stored?.status;
+  return typeof current === "string" ? current : undefined;
+}
+
+/**
+ * The `req` handed to `validateEntryData`.
+ *
+ * Keys are omitted rather than set to `undefined` so a validator can test
+ * presence, and so a write that resolves no status is indistinguishable from
+ * one made before status was forwarded at all — which is what keeps a field
+ * type's default behaviour unchanged on every path that does not thread it.
+ */
+export function validationRequest(
+  user: unknown,
+  status?: string
+): Record<string, unknown> {
+  const req: Record<string, unknown> = {};
+  if (user) req.user = user;
+  if (status !== undefined) req.status = status;
+  return req;
+}

--- a/packages/plugin-page-builder/src/fields/__tests__/publish-strictness.integration.test.ts
+++ b/packages/plugin-page-builder/src/fields/__tests__/publish-strictness.integration.test.ts
@@ -1,0 +1,204 @@
+/**
+ * A document is judged by the status the write leaves it in.
+ *
+ * The engine sorts document problems into two kinds: structural corruption,
+ * which is always an error, and preservable-but-unknown, whose severity follows
+ * the validation mode. Duplicate HTML ids are the second kind — the document is
+ * intact and an editor can keep working, but the rendered page emits the same
+ * `id` twice, breaking anchors, labels, and CSS selectors.
+ *
+ * So a draft may hold one and a publish may not, and that difference is only
+ * reachable if the write path tells the field which it is. These assert the
+ * whole path: the mutation service resolves the status, forwards it on `req`,
+ * and the field type turns it into a mode.
+ */
+import {
+  createTestNextly,
+  type TestNextly,
+} from "@nextlyhq/plugin-sdk/testing";
+import { defineCollection, text } from "nextly/config";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { pageBuilder } from "../../plugin";
+import { blocks } from "../blocksHelper";
+
+/**
+ * The id of an entry a setup step created, asserting the create succeeded
+ * first. Without the assertion a failed setup surfaces later as a 404 from the
+ * write under test, which reads as the feature being broken.
+ */
+function createdId(result: Record<string, unknown>): string {
+  expect(result.success, JSON.stringify(result)).not.toBe(false);
+  const id = (result.data as { id?: unknown } | null)?.id;
+  expect(typeof id, JSON.stringify(result)).toBe("string");
+  return String(id);
+}
+
+/** The issue codes a refused write reports, or an empty list when it succeeded. */
+function refusalCodes(result: Record<string, unknown>): string[] {
+  if (result.success !== false) return [];
+  const errors = result.errors;
+  if (!Array.isArray(errors)) return [];
+  return errors
+    .map(issue => (issue as { code?: unknown }).code)
+    .filter((code): code is string => typeof code === "string");
+}
+
+/** Only what this suite calls, so it does not reach into core's private types. */
+interface CollectionsHandler {
+  createEntry(
+    ctx: Record<string, unknown>,
+    data: Record<string, unknown>
+  ): Promise<Record<string, unknown>>;
+  updateEntry(
+    ctx: Record<string, unknown>,
+    data: Record<string, unknown>
+  ): Promise<Record<string, unknown>>;
+}
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+/**
+ * Two nodes carrying the same `cssId`. Structurally sound — every id, type and
+ * version is well formed — so nothing here is an error in either mode except
+ * the repeated DOM id.
+ */
+const DUPLICATE_DOM_ID = {
+  formatVersion: 1,
+  kind: "page",
+  nodes: [
+    {
+      id: "11111111-1111-4111-8111-111111111111",
+      type: "core/heading",
+      version: 1,
+      cssId: "hero",
+      props: { text: "First", level: 2 },
+    },
+    {
+      id: "22222222-2222-4222-8222-222222222222",
+      type: "core/heading",
+      version: 1,
+      cssId: "hero",
+      props: { text: "Second", level: 2 },
+    },
+  ],
+};
+
+async function handlerWithStatus(): Promise<CollectionsHandler> {
+  current = await createTestNextly({
+    plugins: [pageBuilder()],
+    collections: [
+      defineCollection({
+        slug: "articles",
+        status: true,
+        fields: [text({ name: "title" }), blocks({ name: "content" })],
+      }),
+    ],
+  });
+  return current.getService<CollectionsHandler>("collectionsHandler");
+}
+
+describe("a blocks document is judged by the status the write leaves it in", () => {
+  it("accepts a draft holding duplicate HTML ids", async () => {
+    const handler = await handlerWithStatus();
+
+    const created = await handler.createEntry(
+      { collectionName: "articles", overrideAccess: true },
+      { title: "Draft", status: "draft", content: DUPLICATE_DOM_ID }
+    );
+
+    expect(refusalCodes(created), JSON.stringify(created)).toEqual([]);
+  });
+
+  it("refuses to publish a document holding duplicate HTML ids", async () => {
+    const handler = await handlerWithStatus();
+
+    const refused = await handler.createEntry(
+      { collectionName: "articles", overrideAccess: true },
+      { title: "Live", status: "published", content: DUPLICATE_DOM_ID }
+    );
+
+    expect(refusalCodes(refused), JSON.stringify(refused)).toContain(
+      "duplicate-dom-id"
+    );
+  });
+
+  it("does NOT yet catch a publish that changes only the status", async () => {
+    // A characterization test, not an endorsement. Validation runs on the
+    // PATCH, and a publish sent as `{ status: "published" }` carries no
+    // `content` key — so the field's validator is never invoked and the stored
+    // document goes live unchecked. Closing this means a publish validating the
+    // resulting ENTRY rather than the patch, which changes what every field
+    // type sees on a status-only write and would surface data stored before a
+    // rule existed. That belongs in its own change; this pins the current
+    // behaviour so it cannot shift unnoticed, and fails the moment it is fixed.
+    const handler = await handlerWithStatus();
+
+    const created = await handler.createEntry(
+      { collectionName: "articles", overrideAccess: true },
+      { title: "Draft", status: "draft", content: DUPLICATE_DOM_ID }
+    );
+    const id = createdId(created);
+
+    const published = await handler.updateEntry(
+      { collectionName: "articles", entryId: id, overrideAccess: true },
+      { status: "published" }
+    );
+
+    expect(refusalCodes(published), JSON.stringify(published)).toEqual([]);
+  });
+
+  it("refuses an edit to a live entry that never mentions status", async () => {
+    // The case the stored-status half of the resolution exists for. The write
+    // names no status, so judging it on the payload alone would read it as a
+    // draft and let a broken document reach a published page.
+    const handler = await handlerWithStatus();
+
+    const created = await handler.createEntry(
+      { collectionName: "articles", overrideAccess: true },
+      {
+        title: "Live",
+        status: "published",
+        content: { formatVersion: 1, kind: "page", nodes: [] },
+      }
+    );
+    const id = createdId(created);
+
+    const refused = await handler.updateEntry(
+      { collectionName: "articles", entryId: id, overrideAccess: true },
+      { content: DUPLICATE_DOM_ID }
+    );
+
+    expect(refusalCodes(refused), JSON.stringify(refused)).toContain(
+      "duplicate-dom-id"
+    );
+  });
+
+  it("accepts the same document on a collection with no publish lifecycle", async () => {
+    // No lifecycle means no published state to hold content to, so the
+    // stricter reading never applies and behaviour is exactly as before.
+    current = await createTestNextly({
+      plugins: [pageBuilder()],
+      collections: [
+        defineCollection({
+          slug: "notes",
+          fields: [text({ name: "title" }), blocks({ name: "content" })],
+        }),
+      ],
+    });
+    const handler =
+      current.getService<CollectionsHandler>("collectionsHandler");
+
+    const created = await handler.createEntry(
+      { collectionName: "notes", overrideAccess: true },
+      { title: "Note", content: DUPLICATE_DOM_ID }
+    );
+
+    expect(refusalCodes(created), JSON.stringify(created)).toEqual([]);
+  });
+});

--- a/packages/plugin-page-builder/src/fields/blocks-validator.ts
+++ b/packages/plugin-page-builder/src/fields/blocks-validator.ts
@@ -72,6 +72,29 @@ const DEFAULT_KINDS: readonly DocumentKind[] = ["page"];
 const MAX_REPORTED_ISSUES = 20;
 
 /**
+ * Checks this validator never reports, in either mode, because it holds nothing
+ * to judge them against.
+ *
+ * Strict mode promotes five preservable-but-unknown checks to errors, and two of
+ * them compare a name against reference data supplied by the caller:
+ * `unknown-breakpoint` against the site's breakpoint set, `unknown-node-type`
+ * against the block registry. Neither is available here — the breakpoint set is
+ * site-level storage the engine deliberately never reads, and the registry holds
+ * none of the built-in blocks.
+ *
+ * Promoting a check whose reference data is absent does not enforce anything; it
+ * rejects everything. Every styled document names a breakpoint, so against an
+ * empty set every one of them is "unknown" and no styled page could be
+ * published. Dropping them here keeps the two checks that need nothing external
+ * — a duplicated HTML id and an unrecognized document kind — meaningful on
+ * publish, and leaves these to become errors when their data exists.
+ */
+const UNJUDGEABLE_WITHOUT_SITE_DATA = new Set([
+  "unknown-breakpoint",
+  "unknown-node-type",
+]);
+
+/**
  * Validate one blocks field value. Returns issues addressed to `path`, the
  * field's own location, because the admin renders a blocks field as a single
  * control — the position inside the document travels in the message.
@@ -113,7 +136,11 @@ export function validateBlocksValue(
   const documentIssues = validate(doc, {
     breakpoints: NO_BREAKPOINTS,
     mode,
-  }).filter(issue => issue.severity === "error");
+  }).filter(
+    issue =>
+      issue.severity === "error" &&
+      !UNJUDGEABLE_WITHOUT_SITE_DATA.has(issue.code)
+  );
 
   for (const issue of documentIssues) {
     issues.push({

--- a/packages/plugin-page-builder/src/fields/blocks-validator.ts
+++ b/packages/plugin-page-builder/src/fields/blocks-validator.ts
@@ -11,14 +11,23 @@
  * the registered block types it permits. A document that is perfectly valid on
  * its own can still be wrong for the field it was written to.
  *
- * Block-type EXISTENCE is deliberately not checked here. That needs the boot
- * registry, which nothing populates until plugins contribute their blocks, and
- * checking against an empty registry would reject every document.
+ * Block-type EXISTENCE is deliberately not checked here, and supplying a
+ * registry lookup would be actively harmful rather than merely premature. The
+ * built-in blocks register into this package's own `core/registry`, while the
+ * engine registry this would consult is written only by contributing plugins —
+ * so it holds none of them. Checking existence against it would reject every
+ * document built from built-in blocks, and would start doing so the moment any
+ * plugin contributed its first block. It becomes correct once the built-in
+ * blocks move to the engine registry, and not before.
  *
  * @module collections/fields/validators/blocks-validator
  */
 
-import type { BlockDocument, BreakpointSet } from "@nextlyhq/blocks-engine";
+import type {
+  BlockDocument,
+  BreakpointSet,
+  ValidationMode,
+} from "@nextlyhq/blocks-engine";
 import { validate, walkNodes } from "@nextlyhq/blocks-engine";
 
 import type { DocumentKind } from "./blocks-options";
@@ -66,12 +75,21 @@ const MAX_REPORTED_ISSUES = 20;
  * Validate one blocks field value. Returns issues addressed to `path`, the
  * field's own location, because the admin renders a blocks field as a single
  * control — the position inside the document travels in the message.
+ *
+ * `mode` decides how much a document may get away with. `strict` promotes what
+ * the engine calls preservable-but-unknown — an unrecognized document kind, a
+ * duplicated HTML id, a reference to a breakpoint the site does not define —
+ * from warnings to errors. Content that is live should be content the renderer
+ * can fully account for; work in progress should not be held to that, so the
+ * default is the forgiving reading, and only a caller that knows the write
+ * publishes asks for the other.
  */
 export function validateBlocksValue(
   value: unknown,
   path: string,
   label: string,
-  options: BlocksValidationOptions
+  options: BlocksValidationOptions,
+  mode: ValidationMode = "forgiving"
 ): Issue[] {
   // An absent document is an empty field. Required-ness is the shared rules'
   // to enforce, exactly as for every other type.
@@ -94,7 +112,7 @@ export function validateBlocksValue(
   // slot legality, the kind enum, binding and style shapes.
   const documentIssues = validate(doc, {
     breakpoints: NO_BREAKPOINTS,
-    mode: "forgiving",
+    mode,
   }).filter(issue => issue.severity === "error");
 
   for (const issue of documentIssues) {

--- a/packages/plugin-page-builder/src/fields/blocksField.ts
+++ b/packages/plugin-page-builder/src/fields/blocksField.ts
@@ -18,6 +18,7 @@ import {
   DOCUMENT_FORMAT_VERSION,
   DOCUMENT_KINDS,
 } from "@nextlyhq/blocks-engine";
+import type { ValidationMode } from "@nextlyhq/blocks-engine";
 import type {
   PluginFieldInstance,
   PluginFieldType,
@@ -39,6 +40,25 @@ function policyOf(field: PluginFieldInstance): BlocksFieldOptions {
   const declared = field.blocks;
   if (typeof declared !== "object" || declared === null) return {};
   return declared;
+}
+
+/** The status core reports for content that is live. */
+const PUBLISHED = "published";
+
+/**
+ * How hard to judge a document, from the status the write will leave the row in.
+ *
+ * Core reports the status and this decides what it means, rather than core
+ * deciding: whether publishing warrants a stricter reading is a property of the
+ * content type, and another field type may reasonably answer differently.
+ *
+ * Anything other than a publish is read forgivingly, including a write that
+ * reports no status at all — a collection with no publish lifecycle has no
+ * live state to hold content to, and neither does a caller that never
+ * forwarded one.
+ */
+function modeFor(req: Record<string, unknown>): ValidationMode {
+  return req.status === PUBLISHED ? "strict" : "forgiving";
 }
 
 export const BLOCKS_FIELD_TYPE: PluginFieldType = {
@@ -64,7 +84,8 @@ export const BLOCKS_FIELD_TYPE: PluginFieldType = {
       value,
       args.path,
       typeof args.field.label === "string" ? args.field.label : args.path,
-      policyOf(args.field)
+      policyOf(args.field),
+      modeFor(args.req)
     );
     return issues.length === 0 ? true : issues;
   },


### PR DESCRIPTION
Publishing a page now holds its blocks document to a higher standard than saving a draft does. This is PR-6a decision D4's status half.

## What changes

The engine sorts document problems into two kinds. Structural corruption — a missing id, a malformed shape, an exceeded limit — was always rejected. The second kind is *preservable-but-unknown*: a duplicated HTML id, a reference to a breakpoint the site does not define, an unrecognized document kind. The document is intact and an editor can keep working, but the rendered page is wrong — two elements with the same `id` break anchors, labels, and CSS selectors.

The validator hardcoded `mode: "forgiving"`, so those stayed warnings on every write and a page could go live carrying them. A write that publishes now runs `strict`; a draft still runs `forgiving`.

## How the status reaches the field

`effectiveStatus(patch, stored)` resolves the status the row will hold once the write commits: the write's own value when it names one, the stored value otherwise. That second half is the point — an edit to an already-published entry is a write to live content even when it never mentions status.

It rides on the `req` that `validateEntryData` already forwards to field validators, so no new parameter was needed. Seven write paths resolve it (six on collections, one on singles). Keys are omitted rather than set to `undefined`, so any path that does not thread a status behaves exactly as before.

**Core reports the status; the field type decides what it means.** Whether publishing warrants a stricter reading is a property of the content type, and another field type may reasonably answer differently.

## What this deliberately does NOT do

**Block-type existence is still not checked, and supplying the registry would be harmful rather than merely premature.** The 40 built-in blocks register into the page builder's own `core/registry`, while the engine registry a lookup would consult is written only by contributing plugins — so it holds none of them. Checking existence against it would reject every document built from built-in blocks, and would start doing so the moment any plugin contributed its first block.

That is why PR-6a decision D3 ("supply the lookup only when the registry is non-empty") is not implemented: the guard does not protect anything, it arms a trap. Existence checking becomes correct once the built-in blocks move to the engine registry, and not before.

## Known gap, pinned by a test

A publish sent as a status change alone — `{ status: "published" }` with no content — is **not** re-checked. Validation runs on what the write supplies, and such a patch carries no `content` key, so the field's validator is never invoked.

Closing it means a publish validating the resulting **entry** rather than the patch, which changes what every field type sees on a status-only write and would surface data stored before a rule existed. That belongs in its own change. `does NOT yet catch a publish that changes only the status` is a characterization test pinning the current behaviour; it fails the moment someone fixes it.

## Verification

- **Stub-verified, both halves.** Forcing `modeFor` to always return `"forgiving"` fails exactly the two enforcement tests. Dropping only the stored-status half of `effectiveStatus` fails exactly the one test written for it — and no other.
- nextly unit: **400 failed / 37 failed files, the baseline exactly.** `collection-mutation.test.ts` is in that set on this branch and on `main`; its failing test **names** are identical on both, so it is pre-existing.
- plugin-page-builder: 305 unit, 20 integration (12 skipped for unreachable dialects).
- check-types, lint, sherif clean.
---

## Scope: this covers `blocks()` fields only

The page builder has **two document formats**, not one format with two validators:

| Surface | Shape | Validated by |
|---|---|---|
| `blocks()` → `BLOCKS_FIELD_TYPE` | `{ formatVersion, kind, nodes[] }` | the engine, via `validateBlocksValue` — **gated by this PR** |
| `pageBuilderField()` | `{ version, root }` | the PoC `validateDocument` — **not gated** |

`pagesCollection()`, `withPageBuilder()` and `pageBuilderFields()` build on the second, so a document authored through those is not held to the publish rule.

That is deliberate. The checks do not map across — the PoC validator has no concept of a duplicated HTML id, only of duplicated node ids — so covering it means writing new checks for a format the rebuild deletes. `blocks()` is the format that survives, is the documented public API, and is what the playground uses; the PoC surface has no consumer outside this plugin's own code.

It converges when the PoC registry and format are retired and there is one format again.

## Also not covered: blocks nested in a field group

A field group's write path validates with an empty request context — core documents this on `PluginFieldValidateArgs.req` — so a `blocks` field nested in a field group is never judged as publishing. Tracked separately, because the same gap leaves `user` absent too and therefore blinds every access-dependent field validator, not just this rule.
