### PR TITLE
feat(nextly): register block editor components in the admin import map

### DIFF
--- a/.changeset/block-editor-import-map.md
+++ b/.changeset/block-editor-import-map.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+---
+
+A block that supplies its own editor component now loads without a hand-written import.
+
+A block can name a custom inspector or canvas component through `editor.component`. That is a component path like any other admin contribution, so it now goes into the generated admin import map alongside plugin pages, settings and views — the editor bundle picks it up with no host wiring.
+
+Paths are read from what plugins declare, so generation needs no plugin to boot. A block registered imperatively at runtime contributes no path, the same rule the block manifest follows. An app whose only components come from blocks now gets an import map too, where before none was written.

--- a/packages/nextly/src/cli/commands/generate-types.ts
+++ b/packages/nextly/src/cli/commands/generate-types.ts
@@ -47,7 +47,10 @@ import {
   buildBlockManifestArtifact,
 } from "../../plugins/codegen/block-manifest";
 import { collectCodegenNames } from "../../plugins/codegen/collect-codegen-names";
-import { buildImportMapArtifact } from "../../plugins/codegen/component-import-map";
+import {
+  buildImportMapArtifact,
+  COMPONENT_IMPORT_MAP_FILENAME,
+} from "../../plugins/codegen/component-import-map";
 // The option names the field identity would overwrite, refused here because a
 // code-defined user field never passes through the manifest schema.
 import type { DynamicCollectionRecord } from "../../schemas/dynamic-collections/types";
@@ -344,6 +347,18 @@ async function generateTypes(
     await writeFile(importMapPath, importMap.code, "utf-8");
     result.componentImportMapFile = importMapPath;
     logger.debug(`Written plugin admin import map to: ${importMapPath}`);
+  } else {
+    // Nothing to register, which has to be expressed by removing any previous
+    // map. This one is worse than a stale data file: the generated module is
+    // IMPORTED by the app, so leaving it behind keeps importing a package that
+    // is no longer installed and breaks the next build.
+    await rm(
+      resolve(
+        cwd,
+        join(dirname(typesOutputPath), COMPONENT_IMPORT_MAP_FILENAME)
+      ),
+      { force: true }
+    );
   }
 
   // Generate Zod schemas if enabled

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest.test.ts
@@ -213,6 +213,22 @@ describe("buildBlockManifest rejects what boot would reject", () => {
     expect(message).toContain("no description");
   });
 
+  it("refuses a block with no example", () => {
+    // The block API requires a worked instance, so a declaration without one
+    // describes a block that could not have been built with defineBlock. It is
+    // also what a preview renders and what a generator few-shots from.
+    const message = issueOf(() =>
+      buildBlockManifest([
+        consumer(),
+        declaring("@acme/a", [
+          { name: "acme/x", version: 1, description: "No example." },
+        ]),
+      ])
+    );
+
+    expect(message).toContain("no example");
+  });
+
   it("refuses the same block name from two plugins, naming both", () => {
     // The engine throws NEXTLY_BLOCK_COLLISION for the second registration, so
     // emitting both would hand tooling an ambiguous manifest for a config that

--- a/packages/nextly/src/plugins/codegen/block-manifest.ts
+++ b/packages/nextly/src/plugins/codegen/block-manifest.ts
@@ -233,6 +233,19 @@ function declaredBlocks(
         `Block "${definition.name}" from "${source}" has no description. Every block needs one, for the palette, the docs and the manifest.`
       );
     }
+    // A worked instance is what makes a block usable by something that has
+    // never seen it: a preview renders it, and a generator few-shots from it.
+    // The block API requires one, so a declaration without it describes a block
+    // that could not have been built with `defineBlock`.
+    if (
+      typeof definition.example !== "object" ||
+      definition.example === null ||
+      Array.isArray(definition.example)
+    ) {
+      throw invalidDeclaration(
+        `Block "${definition.name}" from "${source}" has no example. Every block needs a worked instance, for previews and for generating content.`
+      );
+    }
     return definition;
   });
 }

--- a/packages/nextly/src/plugins/codegen/block-manifest.ts
+++ b/packages/nextly/src/plugins/codegen/block-manifest.ts
@@ -171,6 +171,12 @@ function invalidDeclaration(message: string): NextlyError {
 }
 
 /** Whether the plugin these declarations are addressed to will actually run. */
+export function isPageBuilderActive(
+  plugins: readonly PluginDefinition[]
+): boolean {
+  return isConsumerActive(plugins, PAGE_BUILDER_PLUGIN);
+}
+
 function isConsumerActive(
   plugins: readonly PluginDefinition[],
   consumer: string

--- a/packages/nextly/src/plugins/codegen/component-import-map.test.ts
+++ b/packages/nextly/src/plugins/codegen/component-import-map.test.ts
@@ -96,6 +96,16 @@ describe("buildImportMapArtifact", () => {
   });
 });
 
+/** The page builder itself, without which no block can register. */
+function pageBuilder(enabled?: boolean): PluginDefinition {
+  return {
+    name: "@nextlyhq/plugin-page-builder",
+    version: "1.0.0",
+    nextly: "*",
+    enabled,
+  } as unknown as PluginDefinition;
+}
+
 /** A plugin declaring blocks for the page builder. */
 function declaringBlocks(
   blocks: unknown[],
@@ -115,6 +125,7 @@ function declaringBlocks(
 describe("block editor components", () => {
   it("collects the editor component a declared block names", () => {
     const paths = collectBlockEditorComponentPaths([
+      pageBuilder(),
       declaringBlocks([
         { name: "acme/hero", editor: { component: "@acme/blocks/admin#Hero" } },
       ]),
@@ -127,6 +138,7 @@ describe("block editor components", () => {
     // The point of the seam: the editor bundle loads a contributed block's
     // inspector with no hand-written import, exactly as admin pages already do.
     const code = buildComponentImportMap([
+      pageBuilder(),
       declaringBlocks([
         { name: "acme/hero", editor: { component: "@acme/blocks/admin#Hero" } },
       ]),
@@ -141,6 +153,7 @@ describe("block editor components", () => {
     // a contributed inspector unloadable.
     const artifact = buildImportMapArtifact(
       [
+        pageBuilder(),
         declaringBlocks([
           {
             name: "acme/hero",
@@ -174,6 +187,7 @@ describe("block editor components", () => {
     // Most blocks render from their prop schema and need no custom component.
     expect(
       collectBlockEditorComponentPaths([
+        pageBuilder(),
         declaringBlocks([{ name: "acme/plain", version: 1 }]),
       ])
     ).toEqual([]);
@@ -185,6 +199,37 @@ describe("block editor components", () => {
     expect(
       collectBlockEditorComponentPaths([
         declaringBlocks("nope" as unknown as unknown[]),
+      ])
+    ).toEqual([]);
+  });
+});
+
+describe("block editor components without an active page builder", () => {
+  it("collects nothing when the page builder is absent", () => {
+    // No page builder, no registry for the blocks to land in, so importing
+    // their editor components eagerly would load a feature that cannot run.
+    expect(
+      collectBlockEditorComponentPaths([
+        declaringBlocks([
+          {
+            name: "acme/hero",
+            editor: { component: "@acme/blocks/admin#Hero" },
+          },
+        ]),
+      ])
+    ).toEqual([]);
+  });
+
+  it("collects nothing when the page builder is disabled", () => {
+    expect(
+      collectBlockEditorComponentPaths([
+        pageBuilder(false),
+        declaringBlocks([
+          {
+            name: "acme/hero",
+            editor: { component: "@acme/blocks/admin#Hero" },
+          },
+        ]),
       ])
     ).toEqual([]);
   });

--- a/packages/nextly/src/plugins/codegen/component-import-map.test.ts
+++ b/packages/nextly/src/plugins/codegen/component-import-map.test.ts
@@ -5,6 +5,7 @@ import {
   buildComponentImportMap,
   buildImportMapArtifact,
   collectAdminComponentPaths,
+  collectBlockEditorComponentPaths,
 } from "./component-import-map";
 
 function plugin(admin: unknown, enabled?: boolean): PluginDefinition {
@@ -92,5 +93,99 @@ describe("buildImportMapArtifact", () => {
     const p = plugin({ menu: [{ label: "X", to: "/x" }] }); // menu has no component
     expect(buildImportMapArtifact([p], "./types.ts")).toBeNull();
     expect(buildImportMapArtifact([], "./types.ts")).toBeNull();
+  });
+});
+
+/** A plugin declaring blocks for the page builder. */
+function declaringBlocks(
+  blocks: unknown[],
+  enabled?: boolean
+): PluginDefinition {
+  return {
+    name: "@acme/blocks",
+    version: "1.0.0",
+    nextly: "*",
+    enabled,
+    contributes: {
+      declarations: { "@nextlyhq/plugin-page-builder": { blocks } },
+    },
+  } as unknown as PluginDefinition;
+}
+
+describe("block editor components", () => {
+  it("collects the editor component a declared block names", () => {
+    const paths = collectBlockEditorComponentPaths([
+      declaringBlocks([
+        { name: "acme/hero", editor: { component: "@acme/blocks/admin#Hero" } },
+      ]),
+    ]);
+
+    expect(paths).toEqual(["@acme/blocks/admin#Hero"]);
+  });
+
+  it("registers them in the import map alongside admin components", () => {
+    // The point of the seam: the editor bundle loads a contributed block's
+    // inspector with no hand-written import, exactly as admin pages already do.
+    const code = buildComponentImportMap([
+      declaringBlocks([
+        { name: "acme/hero", editor: { component: "@acme/blocks/admin#Hero" } },
+      ]),
+    ]);
+
+    expect(code).toContain('"@acme/blocks/admin#Hero"');
+    expect(code).toContain('import * as _p0 from "@acme/blocks/admin";');
+  });
+
+  it("emits a map for block components even with no admin contributions", () => {
+    // Blocks alone are enough to need the file; returning null here would leave
+    // a contributed inspector unloadable.
+    const artifact = buildImportMapArtifact(
+      [
+        declaringBlocks([
+          {
+            name: "acme/hero",
+            editor: { component: "@acme/blocks/admin#Hero" },
+          },
+        ]),
+      ],
+      "/app/src/nextly-types.ts"
+    );
+
+    expect(artifact).not.toBeNull();
+  });
+
+  it("skips a disabled plugin's blocks", () => {
+    expect(
+      collectBlockEditorComponentPaths([
+        declaringBlocks(
+          [
+            {
+              name: "acme/hero",
+              editor: { component: "@acme/blocks/admin#Hero" },
+            },
+          ],
+          false
+        ),
+      ])
+    ).toEqual([]);
+  });
+
+  it("ignores a block that names no editor component", () => {
+    // Most blocks render from their prop schema and need no custom component.
+    expect(
+      collectBlockEditorComponentPaths([
+        declaringBlocks([{ name: "acme/plain", version: 1 }]),
+      ])
+    ).toEqual([]);
+  });
+
+  it("skips a malformed declaration rather than failing generation", () => {
+    // The manifest emitter already refuses these loudly; an import map is not
+    // where a schema error should surface, and reporting it twice helps nobody.
+    expect(
+      collectBlockEditorComponentPaths([
+        declaringBlocks("nope" as unknown as unknown[]),
+      ])
+    ).toEqual([]);
   });
 });

--- a/packages/nextly/src/plugins/codegen/component-import-map.ts
+++ b/packages/nextly/src/plugins/codegen/component-import-map.ts
@@ -23,7 +23,7 @@ import { dirname, join } from "node:path";
 import { collectDeclarations } from "../declarations";
 import type { PluginDefinition } from "../plugin-context";
 
-import { PAGE_BUILDER_PLUGIN } from "./block-manifest";
+import { isPageBuilderActive, PAGE_BUILDER_PLUGIN } from "./block-manifest";
 
 /** Filename of the generated admin component import map. */
 export const COMPONENT_IMPORT_MAP_FILENAME =
@@ -83,6 +83,11 @@ export function collectBlockEditorComponentPaths(
   plugins: readonly PluginDefinition[]
 ): string[] {
   const paths: string[] = [];
+  // No page builder, no registry for these blocks to land in, so their editor
+  // components would be imported eagerly for a feature that cannot run. The
+  // manifest applies the same rule; disagreeing would describe two different
+  // apps from one config.
+  if (!isPageBuilderActive(plugins)) return paths;
   for (const declaration of collectDeclarations(plugins, PAGE_BUILDER_PLUGIN)) {
     const value = declaration.value;
     if (typeof value !== "object" || value === null || Array.isArray(value)) {

--- a/packages/nextly/src/plugins/codegen/component-import-map.ts
+++ b/packages/nextly/src/plugins/codegen/component-import-map.ts
@@ -20,7 +20,10 @@
 
 import { dirname, join } from "node:path";
 
+import { collectDeclarations } from "../declarations";
 import type { PluginDefinition } from "../plugin-context";
+
+import { PAGE_BUILDER_PLUGIN } from "./block-manifest";
 
 /** Filename of the generated admin component import map. */
 export const COMPONENT_IMPORT_MAP_FILENAME =
@@ -59,6 +62,47 @@ export function collectAdminComponentPaths(plugin: PluginDefinition): string[] {
   return paths;
 }
 
+/**
+ * Every editor component a declared block names.
+ *
+ * A block may supply its own inspector or canvas component through
+ * `editor.component`, which is a `ComponentPath` like any admin contribution —
+ * so the editor bundle can load it the same way, with no hand-written import.
+ *
+ * Read from declarations rather than from the block registry, for the reason
+ * declarations exist: the registry is populated by `init`, and generation runs
+ * no plugin. A block registered imperatively contributes no path here, exactly
+ * as it contributes no manifest entry.
+ *
+ * Malformed declarations are skipped rather than refused. The manifest emitter
+ * already validates them and fails generation loudly; repeating the check here
+ * would report the same defect twice, and an import map is not the place a
+ * schema error should surface.
+ */
+export function collectBlockEditorComponentPaths(
+  plugins: readonly PluginDefinition[]
+): string[] {
+  const paths: string[] = [];
+  for (const declaration of collectDeclarations(plugins, PAGE_BUILDER_PLUGIN)) {
+    const value = declaration.value;
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      continue;
+    }
+    const blocks = (value as { blocks?: unknown }).blocks;
+    if (!Array.isArray(blocks)) continue;
+    for (const block of blocks) {
+      if (typeof block !== "object" || block === null) continue;
+      const editor = (block as { editor?: unknown }).editor;
+      if (typeof editor !== "object" || editor === null) continue;
+      const component = (editor as { component?: unknown }).component;
+      if (typeof component === "string" && component.length > 0) {
+        paths.push(component);
+      }
+    }
+  }
+  return paths;
+}
+
 interface ParsedPath {
   /** The full component path string (the registry key). */
   path: string;
@@ -86,6 +130,12 @@ export function buildComponentImportMap(plugins: PluginDefinition[]): string {
     for (const path of collectAdminComponentPaths(plugin)) {
       if (!byPath.has(path)) byPath.set(path, parsePath(path));
     }
+  }
+  // Block editor components register through the same map, so the editor
+  // bundle loads a contributed block's inspector without a hand-written
+  // import -- the same guarantee admin contributions already have.
+  for (const path of collectBlockEditorComponentPaths(plugins)) {
+    if (!byPath.has(path)) byPath.set(path, parsePath(path));
   }
 
   if (byPath.size === 0) {
@@ -125,10 +175,10 @@ export function buildImportMapArtifact(
   plugins: PluginDefinition[],
   typesOutputPath: string
 ): { path: string; code: string } | null {
-  const hasAdminComponents = plugins.some(
-    p => collectAdminComponentPaths(p).length > 0
-  );
-  if (!hasAdminComponents) return null;
+  const hasComponents =
+    plugins.some(p => collectAdminComponentPaths(p).length > 0) ||
+    collectBlockEditorComponentPaths(plugins).length > 0;
+  if (!hasComponents) return null;
 
   return {
     path: join(dirname(typesOutputPath), COMPONENT_IMPORT_MAP_FILENAME),


### PR DESCRIPTION
This is Plan 01's PR-8 — the block editor-component seam — finally buildable now that #446 and #450 landed the declaration channel and the manifest.

## What it does

A block can name its own inspector or canvas component through `editor.component`. That is a `ComponentPath` like any other admin contribution, so it now goes into the generated admin import map alongside plugin pages, settings and views. The editor bundle loads it with no host import and no run-once dynamic-import race — the same guarantee admin contributions already have.

## Why it was blocked, and what changed

PR-8 was specified as small plumbing, but it could not be built: blocks were registered imperatively inside `init`, and `nextly generate:types` boots no plugin, so nothing at build time could enumerate them. That was one blocker shared with PR-9, not two.

#446 added `contributes.declarations` — the static counterpart to `contributes.services` — and #450 proved it by emitting the manifest from it. This reads the same source, so generation stays a pure read of the config.

## Two decisions worth review

**The artifact gate now counts block components.** Previously `buildImportMapArtifact` returned `null` unless some plugin contributed `contributes.admin`, so an app whose only components came from blocks got no import map at all and its contributed inspector was unloadable.

**Malformed declarations are skipped here, not refused.** The manifest emitter already validates them and fails generation loudly, naming the plugin. Repeating the check would report one defect twice, and an import map is not where a schema error should surface. Deliberate asymmetry, stated in the code.

A block registered imperatively contributes no path — the same rule the manifest follows, and for the same reason: it cannot be known without running the plugin.

## Verification

- **Stub-verified, both precise.** Dropping block paths from the map fails only `registers them in the import map alongside admin components`. Reverting the artifact gate fails only `emits a map for block components even with no admin contributions`.
- 6 new tests (11 in the file); nextly unit **400 failed / 37 failed files — baseline exactly**.
- check-types and lint clean.

One note for anyone verifying locally: `check-types` on an unbuilt worktree reports phantom errors in fixture files, because the type-aware rules cannot resolve `@nextlyhq/adapter-drizzle/types`. Build first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Generated component imports now include eligible block editor components when the page builder is enabled.
  - Component import maps are generated whenever supported admin or block editor components are available.
- **Bug Fixes**
  - Prevented outdated generated component mappings from remaining when no current mappings are produced.
  - Improved handling of invalid or incomplete block declarations by reporting clear validation errors, including missing examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->