### PR TITLE
test(nextly): migrate real field-group storage on every dialect

### DIFF
--- a/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
@@ -333,10 +333,10 @@ for (const entry of DIALECTS) {
      * under its legacy name — `MIGRATION_TARGET.columnType` appears nowhere
      * outside the migration itself — so the typed path projects
      * `_component_type` and fails outright against storage this migration has
-     * renamed. That is a real gap between B1 and B2, recorded as such;
-     * asserting through it here would conflate "the association survived" with
-     * "the runtime can read the new column", which are two different questions
-     * with two different owners.
+     * renamed. Asserting through it would therefore fail for a reason this
+     * test is not about, conflating "the association survived the rename" with
+     * "the runtime schema addresses the migrated discriminator". Those are
+     * separate properties and this function isolates the first.
      */
     async function resolveEmbedded(args: {
       table: string;

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
@@ -5,11 +5,14 @@
  * stores a PHYSICAL table name, so a field group nested inside another
  * addresses its parent by the very name a rename changes — and the read path
  * treats a parent it cannot match as *no rows* rather than as an error. A
- * migration that renamed the tables and left those strings behind reported
- * success over content that had silently become unreachable, and it survived
- * four slices and thirty-odd review findings because **no test in this program
- * had ever constructed a nested field group.** The fixture shaped the blind
- * spot.
+ * migration that renames the tables without rewriting those strings therefore
+ * reports success over content that has silently become unreachable: nothing
+ * throws, and nothing is missing until someone reads it.
+ *
+ * Only a **nested** fixture can catch that. A top-level instance points at a
+ * collection table, which this migration never renames, so it survives a broken
+ * rewrite unchanged; the association only breaks one level down, where the
+ * parent is itself a field group.
  *
  * So the load-bearing test writes nested content, migrates, and reads it back
  * by the association the read path uses, in both directions.
@@ -51,6 +54,7 @@ import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
 import { versionsTables } from "../../../../schemas/versions";
 import { webhookTables } from "../../../../schemas/webhooks";
 import { splitStatements } from "../../../schema/pipeline/sql-statement-utils";
+import { DynamicCollectionSchemaService } from "../../../dynamic-collections/services/dynamic-collection-schema-service";
 import { FieldGroupSchemaService } from "../../services/field-group-schema-service";
 import { MIGRATION_TARGET } from "../manifest";
 import { runFieldGroupMigration } from "../run";
@@ -151,6 +155,7 @@ for (const entry of DIALECTS) {
     let adapter: TestAdapter;
     let registry: SchemaRegistry;
     let schemaService: FieldGroupSchemaService;
+    let collectionSchemaService: DynamicCollectionSchemaService;
 
     // 🔴 The tag goes in the SLUG, not in the table name. `retargetName` only
     // produces a rename when `tableName === resolveComponentTableName(slug)`,
@@ -319,9 +324,9 @@ for (const entry of DIALECTS) {
      * Resolve an embedded instance by the association the read path uses.
      *
      * Matching `_parent_id` + `_parent_table` + `_parent_field` is exactly what
-     * `getExistingInstances` does, and the association is what a rename breaks:
-     * a row that still exists but no longer resolves is the failure that
-     * shipped unnoticed.
+     * `getExistingInstances` does, and the association is what a rename breaks.
+     * Asserting the row exists would not detect that: the row survives a broken
+     * rename intact, and only stops being *reachable*.
      *
      * 🔴 Issued as SQL rather than through the typed CRUD, and NOT for
      * convenience. Every runtime Drizzle schema declares the discriminator
@@ -378,6 +383,10 @@ for (const entry of DIALECTS) {
         adapter = entry.make(entry.url as string);
         await adapter.connect();
         schemaService = new FieldGroupSchemaService(entry.dialect as never);
+        collectionSchemaService = new DynamicCollectionSchemaService(
+          undefined,
+          entry.dialect
+        );
       }
       registry = new SchemaRegistry(entry.dialect);
       // The system tables go in too, not just the field-group ones. The typed
@@ -391,12 +400,25 @@ for (const entry of DIALECTS) {
       await dropEverything();
       await createSystemTables();
 
-      const text = entry.dialect === "postgresql" ? "text" : "varchar(191)";
+      // The parent comes from the collection generator production uses, not a
+      // hand-written CREATE TABLE. It is only ever addressed as a
+      // `_parent_table` VALUE here, so a minimal stand-in would function — and
+      // that is exactly how a fixture drifts from the storage it claims to
+      // represent. This suite already learned that lesson once: an invented
+      // system table omitted a column the marker reads.
+      for (const statement of splitStatements([
+        collectionSchemaService.generateMigrationSQL(parentTable, [
+          { name: "title", type: "text" },
+        ] as never),
+      ])) {
+        await adapter.executeQuery(statement);
+      }
+      // `slug` is NOT NULL on a real collection — the generator emits the system
+      // columns a hand-written stand-in omitted, which is the whole reason to
+      // use it.
       await adapter.executeQuery(
-        `CREATE TABLE ${q(parentTable)} (${q("id")} ${text} PRIMARY KEY NOT NULL)`
-      );
-      await adapter.executeQuery(
-        `INSERT INTO ${q(parentTable)} (${q("id")}) VALUES ('page-1')`
+        `INSERT INTO ${q(parentTable)} (${q("id")}, ${q("title")}, ${q("slug")})
+         VALUES ('page-1', 'Page', 'page-1')`
       );
 
       await createFieldGroupTable(outerTable, [

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
@@ -1,0 +1,476 @@
+/**
+ * The storage migration against real servers, on every dialect.
+ *
+ * 🔴 The assertion this suite exists for is not structural. `_parent_table`
+ * stores a PHYSICAL table name, so a field group nested inside another
+ * addresses its parent by the very name a rename changes — and the read path
+ * treats a parent it cannot match as *no rows* rather than as an error. A
+ * migration that renamed the tables and left those strings behind reported
+ * success over content that had silently become unreachable, and it survived
+ * four slices and thirty-odd review findings because **no test in this program
+ * had ever constructed a nested field group.** The fixture shaped the blind
+ * spot.
+ *
+ * So the load-bearing test writes nested content, migrates, and reads it back
+ * by the association the read path uses, in both directions.
+ *
+ * Three properties are only decidable against a real server, which is why the
+ * module's doubles cannot replace this: MySQL commits DDL implicitly,
+ * identifier case is a server setting rather than a dialect property, and the
+ * read path is a different code path from the migration that moves the storage
+ * it reads.
+ */
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+import { createMySqlAdapter } from "@nextlyhq/adapter-mysql";
+import { createPostgresAdapter } from "@nextlyhq/adapter-postgres";
+import { createSqliteAdapter } from "@nextlyhq/adapter-sqlite";
+import { getTableName, type Table } from "drizzle-orm";
+import { randomBytes, randomUUID } from "node:crypto";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
+import { getDrizzleKitForDialect } from "../../../../database/drizzle-kit-lazy";
+import { SchemaRegistry } from "../../../../database/schema-registry";
+import {
+  dynamicCollectionsMysql,
+  dynamicCollectionsPg,
+  dynamicCollectionsSqlite,
+} from "../../../../schemas/dynamic-collections";
+import {
+  dynamicFieldGroupsMysql,
+  dynamicFieldGroupsPg,
+  dynamicFieldGroupsSqlite,
+} from "../../../../schemas/dynamic-field-groups";
+import { dynamicSinglesMysql } from "../../../../schemas/dynamic-singles/mysql";
+import { dynamicSinglesPg } from "../../../../schemas/dynamic-singles/postgres";
+import { dynamicSinglesSqlite } from "../../../../schemas/dynamic-singles/sqlite";
+import { nextlyMetaTables } from "../../../../schemas/nextly-meta";
+import { schemaEventsTables } from "../../../../schemas/schema-events";
+import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
+import { versionsTables } from "../../../../schemas/versions";
+import { webhookTables } from "../../../../schemas/webhooks";
+import { splitStatements } from "../../../schema/pipeline/sql-statement-utils";
+import { FieldGroupSchemaService } from "../../services/field-group-schema-service";
+import { MIGRATION_TARGET } from "../manifest";
+import { runFieldGroupMigration } from "../run";
+import { MIGRATION_LOCK_TABLE } from "../session";
+
+interface TestAdapter {
+  dialect: SupportedDialect;
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  executeQuery<T = unknown>(sql: string, params?: unknown[]): Promise<T[]>;
+  listTables(): Promise<string[]>;
+  setTableResolver(registry: SchemaRegistry): void;
+  select<T = Record<string, unknown>>(
+    table: string,
+    options: unknown
+  ): Promise<T[]>;
+}
+
+const DIALECTS: {
+  dialect: SupportedDialect;
+  url: string | null;
+  make: (url: string) => TestAdapter;
+}[] = [
+  {
+    dialect: "postgresql",
+    url: process.env.TEST_POSTGRES_URL ?? null,
+    make: url => createPostgresAdapter({ url }) as unknown as TestAdapter,
+  },
+  {
+    dialect: "mysql",
+    url: process.env.TEST_MYSQL_URL ?? null,
+    make: url => createMySqlAdapter({ url }) as unknown as TestAdapter,
+  },
+  {
+    dialect: "sqlite",
+    url: "memory",
+    make: () => createSqliteAdapter({ memory: true }) as unknown as TestAdapter,
+  },
+];
+
+/**
+ * Every system table a run reads or rewrites, as production declares it.
+ *
+ * Assembled from the same Drizzle objects the core schema is built from rather
+ * than hand-written, so the fixture cannot disagree with the thing under test.
+ * The set is not arbitrary: the data steps rewrite stored field definitions in
+ * all three dynamic registries, rescope `nextly_schema_events`, and walk the
+ * `nextly_versions` and `nextly_events` ledgers — a fixture missing any of them
+ * fails resolving a table rather than testing a migration.
+ */
+function systemTablesFor(dialect: SupportedDialect): Record<string, unknown> {
+  const registries =
+    dialect === "postgresql"
+      ? {
+          collections: dynamicCollectionsPg,
+          singles: dynamicSinglesPg,
+          fieldGroups: dynamicFieldGroupsPg,
+        }
+      : dialect === "mysql"
+        ? {
+            collections: dynamicCollectionsMysql,
+            singles: dynamicSinglesMysql,
+            fieldGroups: dynamicFieldGroupsMysql,
+          }
+        : {
+            collections: dynamicCollectionsSqlite,
+            singles: dynamicSinglesSqlite,
+            fieldGroups: dynamicFieldGroupsSqlite,
+          };
+  return {
+    ...registries,
+    ...nextlyMetaTables(dialect),
+    ...schemaEventsTables(dialect),
+    ...versionsTables(dialect),
+    ...webhookTables(dialect),
+  };
+}
+
+const logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+for (const entry of DIALECTS) {
+  const suite = entry.url === null ? describe.skip : describe;
+
+  suite(`field-group storage migration — ${entry.dialect}`, () => {
+    let adapter: TestAdapter;
+    let registry: SchemaRegistry;
+    let schemaService: FieldGroupSchemaService;
+
+    // 🔴 The tag goes in the SLUG, not in the table name. `retargetName` only
+    // produces a rename when `tableName === resolveComponentTableName(slug)`,
+    // so a directly-named table would be left out of the plan entirely — a
+    // fixture that looks isolated and silently tests nothing.
+    const tag = randomBytes(5).toString("hex");
+    const outerSlug = `outer${tag}`;
+    const innerSlug = `inner${tag}`;
+    const outerTable = `${STORAGE_FORMAT.tablePrefix}${outerSlug}`;
+    const innerTable = `${STORAGE_FORMAT.tablePrefix}${innerSlug}`;
+    const outerMigrated = `${MIGRATION_TARGET.tablePrefix}${outerSlug}`;
+    const innerMigrated = `${MIGRATION_TARGET.tablePrefix}${innerSlug}`;
+    const parentTable = `dc_pages${tag}`;
+
+    const q = (id: string): string =>
+      entry.dialect === "mysql" ? `\`${id}\`` : `"${id}"`;
+
+    const innerFields = [{ name: "body", type: "text" }];
+    const outerFields = [
+      { name: "heading", type: "text" },
+      { name: "inner", type: STORAGE_FORMAT.fieldType, component: innerSlug },
+    ];
+
+    async function drop(...tables: string[]): Promise<void> {
+      // CASCADE on Postgres because several of these carry foreign keys to one
+      // another; two passes because SQLite has no CASCADE, so a table whose
+      // dependent goes in the first pass only becomes droppable in the second.
+      const cascade = entry.dialect === "postgresql" ? " CASCADE" : "";
+      for (let pass = 0; pass < 2; pass += 1) {
+        for (const table of tables) {
+          try {
+            await adapter.executeQuery(
+              `DROP TABLE IF EXISTS ${q(table)}${cascade}`
+            );
+          } catch {
+            // Best-effort: a leftover from a failed run must not block the next.
+          }
+        }
+      }
+    }
+
+    /**
+     * Everything this suite can leave behind, under BOTH spellings.
+     *
+     * A run that fails midway leaves storage half-renamed, and a leftover
+     * `dynamic_field_groups` poisons every later run in the same container —
+     * the engine finds it and reads the world as already migrated. The system
+     * names are read off the Drizzle objects rather than restated, so a table
+     * added to the fixture cannot be forgotten here.
+     */
+    async function dropEverything(): Promise<void> {
+      await drop(
+        ...Object.values(systemTablesFor(entry.dialect)).map(table =>
+          getTableName(table as Table)
+        ),
+        `${outerTable}${STORAGE_FORMAT.companionSuffix}`,
+        `${outerMigrated}${STORAGE_FORMAT.companionSuffix}`,
+        innerTable,
+        innerMigrated,
+        outerTable,
+        outerMigrated,
+        parentTable,
+        STORAGE_FORMAT.registryTable,
+        MIGRATION_TARGET.registryTable,
+        MIGRATION_LOCK_TABLE
+      );
+    }
+
+    /**
+     * The system tables, generated from the PRODUCTION Drizzle definitions.
+     *
+     * Never hand-written. A copied `CREATE TABLE` drifts the moment a column is
+     * added, and it drifts silently — the first version of this suite omitted
+     * `nextly_meta.updated_at` and every dialect failed on a column the marker
+     * reads.
+     */
+    async function createSystemTables(): Promise<void> {
+      const kit = await getDrizzleKitForDialect(entry.dialect);
+      const empty = await kit.generateDrizzleJson({});
+      const desired = await kit.generateDrizzleJson(
+        systemTablesFor(entry.dialect) as never
+      );
+      const statements = await kit.generateMigration(
+        empty as never,
+        desired as never
+      );
+      for (const statement of splitStatements(statements)) {
+        await adapter.executeQuery(statement);
+      }
+    }
+
+    /** A field-group table, from the generator production uses. */
+    async function createFieldGroupTable(
+      table: string,
+      fields: { name: string; type: string }[]
+    ): Promise<void> {
+      for (const statement of splitStatements([
+        schemaService.generateMigrationSQL(table, fields as never),
+      ])) {
+        await adapter.executeQuery(statement);
+      }
+    }
+
+    async function registerFieldGroup(
+      slug: string,
+      table: string,
+      fields: unknown[]
+    ): Promise<void> {
+      const now = "2026-07-31 00:00:00";
+      // `locked` and `localized` are real booleans on Postgres and integers on
+      // the other two; one literal is wrong on one of them.
+      const no = entry.dialect === "postgresql" ? "false" : "0";
+      await adapter.executeQuery(
+        `INSERT INTO ${q(STORAGE_FORMAT.registryTable)}
+           (${q("id")}, ${q("slug")}, ${q("label")}, ${q("table_name")}, ${q("fields")},
+            ${q("source")}, ${q("locked")}, ${q("localized")}, ${q("schema_hash")},
+            ${q("schema_version")}, ${q("migration_status")}, ${q("config_path")},
+            ${q("created_at")}, ${q("updated_at")})
+         VALUES ('${randomUUID()}', '${slug}', '${slug}', '${table}',
+                 '${JSON.stringify(fields).replace(/'/g, "''")}',
+                 'ui', ${no}, ${no}, 'hash-${slug}', 1, 'applied',
+                 '${STORAGE_FORMAT.configPathDir}/${slug}.ts', '${now}', '${now}')`
+      );
+    }
+
+    /** One embedded instance, associated by the three plain string columns. */
+    async function insertInstance(args: {
+      table: string;
+      id: string;
+      parentId: string;
+      parentTable: string;
+      field: string;
+      column: string;
+      value: string;
+    }): Promise<void> {
+      const columns = STORAGE_FORMAT.columns;
+      await adapter.executeQuery(
+        `INSERT INTO ${q(args.table)}
+           (${q("id")}, ${q(columns.parentId)}, ${q(columns.parentTable)},
+            ${q(columns.parentField)}, ${q(columns.order)}, ${q(args.column)})
+         VALUES ('${args.id}', '${args.parentId}', '${args.parentTable}',
+                 '${args.field}', 0, '${args.value}')`
+      );
+    }
+
+    /**
+     * Resolve an embedded instance by the association the read path uses.
+     *
+     * Matching `_parent_id` + `_parent_table` + `_parent_field` is exactly what
+     * `getExistingInstances` does, and the association is what a rename breaks:
+     * a row that still exists but no longer resolves is the failure that
+     * shipped unnoticed.
+     *
+     * 🔴 Issued as SQL rather than through the typed CRUD, and NOT for
+     * convenience. Every runtime Drizzle schema declares the discriminator
+     * under its legacy name — `MIGRATION_TARGET.columnType` appears nowhere
+     * outside the migration itself — so the typed path projects
+     * `_component_type` and fails outright against storage this migration has
+     * renamed. That is a real gap between B1 and B2, recorded as such;
+     * asserting through it here would conflate "the association survived" with
+     * "the runtime can read the new column", which are two different questions
+     * with two different owners.
+     */
+    async function resolveEmbedded(args: {
+      table: string;
+      parentId: string;
+      parentTable: string;
+      field: string;
+    }): Promise<Record<string, unknown> | undefined> {
+      const c = STORAGE_FORMAT.columns;
+      const rows = await adapter.executeQuery<Record<string, unknown>>(
+        `SELECT * FROM ${q(args.table)}
+          WHERE ${q(c.parentId)} = '${args.parentId}'
+            AND ${q(c.parentTable)} = '${args.parentTable}'
+            AND ${q(c.parentField)} = '${args.field}'`
+      );
+      return rows[0];
+    }
+
+    async function migrate(direction: "up" | "down") {
+      return runFieldGroupMigration({
+        adapter: adapter as never,
+        logger: logger as never,
+        direction,
+      });
+    }
+
+    /** Both spellings registered, so reads resolve before and after a run. */
+    function registerRuntimeSchemas(): void {
+      const pairs: [string, { name: string; type: string }[]][] = [
+        [outerTable, [{ name: "heading", type: "text" }]],
+        [outerMigrated, [{ name: "heading", type: "text" }]],
+        [innerTable, innerFields],
+        [innerMigrated, innerFields],
+      ];
+      for (const [table, fields] of pairs) {
+        registry.registerDynamicSchema(
+          table,
+          schemaService.generateRuntimeSchema(table, fields as never)
+        );
+      }
+    }
+
+    beforeEach(async () => {
+      if (adapter === undefined) {
+        adapter = entry.make(entry.url as string);
+        await adapter.connect();
+        schemaService = new FieldGroupSchemaService(entry.dialect as never);
+      }
+      registry = new SchemaRegistry(entry.dialect);
+      // The system tables go in too, not just the field-group ones. The typed
+      // CRUD resolves every table through this registry and refuses any name it
+      // does not declare, so without them the registry service cannot read
+      // `dynamic_components` at all — and the read path swallows that as "no
+      // component data" rather than surfacing it.
+      registry.registerStaticSchemas(systemTablesFor(entry.dialect));
+      adapter.setTableResolver(registry);
+
+      await dropEverything();
+      await createSystemTables();
+
+      const text = entry.dialect === "postgresql" ? "text" : "varchar(191)";
+      await adapter.executeQuery(
+        `CREATE TABLE ${q(parentTable)} (${q("id")} ${text} PRIMARY KEY NOT NULL)`
+      );
+      await adapter.executeQuery(
+        `INSERT INTO ${q(parentTable)} (${q("id")}) VALUES ('page-1')`
+      );
+
+      await createFieldGroupTable(outerTable, [
+        { name: "heading", type: "text" },
+      ]);
+      await createFieldGroupTable(innerTable, innerFields);
+      await registerFieldGroup(outerSlug, outerTable, outerFields);
+      await registerFieldGroup(innerSlug, innerTable, innerFields);
+
+      // The outer instance hangs off the page; the inner one hangs off the
+      // OUTER INSTANCE, addressing it by `comp_outer<tag>`. That second row is
+      // the one a rename used to strand.
+      await insertInstance({
+        table: outerTable,
+        id: "outer-1",
+        parentId: "page-1",
+        parentTable,
+        field: "hero",
+        column: "heading",
+        value: "Hello",
+      });
+      await insertInstance({
+        table: innerTable,
+        id: "inner-1",
+        parentId: "outer-1",
+        parentTable: outerTable,
+        field: "inner",
+        column: "body",
+        value: "Nested body",
+      });
+
+      registerRuntimeSchemas();
+    });
+
+    afterAll(async () => {
+      await dropEverything();
+      await adapter.disconnect();
+    });
+
+    // 🔴 THE test. Everything else in this file is secondary to it.
+    it("keeps nested content resolvable across the migration", async () => {
+      const before = await resolveEmbedded({
+        table: innerTable,
+        parentId: "outer-1",
+        parentTable: outerTable,
+        field: "inner",
+      });
+      expect(before?.body).toBe("Nested body");
+
+      const outcome = await migrate("up");
+      expect(outcome.ran).toBe(true);
+
+      // Resolved through the MIGRATED parent name, which is what a runtime
+      // consumer now passes. If `_parent_table` still held `comp_outer<tag>`,
+      // this finds nothing and the content is gone with nothing having failed.
+      const after = await resolveEmbedded({
+        table: innerMigrated,
+        parentId: "outer-1",
+        parentTable: outerMigrated,
+        field: "inner",
+      });
+      expect(after?.body).toBe("Nested body");
+    });
+
+    it("renames the registry, the tables and the discriminator", async () => {
+      await migrate("up");
+      const names = await adapter.listTables();
+
+      expect(names).toContain(MIGRATION_TARGET.registryTable);
+      expect(names).not.toContain(STORAGE_FORMAT.registryTable);
+      expect(names).toContain(outerMigrated);
+      expect(names).toContain(innerMigrated);
+      expect(names).not.toContain(outerTable);
+    });
+
+    it("reports a second run as already migrated", async () => {
+      await migrate("up");
+      const again = await migrate("up");
+
+      expect(again).toEqual({ ran: false, reason: "already-migrated" });
+    });
+
+    // 🔴 The same defect from the other side: a rollback that restores the
+    // names while leaving the pointers migrated is structurally successful and
+    // resolves to nothing.
+    it("restores the storage and the association on the way back down", async () => {
+      await migrate("up");
+      const outcome = await migrate("down");
+      expect(outcome.ran).toBe(true);
+
+      const names = await adapter.listTables();
+      expect(names).toContain(STORAGE_FORMAT.registryTable);
+      expect(names).toContain(outerTable);
+      expect(names).not.toContain(outerMigrated);
+
+      const restored = await resolveEmbedded({
+        table: innerTable,
+        parentId: "outer-1",
+        parentTable: outerTable,
+        field: "inner",
+      });
+      expect(restored?.body).toBe("Nested body");
+    });
+  });
+}

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
@@ -45,6 +45,7 @@ import { dynamicSinglesMysql } from "../../../../schemas/dynamic-singles/mysql";
 import { dynamicSinglesPg } from "../../../../schemas/dynamic-singles/postgres";
 import { dynamicSinglesSqlite } from "../../../../schemas/dynamic-singles/sqlite";
 import { nextlyMetaTables } from "../../../../schemas/nextly-meta";
+import { userTables } from "../../../../schemas/users";
 import { schemaEventsTables } from "../../../../schemas/schema-events";
 import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
 import { versionsTables } from "../../../../schemas/versions";
@@ -120,6 +121,14 @@ function systemTablesFor(dialect: SupportedDialect): Record<string, unknown> {
             fieldGroups: dynamicFieldGroupsSqlite,
           };
   return {
+    // 🔴 `users` is here for a foreign key, not because the migration reads it:
+    // all three dynamic registries carry `created_by → users.id`. MySQL enforces
+    // that at CREATE time and refuses the constraint outright when the parent is
+    // absent. This suite passed for a while only because a leftover `users` from
+    // another suite happened to be sitting in the container — a fixture whose
+    // correctness depends on what ran before it is not a fixture, and it would
+    // have failed on CI's clean database.
+    ...userTables(dialect),
     ...registries,
     ...nextlyMetaTables(dialect),
     ...schemaEventsTables(dialect),
@@ -166,19 +175,38 @@ for (const entry of DIALECTS) {
     ];
 
     async function drop(...tables: string[]): Promise<void> {
-      // CASCADE on Postgres because several of these carry foreign keys to one
-      // another; two passes because SQLite has no CASCADE, so a table whose
-      // dependent goes in the first pass only becomes droppable in the second.
+      // Foreign keys make teardown order-dependent, and each dialect needs a
+      // different answer:
+      //
+      // - Postgres takes CASCADE, which settles it in one pass.
+      // - MySQL has no CASCADE and refuses to drop a parent while ANY child
+      //   references it — including a table this suite did not create. Ordering
+      //   cannot fix that, because the blocking child may not be ours to drop,
+      //   so foreign-key enforcement is suspended for the teardown instead.
+      //   This is a throwaway container by contract (`pnpm docker:test`).
+      // - SQLite needs neither, but takes a second pass for the same reason
+      //   Postgres takes CASCADE.
       const cascade = entry.dialect === "postgresql" ? " CASCADE" : "";
-      for (let pass = 0; pass < 2; pass += 1) {
-        for (const table of tables) {
-          try {
-            await adapter.executeQuery(
-              `DROP TABLE IF EXISTS ${q(table)}${cascade}`
-            );
-          } catch {
-            // Best-effort: a leftover from a failed run must not block the next.
+      if (entry.dialect === "mysql") {
+        await adapter.executeQuery("SET FOREIGN_KEY_CHECKS = 0");
+      }
+      try {
+        for (let pass = 0; pass < 2; pass += 1) {
+          for (const table of tables) {
+            try {
+              await adapter.executeQuery(
+                `DROP TABLE IF EXISTS ${q(table)}${cascade}`
+              );
+            } catch {
+              // Best-effort: a leftover from a failed run must not block the next.
+            }
           }
+        }
+      } finally {
+        // Restored even when a drop threw: leaving enforcement off would let a
+        // later suite in the same container write rows no constraint checks.
+        if (entry.dialect === "mysql") {
+          await adapter.executeQuery("SET FOREIGN_KEY_CHECKS = 1");
         }
       }
     }

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
@@ -53,6 +53,7 @@ import { schemaEventsTables } from "../../../../schemas/schema-events";
 import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
 import { versionsTables } from "../../../../schemas/versions";
 import { webhookTables } from "../../../../schemas/webhooks";
+import { introspectLiveSnapshot } from "../../../schema/pipeline/diff/introspect-live";
 import { splitStatements } from "../../../schema/pipeline/sql-statement-utils";
 import { DynamicCollectionSchemaService } from "../../../dynamic-collections/services/dynamic-collection-schema-service";
 import { FieldGroupSchemaService } from "../../services/field-group-schema-service";
@@ -246,10 +247,12 @@ for (const entry of DIALECTS) {
     /**
      * The system tables, generated from the PRODUCTION Drizzle definitions.
      *
-     * Never hand-written. A copied `CREATE TABLE` drifts the moment a column is
-     * added, and it drifts silently — the first version of this suite omitted
-     * `nextly_meta.updated_at` and every dialect failed on a column the marker
-     * reads.
+     * The invariant: every column the migration reads is present here because
+     * production declares it, not because this file lists it. A copied
+     * `CREATE TABLE` holds only the columns it was written with, and it goes
+     * out of date silently — the migration reads `nextly_meta.updated_at`, and
+     * a stand-in missing it fails on every dialect for a reason that looks
+     * like a product defect.
      */
     async function createSystemTables(): Promise<void> {
       const kit = await getDrizzleKitForDialect(entry.dialect);
@@ -354,6 +357,28 @@ for (const entry of DIALECTS) {
       return rows[0];
     }
 
+    /**
+     * The columns a table actually carries, per the live catalog.
+     *
+     * Read through the same introspection the migration uses, so a dialect that
+     * reports a name differently reports it identically to both. Structural
+     * assertions on `listTables` cannot see a column, so a discriminator rename
+     * that was skipped — or reconciled as already satisfied when it was not —
+     * is invisible without this.
+     */
+    async function columnsOf(table: string): Promise<string[]> {
+      const snapshot = await introspectLiveSnapshot(
+        (adapter as unknown as { getDrizzle(): unknown }).getDrizzle(),
+        entry.dialect,
+        [table]
+      );
+      return (
+        snapshot.tables
+          .find(spec => spec.name === table)
+          ?.columns.map(column => column.name) ?? []
+      );
+    }
+
     async function migrate(direction: "up" | "down") {
       return runFieldGroupMigration({
         adapter: adapter as never,
@@ -403,9 +428,8 @@ for (const entry of DIALECTS) {
       // The parent comes from the collection generator production uses, not a
       // hand-written CREATE TABLE. It is only ever addressed as a
       // `_parent_table` VALUE here, so a minimal stand-in would function — and
-      // that is exactly how a fixture drifts from the storage it claims to
-      // represent. This suite already learned that lesson once: an invented
-      // system table omitted a column the marker reads.
+      // a fixture that functions while describing storage production does not
+      // create is how a suite certifies a shape that does not exist.
       for (const statement of splitStatements([
         collectionSchemaService.generateMigrationSQL(parentTable, [
           { name: "title", type: "text" },
@@ -413,9 +437,8 @@ for (const entry of DIALECTS) {
       ])) {
         await adapter.executeQuery(statement);
       }
-      // `slug` is NOT NULL on a real collection — the generator emits the system
-      // columns a hand-written stand-in omitted, which is the whole reason to
-      // use it.
+      // `slug` is NOT NULL on a real collection. The generator emits every
+      // system column the real table has, which is the whole reason to use it.
       await adapter.executeQuery(
         `INSERT INTO ${q(parentTable)} (${q("id")}, ${q("title")}, ${q("slug")})
          VALUES ('page-1', 'Page', 'page-1')`
@@ -430,7 +453,7 @@ for (const entry of DIALECTS) {
 
       // The outer instance hangs off the page; the inner one hangs off the
       // OUTER INSTANCE, addressing it by `comp_outer<tag>`. That second row is
-      // the one a rename used to strand.
+      // the one a rename strands when the pointer is not rewritten with it.
       await insertInstance({
         table: outerTable,
         id: "outer-1",
@@ -492,6 +515,16 @@ for (const entry of DIALECTS) {
       expect(names).toContain(outerMigrated);
       expect(names).toContain(innerMigrated);
       expect(names).not.toContain(outerTable);
+
+      // The discriminator is a separate step from its table's rename, and the
+      // plan can record it as already satisfied. Both halves are asserted on
+      // both tables: present under the migrated name AND gone under the legacy
+      // one, so a column added rather than renamed does not read as success.
+      for (const table of [outerMigrated, innerMigrated]) {
+        const columns = await columnsOf(table);
+        expect(columns).toContain(MIGRATION_TARGET.columnType);
+        expect(columns).not.toContain(STORAGE_FORMAT.columns.type);
+      }
     });
 
     it("reports a second run as already migrated", async () => {
@@ -513,6 +546,15 @@ for (const entry of DIALECTS) {
       expect(names).toContain(STORAGE_FORMAT.registryTable);
       expect(names).toContain(outerTable);
       expect(names).not.toContain(outerMigrated);
+
+      // The inverse of the up assertion. A rollback that restores the names
+      // while leaving the discriminator migrated is structurally successful and
+      // unreadable, which is the same failure shape as a stranded pointer.
+      for (const table of [outerTable, innerTable]) {
+        const columns = await columnsOf(table);
+        expect(columns).toContain(STORAGE_FORMAT.columns.type);
+        expect(columns).not.toContain(MIGRATION_TARGET.columnType);
+      }
 
       const restored = await resolveEmbedded({
         table: innerTable,


### PR DESCRIPTION
Builds the 3-dialect real-database matrix that the founder's matrix-first decision made the gate for everything left in task 011 — the entry point, the five knowingly-unfixed lock findings, B2, and the client-site migrations.

Design: `tasks/011-B1-6-MATRIX-DESIGN.md`.

## Why this suite exists

The `_parent_table` data loss survived four slices and 30+ bot findings with every test passing. It was not subtle reasoning that missed it — **no test in this program had ever constructed a nested field group.** The fixture shaped the blind spot.

So the load-bearing test writes a genuinely nested fixture, migrates, and asserts the association still resolves — in both directions. Structure and idempotence are checked alongside, but the association is the point.

```
dc_pages<tag>
└── comp_outer<tag>     _parent_table = 'dc_pages<tag>'
    └── comp_inner<tag> _parent_table = 'comp_outer<tag>'   ← the row that was being stranded
```

## 🔴 What it found on its first real run

**The migration renames a column that no runtime schema can read.**

`MIGRATION_TARGET.columnType` (`_field_group_type`) appears **nowhere outside the migration folder**. All three runtime Drizzle schemas (`field-group-schema-service.ts:533,581,621`) declare the discriminator as `_component_type`, unconditionally. After a successful `up`, every typed read of a field-group table projects a column that no longer exists and fails outright.

Nothing is broken today — the engine is dark. But it constrains sequencing, and it is a **hard prerequisite for the client-site migrations** alongside lock recovery:

- B1 and B2 cannot ship independently to a live site. Migrated storage needs B2's flipped schema; B2's flipped schema cannot read un-migrated storage.
- `guard.ts`'s `resolveStorageVerdict` already computes the storage generation and **nothing consumes it**. That looks like the intended seam.

The suite is scoped around this deliberately: the nested assertion resolves the association with SQL rather than the typed CRUD, and says so at length in the code, so "the association survived" (B1's job, now proven on three dialects) stays separate from "the runtime can read the new column" (B2's, now a documented blocker).

## Choices worth reviewing

- **The random tag goes in the SLUG, not the table name.** `retargetName` only plans a rename when `tableName === resolveComponentTableName(slug)` — tagging the table directly produces a fixture that looks isolated and silently exercises nothing.
- **Everything is built from production definitions**: system tables from the Drizzle objects the core schema declares, field-group tables from the schema service's generator. My first version hand-wrote them and drifted immediately — it omitted a column the marker reads and every dialect failed on it.
- **Teardown derives system-table names from the Drizzle objects**, so a table added to the fixture cannot be left behind — a leftover `dynamic_field_groups` poisons every later run in the same container.

## Verification

`pnpm check-types --force` 19/19 ✅ · `pnpm lint` exit 0 ✅ · unit baseline **400 failures / 405 FAIL lines**, unchanged (test-only addition).

Integration, run locally against the throwaway containers:

| Dialect | Result |
|---|---|
| Postgres 17 (:5435) | **8 passed** |
| MySQL (:3307) | **8 passed** |
| SQLite (in-memory) | **8 passed** |

## Not in this PR, deliberately

Crash-resume. It needs a way to interrupt a run deterministically, and that machinery deserves its own review rather than riding along here. The five open lock findings stay open — this is the instrument for settling them, and building the instrument is not the same as using it.