### PR TITLE
feat(nextly): emit a block manifest from declared blocks

### DIFF
--- a/.changeset/block-manifest.md
+++ b/.changeset/block-manifest.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+`nextly generate:types` now writes a block manifest listing every block your plugins declare.
+
+Until now the only way to ask what blocks an app has was to boot it and inspect the registry, which is not available to an editor build, a docs page, or an agent writing a page document. The manifest states it as a file beside your generated types: each block's name, schema version, description, worked example, prop schemas, style capabilities, slots, and the plugin that declared it.
+
+It is written from what plugins declare rather than from the running registry, so generation stays a pure read of your config: no plugin boots and no database opens. Blocks registered imperatively at runtime are not listed, because they cannot be known without running the plugin. No file is written when nothing declares a block.

--- a/packages/nextly/src/cli/commands/generate-types.ts
+++ b/packages/nextly/src/cli/commands/generate-types.ts
@@ -41,6 +41,7 @@ import { describeError } from "../../errors/index";
 // Reserved-option refusals are reported through the canonical error shape, so
 // the CLI renders them like any other declaration failure.
 import type { FieldGroupConfig } from "../../field-groups/config/types";
+import { buildBlockManifestArtifact } from "../../plugins/codegen/block-manifest";
 import { collectCodegenNames } from "../../plugins/codegen/collect-codegen-names";
 import { buildImportMapArtifact } from "../../plugins/codegen/component-import-map";
 // The option names the field identity would overwrite, refused here because a
@@ -100,6 +101,8 @@ interface ResolvedGenerateTypesOptions extends GenerateTypesCommandOptions {
 interface GenerationResult {
   /** Path to generated TypeScript types file */
   typesFile?: string;
+  /** Path to the generated block manifest, when plugins declare blocks. */
+  blockManifestFile?: string;
   /** Path to the generated admin component import map, when plugins contribute admin UI (D60) */
   componentImportMapFile?: string;
   /** Number of collection interfaces generated */
@@ -299,6 +302,21 @@ async function generateTypes(
     await writeFile(importMapPath, importMap.code, "utf-8");
     result.componentImportMapFile = importMapPath;
     logger.debug(`Written plugin admin import map to: ${importMapPath}`);
+  }
+
+  // What blocks this app has, as data, so an editor build or an agent can read
+  // them without booting the app. Emitted from declarations, so this stays a
+  // pure read of the config.
+  const blockManifest = buildBlockManifestArtifact(
+    config.plugins ?? [],
+    typesOutputPath
+  );
+  if (blockManifest) {
+    const manifestPath = resolve(cwd, blockManifest.path);
+    await ensureDir(dirname(manifestPath));
+    await writeFile(manifestPath, blockManifest.code, "utf-8");
+    result.blockManifestFile = manifestPath;
+    logger.debug(`Written block manifest to: ${manifestPath}`);
   }
 
   // Generate Zod schemas if enabled

--- a/packages/nextly/src/cli/commands/generate-types.ts
+++ b/packages/nextly/src/cli/commands/generate-types.ts
@@ -42,6 +42,7 @@ import { describeError } from "../../errors/index";
 // the CLI renders them like any other declaration failure.
 import type { FieldGroupConfig } from "../../field-groups/config/types";
 import {
+  assertManifestPathIsFree,
   BLOCK_MANIFEST_FILENAME,
   buildBlockManifestArtifact,
 } from "../../plugins/codegen/block-manifest";
@@ -188,6 +189,9 @@ export async function runGenerateTypes(
   const manifestCwd = options.cwd ?? process.cwd();
   const manifestOutputPath =
     options.output ?? configResult.config.typescript.outputFile;
+  // Checked before either branch: the cleanup path deletes by name, so a
+  // collision here would remove the types output rather than a stale manifest.
+  assertManifestPathIsFree(manifestOutputPath);
   const blockManifest = buildBlockManifestArtifact(
     configResult.config.plugins ?? [],
     manifestOutputPath

--- a/packages/nextly/src/cli/commands/generate-types.ts
+++ b/packages/nextly/src/cli/commands/generate-types.ts
@@ -24,8 +24,8 @@
  * ```
  */
 
-import { mkdir, writeFile } from "node:fs/promises";
-import { resolve, dirname } from "node:path";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { resolve, dirname, join } from "node:path";
 
 import type { Command } from "commander";
 
@@ -41,7 +41,10 @@ import { describeError } from "../../errors/index";
 // Reserved-option refusals are reported through the canonical error shape, so
 // the CLI renders them like any other declaration failure.
 import type { FieldGroupConfig } from "../../field-groups/config/types";
-import { buildBlockManifestArtifact } from "../../plugins/codegen/block-manifest";
+import {
+  BLOCK_MANIFEST_FILENAME,
+  buildBlockManifestArtifact,
+} from "../../plugins/codegen/block-manifest";
 import { collectCodegenNames } from "../../plugins/codegen/collect-codegen-names";
 import { buildImportMapArtifact } from "../../plugins/codegen/component-import-map";
 // The option names the field identity would overwrite, refused here because a
@@ -317,6 +320,16 @@ async function generateTypes(
     await writeFile(manifestPath, blockManifest.code, "utf-8");
     result.blockManifestFile = manifestPath;
     logger.debug(`Written block manifest to: ${manifestPath}`);
+  } else {
+    // No manifest for this config, which has to be expressed by removing any
+    // previous one. Writing nothing would leave the last run's file on disk
+    // still advertising blocks the app no longer has -- worse than never
+    // having generated it, because it reads as current.
+    const stalePath = resolve(
+      cwd,
+      join(dirname(typesOutputPath), BLOCK_MANIFEST_FILENAME)
+    );
+    await rm(stalePath, { force: true });
   }
 
   // Generate Zod schemas if enabled

--- a/packages/nextly/src/cli/commands/generate-types.ts
+++ b/packages/nextly/src/cli/commands/generate-types.ts
@@ -180,6 +180,38 @@ export async function runGenerateTypes(
   // User fields alone are enough to generate for: the `User` interface carries
   // them, and stopping here would leave an app with no output, or a stale file
   // from a previous run.
+  // Settled BEFORE the empty-schema return below, which exits without running
+  // anything after it. An app whose only schema came from a page-builder plugin
+  // reaches zero on every count the moment that plugin is removed, and that is
+  // exactly when its manifest most needs deleting. The path is recorded and
+  // reported on the result further down, where that object exists.
+  const manifestCwd = options.cwd ?? process.cwd();
+  const manifestOutputPath =
+    options.output ?? configResult.config.typescript.outputFile;
+  const blockManifest = buildBlockManifestArtifact(
+    configResult.config.plugins ?? [],
+    manifestOutputPath
+  );
+  let writtenManifestPath: string | undefined;
+  if (blockManifest) {
+    writtenManifestPath = resolve(manifestCwd, blockManifest.path);
+    await ensureDir(dirname(writtenManifestPath));
+    await writeFile(writtenManifestPath, blockManifest.code, "utf-8");
+    logger.debug(`Written block manifest to: ${writtenManifestPath}`);
+  } else {
+    // No manifest for this config, expressed by removing any previous one.
+    // Writing nothing would leave the last run's file on disk still
+    // advertising blocks the app no longer has -- worse than never having
+    // generated it, because it reads as current.
+    await rm(
+      resolve(
+        manifestCwd,
+        join(dirname(manifestOutputPath), BLOCK_MANIFEST_FILENAME)
+      ),
+      { force: true }
+    );
+  }
+
   if (
     collectionCount === 0 &&
     singleCount === 0 &&
@@ -199,6 +231,9 @@ export async function runGenerateTypes(
 
   try {
     const result = await generateTypes(configResult, options, context);
+    // Reported here because the manifest is settled earlier, before the
+    // empty-schema return, while this object is built by the call above.
+    result.blockManifestFile = writtenManifestPath;
 
     // Step 3: Display results
     displayResults(result, options, context);
@@ -305,31 +340,6 @@ async function generateTypes(
     await writeFile(importMapPath, importMap.code, "utf-8");
     result.componentImportMapFile = importMapPath;
     logger.debug(`Written plugin admin import map to: ${importMapPath}`);
-  }
-
-  // What blocks this app has, as data, so an editor build or an agent can read
-  // them without booting the app. Emitted from declarations, so this stays a
-  // pure read of the config.
-  const blockManifest = buildBlockManifestArtifact(
-    config.plugins ?? [],
-    typesOutputPath
-  );
-  if (blockManifest) {
-    const manifestPath = resolve(cwd, blockManifest.path);
-    await ensureDir(dirname(manifestPath));
-    await writeFile(manifestPath, blockManifest.code, "utf-8");
-    result.blockManifestFile = manifestPath;
-    logger.debug(`Written block manifest to: ${manifestPath}`);
-  } else {
-    // No manifest for this config, which has to be expressed by removing any
-    // previous one. Writing nothing would leave the last run's file on disk
-    // still advertising blocks the app no longer has -- worse than never
-    // having generated it, because it reads as current.
-    const stalePath = resolve(
-      cwd,
-      join(dirname(typesOutputPath), BLOCK_MANIFEST_FILENAME)
-    );
-    await rm(stalePath, { force: true });
   }
 
   // Generate Zod schemas if enabled

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest.test.ts
@@ -130,13 +130,38 @@ describe("buildBlockManifest", () => {
     expect(manifest.blocks).toEqual([]);
   });
 
-  it("ignores a declaration whose blocks are not an array", () => {
+  it("ignores a declaration carrying no blocks key", () => {
+    // Another version of the page builder may read keys this one does not, so
+    // an unread declaration is not a defect.
     const manifest = buildBlockManifest([
       consumer(),
-      declaring("@acme/bad", undefined as unknown as unknown[]),
+      declaring("@acme/other", undefined as unknown as unknown[]),
     ]);
 
     expect(manifest.blocks).toEqual([]);
+  });
+
+  it("refuses a blocks value that is present but not an array", () => {
+    // The runtime refuses the same input, so reading it as "no blocks" here
+    // would emit -- or delete -- a manifest describing a config that cannot
+    // boot, and the first sign of trouble would be a failing start.
+    let thrown: unknown;
+    try {
+      buildBlockManifest([
+        consumer(),
+        declaring("@acme/bad", { nope: true } as unknown as unknown[]),
+      ]);
+    } catch (error) {
+      thrown = error;
+    }
+
+    // Asserted on the structured issue rather than the message: the public
+    // message is deliberately generic, and the plugin to go and fix is named
+    // in the issue.
+    const issues = (
+      thrown as { publicData?: { errors?: { message: string }[] } }
+    )?.publicData?.errors;
+    expect(issues?.[0]?.message, String(thrown)).toContain("@acme/bad");
   });
 });
 

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BLOCK_MANIFEST_FILENAME,
+  buildBlockManifest,
+  buildBlockManifestArtifact,
+  PAGE_BUILDER_PLUGIN,
+} from "../block-manifest";
+import { definePlugin, type PluginDefinition } from "../../plugin-context";
+
+/** A block definition as a plugin declares one. */
+function block(name: string, extra: Record<string, unknown> = {}) {
+  return {
+    name,
+    version: 1,
+    description: `The ${name} block.`,
+    example: { props: {} },
+    render: () => null,
+    ...extra,
+  };
+}
+
+/** A plugin declaring blocks for the page builder. */
+function declaring(name: string, blocks: unknown[]): PluginDefinition {
+  return definePlugin({
+    name,
+    version: "1.0.0",
+    nextly: ">=0.0.0",
+    contributes: { declarations: { [PAGE_BUILDER_PLUGIN]: { blocks } } },
+  });
+}
+
+describe("buildBlockManifest", () => {
+  it("states each declared block and who declared it", () => {
+    const manifest = buildBlockManifest([
+      declaring("@acme/pricing", [block("acme/pricing-table")]),
+    ]);
+
+    expect(manifest.blocks).toEqual([
+      {
+        name: "acme/pricing-table",
+        version: 1,
+        description: "The acme/pricing-table block.",
+        source: "@acme/pricing",
+        example: { props: {} },
+      },
+    ]);
+  });
+
+  it("drops the render function", () => {
+    // A function cannot be serialized, and the manifest describes what a block
+    // accepts rather than how it draws.
+    const manifest = buildBlockManifest([
+      declaring("@acme/a", [block("acme/one")]),
+    ]);
+
+    expect(manifest.blocks[0]).not.toHaveProperty("render");
+    expect(() => JSON.stringify(manifest)).not.toThrow();
+  });
+
+  it("carries props, supports and slots when the block declares them", () => {
+    const manifest = buildBlockManifest([
+      declaring("@acme/a", [
+        block("acme/section", {
+          props: { width: { type: "text" } },
+          supports: { spacing: true },
+          slots: { default: { allow: ["core/*"] } },
+        }),
+      ]),
+    ]);
+
+    expect(manifest.blocks[0]).toMatchObject({
+      props: { width: { type: "text" } },
+      supports: { spacing: true },
+      slots: { default: { allow: ["core/*"] } },
+    });
+  });
+
+  it("sorts blocks by name so the artifact is stable", () => {
+    // Reordering plugins must not rewrite the file, or every unrelated config
+    // edit shows a diff and a drift test cannot tell a change from a shuffle.
+    const forward = buildBlockManifest([
+      declaring("@acme/a", [block("acme/zebra")]),
+      declaring("@acme/b", [block("acme/alpha")]),
+    ]);
+    const reversed = buildBlockManifest([
+      declaring("@acme/b", [block("acme/alpha")]),
+      declaring("@acme/a", [block("acme/zebra")]),
+    ]);
+
+    expect(forward.blocks.map(b => b.name)).toEqual([
+      "acme/alpha",
+      "acme/zebra",
+    ]);
+    expect(reversed).toEqual(forward);
+  });
+
+  it("ignores a declaration whose blocks are not an array", () => {
+    const manifest = buildBlockManifest([
+      declaring("@acme/bad", undefined as unknown as unknown[]),
+    ]);
+
+    expect(manifest.blocks).toEqual([]);
+  });
+});
+
+describe("buildBlockManifestArtifact", () => {
+  it("emits nothing when no plugin declared a block", () => {
+    // An empty manifest and an absent one mean the same thing, and only one of
+    // them leaves a stale file behind when the last block plugin is removed.
+    expect(
+      buildBlockManifestArtifact([], "/app/src/nextly-types.ts")
+    ).toBeNull();
+  });
+
+  it("writes beside the generated types, as parseable JSON", () => {
+    const artifact = buildBlockManifestArtifact(
+      [declaring("@acme/a", [block("acme/one")])],
+      "/app/src/nextly-types.ts"
+    );
+
+    expect(artifact?.path).toBe(`/app/src/${BLOCK_MANIFEST_FILENAME}`);
+    expect(artifact?.code.endsWith("\n")).toBe(true);
+    expect(JSON.parse(String(artifact?.code)).blocks).toHaveLength(1);
+  });
+});

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest.test.ts
@@ -20,6 +20,16 @@ function block(name: string, extra: Record<string, unknown> = {}) {
   };
 }
 
+/** The page builder itself, which must be present for anything to register. */
+function consumer(enabled?: boolean): PluginDefinition {
+  return definePlugin({
+    name: PAGE_BUILDER_PLUGIN,
+    version: "1.0.0",
+    nextly: ">=0.0.0",
+    enabled,
+  });
+}
+
 /** A plugin declaring blocks for the page builder. */
 function declaring(name: string, blocks: unknown[]): PluginDefinition {
   return definePlugin({
@@ -33,6 +43,7 @@ function declaring(name: string, blocks: unknown[]): PluginDefinition {
 describe("buildBlockManifest", () => {
   it("states each declared block and who declared it", () => {
     const manifest = buildBlockManifest([
+      consumer(),
       declaring("@acme/pricing", [block("acme/pricing-table")]),
     ]);
 
@@ -51,6 +62,7 @@ describe("buildBlockManifest", () => {
     // A function cannot be serialized, and the manifest describes what a block
     // accepts rather than how it draws.
     const manifest = buildBlockManifest([
+      consumer(),
       declaring("@acme/a", [block("acme/one")]),
     ]);
 
@@ -60,6 +72,7 @@ describe("buildBlockManifest", () => {
 
   it("carries props, supports and slots when the block declares them", () => {
     const manifest = buildBlockManifest([
+      consumer(),
       declaring("@acme/a", [
         block("acme/section", {
           props: { width: { type: "text" } },
@@ -80,10 +93,12 @@ describe("buildBlockManifest", () => {
     // Reordering plugins must not rewrite the file, or every unrelated config
     // edit shows a diff and a drift test cannot tell a change from a shuffle.
     const forward = buildBlockManifest([
+      consumer(),
       declaring("@acme/a", [block("acme/zebra")]),
       declaring("@acme/b", [block("acme/alpha")]),
     ]);
     const reversed = buildBlockManifest([
+      consumer(),
       declaring("@acme/b", [block("acme/alpha")]),
       declaring("@acme/a", [block("acme/zebra")]),
     ]);
@@ -95,8 +110,29 @@ describe("buildBlockManifest", () => {
     expect(reversed).toEqual(forward);
   });
 
+  it("lists nothing when the page builder is disabled", () => {
+    // A disabled plugin runs no init and contributes no services, so the
+    // registry these declarations would fill never exists. Listing them would
+    // tell tooling the app has blocks it cannot render.
+    const manifest = buildBlockManifest([
+      consumer(false),
+      declaring("@acme/a", [block("acme/one")]),
+    ]);
+
+    expect(manifest.blocks).toEqual([]);
+  });
+
+  it("lists nothing when the page builder is not installed", () => {
+    const manifest = buildBlockManifest([
+      declaring("@acme/a", [block("acme/one")]),
+    ]);
+
+    expect(manifest.blocks).toEqual([]);
+  });
+
   it("ignores a declaration whose blocks are not an array", () => {
     const manifest = buildBlockManifest([
+      consumer(),
       declaring("@acme/bad", undefined as unknown as unknown[]),
     ]);
 
@@ -115,7 +151,7 @@ describe("buildBlockManifestArtifact", () => {
 
   it("writes beside the generated types, as parseable JSON", () => {
     const artifact = buildBlockManifestArtifact(
-      [declaring("@acme/a", [block("acme/one")])],
+      [consumer(), declaring("@acme/a", [block("acme/one")])],
       "/app/src/nextly-types.ts"
     );
 

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  assertManifestPathIsFree,
   BLOCK_MANIFEST_FILENAME,
   buildBlockManifest,
   buildBlockManifestArtifact,
@@ -162,6 +163,86 @@ describe("buildBlockManifest", () => {
       thrown as { publicData?: { errors?: { message: string }[] } }
     )?.publicData?.errors;
     expect(issues?.[0]?.message, String(thrown)).toContain("@acme/bad");
+  });
+});
+
+describe("buildBlockManifest rejects what boot would reject", () => {
+  /** The message of the first issue on a thrown validation error. */
+  function issueOf(run: () => unknown): string {
+    try {
+      run();
+    } catch (error) {
+      const issues = (
+        error as { publicData?: { errors?: { message: string }[] } }
+      )?.publicData?.errors;
+      return issues?.[0]?.message ?? String(error);
+    }
+    return "";
+  }
+
+  it("refuses a non-object entry inside a valid array", () => {
+    // Filtering it would drop a block the author meant to ship and leave the
+    // manifest quietly short, while the engine rejects the same element at
+    // registration.
+    const message = issueOf(() =>
+      buildBlockManifest([consumer(), declaring("@acme/a", ["not-a-block"])])
+    );
+
+    expect(message).toContain("@acme/a");
+    expect(message).toContain("index 0");
+  });
+
+  it("refuses a block with no name", () => {
+    const message = issueOf(() =>
+      buildBlockManifest([consumer(), declaring("@acme/a", [{ version: 1 }])])
+    );
+
+    expect(message).toContain("no name");
+  });
+
+  it("refuses a block with no description", () => {
+    // Required by the block API and by the manifest's own contract: it is what
+    // the palette, the docs and an agent read.
+    const message = issueOf(() =>
+      buildBlockManifest([
+        consumer(),
+        declaring("@acme/a", [{ name: "acme/x", version: 1 }]),
+      ])
+    );
+
+    expect(message).toContain("no description");
+  });
+
+  it("refuses the same block name from two plugins, naming both", () => {
+    // The engine throws NEXTLY_BLOCK_COLLISION for the second registration, so
+    // emitting both would hand tooling an ambiguous manifest for a config that
+    // cannot boot.
+    const message = issueOf(() =>
+      buildBlockManifest([
+        consumer(),
+        declaring("@acme/a", [block("acme/dup")]),
+        declaring("@acme/b", [block("acme/dup")]),
+      ])
+    );
+
+    expect(message).toContain("@acme/a");
+    expect(message).toContain("@acme/b");
+  });
+});
+
+describe("assertManifestPathIsFree", () => {
+  it("refuses a types output named like the manifest", () => {
+    // Same directory, same filename: with blocks the types overwrite the
+    // manifest, and with none the cleanup deletes the types output.
+    expect(() =>
+      assertManifestPathIsFree(`/app/src/${BLOCK_MANIFEST_FILENAME}`)
+    ).toThrow();
+  });
+
+  it("accepts an ordinary types output", () => {
+    expect(() =>
+      assertManifestPathIsFree("/app/src/nextly-types.ts")
+    ).not.toThrow();
   });
 });
 

--- a/packages/nextly/src/plugins/codegen/block-manifest.ts
+++ b/packages/nextly/src/plugins/codegen/block-manifest.ts
@@ -78,6 +78,13 @@ export function buildBlockManifest(
   plugins: readonly PluginDefinition[]
 ): BlockManifest {
   const blocks: BlockManifestEntry[] = [];
+  // Nothing can register when the consumer is absent or disabled: a disabled
+  // plugin runs no `init` and contributes no services, so the registry these
+  // declarations would fill never exists. Listing them anyway would tell
+  // tooling the app has blocks it cannot render.
+  if (!isConsumerActive(plugins, PAGE_BUILDER_PLUGIN)) {
+    return { manifestVersion: BLOCK_MANIFEST_VERSION, blocks };
+  }
   for (const declaration of collectDeclarations(plugins, PAGE_BUILDER_PLUGIN)) {
     for (const block of declaredBlocks(declaration.value)) {
       blocks.push(toEntry(block, declaration.source));
@@ -93,7 +100,10 @@ export function buildBlockManifest(
  * empty manifest and an absent one mean the same thing, and only one of them
  * leaves a stale artifact behind when the last block plugin is removed.
  *
- * Placed beside the generated types so it ships with the app.
+ * Placed beside the generated types so it ships with the app. Returning `null`
+ * means "this app has no manifest", which the caller must express by REMOVING
+ * any previous file: writing nothing would leave the last run's manifest on
+ * disk advertising blocks the app no longer has.
  */
 export function buildBlockManifestArtifact(
   plugins: readonly PluginDefinition[],
@@ -107,6 +117,15 @@ export function buildBlockManifestArtifact(
     // does not show a no-newline marker in every diff.
     code: `${JSON.stringify(manifest, null, 2)}\n`,
   };
+}
+
+/** Whether the plugin these declarations are addressed to will actually run. */
+function isConsumerActive(
+  plugins: readonly PluginDefinition[],
+  consumer: string
+): boolean {
+  const found = plugins.find(plugin => plugin.name === consumer);
+  return found !== undefined && found.enabled !== false;
 }
 
 /** The block list inside one declaration, or none when it holds no usable one. */

--- a/packages/nextly/src/plugins/codegen/block-manifest.ts
+++ b/packages/nextly/src/plugins/codegen/block-manifest.ts
@@ -21,6 +21,7 @@
 
 import { join, dirname } from "node:path";
 
+import { NextlyError } from "../../errors";
 import { collectDeclarations } from "../declarations";
 import type { PluginDefinition } from "../plugin-context";
 
@@ -86,7 +87,7 @@ export function buildBlockManifest(
     return { manifestVersion: BLOCK_MANIFEST_VERSION, blocks };
   }
   for (const declaration of collectDeclarations(plugins, PAGE_BUILDER_PLUGIN)) {
-    for (const block of declaredBlocks(declaration.value)) {
+    for (const block of declaredBlocks(declaration.value, declaration.source)) {
       blocks.push(toEntry(block, declaration.source));
     }
   }
@@ -128,13 +129,38 @@ function isConsumerActive(
   return found !== undefined && found.enabled !== false;
 }
 
-/** The block list inside one declaration, or none when it holds no usable one. */
-function declaredBlocks(value: unknown): Record<string, unknown>[] {
+/**
+ * The block list inside one declaration.
+ *
+ * A `blocks` value that is present but not an array is refused rather than read
+ * as empty. The runtime refuses it too, so treating it as "no blocks" here
+ * would emit — or delete — a manifest describing a configuration that cannot
+ * boot, and the first sign of trouble would be a failing start rather than a
+ * failing generate.
+ *
+ * A declaration carrying no `blocks` key at all is not an error: another
+ * version of the page builder may read keys this one does not.
+ */
+function declaredBlocks(
+  value: unknown,
+  source: string
+): Record<string, unknown>[] {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return [];
   }
   const blocks = (value as { blocks?: unknown }).blocks;
-  if (!Array.isArray(blocks)) return [];
+  if (blocks === undefined) return [];
+  if (!Array.isArray(blocks)) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: `contributes.declarations.${PAGE_BUILDER_PLUGIN}.blocks`,
+          code: "INVALID_BLOCK_DECLARATION",
+          message: `Plugin "${source}" declared blocks for the page builder as ${typeof blocks}; it must be an array of block definitions.`,
+        },
+      ],
+    });
+  }
   return blocks.filter(
     (block): block is Record<string, unknown> =>
       typeof block === "object" && block !== null && !Array.isArray(block)

--- a/packages/nextly/src/plugins/codegen/block-manifest.ts
+++ b/packages/nextly/src/plugins/codegen/block-manifest.ts
@@ -19,7 +19,7 @@
  * @module plugins/codegen/block-manifest
  */
 
-import { join, dirname } from "node:path";
+import { join, dirname, basename } from "node:path";
 
 import { NextlyError } from "../../errors";
 import { collectDeclarations } from "../declarations";
@@ -86,9 +86,20 @@ export function buildBlockManifest(
   if (!isConsumerActive(plugins, PAGE_BUILDER_PLUGIN)) {
     return { manifestVersion: BLOCK_MANIFEST_VERSION, blocks };
   }
+  // Where each name came from, so a collision names both plugins rather than
+  // just the one that lost.
+  const declaredBy = new Map<string, string>();
   for (const declaration of collectDeclarations(plugins, PAGE_BUILDER_PLUGIN)) {
     for (const block of declaredBlocks(declaration.value, declaration.source)) {
-      blocks.push(toEntry(block, declaration.source));
+      const entry = toEntry(block, declaration.source);
+      const firstSource = declaredBy.get(entry.name);
+      if (firstSource !== undefined) {
+        throw invalidDeclaration(
+          `Block "${entry.name}" is declared by both "${firstSource}" and "${declaration.source}". Block names are global, so one of them has to change.`
+        );
+      }
+      declaredBy.set(entry.name, declaration.source);
+      blocks.push(entry);
     }
   }
   blocks.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
@@ -106,6 +117,25 @@ export function buildBlockManifest(
  * any previous file: writing nothing would leave the last run's manifest on
  * disk advertising blocks the app no longer has.
  */
+export function assertManifestPathIsFree(typesOutputPath: string): void {
+  // The manifest sits beside the generated types, so a types file named
+  // `blocks.manifest.json` resolves to the same path. With blocks declared the
+  // manifest is written and then overwritten by the types; with none, the
+  // cleanup deletes the types output the user asked for. Both are silent, and
+  // one destroys work, so the collision is refused before either happens.
+  if (basename(typesOutputPath) === BLOCK_MANIFEST_FILENAME) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "typescript.outputFile",
+          code: "OUTPUT_PATH_COLLISION",
+          message: `The generated types output cannot be named "${BLOCK_MANIFEST_FILENAME}": the block manifest is written to that name in the same directory, and one would overwrite or delete the other.`,
+        },
+      ],
+    });
+  }
+}
+
 export function buildBlockManifestArtifact(
   plugins: readonly PluginDefinition[],
   typesOutputPath: string
@@ -118,6 +148,26 @@ export function buildBlockManifestArtifact(
     // does not show a no-newline marker in every diff.
     code: `${JSON.stringify(manifest, null, 2)}\n`,
   };
+}
+
+/**
+ * A generation-time refusal, addressed at the declaration that caused it.
+ *
+ * Generation must not be more permissive than boot. Anything the page builder
+ * would reject when it registers has to fail here too, or `generate:types`
+ * reports success -- and may delete the previous manifest -- for a
+ * configuration that cannot start.
+ */
+function invalidDeclaration(message: string): NextlyError {
+  return NextlyError.validation({
+    errors: [
+      {
+        path: `contributes.declarations.${PAGE_BUILDER_PLUGIN}.blocks`,
+        code: "INVALID_BLOCK_DECLARATION",
+        message,
+      },
+    ],
+  });
 }
 
 /** Whether the plugin these declarations are addressed to will actually run. */
@@ -151,20 +201,40 @@ function declaredBlocks(
   const blocks = (value as { blocks?: unknown }).blocks;
   if (blocks === undefined) return [];
   if (!Array.isArray(blocks)) {
-    throw NextlyError.validation({
-      errors: [
-        {
-          path: `contributes.declarations.${PAGE_BUILDER_PLUGIN}.blocks`,
-          code: "INVALID_BLOCK_DECLARATION",
-          message: `Plugin "${source}" declared blocks for the page builder as ${typeof blocks}; it must be an array of block definitions.`,
-        },
-      ],
-    });
+    throw invalidDeclaration(
+      `Plugin "${source}" declared blocks for the page builder as ${typeof blocks}; it must be an array of block definitions.`
+    );
   }
-  return blocks.filter(
-    (block): block is Record<string, unknown> =>
-      typeof block === "object" && block !== null && !Array.isArray(block)
-  );
+  return blocks.map((block, index) => {
+    // Filtering a bad element would drop a block the author meant to ship and
+    // leave the manifest quietly short; the engine rejects the same element at
+    // registration, so it fails here instead.
+    if (typeof block !== "object" || block === null || Array.isArray(block)) {
+      throw invalidDeclaration(
+        `Plugin "${source}" declared a block at index ${index} that is ${describeKind(block)}; each entry must be a block definition.`
+      );
+    }
+    const definition = block as Record<string, unknown>;
+    if (typeof definition.name !== "string" || definition.name.length === 0) {
+      throw invalidDeclaration(
+        `Plugin "${source}" declared a block at index ${index} with no name.`
+      );
+    }
+    if (typeof definition.version !== "number") {
+      throw invalidDeclaration(
+        `Block "${definition.name}" from "${source}" has no numeric version.`
+      );
+    }
+    if (
+      typeof definition.description !== "string" ||
+      definition.description.length === 0
+    ) {
+      throw invalidDeclaration(
+        `Block "${definition.name}" from "${source}" has no description. Every block needs one, for the palette, the docs and the manifest.`
+      );
+    }
+    return definition;
+  });
 }
 
 /**
@@ -191,6 +261,12 @@ function toEntry(
   if (isRecord(block.supports)) entry.supports = block.supports;
   if (isRecord(block.slots)) entry.slots = block.slots;
   return entry;
+}
+
+/** A short, safe description of a bad value, for an error a human reads. */
+function describeKind(value: unknown): string {
+  if (value === null) return "null";
+  return Array.isArray(value) ? "an array" : `a ${typeof value}`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/nextly/src/plugins/codegen/block-manifest.ts
+++ b/packages/nextly/src/plugins/codegen/block-manifest.ts
@@ -1,0 +1,153 @@
+/**
+ * The block manifest: what blocks this app has, as data.
+ *
+ * A block's definition lives in a plugin and is registered into a per-boot
+ * registry, so the only way to ask "what blocks exist here?" has been to boot
+ * the app and inspect it. That is not available to the things that most need
+ * the answer — an editor build, a docs page, an agent writing a page document —
+ * so the manifest states it as a file instead.
+ *
+ * Emitted from what plugins DECLARED (`contributes.declarations`), never from
+ * the runtime registry, which is what lets generation stay a pure read of the
+ * config: no plugin boots, no database opens. A block registered imperatively
+ * from `init` is deliberately absent — it is not knowable without running the
+ * plugin, and a manifest that were sometimes complete would be worse than one
+ * whose rule is stated.
+ *
+ * Pure — no IO. The CLI writes the returned string.
+ *
+ * @module plugins/codegen/block-manifest
+ */
+
+import { join, dirname } from "node:path";
+
+import { collectDeclarations } from "../declarations";
+import type { PluginDefinition } from "../plugin-context";
+
+/** Filename of the generated block manifest. */
+export const BLOCK_MANIFEST_FILENAME = "blocks.manifest.json";
+
+/**
+ * The consumer key block declarations are addressed to. Stated here rather than
+ * imported so core carries no dependency on the page builder; it is the same
+ * string that plugin publishes.
+ */
+export const PAGE_BUILDER_PLUGIN = "@nextlyhq/plugin-page-builder";
+
+/**
+ * The manifest's own version, bumped when its SHAPE changes.
+ *
+ * Separate from any block's `version`, which describes one block's props. A
+ * reader checks this to know whether it understands the file at all.
+ */
+export const BLOCK_MANIFEST_VERSION = 1;
+
+/** One block, as the manifest states it. */
+export interface BlockManifestEntry {
+  name: string;
+  /** The block's own schema version, stamped onto every node of its type. */
+  version: number;
+  description: string;
+  /** The plugin that declared it, so a reader knows what to install. */
+  source: string;
+  /** A worked instance, for previews and few-shot prompting. */
+  example?: unknown;
+  /** Prop schemas keyed by prop name. */
+  props?: Record<string, unknown>;
+  /** Style capabilities the block opts into. */
+  supports?: Record<string, unknown>;
+  /** Named child regions, for container blocks. */
+  slots?: Record<string, unknown>;
+}
+
+/** The emitted document. */
+export interface BlockManifest {
+  manifestVersion: number;
+  blocks: BlockManifestEntry[];
+}
+
+/**
+ * Build the manifest from what plugins declared.
+ *
+ * Blocks are sorted by name so the emitted file is stable: an artifact that
+ * reordered itself when plugins were reordered would show a diff on every
+ * unrelated config edit, and a drift test could not tell a real change from a
+ * shuffle.
+ */
+export function buildBlockManifest(
+  plugins: readonly PluginDefinition[]
+): BlockManifest {
+  const blocks: BlockManifestEntry[] = [];
+  for (const declaration of collectDeclarations(plugins, PAGE_BUILDER_PLUGIN)) {
+    for (const block of declaredBlocks(declaration.value)) {
+      blocks.push(toEntry(block, declaration.source));
+    }
+  }
+  blocks.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  return { manifestVersion: BLOCK_MANIFEST_VERSION, blocks };
+}
+
+/**
+ * Decide whether to emit a manifest and where. Returns `null` when no plugin
+ * declared a block, so the caller writes no file rather than an empty one — an
+ * empty manifest and an absent one mean the same thing, and only one of them
+ * leaves a stale artifact behind when the last block plugin is removed.
+ *
+ * Placed beside the generated types so it ships with the app.
+ */
+export function buildBlockManifestArtifact(
+  plugins: readonly PluginDefinition[],
+  typesOutputPath: string
+): { path: string; code: string } | null {
+  const manifest = buildBlockManifest(plugins);
+  if (manifest.blocks.length === 0) return null;
+  return {
+    path: join(dirname(typesOutputPath), BLOCK_MANIFEST_FILENAME),
+    // Trailing newline so the file is well-formed for line-based tooling and
+    // does not show a no-newline marker in every diff.
+    code: `${JSON.stringify(manifest, null, 2)}\n`,
+  };
+}
+
+/** The block list inside one declaration, or none when it holds no usable one. */
+function declaredBlocks(value: unknown): Record<string, unknown>[] {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return [];
+  }
+  const blocks = (value as { blocks?: unknown }).blocks;
+  if (!Array.isArray(blocks)) return [];
+  return blocks.filter(
+    (block): block is Record<string, unknown> =>
+      typeof block === "object" && block !== null && !Array.isArray(block)
+  );
+}
+
+/**
+ * One declared block as a manifest entry.
+ *
+ * `render` and `resolve` are functions and are deliberately dropped: they
+ * cannot be serialized, and a manifest is a description of what a block accepts
+ * rather than of how it draws. Everything kept is data the declaration already
+ * holds, copied rather than reshaped, so the file and the definition cannot
+ * drift into different vocabularies.
+ */
+function toEntry(
+  block: Record<string, unknown>,
+  source: string
+): BlockManifestEntry {
+  const entry: BlockManifestEntry = {
+    name: typeof block.name === "string" ? block.name : "",
+    version: typeof block.version === "number" ? block.version : 0,
+    description: typeof block.description === "string" ? block.description : "",
+    source,
+  };
+  if (block.example !== undefined) entry.example = block.example;
+  if (isRecord(block.props)) entry.props = block.props;
+  if (isRecord(block.supports)) entry.supports = block.supports;
+  if (isRecord(block.slots)) entry.slots = block.slots;
+  return entry;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
`nextly generate:types` now emits `blocks.manifest.json` beside the generated types. First slice of PR-9, built on the declaration channel from #446.

## Why

The only way to ask "what blocks does this app have?" has been to boot the app and inspect the per-boot registry. The things that most need the answer cannot do that: an editor build, a docs page, an agent writing a page document. The manifest states it as data.

## What it contains

Per block: `name`, schema `version`, `description`, worked `example`, `props`, `supports`, `slots`, and `source` — the plugin that declared it, so a reader knows what to install.

`render` and `resolve` are dropped: they are functions, and a manifest describes what a block accepts rather than how it draws.

## Two design points worth review

**Built from declarations, never from the runtime registry.** That is what keeps generation a pure read of the config — no plugin boots, no database opens. A block registered imperatively from `init` is therefore absent. That is deliberate and stated in the module: it cannot be known without running the plugin, and a manifest that were *sometimes* complete would be worse than one whose rule is explicit.

**Nothing is emitted when nothing is declared.** An empty manifest and an absent one mean the same thing, but only one of them leaves a stale file behind when the last block plugin is removed.

## Verification

- **Stub-verified, both precise.** Removing the name sort fails only `sorts blocks by name so the artifact is stable`. Removing the empty guard fails only `emits nothing when no plugin declared a block`.
- nextly unit: **400 failed / 37 failed files — the baseline exactly.** 7 new tests.
- plugin-sdk suite run explicitly (14/14) — the export-surface snapshot that caught me on #446.
- check-types, lint clean.

**One thing worth recording:** on an unbuilt worktree, `@typescript-eslint/no-unnecessary-type-assertion` reported 18 errors across files I never touched, because the rule is type-aware and types could not resolve. Building first cleared all 18. A type-aware lint result on an unbuilt tree is not a signal.

## Deliberately not in this PR

The zod self-validation schema, the `generate:manifest` CI subcommand, and the lint that fails generation on a missing description/example. Those are additive on top of this emitter; splitting them keeps this reviewable.
