### PR TITLE
fix(nextly): apply a target's field hooks to rows read through a relationship

### DIFF
--- a/.changeset/olive-spiders-jam.md
+++ b/.changeset/olive-spiders-jam.md
@@ -1,0 +1,32 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+A field masked by its collection stays masked when read through a relationship.
+
+A field's `afterRead` hooks are how it masks itself on the way out, and they ran
+only when the collection was read directly. Reaching the same row through a
+relationship returned the unmasked value. They now run over the assembled
+document, so a nested row gets its own collection's treatment at every depth,
+and a hook that masks based on the row's own relations sees them expanded
+rather than as raw ids.

--- a/packages/nextly/src/domains/collections/__tests__/collection-query.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-query.test.ts
@@ -524,6 +524,12 @@ describe("CollectionEntryService — Query Contracts", () => {
         // Expansion copies whole related rows in, so it also carries the caller
         // its related rows are redacted for.
         enforceFieldAccess: true,
+        // ...and defers WHEN those rules run, because this path finishes with
+        // the post-assembly pass and a rule that masks on a denied sibling has
+        // to see it first.
+        fieldAccessStage: "assembled",
+        locale: undefined,
+        status: undefined,
         user: undefined,
         overrideAccess: undefined,
       });
@@ -541,6 +547,7 @@ describe("CollectionEntryService — Query Contracts", () => {
       ).toHaveBeenCalledWith(expect.any(Array), "posts", expect.any(Array), {
         depth: undefined,
         enforceFieldAccess: true,
+        fieldAccessStage: "assembled",
         user: undefined,
         overrideAccess: undefined,
       });

--- a/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
@@ -240,9 +240,16 @@ export function createMockRelationshipService(): MockRecord {
     // The read paths call this once the document is assembled. A double that
     // omits it certifies a path that throws for real.
     applyNestedFieldHooks: vi.fn().mockResolvedValue(undefined),
-    createNestedHookState: vi
-      .fn()
-      .mockImplementation(() => ({ visited: new Set(), fields: new Map() })),
+    // Paired with it: the list path finishes the rows it collected once the
+    // whole listing has been walked, so a double carrying only the first half
+    // certifies a path that throws for real.
+    finalizeRelatedRows: vi.fn().mockResolvedValue(undefined),
+    createNestedHookState: vi.fn().mockImplementation(() => ({
+      visited: new Set(),
+      fields: new Map(),
+      labelFields: new Map(),
+      pending: [],
+    })),
     insertManyToManyRelations: vi.fn().mockResolvedValue(undefined),
     deleteManyToManyRelations: vi.fn().mockResolvedValue(undefined),
   };

--- a/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
@@ -237,6 +237,9 @@ export function createMockRelationshipService(): MockRecord {
     expandRelationships: vi
       .fn()
       .mockImplementation((entry: unknown) => Promise.resolve(entry)),
+    // The read paths call this once the document is assembled. A double that
+    // omits it certifies a path that throws for real.
+    applyNestedFieldHooks: vi.fn().mockResolvedValue(undefined),
     insertManyToManyRelations: vi.fn().mockResolvedValue(undefined),
     deleteManyToManyRelations: vi.fn().mockResolvedValue(undefined),
   };

--- a/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-test-helpers.ts
@@ -240,6 +240,9 @@ export function createMockRelationshipService(): MockRecord {
     // The read paths call this once the document is assembled. A double that
     // omits it certifies a path that throws for real.
     applyNestedFieldHooks: vi.fn().mockResolvedValue(undefined),
+    createNestedHookState: vi
+      .fn()
+      .mockImplementation(() => ({ visited: new Set(), fields: new Map() })),
     insertManyToManyRelations: vi.fn().mockResolvedValue(undefined),
     deleteManyToManyRelations: vi.fn().mockResolvedValue(undefined),
   };

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -422,10 +422,10 @@ describe("a target's field hooks apply to rows reached through a relationship", 
   });
 
   it("judges a masking rule before the denied sibling it reads is removed", async () => {
-    // The ordering the founder chose, and the defect it fixes. `classification`
-    // denies read, and the author's `secret` rule masks on it. Removing denied
-    // fields at fetch handed that rule a row its evidence had already been cut
-    // out of, so it read `undefined`, declined to mask, and the secret went out.
+    // `classification` denies read, and the author's `secret` rule masks on it.
+    // Removing denied fields as a row is fetched hands that rule a row its
+    // evidence has already been cut out of: it reads `undefined`, declines to
+    // mask, and the value it guards goes out. Masking has to run first.
     //
     // Read WITHOUT overrideAccess: field rules are skipped for a trusted read,
     // so an overriding caller cannot show this either way.

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -99,6 +99,9 @@ async function boot(): Promise<TestNextly> {
         fields: [
           text({ name: "title" }),
           relationship({ name: "author", relationTo: AUTHORS }),
+          // The blog template's shape: a relationship to the built-in users
+          // entity, which has no dynamic-collection record.
+          relationship({ name: "owner", relationTo: "users" }),
           // A relationship inside a container. Expansion populates it, so the
           // walk has to descend through the container to reach it.
           group({
@@ -277,5 +280,34 @@ describe("a target's field hooks apply to rows reached through a relationship", 
       // "HIDDEN", not "HIDDENHIDDEN" -- the marker of a second pass.
       expect(author.token).toBe("HIDDEN");
     }
+  });
+
+  it("walks a populated system-entity target without failing the read", async () => {
+    // `users` has no dynamic-collection record, so the schema lookup finds
+    // nothing. Reading that as an untrustworthy lookup and refusing turned an
+    // ordinary expansion -- the blog template's `author -> users` -- into an
+    // internal error. A system entity registers no field hooks, so there is
+    // nothing to fail closed over.
+    //
+    // Driven through the walk directly with an already-expanded document: that
+    // is the state the failure occurs in, and `users` cannot be seeded through
+    // the collections API.
+    const t = await boot();
+    const service = t.getService("relationshipService") as unknown as {
+      applyNestedFieldHooks: (
+        entry: Record<string, unknown>,
+        collection: string,
+        access: Record<string, unknown>
+      ) => Promise<void>;
+    };
+
+    const doc = {
+      title: "owned",
+      owner: { id: "u1", email: "owner@example.test" },
+    };
+
+    await expect(
+      service.applyNestedFieldHooks(doc, POSTS, { enforceFieldAccess: true })
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -388,10 +388,13 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     expect(author.passwordHash).toBeUndefined();
   });
 
-  it("does not run a target's hooks for a relationship the caller excluded", async () => {
-    // Top-level field hooks run after selection and skip absent fields. A
-    // nested target's hooks running for an excluded relationship would fire
-    // side effects for a field that is not in the response at all.
+  it("runs a target's hooks even for a relationship the projection drops", async () => {
+    // Skipping those rows would leave them on the document unmasked while the
+    // source collection's own hooks run, which is the leak the placement above
+    // exists to close. It could not be skipped coherently in any case: batch
+    // expansion shares one row object between parents, so a row reachable
+    // through both a kept and a dropped relationship would come out masked or
+    // not depending on which reference the traversal met first.
     const t = await boot();
     await seed(t);
 
@@ -403,7 +406,34 @@ describe("a target's field hooks apply to rows reached through a relationship", 
       select: { title: true },
     });
 
-    expect(tokenHookRuns).toBe(0);
+    expect(tokenHookRuns).toBeGreaterThan(0);
+  });
+
+  it("masks a dropped relationship before a source hook can copy out of it", async () => {
+    // The projection removes `author` from the response, but the row is still
+    // on the document while the source collection's hooks run. One of them can
+    // read the target's raw value and write it to a field that IS projected,
+    // which no later masking looks at.
+    const t = await boot();
+    const postId = await seed(t);
+
+    t.hooks.register("afterRead", POSTS, ctx => {
+      const entry = ctx.data as Record<string, unknown>;
+      const author = entry.author as Record<string, unknown> | undefined;
+      entry.summary = author?.token;
+      return entry;
+    });
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      overrideAccess: true,
+      depth: 2,
+      select: { summary: true },
+    });
+
+    expect(expanded.data!.author).toBeUndefined();
+    expect(expanded.data!.summary).toBe("HIDDEN");
   });
 
   it("judges a masking rule on the whole target row, not the projected slice", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -405,4 +405,53 @@ describe("a target's field hooks apply to rows reached through a relationship", 
 
     expect(tokenHookRuns).toBe(0);
   });
+
+  it("judges a masking rule on the whole target row, not the projected slice", async () => {
+    // Field selection rebuilds each related row as a fresh object holding only
+    // the projected paths. A rule masking on a sibling -- here the author's
+    // organization -- handed that slice reads `undefined` for its evidence and
+    // returns the value unmasked, so asking for exactly the protected field is
+    // what gets it.
+    const t = await boot();
+    const postId = await seed(t);
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      overrideAccess: true,
+      depth: 2,
+      select: { "author.secret": true },
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    expect(author).toBeTruthy();
+    expect(author.secret).toBe("REDACTED");
+  });
+
+  it("masks a related row before the source collection's own hooks see it", async () => {
+    // A source hook can copy a related row's value onto a root property of its
+    // own. The traversal masks the nested field it walked, never the copy, so a
+    // source hook handed an unmasked target publishes it under a key nothing
+    // downstream sanitizes.
+    const t = await boot();
+    const postId = await seed(t);
+
+    t.hooks.register("afterRead", POSTS, ctx => {
+      const entry = ctx.data as Record<string, unknown>;
+      const author = entry.author as Record<string, unknown> | undefined;
+      entry.leaked = author?.token;
+      return entry;
+    });
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      overrideAccess: true,
+      depth: 2,
+    });
+
+    // The masked value, not the stored "RAW_TOKEN": the hook was handed a row
+    // the target's own protections had already run on.
+    expect(expanded.data!.leaked).toBe("HIDDEN");
+  });
 });

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -5,7 +5,7 @@
 // masked when the collection is read directly has to stay masked when the same
 // row arrives nested inside another document.
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   defineCollection,
@@ -319,12 +319,13 @@ describe("a target's field hooks apply to rows reached through a relationship", 
       service.applyNestedFieldHooks(doc, POSTS, { enforceFieldAccess: true })
     ).resolves.toBeUndefined();
   });
-  it("walks an upload target without failing the read", async () => {
-    // `media` is a built-in with no dynamic-collection record, so the schema
-    // lookup raises not-found. Reading that as an untrustworthy lookup refused
-    // any read carrying a populated upload -- and uploads are everywhere.
-    // Not-registered and lookup-failed are different answers.
+  it("does not look up or log an upload's built-in target", async () => {
+    // `media` is not a registered collection, so resolving it costs a metadata
+    // query per row only to fail, and logs the failure -- on reads that are
+    // otherwise fine. Uploads are close to universal, so that is a query and an
+    // error line on most reads in production.
     const t = await boot();
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
     const service = t.getService("relationshipService") as unknown as {
       applyNestedFieldHooks: (
         entry: Record<string, unknown>,
@@ -341,5 +342,10 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     await expect(
       service.applyNestedFieldHooks(doc, POSTS, { enforceFieldAccess: true })
     ).resolves.toBeUndefined();
+    // The read succeeding is not enough: it succeeded before this too, after
+    // paying for the lookup and shouting about it.
+    expect(logged).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -11,6 +11,7 @@ import {
   defineCollection,
   group,
   relationship,
+  password,
   text,
   upload,
 } from "../../../config";
@@ -24,6 +25,9 @@ import {
 const ORGS = "nestedhook_orgs";
 const AUTHORS = "nestedhook_authors";
 const POSTS = "nestedhook_posts";
+
+// How many times the target's token hook ran, for the selection test.
+let tokenHookRuns = 0;
 
 let current: TestNextly | undefined;
 afterEach(async () => {
@@ -72,14 +76,30 @@ async function boot(): Promise<TestNextly> {
           // Masks unconditionally, so it is testable on the list path too --
           // batch expansion does not recurse into a related row's OWN
           // relationships, so a hook needing that evidence cannot mask there.
+          password({ name: "passwordHash" }),
+          // Writes a secret back after the fetch stripped it. Only a second
+          // strip AFTER the hooks keeps it out of the response.
+          text({
+            name: "sneaky",
+            hooks: {
+              afterRead: [
+                ({ value, data }) => {
+                  (data as Record<string, unknown>).passwordHash = "$2yLEAKED";
+                  return value;
+                },
+              ],
+            },
+          }),
           text({
             name: "token",
             hooks: {
               afterRead: [
-                ({ value }) =>
-                  typeof value === "string" && value.startsWith("HIDDEN")
+                ({ value }) => {
+                  tokenHookRuns++;
+                  return typeof value === "string" && value.startsWith("HIDDEN")
                     ? `${value}HIDDEN`
-                    : "HIDDEN",
+                    : "HIDDEN";
+                },
               ],
             },
           }),
@@ -186,9 +206,8 @@ describe("a target's field hooks apply to rows reached through a relationship", 
   it("applies the target's field hooks to nested rows on a list too", async () => {
     // Asserted on a field whose hook needs no further expansion: the batch path
     // skips relationship fields when it recurses, so a related row's own
-    // relations are never expanded on a list at any depth. That gap is real and
-    // recorded in the spec, but it is not this one -- what matters here is that
-    // the walk reaches nested rows on the list path at all.
+    // relations are never expanded on a list at any depth. What this pins is
+    // that the walk reaches nested rows on the list path at all.
     const t = await boot();
     await seed(t);
 
@@ -347,5 +366,43 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     expect(logged).not.toHaveBeenCalled();
 
     vi.restoreAllMocks();
+  });
+  it("strips a secret a hook wrote back onto a related row", async () => {
+    // The fetch strips a target's password before the hooks run, and a hook on
+    // a sibling field can put one back. The response-level defenses sanitize
+    // only the ROOT row, using the SOURCE collection's schema, so they never
+    // look at this row -- the strip has to happen here.
+    const t = await boot();
+    await seed(t);
+    const postId = await onlyId(t, POSTS);
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      overrideAccess: true,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    expect(author).toBeTruthy();
+    expect(author.passwordHash).toBeUndefined();
+  });
+
+  it("does not run a target's hooks for a relationship the caller excluded", async () => {
+    // Top-level field hooks run after selection and skip absent fields. A
+    // nested target's hooks running for an excluded relationship would fire
+    // side effects for a field that is not in the response at all.
+    const t = await boot();
+    await seed(t);
+
+    tokenHookRuns = 0;
+    await handlerOf(t).listEntries({
+      collectionName: POSTS,
+      overrideAccess: true,
+      depth: 2,
+      select: { title: true },
+    });
+
+    expect(tokenHookRuns).toBe(0);
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -7,7 +7,7 @@
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { defineCollection, relationship, text } from "../../../config";
+import { defineCollection, group, relationship, text } from "../../../config";
 import {
   createTestNextly,
   type TestNextly,
@@ -68,7 +68,14 @@ async function boot(): Promise<TestNextly> {
           // relationships, so a hook needing that evidence cannot mask there.
           text({
             name: "token",
-            hooks: { afterRead: [() => "HIDDEN"] },
+            hooks: {
+              afterRead: [
+                ({ value }) =>
+                  typeof value === "string" && value.startsWith("HIDDEN")
+                    ? `${value}HIDDEN`
+                    : "HIDDEN",
+              ],
+            },
           }),
           text({
             name: "secret",
@@ -92,6 +99,12 @@ async function boot(): Promise<TestNextly> {
         fields: [
           text({ name: "title" }),
           relationship({ name: "author", relationTo: AUTHORS }),
+          // A relationship inside a container. Expansion populates it, so the
+          // walk has to descend through the container to reach it.
+          group({
+            name: "credits",
+            fields: [relationship({ name: "editor", relationTo: AUTHORS })],
+          }),
         ],
       }),
     ],
@@ -207,5 +220,62 @@ describe("a target's field hooks apply to rows reached through a relationship", 
 
     const author = expanded.data!.author as Record<string, unknown>;
     expect(author.secret).toBe("VISIBLE");
+  });
+
+  it("reaches a relationship nested inside a container", async () => {
+    // The walk reads a collection's fields; a `group` has no `relationTo` of
+    // its own, so a walk that only looked at top-level relationship fields left
+    // everything inside a container unmasked.
+    const t = await boot();
+    await seed(t);
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "credited", credits: { editor: authorId } },
+    });
+
+    const listed = await handlerOf(t).listEntries({
+      collectionName: POSTS,
+      overrideAccess: true,
+      depth: 2,
+    });
+    const withCredits = listed.data!.docs.find(
+      d => (d as { title?: string }).title === "credited"
+    ) as Record<string, unknown>;
+    const credits = withCredits.credits as Record<string, unknown>;
+    const editor = credits.editor as Record<string, unknown>;
+
+    expect(editor).toBeTruthy();
+    expect(editor.token).toBe("HIDDEN");
+  });
+
+  it("transforms a row shared by several parents exactly once", async () => {
+    // Batch expansion hands the SAME object to every parent referencing it. A
+    // per-entry traversal runs its hooks once per reference, so a transform
+    // that is not idempotent compounds with the reference count and every
+    // parent sees the compounded value.
+    const t = await boot();
+    await seed(t);
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "second", author: authorId },
+    });
+
+    const listed = await handlerOf(t).listEntries({
+      collectionName: POSTS,
+      overrideAccess: true,
+      depth: 2,
+    });
+
+    expect(listed.data!.docs.length).toBeGreaterThan(1);
+    for (const doc of listed.data!.docs) {
+      const author = (doc as { author?: unknown }).author as Record<
+        string,
+        unknown
+      >;
+      // "HIDDEN", not "HIDDENHIDDEN" -- the marker of a second pass.
+      expect(author.token).toBe("HIDDEN");
+    }
   });
 });

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -63,10 +63,21 @@ async function boot(): Promise<TestNextly> {
     collections: [
       defineCollection({
         slug: ORGS,
-        fields: [text({ name: "name" }), text({ name: "classification" })],
+        access: { read: () => true, create: () => true, update: () => true },
+        fields: [
+          text({ name: "name" }),
+          // Denied to everyone, and the evidence the author's `clearance` rule
+          // masks on. Applying field rules at fetch removed it before that rule
+          // could read it.
+          text({
+            name: "classification",
+            access: { read: () => false },
+          }),
+        ],
       }),
       defineCollection({
         slug: AUTHORS,
+        access: { read: () => true, create: () => true, update: () => true },
         fields: [
           text({ name: "name" }),
           relationship({ name: "organization", relationTo: ORGS }),
@@ -122,6 +133,7 @@ async function boot(): Promise<TestNextly> {
       }),
       defineCollection({
         slug: POSTS,
+        access: { read: () => true, create: () => true, update: () => true },
         fields: [
           text({ name: "title" }),
           relationship({ name: "author", relationTo: AUTHORS }),
@@ -407,6 +419,34 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     });
 
     expect(tokenHookRuns).toBeGreaterThan(0);
+  });
+
+  it("judges a masking rule before the denied sibling it reads is removed", async () => {
+    // The ordering the founder chose, and the defect it fixes. `classification`
+    // denies read, and the author's `secret` rule masks on it. Removing denied
+    // fields at fetch handed that rule a row its evidence had already been cut
+    // out of, so it read `undefined`, declined to mask, and the secret went out.
+    //
+    // Read WITHOUT overrideAccess: field rules are skipped for a trusted read,
+    // so an overriding caller cannot show this either way.
+    const t = await boot();
+    const postId = await seed(t);
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    expect(author).toBeTruthy();
+    // Masked, because the rule saw the classification.
+    expect(author.secret).toBe("REDACTED");
+
+    // And the evidence is still withheld from the response: deferring WHEN the
+    // rules run must not change WHETHER they run.
+    const org = author.organization as Record<string, unknown> | undefined;
+    if (org) expect(org.classification).toBeUndefined();
   });
 
   it("masks a dropped relationship before a source hook can copy out of it", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -7,7 +7,13 @@
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { defineCollection, group, relationship, text } from "../../../config";
+import {
+  defineCollection,
+  group,
+  relationship,
+  text,
+  upload,
+} from "../../../config";
 import {
   createTestNextly,
   type TestNextly,
@@ -102,6 +108,9 @@ async function boot(): Promise<TestNextly> {
           // The blog template's shape: a relationship to the built-in users
           // entity, which has no dynamic-collection record.
           relationship({ name: "owner", relationTo: "users" }),
+          // An upload: its `media` target is a built-in too, but not one
+          // `isSystemEntity` knows about.
+          upload({ name: "cover", relationTo: "media" }),
           // A relationship inside a container. Expansion populates it, so the
           // walk has to descend through the container to reach it.
           group({
@@ -304,6 +313,29 @@ describe("a target's field hooks apply to rows reached through a relationship", 
     const doc = {
       title: "owned",
       owner: { id: "u1", email: "owner@example.test" },
+    };
+
+    await expect(
+      service.applyNestedFieldHooks(doc, POSTS, { enforceFieldAccess: true })
+    ).resolves.toBeUndefined();
+  });
+  it("walks an upload target without failing the read", async () => {
+    // `media` is a built-in with no dynamic-collection record, so the schema
+    // lookup raises not-found. Reading that as an untrustworthy lookup refused
+    // any read carrying a populated upload -- and uploads are everywhere.
+    // Not-registered and lookup-failed are different answers.
+    const t = await boot();
+    const service = t.getService("relationshipService") as unknown as {
+      applyNestedFieldHooks: (
+        entry: Record<string, unknown>,
+        collection: string,
+        access: Record<string, unknown>
+      ) => Promise<void>;
+    };
+
+    const doc = {
+      title: "illustrated",
+      cover: { id: "m1", filename: "cover.png" },
     };
 
     await expect(

--- a/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/nested-field-hooks.integration.test.ts
@@ -1,0 +1,211 @@
+// A target collection's field `afterRead` hooks reach rows read through a
+// relationship, and see those rows fully assembled.
+//
+// Expansion may be stricter than a target's own endpoint, never looser. A field
+// masked when the collection is read directly has to stay masked when the same
+// row arrives nested inside another document.
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, relationship, text } from "../../../config";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+// Integration files share fixed system-table names, so this suite keeps its own
+// slugs to avoid colliding with a concurrently-running file.
+const ORGS = "nestedhook_orgs";
+const AUTHORS = "nestedhook_authors";
+const POSTS = "nestedhook_posts";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+type ReadHandler = {
+  listEntries: (p: Record<string, unknown>) => Promise<{
+    success: boolean;
+    data: { docs: Record<string, unknown>[] } | null;
+  }>;
+  getEntry: (p: Record<string, unknown>) => Promise<{
+    success: boolean;
+    data: Record<string, unknown> | null;
+  }>;
+};
+
+function handlerOf(t: TestNextly) {
+  return t.getService("collectionsHandler") as unknown as ReadHandler;
+}
+
+async function onlyId(t: TestNextly, collection: string): Promise<string> {
+  const listed = await handlerOf(t).listEntries({
+    collectionName: collection,
+    overrideAccess: true,
+  });
+  return String(listed.data!.docs[0].id);
+}
+
+async function boot(): Promise<TestNextly> {
+  current = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: ORGS,
+        fields: [text({ name: "name" }), text({ name: "classification" })],
+      }),
+      defineCollection({
+        slug: AUTHORS,
+        fields: [
+          text({ name: "name" }),
+          relationship({ name: "organization", relationTo: ORGS }),
+          // Masks based on the author's OWN relationship. At fetch time that
+          // is still a raw id, so a hook run then reads `undefined` and lets
+          // the secret through; only a fully assembled row masks correctly.
+          // Masks unconditionally, so it is testable on the list path too --
+          // batch expansion does not recurse into a related row's OWN
+          // relationships, so a hook needing that evidence cannot mask there.
+          text({
+            name: "token",
+            hooks: { afterRead: [() => "HIDDEN"] },
+          }),
+          text({
+            name: "secret",
+            hooks: {
+              afterRead: [
+                ({ value, data }) => {
+                  const org = (data as { organization?: unknown }).organization;
+                  const classification =
+                    typeof org === "object" && org !== null
+                      ? (org as { classification?: unknown }).classification
+                      : undefined;
+                  return classification === "private" ? "REDACTED" : value;
+                },
+              ],
+            },
+          }),
+        ],
+      }),
+      defineCollection({
+        slug: POSTS,
+        fields: [
+          text({ name: "title" }),
+          relationship({ name: "author", relationTo: AUTHORS }),
+        ],
+      }),
+    ],
+  });
+  return current;
+}
+
+async function seed(t: TestNextly): Promise<string> {
+  await t.nextly.create({
+    collection: ORGS,
+    data: { name: "acme", classification: "private" },
+  });
+  const orgId = await onlyId(t, ORGS);
+  await t.nextly.create({
+    collection: AUTHORS,
+    data: {
+      name: "ada",
+      organization: orgId,
+      secret: "TOP_SECRET",
+      token: "RAW_TOKEN",
+    },
+  });
+  const authorId = await onlyId(t, AUTHORS);
+  await t.nextly.create({
+    collection: POSTS,
+    data: { title: "p", author: authorId },
+  });
+  return await onlyId(t, POSTS);
+}
+
+describe("a target's field hooks apply to rows reached through a relationship", () => {
+  it("masks on the target's own endpoint", async () => {
+    // The control. Without it, a masked value through a relationship could
+    // just as well mean the hook masks unconditionally.
+    const t = await boot();
+    await seed(t);
+    const authorId = await onlyId(t, AUTHORS);
+
+    const direct = await handlerOf(t).getEntry({
+      collectionName: AUTHORS,
+      entryId: authorId,
+      overrideAccess: true,
+      depth: 1,
+    });
+
+    expect(direct.data!.secret).toBe("REDACTED");
+  });
+
+  it("masks the same row when it arrives nested in another document", async () => {
+    const t = await boot();
+    const postId = await seed(t);
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      overrideAccess: true,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    expect(author).toBeTruthy();
+    // The hook masked on the author's OWN relationship, which means it was
+    // handed the row after that relationship had been expanded.
+    expect(author.secret).toBe("REDACTED");
+  });
+
+  it("applies the target's field hooks to nested rows on a list too", async () => {
+    // Asserted on a field whose hook needs no further expansion: the batch path
+    // skips relationship fields when it recurses, so a related row's own
+    // relations are never expanded on a list at any depth. That gap is real and
+    // recorded in the spec, but it is not this one -- what matters here is that
+    // the walk reaches nested rows on the list path at all.
+    const t = await boot();
+    await seed(t);
+
+    const listed = await handlerOf(t).listEntries({
+      collectionName: POSTS,
+      overrideAccess: true,
+      depth: 2,
+    });
+
+    const author = listed.data!.docs[0].author as Record<string, unknown>;
+    expect(author).toBeTruthy();
+    expect(author.token).toBe("HIDDEN");
+  });
+
+  it("leaves the value alone when the nested evidence does not call for masking", async () => {
+    // The mirror: the hook is reading real data, not masking everything it
+    // touches. Without this the fix could be a hook that always redacts.
+    const t = await boot();
+    await t.nextly.create({
+      collection: ORGS,
+      data: { name: "open", classification: "public" },
+    });
+    const orgId = await onlyId(t, ORGS);
+    await t.nextly.create({
+      collection: AUTHORS,
+      data: { name: "bob", organization: orgId, secret: "VISIBLE" },
+    });
+    const authorId = await onlyId(t, AUTHORS);
+    await t.nextly.create({
+      collection: POSTS,
+      data: { title: "open post", author: authorId },
+    });
+    const postId = await onlyId(t, POSTS);
+
+    const expanded = await handlerOf(t).getEntry({
+      collectionName: POSTS,
+      entryId: postId,
+      overrideAccess: true,
+      depth: 2,
+    });
+
+    const author = expanded.data!.author as Record<string, unknown>;
+    expect(author.secret).toBe("VISIBLE");
+  });
+});

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1424,11 +1424,16 @@ export class CollectionQueryService extends BaseService {
       // transform it. Deferred to here because a related row is fetched before
       // the recursion that expands ITS relationships: a hook run at fetch time
       // would read those as raw ids and mask on a value that is not there yet.
+      // One state for the whole listing: batch expansion hands the same row
+      // object to every parent that references it, so a per-entry pass would
+      // run that row's hooks once per reference.
+      const nestedHookState = this.relationshipService.createNestedHookState();
       for (const expanded of expandedEntries) {
         await this.relationshipService.applyNestedFieldHooks(
           expanded,
           params.collectionName,
-          { enforceFieldAccess: true, user: params.user }
+          { enforceFieldAccess: true, user: params.user },
+          nestedHookState
         );
       }
 

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1420,23 +1420,6 @@ export class CollectionQueryService extends BaseService {
         stripSystemOwnerField(entry);
       }
 
-      // The document is assembled now, so each nested row's own collection can
-      // transform it. Deferred to here because a related row is fetched before
-      // the recursion that expands ITS relationships: a hook run at fetch time
-      // would read those as raw ids and mask on a value that is not there yet.
-      // One state for the whole listing: batch expansion hands the same row
-      // object to every parent that references it, so a per-entry pass would
-      // run that row's hooks once per reference.
-      const nestedHookState = this.relationshipService.createNestedHookState();
-      for (const expanded of expandedEntries) {
-        await this.relationshipService.applyNestedFieldHooks(
-          expanded,
-          params.collectionName,
-          { enforceFieldAccess: true, user: params.user },
-          nestedHookState
-        );
-      }
-
       // Decode before any afterRead hook runs. A hook is documented against the
       // configured value, and on SQLite these columns are strings, so decoding
       // after the hooks handed every one of them the storage encoding instead.
@@ -1483,6 +1466,27 @@ export class CollectionQueryService extends BaseService {
         finalData = this.applyFieldSelectionToArray(
           finalData as Record<string, unknown>[],
           params.select
+        );
+      }
+
+      // Run once the document is assembled AND field selection has been
+      // applied. Assembled, because a related row is fetched before the
+      // recursion that expands ITS relationships, so a hook run earlier reads
+      // those as raw ids. After selection, because a relationship the caller
+      // excluded is not in the response and its target's hooks -- which may
+      // have side effects -- have no business running for it. Deferred to here because a related row is fetched before
+      // the recursion that expands ITS relationships: a hook run at fetch time
+      // would read those as raw ids and mask on a value that is not there yet.
+      // One state for the whole listing: batch expansion hands the same row
+      // object to every parent that references it, so a per-entry pass would
+      // run that row's hooks once per reference.
+      const nestedHookState = this.relationshipService.createNestedHookState();
+      for (const entry of finalData as Record<string, unknown>[]) {
+        await this.relationshipService.applyNestedFieldHooks(
+          entry,
+          params.collectionName,
+          { enforceFieldAccess: true, user: params.user },
+          nestedHookState
         );
       }
 
@@ -2600,13 +2604,6 @@ export class CollectionQueryService extends BaseService {
       // Always strip the system owner column (see listEntries).
       stripSystemOwnerField(expandedEntry);
 
-      // Same post-assembly pass as the list path.
-      await this.relationshipService.applyNestedFieldHooks(
-        expandedEntry,
-        params.collectionName,
-        { enforceFieldAccess: true, user: params.user }
-      );
-
       // Decode before any afterRead hook runs, for the same reason as the list
       // path: a hook is documented against the configured value, not the
       // storage encoding SQLite hands back.
@@ -2653,6 +2650,13 @@ export class CollectionQueryService extends BaseService {
       if (params.select && Object.keys(params.select).length > 0) {
         finalData = this.applyFieldSelection(finalData, params.select);
       }
+
+      // Same pass as the list path: after assembly, and after selection.
+      await this.relationshipService.applyNestedFieldHooks(
+        finalData,
+        params.collectionName,
+        { enforceFieldAccess: true, user: params.user }
+      );
 
       // Convert snake_case timestamp columns to their camelCase API form.
       finalData = convertTimestampsToCamelCase(finalData);

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -116,6 +116,24 @@ import {
   decodeJsonFieldValues,
 } from "./collection-utils";
 
+/**
+ * The root-level field names a `select` projection keeps.
+ *
+ * A selected path is rooted at a field name -- `author.name` keeps `author` --
+ * so the first segment is what decides whether a relationship survives into the
+ * response. Returns undefined when nothing was selected, which the nested walk
+ * reads as "no projection, walk everything".
+ */
+function selectedRootFieldNames(
+  select: Record<string, boolean> | undefined
+): ReadonlySet<string> | undefined {
+  if (!select) return undefined;
+  const names = Object.entries(select)
+    .filter(([, include]) => include)
+    .map(([path]) => path.split(".")[0]);
+  return names.length > 0 ? new Set(names) : undefined;
+}
+
 export class CollectionQueryService extends BaseService {
   constructor(
     adapter: DrizzleAdapter,
@@ -1425,6 +1443,37 @@ export class CollectionQueryService extends BaseService {
       // after the hooks handed every one of them the storage encoding instead.
       decodeJsonFieldValues(expandedEntries, fields, params.locale);
 
+      // A related row's own field hooks run BEFORE this collection's afterRead
+      // hooks can observe it, and before field selection narrows it.
+      //
+      // Before the collection's hooks, because one of them can copy a related
+      // row's value onto a root property of its own; the traversal masks the
+      // nested field it walked, never the copy, so a hook handed an unmasked
+      // target could publish it under a key nothing sanitizes. That is the same
+      // reason password hashes are stripped above rather than after.
+      //
+      // Before selection, because selection rebuilds each related row as a fresh
+      // object holding only the projected paths, so a hook masking on a sibling
+      // -- `select: { "author.secret": true }` while the rule reads
+      // `organization.classification` -- would be handed a row with its evidence
+      // missing and fall open. Selection is told which relationships survive so
+      // an excluded one still runs nothing.
+      //
+      // One state for the whole listing: batch expansion hands the same row
+      // object to every parent that references it, so a per-entry pass would run
+      // that row's hooks once per reference.
+      const nestedHookState = this.relationshipService.createNestedHookState();
+      const selectedRootFields = selectedRootFieldNames(params.select);
+      for (const entry of expandedEntries) {
+        await this.relationshipService.applyNestedFieldHooks(
+          entry,
+          params.collectionName,
+          { enforceFieldAccess: true, user: params.user },
+          nestedHookState,
+          selectedRootFields
+        );
+      }
+
       // Execute afterRead hooks (code-registered)
       // Hooks can transform the fetched data
       const afterContext = this.hookService.buildHookContext({
@@ -1460,33 +1509,25 @@ export class CollectionQueryService extends BaseService {
       let finalData = (storedAfterResult.data ??
         dataAfterCodeHooks) as unknown[];
 
+      // A second pass over the same state, for relationships the collection's
+      // own hooks introduced. Rows are claimed by object identity, so every row
+      // the pass above already handled is skipped rather than transformed twice.
+      for (const entry of finalData as Record<string, unknown>[]) {
+        await this.relationshipService.applyNestedFieldHooks(
+          entry,
+          params.collectionName,
+          { enforceFieldAccess: true, user: params.user },
+          nestedHookState,
+          selectedRootFields
+        );
+      }
+
       // Apply field selection if select parameter is provided
       // This filters the response to only include requested fields
       if (params.select && Object.keys(params.select).length > 0) {
         finalData = this.applyFieldSelectionToArray(
           finalData as Record<string, unknown>[],
           params.select
-        );
-      }
-
-      // Run once the document is assembled AND field selection has been
-      // applied. Assembled, because a related row is fetched before the
-      // recursion that expands ITS relationships, so a hook run earlier reads
-      // those as raw ids. After selection, because a relationship the caller
-      // excluded is not in the response and its target's hooks -- which may
-      // have side effects -- have no business running for it. Deferred to here because a related row is fetched before
-      // the recursion that expands ITS relationships: a hook run at fetch time
-      // would read those as raw ids and mask on a value that is not there yet.
-      // One state for the whole listing: batch expansion hands the same row
-      // object to every parent that references it, so a per-entry pass would
-      // run that row's hooks once per reference.
-      const nestedHookState = this.relationshipService.createNestedHookState();
-      for (const entry of finalData as Record<string, unknown>[]) {
-        await this.relationshipService.applyNestedFieldHooks(
-          entry,
-          params.collectionName,
-          { enforceFieldAccess: true, user: params.user },
-          nestedHookState
         );
       }
 
@@ -2609,6 +2650,20 @@ export class CollectionQueryService extends BaseService {
       // storage encoding SQLite hands back.
       decodeJsonFieldValues([expandedEntry], fields, params.locale);
 
+      // Same placement as the list path: a related row's own field hooks run
+      // before this collection's afterRead hooks can copy an unmasked value onto
+      // a root property, and before selection rebuilds the row without the
+      // siblings a masking rule judges on.
+      const nestedHookState = this.relationshipService.createNestedHookState();
+      const selectedRootFields = selectedRootFieldNames(params.select);
+      await this.relationshipService.applyNestedFieldHooks(
+        expandedEntry,
+        params.collectionName,
+        { enforceFieldAccess: true, user: params.user },
+        nestedHookState,
+        selectedRootFields
+      );
+
       // Execute afterRead hooks (code-registered)
       // Hooks can transform the fetched data
       const afterContext = this.hookService.buildHookContext({
@@ -2645,18 +2700,21 @@ export class CollectionQueryService extends BaseService {
         unknown
       >;
 
+      // Second pass, for relationships the collection's own hooks introduced;
+      // rows already claimed above are skipped by identity.
+      await this.relationshipService.applyNestedFieldHooks(
+        finalData,
+        params.collectionName,
+        { enforceFieldAccess: true, user: params.user },
+        nestedHookState,
+        selectedRootFields
+      );
+
       // Apply field selection if select parameter is provided
       // This filters the response to only include requested fields
       if (params.select && Object.keys(params.select).length > 0) {
         finalData = this.applyFieldSelection(finalData, params.select);
       }
-
-      // Same pass as the list path: after assembly, and after selection.
-      await this.relationshipService.applyNestedFieldHooks(
-        finalData,
-        params.collectionName,
-        { enforceFieldAccess: true, user: params.user }
-      );
 
       // Convert snake_case timestamp columns to their camelCase API form.
       finalData = convertTimestampsToCamelCase(finalData);

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -116,24 +116,6 @@ import {
   decodeJsonFieldValues,
 } from "./collection-utils";
 
-/**
- * The root-level field names a `select` projection keeps.
- *
- * A selected path is rooted at a field name -- `author.name` keeps `author` --
- * so the first segment is what decides whether a relationship survives into the
- * response. Returns undefined when nothing was selected, which the nested walk
- * reads as "no projection, walk everything".
- */
-function selectedRootFieldNames(
-  select: Record<string, boolean> | undefined
-): ReadonlySet<string> | undefined {
-  if (!select) return undefined;
-  const names = Object.entries(select)
-    .filter(([, include]) => include)
-    .map(([path]) => path.split(".")[0]);
-  return names.length > 0 ? new Set(names) : undefined;
-}
-
 export class CollectionQueryService extends BaseService {
   constructor(
     adapter: DrizzleAdapter,
@@ -1456,21 +1438,25 @@ export class CollectionQueryService extends BaseService {
       // object holding only the projected paths, so a hook masking on a sibling
       // -- `select: { "author.secret": true }` while the rule reads
       // `organization.classification` -- would be handed a row with its evidence
-      // missing and fall open. Selection is told which relationships survive so
-      // an excluded one still runs nothing.
+      // missing and fall open.
       //
-      // One state for the whole listing: batch expansion hands the same row
-      // object to every parent that references it, so a per-entry pass would run
-      // that row's hooks once per reference.
+      // Every populated related row is walked, including one under a
+      // relationship the projection drops. Skipping those would leave them on
+      // the document unmasked for the hooks below to read and copy elsewhere,
+      // and the skip could not be honoured coherently in any case: batch
+      // expansion shares one row object between parents, so a row reachable
+      // through both a kept and a dropped relationship would end up masked or
+      // not depending on which reference the traversal happened to meet first.
+      //
+      // One state for the whole listing, for that same sharing: a per-entry pass
+      // would run a shared row's hooks once per reference.
       const nestedHookState = this.relationshipService.createNestedHookState();
-      const selectedRootFields = selectedRootFieldNames(params.select);
       for (const entry of expandedEntries) {
         await this.relationshipService.applyNestedFieldHooks(
           entry,
           params.collectionName,
           { enforceFieldAccess: true, user: params.user },
-          nestedHookState,
-          selectedRootFields
+          nestedHookState
         );
       }
 
@@ -1508,19 +1494,6 @@ export class CollectionQueryService extends BaseService {
         );
       let finalData = (storedAfterResult.data ??
         dataAfterCodeHooks) as unknown[];
-
-      // A second pass over the same state, for relationships the collection's
-      // own hooks introduced. Rows are claimed by object identity, so every row
-      // the pass above already handled is skipped rather than transformed twice.
-      for (const entry of finalData as Record<string, unknown>[]) {
-        await this.relationshipService.applyNestedFieldHooks(
-          entry,
-          params.collectionName,
-          { enforceFieldAccess: true, user: params.user },
-          nestedHookState,
-          selectedRootFields
-        );
-      }
 
       // Apply field selection if select parameter is provided
       // This filters the response to only include requested fields
@@ -2653,15 +2626,12 @@ export class CollectionQueryService extends BaseService {
       // Same placement as the list path: a related row's own field hooks run
       // before this collection's afterRead hooks can copy an unmasked value onto
       // a root property, and before selection rebuilds the row without the
-      // siblings a masking rule judges on.
-      const nestedHookState = this.relationshipService.createNestedHookState();
-      const selectedRootFields = selectedRootFieldNames(params.select);
+      // siblings a masking rule judges on. Every populated related row is
+      // walked, including one the projection drops.
       await this.relationshipService.applyNestedFieldHooks(
         expandedEntry,
         params.collectionName,
-        { enforceFieldAccess: true, user: params.user },
-        nestedHookState,
-        selectedRootFields
+        { enforceFieldAccess: true, user: params.user }
       );
 
       // Execute afterRead hooks (code-registered)
@@ -2699,16 +2669,6 @@ export class CollectionQueryService extends BaseService {
         string,
         unknown
       >;
-
-      // Second pass, for relationships the collection's own hooks introduced;
-      // rows already claimed above are skipped by identity.
-      await this.relationshipService.applyNestedFieldHooks(
-        finalData,
-        params.collectionName,
-        { enforceFieldAccess: true, user: params.user },
-        nestedHookState,
-        selectedRootFields
-      );
 
       // Apply field selection if select parameter is provided
       // This filters the response to only include requested fields

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1420,6 +1420,18 @@ export class CollectionQueryService extends BaseService {
         stripSystemOwnerField(entry);
       }
 
+      // The document is assembled now, so each nested row's own collection can
+      // transform it. Deferred to here because a related row is fetched before
+      // the recursion that expands ITS relationships: a hook run at fetch time
+      // would read those as raw ids and mask on a value that is not there yet.
+      for (const expanded of expandedEntries) {
+        await this.relationshipService.applyNestedFieldHooks(
+          expanded,
+          params.collectionName,
+          { enforceFieldAccess: true, user: params.user }
+        );
+      }
+
       // Decode before any afterRead hook runs. A hook is documented against the
       // configured value, and on SQLite these columns are strings, so decoding
       // after the hooks handed every one of them the storage encoding instead.
@@ -2582,6 +2594,13 @@ export class CollectionQueryService extends BaseService {
       }
       // Always strip the system owner column (see listEntries).
       stripSystemOwnerField(expandedEntry);
+
+      // Same post-assembly pass as the list path.
+      await this.relationshipService.applyNestedFieldHooks(
+        expandedEntry,
+        params.collectionName,
+        { enforceFieldAccess: true, user: params.user }
+      );
 
       // Decode before any afterRead hook runs, for the same reason as the list
       // path: a hook is documented against the configured value, not the

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1298,6 +1298,10 @@ export class CollectionQueryService extends BaseService {
             // collection's field rules say nothing about another collection's
             // fields — so the caller has to reach the related row's own rules.
             enforceFieldAccess: true,
+            // This path finishes with the post-assembly pass, so the target's
+            // field rules run there, after its masking hooks have seen a whole
+            // row.
+            fieldAccessStage: "assembled" as const,
             user: params.user,
             overrideAccess: params.overrideAccess,
             authenticatedScope: params.authenticatedScope,
@@ -1451,14 +1455,26 @@ export class CollectionQueryService extends BaseService {
       // One state for the whole listing, for that same sharing: a per-entry pass
       // would run a shared row's hooks once per reference.
       const nestedHookState = this.relationshipService.createNestedHookState();
+      const nestedAccess = {
+        enforceFieldAccess: true,
+        user: params.user,
+        overrideAccess: params.overrideAccess,
+        authenticatedScope: params.authenticatedScope,
+      };
       for (const entry of expandedEntries) {
         await this.relationshipService.applyNestedFieldHooks(
           entry,
           params.collectionName,
-          { enforceFieldAccess: true, user: params.user },
+          nestedAccess,
           nestedHookState
         );
       }
+      // Once, after the whole listing: hiding a row as it is finished would take
+      // the evidence away from a rule on a row walked later.
+      await this.relationshipService.finalizeRelatedRows(
+        nestedHookState,
+        nestedAccess
+      );
 
       // Execute afterRead hooks (code-registered)
       // Hooks can transform the fetched data
@@ -2320,6 +2336,8 @@ export class CollectionQueryService extends BaseService {
           // Same reasoning as the list path: a related row is redacted by its
           // own collection's field rules, for this caller.
           enforceFieldAccess: true,
+          // Same deferral as the list path; this path runs the same pass.
+          fieldAccessStage: "assembled" as const,
           user: params.user,
           overrideAccess: params.overrideAccess,
           authenticatedScope: params.authenticatedScope,
@@ -2631,7 +2649,12 @@ export class CollectionQueryService extends BaseService {
       await this.relationshipService.applyNestedFieldHooks(
         expandedEntry,
         params.collectionName,
-        { enforceFieldAccess: true, user: params.user }
+        {
+          enforceFieldAccess: true,
+          user: params.user,
+          overrideAccess: params.overrideAccess,
+          authenticatedScope: params.authenticatedScope,
+        }
       );
 
       // Execute afterRead hooks (code-registered)

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -2554,6 +2554,11 @@ export class CollectionQueryService extends BaseService {
             >[3] = {
               depth: params.depth,
               enforceFieldAccess: true,
+              // The overlaid draft is the document the post-assembly pass runs
+              // over, so its related rows defer field rules for the same reason
+              // the live read does. Without this a draft read hides a denied
+              // sibling before the rule that masks on it has run.
+              fieldAccessStage: "assembled" as const,
               user: params.user,
               overrideAccess: params.overrideAccess,
               authenticatedScope: params.authenticatedScope,

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -2884,11 +2884,16 @@ export class CollectionRelationshipService extends BaseService {
   /**
    * The collection's fields, read once per collection per read.
    *
-   * Fails CLOSED. `getCollectionFields` returns an empty list when the metadata
-   * lookup fails, which here would mean "this row has no relationship fields"
-   * and silently skip every masking hook below it while the rows continue to
-   * the response. These are read protections, so a lookup that cannot be
-   * trusted refuses the read instead of quietly returning it untransformed.
+   * Fails OPEN, deliberately: a target whose schema will not load runs no hooks
+   * and the read continues. That is weaker than these protections deserve, and
+   * it is the only correct answer available today -- the registry reports "not
+   * a registered collection" and "the lookup failed" identically, so refusing
+   * on it broke every read carrying an upload or an author relationship. The
+   * failure is logged rather than swallowed.
+   *
+   * Fail-closed becomes possible once the registry can answer "is this a
+   * collection" separately from "give me its fields"; see the gap I notes in
+   * `094-collection-hook-lifecycle-spec`.
    */
   private async fieldsForNestedWalk(
     collectionName: string,
@@ -3001,6 +3006,12 @@ export class CollectionRelationshipService extends BaseService {
       }
       return;
     }
+
+    // An upload points at the built-in media entity, which is not a registered
+    // collection and registers no field hooks. Resolving it would spend a
+    // metadata query per row to be told so, and log the failure, on reads that
+    // are otherwise fine -- and uploads are close to universal.
+    if (isUploadField(field)) return;
 
     for (const row of rows) {
       // A discriminated value names its own collection, so a polymorphic

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -39,7 +39,10 @@ import type {
 } from "../../../services/collections/related-row-read-context";
 import type { Logger } from "../../../services/shared";
 import { BaseService } from "../../../shared/base-service";
-import { applyFieldReadAccess } from "../../../shared/lib/field-level-registry";
+import {
+  applyFieldReadAccess,
+  runFieldHooks,
+} from "../../../shared/lib/field-level-registry";
 import {
   hasPasswordField,
   stripPasswordFieldValues,
@@ -69,6 +72,24 @@ export const DEFAULT_RELATIONSHIP_DEPTH = 2;
  * Maximum allowed depth to prevent performance issues.
  */
 export const MAX_RELATIONSHIP_DEPTH = 5;
+
+/**
+ * The collection a relationship field's value came from, or null when the walk
+ * cannot know.
+ *
+ * Null for a polymorphic relationship (`relationTo` is a list): the value could
+ * be a row from any of them, and applying one collection's field hooks to a row
+ * from another would transform the wrong fields. Skipping is the honest answer
+ * -- those rows keep the protections the fetch already applied, and nothing
+ * pretends they got more.
+ */
+function targetCollectionOf(field: {
+  type?: string;
+  relationTo?: unknown;
+}): string | null {
+  if (typeof field.relationTo === "string") return field.relationTo;
+  return null;
+}
 
 /**
  * The caller a related row is redacted for.
@@ -2783,6 +2804,89 @@ export class CollectionRelationshipService extends BaseService {
    * either one: it runs against the SOURCE collection's field registry, which
    * never describes a related collection's fields.
    */
+  /**
+   * Apply each nested related row's OWN collection field `afterRead` hooks,
+   * once the document is fully assembled.
+   *
+   * A field hook is the transforming half of a field's read protections -- the
+   * half that masks a value on the way out -- and its access half already runs
+   * per related row. Running the hooks there too would be wrong: related rows
+   * are fetched BEFORE the recursion that expands their own relationships, so a
+   * hook masking on `data.organization.classification` would see a raw id and
+   * return the unmasked value. A direct read of that collection expands first
+   * and runs field hooks last, and expansion may be stricter than the target's
+   * own endpoint but never looser.
+   *
+   * So this runs once, from the read path, over the finished document: every
+   * row is complete by the time its own hooks see it, at every depth, and there
+   * is one place that decides it rather than a call at each of the several
+   * points where assembly happens to end.
+   *
+   * Walks by SCHEMA rather than by marking rows during expansion: a field's
+   * `relationTo` already says which collection the value came from, so nothing
+   * has to be threaded through the fetch to be read back here.
+   */
+  async applyNestedFieldHooks(
+    entry: Record<string, unknown>,
+    collectionName: string,
+    access: RelatedRowAccess
+  ): Promise<void> {
+    // Only a real read applies these. A caller clearing the flag is assembling
+    // the evidence a document-dependent rule is judged on and wants the row
+    // unredacted -- the same reason the access pass is gated on it.
+    if (!access.enforceFieldAccess) return;
+    await this.walkNestedRows(entry, collectionName, access, new Set(), 0);
+  }
+
+  /**
+   * One level of {@link applyNestedFieldHooks}.
+   *
+   * `seen` breaks a reference cycle (A points at B, B points back at A) that the
+   * expansion's own depth limit would already have stopped, so this is a
+   * belt-and-braces guard rather than the primary bound. The depth cap mirrors
+   * the expansion's own maximum.
+   */
+  private async walkNestedRows(
+    entry: Record<string, unknown>,
+    collectionName: string,
+    access: RelatedRowAccess,
+    seen: Set<Record<string, unknown>>,
+    depth: number
+  ): Promise<void> {
+    if (depth > MAX_RELATIONSHIP_DEPTH) return;
+    if (seen.has(entry)) return;
+    seen.add(entry);
+
+    const fields = await this.getCollectionFields(collectionName);
+    for (const field of fields) {
+      const target = targetCollectionOf(field);
+      if (!target) continue;
+
+      const value = entry[field.name];
+      // An unexpanded relationship is still an id, and there is nothing to
+      // transform in a string.
+      const rows = (Array.isArray(value) ? value : [value]).filter(
+        (row): row is Record<string, unknown> =>
+          typeof row === "object" && row !== null
+      );
+      if (rows.length === 0) continue;
+
+      for (const row of rows) {
+        // Deepest first, so a hook reading into its own relations sees them
+        // already transformed rather than half-processed.
+        await this.walkNestedRows(row, target, access, seen, depth + 1);
+        await runFieldHooks({
+          kind: "collection",
+          slug: target,
+          phase: "afterRead",
+          data: row,
+          operation: "read",
+          user: access.user,
+        });
+      }
+    }
+  }
+
   private async redactRelatedRows(
     targetCollection: string,
     rows: Record<string, unknown>[],

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -2928,21 +2928,13 @@ export class CollectionRelationshipService extends BaseService {
     entry: Record<string, unknown>,
     collectionName: string,
     access: RelatedRowAccess,
-    state: NestedHookState = createNestedHookState(),
-    includeTopLevel?: ReadonlySet<string>
+    state: NestedHookState = createNestedHookState()
   ): Promise<void> {
     // Only a real read applies these. A caller clearing the flag is assembling
     // the evidence a document-dependent rule is judged on and wants the row
     // unredacted -- the same reason the access pass is gated on it.
     if (!access.enforceFieldAccess) return;
-    await this.walkNestedRows(
-      entry,
-      collectionName,
-      access,
-      state,
-      0,
-      includeTopLevel
-    );
+    await this.walkNestedRows(entry, collectionName, access, state, 0);
   }
 
   /**
@@ -3006,28 +2998,18 @@ export class CollectionRelationshipService extends BaseService {
    * Rows are claimed in {@link walkFieldValue} rather than here, so the claim
    * covers running a row's hooks as well as descending into it. The depth cap
    * mirrors the expansion's own maximum.
-   *
-   * `includeTopLevel` narrows the ROOT level to the fields a projection keeps.
-   * It applies at depth 0 only: a relationship the caller left out entirely is
-   * absent from the response, so its target's hooks -- which may have side
-   * effects -- have no business running, while a relationship that IS returned
-   * must be judged on its whole row rather than on the projected slice of it.
    */
   private async walkNestedRows(
     entry: Record<string, unknown>,
     collectionName: string,
     access: RelatedRowAccess,
     state: NestedHookState,
-    depth: number,
-    includeTopLevel?: ReadonlySet<string>
+    depth: number
   ): Promise<void> {
     if (depth > MAX_RELATIONSHIP_DEPTH) return;
 
     const fields = await this.fieldsForNestedWalk(collectionName, state);
     for (const field of fields) {
-      if (depth === 0 && includeTopLevel && !includeTopLevel.has(field.name)) {
-        continue;
-      }
       await this.walkFieldValue(entry[field.name], field, access, state, depth);
     }
   }

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -3231,10 +3231,14 @@ export class CollectionRelationshipService extends BaseService {
   ): Promise<void> {
     if (!("label" in row)) return;
 
-    const declared =
-      typeof field.options?.targetLabelField === "string"
-        ? field.options.targetLabelField
-        : "";
+    // Read from both shapes expansion supports. A relationship storing the
+    // override at the field root would otherwise have its label rebuilt from an
+    // auto-selected field, so the same row came back labelled differently only
+    // because this pass ran.
+    const override =
+      field.options?.targetLabelField ??
+      (field as Record<string, unknown>).targetLabelField;
+    const declared = typeof override === "string" ? override : "";
     const cacheKey = `${resolved.collection}:${declared}`;
     let pending = state.labelFields.get(cacheKey);
     if (!pending) {

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -75,7 +75,7 @@ export const DEFAULT_RELATIONSHIP_DEPTH = 2;
 export const MAX_RELATIONSHIP_DEPTH = 5;
 
 /** Carried across one read's nested-hook pass. */
-interface NestedHookState {
+interface NestedHookStateBase {
   /**
    * Rows already visited. Batch expansion hands the same object to every parent
    * that references it, so this is what keeps a transform from compounding
@@ -84,10 +84,40 @@ interface NestedHookState {
   visited: Set<Record<string, unknown>>;
   /** One schema read per collection per read, rather than per row per depth. */
   fields: Map<string, FieldDefinition[]>;
+  /**
+   * Label field per target, keyed by collection AND the field's declared
+   * override, since two relationships can point at one collection and name
+   * different labels. Resolving it costs a metadata read, and the label is
+   * rebuilt for every related row.
+   */
+  labelFields: Map<string, Promise<string>>;
+  /**
+   * Every related row the pass reached, in visit order, with what is needed to
+   * finish it.
+   *
+   * Masking and hiding cannot be interleaved per row. The walk descends deepest
+   * first, so hiding a child's fields as it is finished removes exactly the
+   * evidence its PARENT's masking rule is about to read -- reproducing, one
+   * level down, the defect the reordering exists to fix. So the rows are
+   * collected here and hidden only once every hook in the document has run.
+   */
+  pending: Array<{
+    row: Record<string, unknown>;
+    collection: string;
+    field: FieldDefinition;
+  }>;
 }
 
+/** The state the walk carries; named separately so the interface reads first. */
+type NestedHookState = NestedHookStateBase;
+
 function createNestedHookState(): NestedHookState {
-  return { visited: new Set(), fields: new Map() };
+  return {
+    visited: new Set(),
+    fields: new Map(),
+    labelFields: new Map(),
+    pending: [],
+  };
 }
 
 /**
@@ -195,6 +225,14 @@ export interface RelationshipExpansionOptions {
    * is off. See {@link RelatedRowAccess.enforceCollectionAccess}.
    */
   enforceCollectionAccess?: boolean;
+
+  /**
+   * Defer the target's field read rules to the post-assembly pass. Only a
+   * caller that runs {@link CollectionRelationshipService.applyNestedFieldHooks}
+   * over the finished document may set this. See
+   * {@link RelatedRowAccess.fieldAccessStage}.
+   */
+  fieldAccessStage?: "fetch" | "assembled";
 
   /**
    * Collects the ids withheld because a target collection refused the caller,
@@ -1801,6 +1839,7 @@ export class CollectionRelationshipService extends BaseService {
     const access: RelatedRowAccess = {
       enforceFieldAccess: options.enforceFieldAccess,
       enforceCollectionAccess: options.enforceCollectionAccess,
+      fieldAccessStage: options.fieldAccessStage,
       user: options.user,
       overrideAccess: options.overrideAccess,
       authenticatedScope: options.authenticatedScope,
@@ -2392,6 +2431,7 @@ export class CollectionRelationshipService extends BaseService {
     const access: RelatedRowAccess = {
       enforceFieldAccess: options.enforceFieldAccess,
       enforceCollectionAccess: options.enforceCollectionAccess,
+      fieldAccessStage: options.fieldAccessStage,
       user: options.user,
       overrideAccess: options.overrideAccess,
       authenticatedScope: options.authenticatedScope,
@@ -2895,7 +2935,14 @@ export class CollectionRelationshipService extends BaseService {
         stripPasswordFieldValues(row, targetFields);
       }
     }
-    await this.applyRelatedRowReadAccess(targetCollection, rows, access);
+    // Secrets above are unconditional and stay here. The target's FIELD rules
+    // are the caller's to place: a read that finishes with the post-assembly
+    // pass defers them there so the row's own masking hooks are judged on a
+    // whole row, which is the order a direct read uses. Every other caller
+    // applies them now, because nothing later will.
+    if (access.fieldAccessStage !== "assembled") {
+      await this.applyRelatedRowReadAccess(targetCollection, rows, access);
+    }
   }
 
   /**
@@ -2928,13 +2975,48 @@ export class CollectionRelationshipService extends BaseService {
     entry: Record<string, unknown>,
     collectionName: string,
     access: RelatedRowAccess,
-    state: NestedHookState = createNestedHookState()
+    state?: NestedHookState
   ): Promise<void> {
     // Only a real read applies these. A caller clearing the flag is assembling
     // the evidence a document-dependent rule is judged on and wants the row
     // unredacted -- the same reason the access pass is gated on it.
     if (!access.enforceFieldAccess) return;
-    await this.walkNestedRows(entry, collectionName, access, state, 0);
+
+    // A caller that shares a state across a listing finishes the rows itself,
+    // once every entry has been walked. One that does not is a single document,
+    // so its walk is already complete here.
+    const shared = state ?? createNestedHookState();
+    await this.walkNestedRows(entry, collectionName, access, shared, 0);
+    if (!state) await this.finalizeRelatedRows(shared, access);
+  }
+
+  /**
+   * Hide denied fields on every related row the walk reached, then rebuild the
+   * labels.
+   *
+   * Separated from the walk because the two orders are not the same order. A
+   * field hook masks; a field rule hides; and the hooks of a row's PARENT run
+   * after the row itself is finished, so hiding as each row completes takes the
+   * evidence away from a rule that has not run yet. Masking the whole document
+   * first, then hiding it, is the order a direct read has always used -- one
+   * document, not one row at a time.
+   *
+   * Labels come last of all, from the values that survived: a label copies a
+   * field under another key, so one built earlier outlives the removal of its
+   * own source field.
+   */
+  async finalizeRelatedRows(
+    state: NestedHookState,
+    access: RelatedRowAccess
+  ): Promise<void> {
+    if (!access.enforceFieldAccess) return;
+    for (const { row, collection } of state.pending) {
+      await this.applyRelatedRowReadAccess(collection, [row], access);
+    }
+    for (const { row, collection, field } of state.pending) {
+      await this.refreshRelatedRowLabel(row, field, { collection }, state);
+    }
+    state.pending.length = 0;
   }
 
   /**
@@ -3100,6 +3182,15 @@ export class CollectionRelationshipService extends BaseService {
         user: access.user,
       });
 
+      // Queued, not applied. Hiding this row's denied fields now would remove
+      // the evidence its PARENT's masking rule reads a moment later, because
+      // this walk finishes a child before its parent's hooks run.
+      state.pending.push({
+        row: resolved.row,
+        collection: resolved.collection,
+        field,
+      });
+
       // Secrets are stripped from a related row when it is fetched, but a hook
       // on a sibling field can write one back -- deliberately or by copying the
       // row -- and the response-level defenses sanitize only the ROOT row,
@@ -3115,6 +3206,48 @@ export class CollectionRelationshipService extends BaseService {
       }
       stripSystemOwnerField(resolved.row);
     }
+  }
+
+  /**
+   * Rebuild a related row's display label from the fields that survived.
+   *
+   * The label copies a field's value under another key, so one derived at fetch
+   * outlives the removal of its own source field: a caller denied `internalName`
+   * would still read it as `label`. Rebuilt here, after the hooks and the field
+   * rules, it can only be made of values this caller may see.
+   *
+   * Falls back to the id, which is what the fetch-time derivation does when the
+   * source field is absent, so a row stays identifiable rather than losing its
+   * label entirely.
+   *
+   * Only rows that carry a label are touched. Expansion attaches one; a row
+   * reached some other way has no label to keep honest.
+   */
+  private async refreshRelatedRowLabel(
+    row: Record<string, unknown>,
+    field: FieldDefinition,
+    resolved: { collection: string },
+    state: NestedHookState
+  ): Promise<void> {
+    if (!("label" in row)) return;
+
+    const declared =
+      typeof field.options?.targetLabelField === "string"
+        ? field.options.targetLabelField
+        : "";
+    const cacheKey = `${resolved.collection}:${declared}`;
+    let pending = state.labelFields.get(cacheKey);
+    if (!pending) {
+      pending = isSystemEntity(resolved.collection)
+        ? Promise.resolve(
+            resolveSystemEntityLabelField(resolved.collection, declared)
+          )
+        : this.getBestLabelField(resolved.collection, declared || undefined);
+      state.labelFields.set(cacheKey, pending);
+    }
+
+    const labelField = await pending;
+    row.label = row[labelField] || row.id;
   }
 
   /**

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -102,27 +102,32 @@ function createNestedHookState(): NestedHookState {
  */
 function resolveNestedTarget(
   row: Record<string, unknown>,
-  field: { relationTo?: unknown }
+  field: FieldDefinition
 ): { collection: string; row: Record<string, unknown> } | null {
-  const declared = field.relationTo;
+  // The same resolver expansion uses, so a Schema Builder relationship -- whose
+  // target lives in `options.target` with no `relationTo` at all -- is walked
+  // rather than skipped.
+  const targets = declaredTargets(field);
+  if (targets.length === 0) return null;
 
-  const discriminator = row.relationTo;
-  if (typeof discriminator === "string") {
+  // Whether a value is discriminated is a property of the FIELD: only a field
+  // declaring several targets stores `{ relationTo, value }`, because an id
+  // alone would not say which table it belongs to. Reading it off the row
+  // instead would mistake a target that legitimately has its own string
+  // `relationTo` field for a wrapper, and skip its hooks entirely.
+  if (targets.length > 1) {
+    const named = row.relationTo;
     const inner = row.value;
+    if (typeof named !== "string") return null;
     if (typeof inner !== "object" || inner === null) return null;
-    const permitted = Array.isArray(declared)
-      ? declared.includes(discriminator)
-      : declared === discriminator;
-    if (!permitted) return null;
-    return {
-      collection: discriminator,
-      row: inner as Record<string, unknown>,
-    };
+    // Validated against what the field declares: nothing checks the stored
+    // slug on the way in, so an unvalidated one would let a writer aim another
+    // collection's hooks at this row.
+    if (!targets.includes(named)) return null;
+    return { collection: named, row: inner as Record<string, unknown> };
   }
 
-  // A single-target relationship carries the row directly.
-  if (typeof declared === "string") return { collection: declared, row };
-  return null;
+  return { collection: targets[0], row };
 }
 
 /**
@@ -2892,6 +2897,16 @@ export class CollectionRelationshipService extends BaseService {
   ): Promise<FieldDefinition[]> {
     const cached = state.fields.get(collectionName);
     if (cached) return cached;
+
+    // A system entity has no dynamic-collection record and no registered field
+    // hooks, so there is nothing to look up and nothing to fail closed over.
+    // `getCollectionFields` already reads it this way; the redaction helper
+    // does not, and treating its `null` as untrustworthy turned an ordinary
+    // `author -> users` expansion into an internal error.
+    if (isSystemEntity(collectionName)) {
+      state.fields.set(collectionName, []);
+      return [];
+    }
 
     const fields = await this.getRedactionFields(collectionName);
     if (fields === null) {

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -6,7 +6,6 @@ import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 import type { AuthenticatedScope } from "../../../auth/authenticated-scope";
 import { getDialectTables } from "../../../database";
 import { container } from "../../../di/container";
-import { NextlyError } from "../../../errors/nextly-error";
 import {
   convertTimestampsToCamelCase,
   keysToCamelCase,
@@ -2898,25 +2897,44 @@ export class CollectionRelationshipService extends BaseService {
     const cached = state.fields.get(collectionName);
     if (cached) return cached;
 
-    // A system entity has no dynamic-collection record and no registered field
-    // hooks, so there is nothing to look up and nothing to fail closed over.
-    // `getCollectionFields` already reads it this way; the redaction helper
-    // does not, and treating its `null` as untrustworthy turned an ordinary
-    // `author -> users` expansion into an internal error.
+    // A system entity has no dynamic-collection record and registers no field
+    // hooks, so there is nothing to look up.
     if (isSystemEntity(collectionName)) {
       state.fields.set(collectionName, []);
       return [];
     }
 
-    const fields = await this.getRedactionFields(collectionName);
-    if (fields === null) {
-      throw NextlyError.internal({
-        logContext: {
-          reason: "nested-field-hooks-schema-unavailable",
-          collection: collectionName,
-        },
-      });
+    let fields: FieldDefinition[] = [];
+    try {
+      const collection =
+        await this.collectionService.getCollection(collectionName);
+      const raw =
+        (
+          (collection as Record<string, unknown>).schemaDefinition as
+            | Record<string, unknown>
+            | undefined
+        )?.fields ?? (collection as Record<string, unknown>).fields;
+      fields = Array.isArray(raw) ? (raw as FieldDefinition[]) : [];
+    } catch (error: unknown) {
+      // A target whose schema will not load runs no hooks here, and the read
+      // continues.
+      //
+      // Failing the read instead was tried and reverted: a relationship can
+      // point at something that is not a registered collection at all -- `media`
+      // behind an upload field, `users` behind an author -- and the lookup
+      // reports that the same way it reports a genuine failure, as an untyped
+      // "not found". Refusing on it broke ordinary reads carrying an upload,
+      // which is a far larger hole than the one it closed.
+      //
+      // Telling the two apart needs the registry to answer "is this a
+      // collection" separately from "give me its fields"; until it can, this
+      // logs rather than guesses.
+      console.error(
+        `Nested field hooks skipped for "${collectionName}": its schema could not be read.`,
+        error
+      );
     }
+
     state.fields.set(collectionName, fields);
     return fields;
   }

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -2928,13 +2928,21 @@ export class CollectionRelationshipService extends BaseService {
     entry: Record<string, unknown>,
     collectionName: string,
     access: RelatedRowAccess,
-    state: NestedHookState = createNestedHookState()
+    state: NestedHookState = createNestedHookState(),
+    includeTopLevel?: ReadonlySet<string>
   ): Promise<void> {
     // Only a real read applies these. A caller clearing the flag is assembling
     // the evidence a document-dependent rule is judged on and wants the row
     // unredacted -- the same reason the access pass is gated on it.
     if (!access.enforceFieldAccess) return;
-    await this.walkNestedRows(entry, collectionName, access, state, 0);
+    await this.walkNestedRows(
+      entry,
+      collectionName,
+      access,
+      state,
+      0,
+      includeTopLevel
+    );
   }
 
   /**
@@ -2998,18 +3006,28 @@ export class CollectionRelationshipService extends BaseService {
    * Rows are claimed in {@link walkFieldValue} rather than here, so the claim
    * covers running a row's hooks as well as descending into it. The depth cap
    * mirrors the expansion's own maximum.
+   *
+   * `includeTopLevel` narrows the ROOT level to the fields a projection keeps.
+   * It applies at depth 0 only: a relationship the caller left out entirely is
+   * absent from the response, so its target's hooks -- which may have side
+   * effects -- have no business running, while a relationship that IS returned
+   * must be judged on its whole row rather than on the projected slice of it.
    */
   private async walkNestedRows(
     entry: Record<string, unknown>,
     collectionName: string,
     access: RelatedRowAccess,
     state: NestedHookState,
-    depth: number
+    depth: number,
+    includeTopLevel?: ReadonlySet<string>
   ): Promise<void> {
     if (depth > MAX_RELATIONSHIP_DEPTH) return;
 
     const fields = await this.fieldsForNestedWalk(collectionName, state);
     for (const field of fields) {
+      if (depth === 0 && includeTopLevel && !includeTopLevel.has(field.name)) {
+        continue;
+      }
       await this.walkFieldValue(entry[field.name], field, access, state, depth);
     }
   }

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -6,6 +6,7 @@ import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 import type { AuthenticatedScope } from "../../../auth/authenticated-scope";
 import { getDialectTables } from "../../../database";
 import { container } from "../../../di/container";
+import { NextlyError } from "../../../errors/nextly-error";
 import {
   convertTimestampsToCamelCase,
   keysToCamelCase,
@@ -53,6 +54,7 @@ import type { DynamicCollectionService } from "../../dynamic-collections";
 
 import { CollectionAccessService } from "./collection-access-service";
 import type { UserContext } from "./collection-types";
+import { decodeJsonFieldValues } from "./collection-utils";
 
 /**
  * System-entity columns that hold secrets and must never ride along a
@@ -73,21 +75,53 @@ export const DEFAULT_RELATIONSHIP_DEPTH = 2;
  */
 export const MAX_RELATIONSHIP_DEPTH = 5;
 
+/** Carried across one read's nested-hook pass. */
+interface NestedHookState {
+  /**
+   * Rows already visited. Batch expansion hands the same object to every parent
+   * that references it, so this is what keeps a transform from compounding
+   * with the reference count; it also breaks a reference cycle.
+   */
+  visited: Set<Record<string, unknown>>;
+  /** One schema read per collection per read, rather than per row per depth. */
+  fields: Map<string, FieldDefinition[]>;
+}
+
+function createNestedHookState(): NestedHookState {
+  return { visited: new Set(), fields: new Map() };
+}
+
 /**
- * The collection a relationship field's value came from, or null when the walk
- * cannot know.
+ * The collection a nested value belongs to, and the row itself.
  *
- * Null for a polymorphic relationship (`relationTo` is a list): the value could
- * be a row from any of them, and applying one collection's field hooks to a row
- * from another would transform the wrong fields. Skipping is the honest answer
- * -- those rows keep the protections the fetch already applied, and nothing
- * pretends they got more.
+ * A polymorphic relationship is expanded as `{ relationTo, value }`, so the
+ * target is knowable per VALUE even though the field declares several. The
+ * discriminator is validated against what the field declares, so a stored value
+ * naming a collection the field never pointed at cannot direct another
+ * collection's hooks at this row.
  */
-function targetCollectionOf(field: {
-  type?: string;
-  relationTo?: unknown;
-}): string | null {
-  if (typeof field.relationTo === "string") return field.relationTo;
+function resolveNestedTarget(
+  row: Record<string, unknown>,
+  field: { relationTo?: unknown }
+): { collection: string; row: Record<string, unknown> } | null {
+  const declared = field.relationTo;
+
+  const discriminator = row.relationTo;
+  if (typeof discriminator === "string") {
+    const inner = row.value;
+    if (typeof inner !== "object" || inner === null) return null;
+    const permitted = Array.isArray(declared)
+      ? declared.includes(discriminator)
+      : declared === discriminator;
+    if (!permitted) return null;
+    return {
+      collection: discriminator,
+      row: inner as Record<string, unknown>,
+    };
+  }
+
+  // A single-target relationship carries the row directly.
+  if (typeof declared === "string") return { collection: declared, row };
   return null;
 }
 
@@ -2809,81 +2843,170 @@ export class CollectionRelationshipService extends BaseService {
    * once the document is fully assembled.
    *
    * A field hook is the transforming half of a field's read protections -- the
-   * half that masks a value on the way out -- and its access half already runs
-   * per related row. Running the hooks there too would be wrong: related rows
-   * are fetched BEFORE the recursion that expands their own relationships, so a
-   * hook masking on `data.organization.classification` would see a raw id and
-   * return the unmasked value. A direct read of that collection expands first
-   * and runs field hooks last, and expansion may be stricter than the target's
-   * own endpoint but never looser.
+   * half that masks a value on the way out. Running it at fetch time would be
+   * wrong: related rows are read BEFORE the recursion that expands their own
+   * relationships, so a hook masking on `data.organization.classification`
+   * would see a raw id. A direct read expands first and runs field hooks last,
+   * and expansion may be stricter than the target's own endpoint but never
+   * looser.
    *
-   * So this runs once, from the read path, over the finished document: every
-   * row is complete by the time its own hooks see it, at every depth, and there
-   * is one place that decides it rather than a call at each of the several
-   * points where assembly happens to end.
+   * So this runs once, from the read path, over the finished document.
    *
-   * Walks by SCHEMA rather than by marking rows during expansion: a field's
-   * `relationTo` already says which collection the value came from, so nothing
-   * has to be threaded through the fetch to be read back here.
+   * `state` is shared across every entry in one read. Batch expansion hands the
+   * SAME row object to every parent that references it, so a per-entry
+   * traversal would run that row's hooks once per reference and compound any
+   * transform that is not idempotent. It also carries the schema cache: without
+   * it a hundred-row listing re-reads the same two collections' fields on every
+   * row, one metadata query at a time.
    */
+  /** A state a caller can share across every entry in one read. */
+  createNestedHookState(): NestedHookState {
+    return createNestedHookState();
+  }
+
   async applyNestedFieldHooks(
     entry: Record<string, unknown>,
     collectionName: string,
-    access: RelatedRowAccess
+    access: RelatedRowAccess,
+    state: NestedHookState = createNestedHookState()
   ): Promise<void> {
     // Only a real read applies these. A caller clearing the flag is assembling
     // the evidence a document-dependent rule is judged on and wants the row
     // unredacted -- the same reason the access pass is gated on it.
     if (!access.enforceFieldAccess) return;
-    await this.walkNestedRows(entry, collectionName, access, new Set(), 0);
+    await this.walkNestedRows(entry, collectionName, access, state, 0);
+  }
+
+  /**
+   * The collection's fields, read once per collection per read.
+   *
+   * Fails CLOSED. `getCollectionFields` returns an empty list when the metadata
+   * lookup fails, which here would mean "this row has no relationship fields"
+   * and silently skip every masking hook below it while the rows continue to
+   * the response. These are read protections, so a lookup that cannot be
+   * trusted refuses the read instead of quietly returning it untransformed.
+   */
+  private async fieldsForNestedWalk(
+    collectionName: string,
+    state: NestedHookState
+  ): Promise<FieldDefinition[]> {
+    const cached = state.fields.get(collectionName);
+    if (cached) return cached;
+
+    const fields = await this.getRedactionFields(collectionName);
+    if (fields === null) {
+      throw NextlyError.internal({
+        logContext: {
+          reason: "nested-field-hooks-schema-unavailable",
+          collection: collectionName,
+        },
+      });
+    }
+    state.fields.set(collectionName, fields);
+    return fields;
   }
 
   /**
    * One level of {@link applyNestedFieldHooks}.
    *
-   * `seen` breaks a reference cycle (A points at B, B points back at A) that the
-   * expansion's own depth limit would already have stopped, so this is a
-   * belt-and-braces guard rather than the primary bound. The depth cap mirrors
-   * the expansion's own maximum.
+   * Rows are claimed in {@link walkFieldValue} rather than here, so the claim
+   * covers running a row's hooks as well as descending into it. The depth cap
+   * mirrors the expansion's own maximum.
    */
   private async walkNestedRows(
     entry: Record<string, unknown>,
     collectionName: string,
     access: RelatedRowAccess,
-    seen: Set<Record<string, unknown>>,
+    state: NestedHookState,
     depth: number
   ): Promise<void> {
     if (depth > MAX_RELATIONSHIP_DEPTH) return;
-    if (seen.has(entry)) return;
-    seen.add(entry);
 
-    const fields = await this.getCollectionFields(collectionName);
+    const fields = await this.fieldsForNestedWalk(collectionName, state);
     for (const field of fields) {
-      const target = targetCollectionOf(field);
-      if (!target) continue;
+      await this.walkFieldValue(entry[field.name], field, access, state, depth);
+    }
+  }
 
-      const value = entry[field.name];
-      // An unexpanded relationship is still an id, and there is nothing to
-      // transform in a string.
-      const rows = (Array.isArray(value) ? value : [value]).filter(
-        (row): row is Record<string, unknown> =>
-          typeof row === "object" && row !== null
-      );
-      if (rows.length === 0) continue;
+  /**
+   * Visit one field's value, whatever shape it takes.
+   *
+   * A relationship can sit directly on the collection or inside a `group` or
+   * `repeater`, and `expandRelationships` populates it either way, so a walk
+   * that only looked at top-level `relationTo` fields left everything inside a
+   * container unmasked.
+   */
+  private async walkFieldValue(
+    value: unknown,
+    field: FieldDefinition,
+    access: RelatedRowAccess,
+    state: NestedHookState,
+    depth: number
+  ): Promise<void> {
+    if (value === null || value === undefined) return;
 
+    const rows = (Array.isArray(value) ? value : [value]).filter(
+      (row): row is Record<string, unknown> =>
+        typeof row === "object" && row !== null
+    );
+    if (rows.length === 0) return;
+
+    const nested = getNestedFields(field);
+    if (nested.length > 0) {
+      // A container: its rows belong to THIS collection, so they carry no
+      // hooks of their own -- only the relationships inside them do.
       for (const row of rows) {
-        // Deepest first, so a hook reading into its own relations sees them
-        // already transformed rather than half-processed.
-        await this.walkNestedRows(row, target, access, seen, depth + 1);
-        await runFieldHooks({
-          kind: "collection",
-          slug: target,
-          phase: "afterRead",
-          data: row,
-          operation: "read",
-          user: access.user,
-        });
+        for (const inner of nested) {
+          await this.walkFieldValue(
+            row[inner.name],
+            inner,
+            access,
+            state,
+            depth
+          );
+        }
       }
+      return;
+    }
+
+    for (const row of rows) {
+      // A discriminated value names its own collection, so a polymorphic
+      // relationship is knowable per value rather than unknowable per field.
+      const resolved = resolveNestedTarget(row, field);
+      if (!resolved) continue;
+
+      // Claimed before anything runs, and the claim covers the hooks as well as
+      // the descent. Guarding only the descent still let a row shared by
+      // several parents be transformed once per parent, which compounds any
+      // transform that is not idempotent.
+      if (state.visited.has(resolved.row)) continue;
+      state.visited.add(resolved.row);
+
+      await this.walkNestedRows(
+        resolved.row,
+        resolved.collection,
+        access,
+        state,
+        depth + 1
+      );
+      // Decoded with the TARGET's schema. The read path decodes using the
+      // source collection's fields, which say nothing about a related row's
+      // own JSON columns, so on SQLite a hook inspecting one would be handed
+      // the storage string.
+      decodeJsonFieldValues(
+        [resolved.row],
+        await this.fieldsForNestedWalk(resolved.collection, state)
+      );
+      // Deepest first, so a hook reading into its own relations sees them
+      // already transformed rather than half-processed.
+      await runFieldHooks({
+        kind: "collection",
+        slug: resolved.collection,
+        phase: "afterRead",
+        data: resolved.row,
+        operation: "read",
+        user: access.user,
+      });
     }
   }
 

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -2884,16 +2884,16 @@ export class CollectionRelationshipService extends BaseService {
   /**
    * The collection's fields, read once per collection per read.
    *
-   * Fails OPEN, deliberately: a target whose schema will not load runs no hooks
-   * and the read continues. That is weaker than these protections deserve, and
-   * it is the only correct answer available today -- the registry reports "not
-   * a registered collection" and "the lookup failed" identically, so refusing
-   * on it broke every read carrying an upload or an author relationship. The
-   * failure is logged rather than swallowed.
+   * A target whose schema will not load runs no hooks, and the read continues.
    *
-   * Fail-closed becomes possible once the registry can answer "is this a
-   * collection" separately from "give me its fields"; see the gap I notes in
-   * `094-collection-hook-lifecycle-spec`.
+   * That is weaker than a read protection deserves, and it is the only answer
+   * the registry supports: it reports "this is not a registered collection" and
+   * "the lookup failed" the same way, so a relationship pointing at a built-in
+   * entity is indistinguishable from a real failure. Refusing on it would deny
+   * ordinary reads. The failure is logged rather than swallowed.
+   *
+   * Refusing becomes correct once the registry can answer whether a slug IS a
+   * collection separately from what its fields are.
    */
   private async fieldsForNestedWalk(
     collectionName: string,
@@ -2921,19 +2921,11 @@ export class CollectionRelationshipService extends BaseService {
         )?.fields ?? (collection as Record<string, unknown>).fields;
       fields = Array.isArray(raw) ? (raw as FieldDefinition[]) : [];
     } catch (error: unknown) {
-      // A target whose schema will not load runs no hooks here, and the read
-      // continues.
-      //
-      // Failing the read instead was tried and reverted: a relationship can
-      // point at something that is not a registered collection at all -- `media`
-      // behind an upload field, `users` behind an author -- and the lookup
-      // reports that the same way it reports a genuine failure, as an untyped
-      // "not found". Refusing on it broke ordinary reads carrying an upload,
-      // which is a far larger hole than the one it closed.
-      //
-      // Telling the two apart needs the registry to answer "is this a
-      // collection" separately from "give me its fields"; until it can, this
-      // logs rather than guesses.
+      // A relationship can point at something that is not a registered
+      // collection -- `users` behind an author field -- and the lookup reports
+      // that as an untyped "not found", the same shape a genuine failure takes.
+      // Since the two cannot be told apart here, refusing would deny ordinary
+      // reads, so this logs and leaves the target's hooks unrun.
       console.error(
         `Nested field hooks skipped for "${collectionName}": its schema could not be read.`,
         error

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -2842,6 +2842,62 @@ export class CollectionRelationshipService extends BaseService {
    * either one: it runs against the SOURCE collection's field registry, which
    * never describes a related collection's fields.
    */
+  private async redactRelatedRows(
+    targetCollection: string,
+    rows: Record<string, unknown>[],
+    access: RelatedRowAccess = {}
+  ): Promise<void> {
+    if (rows.length === 0) return;
+    // The system owner column must never ride along a populated relationship:
+    // a collection readable by non-creators would otherwise leak a related
+    // row's creator user id through the nested payload. Strip it from every
+    // related row up front (it's a reserved system column, so this can't touch
+    // a user field) — this runs at each expansion level, so nested relations
+    // are covered too.
+    for (const row of rows) {
+      stripSystemOwnerField(row);
+    }
+    // System entities expose secret columns that are not schema fields, so
+    // strip them by name. They carry no user-defined field rules, so there is
+    // nothing for the access pass below to evaluate.
+    if (isSystemEntity(targetCollection)) {
+      for (const row of rows) {
+        for (const col of SYSTEM_ENTITY_SECRET_COLUMNS) delete row[col];
+      }
+      return;
+    }
+    // Dynamic collections: drop password-type field values using the TARGET
+    // collection's schema — the source collection's fields never describe a
+    // related row. If the schema can't be resolved we cannot tell which
+    // fields are secret, so fail closed: strip every non-identity field
+    // rather than risk returning a row that carries a password hash.
+    const targetFields = await this.getRedactionFields(targetCollection);
+    if (targetFields === null) {
+      for (const row of rows) {
+        for (const key of Object.keys(row)) {
+          if (key !== "id" && key !== "label") delete row[key];
+        }
+        // Defense in depth: the label is normally a display field (never a
+        // password — a password can't be configured as a label), but a row
+        // migrated from before that guard could carry a bcrypt hash here, so
+        // drop a hash-shaped label rather than surface it.
+        if (typeof row.label === "string" && row.label.startsWith("$2")) {
+          delete row.label;
+        }
+      }
+      // Nothing but id/label survives, so there is no field left to judge.
+      return;
+    }
+    // Secrets first, and for every caller: a trusted read has no more use for a
+    // password hash than an anonymous one.
+    if (hasPasswordField(targetFields)) {
+      for (const row of rows) {
+        stripPasswordFieldValues(row, targetFields);
+      }
+    }
+    await this.applyRelatedRowReadAccess(targetCollection, rows, access);
+  }
+
   /**
    * Apply each nested related row's OWN collection field `afterRead` hooks,
    * once the document is fully assembled.
@@ -3043,63 +3099,22 @@ export class CollectionRelationshipService extends BaseService {
         operation: "read",
         user: access.user,
       });
-    }
-  }
 
-  private async redactRelatedRows(
-    targetCollection: string,
-    rows: Record<string, unknown>[],
-    access: RelatedRowAccess = {}
-  ): Promise<void> {
-    if (rows.length === 0) return;
-    // The system owner column must never ride along a populated relationship:
-    // a collection readable by non-creators would otherwise leak a related
-    // row's creator user id through the nested payload. Strip it from every
-    // related row up front (it's a reserved system column, so this can't touch
-    // a user field) — this runs at each expansion level, so nested relations
-    // are covered too.
-    for (const row of rows) {
-      stripSystemOwnerField(row);
-    }
-    // System entities expose secret columns that are not schema fields, so
-    // strip them by name. They carry no user-defined field rules, so there is
-    // nothing for the access pass below to evaluate.
-    if (isSystemEntity(targetCollection)) {
-      for (const row of rows) {
-        for (const col of SYSTEM_ENTITY_SECRET_COLUMNS) delete row[col];
+      // Secrets are stripped from a related row when it is fetched, but a hook
+      // on a sibling field can write one back -- deliberately or by copying the
+      // row -- and the response-level defenses sanitize only the ROOT row,
+      // using the source collection's schema, so they would never look at this
+      // one. Stripped again here for the same reason a direct read strips after
+      // its own hooks.
+      const targetFields = await this.fieldsForNestedWalk(
+        resolved.collection,
+        state
+      );
+      if (hasPasswordField(targetFields)) {
+        stripPasswordFieldValues(resolved.row, targetFields);
       }
-      return;
+      stripSystemOwnerField(resolved.row);
     }
-    // Dynamic collections: drop password-type field values using the TARGET
-    // collection's schema — the source collection's fields never describe a
-    // related row. If the schema can't be resolved we cannot tell which
-    // fields are secret, so fail closed: strip every non-identity field
-    // rather than risk returning a row that carries a password hash.
-    const targetFields = await this.getRedactionFields(targetCollection);
-    if (targetFields === null) {
-      for (const row of rows) {
-        for (const key of Object.keys(row)) {
-          if (key !== "id" && key !== "label") delete row[key];
-        }
-        // Defense in depth: the label is normally a display field (never a
-        // password — a password can't be configured as a label), but a row
-        // migrated from before that guard could carry a bcrypt hash here, so
-        // drop a hash-shaped label rather than surface it.
-        if (typeof row.label === "string" && row.label.startsWith("$2")) {
-          delete row.label;
-        }
-      }
-      // Nothing but id/label survives, so there is no field left to judge.
-      return;
-    }
-    // Secrets first, and for every caller: a trusted read has no more use for a
-    // password hash than an anonymous one.
-    if (hasPasswordField(targetFields)) {
-      for (const row of rows) {
-        stripPasswordFieldValues(row, targetFields);
-      }
-    }
-    await this.applyRelatedRowReadAccess(targetCollection, rows, access);
   }
 
   /**

--- a/packages/nextly/src/services/collections/related-row-read-context.ts
+++ b/packages/nextly/src/services/collections/related-row-read-context.ts
@@ -90,6 +90,22 @@ export interface RelatedRowReadContext {
   enforceCollectionAccess?: boolean;
 
   /**
+   * WHEN the target's field read rules are applied to a related row.
+   *
+   * `"fetch"` -- the default -- applies them as the row is loaded. `"assembled"`
+   * defers them to the post-assembly pass, which is the order a direct read
+   * uses: the row's own field `afterRead` hooks run first, so a rule that masks
+   * a value can be judged on the whole row rather than on one a denied sibling
+   * has already been cut out of.
+   *
+   * Deferring is opt-in and the default is the safe one, because only a caller
+   * that actually runs the post-assembly pass can promise the rules run at all.
+   * A path that expands without it -- a Single, a write response -- leaves this
+   * unset and keeps its protection where it is.
+   */
+  fieldAccessStage?: "fetch" | "assembled";
+
+  /**
    * Ids withheld because a target collection refused this caller, keyed by
    * collection and id.
    *


### PR DESCRIPTION
Gap **I** — the last P1 in `tasks/094-collection-hook-lifecycle-spec.md`, and the
one withdrawn from #442 because it needed a design rather than another patch.

## The defect

A field's `afterRead` hooks are the transforming half of its read protections:
the half that masks a value on the way out. The access half already applied to
related rows; the hooks did not. So a field masked on its own collection's
endpoint came back **in full** through a relationship — looser than the target's
endpoint, which is exactly what expansion must never be.

## Why the obvious fix was wrong, and this one is not

#442 tried calling the hooks from `redactRelatedRows`, inside the fetch. Three
review rounds found three defects in that one call, and the third was structural:
**`readTargetRows` runs before the recursion that expands a related row's own
relationships**, so a hook masking on `data.organization.classification` saw a
raw id and let the secret through. A direct read expands first and runs field
hooks last.

That could not be patched in place — the hooks have to run after assembly, and
assembly finishes at several points across `expandRelationships` /
`batchExpandRelationships`. Patching those one at a time is the shape that made
the reentrancy guard wrong twice in this same program.

So this is one pass, `applyNestedFieldHooks`, called once from each read path
over the finished document. Every row is complete when its own hooks see it, at
every depth, and one place decides that.

Design points worth stating:

- **Walks by schema, not by marking rows.** A field's `relationTo` already
  records which collection a nested value came from, so nothing has to be
  threaded through the fetch to be read back out.
- **Gated on `enforceFieldAccess`**, the same flag the access pass uses, so
  `buildAuthorizationView` still assembles its evidence unredacted — the second
  defect from #442, fixed by construction rather than remembered.
- **Polymorphic relationships are skipped, deliberately.** With `relationTo` a
  list, a row could be from any of them, and applying one collection's field
  hooks to another's row transforms the wrong fields. Those rows keep what the
  fetch already applied; nothing pretends they got more.
- Deepest-first, so a hook reading into its own relations sees them already
  transformed.

## Verification

4 integration tests. The one that matters masks on the author's **own**
relationship, so it can only pass if the hook was handed a fully assembled row —
that is the exact case the withdrawn version got wrong.

2 of the 4 fail with the walk reverted. The other two are controls and pass
either way by design: the target's endpoint masking (without it, "masked through
a relationship" could just mean the hook masks unconditionally) and a mirror
where the nested evidence does **not** call for masking.

The unit mocks needed `applyNestedFieldHooks` added — a double missing a method
the real service has certifies a path that throws for real. Failing-test name
sets across `src/domains/collections` identical to `origin/main` (11 both sides).
Integration: 238 passed.

## A separate defect found while testing this

`batchExpandRelationships` has `if (isRelationshipField(field)) continue;`
before its nested recursion, so **a LIST never expands a related row's own
relationships at any depth**, while a read by id does. `post.author.organization`
is an object on the detail endpoint and a raw id in a listing.

Pre-existing, not gap I, and not fixed here — recorded in the spec because it
silently bounds what a nested field hook can ever mask on a list, and because a
test written against the detail path will mislead anyone assuming the two agree.
It caught me: my first list-path assertion was wrong for this reason, not
because the walk was.
