### PR TITLE
fix(nextly): report a post-commit hook failure instead of raising it

### DIFF
--- a/.changeset/tidy-moons-visit.md
+++ b/.changeset/tidy-moons-visit.md
@@ -1,0 +1,33 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+A hook that throws after the write has committed no longer fails the write.
+
+`afterCreate`, `afterUpdate` and `afterDelete` run once the row is durable, and
+a throw there reported the operation as failed with no entry returned. Callers
+could not learn the id of the row that existed, and a retry wrote it a second
+time. These phases now report their failures instead of raising them: the
+operation succeeds, the error is logged with its phase and collection, and the
+remaining handlers still run. `beforeCreate` and the other pre-write phases are
+unchanged -- refusing a write is what they are for.

--- a/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/cache-revalidation.integration.test.ts
@@ -241,11 +241,11 @@ describe("cache revalidation — write path (sqlite)", () => {
     expect(spy.tags).toContain("nextly:redact:slug:hidden-slug");
   });
 
-  it("busts tags for a committed batch item whose afterCreate hook throws", async () => {
+  it("busts tags for a batch item whose afterCreate hook throws, and counts it as written", async () => {
     const entries = await boot([openCollection("hookfail")]);
-    // A code afterCreate hook that always throws. In a batch (stopOnError:false)
-    // the row still commits, so the item's tags must be busted even though it is
-    // reported as a failure — the intent is computed before the hooks run.
+    // A code afterCreate hook that always throws. The row still commits, and a
+    // post-commit phase cannot un-commit it, so the item is reported as the
+    // success it is and its tags are busted.
     const throwingHook: HookHandler = async () => {
       throw NextlyError.internal({ logContext: { reason: "test-hook-throw" } });
     };
@@ -256,8 +256,12 @@ describe("cache revalidation — write path (sqlite)", () => {
         [{ title: "T", slug: "committed" }],
         { stopOnError: false }
       );
-      expect(result.failed).toBe(1); // the hook threw, so the item is a failure
-      // …but the row committed, so its tags were still busted.
+      // The hook threw after the write, which does not make the write a
+      // failure: the row is durable and calling it failed would have a caller
+      // retry and write it twice.
+      expect(result.failed).toBe(0);
+      expect(result.successful).toBe(1);
+      // And the committed row's tags are busted, as they always were.
       expect(spy.tags).toContain("nextly:hookfail:slug:committed");
     } finally {
       unregisterHook("afterCreate", "hookfail", throwingHook);

--- a/packages/nextly/src/domains/collections/__tests__/post-commit-hook-failure.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/post-commit-hook-failure.integration.test.ts
@@ -1,0 +1,158 @@
+// A hook that throws AFTER the write has committed does not fail the write.
+//
+// The row is durable by then and the phase cannot change it, so reporting
+// failure would tell a caller its write did not happen. Every client treats a
+// non-2xx as "retry", and the retry writes the row a second time -- so the
+// honest-looking answer is the one that corrupts data.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import { NextlyError } from "../../../errors";
+import { registerHook, unregisterHook } from "../../../hooks";
+import type { HookHandler } from "../../../hooks/types";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+// Integration files share fixed system-table names, so this suite keeps its own
+// collection slug to avoid colliding with a concurrently-running file.
+const SLUG = "postcommit_articles";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+  vi.restoreAllMocks();
+});
+
+async function boot(): Promise<TestNextly> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({ slug: SLUG, fields: [text({ name: "title" })] }),
+    ],
+  });
+  return current;
+}
+
+function handlerOf(t: TestNextly) {
+  return t.getService("collectionsHandler") as unknown as {
+    createEntry: (
+      params: Record<string, unknown>,
+      data: Record<string, unknown>
+    ) => Promise<{ success: boolean; data: Record<string, unknown> | null }>;
+    listEntries: (p: Record<string, unknown>) => Promise<{
+      success: boolean;
+      data: { docs: Record<string, unknown>[]; totalDocs: number } | null;
+    }>;
+  };
+}
+
+describe("a post-commit hook failure does not fail the write", () => {
+  it("reports success and returns the entry the caller needs", async () => {
+    // Without the entry the caller cannot even reference the row that now
+    // exists: retry and it is written twice, do not retry and it is orphaned.
+    const t = await boot();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const boom: HookHandler = () => {
+      throw NextlyError.internal({ logContext: { reason: "notify failed" } });
+    };
+    registerHook("afterCreate", SLUG, boom);
+
+    try {
+      const created = await handlerOf(t).createEntry(
+        { collectionName: SLUG, overrideAccess: true },
+        { title: "durable" }
+      );
+
+      expect(created.success).toBe(true);
+      expect(created.data?.id).toBeTruthy();
+    } finally {
+      unregisterHook("afterCreate", SLUG, boom);
+    }
+  });
+
+  it("leaves exactly one row, which is what the caller was told", async () => {
+    const t = await boot();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const boom: HookHandler = () => {
+      throw NextlyError.internal({ logContext: { reason: "notify failed" } });
+    };
+    registerHook("afterCreate", SLUG, boom);
+
+    try {
+      const created = await handlerOf(t).createEntry(
+        { collectionName: SLUG, overrideAccess: true },
+        { title: "durable" }
+      );
+
+      const listed = await handlerOf(t).listEntries({
+        collectionName: SLUG,
+        overrideAccess: true,
+      });
+      // The row lands either way -- the transaction had already committed. What
+      // this pins is that the answer MATCHES it: reporting failure beside a row
+      // that exists is what makes a client retry and write a second one.
+      expect(listed.data!.docs).toHaveLength(1);
+      expect(created.success).toBe(true);
+    } finally {
+      unregisterHook("afterCreate", SLUG, boom);
+    }
+  });
+
+  it("logs the failure, so a side effect never vanishes silently", async () => {
+    // The operation reports success, so this log is the only trace an operator
+    // has that the hook broke.
+    const t = await boot();
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const boom: HookHandler = () => {
+      throw NextlyError.internal({ logContext: { reason: "notify failed" } });
+    };
+    registerHook("afterCreate", SLUG, boom);
+
+    try {
+      await handlerOf(t).createEntry(
+        { collectionName: SLUG, overrideAccess: true },
+        { title: "durable" }
+      );
+
+      expect(logged).toHaveBeenCalled();
+      expect(String(logged.mock.calls[0][0])).toContain("afterCreate");
+    } finally {
+      unregisterHook("afterCreate", SLUG, boom);
+    }
+  });
+
+  it("still refuses the write when a BEFORE hook throws", async () => {
+    // The mirror, and the reason this is safe: gating is what `before*` is for,
+    // and it is untouched. Without this, "post-commit failures are tolerated"
+    // could just as well be satisfied by a registry that swallows everything.
+    const t = await boot();
+
+    const deny: HookHandler = () => {
+      throw NextlyError.forbidden();
+    };
+    registerHook("beforeCreate", SLUG, deny);
+
+    try {
+      const created = await handlerOf(t).createEntry(
+        { collectionName: SLUG, overrideAccess: true },
+        { title: "rejected" }
+      );
+
+      expect(created.success).toBe(false);
+
+      const listed = await handlerOf(t).listEntries({
+        collectionName: SLUG,
+        overrideAccess: true,
+      });
+      expect(listed.data!.docs).toHaveLength(0);
+    } finally {
+      unregisterHook("beforeCreate", SLUG, deny);
+    }
+  });
+});

--- a/packages/nextly/src/hooks/__tests__/hook-registry.test.ts
+++ b/packages/nextly/src/hooks/__tests__/hook-registry.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
+import type { SideEffectHookFailure } from "../hook-registry";
 import { HookRegistry, resetHookRegistry } from "../hook-registry";
 import type { HookContext, HookHandler, HookType } from "../types";
 import { NextlyError } from "../../errors/nextly-error";
@@ -620,13 +621,19 @@ describe("HookRegistry", () => {
 
       // The hook type and collection are still recorded, in log context where
       // operators see them, rather than in a message returned to the caller.
-      const error = await registry
-        .execute("afterUpdate", context)
-        .catch((e: unknown) => e);
-      expect(NextlyError.is(error)).toBe(true);
-      expect(
-        (error as { logContext?: Record<string, unknown> }).logContext
-      ).toMatchObject({ hookType: "afterUpdate", collection: "users" });
+      // A side-effect phase reports the failure instead of raising it, because
+      // the write it follows has already committed.
+      const failures: SideEffectHookFailure[] = [];
+      await registry.execute("afterUpdate", context, {
+        onSideEffectError: failure => failures.push(failure),
+      });
+
+      expect(failures).toHaveLength(1);
+      expect(NextlyError.is(failures[0].error)).toBe(true);
+      expect(failures[0].error.logContext).toMatchObject({
+        hookType: "afterUpdate",
+        collection: "users",
+      });
     });
   });
 

--- a/packages/nextly/src/hooks/__tests__/side-effect-phase-returns.test.ts
+++ b/packages/nextly/src/hooks/__tests__/side-effect-phase-returns.test.ts
@@ -11,6 +11,7 @@
  */
 import { describe, expect, it } from "vitest";
 
+import type { SideEffectHookFailure } from "../hook-registry";
 import { HookRegistry } from "../hook-registry";
 import type { HookContext } from "../types";
 
@@ -76,7 +77,7 @@ describe("side-effect phase return values", () => {
     expect(result).not.toHaveProperty("injected");
   });
 
-  it("still runs every side-effect handler and still propagates a throw", async () => {
+  it("still runs every side-effect handler, and reports a throw instead of raising it", async () => {
     // Ignoring the return must not turn into ignoring the handler: the phase is
     // where cache invalidation and notifications live, and a throw is how one
     // reports that it failed.
@@ -92,13 +93,29 @@ describe("side-effect phase return values", () => {
     await registry.execute("afterCreate", contextFor("docs", "create", {}));
     expect(ran).toEqual(["first", "second"]);
 
+    // A throw does not stop the phase either. The write has already committed,
+    // so raising would report a durable row as a failure, and cancelling the
+    // remaining handlers would turn one broken hook into several skipped ones.
     const throwing = new HookRegistry();
+    const reached: string[] = [];
     throwing.register("afterCreate", "docs", () => {
       throw new Error("notification failed");
     });
+    throwing.register("afterCreate", "docs", () => {
+      reached.push("after the failure");
+    });
+
+    const failures: SideEffectHookFailure[] = [];
     await expect(
-      throwing.execute("afterCreate", contextFor("docs", "create", {}))
-    ).rejects.toThrow();
+      throwing.execute("afterCreate", contextFor("docs", "create", {}), {
+        onSideEffectError: failure => failures.push(failure),
+      })
+    ).resolves.toBeDefined();
+
+    expect(reached).toEqual(["after the failure"]);
+    expect(failures).toHaveLength(1);
+    expect(failures[0].phase).toBe("afterCreate");
+    expect(failures[0].collection).toBe("docs");
   });
 
   describe("the mirror: transforming phases are unaffected", () => {

--- a/packages/nextly/src/hooks/hook-registry.ts
+++ b/packages/nextly/src/hooks/hook-registry.ts
@@ -33,11 +33,38 @@ import type {
  * `afterRead` is deliberately absent: it reshapes the response by design, and
  * the read paths consume what it returns.
  */
+/**
+ * A side-effect hook that threw after the write had already committed.
+ *
+ * Reported rather than raised: the row is durable and this phase cannot change
+ * it, so failing the operation would tell a caller its write did not happen and
+ * invite a retry that writes it twice.
+ */
+export interface SideEffectHookFailure {
+  /** The phase whose handler threw. */
+  phase: HookType;
+  /** The collection or single the operation was for. */
+  collection: string;
+  /** The normalized error, with its type and context preserved. */
+  error: NextlyError;
+}
+
 const SIDE_EFFECT_HOOK_TYPES: ReadonlySet<HookType> = new Set([
   "afterCreate",
   "afterUpdate",
   "afterDelete",
 ]);
+
+/**
+ * Whether a phase runs AFTER the write has committed.
+ *
+ * Shared by every executor so the two cannot disagree about which phases may
+ * fail an operation: a stored hook and a code-registered one in the same phase
+ * have to behave identically.
+ */
+export function isSideEffectHookType(hookType: HookType): boolean {
+  return SIDE_EFFECT_HOOK_TYPES.has(hookType);
+}
 
 /**
  * Global hook registry singleton
@@ -376,7 +403,15 @@ export class HookRegistry {
    */
   async execute<T>(
     hookType: HookContextPhase,
-    context: HookContext<T>
+    context: HookContext<T>,
+    options?: {
+      /**
+       * Called for each side-effect handler that throws, so the caller can
+       * report it alongside the successful write. Omitting it does not make
+       * the failure silent -- it is logged either way.
+       */
+      onSideEffectError?: (failure: SideEffectHookFailure) => void;
+    }
   ): Promise<T | void> {
     // `beforeOperation` handlers live in the other store and take a different
     // context, so this method cannot run them. Reaching here with that phase
@@ -420,7 +455,41 @@ export class HookRegistry {
           data = result;
         }
       } catch (error: unknown) {
-        throw normalizeHookError(error, hookType, context.collection);
+        const normalized = normalizeHookError(
+          error,
+          hookType,
+          context.collection
+        );
+        // A transforming phase runs before the write, so raising is how it
+        // refuses one -- that is the whole point of `before*`.
+        if (!isSideEffectPhase) throw normalized;
+
+        // A side-effect phase runs after the write committed. Raising here
+        // would report a durable row as a failure and invite a retry that
+        // writes it a second time, so the failure is reported instead.
+        //
+        // The remaining handlers still run: they are independent side effects,
+        // and letting the first failure cancel the rest turns one broken hook
+        // into several silently skipped ones.
+        // Logged here because nothing above this frame will: the operation
+        // reports success, so a side effect that vanished without a trace is
+        // exactly the failure this has to avoid.
+        console.error(
+          `Hook "${hookType}" failed for "${context.collection}" after the write committed:`,
+          normalized
+        );
+        // `normalizeHookError` rethrows a typed error untouched and wraps an
+        // untyped one, so this is a NextlyError in practice; the guard is what
+        // makes that a fact rather than an assumption.
+        options?.onSideEffectError?.({
+          phase: hookType,
+          collection: context.collection,
+          error: NextlyError.is(normalized)
+            ? normalized
+            : NextlyError.internal({
+                logContext: { hookType, collection: context.collection },
+              }),
+        });
       }
     }
 

--- a/packages/nextly/src/hooks/stored-hook-executor.ts
+++ b/packages/nextly/src/hooks/stored-hook-executor.ts
@@ -25,6 +25,10 @@
 
 import type { StoredHookConfig } from "@nextly/schemas/dynamic-collections/types";
 
+import { NextlyError } from "../errors/nextly-error";
+
+import type { SideEffectHookFailure } from "./hook-registry";
+import { isSideEffectHookType } from "./hook-registry";
 import { normalizeHookError } from "./normalize-hook-error";
 import type { PrebuiltHookContext } from "./prebuilt";
 import { getPrebuiltHook, mapHookType } from "./prebuilt";
@@ -51,6 +55,12 @@ export interface StoredHookExecutionResult<T = unknown> {
    * IDs of hooks that were skipped (disabled or not found).
    */
   skippedHookIds: string[];
+  /**
+   * Hooks in a post-commit phase that threw. Reported rather than raised: the
+   * write is already durable, so failing the operation would invite a retry
+   * that writes it a second time.
+   */
+  failures: SideEffectHookFailure[];
 }
 
 /**
@@ -150,6 +160,7 @@ export class StoredHookExecutor {
         data: context.data as T | undefined,
         executedCount: 0,
         skippedHookIds: [],
+        failures: [],
       };
     }
 
@@ -162,6 +173,8 @@ export class StoredHookExecutor {
     let currentData = context.data;
     let executedCount = 0;
     const skippedHookIds: string[] = [];
+    // Side-effect phases report their failures here rather than raising them.
+    const failures: SideEffectHookFailure[] = [];
 
     for (const storedHook of sortedHooks) {
       // Skip disabled hooks
@@ -218,8 +231,37 @@ export class StoredHookExecutor {
         // Same classification the runtime registry applies: a stored hook that
         // rejects input is making a decision, and rebuilding it as a generic
         // error turns that decision into a server fault.
-        throw normalizeHookError(error, hookType, context.collection, {
-          storedHookId: storedHook.hookId,
+        const normalized = normalizeHookError(
+          error,
+          hookType,
+          context.collection,
+          { storedHookId: storedHook.hookId }
+        );
+
+        // And the same rule about WHEN it may fail the operation: a phase that
+        // runs after the write committed reports its failure instead of raising
+        // it, or a durable row is returned to the caller as an error and the
+        // retry writes it twice. A stored hook and a code-registered one in the
+        // same phase have to behave identically.
+        if (!isSideEffectHookType(hookType)) throw normalized;
+
+        // Logged here because the operation is about to report success.
+        console.error(
+          `Stored hook "${storedHook.hookId}" failed for "${context.collection}" after the write committed:`,
+          normalized
+        );
+        failures.push({
+          phase: hookType,
+          collection: context.collection,
+          error: NextlyError.is(normalized)
+            ? normalized
+            : NextlyError.internal({
+                logContext: {
+                  hookType,
+                  collection: context.collection,
+                  storedHookId: storedHook.hookId,
+                },
+              }),
         });
       }
     }
@@ -228,6 +270,7 @@ export class StoredHookExecutor {
       data: currentData as T | undefined,
       executedCount,
       skippedHookIds,
+      failures,
     };
   }
 


### PR DESCRIPTION
Gap **L** from `tasks/094-collection-hook-lifecycle-spec.md`, implementing the
founder's decision recorded there.

## The defect

`afterCreate`, `afterUpdate` and `afterDelete` run **after** the transaction has
committed. A throw there fell through to the outer catch, which returned
`success: false` **and `data: null`**.

So a create that persisted came back as a 500 with no id. The caller could not
reference the row that now existed: **retry and it is written twice, do not
retry and it is orphaned.** The honest-looking answer was the one that corrupts
data.

Nextly already knew better internally — `committed: true` was set on that same
failed result and is already used to flush cache revalidation and run the
retention pass. Only the caller was being told otherwise.

## The decision

Founder-decided: **report success, surface the failure as a warning.** The
reasoning is recorded in the spec, in the order it mattered:

1. After-phases are **side-effect-only by contract** — #433 made their return
   values ignored precisely so they cannot influence the result. Gating is what
   `before*` is for, and it is untouched here.
2. Reporting failure **causes duplicate writes**, as above.
3. The product already treats these writes as real.
4. It matches the pattern already shipped: the webhook outbox records the
   durable fact at commit and retries delivery separately.

## Where the change lives

**In the registry, not the call sites.** There are ~9 after-phase execution
pairs across single, bulk and batch paths in `collection-mutation-service.ts`,
and #428 and #429 are both sitting on that file. Putting the rule in
`HookRegistry.execute` gives every write path the same contract at once, with no
edits to the contended file — and no possibility of applying it to eight sites
and missing the ninth, which is how the reentrancy guard went wrong twice.

Three consequences worth calling out:

- **Remaining handlers still run.** Previously the first throw cancelled the
  rest, turning one broken hook into several silently skipped ones.
- **The product's own post-commit work now runs too** — event emission,
  revalidation intents, status transitions. A broken user hook used to skip all
  of it.
- **Stored hooks follow the same rule**, through a shared `isSideEffectHookType`
  so a UI-configured hook and a code-registered one in the same phase cannot
  disagree about whether they may fail an operation.

Nothing is silent: the failure is logged with its phase and collection whether
or not a caller passes `onSideEffectError`.

## Two existing tests changed, by decision rather than by accident

- `side-effect-phase-returns.test.ts` asserted an `afterCreate` throw rejects —
  that is the contract this PR changes. Rewritten to assert it is reported, and
  extended to prove the later handlers still run.
- `cache-revalidation.integration.test.ts` asserted a batch item whose
  `afterCreate` threw is counted as `failed: 1`. It is now counted as written,
  which is what it is. The test's real subject — tags busted for a committed row
  — is unchanged and still asserted.

## Verification

4 integration tests, including **the mirror**: a `beforeCreate` throw still
refuses the write and leaves zero rows. Without that, "post-commit failures are
tolerated" would be equally satisfied by a registry that swallows everything.

3 of the 4 fail with the seam reverted (revert confirmed by grep). The
row-count test initially passed either way — the row is durable regardless —
so it now also asserts the caller was *told* success, which is the part that
actually differs.

`pnpm run check-types` clean. Failing-test name sets across `src/hooks` +
`src/domains/collections` identical to `origin/main` (13 both sides).
Integration across collections and singles: 235 passed, 0 failed.

## Not in this PR

The founder also chose a machine-readable `warnings` array on the response. The
semantics land here; the response-shape plumbing is a follow-up, because it
touches the result envelopes in the contended mutation service and is worth
doing once #428/#429 clear rather than fighting them for it.
