### PR TITLE
feat(nextly): resolve field-group storage names from the catalog

### DIFF
--- a/.changeset/field-group-storage-name-resolution.md
+++ b/.changeset/field-group-storage-name-resolution.md
@@ -1,0 +1,27 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+Field-group storage is now addressed by the name the database actually holds.
+
+The storage migration renames the field-group registry table and each data table's type discriminator. Every reader resolves those names from the database catalog instead of a constant, so a database that has run the migration and one that has not are both read correctly by the same build. Nothing about stored data changes, and a database that has not migrated behaves exactly as before.

--- a/packages/nextly/src/cli/commands/db-sync.ts
+++ b/packages/nextly/src/cli/commands/db-sync.ts
@@ -64,6 +64,7 @@ import { getDialectTables } from "../../database/index";
 import { SchemaRegistry } from "../../database/schema-registry";
 import { withMigrationExcluded } from "../../domains/field-groups/migration/sync-guard";
 import { registerComponentSchemas } from "../../domains/field-groups/services/register-field-group-schemas";
+import { getFieldGroupRegistryAliases } from "../../domains/field-groups/storage/registry-schemas";
 import { runWithFieldTypes } from "../../domains/schema/field-types/field-type-scope";
 import { describeError } from "../../errors/index";
 import { assertPluginFieldDeclarations } from "../../shared/lib/assert-plugin-field-declarations";
@@ -261,8 +262,13 @@ export async function runDbSync(
     const dialect = (adapter as unknown as DrizzleAdapter).getCapabilities()
       .dialect;
     schemaRegistry = new SchemaRegistry(dialect);
-    const staticSchemas = getDialectTables(dialect);
-    schemaRegistry.registerStaticSchemas(staticSchemas);
+    // Both spellings of the field-group registry: the schema registry keys a
+    // table by the physical name its Drizzle object carries, so a database
+    // whose storage migration has run has no handle for its registry otherwise.
+    schemaRegistry.registerStaticSchemas({
+      ...getDialectTables(dialect),
+      ...getFieldGroupRegistryAliases(dialect),
+    });
     (adapter as unknown as DrizzleAdapter).setTableResolver(schemaRegistry);
     logger.debug("Schema registry initialized with static tables");
   } catch (error) {

--- a/packages/nextly/src/cli/commands/dev-build.ts
+++ b/packages/nextly/src/cli/commands/dev-build.ts
@@ -13,6 +13,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import { PermissionSeedService } from "../../domains/auth/services/permission-seed-service";
 import { teardownEntityComponentData } from "../../domains/field-groups/services/teardown-entity-field-group-data";
+import { resolveFieldGroupRegistryName } from "../../domains/field-groups/storage/resolve-storage-names";
 import { teardownEntityI18n } from "../../domains/i18n/migration/teardown-entity-i18n";
 import {
   bindTransitionRecorder,
@@ -764,7 +765,10 @@ async function handleRemovedComponents(
       });
 
       // Delete registry entry directly
-      await adapter.delete(STORAGE_FORMAT.registryTable, {
+      // Resolved: this delete runs AFTER the nested instances and localized
+      // data are torn down, so addressing a registry that is not there fails
+      // once the dependent content is already gone.
+      await adapter.delete(await resolveFieldGroupRegistryName(adapter), {
         and: [{ column: "slug", op: "=", value: slug }],
       });
 

--- a/packages/nextly/src/cli/commands/dev-server.ts
+++ b/packages/nextly/src/cli/commands/dev-server.ts
@@ -21,6 +21,7 @@ import { generateSqliteCoreTableStatements } from "../../database/sqlite-core-ta
 // MySQL because it has no caller-supplied URL. Once F8 PR 2/3 collapses
 // the two paths, this can collapse back to a single import.
 import { CollectionRegistryService } from "../../domains/collections/services/collection-registry-service";
+import { getFieldGroupRegistryAliases } from "../../domains/field-groups/storage/registry-schemas";
 import { createApplyDesiredSchema } from "../../domains/schema/pipeline/apply";
 import { RealClassifier } from "../../domains/schema/pipeline/classifier/classifier";
 import { extractDatabaseNameFromUrl } from "../../domains/schema/pipeline/database-url";
@@ -245,8 +246,13 @@ export async function performAutoSync(
   // here to wire `setTableResolver` so adapter CRUD on dynamic tables
   // works for the rest of this CLI invocation (seed scripts, etc.).
   const schemaRegistry = new SchemaRegistry(dialect);
-  const staticSchemas = getDialectTables(dialect);
-  schemaRegistry.registerStaticSchemas(staticSchemas);
+  // Both spellings of the field-group registry: the schema registry keys a
+  // table by the physical name its Drizzle object carries, so a database whose
+  // storage migration has run has no handle for its registry otherwise.
+  schemaRegistry.registerStaticSchemas({
+    ...getDialectTables(dialect),
+    ...getFieldGroupRegistryAliases(dialect),
+  });
 
   // F8 PR 1: collections flow through the F2 applyDesiredSchema pipeline
   // (rename detection + classifier + pre-cleanup + pushSchema, all inside

--- a/packages/nextly/src/cli/commands/prune.ts
+++ b/packages/nextly/src/cli/commands/prune.ts
@@ -22,6 +22,7 @@ import { getDialectTables } from "../../database/index";
 import { SchemaRegistry } from "../../database/schema-registry";
 import { CollectionRegistryService } from "../../domains/collections/services/collection-registry-service";
 import { registerComponentSchemas } from "../../domains/field-groups/services/register-field-group-schemas";
+import { getFieldGroupRegistryAliases } from "../../domains/field-groups/storage/registry-schemas";
 import {
   teardownEntityI18n,
   type TeardownI18nAdapter,
@@ -186,7 +187,12 @@ export async function runPruneCommand(
     const drizzleAdapter = adapter as unknown as DrizzleAdapter;
     const { dialect } = drizzleAdapter.getCapabilities();
     const schemaRegistry = new SchemaRegistry(dialect);
-    schemaRegistry.registerStaticSchemas(getDialectTables(dialect));
+    // Both spellings of the field-group registry: a database whose storage
+    // migration has run has no handle for its registry otherwise.
+    schemaRegistry.registerStaticSchemas({
+      ...getDialectTables(dialect),
+      ...getFieldGroupRegistryAliases(dialect),
+    });
     drizzleAdapter.setTableResolver(schemaRegistry);
     await registerComponentSchemas({
       adapter: drizzleAdapter,

--- a/packages/nextly/src/cli/commands/webhooks-prune.ts
+++ b/packages/nextly/src/cli/commands/webhooks-prune.ts
@@ -24,6 +24,7 @@ import type { Command } from "commander";
 
 import { getDialectTables } from "../../database/index";
 import { SchemaRegistry } from "../../database/schema-registry";
+import { getFieldGroupRegistryAliases } from "../../domains/field-groups/storage/registry-schemas";
 import { pruneWebhookData } from "../../domains/webhooks/prune";
 import { describeError } from "../../errors/index";
 import { createContext, type CommandContext } from "../program";
@@ -88,7 +89,12 @@ export async function runWebhooksPruneCommand(
     const drizzleAdapter = adapter as unknown as DrizzleAdapter;
     const { dialect } = drizzleAdapter.getCapabilities();
     const schemaRegistry = new SchemaRegistry(dialect);
-    schemaRegistry.registerStaticSchemas(getDialectTables(dialect));
+    // Both spellings of the field-group registry: a database whose storage
+    // migration has run has no handle for its registry otherwise.
+    schemaRegistry.registerStaticSchemas({
+      ...getDialectTables(dialect),
+      ...getFieldGroupRegistryAliases(dialect),
+    });
     drizzleAdapter.setTableResolver(schemaRegistry);
 
     const dryRun = options.dryRun ?? false;

--- a/packages/nextly/src/di/__tests__/load-dynamic-tables.test.ts
+++ b/packages/nextly/src/di/__tests__/load-dynamic-tables.test.ts
@@ -13,6 +13,12 @@
  */
 import { describe, it, expect, vi } from "vitest";
 
+import { MIGRATION_TARGET } from "../../domains/field-groups/migration/manifest";
+import {
+  forgetFieldGroupStorageNames,
+  resolveFieldGroupRegistryName,
+} from "../../domains/field-groups/storage/resolve-storage-names";
+import { STORAGE_FORMAT } from "../../schemas/storage-format";
 import { loadDynamicTables } from "../load-dynamic-tables";
 
 function makeAdapter(rows: unknown[], opts: { throwOnSelect?: boolean } = {}) {
@@ -217,5 +223,104 @@ describe("loadDynamicTables — fault tolerance", () => {
       "SELECT table_name, fields, slug, status FROM dynamic_collections"
     );
     expect(register).toHaveBeenCalledWith("dc_pages", [], true, false);
+  });
+});
+
+/**
+ * 🔴 The boot pass has to address the registry that is actually there.
+ *
+ * `loadDynamicTables` treats a failed read as the fresh-database case — correct
+ * for a database that has no registry yet, and silent for one whose registry
+ * has been renamed. Addressing the legacy name on a migrated database therefore
+ * registers NOTHING and raises nothing, leaving every field-group table
+ * unaddressable until someone notices reads coming back empty.
+ */
+describe("loadDynamicTables — the field-group registry is resolved, not assumed", () => {
+  function catalogAdapter(tables: string[], rows: unknown[]) {
+    const selected: string[] = [];
+    return {
+      selected,
+      adapter: {
+        dialect: "sqlite" as const,
+        listTables: vi.fn(async () => tables),
+        getDrizzle: <T>(): T => ({}) as T,
+        executeQuery: vi.fn(async (sql: string) => {
+          selected.push(sql);
+          // Only the table this database actually has answers; anything else
+          // fails the way a real driver fails, which is what the boot pass
+          // swallows.
+          const target = tables.find(table => sql.includes(table));
+          if (target === undefined) throw new Error("no such table");
+          return rows;
+        }),
+      },
+    };
+  }
+
+  const componentRow = {
+    table_name: "fg_hero",
+    fields: JSON.stringify([{ name: "heading", type: "text" }]),
+    slug: "hero",
+    localized: 0,
+  };
+
+  it("registers components from the migrated registry after a rename", async () => {
+    forgetFieldGroupStorageNames();
+    const { adapter, selected } = catalogAdapter(
+      [MIGRATION_TARGET.registryTable],
+      [componentRow]
+    );
+    const register = vi.fn(async () => {});
+
+    await loadDynamicTables(
+      adapter as unknown as Parameters<typeof loadDynamicTables>[0],
+      await resolveFieldGroupRegistryName(adapter),
+      register
+    );
+
+    expect(register).toHaveBeenCalledTimes(1);
+    expect(register).toHaveBeenCalledWith(
+      "fg_hero",
+      [{ name: "heading", type: "text" }],
+      false,
+      false
+    );
+    expect(selected.join("\n")).toContain(MIGRATION_TARGET.registryTable);
+  });
+
+  // The migrated registry has no `status` column either, so a branch that only
+  // recognises the legacy spelling would select one that is not there.
+  it("never selects a status column from the migrated registry", async () => {
+    forgetFieldGroupStorageNames();
+    const { adapter, selected } = catalogAdapter(
+      [MIGRATION_TARGET.registryTable],
+      [componentRow]
+    );
+
+    await loadDynamicTables(
+      adapter as unknown as Parameters<typeof loadDynamicTables>[0],
+      await resolveFieldGroupRegistryName(adapter),
+      async () => {}
+    );
+
+    expect(selected.join("\n")).not.toContain("status");
+  });
+
+  it("still addresses the legacy registry on a database that has not migrated", async () => {
+    forgetFieldGroupStorageNames();
+    const { adapter, selected } = catalogAdapter(
+      [STORAGE_FORMAT.registryTable],
+      [{ ...componentRow, table_name: "comp_hero" }]
+    );
+    const register = vi.fn(async () => {});
+
+    await loadDynamicTables(
+      adapter as unknown as Parameters<typeof loadDynamicTables>[0],
+      await resolveFieldGroupRegistryName(adapter),
+      register
+    );
+
+    expect(register).toHaveBeenCalledTimes(1);
+    expect(selected.join("\n")).toContain(STORAGE_FORMAT.registryTable);
   });
 });

--- a/packages/nextly/src/di/load-dynamic-tables.ts
+++ b/packages/nextly/src/di/load-dynamic-tables.ts
@@ -16,7 +16,33 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import type { FieldConfig } from "../collections/fields/types";
+import { MIGRATION_TARGET } from "../domains/field-groups/migration/manifest";
+import {
+  isFieldGroupRegistry,
+  resolveRegistryTableName,
+} from "../domains/field-groups/storage/resolve-storage-names";
 import { STORAGE_FORMAT } from "../schemas/storage-format";
+
+/**
+ * The two names the field-group registry can carry on disk.
+ *
+ * Named rather than inlined because three signatures below accept it, and a
+ * union that lists only the legacy spelling would reject the resolved name at
+ * the call site while the runtime happily addressed it.
+ */
+export type FieldGroupRegistryName =
+  | typeof STORAGE_FORMAT.registryTable
+  | typeof MIGRATION_TARGET.registryTable;
+
+/** The registry this database holds, typed as the union these readers accept. */
+async function resolveFieldGroupRegistry(
+  adapter: DrizzleAdapter
+): Promise<FieldGroupRegistryName> {
+  const name = await resolveRegistryTableName(adapter);
+  return name === MIGRATION_TARGET.registryTable
+    ? MIGRATION_TARGET.registryTable
+    : STORAGE_FORMAT.registryTable;
+}
 
 /**
  * Row shape returned by the `SELECT table_name, fields, slug, status FROM
@@ -50,7 +76,7 @@ export async function loadDynamicTables(
   sourceTable:
     | "dynamic_collections"
     | "dynamic_singles"
-    | typeof STORAGE_FORMAT.registryTable,
+    | FieldGroupRegistryName,
   register: (
     tableName: string,
     fields: unknown[],
@@ -60,8 +86,10 @@ export async function loadDynamicTables(
 ): Promise<void> {
   // Components have no `status` column (they're not Draft/Published) — selecting it
   // would fail. They DO carry `localized` (i18n). Collections/singles carry both.
-  const statusCol =
-    sourceTable !== STORAGE_FORMAT.registryTable ? ", status" : "";
+  // Asked under both registry spellings: the storage migration renames this
+  // table, and comparing against the legacy name alone would add `status` to the
+  // select the moment it has run.
+  const statusCol = isFieldGroupRegistry(sourceTable) ? "" : ", status";
 
   // Read the rows, tolerating an existing DB that predates the i18n `localized`
   // column: try the full select first, and on failure fall back to one without
@@ -137,10 +165,7 @@ export async function loadDynamicSlugs(
   const all = new Set<string>();
   const collections = new Set<string>();
   const read = async (
-    table:
-      | "dynamic_collections"
-      | "dynamic_singles"
-      | typeof STORAGE_FORMAT.registryTable,
+    table: "dynamic_collections" | "dynamic_singles" | FieldGroupRegistryName,
     into?: Set<string>
   ): Promise<void> => {
     try {
@@ -159,7 +184,7 @@ export async function loadDynamicSlugs(
   };
   await read("dynamic_collections", collections);
   await read("dynamic_singles");
-  await read(STORAGE_FORMAT.registryTable);
+  await read(await resolveFieldGroupRegistry(adapter));
   return { all, collections };
 }
 
@@ -191,10 +216,7 @@ export async function loadBuilderEntities(
   adapter: DrizzleAdapter
 ): Promise<LoadedBuilderEntities> {
   const read = async (
-    table:
-      | "dynamic_collections"
-      | "dynamic_singles"
-      | typeof STORAGE_FORMAT.registryTable,
+    table: "dynamic_collections" | "dynamic_singles" | FieldGroupRegistryName,
     hasStatusColumn: boolean
   ): Promise<LoadedBuilderEntity[]> => {
     const selectSql = hasStatusColumn
@@ -231,6 +253,6 @@ export async function loadBuilderEntities(
   return {
     collections: await read("dynamic_collections", true),
     singles: await read("dynamic_singles", true),
-    components: await read(STORAGE_FORMAT.registryTable, false),
+    components: await read(await resolveFieldGroupRegistry(adapter), false),
   };
 }

--- a/packages/nextly/src/di/load-dynamic-tables.ts
+++ b/packages/nextly/src/di/load-dynamic-tables.ts
@@ -162,7 +162,12 @@ export async function loadDynamicSlugs(
   };
   await read("dynamic_collections", collections);
   await read("dynamic_singles");
-  await read(await resolveFieldGroupRegistryName(adapter));
+  try {
+    await read(await resolveFieldGroupRegistryName(adapter));
+  } catch {
+    // Same contract as `read` itself: a catalog probe that cannot answer leaves
+    // the sets as they are rather than failing the boot that called it.
+  }
   return { all, collections };
 }
 
@@ -228,9 +233,22 @@ export async function loadBuilderEntities(
     }
   };
 
+  // The registry NAME is resolved inside the same best-effort boundary as the
+  // read it feeds. Resolving outside it turns a transient catalog failure — a
+  // `listTables` blip, or a denied `lower_case_table_names` query on MySQL —
+  // into a rejection that aborts service registration, where this helper's
+  // whole contract is to answer with an empty list instead.
+  const readComponents = async (): Promise<LoadedBuilderEntity[]> => {
+    try {
+      return await read(await resolveFieldGroupRegistryName(adapter), false);
+    } catch {
+      return [];
+    }
+  };
+
   return {
     collections: await read("dynamic_collections", true),
     singles: await read("dynamic_singles", true),
-    components: await read(await resolveFieldGroupRegistryName(adapter), false),
+    components: await readComponents(),
   };
 }

--- a/packages/nextly/src/di/load-dynamic-tables.ts
+++ b/packages/nextly/src/di/load-dynamic-tables.ts
@@ -16,33 +16,11 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import type { FieldConfig } from "../collections/fields/types";
-import { MIGRATION_TARGET } from "../domains/field-groups/migration/manifest";
 import {
   isFieldGroupRegistry,
-  resolveRegistryTableName,
+  resolveFieldGroupRegistryName,
+  type FieldGroupRegistryName,
 } from "../domains/field-groups/storage/resolve-storage-names";
-import { STORAGE_FORMAT } from "../schemas/storage-format";
-
-/**
- * The two names the field-group registry can carry on disk.
- *
- * Named rather than inlined because three signatures below accept it, and a
- * union that lists only the legacy spelling would reject the resolved name at
- * the call site while the runtime happily addressed it.
- */
-export type FieldGroupRegistryName =
-  | typeof STORAGE_FORMAT.registryTable
-  | typeof MIGRATION_TARGET.registryTable;
-
-/** The registry this database holds, typed as the union these readers accept. */
-async function resolveFieldGroupRegistry(
-  adapter: DrizzleAdapter
-): Promise<FieldGroupRegistryName> {
-  const name = await resolveRegistryTableName(adapter);
-  return name === MIGRATION_TARGET.registryTable
-    ? MIGRATION_TARGET.registryTable
-    : STORAGE_FORMAT.registryTable;
-}
 
 /**
  * Row shape returned by the `SELECT table_name, fields, slug, status FROM
@@ -184,7 +162,7 @@ export async function loadDynamicSlugs(
   };
   await read("dynamic_collections", collections);
   await read("dynamic_singles");
-  await read(await resolveFieldGroupRegistry(adapter));
+  await read(await resolveFieldGroupRegistryName(adapter));
   return { all, collections };
 }
 
@@ -253,6 +231,6 @@ export async function loadBuilderEntities(
   return {
     collections: await read("dynamic_collections", true),
     singles: await read("dynamic_singles", true),
-    components: await read(await resolveFieldGroupRegistry(adapter), false),
+    components: await read(await resolveFieldGroupRegistryName(adapter), false),
   };
 }

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -44,8 +44,8 @@ import {
   resetEmailProviderRegistry,
 } from "../domains/email/services/email-provider-registry";
 import {
-  assumeTypeColumn,
-  resolveFieldGroupRegistryTable,
+  resolveFieldGroupRegistryName,
+  resolveKnownTypeColumns,
   resolveTypeColumns,
 } from "../domains/field-groups/storage/resolve-storage-names";
 import type { SanitizedLocalizationConfig } from "../domains/i18n/config/types";
@@ -1200,12 +1200,12 @@ async function initializeSchemaRegistry(
     // `initializeSchemaRegistry`'s outer catch — which returns `undefined` and
     // skips config-table registration entirely, discarding a registry that was
     // otherwise fine.
-    const fieldGroupRegistry = await resolveFieldGroupRegistryTable(
+    const fieldGroupRegistry = await resolveFieldGroupRegistryName(
       adapter
     ).catch(() => undefined);
     await loadDynamicTables(
       adapter,
-      fieldGroupRegistry?.name ?? STORAGE_FORMAT.registryTable,
+      fieldGroupRegistry ?? STORAGE_FORMAT.registryTable,
       (tableName, fields, _hasStatus, localized) => {
         loadedFieldGroups.push({
           tableName,
@@ -1219,29 +1219,34 @@ async function initializeSchemaRegistry(
     // registry last, and a table an author named itself keeps its own name
     // while its column still moves, so the two generations can be mixed across
     // the very set being registered here.
-    // Contained for the same reason the registry resolution above is: a failure
-    // here would reach `initializeSchemaRegistry`'s outer catch, which returns
-    // `undefined` and skips config-table registration entirely — discarding a
-    // boot that was otherwise fine over one metadata probe.
-    const fieldGroupTypeColumns = await resolveTypeColumns(
+    // Never rejects, so this cannot reach `initializeSchemaRegistry`'s outer
+    // catch — which returns `undefined` and skips config-table registration
+    // entirely, discarding a boot that was otherwise fine over one metadata
+    // probe. A table it could not speak for is absent from the map.
+    const fieldGroupTypeColumns = await resolveKnownTypeColumns(
       adapter,
       loadedFieldGroups.map(entry => entry.tableName)
-    ).catch((err: unknown) => {
-      // Loudly, because everything below now runs on an assumption rather than
-      // a reading, and a boot that quietly registers the wrong column name is
-      // indistinguishable from a healthy one until the first write fails.
-      console.warn(
-        `[Nextly schema] Could not read field-group discriminator columns; ` +
-          `falling back to the spelling the registry implies: ` +
-          `${err instanceof Error ? err.message : String(err)}`
-      );
-      return new Map<string, string>();
-    });
-    // What the tables the probe could not speak for are addressed as. The
-    // registry's own generation is the only evidence left once the catalog is
-    // unreadable, and it is not symmetric — see `assumeTypeColumn`.
-    const assumedTypeColumn = assumeTypeColumn(fieldGroupRegistry);
+    );
     for (const { tableName, fields, localized } of loadedFieldGroups) {
+      const typeColumn = fieldGroupTypeColumns.get(tableName);
+      if (typeColumn === undefined) {
+        // 🔴 Left unregistered rather than registered on a guess.
+        //
+        // Both outcomes break this group's reads and writes until the next
+        // boot, so the choice is only in how. A guessed discriminator fails
+        // inside SQL, naming a column nobody wrote, and a dynamic-zone write
+        // would be aiming at that column; an absent registration fails as an
+        // unknown table, which says what actually happened. The same policy
+        // `loadDynamicTables` already applies to a row it cannot turn into a
+        // schema.
+        console.warn(
+          `[Nextly schema] Could not read the discriminator column of ` +
+            `'${tableName}'; leaving it unregistered rather than addressing ` +
+            `it by a name that was not verified. Field-group reads and writes ` +
+            `for it will fail until the next start.`
+        );
+        continue;
+      }
       const { FieldGroupSchemaService } = await import(
         "../services/field-groups/field-group-schema-service"
       );
@@ -1249,10 +1254,7 @@ async function initializeSchemaRegistry(
       const runtimeTable = compSchemaService.generateRuntimeSchema(
         tableName,
         fields,
-        {
-          localized,
-          typeColumn: fieldGroupTypeColumns.get(tableName) ?? assumedTypeColumn,
-        }
+        { localized, typeColumn }
       );
       registry.registerDynamicSchema(tableName, runtimeTable);
       if (localized) {

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -1218,10 +1218,16 @@ async function initializeSchemaRegistry(
     // registry last, and a table an author named itself keeps its own name
     // while its column still moves, so the two generations can be mixed across
     // the very set being registered here.
+    // Contained for the same reason the registry resolution above is: a failure
+    // here would reach `initializeSchemaRegistry`'s outer catch, which returns
+    // `undefined` and skips config-table registration entirely — discarding a
+    // boot that was otherwise fine over one metadata probe. An empty map sends
+    // every table to the documented default below, which is the spelling this
+    // release's DDL writes.
     const fieldGroupTypeColumns = await resolveTypeColumns(
       adapter,
       loadedFieldGroups.map(entry => entry.tableName)
-    );
+    ).catch(() => new Map<string, string>());
     for (const { tableName, fields, localized } of loadedFieldGroups) {
       const { FieldGroupSchemaService } = await import(
         "../services/field-groups/field-group-schema-service"

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -1182,60 +1182,82 @@ async function initializeSchemaRegistry(
     // the fresh-database case, so addressing a renamed registry by its legacy
     // name does not raise — it registers nothing, and every field-group table
     // is unaddressable until someone notices reads returning empty.
+    // Collected first, registered second. `introspectLiveSnapshot` issues
+    // separate column and index catalog queries — plus the identifier-case
+    // query on MySQL — so resolving inside the per-row callback would cost two
+    // or three metadata round trips PER field group at every boot. One pass
+    // over the rows makes it one batch for the whole set, which is what
+    // `registerComponentSchemas` already does.
+    const loadedFieldGroups: Array<{
+      tableName: string;
+      fields: FieldConfig[];
+      localized: boolean;
+    }> = [];
     await loadDynamicTables(
       adapter,
       await resolveFieldGroupRegistryName(adapter),
-      async (tableName, fields, _hasStatus, localized) => {
-        const { FieldGroupSchemaService } = await import(
-          "../services/field-groups/field-group-schema-service"
-        );
-        const compSchemaService = new FieldGroupSchemaService(dialect);
-        // Resolved per table: the storage migration renames the discriminator,
-        // and a table an author named itself keeps its own table name while its
-        // column still moves, so the two generations can be mixed across the
-        // very set being registered here.
-        const typeColumns = await resolveTypeColumns(adapter, [tableName]);
-        const runtimeTable = compSchemaService.generateRuntimeSchema(
+      (tableName, fields, _hasStatus, localized) => {
+        loadedFieldGroups.push({
           tableName,
-          fields as FieldConfig[],
-          {
-            localized,
-            typeColumn:
-              typeColumns.get(tableName) ?? STORAGE_FORMAT.columns.type,
-          }
-        );
-        registry.registerDynamicSchema(tableName, runtimeTable);
-        if (localized) {
-          const { ensureCompanionTable } = await import(
-            "../domains/i18n/runtime/companion-io"
-          );
-          await ensureCompanionTable(adapter, {
-            slug: tableName,
-            tableName,
-            fields: fields as { name: string; type: string }[],
-            dialect,
-            status: false,
-          });
-          const { buildCompanionRuntimeTable } = await import(
-            "../domains/i18n/runtime/companion-registration"
-          );
-          const companion = buildCompanionRuntimeTable({
-            slug: tableName,
-            tableName,
-            fields: fields as { name: string; type: string }[],
-            dialect,
-            localized: true,
-            status: false,
-          });
-          if (companion) {
-            registry.registerDynamicSchema(
-              companion.companionTableName,
-              companion.table
-            );
-          }
-        }
+          fields: fields as FieldConfig[],
+          localized,
+        });
+        return Promise.resolve();
       }
     );
+    // Resolved per table even though it is one query: the migration renames the
+    // registry last, and a table an author named itself keeps its own name
+    // while its column still moves, so the two generations can be mixed across
+    // the very set being registered here.
+    const fieldGroupTypeColumns = await resolveTypeColumns(
+      adapter,
+      loadedFieldGroups.map(entry => entry.tableName)
+    );
+    for (const { tableName, fields, localized } of loadedFieldGroups) {
+      const { FieldGroupSchemaService } = await import(
+        "../services/field-groups/field-group-schema-service"
+      );
+      const compSchemaService = new FieldGroupSchemaService(dialect);
+      const runtimeTable = compSchemaService.generateRuntimeSchema(
+        tableName,
+        fields,
+        {
+          localized,
+          typeColumn:
+            fieldGroupTypeColumns.get(tableName) ?? STORAGE_FORMAT.columns.type,
+        }
+      );
+      registry.registerDynamicSchema(tableName, runtimeTable);
+      if (localized) {
+        const { ensureCompanionTable } = await import(
+          "../domains/i18n/runtime/companion-io"
+        );
+        await ensureCompanionTable(adapter, {
+          slug: tableName,
+          tableName,
+          fields: fields as { name: string; type: string }[],
+          dialect,
+          status: false,
+        });
+        const { buildCompanionRuntimeTable } = await import(
+          "../domains/i18n/runtime/companion-registration"
+        );
+        const companion = buildCompanionRuntimeTable({
+          slug: tableName,
+          tableName,
+          fields: fields as { name: string; type: string }[],
+          dialect,
+          localized: true,
+          status: false,
+        });
+        if (companion) {
+          registry.registerDynamicSchema(
+            companion.companionTableName,
+            companion.table
+          );
+        }
+      }
+    }
 
     return registry;
   } catch {
@@ -1962,15 +1984,23 @@ async function syncCodeFirstComponents(
           logger.info?.(`Created table ${tableName} for component ${slug}`);
 
           try {
+            // 🔴 Resolved, not assumed. The DDL above is
+            // `CREATE TABLE IF NOT EXISTS`, so a component whose *fields*
+            // changed reaches here with its table untouched — and this
+            // registration then overwrites the catalog-resolved one made during
+            // the boot pass. Hard-coding the creator's spelling here therefore
+            // does not describe a table this code just made; it describes a
+            // table that may have been migrated long ago.
+            const syncTypeColumns = await resolveTypeColumns(adapter, [
+              tableName,
+            ]);
             const compRuntimeTable = compSchemaService.generateRuntimeSchema(
               tableName,
               compConfig.fields,
               {
                 localized: compLocalized,
-                // This table was created by the DDL a few lines above, so it
-                // carries the spelling that generator writes. The same constant,
-                // read twice — not a guess, and not worth a catalog round trip.
-                typeColumn: STORAGE_FORMAT.columns.type,
+                typeColumn:
+                  syncTypeColumns.get(tableName) ?? STORAGE_FORMAT.columns.type,
               }
             );
             const resolver = (

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -44,7 +44,8 @@ import {
   resetEmailProviderRegistry,
 } from "../domains/email/services/email-provider-registry";
 import {
-  resolveFieldGroupRegistryName,
+  assumeTypeColumn,
+  resolveFieldGroupRegistryTable,
   resolveTypeColumns,
 } from "../domains/field-groups/storage/resolve-storage-names";
 import type { SanitizedLocalizationConfig } from "../domains/i18n/config/types";
@@ -1199,12 +1200,12 @@ async function initializeSchemaRegistry(
     // `initializeSchemaRegistry`'s outer catch — which returns `undefined` and
     // skips config-table registration entirely, discarding a registry that was
     // otherwise fine.
-    const fieldGroupRegistry = await resolveFieldGroupRegistryName(
+    const fieldGroupRegistry = await resolveFieldGroupRegistryTable(
       adapter
     ).catch(() => undefined);
     await loadDynamicTables(
       adapter,
-      fieldGroupRegistry ?? STORAGE_FORMAT.registryTable,
+      fieldGroupRegistry?.name ?? STORAGE_FORMAT.registryTable,
       (tableName, fields, _hasStatus, localized) => {
         loadedFieldGroups.push({
           tableName,
@@ -1221,13 +1222,25 @@ async function initializeSchemaRegistry(
     // Contained for the same reason the registry resolution above is: a failure
     // here would reach `initializeSchemaRegistry`'s outer catch, which returns
     // `undefined` and skips config-table registration entirely — discarding a
-    // boot that was otherwise fine over one metadata probe. An empty map sends
-    // every table to the documented default below, which is the spelling this
-    // release's DDL writes.
+    // boot that was otherwise fine over one metadata probe.
     const fieldGroupTypeColumns = await resolveTypeColumns(
       adapter,
       loadedFieldGroups.map(entry => entry.tableName)
-    ).catch(() => new Map<string, string>());
+    ).catch((err: unknown) => {
+      // Loudly, because everything below now runs on an assumption rather than
+      // a reading, and a boot that quietly registers the wrong column name is
+      // indistinguishable from a healthy one until the first write fails.
+      console.warn(
+        `[Nextly schema] Could not read field-group discriminator columns; ` +
+          `falling back to the spelling the registry implies: ` +
+          `${err instanceof Error ? err.message : String(err)}`
+      );
+      return new Map<string, string>();
+    });
+    // What the tables the probe could not speak for are addressed as. The
+    // registry's own generation is the only evidence left once the catalog is
+    // unreadable, and it is not symmetric — see `assumeTypeColumn`.
+    const assumedTypeColumn = assumeTypeColumn(fieldGroupRegistry);
     for (const { tableName, fields, localized } of loadedFieldGroups) {
       const { FieldGroupSchemaService } = await import(
         "../services/field-groups/field-group-schema-service"
@@ -1238,8 +1251,7 @@ async function initializeSchemaRegistry(
         fields,
         {
           localized,
-          typeColumn:
-            fieldGroupTypeColumns.get(tableName) ?? STORAGE_FORMAT.columns.type,
+          typeColumn: fieldGroupTypeColumns.get(tableName) ?? assumedTypeColumn,
         }
       );
       registry.registerDynamicSchema(tableName, runtimeTable);

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -43,7 +43,10 @@ import {
   getEmailProviderRegistry,
   resetEmailProviderRegistry,
 } from "../domains/email/services/email-provider-registry";
-import { resolveTypeColumns } from "../domains/field-groups/storage/resolve-storage-names";
+import {
+  resolveFieldGroupRegistryName,
+  resolveTypeColumns,
+} from "../domains/field-groups/storage/resolve-storage-names";
 import type { SanitizedLocalizationConfig } from "../domains/i18n/config/types";
 import type { MetaService } from "../domains/meta";
 import {
@@ -1175,9 +1178,13 @@ async function initializeSchemaRegistry(
     // Step 4: Dynamic components (comp_* tables). Components have no status
     // column, but a localized component omits its translatable columns from the
     // main comp_ table and registers/creates its companion `comp_<slug>_locales`.
+    // 🔴 Resolved, not assumed. `loadDynamicTables` swallows a failed read as
+    // the fresh-database case, so addressing a renamed registry by its legacy
+    // name does not raise — it registers nothing, and every field-group table
+    // is unaddressable until someone notices reads returning empty.
     await loadDynamicTables(
       adapter,
-      STORAGE_FORMAT.registryTable,
+      await resolveFieldGroupRegistryName(adapter),
       async (tableName, fields, _hasStatus, localized) => {
         const { FieldGroupSchemaService } = await import(
           "../services/field-groups/field-group-schema-service"

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -1193,9 +1193,18 @@ async function initializeSchemaRegistry(
       fields: FieldConfig[];
       localized: boolean;
     }> = [];
+    // Resolved inside the same best-effort boundary as the load it feeds. An
+    // `await` in the argument position rejects BEFORE `loadDynamicTables`
+    // enters its own `try`, so a transient catalog failure would escape to
+    // `initializeSchemaRegistry`'s outer catch — which returns `undefined` and
+    // skips config-table registration entirely, discarding a registry that was
+    // otherwise fine.
+    const fieldGroupRegistry = await resolveFieldGroupRegistryName(
+      adapter
+    ).catch(() => undefined);
     await loadDynamicTables(
       adapter,
-      await resolveFieldGroupRegistryName(adapter),
+      fieldGroupRegistry ?? STORAGE_FORMAT.registryTable,
       (tableName, fields, _hasStatus, localized) => {
         loadedFieldGroups.push({
           tableName,

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -43,6 +43,7 @@ import {
   getEmailProviderRegistry,
   resetEmailProviderRegistry,
 } from "../domains/email/services/email-provider-registry";
+import { resolveTypeColumns } from "../domains/field-groups/storage/resolve-storage-names";
 import type { SanitizedLocalizationConfig } from "../domains/i18n/config/types";
 import type { MetaService } from "../domains/meta";
 import {
@@ -635,6 +636,11 @@ export async function registerServices(
         changed: ReadonlyArray<{ slug: string; fields?: FieldConfig[] }>,
         loaded: LoadedBuilderEntity[],
         persist: (slug: string, fields: FieldConfig[]) => Promise<unknown>,
+        // Returns the runtime table, or a promise of one: the field-group
+        // implementation resolves its discriminator from the catalog first,
+        // while the collection and single ones are synchronous. Typed as
+        // `unknown` because a `unknown | Promise<unknown>` union collapses to
+        // `unknown` anyway; the call site awaits, which is correct for both.
         makeRuntime: (
           tableName: string,
           fields: FieldConfig[],
@@ -657,7 +663,7 @@ export async function registerServices(
             if (schemaRegistry) {
               schemaRegistry.registerDynamicSchema(
                 before.tableName,
-                makeRuntime(before.tableName, fields, before.status)
+                await makeRuntime(before.tableName, fields, before.status)
               );
             }
           } catch (err) {
@@ -731,8 +737,13 @@ export async function registerServices(
           compChanged,
           builderEntities.components,
           (slug, fields) => reg.updateComponent(slug, { fields: fields }),
-          (tableName, fields) =>
-            compSchema.generateRuntimeSchema(tableName, fields)
+          async (tableName, fields) =>
+            compSchema.generateRuntimeSchema(tableName, fields, {
+              typeColumn:
+                (await resolveTypeColumns(adapter, [tableName])).get(
+                  tableName
+                ) ?? STORAGE_FORMAT.columns.type,
+            })
         );
       }
     }
@@ -1172,10 +1183,19 @@ async function initializeSchemaRegistry(
           "../services/field-groups/field-group-schema-service"
         );
         const compSchemaService = new FieldGroupSchemaService(dialect);
+        // Resolved per table: the storage migration renames the discriminator,
+        // and a table an author named itself keeps its own table name while its
+        // column still moves, so the two generations can be mixed across the
+        // very set being registered here.
+        const typeColumns = await resolveTypeColumns(adapter, [tableName]);
         const runtimeTable = compSchemaService.generateRuntimeSchema(
           tableName,
           fields as FieldConfig[],
-          { localized }
+          {
+            localized,
+            typeColumn:
+              typeColumns.get(tableName) ?? STORAGE_FORMAT.columns.type,
+          }
         );
         registry.registerDynamicSchema(tableName, runtimeTable);
         if (localized) {
@@ -1938,7 +1958,13 @@ async function syncCodeFirstComponents(
             const compRuntimeTable = compSchemaService.generateRuntimeSchema(
               tableName,
               compConfig.fields,
-              { localized: compLocalized }
+              {
+                localized: compLocalized,
+                // This table was created by the DDL a few lines above, so it
+                // carries the spelling that generator writes. The same constant,
+                // read twice — not a guess, and not worth a catalog round trip.
+                typeColumn: STORAGE_FORMAT.columns.type,
+              }
             );
             const resolver = (
               adapter as unknown as {

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -1012,13 +1012,23 @@ async function initializeSchemaRegistry(
   try {
     const { SchemaRegistry } = await import("../database/schema-registry");
     const { getDialectTables } = await import("../database/index");
+    const { getFieldGroupRegistryAliases } = await import(
+      "../domains/field-groups/storage/registry-schemas"
+    );
     const dialect = adapter.getCapabilities().dialect;
     const registry = new SchemaRegistry(dialect);
 
     container.registerSingleton("schemaRegistry", () => registry);
 
-    // Step 1: Register static system tables.
-    registry.registerStaticSchemas(getDialectTables(dialect));
+    // Step 1: Register static system tables. The field-group registry is
+    // declared under both of its names so a database whose storage migration
+    // has run is addressable — the schema registry keys a table by the
+    // physical name its Drizzle object carries, so the renamed table has no
+    // handle otherwise. Kept out of the push bundle above deliberately.
+    registry.registerStaticSchemas({
+      ...getDialectTables(dialect),
+      ...getFieldGroupRegistryAliases(dialect),
+    });
     adapter.setTableResolver(registry);
 
     // Step 1.5 (F8 PR 6): first-run static-table push. Probes for

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -415,7 +415,24 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
               dialect,
               tableName,
               b.fields,
-              await resolveComponentTypeColumn(diAdapter, tableName),
+              // 🔴 The constant, NOT a probe — and this is the one path where
+              // that inference is sound, so the reason is worth stating.
+              //
+              // This is the CREATE path for a new slug, and the statement
+              // executed above is the DDL generator's own, which writes
+              // `STORAGE_FORMAT.columns.type`. The storage migration cannot
+              // have moved a table that did not exist a moment ago, and a
+              // migrated table would carry the migrated PREFIX, so it could not
+              // be addressed by this name at all.
+              //
+              // Probing here can only hurt: a transient introspection failure
+              // is caught below, records the registry row as `failed`, and
+              // still returns 201 — leaving a created table with no runtime
+              // schema and its CRUD unavailable until a restart. Contrast the
+              // code-first sync path, where `CREATE TABLE IF NOT EXISTS` may
+              // no-op over a table that is years old; there the probe is
+              // required, and assuming the constant was a real defect.
+              STORAGE_FORMAT.columns.type,
               // i18n: main runtime table omits translatable columns for a localized component.
               isLocalized
             );

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -139,30 +139,45 @@ async function executeMigrationStatements(
 
 // Refresh the cached Drizzle table so the next entry query joining this
 // component uses the new column layout without a server restart.
-async function registerComponentRuntimeSchema(
+/**
+ * The discriminator a component table carries, resolved BEFORE its DDL runs.
+ *
+ * 🔴 Deliberately not inside `registerComponentRuntimeSchema`. That function's
+ * `catch` is a cache-refresh failsafe — it suppresses so a refresh problem does
+ * not fail a request whose schema change already committed — and a catalog
+ * probe inside it inherits that policy, letting a handler report success while
+ * leaving the runtime table unregistered or holding obsolete columns.
+ *
+ * Resolving first is equivalent and safer: the schema change only ever alters
+ * user columns, so the discriminator is the same before and after, and a probe
+ * that cannot answer now fails the request before anything is committed.
+ */
+async function resolveComponentTypeColumn(
+  adapter: DrizzleAdapter,
+  tableName: string
+): Promise<string> {
+  const typeColumns = await resolveTypeColumns(adapter, [tableName]);
+  return typeColumns.get(tableName) ?? STORAGE_FORMAT.columns.type;
+}
+
+function registerComponentRuntimeSchema(
   adapter: DrizzleAdapter,
   dialect: string,
   tableName: string,
   fields: FieldConfig[],
+  typeColumn: string,
   // i18n: when localized, the main comp_ runtime table omits translatable columns and the
   // companion comp_<slug>_locales runtime table is registered for per-language reads/writes.
   localized = false
-): Promise<void> {
+): void {
   try {
     const fieldGroupSchemaService = new FieldGroupSchemaService(
       dialect as ConstructorParameters<typeof FieldGroupSchemaService>[0]
     );
-    // Asked of the catalog rather than assumed from the DDL just applied: the
-    // alter above changes user columns only, so the discriminator is whichever
-    // one the table already carried.
-    const typeColumns = await resolveTypeColumns(adapter, [tableName]);
     const runtimeTable = fieldGroupSchemaService.generateRuntimeSchema(
       tableName,
       fields,
-      {
-        localized,
-        typeColumn: typeColumns.get(tableName) ?? STORAGE_FORMAT.columns.type,
-      }
+      { localized, typeColumn }
     );
     const companion = localized
       ? buildCompanionRuntimeTable({
@@ -395,11 +410,12 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
           const tableExists = await diAdapter.tableExists(tableName);
           if (tableExists) {
             migrationStatus = "applied";
-            await registerComponentRuntimeSchema(
+            registerComponentRuntimeSchema(
               diAdapter,
               dialect,
               tableName,
               b.fields,
+              await resolveComponentTypeColumn(diAdapter, tableName),
               // i18n: main runtime table omits translatable columns for a localized component.
               isLocalized
             );
@@ -548,11 +564,12 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         if (container.has("adapter")) {
           const adapter = container.get<DrizzleAdapter>("adapter");
           const newFields = b?.fields ?? existing.fields;
-          await registerComponentRuntimeSchema(
+          registerComponentRuntimeSchema(
             adapter,
             adapter.getCapabilities().dialect,
             existing.tableName,
             newFields,
+            await resolveComponentTypeColumn(adapter, existing.tableName),
             // i18n: main runtime table omits translatable columns when localized.
             isLocalized
           );
@@ -722,6 +739,17 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
 
       const adapter = getAdapterFromDI();
       if (!adapter) throw new Error("Database adapter not initialized");
+      // 🔴 Resolved BEFORE the apply. The runtime refresh at the end of this
+      // handler suppresses its own failures by design, so a probe placed there
+      // could let the handler report success over an unregistered or stale
+      // table. The apply only alters user columns, so this answer is the same
+      // either side of it — and asking now means a probe that cannot answer
+      // fails the request before anything commits.
+      const componentTypeColumn = await resolveComponentTypeColumn(
+        adapter,
+        tableName
+      );
+
       const dialect = adapter.dialect;
       const db = adapter.getDrizzle();
       const databaseName =
@@ -843,11 +871,12 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
       // so the registered table includes component system columns
       // (_parent_id, _parent_table, _parent_field, _order, _component_type)
       // instead of collection columns (title, slug).
-      await registerComponentRuntimeSchema(
+      registerComponentRuntimeSchema(
         adapter,
         dialect,
         tableName,
         fields as FieldConfig[],
+        componentTypeColumn,
         isLocalized
       );
 

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -26,6 +26,7 @@ import {
 } from "../../api/response-shapes";
 import type { FieldConfig } from "../../collections/fields/types";
 import { container } from "../../di/container";
+import { resolveTypeColumns } from "../../domains/field-groups/storage/resolve-storage-names";
 import { buildCompanionTransitionStatements } from "../../domains/i18n/migration/reconcile-companion";
 import { localizedColumnsOnMain } from "../../domains/i18n/runtime/companion-io";
 import { buildCompanionRuntimeTable } from "../../domains/i18n/runtime/companion-registration";
@@ -135,7 +136,7 @@ async function executeMigrationStatements(
 
 // Refresh the cached Drizzle table so the next entry query joining this
 // component uses the new column layout without a server restart.
-function registerComponentRuntimeSchema(
+async function registerComponentRuntimeSchema(
   adapter: DrizzleAdapter,
   dialect: string,
   tableName: string,
@@ -143,15 +144,22 @@ function registerComponentRuntimeSchema(
   // i18n: when localized, the main comp_ runtime table omits translatable columns and the
   // companion comp_<slug>_locales runtime table is registered for per-language reads/writes.
   localized = false
-): void {
+): Promise<void> {
   try {
     const fieldGroupSchemaService = new FieldGroupSchemaService(
       dialect as ConstructorParameters<typeof FieldGroupSchemaService>[0]
     );
+    // Asked of the catalog rather than assumed from the DDL just applied: the
+    // alter above changes user columns only, so the discriminator is whichever
+    // one the table already carried.
+    const typeColumns = await resolveTypeColumns(adapter, [tableName]);
     const runtimeTable = fieldGroupSchemaService.generateRuntimeSchema(
       tableName,
       fields,
-      { localized }
+      {
+        localized,
+        typeColumn: typeColumns.get(tableName) ?? STORAGE_FORMAT.columns.type,
+      }
     );
     const companion = localized
       ? buildCompanionRuntimeTable({
@@ -384,7 +392,7 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
           const tableExists = await diAdapter.tableExists(tableName);
           if (tableExists) {
             migrationStatus = "applied";
-            registerComponentRuntimeSchema(
+            await registerComponentRuntimeSchema(
               diAdapter,
               dialect,
               tableName,
@@ -537,7 +545,7 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
         if (container.has("adapter")) {
           const adapter = container.get<DrizzleAdapter>("adapter");
           const newFields = b?.fields ?? existing.fields;
-          registerComponentRuntimeSchema(
+          await registerComponentRuntimeSchema(
             adapter,
             adapter.getCapabilities().dialect,
             existing.tableName,
@@ -828,7 +836,7 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
       // so the registered table includes component system columns
       // (_parent_id, _parent_table, _parent_field, _order, _component_type)
       // instead of collection columns (title, slug).
-      registerComponentRuntimeSchema(
+      await registerComponentRuntimeSchema(
         adapter,
         dialect,
         tableName,

--- a/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/component-dispatcher.ts
@@ -26,7 +26,10 @@ import {
 } from "../../api/response-shapes";
 import type { FieldConfig } from "../../collections/fields/types";
 import { container } from "../../di/container";
-import { resolveTypeColumns } from "../../domains/field-groups/storage/resolve-storage-names";
+import {
+  resolveFieldGroupRegistryName,
+  resolveTypeColumns,
+} from "../../domains/field-groups/storage/resolve-storage-names";
 import { buildCompanionTransitionStatements } from "../../domains/i18n/migration/reconcile-companion";
 import { localizedColumnsOnMain } from "../../domains/i18n/runtime/companion-io";
 import { buildCompanionRuntimeTable } from "../../domains/i18n/runtime/companion-registration";
@@ -810,7 +813,11 @@ const COMPONENTS_METHODS: Record<string, MethodHandler<ComponentsServices>> = {
       let versionPersisted = true;
       try {
         await adapter.update(
-          STORAGE_FORMAT.registryTable,
+          // The registry this database holds. The failure is otherwise silent
+          // in the worst way: the DDL has already committed, this write is
+          // treated as non-fatal, and the stale row rebuilds the pre-change
+          // runtime schema on the next restart.
+          await resolveFieldGroupRegistryName(adapter),
           {
             fields: JSON.stringify(fields),
             schema_hash: calculateSchemaHash(fields as FieldConfig[]),

--- a/packages/nextly/src/domains/auth/services/permission-seed-service.ts
+++ b/packages/nextly/src/domains/auth/services/permission-seed-service.ts
@@ -1,5 +1,5 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
-import { eq } from "drizzle-orm";
+import { sql, eq } from "drizzle-orm";
 
 import type { RBACDatabaseInstance } from "@nextly/types/rbac-operations";
 
@@ -7,6 +7,7 @@ import type { CollectedPermission } from "../../../plugins/permissions/collect-p
 import { SYSTEM_RESOURCES } from "../../../schemas/_zod/rbac";
 import { BaseService } from "../../../services/base-service";
 import type { Logger } from "../../../services/shared";
+import { resolveRegistryTableName } from "../../field-groups/storage/resolve-storage-names";
 
 import { PermissionService } from "./permission-service";
 import { RolePermissionService } from "./role-permission-service";
@@ -900,14 +901,30 @@ export class PermissionSeedService extends BaseService {
     return rows.map((row: { slug: string }) => String(row.slug));
   }
 
+  /**
+   * Every field-group slug the registry knows about.
+   *
+   * 🔴 Addressed by the resolved name rather than through
+   * `getDialectTables().dynamicFieldGroups`, whose Drizzle object carries the
+   * legacy table name. On a database whose storage migration has run, that
+   * object names a table that is gone; the missing-table error is caught by
+   * `cleanupOrphanedPermissions`, which then reports no removals while every
+   * field-group permission is silently treated as orphaned.
+   *
+   * Issued as a statement rather than through the query builder for the same
+   * reason the migration reads the registry that way: the builder resolves a
+   * table through the schema registry, and the name to address here is the one
+   * the catalog reports.
+   */
   private async getAllComponentSlugs(): Promise<string[]> {
     if (!this.tables?.dynamicFieldGroups) return [];
 
-    const rows = await this.db
-      .select({ slug: this.tables.dynamicFieldGroups.slug })
-      .from(this.tables.dynamicFieldGroups);
+    const registryTable = await resolveRegistryTableName(this.adapter);
+    const rows = await this.adapter.queryStatement<{ slug: string }>(
+      sql`SELECT ${sql.identifier("slug")} FROM ${sql.identifier(registryTable)}`
+    );
 
-    return rows.map((row: { slug: string }) => String(row.slug));
+    return rows.map(row => String(row.slug));
   }
 
   private slugToLabel(slug: string): string {

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1067,16 +1067,19 @@ export class CollectionQueryService extends BaseService {
       // Build component field EXISTS conditions
       const componentTables =
         await this.resolveComponentTableNames(componentFilters);
+      // Kept so the count over these same filters can reuse them instead of
+      // repeating the registry lookup and the catalog introspection.
+      const componentTypeColumns = await this.resolveComponentTypeColumns(
+        componentFilters,
+        componentTables.values()
+      );
       const componentCondition = this.buildComponentFieldConditions(
         componentFilters,
         tableName,
         schema.id,
         dialect,
         componentTables,
-        await this.resolveComponentTypeColumns(
-          componentFilters,
-          componentTables.values()
-        )
+        componentTypeColumns
       );
 
       // Apply component field conditions to query
@@ -1269,6 +1272,9 @@ export class CollectionQueryService extends BaseService {
             collectionName: params.collectionName,
             user: params.user,
             search: params.search,
+            // Resolved once for this request; see the parameter's own note.
+            resolvedComponentTables: componentTables,
+            resolvedComponentTypeColumns: componentTypeColumns,
             // Geo operators removed (the count cannot apply them), but component
             // predicates kept: `cleanedWhere` has BOTH stripped, and the count
             // builds its own EXISTS conditions from the ones it is given. Sending
@@ -1749,6 +1755,18 @@ export class CollectionQueryService extends BaseService {
      * would over-count.
      */
     translationFilter?: TranslationStatusFilter;
+    /**
+     * Component table names and discriminator columns, already resolved by the
+     * caller (listEntries) for this same request.
+     *
+     * The list path resolves both to build its page, then asks for a total over
+     * the same filters, so without this the count repeats a registry lookup per
+     * component slug and a catalog introspection per table: column and index
+     * reads on Postgres and MySQL, a PRAGMA each on SQLite. A standalone count
+     * omits them and resolves its own.
+     */
+    resolvedComponentTables?: Map<string, string>;
+    resolvedComponentTypeColumns?: Map<string, string>;
     /** Arbitrary data passed to hooks via context */
     context?: Record<string, unknown>;
   }): Promise<CollectionServiceResult<{ totalDocs: number }>> {
@@ -1958,17 +1976,19 @@ export class CollectionQueryService extends BaseService {
 
         // Build component field EXISTS conditions
         const componentTables =
-          await this.resolveComponentTableNames(componentFilters);
+          params.resolvedComponentTables ??
+          (await this.resolveComponentTableNames(componentFilters));
         const componentCondition = this.buildComponentFieldConditions(
           componentFilters,
           tableName,
           schema.id,
           dialect,
           componentTables,
-          await this.resolveComponentTypeColumns(
-            componentFilters,
-            componentTables.values()
-          )
+          params.resolvedComponentTypeColumns ??
+            (await this.resolveComponentTypeColumns(
+              componentFilters,
+              componentTables.values()
+            ))
         );
 
         if (componentCondition) {

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -80,6 +80,7 @@ import {
 } from "../../../types/pagination";
 import type { PaginatedResponse } from "../../../types/pagination";
 import type { DynamicCollectionService } from "../../dynamic-collections";
+import { resolveTypeColumns } from "../../field-groups/storage/resolve-storage-names";
 import {
   buildCompanionExists,
   buildLocalizedOrderExpr,
@@ -115,6 +116,91 @@ import {
   getMinSearchLength,
   decodeJsonFieldValues,
 } from "./collection-utils";
+
+/**
+ * One component-field predicate, as raw SQL against a named column.
+ *
+ * Extracted from the filter loop so it can be built once per component TABLE
+ * rather than once per filter: a `_componentType` filter over a dynamic zone
+ * spans several tables, and the storage migration can have moved the
+ * discriminator on some of them and not others.
+ */
+function buildComponentValueCondition(
+  filter: ComponentFieldFilter,
+  dbColumnName: string,
+  dialect: string
+): ReturnType<typeof sql> | undefined {
+  let valueCondition: ReturnType<typeof sql>;
+
+  switch (filter.operator) {
+    case "equals":
+      valueCondition = sql`${sql.identifier(dbColumnName)} = ${filter.value}`;
+      break;
+    case "not_equals":
+      valueCondition = sql`${sql.identifier(dbColumnName)} != ${filter.value}`;
+      break;
+    case "greater_than":
+      valueCondition = sql`${sql.identifier(dbColumnName)} > ${filter.value}`;
+      break;
+    case "greater_than_equal":
+      valueCondition = sql`${sql.identifier(dbColumnName)} >= ${filter.value}`;
+      break;
+    case "less_than":
+      valueCondition = sql`${sql.identifier(dbColumnName)} < ${filter.value}`;
+      break;
+    case "less_than_equal":
+      valueCondition = sql`${sql.identifier(dbColumnName)} <= ${filter.value}`;
+      break;
+    case "like":
+      valueCondition = sql`${sql.identifier(dbColumnName)} LIKE ${`%${String(filter.value)}%`}`;
+      break;
+    case "contains":
+    case "search":
+      // Use ILIKE for PostgreSQL, LIKE for others
+      if (dialect === "postgresql") {
+        valueCondition = sql`${sql.identifier(dbColumnName)} ILIKE ${`%${String(filter.value)}%`}`;
+      } else {
+        valueCondition = sql`LOWER(${sql.identifier(dbColumnName)}) LIKE LOWER(${`%${String(filter.value)}%`})`;
+      }
+      break;
+    case "in": {
+      const inValues = Array.isArray(filter.value)
+        ? filter.value
+        : [filter.value];
+      if (inValues.length === 0) return undefined;
+      const inPlaceholders = sql.join(
+        inValues.map(v => sql`${v}`),
+        sql`, `
+      );
+      valueCondition = sql`${sql.identifier(dbColumnName)} IN (${inPlaceholders})`;
+      break;
+    }
+    case "not_in": {
+      const notInValues = Array.isArray(filter.value)
+        ? filter.value
+        : [filter.value];
+      if (notInValues.length === 0) return undefined;
+      const notInPlaceholders = sql.join(
+        notInValues.map(v => sql`${v}`),
+        sql`, `
+      );
+      valueCondition = sql`${sql.identifier(dbColumnName)} NOT IN (${notInPlaceholders})`;
+      break;
+    }
+    case "exists":
+      if (filter.value === true || filter.value === "true") {
+        valueCondition = sql`${sql.identifier(dbColumnName)} IS NOT NULL`;
+      } else {
+        valueCondition = sql`${sql.identifier(dbColumnName)} IS NULL`;
+      }
+      break;
+    default:
+      // An operator this builder does not implement contributes no condition.
+      return undefined;
+  }
+
+  return valueCondition;
+}
 
 export class CollectionQueryService extends BaseService {
   constructor(
@@ -979,12 +1065,15 @@ export class CollectionQueryService extends BaseService {
       const tableName = getTableName(params.collectionName);
 
       // Build component field EXISTS conditions
+      const componentTables =
+        await this.resolveComponentTableNames(componentFilters);
       const componentCondition = this.buildComponentFieldConditions(
         componentFilters,
         tableName,
         schema.id,
         dialect,
-        await this.resolveComponentTableNames(componentFilters)
+        componentTables,
+        await this.resolveComponentTypeColumns(componentTables.values())
       );
 
       // Apply component field conditions to query
@@ -1865,12 +1954,15 @@ export class CollectionQueryService extends BaseService {
         const tableName = getTableName(params.collectionName);
 
         // Build component field EXISTS conditions
+        const componentTables =
+          await this.resolveComponentTableNames(componentFilters);
         const componentCondition = this.buildComponentFieldConditions(
           componentFilters,
           tableName,
           schema.id,
           dialect,
-          await this.resolveComponentTableNames(componentFilters)
+          componentTables,
+          await this.resolveComponentTypeColumns(componentTables.values())
         );
 
         if (componentCondition) {
@@ -2925,13 +3017,31 @@ export class CollectionQueryService extends BaseService {
     return resolved;
   }
 
+  /**
+   * The physical discriminator column each named component table carries.
+   *
+   * 🔴 This predicate is built as raw SQL rather than through the table object,
+   * so it does not get the runtime schema's stable property key: it emits the
+   * column name it is handed. A `_componentType` filter must therefore be given
+   * the name the table actually has, or it addresses a column the storage
+   * migration has moved and the query fails instead of matching documents.
+   */
+  private async resolveComponentTypeColumns(
+    tableNames: Iterable<string>
+  ): Promise<Map<string, string>> {
+    const tables = [...new Set(tableNames)];
+    if (tables.length === 0) return new Map();
+    return resolveTypeColumns(this.adapter, tables);
+  }
+
   private buildComponentFieldConditions(
     componentFilters: ComponentFieldFilter[],
     parentTableName: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle column reference
     parentIdColumn: any,
     dialect: string = "postgresql",
-    componentTableNames: Map<string, string> = new Map()
+    componentTableNames: Map<string, string> = new Map(),
+    componentTypeColumns: Map<string, string> = new Map()
   ): ReturnType<typeof and> | undefined {
     if (componentFilters.length === 0) {
       return undefined;
@@ -2944,80 +3054,12 @@ export class CollectionQueryService extends BaseService {
       // Convert component field path to snake_case for database column
       const columnName = toSnakeCase(filter.componentFieldPath);
 
-      // Handle _componentType filter specially (already snake_case)
-      const dbColumnName = filter.isComponentTypeFilter
-        ? STORAGE_FORMAT.columns.type
-        : columnName;
-
-      // Build the value condition based on operator
-      let valueCondition: ReturnType<typeof sql>;
-
-      switch (filter.operator) {
-        case "equals":
-          valueCondition = sql`${sql.identifier(dbColumnName)} = ${filter.value}`;
-          break;
-        case "not_equals":
-          valueCondition = sql`${sql.identifier(dbColumnName)} != ${filter.value}`;
-          break;
-        case "greater_than":
-          valueCondition = sql`${sql.identifier(dbColumnName)} > ${filter.value}`;
-          break;
-        case "greater_than_equal":
-          valueCondition = sql`${sql.identifier(dbColumnName)} >= ${filter.value}`;
-          break;
-        case "less_than":
-          valueCondition = sql`${sql.identifier(dbColumnName)} < ${filter.value}`;
-          break;
-        case "less_than_equal":
-          valueCondition = sql`${sql.identifier(dbColumnName)} <= ${filter.value}`;
-          break;
-        case "like":
-          valueCondition = sql`${sql.identifier(dbColumnName)} LIKE ${`%${String(filter.value)}%`}`;
-          break;
-        case "contains":
-        case "search":
-          // Use ILIKE for PostgreSQL, LIKE for others
-          if (dialect === "postgresql") {
-            valueCondition = sql`${sql.identifier(dbColumnName)} ILIKE ${`%${String(filter.value)}%`}`;
-          } else {
-            valueCondition = sql`LOWER(${sql.identifier(dbColumnName)}) LIKE LOWER(${`%${String(filter.value)}%`})`;
-          }
-          break;
-        case "in": {
-          const inValues = Array.isArray(filter.value)
-            ? filter.value
-            : [filter.value];
-          if (inValues.length === 0) continue;
-          const inPlaceholders = sql.join(
-            inValues.map(v => sql`${v}`),
-            sql`, `
-          );
-          valueCondition = sql`${sql.identifier(dbColumnName)} IN (${inPlaceholders})`;
-          break;
-        }
-        case "not_in": {
-          const notInValues = Array.isArray(filter.value)
-            ? filter.value
-            : [filter.value];
-          if (notInValues.length === 0) continue;
-          const notInPlaceholders = sql.join(
-            notInValues.map(v => sql`${v}`),
-            sql`, `
-          );
-          valueCondition = sql`${sql.identifier(dbColumnName)} NOT IN (${notInPlaceholders})`;
-          break;
-        }
-        case "exists":
-          if (filter.value === true || filter.value === "true") {
-            valueCondition = sql`${sql.identifier(dbColumnName)} IS NOT NULL`;
-          } else {
-            valueCondition = sql`${sql.identifier(dbColumnName)} IS NULL`;
-          }
-          break;
-        default:
-          // Unknown operator, skip
-          continue;
-      }
+      // 🔴 The discriminator's physical name is resolved PER TABLE, so the
+      // condition is built inside the per-table loop below rather than once for
+      // the filter. This predicate is raw SQL and does not go through the
+      // runtime table object, so it emits whatever column name it is handed —
+      // and a dynamic-zone filter can span several tables whose storage the
+      // migration has moved independently.
 
       // For _componentType filter on dynamic zone, we may need to query multiple tables
       // But the filter value tells us which specific component type to look for
@@ -3038,6 +3080,19 @@ export class CollectionQueryService extends BaseService {
         // fallback when the lookup was unavailable.
         const componentTableName =
           componentTableNames.get(slug) ?? resolveComponentTableName(slug);
+
+        const dbColumnName = filter.isComponentTypeFilter
+          ? (componentTypeColumns.get(componentTableName) ??
+            STORAGE_FORMAT.columns.type)
+          : columnName;
+        const valueCondition = buildComponentValueCondition(
+          filter,
+          dbColumnName,
+          dialect
+        );
+        // An operator with nothing to match — an empty `in` list, or one this
+        // builder does not implement — contributes no condition for this table.
+        if (valueCondition === undefined) continue;
 
         // Build EXISTS subquery:
         // EXISTS (SELECT 1 FROM comp_{slug}

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -1073,7 +1073,10 @@ export class CollectionQueryService extends BaseService {
         schema.id,
         dialect,
         componentTables,
-        await this.resolveComponentTypeColumns(componentTables.values())
+        await this.resolveComponentTypeColumns(
+          componentFilters,
+          componentTables.values()
+        )
       );
 
       // Apply component field conditions to query
@@ -1962,7 +1965,10 @@ export class CollectionQueryService extends BaseService {
           schema.id,
           dialect,
           componentTables,
-          await this.resolveComponentTypeColumns(componentTables.values())
+          await this.resolveComponentTypeColumns(
+            componentFilters,
+            componentTables.values()
+          )
         );
 
         if (componentCondition) {
@@ -3027,8 +3033,15 @@ export class CollectionQueryService extends BaseService {
    * migration has moved and the query fails instead of matching documents.
    */
   private async resolveComponentTypeColumns(
+    filters: readonly ComponentFieldFilter[],
     tableNames: Iterable<string>
   ): Promise<Map<string, string>> {
+    // Only a `_componentType` filter addresses the discriminator. Every other
+    // component filter names a user column, so introspecting here would spend
+    // per-table catalog queries — column and index reads, or a PRAGMA each on
+    // SQLite — on a value nothing goes on to read.
+    if (!filters.some(filter => filter.isComponentTypeFilter)) return new Map();
+
     const tables = [...new Set(tableNames)];
     if (tables.length === 0) return new Map();
     return resolveTypeColumns(this.adapter, tables);

--- a/packages/nextly/src/domains/field-groups/__tests__/entity-delete-field-group-data.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/__tests__/entity-delete-field-group-data.integration.test.ts
@@ -17,6 +17,8 @@
  */
 
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import { createMySqlAdapter } from "@nextlyhq/adapter-mysql";
 import { createPostgresAdapter } from "@nextlyhq/adapter-postgres";
 import { createSqliteAdapter } from "@nextlyhq/adapter-sqlite";
@@ -131,7 +133,11 @@ for (const entry of DIALECTS) {
       }
       registry.registerDynamicSchema(
         name,
-        schemaService.generateRuntimeSchema(name, fields)
+        // The fixture created this table with the production DDL generator on
+        // the line above, so it carries the spelling that generator writes.
+        schemaService.generateRuntimeSchema(name, fields, {
+          typeColumn: STORAGE_FORMAT.columns.type,
+        })
       );
     }
 

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
@@ -127,12 +127,12 @@ function systemTablesFor(dialect: SupportedDialect): Record<string, unknown> {
           };
   return {
     // 🔴 `users` is here for a foreign key, not because the migration reads it:
-    // all three dynamic registries carry `created_by → users.id`. MySQL enforces
-    // that at CREATE time and refuses the constraint outright when the parent is
-    // absent. This suite passed for a while only because a leftover `users` from
-    // another suite happened to be sitting in the container — a fixture whose
-    // correctness depends on what ran before it is not a fixture, and it would
-    // have failed on CI's clean database.
+    // all three dynamic registries carry `created_by → users.id`, and MySQL
+    // enforces that at CREATE time, refusing the constraint outright when the
+    // parent table is absent. It is declared here rather than assumed because
+    // the container is shared: a `users` left behind by another suite would
+    // satisfy the constraint on a developer machine and be absent on a clean
+    // one, so the fixture creates every table it depends on.
     ...userTables(dialect),
     ...registries,
     ...nextlyMetaTables(dialect),

--- a/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
+++ b/packages/nextly/src/domains/field-groups/migration/__tests__/storage-migration.integration.test.ts
@@ -59,6 +59,7 @@ import { DynamicCollectionSchemaService } from "../../../dynamic-collections/ser
 import { FieldGroupSchemaService } from "../../services/field-group-schema-service";
 import { MIGRATION_TARGET } from "../manifest";
 import { runFieldGroupMigration } from "../run";
+import { resolveTypeColumns } from "../../storage/resolve-storage-names";
 import { MIGRATION_LOCK_TABLE } from "../session";
 
 interface TestAdapter {
@@ -387,18 +388,31 @@ for (const entry of DIALECTS) {
       });
     }
 
-    /** Both spellings registered, so reads resolve before and after a run. */
-    function registerRuntimeSchemas(): void {
+    /**
+     * Both spellings registered, so reads resolve before and after a run.
+     *
+     * The discriminator is resolved from the live catalog rather than assumed,
+     * which is what a booting process does. Registered before a run it names
+     * the legacy column; re-registered after one it names the migrated column,
+     * from the same code and without being told which generation it is in.
+     */
+    async function registerRuntimeSchemas(): Promise<void> {
       const pairs: [string, { name: string; type: string }[]][] = [
         [outerTable, [{ name: "heading", type: "text" }]],
         [outerMigrated, [{ name: "heading", type: "text" }]],
         [innerTable, innerFields],
         [innerMigrated, innerFields],
       ];
+      const typeColumns = await resolveTypeColumns(
+        adapter as never,
+        pairs.map(([table]) => table)
+      );
       for (const [table, fields] of pairs) {
         registry.registerDynamicSchema(
           table,
-          schemaService.generateRuntimeSchema(table, fields as never)
+          schemaService.generateRuntimeSchema(table, fields as never, {
+            typeColumn: typeColumns.get(table) ?? STORAGE_FORMAT.columns.type,
+          })
         );
       }
     }
@@ -473,7 +487,7 @@ for (const entry of DIALECTS) {
         value: "Nested body",
       });
 
-      registerRuntimeSchemas();
+      await registerRuntimeSchemas();
     });
 
     afterAll(async () => {
@@ -504,6 +518,53 @@ for (const entry of DIALECTS) {
         field: "inner",
       });
       expect(after?.body).toBe("Nested body");
+    });
+
+    // 🔴 The assertion the reader-side expansion exists for, and the one the
+    // suite could not make before it: the SAME code reads content through the
+    // typed CRUD on both generations, choosing the discriminator from the
+    // catalog rather than being told which generation it is in. Before this
+    // resolution existed the post-migration read projected `_component_type`
+    // against a table carrying `_field_group_type` and failed outright.
+    it("reads content through the typed CRUD on either generation", async () => {
+      const readTyped = async (table: string, parent: string) => {
+        await registerRuntimeSchemas();
+        const rows = await adapter.select<Record<string, unknown>>(table, {
+          where: {
+            and: [
+              {
+                column: STORAGE_FORMAT.columns.parentId,
+                op: "=",
+                value: "outer-1",
+              },
+              {
+                column: STORAGE_FORMAT.columns.parentTable,
+                op: "=",
+                value: parent,
+              },
+              {
+                column: STORAGE_FORMAT.columns.parentField,
+                op: "=",
+                value: "inner",
+              },
+            ],
+          },
+        });
+        return rows[0];
+      };
+
+      const before = await readTyped(innerTable, outerTable);
+      expect(before?.body).toBe("Nested body");
+      // The discriminator comes back under its stable property key whichever
+      // physical column carries it, which is what keeps every consumer of a
+      // component row unchanged across the migration.
+      expect(before).toHaveProperty(STORAGE_FORMAT.columns.type);
+
+      await migrate("up");
+
+      const after = await readTyped(innerMigrated, outerMigrated);
+      expect(after?.body).toBe("Nested body");
+      expect(after).toHaveProperty(STORAGE_FORMAT.columns.type);
     });
 
     it("renames the registry, the tables and the discriminator", async () => {

--- a/packages/nextly/src/domains/field-groups/migration/run.ts
+++ b/packages/nextly/src/domains/field-groups/migration/run.ts
@@ -299,48 +299,51 @@ export async function runFieldGroupMigration(
       });
 
       const fromStep = state.status === "migrating" ? state.step + 1 : 1;
-      await runMigrationSteps({
-        session,
-        meta,
-        migrationId,
-        steps,
-        fromStep,
-      });
+      // 🔴 Invalidated whenever the steps may have RUN, not only when the run
+      // reports success. A rename can commit and `assertStorageComplete` or
+      // `settleMigration` can then throw — at which point the memoized registry
+      // name in this process points at a table that no longer exists, and every
+      // recovery attempt addresses the wrong one. The memo is a schema fact;
+      // the moment storage may have moved, the honest answer is "I no longer
+      // know", and one extra catalog read is the whole cost of saying so.
+      try {
+        await runMigrationSteps({
+          session,
+          meta,
+          migrationId,
+          steps,
+          fromStep,
+        });
 
-      // Asked of the database rather than inferred from the steps having run.
-      // A step reports its own postcondition; this asks whether the storage as
-      // a whole is now what the generation claims, which is the question a
-      // settled marker will be believed on afterwards.
-      await assertStorageComplete({
-        adapter,
-        dialect,
-        rows: await readRegistryRows(adapter, dialect, identifierCase),
-        identifierCase,
-        // Every name this run renamed away. A row still addressing one of them
-        // is content the read path would return nothing for, and it is asked
-        // about here rather than per step because the failure worth catching is
-        // a data table no step ever observed.
-        renamedAway: directed
-          .filter(entry => entry.kind === "table")
-          .map(entry => entry.from),
-        owned,
-        generation,
-      });
+        // Asked of the database rather than inferred from the steps having run.
+        // A step reports its own postcondition; this asks whether the storage as
+        // a whole is now what the generation claims, which is the question a
+        // settled marker will be believed on afterwards.
+        await assertStorageComplete({
+          adapter,
+          dialect,
+          rows: await readRegistryRows(adapter, dialect, identifierCase),
+          identifierCase,
+          // Every name this run renamed away. A row still addressing one of them
+          // is content the read path would return nothing for, and it is asked
+          // about here rather than per step because the failure worth catching is
+          // a data table no step ever observed.
+          renamedAway: directed
+            .filter(entry => entry.kind === "table")
+            .map(entry => entry.from),
+          owned,
+          generation,
+        });
 
-      await settleMigration(
-        meta,
-        generation === "field-groups-v2"
-          ? { generation, appliedManifest: entries }
-          : { generation }
-      );
-
-      // 🔴 The run just invalidated its own process's answer. Readers memoize
-      // which registry table this database holds — it is a schema fact, and
-      // asking per query would cost a catalog round trip on every registry read
-      // — so the one thing that can change it has to say so. Without this,
-      // every `FieldGroupRegistryService` call in this process keeps addressing
-      // the pre-migration name until a restart.
-      forgetFieldGroupStorageNames(adapter);
+        await settleMigration(
+          meta,
+          generation === "field-groups-v2"
+            ? { generation, appliedManifest: entries }
+            : { generation }
+        );
+      } finally {
+        forgetFieldGroupStorageNames(adapter);
+      }
 
       logger.info(
         `Field group storage migrated ${direction} (${String(steps.length)} steps).`

--- a/packages/nextly/src/domains/field-groups/migration/run.ts
+++ b/packages/nextly/src/domains/field-groups/migration/run.ts
@@ -31,6 +31,7 @@ import {
   resolveCatalogName,
   type IdentifierCaseRules,
 } from "../../schema/utils/resolve-catalog-name";
+import { forgetFieldGroupStorageNames } from "../storage/resolve-storage-names";
 
 import { resolveStorageVerdict } from "./guard";
 import {
@@ -332,6 +333,14 @@ export async function runFieldGroupMigration(
           ? { generation, appliedManifest: entries }
           : { generation }
       );
+
+      // 🔴 The run just invalidated its own process's answer. Readers memoize
+      // which registry table this database holds — it is a schema fact, and
+      // asking per query would cost a catalog round trip on every registry read
+      // — so the one thing that can change it has to say so. Without this,
+      // every `FieldGroupRegistryService` call in this process keeps addressing
+      // the pre-migration name until a restart.
+      forgetFieldGroupStorageNames(adapter);
 
       logger.info(
         `Field group storage migrated ${direction} (${String(steps.length)} steps).`

--- a/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
@@ -692,12 +692,16 @@ export class FieldGroupRegistryService extends BaseRegistryService<
       });
     }
 
-    // Resolved once and reused by the failure log below: a message naming a
-    // table this code did not read sends an operator to the wrong place, and
-    // the two names differ on exactly the databases where a failure is hardest
-    // to diagnose.
-    const registryTable = await this.resolveRegistryTableName();
+    // Declared out here so the failure log can name it, ASSIGNED inside the
+    // try so a failed resolution is contained like any other read failure.
+    // This scan is best effort — it informs a reference check, and a catalog
+    // hiccup must not turn that into a hard failure — so the resolution has to
+    // sit inside the same boundary as the read it feeds. Its initial value is
+    // the name this release's DDL creates, which is what the message should say
+    // when resolution itself is what failed.
+    let registryTable: string = STORAGE_FORMAT.registryTable;
     try {
+      registryTable = await this.resolveRegistryTableName();
       const components = await this.adapter.select<Record<string, unknown>>(
         registryTable,
         { columns: ["slug", "fields"] }

--- a/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
@@ -27,6 +27,7 @@ import {
   schemaHashesMatch,
 } from "../../schema/services/schema-hash";
 import { resolveComponentTableName } from "../../schema/utils/resolve-table-name";
+import { resolveRegistryTableName } from "../storage/resolve-storage-names";
 
 import { teardownEntityComponentData } from "./teardown-entity-field-group-data";
 
@@ -106,6 +107,19 @@ export class FieldGroupRegistryService extends BaseRegistryService<
 
   constructor(adapter: DrizzleAdapter, logger: Logger) {
     super(adapter, logger);
+  }
+
+  /**
+   * The registry table this database actually holds.
+   *
+   * Unlike the collection and single registries, this one is renamed by the
+   * field-group storage migration, so the declared name above is what a
+   * database has *before* that runs and not a fact about the database in front
+   * of us. Resolved from the catalog and memoized per adapter, so the answer
+   * costs one catalog read per process rather than one per query.
+   */
+  protected override async resolveRegistryTableName(): Promise<string> {
+    return resolveRegistryTableName(this.adapter);
   }
 
   protected getSearchColumns(): string[] {
@@ -211,7 +225,7 @@ export class FieldGroupRegistryService extends BaseRegistryService<
 
     try {
       const result = await this.adapter.insert<DynamicFieldGroupRecord>(
-        this.registryTableName,
+        await this.resolveRegistryTableName(),
         record,
         { returning: "*" }
       );
@@ -236,7 +250,7 @@ export class FieldGroupRegistryService extends BaseRegistryService<
     data: DynamicFieldGroupInsert
   ): Promise<DynamicFieldGroupRecord> {
     const existing = await tx.selectOne<DynamicFieldGroupRecord>(
-      this.registryTableName,
+      await this.resolveRegistryTableName(),
       {
         where: this.whereEq("slug", data.slug),
       }
@@ -276,7 +290,7 @@ export class FieldGroupRegistryService extends BaseRegistryService<
     };
 
     const result = await tx.insert<DynamicFieldGroupRecord>(
-      this.registryTableName,
+      await this.resolveRegistryTableName(),
       record,
       { returning: "*" }
     );
@@ -359,7 +373,7 @@ export class FieldGroupRegistryService extends BaseRegistryService<
 
     try {
       const results = await this.adapter.update<DynamicFieldGroupRecord>(
-        this.registryTableName,
+        await this.resolveRegistryTableName(),
         updateData,
         this.whereEq("slug", slug),
         { returning: "*" }
@@ -442,7 +456,7 @@ export class FieldGroupRegistryService extends BaseRegistryService<
 
       // PG RETURNING-less DELETE always returns 0 rows, so no post-delete count check.
       await this.adapter.delete(
-        this.registryTableName,
+        await this.resolveRegistryTableName(),
         this.whereEq("slug", slug)
       );
 
@@ -680,7 +694,7 @@ export class FieldGroupRegistryService extends BaseRegistryService<
 
     try {
       const components = await this.adapter.select<Record<string, unknown>>(
-        this.registryTableName,
+        await this.resolveRegistryTableName(),
         { columns: ["slug", "fields"] }
       );
 
@@ -783,7 +797,7 @@ export class FieldGroupRegistryService extends BaseRegistryService<
 
     try {
       const results = await this.adapter.select<DynamicFieldGroupRecord>(
-        this.registryTableName,
+        await this.resolveRegistryTableName(),
         {
           where: {
             and: [

--- a/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-registry-service.ts
@@ -692,9 +692,14 @@ export class FieldGroupRegistryService extends BaseRegistryService<
       });
     }
 
+    // Resolved once and reused by the failure log below: a message naming a
+    // table this code did not read sends an operator to the wrong place, and
+    // the two names differ on exactly the databases where a failure is hardest
+    // to diagnose.
+    const registryTable = await this.resolveRegistryTableName();
     try {
       const components = await this.adapter.select<Record<string, unknown>>(
-        await this.resolveRegistryTableName(),
+        registryTable,
         { columns: ["slug", "fields"] }
       );
 
@@ -715,12 +720,9 @@ export class FieldGroupRegistryService extends BaseRegistryService<
         }
       }
     } catch (error) {
-      this.logger.debug(
-        `Could not scan ${STORAGE_FORMAT.registryTable} for references`,
-        {
-          error: error instanceof Error ? error.message : String(error),
-        }
-      );
+      this.logger.debug(`Could not scan ${registryTable} for references`, {
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
 
     if (references.length > 0) {

--- a/packages/nextly/src/domains/field-groups/services/field-group-schema-service.ts
+++ b/packages/nextly/src/domains/field-groups/services/field-group-schema-service.ts
@@ -146,6 +146,22 @@ const TIMESTAMP_DEFAULT: Record<SupportedDialect, string> = {
   sqlite: "DEFAULT (strftime('%s', 'now'))",
 };
 
+/**
+ * What `generateRuntimeSchema` needs beyond the fields.
+ *
+ * `typeColumn` is required rather than defaulted. The storage migration renames
+ * the discriminator, so the right physical name is a property of the database in
+ * front of us, and a default would let a call site that never learned to resolve
+ * it compile and then silently project a column that is not there. Required
+ * makes the type checker the completeness proof. Callers supply either the
+ * resolved name from the catalog or, for a table this process just created,
+ * `STORAGE_FORMAT.columns.type` — the same constant the DDL just wrote.
+ */
+export interface RuntimeSchemaOptions {
+  localized?: boolean;
+  typeColumn: string;
+}
+
 export class FieldGroupSchemaService {
   private readonly dialect: SupportedDialect;
   private readonly q: string;
@@ -480,7 +496,7 @@ export class FieldGroupSchemaService {
   generateRuntimeSchema(
     tableName: string,
     fields: FieldConfig[],
-    options: { localized?: boolean } = {}
+    options: RuntimeSchemaOptions
   ): unknown {
     // i18n: when the component is localized, its translatable fields live in the
     // companion `comp_<slug>_locales` table and are omitted from the main runtime
@@ -500,13 +516,14 @@ export class FieldGroupSchemaService {
       const name = "name" in f ? (f as { name?: string }).name : undefined;
       return !name || !localizedNames.has(name);
     });
+    const typeColumn = options.typeColumn;
     switch (this.dialect) {
       case "postgresql":
-        return this.generatePostgresSchema(tableName, mainFields);
+        return this.generatePostgresSchema(tableName, mainFields, typeColumn);
       case "mysql":
-        return this.generateMySQLSchema(tableName, mainFields);
+        return this.generateMySQLSchema(tableName, mainFields, typeColumn);
       case "sqlite":
-        return this.generateSQLiteSchema(tableName, mainFields);
+        return this.generateSQLiteSchema(tableName, mainFields, typeColumn);
       default:
         throw new Error(`Unsupported dialect: ${String(this.dialect)}`);
     }
@@ -514,7 +531,8 @@ export class FieldGroupSchemaService {
 
   private generatePostgresSchema(
     tableName: string,
-    fields: FieldConfig[]
+    fields: FieldConfig[],
+    typeColumn: string
   ): unknown {
     // Required by Drizzle: pgTable() expects a `Record<string, PgColumnBuilderBase>`
     // but the column builders returned by helpers (pgText, pgInteger, ...) have
@@ -530,7 +548,13 @@ export class FieldGroupSchemaService {
         length: 255,
       }).notNull(),
       _order: pgInteger(STORAGE_FORMAT.columns.order).default(0),
-      _component_type: pgVarchar(STORAGE_FORMAT.columns.type, { length: 255 }),
+      // 🔴 The Drizzle property key stays `STORAGE_FORMAT.columns.type` while the
+      // physical name is resolved. The adapter addresses columns by property key
+      // everywhere — rows come back keyed by it, `buildDrizzleWhere` and
+      // `orderBy` look columns up by it — so every consumer downstream reads the
+      // same key whichever spelling the storage carries, and keeps reading it
+      // when the constant itself moves.
+      [STORAGE_FORMAT.columns.type]: pgVarchar(typeColumn, { length: 255 }),
       created_at: pgTimestamp("created_at").defaultNow().notNull(),
       updated_at: pgTimestamp("updated_at").defaultNow().notNull(),
     };
@@ -564,7 +588,8 @@ export class FieldGroupSchemaService {
 
   private generateMySQLSchema(
     tableName: string,
-    fields: FieldConfig[]
+    fields: FieldConfig[],
+    typeColumn: string
   ): unknown {
     const columns: Record<string, unknown> = {
       id: mysqlVarchar("id", { length: 36 }).primaryKey(),
@@ -578,7 +603,7 @@ export class FieldGroupSchemaService {
         length: 255,
       }).notNull(),
       _order: mysqlInt(STORAGE_FORMAT.columns.order).default(0),
-      _component_type: mysqlVarchar(STORAGE_FORMAT.columns.type, {
+      [STORAGE_FORMAT.columns.type]: mysqlVarchar(typeColumn, {
         length: 255,
       }),
       created_at: mysqlTimestamp("created_at").defaultNow().notNull(),
@@ -610,7 +635,8 @@ export class FieldGroupSchemaService {
 
   private generateSQLiteSchema(
     tableName: string,
-    fields: FieldConfig[]
+    fields: FieldConfig[],
+    typeColumn: string
   ): unknown {
     const columns: Record<string, unknown> = {
       id: sqliteText("id").primaryKey(),
@@ -618,7 +644,7 @@ export class FieldGroupSchemaService {
       _parent_table: sqliteText(STORAGE_FORMAT.columns.parentTable).notNull(),
       _parent_field: sqliteText(STORAGE_FORMAT.columns.parentField).notNull(),
       _order: sqliteInteger(STORAGE_FORMAT.columns.order).default(0),
-      _component_type: sqliteText(STORAGE_FORMAT.columns.type),
+      [STORAGE_FORMAT.columns.type]: sqliteText(typeColumn),
       created_at: sqliteInteger("created_at", { mode: "timestamp" })
         .notNull()
         .$defaultFn(() => new Date()),

--- a/packages/nextly/src/domains/field-groups/services/register-field-group-schemas.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/register-field-group-schemas.test.ts
@@ -5,7 +5,11 @@
  * runtime schema for every component the database knows about.
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { STORAGE_FORMAT } from "../../../schemas/storage-format";
+import { MIGRATION_TARGET } from "../migration/manifest";
+import { forgetFieldGroupStorageNames } from "../storage/resolve-storage-names";
 
 import { registerComponentSchemas } from "./register-field-group-schemas";
 
@@ -16,14 +20,25 @@ const silentLogger = {
   error: vi.fn(),
 };
 
-/** Adapter returning `components` from the `dynamic_components` registry table. */
-function makeAdapter(components: Array<Record<string, unknown>>) {
+/**
+ * Adapter returning `components` from whichever registry `tables` says is there.
+ *
+ * `listTables` is not decoration: the registry table is resolved from the
+ * catalog because the storage migration renames it, so a double that cannot
+ * answer what tables exist certifies a path production cannot take.
+ */
+function makeAdapter(
+  components: Array<Record<string, unknown>>,
+  tables: string[] = [STORAGE_FORMAT.registryTable]
+) {
   return {
-    dialect: "postgresql",
+    dialect: "postgresql" as const,
     getCapabilities: () => ({ dialect: "postgresql" }),
     select: vi.fn().mockResolvedValue(components),
     selectOne: vi.fn().mockResolvedValue(null),
     executeQuery: vi.fn().mockResolvedValue([]),
+    listTables: vi.fn().mockResolvedValue(tables),
+    getDrizzle: () => ({}),
   };
 }
 
@@ -47,6 +62,10 @@ function componentRow(overrides: Record<string, unknown> = {}) {
 }
 
 describe("registerComponentSchemas", () => {
+  // The resolution is memoized per adapter; each fixture builds its own, and
+  // this keeps a shared module instance from carrying one answer into the next.
+  beforeEach(() => forgetFieldGroupStorageNames());
+
   it("registers a runtime schema for every component in the database", async () => {
     const adapter = makeAdapter([
       componentRow(),
@@ -83,6 +102,33 @@ describe("registerComponentSchemas", () => {
     const registered = registry.registerDynamicSchema.mock.calls.map(c => c[0]);
     expect(registered).toContain("comp_hero");
     expect(registered).toContain("comp_hero_locales");
+  });
+
+  // 🔴 The whole reason this helper had to change. Before the registry name was
+  // resolved it addressed `dynamic_components` by constant, so on a database
+  // whose storage migration has run it read a table that no longer exists and
+  // registered nothing at all — every field group unreadable, silently.
+  it("reads the migrated registry on a database whose storage moved", async () => {
+    const adapter = makeAdapter(
+      [componentRow({ table_name: "fg_hero" })],
+      [MIGRATION_TARGET.registryTable]
+    );
+    const registry = { registerDynamicSchema: vi.fn() };
+
+    const count = await registerComponentSchemas({
+      adapter: adapter as never,
+      registry: registry as never,
+      dialect: "postgresql",
+      logger: silentLogger as never,
+    });
+
+    expect(adapter.select.mock.calls.map(call => call[0])).toEqual([
+      MIGRATION_TARGET.registryTable,
+    ]);
+    expect(count).toBe(1);
+    expect(registry.registerDynamicSchema.mock.calls.map(c => c[0])).toContain(
+      "fg_hero"
+    );
   });
 
   it("is a no-op when the database holds no components", async () => {

--- a/packages/nextly/src/domains/field-groups/services/register-field-group-schemas.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/register-field-group-schemas.test.ts
@@ -38,7 +38,13 @@ function makeAdapter(
     selectOne: vi.fn().mockResolvedValue(null),
     executeQuery: vi.fn().mockResolvedValue([]),
     listTables: vi.fn().mockResolvedValue(tables),
-    getDrizzle: () => ({}),
+    // The discriminator resolution introspects `information_schema` through the
+    // Drizzle handle. An empty result is a truthful answer here — the catalog
+    // describes none of these tables — and it exercises the documented fallback
+    // to the spelling the DDL writes. Whether a REAL catalog steers the
+    // generator to the migrated column is a question only a live server can
+    // answer, and the three-dialect matrix asks it there.
+    getDrizzle: () => ({ execute: async () => ({ rows: [] }) }),
   };
 }
 

--- a/packages/nextly/src/domains/field-groups/services/register-field-group-schemas.test.ts
+++ b/packages/nextly/src/domains/field-groups/services/register-field-group-schemas.test.ts
@@ -9,7 +9,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import { MIGRATION_TARGET } from "../migration/manifest";
-import { forgetFieldGroupStorageNames } from "../storage/resolve-storage-names";
+import {
+  forgetFieldGroupStorageNames,
+  resolveTypeColumns,
+} from "../storage/resolve-storage-names";
 
 import { registerComponentSchemas } from "./register-field-group-schemas";
 
@@ -150,5 +153,43 @@ describe("registerComponentSchemas", () => {
 
     expect(count).toBe(0);
     expect(registry.registerDynamicSchema).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * 🔴 A table this process "just created" may be years old.
+ *
+ * The code-first sync issues `CREATE TABLE IF NOT EXISTS`, so a component whose
+ * *fields* changed reaches the registration path with its table untouched. If
+ * that path hard-codes the creator's spelling it overwrites the boot pass's
+ * catalog-resolved registration and every later read addresses a column the
+ * storage migration moved. The resolver has to answer from the catalog even for
+ * a table the surrounding code believes it owns.
+ */
+describe("resolveTypeColumns — an existing table keeps its own discriminator", () => {
+  it("answers the migrated spelling for a table the DDL did not recreate", async () => {
+    const adapter = {
+      dialect: "postgresql" as const,
+      getDrizzle: <T>(): T =>
+        ({
+          execute: async () => ({
+            rows: [
+              {
+                table_name: "fg_hero",
+                column_name: MIGRATION_TARGET.columnType,
+                udt_name: "varchar",
+                is_nullable: "YES",
+                column_default: null,
+                owned_sequence_default: false,
+              },
+            ],
+          }),
+        }) as T,
+    };
+
+    const resolved = await resolveTypeColumns(adapter, ["fg_hero"]);
+
+    expect(resolved.get("fg_hero")).toBe(MIGRATION_TARGET.columnType);
+    expect(resolved.get("fg_hero")).not.toBe(STORAGE_FORMAT.columns.type);
   });
 });

--- a/packages/nextly/src/domains/field-groups/services/register-field-group-schemas.ts
+++ b/packages/nextly/src/domains/field-groups/services/register-field-group-schemas.ts
@@ -16,8 +16,10 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
 import type { SchemaRegistry } from "../../../database/schema-registry";
+import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import type { Logger } from "../../../shared/types";
 import { buildCompanionRuntimeTable } from "../../i18n/runtime/companion-registration";
+import { resolveTypeColumns } from "../storage/resolve-storage-names";
 
 import { FieldGroupRegistryService } from "./field-group-registry-service";
 import { FieldGroupSchemaService } from "./field-group-schema-service";
@@ -47,6 +49,15 @@ export async function registerComponentSchemas(
 
   const components = await componentRegistry.getAllComponents();
 
+  // One catalog read for the whole set. Resolved per table rather than once for
+  // the database: the storage migration renames the registry LAST, so between a
+  // table's rename and the registry's the two generations coexist, and a table
+  // an author named itself is never renamed while its column always is.
+  const typeColumns = await resolveTypeColumns(
+    adapter,
+    components.map(component => component.tableName)
+  );
+
   for (const component of components) {
     const localized = component.localized === true;
     const fields = component.fields ?? [];
@@ -55,6 +66,8 @@ export async function registerComponentSchemas(
       component.tableName,
       schemaService.generateRuntimeSchema(component.tableName, fields, {
         localized,
+        typeColumn:
+          typeColumns.get(component.tableName) ?? STORAGE_FORMAT.columns.type,
       })
     );
 

--- a/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.ts
+++ b/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.ts
@@ -40,12 +40,21 @@ import {
   indexCatalog,
   resolveCatalogName,
 } from "../../schema/utils/resolve-catalog-name";
+import { resolveRegistryTableName } from "../storage/resolve-storage-names";
 
 /** Bound on how deep component nesting is followed; mirrors MAX_FIELD_GROUP_NESTING_DEPTH. */
 const DEFAULT_MAX_DEPTH = 10;
 
-/** Registry table holding one row per component, including its physical table name. */
-const REGISTRY_TABLE = STORAGE_FORMAT.registryTable;
+/**
+ * Registry table holding one row per component, including its physical table
+ * name. Resolved rather than constant: the field-group storage migration
+ * renames it, so which of the two names a database holds is an observation.
+ */
+async function registryTableName(
+  adapter: TeardownComponentDataAdapter
+): Promise<string> {
+  return resolveRegistryTableName(adapter);
+}
 
 /**
  * Chunk size for `IN (...)` lists. Keeps a very large entity from exceeding a driver's
@@ -230,7 +239,8 @@ async function listRegisteredComponentTables(
   // *Which catalog entry is the registry* is physical identity, so it is resolved
   // through the server's comparison rules and the answer is the spelling the
   // catalog reports. That spelling is what the metadata exclusion below needs.
-  const registryTable = resolveCatalogName(catalog, REGISTRY_TABLE);
+  const declared = await registryTableName(adapter);
+  const registryTable = resolveCatalogName(catalog, declared);
   if (registryTable === undefined) return [];
 
   // *How to address the registry through the ORM* is a different question with a
@@ -247,12 +257,9 @@ async function listRegisteredComponentTables(
   // stays complete for everything such an executor can reach. Probing rather
   // than catching keeps genuine read failures propagating instead of being
   // mistaken for "nothing registered".
-  if (!(await isResolvable(adapter, REGISTRY_TABLE))) return [];
+  if (!(await isResolvable(adapter, declared))) return [];
 
-  const rows = await adapter.select<Record<string, unknown>>(
-    REGISTRY_TABLE,
-    {}
-  );
+  const rows = await adapter.select<Record<string, unknown>>(declared, {});
 
   return (
     rows
@@ -294,6 +301,7 @@ export async function teardownEntityComponentData(
   // scanned as parents).
   const discovered = await adapter.listTables();
   const registered = await listRegisteredComponentTables(adapter, discovered);
+  const registry = await registryTableName(adapter);
   const componentTables = [
     ...new Set([
       ...discovered.filter(name => name.startsWith(STORAGE_FORMAT.tablePrefix)),
@@ -303,7 +311,7 @@ export async function teardownEntityComponentData(
     // at it would otherwise be probed as an instance table, where a missing
     // `_parent_table` column breaks the delete and a permissive adapter could
     // damage the metadata.
-  ].filter(name => name !== REGISTRY_TABLE && !isCompanionTable(name));
+  ].filter(name => name !== registry && !isCompanionTable(name));
 
   if (componentTables.length === 0) {
     return { instancesDeleted: 0, tablesTouched: [], skippedTables: [] };

--- a/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.ts
+++ b/packages/nextly/src/domains/field-groups/services/teardown-entity-field-group-data.ts
@@ -40,6 +40,7 @@ import {
   indexCatalog,
   resolveCatalogName,
 } from "../../schema/utils/resolve-catalog-name";
+import { MIGRATION_TARGET } from "../migration/manifest";
 import { resolveRegistryTableName } from "../storage/resolve-storage-names";
 
 /** Bound on how deep component nesting is followed; mirrors MAX_FIELD_GROUP_NESTING_DEPTH. */
@@ -304,7 +305,15 @@ export async function teardownEntityComponentData(
   const registry = await registryTableName(adapter);
   const componentTables = [
     ...new Set([
-      ...discovered.filter(name => name.startsWith(STORAGE_FORMAT.tablePrefix)),
+      // Both prefixes. The registry-derived list below cannot recover a table
+      // whose metadata row is exactly what went missing, so prefix discovery is
+      // the only route to an orphan — and after the storage migration a
+      // generated table carries `fg_`, not `comp_`.
+      ...discovered.filter(
+        name =>
+          name.startsWith(STORAGE_FORMAT.tablePrefix) ||
+          name.startsWith(MIGRATION_TARGET.tablePrefix)
+      ),
       ...registered,
     ]),
     // The registry itself is metadata, never component storage. A row pointing

--- a/packages/nextly/src/domains/field-groups/storage/__tests__/resolve-storage-names.test.ts
+++ b/packages/nextly/src/domains/field-groups/storage/__tests__/resolve-storage-names.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
+import { identifierCaseRules } from "../../../schema/utils/resolve-catalog-name";
+import { MIGRATION_TARGET } from "../../migration/manifest";
+import type { TableColumns } from "../../migration/reconcile";
+import {
+  chooseRegistryTable,
+  chooseTypeColumns,
+  forgetFieldGroupStorageNames,
+  resolveFieldGroupRegistryTable,
+  resolveRegistryTableName,
+  type StorageNameAdapter,
+} from "../resolve-storage-names";
+
+const LEGACY_REGISTRY = STORAGE_FORMAT.registryTable;
+const MIGRATED_REGISTRY = MIGRATION_TARGET.registryTable;
+const LEGACY_COLUMN = STORAGE_FORMAT.columns.type;
+const MIGRATED_COLUMN = MIGRATION_TARGET.columnType;
+
+/** Postgres: every identifier is quoted, so case is significant. */
+const PRESERVING = identifierCaseRules({ dialect: "postgresql" });
+/** SQLite, and MySQL under lower_case_table_names=1. */
+const FOLDING = identifierCaseRules({ dialect: "sqlite" });
+
+describe("chooseRegistryTable", () => {
+  it("addresses the legacy registry when only it is present", () => {
+    expect(chooseRegistryTable([LEGACY_REGISTRY, "users"], PRESERVING)).toEqual(
+      {
+        name: LEGACY_REGISTRY,
+        migrated: false,
+      }
+    );
+  });
+
+  it("addresses the migrated registry when only it is present", () => {
+    expect(
+      chooseRegistryTable([MIGRATED_REGISTRY, "users"], PRESERVING)
+    ).toEqual({ name: MIGRATED_REGISTRY, migrated: true });
+  });
+
+  // 🔴 The whole preference order in one case. Both present is a database the
+  // migration guard refuses to migrate, but a reader still has to serve it, and
+  // the legacy one is the table every write in this release has been going to.
+  // Preferring the migrated name here would read an object this process never
+  // moved while continuing to write to the other.
+  it("prefers the legacy registry when both are present", () => {
+    expect(
+      chooseRegistryTable([MIGRATED_REGISTRY, LEGACY_REGISTRY], PRESERVING)
+    ).toEqual({ name: LEGACY_REGISTRY, migrated: false });
+  });
+
+  // A fresh database has neither. The legacy name is the answer rather than a
+  // refusal because it is the name the system-table DDL is about to create.
+  it("falls back to the legacy name on a database holding neither", () => {
+    expect(chooseRegistryTable(["users"], PRESERVING)).toEqual({
+      name: LEGACY_REGISTRY,
+      migrated: false,
+    });
+  });
+
+  // MySQL under lower_case_table_names=1 reports whatever case it stored. An
+  // exact-only lookup would call a present registry missing and fall through to
+  // the legacy default, addressing a table that is not there.
+  it("finds a registry the server reported under another case", () => {
+    expect(
+      chooseRegistryTable([MIGRATED_REGISTRY.toUpperCase()], FOLDING)
+    ).toEqual({ name: MIGRATED_REGISTRY, migrated: true });
+  });
+
+  // The mirror of the case above: on a preserving server the two spellings are
+  // two different objects, so folding would report a missing table as present.
+  it("does not fold on a case-preserving server", () => {
+    expect(
+      chooseRegistryTable([MIGRATED_REGISTRY.toUpperCase()], PRESERVING)
+    ).toEqual({ name: LEGACY_REGISTRY, migrated: false });
+  });
+});
+
+describe("chooseTypeColumns", () => {
+  function catalog(entries: Record<string, string[]>): TableColumns[] {
+    return Object.entries(entries).map(([table, columns]) => ({
+      table,
+      columns,
+    }));
+  }
+
+  it("reads the legacy discriminator on an unmigrated table", () => {
+    const resolved = chooseTypeColumns(
+      catalog({ comp_hero: ["id", LEGACY_COLUMN] }),
+      ["comp_hero"],
+      PRESERVING
+    );
+    expect(resolved.get("comp_hero")).toBe(LEGACY_COLUMN);
+  });
+
+  it("reads the migrated discriminator on a migrated table", () => {
+    const resolved = chooseTypeColumns(
+      catalog({ fg_hero: ["id", MIGRATED_COLUMN] }),
+      ["fg_hero"],
+      PRESERVING
+    );
+    expect(resolved.get("fg_hero")).toBe(MIGRATED_COLUMN);
+  });
+
+  // 🔴 The case a single per-database generation cannot express, and the reason
+  // this resolution is per table. It is reachable three ways: mid-run before the
+  // registry's own rename, after a crash between two table steps, and — for a
+  // whole release — whenever a field group is created after a migration, since
+  // the DDL still writes the legacy spelling.
+  it("resolves each table independently when the two generations are mixed", () => {
+    const resolved = chooseTypeColumns(
+      catalog({
+        fg_hero: ["id", MIGRATED_COLUMN],
+        comp_late: ["id", LEGACY_COLUMN],
+      }),
+      ["fg_hero", "comp_late"],
+      PRESERVING
+    );
+    expect(resolved.get("fg_hero")).toBe(MIGRATED_COLUMN);
+    expect(resolved.get("comp_late")).toBe(LEGACY_COLUMN);
+  });
+
+  // Same preference order as the registry, for the same reason: a user column
+  // named like our migrated one must not be adopted while ours is still there.
+  it("prefers the legacy discriminator when a table carries both", () => {
+    const resolved = chooseTypeColumns(
+      catalog({ comp_hero: [MIGRATED_COLUMN, LEGACY_COLUMN] }),
+      ["comp_hero"],
+      PRESERVING
+    );
+    expect(resolved.get("comp_hero")).toBe(LEGACY_COLUMN);
+  });
+
+  it("falls back to the legacy spelling for a table the catalog omits", () => {
+    const resolved = chooseTypeColumns(catalog({}), ["comp_unborn"], FOLDING);
+    expect(resolved.get("comp_unborn")).toBe(LEGACY_COLUMN);
+  });
+
+  // MySQL folds column names on every server whatever lower_case_table_names
+  // says, so a catalog reporting a folded spelling still names our column.
+  it("finds a discriminator the server reported under another case", () => {
+    const resolved = chooseTypeColumns(
+      catalog({ fg_hero: [MIGRATED_COLUMN.toUpperCase()] }),
+      ["fg_hero"],
+      FOLDING
+    );
+    expect(resolved.get("fg_hero")).toBe(MIGRATED_COLUMN);
+  });
+
+  it("matches a table the server reported under another case", () => {
+    const resolved = chooseTypeColumns(
+      catalog({ FG_HERO: [MIGRATED_COLUMN] }),
+      ["fg_hero"],
+      FOLDING
+    );
+    expect(resolved.get("fg_hero")).toBe(MIGRATED_COLUMN);
+  });
+
+  it("answers for every requested table, present or not", () => {
+    const resolved = chooseTypeColumns(
+      catalog({ fg_hero: [MIGRATED_COLUMN] }),
+      ["fg_hero", "fg_missing"],
+      PRESERVING
+    );
+    expect([...resolved.keys()]).toEqual(["fg_hero", "fg_missing"]);
+  });
+});
+
+describe("resolveFieldGroupRegistryTable", () => {
+  /**
+   * A SQLite adapter double.
+   *
+   * SQLite so `readIdentifierCaseRules` decides from the dialect alone and
+   * never reaches `getDrizzle`, which lets these tests count catalog reads
+   * without standing up a database.
+   */
+  function adapterDouble(tables: string[]): StorageNameAdapter & {
+    listTables: ReturnType<typeof vi.fn>;
+  } {
+    return {
+      dialect: "sqlite",
+      listTables: vi.fn(async () => tables),
+      getDrizzle: <T>() => ({}) as T,
+    };
+  }
+
+  it("reads the catalog once and answers from the memo afterwards", async () => {
+    const adapter = adapterDouble([MIGRATED_REGISTRY]);
+
+    await expect(resolveRegistryTableName(adapter)).resolves.toBe(
+      MIGRATED_REGISTRY
+    );
+    await expect(resolveRegistryTableName(adapter)).resolves.toBe(
+      MIGRATED_REGISTRY
+    );
+
+    expect(adapter.listTables).toHaveBeenCalledTimes(1);
+  });
+
+  // Concurrent boot paths resolve at the same moment. Caching the promise
+  // rather than the value is what keeps that one read instead of several.
+  it("shares one catalog read between concurrent callers", async () => {
+    const adapter = adapterDouble([LEGACY_REGISTRY]);
+
+    await Promise.all([
+      resolveRegistryTableName(adapter),
+      resolveRegistryTableName(adapter),
+      resolveRegistryTableName(adapter),
+    ]);
+
+    expect(adapter.listTables).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-reads the catalog after the memo is dropped", async () => {
+    const adapter = adapterDouble([LEGACY_REGISTRY]);
+    await resolveRegistryTableName(adapter);
+
+    forgetFieldGroupStorageNames(adapter);
+    await resolveRegistryTableName(adapter);
+
+    expect(adapter.listTables).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears every memo when called without an adapter", async () => {
+    const first = adapterDouble([LEGACY_REGISTRY]);
+    const second = adapterDouble([MIGRATED_REGISTRY]);
+    await resolveRegistryTableName(first);
+    await resolveRegistryTableName(second);
+
+    forgetFieldGroupStorageNames();
+    await resolveRegistryTableName(first);
+    await resolveRegistryTableName(second);
+
+    expect(first.listTables).toHaveBeenCalledTimes(2);
+    expect(second.listTables).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps two adapters' resolutions apart", async () => {
+    const legacy = adapterDouble([LEGACY_REGISTRY]);
+    const migrated = adapterDouble([MIGRATED_REGISTRY]);
+
+    await expect(resolveFieldGroupRegistryTable(legacy)).resolves.toEqual({
+      name: LEGACY_REGISTRY,
+      migrated: false,
+    });
+    await expect(resolveFieldGroupRegistryTable(migrated)).resolves.toEqual({
+      name: MIGRATED_REGISTRY,
+      migrated: true,
+    });
+  });
+
+  // 🔴 A transient catalog error must not become the process's permanent
+  // answer. Remembering the rejected promise would pin every later read to it.
+  it("does not remember a failed probe", async () => {
+    const adapter = adapterDouble([LEGACY_REGISTRY]);
+    adapter.listTables.mockRejectedValueOnce(new Error("catalog unavailable"));
+
+    await expect(resolveRegistryTableName(adapter)).rejects.toThrow(
+      "catalog unavailable"
+    );
+    await expect(resolveRegistryTableName(adapter)).resolves.toBe(
+      LEGACY_REGISTRY
+    );
+  });
+});

--- a/packages/nextly/src/domains/field-groups/storage/__tests__/resolve-storage-names.test.ts
+++ b/packages/nextly/src/domains/field-groups/storage/__tests__/resolve-storage-names.test.ts
@@ -5,6 +5,7 @@ import { identifierCaseRules } from "../../../schema/utils/resolve-catalog-name"
 import { MIGRATION_TARGET } from "../../migration/manifest";
 import type { TableColumns } from "../../migration/reconcile";
 import {
+  assumeTypeColumn,
   chooseRegistryTable,
   chooseTypeColumns,
   forgetFieldGroupStorageNames,
@@ -262,5 +263,37 @@ describe("resolveFieldGroupRegistryTable", () => {
     await expect(resolveRegistryTableName(adapter)).resolves.toBe(
       LEGACY_REGISTRY
     );
+  });
+});
+
+/**
+ * 🔴 What the boot pass addresses tables as when the catalog cannot be read.
+ *
+ * The containment that keeps a metadata blip from aborting service registration
+ * leaves every table unresolved, and something still has to be registered. The
+ * spelling chosen there is not free: on migrated storage the legacy column is on
+ * none of those tables, so every field-group read and write fails until the
+ * process restarts — a boot that looks healthy and works for nothing.
+ */
+describe("assumeTypeColumn", () => {
+  // The registry renames last going up, so a migrated registry is proof that
+  // every column rename ahead of it committed.
+  it("assumes the migrated column when the registry has been renamed", () => {
+    expect(assumeTypeColumn({ name: MIGRATED_REGISTRY, migrated: true })).toBe(
+      MIGRATED_COLUMN
+    );
+  });
+
+  it("assumes the legacy column on a database that has not migrated", () => {
+    expect(assumeTypeColumn({ name: LEGACY_REGISTRY, migrated: false })).toBe(
+      LEGACY_COLUMN
+    );
+  });
+
+  // A rollback renames the registry FIRST, so a legacy registry proves nothing
+  // about the columns — and neither does a registry probe that itself failed.
+  // Both take the spelling this release's DDL writes rather than guess further.
+  it("assumes the legacy column when the registry could not be resolved", () => {
+    expect(assumeTypeColumn(undefined)).toBe(LEGACY_COLUMN);
   });
 });

--- a/packages/nextly/src/domains/field-groups/storage/__tests__/resolve-storage-names.test.ts
+++ b/packages/nextly/src/domains/field-groups/storage/__tests__/resolve-storage-names.test.ts
@@ -1,18 +1,29 @@
 import { describe, expect, it, vi } from "vitest";
 
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
 import { STORAGE_FORMAT } from "../../../../schemas/storage-format";
+import { introspectLiveSnapshot } from "../../../schema/pipeline/diff/introspect-live";
+import type { ColumnSpec } from "../../../schema/pipeline/diff/types";
 import { identifierCaseRules } from "../../../schema/utils/resolve-catalog-name";
 import { MIGRATION_TARGET } from "../../migration/manifest";
 import type { TableColumns } from "../../migration/reconcile";
 import {
-  assumeTypeColumn,
+  resolveKnownTypeColumns,
   chooseRegistryTable,
   chooseTypeColumns,
   forgetFieldGroupStorageNames,
   resolveFieldGroupRegistryTable,
   resolveRegistryTableName,
+  type CatalogReadAdapter,
   type StorageNameAdapter,
 } from "../resolve-storage-names";
+
+// The live-snapshot read is the only I/O `resolveTypeColumns` does that these
+// cases need to control; everything else in the module answers from the dialect.
+vi.mock("../../../schema/pipeline/diff/introspect-live", () => ({
+  introspectLiveSnapshot: vi.fn(),
+}));
 
 const LEGACY_REGISTRY = STORAGE_FORMAT.registryTable;
 const MIGRATED_REGISTRY = MIGRATION_TARGET.registryTable;
@@ -267,33 +278,90 @@ describe("resolveFieldGroupRegistryTable", () => {
 });
 
 /**
- * 🔴 What the boot pass addresses tables as when the catalog cannot be read.
+ * 🔴 What a boot addresses a table as when the probe cannot speak for it.
  *
- * The containment that keeps a metadata blip from aborting service registration
- * leaves every table unresolved, and something still has to be registered. The
- * spelling chosen there is not free: on migrated storage the legacy column is on
- * none of those tables, so every field-group read and write fails until the
- * process restarts — a boot that looks healthy and works for nothing.
+ * Nothing here may guess. The two generations coexist legitimately on one
+ * database — a group created after a migration carries the legacy column beside
+ * migrated siblings, an author-named table keeps its name while its column
+ * moves, and a crash between two rename steps leaves both — so no single answer
+ * derived from the database as a whole is right for every table in it.
  */
-describe("assumeTypeColumn", () => {
-  // The registry renames last going up, so a migrated registry is proof that
-  // every column rename ahead of it committed.
-  it("assumes the migrated column when the registry has been renamed", () => {
-    expect(assumeTypeColumn({ name: MIGRATED_REGISTRY, migrated: true })).toBe(
-      MIGRATED_COLUMN
+describe("resolveKnownTypeColumns", () => {
+  /** A column list in the shape the live snapshot reports. */
+  const columns = (names: string[]): ColumnSpec[] =>
+    names.map(name => ({ name, type: "text", nullable: true }));
+
+  /**
+   * SQLite so `readIdentifierCaseRules` answers from the dialect alone. The
+   * snapshot is served from `catalog`, and any table listed in `poison` throws
+   * the way a driver does when it cannot describe one — which fails the whole
+   * batch, since one query covers every table.
+   */
+  function adapterDouble(
+    catalog: Record<string, string[]>,
+    poison: string[] = []
+  ): CatalogReadAdapter {
+    vi.mocked(introspectLiveSnapshot).mockImplementation(
+      (_db: unknown, _dialect: SupportedDialect, tables?: string[]) => {
+        const asked = tables ?? [];
+        if (asked.some(table => poison.includes(table))) {
+          return Promise.reject(new Error("could not describe table"));
+        }
+        return Promise.resolve({
+          tables: asked
+            .filter(table => table in catalog)
+            .map(table => ({ name: table, columns: columns(catalog[table]) })),
+        });
+      }
     );
+    return { dialect: "sqlite", getDrizzle: <T>() => ({}) as T };
+  }
+
+  it("reads every table when the batch succeeds", async () => {
+    const adapter = adapterDouble({
+      fg_hero: [MIGRATED_COLUMN],
+      comp_late: [LEGACY_COLUMN],
+    });
+
+    const resolved = await resolveKnownTypeColumns(adapter, [
+      "fg_hero",
+      "comp_late",
+    ]);
+
+    expect(resolved.get("fg_hero")).toBe(MIGRATED_COLUMN);
+    expect(resolved.get("comp_late")).toBe(LEGACY_COLUMN);
   });
 
-  it("assumes the legacy column on a database that has not migrated", () => {
-    expect(assumeTypeColumn({ name: LEGACY_REGISTRY, migrated: false })).toBe(
-      LEGACY_COLUMN
+  // 🔴 The case the whole function exists for. One table takes the batch down,
+  // and the rest must still be registered from evidence rather than from a
+  // property of the database that does not describe them individually.
+  it("keeps the tables that can still answer when one poisons the batch", async () => {
+    const adapter = adapterDouble(
+      { fg_hero: [MIGRATED_COLUMN], comp_late: [LEGACY_COLUMN] },
+      ["fg_broken"]
     );
+
+    const resolved = await resolveKnownTypeColumns(adapter, [
+      "fg_hero",
+      "comp_late",
+      "fg_broken",
+    ]);
+
+    expect(resolved.get("fg_hero")).toBe(MIGRATED_COLUMN);
+    expect(resolved.get("comp_late")).toBe(LEGACY_COLUMN);
+    // Absent, not guessed. A migrated database holds both spellings at once, so
+    // there is no answer to fall back to that is right for every table.
+    expect(resolved.has("fg_broken")).toBe(false);
   });
 
-  // A rollback renames the registry FIRST, so a legacy registry proves nothing
-  // about the columns — and neither does a registry probe that itself failed.
-  // Both take the spelling this release's DDL writes rather than guess further.
-  it("assumes the legacy column when the registry could not be resolved", () => {
-    expect(assumeTypeColumn(undefined)).toBe(LEGACY_COLUMN);
+  it("answers for nothing when no table can be read", async () => {
+    const adapter = adapterDouble({}, ["fg_hero", "comp_late"]);
+
+    const resolved = await resolveKnownTypeColumns(adapter, [
+      "fg_hero",
+      "comp_late",
+    ]);
+
+    expect(resolved.size).toBe(0);
   });
 });

--- a/packages/nextly/src/domains/field-groups/storage/registry-schemas.ts
+++ b/packages/nextly/src/domains/field-groups/storage/registry-schemas.ts
@@ -24,6 +24,7 @@
 
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
+import { NextlyError } from "../../../errors/nextly-error";
 import {
   buildDynamicFieldGroupsMysql,
   buildDynamicFieldGroupsPg,
@@ -45,7 +46,12 @@ export function buildFieldGroupRegistryTable(
       return buildDynamicFieldGroupsSqlite(tableName);
     default: {
       const exhaustive: never = dialect;
-      throw new Error(`Unsupported dialect: ${String(exhaustive)}`);
+      throw NextlyError.internal({
+        logContext: {
+          reason: "cannot build the field-group registry for this dialect",
+          dialect: String(exhaustive),
+        },
+      });
     }
   }
 }

--- a/packages/nextly/src/domains/field-groups/storage/registry-schemas.ts
+++ b/packages/nextly/src/domains/field-groups/storage/registry-schemas.ts
@@ -1,0 +1,73 @@
+/**
+ * The field-group registry, declared under both of its names.
+ *
+ * `SchemaRegistry.registerStaticSchemas` keys a table by the physical SQL name
+ * the Drizzle object carries, and `adapter.select`/`insert`/`update`/`delete`
+ * look a table up by that same key. So a database whose registry has been
+ * renamed cannot be addressed at all unless an object built under the renamed
+ * name is registered: there is no handle to redirect, because the handle *is*
+ * the name.
+ *
+ * Registering both is what makes the two spellings addressable from one build.
+ * It is not an alias — each object names exactly the table it is built for, and
+ * nothing decides which to address here. {@link resolveFieldGroupRegistryTable}
+ * makes that choice from the catalog, and only one of the two tables exists in
+ * any database.
+ *
+ * 🔴 This bundle is for the schema **registry** only, never for a schema
+ * **push**. `getDialectTables` feeds `freshPushSchema`, and adding the migrated
+ * spelling there would create an empty second registry on every database that
+ * has never migrated.
+ *
+ * @module domains/field-groups/storage/registry-schemas
+ */
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+import {
+  buildDynamicFieldGroupsMysql,
+  buildDynamicFieldGroupsPg,
+  buildDynamicFieldGroupsSqlite,
+} from "../../../schemas/dynamic-field-groups";
+import { MIGRATION_TARGET } from "../migration/manifest";
+
+/** Build the registry table for a dialect under an explicit name. */
+export function buildFieldGroupRegistryTable(
+  dialect: SupportedDialect,
+  tableName: string
+): unknown {
+  switch (dialect) {
+    case "postgresql":
+      return buildDynamicFieldGroupsPg(tableName);
+    case "mysql":
+      return buildDynamicFieldGroupsMysql(tableName);
+    case "sqlite":
+      return buildDynamicFieldGroupsSqlite(tableName);
+    default: {
+      const exhaustive: never = dialect;
+      throw new Error(`Unsupported dialect: ${String(exhaustive)}`);
+    }
+  }
+}
+
+/**
+ * The migrated-name registry object, keyed for `registerStaticSchemas`.
+ *
+ * Spread alongside `getDialectTables(dialect)` at every site that builds a
+ * schema registry. The legacy-name object already arrives from that bundle, so
+ * only the migrated one is added here.
+ *
+ * The key is the export name rather than the table name because
+ * `registerStaticSchemas` re-keys every Drizzle table by its physical name; the
+ * key below is only what the object is called in the map it travels in.
+ */
+export function getFieldGroupRegistryAliases(
+  dialect: SupportedDialect
+): Record<string, unknown> {
+  return {
+    dynamicFieldGroupsMigrated: buildFieldGroupRegistryTable(
+      dialect,
+      MIGRATION_TARGET.registryTable
+    ),
+  };
+}

--- a/packages/nextly/src/domains/field-groups/storage/resolve-storage-names.ts
+++ b/packages/nextly/src/domains/field-groups/storage/resolve-storage-names.ts
@@ -68,8 +68,12 @@ export interface StorageNameAdapter extends CatalogReadAdapter {
 
 /** The registry table a database holds, and whether it has been migrated. */
 export interface FieldGroupRegistryTable {
-  /** The name to address, always one of the two constants. */
-  name: string;
+  /**
+   * The name to address, always one of the two constants — typed as the union
+   * rather than `string` so a caller passing it to a signature that accepts
+   * only those two does not have to re-derive it from {@link migrated}.
+   */
+  name: FieldGroupRegistryName;
   /** `true` when the migrated registry is the one present. */
   migrated: boolean;
 }
@@ -173,6 +177,33 @@ export function chooseTypeColumns(
   return resolved;
 }
 
+/**
+ * The discriminator to assume when the catalog could not be read at all.
+ *
+ * 🔴 Not simply the legacy spelling. The storage migration renames the registry
+ * **last**, so a registry already carrying the migrated name proves every column
+ * rename ahead of it committed; assuming the legacy column there names one that
+ * exists on none of those tables, and every field-group read and write fails
+ * until the process restarts.
+ *
+ * The reverse is not claimed. A rollback renames the registry **first**, so a
+ * legacy registry does not prove the columns are legacy — and with the catalog
+ * unreadable there is nothing further to infer from, so that case takes the
+ * spelling this release's DDL writes, which is also the right answer for the
+ * database that has simply never migrated.
+ *
+ * Distinct from {@link chooseTypeColumns}'s own default for a table the catalog
+ * does not describe: that one answers about a table the catalog was able to
+ * speak for, this one answers when it could not speak at all.
+ */
+export function assumeTypeColumn(
+  registry: FieldGroupRegistryTable | undefined
+): string {
+  return registry?.migrated === true
+    ? MIGRATION_TARGET.columnType
+    : STORAGE_FORMAT.columns.type;
+}
+
 /** The discriminator on one table's column list. */
 function chooseTypeColumn(
   columns: readonly string[],
@@ -243,14 +274,11 @@ export type FieldGroupRegistryName =
   | typeof STORAGE_FORMAT.registryTable
   | typeof MIGRATION_TARGET.registryTable;
 
-/** The resolved registry name, narrowed to the union those signatures accept. */
+/** The resolved registry name, for callers that need nothing else about it. */
 export async function resolveFieldGroupRegistryName(
   adapter: StorageNameAdapter
 ): Promise<FieldGroupRegistryName> {
-  const resolved = await resolveFieldGroupRegistryTable(adapter);
-  return resolved.migrated
-    ? MIGRATION_TARGET.registryTable
-    : STORAGE_FORMAT.registryTable;
+  return (await resolveFieldGroupRegistryTable(adapter)).name;
 }
 
 /**

--- a/packages/nextly/src/domains/field-groups/storage/resolve-storage-names.ts
+++ b/packages/nextly/src/domains/field-groups/storage/resolve-storage-names.ts
@@ -49,16 +49,21 @@ import { MIGRATION_TARGET } from "../migration/manifest";
 import type { TableColumns } from "../migration/reconcile";
 
 /**
- * The adapter surface this module needs.
+ * What reading a table's columns needs.
  *
- * Declared structurally rather than importing `DrizzleAdapter` so a caller
- * holding a narrower adapter can still resolve, and so the wrappers can be
- * exercised without constructing one.
+ * Declared structurally rather than importing `DrizzleAdapter`, and kept
+ * separate from {@link StorageNameAdapter} because it genuinely needs less: the
+ * HMR reload path holds an adapter type with no `listTables`, and widening that
+ * type to satisfy a requirement this function does not have would be a fiction.
  */
-export interface StorageNameAdapter {
+export interface CatalogReadAdapter {
   dialect: SupportedDialect;
-  listTables(): Promise<string[]>;
   getDrizzle<T = unknown>(): T;
+}
+
+/** What choosing between the two registry names needs, on top of the above. */
+export interface StorageNameAdapter extends CatalogReadAdapter {
+  listTables(): Promise<string[]>;
 }
 
 /** The registry table a database holds, and whether it has been migrated. */
@@ -102,6 +107,21 @@ export function chooseRegistryTable(
     return { name: MIGRATION_TARGET.registryTable, migrated: true };
   }
   return { name: STORAGE_FORMAT.registryTable, migrated: false };
+}
+
+/**
+ * Whether a table name is the field-group registry, under either spelling.
+ *
+ * The registry has no `status` column where the collection and single
+ * registries do, so a caller that branches on "is this the field-group
+ * registry?" and only compares against the legacy name would select a column
+ * that does not exist the moment the storage migration has run.
+ */
+export function isFieldGroupRegistry(tableName: string): boolean {
+  return (
+    tableName === STORAGE_FORMAT.registryTable ||
+    tableName === MIGRATION_TARGET.registryTable
+  );
 }
 
 /**
@@ -238,7 +258,7 @@ export function forgetFieldGroupStorageNames(
  * every caller already holds the full list it cares about.
  */
 export async function resolveTypeColumns(
-  adapter: StorageNameAdapter,
+  adapter: CatalogReadAdapter,
   tables: readonly string[]
 ): Promise<Map<string, string>> {
   if (tables.length === 0) return new Map();

--- a/packages/nextly/src/domains/field-groups/storage/resolve-storage-names.ts
+++ b/packages/nextly/src/domains/field-groups/storage/resolve-storage-names.ts
@@ -177,33 +177,6 @@ export function chooseTypeColumns(
   return resolved;
 }
 
-/**
- * The discriminator to assume when the catalog could not be read at all.
- *
- * 🔴 Not simply the legacy spelling. The storage migration renames the registry
- * **last**, so a registry already carrying the migrated name proves every column
- * rename ahead of it committed; assuming the legacy column there names one that
- * exists on none of those tables, and every field-group read and write fails
- * until the process restarts.
- *
- * The reverse is not claimed. A rollback renames the registry **first**, so a
- * legacy registry does not prove the columns are legacy — and with the catalog
- * unreadable there is nothing further to infer from, so that case takes the
- * spelling this release's DDL writes, which is also the right answer for the
- * database that has simply never migrated.
- *
- * Distinct from {@link chooseTypeColumns}'s own default for a table the catalog
- * does not describe: that one answers about a table the catalog was able to
- * speak for, this one answers when it could not speak at all.
- */
-export function assumeTypeColumn(
-  registry: FieldGroupRegistryTable | undefined
-): string {
-  return registry?.migrated === true
-    ? MIGRATION_TARGET.columnType
-    : STORAGE_FORMAT.columns.type;
-}
-
 /** The discriminator on one table's column list. */
 function chooseTypeColumn(
   columns: readonly string[],
@@ -326,6 +299,47 @@ export async function resolveTypeColumns(
     tables,
     rules
   );
+}
+
+/**
+ * The same resolution for a caller that must survive a probe it cannot repeat.
+ *
+ * 🔴 A table missing from the result means the probe could not speak for it,
+ * and there is deliberately nothing here that guesses on its behalf. No property
+ * of the database implies one table's discriminator: the two generations coexist
+ * legitimately — an author-named table keeps its name while its column moves, a
+ * group created after a migration carries the legacy column beside migrated
+ * siblings, and a crash between two rename steps leaves both — so any single
+ * answer applied to the whole set is wrong for some of it.
+ *
+ * The batch is attempted first because that is one catalog read for every table.
+ * Its realistic failure is one problematic table taking the query down with it,
+ * so the fallback asks per table rather than giving up on the set: the tables
+ * that can still answer are registered from evidence, and only the ones that
+ * genuinely cannot are left out.
+ */
+export async function resolveKnownTypeColumns(
+  adapter: CatalogReadAdapter,
+  tables: readonly string[]
+): Promise<Map<string, string>> {
+  try {
+    return await resolveTypeColumns(adapter, tables);
+  } catch {
+    const resolved = new Map<string, string>();
+    await Promise.all(
+      tables.map(async table => {
+        try {
+          const column = (await resolveTypeColumns(adapter, [table])).get(
+            table
+          );
+          if (column !== undefined) resolved.set(table, column);
+        } catch {
+          // Left out of the map, which is how the caller learns it is unknown.
+        }
+      })
+    );
+    return resolved;
+  }
 }
 
 async function readRegistryTable(

--- a/packages/nextly/src/domains/field-groups/storage/resolve-storage-names.ts
+++ b/packages/nextly/src/domains/field-groups/storage/resolve-storage-names.ts
@@ -1,0 +1,267 @@
+/**
+ * Which spelling the field-group storage in this database actually uses.
+ *
+ * The storage migration renames the registry table and every data table's type
+ * discriminator. Both spellings therefore exist in the world at once — one per
+ * database, depending on whether that database has run the migration — and the
+ * read path has to address whichever is really there.
+ *
+ * 🔴 Resolved from the **catalog**, never from the migration marker. The marker
+ * is a recorded claim; the catalog is an observable fact. A database restored
+ * from a backup or repaired by hand can carry a marker that disagrees with its
+ * own storage, which is precisely the case a reader must survive, so a
+ * resolution that depends on the marker is wrong exactly when it matters.
+ *
+ * The one rule, applied to both names:
+ *
+ * > **Read the migrated spelling only when the legacy one is absent.**
+ *
+ * That is the preference order the migration itself uses. It is the only order
+ * correct in both directions: `up` renames the registry last and `down` renames
+ * it first, so "legacy if present" always names the live object and never
+ * adopts one this migration did not move.
+ *
+ * Every value returned here is one of the two constants, never the catalog's
+ * own spelling of it. The registry name is used as a `SchemaRegistry` key and
+ * the column name becomes a Drizzle column's emitted identifier, so both have
+ * to be the name the rest of the code knows. The catalog decides *which* of the
+ * two; it does not supply the string.
+ *
+ * The decisions are pure functions over a catalog listing, and the exported
+ * `resolve*` wrappers are the I/O that feeds them. That split is what lets the
+ * folding and mixed-generation cases be tested without a database, while the
+ * three-dialect matrix covers the reading itself.
+ *
+ * @module domains/field-groups/storage/resolve-storage-names
+ */
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+import { STORAGE_FORMAT } from "../../../schemas/storage-format";
+import { introspectLiveSnapshot } from "../../schema/pipeline/diff/introspect-live";
+import { readIdentifierCaseRules } from "../../schema/utils/read-identifier-case";
+import {
+  indexCatalog,
+  resolveCatalogName,
+} from "../../schema/utils/resolve-catalog-name";
+import type { IdentifierCaseRules } from "../../schema/utils/resolve-catalog-name";
+import { MIGRATION_TARGET } from "../migration/manifest";
+import type { TableColumns } from "../migration/reconcile";
+
+/**
+ * The adapter surface this module needs.
+ *
+ * Declared structurally rather than importing `DrizzleAdapter` so a caller
+ * holding a narrower adapter can still resolve, and so the wrappers can be
+ * exercised without constructing one.
+ */
+export interface StorageNameAdapter {
+  dialect: SupportedDialect;
+  listTables(): Promise<string[]>;
+  getDrizzle<T = unknown>(): T;
+}
+
+/** The registry table a database holds, and whether it has been migrated. */
+export interface FieldGroupRegistryTable {
+  /** The name to address, always one of the two constants. */
+  name: string;
+  /** `true` when the migrated registry is the one present. */
+  migrated: boolean;
+}
+
+/**
+ * Cached per adapter: see {@link forgetFieldGroupStorageNames}.
+ *
+ * Reassignable because a `WeakMap` cannot be enumerated, so "forget everything"
+ * can only be expressed by replacing it. Nothing outside this module holds a
+ * reference to the map, so replacing it is invisible to callers.
+ */
+let registryTableCache = new WeakMap<
+  StorageNameAdapter,
+  Promise<FieldGroupRegistryTable>
+>();
+
+/**
+ * Choose the registry table from a catalog listing.
+ *
+ * Neither present is not an error: a database that has not created one yet
+ * resolves to the legacy name, because that is what this release's system-table
+ * DDL is about to create.
+ */
+export function chooseRegistryTable(
+  tables: readonly string[],
+  rules: IdentifierCaseRules
+): FieldGroupRegistryTable {
+  const catalog = indexCatalog(tables, rules.tables);
+  if (resolveCatalogName(catalog, STORAGE_FORMAT.registryTable) !== undefined) {
+    return { name: STORAGE_FORMAT.registryTable, migrated: false };
+  }
+  if (
+    resolveCatalogName(catalog, MIGRATION_TARGET.registryTable) !== undefined
+  ) {
+    return { name: MIGRATION_TARGET.registryTable, migrated: true };
+  }
+  return { name: STORAGE_FORMAT.registryTable, migrated: false };
+}
+
+/**
+ * Choose the discriminator column for each requested table.
+ *
+ * 🔴 Per table, not once per database, and none of the three reasons is
+ * hypothetical:
+ *
+ * 1. The migration renames the registry **last**, so between the first table's
+ *    rename and the registry's there is a window — and after a crash, a lasting
+ *    state — where data columns have moved and the registry has not. A single
+ *    generation read off the registry name is wrong for every table in it.
+ * 2. A table whose stored name this migration did not generate (an author's
+ *    `dbName`) is never renamed, while its column always is. Table generation
+ *    and column generation are independent by construction.
+ * 3. The DDL that creates a field-group table writes the current release's
+ *    spelling, so a group created after a migration carries the legacy column
+ *    while its siblings carry the migrated one until the creator flips too.
+ *
+ * A table the catalog does not describe, including one that does not exist yet,
+ * resolves to the legacy spelling: that is what the DDL writes, so a table
+ * about to be created is addressed correctly rather than refused.
+ */
+export function chooseTypeColumns(
+  catalog: readonly TableColumns[],
+  tables: readonly string[],
+  rules: IdentifierCaseRules
+): Map<string, string> {
+  // Indexed under the server's own table rules, because MySQL with
+  // `lower_case_table_names=1` reports a lowercased name for a table asked for
+  // under another case, and an exact comparison would discard the entry
+  // describing the very table requested.
+  const byTable = indexCatalog(
+    catalog.map(entry => entry.table),
+    rules.tables
+  );
+
+  const resolved = new Map<string, string>();
+  for (const table of tables) {
+    const catalogName = resolveCatalogName(byTable, table);
+    const entry = catalog.find(candidate => candidate.table === catalogName);
+    resolved.set(
+      table,
+      entry === undefined
+        ? STORAGE_FORMAT.columns.type
+        : chooseTypeColumn(entry.columns, rules)
+    );
+  }
+  return resolved;
+}
+
+/** The discriminator on one table's column list. */
+function chooseTypeColumn(
+  columns: readonly string[],
+  rules: IdentifierCaseRules
+): string {
+  const catalog = indexCatalog(columns, rules.columns);
+  if (resolveCatalogName(catalog, STORAGE_FORMAT.columns.type) !== undefined) {
+    return STORAGE_FORMAT.columns.type;
+  }
+  if (resolveCatalogName(catalog, MIGRATION_TARGET.columnType) !== undefined) {
+    return MIGRATION_TARGET.columnType;
+  }
+  return STORAGE_FORMAT.columns.type;
+}
+
+/**
+ * The registry table this database actually holds.
+ *
+ * Memoized per adapter. `FieldGroupRegistryService` is a DI singleton, so an
+ * unmemoized resolution would add a catalog round trip to every registry query
+ * — an entry read populating several field groups issues one per group. Caching
+ * a schema fact for the life of a process is what every mature ORM does (Rails
+ * caches the schema and expects a restart after a migration; Django caches
+ * introspection) and it is what Nextly already does with the runtime Drizzle
+ * tables, which are registered once at boot and are equally stale if a table is
+ * renamed under a live process.
+ *
+ * A memo that outlives a migration performed by a *different* process fails
+ * loudly — the table it names is gone — rather than silently reading the wrong
+ * one. {@link forgetFieldGroupStorageNames} is how the process that performs a
+ * migration drops its own.
+ */
+export async function resolveFieldGroupRegistryTable(
+  adapter: StorageNameAdapter
+): Promise<FieldGroupRegistryTable> {
+  const cached = registryTableCache.get(adapter);
+  if (cached !== undefined) return cached;
+
+  // The promise is cached, not the value, so concurrent callers during boot
+  // share one catalog read instead of racing to issue several.
+  const pending = readRegistryTable(adapter);
+  registryTableCache.set(adapter, pending);
+  try {
+    return await pending;
+  } catch (error) {
+    // A failed probe must not be remembered as the answer, or one transient
+    // catalog error would pin the process to a wrong name for its whole life.
+    registryTableCache.delete(adapter);
+    throw error;
+  }
+}
+
+/** Convenience for the many callers that only need the name. */
+export async function resolveRegistryTableName(
+  adapter: StorageNameAdapter
+): Promise<string> {
+  return (await resolveFieldGroupRegistryTable(adapter)).name;
+}
+
+/**
+ * Drop the memoized resolution.
+ *
+ * Called by the process that runs the migration, immediately after storage
+ * moves. Omitting the adapter clears every entry, which is what a test sharing
+ * one module instance across fixtures needs.
+ */
+export function forgetFieldGroupStorageNames(
+  adapter?: StorageNameAdapter
+): void {
+  if (adapter === undefined) {
+    registryTableCache = new WeakMap();
+    return;
+  }
+  registryTableCache.delete(adapter);
+}
+
+/**
+ * The discriminator column each named data table actually carries.
+ *
+ * One `introspectLiveSnapshot` covers every table, so the cost is a single
+ * catalog read at the point runtime schemas are registered — boot, or a schema
+ * mutation — and nothing on a read path. Not memoized for the same reason:
+ * every caller already holds the full list it cares about.
+ */
+export async function resolveTypeColumns(
+  adapter: StorageNameAdapter,
+  tables: readonly string[]
+): Promise<Map<string, string>> {
+  if (tables.length === 0) return new Map();
+
+  const rules = await readIdentifierCaseRules(adapter);
+  const snapshot = await introspectLiveSnapshot(
+    adapter.getDrizzle(),
+    adapter.dialect,
+    [...tables]
+  );
+  return chooseTypeColumns(
+    snapshot.tables.map(entry => ({
+      table: entry.name,
+      columns: entry.columns.map(column => column.name),
+    })),
+    tables,
+    rules
+  );
+}
+
+async function readRegistryTable(
+  adapter: StorageNameAdapter
+): Promise<FieldGroupRegistryTable> {
+  const rules = await readIdentifierCaseRules(adapter);
+  return chooseRegistryTable(await adapter.listTables(), rules);
+}

--- a/packages/nextly/src/domains/field-groups/storage/resolve-storage-names.ts
+++ b/packages/nextly/src/domains/field-groups/storage/resolve-storage-names.ts
@@ -233,6 +233,27 @@ export async function resolveRegistryTableName(
 }
 
 /**
+ * The two names the field-group registry can carry on disk.
+ *
+ * Named because several signatures accept it, and a parameter typed as the
+ * legacy spelling alone would reject the resolved name at the call site while
+ * the runtime addressed it happily.
+ */
+export type FieldGroupRegistryName =
+  | typeof STORAGE_FORMAT.registryTable
+  | typeof MIGRATION_TARGET.registryTable;
+
+/** The resolved registry name, narrowed to the union those signatures accept. */
+export async function resolveFieldGroupRegistryName(
+  adapter: StorageNameAdapter
+): Promise<FieldGroupRegistryName> {
+  const resolved = await resolveFieldGroupRegistryTable(adapter);
+  return resolved.migrated
+    ? MIGRATION_TARGET.registryTable
+    : STORAGE_FORMAT.registryTable;
+}
+
+/**
  * Drop the memoized resolution.
  *
  * Called by the process that runs the migration, immediately after storage

--- a/packages/nextly/src/domains/schema/pipeline/managed-tables.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/managed-tables.test.ts
@@ -15,6 +15,16 @@ describe("isCompanionTable", () => {
     expect(isCompanionTable("users")).toBe(false);
   });
 
+  // A localized field group whose storage has been migrated has a companion
+  // under the migrated prefix. A caller that walks the catalog rather than the
+  // managed filter reaches it, and one that does not recognise it as a
+  // companion probes it as an instance table — for an `id` column a companion
+  // does not have, which fails the delete of any entity that gets that far.
+  it("detects companions under the migrated field-group prefix", () => {
+    expect(isCompanionTable("fg_hero_locales")).toBe(true);
+    expect(isCompanionTable("fg_hero")).toBe(false);
+  });
+
   it("companion tables still match the managed-prefix regex (prefix-based)", () => {
     // They are prefixed dc_/single_ so tablesFilter still covers them — the
     // pipeline must additionally exclude them via isCompanionTable.

--- a/packages/nextly/src/domains/schema/pipeline/managed-tables.ts
+++ b/packages/nextly/src/domains/schema/pipeline/managed-tables.ts
@@ -1,4 +1,5 @@
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
+import { MIGRATION_TARGET } from "../../field-groups/migration/manifest";
 // Identifies which tables Nextly manages. Used as the tablesFilter
 // argument to drizzle-kit's pushSchema so we never touch user tables
 // or non-managed nextly_* tables.
@@ -21,8 +22,16 @@ export function isManagedTable(name: string): boolean {
 // They match the managed prefix above, so the diff/pushSchema pipeline MUST additionally
 // exclude them via `isCompanionTable`, or it would introspect/diff them against a desired state
 // that never declares them and spuriously add/drop the table.
+//
+// 🔴 The field-group prefix is matched under BOTH storage generations, which is
+// wider than `isManagedTable` above deliberately. A companion is recognised so
+// that callers can EXCLUDE it, and a caller that reaches a field-group table by
+// walking the catalog rather than through the managed filter — the orphan sweep
+// does exactly that — sees the migrated companion whether or not the pipeline
+// considers the prefix managed. Failing to recognise it there means probing a
+// companion as though it were an instance table, for a column it does not have.
 const COMPANION_TABLE_REGEX = new RegExp(
-  `^(dc_|single_|${STORAGE_FORMAT.tablePrefix}).+${STORAGE_FORMAT.companionSuffix}$`
+  `^(dc_|single_|${STORAGE_FORMAT.tablePrefix}|${MIGRATION_TARGET.tablePrefix}).+${STORAGE_FORMAT.companionSuffix}$`
 );
 
 export function isCompanionTable(name: string): boolean {

--- a/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
+++ b/packages/nextly/src/domains/schema/pipeline/pushschema-pipeline.ts
@@ -32,6 +32,7 @@ import {
 } from "../../../init/schema-snapshot-cache";
 import { buildNotificationEvent } from "../../../runtime/notifications/build-event";
 import type { MigrationScope } from "../../../runtime/notifications/types";
+import { STORAGE_FORMAT } from "../../../schemas/storage-format";
 import { FieldGroupSchemaService } from "../../field-groups/services/field-group-schema-service";
 import { generateRuntimeSchema } from "../services/runtime-schema-generator";
 
@@ -1253,7 +1254,14 @@ export class PushSchemaPipeline {
       const componentTable = fieldGroupSchemaService.generateRuntimeSchema(
         c.tableName,
         c.fields,
-        { localized: (c as { localized?: boolean }).localized === true }
+        {
+          localized: (c as { localized?: boolean }).localized === true,
+          // The DESIRED schema, handed to drizzle-kit to diff against the live
+          // one — so it names the discriminator this release's DDL creates, not
+          // whatever the database currently holds. Resolving here would make the
+          // desired shape follow the live shape and the diff always empty.
+          typeColumn: STORAGE_FORMAT.columns.type,
+        }
       );
       out[c.tableName] = componentTable;
     }

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -92,6 +92,8 @@ describe("reloadNextlyConfig", () => {
   function buildResolver(opts?: {
     /** Catalog listing the reload probes to tell absent from unreadable. */
     catalogTables?: string[];
+    /** Rows the field-group registry returns for `slug` / `table_name`. */
+    registryRows?: Array<{ slug: string; table_name: string }>;
     withAdapter?: boolean;
     allCollections?: Array<{
       slug: string;
@@ -149,6 +151,10 @@ describe("reloadNextlyConfig", () => {
             // that is indistinguishable from a database whose registry read
             // failed, which is the state the reload now refuses to guess past.
             listTables: vi.fn().mockResolvedValue(opts?.catalogTables ?? []),
+            // The stored `slug → table_name` rows. Read through the adapter's
+            // statement path so the three driver envelopes are normalised in
+            // one place; the double answers the normalised shape.
+            queryStatement: vi.fn().mockResolvedValue(opts?.registryRows ?? []),
           })
         : undefined,
       collectionRegistryService: {
@@ -1220,4 +1226,15 @@ describe("reloadNextlyConfig", () => {
       resetWebhookRecordingPolicy();
     });
   });
+
+  /**
+   * 🔴 The reload must address a field group's STORED table name.
+   *
+   * `resolveComponentTableName` answers what this release's creator WOULD name a
+   * table; the registry records what it is actually called. They differ for an
+   * author-chosen `dbName` and, after the storage migration, for every field
+   * group. Deriving the name makes the diff miss the populated table, read the
+   * component as new, and create an empty one beside it — silently, and looking
+   * exactly like content loss.
+   */
 });

--- a/packages/nextly/src/init/__tests__/reload-config.test.ts
+++ b/packages/nextly/src/init/__tests__/reload-config.test.ts
@@ -90,6 +90,8 @@ describe("reloadNextlyConfig", () => {
   // Build a service resolver fake. Returns the service or undefined per
   // service name. Tests pass this into reloadNextlyConfig via opts.resolver.
   function buildResolver(opts?: {
+    /** Catalog listing the reload probes to tell absent from unreadable. */
+    catalogTables?: string[];
     withAdapter?: boolean;
     allCollections?: Array<{
       slug: string;
@@ -141,6 +143,12 @@ describe("reloadNextlyConfig", () => {
             dialect: "sqlite" as const,
             getCapabilities: () => ({ dialect: "sqlite" }),
             getDrizzle: lockDouble.adapter.getDrizzle.bind(lockDouble.adapter),
+            // The reload resolves each field group's PHYSICAL table name from
+            // the registry, and distinguishes "no registry" from "registry
+            // unreadable" by listing the catalog. A double that cannot answer
+            // that is indistinguishable from a database whose registry read
+            // failed, which is the state the reload now refuses to guess past.
+            listTables: vi.fn().mockResolvedValue(opts?.catalogTables ?? []),
           })
         : undefined,
       collectionRegistryService: {

--- a/packages/nextly/src/init/__tests__/stored-field-group-tables.test.ts
+++ b/packages/nextly/src/init/__tests__/stored-field-group-tables.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Where a reload believes its field groups are physically stored.
+ *
+ * 🔴 `resolveComponentTableName` answers what this release's creator WOULD name
+ * a table; the registry records what it is actually called. They differ for an
+ * author-chosen `dbName`, and after the storage migration for every field
+ * group. A reload that derives the name diffs against a table that is not
+ * there, reads the field group as new, and creates an EMPTY one beside the
+ * populated one it meant to edit — silently, and looking exactly like content
+ * loss.
+ *
+ * The second property is the subtler one: a registry that is absent and a
+ * registry that is present but unreadable need different answers, and only the
+ * first may be guessed past.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { MIGRATION_TARGET } from "../../domains/field-groups/migration/manifest";
+import { forgetFieldGroupStorageNames } from "../../domains/field-groups/storage/resolve-storage-names";
+import { STORAGE_FORMAT } from "../../schemas/storage-format";
+import { readStoredFieldGroupTables } from "../reload-config";
+
+/**
+ * A SQLite adapter double.
+ *
+ * SQLite so the identifier-case rules come from the dialect alone and no extra
+ * query is needed to establish them.
+ */
+function adapterDouble(opts: {
+  catalog?: string[];
+  rows?: Array<Record<string, unknown>>;
+  readFails?: boolean;
+  catalogFails?: boolean;
+}) {
+  return {
+    dialect: "sqlite" as const,
+    getDrizzle: <T>(): T => ({}) as T,
+    executeQuery: vi.fn(async () => []),
+    listTables: vi.fn(async () => {
+      if (opts.catalogFails) throw new Error("catalog unavailable");
+      return opts.catalog ?? [];
+    }),
+    queryStatement: vi.fn(async () => {
+      if (opts.readFails) throw new Error("registry read failed");
+      return opts.rows ?? [];
+    }),
+  };
+}
+
+describe("readStoredFieldGroupTables", () => {
+  it("returns the stored name for each field group", async () => {
+    forgetFieldGroupStorageNames();
+    const adapter = adapterDouble({
+      catalog: [MIGRATION_TARGET.registryTable],
+      rows: [{ slug: "hero", table_name: "fg_hero" }],
+    });
+
+    const stored = await readStoredFieldGroupTables(adapter as never);
+
+    expect(stored.usable).toBe(true);
+    expect(stored.tables.get("hero")).toBe("fg_hero");
+  });
+
+  it("reads the migrated registry when that is the one present", async () => {
+    forgetFieldGroupStorageNames();
+    const adapter = adapterDouble({
+      catalog: [MIGRATION_TARGET.registryTable],
+      rows: [{ slug: "hero", table_name: "fg_hero" }],
+    });
+
+    await readStoredFieldGroupTables(adapter as never);
+
+    // One statement, against the registry the catalog reported. The name is not
+    // asserted from the SQL text: the statement is a Drizzle object, and the
+    // resolution it used is what the previous test already pins.
+    expect(adapter.queryStatement).toHaveBeenCalledTimes(1);
+    expect(adapter.listTables).toHaveBeenCalled();
+  });
+
+  // A fresh database. Deriving `comp_*` names is correct here, so the caller is
+  // told the derived names may be used.
+  it("is usable when the registry is genuinely absent", async () => {
+    forgetFieldGroupStorageNames();
+    const adapter = adapterDouble({ catalog: ["users"], readFails: true });
+
+    const stored = await readStoredFieldGroupTables(adapter as never);
+
+    expect(stored.usable).toBe(true);
+    expect(stored.tables.size).toBe(0);
+  });
+
+  // 🔴 The case the type exists for. The registry is there and the read failed,
+  // so the physical names are UNKNOWN — and deriving them is what creates the
+  // empty table.
+  it("is NOT usable when the registry is present but unreadable", async () => {
+    forgetFieldGroupStorageNames();
+    const adapter = adapterDouble({
+      catalog: [STORAGE_FORMAT.registryTable],
+      readFails: true,
+    });
+
+    const stored = await readStoredFieldGroupTables(adapter as never);
+
+    expect(stored.usable).toBe(false);
+  });
+
+  // Not even the catalog could answer, so absence was never established. The
+  // unsafe direction must not be the default.
+  it("is NOT usable when the catalog itself cannot be read", async () => {
+    forgetFieldGroupStorageNames();
+    const adapter = adapterDouble({ readFails: true, catalogFails: true });
+
+    const stored = await readStoredFieldGroupTables(adapter as never);
+
+    expect(stored.usable).toBe(false);
+  });
+
+  it("ignores rows whose slug or table name is not a string", async () => {
+    forgetFieldGroupStorageNames();
+    const adapter = adapterDouble({
+      catalog: [STORAGE_FORMAT.registryTable],
+      rows: [
+        { slug: "hero", table_name: "comp_hero" },
+        { slug: 7, table_name: "comp_seven" },
+        { slug: "no-table", table_name: null },
+      ],
+    });
+
+    const stored = await readStoredFieldGroupTables(adapter as never);
+
+    expect([...stored.tables.keys()]).toEqual(["hero"]);
+  });
+});

--- a/packages/nextly/src/init/__tests__/stored-field-group-tables.test.ts
+++ b/packages/nextly/src/init/__tests__/stored-field-group-tables.test.ts
@@ -163,6 +163,23 @@ describe("readStoredFieldGroupTables", () => {
     expect(stored.reason).toContain("registry read failed");
   });
 
+  // A folding server reports the registry under a spelling the code never
+  // wrote. `chooseRegistryTable` matches under the server's rules, so the
+  // absence probe has to match the same way: an exact comparison calls a
+  // present registry absent, the derived names are then declared usable, and
+  // the reload builds legacy tables beside the populated migrated ones.
+  it("is NOT usable when a folding server reports the registry under another case", async () => {
+    forgetFieldGroupStorageNames();
+    const adapter = adapterDouble({
+      catalog: [MIGRATION_TARGET.registryTable.toUpperCase()],
+      readFails: true,
+    });
+
+    const stored = await readStoredFieldGroupTables(adapter as never);
+
+    expect(stored.usable).toBe(false);
+  });
+
   // Not even the catalog could answer, so absence was never established. The
   // unsafe direction must not be the default.
   it("is NOT usable when the catalog itself cannot be read", async () => {

--- a/packages/nextly/src/init/__tests__/stored-field-group-tables.test.ts
+++ b/packages/nextly/src/init/__tests__/stored-field-group-tables.test.ts
@@ -13,12 +13,33 @@
  * registry that is present but unreadable need different answers, and only the
  * first may be guessed past.
  */
+import type { SQL } from "drizzle-orm";
 import { describe, expect, it, vi } from "vitest";
 
 import { MIGRATION_TARGET } from "../../domains/field-groups/migration/manifest";
 import { forgetFieldGroupStorageNames } from "../../domains/field-groups/storage/resolve-storage-names";
 import { STORAGE_FORMAT } from "../../schemas/storage-format";
 import { readStoredFieldGroupTables } from "../reload-config";
+
+/**
+ * The identifiers a Drizzle statement addresses.
+ *
+ * `sql.identifier(name)` compiles to a `Name` chunk carrying the raw name, so
+ * this reads what the statement actually targets without rendering it to a
+ * dialect-specific string.
+ */
+function identifiersIn(statement: SQL): string[] {
+  const chunks = (statement as unknown as { queryChunks?: unknown[] })
+    .queryChunks;
+  if (!Array.isArray(chunks)) return [];
+  return chunks
+    .map(chunk =>
+      chunk !== null && typeof chunk === "object" && "value" in chunk
+        ? (chunk as { value: unknown }).value
+        : undefined
+    )
+    .filter((value): value is string => typeof value === "string");
+}
 
 /**
  * A SQLite adapter double.
@@ -40,8 +61,20 @@ function adapterDouble(opts: {
       if (opts.catalogFails) throw new Error("catalog unavailable");
       return opts.catalog ?? [];
     }),
-    queryStatement: vi.fn(async () => {
+    // 🔴 The double REFUSES a table it does not hold, which is what makes the
+    // assertions below about *which* registry was addressed real rather than
+    // decorative. A permissive double would answer the same rows whatever name
+    // the code asked for, so a regression that queried the legacy or derived
+    // name would pass unnoticed — the exact shape of hollow test this suite
+    // exists to prevent.
+    queryStatement: vi.fn(async (statement: SQL) => {
       if (opts.readFails) throw new Error("registry read failed");
+      const addressed = identifiersIn(statement);
+      const held = opts.catalog ?? [];
+      const target = addressed.find(name => name.startsWith("dynamic_"));
+      if (target !== undefined && !held.includes(target)) {
+        throw new Error(`no such table: ${target}`);
+      }
       return opts.rows ?? [];
     }),
   };
@@ -61,20 +94,39 @@ describe("readStoredFieldGroupTables", () => {
     expect(stored.tables.get("hero")).toBe("fg_hero");
   });
 
-  it("reads the migrated registry when that is the one present", async () => {
+  it("addresses the migrated registry when that is the one present", async () => {
     forgetFieldGroupStorageNames();
     const adapter = adapterDouble({
       catalog: [MIGRATION_TARGET.registryTable],
       rows: [{ slug: "hero", table_name: "fg_hero" }],
     });
 
-    await readStoredFieldGroupTables(adapter as never);
+    const stored = await readStoredFieldGroupTables(adapter as never);
 
-    // One statement, against the registry the catalog reported. The name is not
-    // asserted from the SQL text: the statement is a Drizzle object, and the
-    // resolution it used is what the previous test already pins.
-    expect(adapter.queryStatement).toHaveBeenCalledTimes(1);
-    expect(adapter.listTables).toHaveBeenCalled();
+    // The identifier the statement targets, not merely that a statement ran.
+    const addressed = identifiersIn(
+      adapter.queryStatement.mock.calls[0]?.[0] as SQL
+    );
+    expect(addressed).toContain(MIGRATION_TARGET.registryTable);
+    expect(addressed).not.toContain(STORAGE_FORMAT.registryTable);
+    expect(stored.usable).toBe(true);
+  });
+
+  it("addresses the legacy registry when that is the one present", async () => {
+    forgetFieldGroupStorageNames();
+    const adapter = adapterDouble({
+      catalog: [STORAGE_FORMAT.registryTable],
+      rows: [{ slug: "hero", table_name: "comp_hero" }],
+    });
+
+    const stored = await readStoredFieldGroupTables(adapter as never);
+
+    const addressed = identifiersIn(
+      adapter.queryStatement.mock.calls[0]?.[0] as SQL
+    );
+    expect(addressed).toContain(STORAGE_FORMAT.registryTable);
+    expect(addressed).not.toContain(MIGRATION_TARGET.registryTable);
+    expect(stored.tables.get("hero")).toBe("comp_hero");
   });
 
   // A fresh database. Deriving `comp_*` names is correct here, so the caller is
@@ -102,6 +154,10 @@ describe("readStoredFieldGroupTables", () => {
     const stored = await readStoredFieldGroupTables(adapter as never);
 
     expect(stored.usable).toBe(false);
+    // The cause travels with the verdict, so the caller's log can name it. A
+    // deferral whose reason is lost tells an operator only that something went
+    // wrong, on the one path that skips an entire reload.
+    expect(stored.reason).toContain("registry read failed");
   });
 
   // Not even the catalog could answer, so absence was never established. The

--- a/packages/nextly/src/init/__tests__/stored-field-group-tables.test.ts
+++ b/packages/nextly/src/init/__tests__/stored-field-group-tables.test.ts
@@ -61,12 +61,11 @@ function adapterDouble(opts: {
       if (opts.catalogFails) throw new Error("catalog unavailable");
       return opts.catalog ?? [];
     }),
-    // 🔴 The double REFUSES a table it does not hold, which is what makes the
-    // assertions below about *which* registry was addressed real rather than
-    // decorative. A permissive double would answer the same rows whatever name
-    // the code asked for, so a regression that queried the legacy or derived
-    // name would pass unnoticed — the exact shape of hollow test this suite
-    // exists to prevent.
+    // 🔴 Answers only for a table the catalog lists, and throws `no such table`
+    // otherwise — the same way a real driver behaves. That is what gives the
+    // assertions below their meaning: a double that returned these rows
+    // whatever name it was handed would be satisfied by code addressing the
+    // legacy or the derived registry just as readily as the right one.
     queryStatement: vi.fn(async (statement: SQL) => {
       if (opts.readFails) throw new Error("registry read failed");
       const addressed = identifiersIn(statement);
@@ -112,6 +111,10 @@ describe("readStoredFieldGroupTables", () => {
     expect(stored.usable).toBe(true);
   });
 
+  // The mirror of the case above, and not redundant with it: the resolution
+  // must pick each generation from the catalog rather than favouring either, so
+  // both directions are pinned. A rule that always answered "migrated" would
+  // satisfy the previous test on its own.
   it("addresses the legacy registry when that is the one present", async () => {
     forgetFieldGroupStorageNames();
     const adapter = adapterDouble({

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -65,6 +65,10 @@ import type {
 import { DrizzleStatementExecutor } from "../domains/schema/services/drizzle-statement-executor";
 import { generateRuntimeSchema } from "../domains/schema/services/runtime-schema-generator";
 import { readIdentifierCaseRules } from "../domains/schema/utils/read-identifier-case";
+import {
+  indexCatalog,
+  resolveCatalogName,
+} from "../domains/schema/utils/resolve-catalog-name";
 import type { IdentifierCaseRules } from "../domains/schema/utils/resolve-catalog-name";
 import {
   resolveCollectionTableName,
@@ -1089,11 +1093,18 @@ async function registryIsAbsent(
   adapter: AdapterLike
 ): Promise<boolean | undefined> {
   try {
-    const tables = await adapter.listTables();
-    return !tables.some(
-      table =>
-        table === STORAGE_FORMAT.registryTable ||
-        table === MIGRATION_TARGET.registryTable
+    // Matched under the server's own rules, not by exact spelling — the same
+    // way `chooseRegistryTable` matches. A folding server can report the
+    // registry as `DYNAMIC_FIELD_GROUPS`, and an exact comparison would call a
+    // present registry absent: the caller would then treat derived `comp_*`
+    // names as usable and let the reload build them beside the populated
+    // migrated tables, which is precisely the outcome this probe exists to
+    // prevent.
+    const rules = await readIdentifierCaseRules(adapter);
+    const catalog = indexCatalog(await adapter.listTables(), rules.tables);
+    return (
+      resolveCatalogName(catalog, STORAGE_FORMAT.registryTable) === undefined &&
+      resolveCatalogName(catalog, MIGRATION_TARGET.registryTable) === undefined
     );
   } catch {
     return undefined;

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -1368,6 +1368,20 @@ async function applyReload(opts?: {
     });
   }
 
+  // 🔴 Checked BEFORE the empty-target branch below. `loadConfig` has already
+  // replaced the process-global field-type registry, so returning without
+  // restoring it leaves the deferred config's validators and storage mappings
+  // live against a schema this reload chose not to touch. The empty-target
+  // branch is for a config that genuinely declares nothing; a config whose
+  // entities were all SKIPPED is a different state and must unwind.
+  if (skippedComponentSlugs.size > 0 && componentTargets.length === 0) {
+    logger?.warn(
+      "[Nextly HMR] Every field group was deferred; abandoning this reload."
+    );
+    abandonReload();
+    return;
+  }
+
   if (
     targets.length === 0 &&
     singleTargets.length === 0 &&
@@ -1454,7 +1468,11 @@ async function applyReload(opts?: {
   // metadata-only sync run at all"; this answers "may THIS entity be provisioned", which is a
   // per-entity question — see `ensureLocalizedCompanionsForReload`.
   const deferredEntities = new Set<string>(
-    [...skippedComponentSlugs].map(slug => `component:${slug}`)
+    // `fieldGroup:` — the prefix every other producer and consumer of this set
+    // uses. A deferral recorded under a different key is not a deferral: the
+    // localization helper checks membership and would carry on deriving the
+    // obsolete name for an entity this reload deliberately skipped.
+    [...skippedComponentSlugs].map(slug => `fieldGroup:${slug}`)
   );
 
   const desiredCollections: Record<string, DesiredCollection> = {};

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -2055,8 +2055,17 @@ async function applyReload(opts?: {
       const compReg = (await resolve(
         "fieldGroupRegistryService"
       )) as ComponentRegistrySurface;
+      // 🔴 Deferred groups are excluded here too, not only from the DDL.
+      //
+      // Skipping a group's schema change and then persisting its new `fields`
+      // is the worst of both: the registry would describe columns the table
+      // does not have, and the next restart would build a runtime schema from
+      // that description and fail every read and write for it. The metadata and
+      // the storage it describes move together or not at all.
       const codeFirstComponentConfigs = buildComponentSyncPayload(
-        newConfig.fieldGroups ?? []
+        (newConfig.fieldGroups ?? []).filter(
+          group => !skippedComponentSlugs.has(group.slug ?? "")
+        )
       );
       if (codeFirstComponentConfigs.length > 0) {
         await compReg.syncCodeFirstComponents(codeFirstComponentConfigs);

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -65,6 +65,7 @@ import type {
 import { DrizzleStatementExecutor } from "../domains/schema/services/drizzle-statement-executor";
 import { generateRuntimeSchema } from "../domains/schema/services/runtime-schema-generator";
 import { readIdentifierCaseRules } from "../domains/schema/utils/read-identifier-case";
+import type { IdentifierCaseRules } from "../domains/schema/utils/resolve-catalog-name";
 import {
   resolveCollectionTableName,
   resolveComponentTableName,
@@ -1444,8 +1445,23 @@ async function applyReload(opts?: {
   // (collections + singles). If the call fails, abort the reload entirely —
   // it's a connection-level failure, not a per-table problem.
   let liveSnapshot: NextlySchemaSnapshot;
+  // 🔴 Both probes run HERE, before the apply, and both abort it on failure.
+  //
+  // The identifier rules are read alongside the snapshot rather than where they
+  // are used, because where they are used is *after* the DDL has committed —
+  // inside a block whose catch is documented "non-fatal" and skips every runtime
+  // schema refresh. A transient failure there would leave the registry metadata
+  // synchronized and this process still holding the pre-change Drizzle
+  // descriptors, so component reads and writes would address columns that no
+  // longer exist until another reload or a restart. Failing before anything
+  // commits is the only version of that failure a reload can recover from.
+  //
+  // Free on Postgres and SQLite, where the rules follow from the dialect alone;
+  // only MySQL issues a query, and only MySQL can fail here.
+  let identifierCase: IdentifierCaseRules;
   try {
     liveSnapshot = await introspectLiveSnapshot(db, dialect, managedTableNames);
+    identifierCase = await readIdentifierCaseRules(adapter);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     logger?.error(
@@ -2134,10 +2150,8 @@ async function applyReload(opts?: {
           columns: table.columns.map(column => column.name),
         })),
         Object.values(desiredComponents).map(comp => comp.tableName),
-        // Asked of the server, never assumed: MySQL's table-name folding is
-        // `lower_case_table_names`, which is server configuration, and a static
-        // guess is wrong in one direction or the other on every server.
-        await readIdentifierCaseRules(adapter)
+        // Read before the apply, not here: see the probe block above.
+        identifierCase
       );
       for (const comp of Object.values(desiredComponents)) {
         // i18n: a localized component omits its translatable columns from the main

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -25,6 +25,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
 import { withMigrationExcluded } from "../domains/field-groups/migration/sync-guard";
+import { chooseTypeColumns } from "../domains/field-groups/storage/resolve-storage-names";
 import type { I18nTransitionKind } from "../domains/i18n/migration/transition-state";
 import { createApplyDesiredSchema } from "../domains/schema/pipeline/apply";
 import { RealClassifier } from "../domains/schema/pipeline/classifier/classifier";
@@ -58,6 +59,7 @@ import type {
 } from "../domains/schema/pipeline/types";
 import { DrizzleStatementExecutor } from "../domains/schema/services/drizzle-statement-executor";
 import { generateRuntimeSchema } from "../domains/schema/services/runtime-schema-generator";
+import { readIdentifierCaseRules } from "../domains/schema/utils/read-identifier-case";
 import {
   resolveCollectionTableName,
   resolveComponentTableName,
@@ -79,6 +81,7 @@ import { NextlyError } from "../errors/nextly-error";
 import type { PluginFieldType } from "../plugins/contributions";
 import type { RevalidateConfig } from "../revalidation/types";
 import { getProductionNotifier } from "../runtime/notifications/index";
+import { STORAGE_FORMAT } from "../schemas/storage-format";
 import type { VersionsConfig } from "../schemas/versions/types";
 import { FieldGroupSchemaService } from "../services/field-groups/field-group-schema-service";
 
@@ -1963,6 +1966,22 @@ async function applyReload(opts?: {
       // breaking every component read (filter by _parent_id) and write (insert
       // _parent_*) after an HMR config reload.
       const fieldGroupSchemaService = new FieldGroupSchemaService(dialect);
+      // The discriminator each component table actually carries, taken from the
+      // batched snapshot this reload already read rather than probed again. That
+      // snapshot covers every managed table including the component ones, so a
+      // second introspection here would be a duplicate round trip on the HMR
+      // path — and `chooseTypeColumns` needs nothing the snapshot does not hold.
+      const componentTypeColumns = chooseTypeColumns(
+        liveSnapshot.tables.map(table => ({
+          table: table.name,
+          columns: table.columns.map(column => column.name),
+        })),
+        Object.values(desiredComponents).map(comp => comp.tableName),
+        // Asked of the server, never assumed: MySQL's table-name folding is
+        // `lower_case_table_names`, which is server configuration, and a static
+        // guess is wrong in one direction or the other on every server.
+        await readIdentifierCaseRules(adapter)
+      );
       for (const comp of Object.values(desiredComponents)) {
         // i18n: a localized component omits its translatable columns from the main
         // comp_ runtime table and registers the companion `comp_<slug>_locales` table.
@@ -1970,7 +1989,12 @@ async function applyReload(opts?: {
         const table = fieldGroupSchemaService.generateRuntimeSchema(
           comp.tableName,
           comp.fields,
-          { localized }
+          {
+            localized,
+            typeColumn:
+              componentTypeColumns.get(comp.tableName) ??
+              STORAGE_FORMAT.columns.type,
+          }
         );
         componentFreshTables.set(comp.tableName, table);
         if (localized) {

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -116,6 +116,9 @@ interface AdapterLike {
   // storage migration renames it, so the name is read from the catalog rather
   // than spelled here.
   listTables(): Promise<string[]>;
+  // The registry read goes through the adapter's statement path so the driver
+  // envelopes are normalised in one place rather than per caller.
+  queryStatement<T = Record<string, unknown>>(statement: SQL): Promise<T[]>;
   // Needed to provision the localized companion below: creating the table and adding
   // columns to it are both DDL, and the status backfill that accompanies a new `_status`
   // column is a write.
@@ -1004,37 +1007,56 @@ async function runReload(opts?: {
   }
 }
 
+/** What a reload knows about where its field groups are physically stored. */
+export interface StoredFieldGroupTables {
+  /** `slug` → the physical table name the registry records. */
+  tables: Map<string, string>;
+  /**
+   * Whether those names can be relied on.
+   *
+   * 🔴 The distinction this type exists for: a registry that is ABSENT means a
+   * fresh database, where deriving `comp_*` names is correct. A registry that
+   * is PRESENT but unreadable means the names are UNKNOWN, and deriving them
+   * addresses storage that is not there — which is how a reload creates an
+   * empty table beside the populated one it meant to edit. Only the first case
+   * may guess.
+   */
+  usable: boolean;
+}
+
 /**
- * Read `slug` and `table_name` from the field-group registry.
+ * The physical table name each field group is stored under.
  *
- * A Drizzle statement rather than the query builder: the builder resolves a
- * table through the schema registry, and the name to address here is the one
- * the catalog reports. Same reason the migration's own registry read is written
- * this way.
+ * Read rather than derived: `resolveComponentTableName` answers what this
+ * release's creator WOULD name a table, while the registry records what it is
+ * actually called. They differ for an author-chosen `dbName`, and after the
+ * storage migration for every field group.
+ *
+ * Issued through the adapter's statement path so the three driver envelopes are
+ * normalised in one place, and so an unrecognised shape is refused rather than
+ * reported as no rows.
  */
-async function runRegistrySelect(
-  db: unknown,
-  registryTable: string
-): Promise<Array<{ slug?: unknown; table_name?: unknown }>> {
-  const executor = db as {
-    execute?: (query: SQL) => Promise<unknown>;
-    all?: (query: SQL) => Promise<unknown>;
-  };
-  const statement = sql`SELECT ${sql.identifier("slug")}, ${sql.identifier(
-    "table_name"
-  )} FROM ${sql.identifier(registryTable)}`;
-  // SQLite's driver exposes `all`; Postgres and MySQL expose `execute` and wrap
-  // rows in a driver-specific envelope.
-  const result = await (executor.all
-    ? executor.all(statement)
-    : executor.execute?.(statement));
-  if (Array.isArray(result)) {
-    return result as Array<{ slug?: unknown; table_name?: unknown }>;
+export async function readStoredFieldGroupTables(
+  adapter: AdapterLike
+): Promise<StoredFieldGroupTables> {
+  const tables = new Map<string, string>();
+  try {
+    const registryTable = await resolveFieldGroupRegistryName(adapter);
+    const rows = await adapter.queryStatement<{
+      slug?: unknown;
+      table_name?: unknown;
+    }>(
+      sql`SELECT ${sql.identifier("slug")}, ${sql.identifier("table_name")} FROM ${sql.identifier(registryTable)}`
+    );
+    for (const row of rows) {
+      if (typeof row.slug === "string" && typeof row.table_name === "string") {
+        tables.set(row.slug, row.table_name);
+      }
+    }
+    return { tables, usable: true };
+  } catch {
+    return { tables, usable: (await registryIsAbsent(adapter)) === true };
   }
-  const rows = (result as { rows?: unknown })?.rows;
-  return Array.isArray(rows)
-    ? (rows as Array<{ slug?: unknown; table_name?: unknown }>)
-    : [];
 }
 
 /**
@@ -1314,40 +1336,16 @@ async function applyReload(opts?: {
   // Best effort by design: a registry that cannot be read leaves every name
   // derived, which is exactly the behaviour of a database that has no registry
   // yet.
-  const storedComponentTables = new Map<string, string>();
+  const stored = await readStoredFieldGroupTables(adapter);
+  const storedComponentTables = stored.tables;
+  const storedNamesUsable = stored.usable;
   /** Field groups left out of this reload because their storage is unknown. */
   const skippedComponentSlugs = new Set<string>();
-  // 🔴 A failed probe is NOT evidence of a fresh database.
-  //
-  // Deriving `comp_*` names because the lookup threw is only sound when the
-  // registry is genuinely absent. If it exists and the read merely failed —
-  // a transient error, a denied catalog query — the derived names address
-  // tables that are not there, and the reload goes on to create empty ones
-  // beside the populated tables it meant to edit. So the two cases are
-  // separated: absent means derive, unreadable means skip the component apply
-  // and let the next reload retry.
-  let storedNamesUsable = true;
-  try {
-    const registryTable = await resolveFieldGroupRegistryName(adapter);
-    // Drizzle statement rather than an interpolated string: database access in
-    // product code goes through Drizzle, and the query builder is not usable
-    // here because it resolves a table through the schema registry, which knows
-    // this table under whichever name it was registered with.
-    const db = adapter.getDrizzle<{ execute?: unknown }>();
-    const rows = await runRegistrySelect(db, registryTable);
-    for (const row of rows) {
-      if (typeof row.slug === "string" && typeof row.table_name === "string") {
-        storedComponentTables.set(row.slug, row.table_name);
-      }
-    }
-  } catch {
-    storedNamesUsable = (await registryIsAbsent(adapter)) === true;
-    if (!storedNamesUsable) {
-      logger?.warn(
-        "[Nextly HMR] Could not read stored field-group table names; " +
-          "deferring the field-group apply to the next reload."
-      );
-    }
+  if (!storedNamesUsable) {
+    logger?.warn(
+      "[Nextly HMR] Could not read stored field-group table names; " +
+        "deferring the field-group apply to the next reload."
+    );
   }
 
   for (const c of newConfig.fieldGroups ?? []) {

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -25,7 +25,10 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
 import { withMigrationExcluded } from "../domains/field-groups/migration/sync-guard";
-import { chooseTypeColumns } from "../domains/field-groups/storage/resolve-storage-names";
+import {
+  chooseTypeColumns,
+  resolveFieldGroupRegistryName,
+} from "../domains/field-groups/storage/resolve-storage-names";
 import type { I18nTransitionKind } from "../domains/i18n/migration/transition-state";
 import { createApplyDesiredSchema } from "../domains/schema/pipeline/apply";
 import { RealClassifier } from "../domains/schema/pipeline/classifier/classifier";
@@ -107,6 +110,10 @@ type LoggerLike = {
 interface AdapterLike {
   readonly dialect: "postgresql" | "mysql" | "sqlite";
   getDrizzle<T = unknown>(): T;
+  // Needed to resolve which field-group registry this database holds: the
+  // storage migration renames it, so the name is read from the catalog rather
+  // than spelled here.
+  listTables(): Promise<string[]>;
   // Needed to provision the localized companion below: creating the table and adding
   // columns to it are both DDL, and the status backfill that accompanies a new `_status`
   // column is a write.
@@ -1236,11 +1243,40 @@ async function applyReload(opts?: {
     fields: MinimalField[];
     localized?: boolean;
   }> = [];
+  // 🔴 The STORED physical name wins over the one derived from the slug.
+  //
+  // `resolveComponentTableName` answers what this release's creator WOULD name
+  // a table; the registry records what the table is actually called. Those
+  // differ for an author-chosen `dbName`, and — after the storage migration —
+  // for every field group. Deriving the name would make the reload diff against
+  // a table that is not there, decide the component is new, and create an empty
+  // one beside the populated one it meant to edit.
+  //
+  // Best effort by design: a registry that cannot be read leaves every name
+  // derived, which is exactly the behaviour of a database that has no registry
+  // yet.
+  const storedComponentTables = new Map<string, string>();
+  try {
+    const registryTable = await resolveFieldGroupRegistryName(adapter);
+    const rows = await adapter.executeQuery<{
+      slug: string;
+      table_name: string;
+    }>(`SELECT slug, table_name FROM ${registryTable}`);
+    for (const row of rows) {
+      if (typeof row.slug === "string" && typeof row.table_name === "string") {
+        storedComponentTables.set(row.slug, row.table_name);
+      }
+    }
+  } catch {
+    // No registry yet, or a transient catalog failure. Derived names below.
+  }
+
   for (const c of newConfig.fieldGroups ?? []) {
     if (!c.slug) continue;
     componentTargets.push({
       slug: c.slug,
-      tableName: resolveComponentTableName(c.slug),
+      tableName:
+        storedComponentTables.get(c.slug) ?? resolveComponentTableName(c.slug),
       fields: (c.fields ?? []) as MinimalField[],
       // i18n: carry `localized` so the HMR diff omits translatable columns from the
       // component's main table and registers its companion.

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -1022,6 +1022,13 @@ export interface StoredFieldGroupTables {
    * may guess.
    */
   usable: boolean;
+  /**
+   * Why the read failed, when it did.
+   *
+   * Present only on the failure path, and carried so the caller's log can name
+   * the cause rather than only the symptom.
+   */
+  reason?: string;
 }
 
 /**
@@ -1054,8 +1061,17 @@ export async function readStoredFieldGroupTables(
       }
     }
     return { tables, usable: true };
-  } catch {
-    return { tables, usable: (await registryIsAbsent(adapter)) === true };
+  } catch (error) {
+    // The reason travels with the verdict. Without it the caller can only say
+    // "could not read stored field-group table names", which tells an operator
+    // nothing about whether they are looking at a permission problem, a dropped
+    // connection, or a malformed row — and this is the failure that defers a
+    // whole reload, so it is the one worth diagnosing.
+    return {
+      tables,
+      usable: (await registryIsAbsent(adapter)) === true,
+      reason: error instanceof Error ? error.message : String(error),
+    };
   }
 }
 
@@ -1343,8 +1359,9 @@ async function applyReload(opts?: {
   const skippedComponentSlugs = new Set<string>();
   if (!storedNamesUsable) {
     logger?.warn(
-      "[Nextly HMR] Could not read stored field-group table names; " +
-        "deferring the field-group apply to the next reload."
+      "[Nextly HMR] Could not read stored field-group table names" +
+        (stored.reason ? `: ${stored.reason}` : "") +
+        ". Deferring the field-group apply to the next reload."
     );
   }
 

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -23,7 +23,9 @@
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+import { sql, type SQL } from "drizzle-orm";
 
+import { MIGRATION_TARGET } from "../domains/field-groups/migration/manifest";
 import { withMigrationExcluded } from "../domains/field-groups/migration/sync-guard";
 import {
   chooseTypeColumns,
@@ -1002,6 +1004,63 @@ async function runReload(opts?: {
   }
 }
 
+/**
+ * Read `slug` and `table_name` from the field-group registry.
+ *
+ * A Drizzle statement rather than the query builder: the builder resolves a
+ * table through the schema registry, and the name to address here is the one
+ * the catalog reports. Same reason the migration's own registry read is written
+ * this way.
+ */
+async function runRegistrySelect(
+  db: unknown,
+  registryTable: string
+): Promise<Array<{ slug?: unknown; table_name?: unknown }>> {
+  const executor = db as {
+    execute?: (query: SQL) => Promise<unknown>;
+    all?: (query: SQL) => Promise<unknown>;
+  };
+  const statement = sql`SELECT ${sql.identifier("slug")}, ${sql.identifier(
+    "table_name"
+  )} FROM ${sql.identifier(registryTable)}`;
+  // SQLite's driver exposes `all`; Postgres and MySQL expose `execute` and wrap
+  // rows in a driver-specific envelope.
+  const result = await (executor.all
+    ? executor.all(statement)
+    : executor.execute?.(statement));
+  if (Array.isArray(result)) {
+    return result as Array<{ slug?: unknown; table_name?: unknown }>;
+  }
+  const rows = (result as { rows?: unknown })?.rows;
+  return Array.isArray(rows)
+    ? (rows as Array<{ slug?: unknown; table_name?: unknown }>)
+    : [];
+}
+
+/**
+ * Whether the database genuinely has no field-group registry.
+ *
+ * The distinction that matters after a failed read: absent means a fresh
+ * database, where deriving names is correct; present-but-unreadable means the
+ * names are unknown, and deriving them would address storage that is not there.
+ * Answered `undefined` when even this cannot be established, which is treated
+ * as unreadable.
+ */
+async function registryIsAbsent(
+  adapter: AdapterLike
+): Promise<boolean | undefined> {
+  try {
+    const tables = await adapter.listTables();
+    return !tables.some(
+      table =>
+        table === STORAGE_FORMAT.registryTable ||
+        table === MIGRATION_TARGET.registryTable
+    );
+  } catch {
+    return undefined;
+  }
+}
+
 async function applyReload(opts?: {
   resolver?: ServiceResolver;
   dispatcher?: PromptDispatcher;
@@ -1256,23 +1315,50 @@ async function applyReload(opts?: {
   // derived, which is exactly the behaviour of a database that has no registry
   // yet.
   const storedComponentTables = new Map<string, string>();
+  /** Field groups left out of this reload because their storage is unknown. */
+  const skippedComponentSlugs = new Set<string>();
+  // 🔴 A failed probe is NOT evidence of a fresh database.
+  //
+  // Deriving `comp_*` names because the lookup threw is only sound when the
+  // registry is genuinely absent. If it exists and the read merely failed —
+  // a transient error, a denied catalog query — the derived names address
+  // tables that are not there, and the reload goes on to create empty ones
+  // beside the populated tables it meant to edit. So the two cases are
+  // separated: absent means derive, unreadable means skip the component apply
+  // and let the next reload retry.
+  let storedNamesUsable = true;
   try {
     const registryTable = await resolveFieldGroupRegistryName(adapter);
-    const rows = await adapter.executeQuery<{
-      slug: string;
-      table_name: string;
-    }>(`SELECT slug, table_name FROM ${registryTable}`);
+    // Drizzle statement rather than an interpolated string: database access in
+    // product code goes through Drizzle, and the query builder is not usable
+    // here because it resolves a table through the schema registry, which knows
+    // this table under whichever name it was registered with.
+    const db = adapter.getDrizzle<{ execute?: unknown }>();
+    const rows = await runRegistrySelect(db, registryTable);
     for (const row of rows) {
       if (typeof row.slug === "string" && typeof row.table_name === "string") {
         storedComponentTables.set(row.slug, row.table_name);
       }
     }
   } catch {
-    // No registry yet, or a transient catalog failure. Derived names below.
+    storedNamesUsable = (await registryIsAbsent(adapter)) === true;
+    if (!storedNamesUsable) {
+      logger?.warn(
+        "[Nextly HMR] Could not read stored field-group table names; " +
+          "deferring the field-group apply to the next reload."
+      );
+    }
   }
 
   for (const c of newConfig.fieldGroups ?? []) {
     if (!c.slug) continue;
+    // Skipped entirely when the stored names could not be established: a
+    // derived name is a guess about physical storage, and guessing here is what
+    // creates the empty table.
+    if (!storedNamesUsable) {
+      skippedComponentSlugs.add(c.slug);
+      continue;
+    }
     componentTargets.push({
       slug: c.slug,
       tableName:
@@ -1365,11 +1451,13 @@ async function applyReload(opts?: {
   // registry's `fields` would disagree with the physical table, so the no-DDL
   // metadata-only sync below must be skipped rather than persist unmigrated
   // schema metadata; it retries on the next clean reload or restart.
-  let deferredSchemaChange = false;
+  let deferredSchemaChange = skippedComponentSlugs.size > 0;
   // Which entities were deferred, as `<kind>:<slug>`. The flag above answers "may the
   // metadata-only sync run at all"; this answers "may THIS entity be provisioned", which is a
   // per-entity question — see `ensureLocalizedCompanionsForReload`.
-  const deferredEntities = new Set<string>();
+  const deferredEntities = new Set<string>(
+    [...skippedComponentSlugs].map(slug => `component:${slug}`)
+  );
 
   const desiredCollections: Record<string, DesiredCollection> = {};
   for (const target of targets) {

--- a/packages/nextly/src/init/reload-config.ts
+++ b/packages/nextly/src/init/reload-config.ts
@@ -1392,9 +1392,17 @@ async function applyReload(opts?: {
   // live against a schema this reload chose not to touch. The empty-target
   // branch is for a config that genuinely declares nothing; a config whose
   // entities were all SKIPPED is a different state and must unwind.
-  if (skippedComponentSlugs.size > 0 && componentTargets.length === 0) {
+  if (
+    skippedComponentSlugs.size > 0 &&
+    componentTargets.length === 0 &&
+    targets.length === 0 &&
+    singleTargets.length === 0
+  ) {
+    // Only when NOTHING survives. A field-group deferral is not a reason to
+    // strand a collection or single whose storage this reload can address
+    // perfectly well — the registry read that failed says nothing about them.
     logger?.warn(
-      "[Nextly HMR] Every field group was deferred; abandoning this reload."
+      "[Nextly HMR] Every target was deferred; abandoning this reload."
     );
     abandonReload();
     return;

--- a/packages/nextly/src/schemas/dynamic-field-groups/index.ts
+++ b/packages/nextly/src/schemas/dynamic-field-groups/index.ts
@@ -42,6 +42,7 @@ export {
 // ============================================================
 
 export {
+  buildDynamicFieldGroupsPg,
   dynamicFieldGroupsPg,
   type DynamicFieldGroupPg,
   type DynamicFieldGroupInsertPg,
@@ -52,6 +53,7 @@ export {
 // ============================================================
 
 export {
+  buildDynamicFieldGroupsMysql,
   dynamicFieldGroupsMysql,
   type DynamicFieldGroupMysql,
   type DynamicFieldGroupInsertMysql,
@@ -62,6 +64,7 @@ export {
 // ============================================================
 
 export {
+  buildDynamicFieldGroupsSqlite,
   dynamicFieldGroupsSqlite,
   type DynamicFieldGroupSqlite,
   type DynamicFieldGroupInsertSqlite,

--- a/packages/nextly/src/schemas/dynamic-field-groups/mysql.ts
+++ b/packages/nextly/src/schemas/dynamic-field-groups/mysql.ts
@@ -67,157 +67,179 @@ import type { FieldGroupSource, FieldGroupMigrationStatus } from "./types";
  * - Migration status (synced, pending, generated, applied)
  * - Schema versioning and change detection
  */
-export const dynamicFieldGroupsMysql = mysqlTable(
-  STORAGE_FORMAT.registryTable,
-  {
-    // --------------------------------------------------------
-    // Primary Key
-    // --------------------------------------------------------
+export function buildDynamicFieldGroupsMysql(tableName: string) {
+  return mysqlTable(
+    tableName,
+    {
+      // --------------------------------------------------------
+      // Primary Key
+      // --------------------------------------------------------
 
-    /** Unique identifier (UUID v4, auto-generated) */
-    id: varchar("id", { length: 36 })
-      .primaryKey()
-      .$defaultFn(() => crypto.randomUUID()),
+      /** Unique identifier (UUID v4, auto-generated) */
+      id: varchar("id", { length: 36 })
+        .primaryKey()
+        .$defaultFn(() => crypto.randomUUID()),
 
-    // --------------------------------------------------------
-    // Component Identity
-    // --------------------------------------------------------
+      // --------------------------------------------------------
+      // Component Identity
+      // --------------------------------------------------------
 
-    /**
-     * Unique slug identifier for the Component.
-     * Must be unique across all Components, Collections, AND Singles.
-     */
-    slug: varchar("slug", { length: 255 }).unique().notNull(),
+      /**
+       * Unique slug identifier for the Component.
+       * Must be unique across all Components, Collections, AND Singles.
+       */
+      slug: varchar("slug", { length: 255 }).unique().notNull(),
 
-    /**
-     * Display label for the Admin UI.
-     * Components only need a singular label.
-     */
-    label: varchar("label", { length: 255 }).notNull(),
+      /**
+       * Display label for the Admin UI.
+       * Components only need a singular label.
+       */
+      label: varchar("label", { length: 255 }).notNull(),
 
-    /**
-     * Database table name for this Component's data.
-     * Convention: prefix with `comp_` (e.g., 'comp_seo').
-     */
-    tableName: varchar("table_name", { length: 255 }).unique().notNull(),
+      /**
+       * Database table name for this Component's data.
+       * Convention: prefix with `comp_` (e.g., 'comp_seo').
+       */
+      tableName: varchar("table_name", { length: 255 }).unique().notNull(),
 
-    /** Optional description of the Component's purpose */
-    description: text("description"),
+      /** Optional description of the Component's purpose */
+      description: text("description"),
 
-    // --------------------------------------------------------
-    // Schema Definition
-    // --------------------------------------------------------
+      // --------------------------------------------------------
+      // Schema Definition
+      // --------------------------------------------------------
 
-    /**
-     * Field configurations defining the Component's structure.
-     * Supports all field types including nested component fields.
-     */
-    fields: json("fields").$type<FieldConfig[]>().notNull(),
+      /**
+       * Field configurations defining the Component's structure.
+       * Supports all field types including nested component fields.
+       */
+      fields: json("fields").$type<FieldConfig[]>().notNull(),
 
-    /**
-     * Admin UI configuration options.
-     * Controls category grouping, icon, visibility, etc.
-     */
-    admin: json("admin").$type<FieldGroupAdminOptions>(),
+      /**
+       * Admin UI configuration options.
+       * Controls category grouping, icon, visibility, etc.
+       */
+      admin: json("admin").$type<FieldGroupAdminOptions>(),
 
-    // --------------------------------------------------------
-    // Unified Model Fields
-    // --------------------------------------------------------
+      // --------------------------------------------------------
+      // Unified Model Fields
+      // --------------------------------------------------------
 
-    /**
-     * Where the Component was defined.
-     * - 'code': defineFieldGroup() in a config file
-     * - 'ui': Visual Component Builder
-     */
-    source: varchar("source", { length: 255 })
-      .$type<FieldGroupSource>()
-      .default("ui")
-      .notNull(),
+      /**
+       * Where the Component was defined.
+       * - 'code': defineFieldGroup() in a config file
+       * - 'ui': Visual Component Builder
+       */
+      source: varchar("source", { length: 255 })
+        .$type<FieldGroupSource>()
+        .default("ui")
+        .notNull(),
 
-    /**
-     * If true, the Component cannot be modified via the Admin UI.
-     * Code-first Components are locked by default.
-     */
-    locked: boolean("locked").default(false).notNull(),
+      /**
+       * If true, the Component cannot be modified via the Admin UI.
+       * Code-first Components are locked by default.
+       */
+      locked: boolean("locked").default(false).notNull(),
 
-    // i18n: whether the component is localized (translatable fields live in the
-    // companion `comp_<slug>_locales` table). Mirrors dynamic_collections/singles.
-    localized: boolean("localized").default(false).notNull(),
+      // i18n: whether the component is localized (translatable fields live in the
+      // companion `comp_<slug>_locales` table). Mirrors dynamic_collections/singles.
+      localized: boolean("localized").default(false).notNull(),
 
-    /**
-     * Path to the config file (code-first Components only).
-     * @example "src/components/seo.ts"
-     */
-    configPath: varchar("config_path", { length: 500 }),
+      /**
+       * Path to the config file (code-first Components only).
+       * @example "src/components/seo.ts"
+       */
+      configPath: varchar("config_path", { length: 500 }),
 
-    // --------------------------------------------------------
-    // Migration & Versioning
-    // --------------------------------------------------------
+      // --------------------------------------------------------
+      // Migration & Versioning
+      // --------------------------------------------------------
 
-    /**
-     * SHA-256 hash of the fields definition.
-     * Used for change detection during sync operations.
-     */
-    schemaHash: varchar("schema_hash", { length: 64 }).notNull(),
+      /**
+       * SHA-256 hash of the fields definition.
+       * Used for change detection during sync operations.
+       */
+      schemaHash: varchar("schema_hash", { length: 64 }).notNull(),
 
-    /**
-     * Schema version number, incremented on each change.
-     * Starts at 1 for new Components.
-     */
-    schemaVersion: int("schema_version").default(1).notNull(),
+      /**
+       * Schema version number, incremented on each change.
+       * Starts at 1 for new Components.
+       */
+      schemaVersion: int("schema_version").default(1).notNull(),
 
-    /**
-     * Current migration status.
-     */
-    migrationStatus: varchar("migration_status", { length: 20 })
-      .$type<FieldGroupMigrationStatus>()
-      .default("pending")
-      .notNull(),
+      /**
+       * Current migration status.
+       */
+      migrationStatus: varchar("migration_status", { length: 20 })
+        .$type<FieldGroupMigrationStatus>()
+        .default("pending")
+        .notNull(),
 
-    /**
-     * Reference to the last applied migration ID.
-     */
-    lastMigrationId: varchar("last_migration_id", { length: 36 }),
+      /**
+       * Reference to the last applied migration ID.
+       */
+      lastMigrationId: varchar("last_migration_id", { length: 36 }),
 
-    // --------------------------------------------------------
-    // Metadata
-    // --------------------------------------------------------
+      // --------------------------------------------------------
+      // Metadata
+      // --------------------------------------------------------
 
-    /** User ID who created the Component (optional) */
-    createdBy: varchar("created_by", { length: 36 }),
+      /** User ID who created the Component (optional) */
+      createdBy: varchar("created_by", { length: 36 }),
 
-    /** When the Component was created */
-    createdAt: datetime("created_at")
-      .notNull()
-      .$defaultFn(() => new Date()),
+      /** When the Component was created */
+      createdAt: datetime("created_at")
+        .notNull()
+        .$defaultFn(() => new Date()),
 
-    /** When the Component was last updated */
-    updatedAt: datetime("updated_at")
-      .notNull()
-      .$defaultFn(() => new Date()),
-  },
-  table => [
-    // --------------------------------------------------------
-    // Indexes for Query Performance
-    // --------------------------------------------------------
+      /** When the Component was last updated */
+      updatedAt: datetime("updated_at")
+        .notNull()
+        .$defaultFn(() => new Date()),
+    },
+    table => [
+      // --------------------------------------------------------
+      // Indexes for Query Performance
+      // --------------------------------------------------------
 
-    /** Index for filtering Components by source (code, ui) */
-    index(`${STORAGE_FORMAT.registryTable}_source_idx`).on(table.source),
+      /** Index for filtering Components by source (code, ui) */
+      index(`${STORAGE_FORMAT.registryTable}_source_idx`).on(table.source),
 
-    /** Index for finding Components needing migration */
-    index(`${STORAGE_FORMAT.registryTable}_migration_status_idx`).on(
-      table.migrationStatus
-    ),
+      /** Index for finding Components needing migration */
+      index(`${STORAGE_FORMAT.registryTable}_migration_status_idx`).on(
+        table.migrationStatus
+      ),
 
-    /** Index for filtering by creator */
-    index(`${STORAGE_FORMAT.registryTable}_created_by_idx`).on(table.createdBy),
+      /** Index for filtering by creator */
+      index(`${STORAGE_FORMAT.registryTable}_created_by_idx`).on(
+        table.createdBy
+      ),
 
-    /** Index for sorting by creation date */
-    index(`${STORAGE_FORMAT.registryTable}_created_at_idx`).on(table.createdAt),
+      /** Index for sorting by creation date */
+      index(`${STORAGE_FORMAT.registryTable}_created_at_idx`).on(
+        table.createdAt
+      ),
 
-    /** Index for sorting by last modified date */
-    index(`${STORAGE_FORMAT.registryTable}_updated_at_idx`).on(table.updatedAt),
-  ]
+      /** Index for sorting by last modified date */
+      index(`${STORAGE_FORMAT.registryTable}_updated_at_idx`).on(
+        table.updatedAt
+      ),
+    ]
+  );
+}
+
+/**
+ * The registry under the name this release's DDL creates.
+ *
+ * The factory exists because the storage migration renames this table, and a
+ * Drizzle object carries its physical name: addressing the renamed table needs
+ * an object built under that name. Index names are derived from the legacy
+ * constant in both instances on purpose — the migration renames the table and
+ * its type discriminator and nothing else, so a renamed table keeps the index
+ * names it was created with on every dialect.
+ */
+export const dynamicFieldGroupsMysql = buildDynamicFieldGroupsMysql(
+  STORAGE_FORMAT.registryTable
 );
 
 // ============================================================

--- a/packages/nextly/src/schemas/dynamic-field-groups/postgres.ts
+++ b/packages/nextly/src/schemas/dynamic-field-groups/postgres.ts
@@ -83,168 +83,190 @@ import type { FieldGroupSource, FieldGroupMigrationStatus } from "./types";
  *   .where(eq(dynamicFieldGroupsPg.migrationStatus, 'pending'));
  * ```
  */
-export const dynamicFieldGroupsPg = pgTable(
-  STORAGE_FORMAT.registryTable,
-  {
-    // --------------------------------------------------------
-    // Primary Key
-    // --------------------------------------------------------
+export function buildDynamicFieldGroupsPg(tableName: string) {
+  return pgTable(
+    tableName,
+    {
+      // --------------------------------------------------------
+      // Primary Key
+      // --------------------------------------------------------
 
-    /** Unique identifier (UUID v4, auto-generated) */
-    id: uuid("id").primaryKey().defaultRandom(),
+      /** Unique identifier (UUID v4, auto-generated) */
+      id: uuid("id").primaryKey().defaultRandom(),
 
-    // --------------------------------------------------------
-    // Component Identity
-    // --------------------------------------------------------
+      // --------------------------------------------------------
+      // Component Identity
+      // --------------------------------------------------------
 
-    /**
-     * Unique slug identifier for the Component.
-     * Used in component field references and API operations.
-     * Must be unique across all Components, Collections, AND Singles.
-     */
-    slug: varchar("slug", { length: 255 }).unique().notNull(),
+      /**
+       * Unique slug identifier for the Component.
+       * Used in component field references and API operations.
+       * Must be unique across all Components, Collections, AND Singles.
+       */
+      slug: varchar("slug", { length: 255 }).unique().notNull(),
 
-    /**
-     * Display label for the Admin UI.
-     * Components only need a singular label.
-     *
-     * @example 'SEO Metadata', 'Hero Section', 'Call To Action'
-     */
-    label: varchar("label", { length: 255 }).notNull(),
+      /**
+       * Display label for the Admin UI.
+       * Components only need a singular label.
+       *
+       * @example 'SEO Metadata', 'Hero Section', 'Call To Action'
+       */
+      label: varchar("label", { length: 255 }).notNull(),
 
-    /**
-     * Database table name for this Component's data.
-     * Must be unique across all tables.
-     * Convention: prefix with `comp_` (e.g., 'comp_seo').
-     */
-    tableName: varchar("table_name", { length: 255 }).unique().notNull(),
+      /**
+       * Database table name for this Component's data.
+       * Must be unique across all tables.
+       * Convention: prefix with `comp_` (e.g., 'comp_seo').
+       */
+      tableName: varchar("table_name", { length: 255 }).unique().notNull(),
 
-    /** Optional description of the Component's purpose */
-    description: text("description"),
+      /** Optional description of the Component's purpose */
+      description: text("description"),
 
-    // --------------------------------------------------------
-    // Schema Definition
-    // --------------------------------------------------------
+      // --------------------------------------------------------
+      // Schema Definition
+      // --------------------------------------------------------
 
-    /**
-     * Field configurations defining the Component's structure.
-     * Supports all field types including nested component fields.
-     */
-    fields: jsonb("fields").$type<FieldConfig[]>().notNull(),
+      /**
+       * Field configurations defining the Component's structure.
+       * Supports all field types including nested component fields.
+       */
+      fields: jsonb("fields").$type<FieldConfig[]>().notNull(),
 
-    /**
-     * Admin UI configuration options.
-     * Controls category grouping, icon, visibility, etc.
-     */
-    admin: jsonb("admin").$type<FieldGroupAdminOptions>(),
+      /**
+       * Admin UI configuration options.
+       * Controls category grouping, icon, visibility, etc.
+       */
+      admin: jsonb("admin").$type<FieldGroupAdminOptions>(),
 
-    // --------------------------------------------------------
-    // Unified Model Fields
-    // --------------------------------------------------------
+      // --------------------------------------------------------
+      // Unified Model Fields
+      // --------------------------------------------------------
 
-    /**
-     * Where the Component was defined.
-     * - 'code': defineFieldGroup() in a config file
-     * - 'ui': Visual Component Builder
-     */
-    source: varchar("source", { length: 255 })
-      .$type<FieldGroupSource>()
-      .default("ui")
-      .notNull(),
+      /**
+       * Where the Component was defined.
+       * - 'code': defineFieldGroup() in a config file
+       * - 'ui': Visual Component Builder
+       */
+      source: varchar("source", { length: 255 })
+        .$type<FieldGroupSource>()
+        .default("ui")
+        .notNull(),
 
-    /**
-     * If true, the Component cannot be modified via the Admin UI.
-     * Code-first Components are locked by default.
-     */
-    locked: boolean("locked").default(false).notNull(),
+      /**
+       * If true, the Component cannot be modified via the Admin UI.
+       * Code-first Components are locked by default.
+       */
+      locked: boolean("locked").default(false).notNull(),
 
-    /**
-     * i18n: whether the component is localized. When true, translatable fields live in
-     * the companion `comp_<slug>_locales` table and embedded instances resolve/write them
-     * per language (mirrors `dynamic_collections.localized` / `dynamic_singles.localized`).
-     */
-    localized: boolean("localized").default(false).notNull(),
+      /**
+       * i18n: whether the component is localized. When true, translatable fields live in
+       * the companion `comp_<slug>_locales` table and embedded instances resolve/write them
+       * per language (mirrors `dynamic_collections.localized` / `dynamic_singles.localized`).
+       */
+      localized: boolean("localized").default(false).notNull(),
 
-    /**
-     * Path to the config file (code-first Components only).
-     * Used for syncing and displaying source location.
-     * @example "src/components/seo.ts"
-     */
-    configPath: varchar("config_path", { length: 500 }),
+      /**
+       * Path to the config file (code-first Components only).
+       * Used for syncing and displaying source location.
+       * @example "src/components/seo.ts"
+       */
+      configPath: varchar("config_path", { length: 500 }),
 
-    // --------------------------------------------------------
-    // Migration & Versioning
-    // --------------------------------------------------------
+      // --------------------------------------------------------
+      // Migration & Versioning
+      // --------------------------------------------------------
 
-    /**
-     * SHA-256 hash of the fields definition.
-     * Used for change detection during sync operations.
-     */
-    schemaHash: varchar("schema_hash", { length: 64 }).notNull(),
+      /**
+       * SHA-256 hash of the fields definition.
+       * Used for change detection during sync operations.
+       */
+      schemaHash: varchar("schema_hash", { length: 64 }).notNull(),
 
-    /**
-     * Schema version number, incremented on each change.
-     * Starts at 1 for new Components.
-     */
-    schemaVersion: integer("schema_version").default(1).notNull(),
+      /**
+       * Schema version number, incremented on each change.
+       * Starts at 1 for new Components.
+       */
+      schemaVersion: integer("schema_version").default(1).notNull(),
 
-    /**
-     * Current migration status.
-     * - 'synced': Schema matches database
-     * - 'pending': Changes detected, migration needed
-     * - 'generated': Migration file created
-     * - 'applied': Migration applied to database
-     */
-    migrationStatus: varchar("migration_status", { length: 20 })
-      .$type<FieldGroupMigrationStatus>()
-      .default("pending")
-      .notNull(),
+      /**
+       * Current migration status.
+       * - 'synced': Schema matches database
+       * - 'pending': Changes detected, migration needed
+       * - 'generated': Migration file created
+       * - 'applied': Migration applied to database
+       */
+      migrationStatus: varchar("migration_status", { length: 20 })
+        .$type<FieldGroupMigrationStatus>()
+        .default("pending")
+        .notNull(),
 
-    /**
-     * Reference to the last applied migration ID.
-     * Null for Components that haven't been migrated yet.
-     */
-    lastMigrationId: uuid("last_migration_id"),
+      /**
+       * Reference to the last applied migration ID.
+       * Null for Components that haven't been migrated yet.
+       */
+      lastMigrationId: uuid("last_migration_id"),
 
-    // --------------------------------------------------------
-    // Metadata
-    // --------------------------------------------------------
+      // --------------------------------------------------------
+      // Metadata
+      // --------------------------------------------------------
 
-    /** User ID who created the Component (optional) */
-    createdBy: uuid("created_by"),
+      /** User ID who created the Component (optional) */
+      createdBy: uuid("created_by"),
 
-    /** When the Component was created */
-    createdAt: timestamp("created_at", { withTimezone: false })
-      .defaultNow()
-      .notNull(),
+      /** When the Component was created */
+      createdAt: timestamp("created_at", { withTimezone: false })
+        .defaultNow()
+        .notNull(),
 
-    /** When the Component was last updated */
-    updatedAt: timestamp("updated_at", { withTimezone: false })
-      .defaultNow()
-      .notNull(),
-  },
-  table => [
-    // --------------------------------------------------------
-    // Indexes for Query Performance
-    // --------------------------------------------------------
+      /** When the Component was last updated */
+      updatedAt: timestamp("updated_at", { withTimezone: false })
+        .defaultNow()
+        .notNull(),
+    },
+    table => [
+      // --------------------------------------------------------
+      // Indexes for Query Performance
+      // --------------------------------------------------------
 
-    /** Index for filtering Components by source (code, ui) */
-    index(`${STORAGE_FORMAT.registryTable}_source_idx`).on(table.source),
+      /** Index for filtering Components by source (code, ui) */
+      index(`${STORAGE_FORMAT.registryTable}_source_idx`).on(table.source),
 
-    /** Index for finding Components needing migration */
-    index(`${STORAGE_FORMAT.registryTable}_migration_status_idx`).on(
-      table.migrationStatus
-    ),
+      /** Index for finding Components needing migration */
+      index(`${STORAGE_FORMAT.registryTable}_migration_status_idx`).on(
+        table.migrationStatus
+      ),
 
-    /** Index for filtering by creator */
-    index(`${STORAGE_FORMAT.registryTable}_created_by_idx`).on(table.createdBy),
+      /** Index for filtering by creator */
+      index(`${STORAGE_FORMAT.registryTable}_created_by_idx`).on(
+        table.createdBy
+      ),
 
-    /** Index for sorting by creation date */
-    index(`${STORAGE_FORMAT.registryTable}_created_at_idx`).on(table.createdAt),
+      /** Index for sorting by creation date */
+      index(`${STORAGE_FORMAT.registryTable}_created_at_idx`).on(
+        table.createdAt
+      ),
 
-    /** Index for sorting by last modified date */
-    index(`${STORAGE_FORMAT.registryTable}_updated_at_idx`).on(table.updatedAt),
-  ]
+      /** Index for sorting by last modified date */
+      index(`${STORAGE_FORMAT.registryTable}_updated_at_idx`).on(
+        table.updatedAt
+      ),
+    ]
+  );
+}
+
+/**
+ * The registry under the name this release's DDL creates.
+ *
+ * The factory exists because the storage migration renames this table, and a
+ * Drizzle object carries its physical name: addressing the renamed table needs
+ * an object built under that name. Index names are derived from the legacy
+ * constant in both instances on purpose — the migration renames the table and
+ * its type discriminator and nothing else, so a renamed table keeps the index
+ * names it was created with on every dialect.
+ */
+export const dynamicFieldGroupsPg = buildDynamicFieldGroupsPg(
+  STORAGE_FORMAT.registryTable
 );
 
 // ============================================================

--- a/packages/nextly/src/schemas/dynamic-field-groups/sqlite.ts
+++ b/packages/nextly/src/schemas/dynamic-field-groups/sqlite.ts
@@ -58,156 +58,178 @@ import type { FieldGroupSource, FieldGroupMigrationStatus } from "./types";
  * - Migration status (synced, pending, generated, applied)
  * - Schema versioning and change detection
  */
-export const dynamicFieldGroupsSqlite = sqliteTable(
-  STORAGE_FORMAT.registryTable,
-  {
-    // --------------------------------------------------------
-    // Primary Key
-    // --------------------------------------------------------
+export function buildDynamicFieldGroupsSqlite(tableName: string) {
+  return sqliteTable(
+    tableName,
+    {
+      // --------------------------------------------------------
+      // Primary Key
+      // --------------------------------------------------------
 
-    /** Unique identifier (UUID v4, auto-generated) */
-    id: text("id")
-      .primaryKey()
-      .$defaultFn(() => crypto.randomUUID()),
+      /** Unique identifier (UUID v4, auto-generated) */
+      id: text("id")
+        .primaryKey()
+        .$defaultFn(() => crypto.randomUUID()),
 
-    // --------------------------------------------------------
-    // Component Identity
-    // --------------------------------------------------------
+      // --------------------------------------------------------
+      // Component Identity
+      // --------------------------------------------------------
 
-    /**
-     * Unique slug identifier for the Component.
-     * Must be unique across all Components, Collections, AND Singles.
-     */
-    slug: text("slug").unique().notNull(),
+      /**
+       * Unique slug identifier for the Component.
+       * Must be unique across all Components, Collections, AND Singles.
+       */
+      slug: text("slug").unique().notNull(),
 
-    /**
-     * Display label for the Admin UI.
-     * Components only need a singular label.
-     */
-    label: text("label").notNull(),
+      /**
+       * Display label for the Admin UI.
+       * Components only need a singular label.
+       */
+      label: text("label").notNull(),
 
-    /**
-     * Database table name for this Component's data.
-     * Convention: prefix with `comp_` (e.g., 'comp_seo').
-     */
-    tableName: text("table_name").unique().notNull(),
+      /**
+       * Database table name for this Component's data.
+       * Convention: prefix with `comp_` (e.g., 'comp_seo').
+       */
+      tableName: text("table_name").unique().notNull(),
 
-    /** Optional description of the Component's purpose */
-    description: text("description"),
+      /** Optional description of the Component's purpose */
+      description: text("description"),
 
-    // --------------------------------------------------------
-    // Schema Definition
-    // --------------------------------------------------------
+      // --------------------------------------------------------
+      // Schema Definition
+      // --------------------------------------------------------
 
-    /**
-     * Field configurations defining the Component's structure.
-     * Supports all field types including nested component fields.
-     */
-    fields: text("fields", { mode: "json" }).$type<FieldConfig[]>().notNull(),
+      /**
+       * Field configurations defining the Component's structure.
+       * Supports all field types including nested component fields.
+       */
+      fields: text("fields", { mode: "json" }).$type<FieldConfig[]>().notNull(),
 
-    /**
-     * Admin UI configuration options.
-     * Controls category grouping, icon, visibility, etc.
-     */
-    admin: text("admin", { mode: "json" }).$type<FieldGroupAdminOptions>(),
+      /**
+       * Admin UI configuration options.
+       * Controls category grouping, icon, visibility, etc.
+       */
+      admin: text("admin", { mode: "json" }).$type<FieldGroupAdminOptions>(),
 
-    // --------------------------------------------------------
-    // Unified Model Fields
-    // --------------------------------------------------------
+      // --------------------------------------------------------
+      // Unified Model Fields
+      // --------------------------------------------------------
 
-    /**
-     * Where the Component was defined.
-     * - 'code': defineFieldGroup() in a config file
-     * - 'ui': Visual Component Builder
-     */
-    source: text("source").$type<FieldGroupSource>().default("ui").notNull(),
+      /**
+       * Where the Component was defined.
+       * - 'code': defineFieldGroup() in a config file
+       * - 'ui': Visual Component Builder
+       */
+      source: text("source").$type<FieldGroupSource>().default("ui").notNull(),
 
-    /**
-     * If true, the Component cannot be modified via the Admin UI.
-     * Code-first Components are locked by default.
-     */
-    locked: integer("locked", { mode: "boolean" }).default(false).notNull(),
+      /**
+       * If true, the Component cannot be modified via the Admin UI.
+       * Code-first Components are locked by default.
+       */
+      locked: integer("locked", { mode: "boolean" }).default(false).notNull(),
 
-    // i18n: whether the component is localized (translatable fields live in the
-    // companion `comp_<slug>_locales` table). Mirrors dynamic_collections/singles.
-    localized: integer("localized", { mode: "boolean" })
-      .default(false)
-      .notNull(),
+      // i18n: whether the component is localized (translatable fields live in the
+      // companion `comp_<slug>_locales` table). Mirrors dynamic_collections/singles.
+      localized: integer("localized", { mode: "boolean" })
+        .default(false)
+        .notNull(),
 
-    /**
-     * Path to the config file (code-first Components only).
-     * @example "src/components/seo.ts"
-     */
-    configPath: text("config_path"),
+      /**
+       * Path to the config file (code-first Components only).
+       * @example "src/components/seo.ts"
+       */
+      configPath: text("config_path"),
 
-    // --------------------------------------------------------
-    // Migration & Versioning
-    // --------------------------------------------------------
+      // --------------------------------------------------------
+      // Migration & Versioning
+      // --------------------------------------------------------
 
-    /**
-     * SHA-256 hash of the fields definition.
-     * Used for change detection during sync operations.
-     */
-    schemaHash: text("schema_hash").notNull(),
+      /**
+       * SHA-256 hash of the fields definition.
+       * Used for change detection during sync operations.
+       */
+      schemaHash: text("schema_hash").notNull(),
 
-    /**
-     * Schema version number, incremented on each change.
-     * Starts at 1 for new Components.
-     */
-    schemaVersion: integer("schema_version").default(1).notNull(),
+      /**
+       * Schema version number, incremented on each change.
+       * Starts at 1 for new Components.
+       */
+      schemaVersion: integer("schema_version").default(1).notNull(),
 
-    /**
-     * Current migration status.
-     */
-    migrationStatus: text("migration_status")
-      .$type<FieldGroupMigrationStatus>()
-      .default("pending")
-      .notNull(),
+      /**
+       * Current migration status.
+       */
+      migrationStatus: text("migration_status")
+        .$type<FieldGroupMigrationStatus>()
+        .default("pending")
+        .notNull(),
 
-    /**
-     * Reference to the last applied migration ID.
-     */
-    lastMigrationId: text("last_migration_id"),
+      /**
+       * Reference to the last applied migration ID.
+       */
+      lastMigrationId: text("last_migration_id"),
 
-    // --------------------------------------------------------
-    // Metadata
-    // --------------------------------------------------------
+      // --------------------------------------------------------
+      // Metadata
+      // --------------------------------------------------------
 
-    /** User ID who created the Component (optional) */
-    createdBy: text("created_by"),
+      /** User ID who created the Component (optional) */
+      createdBy: text("created_by"),
 
-    /** When the Component was created */
-    createdAt: integer("created_at", { mode: "timestamp" })
-      .notNull()
-      .$defaultFn(() => new Date()),
+      /** When the Component was created */
+      createdAt: integer("created_at", { mode: "timestamp" })
+        .notNull()
+        .$defaultFn(() => new Date()),
 
-    /** When the Component was last updated */
-    updatedAt: integer("updated_at", { mode: "timestamp" })
-      .notNull()
-      .$defaultFn(() => new Date()),
-  },
-  table => [
-    // --------------------------------------------------------
-    // Indexes for Query Performance
-    // --------------------------------------------------------
+      /** When the Component was last updated */
+      updatedAt: integer("updated_at", { mode: "timestamp" })
+        .notNull()
+        .$defaultFn(() => new Date()),
+    },
+    table => [
+      // --------------------------------------------------------
+      // Indexes for Query Performance
+      // --------------------------------------------------------
 
-    /** Index for filtering Components by source (code, ui) */
-    index(`${STORAGE_FORMAT.registryTable}_source_idx`).on(table.source),
+      /** Index for filtering Components by source (code, ui) */
+      index(`${STORAGE_FORMAT.registryTable}_source_idx`).on(table.source),
 
-    /** Index for finding Components needing migration */
-    index(`${STORAGE_FORMAT.registryTable}_migration_status_idx`).on(
-      table.migrationStatus
-    ),
+      /** Index for finding Components needing migration */
+      index(`${STORAGE_FORMAT.registryTable}_migration_status_idx`).on(
+        table.migrationStatus
+      ),
 
-    /** Index for filtering by creator */
-    index(`${STORAGE_FORMAT.registryTable}_created_by_idx`).on(table.createdBy),
+      /** Index for filtering by creator */
+      index(`${STORAGE_FORMAT.registryTable}_created_by_idx`).on(
+        table.createdBy
+      ),
 
-    /** Index for sorting by creation date */
-    index(`${STORAGE_FORMAT.registryTable}_created_at_idx`).on(table.createdAt),
+      /** Index for sorting by creation date */
+      index(`${STORAGE_FORMAT.registryTable}_created_at_idx`).on(
+        table.createdAt
+      ),
 
-    /** Index for sorting by last modified date */
-    index(`${STORAGE_FORMAT.registryTable}_updated_at_idx`).on(table.updatedAt),
-  ]
+      /** Index for sorting by last modified date */
+      index(`${STORAGE_FORMAT.registryTable}_updated_at_idx`).on(
+        table.updatedAt
+      ),
+    ]
+  );
+}
+
+/**
+ * The registry under the name this release's DDL creates.
+ *
+ * The factory exists because the storage migration renames this table, and a
+ * Drizzle object carries its physical name: addressing the renamed table needs
+ * an object built under that name. Index names are derived from the legacy
+ * constant in both instances on purpose — the migration renames the table and
+ * its type discriminator and nothing else, so a renamed table keeps the index
+ * names it was created with on every dialect.
+ */
+export const dynamicFieldGroupsSqlite = buildDynamicFieldGroupsSqlite(
+  STORAGE_FORMAT.registryTable
 );
 
 // ============================================================

--- a/packages/nextly/src/shared/base-registry-service.ts
+++ b/packages/nextly/src/shared/base-registry-service.ts
@@ -129,6 +129,19 @@ export abstract class BaseRegistryService<
   /** The metadata table name (e.g., "dynamic_collections"). */
   protected abstract readonly registryTableName: string;
 
+  /**
+   * The metadata table to address for this call.
+   *
+   * Separate from {@link registryTableName} because one registry's table can be
+   * renamed under a running database: the field-group storage migration moves
+   * it, so its name is an observation rather than a constant there. Every query
+   * below goes through this, and the default answers with the declared name, so
+   * a registry whose table never moves costs nothing and reads identically.
+   */
+  protected async resolveRegistryTableName(): Promise<string> {
+    return this.registryTableName;
+  }
+
   /** Human-readable resource type for error messages (e.g., "Collection"). */
   protected abstract readonly resourceType: string;
 
@@ -156,7 +169,7 @@ export abstract class BaseRegistryService<
   ): Promise<TRecord | null> {
     try {
       const result = await this.adapter.selectOne<TRecord>(
-        this.registryTableName,
+        await this.resolveRegistryTableName(),
         {
           where: this.whereEq("slug", slug),
         },
@@ -206,7 +219,7 @@ export abstract class BaseRegistryService<
       const conditions = this.buildFilterConditions(options);
 
       const results = await this.adapter.select<TRecord>(
-        this.registryTableName,
+        await this.resolveRegistryTableName(),
         {
           where: conditions.length > 0 ? { and: conditions } : undefined,
           orderBy: [{ column: "created_at", direction: "asc" }],
@@ -258,7 +271,7 @@ export abstract class BaseRegistryService<
 
       // Get total count (without pagination)
       const allResults = await this.adapter.select<{ id: string }>(
-        this.registryTableName,
+        await this.resolveRegistryTableName(),
         {
           where: whereClause,
           columns: ["id"],
@@ -268,7 +281,7 @@ export abstract class BaseRegistryService<
 
       // Get paginated results
       const results = await this.adapter.select<TRecord>(
-        this.registryTableName,
+        await this.resolveRegistryTableName(),
         {
           where: whereClause,
           orderBy: [{ column: "created_at", direction: "asc" }],
@@ -322,7 +335,7 @@ export abstract class BaseRegistryService<
       }
 
       const results = await this.adapter.update(
-        this.registryTableName,
+        await this.resolveRegistryTableName(),
         updateData,
         this.whereEq("slug", slug),
         { returning: "*" }
@@ -398,7 +411,7 @@ export abstract class BaseRegistryService<
   protected async getRecordsWithPendingMigrations(): Promise<TRecord[]> {
     try {
       const results = await this.adapter.select<TRecord>(
-        this.registryTableName,
+        await this.resolveRegistryTableName(),
         {
           where: {
             and: [

--- a/packages/nextly/src/shared/base-registry-service.ts
+++ b/packages/nextly/src/shared/base-registry-service.ts
@@ -138,8 +138,11 @@ export abstract class BaseRegistryService<
    * below goes through this, and the default answers with the declared name, so
    * a registry whose table never moves costs nothing and reads identically.
    */
-  protected async resolveRegistryTableName(): Promise<string> {
-    return this.registryTableName;
+  protected resolveRegistryTableName(): Promise<string> {
+    // Not `async`: the default has nothing to await, and a registry whose table
+    // never moves should not pay a microtask per query for a constant. The
+    // field-group override is `async` because its answer comes from the catalog.
+    return Promise.resolve(this.registryTableName);
   }
 
   /** Human-readable resource type for error messages (e.g., "Collection"). */


### PR DESCRIPTION
## What

The expand step of **expand → migrate → contract** for task 011. Every reader that addresses field-group storage now resolves the name from the database catalog instead of a constant, so one build reads both generations correctly.

**This changes no storage.** It adds no column, moves no data, and does not touch the merged migration engine. A database that has not migrated behaves exactly as before.

## Why now

The three-dialect matrix (#448) found on its first real run that **the migration renames things no runtime code can address**. `MIGRATION_TARGET.columnType` appeared nowhere outside the migration folder, and `FieldGroupRegistryService.registryTableName` was a constant — so after a successful `up`, **zero runtime schemas register** and every field group reads as absent. B1 and B2 therefore could not ship independently. Expand is what separates them.

## The rule

> **Read the migrated spelling only when the legacy one is absent.**

Applied identically to the registry table and to each data table's discriminator. It is the order the migration itself uses, and the only one correct in both directions: `up` renames the registry last, `down` renames it first, so "legacy if present" always names the live object and never adopts one this migration did not move.

🔴 **Resolved from the catalog, never from the marker.** The marker is a recorded claim; the catalog is an observable fact. A database restored from backup can carry a marker that disagrees with its own storage — which is exactly the case a reader has to survive. `guard.ts`'s `resolveStorageVerdict` is *not* the seam: it combines the marker with the probe and throws on every pair it cannot explain, so wiring it into the read path would turn a restored database from "reads correctly" into "refuses to boot".

## Two design points worth reviewing closely

**1. The Drizzle property key stays put; only the physical name moves.** The adapter addresses columns by property key everywhere — `db.select().from(tableObj)` returns rows keyed by property, `buildDrizzleWhere` resolves `getColumns(table)[cond.column]`, `mapDataToColumnNames` falls back to the key it was given. Keeping the key equal to `STORAGE_FORMAT.columns.type` therefore leaves every consumer of a component row unchanged, and keeps them correct through B2 when that constant flips.

The registry **table** gets no such luck: `SchemaRegistry.registerStaticSchemas` keys a table by `getTableName(value)` — the physical name — so there the handle *is* the name. Both the Drizzle object and the string that addresses it had to move together, which is why the dialect schemas became factories and both spellings are registered (for the schema registry only, never for a schema push).

**2. The discriminator is resolved per table, not once per database.** Three independent reasons, none hypothetical: the registry renames **last**, so mid-run and post-crash the two generations coexist; `retargetName` returns `null` for an author-named table, so its column moves while its table does not; and the DDL keeps writing the legacy spelling for a whole release, so a group created after a migration carries the legacy column while its siblings carry the migrated one.

## `typeColumn` is required, not defaulted

A default would let a call site that never learned to resolve compile and then silently project a column that is not there — the exact failure this PR exists to remove. Making it required turned the type checker into the completeness proof: it named all seven call sites. Each one supplies either the resolved value, or `STORAGE_FORMAT.columns.type` where the code *just wrote that DDL itself* (the same constant read twice, not a guess). `pushschema-pipeline.ts` deliberately uses the constant — it builds the **desired** schema handed to drizzle-kit, so resolving there would make the desired shape follow the live shape and the diff always empty.

## Tests

- **20 unit tests** on the resolver, **four proven by breaking it**: reversed preference order, collapsed per-table resolution to one global answer, cached the value instead of the promise, remembered a failed probe. Each killed exactly one test.
- **A new matrix test — `reads content through the typed CRUD on either generation`** — the assertion this slice exists for, and the one the suite could not make before. The same code reads content through the typed ORM before and after the migration, choosing the discriminator from the catalog rather than being told which generation it is in. Proven load-bearing: making the resolution always answer the legacy spelling failed **exactly and only** that test, on both Postgres and SQLite, with the test count unchanged.
- `registerComponentSchemas` gets a test that fails when the registry resolution is reverted to the constant.
- The HMR path reuses the batched snapshot the reload already read rather than probing again — caught by an existing test asserting that reload issues **one** introspect call.

## 🔴 A gap this does NOT close, and it blocks the entry point

`getCoreSchema(dialect)` includes the field-group registry, and `reconcileCore` introspects `CORE_TABLE_NAMES` (which lists `dynamic_components`) and diffs. On a **migrated** database running this release's code, that diff sees the legacy registry missing and emits a CREATE — an empty duplicate. `ensureSystemTables` does the same via `CREATE TABLE IF NOT EXISTS`. On the next boot, legacy-first resolution would then pick the **empty** one.

It is not reachable today, because nothing migrates storage without the entry point, which does not exist. It is filed as the next slice and must land **before** the entry point: without it, the rollback safety that justified expand→migrate→contract does not exist. Keeping it out of this PR is deliberate — `reconcileCore` can drop tables and earns its own review rather than riding along.

## Verification

- `pnpm build` ✅ · `pnpm lint` exit **0** ✅
- `pnpm check-types --force`: 8 errors, **byte-identical to `main`'s own** (i18n/companion + collection-bulk test files, from #429, none touched here). Verified by running it on a clean `origin/main` worktree. **This branch introduces none.**
- Unit suite **400 failed / 5891 passed / 42 skipped (6339)**, 400 unique failing test names, diffed at test-name level against a freshly measured baseline in its own installed-and-built worktree — **empty in both directions**.
- Integration: **10 passed** on Postgres 17 and **10 passed** on MySQL (SQLite in-memory in both legs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with legacy and migrated database schemas, including renamed or case-sensitive registry tables.
  * Ensured dynamic field groups, components, collections, permissions, webhooks, reloads, and cleanup workflows resolve the correct tables and type columns.
  * Improved schema generation and migration behavior across PostgreSQL, MySQL, and SQLite.
  * Prevented unsupported filters and empty membership conditions from producing invalid query behavior.

* **Tests**
  * Added coverage for migrations, mixed schema generations, storage-name resolution, caching, reloads, and typed CRUD operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->