### PR TITLE
fix(nextly): keep the publishing state when localization is turned off

### DIFF
--- a/.changeset/i18n-disable-publishing-state.md
+++ b/.changeset/i18n-disable-publishing-state.md
@@ -1,0 +1,25 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Turning localization off now brings an entry back with the publishing state it was actually published under. Publishing is per language while an entity is localized, so an entry published only under a language that is not your default carried that state on its translation row alone — and the disable drops that table straight after restoring, so the state was lost for good. A draft could become publicly visible, or live content disappear.

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -790,6 +790,11 @@ const COLLECTIONS_METHODS: Record<
             status: collection.status === true,
             wasLocalized,
             isLocalized,
+            // The PERSISTED status, which is what the disable restore needs: it decides whether
+            // main carried `status` and the companion `_status` before this apply. `collection`
+            // here is the registry record, so this is the prior state for the same reason
+            // `wasLocalized` above is.
+            wasStatus: collection.status === true,
             oldFields,
             newFields,
             companionExists,

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -240,6 +240,8 @@ async function reconcileComponentCompanion(args: {
     defaultLocale,
     // Components are never Draft/Published — companion has no `_status`.
     status: false,
+    // And never had one, so the disable restore has no status to carry back.
+    wasStatus: false,
     wasLocalized,
     isLocalized: localized,
     oldFields,

--- a/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/single-dispatcher.ts
@@ -250,10 +250,26 @@ async function reconcileSingleCompanion(args: {
   /** Localization state BEFORE this save (persisted). Drives enable/disable detection. */
   wasLocalized: boolean;
   status: boolean;
+  /**
+   * Whether the single had Draft/Published BEFORE this apply.
+   *
+   * Separate from `status` because the disable restore asks a different question: not what the
+   * single is being saved as, but whether main carried `status` and the companion `_status`
+   * beforehand — a copy from columns that were not there fails the whole migration.
+   */
+  wasStatus: boolean;
   adapter: DrizzleAdapter;
 }): Promise<void> {
-  const { slug, tableName, oldFields, newFields, localized, status, adapter } =
-    args;
+  const {
+    slug,
+    tableName,
+    oldFields,
+    newFields,
+    localized,
+    status,
+    wasStatus,
+    adapter,
+  } = args;
   const wasLocalized = args.wasLocalized;
   // Nothing to do when the single was and remains non-localized.
   if (!wasLocalized && !localized) return;
@@ -284,6 +300,7 @@ async function reconcileSingleCompanion(args: {
     newFields,
     companionExists,
     companionHasStatus,
+    wasStatus,
     // Which translatable columns the main table still carries. A disable must not re-add one that
     // is already there, and must still restore it: presence says the column exists, never that its
     // value is current, because every localized write went to the companion alone.
@@ -712,6 +729,8 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
                 // A brand-new single was never localized before, so a localized create is a
                 // create-only companion (no seed/drop) rather than an enable transition.
                 wasLocalized: false,
+                // A single being created has no prior state at all.
+                wasStatus: false,
                 status: b.status === true,
                 adapter,
               });
@@ -1298,6 +1317,9 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
                   localized: isLocalized,
                   wasLocalized,
                   status: hasStatus,
+                  // Already computed above from the persisted record, for the shared ALTER. The
+                  // disable restore needs the same fact.
+                  wasStatus,
                   adapter,
                 });
               } catch (companionErr) {
@@ -1346,10 +1368,13 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
             const tableName = existing.tableName;
             const existingFields =
               existing.fields as unknown as FieldDefinition[];
+            // What the single is being saved AS, and what it currently IS. The disable restore
+            // needs the second: whether main carried `status` and the companion `_status` before
+            // this apply.
+            const wasStatus =
+              (existing as { status?: boolean }).status === true;
             const hasStatus =
-              b.status !== undefined
-                ? b.status === true
-                : (existing as { status?: boolean }).status === true;
+              b.status !== undefined ? b.status === true : wasStatus;
             await reconcileSingleCompanion({
               slug,
               tableName,
@@ -1358,6 +1383,7 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
               localized: isLocalized,
               wasLocalized,
               status: hasStatus,
+              wasStatus,
               adapter,
             });
             // Re-register the main runtime table so it reflects the new column shape: a disable
@@ -1618,6 +1644,9 @@ const SINGLES_METHODS: Record<string, MethodHandler<SinglesServices>> = {
           // seeds/restores existing rows rather than only creating an empty companion.
           wasLocalized: (single as { localized?: boolean }).localized === true,
           status: single.status === true,
+          // Read from the same persisted record as `wasLocalized`, so both describe the state
+          // before this apply.
+          wasStatus: single.status === true,
           adapter,
         });
       } catch (err) {

--- a/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
+++ b/packages/nextly/src/domains/dynamic-collections/services/dynamic-collection-service.ts
@@ -385,6 +385,8 @@ export class DynamicCollectionService extends BaseService {
     wasLocalized: boolean;
     isLocalized: boolean;
     status: boolean;
+    /** Whether the entity HAD Draft/Published before this save — see `wasStatus` on the args. */
+    wasStatus: boolean;
   }): Promise<{ sql: string; localSql?: string; needsArchive: boolean }> {
     const companionTable = `${args.tableName}_locales`;
     const companionExists = await this.adapter.tableExists(companionTable);
@@ -409,6 +411,7 @@ export class DynamicCollectionService extends BaseService {
       newFields: args.newFields,
       companionExists,
       companionHasStatus,
+      wasStatus: args.wasStatus,
     };
 
     // Which translatable columns the main table still carries. A disable must not re-add one that
@@ -722,6 +725,7 @@ export class DynamicCollectionService extends BaseService {
           wasLocalized: collectionWasLocalized,
           isLocalized: collectionIsLocalized,
           status: hasStatus,
+          wasStatus,
         });
         const archiveSQL = needsArchive
           ? this.toBreakpointSql(getI18nArchiveDdl(this.adapter.dialect))
@@ -787,6 +791,7 @@ export class DynamicCollectionService extends BaseService {
         wasLocalized: collectionWasLocalized,
         isLocalized: collectionIsLocalized,
         status: hasStatus,
+        wasStatus: wasStatusForUpdate,
       });
       const archiveSQL = needsArchive
         ? this.toBreakpointSql(getI18nArchiveDdl(this.adapter.dialect))

--- a/packages/nextly/src/domains/i18n/migration/__tests__/companion-transition.integration.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/__tests__/companion-transition.integration.test.ts
@@ -367,6 +367,38 @@ describe("buildCompanionTransitionStatements — disable with Draft/Published", 
     expect(row.status).toBe("published");
   });
 
+  it("leaves status alone when Draft/Published is turned off in the same save", () => {
+    // Main's `status` column is being dropped by the shared ALTER, and whether that runs before or
+    // after this plan differs by flow: the single schema path applies it first, the collection path
+    // second. Copying into a column that is going away is pointless in both and fails outright in
+    // the one that removes it first, leaving the schema half-applied.
+    const enable = buildCompanionTransitionStatements(
+      withStatus({
+        status: true,
+        wasLocalized: false,
+        isLocalized: true,
+        companionExists: false,
+      })
+    );
+    sqlite.prepare(`ALTER TABLE "single_hero" ADD COLUMN "status" text`).run();
+    sqlite.prepare(`UPDATE "single_hero" SET "status" = 'draft'`).run();
+    run(enable.statements);
+
+    const plan = buildCompanionTransitionStatements(
+      withStatus({
+        // Localization AND Draft/Published both going off.
+        status: false,
+        wasStatus: true,
+        wasLocalized: true,
+        isLocalized: false,
+        companionExists: true,
+        companionHasStatus: true,
+      })
+    );
+
+    expect(plan.statements.join("\n")).not.toContain(`"_status"`);
+  });
+
   it("leaves status alone when the entity did not have it before this save", () => {
     // Turning Draft/Published ON in the same save that disables localization. The old companion
     // has no `_status` and main has not been given `status` yet, because a disable runs the

--- a/packages/nextly/src/domains/i18n/migration/__tests__/companion-transition.integration.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/__tests__/companion-transition.integration.test.ts
@@ -297,3 +297,102 @@ describe("buildCompanionTransitionStatements — disable", () => {
     expect(companionStillThere).toBeUndefined();
   });
 });
+
+/**
+ * Disabling localization must bring a row's publishing state back with its content.
+ *
+ * Publishing is per locale while an entity is localized, so a row published only under a
+ * non-default language carries that state on its companion row alone. This transition archives the
+ * other languages and then DROPS the companion, so content restored without the state it was
+ * published under cannot be corrected afterwards: a draft becomes publicly visible, or live content
+ * disappears.
+ *
+ * Driven against a real database rather than asserted on SQL text, because the defect this replaces
+ * was a condition that could never be true — a text assertion would have kept passing while the
+ * copy never ran.
+ */
+describe("buildCompanionTransitionStatements — disable with Draft/Published", () => {
+  const withStatus = (over: Record<string, unknown>) => ({
+    slug: "hero",
+    tableName: "single_hero",
+    dialect: "sqlite" as const,
+    defaultLocale: "en",
+    oldFields: FIELDS,
+    newFields: FIELDS,
+    ...over,
+  });
+
+  it("carries the restored row's publishing state onto main", () => {
+    // What the shared ALTER gives a status-enabled entity. The fixture builds the main table
+    // without it, and the transition statements deliberately do not add it — that is the other
+    // migration's job.
+    sqlite.prepare(`ALTER TABLE "single_hero" ADD COLUMN "status" text`).run();
+    // The seed copies main's status into the companion's NOT NULL `_status`, so main has to hold
+    // one before the enable runs.
+    sqlite.prepare(`UPDATE "single_hero" SET "status" = 'draft'`).run();
+    const enable = buildCompanionTransitionStatements(
+      withStatus({
+        status: true,
+        wasLocalized: false,
+        isLocalized: true,
+        companionExists: false,
+      })
+    );
+    run(enable.statements);
+    // Published under a language that is not the default, which is where main is deliberately left
+    // alone while the entity is localized.
+    sqlite
+      .prepare(
+        `UPDATE "single_hero_locales" SET "_status" = 'published' WHERE "_locale" = 'en'`
+      )
+      .run();
+    sqlite.prepare(`UPDATE "single_hero" SET "status" = 'draft'`).run();
+
+    const plan = buildCompanionTransitionStatements(
+      withStatus({
+        status: true,
+        wasStatus: true,
+        wasLocalized: true,
+        isLocalized: false,
+        companionExists: true,
+        companionHasStatus: true,
+      })
+    );
+    run(getI18nArchiveDdl("sqlite"));
+    run(plan.statements);
+
+    const row = sqlite
+      .prepare(`SELECT "status" FROM "single_hero" WHERE "id" = 'h1'`)
+      .get() as { status: string };
+    expect(row.status).toBe("published");
+  });
+
+  it("leaves status alone when the entity did not have it before this save", () => {
+    // Turning Draft/Published ON in the same save that disables localization. The old companion has
+    // no `_status` and main has not been given `status` yet — a disable runs the companion
+    // transition before the shared ALTER — so a copy here would fail the whole migration.
+    const enable = buildCompanionTransitionStatements(
+      withStatus({
+        status: false,
+        wasLocalized: false,
+        isLocalized: true,
+        companionExists: false,
+      })
+    );
+    run(enable.statements);
+
+    const plan = buildCompanionTransitionStatements(
+      withStatus({
+        status: true,
+        wasStatus: false,
+        wasLocalized: true,
+        isLocalized: false,
+        companionExists: true,
+      })
+    );
+    expect(plan.statements.join("\n")).not.toContain(`"_status"`);
+    run(getI18nArchiveDdl("sqlite"));
+    // Runs to completion rather than failing on a column neither table has yet.
+    expect(() => run(plan.statements)).not.toThrow();
+  });
+});

--- a/packages/nextly/src/domains/i18n/migration/__tests__/companion-transition.integration.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/__tests__/companion-transition.integration.test.ts
@@ -307,9 +307,9 @@ describe("buildCompanionTransitionStatements — disable", () => {
  * published under cannot be corrected afterwards: a draft becomes publicly visible, or live content
  * disappears.
  *
- * Driven against a real database rather than asserted on SQL text, because the defect this replaces
- * was a condition that could never be true — a text assertion would have kept passing while the
- * copy never ran.
+ * Driven against a real database rather than asserted on statement text: the point is that the
+ * generated statements EXECUTE and leave main holding the restored row's status. A text assertion
+ * can only say the statement was emitted, which is true of a copy that never runs.
  */
 describe("buildCompanionTransitionStatements — disable with Draft/Published", () => {
   const withStatus = (over: Record<string, unknown>) => ({
@@ -339,8 +339,8 @@ describe("buildCompanionTransitionStatements — disable with Draft/Published", 
       })
     );
     run(enable.statements);
-    // Published under a language that is not the default, which is where main is deliberately left
-    // alone while the entity is localized.
+    // The row is published in `en`, the default locale — the row a disable restores onto main —
+    // while main itself sits at `draft`, which is what makes the two distinguishable afterwards.
     sqlite
       .prepare(
         `UPDATE "single_hero_locales" SET "_status" = 'published' WHERE "_locale" = 'en'`
@@ -368,9 +368,9 @@ describe("buildCompanionTransitionStatements — disable with Draft/Published", 
   });
 
   it("leaves status alone when the entity did not have it before this save", () => {
-    // Turning Draft/Published ON in the same save that disables localization. The old companion has
-    // no `_status` and main has not been given `status` yet — a disable runs the companion
-    // transition before the shared ALTER — so a copy here would fail the whole migration.
+    // Turning Draft/Published ON in the same save that disables localization. The old companion
+    // has no `_status` and main has not been given `status` yet, because a disable runs the
+    // companion transition before the shared ALTER, so a copy here would fail the migration.
     const enable = buildCompanionTransitionStatements(
       withStatus({
         status: false,

--- a/packages/nextly/src/domains/i18n/migration/reconcile-companion.ts
+++ b/packages/nextly/src/domains/i18n/migration/reconcile-companion.ts
@@ -192,6 +192,20 @@ export interface CompanionTransitionArgs {
    * or a migration file leaves behind.
    */
   existingMainColumns?: readonly string[];
+  /**
+   * Whether the entity had Draft/Published BEFORE this change.
+   *
+   * A history fact, unlike {@link CompanionTransitionArgs.existingMainColumns}, which describes
+   * only the database in front of you and is deliberately stripped from the migration artefact.
+   * That distinction is what makes this the right signal for the disable restore: it is equally
+   * true for a database that has only ever replayed migrations.
+   *
+   * It answers exactly what that restore needs — did main carry `status` and the companion
+   * `_status` before this save. Deriving it from the DESIRED status instead would emit a copy from
+   * a `_status` the old companion never had, into a `status` main has not been given yet, because a
+   * disable deliberately runs the companion transition before the shared ALTER that adds it.
+   */
+  wasStatus?: boolean;
   /** Whether the existing companion physically has `_status` (see ReconcileCompanionArgs). */
   companionHasStatus?: boolean;
 }
@@ -316,9 +330,10 @@ export function buildCompanionTransitionStatements(
         // would have this restore read a `_status` the old companion never had — and main receive
         // it before the shared ALTER that adds `status`, because a disable deliberately runs the
         // companion transition first. Both columns have to be there already.
-        restoreStatus:
-          args.companionHasStatus === true &&
-          (args.existingMainColumns?.includes("status") ?? false),
+        // Whether both sides HAD the column before this save. `existingMainColumns` cannot answer
+        // it: it is built from localized user fields, so it never contains `status`, and it is
+        // cleared for the artefact so a migration file cannot depend on local introspection.
+        restoreStatus: args.wasStatus === true,
       }),
       needsArchive: true,
       companionDropped: true,

--- a/packages/nextly/src/domains/i18n/migration/reconcile-companion.ts
+++ b/packages/nextly/src/domains/i18n/migration/reconcile-companion.ts
@@ -335,10 +335,19 @@ export function buildCompanionTransitionStatements(
         // would have this restore read a `_status` the old companion never had — and main receive
         // it before the shared ALTER that adds `status`, because a disable deliberately runs the
         // companion transition first. Both columns have to be there already.
-        // Whether both sides HAD the column before this save. `existingMainColumns` cannot answer
-        // it: it is built from localized user fields, so it never contains `status`, and it is
-        // cleared for the artefact so a migration file cannot depend on local introspection.
-        restoreStatus: args.wasStatus === true,
+        // The column has to be there BEFORE this save and still be there after.
+        //
+        // Before, because the copy reads the companion's `_status` and writes main's `status`, and
+        // neither exists for an entity that did not have Draft/Published. `existingMainColumns`
+        // cannot answer that: it is built from localized user fields, so it never contains
+        // `status`, and it is cleared for the artefact so a migration file cannot depend on local
+        // introspection.
+        //
+        // After, because turning Draft/Published off in the same save drops main's `status`, and
+        // whether that ALTER lands before or after this plan differs by flow — the single schema
+        // path runs it first, the collection path runs it second. Restoring into a column that is
+        // being removed is pointless in both, and fatal in the one that removes it first.
+        restoreStatus: args.wasStatus === true && status === true,
       }),
       needsArchive: true,
       companionDropped: true,

--- a/packages/nextly/src/domains/i18n/migration/reconcile-companion.ts
+++ b/packages/nextly/src/domains/i18n/migration/reconcile-companion.ts
@@ -204,8 +204,13 @@ export interface CompanionTransitionArgs {
    * `_status` before this save. Deriving it from the DESIRED status instead would emit a copy from
    * a `_status` the old companion never had, into a `status` main has not been given yet, because a
    * disable deliberately runs the companion transition before the shared ALTER that adds it.
+   *
+   * REQUIRED rather than optional, and that is the point. An optional history signal is one a
+   * caller can omit without noticing, and the copy it gates then silently stops happening for that
+   * caller alone — which is exactly how this went wrong once already. `undefined` is not a
+   * shorthand for "no status"; a caller that genuinely has none says `false`.
    */
-  wasStatus?: boolean;
+  wasStatus: boolean;
   /** Whether the existing companion physically has `_status` (see ReconcileCompanionArgs). */
   companionHasStatus?: boolean;
 }


### PR DESCRIPTION
Follow-up to #429, which merged with this one finding still open.

## What was wrong

Disabling localization restores each entry's content from its companion and then drops that table. It was supposed to bring the row's publishing state back with the values — publishing is per language while an entity is localized, so an entry published only under a language that is not the default carries that state on its translation row alone.

The gate I wrote for that could never be true:

```ts
restoreStatus: args.companionHasStatus === true &&
  (args.existingMainColumns?.includes("status") ?? false)
```

`existingMainColumns` is built from localized user fields, so it never contains `status`. It is also deliberately cleared when building the migration artefact, so that a replayable file cannot depend on introspecting whichever database happens to be in front of you. And `companionHasStatus` is only probed for a field change on a still-localized entity, never for a disable.

So the copy never ran. Content came back, main kept a stale status, and the companion holding the real one was dropped in the same migration. A draft could become publicly visible, or live content disappear.

## The fix

Gated on `wasStatus` — whether the entity had Draft/Published **before** this save.

That is a history fact rather than local introspection, which is what makes it usable here: it is equally true for a database that has only ever replayed migrations, so it can live in the artefact. And it answers exactly what the copy needs — did main carry `status` and the companion `_status` before this change. It was already computed at the call site for the shared ALTER; it just was not reaching this decision.

Turning Draft/Published on in the same save that disables localization still copies nothing, because neither column exists at that point: a disable deliberately runs the companion transition before the ALTER that adds `status` to main.

## Verification

Two tests, driven against a real SQLite database rather than asserted on statement text — deliberately, because what this replaces was a condition that could never hold, and a text assertion would have kept passing while the copy never ran.

Without the fix the first fails with:

```
AssertionError: expected 'draft' to be 'published'
```

The second covers the same-save case and asserts the migration runs to completion rather than failing on a column neither table has yet.

Unit suite matches `main` (the two `Phase D rename detection` failures are pre-existing there). Full dialect legs running.

## Not in this PR

Two things stay logged on task 078 for the 077 work, because both need the same marker payload evolution:

- the marker does not record which columns the companion owns, so a field made shared and then having its flag deleted in the disabling edit is indistinguishable from one localized until now;
- a run that dies mid-destructive-refresh is now recoverable, but the marker still cannot say what a claim was for beyond that one bit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transitions when disabling localization alongside Draft/Published status.
  * Preserved the default locale’s status information after translated content is archived.
  * Prevented migration issues when Draft/Published status is enabled and localization is changed in the same update.

* **Tests**
  * Added coverage for localization and Draft/Published status transition scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->