### PR TITLE
feat(nextly): add a static declaration channel for plugin-to-plugin data

### DIFF
--- a/.changeset/plugin-declarations-channel.md
+++ b/.changeset/plugin-declarations-channel.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+A plugin can now declare data for another plugin statically, and the page builder registers contributed blocks from it.
+
+`contributes.declarations` is the static counterpart to `contributes.services`. A service is a factory, so what it provides is knowable only once a plugin has booted — and `nextly generate:types` boots nothing, reading the config alone. A capability offered only through a service is therefore invisible to generation and cannot appear in generated types, an import map, or a manifest.
+
+A block contributor can now declare its blocks instead of registering them by hand, and the page builder registers them at boot from the same declaration the tooling reads, attributed to the plugin that declared them. Registering imperatively from `init` still works for a plugin whose block list depends on runtime state.

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -371,6 +371,7 @@ export {
 // Plugin System - Types and helpers for creating plugins
 export {
   AdminPlacement,
+  collectDeclarations,
   definePlugin,
   createPluginContext,
   type PluginAdminAppearance,
@@ -378,6 +379,7 @@ export {
   type PluginCategory,
   type PluginContext,
   type PluginContributions,
+  type PluginDeclaration,
   type PluginDefinition,
   type PluginPermission,
   type PluginRole,

--- a/packages/nextly/src/plugins/__tests__/declarations.test.ts
+++ b/packages/nextly/src/plugins/__tests__/declarations.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { collectDeclarations } from "../declarations";
+import type { PluginDefinition } from "../plugin-context";
+
+/** A plugin definition carrying only what this reader looks at. */
+function plugin(
+  name: string,
+  declarations?: Record<string, unknown>,
+  enabled?: boolean
+): PluginDefinition {
+  return {
+    name,
+    version: "1.0.0",
+    enabled,
+    contributes: declarations ? { declarations } : undefined,
+  } as PluginDefinition;
+}
+
+describe("collectDeclarations", () => {
+  it("returns only the declarations addressed to the consumer", () => {
+    const found = collectDeclarations(
+      [
+        plugin("@acme/a", { "@nextlyhq/page-builder": { blocks: [1] } }),
+        plugin("@acme/b", { "@nextlyhq/other": { blocks: [2] } }),
+      ],
+      "@nextlyhq/page-builder"
+    );
+
+    expect(found).toEqual([{ source: "@acme/a", value: { blocks: [1] } }]);
+  });
+
+  it("names the plugin that made each declaration", () => {
+    // A collision has to name both culprits, which needs the value paired with
+    // its author rather than merged into one list.
+    const found = collectDeclarations(
+      [
+        plugin("@acme/a", { pb: { blocks: ["x"] } }),
+        plugin("@acme/b", { pb: { blocks: ["x"] } }),
+      ],
+      "pb"
+    );
+
+    expect(found.map(d => d.source)).toEqual(["@acme/a", "@acme/b"]);
+  });
+
+  it("skips a disabled plugin", () => {
+    // `enabled: false` withholds behaviour, and a declaration is behaviour the
+    // consumer would otherwise act on.
+    const found = collectDeclarations(
+      [plugin("@acme/a", { pb: { blocks: [1] } }, false)],
+      "pb"
+    );
+
+    expect(found).toEqual([]);
+  });
+
+  it("keeps a declaration whose value is falsy", () => {
+    // Only the consumer knows whether a falsy value means anything, so presence
+    // is tested rather than truthiness.
+    const found = collectDeclarations([plugin("@acme/a", { pb: null })], "pb");
+
+    expect(found).toEqual([{ source: "@acme/a", value: null }]);
+  });
+
+  it("ignores a declarations block that is an array", () => {
+    // An array would be indexed by the consumer name and yield undefined for
+    // every consumer, which reads as a valid but empty declaration.
+    const found = collectDeclarations(
+      [
+        plugin("@acme/a", ["not-a-record"] as unknown as Record<
+          string,
+          unknown
+        >),
+      ],
+      "pb"
+    );
+
+    expect(found).toEqual([]);
+  });
+
+  it("returns nothing when no plugin declares for the consumer", () => {
+    expect(collectDeclarations([plugin("@acme/a")], "pb")).toEqual([]);
+  });
+});

--- a/packages/nextly/src/plugins/contributions.ts
+++ b/packages/nextly/src/plugins/contributions.ts
@@ -466,6 +466,36 @@ export interface PluginContributions {
    */
   services?: Record<string, (ctx: PluginContext) => unknown>;
   /**
+   * @experimental Static data this plugin publishes for OTHER plugins, keyed by
+   * the consuming plugin's name. Core stores it and never reads inside it.
+   *
+   * The counterpart to `services`, and the reason it exists: a service is a
+   * factory, so its contents are knowable only once a plugin's `init` has run.
+   * Everything else here is plain data, which is what lets `nextly generate:types`
+   * build generated artifacts by reading the config alone — it loads no plugin
+   * runtime and opens no database. A capability offered only through `services`
+   * is therefore invisible to generation, and cannot appear in an import map, a
+   * manifest, or generated types.
+   *
+   * Declaring the data here and registering FROM it at boot keeps one source for
+   * both, so tooling and runtime cannot disagree about what a plugin provides.
+   *
+   * Keyed by consumer name rather than by capability so core stays out of it:
+   * a page builder reads `declarations["@nextlyhq/plugin-page-builder"]` and
+   * decides what its own shape means, exactly as it already does for the
+   * service it hands back.
+   *
+   * @example
+   * ```ts
+   * contributes: {
+   *   declarations: {
+   *     "@nextlyhq/plugin-page-builder": { blocks: [pricingTable] },
+   *   },
+   * }
+   * ```
+   */
+  declarations?: Record<string, unknown>;
+  /**
    * @experimental Scheduled tasks — **RESERVED, NOT EXECUTED** in this
    * release. The shape is published so authors aren't surprised by its absence,
    * but the runtime does not run these yet (a real scheduler needs durable jobs,

--- a/packages/nextly/src/plugins/declarations.ts
+++ b/packages/nextly/src/plugins/declarations.ts
@@ -1,0 +1,64 @@
+/**
+ * Reading what plugins statically declared for one another.
+ *
+ * `contributes.declarations` is deliberately typed `unknown` in core, because
+ * core does not know what any of it means. This is the one place that walks it,
+ * so a consuming plugin gets its entries already paired with the plugin that
+ * wrote them instead of every consumer re-deriving that from the plugin list.
+ *
+ * Provenance travels with the value for the same reason it does on a contributed
+ * block: when two plugins declare something that collides, the error has to name
+ * both, and a value separated from its author cannot.
+ *
+ * @module plugins/declarations
+ */
+
+import type { PluginDefinition } from "./plugin-context";
+
+/** One plugin's declaration for a consumer, with the plugin that made it. */
+export interface PluginDeclaration {
+  /** The declaring plugin's name, for attribution in errors. */
+  source: string;
+  /** Whatever that plugin declared. The consumer decides what shape is valid. */
+  value: unknown;
+}
+
+/**
+ * Every declaration addressed to `consumer`, in plugin order.
+ *
+ * Disabled plugins are skipped: `enabled: false` withholds behavior, and a
+ * declaration is behavior the consumer would otherwise act on. Plugins that
+ * declare nothing for this consumer contribute no entry rather than an empty
+ * one, so a consumer can treat "no entries" as "nobody declared".
+ *
+ * Reads the plugin list alone, so it works identically at boot and at generation
+ * time — which is the property the whole channel exists for.
+ */
+export function collectDeclarations(
+  plugins: readonly PluginDefinition[],
+  consumer: string
+): PluginDeclaration[] {
+  const found: PluginDeclaration[] = [];
+  for (const plugin of plugins) {
+    if (plugin.enabled === false) continue;
+    const declared = plugin.contributes?.declarations;
+    if (!isPlainRecord(declared)) continue;
+    // `in` rather than a truthiness test: a plugin may deliberately declare a
+    // falsy value, and only the consumer knows whether that means anything.
+    if (!(consumer in declared)) continue;
+    found.push({ source: plugin.name, value: declared[consumer] });
+  }
+  return found;
+}
+
+/**
+ * Whether a value is a plain object usable as a keyed record.
+ *
+ * An array passes `typeof === "object"` and would then be indexed by the
+ * consumer name, yielding `undefined` for every consumer while looking like a
+ * valid declaration block. Rejecting it here makes a misdeclared array visible
+ * as "nothing declared" rather than as a silently empty lookup.
+ */
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/nextly/src/plugins/index.ts
+++ b/packages/nextly/src/plugins/index.ts
@@ -9,6 +9,8 @@
  */
 
 export { AdminPlacement } from "./admin-placement";
+export { collectDeclarations } from "./declarations";
+export type { PluginDeclaration } from "./declarations";
 export type { AdminPlacement as AdminPlacementType } from "./admin-placement";
 
 export {

--- a/packages/plugin-page-builder/src/blocks/__tests__/declared-blocks.integration.test.ts
+++ b/packages/plugin-page-builder/src/blocks/__tests__/declared-blocks.integration.test.ts
@@ -1,0 +1,93 @@
+/**
+ * A plugin can declare its blocks instead of registering them.
+ *
+ * The imperative call registers from inside `init`, so what a plugin
+ * contributes is knowable only after that plugin has booted. Generation never
+ * boots anything, so a block registered that way cannot reach an import map, a
+ * manifest, or generated types. A declared block is plain data on the plugin
+ * definition, which both readers can see.
+ *
+ * These assert the runtime half: the page builder registers what was declared,
+ * attributes it to the plugin that declared it, and does so for a plugin with
+ * no `init` of its own at all.
+ */
+import { getBlock, getBlockSource, clearBlocks } from "@nextlyhq/blocks-engine";
+import { defineBlock } from "@nextlyhq/plugin-sdk/blocks";
+import { createTestNextly, type TestNextly } from "nextly/testing";
+import { definePlugin } from "@nextlyhq/plugin-sdk";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { PAGE_BUILDER_PLUGIN } from "../registration-service";
+import { pageBuilder } from "../../plugin";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+  clearBlocks();
+});
+
+const pricingTable = defineBlock({
+  name: "acme/declared-pricing",
+  version: 1,
+  description: "A declared pricing table.",
+  example: { props: {} },
+  props: {},
+  render: () => null,
+});
+
+/** A plugin that declares a block and defines no `init` at all. */
+function declaring(
+  name = "@acme/declared-blocks",
+  blocks: unknown = [pricingTable]
+) {
+  return definePlugin({
+    name,
+    version: "1.0.0",
+    nextly: ">=0.0.0",
+    contributes: { declarations: { [PAGE_BUILDER_PLUGIN]: { blocks } } },
+  } as never);
+}
+
+describe("a plugin declares blocks statically", () => {
+  it("registers them at boot with no init of its own", async () => {
+    current = await createTestNextly({
+      plugins: [pageBuilder(), declaring()],
+    });
+
+    expect(getBlock("acme/declared-pricing")).toBeDefined();
+  });
+
+  it("attributes the block to the plugin that declared it", async () => {
+    // Registered on the declarer's behalf by the page builder, so the naive
+    // attribution would be the page builder itself and a collision would send
+    // a reader to the wrong package.
+    current = await createTestNextly({
+      plugins: [pageBuilder(), declaring()],
+    });
+
+    expect(getBlockSource("acme/declared-pricing")).toBe(
+      "@acme/declared-blocks"
+    );
+  });
+
+  it("registers whichever order the plugins are listed in", async () => {
+    current = await createTestNextly({
+      plugins: [declaring(), pageBuilder()],
+    });
+
+    expect(getBlock("acme/declared-pricing")).toBeDefined();
+  });
+
+  it("refuses a declaration whose blocks are not an array", async () => {
+    // Addressed to this reader by name, so the author meant it to take effect;
+    // skipping it would leave the plugin looking installed and contributing
+    // nothing.
+    await expect(
+      createTestNextly({
+        plugins: [pageBuilder(), declaring("@acme/bad", { nope: true })],
+      })
+    ).rejects.toThrow(/@acme\/bad/);
+  });
+});

--- a/packages/plugin-page-builder/src/blocks/declared-blocks.ts
+++ b/packages/plugin-page-builder/src/blocks/declared-blocks.ts
@@ -1,0 +1,55 @@
+/**
+ * Blocks a plugin declares statically, rather than registering by hand.
+ *
+ * `blockRegistry(ctx).register(...)` inside `init` is a runtime call, so what a
+ * plugin contributes is knowable only once that plugin has booted. Generation
+ * never boots anything — it reads the config and writes its artifacts — so a
+ * block registered that way cannot appear in an import map, a manifest, or
+ * generated types.
+ *
+ * A declared block is plain data on the plugin definition, so both readers see
+ * the same thing: generation reads it from the config, and boot registers from
+ * it here. The imperative call remains for a plugin whose block list genuinely
+ * depends on runtime state.
+ *
+ * @module blocks/declared-blocks
+ */
+
+import type { AnyBlockDefinition } from "@nextlyhq/blocks-engine";
+import type { PluginDeclaration } from "@nextlyhq/plugin-sdk";
+
+/** What a plugin puts under the page builder's key in `contributes.declarations`. */
+export interface PageBuilderDeclaration {
+  /** Block definitions to register at boot. */
+  blocks?: AnyBlockDefinition[];
+}
+
+/**
+ * The blocks in one declaration, with the plugin that declared them.
+ *
+ * Returns nothing rather than throwing for a declaration that is not the shape
+ * this plugin expects: another version of the page builder may understand keys
+ * this one does not, and refusing to boot over an unread key would make every
+ * such pairing fatal. A malformed `blocks` value is the one case worth naming,
+ * because the author meant it for exactly this reader.
+ */
+export function blocksIn(declaration: PluginDeclaration): {
+  blocks: AnyBlockDefinition[];
+  error?: string;
+} {
+  const value = declaration.value;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { blocks: [] };
+  }
+  const declared = (value as PageBuilderDeclaration).blocks;
+  if (declared === undefined) return { blocks: [] };
+  if (!Array.isArray(declared)) {
+    return {
+      blocks: [],
+      error:
+        `"${declaration.source}" declared blocks for the page builder as ` +
+        `${typeof declared}; it must be an array of block definitions.`,
+    };
+  }
+  return { blocks: declared };
+}

--- a/packages/plugin-page-builder/src/blocks/registration-service.ts
+++ b/packages/plugin-page-builder/src/blocks/registration-service.ts
@@ -25,6 +25,9 @@ import {
   type SupportDefinition,
 } from "@nextlyhq/blocks-engine";
 import type { PluginContext } from "@nextlyhq/plugin-sdk";
+import { collectDeclarations } from "nextly";
+
+import { blocksIn } from "./declared-blocks";
 
 /** The page builder's own name, as the cross-plugin namespace keys it. */
 export const PAGE_BUILDER_PLUGIN = "@nextlyhq/plugin-page-builder";
@@ -176,4 +179,33 @@ function isBlockRegistrationBackend(
     value !== null &&
     typeof (value as { register?: unknown }).register === "function"
   );
+}
+
+/**
+ * Register every block plugins declared for the page builder.
+ *
+ * Called from the page builder's own `init`, which is also what guarantees the
+ * per-boot reset runs: resolving the service is what empties the registry, and
+ * that has to happen before anything is registered into it.
+ *
+ * Each block is attributed to the plugin that DECLARED it, not to the page
+ * builder that registered it on its behalf, so a name collision still names the
+ * package a reader has to go and fix.
+ *
+ * A declaration whose `blocks` is not an array throws rather than being skipped.
+ * It was addressed to this reader by name, so the author meant it to take
+ * effect; silently ignoring it would leave a plugin looking installed while
+ * contributing nothing.
+ */
+export function registerDeclaredBlocks(ctx: PluginContext): void {
+  const service = ctx.services.plugins[PAGE_BUILDER_PLUGIN]?.[BLOCK_SERVICE];
+  if (!isBlockRegistrationBackend(service)) return;
+  for (const declaration of collectDeclarations(
+    ctx.config.plugins ?? [],
+    PAGE_BUILDER_PLUGIN
+  )) {
+    const { blocks, error } = blocksIn(declaration);
+    if (error) throw new Error(error);
+    if (blocks.length > 0) service.register(blocks, declaration.source);
+  }
 }

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -10,8 +10,8 @@ import { version as PLUGIN_VERSION } from "../package.json";
 
 import {
   BLOCK_SERVICE,
-  blockRegistry,
   createBlockRegistrationService,
+  registerDeclaredBlocks,
 } from "./blocks/registration-service";
 import { PAGE_BUILDER_FIELD_TYPE } from "./collections/pageBuilderEntry";
 import { pagesCollection } from "./collections/pages";
@@ -48,15 +48,15 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) =>
       description:
         "Build pages visually from blocks with drag-and-drop editing",
     },
-    // Resolving the block registry is what empties it for the boot, and the
-    // service is lazy: on a boot where nothing contributes, no contributor
-    // resolves it and the previous boot's blocks would survive. Resolving it
-    // here makes the reset unconditional. The handle is deliberately unused —
-    // the page builder registers no blocks of its own — and resolving from
-    // `init` cannot wipe a contributor that ran first, because the factory is
-    // memoized for the boot and clears only on its first resolution.
+    // Registers what other plugins DECLARED, and resolves the registry service
+    // on the way, which is what empties it for the boot. The service is lazy:
+    // on a boot where nothing contributes, nobody else resolves it and the
+    // previous boot's blocks would survive. Doing it here makes the reset
+    // unconditional, and cannot wipe a contributor whose `init` ran first,
+    // because the factory is memoized for the boot and clears only on its
+    // first resolution.
     init: ctx => {
-      blockRegistry(ctx);
+      registerDeclaredBlocks(ctx);
     },
     contributes: {
       // The channel another plugin adds blocks through. Core carries no

--- a/packages/plugin-sdk/src/__snapshots__/plugin-surface.test.ts.snap
+++ b/packages/plugin-sdk/src/__snapshots__/plugin-surface.test.ts.snap
@@ -126,6 +126,7 @@ exports[`plugin-sdk public export surface > \`.\` (index) surface is unchanged 1
   "PluginContext (type)",
   "PluginContributions (type)",
   "PluginDataFieldConfig (type)",
+  "PluginDeclaration (type)",
   "PluginDefinition (type)",
   "PluginEmailProvider (type)",
   "PluginEmailTemplate (type)",

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -30,6 +30,7 @@ export { definePlugin } from "nextly";
 export type {
   PluginDefinition,
   PluginContributions,
+  PluginDeclaration,
   PluginCategory,
   PluginContext,
   PluginHookRegistry,


### PR DESCRIPTION
Adds the static counterpart to `contributes.services`, and makes the page builder register contributed blocks from it.

## The problem

`PluginContributions` has 14 channels. **Thirteen are static data** — `collections`, `fieldTypes`, `events`, `routes`, `admin` and the rest. Exactly one is a runtime factory:

```ts
services?: Record<string, (ctx: PluginContext) => unknown>
```

A factory's contents are knowable only once a plugin's `init` has run. `nextly generate:types` runs no `init` — it loads the config and writes its artifacts, opening no database and booting no plugin. So **a capability offered only through a service is invisible to generation** and cannot appear in generated types, an import map, or a manifest.

Blocks went through `services`, which is why both the block manifest (PR-9) and the block editor-component import map (PR-8) are blocked. It is one blocker, not two.

## The change

```ts
declarations?: Record<string, unknown>;
```

Plain data, keyed by the **consuming** plugin's name. Core stores it and never reads inside it — so core gains no knowledge of blocks, which is the property #441 established when it kept `contributes.blocks` out of core.

```ts
definePlugin({
  name: "@acme/pricing-blocks",
  contributes: {
    declarations: { "@nextlyhq/plugin-page-builder": { blocks: [pricingTable] } },
  },
})
```

The page builder registers these at boot from the same declaration tooling reads, so the two cannot disagree about what a plugin provides. `blockRegistry(ctx).register(...)` still works for a plugin whose block list depends on runtime state.

Blocks stay attributed to the plugin that **declared** them, not the page builder that registered them on its behalf — a collision must still name the package to go and fix.

## Why keyed by consumer, not a `blocks` key

A `contributes.blocks` key would put the blocks concept back in core, which #441 rejected: contributing blocks is contributing to the page builder, not to Nextly. A namespaced bag keeps core out of it and serves the next plugin that needs tooling-visible data without another core change.

## Prior art

This is the split VS Code makes. Its contribution points are static declarations in the manifest precisely so tooling can read an extension's capabilities [without activating the extension](https://code.visualstudio.com/api/references/contribution-points) — activation is separate and lazy. Nextly's thirteen static channels already have that property; blocks lost it by going through the one runtime channel.

## Verification

- **Stub-verified, twice, and precisely.** Attributing a declared block to the page builder instead of its declarer fails exactly one test — the attribution test. Removing the boot registration entirely fails all four new tests *plus* the existing `drops a removed contributor's blocks on the next boot`, which correctly confirms the per-boot registry reset is still hooked to the same call.
- nextly unit: **400 failed / 37 failed files — the baseline exactly.**
- 6 new unit tests for the reader, 4 new integration tests for the boot path; page-builder integration 19 passed / 12 skipped.
- check-types, lint, sherif clean.

## What this unblocks

PR-9 (manifest) reads declarations; PR-8 (import map) reads `editor.component` from the same source. Neither needs to boot plugins during codegen.
