### PR TITLE
feat(nextly): add draft read option to fetch a working draft

### DIFF
--- a/.changeset/draft-read-option.md
+++ b/.changeset/draft-read-option.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Add a `draft` read option to fetch a document's pending working draft.
+
+`nextly.findByID({ collection, id, draft: true })` and the REST `?draft=true` query parameter now return a published document's pending working draft in place of the live version. Access is gated on edit capability: a caller who cannot update the document still receives the published version, so this never exposes a draft to a read-only reader. Only non-localized collections with draft/published status and drafts-enabled versioning have a working draft to return.

--- a/packages/nextly/src/direct-api/namespaces/collections.ts
+++ b/packages/nextly/src/direct-api/namespaces/collections.ts
@@ -121,6 +121,9 @@ export async function findByID<TSlug extends CollectionSlug>(
       richTextFormat: config.richTextFormat,
       overrideAccess: config.overrideAccess,
       user: config.user,
+      // Overlay the pending working draft when the caller opts in; the service
+      // still gates it on an update-capability probe.
+      includeWorkingDraft: args.draft,
       // i18n M4: forward the content locale + fallback so localized fields resolve.
       locale: config.locale,
       fallbackLocale: config.fallbackLocale,

--- a/packages/nextly/src/direct-api/types/collections.ts
+++ b/packages/nextly/src/direct-api/types/collections.ts
@@ -149,6 +149,18 @@ export interface FindByIDArgs<TSlug extends CollectionSlug = CollectionSlug>
   id: string;
 
   /**
+   * Return the pending working draft in place of the live row when one exists
+   * (draft/published split). Mirrors the read-side `draft` parameter in
+   * Payload's `findByID`. Effective only on a drafts-enabled, non-localized
+   * collection with the `status` lifecycle, and gated by an update-capability
+   * probe: a caller who cannot edit the document still gets the published row,
+   * so this never exposes a draft to a read-only caller.
+   *
+   * @default false
+   */
+  draft?: boolean;
+
+  /**
    * Specific fields to include/exclude.
    */
   select?: Record<string, boolean>;

--- a/packages/nextly/src/direct-api/types/users.ts
+++ b/packages/nextly/src/direct-api/types/users.ts
@@ -86,8 +86,14 @@ export interface FindOneUserArgs extends DirectAPIConfig {
 
 /**
  * Arguments for finding a user by ID.
+ *
+ * `draft` is omitted from the shared find-by-ID options: the working-draft
+ * overlay applies to drafts-enabled content collections, and the users
+ * namespace does not forward it, so exposing it here would advertise an option
+ * that is silently ignored.
  */
-export interface FindUserByIDArgs extends Omit<FindByIDArgs, "collection"> {
+export interface FindUserByIDArgs
+  extends Omit<FindByIDArgs, "collection" | "draft"> {
   /** User collection slug (defaults to 'users') */
   collection?: string;
 }

--- a/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-read-access.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-read-access.test.ts
@@ -142,6 +142,34 @@ describe("collection read handlers forward the caller to the query service", () 
     expect(args).toHaveProperty("authenticatedScope");
   });
 
+  it("getEntry forwards the working-draft overlay opt-in from ?draft=true", async () => {
+    // Without this the merged draft/published-split engine is unreachable over
+    // HTTP: the query service honors `includeWorkingDraft`, but nothing sets it.
+    const getEntry = vi.fn().mockResolvedValue(docResult);
+    await dispatchCollections(
+      makeContainer({ getEntry }),
+      "getEntry",
+      { ...authedParams, entryId: "e1", draft: "true" },
+      undefined
+    );
+
+    expect(getEntry.mock.calls[0][0].includeWorkingDraft).toBe(true);
+  });
+
+  it("getEntry leaves the working-draft opt-in off when ?draft is absent", async () => {
+    // The overlay is opt-in: a plain read must keep returning the live row, so
+    // the flag is explicitly false rather than undefined-and-forgotten.
+    const getEntry = vi.fn().mockResolvedValue(docResult);
+    await dispatchCollections(
+      makeContainer({ getEntry }),
+      "getEntry",
+      { ...authedParams, entryId: "e1" },
+      undefined
+    );
+
+    expect(getEntry.mock.calls[0][0].includeWorkingDraft).toBe(false);
+  });
+
   it("countEntries counts under the same caller context listEntries filters by", async () => {
     const listEntries = vi.fn().mockResolvedValue(listResult);
     const countEntries = vi.fn().mockResolvedValue(countResult);

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -1174,6 +1174,11 @@ const COLLECTIONS_METHODS: Record<
         select: parseSelectParam(p.select),
         richTextFormat: parseRichTextFormat(p.richTextFormat),
         status,
+        // `?draft=true` overlays the pending working draft in place of the live
+        // row (draft/published split), matching Payload's read-side `draft`
+        // parameter. The service gates it on an update-capability probe, so a
+        // read-only caller passing it still receives the published row.
+        includeWorkingDraft: isTruthyParam(p.draft),
         // i18n M4: `?locale=` selects the content language; `?fallback-locale=none`
         // disables fallback. Non-localized collections ignore both.
         locale: p.locale,

--- a/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/draft-published-split.integration.test.ts
@@ -213,6 +213,41 @@ describe("draft/published split — updateEntry (integration)", () => {
     );
   });
 
+  it("makes the working draft reachable through the Direct API findByID draft option", async () => {
+    // End-to-end reachability: the split engine's read overlay is dormant unless
+    // a caller-facing surface forwards the opt-in. This drives the full
+    // Direct API -> handler -> entry service -> query service chain.
+    const entries = await boot();
+    const ctx = { collectionName: COLLECTION, overrideAccess: true };
+
+    await entries.createEntry(ctx, { title: "live", status: "published" });
+    const [row] = await handle!.adapter.select<LiveRow>(TABLE);
+    const id = row.id;
+
+    // Stash a pending edit as the working draft (a trusted status-less save).
+    await entries.updateEntry(
+      { ...ctx, entryId: id },
+      { title: "edited-in-draft" }
+    );
+
+    // A plain findByID returns the live published row.
+    const live = await handle!.nextly.findByID({
+      collection: COLLECTION,
+      id,
+      overrideAccess: true,
+    });
+    expect((live as { title?: string } | null)?.title).toBe("live");
+
+    // The `draft: true` opt-in surfaces the pending working draft instead.
+    const draft = await handle!.nextly.findByID({
+      collection: COLLECTION,
+      id,
+      draft: true,
+      overrideAccess: true,
+    });
+    expect((draft as { title?: string } | null)?.title).toBe("edited-in-draft");
+  });
+
   it("surfaces the working draft to an access-enforced authenticated editor, but not to an anonymous read", async () => {
     // A collection whose reads are access-enforced: only an authenticated caller
     // reads it, and everyone who reads it may also update it.

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -595,6 +595,14 @@ export class CollectionsHandler {
      * pass 'all' to see drafts too. Forwarded to query service as-is.
      */
     status?: "published" | "draft" | "all";
+    /**
+     * Opt in to the working-draft overlay (draft/published split): a trusted
+     * editor read returns the pending working draft in place of the live row.
+     * Forwarded wholesale to the entry/query service, which gates it on an
+     * update-capability probe, so a read-only caller passing it still sees the
+     * live row.
+     */
+    includeWorkingDraft?: boolean;
     /** Requested content locale (i18n M4) — forwarded to the query service. */
     locale?: string;
     /** Fallback control (`false`/`"none"` disables fallback). */


### PR DESCRIPTION
## What

Threads the working-draft overlay opt-in through the collection read surfaces so the draft/published split (merged in #428) becomes reachable for callers:

- **Direct API:** `nextly.findByID({ collection, id, draft: true })` returns a published document's pending working draft in place of the live row.
- **REST:** `GET /collections/{slug}/entries/{id}?draft=true` does the same over HTTP.

The internal option is `includeWorkingDraft`; the public surface is `draft` (matching Payload's read-side `draft` parameter). The name stays distinct from the `?status=` lifecycle filter, which they can be combined with.

## Why

The query service already implemented and honored `includeWorkingDraft`, but no caller-facing surface set it, so the engine merged in #428 was dormant on the read side: users stored working drafts but could not read them back. This is the first follow-up (the read half of reachability).

## Access

The overlay is gated in the query service on an **update-capability probe** (or `overrideAccess`). A caller who can read but not update the document still receives the published version, so `?draft=true` never exposes a draft to a read-only or anonymous reader. Absent → the flag is explicitly `false`, so a plain read is unchanged.

## Scope

Server-side read reachability only. The admin panel requesting the draft (paired with a pending-changes indicator so an editor always has a visual signal), draft-enabling admin saves, and the batch/tx write paths follow in subsequent PRs.

## Tests

- **Unit** (`collection-dispatcher-read-access.test.ts`): `?draft=true` → `includeWorkingDraft: true`; absent → `false`.
- **Integration** (`draft-published-split.integration.test.ts`): end-to-end through the Direct API — `findByID` returns the live row by default and the working draft with `draft: true` (drives handler → entry service → query service).
- Both were verified to fail when the forwarding is neutralized, then pass when restored.
- Full `collections/services` + `versions` integration regression green (110 passed, 4 dialect-skipped); the 9 unrelated stale-mock unit failures are the known pre-existing baseline (confirmed identical with the change stashed).

One changeset (all fixed-group packages, patch).