### PR TITLE
test(nextly): repair typecheck errors in i18n and bulk test suites

### DIFF
--- a/packages/nextly/src/domains/collections/__tests__/collection-bulk.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/collection-bulk.test.ts
@@ -177,7 +177,11 @@ describe("CollectionEntryService — Bulk Operation Contracts", () => {
       const openTransaction = mockAdapter.transaction as ReturnType<
         typeof vi.fn
       >;
-      const realTransaction = openTransaction.getMockImplementation();
+      // getMockImplementation returns the impl under a loose signature; assert
+      // the known call shape so it can be invoked to preserve real behavior.
+      const realTransaction = openTransaction.getMockImplementation() as
+        | ((fn: (tx: unknown) => Promise<unknown>) => Promise<unknown>)
+        | undefined;
       openTransaction.mockImplementation(
         (fn: (tx: unknown) => Promise<unknown>) => {
           order.push("transaction");

--- a/packages/nextly/src/domains/i18n/companion-join.integration.test.ts
+++ b/packages/nextly/src/domains/i18n/companion-join.integration.test.ts
@@ -76,6 +76,9 @@ describe("populateCompanionFields (real SQLite)", () => {
         localizedFields: [{ name: "body", column: "body" }],
         rows,
         localeChain: ["en"],
+        // "ready" so the empty-rows short-circuit is what returns here, not the
+        // upstream readiness gate (which returns before the rows are inspected).
+        readiness: "ready",
       })
     ).resolves.toBeUndefined();
   });

--- a/packages/nextly/src/domains/i18n/migration/transition-state.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/transition-state.test.ts
@@ -454,7 +454,9 @@ describe("beginI18nTransition", () => {
     });
     const settled = await readI18nTransitionState(store, "collection", "posts");
     expect(
-      settled.status === "untracked" ? undefined : settled.refresh
+      // `refresh` is declared only on the enabling state; on every other
+      // settled state it is absent and reads as undefined.
+      "refresh" in settled ? settled.refresh : undefined
     ).toBeUndefined();
   });
 

--- a/packages/nextly/src/domains/i18n/runtime/companion-readiness.test.ts
+++ b/packages/nextly/src/domains/i18n/runtime/companion-readiness.test.ts
@@ -4,7 +4,7 @@
  * No database: both are decisions made from what has already been observed, and the point of the
  * cache is that the common case reaches no database at all.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   cachedCompanionReadiness,
@@ -127,14 +127,16 @@ describe("companion readiness", () => {
 
 describe("companionNotReadyMessage", () => {
   const withEnv = (value: string | undefined, run: () => void) => {
-    const previous = process.env.NODE_ENV;
-    if (value === undefined) delete process.env.NODE_ENV;
-    else process.env.NODE_ENV = value;
+    // Set NODE_ENV through Vitest's env stubbing rather than assigning
+    // `process.env.NODE_ENV` directly: stubbing restores the original on
+    // `unstubAllEnvs` and goes through an accessor that does not trip the
+    // read-only `NODE_ENV` typing a direct assignment or `delete` runs into.
+    // Passing `undefined` unsets it, covering the "NODE_ENV absent" case.
+    vi.stubEnv("NODE_ENV", value);
     try {
       run();
     } finally {
-      if (previous === undefined) delete process.env.NODE_ENV;
-      else process.env.NODE_ENV = previous;
+      vi.unstubAllEnvs();
     }
   };
 

--- a/packages/nextly/src/domains/i18n/translation-status.integration.test.ts
+++ b/packages/nextly/src/domains/i18n/translation-status.integration.test.ts
@@ -202,6 +202,10 @@ describe("populateTranslationStatus (real SQLite)", () => {
           locales: ["en", "de"],
           defaultLocale: "en",
           hasStatus: true,
+          // A missing companion table resolves as not-ready, so the readiness
+          // gate returns before any query runs — the no-op under test. Passing
+          // "ready" would instead query the absent table and throw.
+          readiness: "pre-migration",
         })
       ).resolves.toBeUndefined();
       expect(rows[0]._translations).toBeUndefined();


### PR DESCRIPTION
## What

Fixes 8 TypeScript errors across 5 test files that break the **Typecheck** CI step on `main`. No production code changes.

## Why

`main`'s \`Lint / Typecheck / Test / Build\` check has been red since #429 (`151efce4c`): `tsc --noEmit -p tsconfig.tests.json` fails on 5 test files, so every branch cut from main inherits a red typecheck. `341890fa1` (pre-#429) typechecks clean; #429 introduced the regressions. This greens the check for all in-flight PRs.

## The 8 errors and their fixes

| File | Error | Fix |
|---|---|---|
| `i18n/runtime/companion-readiness.test.ts` | ×4 — `delete`/assign `process.env.NODE_ENV` (now typed read-only) | route through `vi.stubEnv`/`vi.unstubAllEnvs` (the repo's existing pattern); `undefined` covers the unset case |
| `i18n/companion-join.integration.test.ts` | missing required `readiness` arg | `readiness: "ready"` so the empty-rows short-circuit is exercised, not the readiness gate |
| `i18n/translation-status.integration.test.ts` | missing required `readiness` arg | `readiness: "pre-migration"` — a missing table resolves as not-ready, so the gate returns before querying the absent table (`"ready"` would query and throw) |
| `i18n/migration/transition-state.test.ts` | `refresh` not on all union members | guard with `"refresh" in settled` (declared only on the enabling state) |
| `collections/__tests__/collection-bulk.test.ts` | `getMockImplementation()` result not callable | assert its known call signature |

## Verification

- `pnpm --filter nextly check-types` → **green** (0 errors, was 8).
- All 5 affected suites pass at runtime: 63 unit + 13 integration tests green.
- Behavior-preserving: the `readiness` values were chosen so each test still exercises the path its title describes.

Test-only change, so no changeset.