### PR TITLE
fix(nextly): rebuild boundary errors from their code, not their status

### DIFF
--- a/.changeset/olive-pianos-argue.md
+++ b/.changeset/olive-pianos-argue.md
@@ -1,0 +1,34 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Keep a typed error's status and code across the service boundary.
+
+A service raising `authRequired`, `rateLimited`, `serviceUnavailable` or any
+other 401 reached a REST caller as a generic 500, because the boundary rebuilt
+errors from their HTTP status and only four statuses had a branch. A 400 was
+rebuilt as a validation failure whatever code it carried, so a caller was told
+its data failed validation when it had not been validated.
+
+Errors are now rebuilt from the canonical code the envelope already carried,
+with the status mapping kept as the fallback for envelopes that carry no code.

--- a/packages/nextly/src/api/singles-detail.ts
+++ b/packages/nextly/src/api/singles-detail.ts
@@ -94,6 +94,9 @@ function throwFromSingleResult<T>(
       ...result,
       errors: result.errors?.map(e => ({
         path: e.field,
+        // The per-field reason travels with the issue; dropping it here would
+        // have the converter substitute a generic one.
+        code: e.code,
         message: e.message,
       })),
     },

--- a/packages/nextly/src/api/singles-detail.ts
+++ b/packages/nextly/src/api/singles-detail.ts
@@ -20,6 +20,7 @@
 import { actorFromAuthContext } from "../auth/request-actor";
 import { getService } from "../di";
 import type { SingleResult } from "../domains/singles/types";
+import { errorFromServiceEnvelope } from "../errors/from-service-envelope";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
 import { withTimezoneFormatting } from "../lib/date-formatting";
@@ -81,29 +82,23 @@ function throwFromSingleResult<T>(
   };
   if (result.errors) logContext.legacyErrors = result.errors;
 
-  if (result.statusCode === 404) {
-    throw NextlyError.notFound({ logContext });
-  }
-
-  // A stored Single access rule (or RBAC) denial surfaces as 403 now that
-  // route writes run with overrideAccess:false; map it to a forbidden error
-  // instead of letting it fall through to a 500.
-  if (result.statusCode === 403) {
-    throw NextlyError.forbidden({ logContext });
-  }
-
-  if (result.statusCode === 400) {
-    throw NextlyError.validation({
-      errors: (result.errors ?? []).map(e => ({
-        path: e.field ?? "",
-        code: "INVALID",
+  // Rebuilt through the shared converter, so a Single hook's typed error --
+  // `authRequired()`, `rateLimited()`, a plugin's own code -- reaches the
+  // caller as itself. Every status outside 400/403/404 used to become a 500,
+  // and a rate limit lost the interval the route needs for `Retry-After`.
+  //
+  // The legacy `{field}` issues are normalised to the canonical `{path}` shape
+  // the converter reads.
+  throw errorFromServiceEnvelope(
+    {
+      ...result,
+      errors: result.errors?.map(e => ({
+        path: e.field,
         message: e.message,
       })),
-      logContext,
-    });
-  }
-
-  throw NextlyError.internal({ logContext });
+    },
+    logContext
+  );
 }
 
 const VALID_RICH_TEXT_FORMATS = ["json", "html", "both"] as const;

--- a/packages/nextly/src/direct-api/namespaces/helpers.ts
+++ b/packages/nextly/src/direct-api/namespaces/helpers.ts
@@ -115,7 +115,7 @@ export interface SingleResultLike {
   messageKey?: string;
   /** The error's own public data -- a rate limit's retry interval, and such. */
   publicData?: unknown;
-  errors?: Array<{ field?: string; message: string }>;
+  errors?: Array<{ field?: string; code?: string; message: string }>;
 }
 
 /**

--- a/packages/nextly/src/direct-api/namespaces/helpers.ts
+++ b/packages/nextly/src/direct-api/namespaces/helpers.ts
@@ -9,6 +9,7 @@
  * @packageDocumentation
  */
 
+import { errorFromServiceEnvelope } from "../../errors/from-service-envelope";
 import { NextlyError } from "../../errors/nextly-error";
 import type { RequestContext } from "../../shared/types/index";
 import type {
@@ -73,6 +74,10 @@ export interface ServiceResultLike {
    */
   code?: string;
   message: string;
+  /** Translation key for the public message, when the thrower set one. */
+  messageKey?: string;
+  /** The error's own public data -- a rate limit's retry interval, and such. */
+  publicData?: unknown;
   data: unknown;
   errors?: Array<{ path: string; code: string; message: string }>;
 }
@@ -81,22 +86,20 @@ export interface ServiceResultLike {
  * Convert a failed service-layer result into a `NextlyError`.
  */
 export function createErrorFromResult(result: ServiceResultLike): NextlyError {
-  // Per-field validation issues survive into the Direct API error so
-  // server-side callers (and agents) see exactly which fields failed.
-  if (result.statusCode === 400 && result.errors?.length) {
-    return NextlyError.validation({ errors: result.errors });
-  }
-  return new NextlyError({
-    // The envelope's own code wins: the status-derived fallback can only
-    // guess the primary code for a status (409 always guesses CONFLICT).
-    code: result.code ?? statusCodeToErrorCode(result.statusCode),
-    publicMessage: result.message,
-    statusCode: result.statusCode,
-    logContext:
-      result.data !== undefined && result.data !== null
-        ? { resultData: result.data }
-        : undefined,
-  });
+  // The shared converter, so a Direct API caller and a REST caller are handed
+  // the same error for the same failure. Its code-keyed rebuild carries the
+  // message key and public data that this boundary used to drop.
+  return errorFromServiceEnvelope(
+    {
+      ...result,
+      // A code-less envelope still needs the status-derived guess this boundary
+      // has always made, rather than falling through to a generic internal.
+      code: result.code ?? statusCodeToErrorCode(result.statusCode),
+    },
+    result.data !== undefined && result.data !== null
+      ? { resultData: result.data }
+      : {}
+  );
 }
 
 /**

--- a/packages/nextly/src/direct-api/namespaces/helpers.ts
+++ b/packages/nextly/src/direct-api/namespaces/helpers.ts
@@ -141,6 +141,9 @@ export function createErrorFromSingleResult(
     // Normalised to the canonical shape; SingleResult still emits `{field}`.
     errors: result.errors?.map(e => ({
       path: e.field,
+      // The per-field reason travels with the issue; dropping it here would
+      // have the converter substitute a generic one.
+      code: e.code,
       message: e.message,
     })),
   });

--- a/packages/nextly/src/direct-api/namespaces/helpers.ts
+++ b/packages/nextly/src/direct-api/namespaces/helpers.ts
@@ -108,7 +108,13 @@ export function createErrorFromResult(result: ServiceResultLike): NextlyError {
 export interface SingleResultLike {
   success: boolean;
   statusCode: number;
+  /** Canonical `NextlyError` code, when the envelope came from one. */
+  code?: string;
   message?: string;
+  /** Translation key for the public message. */
+  messageKey?: string;
+  /** The error's own public data -- a rate limit's retry interval, and such. */
+  publicData?: unknown;
   errors?: Array<{ field?: string; message: string }>;
 }
 
@@ -123,20 +129,20 @@ export function createErrorFromSingleResult(
     result.errors?.map(e => e.message).join(", ") ||
     "Operation failed";
 
-  if (result.statusCode === 400 && result.errors && result.errors.length > 0) {
-    return NextlyError.validation({
-      errors: result.errors.map(e => ({
-        path: e.field ?? "",
-        code: "VALIDATION_ERROR",
-        message: e.message,
-      })),
-    });
-  }
-
-  return new NextlyError({
-    code: statusCodeToErrorCode(result.statusCode),
-    publicMessage: message,
-    statusCode: result.statusCode,
+  // The shared converter, so a Single failure reaches a Direct API caller as
+  // the same error a REST caller gets. Rebuilding from status alone dropped the
+  // message key and the public data -- a rate limit's retry interval among it.
+  return errorFromServiceEnvelope({
+    ...result,
+    message,
+    // A code-less envelope keeps the status-derived guess this boundary has
+    // always made rather than falling through to a generic internal.
+    code: result.code ?? statusCodeToErrorCode(result.statusCode),
+    // Normalised to the canonical shape; SingleResult still emits `{field}`.
+    errors: result.errors?.map(e => ({
+      path: e.field,
+      message: e.message,
+    })),
   });
 }
 

--- a/packages/nextly/src/dispatcher/helpers/__tests__/service-envelope.test.ts
+++ b/packages/nextly/src/dispatcher/helpers/__tests__/service-envelope.test.ts
@@ -202,3 +202,19 @@ describe("unwrapServiceResult rebuilds from the canonical code", () => {
     expect(err.publicMessage).toBe("The upload exceeds the 10 MB limit.");
   });
 });
+
+describe("unwrapServiceResult carries the remaining public fields", () => {
+  it("keeps the message key a localized error selected", () => {
+    // A NextlyError has five public response fields. Dropping this one leaves a
+    // client with nothing but the default string to render.
+    const err = unwrapError({
+      success: false,
+      statusCode: 429,
+      code: "RATE_LIMITED",
+      message: "Too many requests.",
+      messageKey: "errors.rateLimited",
+    });
+
+    expect(err.messageKey).toBe("errors.rateLimited");
+  });
+});

--- a/packages/nextly/src/dispatcher/helpers/__tests__/service-envelope.test.ts
+++ b/packages/nextly/src/dispatcher/helpers/__tests__/service-envelope.test.ts
@@ -84,3 +84,77 @@ describe("unwrapServiceResult 409 disambiguation", () => {
     });
   });
 });
+
+describe("unwrapServiceResult rebuilds from the canonical code", () => {
+  // Status alone cannot identify these: three codes share 401, and 429/503
+  // have no status branch at all, so every one of them reached the caller as a
+  // generic 500 -- a rate limit indistinguishable from a crash.
+  it.each([
+    ["AUTH_REQUIRED", 401],
+    ["AUTH_INVALID_CREDENTIALS", 401],
+    ["TOKEN_EXPIRED", 401],
+    ["RATE_LIMITED", 429],
+    ["SERVICE_UNAVAILABLE", 503],
+  ])("keeps %s and its status instead of collapsing to 500", (code, status) => {
+    const err = unwrapError({
+      success: false,
+      statusCode: status,
+      code,
+      message: "service said no",
+    });
+
+    expect(err.code).toBe(code);
+    expect(err.statusCode).toBe(status);
+  });
+
+  it("keeps a non-validation code carried on a 400", () => {
+    // Every 400 was rebuilt as VALIDATION_ERROR whatever code it carried, so a
+    // caller was told its data failed validation when it had not been
+    // validated at all.
+    const err = unwrapError({
+      success: false,
+      statusCode: 400,
+      code: "INVALID_INPUT",
+      message: "Depth must be between 0 and 5.",
+    });
+
+    expect(err.code).toBe("INVALID_INPUT");
+    // The message round-trips, where the generic validation text replaced it.
+    expect(err.publicMessage).toBe("Depth must be between 0 and 5.");
+  });
+
+  it("still gives the admin the per-field shape for a validation failure", () => {
+    // The mirror. The admin maps `data.errors` onto form fields, so rebuilding
+    // a validation failure through any other path silently breaks form errors.
+    const err = unwrapError({
+      success: false,
+      statusCode: 400,
+      code: "VALIDATION_ERROR",
+      message: "Validation failed.",
+      errors: [{ field: "title", message: "Title is required." }],
+    });
+
+    expect(err.code).toBe("VALIDATION_ERROR");
+    expect((err.publicData as { errors: unknown[] }).errors).toEqual([
+      { path: "title", code: "INVALID", message: "Title is required." },
+    ]);
+  });
+
+  it("falls back to the status when the envelope carries no code", () => {
+    // Envelopes are still built by hand in places, and those must behave
+    // exactly as they did before.
+    const err = unwrapError({ success: false, statusCode: 404 });
+    expect(err.code).toBe("NOT_FOUND");
+  });
+
+  it("falls back to the status for a code it does not recognize", () => {
+    // An unknown code must not throw its way out of the boundary; the status
+    // is still a usable answer.
+    const err = unwrapError({
+      success: false,
+      statusCode: 403,
+      code: "SOMETHING_NEW",
+    });
+    expect(err.code).toBe("FORBIDDEN");
+  });
+});

--- a/packages/nextly/src/dispatcher/helpers/__tests__/service-envelope.test.ts
+++ b/packages/nextly/src/dispatcher/helpers/__tests__/service-envelope.test.ts
@@ -95,6 +95,17 @@ describe("unwrapServiceResult rebuilds from the canonical code", () => {
     ["TOKEN_EXPIRED", 401],
     ["RATE_LIMITED", 429],
     ["SERVICE_UNAVAILABLE", 503],
+    // Codes an enumeration would have to remember. There are roughly thirty,
+    // so the rebuild reads the envelope instead of listing them.
+    ["PAYLOAD_TOO_LARGE", 413],
+    ["EXTERNAL_REQUEST_FAILED", 502],
+    ["UNSUPPORTED_MEDIA_TYPE", 415],
+    ["BUILDER_DISABLED", 403],
+    // Distinct from INTERNAL_ERROR even though they share a status: an
+    // operator reading the log needs to know which one it was.
+    ["DATABASE_ERROR", 500],
+    // A plugin's own code, outside the canonical enum entirely.
+    ["ACME_QUOTA_EXHAUSTED", 402],
   ])("keeps %s and its status instead of collapsing to 500", (code, status) => {
     const err = unwrapError({
       success: false,
@@ -147,14 +158,47 @@ describe("unwrapServiceResult rebuilds from the canonical code", () => {
     expect(err.code).toBe("NOT_FOUND");
   });
 
-  it("falls back to the status for a code it does not recognize", () => {
-    // An unknown code must not throw its way out of the boundary; the status
-    // is still a usable answer.
+  it("keeps a code it has never seen rather than remapping it", () => {
+    // A plugin declares its own codes, and the canonical enum is explicitly not
+    // a closed set. Rewriting one to the nearest built-in would tell a caller
+    // its request was forbidden when the plugin said something else entirely.
     const err = unwrapError({
       success: false,
       statusCode: 403,
-      code: "SOMETHING_NEW",
+      code: "ACME_TENANT_SUSPENDED",
+      message: "This workspace is suspended.",
     });
-    expect(err.code).toBe("FORBIDDEN");
+    expect(err.code).toBe("ACME_TENANT_SUSPENDED");
+    expect(err.statusCode).toBe(403);
+  });
+
+  it("carries the rate limit's retry interval so the route can send Retry-After", () => {
+    // The interval lives in `publicData`, not in the code, so an error rebuilt
+    // from its code alone arrives with the right status and no backoff. The
+    // route only emits `Retry-After` when the value is there, so the client is
+    // told to slow down without being told by how much.
+    const err = unwrapError({
+      success: false,
+      statusCode: 429,
+      code: "RATE_LIMITED",
+      message: "Too many requests.",
+      publicData: { retryAfterSeconds: 30 },
+    });
+
+    expect(err.code).toBe("RATE_LIMITED");
+    expect(err.publicData).toEqual({ retryAfterSeconds: 30 });
+  });
+
+  it("round-trips the error's own public message", () => {
+    // The envelope's message IS the original `publicMessage`, so replacing it
+    // with generic text loses what the thrower chose to say.
+    const err = unwrapError({
+      success: false,
+      statusCode: 413,
+      code: "PAYLOAD_TOO_LARGE",
+      message: "The upload exceeds the 10 MB limit.",
+    });
+
+    expect(err.publicMessage).toBe("The upload exceeds the 10 MB limit.");
   });
 });

--- a/packages/nextly/src/dispatcher/helpers/service-envelope.ts
+++ b/packages/nextly/src/dispatcher/helpers/service-envelope.ts
@@ -35,6 +35,7 @@
 
 import type { PaginationMeta } from "../../api/response-shapes";
 import { NextlyError } from "../../errors/nextly-error";
+import type { PublicData } from "../../errors/public-data";
 
 /**
  * Translate the service-result `{ total, page, limit, totalPages }`
@@ -129,7 +130,7 @@ export function offsetPaginationToMeta(args: {
  * no driver text, no identifier echo, no value leaking).
  *
  * Reconstruction is keyed on the envelope's canonical `code` when it carries
- * one, because that identifies the error exactly; see {@link ERROR_BY_CODE}.
+ * one, because the envelope carries everything an exact rebuild needs.
  * The status mapping below is the fallback for envelopes built by hand that
  * carry no code:
  *   400: NextlyError.validation (with publicData.errors[])
@@ -181,42 +182,6 @@ function validationFromEnvelope(
   });
 }
 
-/**
- * Rebuild a NextlyError from its canonical code.
- *
- * The code is the only key that identifies an error exactly. Status cannot:
- * three codes share 401, two share 409, two share 500, and most statuses have
- * no branch at all, so dispatching on status alone sends `rateLimited` (429),
- * `serviceUnavailable` (503) and every 401 to the caller as a generic 500.
- *
- * A new code round-trips by adding a row here rather than by editing control
- * flow, and one that is missing falls through to the status mapping instead of
- * failing — so an envelope built by hand, carrying no code, behaves exactly as
- * it did before.
- *
- * `VALIDATION_ERROR` and `INVALID_INPUT` are absent on purpose: they carry more
- * than a log context (per-field issues and a public message respectively) and
- * are rebuilt explicitly below.
- */
-const ERROR_BY_CODE: Record<
-  string,
-  (logContext: Record<string, unknown>) => NextlyError
-> = {
-  AUTH_INVALID_CREDENTIALS: logContext =>
-    NextlyError.invalidCredentials({ logContext }),
-  AUTH_REQUIRED: logContext => NextlyError.authRequired({ logContext }),
-  TOKEN_EXPIRED: logContext => NextlyError.tokenExpired({ logContext }),
-  NOT_FOUND: logContext => NextlyError.notFound({ logContext }),
-  FORBIDDEN: logContext => NextlyError.forbidden({ logContext }),
-  CONFLICT: logContext => NextlyError.conflict({ logContext }),
-  DUPLICATE: logContext => NextlyError.duplicate({ logContext }),
-  RATE_LIMITED: logContext => NextlyError.rateLimited({ logContext }),
-  SERVICE_UNAVAILABLE: logContext =>
-    NextlyError.serviceUnavailable({ logContext }),
-  DATABASE_ERROR: logContext => NextlyError.internal({ logContext }),
-  INTERNAL_ERROR: logContext => NextlyError.internal({ logContext }),
-};
-
 export function unwrapServiceResult<T>(
   result: {
     success: boolean;
@@ -225,6 +190,9 @@ export function unwrapServiceResult<T>(
     // NextlyError; disambiguates statuses shared by several codes (409).
     code?: string;
     message?: string;
+    // The error's own public data, so a rebuild keeps meaning that lives there
+    // rather than in the code -- a rate limit's retry interval, for instance.
+    publicData?: unknown;
     data?: unknown;
     // Canonical {path, code} from collection results; legacy {field} from
     // SingleResult. Both normalize below.
@@ -243,22 +211,30 @@ export function unwrapServiceResult<T>(
   const status = result.statusCode ?? 500;
   const ctx = { legacyMessage: result.message, ...logContext };
 
-  // `invalidInput`'s message IS its public message, so it round-trips from the
-  // envelope rather than being replaced by the generic validation text.
-  if (result.code === "INVALID_INPUT" && result.message) {
-    throw NextlyError.invalidInput({
-      message: result.message,
+  // Rebuilt from the envelope itself, not from a table of known codes. There
+  // are roughly thirty canonical codes and plugins may define their own, so any
+  // enumeration here would silently send whatever it missed to the caller as a
+  // 500 -- which is the defect this fixes, reintroduced one code at a time. The
+  // envelope already carries everything an exact rebuild needs.
+  if (result.code) {
+    // Validation keeps its own path: it normalises the legacy `{field}` shape
+    // SingleResult still emits into the canonical `{path}` one the admin maps
+    // onto form fields.
+    if (result.code === "VALIDATION_ERROR") {
+      throw validationFromEnvelope(result.errors, ctx);
+    }
+    throw new NextlyError({
+      code: result.code,
+      // The envelope's message IS the original's `publicMessage` -- that is what
+      // `errorToServiceResult` copied -- so this round-trips rather than
+      // replacing it with generic text.
+      publicMessage: result.message ?? "The request could not be completed.",
+      // Carried explicitly: a plugin code has no entry in the status enum, and
+      // the envelope's status is the one the thrower chose.
+      statusCode: status,
+      publicData: result.publicData as PublicData | undefined,
       logContext: ctx,
     });
-  }
-  // Rebuilt from the code wherever the code says so, not only where the status
-  // happens to agree.
-  if (result.code === "VALIDATION_ERROR") {
-    throw validationFromEnvelope(result.errors, ctx);
-  }
-  if (result.code) {
-    const rebuild = ERROR_BY_CODE[result.code];
-    if (rebuild) throw rebuild(ctx);
   }
 
   if (status === 404) throw NextlyError.notFound({ logContext: ctx });

--- a/packages/nextly/src/dispatcher/helpers/service-envelope.ts
+++ b/packages/nextly/src/dispatcher/helpers/service-envelope.ts
@@ -128,7 +128,10 @@ export function offsetPaginationToMeta(args: {
  * sees only the canonical NextlyError publicMessage (per spec §13.8:
  * no driver text, no identifier echo, no value leaking).
  *
- * Status-to-NextlyError mapping:
+ * Reconstruction is keyed on the envelope's canonical `code` when it carries
+ * one, because that identifies the error exactly; see {@link ERROR_BY_CODE}.
+ * The status mapping below is the fallback for envelopes built by hand that
+ * carry no code:
  *   400: NextlyError.validation (with publicData.errors[])
  *   403: NextlyError.forbidden
  *   404: NextlyError.notFound
@@ -146,6 +149,74 @@ export function offsetPaginationToMeta(args: {
  * entry, and singles services never return null on success), so the
  * cast is safe.
  */
+/**
+ * Build the validation error from an envelope's per-field issues.
+ *
+ * Per-field issues survive into the wire envelope so the admin can map them
+ * onto form fields; the generic single-issue shape is only the fallback for
+ * detail-less 400s. Shared by the code-keyed and status-keyed paths so the two
+ * cannot drift into producing different shapes for the same failure.
+ */
+function validationFromEnvelope(
+  errors:
+    | Array<{ path?: string; field?: string; code?: string; message: string }>
+    | undefined,
+  logContext: Record<string, unknown>
+): NextlyError {
+  return NextlyError.validation({
+    errors: errors?.length
+      ? errors.map(e => ({
+          path: e.path ?? e.field ?? "",
+          code: e.code ?? "INVALID",
+          message: e.message,
+        }))
+      : [
+          {
+            path: "request",
+            code: "INVALID",
+            message: "The submitted data is invalid.",
+          },
+        ],
+    logContext,
+  });
+}
+
+/**
+ * Rebuild a NextlyError from its canonical code.
+ *
+ * The code is the only key that identifies an error exactly. Status cannot:
+ * three codes share 401, two share 409, two share 500, and most statuses have
+ * no branch at all, so dispatching on status alone sends `rateLimited` (429),
+ * `serviceUnavailable` (503) and every 401 to the caller as a generic 500.
+ *
+ * A new code round-trips by adding a row here rather than by editing control
+ * flow, and one that is missing falls through to the status mapping instead of
+ * failing — so an envelope built by hand, carrying no code, behaves exactly as
+ * it did before.
+ *
+ * `VALIDATION_ERROR` and `INVALID_INPUT` are absent on purpose: they carry more
+ * than a log context (per-field issues and a public message respectively) and
+ * are rebuilt explicitly below.
+ */
+const ERROR_BY_CODE: Record<
+  string,
+  (logContext: Record<string, unknown>) => NextlyError
+> = {
+  AUTH_INVALID_CREDENTIALS: logContext =>
+    NextlyError.invalidCredentials({ logContext }),
+  AUTH_REQUIRED: logContext => NextlyError.authRequired({ logContext }),
+  TOKEN_EXPIRED: logContext => NextlyError.tokenExpired({ logContext }),
+  NOT_FOUND: logContext => NextlyError.notFound({ logContext }),
+  FORBIDDEN: logContext => NextlyError.forbidden({ logContext }),
+  CONFLICT: logContext => NextlyError.conflict({ logContext }),
+  DUPLICATE: logContext => NextlyError.duplicate({ logContext }),
+  RATE_LIMITED: logContext => NextlyError.rateLimited({ logContext }),
+  SERVICE_UNAVAILABLE: logContext =>
+    NextlyError.serviceUnavailable({ logContext }),
+  DATABASE_ERROR: logContext => NextlyError.internal({ logContext }),
+  INTERNAL_ERROR: logContext => NextlyError.internal({ logContext }),
+};
+
 export function unwrapServiceResult<T>(
   result: {
     success: boolean;
@@ -171,6 +242,25 @@ export function unwrapServiceResult<T>(
   }
   const status = result.statusCode ?? 500;
   const ctx = { legacyMessage: result.message, ...logContext };
+
+  // `invalidInput`'s message IS its public message, so it round-trips from the
+  // envelope rather than being replaced by the generic validation text.
+  if (result.code === "INVALID_INPUT" && result.message) {
+    throw NextlyError.invalidInput({
+      message: result.message,
+      logContext: ctx,
+    });
+  }
+  // Rebuilt from the code wherever the code says so, not only where the status
+  // happens to agree.
+  if (result.code === "VALIDATION_ERROR") {
+    throw validationFromEnvelope(result.errors, ctx);
+  }
+  if (result.code) {
+    const rebuild = ERROR_BY_CODE[result.code];
+    if (rebuild) throw rebuild(ctx);
+  }
+
   if (status === 404) throw NextlyError.notFound({ logContext: ctx });
   if (status === 403) throw NextlyError.forbidden({ logContext: ctx });
   if (status === 409) {
@@ -185,25 +275,7 @@ export function unwrapServiceResult<T>(
     throw NextlyError.conflict({ logContext: ctx });
   }
   if (status === 400) {
-    // Per-field issues from the service survive into the wire envelope so
-    // the admin can map them onto form fields; the generic single-issue
-    // shape is only the fallback for detail-less 400s.
-    throw NextlyError.validation({
-      errors: result.errors?.length
-        ? result.errors.map(e => ({
-            path: e.path ?? e.field ?? "",
-            code: e.code ?? "INVALID",
-            message: e.message,
-          }))
-        : [
-            {
-              path: "request",
-              code: "INVALID",
-              message: "The submitted data is invalid.",
-            },
-          ],
-      logContext: ctx,
-    });
+    throw validationFromEnvelope(result.errors, ctx);
   }
   throw NextlyError.internal({ logContext: ctx });
 }

--- a/packages/nextly/src/dispatcher/helpers/service-envelope.ts
+++ b/packages/nextly/src/dispatcher/helpers/service-envelope.ts
@@ -34,8 +34,7 @@
  */
 
 import type { PaginationMeta } from "../../api/response-shapes";
-import { NextlyError } from "../../errors/nextly-error";
-import type { PublicData } from "../../errors/public-data";
+import { errorFromServiceEnvelope } from "../../errors/from-service-envelope";
 
 /**
  * Translate the service-result `{ total, page, limit, totalPages }`
@@ -150,38 +149,6 @@ export function offsetPaginationToMeta(args: {
  * entry, and singles services never return null on success), so the
  * cast is safe.
  */
-/**
- * Build the validation error from an envelope's per-field issues.
- *
- * Per-field issues survive into the wire envelope so the admin can map them
- * onto form fields; the generic single-issue shape is only the fallback for
- * detail-less 400s. Shared by the code-keyed and status-keyed paths so the two
- * cannot drift into producing different shapes for the same failure.
- */
-function validationFromEnvelope(
-  errors:
-    | Array<{ path?: string; field?: string; code?: string; message: string }>
-    | undefined,
-  logContext: Record<string, unknown>
-): NextlyError {
-  return NextlyError.validation({
-    errors: errors?.length
-      ? errors.map(e => ({
-          path: e.path ?? e.field ?? "",
-          code: e.code ?? "INVALID",
-          message: e.message,
-        }))
-      : [
-          {
-            path: "request",
-            code: "INVALID",
-            message: "The submitted data is invalid.",
-          },
-        ],
-    logContext,
-  });
-}
-
 export function unwrapServiceResult<T>(
   result: {
     success: boolean;
@@ -190,6 +157,8 @@ export function unwrapServiceResult<T>(
     // NextlyError; disambiguates statuses shared by several codes (409).
     code?: string;
     message?: string;
+    /** Translation key for the public message. */
+    messageKey?: string;
     // The error's own public data, so a rebuild keeps meaning that lives there
     // rather than in the code -- a rate limit's retry interval, for instance.
     publicData?: unknown;
@@ -208,50 +177,6 @@ export function unwrapServiceResult<T>(
   if (result.success) {
     return result.data as T;
   }
-  const status = result.statusCode ?? 500;
   const ctx = { legacyMessage: result.message, ...logContext };
-
-  // Rebuilt from the envelope itself, not from a table of known codes. There
-  // are roughly thirty canonical codes and plugins may define their own, so any
-  // enumeration here would silently send whatever it missed to the caller as a
-  // 500 -- which is the defect this fixes, reintroduced one code at a time. The
-  // envelope already carries everything an exact rebuild needs.
-  if (result.code) {
-    // Validation keeps its own path: it normalises the legacy `{field}` shape
-    // SingleResult still emits into the canonical `{path}` one the admin maps
-    // onto form fields.
-    if (result.code === "VALIDATION_ERROR") {
-      throw validationFromEnvelope(result.errors, ctx);
-    }
-    throw new NextlyError({
-      code: result.code,
-      // The envelope's message IS the original's `publicMessage` -- that is what
-      // `errorToServiceResult` copied -- so this round-trips rather than
-      // replacing it with generic text.
-      publicMessage: result.message ?? "The request could not be completed.",
-      // Carried explicitly: a plugin code has no entry in the status enum, and
-      // the envelope's status is the one the thrower chose.
-      statusCode: status,
-      publicData: result.publicData as PublicData | undefined,
-      logContext: ctx,
-    });
-  }
-
-  if (status === 404) throw NextlyError.notFound({ logContext: ctx });
-  if (status === 403) throw NextlyError.forbidden({ logContext: ctx });
-  if (status === 409) {
-    // 409 is shared by two distinct failures: a unique-constraint duplicate
-    // ("Resource already exists.") and an optimistic-concurrency conflict
-    // ("The resource has changed..."). Only the envelope's code can tell
-    // them apart; without one, staleness is the safer default because it
-    // tells the user to refresh rather than implying the write is invalid.
-    if (result.code === "DUPLICATE") {
-      throw NextlyError.duplicate({ logContext: ctx });
-    }
-    throw NextlyError.conflict({ logContext: ctx });
-  }
-  if (status === 400) {
-    throw validationFromEnvelope(result.errors, ctx);
-  }
-  throw NextlyError.internal({ logContext: ctx });
+  throw errorFromServiceEnvelope(result, ctx);
 }

--- a/packages/nextly/src/domains/collections/__tests__/hook-error-public-data.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/hook-error-public-data.integration.test.ts
@@ -1,0 +1,100 @@
+// A typed error thrown by a hook keeps the data its meaning lives in.
+//
+// A rate limit says how long to wait, and that interval lives in the error's
+// `publicData`, not in its code. An envelope that drops it produces a 429 with
+// no backoff: the caller is told to slow down without being told by how much,
+// and the route cannot emit `Retry-After` at all.
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import { NextlyError } from "../../../errors";
+import { registerHook, unregisterHook } from "../../../hooks";
+import type { HookHandler } from "../../../hooks/types";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+// Integration files share fixed system-table names, so this suite keeps its own
+// collection slug to avoid colliding with a concurrently-running file.
+const SLUG = "pubdata_articles";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+async function boot(): Promise<TestNextly> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({ slug: SLUG, fields: [text({ name: "title" })] }),
+    ],
+  });
+  return current;
+}
+
+function handlerOf(t: TestNextly) {
+  return t.getService("collectionsHandler") as unknown as {
+    createEntry: (
+      params: Record<string, unknown>,
+      data: Record<string, unknown>
+    ) => Promise<{
+      success: boolean;
+      statusCode?: number;
+      code?: string;
+      publicData?: unknown;
+    }>;
+  };
+}
+
+describe("a hook's typed error keeps its public data", () => {
+  it("carries a rate limit's retry interval into the service envelope", async () => {
+    const t = await boot();
+
+    const limit: HookHandler = () => {
+      throw NextlyError.rateLimited({ retryAfterSeconds: 30 });
+    };
+    registerHook("beforeCreate", SLUG, limit);
+
+    try {
+      const result = await handlerOf(t).createEntry(
+        { collectionName: SLUG, overrideAccess: true },
+        { title: "t" }
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.code).toBe("RATE_LIMITED");
+      expect(result.statusCode).toBe(429);
+      // The half a boundary cannot reconstruct on its own.
+      expect(result.publicData).toEqual({ retryAfterSeconds: 30 });
+    } finally {
+      unregisterHook("beforeCreate", SLUG, limit);
+    }
+  });
+
+  it("leaves the envelope's public data absent when the error has none", async () => {
+    // The control. Most errors carry nothing here, and an empty object would
+    // reach the wire as `error.data: {}` where callers expect no key at all.
+    const t = await boot();
+
+    const deny: HookHandler = () => {
+      throw NextlyError.forbidden();
+    };
+    registerHook("beforeCreate", SLUG, deny);
+
+    try {
+      const result = await handlerOf(t).createEntry(
+        { collectionName: SLUG, overrideAccess: true },
+        { title: "t" }
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.code).toBe("FORBIDDEN");
+      expect(result.publicData).toBeUndefined();
+    } finally {
+      unregisterHook("beforeCreate", SLUG, deny);
+    }
+  });
+});

--- a/packages/nextly/src/domains/collections/__tests__/read-hook-typed-error.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/read-hook-typed-error.integration.test.ts
@@ -31,6 +31,7 @@ type Envelope = {
   statusCode?: number;
   code?: string;
   publicData?: unknown;
+  errors?: unknown;
 };
 
 function handlerOf(t: TestNextly) {
@@ -116,6 +117,39 @@ describe("a read hook's typed error survives the read path", () => {
       expect(got.code).toBe("FORBIDDEN");
     } finally {
       unregisterHook("beforeRead", SLUG, deny);
+    }
+  });
+
+  it("carries a validation hook's per-field issues into the envelope", async () => {
+    // Half of the round trip: the read path has to RECORD the issues, which it
+    // does inside `publicData` because that is where `NextlyError.validation`
+    // puts them. The other half -- a boundary reading them back out of that
+    // shape rather than only from a top-level `errors` array -- is asserted in
+    // `errors/__tests__/from-service-envelope.test.ts`, since the converter
+    // does not run at this layer.
+    const t = await boot();
+    const reject: HookHandler = () => {
+      throw NextlyError.validation({
+        errors: [
+          { path: "title", code: "TOO_SHORT", message: "Title is too short." },
+        ],
+      });
+    };
+    registerHook("beforeRead", SLUG, reject);
+
+    try {
+      const listed = await handlerOf(t).listEntries({
+        collectionName: SLUG,
+        overrideAccess: true,
+      });
+
+      expect(listed.success).toBe(false);
+      expect(listed.code).toBe("VALIDATION_ERROR");
+      expect((listed.publicData as { errors: unknown[] }).errors).toEqual([
+        { path: "title", code: "TOO_SHORT", message: "Title is too short." },
+      ]);
+    } finally {
+      unregisterHook("beforeRead", SLUG, reject);
     }
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/read-hook-typed-error.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/read-hook-typed-error.integration.test.ts
@@ -1,0 +1,121 @@
+// A read hook's typed error keeps its own status and code.
+//
+// The read paths recorded only a status in their catch, so the code-keyed
+// rebuild at the boundary had nothing to key on: a `beforeRead` throwing
+// `rateLimited()` reached the caller as a generic 500, and a read by id
+// hardcoded 500 regardless of what was raised.
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import { NextlyError } from "../../../errors";
+import { registerHook, unregisterHook } from "../../../hooks";
+import type { HookHandler } from "../../../hooks/types";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+// Integration files share fixed system-table names, so this suite keeps its own
+// collection slug to avoid colliding with a concurrently-running file.
+const SLUG = "readtyped_articles";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+type Envelope = {
+  success: boolean;
+  statusCode?: number;
+  code?: string;
+  publicData?: unknown;
+};
+
+function handlerOf(t: TestNextly) {
+  return t.getService("collectionsHandler") as unknown as {
+    listEntries: (p: Record<string, unknown>) => Promise<Envelope>;
+    countEntries: (p: Record<string, unknown>) => Promise<Envelope>;
+    getEntry: (p: Record<string, unknown>) => Promise<Envelope>;
+  };
+}
+
+async function boot(): Promise<TestNextly> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({ slug: SLUG, fields: [text({ name: "title" })] }),
+    ],
+  });
+  return current;
+}
+
+describe("a read hook's typed error survives the read path", () => {
+  it("keeps the code and status on a list", async () => {
+    const t = await boot();
+    const limit: HookHandler = () => {
+      throw NextlyError.rateLimited({ retryAfterSeconds: 30 });
+    };
+    registerHook("beforeRead", SLUG, limit);
+
+    try {
+      const listed = await handlerOf(t).listEntries({
+        collectionName: SLUG,
+        overrideAccess: true,
+      });
+
+      expect(listed.success).toBe(false);
+      expect(listed.statusCode).toBe(429);
+      expect(listed.code).toBe("RATE_LIMITED");
+      // The interval the route needs for `Retry-After`.
+      expect(listed.publicData).toEqual({ retryAfterSeconds: 30 });
+    } finally {
+      unregisterHook("beforeRead", SLUG, limit);
+    }
+  });
+
+  it("keeps the code and status on a count", async () => {
+    const t = await boot();
+    const deny: HookHandler = () => {
+      throw NextlyError.authRequired();
+    };
+    registerHook("beforeRead", SLUG, deny);
+
+    try {
+      const counted = await handlerOf(t).countEntries({
+        collectionName: SLUG,
+        overrideAccess: true,
+      });
+
+      expect(counted.success).toBe(false);
+      expect(counted.statusCode).toBe(401);
+      expect(counted.code).toBe("AUTH_REQUIRED");
+    } finally {
+      unregisterHook("beforeRead", SLUG, deny);
+    }
+  });
+
+  it("keeps the code and status on a read by id", async () => {
+    // This path hardcoded 500, so even the status was lost.
+    const t = await boot();
+    await t.nextly.create({ collection: SLUG, data: { title: "t" } });
+    const deny: HookHandler = () => {
+      throw NextlyError.forbidden();
+    };
+    registerHook("beforeRead", SLUG, deny);
+
+    try {
+      const got = await handlerOf(t).getEntry({
+        collectionName: SLUG,
+        entryId: "does-not-matter",
+        overrideAccess: true,
+      });
+
+      expect(got.success).toBe(false);
+      expect(got.statusCode).toBe(403);
+      expect(got.code).toBe("FORBIDDEN");
+    } finally {
+      unregisterHook("beforeRead", SLUG, deny);
+    }
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -254,6 +254,11 @@ export class CollectionBulkService extends BaseService {
 
       if (!sourceResult.success || !sourceResult.data) {
         return {
+          // Forwarded whole rather than rebuilt from two of its fields: the
+          // source read's failure is this operation's failure, and dropping its
+          // code left a rate limit on the source arriving as an internal error
+          // with no retry interval.
+          ...sourceResult,
           success: false,
           statusCode: sourceResult.statusCode || 404,
           message: sourceResult.message || "Source entry not found",

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -659,15 +659,13 @@ export class CollectionBulkService extends BaseService {
       // happen. This is a request-level failure (no items to partially
       // succeed on). Throw the canonical mapping so the dispatcher emits
       // an error envelope rather than a synthetic empty-id failure row.
-      const { code, message } = legacyEnvelopeToFailureFields(listResult);
-      throw new NextlyError({
-        code,
-        publicMessage: message,
-        logContext: {
-          op: "bulkUpdateByQuery",
-          collectionName: params.collectionName,
-          legacyMessage: listResult.message,
-        },
+      // The rebuilt error itself, not a reduction of it: taking only the code
+      // and message dropped the status (so a plugin code fell back to 500) and
+      // the public data a rate limit needs for `Retry-After`.
+      throw errorFromServiceEnvelope(listResult, {
+        op: "bulkUpdateByQuery",
+        collectionName: params.collectionName,
+        legacyMessage: listResult.message,
       });
     }
 
@@ -855,15 +853,13 @@ export class CollectionBulkService extends BaseService {
     });
 
     if (!listResult.success || !listResult.data) {
-      const { code, message } = legacyEnvelopeToFailureFields(listResult);
-      throw new NextlyError({
-        code,
-        publicMessage: message,
-        logContext: {
-          op: "bulkDeleteByQuery",
-          collectionName: params.collectionName,
-          legacyMessage: listResult.message,
-        },
+      // The rebuilt error itself, not a reduction of it: taking only the code
+      // and message dropped the status (so a plugin code fell back to 500) and
+      // the public data a rate limit needs for `Retry-After`.
+      throw errorFromServiceEnvelope(listResult, {
+        op: "bulkDeleteByQuery",
+        collectionName: params.collectionName,
+        legacyMessage: listResult.message,
       });
     }
 

--- a/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-bulk-service.ts
@@ -19,6 +19,7 @@ import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
 
 import type { AuthenticatedScope } from "../../../auth/authenticated-scope";
 import type { RequestActor } from "../../../auth/request-actor";
+import { errorFromServiceEnvelope } from "../../../errors/from-service-envelope";
 import { NextlyError } from "../../../errors/nextly-error";
 import type { RevalidationIntent } from "../../../revalidation/types";
 import type { WhereFilter } from "../../../services/collections/query-operators";
@@ -58,34 +59,13 @@ function legacyEnvelopeToFailureFields(result: {
   code?: string;
   message?: string;
 }): { code: string; message: string } {
-  const status = result.statusCode ?? 500;
-  if (status === 404) {
-    return { code: "NOT_FOUND", message: "Not found." };
-  }
-  if (status === 403) {
-    return {
-      code: "FORBIDDEN",
-      message: "You don't have permission to perform this action.",
-    };
-  }
-  if (status === 409) {
-    // Same disambiguation as unwrapServiceResult: 409 covers both a
-    // unique-constraint duplicate and an optimistic-concurrency conflict,
-    // and only the envelope's code can tell them apart. Staleness is the
-    // conservative default for a code-less envelope.
-    if (result.code === "DUPLICATE") {
-      return { code: "DUPLICATE", message: "Resource already exists." };
-    }
-    return {
-      code: "CONFLICT",
-      message:
-        "The resource has changed since you last loaded it. Please refresh and try again.",
-    };
-  }
-  if (status === 400) {
-    return { code: "VALIDATION_ERROR", message: "Validation failed." };
-  }
-  return { code: "INTERNAL_ERROR", message: "An unexpected error occurred." };
+  // Rebuilt through the shared converter so a per-item failure reports the same
+  // code the single-item endpoint reports for the identical failure. This kept
+  // its own status table, which sent anything outside 400/403/404/409 to
+  // INTERNAL_ERROR -- so an item whose hook threw `rateLimited()` was a rate
+  // limit on the single endpoint and an internal error in bulk.
+  const rebuilt = errorFromServiceEnvelope(result);
+  return { code: String(rebuilt.code), message: rebuilt.publicMessage };
 }
 
 /**

--- a/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
@@ -98,6 +98,10 @@ function errorToMetadataResult(
     statusCode: mapped.statusCode,
     message: mapped.publicMessage,
     data: null,
+    // The mapped error is typed too. Without its code a raw unique violation
+    // becomes a code-less 409, which a boundary reads as staleness rather than
+    // the duplicate it is, and a mapped timeout loses DATABASE_ERROR.
+    ...typedErrorEnvelopeFields(mapped),
   };
 }
 

--- a/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-metadata-service.ts
@@ -10,6 +10,7 @@ import { toDbError } from "../../../database/errors";
 // still consume the result tuple; only the internal error mapping changed.
 import type { PermissionSeedService } from "../../../domains/auth/services/permission-seed-service";
 import { NextlyError, isProgrammerError } from "../../../errors";
+import { typedErrorEnvelopeFields } from "../../../errors/from-service-envelope";
 import type { CollectionFileManager } from "../../../services/collection-file-manager";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
@@ -25,6 +26,14 @@ export interface MetadataServiceResult {
   message: string;
   data: Record<string, unknown> | Record<string, unknown>[] | null;
   meta?: Record<string, unknown>;
+  /**
+   * The failure's typed fields, so a boundary can rebuild the exact error
+   * rather than guess it from the status. Absent on success and on an untyped
+   * failure.
+   */
+  code?: string;
+  messageKey?: string;
+  publicData?: unknown;
 }
 
 /**
@@ -49,6 +58,10 @@ function errorToMetadataResult(
       statusCode: error.statusCode,
       message: error.publicMessage,
       data: null,
+      // The code above all: a boundary rebuilding from status alone cannot tell
+      // a DUPLICATE from a CONFLICT, and an occupied slug would be reported as
+      // a stale-resource conflict.
+      ...typedErrorEnvelopeFields(error),
     };
   }
   // Best-effort DbError detection — fromDatabaseError handles both DbError

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -33,6 +33,7 @@ import { toDbError } from "../../../database/errors";
 // only the internal error mapping changed. fromDatabaseError keeps driver
 // text out of the wire and routes identifying detail to logContext (§13.8).
 import { NextlyError } from "../../../errors";
+import { typedErrorEnvelopeFields } from "../../../errors/from-service-envelope";
 import type { ValidationPublicData } from "../../../errors/public-data";
 import { emitDocumentEvent } from "../../../events/domain-events";
 import { getEventBus } from "../../../events/event-bus";
@@ -3959,6 +3960,10 @@ export class CollectionMutationService extends BaseService {
             ? error.message
             : "Failed to publish all languages",
         data: null,
+        // A typed error keeps its own status and code. Hardcoding 500 reported
+        // a hook's refusal or rate limit as a server fault, and left a boundary
+        // nothing to rebuild it from.
+        ...(typedErrorEnvelopeFields(error) ?? {}),
       };
     }
   }
@@ -6610,6 +6615,14 @@ export class CollectionMutationService extends BaseService {
         message:
           error instanceof Error ? error.message : "Failed to delete entry",
         data: null,
+        // A typed error keeps its own status and code. Hardcoding 500 reported
+        // a hook's refusal or rate limit as a server fault, and left a boundary
+        // nothing to rebuild it from.
+        ...(typedErrorEnvelopeFields(error) ?? {}),
+        // A typed error keeps its own status and code. Hardcoding 500 reported
+        // a delete hook's refusal or rate limit as a server fault, and left a
+        // boundary nothing to rebuild it from.
+        ...(typedErrorEnvelopeFields(error) ?? {}),
         eventRecorded,
         revalidationIntent,
         committed: committedWrite,
@@ -8039,6 +8052,10 @@ export class CollectionMutationService extends BaseService {
             ? error.message
             : "Failed to delete entry in transaction",
         data: null,
+        // A typed error keeps its own status and code. Hardcoding 500 reported
+        // a hook's refusal or rate limit as a server fault, and left a boundary
+        // nothing to rebuild it from.
+        ...(typedErrorEnvelopeFields(error) ?? {}),
         revalidationIntent,
       };
     }
@@ -9586,6 +9603,10 @@ export class CollectionMutationService extends BaseService {
         message:
           error instanceof Error ? error.message : "Failed to delete entry",
         data: null,
+        // A typed error keeps its own status and code. Hardcoding 500 reported
+        // a hook's refusal or rate limit as a server fault, and left a boundary
+        // nothing to rebuild it from.
+        ...(typedErrorEnvelopeFields(error) ?? {}),
         eventRecorded,
         revalidationIntent,
       };

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -237,6 +237,11 @@ function errorToServiceResult<T = unknown>(
       // The canonical code rides along so boundary translators can rebuild
       // the exact error (409 alone cannot separate DUPLICATE from CONFLICT).
       code: error.code,
+      // A localized error selects its message by key, so dropping it leaves a
+      // client unable to render anything but the default string.
+      ...(error.messageKey !== undefined
+        ? { messageKey: error.messageKey }
+        : {}),
       // Public by definition -- it is what `toResponseJSON` puts on the wire --
       // so it rides the envelope and the boundary can rebuild an error whose
       // meaning lives in it rather than in its code.

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -237,6 +237,12 @@ function errorToServiceResult<T = unknown>(
       // The canonical code rides along so boundary translators can rebuild
       // the exact error (409 alone cannot separate DUPLICATE from CONFLICT).
       code: error.code,
+      // Public by definition -- it is what `toResponseJSON` puts on the wire --
+      // so it rides the envelope and the boundary can rebuild an error whose
+      // meaning lives in it rather than in its code.
+      ...(error.publicData !== undefined
+        ? { publicData: error.publicData }
+        : {}),
       message: error.publicMessage,
       data: null,
       ...(validationErrors ? { errors: validationErrors } : {}),

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -23,6 +23,7 @@ import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 import type { AuthenticatedScope } from "../../../auth/authenticated-scope";
 import { isFieldGroupField } from "../../../collections/fields/guards";
 import type { FieldConfig } from "../../../collections/fields/types";
+import { typedErrorEnvelopeFields } from "../../../errors/from-service-envelope";
 import { NextlyError } from "../../../errors/nextly-error";
 import { getFilterRegistry, FilterSeams } from "../../../filters";
 import { toSnakeCase } from "../../../lib/case-conversion";
@@ -1555,6 +1556,11 @@ export class CollectionQueryService extends BaseService {
         statusCode,
         message,
         data: null,
+        // A boundary can only rebuild what the envelope carried. Recording the
+        // status alone left a read hook's `rateLimited()` or `authRequired()`
+        // arriving at the caller as a generic 500, because the code-keyed
+        // rebuild had no code to key on.
+        ...(typedErrorEnvelopeFields(error) ?? {}),
       };
     }
   }
@@ -1985,6 +1991,9 @@ export class CollectionQueryService extends BaseService {
         statusCode: NextlyError.is(error) ? error.statusCode : 500,
         message,
         data: null,
+        // Same reason as listEntries: without the code the boundary rebuilds a
+        // typed refusal as a generic internal error.
+        ...(typedErrorEnvelopeFields(error) ?? {}),
       };
     }
   }
@@ -2680,6 +2689,10 @@ export class CollectionQueryService extends BaseService {
         message:
           error instanceof Error ? error.message : "Failed to fetch entry",
         data: null,
+        // A typed error keeps its own status and code. Hardcoding 500 reported
+        // a read hook's refusal as a server fault, and told a caller nothing it
+        // could act on.
+        ...(typedErrorEnvelopeFields(error) ?? {}),
       };
     }
   }

--- a/packages/nextly/src/domains/collections/services/collection-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service.ts
@@ -723,13 +723,16 @@ export class CollectionService extends BaseService {
     });
 
     if (!result.success) {
-      if (result.statusCode === 404) {
+      // Only a code-less legacy result takes the generic factory. A typed
+      // one -- a plugin's own error, or BUILDER_DISABLED -- keeps its code,
+      // message key and public data through the shared converter below.
+      if (!result.code && result.statusCode === 404) {
         // Generic "Not found." from the factory; identifiers go to logContext.
         throw NextlyError.notFound({
           logContext: { entity: "entry", collectionName, entryId },
         });
       }
-      if (result.statusCode === 403) {
+      if (!result.code && result.statusCode === 403) {
         // Generic forbidden message; the inner result.message often echoes
         // policy reasons that §13.8 keeps off the wire — drop them here and
         // preserve them in logContext only.
@@ -776,13 +779,16 @@ export class CollectionService extends BaseService {
     );
 
     if (!result.success) {
-      if (result.statusCode === 404) {
+      // Only a code-less legacy result takes the generic factory. A typed
+      // one -- a plugin's own error, or BUILDER_DISABLED -- keeps its code,
+      // message key and public data through the shared converter below.
+      if (!result.code && result.statusCode === 404) {
         // Generic "Not found." from the factory; identifiers go to logContext.
         throw NextlyError.notFound({
           logContext: { entity: "entry", collectionName, entryId },
         });
       }
-      if (result.statusCode === 403) {
+      if (!result.code && result.statusCode === 403) {
         // Generic forbidden message; the inner result.message often echoes
         // policy reasons that §13.8 keeps off the wire — drop them here and
         // preserve them in logContext only.
@@ -830,13 +836,16 @@ export class CollectionService extends BaseService {
     });
 
     if (!result.success) {
-      if (result.statusCode === 404) {
+      // Only a code-less legacy result takes the generic factory. A typed
+      // one -- a plugin's own error, or BUILDER_DISABLED -- keeps its code,
+      // message key and public data through the shared converter below.
+      if (!result.code && result.statusCode === 404) {
         // Generic "Not found." from the factory; identifiers go to logContext.
         throw NextlyError.notFound({
           logContext: { entity: "entry", collectionName, entryId },
         });
       }
-      if (result.statusCode === 403) {
+      if (!result.code && result.statusCode === 403) {
         // Generic forbidden message; the inner result.message often echoes
         // policy reasons that §13.8 keeps off the wire — drop them here and
         // preserve them in logContext only.
@@ -986,13 +995,16 @@ export class CollectionService extends BaseService {
     this.collectTxCommittedWrite(tx, result.success);
 
     if (!result.success) {
-      if (result.statusCode === 404) {
+      // Only a code-less legacy result takes the generic factory. A typed
+      // one -- a plugin's own error, or BUILDER_DISABLED -- keeps its code,
+      // message key and public data through the shared converter below.
+      if (!result.code && result.statusCode === 404) {
         // Generic "Not found." from the factory; identifiers go to logContext.
         throw NextlyError.notFound({
           logContext: { entity: "entry", collectionName, entryId },
         });
       }
-      if (result.statusCode === 403) {
+      if (!result.code && result.statusCode === 403) {
         // Generic forbidden message; the inner result.message often echoes
         // policy reasons that §13.8 keeps off the wire — drop them here and
         // preserve them in logContext only.
@@ -1060,13 +1072,16 @@ export class CollectionService extends BaseService {
     this.collectTxCommittedWrite(tx, result.success);
 
     if (!result.success) {
-      if (result.statusCode === 404) {
+      // Only a code-less legacy result takes the generic factory. A typed
+      // one -- a plugin's own error, or BUILDER_DISABLED -- keeps its code,
+      // message key and public data through the shared converter below.
+      if (!result.code && result.statusCode === 404) {
         // Generic "Not found." from the factory; identifiers go to logContext.
         throw NextlyError.notFound({
           logContext: { entity: "entry", collectionName, entryId },
         });
       }
-      if (result.statusCode === 403) {
+      if (!result.code && result.statusCode === 403) {
         // Generic forbidden message; the inner result.message often echoes
         // policy reasons that §13.8 keeps off the wire — drop them here and
         // preserve them in logContext only.

--- a/packages/nextly/src/domains/collections/services/collection-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-service.ts
@@ -58,6 +58,7 @@ import type { TransactionContext } from "@nextlyhq/adapter-drizzle/types";
 // NextlyErrors at this boundary so callers see the new error model.
 import type { RequestActor } from "../../../auth/request-actor";
 import { NextlyError } from "../../../errors";
+import { errorFromServiceEnvelope } from "../../../errors/from-service-envelope";
 import type { RevalidationIntent } from "../../../revalidation/types";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import type { CollectionEntryService } from "../../../services/collections/collection-entry-service";
@@ -1096,59 +1097,32 @@ export class CollectionService extends BaseService {
    * inner legacy message moves to logContext for operators only and never
    * reaches the wire.
    */
+  /**
+   * Rebuild the error a failed service envelope came from.
+   *
+   * Delegates to the shared converter so a plugin calling
+   * `ctx.services.collections` is handed the same error a REST or Direct API
+   * caller would get. This kept its own status table, which sent anything
+   * outside 400/401/403/404/409 to an internal error -- so a hook throwing
+   * `rateLimited()` reached a plugin as a 500 -- and whose input type omitted
+   * `code`, `errors` and `publicData` entirely, so a validation failure also
+   * arrived without its per-field issues.
+   */
   private mapLegacyErrorToNextlyError(result: {
     success: boolean;
     statusCode: number;
+    code?: string;
     message: string;
+    messageKey?: string;
+    publicData?: unknown;
     data: unknown;
+    errors?: Array<{
+      path?: string;
+      field?: string;
+      code?: string;
+      message: string;
+    }>;
   }): NextlyError {
-    const { statusCode, message } = result;
-
-    switch (statusCode) {
-      case 400:
-        // Validation requires structured `errors`; with no per-field detail
-        // available from the legacy shape, surface a single generic entry
-        // and stash the original message in logContext.
-        return NextlyError.validation({
-          errors: [
-            {
-              path: "",
-              code: "INVALID",
-              message: "The request is invalid.",
-            },
-          ],
-          logContext: { innerMessage: message },
-        });
-      case 401:
-        return NextlyError.authRequired({
-          logContext: { innerMessage: message },
-        });
-      case 403:
-        return NextlyError.forbidden({
-          logContext: { innerMessage: message },
-        });
-      case 404:
-        return NextlyError.notFound({
-          logContext: { innerMessage: message },
-        });
-      case 409:
-        return NextlyError.duplicate({
-          logContext: { innerMessage: message },
-        });
-      case 422:
-        // No dedicated factory for business-rule violations — use the
-        // free-form constructor with the canonical code and 422 status
-        // per the migration mapping table.
-        return new NextlyError({
-          code: "BUSINESS_RULE_VIOLATION",
-          publicMessage: "The request could not be completed.",
-          statusCode: 422,
-          logContext: { innerMessage: message },
-        });
-      default:
-        return NextlyError.internal({
-          logContext: { innerMessage: message, statusCode },
-        });
-    }
+    return errorFromServiceEnvelope(result, { innerMessage: result.message });
   }
 }

--- a/packages/nextly/src/domains/collections/services/collection-types.ts
+++ b/packages/nextly/src/domains/collections/services/collection-types.ts
@@ -34,6 +34,8 @@ export interface CollectionServiceResult<T = unknown> {
    * route needs to emit `Retry-After`.
    */
   publicData?: unknown;
+  /** Translation key for the public message, when the thrower set one. */
+  messageKey?: string;
   /**
    * Per-field validation issues (failure only). Carried through the
    * result shape so the dispatcher and Direct API can rebuild the

--- a/packages/nextly/src/domains/collections/services/collection-types.ts
+++ b/packages/nextly/src/domains/collections/services/collection-types.ts
@@ -27,6 +27,14 @@ export interface CollectionServiceResult<T = unknown> {
    */
   code?: string;
   /**
+   * The error's public data (failure only) -- the same object that reaches the
+   * wire as `error.data`. Public by definition, unlike `logContext`, so it can
+   * ride this shape safely, and carrying it is what lets a boundary rebuild an
+   * error whose meaning lives there: a rate limit's retry interval, which the
+   * route needs to emit `Retry-After`.
+   */
+  publicData?: unknown;
+  /**
    * Per-field validation issues (failure only). Carried through the
    * result shape so the dispatcher and Direct API can rebuild the
    * canonical VALIDATION_ERROR envelope with field paths intact.

--- a/packages/nextly/src/domains/singles/__tests__/single-error-result-typed-fields.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-error-result-typed-fields.test.ts
@@ -1,0 +1,57 @@
+// A Single's failure envelope carries the same typed fields a collection's does.
+//
+// The boundary rebuilds an error from the envelope's `code`. Recording only the
+// status left a Single hook's `rateLimited()` taking the status fallback and
+// reaching the caller as a generic 500, without the backoff a rate limit exists
+// to communicate.
+
+import { describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../../errors";
+import { errorFromServiceEnvelope } from "../../../errors/from-service-envelope";
+import { buildSingleErrorResult } from "../services/single-utils";
+
+describe("buildSingleErrorResult records the typed fields", () => {
+  it("carries the code, status and public data of a rate limit", () => {
+    const result = buildSingleErrorResult(
+      NextlyError.rateLimited({ retryAfterSeconds: 30 }),
+      "Failed to read single"
+    );
+
+    expect(result.code).toBe("RATE_LIMITED");
+    expect(result.statusCode).toBe(429);
+    expect(result.publicData).toEqual({ retryAfterSeconds: 30 });
+  });
+
+  it("round-trips through the boundary instead of becoming a 500", () => {
+    // The half that matters to a caller: what the envelope records has to be
+    // enough for the converter to rebuild the same error.
+    const result = buildSingleErrorResult(
+      NextlyError.authRequired(),
+      "Failed to read single"
+    );
+    const rebuilt = errorFromServiceEnvelope(result);
+
+    expect(rebuilt.code).toBe("AUTH_REQUIRED");
+    expect(rebuilt.statusCode).toBe(401);
+  });
+
+  it("still carries per-field issues in the legacy field shape", () => {
+    // The mirror: SingleResult's own `{field}` array predates the canonical
+    // `{path}` one and its consumers still read it.
+    const result = buildSingleErrorResult(
+      NextlyError.validation({
+        errors: [{ path: "title", code: "REQUIRED", message: "Required." }],
+      }),
+      "Failed to update single"
+    );
+
+    expect(result.errors).toEqual([{ field: "title", message: "Required." }]);
+    expect(result.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("leaves the typed fields absent for an untyped error", () => {
+    const result = buildSingleErrorResult(new Error("boom"), "Failed");
+    expect(result.code).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/domains/singles/__tests__/single-error-result-typed-fields.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-error-result-typed-fields.test.ts
@@ -101,3 +101,32 @@ describe("the Single boundaries rebuild the error rather than its status", () =>
     expect(err.code).toBe("NOT_FOUND");
   });
 });
+
+describe("the Single boundaries keep an issue's code", () => {
+  it("carries it through the Direct API's normalization", async () => {
+    // `SingleResult.errors` carries the code now, but the boundary map that
+    // converts `{field}` to `{path}` was dropping it again one layer up, so the
+    // converter substituted a generic reason.
+    const { createErrorFromSingleResult } = await import(
+      "../../../direct-api/namespaces/helpers"
+    );
+    const result = buildSingleErrorResult(
+      NextlyError.validation({
+        errors: [{ path: "title", code: "REQUIRED", message: "Required." }],
+      }),
+      "Failed"
+    );
+
+    const err = createErrorFromSingleResult({
+      success: false,
+      statusCode: result.statusCode,
+      code: result.code,
+      message: result.message,
+      errors: result.errors,
+    });
+
+    expect(
+      (err.publicData as { errors: { code: string }[] }).errors[0].code
+    ).toBe("REQUIRED");
+  });
+});

--- a/packages/nextly/src/domains/singles/__tests__/single-error-result-typed-fields.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-error-result-typed-fields.test.ts
@@ -46,7 +46,12 @@ describe("buildSingleErrorResult records the typed fields", () => {
       "Failed to update single"
     );
 
-    expect(result.errors).toEqual([{ field: "title", message: "Required." }]);
+    // The reason travels with the issue: a boundary normalising this array
+    // would otherwise have to invent one, and REQUIRED would reach the client
+    // as a generic INVALID.
+    expect(result.errors).toEqual([
+      { field: "title", code: "REQUIRED", message: "Required." },
+    ]);
     expect(result.code).toBe("VALIDATION_ERROR");
   });
 

--- a/packages/nextly/src/domains/singles/__tests__/single-error-result-typed-fields.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-error-result-typed-fields.test.ts
@@ -55,3 +55,44 @@ describe("buildSingleErrorResult records the typed fields", () => {
     expect(result.code).toBeUndefined();
   });
 });
+
+describe("the Single boundaries rebuild the error rather than its status", () => {
+  it("keeps a rate limit through the Direct API boundary", async () => {
+    // Reconstructing from status alone dropped `publicData`, so the caller got
+    // a 429 with no interval -- told to slow down without being told by how
+    // much.
+    const { createErrorFromSingleResult } = await import(
+      "../../../direct-api/namespaces/helpers"
+    );
+    const result = buildSingleErrorResult(
+      NextlyError.rateLimited({ retryAfterSeconds: 30 }),
+      "Failed"
+    );
+
+    const err = createErrorFromSingleResult({
+      success: false,
+      statusCode: result.statusCode,
+      code: result.code,
+      message: result.message,
+      publicData: result.publicData,
+    });
+
+    expect(err.code).toBe("RATE_LIMITED");
+    expect(err.statusCode).toBe(429);
+    expect(err.publicData).toEqual({ retryAfterSeconds: 30 });
+  });
+
+  it("still guesses from the status when no code was recorded", async () => {
+    // The mirror: envelopes built by hand carry no code and must keep the
+    // status-derived guess this boundary has always made.
+    const { createErrorFromSingleResult } = await import(
+      "../../../direct-api/namespaces/helpers"
+    );
+    const err = createErrorFromSingleResult({
+      success: false,
+      statusCode: 404,
+      message: "Not found.",
+    });
+    expect(err.code).toBe("NOT_FOUND");
+  });
+});

--- a/packages/nextly/src/domains/singles/services/single-utils.ts
+++ b/packages/nextly/src/domains/singles/services/single-utils.ts
@@ -17,6 +17,7 @@
 
 import type { FieldConfig } from "../../../collections/fields/types";
 import { NextlyError } from "../../../errors";
+import { typedErrorEnvelopeFields } from "../../../errors/from-service-envelope";
 import { convertTimestampsToCamelCase } from "../../../shared/lib/case-conversion";
 import type { ValidatableField } from "../../../shared/lib/entry-validation";
 import { validateEntryData } from "../../../shared/lib/entry-validation";
@@ -673,6 +674,10 @@ export function buildSingleErrorResult(
             })),
           }
         : {}),
+      // Without the code, a Single hook's `authRequired()` or `rateLimited()`
+      // took the boundary's status fallback and reached the caller as a
+      // generic 500, losing the rate-limit backoff with it.
+      ...typedErrorEnvelopeFields(error),
     };
   }
 

--- a/packages/nextly/src/domains/singles/services/single-utils.ts
+++ b/packages/nextly/src/domains/singles/services/single-utils.ts
@@ -658,7 +658,13 @@ export function buildSingleErrorResult(
       error.code === "VALIDATION_ERROR"
         ? (
             error.publicData as
-              | { errors?: Array<{ path: string; message: string }> }
+              | {
+                  errors?: Array<{
+                    path: string;
+                    code?: string;
+                    message: string;
+                  }>;
+                }
               | undefined
           )?.errors
         : undefined;
@@ -670,6 +676,11 @@ export function buildSingleErrorResult(
         ? {
             errors: validationErrors.map(e => ({
               field: e.path,
+              // The per-field reason travels with the issue. Without it a
+              // boundary normalising this array has to invent one, and a
+              // hook's `REQUIRED` arrives at the client as a generic
+              // `INVALID`.
+              ...(e.code !== undefined ? { code: e.code } : {}),
               message: e.message,
             })),
           }

--- a/packages/nextly/src/domains/singles/types.ts
+++ b/packages/nextly/src/domains/singles/types.ts
@@ -196,6 +196,14 @@ export interface SingleResult<T = SingleDocument> {
   /** Error message (on failure) */
   message?: string;
 
+  /**
+   * The failure's typed fields, so a boundary rebuilds the exact error instead
+   * of guessing it from the status. Mirrors `CollectionServiceResult`.
+   */
+  code?: string;
+  messageKey?: string;
+  publicData?: unknown;
+
   /** Error details (on failure) */
   errors?: Array<{ field?: string; message: string }>;
 

--- a/packages/nextly/src/domains/singles/types.ts
+++ b/packages/nextly/src/domains/singles/types.ts
@@ -205,7 +205,7 @@ export interface SingleResult<T = SingleDocument> {
   publicData?: unknown;
 
   /** Error details (on failure) */
-  errors?: Array<{ field?: string; message: string }>;
+  errors?: Array<{ field?: string; code?: string; message: string }>;
 
   /**
    * Whether this write appended a durable outbox event, independent of

--- a/packages/nextly/src/domains/versions/restore-version.ts
+++ b/packages/nextly/src/domains/versions/restore-version.ts
@@ -19,6 +19,8 @@ import type { RequestActor } from "../../auth/request-actor";
 import type { FieldConfig } from "../../collections/fields/types";
 import { getService } from "../../di";
 import { NextlyError } from "../../errors";
+import type { ServiceErrorEnvelope } from "../../errors/from-service-envelope";
+import { errorFromServiceEnvelope } from "../../errors/from-service-envelope";
 import type { VersionScopeKind } from "../../schemas/versions/types";
 import {
   applyFieldReadAccess,
@@ -537,7 +539,10 @@ function assertWriteSucceeded(
   result: {
     success?: boolean;
     statusCode?: number;
+    code?: string;
     message?: string;
+    messageKey?: string;
+    publicData?: unknown;
     errors?: unknown;
   },
   args: RestoreVersionArgs
@@ -581,6 +586,19 @@ function assertWriteSucceeded(
   // since removed, a validator tightened since. Those are answers the editor can
   // act on, so the update's own message is preserved rather than flattened into
   // a server fault.
+  // A typed failure answers as itself. The 4xx branch below treats everything
+  // as a snapshot that failed today's validation rules, which is right for a
+  // stale select option and wrong for a rate limit -- that reached the client
+  // as a 400 with no retry interval.
+  if (result.code) {
+    throw errorFromServiceEnvelope(result as ServiceErrorEnvelope, {
+      reason: "restore-write-failed",
+      scopeKind: args.scopeKind,
+      scopeSlug: args.slug,
+      entryId: args.entryId,
+    });
+  }
+
   if (status >= 400 && status < 500) {
     throw NextlyError.validation({
       errors: Array.isArray(result.errors)

--- a/packages/nextly/src/domains/versions/restore-version.ts
+++ b/packages/nextly/src/domains/versions/restore-version.ts
@@ -566,6 +566,19 @@ function assertWriteSucceeded(
     });
   }
 
+  // A typed failure answers as itself. The 4xx branch below treats everything
+  // as a snapshot that failed today's validation rules, which is right for a
+  // stale select option and wrong for a rate limit -- that reached the client
+  // as a 400 with no retry interval.
+  if (result.code) {
+    throw errorFromServiceEnvelope(result as ServiceErrorEnvelope, {
+      reason: "restore-write-failed",
+      scopeKind: args.scopeKind,
+      scopeSlug: args.slug,
+      entryId: args.entryId,
+    });
+  }
+
   // A conflict stays a conflict. Wrapping it in a validation error would answer
   // 400/VALIDATION_ERROR, and a REST client reads the outer status — so a
   // restore whose slug now collides would stop matching the contract the same
@@ -586,19 +599,6 @@ function assertWriteSucceeded(
   // since removed, a validator tightened since. Those are answers the editor can
   // act on, so the update's own message is preserved rather than flattened into
   // a server fault.
-  // A typed failure answers as itself. The 4xx branch below treats everything
-  // as a snapshot that failed today's validation rules, which is right for a
-  // stale select option and wrong for a rate limit -- that reached the client
-  // as a 400 with no retry interval.
-  if (result.code) {
-    throw errorFromServiceEnvelope(result as ServiceErrorEnvelope, {
-      reason: "restore-write-failed",
-      scopeKind: args.scopeKind,
-      scopeSlug: args.slug,
-      entryId: args.entryId,
-    });
-  }
-
   if (status >= 400 && status < 500) {
     throw NextlyError.validation({
       errors: Array.isArray(result.errors)

--- a/packages/nextly/src/errors/__tests__/from-service-envelope.test.ts
+++ b/packages/nextly/src/errors/__tests__/from-service-envelope.test.ts
@@ -121,3 +121,33 @@ describe("validation issues reach the caller in either envelope shape", () => {
     ).toBe("request");
   });
 });
+
+describe("a localized validation error keeps its message and key", () => {
+  it("does not replace them with the factory's defaults", () => {
+    // `NextlyError.validation` hardcodes "Validation failed." and takes no
+    // message key, so rebuilding through it dropped both and a client selecting
+    // its text by key fell back to the default string.
+    const err = errorFromServiceEnvelope({
+      statusCode: 400,
+      code: "VALIDATION_ERROR",
+      message: "Le formulaire est invalide.",
+      messageKey: "errors.form.invalid",
+      publicData: { errors: [{ path: "title", message: "Requis." }] },
+    });
+
+    expect(err.publicMessage).toBe("Le formulaire est invalide.");
+    expect(err.messageKey).toBe("errors.form.invalid");
+    // ...and the per-field issues still reach the admin.
+    expect((err.publicData as { errors: unknown[] }).errors).toEqual([
+      { path: "title", code: "INVALID", message: "Requis." },
+    ]);
+  });
+
+  it("still falls back to the canonical text when none was carried", () => {
+    const err = errorFromServiceEnvelope({
+      statusCode: 400,
+      code: "VALIDATION_ERROR",
+    });
+    expect(err.publicMessage).toBe("Validation failed.");
+  });
+});

--- a/packages/nextly/src/errors/__tests__/from-service-envelope.test.ts
+++ b/packages/nextly/src/errors/__tests__/from-service-envelope.test.ts
@@ -1,0 +1,81 @@
+// One converter, used by every boundary that hands a service failure back.
+//
+// Each boundary used to keep its own table of statuses, and each omitted
+// different codes, so the same hook failure surfaced as 429 through one and a
+// 500 through the next. These pin the behaviour all of them now share.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  errorFromServiceEnvelope,
+  typedErrorEnvelopeFields,
+} from "../from-service-envelope";
+import { NextlyError } from "../nextly-error";
+
+describe("errorFromServiceEnvelope", () => {
+  it("keeps a code the canonical set does not contain", () => {
+    const err = errorFromServiceEnvelope({
+      statusCode: 402,
+      code: "ACME_QUOTA_EXHAUSTED",
+      message: "Quota exhausted.",
+    });
+    expect(err.code).toBe("ACME_QUOTA_EXHAUSTED");
+    expect(err.statusCode).toBe(402);
+  });
+
+  it("carries every public field the error had", () => {
+    const err = errorFromServiceEnvelope({
+      statusCode: 429,
+      code: "RATE_LIMITED",
+      message: "Too many requests.",
+      messageKey: "errors.rateLimited",
+      publicData: { retryAfterSeconds: 30 },
+    });
+    expect(err.publicMessage).toBe("Too many requests.");
+    expect(err.messageKey).toBe("errors.rateLimited");
+    expect(err.publicData).toEqual({ retryAfterSeconds: 30 });
+  });
+
+  it("falls back to the status when no code was recorded", () => {
+    // Envelopes are still built by hand in places, and they must keep working.
+    expect(errorFromServiceEnvelope({ statusCode: 404 }).code).toBe(
+      "NOT_FOUND"
+    );
+    expect(errorFromServiceEnvelope({ statusCode: 403 }).code).toBe(
+      "FORBIDDEN"
+    );
+    expect(errorFromServiceEnvelope({}).code).toBe("INTERNAL_ERROR");
+  });
+
+  it("normalises the legacy field shape into the canonical path one", () => {
+    // SingleResult still emits `{field}`; the admin maps `{path}` onto inputs.
+    const err = errorFromServiceEnvelope({
+      statusCode: 400,
+      code: "VALIDATION_ERROR",
+      errors: [{ field: "title", message: "Title is required." }],
+    });
+    expect((err.publicData as { errors: unknown[] }).errors).toEqual([
+      { path: "title", code: "INVALID", message: "Title is required." },
+    ]);
+  });
+});
+
+describe("typedErrorEnvelopeFields", () => {
+  it("round-trips a typed error through the envelope and back", () => {
+    // The two halves are only useful together: a converter can rebuild nothing
+    // the catch did not record.
+    const original = NextlyError.rateLimited({ retryAfterSeconds: 15 });
+    const fields = typedErrorEnvelopeFields(original);
+    expect(fields).not.toBeNull();
+
+    const rebuilt = errorFromServiceEnvelope(fields!);
+    expect(rebuilt.code).toBe(original.code);
+    expect(rebuilt.statusCode).toBe(original.statusCode);
+    expect(rebuilt.publicMessage).toBe(original.publicMessage);
+    expect(rebuilt.publicData).toEqual(original.publicData);
+  });
+
+  it("reports nothing for an untyped error, so callers keep their fallback", () => {
+    expect(typedErrorEnvelopeFields(new Error("boom"))).toBeNull();
+  });
+});

--- a/packages/nextly/src/errors/__tests__/from-service-envelope.test.ts
+++ b/packages/nextly/src/errors/__tests__/from-service-envelope.test.ts
@@ -193,3 +193,26 @@ describe("a code-less 400 does not put internal text on the wire", () => {
     ).toBe("REQUIRED");
   });
 });
+
+describe("a typed 409 is not flattened into a generic conflict", () => {
+  it("keeps DUPLICATE and its public fields", () => {
+    // A status-only branch that ran first rebuilt every 409 as CONFLICT, so a
+    // duplicate -- and a plugin 409 carrying its own key and data -- lost what
+    // told them apart.
+    const err = errorFromServiceEnvelope({
+      statusCode: 409,
+      code: "DUPLICATE",
+      message: "Resource already exists.",
+      messageKey: "errors.duplicate",
+    });
+
+    expect(err.code).toBe("DUPLICATE");
+    expect(err.messageKey).toBe("errors.duplicate");
+  });
+
+  it("still defaults a code-less 409 to staleness", () => {
+    // The mirror: without a code, telling the user to refresh is the safer
+    // answer than implying the write was invalid.
+    expect(errorFromServiceEnvelope({ statusCode: 409 }).code).toBe("CONFLICT");
+  });
+});

--- a/packages/nextly/src/errors/__tests__/from-service-envelope.test.ts
+++ b/packages/nextly/src/errors/__tests__/from-service-envelope.test.ts
@@ -79,3 +79,45 @@ describe("typedErrorEnvelopeFields", () => {
     expect(typedErrorEnvelopeFields(new Error("boom"))).toBeNull();
   });
 });
+
+describe("validation issues reach the caller in either envelope shape", () => {
+  it("reads them from publicData when that is where they are", () => {
+    // A read path carries the error's `publicData` verbatim -- that is where
+    // `NextlyError.validation` puts the issues. Reading only the top-level
+    // `errors` replaced a hook's field paths with a fabricated placeholder, so
+    // the admin mapped nothing onto its inputs.
+    const err = errorFromServiceEnvelope({
+      statusCode: 400,
+      code: "VALIDATION_ERROR",
+      publicData: {
+        errors: [{ path: "title", code: "TOO_SHORT", message: "Too short." }],
+      },
+    });
+
+    expect((err.publicData as { errors: unknown[] }).errors).toEqual([
+      { path: "title", code: "TOO_SHORT", message: "Too short." },
+    ]);
+  });
+
+  it("prefers the envelope's own errors when a write path lifted them", () => {
+    // The write path normalises the legacy `{field}` key on the way out, so its
+    // array is the more canonical of the two when both are present.
+    const err = errorFromServiceEnvelope({
+      statusCode: 400,
+      code: "VALIDATION_ERROR",
+      errors: [{ field: "slug", message: "Already taken." }],
+      publicData: { errors: [{ path: "ignored", message: "stale" }] },
+    });
+
+    expect((err.publicData as { errors: unknown[] }).errors).toEqual([
+      { path: "slug", code: "INVALID", message: "Already taken." },
+    ]);
+  });
+
+  it("still falls back when there are no issues at all", () => {
+    const err = errorFromServiceEnvelope({ statusCode: 400 });
+    expect(
+      (err.publicData as { errors: { path: string }[] }).errors[0].path
+    ).toBe("request");
+  });
+});

--- a/packages/nextly/src/errors/__tests__/from-service-envelope.test.ts
+++ b/packages/nextly/src/errors/__tests__/from-service-envelope.test.ts
@@ -151,3 +151,45 @@ describe("a localized validation error keeps its message and key", () => {
     expect(err.publicMessage).toBe("Validation failed.");
   });
 });
+
+describe("a code-less 400 does not put internal text on the wire", () => {
+  it("uses the canonical validation message, not the envelope's", () => {
+    // Legacy converters store a raw exception's `message` in a code-less 400.
+    // Promoting that to the public message would ship internal paths and driver
+    // detail to the client. Only an envelope that says VALIDATION_ERROR is
+    // trusted to carry public text.
+    const err = errorFromServiceEnvelope({
+      statusCode: 400,
+      message: "ENOENT: no such file or directory, open '/srv/app/.nextly/x'",
+    });
+
+    expect(err.publicMessage).toBe("Validation failed.");
+    expect(err.publicMessage).not.toContain("/srv/app");
+  });
+
+  it("still trusts a typed validation envelope's message", () => {
+    // The mirror: the localized message a validation error legitimately
+    // carries must survive, which is what the code is for.
+    const err = errorFromServiceEnvelope({
+      statusCode: 400,
+      code: "VALIDATION_ERROR",
+      message: "Le formulaire est invalide.",
+    });
+
+    expect(err.publicMessage).toBe("Le formulaire est invalide.");
+  });
+
+  it("keeps a per-field issue's own code through normalization", () => {
+    // The legacy Single array carries `{field, message}`; without the reason
+    // travelling with it, a hook's REQUIRED arrives as a generic INVALID.
+    const err = errorFromServiceEnvelope({
+      statusCode: 400,
+      code: "VALIDATION_ERROR",
+      errors: [{ field: "title", code: "REQUIRED", message: "Required." }],
+    });
+
+    expect(
+      (err.publicData as { errors: { code: string }[] }).errors[0].code
+    ).toBe("REQUIRED");
+  });
+});

--- a/packages/nextly/src/errors/from-service-envelope.ts
+++ b/packages/nextly/src/errors/from-service-envelope.ts
@@ -5,6 +5,7 @@
  * @module errors/from-service-envelope
  */
 
+import { NEXTLY_ERROR_STATUS } from "./error-codes";
 import { NextlyError } from "./nextly-error";
 import type { PublicData } from "./public-data";
 
@@ -82,7 +83,7 @@ function validationFromEnvelope(
       envelope.code === "VALIDATION_ERROR" && envelope.message
         ? envelope.message
         : "Validation failed.",
-    statusCode: envelope.statusCode ?? 400,
+    statusCode: envelope.statusCode ?? NEXTLY_ERROR_STATUS.VALIDATION_ERROR,
     messageKey:
       envelope.code === "VALIDATION_ERROR" ? envelope.messageKey : undefined,
     publicData: { errors: normalized },
@@ -109,7 +110,10 @@ export function errorFromServiceEnvelope(
   envelope: ServiceErrorEnvelope,
   logContext: Record<string, unknown> = {}
 ): NextlyError {
-  const status = envelope.statusCode ?? 500;
+  // Read from the canonical map rather than repeated literals: this converter
+  // exists so one place decides how a status and a code correspond, and a
+  // literal here would drift the moment that map changed.
+  const status = envelope.statusCode ?? NEXTLY_ERROR_STATUS.INTERNAL_ERROR;
 
   if (envelope.code) {
     // Validation keeps its own path: it also normalises the legacy `{field}`
@@ -131,14 +135,20 @@ export function errorFromServiceEnvelope(
     });
   }
 
-  if (status === 404) return NextlyError.notFound({ logContext });
-  if (status === 403) return NextlyError.forbidden({ logContext });
-  if (status === 409) {
+  if (status === NEXTLY_ERROR_STATUS.NOT_FOUND) {
+    return NextlyError.notFound({ logContext });
+  }
+  if (status === NEXTLY_ERROR_STATUS.FORBIDDEN) {
+    return NextlyError.forbidden({ logContext });
+  }
+  if (status === NEXTLY_ERROR_STATUS.CONFLICT) {
     // Without a code, staleness is the safer default: it tells the user to
     // refresh rather than implying the write itself was invalid.
     return NextlyError.conflict({ logContext });
   }
-  if (status === 400) return validationFromEnvelope(envelope, logContext);
+  if (status === NEXTLY_ERROR_STATUS.VALIDATION_ERROR) {
+    return validationFromEnvelope(envelope, logContext);
+  }
   return NextlyError.internal({ logContext });
 }
 

--- a/packages/nextly/src/errors/from-service-envelope.ts
+++ b/packages/nextly/src/errors/from-service-envelope.ts
@@ -1,0 +1,141 @@
+/**
+ * Rebuilding a `NextlyError` from the `{ success, statusCode, code, ... }`
+ * envelope the services return.
+ *
+ * @module errors/from-service-envelope
+ */
+
+import { NextlyError } from "./nextly-error";
+import type { PublicData } from "./public-data";
+
+/** The failure fields a service envelope can carry. */
+export interface ServiceErrorEnvelope {
+  statusCode?: number;
+  /** Canonical `NextlyError` code, when the envelope came from one. */
+  code?: string;
+  /** The original `publicMessage`. */
+  message?: string;
+  /** Translation key for the public message, when the thrower set one. */
+  messageKey?: string;
+  /** The error's own public data -- what reaches the wire as `error.data`. */
+  publicData?: unknown;
+  /**
+   * Per-field issues. Canonical `{path}` from collection results, legacy
+   * `{field}` from SingleResult; both normalize here.
+   */
+  errors?: Array<{
+    path?: string;
+    field?: string;
+    code?: string;
+    message: string;
+  }>;
+}
+
+/**
+ * Build the validation error from an envelope's per-field issues.
+ *
+ * Per-field issues survive into the envelope so the admin can map them onto
+ * form fields; the generic single-issue shape is only the fallback for
+ * detail-less 400s.
+ */
+function validationFromEnvelope(
+  errors: ServiceErrorEnvelope["errors"],
+  logContext: Record<string, unknown>
+): NextlyError {
+  return NextlyError.validation({
+    errors: errors?.length
+      ? errors.map(e => ({
+          path: e.path ?? e.field ?? "",
+          code: e.code ?? "INVALID",
+          message: e.message,
+        }))
+      : [
+          {
+            path: "request",
+            code: "INVALID",
+            message: "The submitted data is invalid.",
+          },
+        ],
+    logContext,
+  });
+}
+
+/**
+ * Turn a failed service envelope back into the error that produced it.
+ *
+ * This is the ONLY place that knows how. Every boundary that hands a service
+ * failure to a caller -- the REST dispatcher, the Direct API, the plugin-facing
+ * collection facade, the bulk converter -- used to carry its own table of
+ * statuses, and each table omitted different codes: a hook throwing
+ * `rateLimited()` surfaced as 429 through one and as a 500 through the next.
+ * One converter is what makes those answers agree.
+ *
+ * Reconstruction is keyed on the code, not the status, because only the code
+ * identifies an error exactly: three codes share 401, two share 409, two share
+ * 500, and plugins declare codes outside the canonical set entirely. The status
+ * mapping below is the fallback for envelopes built by hand that carry no code.
+ */
+export function errorFromServiceEnvelope(
+  envelope: ServiceErrorEnvelope,
+  logContext: Record<string, unknown> = {}
+): NextlyError {
+  const status = envelope.statusCode ?? 500;
+
+  if (envelope.code) {
+    // Validation keeps its own path: it also normalises the legacy `{field}`
+    // shape into the canonical `{path}` one the admin maps onto form fields.
+    if (envelope.code === "VALIDATION_ERROR") {
+      return validationFromEnvelope(envelope.errors, logContext);
+    }
+    return new NextlyError({
+      code: envelope.code,
+      // The envelope's message IS the original `publicMessage`, so this round
+      // trips rather than replacing it with generic text.
+      publicMessage: envelope.message ?? "The request could not be completed.",
+      // Carried explicitly: a plugin code has no entry in the status enum, and
+      // the envelope's status is the one the thrower chose.
+      statusCode: status,
+      messageKey: envelope.messageKey,
+      publicData: envelope.publicData as PublicData | undefined,
+      logContext,
+    });
+  }
+
+  if (status === 404) return NextlyError.notFound({ logContext });
+  if (status === 403) return NextlyError.forbidden({ logContext });
+  if (status === 409) {
+    // Without a code, staleness is the safer default: it tells the user to
+    // refresh rather than implying the write itself was invalid.
+    return NextlyError.conflict({ logContext });
+  }
+  if (status === 400)
+    return validationFromEnvelope(envelope.errors, logContext);
+  return NextlyError.internal({ logContext });
+}
+
+/**
+ * The failure fields a service envelope should carry for a typed error.
+ *
+ * The inverse of {@link errorFromServiceEnvelope}, and its necessary partner: a
+ * boundary can only rebuild what the envelope carried, so a catch that records
+ * the status alone leaves the code-keyed rebuild nothing to key on and the
+ * error reaches the caller as a generic 500 however good the converter is.
+ *
+ * Returns null for an untyped error, so a caller keeps whatever fallback it
+ * already applies to those.
+ */
+export function typedErrorEnvelopeFields(
+  error: unknown
+): Pick<
+  ServiceErrorEnvelope,
+  "code" | "statusCode" | "message" | "messageKey" | "publicData"
+> | null {
+  if (!NextlyError.is(error)) return null;
+  return {
+    code: String(error.code),
+    statusCode: error.statusCode,
+    message: error.publicMessage,
+    ...(error.messageKey !== undefined ? { messageKey: error.messageKey } : {}),
+    ...(error.publicData !== undefined ? { publicData: error.publicData } : {}),
+  };
+}

--- a/packages/nextly/src/errors/from-service-envelope.ts
+++ b/packages/nextly/src/errors/from-service-envelope.ts
@@ -54,20 +54,30 @@ function validationFromEnvelope(
         | { errors?: ServiceErrorEnvelope["errors"] }
         | undefined
     )?.errors;
-  return NextlyError.validation({
-    errors: errors?.length
-      ? errors.map(e => ({
-          path: e.path ?? e.field ?? "",
-          code: e.code ?? "INVALID",
-          message: e.message,
-        }))
-      : [
-          {
-            path: "request",
-            code: "INVALID",
-            message: "The submitted data is invalid.",
-          },
-        ],
+  const normalized = errors?.length
+    ? errors.map(e => ({
+        path: e.path ?? e.field ?? "",
+        code: e.code ?? "INVALID",
+        message: e.message,
+      }))
+    : [
+        {
+          path: "request",
+          code: "INVALID",
+          message: "The submitted data is invalid.",
+        },
+      ];
+
+  // Built directly rather than through `NextlyError.validation`, which hardcodes
+  // "Validation failed." and takes no message key -- so a localized validation
+  // error lost both on the way through, and a client selecting its text by key
+  // fell back to the default string.
+  return new NextlyError({
+    code: "VALIDATION_ERROR",
+    publicMessage: envelope.message ?? "Validation failed.",
+    statusCode: envelope.statusCode ?? 400,
+    messageKey: envelope.messageKey,
+    publicData: { errors: normalized },
     logContext,
   });
 }

--- a/packages/nextly/src/errors/from-service-envelope.ts
+++ b/packages/nextly/src/errors/from-service-envelope.ts
@@ -39,9 +39,21 @@ export interface ServiceErrorEnvelope {
  * detail-less 400s.
  */
 function validationFromEnvelope(
-  errors: ServiceErrorEnvelope["errors"],
+  envelope: ServiceErrorEnvelope,
   logContext: Record<string, unknown>
 ): NextlyError {
+  // The issues reach this in one of two shapes. A write path lifts them onto
+  // the envelope's own `errors`, normalising the legacy `{field}` key on the
+  // way; a read path carries the error's `publicData` verbatim, which is where
+  // `NextlyError.validation` puts them. Reading only the first left a read
+  // hook's field paths replaced by the fabricated fallback below.
+  const errors =
+    envelope.errors ??
+    (
+      envelope.publicData as
+        | { errors?: ServiceErrorEnvelope["errors"] }
+        | undefined
+    )?.errors;
   return NextlyError.validation({
     errors: errors?.length
       ? errors.map(e => ({
@@ -85,7 +97,7 @@ export function errorFromServiceEnvelope(
     // Validation keeps its own path: it also normalises the legacy `{field}`
     // shape into the canonical `{path}` one the admin maps onto form fields.
     if (envelope.code === "VALIDATION_ERROR") {
-      return validationFromEnvelope(envelope.errors, logContext);
+      return validationFromEnvelope(envelope, logContext);
     }
     return new NextlyError({
       code: envelope.code,
@@ -108,8 +120,7 @@ export function errorFromServiceEnvelope(
     // refresh rather than implying the write itself was invalid.
     return NextlyError.conflict({ logContext });
   }
-  if (status === 400)
-    return validationFromEnvelope(envelope.errors, logContext);
+  if (status === 400) return validationFromEnvelope(envelope, logContext);
   return NextlyError.internal({ logContext });
 }
 

--- a/packages/nextly/src/errors/from-service-envelope.ts
+++ b/packages/nextly/src/errors/from-service-envelope.ts
@@ -74,9 +74,17 @@ function validationFromEnvelope(
   // fell back to the default string.
   return new NextlyError({
     code: "VALIDATION_ERROR",
-    publicMessage: envelope.message ?? "Validation failed.",
+    // The envelope's message is only trusted when the envelope says it came
+    // from a validation error. A code-less 400 reaches here from legacy
+    // converters that store a raw exception's text, and promoting that to the
+    // public message would put internal paths and driver detail on the wire.
+    publicMessage:
+      envelope.code === "VALIDATION_ERROR" && envelope.message
+        ? envelope.message
+        : "Validation failed.",
     statusCode: envelope.statusCode ?? 400,
-    messageKey: envelope.messageKey,
+    messageKey:
+      envelope.code === "VALIDATION_ERROR" ? envelope.messageKey : undefined,
     publicData: { errors: normalized },
     logContext,
   });


### PR DESCRIPTION
Task `095` (P1), PR 1 of 2. Closes the boundary half of gap **D** —
#426 kept a hook's typed error through the registry, and it was flattened here.

## The defect

`unwrapServiceResult` rebuilt a thrown error from its **HTTP status**, and only
400/403/404/409 had a branch. Everything else became `internal`:

| raised | reached a REST caller as |
|---|---|
| `authRequired`, `invalidCredentials`, `tokenExpired` (401) | **500** |
| `rateLimited` (429) | **500** |
| `serviceUnavailable` (503) | **500** |
| any 400 carrying a non-validation code | **`VALIDATION_ERROR`** |

So a rate limit was indistinguishable from a crash, and a caller could be told
its data failed validation when it had never been validated.

## Why this is a small change

The re-audit turned up something that reframes the task: **the envelope already
carried the canonical code.** `errorToServiceResult` copies it, with a comment
saying why — "so boundary translators can rebuild the exact error (409 alone
cannot separate DUPLICATE from CONFLICT)". `unwrapServiceResult` then consulted
it for 409 and dispatched on status for everything else.

This was never missing information. It was dispatching on the wrong key.

## The fix

Reconstruction is keyed on the code, through an `ERROR_BY_CODE` table.

- **Future-proof:** a new `NextlyError` code round-trips by adding a row, not by
  editing control flow. Nothing can silently collapse to 500 again.
- **Backward compatible:** envelopes still built by hand carry no code and fall
  through to the existing status mapping, unchanged. An *unrecognized* code
  falls through too, rather than escaping the boundary.
- **DRY:** both the code-keyed and status-keyed paths build the validation error
  through one helper, so they cannot drift into different shapes for the same
  failure.

`VALIDATION_ERROR` and `INVALID_INPUT` are deliberately not in the table —
they carry more than a log context (per-field issues; a public message that is
the error's own) and are rebuilt explicitly.

## The admin question, checked rather than assumed

The task flagged that any change to how a 400 is rebuilt has UI consequences.
Verified in `parseApiError.ts`: `apiErrorMessage` reads `data.errors` when
present and falls back to `err.message`. So

- a `VALIDATION_ERROR` keeps its per-field array — form-field mapping is
  untouched, and there is a mirror test pinning it
- a 400/`INVALID_INPUT` now surfaces its **real** message instead of the generic
  "The submitted data is invalid." — strictly better for the person reading it

## Verification

13 tests. 6 fail with the code dispatch reverted (revert confirmed by grep):
the five collapsed statuses and the 400 code.

The other three — the validation mirror, the no-code fallback, and the
unknown-code fallback — **pass either way by design**. Their job is to pin
behaviour this must *preserve*, so they would catch a future over-correction
rather than this change. Saying so explicitly because a test that cannot fail is
worth nothing unless you know why it is there.

`pnpm run check-types` clean (both tsconfigs). `src/dispatcher` failing-test
name set identical to `origin/main` — 5 pre-existing on both sides.

## Not in this PR

`cause` and `logContext` still do not survive the envelope (acceptance criterion
3). That is not an oversight: `errorToServiceResult`'s own docstring says
identifier-bearing detail is dropped **because the result shape is publicly
surfaced**. Diagnostics therefore cannot ride the envelope — they need a channel
that is not its public surface, which is a design question rather than a
plumbing one. PR 2, written up in `tasks/left-tasks/095-...md`.
